### PR TITLE
Added link to the matching org units and a listed the OU link parents

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/forms/messages.js
+++ b/hat/assets/js/apps/Iaso/domains/forms/messages.js
@@ -37,6 +37,10 @@ const MESSAGES = defineMessages({
         id: 'iaso.forms.source',
         defaultMessage: 'Source',
     },
+    parent: {
+        defaultMessage: 'Parent(s)',
+        id: 'iaso.orgUnits.parentsMulti',
+    },
     level: {
         id: 'iaso.forms.level',
         defaultMessage: 'Level',

--- a/hat/assets/js/apps/Iaso/domains/links/components/LinksCompareComponent.js
+++ b/hat/assets/js/apps/Iaso/domains/links/components/LinksCompareComponent.js
@@ -12,8 +12,9 @@ import {
     Grid,
     Typography,
 } from '@material-ui/core';
-
+import { baseUrls } from '../../../constants/urls';
 import LinksValue from './LinksValueComponent';
+import IconButtonComponent from '../../../components/buttons/IconButtonComponent';
 
 import MESSAGES from '../messages';
 
@@ -35,18 +36,24 @@ const LinksCompare = ({ link, compareLink, classes, title, validated }) => {
     return (
         <Paper className={classes.paper}>
             {!isEqual(link, compareLink) && (
-                <Grid container spacing={0} className={classes.title}>
-                    <Grid
-                        container
-                        item
-                        xs={6}
-                        justify="flex-start"
-                        alignItems="center"
-                    >
+                <Grid
+                    container
+                    spacing={0}
+                    alignItems="center"
+                    justify="flex-start"
+                    className={classes.title}
+                >
+                    <Grid item xs={11}>
                         <Typography variant="h6" component="h6" color="primary">
-                            {title} -
-{link.source}
+                            {`${title} - ${link.source}`}
                         </Typography>
+                    </Grid>
+                    <Grid item xs={1}>
+                        <IconButtonComponent
+                            url={`${baseUrls.orgUnitDetails}/orgUnitId/${link.id}/tab/infos`}
+                            icon="orgUnit"
+                            tooltipMessage={MESSAGES.details}
+                        />
                     </Grid>
                 </Grid>
             )}
@@ -67,6 +74,7 @@ const LinksCompare = ({ link, compareLink, classes, title, validated }) => {
                                 return (
                                     <LinksValue
                                         key={key}
+                                        link={link}
                                         linkKey={key}
                                         value={value}
                                         isDifferent={isDifferent}

--- a/hat/assets/js/apps/Iaso/domains/links/components/LinksValueComponent.js
+++ b/hat/assets/js/apps/Iaso/domains/links/components/LinksValueComponent.js
@@ -7,6 +7,7 @@ import { withStyles, TableCell, TableRow } from '@material-ui/core';
 
 import GeoJsonMap from '../../../components/maps/GeoJsonMapComponent';
 import { textPlaceholder } from '../../../constants/uiConstants';
+import { getOrgUnitParentsString } from '../../orgUnits/utils';
 
 import MESSAGES from '../../forms/messages';
 import { MESSAGES as LINKS_MESSAGES } from '../messages';
@@ -35,14 +36,12 @@ const ignoredKeys = [
     'org_unit_type_id',
     'has_geo_json',
     'org_unit_type',
-    'parent',
     'parent_id',
     'sub_source',
     'source',
-    'source_ref',
 ];
 
-const renderValue = (linkKey, value, classes) => {
+const renderValue = (linkKey, link, value, classes) => {
     if (!value || value.toString().length === 0) return textPlaceholder;
     switch (linkKey) {
         case 'geo_json': {
@@ -66,6 +65,9 @@ const renderValue = (linkKey, value, classes) => {
         case 'updated_at': {
             return moment.unix(value).format('DD/MM/YYYY HH:mm');
         }
+        case 'parent': {
+            return getOrgUnitParentsString(link);
+        }
 
         default:
             return value.toString();
@@ -75,6 +77,7 @@ const renderValue = (linkKey, value, classes) => {
 const LinksValue = ({
     linkKey,
     value,
+    link,
     isDifferent,
     classes,
     intl,
@@ -93,7 +96,7 @@ const LinksValue = ({
                 {!MESSAGES[linkKey] && linkKey}
             </TableCell>
             <TableCell className={isDifferent ? differentClass : null}>
-                {renderValue(linkKey, value, classes)}
+                {renderValue(linkKey, link, value, classes)}
             </TableCell>
         </TableRow>
     );
@@ -101,6 +104,7 @@ const LinksValue = ({
 
 LinksValue.defaultProps = {
     value: null,
+    link: null,
     validated: false,
 };
 
@@ -109,6 +113,7 @@ LinksValue.propTypes = {
     classes: PropTypes.object.isRequired,
     linkKey: PropTypes.string.isRequired,
     value: PropTypes.any,
+    link: PropTypes.any,
     isDifferent: PropTypes.bool.isRequired,
     validated: PropTypes.bool,
 };

--- a/iaso/api/data_sources.py
+++ b/iaso/api/data_sources.py
@@ -20,7 +20,7 @@ class DataSourceSerializer(serializers.ModelSerializer):
 
     @staticmethod
     def get_versions(obj: DataSource):
-        return ([v.as_dict_without_data_source() for v in obj.versions.all()],)
+        return [v.as_dict_without_data_source() for v in obj.versions.all()]
 
     @staticmethod
     def get_projects(obj: DataSource):


### PR DESCRIPTION
- Fixed the datasource API endpoint response. Versions attribute shouldn't be an array of arrays
- Added a button to link to orgUnit details
- Listed the parents orgUnits of the current mapping link

![Screenshot 2020-11-18 at 14 14 07](https://user-images.githubusercontent.com/4437445/99535805-b5214380-29a9-11eb-8a2e-2c9a1a878802.png)
