### PR TITLE
Fix org units component when creating a new campaign

### DIFF
--- a/plugins/polio/js/src/components/Inputs/OrgUnitsSelect.js
+++ b/plugins/polio/js/src/components/Inputs/OrgUnitsSelect.js
@@ -8,7 +8,7 @@ import { useGetAuthenticatedUser } from '../../hooks/useGetAuthenticatedUser';
 import { CircularProgress } from '@material-ui/core';
 
 export const OrgUnitsSelect = props => {
-    const { level, source, addLevel, value } = props;
+    const { level, source, onChange, value } = props;
     const { data = {}, isLoading } = useGetOrgUnits(level, source);
     const { orgUnits = [] } = data;
 
@@ -32,12 +32,12 @@ export const OrgUnitsSelect = props => {
                 label: orgUnit.name,
             }))}
             onChange={event => {
-                addLevel({
+                onChange({
                     parent_id: level,
                     org_unit_id: event.target.value,
                 });
             }}
-            value={value ?? 0}
+            value={value ?? ''}
         />
     );
 };
@@ -48,7 +48,6 @@ export const OrgUnitsLevels = ({ field = {}, form, ...props }) => {
     const initialOrgUnit = form?.initialValues?.initial_org_unit ?? null;
 
     const { data: initialState } = useGetAllParentsOrgUnits(initialOrgUnit);
-
     const [levels, setLevel] = useState([null]);
 
     useEffect(() => {
@@ -77,7 +76,7 @@ export const OrgUnitsLevels = ({ field = {}, form, ...props }) => {
                 source={source}
                 label={`Level ${index + 1}`}
                 level={level}
-                addLevel={addLevel}
+                onChange={addLevel}
                 value={levels[index + 1]}
             />
         );

--- a/plugins/polio/js/src/components/Inputs/OrgUnitsSelect.js
+++ b/plugins/polio/js/src/components/Inputs/OrgUnitsSelect.js
@@ -58,6 +58,10 @@ export const OrgUnitsLevels = ({ field = {}, form, ...props }) => {
     const { setFieldValue } = form;
 
     useEffect(() => {
+        if (!levels[levels.length - 1]) {
+            return;
+        }
+
         setFieldValue(name, levels[levels.length - 1]);
     }, [levels, name, setFieldValue]);
 

--- a/plugins/polio/js/src/components/Inputs/OrgUnitsSelect.js
+++ b/plugins/polio/js/src/components/Inputs/OrgUnitsSelect.js
@@ -45,14 +45,14 @@ export const OrgUnitsSelect = props => {
 export const OrgUnitsLevels = ({ field = {}, form, ...props }) => {
     const { data = {} } = useGetAuthenticatedUser();
     const source = data?.account?.default_version?.data_source?.id;
-    const initialOrgUnit = form?.initialValues?.initial_org_unit ?? 0;
+    const initialOrgUnit = form?.initialValues?.initial_org_unit ?? null;
 
     const { data: initialState } = useGetAllParentsOrgUnits(initialOrgUnit);
 
-    const [levels, setLevel] = useState([0]);
+    const [levels, setLevel] = useState([null]);
 
     useEffect(() => {
-        setLevel(initialState ?? [0]);
+        setLevel(initialState ?? [null]);
     }, [initialState]);
 
     const { name } = field;

--- a/plugins/polio/js/src/hooks/useGetOrgUnits.js
+++ b/plugins/polio/js/src/hooks/useGetOrgUnits.js
@@ -13,7 +13,11 @@ export const useGetOrgUnits = (parent, source) => {
         () => {
             const queryString = new URLSearchParams(params);
 
-            if (source === undefined) {
+            if (params.parent_id === null) {
+                queryString.set('parent_id', 0);
+            }
+
+            if (params.source === undefined) {
                 queryString.delete('source');
             }
 
@@ -32,14 +36,15 @@ export const useGetAllParentsOrgUnits = initialOrgUnit => {
     return useQuery(
         ['orgunits', initialOrgUnit],
         async () => {
-            if (initialOrgUnit === 0) {
-                return [0];
+            if (initialOrgUnit === null) {
+                return [null];
             }
 
             const result = await sendRequest(
                 'GET',
                 '/api/orgunits/' + initialOrgUnit,
             );
+
             const initialState = [result.id];
             let currentParent = result.parent;
             while (currentParent) {
@@ -47,7 +52,7 @@ export const useGetAllParentsOrgUnits = initialOrgUnit => {
                 currentParent = currentParent.parent;
             }
 
-            initialState.unshift(0);
+            initialState.unshift(null);
 
             return initialState;
         },


### PR DESCRIPTION
### Fixed
- Not being able to create a campaign without any org units selected
- Fixed create campaign modal with validation errors on an empty state
- Fixed empty value warnings for org units component