### PR TITLE
POC of email sending from Iaso

### DIFF
--- a/hat/settings.py
+++ b/hat/settings.py
@@ -311,3 +311,11 @@ SSL_ON = (not DEBUG) and (not BEANSTALK_WORKER)
 if SSL_ON:
     SECURE_HSTS_SECONDS = 31_536_000  # 1 year
 SECURE_SSL_REDIRECT = SSL_ON
+
+# Email configuration
+
+EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+EMAIL_HOST = os.environ.get('EMAIL_HOST', 'mail.smtpbucket.com')
+EMAIL_HOST_USER = os.environ.get('EMAIL_HOST_USER', '')
+EMAIL_HOST_PASSWORD = os.environ.get('EMAIL_HOST_PASSWORD', '')
+EMAIL_PORT = os.environ.get('EMAIL_PORT', '8025')

--- a/hat/settings.py
+++ b/hat/settings.py
@@ -314,8 +314,8 @@ SECURE_SSL_REDIRECT = SSL_ON
 
 # Email configuration
 
-EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
-EMAIL_HOST = os.environ.get('EMAIL_HOST', 'mail.smtpbucket.com')
-EMAIL_HOST_USER = os.environ.get('EMAIL_HOST_USER', '')
-EMAIL_HOST_PASSWORD = os.environ.get('EMAIL_HOST_PASSWORD', '')
-EMAIL_PORT = os.environ.get('EMAIL_PORT', '8025')
+EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+EMAIL_HOST = os.environ.get("EMAIL_HOST", "mail.smtpbucket.com")
+EMAIL_HOST_USER = os.environ.get("EMAIL_HOST_USER", "")
+EMAIL_HOST_PASSWORD = os.environ.get("EMAIL_HOST_PASSWORD", "")
+EMAIL_PORT = os.environ.get("EMAIL_PORT", "8025")

--- a/iaso/__init__.py
+++ b/iaso/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'iaso.apps.IasoConfig'

--- a/iaso/__init__.py
+++ b/iaso/__init__.py
@@ -1,1 +1,1 @@
-default_app_config = 'iaso.apps.IasoConfig'
+default_app_config = "iaso.apps.IasoConfig"

--- a/iaso/api/signals.py
+++ b/iaso/api/signals.py
@@ -2,18 +2,13 @@ from django.db.models import signals
 from django.dispatch import receiver
 from django.core.mail import EmailMultiAlternatives
 from django.utils.html import strip_tags
-import logging
 
 from iaso.models import Form
-
-logger = logging.getLogger(__name__)
 
 @receiver(signals.post_save, sender=Form)
 def send_form_email(sender, **kwargs):
     created = kwargs['created']
     form = kwargs['instance']
-
-    logger.warning('SIGNAL send_form_email')
 
     if created:
         subject = 'A form has just been created...'

--- a/iaso/api/signals.py
+++ b/iaso/api/signals.py
@@ -1,0 +1,31 @@
+from django.db.models import signals
+from django.dispatch import receiver
+from django.core.mail import EmailMultiAlternatives
+from django.utils.html import strip_tags
+import logging
+
+from iaso.models import Form
+
+logger = logging.getLogger(__name__)
+
+@receiver(signals.post_save, sender=Form)
+def send_form_email(sender, **kwargs):
+    created = kwargs['created']
+    form = kwargs['instance']
+
+    logger.warning('SIGNAL send_form_email')
+
+    if created:
+        subject = 'A form has just been created...'
+
+        body_html = 'Hello there! <br /><br />'
+        body_html += 'A form has just been created: <strong>%s</strong> <br /><br />' % form.name
+        body_html += 'Enjoy!'
+
+        body_text = strip_tags(body_html)
+
+        message = EmailMultiAlternatives(subject=subject, body=body_text, from_email='Iaso <iaso@bluesquare.org>',
+                                         to=['vincent.battaglia@gmail.com'])
+        message.attach_alternative(body_html, "text/html")
+
+        message.send()

--- a/iaso/api/signals.py
+++ b/iaso/api/signals.py
@@ -5,22 +5,24 @@ from django.utils.html import strip_tags
 
 from iaso.models import Form
 
+
 @receiver(signals.post_save, sender=Form)
 def send_form_email(sender, **kwargs):
-    created = kwargs['created']
-    form = kwargs['instance']
+    created = kwargs["created"]
+    form = kwargs["instance"]
 
     if created:
-        subject = 'A form has just been created...'
+        subject = "A form has just been created..."
 
-        body_html = 'Hello there! <br /><br />'
-        body_html += 'A form has just been created: <strong>%s</strong> <br /><br />' % form.name
-        body_html += 'Enjoy!'
+        body_html = "Hello there! <br /><br />"
+        body_html += "A form has just been created: <strong>%s</strong> <br /><br />" % form.name
+        body_html += "Enjoy!"
 
         body_text = strip_tags(body_html)
 
-        message = EmailMultiAlternatives(subject=subject, body=body_text, from_email='Iaso <iaso@bluesquare.org>',
-                                         to=['vincent.battaglia@gmail.com'])
+        message = EmailMultiAlternatives(
+            subject=subject, body=body_text, from_email="Iaso <iaso@bluesquare.org>", to=["vincent.battaglia@gmail.com"]
+        )
         message.attach_alternative(body_html, "text/html")
 
         message.send()

--- a/iaso/apps.py
+++ b/iaso/apps.py
@@ -1,5 +1,7 @@
 from django.apps import AppConfig
 
-
 class IasoConfig(AppConfig):
     name = "iaso"
+
+    def ready(self):
+        import iaso.api.signals

--- a/iaso/apps.py
+++ b/iaso/apps.py
@@ -1,5 +1,6 @@
 from django.apps import AppConfig
 
+
 class IasoConfig(AppConfig):
     name = "iaso"
 


### PR DESCRIPTION
Here is a quick proof of concept of email sending using Django `post_save` signals, the same approach I used on another project. For this POC, I send an email after a `Form` is created, but it can be used on any other model, with other signals as well (`pre_save`, `pre_save`, `post_delete`, etc.)

A few notes:
* At the moment it uses a fake SMTP server. You can see the emails arriving here: https://www.smtpbucket.com/emails?sender=iaso@bluesquare.org. At some point, it will need to be replaced by a real SMTP server of course (to be set up with env variables).
* I use the common email backend at the moment but I suggest moving it to something like Celery (`djcelery_email.backends.CeleryEmailBackend`) so the email sending is not blocking (it's just added to a queue). Using Celery will also allow us to have a log of all the emails that have been sent by the platform.