### PR TITLE
[POLIO] Add fields to budget step

### DIFF
--- a/plugins/polio/js/src/components/Dashboard.js
+++ b/plugins/polio/js/src/components/Dashboard.js
@@ -79,6 +79,8 @@ const schema = yup.object().shape({
     dg_authorized_at: yup.date().nullable(),
 
     eomg: yup.date().nullable(),
+    budget_submitted_at: yup.date().nullable(),
+    district_count: yup.number().nullable().positive().integer(),
     no_regret_fund_amount: yup.number().nullable().positive().integer(),
 
     round_one: round_shape,

--- a/plugins/polio/js/src/components/Dashboard.js
+++ b/plugins/polio/js/src/components/Dashboard.js
@@ -414,6 +414,20 @@ const BudgetForm = () => {
                     />
 
                     <Field
+                        label={'Budget Submitted At'}
+                        name={'budget_submitted_at'}
+                        component={DateInput}
+                        fullWidth
+                    />
+
+                    <Field
+                        label="District Count"
+                        name={'district_count'}
+                        component={TextInput}
+                        className={classes.input}
+                    />
+
+                    <Field
                         label="No Regret Fund"
                         name={'no_regret_fund_amount'}
                         component={TextInput}


### PR DESCRIPTION
### Added

- see https://bluesquare.slack.com/archives/C0214A5BR2L/p1622439729001600
- `district_count` and `budget_submitted_at` fields