### PR TITLE
Fix Allow setting which DB to use via the .env file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       GOOGLE_API_KEY_BASE64: ${GOOGLE_API_KEY_BASE64}
       IASO_ENVIRONMENT: "development"
       RDS_HOSTNAME: db
-      RDS_DB_NAME: iaso
+      RDS_DB_NAME: ${RDS_DB_NAME:-iaso}
       RDS_USERNAME: postgres
       RDS_PASSWORD: postgres
       DEBUG: "true"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
     links: &hat_links
       - db
     environment: &hat_environment
-      PLUGIN_POLIO_ENABLED: ${PLUGIN_POLIO_ENABLED}
+      PLUGIN_POLIO_ENABLED: ${PLUGIN_POLIO_ENABLED:-false}
       GOOGLE_API_KEY_BASE64: ${GOOGLE_API_KEY_BASE64}
       IASO_ENVIRONMENT: "development"
       RDS_HOSTNAME: db

--- a/runiasodev.sh
+++ b/runiasodev.sh
@@ -6,7 +6,7 @@
 
 # You will need to create a venv locally by running: venv . && pip install -r requirements.txt
 
-source bin/activate
+#source bin/activate
 export SECRET_KEY="secret"
 export RDS_PORT="5433"
 export RDS_HOSTNAME="localhost"
@@ -16,5 +16,7 @@ export DEV_SERVER="true"
 export RDS_DB_NAME="iaso"
 export USE_S3="false"
 export RDS_PASSWORD="postgres"
+
+source .env
 
 ./manage.py runserver


### PR DESCRIPTION
In the .env.dev example file there is a settings RDS_DB_NAME to set which env Database to use,  but it was not actually respected by runiasodev.sh or docker-compose.