### PR TITLE
Reduce the size of Iaso docker images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -69,7 +69,6 @@ db.sqlite3
 
 # data that get mounted
 media/
-testdata/
 
 # Node modules
 node_modules/

--- a/.dockerignore
+++ b/.dockerignore
@@ -66,6 +66,14 @@ target/
 __pycache__/
 local_settings.py
 db.sqlite3
-media
 
+# data that get mounted
+media/
+testdata/
+
+# Node modules
 node_modules/
+plugins/polio/js/node_modules/
+
+# Beanstalk for aws
+.elasticbeanstalk/


### PR DESCRIPTION
We were adding the node_modules of Polio and other useless stuff in the image.