### PR TITLE
bluesquare-components install fail with npm-ci

### DIFF
--- a/.docker/webpack/Dockerfile
+++ b/.docker/webpack/Dockerfile
@@ -13,7 +13,7 @@ COPY package.json .
 COPY package-lock.json .
 
 # ci install the exact version of package, compared to install which might a bump minor version
-RUN npm ci
+RUN npm install
 
 ADD hat/ hat/ 
 ADD plugins/ plugins/ 


### PR DESCRIPTION
deactivate it temporarly till we fix it

Step 7/11 : RUN npm ci
 ---> Running in eaf4498c5557
npm ERR! Error while executing:
npm ERR! /usr/bin/git ls-remote -h -t ssh://git@github.com/BLSQ/bluesquare-components.git
npm ERR!
npm ERR! Host key verification failed.
npm ERR! fatal: Could not read from remote repository.
npm ERR!
npm ERR! Please make sure you have the correct access rights
npm ERR! and the repository exists.
npm ERR!
npm ERR! exited with error code: 128