### PR TITLE
Limit the list of campaigns visible to an user to the org units that are under his responsability

### DIFF
--- a/plugins/polio/api.py
+++ b/plugins/polio/api.py
@@ -34,8 +34,7 @@ class CampaignViewSet(ModelViewSet):
         user = self.request.user
 
         if user.iaso_profile.org_units.count():
-            org_units = map(lambda org_unit: OrgUnit.objects.hierarchy(org_unit), user.iaso_profile.org_units.all())
-            org_units = list(itertools.chain.from_iterable(org_units))
+            org_units = OrgUnit.objects.hierarchy(user.iaso_profile.org_units.all())
 
             return Campaign.objects.filter(initial_org_unit__in=org_units).order_by("obr_name")
         else:

--- a/plugins/polio/api.py
+++ b/plugins/polio/api.py
@@ -1,5 +1,8 @@
-from plugins.polio.serializers import CampaignSerializer, PreparednessPreviewSerializer, SurgePreviewSerializer
-from rest_framework import viewsets, routers
+from plugins.polio.serializers import SurgePreviewSerializer
+import itertools
+from iaso.models import OrgUnit
+from plugins.polio.serializers import CampaignSerializer, PreparednessPreviewSerializer
+from rest_framework import routers
 from rest_framework.response import Response
 from rest_framework.request import Request
 from rest_framework.decorators import action
@@ -8,7 +11,6 @@ from iaso.api.common import ModelViewSet
 
 
 class CampaignViewSet(ModelViewSet):
-    queryset = Campaign.objects.all().order_by("obr_name")
     serializer_class = CampaignSerializer
     results_key = "campaigns"
     remove_results_key_if_paginated = True
@@ -28,6 +30,17 @@ class CampaignViewSet(ModelViewSet):
         else:
             return Response(serializer.data)
 
+    def get_queryset(self):
+        user = self.request.user
+
+        if user.iaso_profile.org_units.count():
+            org_units = map(lambda org_unit: OrgUnit.objects.hierarchy(org_unit), user.iaso_profile.org_units.all())
+            org_units = list(itertools.chain.from_iterable(org_units))
+
+            return Campaign.objects.filter(initial_org_unit__in=org_units).order_by("obr_name")
+        else:
+            return Campaign.objects.order_by("obr_name")
+
     @action(methods=["POST"], detail=False, serializer_class=PreparednessPreviewSerializer)
     def preview_preparedness(self, request, **kwargs):
         serializer = self.get_serializer(data=request.data)
@@ -42,4 +55,4 @@ class CampaignViewSet(ModelViewSet):
 
 
 router = routers.SimpleRouter()
-router.register(r"polio/campaigns", CampaignViewSet)
+router.register(r"polio/campaigns", CampaignViewSet, basename="Campaign")


### PR DESCRIPTION
### Updated
- Ony show campaigns for a user's org unit or a descendant of the org unit that is assigned in his profile

---
Closes https://bluesquare.atlassian.net/browse/IA-569