### PR TITLE
Improve pagination and fields ordering implementation

### DIFF
--- a/hat/settings.py
+++ b/hat/settings.py
@@ -113,6 +113,7 @@ INSTALLED_APPS = [
     "storages",
     "corsheaders",
     "rest_framework",
+    "django_filters",
     "webpack_loader",
     "django_ltree",
     "hat.sync",

--- a/plugins/polio/api.py
+++ b/plugins/polio/api.py
@@ -13,6 +13,7 @@ class CampaignViewSet(ModelViewSet):
     serializer_class = CampaignSerializer
     results_key = "campaigns"
     remove_results_key_if_paginated = True
+    filters.OrderingFilter.ordering_param = "order"
 
     filter_backends = [filters.OrderingFilter]
     ordering_fields = ["obr_name", "cvdpv2_notified_at", "detection_status"]

--- a/plugins/polio/api.py
+++ b/plugins/polio/api.py
@@ -1,34 +1,23 @@
+from rest_framework.pagination import PageNumberPagination
 from plugins.polio.serializers import SurgePreviewSerializer
-import itertools
 from iaso.models import OrgUnit
 from plugins.polio.serializers import CampaignSerializer, PreparednessPreviewSerializer
 from rest_framework import routers
 from rest_framework.response import Response
-from rest_framework.request import Request
 from rest_framework.decorators import action
 from .models import Campaign
 from iaso.api.common import ModelViewSet
 
+class StandardResultsSetPagination(PageNumberPagination):
+    page_size = 10
+    page_size_query_param = "limit"
+    max_page_size = 1000
 
 class CampaignViewSet(ModelViewSet):
     serializer_class = CampaignSerializer
     results_key = "campaigns"
-    remove_results_key_if_paginated = True
+    pagination_class = StandardResultsSetPagination
 
-    def list(self, request: Request, *args, **kwargs):
-        order = self.request.GET.get("order", "obr_name")
-        queryset = self.filter_queryset(self.get_queryset().order_by(order))
-
-        page = self.paginate_queryset(queryset)
-        if page is not None:
-            serializer = self.get_serializer(page, many=True)
-            return self.get_paginated_response(serializer.data)
-
-        serializer = self.get_serializer(queryset, many=True)
-        if not self.remove_results_key_if_paginated:
-            return Response({self.get_results_key(): serializer.data})
-        else:
-            return Response(serializer.data)
 
     def get_queryset(self):
         user = self.request.user

--- a/plugins/polio/api.py
+++ b/plugins/polio/api.py
@@ -2,7 +2,7 @@ from rest_framework.pagination import PageNumberPagination
 from plugins.polio.serializers import SurgePreviewSerializer
 from iaso.models import OrgUnit
 from plugins.polio.serializers import CampaignSerializer, PreparednessPreviewSerializer
-from rest_framework import routers
+from rest_framework import routers, filters
 from rest_framework.response import Response
 from rest_framework.decorators import action
 from .models import Campaign
@@ -18,6 +18,8 @@ class CampaignViewSet(ModelViewSet):
     results_key = "campaigns"
     pagination_class = StandardResultsSetPagination
 
+    filter_backends = [filters.OrderingFilter]
+    ordering_fields = ["obr_name", "cvdpv2_notified_at", "detection_status"]
 
     def get_queryset(self):
         user = self.request.user
@@ -25,9 +27,9 @@ class CampaignViewSet(ModelViewSet):
         if user.iaso_profile.org_units.count():
             org_units = OrgUnit.objects.hierarchy(user.iaso_profile.org_units.all())
 
-            return Campaign.objects.filter(initial_org_unit__in=org_units).order_by("obr_name")
+            return Campaign.objects.filter(initial_org_unit__in=org_units)
         else:
-            return Campaign.objects.order_by("obr_name")
+            return Campaign.objects.all()
 
     @action(methods=["POST"], detail=False, serializer_class=PreparednessPreviewSerializer)
     def preview_preparedness(self, request, **kwargs):

--- a/plugins/polio/api.py
+++ b/plugins/polio/api.py
@@ -8,14 +8,15 @@ from rest_framework.decorators import action
 from .models import Campaign
 from iaso.api.common import ModelViewSet
 
+
 class StandardResultsSetPagination(PageNumberPagination):
     page_size = 10
     page_size_query_param = "limit"
     max_page_size = 1000
 
+
 class CampaignViewSet(ModelViewSet):
     serializer_class = CampaignSerializer
-    results_key = "campaigns"
     pagination_class = StandardResultsSetPagination
 
     filter_backends = [filters.OrderingFilter]

--- a/plugins/polio/api.py
+++ b/plugins/polio/api.py
@@ -9,15 +9,10 @@ from .models import Campaign
 from iaso.api.common import ModelViewSet
 
 
-class StandardResultsSetPagination(PageNumberPagination):
-    page_size = 10
-    page_size_query_param = "limit"
-    max_page_size = 1000
-
-
 class CampaignViewSet(ModelViewSet):
     serializer_class = CampaignSerializer
-    pagination_class = StandardResultsSetPagination
+    results_key = "campaigns"
+    remove_results_key_if_paginated = True
 
     filter_backends = [filters.OrderingFilter]
     ordering_fields = ["obr_name", "cvdpv2_notified_at", "detection_status"]

--- a/plugins/polio/js/src/components/Dashboard.js
+++ b/plugins/polio/js/src/components/Dashboard.js
@@ -888,23 +888,28 @@ export const Dashboard = () => {
         });
     };
 
-    const handleClickEditRow = useCallback(id => {
-        setSelectedCampaignId(id);
-        openCreateEditDialog();
-    },[setSelectedCampaignId,openCreateEditDialog]);
+    const handleClickEditRow = useCallback(
+        id => {
+            setSelectedCampaignId(id);
+            openCreateEditDialog();
+        },
+        [setSelectedCampaignId, openCreateEditDialog],
+    );
 
-
-    const handleClickDeleteRow = useCallback(id => {
-        setSelectedCampaignId(id);
-        openDeleteConfirmDialog();
-    },[setSelectedCampaignId,openDeleteConfirmDialog]);
+    const handleClickDeleteRow = useCallback(
+        id => {
+            setSelectedCampaignId(id);
+            openDeleteConfirmDialog();
+        },
+        [setSelectedCampaignId, openDeleteConfirmDialog],
+    );
 
     const handleClickCreateButton = () => {
         setSelectedCampaignId(undefined);
         openCreateEditDialog();
     };
 
-    const selectedCampaign = campaigns?.results?.find(
+    const selectedCampaign = campaigns?.campaigns?.find(
         campaign => campaign.id === selectedCampaignId,
     );
 
@@ -1017,7 +1022,7 @@ export const Dashboard = () => {
                             baseUrl={'/polio'}
                             redirectTo={onTableParamsChange}
                             columns={columns}
-                            data={campaigns.results}
+                            data={campaigns.campaigns}
                             watchToRender={tableParams}
                         />
                     )}

--- a/plugins/polio/js/src/components/Dashboard.js
+++ b/plugins/polio/js/src/components/Dashboard.js
@@ -904,7 +904,7 @@ export const Dashboard = () => {
         openCreateEditDialog();
     };
 
-    const selectedCampaign = campaigns?.campaigns?.find(
+    const selectedCampaign = campaigns?.results?.find(
         campaign => campaign.id === selectedCampaignId,
     );
 
@@ -1017,7 +1017,7 @@ export const Dashboard = () => {
                             baseUrl={'/polio'}
                             redirectTo={onTableParamsChange}
                             columns={columns}
-                            data={campaigns.campaigns}
+                            data={campaigns.results}
                             watchToRender={tableParams}
                         />
                     )}

--- a/plugins/polio/tests.py
+++ b/plugins/polio/tests.py
@@ -213,8 +213,9 @@ class PolioAPITestCase(APITestCase):
         self.assertEqual(response.status_code, 201)
 
         response = self.client.get("/api/polio/campaigns/", format="json")
-        self.assertEqual(len(response.json()), 1)
-        self.assertEqual(response.json()[0]["initial_org_unit"], self.child_org_unit.pk)
+
+        self.assertEqual(len(response.json()["results"]), 1)
+        self.assertEqual(response.json()["results"][0]["initial_org_unit"], self.child_org_unit.pk)
 
 
 class CampaignCalculatorTestCase(TestCase):

--- a/plugins/polio/tests.py
+++ b/plugins/polio/tests.py
@@ -214,8 +214,8 @@ class PolioAPITestCase(APITestCase):
 
         response = self.client.get("/api/polio/campaigns/", format="json")
 
-        self.assertEqual(len(response.json()["results"]), 1)
-        self.assertEqual(response.json()["results"][0]["initial_org_unit"], self.child_org_unit.pk)
+        self.assertEqual(len(response.json()), 1)
+        self.assertEqual(response.json()[0]["initial_org_unit"], self.child_org_unit.pk)
 
 
 class CampaignCalculatorTestCase(TestCase):

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 django==3.1.12
 django-cors-headers==3.2.1
 djangorestframework==3.11.2
+django-filter==2.4.0
 pandas==1.0.1
 cython==0.29.23
 pyproj==3.0.1


### PR DESCRIPTION
### Changed
- Use Django reset framework recommended implementation of filters and pagination


--- 
Separate this improvement in a different pull request but this is needed for the search query of the campaigns.