### PR TITLE
Fixes not showing org unit select box when creating a new campaign

### DIFF
--- a/plugins/polio/js/src/components/Inputs/OrgUnitsSelect.js
+++ b/plugins/polio/js/src/components/Inputs/OrgUnitsSelect.js
@@ -45,7 +45,9 @@ export const OrgUnitsSelect = props => {
 export const OrgUnitsLevels = ({ field = {}, form, ...props }) => {
     const { data = {} } = useGetAuthenticatedUser();
     const source = data?.account?.default_version?.data_source?.id;
-    const initialOrgUnit = form?.initialValues?.initial_org_unit ?? null;
+    const startOrgUnit = data?.org_units[0].id ?? null;
+    const initialOrgUnit =
+        form?.initialValues?.initial_org_unit ?? startOrgUnit;
 
     const { data: initialState } = useGetAllParentsOrgUnits(initialOrgUnit);
     const [levels, setLevel] = useState([null]);


### PR DESCRIPTION
### Fixed
- Org unit select box not showing when creating a new campaign

---
@madewulf If a user has an org unit configured on his profile, the org units select box won't show up when creating a new campaign. This is however not a complete fix to the issue, since a user can have multiple org units configured we need a method to figure out which is the parent org unit we need here.