### PR TITLE
Fix log format issue, add formating to log file

### DIFF
--- a/hat/settings.py
+++ b/hat/settings.py
@@ -65,7 +65,7 @@ TEST_RUNNER = "redgreenunittest.django.runner.RedGreenDiscoverRunner"
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
-    "formatters": {"default": {"format": "%(asctime)s %(name)s -- %(message)s"}},
+    "formatters": {"default": {"format": "%(levelname)-8s %(asctime)s %(name)s -- %(message)s"}},
     "filters": {"no_static": {"()": "hat.common.log_filter.StaticUrlFilter"}},
     "handlers": {
         "console": {
@@ -76,13 +76,14 @@ LOGGING = {
         }
     },
     "loggers": {
-        "django": {"handlers": ["console"], "level": LOGGING_LEVEL},
-        "hat": {"handlers": ["console"], "level": LOGGING_LEVEL},
-        "rq": {"handlers": ["console"], "level": LOGGING_LEVEL},
-        # 'django.db.backends': {
-        #     'level': 'DEBUG',
-        #     'handlers': ['console', ],
-        # },
+        "django": {"level": LOGGING_LEVEL},
+        "rq": {"level": LOGGING_LEVEL},
+        "hat": {"level": LOGGING_LEVEL},
+        "iaso": {"level": LOGGING_LEVEL},
+        "beanstalk_worker": {"level": LOGGING_LEVEL},
+        #  Uncomment to print all sql query
+        # 'django.db.backends': {'level': 'DEBUG'},
+        "": {"handlers": ["console"]},
     },
 }
 
@@ -94,16 +95,15 @@ if os.path.isdir(AWS_LOG_FOLDER):
         LOGGING["handlers"]["file"] = {
             "class": "logging.FileHandler",
             "level": "DEBUG",
+            "formatter": "default",
             "filename": os.path.join(AWS_LOG_FOLDER, "django.log"),
         }
-        for logger in LOGGING["loggers"].values():
-            logger["handlers"].append("file")
+        LOGGING["loggers"][""]["handlers"].append("file")
         LOGGING["loggers"]["hat"]["level"] = "DEBUG"
     else:
         print(f"WARNING: we seem to be running on AWS but {AWS_LOG_FOLDER} is not writable, check ebextensions")
 
 # Application definition
-
 INSTALLED_APPS = [
     "django.contrib.admin",
     "django.contrib.auth",
@@ -130,6 +130,8 @@ INSTALLED_APPS = [
     "django_comments",
 ]
 
+# needed because we customize the comment model
+# see https://django-contrib-comments.readthedocs.io/en/latest/custom.htm
 COMMENTS_APP = "iaso"
 
 if PLUGIN_POLIO_ENABLED:


### PR DESCRIPTION
logger in iaso and beanstalk_worker were not using the correct format
(not printing date and module name) nor did they use the log level.

We now use this format for all modules. and correcty use the log level
env var.

Logging file in production didn't print the date (or use the formatting),
this is now corrected.

Note that at the moment there is no logger under `hat`