### PR TITLE
Update to latest sentry-sdk version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -69,7 +69,7 @@ djangorestframework_simplejwt==4.4.0
 #JSON5 is used for the export_json_for_mobile_app
 json5==0.9.5
 
-sentry-sdk==0.19.4
+sentry-sdk==1.1.0
 django-lazy-services==0.0.3
 dateparser==1.0.0
 


### PR DESCRIPTION
we had a somewhat outdated sentry version that poped warning in their web console
can't really test much locally but read their release note and it should be ok