### PR TITLE
IA439 fix: align name and formId left

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/forms/config.js
+++ b/hat/assets/js/apps/Iaso/domains/forms/config.js
@@ -98,6 +98,7 @@ const formsTableColumns = (
     {
         Header: formatMessage(MESSAGES.name),
         accessor: 'name',
+        style: { justifyContent: 'left' },
         Cell: settings => <ColumnTextComponent text={settings.original.name} />,
     },
     {
@@ -157,6 +158,7 @@ const formsTableColumns = (
     {
         Header: formatMessage(MESSAGES.form_id),
         sortable: false,
+        style: { justifyContent: 'left' },
         Cell: settings => (
             <ColumnTextComponent
                 text={settings.original.form_id || textPlaceholder}


### PR DESCRIPTION
## Changes 

- in `/dashboard/forms/list`'s table, "name" and "formId" fields are now aligned left

![Screenshot 2021-07-05 at 11 52 10](https://user-images.githubusercontent.com/38907762/124453625-db082680-dd87-11eb-94cf-b4052bf9db89.png)
