### PR TITLE
IA458 feat use color code for orgUnit statuses

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/config.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/config.js
@@ -13,7 +13,7 @@ import { baseUrls } from '../../constants/urls';
 import OrgUnitTooltip from './components/OrgUnitTooltip';
 import getDisplayName from '../../utils/usersUtils';
 import MESSAGES from './messages';
-import { getStatusMessage, getOrgUnitGroups } from './utils';
+import { getStatusMessage, getOrgUnitGroups, getStatusColor } from './utils';
 
 export const orgUnitsTableColumns = (formatMessage, classes, searches) => {
     const columns = [
@@ -59,14 +59,14 @@ export const orgUnitsTableColumns = (formatMessage, classes, searches) => {
         {
             Header: formatMessage(MESSAGES.status),
             accessor: 'validation_status',
-            Cell: settings => (
-                <span>
-                    {getStatusMessage(
-                        settings.original.validation_status,
-                        formatMessage,
-                    )}
-                </span>
-            ),
+            Cell: settings => {
+                const status = settings.original.validation_status;
+                return (
+                    <span style={getStatusColor(status)}>
+                        {getStatusMessage(status, formatMessage)}
+                    </span>
+                );
+            },
         },
         {
             Header: formatMessage(MESSAGES.instances_count),

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/config.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/config.js
@@ -13,9 +13,22 @@ import { baseUrls } from '../../constants/urls';
 import OrgUnitTooltip from './components/OrgUnitTooltip';
 import getDisplayName from '../../utils/usersUtils';
 import MESSAGES from './messages';
-import { getStatusMessage, getOrgUnitGroups, getStatusColor } from './utils';
+import { getStatusMessage, getOrgUnitGroups } from './utils';
 
 export const orgUnitsTableColumns = (formatMessage, classes, searches) => {
+    const getStatusColor = status => {
+        switch (status) {
+            case 'NEW': {
+                // value taken from /iaso/hat/assets/css/_iaso.scss
+                return classes.statusNew;
+            }
+            case 'REJECTED': {
+                return classes.statusRejected;
+            }
+            default:
+                return classes.statusValidated;
+        }
+    };
     const columns = [
         {
             Header: 'Id',
@@ -62,7 +75,7 @@ export const orgUnitsTableColumns = (formatMessage, classes, searches) => {
             Cell: settings => {
                 const status = settings.original.validation_status;
                 return (
-                    <span style={getStatusColor(status)}>
+                    <span className={getStatusColor(status)}>
                         {getStatusMessage(status, formatMessage)}
                     </span>
                 );

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/index.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/index.js
@@ -90,6 +90,15 @@ const styles = theme => ({
         height: 15,
         borderRadius: 15,
     },
+    statusNew: {
+        color: theme.palette.primary.main,
+    },
+    statusValidated: {
+        color: theme.palette.success.main,
+    },
+    statusRejected: {
+        color: theme.palette.error.main,
+    },
 });
 
 const getDefaultSource = currentUser =>

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/utils.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/utils.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import orderBy from 'lodash/orderBy';
-import { textPlaceholder, rawTheme } from 'bluesquare-components';
+import { textPlaceholder } from 'bluesquare-components';
 import OrgUnitPopupComponent from './components/OrgUnitPopupComponent';
 import MarkersListComponent from '../../components/maps/markers/MarkersListComponent';
 import { circleColorMarkerOptions } from '../../utils/mapUtils';
@@ -171,20 +171,6 @@ export const getStatusMessage = (status, formatMessage) => {
         }
         default:
             return formatMessage(MESSAGES.validated);
-    }
-};
-
-export const getStatusColor = status => {
-    switch (status) {
-        case 'NEW': {
-            // value taken from /iaso/hat/assets/css/_iaso.scss
-            return { color: '#2372BA' };
-        }
-        case 'REJECTED': {
-            return { color: rawTheme.palette.error.main };
-        }
-        default:
-            return { color: rawTheme.palette.success.main };
     }
 };
 

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/utils.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/utils.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import orderBy from 'lodash/orderBy';
-import { textPlaceholder } from 'bluesquare-components';
+import { textPlaceholder, rawTheme } from 'bluesquare-components';
 import OrgUnitPopupComponent from './components/OrgUnitPopupComponent';
 import MarkersListComponent from '../../components/maps/markers/MarkersListComponent';
 import { circleColorMarkerOptions } from '../../utils/mapUtils';
@@ -171,6 +171,20 @@ export const getStatusMessage = (status, formatMessage) => {
         }
         default:
             return formatMessage(MESSAGES.validated);
+    }
+};
+
+export const getStatusColor = status => {
+    switch (status) {
+        case 'NEW': {
+            // value taken from /iaso/hat/assets/css/_iaso.scss
+            return { color: '#2372BA' };
+        }
+        case 'REJECTED': {
+            return { color: rawTheme.palette.error.main };
+        }
+        default:
+            return { color: rawTheme.palette.success.main };
     }
 };
 


### PR DESCRIPTION
## Changes

- Add color codes for Org Unit status: New = blue, validated = green, rejected=red
- green and red are the same colors as the `SnackBar`s
- blue is taken from `$primary-color` in  `_iaso.scss`

![Screenshot 2021-07-05 at 13 44 56](https://user-images.githubusercontent.com/38907762/124468531-82da2000-dd99-11eb-80c5-509eab8e6a44.png)
