### PR TITLE
[IA-662] Move the map widget to its own tab / Add loader to map widget

### DIFF
--- a/plugins/polio/js/src/components/Dashboard.js
+++ b/plugins/polio/js/src/components/Dashboard.js
@@ -385,7 +385,7 @@ const ScopeForm = () => {
 
     const { group = {} } = values;
 
-    const { data = [] } = useGetRegionGeoJson(
+    const { data = [], isFetching } = useGetRegionGeoJson(
         values.org_unit?.country_parent?.id ||
             values.org_unit?.root?.id ||
             values.org_unit?.id,
@@ -423,10 +423,14 @@ const ScopeForm = () => {
         <>
             <Grid container spacing={2}>
                 <Grid xs={12} item>
-                    <MapContainer
-                        shapes={shapes}
-                        onSelectShape={onSelectOrgUnit}
-                    />
+                    {isFetching ? (
+                        <LoadingSpinner />
+                    ) : (
+                        <MapContainer
+                            shapes={shapes}
+                            onSelectShape={onSelectOrgUnit}
+                        />
+                    )}
                 </Grid>
             </Grid>
         </>

--- a/plugins/polio/js/src/components/Dashboard.js
+++ b/plugins/polio/js/src/components/Dashboard.js
@@ -843,6 +843,10 @@ const CreateEditDialog = ({ isOpen, onClose, onConfirm, selectedCampaign }) => {
             form: RiskAssessmentForm,
         },
         {
+            title: 'Scope',
+            form: ScopeForm,
+        },
+        {
             title: 'Budget',
             form: BudgetForm,
         },

--- a/plugins/polio/js/src/components/Dashboard.js
+++ b/plugins/polio/js/src/components/Dashboard.js
@@ -281,43 +281,7 @@ const unselectedPathOptions = { color: 'gray' };
 
 const RiskAssessmentForm = () => {
     const classes = useStyles();
-    const { values, setFieldValue } = useFormikContext();
-
-    const { group = {} } = values;
-
-    const { data = [] } = useGetRegionGeoJson(
-        values.org_unit?.country_parent?.id ||
-            values.org_unit?.root?.id ||
-            values.org_unit?.id,
-    );
-
-    const shapes = useMemo(() => {
-        return data.map(shape => ({
-            ...shape,
-            pathOptions: group.org_units.find(org_unit => shape.id === org_unit)
-                ? selectedPathOptions
-                : unselectedPathOptions,
-        }));
-    }, [data, group]);
-
-    const onSelectOrgUnit = useCallback(
-        shape => {
-            var { org_units } = group;
-            const hasFound = org_units.find(org_unit => shape.id === org_unit);
-
-            if (hasFound) {
-                org_units = org_units.filter(orgUnit => orgUnit !== shape.id);
-            } else {
-                org_units.push(shape.id);
-            }
-
-            setFieldValue('group', {
-                ...group,
-                org_units,
-            });
-        },
-        [group, setFieldValue],
-    );
+    const { values } = useFormikContext();
 
     const wastageRate = 0.26;
 
@@ -411,7 +375,54 @@ const RiskAssessmentForm = () => {
                         {Number.isNaN(vialsRequested) ? 0 : vialsRequested}
                     </Typography>
                 </Grid>
-                <Grid xs={12} md={6} item>
+            </Grid>
+        </>
+    );
+};
+
+const ScopeForm = () => {
+    const { values, setFieldValue } = useFormikContext();
+
+    const { group = {} } = values;
+
+    const { data = [] } = useGetRegionGeoJson(
+        values.org_unit?.country_parent?.id ||
+            values.org_unit?.root?.id ||
+            values.org_unit?.id,
+    );
+
+    const shapes = useMemo(() => {
+        return data.map(shape => ({
+            ...shape,
+            pathOptions: group.org_units.find(org_unit => shape.id === org_unit)
+                ? selectedPathOptions
+                : unselectedPathOptions,
+        }));
+    }, [data, group]);
+
+    const onSelectOrgUnit = useCallback(
+        shape => {
+            var { org_units } = group;
+            const hasFound = org_units.find(org_unit => shape.id === org_unit);
+
+            if (hasFound) {
+                org_units = org_units.filter(orgUnit => orgUnit !== shape.id);
+            } else {
+                org_units.push(shape.id);
+            }
+
+            setFieldValue('group', {
+                ...group,
+                org_units,
+            });
+        },
+        [group, setFieldValue],
+    );
+
+    return (
+        <>
+            <Grid container spacing={2}>
+                <Grid xs={12} item>
                     <MapContainer
                         shapes={shapes}
                         onSelectShape={onSelectOrgUnit}
@@ -643,40 +654,44 @@ const Round1Form = () => {
                     fullWidth
                 />
                 <Field
-                        label="Districts passing LQAS"
-                        name={'round_one.lqas_district_passing'}
-                        component={TextInput}
-                        className={classes.input}
+                    label="Districts passing LQAS"
+                    name={'round_one.lqas_district_passing'}
+                    component={TextInput}
+                    className={classes.input}
                 />
                 <Field
-                        label="Districts failing LQAS"
-                        name={'round_one.lqas_district_failing'}
-                        component={TextInput}
-                        className={classes.input}
+                    label="Districts failing LQAS"
+                    name={'round_one.lqas_district_failing'}
+                    component={TextInput}
+                    className={classes.input}
                 />
                 <Field
-                        label="Main awareness problem"
-                        name={'round_one.main_awareness_problem'}
-                        component={TextInput}
-                        className={classes.input}
+                    label="Main awareness problem"
+                    name={'round_one.main_awareness_problem'}
+                    component={TextInput}
+                    className={classes.input}
                 />
                 <Field
-                        label="% children missed IN household"
-                        name={'round_one.im_percentage_children_missed_in_household'}
-                        component={TextInput}
-                        className={classes.input}
+                    label="% children missed IN household"
+                    name={
+                        'round_one.im_percentage_children_missed_in_household'
+                    }
+                    component={TextInput}
+                    className={classes.input}
                 />
                 <Field
-                        label="% children missed OUT OF household"
-                        name={'round_one.im_percentage_children_missed_out_household'}
-                        component={TextInput}
-                        className={classes.input}
+                    label="% children missed OUT OF household"
+                    name={
+                        'round_one.im_percentage_children_missed_out_household'
+                    }
+                    component={TextInput}
+                    className={classes.input}
                 />
                 <Field
-                        label="Awareness of campaign planning (%)"
-                        name={'round_one.awareness_of_campaign_planning'}
-                        component={TextInput}
-                        className={classes.input}
+                    label="Awareness of campaign planning (%)"
+                    name={'round_one.awareness_of_campaign_planning'}
+                    component={TextInput}
+                    className={classes.input}
                 />
             </Grid>
         </Grid>
@@ -742,40 +757,44 @@ const Round2Form = () => {
                     fullWidth
                 />
                 <Field
-                        label="Districts passing LQAS"
-                        name={'round_two.lqas_district_passing'}
-                        component={TextInput}
-                        className={classes.input}
+                    label="Districts passing LQAS"
+                    name={'round_two.lqas_district_passing'}
+                    component={TextInput}
+                    className={classes.input}
                 />
                 <Field
-                        label="Districts failing LQAS"
-                        name={'round_two.lqas_district_failing'}
-                        component={TextInput}
-                        className={classes.input}
+                    label="Districts failing LQAS"
+                    name={'round_two.lqas_district_failing'}
+                    component={TextInput}
+                    className={classes.input}
                 />
                 <Field
-                        label="Main awareness problem"
-                        name={'round_two.main_awareness_problem'}
-                        component={TextInput}
-                        className={classes.input}
+                    label="Main awareness problem"
+                    name={'round_two.main_awareness_problem'}
+                    component={TextInput}
+                    className={classes.input}
                 />
                 <Field
-                        label="% children missed IN household"
-                        name={'round_two.im_percentage_children_missed_in_household'}
-                        component={TextInput}
-                        className={classes.input}
+                    label="% children missed IN household"
+                    name={
+                        'round_two.im_percentage_children_missed_in_household'
+                    }
+                    component={TextInput}
+                    className={classes.input}
                 />
                 <Field
-                        label="% children missed OUT OF household"
-                        name={'round_two.im_percentage_children_missed_out_household'}
-                        component={TextInput}
-                        className={classes.input}
+                    label="% children missed OUT OF household"
+                    name={
+                        'round_two.im_percentage_children_missed_out_household'
+                    }
+                    component={TextInput}
+                    className={classes.input}
                 />
                 <Field
-                        label="Awareness of campaign planning (%)"
-                        name={'round_two.awareness_of_campaign_planning'}
-                        component={TextInput}
-                        className={classes.input}
+                    label="Awareness of campaign planning (%)"
+                    name={'round_two.awareness_of_campaign_planning'}
+                    component={TextInput}
+                    className={classes.input}
                 />
             </Grid>
         </Grid>
@@ -874,6 +893,7 @@ const CreateEditDialog = ({ isOpen, onClose, onConfirm, selectedCampaign }) => {
 
     // default to tab 0 when opening
     useEffect(() => {
+        console.log('working???');
         setSelectedTab(0);
     }, [isOpen]);
 

--- a/plugins/polio/js/src/components/Dashboard.js
+++ b/plugins/polio/js/src/components/Dashboard.js
@@ -893,7 +893,6 @@ const CreateEditDialog = ({ isOpen, onClose, onConfirm, selectedCampaign }) => {
 
     // default to tab 0 when opening
     useEffect(() => {
-        console.log('working???');
         setSelectedTab(0);
     }, [isOpen]);
 


### PR DESCRIPTION
### New:
- Scope tab with map widget
- Add spinner component when shapes are still fetching

<img width="1278" alt="Captura de Tela 2021-07-06 às 15 56 36" src="https://user-images.githubusercontent.com/47039931/124652707-ce143180-de72-11eb-8208-1a760d861212.png">


### Removed:
- Map widget from risk assessment tab

<img width="1277" alt="Captura de Tela 2021-07-06 às 15 56 14" src="https://user-images.githubusercontent.com/47039931/124652731-d4a2a900-de72-11eb-8d10-0e13acac7730.png">


