### PR TITLE
IA-652: Prevent refresh window focus

### DIFF
--- a/plugins/polio/js/src/hooks/useGetRegionGeoJson.js
+++ b/plugins/polio/js/src/hooks/useGetRegionGeoJson.js
@@ -27,5 +27,8 @@ export const useGetRegionGeoJson = region => {
         {
             enabled: Boolean(region) && isFetching,
         },
+        {
+            refetchOnWindowFocus: false,
+        },
     );
 };


### PR DESCRIPTION
- Setting [refetchOnWindowFocus](https://react-query.tanstack.com/guides/window-focus-refetching) to false to prevent selected shapes from disappearing after switching tabs on the browser.

Please notice that as I wasn't able to reproduce this bug locally I couldn't test if this solution is solving the problem.