### PR TITLE
IA665 enable region selection

### DIFF
--- a/iaso/models/org_unit.py
+++ b/iaso/models/org_unit.py
@@ -386,6 +386,7 @@ class OrgUnit(TreeModel):
             "id": self.id,
             "name": self.name,
             "short_name": self.name,
+            "parent_id": self.parent_id,
             "latitude": self.location.y if self.location else None,
             "longitude": self.location.x if self.location else None,
             "altitude": self.location.z if self.location else None,

--- a/plugins/polio/js/src/components/Dashboard.js
+++ b/plugins/polio/js/src/components/Dashboard.js
@@ -55,7 +55,6 @@ import { useGetRegionGeoJson } from '../hooks/useGetRegionGeoJson';
 import MESSAGES from '../constants/messages';
 import SearchIcon from '@material-ui/icons/Search';
 import { useDebounce } from 'use-debounce';
-import { classes } from 'istanbul-lib-coverage';
 
 const round_shape = yup.object().shape({
     started_at: yup.date().nullable(),
@@ -396,7 +395,6 @@ const separate = (array, referenceArray) => {
 }
 
 const ScopeForm = () => {
-    // const { formatMessage } = useSafeIntl();
     const [selectRegion, setSelectRegion] = useState(false)
     const { values, setFieldValue } = useFormikContext();
 
@@ -475,7 +473,6 @@ const ScopeForm = () => {
                 <Grid xs={12} item>
                     <FormGroup>
                         <FormControlLabel
-                        // className={classes.switch}
                         style={{width:'max-content'}}
                         control={<Switch size="medium" checked={selectRegion} onChange={toggleRegionSelect} color="primary"/>}
                         label="Select region"

--- a/plugins/polio/js/src/components/Dashboard.js
+++ b/plugins/polio/js/src/components/Dashboard.js
@@ -377,6 +377,7 @@ const RiskAssessmentForm = () => {
 };
 
 const ScopeForm = () => {
+    const [selectRegion, setSelectRegion] = useState(false)
     const { values, setFieldValue } = useFormikContext();
 
     const { group = {} } = values;
@@ -387,6 +388,15 @@ const ScopeForm = () => {
             values.org_unit?.id,
     );
 
+    const toggleRegionMessage = selectRegionEnabled => {
+        if(selectRegionEnabled){
+            return "Select by Org Unit";
+        } 
+        return "Select by Region";
+    }
+    const toggleRegionSelect = () => {
+        setSelectRegion(current => !current)
+    }
     const shapes = useMemo(() => {
         return data.map(shape => ({
             ...shape,
@@ -398,21 +408,34 @@ const ScopeForm = () => {
 
     const onSelectOrgUnit = useCallback(
         shape => {
-            var { org_units } = group;
-            const hasFound = org_units.find(org_unit => shape.id === org_unit);
-
-            if (hasFound) {
-                org_units = org_units.filter(orgUnit => orgUnit !== shape.id);
+            console.log("SHAPE", shape);
+            if (selectRegion){
+                // Select region here
+                const { org_units } = group;
+                const regionShapes = shapes.filter(s=>s.parent_id===shape.parent_id).filter(s=>!org_units.includes(s.id)).map(s=>s.id);
+                const updatedSelection = [...org_units,...regionShapes]
+                console.log("updatedSelection", updatedSelection);
+                setFieldValue('group',{
+                    ...group,
+                    org_units:updatedSelection
+                });
             } else {
-                org_units.push(shape.id);
+                var { org_units } = group;
+                const hasFound = org_units.find(org_unit => shape.id === org_unit);
+    
+                if (hasFound) {
+                    org_units = org_units.filter(orgUnit => orgUnit !== shape.id);
+                } else {
+                    org_units.push(shape.id);
+                }
+    
+                setFieldValue('group', {
+                    ...group,
+                    org_units,
+                });
             }
-
-            setFieldValue('group', {
-                ...group,
-                org_units,
-            });
         },
-        [group, setFieldValue],
+        [group, setFieldValue,selectRegion,shapes],
     );
 
     return (
@@ -428,6 +451,7 @@ const ScopeForm = () => {
                         />
                     )}
                 </Grid>
+                <Button onClick={toggleRegionSelect}>{toggleRegionMessage(selectRegion)}</Button>
             </Grid>
         </>
     );

--- a/plugins/polio/js/src/components/MapComponent/MapComponent.jsx
+++ b/plugins/polio/js/src/components/MapComponent/MapComponent.jsx
@@ -1,6 +1,5 @@
 import { Map, TileLayer, GeoJSON } from 'react-leaflet';
 import { useEffect, useRef } from 'react';
-import {Button} from '@material-ui/core';
 
 import 'leaflet/dist/leaflet.css';
 import { useMapContext } from './Context';

--- a/plugins/polio/js/src/components/MapComponent/MapComponent.jsx
+++ b/plugins/polio/js/src/components/MapComponent/MapComponent.jsx
@@ -1,5 +1,6 @@
 import { Map, TileLayer, GeoJSON } from 'react-leaflet';
 import { useEffect, useRef } from 'react';
+import {Button} from '@material-ui/core';
 
 import 'leaflet/dist/leaflet.css';
 import { useMapContext } from './Context';


### PR DESCRIPTION
## Changes

- added a switch button to toggle selection mode when clicking org unit on map
- The user can either select/unselect an org unit, or all org units of the parent region
- When switching to region select, if org units of the region are already selected, clicking on an org unit of the region will select the remaining ones
- If all org units of a given region are selected, clicking on any org unit of that region will unselect the whole region.
- modified API to receive parent_id


Uploading Screen Recording 2021-07-20 at 14.04.22.mov…



## Notes 

- the switch button label text is hard coded as I couldn't get react-intl to work
- there is inline styling for the switch button, as using className with classes from useStyles didn't seem to work either