### PR TITLE
IA662 fix: pass null to API when date empty

### DIFF
--- a/plugins/polio/js/src/components/Dashboard.js
+++ b/plugins/polio/js/src/components/Dashboard.js
@@ -53,6 +53,7 @@ import { useGetRegionGeoJson } from '../hooks/useGetRegionGeoJson';
 import MESSAGES from '../constants/messages';
 import SearchIcon from '@material-ui/icons/Search';
 import { useDebounce } from 'use-debounce';
+import { convertEmptyStringToNull } from '../utils/convertEmptyStringToNull';
 
 const round_shape = yup.object().shape({
     started_at: yup.date().nullable(),
@@ -838,7 +839,7 @@ const CreateEditDialog = ({ isOpen, onClose, onConfirm, selectedCampaign }) => {
     const classes = useStyles();
 
     const handleSubmit = (values, helpers) =>
-        saveCampaign(values, {
+        saveCampaign(convertEmptyStringToNull(values), {
             onSuccess: () => {
                 helpers.resetForm();
                 onClose();

--- a/plugins/polio/js/src/utils/convertEmptyStringToNull.js
+++ b/plugins/polio/js/src/utils/convertEmptyStringToNull.js
@@ -1,0 +1,12 @@
+const convertEmptyStringToNull = values => {
+    const converted = {...values};
+    const keys = Object.keys(values);
+    keys.forEach(key => {
+        if (values[key]===""){
+            converted[key]=null;
+        }
+    })
+    return converted;
+}
+
+export {convertEmptyStringToNull};

--- a/plugins/polio/js/src/utils/convertEmptyStringToNull.js
+++ b/plugins/polio/js/src/utils/convertEmptyStringToNull.js
@@ -5,6 +5,9 @@ const convertEmptyStringToNull = values => {
         if (values[key]===""){
             converted[key]=null;
         }
+        if (key.includes("round_")){
+            converted[key] = convertEmptyStringToNull(values[key]);
+        }
     })
     return converted;
 }


### PR DESCRIPTION
## Changes

- added `convertEmptyStringsToNull` in /utils
- converting all empty strings to null before passing `values` to `saveCampaign`. All fields that could have a value of `""` are marked as nullable in yup schemas, so this conversion seems safe.

