### PR TITLE
Hotfix: change dropdown label type to string

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/dataSources/components/DataSourceDialogComponent.js
+++ b/hat/assets/js/apps/Iaso/domains/dataSources/components/DataSourceDialogComponent.js
@@ -341,7 +341,7 @@ export class DataSourceDialogComponent extends Component {
                                 options={
                                     initialData
                                         ? initialData.versions.map(v => ({
-                                              label: v.number,
+                                              label: v.number.toString(),
                                               value: v.id,
                                           }))
                                         : []


### PR DESCRIPTION
trying to select a default source in `DataSourcesDialogComponent` would cause the component to crash as it was expecting a string and received a number