### PR TITLE
Mod: standardise table columns a bit

### DIFF
--- a/hat/assets/js/apps/Iaso/components/Cells/DateTimeCell.js
+++ b/hat/assets/js/apps/Iaso/components/Cells/DateTimeCell.js
@@ -1,0 +1,10 @@
+import {
+    displayDateFromTimestamp,
+    textPlaceholder,
+} from 'bluesquare-components';
+
+/* DateTimeCell
+   For use in Table's columns to display DateTime
+ */
+export const DateTimeCell = cellInfo =>
+    cellInfo.value ? displayDateFromTimestamp(cellInfo.value) : textPlaceholder;

--- a/hat/assets/js/apps/Iaso/components/Cells/YesNoCell.js
+++ b/hat/assets/js/apps/Iaso/components/Cells/YesNoCell.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+
+const MESSAGES = defineMessages({
+    yes: {
+        defaultMessage: 'Yes',
+        id: 'iaso.label.yes',
+    },
+    no: {
+        defaultMessage: 'No',
+        id: 'iaso.label.no',
+    },
+});
+
+export const YesNoCell = cellInfo =>
+    cellInfo.value === true ? (
+        <FormattedMessage {...MESSAGES.yes} />
+    ) : (
+        <FormattedMessage {...MESSAGES.no} />
+    );

--- a/hat/assets/js/apps/Iaso/domains/dataSources/config.js
+++ b/hat/assets/js/apps/Iaso/domains/dataSources/config.js
@@ -2,16 +2,13 @@ import React from 'react';
 import CheckCircleIcon from '@material-ui/icons/CheckCircle';
 import { Tooltip } from '@material-ui/core';
 
-// eslint-disable-next-line import/no-named-as-default
-// eslint-disable-next-line import/no-named-as-default-member
-import {
-    IconButton as IconButtonComponent,
-    textPlaceholder,
-} from 'bluesquare-components';
+import { IconButton as IconButtonComponent } from 'bluesquare-components';
+// eslint-disable-next-line import/no-named-as-default-member,import/no-named-as-default
 import DataSourceDialogComponent from './components/DataSourceDialogComponent';
 import MESSAGES from './messages';
 import { AddTask } from './components/AddTaskComponent';
 import { ImportGeoPkgDialog } from './components/ImportGeoPkgDialog';
+import { YesNoCell } from '../../components/Cells/YesNoCell';
 
 const dataSourcesTableColumns = (
     formatMessage,
@@ -23,9 +20,7 @@ const dataSourcesTableColumns = (
         accessor: 'defaultSource',
         sortable: false,
         Cell: settings =>
-            defaultSourceVersion &&
-            defaultSourceVersion.source &&
-            defaultSourceVersion.source.id === settings.row.original.id && (
+            defaultSourceVersion?.source?.id === settings.row.original.id && (
                 <Tooltip title={formatMessage(MESSAGES.defaultSource)}>
                     <CheckCircleIcon color="primary" />
                 </Tooltip>
@@ -33,34 +28,21 @@ const dataSourcesTableColumns = (
     },
     {
         Header: formatMessage(MESSAGES.defaultVersion),
-        accessor: 'default_version__number',
-        Cell: settings => {
-            if (!settings.row.original.default_version) return textPlaceholder;
-            return <span>{settings.row.original.default_version.number}</span>;
-        },
+        id: 'default_version__number',
+        accessor: row => row.default_version?.number,
     },
     {
         Header: formatMessage(MESSAGES.dataSourceName),
         accessor: 'name',
-        Cell: settings => {
-            return <span>{settings.row.original.name}</span>;
-        },
     },
     {
         Header: formatMessage(MESSAGES.dataSourceDescription),
         accessor: 'description',
-        Cell: settings => <span>{settings.row.original.description}</span>,
     },
     {
         Header: formatMessage(MESSAGES.dataSourceReadOnly),
         accessor: 'read_only',
-        Cell: settings => (
-            <span>
-                {settings.row.original.read_only === true
-                    ? formatMessage(MESSAGES.yes)
-                    : formatMessage(MESSAGES.no)}
-            </span>
-        ),
+        Cell: YesNoCell,
     },
     {
         Header: formatMessage(MESSAGES.actions),

--- a/hat/assets/js/apps/Iaso/domains/dataSources/messages.js
+++ b/hat/assets/js/apps/Iaso/domains/dataSources/messages.js
@@ -1,14 +1,6 @@
 import { defineMessages } from 'react-intl';
 
 const MESSAGES = defineMessages({
-    yes: {
-        defaultMessage: 'Yes',
-        id: 'iaso.label.yes',
-    },
-    no: {
-        defaultMessage: 'No',
-        id: 'iaso.label.no',
-    },
     actions: {
         defaultMessage: 'Actions',
         id: 'iaso.label.actions',

--- a/hat/assets/js/apps/Iaso/domains/devices/config.js
+++ b/hat/assets/js/apps/Iaso/domains/devices/config.js
@@ -1,74 +1,46 @@
 import React from 'react';
-import { displayDateFromTimestamp } from 'bluesquare-components';
 import MESSAGES from './messages';
+import { DateTimeCell } from '../../components/Cells/DateTimeCell';
+import { YesNoCell } from '../../components/Cells/YesNoCell';
 
 const devicesTableColumns = formatMessage => [
     {
         Header: formatMessage(MESSAGES.imei),
         sortable: false,
         accessor: 'imei',
-
-        Cell: settings => {
-            return <span>{settings.row.original.imei}</span>;
-        },
     },
     {
         Header: formatMessage(MESSAGES.test_device),
         sortable: false,
         accessor: 'test_device',
-        Cell: settings => {
-            return (
-                <span>
-                    {formatMessage(
-                        settings.row.original.test_device
-                            ? MESSAGES.yes
-                            : MESSAGES.no,
-                    )}
-                </span>
-            );
-        },
+        Cell: YesNoCell,
     },
     {
         Header: formatMessage(MESSAGES.last_owner),
         sortable: false,
         accessor: 'last_owner',
-        Cell: settings => (
-            <span>
-                {settings.row.original.last_owner !== null &&
-                    `${settings.row.original.last_owner.first_name} ${settings.row.original.last_owner.last_name}`}
-            </span>
-        ),
+        Cell: settings =>
+            settings.row.original.last_owner
+                ? `${settings.row.original.last_owner.first_name} ${settings.row.original.last_owner.last_name}`
+                : null,
     },
     {
         Header: formatMessage(MESSAGES.timeSynched),
         sortable: false,
         accessor: 'synched_at',
-        Cell: settings => (
-            <span>
-                {settings.row.original.synched_at !== null &&
-                    displayDateFromTimestamp(settings.row.original.synched_at)}
-            </span>
-        ),
+        Cell: DateTimeCell,
     },
     {
         Header: formatMessage(MESSAGES.timeCreated),
         sortable: false,
         accessor: 'created_at',
-        Cell: settings => (
-            <span>
-                {displayDateFromTimestamp(settings.row.original.created_at)}
-            </span>
-        ),
+        Cell: DateTimeCell,
     },
     {
         Header: formatMessage(MESSAGES.timeUpdated),
         sortable: false,
         accessor: 'updated_at',
-        Cell: settings => (
-            <span>
-                {displayDateFromTimestamp(settings.row.original.updated_at)}
-            </span>
-        ),
+        Cell: DateTimeCell,
     },
 ];
 

--- a/hat/assets/js/apps/Iaso/domains/forms/config.js
+++ b/hat/assets/js/apps/Iaso/domains/forms/config.js
@@ -1,18 +1,15 @@
 import React from 'react';
-import moment from 'moment';
 import { Grid } from '@material-ui/core';
 import { Link } from 'react-router';
 
-import {
-    textPlaceholder,
-    IconButton as IconButtonComponent,
-} from 'bluesquare-components';
+import { IconButton as IconButtonComponent } from 'bluesquare-components';
 import FormVersionsDialog from './components/FormVersionsDialogComponent';
 import { baseUrls } from '../../constants/urls';
 import { getOrgUnitParentsIds } from '../orgUnits/utils';
 
 import MESSAGES from './messages';
 import DeleteDialog from '../../components/dialogs/DeleteDialogComponent';
+import { DateTimeCell } from '../../components/Cells/DateTimeCell';
 
 export const formVersionsTableColumns = (
     formatMessage,
@@ -23,17 +20,14 @@ export const formVersionsTableColumns = (
     {
         Header: formatMessage(MESSAGES.version),
         accessor: 'version_id',
-        Cell: settings => settings.row.original.version_id || textPlaceholder,
     },
     {
         Header: formatMessage(MESSAGES.startPeriod),
         accessor: 'start_period',
-        Cell: settings => settings.row.original.start_period || textPlaceholder,
     },
     {
         Header: formatMessage(MESSAGES.endPeriod),
         accessor: 'end_period',
-        Cell: settings => settings.row.original.end_period || textPlaceholder,
     },
     {
         Header: formatMessage(MESSAGES.actions),
@@ -89,32 +83,21 @@ const formsTableColumns = (
         Header: formatMessage(MESSAGES.name),
         accessor: 'name',
         style: { justifyContent: 'left' },
-        Cell: settings => settings.row.original.name,
     },
     {
         Header: formatMessage(MESSAGES.created_at),
         accessor: 'created_at',
-        Cell: settings =>
-            moment.unix(settings.row.original.created_at).format('LTS'),
+        Cell: DateTimeCell,
     },
     {
         Header: formatMessage(MESSAGES.updated_at),
         accessor: 'updated_at',
-        Cell: settings =>
-            moment.unix(settings.row.original.updated_at).format('LTS'),
+        Cell: DateTimeCell,
     },
     {
         Header: formatMessage(MESSAGES.instance_updated_at),
         accessor: 'instance_updated_at',
-        Cell: settings => {
-            const dateText = settings.row.original.instance_updated_at
-                ? moment
-                      .unix(settings.row.original.instance_updated_at)
-                      .format('LTS')
-                : textPlaceholder;
-
-            return dateText;
-        },
+        Cell: DateTimeCell,
     },
     {
         Header: formatMessage(MESSAGES.type),
@@ -128,14 +111,12 @@ const formsTableColumns = (
     {
         Header: formatMessage(MESSAGES.records),
         accessor: 'instances_count',
-        Cell: settings => settings.row.original.instances_count,
     },
     {
         Header: formatMessage(MESSAGES.form_id),
         accessor: 'form_id',
         sortable: false,
         style: { justifyContent: 'left' },
-        Cell: settings => settings.row.original.form_id || textPlaceholder,
     },
     {
         Header: formatMessage(MESSAGES.latest_version_files),

--- a/hat/assets/js/apps/Iaso/domains/forms/configArchived.js
+++ b/hat/assets/js/apps/Iaso/domains/forms/configArchived.js
@@ -7,18 +7,17 @@ import {
     IconButton as IconButtonComponent,
 } from 'bluesquare-components';
 import MESSAGES from './messages';
+import { DateTimeCell } from '../../components/Cells/DateTimeCell';
 
 const archivedTableColumn = (formatMessage, restoreForm) => [
     {
         Header: formatMessage(MESSAGES.name),
         accessor: 'name',
-        Cell: settings => settings.row.original.name,
     },
     {
         Header: formatMessage(MESSAGES.form_id),
         sortable: false,
         accessor: 'form_id',
-        Cell: settings => settings.row.original.form_id || textPlaceholder,
     },
     {
         Header: formatMessage(MESSAGES.type),
@@ -32,7 +31,6 @@ const archivedTableColumn = (formatMessage, restoreForm) => [
     {
         Header: formatMessage(MESSAGES.records),
         accessor: 'instances_count',
-        Cell: settings => settings.row.original.instances_count,
     },
     {
         Header: formatMessage(MESSAGES.latest_version_files),
@@ -76,20 +74,17 @@ const archivedTableColumn = (formatMessage, restoreForm) => [
     {
         Header: formatMessage(MESSAGES.created_at),
         accessor: 'created_at',
-        Cell: settings =>
-            moment.unix(settings.row.original.created_at).format('LTS'),
+        Cell: DateTimeCell,
     },
     {
         Header: formatMessage(MESSAGES.updated_at),
         accessor: 'updated_at',
-        Cell: settings =>
-            moment.unix(settings.row.original.updated_at).format('LTS'),
+        Cell: DateTimeCell,
     },
     {
         Header: formatMessage(MESSAGES.deleted_at),
         accessor: 'deleted_at',
-        Cell: settings =>
-            moment.unix(settings.row.original.deleted_at).format('LTS'),
+        Cell: DateTimeCell,
     },
     {
         Header: formatMessage(MESSAGES.actions),
@@ -97,17 +92,15 @@ const archivedTableColumn = (formatMessage, restoreForm) => [
         resizable: false,
         sortable: false,
         width: 300,
-        Cell: settings => {
-            return (
-                <section>
-                    <IconButtonComponent
-                        onClick={() => restoreForm(settings.row.original.id)}
-                        icon="restore-from-trash"
-                        tooltipMessage={MESSAGES.restoreFormTooltip}
-                    />
-                </section>
-            );
-        },
+        Cell: settings => (
+            <section>
+                <IconButtonComponent
+                    onClick={() => restoreForm(settings.row.original.id)}
+                    icon="restore-from-trash"
+                    tooltipMessage={MESSAGES.restoreFormTooltip}
+                />
+            </section>
+        ),
     },
 ];
 export default archivedTableColumn;

--- a/hat/assets/js/apps/Iaso/domains/links/config.js
+++ b/hat/assets/js/apps/Iaso/domains/links/config.js
@@ -9,6 +9,7 @@ import {
     formatThousand,
     textPlaceholder,
     Expander,
+    displayDateFromTimestamp,
 } from 'bluesquare-components';
 
 import getDisplayName from '../../utils/usersUtils';
@@ -17,6 +18,7 @@ import DeleteDialog from '../../components/dialogs/DeleteDialogComponent';
 import StarsComponent from '../../components/stars/StarsComponent';
 
 import MESSAGES from './messages';
+import { DateTimeCell } from '../../components/Cells/DateTimeCell';
 
 export const linksTableColumns = (formatMessage, validateLink) => [
     {
@@ -24,17 +26,15 @@ export const linksTableColumns = (formatMessage, validateLink) => [
         width: 170,
         align: 'center',
         accessor: 'similarity_score',
-        Cell: settings => {
-            return (
-                <Box display="flex" justifyContent="center">
-                    <StarsComponent
-                        score={settings.row.original.similarity_score}
-                        bgColor={settings.row.index % 2 ? 'white' : '#f7f7f7'}
-                        displayCount
-                    />
-                </Box>
-            );
-        },
+        Cell: settings => (
+            <Box display="flex" justifyContent="center">
+                <StarsComponent
+                    score={settings.row.original.similarity_score}
+                    bgColor={settings.row.index % 2 ? 'white' : '#f7f7f7'}
+                    displayCount
+                />
+            </Box>
+        ),
     },
     {
         Header: formatMessage(MESSAGES.name),
@@ -79,27 +79,16 @@ export const linksTableColumns = (formatMessage, validateLink) => [
     {
         Header: formatMessage(MESSAGES.updatedAt),
         accessor: 'updated_at',
-        Cell: settings => (
-            <span>
-                {moment.unix(settings.row.original.updated_at).format('LTS')}
-            </span>
-        ),
+        Cell: DateTimeCell,
     },
     {
         Header: formatMessage(MESSAGES.algorithm),
-        accessor: 'algorithm_run',
-        Cell: settings =>
-            settings.row.original.algorithm_run
-                ? settings.row.original.algorithm_run.algorithm.description
-                : '?',
+        id: 'algorithm_run',
+        accessor: row => (row.algorithm_run ? description : '?'),
     },
     {
         Header: formatMessage(MESSAGES.validator),
         accessor: 'validator',
-        Cell: settings =>
-            settings.row.original.validator
-                ? getDisplayName(settings.row.original.validator)
-                : textPlaceholder,
     },
     {
         Header: formatMessage(MESSAGES.validated),
@@ -132,7 +121,7 @@ export const runsTableColumns = (
         Cell: settings => (
             <span>
                 {settings.row.original.ended_at ? (
-                    moment.unix(settings.row.original.ended_at).format('LTS')
+                    displayDateFromTimestamp(settings.value)
                 ) : (
                     <LoadingSpinner
                         fixed={false}
@@ -147,29 +136,18 @@ export const runsTableColumns = (
     {
         Header: formatMessage(MESSAGES.launchedAt),
         accessor: 'created_at',
-        Cell: settings => (
-            <span>
-                {moment.unix(settings.row.original.created_at).format('LTS')}
-            </span>
-        ),
+        Cell: DateTimeCell,
     },
     {
         Header: formatMessage(MESSAGES.name),
-        accessor: 'algorithm__name',
-        Cell: settings => (
-            <span>{settings.row.original.algorithm.description}</span>
-        ),
+        id: 'algorithm__name',
+        accessor: row => row.algorithm.description,
     },
     {
         Header: formatMessage(MESSAGES.launcher),
-        accessor: 'launcher',
-        Cell: settings => (
-            <span>
-                {settings.row.original.launcher
-                    ? getDisplayName(settings.row.original.launcher)
-                    : textPlaceholder}
-            </span>
-        ),
+        id: 'launcher',
+        Cell: settings =>
+            settings.value ? getDisplayName(settings.value) : textPlaceholder,
     },
     {
         Header: formatMessage(MESSAGES.links),

--- a/hat/assets/js/apps/Iaso/domains/mappings/config.js
+++ b/hat/assets/js/apps/Iaso/domains/mappings/config.js
@@ -1,10 +1,8 @@
 import React from 'react';
-import {
-    IconButton as IconButtonComponent,
-    displayDateFromTimestamp,
-} from 'bluesquare-components';
+import { IconButton as IconButtonComponent } from 'bluesquare-components';
 import MESSAGES from './messages';
 import { baseUrls } from '../../constants/urls';
+import { DateTimeCell } from '../../components/Cells/DateTimeCell';
 
 const safePercent = (a, b) => {
     if (b === 0) {
@@ -32,58 +30,46 @@ const mappingsTableColumns = formatMessage => [
     },
     {
         Header: formatMessage(MESSAGES.name),
-        accessor: 'form_version__form__name',
+        id: 'form_version__form__name',
         style: { justifyContent: 'left' },
-        Cell: settings => (
-            <span>{settings.row.original.form_version.form.name}</span>
-        ),
+        accessor: row => row.form_version.form.name,
     },
     {
         Header: formatMessage(MESSAGES.version),
-        accessor: 'form_version__version_id',
-        Cell: settings => (
-            <span>{settings.row.original.form_version.version_id}</span>
-        ),
+        id: 'form_version__version_id',
+        accessor: row => row.form_version.version_id,
     },
 
     {
         Header: formatMessage(MESSAGES.type),
-        accessor: 'mapping__mapping_type',
-        Cell: settings => (
-            <span>{settings.row.original.mapping.mapping_type}</span>
-        ),
+        id: 'mapping__mapping_type',
+        accessor: row => row.mapping.mapping_type,
     },
     {
         Header: formatMessage(MESSAGES.mappedQuestions),
+        sortable: false,
         accessor: 'mapped_questions',
-        Cell: settings => <span>{settings.row.original.mapped_questions}</span>,
     },
     {
         Header: formatMessage(MESSAGES.totalQuestions),
+        sortable: false,
         accessor: 'total_questions',
-        Cell: settings => <span>{settings.row.original.total_questions}</span>,
     },
     {
         Header: formatMessage(MESSAGES.coverage),
         accessor: 'coverage',
-        Cell: settings => (
-            <span>
-                {safePercent(
-                    settings.row.original.mapped_questions,
-                    settings.row.original.total_questions,
-                )}
-            </span>
-        ),
+        sortable: false,
+        Cell: settings =>
+            safePercent(
+                settings.row.original.mapped_questions,
+                settings.row.original.total_questions,
+            ),
     },
 
     {
         Header: formatMessage(MESSAGES.updatedAt),
         accessor: 'updated_at',
-        Cell: settings => (
-            <span>
-                {displayDateFromTimestamp(settings.row.original.updated_at)}
-            </span>
-        ),
+        Cell: DateTimeCell,
     },
 ];
 export default mappingsTableColumns;

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/config.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/config.js
@@ -1,10 +1,8 @@
 import React from 'react';
-import moment from 'moment';
 
 import Color from 'color';
 import {
     IconButton as IconButtonComponent,
-    textPlaceholder,
     Expander,
 } from 'bluesquare-components';
 import { baseUrls } from '../../constants/urls';
@@ -12,6 +10,7 @@ import OrgUnitTooltip from './components/OrgUnitTooltip';
 import getDisplayName from '../../utils/usersUtils';
 import MESSAGES from './messages';
 import { getStatusMessage, getOrgUnitGroups } from './utils';
+import { DateTimeCell } from '../../components/Cells/DateTimeCell';
 
 export const orgUnitsTableColumns = (formatMessage, classes, searches) => {
     const getStatusColor = status => {
@@ -44,71 +43,41 @@ export const orgUnitsTableColumns = (formatMessage, classes, searches) => {
         },
         {
             Header: formatMessage(MESSAGES.type),
-            accessor: 'org_unit_type_id',
-            Cell: settings => (
-                <section>{settings.row.original.org_unit_type_name}</section>
-            ),
+            accessor: 'org_unit_type_name',
         },
         {
             Header: formatMessage(MESSAGES.groups),
             accessor: 'groups',
             width: 400,
-            Cell: settings => (
-                <section>{getOrgUnitGroups(settings.row.original)}</section>
-            ),
+            Cell: settings => getOrgUnitGroups(settings.row.original),
         },
         {
             Header: formatMessage(MESSAGES.source),
             accessor: 'source',
             sortable: false,
-            Cell: settings => (
-                <section>
-                    {settings.row.original.source &&
-                        settings.row.original.source}
-                    {!settings.row.original.source && textPlaceholder}
-                </section>
-            ),
         },
         {
             Header: formatMessage(MESSAGES.status),
             accessor: 'validation_status',
-            Cell: settings => {
-                const status = settings.row.original.validation_status;
-                return (
-                    <span className={getStatusColor(status)}>
-                        {getStatusMessage(status, formatMessage)}
-                    </span>
-                );
-            },
+            Cell: settings => (
+                <span className={getStatusColor(settings.value)}>
+                    {getStatusMessage(settings.value, formatMessage)}
+                </span>
+            ),
         },
         {
             Header: formatMessage(MESSAGES.instances_count),
             accessor: 'instances_count',
-            Cell: settings => (
-                <span>{settings.row.original.instances_count}</span>
-            ),
         },
         {
             Header: formatMessage(MESSAGES.updated_at),
             accessor: 'updated_at',
-            Cell: settings => (
-                <section>
-                    {moment
-                        .unix(settings.row.original.updated_at)
-                        .format('LTS')}
-                </section>
-            ),
+            Cell: DateTimeCell,
         },
         {
             Header: formatMessage(MESSAGES.created_at),
             accessor: 'created_at',
-            Cell: settings => (
-                <section>
-                    {moment
-                        .unix(settings.row.original.created_at)
-                        .format('LTS')}
-                </section>
-            ),
+            Cell: DateTimeCell,
         },
         {
             Header: formatMessage(MESSAGES.action),
@@ -181,18 +150,12 @@ export const orgUnitsLogsColumns = (formatMessage, classes) => [
     {
         Header: formatMessage(MESSAGES.date),
         accessor: 'created_at',
-        Cell: settings => (
-            <span>
-                {moment(settings.row.original.created_at).format('LTS')}
-            </span>
-        ),
+        Cell: DateTimeCell,
     },
     {
         Header: formatMessage(MESSAGES.user),
         accessor: 'user__username',
-        Cell: settings => (
-            <span>{getDisplayName(settings.row.original.user)}</span>
-        ),
+        Cell: settings => getDisplayName(settings.row.original.user),
     },
     {
         expander: true,

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/groups/config.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/groups/config.js
@@ -1,55 +1,42 @@
 import React from 'react';
 import {
-    IconButton as IconButtonComponent,
-    displayDateFromTimestamp,
     formatThousand,
+    IconButton as IconButtonComponent,
     textPlaceholder,
 } from 'bluesquare-components';
 import GroupsDialog from './components/GroupsDialog';
 import DeleteDialog from '../../../components/dialogs/DeleteDialogComponent';
 import MESSAGES from './messages';
+import { DateTimeCell } from '../../../components/Cells/DateTimeCell';
 
 const TableColumns = (formatMessage, component) => [
     {
         Header: formatMessage(MESSAGES.name),
         accessor: 'name',
         align: 'left',
-        Cell: settings => settings.row.original.name,
     },
     {
         Header: formatMessage(MESSAGES.updatedAt),
         accessor: 'updated_at',
-        Cell: settings => (
-            <span>
-                {displayDateFromTimestamp(settings.row.original.updated_at)}
-            </span>
-        ),
+        Cell: DateTimeCell,
     },
     {
         Header: formatMessage(MESSAGES.sourceVersion),
         accessor: 'source_version',
         sortable: false,
-        Cell: settings => {
-            const sourceVersion = settings.row.original.source_version;
-            const text =
-                sourceVersion !== null
-                    ? `${sourceVersion.data_source.name} - ${sourceVersion.number}`
-                    : textPlaceholder;
-
-            return text;
-        },
+        Cell: settings =>
+            settings.value !== null
+                ? `${settings.value.data_source.name} - ${settings.value.number}`
+                : textPlaceholder,
     },
     {
         Header: formatMessage(MESSAGES.sourceRef),
         accessor: 'source_ref',
-        Cell: settings => settings.row.original.source_ref || textPlaceholder,
     },
     {
         Header: formatMessage(MESSAGES.orgUnit),
         accessor: 'org_unit_count',
-        Cell: settings => (
-            <span>{formatThousand(settings.row.original.org_unit_count)}</span>
-        ),
+        Cell: settings => formatThousand(settings.row.original.org_unit_count),
     },
     {
         Header: formatMessage(MESSAGES.actions),

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/types/config.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/types/config.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import {
     IconButton as IconButtonComponent,
-    displayDateFromTimestamp,
     formatThousand,
 } from 'bluesquare-components';
 import OrgUnitsTypesDialog from './components/OrgUnitsTypesDialog';
 import DeleteDialog from '../../../components/dialogs/DeleteDialogComponent';
 import MESSAGES from './messages';
+import { DateTimeCell } from '../../../components/Cells/DateTimeCell';
 
 const TableColumns = (formatMessage, component) => [
     {
@@ -14,56 +14,41 @@ const TableColumns = (formatMessage, component) => [
         accessor: 'name',
         align: 'left',
         sortable: false,
-        Cell: settings => settings.row.original.name,
     },
     {
         Header: formatMessage(MESSAGES.shortName),
         accessor: 'short_name',
         sortable: false,
-        Cell: settings => settings.row.original.short_name,
     },
     {
         Header: formatMessage(MESSAGES.validatedOrgUnitCount),
         accessor: 'units_count',
         sortable: false,
-        Cell: settings => formatThousand(settings.row.original.units_count),
+        Cell: settings => formatThousand(settings.value),
     },
     {
         Header: formatMessage(MESSAGES.depth),
         headerInfo: formatMessage(MESSAGES.depthInfos),
         accessor: 'depth',
         sortable: false,
-        Cell: settings =>
-            settings.row.original.depth !== null
-                ? settings.row.original.depth
-                : '-',
     },
     {
         Header: formatMessage(MESSAGES.projects),
         accessor: 'projects',
         sortable: false,
-        Cell: settings =>
-            settings.row.original.projects.map(p => p.name).join(', '),
+        Cell: settings => settings.value.map(p => p.name).join(', '),
     },
     {
         Header: formatMessage(MESSAGES.createdAt),
         accessor: 'created_at',
         sortable: false,
-        Cell: settings => (
-            <span>
-                {displayDateFromTimestamp(settings.row.original.created_at)}
-            </span>
-        ),
+        Cell: DateTimeCell,
     },
     {
         Header: formatMessage(MESSAGES.updatedAt),
         accessor: 'updated_at',
         sortable: false,
-        Cell: settings => (
-            <span>
-                {displayDateFromTimestamp(settings.row.original.updated_at)}
-            </span>
-        ),
+        Cell: DateTimeCell,
     },
     {
         Header: formatMessage(MESSAGES.actions),

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/types/config.spec.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/types/config.spec.js
@@ -31,32 +31,24 @@ describe('Org unit types config', () => {
         expect(cols).to.have.lengthOf(8);
     });
     it('should render a component if Cell is defined', () => {
+        const settings = colOriginal({
+            name: 'LINK',
+            short_name: 'GANONDORF',
+            depth: 0,
+            projects: [],
+        });
         cols.forEach(c => {
             if (c.Cell) {
-                const cell = c.Cell(
-                    colOriginal({
-                        name: 'LINK',
-                        short_name: 'GANONDORF',
-                        depth: 0,
-                        projects: [],
-                    }),
-                );
+                const cell = c.Cell({
+                    ...settings,
+                    value:
+                        typeof c.accessor === 'function'
+                            ? c.accessor(settings.row.original)
+                            : settings.row.original[c.accessor],
+                });
                 expect(cell).to.exist;
             }
         });
-    });
-    it('should render a component if Cell is defined and no depth', () => {
-        const depthColumn = cols[3];
-        const cell = depthColumn.Cell(
-            colOriginal({
-                name: 'LINK',
-                short_name: 'GANONDORF',
-                depth: null,
-                projects: [],
-            }),
-        );
-
-        expect(cell).to.exist;
     });
     it('should call fetchOrgUnitTypes on click on onConfirmed', () => {
         const actionColumn = cols[cols.length - 1];

--- a/hat/assets/js/apps/Iaso/domains/pages/index.js
+++ b/hat/assets/js/apps/Iaso/domains/pages/index.js
@@ -20,6 +20,7 @@ import CreateEditDialog from './components/CreateEditDialog';
 import PageActions from './components/PageActions';
 import PageAction from './components/PageAction';
 import { PAGES_TYPES } from './constants';
+import { DateTimeCell } from '../../components/Cells/DateTimeCell';
 
 const DEFAULT_PAGE_SIZE = 10;
 const DEFAULT_PAGE = 1;
@@ -123,11 +124,7 @@ const Pages = () => {
             {
                 Header: intl.formatMessage(MESSAGES.updatedAt),
                 accessor: 'updated_at',
-                Cell: settings => {
-                    return moment(settings.row.original.updated_at).format(
-                        'LTS',
-                    );
-                },
+                Cell: DateTimeCell,
             },
             {
                 Header: intl.formatMessage(MESSAGES.actions),

--- a/hat/assets/js/apps/Iaso/domains/projects/config.js
+++ b/hat/assets/js/apps/Iaso/domains/projects/config.js
@@ -10,26 +10,17 @@ import MESSAGES from './messages';
 const projectsTableColumns = (formatMessage, component) => [
     {
         Header: formatMessage(MESSAGES.projectName),
-        accessor: 'project__name',
-        Cell: settings => <span>{settings.row.original.name}</span>,
+        accessor: 'name',
     },
     {
         Header: formatMessage(MESSAGES.appId),
-        accessor: 'project__app_id',
-        Cell: settings => (
-            <span>{settings.row.original.app_id || textPlaceholder}</span>
-        ),
+        accessor: 'app_id',
     },
     {
         Header: formatMessage(MESSAGES.featureFlags),
-        accessor: 'project__needs_authentication',
-        Cell: settings => (
-            <span>
-                {settings.row.original.feature_flags
-                    .map(fF => fF.name)
-                    .join(', ') || textPlaceholder}
-            </span>
-        ),
+        accessor: 'feature_flags',
+        Cell: settings =>
+            settings.value.map(fF => fF.name).join(', ') || textPlaceholder,
     },
     {
         Header: formatMessage(MESSAGES.actions),

--- a/hat/assets/js/apps/Iaso/domains/tasks/config.js
+++ b/hat/assets/js/apps/Iaso/domains/tasks/config.js
@@ -5,6 +5,7 @@ import {
     displayDateFromTimestamp,
 } from 'bluesquare-components';
 import MESSAGES from './messages';
+import { DateTimeCell } from '../../components/Cells/DateTimeCell';
 
 const tasksTableColumns = (formatMessage, killTaskAction) => [
     {
@@ -69,11 +70,7 @@ const tasksTableColumns = (formatMessage, killTaskAction) => [
         Header: formatMessage(MESSAGES.timeCreated),
         sortable: true,
         accessor: 'created_at',
-        Cell: settings => (
-            <span>
-                {displayDateFromTimestamp(settings.row.original.created_at)}
-            </span>
-        ),
+        Cell: DateTimeCell,
     },
     {
         Header: formatMessage(MESSAGES.timeStart),
@@ -83,7 +80,7 @@ const tasksTableColumns = (formatMessage, killTaskAction) => [
             <span>
                 {settings.row.original.status === 'QUEUED' ||
                 settings.row.original.started_at === null
-                    ? '-'
+                    ? ''
                     : displayDateFromTimestamp(
                           settings.row.original.started_at,
                       )}

--- a/hat/assets/js/apps/Iaso/domains/users/config.js
+++ b/hat/assets/js/apps/Iaso/domains/users/config.js
@@ -11,31 +11,26 @@ import MESSAGES from './messages';
 const usersTableColumns = (formatMessage, component) => [
     {
         Header: formatMessage(MESSAGES.userName),
-        accessor: 'user__username',
-        Cell: settings => <span>{settings.row.original.user_name}</span>,
+        id: 'user__username',
+        accessor: 'user_name',
     },
     {
         Header: formatMessage(MESSAGES.firstName),
-        accessor: 'user__first_name',
-        Cell: settings => (
-            <span>{settings.row.original.first_name || textPlaceholder}</span>
-        ),
+        id: 'user__first_name',
+        accessor: 'first_name',
     },
     {
         Header: formatMessage(MESSAGES.lastName),
-        accessor: 'user__last_name',
-        Cell: settings => (
-            <span>{settings.row.original.last_name || textPlaceholder}</span>
-        ),
+        id: 'user__last_name',
+        accessor: 'last_name',
     },
     {
         Header: formatMessage(MESSAGES.email),
-        accessor: 'user__email',
+        id: 'user__email',
+        accessor: 'email',
         Cell: settings =>
-            settings.row.original.email ? (
-                <a href={`mailto:${settings.row.original.email}`}>
-                    {settings.row.original.email}
-                </a>
+            settings.value ? (
+                <a href={`mailto:${settings.value}`}>{settings.value}</a>
             ) : (
                 textPlaceholder
             ),

--- a/plugins/polio/js/src/components/Dashboard.js
+++ b/plugins/polio/js/src/components/Dashboard.js
@@ -1485,84 +1485,46 @@ export const Dashboard = () => {
                 Header: 'Country',
                 accessor: 'top_level_org_unit_name',
                 sortable: false,
-                Cell: settings => {
-                    const text =
-                        settings?.row?.original?.top_level_org_unit_name ??
-                        textPlaceholder;
-                    return <span>{text}</span>;
-                },
             },
             {
                 Header: 'Name',
                 accessor: 'obr_name',
-                Cell: settings => {
-                    return <span>{settings.row.original.obr_name}</span>;
-                },
             },
             {
                 Header: 'cVDPV2 Notification Date',
                 accessor: 'cvdpv2_notified_at',
-                Cell: settings => {
-                    const text =
-                        settings?.row?.original?.cvdpv2_notified_at ??
-                        textPlaceholder;
-                    return <span>{text}</span>;
-                },
             },
             {
                 Header: 'Round 1',
                 accessor: 'round_one__started_at',
-                Cell: settings => {
-                    return (
-                        settings?.row?.original?.round_one?.started_at ??
-                        textPlaceholder
-                    );
-                },
             },
             {
                 Header: 'Round 2',
                 accessor: 'round_two__started_at',
-                Cell: settings => {
-                    return (
-                        settings.row.original?.round_two?.started_at ??
-                        textPlaceholder
-                    );
-                },
             },
             {
                 Header: 'Status',
                 sortable: false,
                 accessor: 'general_status',
-                Cell: settings => {
-                    return settings.row.original.general_status;
-                },
             },
             {
                 Header: 'Actions',
-                accessor: 'actions',
+                accessor: 'id',
                 sortable: false,
-                Cell: settings => {
-                    return (
-                        <>
-                            <IconButtonComponent
-                                icon="edit"
-                                tooltipMessage={MESSAGES.edit}
-                                onClick={() =>
-                                    handleClickEditRow(settings.row.original.id)
-                                }
-                            />
-                            <IconButtonComponent
-                                icon="delete"
-                                tooltipMessage={MESSAGES.delete}
-                                onClick={() =>
-                                    handleClickDeleteRow(
-                                        settings.row.original.id,
-                                    )
-                                }
-                            />
-                        </>
-                    );
-                },
+                Cell: settings => (
+                    <>
+                        <IconButtonComponent
+                            icon="edit"
+                            tooltipMessage={MESSAGES.edit}
+                            onClick={() => handleClickEditRow(settings.value)}
+                        />
+                        <IconButtonComponent
+                            icon="delete"
+                            tooltipMessage={MESSAGES.delete}
+                            onClick={() => handleClickDeleteRow(settings.value)}
+                        />
+                    </>
+                ),
             },
         ],
         [handleClickDeleteRow, handleClickEditRow],

--- a/plugins/test/js/columns.js
+++ b/plugins/test/js/columns.js
@@ -1,29 +1,26 @@
-import moment from 'moment';
 import MESSAGES from './messages';
+import { DateTimeCell } from '../../../hat/assets/js/apps/Iaso/components/Cells/DateTimeCell';
 
 const TableColumns = formatMessage => [
     {
         Header: formatMessage(MESSAGES.titleCol),
         accessor: 'title',
         style: { justifyContent: 'left' },
-        Cell: settings => settings.row.original.title,
     },
     {
         Header: formatMessage(MESSAGES.author),
-        accessor: 'auhtor',
-        Cell: settings => settings.row.original.author.username,
+        id: 'author',
+        accessor: row => row.author.username,
     },
     {
         Header: formatMessage(MESSAGES.createdAt),
         accessor: 'created_at',
-        Cell: settings =>
-            moment(settings.row.original.created_at).format('DD/MM/YYYY HH:mm'),
+        Cell: DateTimeCell,
     },
     {
         Header: formatMessage(MESSAGES.updatedAt),
         accessor: 'updated_at',
-        Cell: settings =>
-            moment(settings.row.original.updated_at).format('DD/MM/YYYY HH:mm'),
+        Cell: DateTimeCell,
     },
 ];
 export default TableColumns;


### PR DESCRIPTION
PR on top of Christophe PR to make each column a bit more the same

- Use `settings.value` to access the value in Cell:
- Use `accessor` function and set an `id` field if we just want a different field *
- Remove useless <span> <section> etc.. in cell
- Remove Cell: when it's simple text we want displayed
- Added a standardised DateTimeCell which handle formatting to display `created_at` `updated_at` etc...
- - Added a standardised YesNoCell for boolean value
- fix some bug of columns marked sortable but which were not and crashed
- fix IA-739 sorting in  the project table

this PR also remove most textPlaceholder (the `--` that get displayed when there is no data) usage was inconsistant, tell me if you prefer with it and I will add it back everywhere.

The general idea is that `id` is the identifier and what we send to the API for ordering. And accessor is the name of the field in the dictionary (and if it's a function how to get the value). Cell is how it is displayed. see https://react-table.tanstack.com/docs/api/useTable#column-options