### PR TITLE
Fix: display single_per_period's value if exists

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/forms/components/FormFormComponent.js
+++ b/hat/assets/js/apps/Iaso/domains/forms/components/FormFormComponent.js
@@ -24,7 +24,6 @@ const useStyles = makeStyles(styles);
 const FormForm = ({ currentForm, setFieldValue }) => {
     const classes = useStyles();
     const intl = useSafeIntl();
-    const [isSinglePerPeriodSet, setIsSinglePeriodSet] = useState(false);
     const allProjects = useSelector(state => state.projects.allProjects);
     const allOrgUnitTypes = useSelector(state => state.orgUnitsTypes.allTypes);
     const setPeriodType = value => {
@@ -46,25 +45,6 @@ const FormForm = ({ currentForm, setFieldValue }) => {
     if (currentForm.project_ids.value.length > 0) {
         projects = currentForm.project_ids.value.join(',');
     }
-    const setSinglePerPeriod = useCallback(
-        (key, value) => {
-            if (!isSinglePerPeriodSet) {
-                setIsSinglePeriodSet(true);
-            }
-            setFieldValue(key, value === 'true');
-        },
-        [isSinglePerPeriodSet, setFieldValue],
-    );
-
-    // Running the effect at every render otherwise it's overwritten when the page loads
-    useEffect(() => {
-        if (
-            !isSinglePerPeriodSet &&
-            currentForm.single_per_period.value !== null
-        ) {
-            setFieldValue('single_per_period', null);
-        }
-    });
 
     return (
         <Grid container spacing={2} justifyContent="flex-start">
@@ -120,7 +100,9 @@ const FormForm = ({ currentForm, setFieldValue }) => {
                             name="single_per_period"
                             disabled={currentForm.period_type.value === null}
                             required
-                            onChange={setSinglePerPeriod}
+                            onChange={(key, value) => {
+                                setFieldValue(key, value === 'true');
+                            }}
                             value={currentForm.single_per_period.value}
                             errors={
                                 currentForm.single_per_period.value === null

--- a/hat/assets/js/apps/Iaso/domains/forms/components/FormFormComponent.spec.js
+++ b/hat/assets/js/apps/Iaso/domains/forms/components/FormFormComponent.spec.js
@@ -133,8 +133,7 @@ describe('FormFormComponent connected component', () => {
                 element.props().onChange(i.keyValue, i.newValue);
                 connectedWrapper.update();
             });
-            // Count went from 16 to 17 switchint to Select input because there's an additional call in a useEffect hook
-            expect(setFieldValueSpy.callCount).to.equal(17);
+            expect(setFieldValueSpy.callCount).to.equal(16);
         });
         it('mount properly without org_unit_type_ids and project_ids', () => {
             connectedWrapper = mount(

--- a/hat/assets/js/apps/Iaso/domains/forms/detail.js
+++ b/hat/assets/js/apps/Iaso/domains/forms/detail.js
@@ -45,7 +45,7 @@ const defaultForm = {
     project_ids: [],
     period_type: null,
     derived: false,
-    single_per_period: false,
+    single_per_period: null,
     periods_before_allowed: 0,
     periods_after_allowed: 0,
     device_field: 'deviceid',


### PR DESCRIPTION
- When editing a form the value for single_per_period is now used

@olethanh , @beygorghor : no need for a double review, whoever has time first

https://user-images.githubusercontent.com/38907762/132011744-3c2e7280-03c6-4542-baa8-d7ae5f759c89.mov

