### PR TITLE
patch: instanceDetails crash when null OrgUnitType

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -114,6 +114,7 @@
     "iaso.instance.instanceEditAction": "Modifier les réponses via Enketo",
     "iaso.instance.instanceExportAction": "Export instance",
     "iaso.instance.instanceReAssignAction": "Modifier la période et/ou l'orgUnit",
+    "iaso.instance.label.noOrgUnitType": "OrgUnit type not specified",
     "iaso.instance.missingFile": "Cannot find an instance with a file",
     "iaso.instance.missingGeolocation": "Cannot find an instance with geolocation",
     "iaso.instance.org_unit": "Org unit",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -116,6 +116,7 @@
     "iaso.instance.instanceEditAction": "Modifier les réponses via Enketo",
     "iaso.instance.instanceExportAction": "Exporter la soumission",
     "iaso.instance.instanceReAssignAction": "Modifier la période et/ou l'orgUnit",
+    "iaso.instance.label.noOrgUnitType": "Type de l'OrgUnit non-précisé",
     "iaso.instance.missingFile": "Aucune fichier trouvé",
     "iaso.instance.missingGeolocation": "Aucune soumission trouvée avec une localisation",
     "iaso.instance.org_unit": "Unités d’organisation (org unit)",

--- a/hat/assets/js/apps/Iaso/domains/instances/components/InstanceDetailsLocation.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/InstanceDetailsLocation.js
@@ -37,7 +37,10 @@ const InstanceDetailsLocation = ({
                 {orgUnitTree.map(ou => (
                     <InstanceDetailsField
                         key={ou.id}
-                        label={ou.org_unit_type?.name ?? MESSAGES.noOrgUnitType}
+                        label={
+                            ou.org_unit_type?.name ??
+                            formatMessage(MESSAGES.noOrgUnitType)
+                        }
                         valueTitle={
                             <OrgUnitLabel orgUnit={ou} withType={false} />
                         }

--- a/hat/assets/js/apps/Iaso/domains/instances/components/InstanceDetailsLocation.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/InstanceDetailsLocation.js
@@ -37,7 +37,7 @@ const InstanceDetailsLocation = ({
                 {orgUnitTree.map(ou => (
                     <InstanceDetailsField
                         key={ou.id}
-                        label={ou.org_unit_type.name}
+                        label={ou.org_unit_type?.name ?? MESSAGES.noOrgUnitType}
                         valueTitle={
                             <OrgUnitLabel orgUnit={ou} withType={false} />
                         }

--- a/hat/assets/js/apps/Iaso/domains/instances/messages.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/messages.js
@@ -305,6 +305,10 @@ const MESSAGES = defineMessages({
         id: 'iaso.instance.deleteInstanceWarning',
         defaultMessage: 'This operation cannot be undone.',
     },
+    noOrgUnitType: {
+        id: 'iaso.instance.label.noOrgUnitType',
+        defaultMessage: 'OrgUnit type not specified',
+    },
 });
 
 export default MESSAGES;

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitSourceRefDisplay.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitSourceRefDisplay.js
@@ -21,7 +21,7 @@ const OrgUnitSourceRefDisplay = ({ orgUnit, classes }) => {
             className={classes.link}
             href={`${orgUnit.source_url}/api/organisationUnits/${orgUnit.source_ref}`}
         >
-            {orgUnit.source_ref}
+            {orgUnit.source_ref ?? textPlaceholder}
         </Link>
     );
 };


### PR DESCRIPTION
## Changes
- added placeholder message when OU type is null
- added textPlaceholder when soiurce reference is null
- added related translations

## Original bug
https://iaso-staging.bluesquare.org/dashboard/instance/instanceId/9427