### PR TITLE
IA763: When sorting children of orgunit it switch tab

### DIFF
--- a/hat/assets/js/apps/Iaso/components/tables/SingleTable.js
+++ b/hat/assets/js/apps/Iaso/components/tables/SingleTable.js
@@ -130,7 +130,7 @@ const SingleTable = ({
     const extraProps = {
         loading,
         defaultPageSize: defaultPageSize || limit,
-        propsToWatch,
+        propsToWatch, // IA-763: pass an extra props that will be watched in table component to force the render
     };
     if (subComponent) {
         extraProps.SubComponent = original =>

--- a/hat/assets/js/apps/Iaso/components/tables/SingleTable.js
+++ b/hat/assets/js/apps/Iaso/components/tables/SingleTable.js
@@ -52,6 +52,7 @@ const SingleTable = ({
     setIsLoading,
     multiSelect,
     selectionActions,
+    propsToWatch,
 }) => {
     const [loading, setLoading] = useState(false);
     const [selection, setSelection] = useState(selectionInitialState);
@@ -129,6 +130,7 @@ const SingleTable = ({
     const extraProps = {
         loading,
         defaultPageSize: defaultPageSize || limit,
+        propsToWatch,
     };
     if (subComponent) {
         extraProps.SubComponent = original =>
@@ -241,6 +243,7 @@ SingleTable.defaultProps = {
     setIsLoading: true,
     multiSelect: false,
     selectionActions: [],
+    propsToWatch: null,
 };
 
 SingleTable.propTypes = {
@@ -270,6 +273,7 @@ SingleTable.propTypes = {
     setIsLoading: PropTypes.bool,
     multiSelect: PropTypes.bool,
     selectionActions: PropTypes.array,
+    propsToWatch: PropTypes.any,
 };
 
 export default withRouter(SingleTable);

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/details.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/details.js
@@ -613,6 +613,7 @@ class OrgUnitDetail extends Component {
                                 exportButton={false}
                                 baseUrl={baseUrl}
                                 endPointPath="forms"
+                                propsToWatch={params.tab}
                                 fetchItems={fetchForms}
                                 columns={this.state.tableColumns}
                                 results={reduxPage}
@@ -641,6 +642,7 @@ class OrgUnitDetail extends Component {
                                         params.orgUnitId,
                                     ),
                                 }}
+                                propsToWatch={params.tab}
                                 baseUrl={baseUrl}
                                 endPointPath="orgunits"
                                 fetchItems={fetchOrgUnitsList}
@@ -666,6 +668,7 @@ class OrgUnitDetail extends Component {
                                 apiParams={{
                                     orgUnitId: currentOrgUnit.id,
                                 }}
+                                propsToWatch={params.tab}
                                 filters={linksFiltersWithPrefix(
                                     'linksParams',
                                     algorithmRuns,


### PR DESCRIPTION
New component table has a useMemo to avoid multiple rerender.

Due to the fact that children table is loaded at the beginning and hidden, while changing tab, the table doesn't update his props and on the redirect is still passing old tab param value.

You have now a new props `propsToWatch` in `SingleTable`.

https://user-images.githubusercontent.com/12494624/132836022-0869c86e-8f8c-435e-98b4-ac88043026d3.mov




