### PR TITLE
OrgUnit Treeview, remove clear button if no selection

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/TreeView/OrgUnitTreeviewPicker.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/TreeView/OrgUnitTreeviewPicker.js
@@ -70,14 +70,22 @@ const OrgUnitTreeviewPicker = ({
     return (
         <Paper variant="outlined" elevation={0} className={classes.paper}>
             {makeTruncatedTrees(selectedItems)}
-            {resetSelection && (
+            {resetSelection && selectedItems.size > 0 && (
                 <IconButton
                     icon="clear"
                     tooltipMessage={MESSAGES.clear}
                     onClick={resetSelection}
-                    style={{ marginRight: '16px' }}
                 />
             )}
+            <IconButton
+                tooltipMessage={
+                    multiselect
+                        ? MESSAGES.selectMultiple
+                        : MESSAGES.selectSingle
+                }
+                icon="orgUnit"
+                onClick={onClick}
+            />
         </Paper>
     );
 };


### PR DESCRIPTION
https://user-images.githubusercontent.com/82500/133590676-283e6e71-60ef-4b41-9940-0a73cfab6720.mp4

add an OrgUnit button to open the dialog.

this is just a suggestion. Because it also mean there is two buttons which change the dyamic a bit?