### PR TITLE
Orgunit Search: display version number for group

### DIFF
--- a/hat/assets/js/apps/Iaso/constants/filters.js
+++ b/hat/assets/js/apps/Iaso/constants/filters.js
@@ -315,7 +315,7 @@ export const group = (groupList, urlKey = 'group') => ({
     isClearable: true,
     options: groupList.map(a => ({
         label: a.source_version
-            ? `${a.name} - ${a.source_version.data_source.name}`
+            ? `${a.name} - ${a.source_version.data_source.name} ${a.source_version.number}`
             : a.name,
         value: a.id,
     })),


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/82500/133595212-0cc9f8ab-35d4-408f-9210-29cf06626172.png)


while waiting for the overhaul of the search view, it should make the life of people in pbf/hfre easier
