### PR TITLE
IA-784 patch dispay orgunit map when switching tab

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgunitsMapComponent.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgunitsMapComponent.js
@@ -36,7 +36,6 @@ import { getColorsFromParams, decodeSearch } from '../utils';
 import MESSAGES from '../messages';
 import { OrgUnitsMapComments } from './orgUnitMap/OrgUnitsMapComments';
 import { innerDrawerStyles } from '../../../components/nav/InnerDrawer/styles';
-import { waitFor } from '../../../utils';
 
 const boundsOptions = {
     padding: [50, 50],
@@ -88,17 +87,12 @@ class OrgunitsMap extends Component {
         this.state = {
             fittedToBounds: false,
         };
-        this.map = React.createRef();
     }
 
-    async componentDidMount() {
+    componentDidMount() {
         const { orgUnitTypes, orgUnits } = this.props;
         this.makePanes(orgUnitTypes);
-        // Added this code here, because otherwise the map wouldn't redraw when going back and forth between list and map tabs
-        // FIXME: some values in the orgUnits prop seem to be null without adding a delay.
-        await waitFor(200);
         this.checkFitToBounds(orgUnits);
-        // End addition
         this.props.setCurrentSubOrgUnit(null);
     }
 
@@ -159,11 +153,11 @@ class OrgunitsMap extends Component {
 
     makePanes(orgUnitTypes) {
         if (orgUnitTypes.length === 0) {
-            this.map.current.leafletElement.createPane('custom-shape-pane');
+            this.map.leafletElement.createPane('custom-shape-pane');
         } else {
             orgUnitTypes.forEach(ot => {
                 const otName = camelCase(ot.name);
-                this.map.current.leafletElement.createPane(
+                this.map.leafletElement.createPane(
                     `custom-shape-pane-${otName}`,
                 );
             });
@@ -187,10 +181,7 @@ class OrgunitsMap extends Component {
         const bounds = getOrgUnitsBounds(orgUnits);
         if (bounds) {
             try {
-                this.map.current.leafletElement.fitBounds(
-                    bounds,
-                    boundsOptions,
-                );
+                this.map.leafletElement.fitBounds(bounds, boundsOptions);
             } catch (e) {
                 console.warn(e);
             }
@@ -223,11 +214,9 @@ class OrgunitsMap extends Component {
                 </Grid>
             );
         }
-        if (this.map.current) {
-            this.map.current.leafletElement.options.maxZoom =
-                currentTile.maxZoom;
+        if (this.map) {
+            this.map.leafletElement.options.maxZoom = currentTile.maxZoom;
         }
-        // console.log('this.map', this.map.current);
         return (
             <Grid container spacing={0}>
                 <InnerDrawer
@@ -264,8 +253,7 @@ class OrgunitsMap extends Component {
                 >
                     <Map
                         ref={ref => {
-                            // console.log('ref', ref);
-                            this.map.current = ref;
+                            this.map = ref;
                         }}
                         scrollWheelZoom={false}
                         maxZoom={currentTile.maxZoom}

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgunitsMapComponent.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgunitsMapComponent.js
@@ -95,16 +95,9 @@ class OrgunitsMap extends Component {
         const { orgUnitTypes, orgUnits } = this.props;
         this.makePanes(orgUnitTypes);
         // Added this code here, because otherwise the map wouldn't redraw when going back and forth between list and map tabs
-        // FIXME : Had to add this timer because otherwise the addition below would cause a crash (some values would be undefined).
+        // FIXME: some values in the orgUnits prop seem to be null without adding a delay.
         await waitFor(200);
-        const { fittedToBounds } = this.state;
-        if (
-            !fittedToBounds &&
-            (orgUnits.locations.length > 0 || orgUnits.shapes.length > 0)
-        ) {
-            this.setFittedToBound();
-            this.fitToBounds();
-        }
+        this.checkFitToBounds(orgUnits);
         // End addition
         this.props.setCurrentSubOrgUnit(null);
     }
@@ -117,22 +110,14 @@ class OrgunitsMap extends Component {
     }
 
     componentDidUpdate(prevProps) {
-        const { orgUnits } = this.props;
-        const { orgUnitTypes } = this.props;
+        const { orgUnits, orgUnitTypes } = this.props;
         const oldOrgUnitTypes = prevProps.orgUnitTypes;
         // creating panes if navigating using deep linking or reloading, as orgUnitTypes
         // are not available to componentDidMount in those cases
         if (!isEqual(oldOrgUnitTypes, orgUnitTypes)) {
             this.makePanes(orgUnitTypes);
         }
-        const { fittedToBounds } = this.state;
-        if (
-            !fittedToBounds &&
-            (orgUnits.locations.length > 0 || orgUnits.shapes.length > 0)
-        ) {
-            this.setFittedToBound();
-            this.fitToBounds();
-        }
+        this.checkFitToBounds(orgUnits);
     }
 
     componentWillUnmount() {
@@ -159,6 +144,17 @@ class OrgunitsMap extends Component {
             currentColor = `#${currentColor}`;
         }
         return currentColor;
+    }
+
+    checkFitToBounds(orgUnits) {
+        const { fittedToBounds } = this.state;
+        if (
+            !fittedToBounds &&
+            (orgUnits.locations.length > 0 || orgUnits.shapes.length > 0)
+        ) {
+            this.setFittedToBound();
+            this.fitToBounds();
+        }
     }
 
     makePanes(orgUnitTypes) {

--- a/hat/assets/js/apps/Iaso/utils/index.js
+++ b/hat/assets/js/apps/Iaso/utils/index.js
@@ -92,3 +92,9 @@ export const getPlugins = pluginsKeys => {
 };
 
 export const PluginsContext = createContext({ plugins: [] });
+
+// create timeout to simulate async call
+// credit https://stackoverflow.com/questions/51200626/using-a-settimeout-in-a-async-function
+// Added it here because using the one from test/utils would cause compilation errors
+export const waitFor = delay =>
+    new Promise(resolve => setTimeout(resolve, delay));


### PR DESCRIPTION
## Changes 
- Added a timeout in `OrgunitsMapComponent` to avoid the map staying grey when navigating back and forth from list to map tab
- Added the `waitFor` function in utils
- duplicated the `fitToBound` related logic from `componentDidUpdate` into `componentDidMount` with the `checkFitToBound` method
