### PR TITLE
IA-795: don't close options list when  using multiselect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4396,7 +4396,7 @@
         },
         "node_modules/bluesquare-components": {
             "version": "0.2.0",
-            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#f98bb186d0b438e71b7c0d7d8b15d0df78191b3e",
+            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#19e384dbc73eda49a0272b57faed8e91fdcc7583",
             "license": "Apache-2.0",
             "dependencies": {
                 "react-intersection-observer": "^8.26.1"
@@ -26446,7 +26446,7 @@
             "dev": true
         },
         "bluesquare-components": {
-            "version": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#f98bb186d0b438e71b7c0d7d8b15d0df78191b3e",
+            "version": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#19e384dbc73eda49a0272b57faed8e91fdcc7583",
             "from": "bluesquare-components@github:BLSQ/bluesquare-components",
             "requires": {
                 "react-intersection-observer": "^8.26.1"


### PR DESCRIPTION
## Changes 
- updated dep to bluesquare-components
- when using multiselect, dropdown list will not close when selecting an option, enabling multiple selctions without having to re-open the list

https://user-images.githubusercontent.com/38907762/133976049-f62931dc-6311-4e59-9b13-90396325fa64.mov

