### PR TITLE
SAFARI crash: fix regex

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/instances/utils.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/utils.js
@@ -110,7 +110,7 @@ const labelLocales = { fr: 'French', en: 'English' };
 const localizeLabel = field => {
     const locale = getCookie('django_language') ?? 'en';
     const singleToDoubleQuotes = field.label.replaceAll("'", '"');
-    const wrongDoubleQuotes = /(?<=[a-zA-Z])"(?=[a-zA-Z])/g;
+    const wrongDoubleQuotes = /(?:[a-zA-Z])"(?=[a-zA-Z])/g;
     const formattedLabel = singleToDoubleQuotes.replace(wrongDoubleQuotes, "'");
     let result;
     try {


### PR DESCRIPTION
According to [this](https://stackoverflow.com/questions/51568821/works-in-chrome-but-breaks-in-safari-invalid-regular-expression-invalid-group), this is fixing the problem, but is the behaviour still correct ?

