### PR TITLE
Absolute js import

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,7 +23,15 @@
   },
   "rules": {
     "no-tabs": "off",
-    "no-console":["error",{"allow":["warn","error"]}],
+    "no-console": [
+      "error",
+      {
+        "allow": [
+          "warn",
+          "error"
+        ]
+      }
+    ],
     "prettier/prettier": "warn",
     "camelcase": "warn",
     "constructor-super": "warn",
@@ -39,9 +47,9 @@
     "jsx-a11y/no-noninteractive-element-interactions": "off",
     "jsx-a11y/no-noninteractive-element-to-interactive-role": "off",
     "react/jsx-one-expression-per-line": "off",
-    "react/jsx-curly-newline":"off",
-    "react/jsx-props-no-spreading":"warn",
-    "react/prop-types":"warn",
+    "react/jsx-curly-newline": "off",
+    "react/jsx-props-no-spreading": "warn",
+    "react/prop-types": "warn",
     "linebreak-style": "off",
     "max-len": [
       "warn",
@@ -60,7 +68,12 @@
     "no-undef": "warn",
     "no-underscore-dangle": "off",
     "no-unreachable": "warn",
-    "no-unused-vars": ["error",{"ignoreRestSiblings":true}],
+    "no-unused-vars": [
+      "error",
+      {
+        "ignoreRestSiblings": true
+      }
+    ],
     "react/button-has-type": "off",
     "react/destructuring-assignment": "off",
     "react/forbid-prop-types": [
@@ -108,6 +121,13 @@
     "shallow": "readonly",
     "mount": "readonly",
     "sinon": "readonly",
-    "render":"readonly"
+    "render": "readonly"
+  },
+  "settings": {
+    "import/resolver": {
+      "webpack": {
+        "config": "hat/webpack.dev.js"
+      }
+    }
   }
 }

--- a/hat/assets/js/apps/Iaso/components/instancesGraph.js
+++ b/hat/assets/js/apps/Iaso/components/instancesGraph.js
@@ -13,8 +13,8 @@ import {
 import { Typography } from '@material-ui/core';
 import { FormattedMessage } from 'react-intl';
 import { getChipColors } from '../constants/chipColors';
-import { getRequest } from '../libs/Api';
-import { useSnackQuery } from '../libs/apiHooks';
+import { getRequest } from 'iaso/libs/Api';
+import { useSnackQuery } from 'iaso/libs/apiHooks';
 
 export const InstancesPerFormGraph = () => {
     const { data, isLoading } = useSnackQuery(['instances', 'stats'], () =>

--- a/hat/assets/js/apps/Iaso/components/instancesTotalGraph.js
+++ b/hat/assets/js/apps/Iaso/components/instancesTotalGraph.js
@@ -11,8 +11,8 @@ import {
 import { Typography } from '@material-ui/core';
 import { LoadingSpinner } from 'bluesquare-components';
 import { FormattedMessage } from 'react-intl';
-import { useSnackQuery } from '../libs/apiHooks';
-import { getRequest } from '../libs/Api';
+import { useSnackQuery } from 'iaso/libs/apiHooks';
+import { getRequest } from 'iaso/libs/Api';
 
 export const InstancesTotalGraph = () => {
     const { data, isLoading } = useSnackQuery(['instances', 'stats_sum'], () =>

--- a/hat/assets/js/apps/Iaso/domains/completeness/components/CompletenessPeriodComponent.js
+++ b/hat/assets/js/apps/Iaso/domains/completeness/components/CompletenessPeriodComponent.js
@@ -12,9 +12,9 @@ import { useDispatch } from 'react-redux';
 import { getColumns } from '../config';
 import { baseUrls } from '../../../constants/urls';
 import { redirectTo } from '../../../routing/actions';
-import { postRequest } from '../../../libs/Api';
+import { postRequest } from 'iaso/libs/Api';
 import MESSAGES from '../../../components/snackBars/messages';
-import { useSnackMutation } from '../../../libs/apiHooks';
+import { useSnackMutation } from 'iaso/libs/apiHooks';
 
 const useStyles = makeStyles(theme => ({
     ...commonStyles(theme),

--- a/hat/assets/js/apps/Iaso/domains/completeness/index.js
+++ b/hat/assets/js/apps/Iaso/domains/completeness/index.js
@@ -5,9 +5,9 @@ import TopBar from '../../components/nav/TopBarComponent';
 import CompletenessListComponent from './components/CompletenessListComponent';
 
 import MESSAGES from './messages';
-import { getRequest } from '../../libs/Api';
+import { getRequest } from 'iaso/libs/Api';
 import snackMessages from '../../components/snackBars/messages';
-import { useSnackQuery } from '../../libs/apiHooks';
+import { useSnackQuery } from 'iaso/libs/apiHooks';
 
 const Completeness = ({ params }) => {
     const { formatMessage } = useSafeIntl();

--- a/hat/assets/js/apps/Iaso/domains/dataSources/requests.js
+++ b/hat/assets/js/apps/Iaso/domains/dataSources/requests.js
@@ -3,12 +3,12 @@ import { useMutation, useQuery } from 'react-query';
 import { useDispatch, useSelector } from 'react-redux';
 import { iasoGetRequest, iasoPostRequest } from '../../utils/requests';
 import { dispatch as storeDispatch } from '../../redux/store';
-import { getRequest, iasoFetch, postRequest, putRequest } from '../../libs/Api';
+import { getRequest, iasoFetch, postRequest, putRequest } from 'iaso/libs/Api';
 import { enqueueSnackbar } from '../../redux/snackBarsReducer';
 import { errorSnackBar } from '../../constants/snackBars';
 import snackBarMessages from '../../components/snackBars/messages';
 import { fetchCurrentUser } from '../users/actions';
-import { useSnackMutation, useSnackQuery } from '../../libs/apiHooks';
+import { useSnackMutation, useSnackQuery } from 'iaso/libs/apiHooks';
 
 /**
  *

--- a/hat/assets/js/apps/Iaso/domains/forms/hooks/useGetInstances.js
+++ b/hat/assets/js/apps/Iaso/domains/forms/hooks/useGetInstances.js
@@ -1,5 +1,5 @@
-import { getRequest } from '../../../libs/Api';
-import { useSnackQuery } from '../../../libs/apiHooks';
+import { getRequest } from 'iaso/libs/Api';
+import { useSnackQuery } from 'iaso/libs/apiHooks';
 
 export const useGetInstances = ({ orgUnitId }) => {
     const params = {

--- a/hat/assets/js/apps/Iaso/domains/forms/requests.js
+++ b/hat/assets/js/apps/Iaso/domains/forms/requests.js
@@ -1,6 +1,6 @@
 import { useQueryClient } from 'react-query';
-import { useSnackQuery } from '../../libs/apiHooks';
-import { getRequest } from '../../libs/Api';
+import { useSnackQuery } from 'iaso/libs/apiHooks';
+import { getRequest } from 'iaso/libs/Api';
 
 export const useGetForm = formId =>
     useSnackQuery(

--- a/hat/assets/js/apps/Iaso/domains/instances/actions.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/actions.js
@@ -4,7 +4,7 @@ import {
     putRequest,
     patchRequest,
     deleteRequest,
-} from '../../libs/Api';
+} from 'iaso/libs/Api';
 import { enqueueSnackbar } from '../../redux/snackBarsReducer';
 import { errorSnackBar, succesfullSnackBar } from '../../constants/snackBars';
 

--- a/hat/assets/js/apps/Iaso/domains/instances/actions.spec.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/actions.spec.js
@@ -20,7 +20,7 @@ import {
     // bulkDelete,
 } from './actions';
 
-// const Api = require('../../libs/Api');
+// const Api = require('iaso/libs/Api');
 // const snackBarsReducer = require('../../redux/snackBarsReducer');
 // const snackBars = require('../../constants/snackBars');
 

--- a/hat/assets/js/apps/Iaso/domains/mappings/actions.js
+++ b/hat/assets/js/apps/Iaso/domains/mappings/actions.js
@@ -1,4 +1,4 @@
-import { getRequest, patchRequest, postRequest } from '../../libs/Api';
+import { getRequest, patchRequest, postRequest } from 'iaso/libs/Api';
 import { enqueueSnackbar } from '../../redux/snackBarsReducer';
 import { errorSnackBar } from '../../constants/snackBars';
 import { redirectTo } from '../../routing/actions';

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/actions.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/actions.js
@@ -1,6 +1,6 @@
 import { enqueueSnackbar } from '../../redux/snackBarsReducer';
 import { errorSnackBar, succesfullSnackBar } from '../../constants/snackBars';
-import { postRequest } from '../../libs/Api';
+import { postRequest } from 'iaso/libs/Api';
 import { saveAction, createAction } from '../../redux/actions/formsActions';
 
 export const SET_ORG_UNITS = 'SET_ORG_UNITS';

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/TreeView/requests.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/TreeView/requests.js
@@ -1,7 +1,7 @@
 import { useQuery } from 'react-query';
 import { iasoGetRequest } from '../../../../utils/requests';
-import { useSnackQuery } from '../../../../libs/apiHooks';
-import { getRequest } from '../../../../libs/Api';
+import { useSnackQuery } from 'iaso/libs/apiHooks';
+import { getRequest } from 'iaso/libs/Api';
 
 const getChildrenData = async id => {
     const response = await iasoGetRequest({

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/orgUnitMap/OrgUnitsMapComments.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/orgUnitMap/OrgUnitsMapComments.js
@@ -10,7 +10,7 @@ import { Box, Typography, makeStyles } from '@material-ui/core';
 import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import { useGetComments, sendComment } from '../../../../utils/requests';
-import { useSnackMutation } from '../../../../libs/apiHooks';
+import { useSnackMutation } from 'iaso/libs/apiHooks';
 
 import MESSAGES from '../../messages';
 

--- a/hat/assets/js/apps/Iaso/domains/pages/hooks/useGetPages.js
+++ b/hat/assets/js/apps/Iaso/domains/pages/hooks/useGetPages.js
@@ -1,5 +1,5 @@
-import { useSnackQuery } from '../../../libs/apiHooks';
-import { getRequest } from '../../../libs/Api';
+import { useSnackQuery } from 'iaso/libs/apiHooks';
+import { getRequest } from 'iaso/libs/Api';
 
 export const useGetPages = options => {
     const params = {

--- a/hat/assets/js/apps/Iaso/domains/pages/hooks/useGetProfiles.js
+++ b/hat/assets/js/apps/Iaso/domains/pages/hooks/useGetProfiles.js
@@ -1,5 +1,5 @@
-import { useSnackQuery } from '../../../libs/apiHooks';
-import { getRequest } from '../../../libs/Api';
+import { useSnackQuery } from 'iaso/libs/apiHooks';
+import { getRequest } from 'iaso/libs/Api';
 
 export const useGetProfiles = () =>
     useSnackQuery(

--- a/hat/assets/js/apps/Iaso/domains/pages/hooks/useRemovePage.js
+++ b/hat/assets/js/apps/Iaso/domains/pages/hooks/useRemovePage.js
@@ -1,6 +1,6 @@
 import { defineMessage } from 'react-intl';
-import { useSnackMutation } from '../../../libs/apiHooks';
-import { deleteRequest } from '../../../libs/Api';
+import { useSnackMutation } from 'iaso/libs/apiHooks';
+import { deleteRequest } from 'iaso/libs/Api';
 
 export const useRemovePage = () =>
     useSnackMutation(

--- a/hat/assets/js/apps/Iaso/domains/pages/hooks/useSavePage.js
+++ b/hat/assets/js/apps/Iaso/domains/pages/hooks/useSavePage.js
@@ -1,5 +1,5 @@
-import { useSnackMutation } from '../../../libs/apiHooks';
-import { postRequest, putRequest } from '../../../libs/Api';
+import { useSnackMutation } from 'iaso/libs/apiHooks';
+import { postRequest, putRequest } from 'iaso/libs/Api';
 
 export const useSavePage = () =>
     useSnackMutation(

--- a/hat/assets/js/apps/Iaso/redux/actions/formsActions.js
+++ b/hat/assets/js/apps/Iaso/redux/actions/formsActions.js
@@ -4,7 +4,7 @@ import {
     postRequest,
     putRequest,
     deleteRequest,
-} from '../../libs/Api';
+} from 'iaso/libs/Api';
 import { enqueueSnackbar } from '../snackBarsReducer';
 import { errorSnackBar, succesfullSnackBar } from '../../constants/snackBars';
 

--- a/hat/assets/js/apps/Iaso/utils/requests.js
+++ b/hat/assets/js/apps/Iaso/utils/requests.js
@@ -5,8 +5,8 @@ import {
     putRequest,
     deleteRequest,
     restoreRequest,
-} from '../libs/Api';
-import { useSnackQuery } from '../libs/apiHooks';
+} from 'iaso/libs/Api';
+import { useSnackQuery } from 'iaso/libs/apiHooks';
 import { enqueueSnackbar } from '../redux/snackBarsReducer';
 import { succesfullSnackBar, errorSnackBar } from '../constants/snackBars';
 import { dispatch as storeDispatch } from '../redux/store';

--- a/hat/assets/js/apps/Iaso/utils/requests.spec.js
+++ b/hat/assets/js/apps/Iaso/utils/requests.spec.js
@@ -10,7 +10,7 @@ import {
     postRequest,
     putRequest,
     restoreRequest,
-} from '../libs/Api';
+} from 'iaso/libs/Api';
 import { requestHandler } from './requests';
 
 const URL = '/api/test';

--- a/hat/webpack.dev.js
+++ b/hat/webpack.dev.js
@@ -195,15 +195,15 @@ module.exports = {
     externals: [{ './cptable': 'var cptable' }],
 
     resolve: {
-        alias:
-            process.env.LIVE_COMPONENTS === 'true'
-                ? {
-                      'bluesquare-components': path.resolve(
-                          __dirname,
-                          '../../bluesquare-components/src/',
-                      ),
-                  }
-                : undefined,
+        alias: {
+            iaso: path.resolve(__dirname, './assets/js/apps/Iaso/'),
+            ...(process.env.LIVE_COMPONENTS === 'true' && {
+                'bluesquare-components': path.resolve(
+                    __dirname,
+                    '../../bluesquare-components/src/',
+                ),
+            }),
+        },
         fallback: {
             fs: false,
         },

--- a/hat/webpack.prod.js
+++ b/hat/webpack.prod.js
@@ -171,6 +171,9 @@ module.exports = {
     externals: [{ './cptable': 'var cptable' }],
 
     resolve: {
+        alias: {
+            iaso: path.resolve(__dirname, './assets/js/apps/Iaso/'),
+        },
         fallback: {
             fs: false,
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,6 +70,7 @@
                 "eslint": "^7.25.0",
                 "eslint-config-airbnb": "^18.2.1",
                 "eslint-config-prettier": "^6.11.0",
+                "eslint-import-resolver-webpack": "^0.13.2",
                 "eslint-plugin-formatjs": "^2.17.3",
                 "eslint-plugin-import": "^2.22.1",
                 "eslint-plugin-jsx-a11y": "^6.2.3",
@@ -3812,6 +3813,12 @@
             "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
             "dev": true
         },
+        "node_modules/array-find": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/array-find/-/array-find-1.0.0.tgz",
+            "integrity": "sha1-bI4obRHtdoMn+OYuzuhzU8o+eLg=",
+            "dev": true
+        },
         "node_modules/array-find-index": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
@@ -6824,6 +6831,88 @@
                 "ms": "^2.1.1"
             }
         },
+        "node_modules/eslint-import-resolver-webpack": {
+            "version": "0.13.2",
+            "resolved": "https://registry.npmjs.org/eslint-import-resolver-webpack/-/eslint-import-resolver-webpack-0.13.2.tgz",
+            "integrity": "sha512-XodIPyg1OgE2h5BDErz3WJoK7lawxKTJNhgPNafRST6csC/MZC+L5P6kKqsZGRInpbgc02s/WZMrb4uGJzcuRg==",
+            "dev": true,
+            "dependencies": {
+                "array-find": "^1.0.0",
+                "debug": "^3.2.7",
+                "enhanced-resolve": "^0.9.1",
+                "find-root": "^1.1.0",
+                "has": "^1.0.3",
+                "interpret": "^1.4.0",
+                "is-core-module": "^2.7.0",
+                "is-regex": "^1.1.4",
+                "lodash": "^4.17.21",
+                "resolve": "^1.20.0",
+                "semver": "^5.7.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            },
+            "peerDependencies": {
+                "eslint-plugin-import": ">=1.4.0",
+                "webpack": ">=1.11.0"
+            }
+        },
+        "node_modules/eslint-import-resolver-webpack/node_modules/debug": {
+            "version": "3.2.7",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+            "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+            "dev": true,
+            "dependencies": {
+                "ms": "^2.1.1"
+            }
+        },
+        "node_modules/eslint-import-resolver-webpack/node_modules/enhanced-resolve": {
+            "version": "0.9.1",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
+            "integrity": "sha1-TW5omzcl+GCQknzMhs2fFjW4ni4=",
+            "dev": true,
+            "dependencies": {
+                "graceful-fs": "^4.1.2",
+                "memory-fs": "^0.2.0",
+                "tapable": "^0.1.8"
+            },
+            "engines": {
+                "node": ">=0.6"
+            }
+        },
+        "node_modules/eslint-import-resolver-webpack/node_modules/interpret": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+            "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "node_modules/eslint-import-resolver-webpack/node_modules/memory-fs": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz",
+            "integrity": "sha1-8rslNovBIeORwlIN6Slpyu4KApA=",
+            "dev": true
+        },
+        "node_modules/eslint-import-resolver-webpack/node_modules/semver": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+            "dev": true,
+            "bin": {
+                "semver": "bin/semver"
+            }
+        },
+        "node_modules/eslint-import-resolver-webpack/node_modules/tapable": {
+            "version": "0.1.10",
+            "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz",
+            "integrity": "sha1-KcNXB8K3DlDQdIK10gLo7URtr9Q=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.6"
+            }
+        },
         "node_modules/eslint-module-utils": {
             "version": "2.6.2",
             "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.2.tgz",
@@ -8058,6 +8147,12 @@
             "engines": {
                 "node": ">=6"
             }
+        },
+        "node_modules/find-root": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+            "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+            "dev": true
         },
         "node_modules/find-up": {
             "version": "2.1.0",
@@ -9663,9 +9758,9 @@
             }
         },
         "node_modules/is-core-module": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.6.0.tgz",
-            "integrity": "sha512-wShG8vs60jKfPWpF2KZRaAtvt3a20OAn7+IJ6hLPECpSABLcKtFKTTI4ZtH5QcBruBHlq+WsdHWyz0BCZW7svQ==",
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.0.tgz",
+            "integrity": "sha512-vd15qHsaqrRL7dtH6QNuy0ndJmRDrS9HAM1CAiSifNUFv4x1a0CCVsj18hJ1mShxIG6T2i1sO78MkP56r0nYRw==",
             "dev": true,
             "dependencies": {
                 "has": "^1.0.3"
@@ -25990,6 +26085,12 @@
             "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
             "dev": true
         },
+        "array-find": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/array-find/-/array-find-1.0.0.tgz",
+            "integrity": "sha1-bI4obRHtdoMn+OYuzuhzU8o+eLg=",
+            "dev": true
+        },
         "array-find-index": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
@@ -28502,6 +28603,71 @@
                 }
             }
         },
+        "eslint-import-resolver-webpack": {
+            "version": "0.13.2",
+            "resolved": "https://registry.npmjs.org/eslint-import-resolver-webpack/-/eslint-import-resolver-webpack-0.13.2.tgz",
+            "integrity": "sha512-XodIPyg1OgE2h5BDErz3WJoK7lawxKTJNhgPNafRST6csC/MZC+L5P6kKqsZGRInpbgc02s/WZMrb4uGJzcuRg==",
+            "dev": true,
+            "requires": {
+                "array-find": "^1.0.0",
+                "debug": "^3.2.7",
+                "enhanced-resolve": "^0.9.1",
+                "find-root": "^1.1.0",
+                "has": "^1.0.3",
+                "interpret": "^1.4.0",
+                "is-core-module": "^2.7.0",
+                "is-regex": "^1.1.4",
+                "lodash": "^4.17.21",
+                "resolve": "^1.20.0",
+                "semver": "^5.7.1"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.2.7",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+                    "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "enhanced-resolve": {
+                    "version": "0.9.1",
+                    "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
+                    "integrity": "sha1-TW5omzcl+GCQknzMhs2fFjW4ni4=",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.2",
+                        "memory-fs": "^0.2.0",
+                        "tapable": "^0.1.8"
+                    }
+                },
+                "interpret": {
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+                    "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+                    "dev": true
+                },
+                "memory-fs": {
+                    "version": "0.2.0",
+                    "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz",
+                    "integrity": "sha1-8rslNovBIeORwlIN6Slpyu4KApA=",
+                    "dev": true
+                },
+                "semver": {
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+                    "dev": true
+                },
+                "tapable": {
+                    "version": "0.1.10",
+                    "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz",
+                    "integrity": "sha1-KcNXB8K3DlDQdIK10gLo7URtr9Q=",
+                    "dev": true
+                }
+            }
+        },
         "eslint-module-utils": {
             "version": "2.6.2",
             "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.2.tgz",
@@ -29357,6 +29523,12 @@
                     }
                 }
             }
+        },
+        "find-root": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+            "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+            "dev": true
         },
         "find-up": {
             "version": "2.1.0",
@@ -30602,9 +30774,9 @@
             "dev": true
         },
         "is-core-module": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.6.0.tgz",
-            "integrity": "sha512-wShG8vs60jKfPWpF2KZRaAtvt3a20OAn7+IJ6hLPECpSABLcKtFKTTI4ZtH5QcBruBHlq+WsdHWyz0BCZW7svQ==",
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.0.tgz",
+            "integrity": "sha512-vd15qHsaqrRL7dtH6QNuy0ndJmRDrS9HAM1CAiSifNUFv4x1a0CCVsj18hJ1mShxIG6T2i1sO78MkP56r0nYRw==",
             "dev": true,
             "requires": {
                 "has": "^1.0.3"

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
         "eslint": "^7.25.0",
         "eslint-config-airbnb": "^18.2.1",
         "eslint-config-prettier": "^6.11.0",
+        "eslint-import-resolver-webpack": "^0.13.2",
         "eslint-plugin-formatjs": "^2.17.3",
         "eslint-plugin-import": "^2.22.1",
         "eslint-plugin-jsx-a11y": "^6.2.3",

--- a/plugins/polio/js/src/components/Buttons/SendEmailButton.js
+++ b/plugins/polio/js/src/components/Buttons/SendEmailButton.js
@@ -5,8 +5,8 @@ import { defineMessage } from 'react-intl';
 import { useFormikContext } from 'formik';
 import { Button, Grid, Typography, Tooltip } from '@material-ui/core';
 import { LoadingSpinner } from 'bluesquare-components';
-import { postRequest } from '../../../../../../hat/assets/js/apps/Iaso/libs/Api';
-import { useSnackMutation } from '../../../../../../hat/assets/js/apps/Iaso/libs/apiHooks';
+import { postRequest } from 'iaso/libs/Api';
+import { useSnackMutation } from 'iaso/libs/apiHooks';
 
 export const SendEmailButton = () => {
     const mutation = useSnackMutation(

--- a/plugins/polio/js/src/components/CountryNotificationsConfig/CountryNotificationsConfig.js
+++ b/plugins/polio/js/src/components/CountryNotificationsConfig/CountryNotificationsConfig.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Box, makeStyles } from '@material-ui/core';
 import { commonStyles } from 'bluesquare-components';
-import TopBar from '../../../../../../hat/assets/js/apps/Iaso/components/nav/TopBarComponent';
+import TopBar from 'iaso/components/nav/TopBarComponent';
 import { CountryNotificationsConfigTable } from './Table/CountryNotificationsConfigTable';
 
 const useStyles = makeStyles(theme => ({

--- a/plugins/polio/js/src/components/CountryNotificationsConfig/CountryNotificationsConfigModal.js
+++ b/plugins/polio/js/src/components/CountryNotificationsConfig/CountryNotificationsConfigModal.js
@@ -1,12 +1,12 @@
 import React, { useCallback, useEffect } from 'react';
 import { isEqual } from 'lodash';
 import { arrayOf, func, number, object, string } from 'prop-types';
-import ConfirmCancelDialogComponent from '../../../../../../hat/assets/js/apps/Iaso/components/dialogs/ConfirmCancelDialogComponent';
+import ConfirmCancelDialogComponent from 'iaso/components/dialogs/ConfirmCancelDialogComponent';
 import MESSAGES from '../../constants/messages';
 import { usePutCountryMutation } from './requests';
-import InputComponent from '../../../../../../hat/assets/js/apps/Iaso/components/forms/InputComponent';
-import { commaSeparatedIdsToArray } from '../../../../../../hat/assets/js/apps/Iaso/utils/forms';
-import { useFormState } from '../../../../../../hat/assets/js/apps/Iaso/hooks/form';
+import InputComponent from 'iaso/components/forms/InputComponent';
+import { commaSeparatedIdsToArray } from 'iaso/utils/forms';
+import { useFormState } from 'iaso/hooks/form';
 
 const makeDropDownListItem = user => {
     return {

--- a/plugins/polio/js/src/components/CountryNotificationsConfig/Table/CountryNotificationsConfigTable.js
+++ b/plugins/polio/js/src/components/CountryNotificationsConfig/Table/CountryNotificationsConfigTable.js
@@ -8,7 +8,7 @@ import { withRouter } from 'react-router';
 import { useGetCountryUsersGroup, useGetProfiles } from '../requests';
 import MESSAGES from '../../../constants/messages';
 import { CountryNotificationsConfigModal } from '../CountryNotificationsConfigModal';
-import { TableWithDeepLink } from '../../../../../../../hat/assets/js/apps/Iaso/components/tables/TableWithDeepLink';
+import { TableWithDeepLink } from 'iaso/components/tables/TableWithDeepLink';
 import { CONFIG_BASE_URL } from '../../../constants/routes';
 
 const makeUserNameToDisplay = user => {

--- a/plugins/polio/js/src/components/CountryNotificationsConfig/requests.js
+++ b/plugins/polio/js/src/components/CountryNotificationsConfig/requests.js
@@ -1,11 +1,5 @@
-import {
-    getRequest,
-    putRequest,
-} from '../../../../../../hat/assets/js/apps/Iaso/libs/Api';
-import {
-    useSnackMutation,
-    useSnackQuery,
-} from '../../../../../../hat/assets/js/apps/Iaso/libs/apiHooks';
+import { getRequest, putRequest } from 'iaso/libs/Api';
+import { useSnackMutation, useSnackQuery } from 'iaso/libs/apiHooks';
 
 export const useGetCountryUsersGroup = params => {
     const searchParams = new URLSearchParams({

--- a/plugins/polio/js/src/components/ImportLineListDialog.js
+++ b/plugins/polio/js/src/components/ImportLineListDialog.js
@@ -5,11 +5,11 @@ import { useMutation, useQueryClient } from 'react-query';
 import { defineMessages } from 'react-intl';
 import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
-import { useFormState } from '../../../../../hat/assets/js/apps/Iaso/hooks/form';
-import ConfirmCancelDialogComponent from '../../../../../hat/assets/js/apps/Iaso/components/dialogs/ConfirmCancelDialogComponent';
-import { iasoPostRequest } from '../../../../../hat/assets/js/apps/Iaso/utils/requests';
-import FileInputComponent from '../../../../../hat/assets/js/apps/Iaso/components/forms/FileInputComponent';
-import { enqueueSnackbar } from '../../../../../hat/assets/js/apps/Iaso/redux/snackBarsReducer';
+import { useFormState } from 'iaso/hooks/form';
+import ConfirmCancelDialogComponent from 'iaso/components/dialogs/ConfirmCancelDialogComponent';
+import { iasoPostRequest } from 'iaso/utils/requests';
+import FileInputComponent from 'iaso/components/forms/FileInputComponent';
+import { enqueueSnackbar } from 'iaso/redux/snackBarsReducer';
 
 const initialFormState = () => ({
     file: null,

--- a/plugins/polio/js/src/components/Inputs/DateInput.js
+++ b/plugins/polio/js/src/components/Inputs/DateInput.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Box } from '@material-ui/core';
 import { DatePicker } from 'bluesquare-components';
 import { get } from 'lodash';
-import { apiDateFormat } from '../../../../../../hat/assets/js/apps/Iaso/utils/dates';
+import { apiDateFormat } from 'iaso/utils/dates';
 
 import MESSAGES from '../../constants/messages';
 

--- a/plugins/polio/js/src/components/Inputs/OrgUnitsSelect.js
+++ b/plugins/polio/js/src/components/Inputs/OrgUnitsSelect.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import { CircularProgress } from '@material-ui/core';
 import PropTypes from 'prop-types';
-import { OrgUnitTreeviewModal } from '../../../../../../hat/assets/js/apps/Iaso/domains/orgUnits/components/TreeView/OrgUnitTreeviewModal';
-import { useGetOrgUnit } from '../../../../../../hat/assets/js/apps/Iaso/domains/orgUnits/components/TreeView/requests';
+import { OrgUnitTreeviewModal } from 'iaso/domains/orgUnits/components/TreeView/OrgUnitTreeviewModal';
+import { useGetOrgUnit } from 'iaso/domains/orgUnits/components/TreeView/requests';
 
 export const OrgUnitsLevels = ({ field, form, label }) => {
     const { name } = field;

--- a/plugins/polio/js/src/components/campaignCalendar/Filters.js
+++ b/plugins/polio/js/src/components/campaignCalendar/Filters.js
@@ -8,8 +8,8 @@ import { Grid, Button, Box } from '@material-ui/core';
 import FiltersIcon from '@material-ui/icons/FilterList';
 import { withRouter } from 'react-router';
 
-import InputComponent from '../../../../../../hat/assets/js/apps/Iaso/components/forms/InputComponent';
-import DatesRange from '../../../../../../hat/assets/js/apps/Iaso/components/filters/DatesRange';
+import InputComponent from 'iaso/components/forms/InputComponent';
+import DatesRange from 'iaso/components/filters/DatesRange';
 
 import MESSAGES from '../../constants/messages';
 import { useGetCountries } from '../../hooks/useGetCountries';

--- a/plugins/polio/js/src/components/campaignCalendar/constants.js
+++ b/plugins/polio/js/src/components/campaignCalendar/constants.js
@@ -1,4 +1,4 @@
-import { apiDateFormat } from '../../../../../../hat/assets/js/apps/Iaso/utils/dates';
+import { apiDateFormat } from 'iaso/utils/dates';
 
 const colsCount = 16;
 const dateFormat = apiDateFormat;

--- a/plugins/polio/js/src/components/campaignCalendar/map/CalendarMap.js
+++ b/plugins/polio/js/src/components/campaignCalendar/map/CalendarMap.js
@@ -14,7 +14,7 @@ import { appId } from '../../../constants/app';
 import { useStyles } from '../Styles';
 
 import 'leaflet/dist/leaflet.css';
-import { getRequest } from '../../../../../../../hat/assets/js/apps/Iaso/libs/Api';
+import { getRequest } from 'iaso/libs/Api';
 
 const CalendarMap = ({ campaigns, loadingCampaigns }) => {
     const classes = useStyles();

--- a/plugins/polio/js/src/hooks/useGetCampaigns.js
+++ b/plugins/polio/js/src/hooks/useGetCampaigns.js
@@ -1,5 +1,5 @@
-import { useSnackQuery } from '../../../../../hat/assets/js/apps/Iaso/libs/apiHooks';
-import { getRequest } from '../../../../../hat/assets/js/apps/Iaso/libs/Api';
+import { useSnackQuery } from 'iaso/libs/apiHooks';
+import { getRequest } from 'iaso/libs/Api';
 
 export const useGetCampaigns = options => {
     const params = {

--- a/plugins/polio/js/src/hooks/useGetCountries.js
+++ b/plugins/polio/js/src/hooks/useGetCountries.js
@@ -1,5 +1,5 @@
-import { getRequest } from '../../../../../hat/assets/js/apps/Iaso/libs/Api';
-import { useSnackQuery } from '../../../../../hat/assets/js/apps/Iaso/libs/apiHooks';
+import { getRequest } from 'iaso/libs/Api';
+import { useSnackQuery } from 'iaso/libs/apiHooks';
 import { appId } from '../constants/app';
 
 export const useGetCountries = () => {

--- a/plugins/polio/js/src/hooks/useGetGeoJson.js
+++ b/plugins/polio/js/src/hooks/useGetGeoJson.js
@@ -1,5 +1,5 @@
-import { getRequest } from '../../../../../hat/assets/js/apps/Iaso/libs/Api';
-import { useSnackQuery } from '../../../../../hat/assets/js/apps/Iaso/libs/apiHooks';
+import { getRequest } from 'iaso/libs/Api';
+import { useSnackQuery } from 'iaso/libs/apiHooks';
 
 export const useGetGeoJson = (country, orgUnitCategory) => {
     const params = {

--- a/plugins/polio/js/src/hooks/useGetPreparednessData.js
+++ b/plugins/polio/js/src/hooks/useGetPreparednessData.js
@@ -1,5 +1,5 @@
-import { useSnackMutation } from '../../../../../hat/assets/js/apps/Iaso/libs/apiHooks';
-import { postRequest } from '../../../../../hat/assets/js/apps/Iaso/libs/Api';
+import { useSnackMutation } from 'iaso/libs/apiHooks';
+import { postRequest } from 'iaso/libs/Api';
 
 // This retrieve data but since it contact data from an external service this is
 // implemented as a post

--- a/plugins/polio/js/src/hooks/useRemoveCampaign.js
+++ b/plugins/polio/js/src/hooks/useRemoveCampaign.js
@@ -1,6 +1,6 @@
 import { defineMessage } from 'react-intl';
-import { useSnackMutation } from '../../../../../hat/assets/js/apps/Iaso/libs/apiHooks';
-import { deleteRequest } from '../../../../../hat/assets/js/apps/Iaso/libs/Api';
+import { useSnackMutation } from 'iaso/libs/apiHooks';
+import { deleteRequest } from 'iaso/libs/Api';
 
 export const useRemoveCampaign = () =>
     useSnackMutation(

--- a/plugins/polio/js/src/hooks/useSaveCampaign.js
+++ b/plugins/polio/js/src/hooks/useSaveCampaign.js
@@ -1,8 +1,5 @@
-import { useSnackMutation } from '../../../../../hat/assets/js/apps/Iaso/libs/apiHooks';
-import {
-    postRequest,
-    putRequest,
-} from '../../../../../hat/assets/js/apps/Iaso/libs/Api';
+import { useSnackMutation } from 'iaso/libs/apiHooks';
+import { postRequest, putRequest } from 'iaso/libs/Api';
 
 export const useSaveCampaign = () =>
     useSnackMutation(

--- a/plugins/polio/js/src/pages/Calendar.js
+++ b/plugins/polio/js/src/pages/Calendar.js
@@ -5,7 +5,7 @@ import { Box, makeStyles, Grid } from '@material-ui/core';
 import { commonStyles, useSafeIntl } from 'bluesquare-components';
 import { useSelector } from 'react-redux';
 
-import TopBar from '../../../../../hat/assets/js/apps/Iaso/components/nav/TopBarComponent';
+import TopBar from 'iaso/components/nav/TopBarComponent';
 
 import { CampaignsCalendar } from '../components/campaignCalendar';
 import { getCampaignColor } from '../constants/campaignsColors';

--- a/plugins/polio/js/src/pages/Dashboard.js
+++ b/plugins/polio/js/src/pages/Dashboard.js
@@ -24,10 +24,10 @@ import { useRemoveCampaign } from '../hooks/useRemoveCampaign';
 import { useStyles } from '../styles/theme';
 import MESSAGES from '../constants/messages';
 
-import TopBar from '../../../../../hat/assets/js/apps/Iaso/components/nav/TopBarComponent';
+import TopBar from 'iaso/components/nav/TopBarComponent';
 import ImportLineListDialog from '../components/ImportLineListDialog';
 import { genUrl } from '../utils/routing';
-import { getApiParamDateString } from '../../../../../hat/assets/js/apps/Iaso/utils/dates';
+import { getApiParamDateString } from 'iaso/utils/dates';
 
 const DEFAULT_PAGE_SIZE = 40;
 const DEFAULT_PAGE = 1;

--- a/plugins/test/js/columns.js
+++ b/plugins/test/js/columns.js
@@ -1,5 +1,5 @@
 import MESSAGES from './messages';
-import { DateTimeCell } from '../../../hat/assets/js/apps/Iaso/components/Cells/DateTimeCell';
+import { DateTimeCell } from 'iaso/components/Cells/DateTimeCell';
 
 const TableColumns = formatMessage => [
     {

--- a/plugins/test/js/index.js
+++ b/plugins/test/js/index.js
@@ -7,13 +7,13 @@ import {
     commonStyles,
     Table,
 } from 'bluesquare-components';
-import TopBar from '../../../hat/assets/js/apps/Iaso/components/nav/TopBarComponent';
+import TopBar from 'iaso/components/nav/TopBarComponent';
 
 import tableColumns from './columns';
 import MESSAGES from './messages';
 
-import { redirectTo } from '../../../hat/assets/js/apps/Iaso/routing/actions';
-import { getRequest } from '../../../hat/assets/js/apps/Iaso/libs/Api';
+import { redirectTo } from 'iaso/routing/actions';
+import { getRequest } from 'iaso/libs/Api';
 
 const baseUrl = 'test';
 


### PR DESCRIPTION
As discussed, an example of how changing to an absolute import could work. I changed the webpack config, added a new dep for eslint so it properly resolve.
And for example I converted all the past in the plugins. And inside iaso all the calls to lib/Api.js.

For guess "rules", on when to use it, I would suggest that we use absolute imports for: 
- the import of Iaso from plugin
- the import to the root utils: utils/, lib/, redux/, constant/, components... etc..
But don't  use it from inside inside within the same directory or domain
Everywhere where we have more than 3 .. would be a good hint I guess

still have to fix the test config if we decide to use it