### PR TITLE
IA-885 & IA-901 restrict actions submissions perm

### DIFF
--- a/hat/assets/js/apps/Iaso/constants/menu.js
+++ b/hat/assets/js/apps/Iaso/constants/menu.js
@@ -21,6 +21,7 @@ import OrgUnitSvg from '../components/svg/OrgUnitSvgComponent';
 import DHIS2Svg from '../components/svg/DHIS2SvgComponent';
 import * as paths from './routes';
 import { hasFeatureFlag, SHOW_PAGES } from '../utils/featureFlags';
+import { locationLimitMax } from '../domains/orgUnits/constants/orgUnitConstants';
 
 import MESSAGES from './messages';
 
@@ -40,8 +41,7 @@ const menuItems = [
             },
             {
                 label: MESSAGES.submissionsTitle,
-                extraPath:
-                    '/tab/list/columns/form__name,updated_at,org_unit__name,created_at,status',
+                extraPath: `/tab/list/columns/form__name,updated_at,org_unit__name,created_at,status/mapResults/${locationLimitMax}`,
                 permissions: paths.instancesPath.permissions,
                 key: 'submissions',
                 icon: props => <Input {...props} />,

--- a/hat/assets/js/apps/Iaso/constants/menu.js
+++ b/hat/assets/js/apps/Iaso/constants/menu.js
@@ -21,7 +21,6 @@ import OrgUnitSvg from '../components/svg/OrgUnitSvgComponent';
 import DHIS2Svg from '../components/svg/DHIS2SvgComponent';
 import * as paths from './routes';
 import { hasFeatureFlag, SHOW_PAGES } from '../utils/featureFlags';
-import { locationLimitMax } from '../domains/orgUnits/constants/orgUnitConstants';
 
 import MESSAGES from './messages';
 
@@ -35,38 +34,39 @@ const menuItems = [
         subMenu: [
             {
                 label: MESSAGES.list,
-                permission: paths.formsPath.permission,
+                permissions: paths.formsPath.permissions,
                 key: 'list',
                 icon: props => <FormatListBulleted {...props} />,
             },
             {
                 label: MESSAGES.submissionsTitle,
-                extraPath: `/tab/list/columns/form__name,updated_at,org_unit__name,created_at,status/mapResults/${locationLimitMax}`,
-                permission: paths.instancesPath.permission,
+                extraPath:
+                    '/tab/list/columns/form__name,updated_at,org_unit__name,created_at,status',
+                permissions: paths.instancesPath.permissions,
                 key: 'submissions',
                 icon: props => <Input {...props} />,
             },
             {
                 label: MESSAGES.formsStats,
-                permission: paths.formsStatsPath.permission,
+                permissions: paths.formsStatsPath.permissions,
                 key: 'stats',
                 icon: props => <AssessmentIcon {...props} />,
             },
             {
                 label: MESSAGES.dhis2Mappings,
-                permission: paths.mappingsPath.permission,
+                permissions: paths.mappingsPath.permissions,
                 key: 'mappings',
                 icon: props => <DHIS2Svg {...props} />,
             },
             {
                 label: MESSAGES.completeness,
-                permission: paths.completenessPath.permission,
+                permissions: paths.completenessPath.permissions,
                 key: 'completeness',
                 icon: props => <DoneAll {...props} />,
             },
             {
                 label: MESSAGES.archived,
-                permission: paths.archivedPath.permission,
+                permissions: paths.archivedPath.permissions,
                 key: 'archived',
                 icon: props => <Delete {...props} />,
             },
@@ -79,19 +79,19 @@ const menuItems = [
         subMenu: [
             {
                 label: MESSAGES.list,
-                permission: paths.orgUnitsPath.permission,
+                permissions: paths.orgUnitsPath.permissions,
                 key: 'list',
                 icon: props => <FormatListBulleted {...props} />,
             },
             {
                 label: MESSAGES.groups,
-                permission: paths.groupsPath.permission,
+                permissions: paths.groupsPath.permissions,
                 key: 'groups',
                 icon: props => <GroupWork {...props} />,
             },
             {
                 label: MESSAGES.orgUnitType,
-                permission: paths.orgUnitTypesPath.permission,
+                permissions: paths.orgUnitTypesPath.permissions,
                 key: 'types',
                 icon: props => <CategoryIcon {...props} />,
             },
@@ -102,7 +102,7 @@ const menuItems = [
                 subMenu: [
                     {
                         label: MESSAGES.list,
-                        permission: paths.dataSourcesPath.permission,
+                        permissions: paths.dataSourcesPath.permissions,
                         key: 'list',
                         icon: props => <FormatListBulleted {...props} />,
                     },
@@ -113,7 +113,7 @@ const menuItems = [
                         subMenu: [
                             {
                                 label: MESSAGES.list,
-                                permission: paths.linksPath.permission,
+                                permissions: paths.linksPath.permissions,
                                 key: 'list',
                                 icon: props => (
                                     <FormatListBulleted {...props} />
@@ -121,7 +121,7 @@ const menuItems = [
                             },
                             {
                                 label: MESSAGES.algorithmsRuns,
-                                permission: paths.algosPath.permission,
+                                permissions: paths.algosPath.permissions,
                                 key: 'runs',
                                 icon: props => <CompareArrows {...props} />,
                             },
@@ -139,25 +139,25 @@ const menuItems = [
             {
                 label: MESSAGES.tasks,
                 key: 'tasks',
-                permission: paths.tasksPath.permission,
+                permissions: paths.tasksPath.permissions,
                 icon: props => <AssignmentRoundedIcon {...props} />,
             },
             {
                 label: MESSAGES.monitoring,
                 key: 'devices',
-                permission: paths.devicesPath.permission,
+                permissions: paths.devicesPath.permissions,
                 icon: props => <ImportantDevicesRoundedIcon {...props} />,
             },
             {
                 label: MESSAGES.projects,
                 key: 'projects',
-                permission: paths.projectsPath.permission,
+                permissions: paths.projectsPath.permissions,
                 icon: props => <PhonelinkSetupIcon {...props} />,
             },
             {
                 label: MESSAGES.users,
                 key: 'users',
-                permission: paths.usersPath.permission,
+                permissions: paths.usersPath.permissions,
                 icon: props => <SupervisorAccount {...props} />,
             },
         ],
@@ -172,7 +172,7 @@ const getMenuItems = (currentUser, enabledPlugins) => {
             label: MESSAGES.pages,
             key: 'pages',
             icon: props => <BookIcon {...props} />,
-            permission: paths.pagesPath.permission,
+            permissions: paths.pagesPath.permissions,
         });
     }
     return [...basicItems, ...pluginsMenu];

--- a/hat/assets/js/apps/Iaso/constants/routes.js
+++ b/hat/assets/js/apps/Iaso/constants/routes.js
@@ -105,7 +105,7 @@ export const archivedPath = {
 
 export const formDetailPath = {
     baseUrl: baseUrls.formDetail,
-    permissions: ['iaso_forms'],
+    permissions: ['iaso_forms', 'iaso_submissions'],
     component: props => <FormDetail {...props} />,
     params: [
         {

--- a/hat/assets/js/apps/Iaso/constants/routes.js
+++ b/hat/assets/js/apps/Iaso/constants/routes.js
@@ -61,7 +61,7 @@ export const getPath = path => {
 
 export const formsPath = {
     baseUrl: baseUrls.forms,
-    permission: 'iaso_forms',
+    permissions: ['iaso_forms', 'iaso_submissions'],
     params: [
         ...paginationPathParams,
         {
@@ -79,7 +79,7 @@ export const formsPath = {
 
 export const pagesPath = {
     baseUrl: baseUrls.pages,
-    permission: 'iaso_pages',
+    permissions: ['iaso_pages'],
     featureFlag: SHOW_PAGES,
     params: [],
     component: props => <Pages {...props} />,
@@ -87,7 +87,7 @@ export const pagesPath = {
 
 export const archivedPath = {
     baseUrl: baseUrls.archived,
-    permission: 'iaso_forms',
+    permissions: ['iaso_forms', 'iaso_submissions'],
     params: [
         ...paginationPathParams,
         {
@@ -105,7 +105,7 @@ export const archivedPath = {
 
 export const formDetailPath = {
     baseUrl: baseUrls.formDetail,
-    permission: 'iaso_forms',
+    permissions: ['iaso_forms'],
     component: props => <FormDetail {...props} />,
     params: [
         {
@@ -118,7 +118,7 @@ export const formDetailPath = {
 
 export const mappingsPath = {
     baseUrl: baseUrls.mappings,
-    permission: 'iaso_mappings',
+    permissions: ['iaso_mappings'],
     component: props => <Mappings {...props} />,
     params: [
         {
@@ -134,7 +134,7 @@ export const mappingsPath = {
 
 export const mappingDetailPath = {
     baseUrl: baseUrls.mappingDetail,
-    permission: 'iaso_mappings',
+    permissions: ['iaso_mappings'],
     component: props => <MappingDetails {...props} />,
     params: [
         {
@@ -150,7 +150,7 @@ export const mappingDetailPath = {
 
 export const instancesPath = {
     baseUrl: baseUrls.instances,
-    permission: 'iaso_submissions',
+    permissions: ['iaso_submissions'],
     component: props => <Instances {...props} />,
     params: [
         {
@@ -219,7 +219,7 @@ export const instancesPath = {
 
 export const instanceDetailPath = {
     baseUrl: baseUrls.instanceDetail,
-    permission: 'iaso_forms',
+    permissions: ['iaso_forms', 'iaso_submissions'],
     component: props => <InstanceDetail {...props} />,
     params: [
         {
@@ -231,14 +231,14 @@ export const instanceDetailPath = {
 
 export const formsStatsPath = {
     baseUrl: baseUrls.formsStats,
-    permission: 'iaso_forms',
+    permissions: ['iaso_forms'],
     component: () => <FormsStats />,
     params: [],
 };
 
 export const orgUnitsPath = {
     baseUrl: baseUrls.orgUnits,
-    permission: 'iaso_org_units',
+    permissions: ['iaso_org_units'],
     component: props => <OrgUnits {...props} />,
     params: [
         {
@@ -281,7 +281,7 @@ const linksFiltersPathParamsWithPrefix = prefix =>
 
 export const orgUnitsDetailsPath = {
     baseUrl: baseUrls.orgUnitDetails,
-    permission: 'iaso_org_units',
+    permissions: ['iaso_org_units'],
     component: props => <OrgUnitDetail {...props} />,
     params: [
         {
@@ -312,7 +312,7 @@ export const orgUnitsDetailsPath = {
 
 export const linksPath = {
     baseUrl: baseUrls.links,
-    permission: 'iaso_links',
+    permissions: ['iaso_links'],
     component: props => <Links {...props} />,
     params: [
         {
@@ -373,7 +373,7 @@ export const linksPath = {
 
 export const algosPath = {
     baseUrl: baseUrls.algos,
-    permission: 'iaso_links',
+    permissions: ['iaso_links'],
     component: props => <Runs {...props} />,
     params: [
         {
@@ -410,14 +410,14 @@ export const algosPath = {
 
 export const completenessPath = {
     baseUrl: baseUrls.completeness,
-    permission: 'iaso_completeness',
+    permissions: ['iaso_completeness'],
     component: props => <Completeness {...props} />,
     params: [],
 };
 
 export const usersPath = {
     baseUrl: baseUrls.users,
-    permission: 'iaso_users',
+    permissions: ['iaso_users'],
     component: props => <Users {...props} />,
     params: [
         {
@@ -433,35 +433,35 @@ export const usersPath = {
 
 export const projectsPath = {
     baseUrl: baseUrls.projects,
-    permission: 'iaso_projects',
+    permissions: ['iaso_projects'],
     component: props => <Projects {...props} />,
     params: [...paginationPathParams],
 };
 
 export const dataSourcesPath = {
     baseUrl: baseUrls.sources,
-    permission: 'iaso_sources',
+    permissions: ['iaso_sources'],
     component: props => <DataSources {...props} />,
     params: [...paginationPathParams],
 };
 
 export const tasksPath = {
     baseUrl: baseUrls.tasks,
-    permission: 'iaso_data_tasks',
+    permissions: ['iaso_data_tasks'],
     component: props => <Tasks {...props} />,
     params: [...paginationPathParams],
 };
 
 export const devicesPath = {
     baseUrl: baseUrls.devices,
-    permission: 'iaso_data_devices',
+    permissions: ['iaso_data_devices'],
     component: props => <Devices {...props} />,
     params: [...paginationPathParams],
 };
 
 export const groupsPath = {
     baseUrl: baseUrls.groups,
-    permission: 'iaso_org_units',
+    permissions: ['iaso_org_units'],
     component: props => <Groups {...props} />,
     params: [
         {
@@ -476,7 +476,7 @@ export const groupsPath = {
 };
 export const orgUnitTypesPath = {
     baseUrl: baseUrls.orgUnitTypes,
-    permission: 'iaso_org_units',
+    permissions: ['iaso_org_units'],
     component: props => <Types {...props} />,
     params: [
         {

--- a/hat/assets/js/apps/Iaso/domains/forms/config.js
+++ b/hat/assets/js/apps/Iaso/domains/forms/config.js
@@ -6,7 +6,7 @@ import { IconButton as IconButtonComponent } from 'bluesquare-components';
 import FormVersionsDialog from './components/FormVersionsDialogComponent';
 import { baseUrls } from '../../constants/urls';
 import { getOrgUnitParentsIds } from '../orgUnits/utils';
-
+import { userHasPermission } from '../users/utils';
 import MESSAGES from './messages';
 import DeleteDialog from '../../components/dialogs/DeleteDialogComponent';
 import { DateTimeCell } from '../../components/Cells/DateTimeCell';
@@ -75,9 +75,11 @@ export const formVersionsTableColumns = (
 const formsTableColumns = ({
     formatMessage,
     component,
-    showEditAction = true,
-    showMappingAction = true,
-    showDeleteAction = true,
+    user,
+    // showGoInstancesAction = true,
+    // showEditAction = true,
+    // showMappingAction = true,
+    // showDeleteAction = true,
     deleteForm = () => null,
 }) => [
     {
@@ -180,26 +182,28 @@ const formsTableColumns = ({
 
             return (
                 <section>
-                    <IconButtonComponent
-                        url={`${urlToInstances}`}
-                        icon="remove-red-eye"
-                        tooltipMessage={MESSAGES.viewInstances}
-                    />
-                    {showEditAction && (
+                    {userHasPermission('iaso_submissions', user) && (
+                        <IconButtonComponent
+                            url={`${urlToInstances}`}
+                            icon="remove-red-eye"
+                            tooltipMessage={MESSAGES.viewInstances}
+                        />
+                    )}
+                    {userHasPermission('iaso_forms', user) && (
                         <IconButtonComponent
                             url={`${baseUrls.formDetail}/formId/${settings.row.original.id}`}
                             icon="edit"
                             tooltipMessage={MESSAGES.edit}
                         />
                     )}
-                    {showMappingAction && (
+                    {userHasPermission('iaso_forms', user) && (
                         <IconButtonComponent
                             url={`/forms/mappings/formId/${settings.row.original.id}/order/form_version__form__name,form_version__version_id,mapping__mapping_type/pageSize/20/page/1`}
                             icon="dhis"
                             tooltipMessage={MESSAGES.dhis2Mappings}
                         />
                     )}
-                    {showDeleteAction && (
+                    {userHasPermission('iaso_forms', user) && (
                         <DeleteDialog
                             titleMessage={MESSAGES.deleteFormTitle}
                             message={MESSAGES.deleteFormText}

--- a/hat/assets/js/apps/Iaso/domains/forms/config.js
+++ b/hat/assets/js/apps/Iaso/domains/forms/config.js
@@ -5,7 +5,6 @@ import { Link } from 'react-router';
 import { IconButton as IconButtonComponent } from 'bluesquare-components';
 import FormVersionsDialog from './components/FormVersionsDialogComponent';
 import { baseUrls } from '../../constants/urls';
-import { getOrgUnitParentsIds } from '../orgUnits/utils';
 import { userHasPermission } from '../users/utils';
 import MESSAGES from './messages';
 import DeleteDialog from '../../components/dialogs/DeleteDialogComponent';

--- a/hat/assets/js/apps/Iaso/domains/forms/config.js
+++ b/hat/assets/js/apps/Iaso/domains/forms/config.js
@@ -74,12 +74,7 @@ export const formVersionsTableColumns = (
 
 const formsTableColumns = ({
     formatMessage,
-    component,
     user,
-    // showGoInstancesAction = true,
-    // showEditAction = true,
-    // showMappingAction = true,
-    // showDeleteAction = true,
     deleteForm = () => null,
 }) => [
     {
@@ -167,18 +162,7 @@ const formsTableColumns = ({
         width: 250,
         accessor: 'actions',
         Cell: settings => {
-            let urlToInstances = `${baseUrls.instances}/formIds/${settings.row.original.id}/tab/list/columns/updated_at,org_unit__name,created_at,status`;
-            if (
-                component &&
-                component.state &&
-                component.state.currentOrgUnit !== undefined
-            ) {
-                const parentIds = getOrgUnitParentsIds(
-                    component.state.currentOrgUnit,
-                );
-                parentIds.push(component.state.currentOrgUnit.id);
-                urlToInstances += `/levels/${parentIds.join(',')}`;
-            }
+            const urlToInstances = `${baseUrls.instances}/formIds/${settings.row.original.id}/tab/list/columns/updated_at,org_unit__name,created_at,status`;
 
             return (
                 <section>

--- a/hat/assets/js/apps/Iaso/domains/forms/config.js
+++ b/hat/assets/js/apps/Iaso/domains/forms/config.js
@@ -77,7 +77,8 @@ const formsTableColumns = (
     component,
     showEditAction = true,
     showMappingAction = true,
-    deleteForm = null,
+    showDeleteAction = true,
+    deleteForm = () => null,
 ) => [
     {
         Header: formatMessage(MESSAGES.name),
@@ -198,15 +199,17 @@ const formsTableColumns = (
                             tooltipMessage={MESSAGES.dhis2Mappings}
                         />
                     )}
-                    <DeleteDialog
-                        titleMessage={MESSAGES.deleteFormTitle}
-                        message={MESSAGES.deleteFormText}
-                        onConfirm={closeDialog =>
-                            deleteForm(settings.row.original.id).then(
-                                closeDialog,
-                            )
-                        }
-                    />
+                    {showDeleteAction && (
+                        <DeleteDialog
+                            titleMessage={MESSAGES.deleteFormTitle}
+                            message={MESSAGES.deleteFormText}
+                            onConfirm={closeDialog =>
+                                deleteForm(settings.row.original.id).then(
+                                    closeDialog,
+                                )
+                            }
+                        />
+                    )}
                 </section>
             );
         },

--- a/hat/assets/js/apps/Iaso/domains/forms/config.js
+++ b/hat/assets/js/apps/Iaso/domains/forms/config.js
@@ -72,14 +72,14 @@ export const formVersionsTableColumns = (
     },
 ];
 
-const formsTableColumns = (
+const formsTableColumns = ({
     formatMessage,
     component,
     showEditAction = true,
     showMappingAction = true,
     showDeleteAction = true,
     deleteForm = () => null,
-) => [
+}) => [
     {
         Header: formatMessage(MESSAGES.name),
         accessor: 'name',

--- a/hat/assets/js/apps/Iaso/domains/forms/config.spec.js
+++ b/hat/assets/js/apps/Iaso/domains/forms/config.spec.js
@@ -129,6 +129,7 @@ describe('Forms config', () => {
                     defaultProps,
                     false,
                     false,
+                    true,
                     () => {
                         deleteFormSpy();
                         return new Promise(resolve => resolve());
@@ -160,6 +161,7 @@ describe('Forms config', () => {
                     { ...defaultProps, state: { currentOrgUnit: { id: 1 } } },
                     false,
                     false,
+                    false,
                 );
                 actionColumn = columns[columns.length - 1];
                 wrapper = shallow(actionColumn.Cell(colOriginal(tempForm)));
@@ -178,6 +180,7 @@ describe('Forms config', () => {
             columns = archivedTableColumn(
                 () => null,
                 () => restoreFormSpy(),
+                true,
             );
             expect(columns).to.have.lengthOf(9);
         });
@@ -207,8 +210,8 @@ describe('Forms config', () => {
                 }
             });
         });
-        describe('action colmumn', () => {
-            it('should render restore icon', () => {
+        describe('action column', () => {
+            it('should render restore icon if user has permission', () => {
                 actionColumn = columns[columns.length - 1];
                 wrapper = shallow(actionColumn.Cell(colOriginal(fakeForm)));
                 restoreIcon = wrapper.find('[icon="restore-from-trash"]');

--- a/hat/assets/js/apps/Iaso/domains/forms/config.spec.js
+++ b/hat/assets/js/apps/Iaso/domains/forms/config.spec.js
@@ -10,14 +10,6 @@ import formVersionsfixture from './fixtures/formVersions.json';
 
 import { colOriginal } from '../../../../test/utils';
 
-const defaultProps = {
-    state: {
-        currentOrgUnit: undefined,
-    },
-    setState: () => null,
-    deleteForm: () => null,
-};
-
 const superUser = {
     is_superuser: true,
 };
@@ -53,7 +45,7 @@ let restoreFormSpy;
 let restoreIcon;
 const setForceRefreshSpy = sinon.spy();
 
-describe.only('Forms config', () => {
+describe('Forms config', () => {
     describe('formVersionsTableColumns', () => {
         it('sould return an array of 4 columns', () => {
             formVersionscolumns = formVersionsTableColumns(
@@ -109,7 +101,6 @@ describe.only('Forms config', () => {
         it('sould return an array of 9 columns', () => {
             columns = formsTableColumns({
                 formatMessage: () => null,
-                component: defaultProps,
             });
             expect(columns).to.have.lengthOf(9);
         });
@@ -239,25 +230,6 @@ describe.only('Forms config', () => {
                 expect(deleteDialog).to.have.lengthOf(1);
                 deleteDialog.props().onConfirm();
                 expect(deleteFormSpy.calledOnce).to.equal(true);
-            });
-            it('should change url if currentOrg unit is defined and display red eye icon', () => {
-                const tempForm = { ...fakeForm };
-                tempForm.instances_count = 5;
-                columns = formsTableColumns({
-                    formatMessage: () => null,
-                    component: {
-                        ...defaultProps,
-                        state: { currentOrgUnit: { id: 1 } },
-                    },
-                    user: userWithSubmissionsPermission,
-                });
-                actionColumn = columns[columns.length - 1];
-                wrapper = shallow(actionColumn.Cell(colOriginal(tempForm)));
-                const redEyeIcon = wrapper.find('[icon="remove-red-eye"]');
-                expect(redEyeIcon.prop('url')).to.equal(
-                    'forms/submissions/formIds/69/tab/list/columns/updated_at,org_unit__name,created_at,status/levels/1',
-                );
-                expect(redEyeIcon).to.have.lengthOf(1);
             });
         });
     });

--- a/hat/assets/js/apps/Iaso/domains/forms/configArchived.js
+++ b/hat/assets/js/apps/Iaso/domains/forms/configArchived.js
@@ -9,100 +9,108 @@ const archivedTableColumn = (
     formatMessage,
     restoreForm,
     hasPermission = false,
-) => [
-    {
-        Header: formatMessage(MESSAGES.name),
-        accessor: 'name',
-    },
-    {
-        Header: formatMessage(MESSAGES.form_id),
-        sortable: false,
-        accessor: 'form_id',
-    },
-    {
-        Header: formatMessage(MESSAGES.type),
-        sortable: false,
-        accessor: 'org_unit_types',
-        Cell: settings =>
-            settings.row.original.org_unit_types
-                .map(o => o.short_name)
-                .join(', '),
-    },
-    {
-        Header: formatMessage(MESSAGES.records),
-        accessor: 'instances_count',
-    },
-    {
-        Header: formatMessage(MESSAGES.latest_version_files),
-        accessor: 'latest_version_files',
-        sortable: false,
-        Cell: settings =>
-            settings.row.original.latest_form_version !== null && (
-                <Grid container spacing={1} justifyContent="center">
-                    <Grid item>
-                        {settings.row.original.latest_form_version.version_id}
-                    </Grid>
+) => {
+    const columns = [
+        {
+            Header: formatMessage(MESSAGES.name),
+            accessor: 'name',
+        },
+        {
+            Header: formatMessage(MESSAGES.form_id),
+            sortable: false,
+            accessor: 'form_id',
+        },
+        {
+            Header: formatMessage(MESSAGES.type),
+            sortable: false,
+            accessor: 'org_unit_types',
+            Cell: settings =>
+                settings.row.original.org_unit_types
+                    .map(o => o.short_name)
+                    .join(', '),
+        },
+        {
+            Header: formatMessage(MESSAGES.records),
+            accessor: 'instances_count',
+        },
+        {
+            Header: formatMessage(MESSAGES.latest_version_files),
+            accessor: 'latest_version_files',
+            sortable: false,
+            Cell: settings =>
+                settings.row.original.latest_form_version !== null && (
                     <Grid container spacing={1} justifyContent="center">
-                        {settings.row.original.latest_form_version.xls_file && (
+                        <Grid item>
+                            {
+                                settings.row.original.latest_form_version
+                                    .version_id
+                            }
+                        </Grid>
+                        <Grid container spacing={1} justifyContent="center">
+                            {settings.row.original.latest_form_version
+                                .xls_file && (
+                                <Grid item>
+                                    <Link
+                                        download
+                                        href={
+                                            settings.row.original
+                                                .latest_form_version.xls_file
+                                        }
+                                    >
+                                        XLS
+                                    </Link>
+                                </Grid>
+                            )}
                             <Grid item>
                                 <Link
                                     download
                                     href={
                                         settings.row.original
-                                            .latest_form_version.xls_file
+                                            .latest_form_version.file
                                     }
                                 >
-                                    XLS
+                                    XML
                                 </Link>
                             </Grid>
-                        )}
-                        <Grid item>
-                            <Link
-                                download
-                                href={
-                                    settings.row.original.latest_form_version
-                                        .file
-                                }
-                            >
-                                XML
-                            </Link>
                         </Grid>
                     </Grid>
-                </Grid>
-            ),
-    },
-    {
-        Header: formatMessage(MESSAGES.created_at),
-        accessor: 'created_at',
-        Cell: DateTimeCell,
-    },
-    {
-        Header: formatMessage(MESSAGES.updated_at),
-        accessor: 'updated_at',
-        Cell: DateTimeCell,
-    },
-    {
-        Header: formatMessage(MESSAGES.deleted_at),
-        accessor: 'deleted_at',
-        Cell: DateTimeCell,
-    },
-    {
-        Header: formatMessage(MESSAGES.actions),
-        accessor: 'actions',
-        resizable: false,
-        sortable: false,
-        width: 300,
-        Cell: settings => (
-            <section>
-                {hasPermission && (
+                ),
+        },
+        {
+            Header: formatMessage(MESSAGES.created_at),
+            accessor: 'created_at',
+            Cell: DateTimeCell,
+        },
+        {
+            Header: formatMessage(MESSAGES.updated_at),
+            accessor: 'updated_at',
+            Cell: DateTimeCell,
+        },
+        {
+            Header: formatMessage(MESSAGES.deleted_at),
+            accessor: 'deleted_at',
+            Cell: DateTimeCell,
+        },
+        {
+            Header: formatMessage(MESSAGES.actions),
+            accessor: 'actions',
+            resizable: false,
+            sortable: false,
+            width: 300,
+            Cell: settings => (
+                <section>
                     <IconButtonComponent
                         onClick={() => restoreForm(settings.row.original.id)}
                         icon="restore-from-trash"
                         tooltipMessage={MESSAGES.restoreFormTooltip}
                     />
-                )}
-            </section>
-        ),
-    },
-];
+                </section>
+            ),
+        },
+    ];
+    if (!hasPermission) {
+        columns.pop();
+    }
+    return columns;
+};
 export default archivedTableColumn;

--- a/hat/assets/js/apps/Iaso/domains/forms/configArchived.js
+++ b/hat/assets/js/apps/Iaso/domains/forms/configArchived.js
@@ -1,15 +1,15 @@
 import React from 'react';
-import moment from 'moment';
 import { Grid } from '@material-ui/core';
 import { Link } from 'react-router';
-import {
-    textPlaceholder,
-    IconButton as IconButtonComponent,
-} from 'bluesquare-components';
+import { IconButton as IconButtonComponent } from 'bluesquare-components';
 import MESSAGES from './messages';
 import { DateTimeCell } from '../../components/Cells/DateTimeCell';
 
-const archivedTableColumn = (formatMessage, restoreForm) => [
+const archivedTableColumn = (
+    formatMessage,
+    restoreForm,
+    hasPermission = false,
+) => [
     {
         Header: formatMessage(MESSAGES.name),
         accessor: 'name',
@@ -94,11 +94,13 @@ const archivedTableColumn = (formatMessage, restoreForm) => [
         width: 300,
         Cell: settings => (
             <section>
-                <IconButtonComponent
-                    onClick={() => restoreForm(settings.row.original.id)}
-                    icon="restore-from-trash"
-                    tooltipMessage={MESSAGES.restoreFormTooltip}
-                />
+                {hasPermission && (
+                    <IconButtonComponent
+                        onClick={() => restoreForm(settings.row.original.id)}
+                        icon="restore-from-trash"
+                        tooltipMessage={MESSAGES.restoreFormTooltip}
+                    />
+                )}
             </section>
         ),
     },

--- a/hat/assets/js/apps/Iaso/domains/forms/index.js
+++ b/hat/assets/js/apps/Iaso/domains/forms/index.js
@@ -47,9 +47,7 @@ const Forms = ({ params, showOnlyDeleted }) => {
           )
         : formsTableColumns({
               formatMessage: intl.formatMessage,
-              showEditAction: userHasFormsPermission,
-              showMappingAction: userHasFormsPermission,
-              showDeleteAction: userHasFormsPermission,
+              user: currentUser,
               deleteForm: handleDeleteForm,
           });
     const reduxPage = useSelector(state => state.forms.formsPage);

--- a/hat/assets/js/apps/Iaso/domains/forms/index.js
+++ b/hat/assets/js/apps/Iaso/domains/forms/index.js
@@ -22,11 +22,14 @@ import MESSAGES from './messages';
 
 import { baseUrls } from '../../constants/urls';
 import { formsFilters } from '../../constants/filters';
+import { userHasPermission } from '../users/utils';
 
 const Forms = ({ params, showOnlyDeleted }) => {
     const baseUrl = showOnlyDeleted ? baseUrls.archived : baseUrls.forms;
     const intl = useSafeIntl();
     const dispatch = useDispatch();
+    const currentUser = useSelector(state => state.users.current);
+    const userHasFormsPermission = userHasPermission('forms', currentUser);
     const [forceRefresh, setForceRefresh] = useState(false);
     const handleDeleteForm = formId =>
         deleteForm(dispatch, formId).then(() => {
@@ -41,8 +44,9 @@ const Forms = ({ params, showOnlyDeleted }) => {
         : formsTableColumns(
               intl.formatMessage,
               null,
-              true,
-              true,
+              userHasFormsPermission,
+              userHasFormsPermission,
+              userHasFormsPermission,
               handleDeleteForm,
           );
     const reduxPage = useSelector(state => state.forms.formsPage);

--- a/hat/assets/js/apps/Iaso/domains/forms/index.js
+++ b/hat/assets/js/apps/Iaso/domains/forms/index.js
@@ -29,7 +29,7 @@ const Forms = ({ params, showOnlyDeleted }) => {
     const intl = useSafeIntl();
     const dispatch = useDispatch();
     const currentUser = useSelector(state => state.users.current);
-    const userHasFormsPermission = userHasPermission('forms', currentUser);
+    const userHasFormsPermission = userHasPermission('iaso_forms', currentUser);
     const [forceRefresh, setForceRefresh] = useState(false);
     const handleDeleteForm = formId =>
         deleteForm(dispatch, formId).then(() => {
@@ -40,15 +40,18 @@ const Forms = ({ params, showOnlyDeleted }) => {
             setForceRefresh(true);
         });
     const columnsConfig = showOnlyDeleted
-        ? archivedFormsTableColumns(intl.formatMessage, handleRestoreForm)
-        : formsTableColumns(
+        ? archivedFormsTableColumns(
               intl.formatMessage,
-              null,
+              handleRestoreForm,
               userHasFormsPermission,
-              userHasFormsPermission,
-              userHasFormsPermission,
-              handleDeleteForm,
-          );
+          )
+        : formsTableColumns({
+              formatMessage: intl.formatMessage,
+              showEditAction: userHasFormsPermission,
+              showMappingAction: userHasFormsPermission,
+              showDeleteAction: userHasFormsPermission,
+              deleteForm: handleDeleteForm,
+          });
     const reduxPage = useSelector(state => state.forms.formsPage);
 
     useEffect(() => {
@@ -80,7 +83,8 @@ const Forms = ({ params, showOnlyDeleted }) => {
                 onForceRefreshDone={() => setForceRefresh(false)}
                 results={reduxPage}
                 extraComponent={
-                    !showOnlyDeleted && (
+                    !showOnlyDeleted &&
+                    userHasFormsPermission && (
                         <AddButtonComponent
                             onClick={() => {
                                 dispatch(

--- a/hat/assets/js/apps/Iaso/domains/forms/index.js
+++ b/hat/assets/js/apps/Iaso/domains/forms/index.js
@@ -55,6 +55,8 @@ const Forms = ({ params, showOnlyDeleted }) => {
     useEffect(() => {
         dispatch(fetchAllProjects());
         dispatch(fetchAllOrgUnitTypes());
+        // This fix a bug in redux cache when we passed from "archived" to "non-archived" form page and vice versa
+        setForceRefresh(true);
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
     return (

--- a/hat/assets/js/apps/Iaso/domains/instances/constants.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/constants.js
@@ -7,6 +7,8 @@ import { usePrettyPeriod } from '../periods/utils';
 import { OrgUnitLabel } from '../orgUnits/utils';
 import MESSAGES from './messages';
 import { Link } from 'react-router';
+import { useSelector } from 'react-redux';
+import { userHasPermission } from '../users/utils';
 
 export const INSTANCE_STATUS_READY = 'READY';
 export const INSTANCE_STATUS_ERROR = 'ERROR';
@@ -21,6 +23,15 @@ export const INSTANCE_STATUSES = [
 const PrettyPeriod = ({ value }) => {
     const formatPeriod = usePrettyPeriod();
     return formatPeriod(value);
+};
+
+const LinkToForm = ({ formId, formName }) => {
+    const user = useSelector(state => state.users.current);
+    if (userHasPermission('iaso_forms', user)) {
+        const formUrl = `/forms/detail/formId/${formId}`;
+        return <Link to={formUrl}>{formName}</Link>;
+    }
+    return formName;
 };
 
 export const INSTANCE_METAS_FIELDS = [
@@ -40,8 +51,9 @@ export const INSTANCE_METAS_FIELDS = [
         type: 'info',
         Cell: settings => {
             const data = settings.row.original;
-            const formUrl = `/forms/detail/formId/${data.form_id}`;
-            return <Link to={formUrl}>{data.form_name}</Link>;
+            return (
+                <LinkToForm formId={data.form_id} formName={data.form_name} />
+            );
         },
     },
     {

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/details.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/details.js
@@ -126,12 +126,13 @@ class OrgUnitDetail extends Component {
             orgUnitModified: false,
             orgUnitLocationModified: false,
             sourcesSelected: undefined,
-            tableColumns: formsTableColumns(
-                props.intl.formatMessage,
-                this,
-                false,
-                false,
-            ),
+            tableColumns: formsTableColumns({
+                formatMessage: props.intl.formatMessage,
+                component: this,
+                showEditAction: false,
+                showMappingAction: false,
+                showDeleteAction: true,
+            }),
         };
     }
 

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/details.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/details.js
@@ -134,7 +134,6 @@ class OrgUnitDetail extends Component {
             sourcesSelected: undefined,
             tableColumns: formsTableColumns({
                 formatMessage: props.intl.formatMessage,
-                component: this,
                 user: this.props.currentUser,
                 deleteForm: this.handleDeleteForm,
             }),

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/details.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/details.js
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 import React, { Component } from 'react';
 import omit from 'lodash/omit';
 import { connect } from 'react-redux';
@@ -44,6 +45,7 @@ import {
     fetchAlgorithmRuns,
     saveLink,
     fetchAssociatedOrgUnits,
+    deleteForm,
 } from '../../utils/requests';
 import {
     getAliasesArrayFromString,
@@ -120,6 +122,9 @@ const initialOrgUnit = {
 class OrgUnitDetail extends Component {
     constructor(props) {
         super(props);
+        this.handleDeleteForm = this.handleDeleteForm.bind(this);
+        this.resetSingleTableForceRefresh =
+            this.resetSingleTableForceRefresh.bind(this);
         this.state = {
             tab: props.params.tab ? props.params.tab : 'infos',
             currentOrgUnit: undefined,
@@ -132,7 +137,9 @@ class OrgUnitDetail extends Component {
                 showEditAction: false,
                 showMappingAction: false,
                 showDeleteAction: true,
+                deleteForm: this.handleDeleteForm,
             }),
+            forceSingleTableRefresh: false,
         };
     }
 
@@ -322,6 +329,12 @@ class OrgUnitDetail extends Component {
         dispatch(setFetchingDetail(false));
     }
 
+    async handleDeleteForm(formId) {
+        const { dispatch } = this.props;
+        await deleteForm(dispatch, formId);
+        this.setState({ forceSingleTableRefresh: true });
+    }
+
     setOrgUnitLocationModified(orgUnitLocationModified = true) {
         this.setState({
             orgUnitLocationModified,
@@ -332,6 +345,10 @@ class OrgUnitDetail extends Component {
         this.setState({
             currentOrgUnit: undefined,
         });
+    }
+
+    resetSingleTableForceRefresh() {
+        this.setState({ forceSingleTableRefresh: false });
     }
 
     fetchDetail() {
@@ -576,6 +593,12 @@ class OrgUnitDetail extends Component {
                                         pages,
                                     );
                                 }}
+                                forceRefresh={
+                                    this.state.forceSingleTableRefresh
+                                }
+                                onForceRefreshDone={() =>
+                                    this.resetSingleTableForceRefresh()
+                                }
                             />
                         )}
                         <div

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/details.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/details.js
@@ -72,6 +72,7 @@ import {
 import { orgUnitsTableColumns } from './config';
 import { linksTableColumns } from '../links/config';
 import { OrgUnitsMapComments } from './components/orgUnitMap/OrgUnitsMapComments';
+import { userHasPermission } from '../users/utils';
 
 const baseUrl = baseUrls.orgUnitDetails;
 
@@ -134,9 +135,7 @@ class OrgUnitDetail extends Component {
             tableColumns: formsTableColumns({
                 formatMessage: props.intl.formatMessage,
                 component: this,
-                showEditAction: false,
-                showMappingAction: false,
-                showDeleteAction: true,
+                user: this.props.currentUser,
                 deleteForm: this.handleDeleteForm,
             }),
             forceSingleTableRefresh: false,
@@ -454,7 +453,7 @@ class OrgUnitDetail extends Component {
                 }`;
             }
         }
-        const tabs = [
+        const allTabs = [
             'infos',
             'map',
             'children',
@@ -463,6 +462,10 @@ class OrgUnitDetail extends Component {
             'forms',
             'comments',
         ];
+
+        const tabs = userHasPermission('iaso_forms', this.props.currentUser)
+            ? allTabs
+            : allTabs.filter(t => t !== 'forms');
         return (
             <section className={classes.root}>
                 <TopBar
@@ -735,6 +738,7 @@ OrgUnitDetail.propTypes = {
     algorithms: PropTypes.array.isRequired,
     algorithmRuns: PropTypes.array.isRequired,
     fetchUsersProfiles: PropTypes.func.isRequired,
+    currentUser: PropTypes.object.isRequired,
 };
 
 const MapStateToProps = state => ({
@@ -747,6 +751,7 @@ const MapStateToProps = state => ({
     profiles: state.users.list,
     algorithms: state.links.algorithmsList,
     algorithmRuns: state.links.algorithmRunsList,
+    currentUser: state.users.current,
 });
 
 const MapDispatchToProps = dispatch => ({

--- a/hat/assets/js/apps/Iaso/domains/users/components/ProtectedRoute.js
+++ b/hat/assets/js/apps/Iaso/domains/users/components/ProtectedRoute.js
@@ -9,7 +9,7 @@ import SidebarMenu from '../../app/components/SidebarMenuComponent';
 import { fetchCurrentUser as fetchCurrentUserAction } from '../actions';
 import { redirectTo as redirectToAction } from '../../../routing/actions';
 
-import { userHasPermission, getFirstAllowedUrl } from '../utils';
+import { userHasOneOfPermissions, getFirstAllowedUrl } from '../utils';
 
 import PageError from '../../../components/errors/PageError';
 import { switchLocale } from '../../app/actions';
@@ -21,15 +21,16 @@ class ProtectedRoute extends Component {
     }
 
     componentDidUpdate(prevProps) {
-        const { isRootUrl, permission, redirectTo, currentUser, allRoutes } =
+        const { isRootUrl, permissions, redirectTo, currentUser, allRoutes } =
             this.props;
         if (currentUser && currentUser !== prevProps.currentUser) {
-            const isAuthorized = permission
-                ? userHasPermission(permission, currentUser)
-                : true;
+            const isAuthorized =
+                permissions.length > 0
+                    ? userHasOneOfPermissions(permissions, currentUser)
+                    : true;
             if (!isAuthorized && isRootUrl) {
                 const newBaseUrl = getFirstAllowedUrl(
-                    permission,
+                    permissions,
                     currentUser,
                     allRoutes,
                 );
@@ -48,11 +49,12 @@ class ProtectedRoute extends Component {
     }
 
     render() {
-        const { component, currentUser, permission, featureFlag, location } =
+        const { component, currentUser, permissions, featureFlag, location } =
             this.props;
-        let isAuthorized = permission
-            ? userHasPermission(permission, currentUser)
-            : true;
+        let isAuthorized =
+            permissions.length > 0
+                ? userHasOneOfPermissions(permissions, currentUser)
+                : true;
         if (featureFlag && !hasFeatureFlag(currentUser, featureFlag)) {
             isAuthorized = false;
         }
@@ -70,7 +72,7 @@ class ProtectedRoute extends Component {
 }
 ProtectedRoute.defaultProps = {
     currentUser: null,
-    permission: null,
+    permissions: [],
     isRootUrl: false,
     featureFlag: null,
     allRoutes: [],
@@ -80,7 +82,7 @@ ProtectedRoute.propTypes = {
     fetchCurrentUser: PropTypes.func.isRequired,
     redirectTo: PropTypes.func.isRequired,
     component: PropTypes.node.isRequired,
-    permission: PropTypes.any,
+    permissions: PropTypes.arrayOf(PropTypes.string),
     currentUser: PropTypes.object,
     isRootUrl: PropTypes.bool,
     dispatch: PropTypes.func.isRequired,

--- a/hat/assets/js/apps/Iaso/domains/users/utils.js
+++ b/hat/assets/js/apps/Iaso/domains/users/utils.js
@@ -45,10 +45,10 @@ export const listMenuPermission = (menuItem, permissions = []) => {
     let permissionsTemp = [...permissions];
     if (menuItem) {
         if (
-            menuItem.permission &&
-            !permissionsTemp.find(p => p === menuItem.permission) // Avoid duplicate permission
+            menuItem?.permissions?.length > 0 &&
+            !permissionsTemp.find(p => menuItem.permissions.includes(p)) // Avoid duplicate permission
         ) {
-            permissionsTemp.push(menuItem.permission);
+            permissionsTemp = [...permissionsTemp, ...menuItem.permissions];
         }
         menuItem.subMenu &&
             menuItem.subMenu.forEach(subMenuItem => {
@@ -56,7 +56,7 @@ export const listMenuPermission = (menuItem, permissions = []) => {
                     subMenuItem,
                     permissionsTemp,
                 ).filter(sp => !permissionsTemp.includes(sp)); // Avoid duplicate permission
-                permissionsTemp = permissionsTemp.concat(subPerms);
+                permissionsTemp = [...permissionsTemp, ...subPerms];
             });
     }
     return permissionsTemp;
@@ -69,10 +69,10 @@ export const listMenuPermission = (menuItem, permissions = []) => {
  * @param {Object} user
  * @return {String}
  */
-export const getFirstAllowedUrl = (rootPermission, user, routes) => {
+export const getFirstAllowedUrl = (rootPermissions, user, routes) => {
     let newRoot;
     user?.permissions.forEach(p => {
-        if (!newRoot && p !== rootPermission) {
+        if (!newRoot && !rootPermissions.includes(p)) {
             newRoot = p;
         }
     });

--- a/hat/assets/js/apps/Iaso/domains/users/utils.js
+++ b/hat/assets/js/apps/Iaso/domains/users/utils.js
@@ -9,6 +9,7 @@ export const userHasPermission = (permission, user) => {
     if (!user) {
         return false;
     }
+    if (!user.permissions || !Array.isArray(user.permissions)) return false;
     if (user.is_superuser || user.permissions.find(p => p === permission)) {
         return true;
     }

--- a/hat/assets/js/apps/Iaso/index.js
+++ b/hat/assets/js/apps/Iaso/index.js
@@ -25,6 +25,7 @@ export default function iasoApp(element, enabledPluginsName) {
     const plugins = getPlugins(enabledPluginsName);
     const allRoutesConfigs = [
         ...routeConfigs,
+        // Beware not to flatten too far
         ...plugins.map(plugin => plugin.routes).flat(),
     ];
     const baseRoutes = allRoutesConfigs.map(routeConfig => (
@@ -34,10 +35,10 @@ export default function iasoApp(element, enabledPluginsName) {
                 routeConfig.allowAnonymous
                     ? routeConfig.component
                     : props => (
-                          <ProtectedRoute
+                        <ProtectedRoute
                               {...props}
                               featureFlag={routeConfig.featureFlag}
-                              permission={routeConfig.permission}
+                              permissions={routeConfig.permissions}
                               component={routeConfig.component(props)}
                               isRootUrl={routeConfig.isRootUrl}
                               allRoutes={allRoutesConfigs}

--- a/hat/assets/js/test/utils.js
+++ b/hat/assets/js/test/utils.js
@@ -3,8 +3,9 @@ import ReactDOM from 'react-dom';
 import TestUtils, { act } from 'react-dom/test-utils';
 import { IntlProvider } from 'react-intl';
 import { Provider } from 'react-redux';
-import InputComponent from '../apps/Iaso/components/forms/InputComponent';
 import { QueryClient, QueryClientProvider } from 'react-query';
+import InputComponent from '../apps/Iaso/components/forms/InputComponent';
+
 const queryClient = new QueryClient();
 
 export function renderWithIntl(Component, props) {

--- a/iaso/api/form_versions.py
+++ b/iaso/api/form_versions.py
@@ -83,14 +83,15 @@ class FormVersionSerializer(DynamicFieldsModelSerializer):
 
     def validate(self, data: typing.MutableMapping):
         # TODO: validate start en end period (is a period and start before end)
-        if self.context["request"].method == "PUT":
-            # Skip validation for update, permission in that case is checked via the get_queryset.
-            return data
         form = data["form"]
+
         # validate form (access check)
         permission_checker = HasFormPermission()
         if not permission_checker.has_object_permission(self.context["request"], self.context["view"], form):
             raise serializers.ValidationError({"form_id": "Invalid form id"})
+        if self.context["request"].method == "PUT":
+            # if update skip the rest of check
+            return data
 
         # handle xls to xml conversion
         try:

--- a/iaso/api/forms.py
+++ b/iaso/api/forms.py
@@ -20,6 +20,11 @@ class HasFormPermission(permissions.BasePermission):
 
         return request.user.is_authenticated and request.user.has_perm("menupermissions.iaso_forms")
 
+    def has_object_permission(self, request, view, obj):
+        if not self.has_permission(request, view):
+            return False
+        return obj in Form.objects.filter_for_user_and_app_id(request.user, request.query_params.get("app_id"))
+
 
 class FormSerializer(DynamicFieldsModelSerializer):
     class Meta:

--- a/iaso/api/forms.py
+++ b/iaso/api/forms.py
@@ -12,13 +12,14 @@ from .common import ModelViewSet, TimestampField, DynamicFieldsModelSerializer
 from hat.api.export_utils import Echo, generate_xlsx, iter_items
 from .projects import ProjectSerializer
 
-#Used for form versions
+# Used for form versions
 class HasFormPermission(permissions.BasePermission):
     def has_permission(self, request, view):
         if request.method in permissions.SAFE_METHODS:
             return True
 
         return request.user.is_authenticated and request.user.has_perm("menupermissions.iaso_forms")
+
 
 # Used for forms, which have limited access front-end side with submissions permission
 class HasFormOrSubmissionPermission(permissions.BasePermission):

--- a/iaso/api/forms.py
+++ b/iaso/api/forms.py
@@ -12,13 +12,24 @@ from .common import ModelViewSet, TimestampField, DynamicFieldsModelSerializer
 from hat.api.export_utils import Echo, generate_xlsx, iter_items
 from .projects import ProjectSerializer
 
-
+#Used for form versions
 class HasFormPermission(permissions.BasePermission):
     def has_permission(self, request, view):
         if request.method in permissions.SAFE_METHODS:
             return True
 
         return request.user.is_authenticated and request.user.has_perm("menupermissions.iaso_forms")
+
+# Used for forms, which have limited access front-end side with submissions permission
+class HasFormOrSubmissionPermission(permissions.BasePermission):
+    def has_permission(self, request, view):
+        if request.method in permissions.SAFE_METHODS:
+            return True
+
+        return request.user.is_authenticated and (
+            request.user.has_perm("menupermissions.iaso_forms")
+            or request.user.has_perm("menupermissions.iaso_submissions")
+        )
 
 
 class FormSerializer(DynamicFieldsModelSerializer):
@@ -139,7 +150,7 @@ class FormsViewSet(ModelViewSet):
     """Forms API
 
     Read-only methods are accessible to anonymous users. All other actions are restricted to authenticated users
-    having the "menupermissions.iaso_forms" permission.
+    having the "menupermissions.iaso_forms" or "menupermissions.iaso_submissions" permission.
 
     GET /api/forms/
     GET /api/forms/<id>
@@ -149,7 +160,7 @@ class FormsViewSet(ModelViewSet):
     DELETE /api/forms/<id>
     """
 
-    permission_classes = [HasFormPermission]
+    permission_classes = [HasFormOrSubmissionPermission]
     serializer_class = FormSerializer
     results_key = "forms"
 

--- a/iaso/api/forms.py
+++ b/iaso/api/forms.py
@@ -23,7 +23,9 @@ class HasFormPermission(permissions.BasePermission):
     def has_object_permission(self, request, view, obj):
         if not self.has_permission(request, view):
             return False
-        return obj in Form.objects.filter_for_user_and_app_id(request.user, request.query_params.get("app_id"))
+        return obj in Form.objects_include_deleted.filter_for_user_and_app_id(
+            request.user, request.query_params.get("app_id")
+        )
 
 
 class FormSerializer(DynamicFieldsModelSerializer):

--- a/iaso/api/forms.py
+++ b/iaso/api/forms.py
@@ -12,25 +12,13 @@ from .common import ModelViewSet, TimestampField, DynamicFieldsModelSerializer
 from hat.api.export_utils import Echo, generate_xlsx, iter_items
 from .projects import ProjectSerializer
 
-# Used for form versions
+
 class HasFormPermission(permissions.BasePermission):
     def has_permission(self, request, view):
         if request.method in permissions.SAFE_METHODS:
             return True
 
         return request.user.is_authenticated and request.user.has_perm("menupermissions.iaso_forms")
-
-
-# Used for forms, which have limited access front-end side with submissions permission
-class HasFormOrSubmissionPermission(permissions.BasePermission):
-    def has_permission(self, request, view):
-        if request.method in permissions.SAFE_METHODS:
-            return True
-
-        return request.user.is_authenticated and (
-            request.user.has_perm("menupermissions.iaso_forms")
-            or request.user.has_perm("menupermissions.iaso_submissions")
-        )
 
 
 class FormSerializer(DynamicFieldsModelSerializer):
@@ -151,7 +139,7 @@ class FormsViewSet(ModelViewSet):
     """Forms API
 
     Read-only methods are accessible to anonymous users. All other actions are restricted to authenticated users
-    having the "menupermissions.iaso_forms" or "menupermissions.iaso_submissions" permission.
+    having the "menupermissions.iaso_forms"  permission.
 
     GET /api/forms/
     GET /api/forms/<id>
@@ -161,7 +149,7 @@ class FormsViewSet(ModelViewSet):
     DELETE /api/forms/<id>
     """
 
-    permission_classes = [HasFormOrSubmissionPermission]
+    permission_classes = [HasFormPermission]
     serializer_class = FormSerializer
     results_key = "forms"
 

--- a/plugins/polio/js/config.js
+++ b/plugins/polio/js/config.js
@@ -38,7 +38,7 @@ const routes = [
     {
         baseUrl: DASHBOARD_BASE_URL,
         component: props => <Dashboard {...props} />,
-        permission: 'iaso_polio',
+        permissions: ['iaso_polio'],
         params: [
             {
                 isRequired: false,
@@ -50,7 +50,7 @@ const routes = [
     {
         baseUrl: CALENDAR_BASE_URL,
         component: props => <Calendar {...props} />,
-        permission: 'iaso_polio',
+        permissions: ['iaso_polio'],
         params: [
             {
                 isRequired: false,
@@ -66,7 +66,7 @@ const routes = [
     {
         baseUrl: CONFIG_BASE_URL,
         component: () => <CountryNotificationsConfig />,
-        permission: 'iaso_polio',
+        permissions: ['iaso_polio'],
         params: [
             {
                 isRequired: false,
@@ -110,19 +110,19 @@ const menu = [
             {
                 label: MESSAGES.campaigns,
                 key: 'list',
-                permission: 'iaso_polio',
+                permissions: ['iaso_polio'],
                 icon: props => <FormatListBulleted {...props} />,
             },
             {
                 label: MESSAGES.calendar,
                 key: 'calendar',
-                permission: 'iaso_polio',
+                permissions: ['iaso_polio'],
                 icon: props => <CalendarToday {...props} />,
             },
             {
                 label: MESSAGES.configuration,
                 key: 'config',
-                permission: 'iaso_polio',
+                permissions: ['iaso_polio'],
                 icon: props => <SettingsIcon {...props} />,
             },
         ],


### PR DESCRIPTION
## Changes

- changed "permission" field to "permissions" in `menuItems`. It now takes an array i.o a string
- gave access to Forms to "iaso_submissions" permission
- updated `ProtectedRoutes` to check for an array of permissions i.o single one
- users with `iaso_submissions` permission can view `/forms/list`, but write actions are not available
- id. for ArchivedForms: the actions column is removed

https://user-images.githubusercontent.com/38907762/140543052-6c7570ce-3355-4995-b42e-6ab17af2bd1c.mov



