### PR TITLE
IA-873: return 400 for badly formatted xls

### DIFF
--- a/iaso/api/form_versions.py
+++ b/iaso/api/form_versions.py
@@ -122,7 +122,7 @@ class FormVersionSerializer(DynamicFieldsModelSerializer):
         try:
             return FormVersion.objects.create_for_form_and_survey(form=form, survey=survey, **validated_data)
         except Exception as e:
-            raise exceptions.ValidationError(e)
+            raise exceptions.ValidationError({"xls_file":e})
 
     def update(self, form_version, validated_data):
         form_version.start_period = validated_data.pop("start_period", None)

--- a/iaso/api/form_versions.py
+++ b/iaso/api/form_versions.py
@@ -1,5 +1,7 @@
 import typing
-from rest_framework import serializers, parsers, permissions
+
+from django.http.response import HttpResponseBadRequest
+from rest_framework import serializers, parsers, permissions, exceptions
 
 from iaso.models import Form, FormVersion
 from django.db.models.functions import Concat
@@ -117,8 +119,10 @@ class FormVersionSerializer(DynamicFieldsModelSerializer):
     def create(self, validated_data):
         form = validated_data.pop("form")
         survey = validated_data.pop("survey")
-
-        return FormVersion.objects.create_for_form_and_survey(form=form, survey=survey, **validated_data)
+        try:
+            return FormVersion.objects.create_for_form_and_survey(form=form, survey=survey, **validated_data)
+        except Exception as e:
+            raise exceptions.ValidationError(e)
 
     def update(self, form_version, validated_data):
         form_version.start_period = validated_data.pop("start_period", None)

--- a/iaso/api/form_versions.py
+++ b/iaso/api/form_versions.py
@@ -122,7 +122,8 @@ class FormVersionSerializer(DynamicFieldsModelSerializer):
         try:
             return FormVersion.objects.create_for_form_and_survey(form=form, survey=survey, **validated_data)
         except Exception as e:
-            raise exceptions.ValidationError({"xls_file": e})
+            # putting the error in an array to prevent front-end crash
+            raise exceptions.ValidationError({"xls_file": [e]})
 
     def update(self, form_version, validated_data):
         form_version.start_period = validated_data.pop("start_period", None)

--- a/iaso/api/form_versions.py
+++ b/iaso/api/form_versions.py
@@ -122,7 +122,7 @@ class FormVersionSerializer(DynamicFieldsModelSerializer):
         try:
             return FormVersion.objects.create_for_form_and_survey(form=form, survey=survey, **validated_data)
         except Exception as e:
-            raise exceptions.ValidationError({"xls_file":e})
+            raise exceptions.ValidationError({"xls_file": e})
 
     def update(self, form_version, validated_data):
         form_version.start_period = validated_data.pop("start_period", None)

--- a/iaso/odk/parsing.py
+++ b/iaso/odk/parsing.py
@@ -18,7 +18,6 @@ class Survey:
         self._xls_file_name = xls_file_name
 
     def to_xml(self):
-        # try:
         xml_file_content = self._survey.to_xml(validate=False)
 
         return xml_file_content.encode("utf-8")

--- a/iaso/odk/parsing.py
+++ b/iaso/odk/parsing.py
@@ -18,6 +18,7 @@ class Survey:
         self._xls_file_name = xls_file_name
 
     def to_xml(self):
+        # try:
         xml_file_content = self._survey.to_xml(validate=False)
 
         return xml_file_content.encode("utf-8")


### PR DESCRIPTION
## Changes 

- raise a `ValidationError` exception when `pyxform.Survey.to_xml` fails
- No changes on the front-end as the error is displayed and available for copy in the snackbar as with other API errors

It's a very basic change, I'm open for improvements

https://user-images.githubusercontent.com/38907762/141807711-ca81c350-1ba2-4532-9c50-c2f0a0ff8b32.mov

