### PR TITLE
IA-994 Speed up the group filter selector

### DIFF
--- a/iaso/api/groups.py
+++ b/iaso/api/groups.py
@@ -37,7 +37,7 @@ class GroupSerializer(serializers.ModelSerializer):
         fields = ["id", "name", "source_ref", "source_version", "org_unit_count", "created_at", "updated_at"]
         read_only_fields = ["id", "source_version", "org_unit_count", "created_at", "updated_at"]
 
-    source_version = SourceVersionSerializerForGroup()
+    source_version = SourceVersionSerializerForGroup(read_only=True)
     org_unit_count = serializers.IntegerField(read_only=True)
     created_at = TimestampField(read_only=True)
     updated_at = TimestampField(read_only=True)


### PR DESCRIPTION
Prefetch related queries
and only return necessary data. Previously we were returning the DataSource and all the versions with no relation to the group

This diminish the response size, the returned json is now 36k from
216.25kb before.
And the number of SQL queries on my local database goes from 1300 to 7.

Request Reponse time have been improved from 4622 ms (4 seconds) to
831ms.