### PR TITLE
POLIO-118 Direct Link Campaign in email

### DIFF
--- a/plugins/polio/api.py
+++ b/plugins/polio/api.py
@@ -124,7 +124,7 @@ class CampaignViewSet(ModelViewSet):
 This is an automated email.
 
 Following the newly confirmed virus {virus_type} reported from {initial_orgunit_name} with date of onset/sample collection {onset_date}. \
-A new outbreak {obr_name} has been created on the timeline tracker, to visualize the campaign visit: {url}
+A new outbreak {obr_name} has been created on the timeline tracker, to visualize the campaign visit: {url_campaign}
 
 Some campaign details are missing at this stage. It is important to update the outbreak response information on this link {url}, \
 to ensure optimal coordination of activities. The information should be updated at least weekly. Details for log in will be provided.
@@ -153,6 +153,7 @@ Timeline tracker Automated message
             initial_orgunit_name=campaign.initial_org_unit.name
             + (", " + campaign.initial_org_unit.parent.name if campaign.initial_org_unit.parent else ""),
             url=f"https://{domain}/dashboard/polio/list",
+            url_campaign=f"https://{domain}/dashboard/polio/list/campaignId/{campaign.id}",
         )
 
         try:

--- a/plugins/polio/management/commands/weekly_email.py
+++ b/plugins/polio/management/commands/weekly_email.py
@@ -40,7 +40,7 @@ def send_notification_email(campaign):
         else ""
     )
     c = campaign
-    url = f"https://{domain}/dashboard/polio/list"
+    url = f"https://{domain}/dashboard/polio/list/campaignId/{campaign.id}"
     # format thousand
     target_population = f"{c.round_one.target_population:,}" if c.round_one and c.round_one.target_population else ""
 


### PR DESCRIPTION
Now that we have deep linking for campaign in creation email and update email, directly link to the concerned campaign
instead of the campaign page.