### PR TITLE
POLIO-165: Hotfix add senegal to lqas im

### DIFF
--- a/plugins/polio/api.py
+++ b/plugins/polio/api.py
@@ -991,7 +991,6 @@ class LQASStatsViewSet(viewsets.ViewSet):
                     day_country_not_found[country.name][today_string] += 1
                     form_campaign_not_found_count += 1
                 form_count += 1
-            
 
         response = {
             "stats": campaign_stats,

--- a/plugins/polio/api.py
+++ b/plugins/polio/api.py
@@ -618,6 +618,8 @@ class IMStatsViewSet(viewsets.ViewSet):
 
 def find_campaign(campaigns, today, country):
     for c in campaigns:
+        if not c.round_one.started_at:
+            continue
         if c.country_id == country.id and c.round_one.started_at <= today < c.round_one.started_at + timedelta(
             days=+28
         ):
@@ -978,6 +980,7 @@ class LQASStatsViewSet(viewsets.ViewSet):
                     district = find_district(district_name, region_name, districts_qs, district_dict)
                     if not district:
                         district_long_name = "%s - %s" % (district_name, region_name)
+                        d["region_name"] = region_name
 
                         if district_long_name not in campaign_stats[campaign_name]["districts_not_found"]:
                             campaign_stats[campaign_name]["districts_not_found"].append(district_long_name)
@@ -988,6 +991,7 @@ class LQASStatsViewSet(viewsets.ViewSet):
                     day_country_not_found[country.name][today_string] += 1
                     form_campaign_not_found_count += 1
                 form_count += 1
+            
 
         response = {
             "stats": campaign_stats,

--- a/plugins/polio/api.py
+++ b/plugins/polio/api.py
@@ -618,7 +618,7 @@ class IMStatsViewSet(viewsets.ViewSet):
 
 def find_campaign(campaigns, today, country):
     for c in campaigns:
-        if not c.round_one.started_at:
+        if not (c.round_one and c.round_one.started_at):
             continue
         if c.country_id == country.id and c.round_one.started_at <= today < c.round_one.started_at + timedelta(
             days=+28

--- a/plugins/polio/js/src/pages/LQAS/utils.ts
+++ b/plugins/polio/js/src/pages/LQAS/utils.ts
@@ -174,7 +174,10 @@ export const makeDataForTable = (
 };
 
 export const convertStatToPercent = (data = 0, total = 1): string => {
-    if (data > total) throw new Error("data can't be greater than total");
+    if (data > total)
+        throw new Error(
+            `data can't be greater than total. data: ${data}, total: ${total}`,
+        );
     // using safeTotal, because 0 can still be passed as arg and override default value
     const safeTotal = total || 1;
     const ratio = (100 * data) / safeTotal;


### PR DESCRIPTION
## Changes

- Added null check on `round_1.started_at` in `findCampaigns` method

## Test

- get updated config files from 1Password
- update lqas-config and im-config in django admin
- check that the country ids match those in your local DB
- To display results, match the districts not found using org unit aliases
![Screenshot 2022-01-12 at 11 43 14](https://user-images.githubusercontent.com/38907762/149125518-9142662c-5bff-4b81-bf8b-1294cdb4ac41.png)


