### PR TITLE
POLIO-166: add % to globalIM, remove txt shadow

### DIFF
--- a/plugins/polio/js/src/components/LQAS-IM/ImSummary.tsx
+++ b/plugins/polio/js/src/components/LQAS-IM/ImSummary.tsx
@@ -1,12 +1,18 @@
 /* eslint-disable react/require-default-props */
-import { Grid, makeStyles, Paper, Typography } from '@material-ui/core';
+import {
+    Grid,
+    makeStyles,
+    Paper,
+    rgbToHex,
+    Typography,
+} from '@material-ui/core';
 import React, { FunctionComponent, useMemo } from 'react';
 import { useSafeIntl } from 'bluesquare-components';
 import { RoundString } from '../../constants/types';
 import { useConvertedLqasImData } from '../../pages/IM/requests';
 import { makeAccordionData } from '../../utils/LqasIm';
 import MESSAGES from '../../constants/messages';
-import { FAIL_COLOR, OK_COLOR, WARNING_COLOR } from '../../styles/constants';
+import { FAIL_COLOR, OK_COLOR } from '../../styles/constants';
 
 type Props = {
     campaign?: string;
@@ -24,9 +30,9 @@ const style = theme => ({
     containerGrid: { justifyContent: 'space-evenly' },
     centerText: { textAlign: 'center' },
     boldText: { fontWeight: 'bold' },
-    pass: { color: OK_COLOR, textShadow: '1px 1px 2px black' },
-    fail: { color: FAIL_COLOR, textShadow: '1px 1px 2px black' },
-    warning: { color: WARNING_COLOR, textShadow: '1px 1px 2px black' },
+    pass: { color: OK_COLOR },
+    fail: { color: FAIL_COLOR },
+    warning: { color: 'rgb(255,196,53)' },
 });
 
 const useStyles = makeStyles(style);
@@ -109,22 +115,20 @@ export const ImSummary: FunctionComponent<Props> = ({
                                 {`${reportingDistricts.value}`}
                             </Typography>
                         </Grid>
-                        {type !== 'imGlobal' && (
-                            <Grid item xs={4} sm={3}>
-                                <Typography
-                                    variant="body1"
-                                    className={classes.centerText}
-                                >
-                                    {formatMessage(MESSAGES[vaccinated.id])}
-                                </Typography>
-                                <Typography
-                                    variant="h6"
-                                    className={`${classes.centerText} ${classes.boldText} ${colorVaccinated}`}
-                                >
-                                    {vaccinated.value}
-                                </Typography>
-                            </Grid>
-                        )}
+                        <Grid item xs={4} sm={3}>
+                            <Typography
+                                variant="body1"
+                                className={classes.centerText}
+                            >
+                                {formatMessage(MESSAGES[vaccinated.id])}
+                            </Typography>
+                            <Typography
+                                variant="h6"
+                                className={`${classes.centerText} ${classes.boldText} ${colorVaccinated}`}
+                            >
+                                {vaccinated.value}
+                            </Typography>
+                        </Grid>
                     </Grid>
                 </Paper>
             )}

--- a/plugins/polio/js/src/components/LQAS-IM/LqasSummary.tsx
+++ b/plugins/polio/js/src/components/LQAS-IM/LqasSummary.tsx
@@ -4,7 +4,7 @@ import { makeStyles } from '@material-ui/styles';
 import React, { FunctionComponent, useMemo } from 'react';
 import { RoundString } from '../../constants/types';
 import { useConvertedLqasImData } from '../../pages/IM/requests';
-import { FAIL_COLOR, OK_COLOR, WARNING_COLOR } from '../../styles/constants';
+import { FAIL_COLOR, OK_COLOR } from '../../styles/constants';
 import {
     convertStatToPercent,
     getLqasStatsForRound,
@@ -26,9 +26,9 @@ const style = theme => ({
     containerGrid: { justifyContent: 'space-evenly' },
     centerText: { textAlign: 'center' },
     boldText: { fontWeight: 'bold' },
-    pass: { color: OK_COLOR, textShadow: '1px 1px 2px black' },
-    fail: { color: FAIL_COLOR, textShadow: '1px 1px 2px black' },
-    warning: { color: WARNING_COLOR, textShadow: '1px 1px 2px black' },
+    pass: { color: OK_COLOR },
+    fail: { color: FAIL_COLOR },
+    warning: { color: 'rgb(255,196,53)' },
 });
 
 const useStyles = makeStyles(style);

--- a/plugins/polio/js/src/utils/LqasIm.tsx
+++ b/plugins/polio/js/src/utils/LqasIm.tsx
@@ -97,12 +97,6 @@ const makeCollectionStats = ({
         );
         const { total_child_checked, total_sites_visited, reportingDistricts } =
             aggregatedData;
-        if (type === 'imGlobal')
-            return {
-                total_child_checked,
-                total_sites_visited,
-                reportingDistricts,
-            };
         const { total_child_checked: checked, total_child_fmd: marked } =
             aggregatedData;
         const ratioUnvaccinated = convertStatToPercent(


### PR DESCRIPTION
## Changes

- Removed condition preventing calculation of vaccinated % for `ImSummary` for Global IM
- removed text-shadow and used darker color for text with status `warning`in `LqasSummary`and `ImSummary

![Screenshot 2022-01-17 at 14 30 19](https://user-images.githubusercontent.com/38907762/149778151-3e35e500-376f-46ae-b44e-f02c9066710c.png)
