### PR TITLE
IA-1007 Display warning for restricted user

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -15,6 +15,7 @@
     "iaso.algo.addRun": "Add algorithm run",
     "iaso.archived.title": "Archives",
     "iaso.area": "Health area",
+    "iaso.restricted_submissions_by_orgunits": "You're only allowed to see submissions for the following orgunits:",
     "iaso.completeness.generateDerivedInstances": "Generate derived instances",
     "iaso.completeness.title": "Completeness",
     "iaso.dataSources.continueOnError": "Continue on error",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -15,6 +15,7 @@
     "iaso.algo.addRun": "Exécuter un algorithme",
     "iaso.archived.title": "Archives",
     "iaso.area": "Aire de santé",
+    "iaso.restricted_submissions_by_orgunits": "Vous êtes autorisé(e) à voir uniquement les unités d'organisation suivantes:",
     "iaso.completeness.generateDerivedInstances": "Générer les instances dérivées",
     "iaso.completeness.title": "Complétude des données",
     "iaso.dataSources.continueOnError": "Continuer en cas d'erreur",

--- a/hat/assets/js/apps/Iaso/domains/instances/components/InstancesFiltersComponent.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/InstancesFiltersComponent.js
@@ -1,9 +1,9 @@
-import React, { useState, useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 
 import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
 
-import { Button, makeStyles, Grid, Box, Typography } from '@material-ui/core';
+import { Box, Button, Grid, makeStyles, Typography } from '@material-ui/core';
 
 import Search from '@material-ui/icons/Search';
 import { commonStyles, useSafeIntl } from 'bluesquare-components';
@@ -19,7 +19,7 @@ import { Period } from '../../periods/models';
 import { INSTANCE_STATUSES } from '../constants';
 import { setInstancesFilterUpdated } from '../actions';
 
-import { useInstancesFiltersData, useGetForms } from '../hooks';
+import { useGetForms, useInstancesFiltersData } from '../hooks';
 import { getInstancesFilterValues, useFormState } from '../../../hooks/form';
 
 import MESSAGES from '../messages';
@@ -27,6 +27,7 @@ import { OrgUnitTreeviewModal } from '../../orgUnits/components/TreeView/OrgUnit
 import { useGetOrgUnit } from '../../orgUnits/components/TreeView/requests';
 
 import { LocationLimit } from '../../../utils/map/LocationLimit';
+import { UserOrgUnitRestriction } from './UserOrgUnitRestriction';
 
 export const instanceStatusOptions = INSTANCE_STATUSES.map(status => ({
     value: status,
@@ -136,8 +137,10 @@ const InstancesFiltersComponent = ({
         }
         return false;
     }, [formState.startPeriod, formState.endPeriod]);
+
     return (
         <div className={classes.marginBottomBig}>
+            <UserOrgUnitRestriction />
             <Grid container spacing={4}>
                 <Grid item xs={4}>
                     <InputComponent

--- a/hat/assets/js/apps/Iaso/domains/instances/components/UserOrgUnitRestriction.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/UserOrgUnitRestriction.js
@@ -1,7 +1,7 @@
-import { useCurrentUser } from '../../../utils/usersUtils';
 import { useSafeIntl } from 'bluesquare-components';
-import { Card, CardContent, Typography } from '@material-ui/core';
 import React from 'react';
+import { Alert } from '@material-ui/lab';
+import { useCurrentUser } from 'Iaso/utils/usersUtils';
 import MESSAGES from '../messages';
 
 export const UserOrgUnitRestriction = () => {
@@ -12,15 +12,9 @@ export const UserOrgUnitRestriction = () => {
         return null;
     }
     return (
-        <Card>
-            {/* Override the rule for the last child that make it seems */}
-            {/* unbalanced */}
-            <CardContent style={{ paddingBottom: 16 }}>
-                <Typography>
-                    {formatMessage(MESSAGES.restricted_submissions_by_orgunits)}{' '}
-                    {currentUser.org_units.map(ou => ou.name).join(', ')}
-                </Typography>
-            </CardContent>
-        </Card>
+        <Alert severity="info">
+            {formatMessage(MESSAGES.restricted_submissions_by_orgunits)}{' '}
+            {currentUser.org_units.map(ou => ou.name).join(', ')}
+        </Alert>
     );
 };

--- a/hat/assets/js/apps/Iaso/domains/instances/components/UserOrgUnitRestriction.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/UserOrgUnitRestriction.js
@@ -1,0 +1,26 @@
+import { useCurrentUser } from '../../../utils/usersUtils';
+import { useSafeIntl } from 'bluesquare-components';
+import { Card, CardContent, Typography } from '@material-ui/core';
+import React from 'react';
+import MESSAGES from '../messages';
+
+export const UserOrgUnitRestriction = () => {
+    const currentUser = useCurrentUser();
+    const { formatMessage } = useSafeIntl();
+
+    if (currentUser.org_units.length === 0) {
+        return null;
+    }
+    return (
+        <Card>
+            {/* Override the rule for the last child that make it seems */}
+            {/* unbalanced */}
+            <CardContent style={{ paddingBottom: 16 }}>
+                <Typography>
+                    {formatMessage(MESSAGES.restricted_submissions_by_orgunits)}{' '}
+                    {currentUser.org_units.map(ou => ou.name).join(', ')}
+                </Typography>
+            </CardContent>
+        </Card>
+    );
+};

--- a/hat/assets/js/apps/Iaso/domains/instances/components/UserOrgUnitRestriction.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/UserOrgUnitRestriction.js
@@ -1,5 +1,5 @@
 import { useSafeIntl } from 'bluesquare-components';
-import React from 'react';
+import React, { useState } from 'react';
 import { Alert } from '@material-ui/lab';
 import { useCurrentUser } from 'Iaso/utils/usersUtils';
 import { Snackbar } from '@material-ui/core';
@@ -8,13 +8,14 @@ import MESSAGES from '../messages';
 export const UserOrgUnitRestriction = () => {
     const currentUser = useCurrentUser();
     const { formatMessage } = useSafeIntl();
+    const [isOpen, setIsOpen] = useState(true);
 
     if (currentUser.org_units.length === 0) {
         return null;
     }
     return (
-        <Snackbar open>
-            <Alert severity="info">
+        <Snackbar open={isOpen}>
+            <Alert onClose={() => setIsOpen(false)} severity="info">
                 {formatMessage(MESSAGES.restricted_submissions_by_orgunits)}{' '}
                 {currentUser.org_units.map(ou => ou.name).join(', ')}
             </Alert>

--- a/hat/assets/js/apps/Iaso/domains/instances/components/UserOrgUnitRestriction.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/UserOrgUnitRestriction.js
@@ -2,6 +2,7 @@ import { useSafeIntl } from 'bluesquare-components';
 import React from 'react';
 import { Alert } from '@material-ui/lab';
 import { useCurrentUser } from 'Iaso/utils/usersUtils';
+import { Snackbar } from '@material-ui/core';
 import MESSAGES from '../messages';
 
 export const UserOrgUnitRestriction = () => {
@@ -12,9 +13,11 @@ export const UserOrgUnitRestriction = () => {
         return null;
     }
     return (
-        <Alert severity="info">
-            {formatMessage(MESSAGES.restricted_submissions_by_orgunits)}{' '}
-            {currentUser.org_units.map(ou => ou.name).join(', ')}
-        </Alert>
+        <Snackbar open>
+            <Alert severity="info">
+                {formatMessage(MESSAGES.restricted_submissions_by_orgunits)}{' '}
+                {currentUser.org_units.map(ou => ou.name).join(', ')}
+            </Alert>
+        </Snackbar>
     );
 };

--- a/hat/assets/js/apps/Iaso/domains/instances/messages.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/messages.js
@@ -381,6 +381,11 @@ const MESSAGES = defineMessages({
         id: 'iaso.formversions.chronologicalPeriodError',
         defaultMessage: 'Start period should be before end period',
     },
+    restricted_submissions_by_orgunits: {
+        id: 'iaso.restricted_submissions_by_orgunits',
+        defaultMessage:
+            'Your user can only see submissions for the following orgunits: ',
+    },
 });
 
 export default MESSAGES;

--- a/hat/assets/js/apps/Iaso/utils/usersUtils.js
+++ b/hat/assets/js/apps/Iaso/utils/usersUtils.js
@@ -1,3 +1,5 @@
+import { useSelector } from 'react-redux';
+
 const getDisplayName = user => {
     if (!user.first_name && !user.last_name) {
         return user.user_name;
@@ -8,3 +10,9 @@ const getDisplayName = user => {
 };
 
 export default getDisplayName;
+
+export const useCurrentUser = () => {
+    // noinspection UnnecessaryLocalVariableJS
+    const currentUser = useSelector(state => state.users.current);
+    return currentUser;
+};

--- a/iaso/api/instances.py
+++ b/iaso/api/instances.py
@@ -123,6 +123,12 @@ class InstancesViewSet(viewsets.ViewSet):
         queryset = Instance.objects.order_by("-id")
 
         profile = request.user.iaso_profile
+
+        # If user is restricted to some org unit, filter on thoses
+        if profile.org_units.exists():
+            orgunits = OrgUnit.objects.hierarchy(profile.org_units.all())
+
+            queryset = queryset.filter(org_unit__in=orgunits)
         queryset = queryset.filter(project__account=profile.account)
 
         queryset = queryset.exclude(file="").exclude(device__test_device=True)


### PR DESCRIPTION
Follow up on IA-987 pr, This a proposal according to Martin suggestion to display a warning to the user when the org unit he can see are restricted.

![image](https://user-images.githubusercontent.com/82500/149915033-f093f87a-fe0b-4cac-bc91-9a5d07c92b69.png)

Wholly open to suggestions  on how we can make it look nicer and how to improve the warning  and for a French translation. We can also replicate this in the OrgUnit page