### PR TITLE
IA-980: add warning icon for bulk org uniot update

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -432,6 +432,7 @@
     "iaso.orgUnits.addOrgUnitType": "Add org unit type",
     "iaso.orgUnits.addSource": "Add source",
     "iaso.orgUnits.addToGroups": "Add to group(s)",
+    "iaso.orgUnits.bulkChangeCount": "You are about to change {count} Org units",
     "iaso.orgUnits.confirmMultiChange": "Confirm bulk changes ?",
     "iaso.orgUnits.dataSources": "Data Sources",
     "iaso.orgUnits.depth": "Level",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -227,6 +227,7 @@
     "iaso.label.ended_at": "Fin",
     "iaso.label.execute": "Exécuter",
     "iaso.label.export": "Export",
+    "iaso.orgUnits.bulkChangeCount": "Vous allez modifier {count} unités d'org.",
     "iaso.label.exportRequests": "Demandes d'export",
     "iaso.label.exportSelection": "Exporter {count} soumissions",
     "iaso.label.featureFlags": "Options",

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitsMultiActionsDialog.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitsMultiActionsDialog.js
@@ -11,6 +11,9 @@ import {
     DialogActions,
     Button,
     withStyles,
+    Box,
+    Grid,
+    Typography,
 } from '@material-ui/core';
 
 import {
@@ -311,9 +314,28 @@ const OrgUnitsMultiActionsDialog = ({
                     <ConfirmDialog
                         btnMessage={<FormattedMessage {...MESSAGES.validate} />}
                         question={
-                            <FormattedMessage
-                                {...MESSAGES.confirmMultiChange}
-                            />
+                            <Grid direction="column" container>
+                                <Grid item>
+                                    <Box>
+                                        <FormattedMessage
+                                            {...MESSAGES.confirmMultiChange}
+                                        />
+                                        <>🚨</>
+                                    </Box>
+                                </Grid>
+                                <Grid item>
+                                    <Box>
+                                        <Typography variant="body2">
+                                            <FormattedMessage
+                                                {...MESSAGES.bulkChangeCount}
+                                                values={{
+                                                    count: selectCount ?? 0,
+                                                }}
+                                            />
+                                        </Typography>
+                                    </Box>
+                                </Grid>
+                            </Grid>
                         }
                         confirm={() => saveAndReset()}
                         btnDisabled={isSaveDisabled()}

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/messages.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/messages.js
@@ -338,6 +338,10 @@ const MESSAGES = defineMessages({
         id: 'iaso.orgUnits.statusRejected',
         defaultMessage: 'Validation status: REJECTED',
     },
+    bulkChangeCount: {
+        id: 'iaso.orgUnits.bulkChangeCount',
+        defaultMessage: 'You are about to change {count} Org units',
+    },
 });
 
 export default MESSAGES;


### PR DESCRIPTION
## Changes

- Added  a "warning icon" (an emoji really) at the end of the confirmation message
- Added a "sub-title" showing the amount of org units about to be modified
- Added corresponding translations
![Screenshot 2022-01-26 at 13 18 16](https://user-images.githubusercontent.com/38907762/151162311-4972c91b-6876-438c-bd06-a8551b9d60f9.png)

