### PR TITLE
IA-1028 & IA-1025 failing export

### DIFF
--- a/iaso/api/export_requests.py
+++ b/iaso/api/export_requests.py
@@ -1,8 +1,11 @@
 import typing
 import logging
+from datetime import timedelta
+
+from django.utils.timezone import now
 
 logger = logging.getLogger(__name__)
-from iaso.models import ExportRequest
+from iaso.models import ExportRequest, KILLED, QUEUED
 from rest_framework import serializers, permissions
 
 from iaso.dhis2.export_request_builder import ExportRequestBuilder
@@ -32,6 +35,18 @@ class ExportRequestSerializer(serializers.ModelSerializer):
         return parse_instance_filters(self.context["request"].data)
 
     def create(self, validated_data: typing.MutableMapping):
+        # FIXME: Temporary fix till we reimplement this in the new task system, timeout old queued requests.
+        REQUEST_TIMEOUT_S = 15 * 60  # 15 minutes
+        export_requests = ExportRequest.objects.filter(status=QUEUED).filter(
+            queued_at__gt=now() - timedelta(seconds=REQUEST_TIMEOUT_S)
+        )
+        for export_request in export_requests:
+            logger.warning(f"Timeouting {export_request}")
+            export_request.status = KILLED
+            export_request.last_error_message = "Timeout"
+            export_request.exportstatus_set.filter(status=QUEUED).update(status="SKIPPED", last_error_message="Timeout")
+            export_request.save()
+
         try:
             user = self.context["request"].user
             force_export = self.context["request"].data.get("forceExport", False)

--- a/iaso/api/forms.py
+++ b/iaso/api/forms.py
@@ -124,6 +124,7 @@ class FormSerializer(DynamicFieldsModelSerializer):
 
             # validate org_unit_types against projects
             allowed_org_unit_types = [ut for p in data["projects"] for ut in p.unit_types.all()]
+            print(allowed_org_unit_types)
             if len(set(data["org_unit_types"]) - set(allowed_org_unit_types)) > 0:
                 raise serializers.ValidationError({"org_unit_type_ids": "Invalid org unit type ids"})
 

--- a/iaso/api/forms.py
+++ b/iaso/api/forms.py
@@ -124,7 +124,6 @@ class FormSerializer(DynamicFieldsModelSerializer):
 
             # validate org_unit_types against projects
             allowed_org_unit_types = [ut for p in data["projects"] for ut in p.unit_types.all()]
-            print(allowed_org_unit_types)
             if len(set(data["org_unit_types"]) - set(allowed_org_unit_types)) > 0:
                 raise serializers.ValidationError({"org_unit_type_ids": "Invalid org unit type ids"})
 

--- a/iaso/dhis2/datavalue_exporter.py
+++ b/iaso/dhis2/datavalue_exporter.py
@@ -787,14 +787,22 @@ class DataValueExporter:
             .all(),
             page_size,
         )
+        if paginator.count == 0:
+            logger.warning(f"Not linked error status for {export_request}")
+
         skipped = []
         stats = {"exported_count": 0, "errored_count": 0}
+        export_statuses = []
         for page in range(1, paginator.num_pages + 1):
             print(page)
             page_start = timer()
             prefix = "page %d/%d" % (page, paginator.num_pages)
+
             try:
                 export_statuses = paginator.page(page).object_list
+                if len(export_statuses) == 0:
+                    logger.warning(f"Empty page {page} for {export_request}")
+                    continue
                 data = self.map_page_to_data_values(prefix, export_statuses, skipped)
                 api = self.get_api(export_statuses[0].mapping_version)
 


### PR DESCRIPTION
As a temporary fix for the Uganda export that were staying as queued, I implemented a timeout, that happen when creating new export requests. This is a temporary fix till we move it to the task worker system.

I also put a mitigation for when the system was craching because of queued ExportRequest with no attached status, and thus nos attached submission, but I still haven't figured how theses happened in the first place, since normally the system forbidding creating those. Theses requests were created by the properly it seems so there is probably a serious bug underneath that may cause problem for the user. From the sentry log it's not a recent problem either. So with the fix it now display a proper error message  but the error is still occuring