### PR TITLE
IA-1027 Add skipped forms to LQASStats response

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/forms/components/FormsFilterComponent.js
+++ b/hat/assets/js/apps/Iaso/domains/forms/components/FormsFilterComponent.js
@@ -51,7 +51,7 @@ export const FormsFilterComponent = ({ setFormsSelected, formsSelected }) => {
             </Box>
             <Select
                 keyValue="forms"
-                label={formatMessage(MESSAGES.defaultMessage)}
+                label={formatMessage(MESSAGES.title)}
                 disabled={forms.length === 0}
                 loading={isLoading}
                 clearable

--- a/plugins/polio/api.py
+++ b/plugins/polio/api.py
@@ -608,10 +608,7 @@ class IMStatsViewSet(viewsets.ViewSet):
                     continue
                 round_number = form["roundNumber"]
                 if round_number.endswith("1") or round_number.endswith("2"):
-                    if round_number.endswith("1"):
-                        round_number = "Rnd1"
-                    if round_number.endswith("2"):
-                        round_number = "Rnd2"
+                    round_number = "Rnd" + round_number[-1]
                 else:
                     skipped_forms_list.append(
                         {form["_id"]: {"round": form["roundNumber"], "date": form["date_monitored"]}}
@@ -1086,10 +1083,7 @@ class LQASStatsViewSet(viewsets.ViewSet):
                     continue
                 round_number = form["roundNumber"]
                 if round_number.endswith("1") or round_number.endswith("2"):
-                    if round_number.endswith("1"):
-                        round_number = "Rnd1"
-                    if round_number.endswith("2"):
-                        round_number = "Rnd2"
+                    round_number = "Rnd" + round_number[-1]
                 else:
                     skipped_forms_list.append(
                         {form["_id"]: {"round": form["roundNumber"], "date": form["Date_of_LQAS"]}}

--- a/plugins/polio/api.py
+++ b/plugins/polio/api.py
@@ -964,9 +964,8 @@ class LQASStatsViewSet(viewsets.ViewSet):
         campaigns = Campaign.objects.all()
         config = get_object_or_404(Config, slug="lqas-config")
         requested_country = request.GET.get("country_id", None)
-        skipped_forms_count = 0
         skipped_forms_list = []
-        skipped_forms = {"count": skipped_forms_count, "forms": skipped_forms_list}
+        skipped_forms = {"count": 0, "forms": skipped_forms_list}
 
         if requested_country is None:
             return HttpResponseBadRequest
@@ -1064,8 +1063,8 @@ class LQASStatsViewSet(viewsets.ViewSet):
                     round_number = "Rnd2"
                 # FIXME ignored forms should be logged somewhere
                 if round_number != "Rnd1" and round_number != "Rnd2":
-                    skipped_forms_count += 1
                     skipped_forms_list.append(form)
+                    skipped_forms.update({"count": len(skipped_forms_list)})
                     continue
                 HH_COUNT = form.get("Count_HH", None)
                 if HH_COUNT is None:
@@ -1176,6 +1175,7 @@ class LQASStatsViewSet(viewsets.ViewSet):
             "day_country_not_found": day_country_not_found,
             "skipped_forms": skipped_forms,
         }
+
         return JsonResponse(response, safe=False)
 
 

--- a/plugins/polio/api.py
+++ b/plugins/polio/api.py
@@ -960,11 +960,14 @@ class LQASStatsViewSet(viewsets.ViewSet):
     """
     Endpoint used to transform IM (independent monitoring) data from existing ODK forms stored in ONA.
     """
-
     def list(self, request):
         campaigns = Campaign.objects.all()
         config = get_object_or_404(Config, slug="lqas-config")
         requested_country = request.GET.get("country_id", None)
+        skipped_forms_count = 0
+        skipped_forms_list = []
+        skipped_forms = {"count": skipped_forms_count, "forms": skipped_forms_list}
+
         if requested_country is None:
             return HttpResponseBadRequest
         requested_country = int(requested_country)
@@ -1061,6 +1064,8 @@ class LQASStatsViewSet(viewsets.ViewSet):
                     round_number = "Rnd2"
                 # FIXME ignored forms should be logged somewhere
                 if round_number != "Rnd1" and round_number != "Rnd2":
+                    skipped_forms_count += 1
+                    skipped_forms_list.append(form)
                     continue
                 HH_COUNT = form.get("Count_HH", None)
                 if HH_COUNT is None:
@@ -1169,6 +1174,7 @@ class LQASStatsViewSet(viewsets.ViewSet):
             "form_count": form_count,
             "form_campaign_not_found_count": form_campaign_not_found_count,
             "day_country_not_found": day_country_not_found,
+            "skipped_forms": skipped_forms,
         }
         return JsonResponse(response, safe=False)
 

--- a/plugins/polio/api.py
+++ b/plugins/polio/api.py
@@ -606,9 +606,12 @@ class IMStatsViewSet(viewsets.ViewSet):
                 if round_number == "Round2":
                     round_number = "Rnd2"
                 if round_number != "Rnd1" and round_number != "Rnd2":
-                    skipped_forms_list.append(form["_id"])
-                    skipped_forms.update({"count": len(skipped_forms_list)})
-                    print("skipped")
+                    try:
+                        skipped_forms_list.append(
+                            {form["_id"]: {"round": form["roundNumber"], "date": form["date_monitored"]}}
+                        )
+                    except KeyError:
+                        skipped_forms_list.append({form["_id"]: {"round": None, "date": form["date_monitored"]}})
                     continue
                 if form.get("HH", None):
                     if "HH" in stats_types:
@@ -682,6 +685,8 @@ class IMStatsViewSet(viewsets.ViewSet):
                 else:
                     day_country_not_found[country.name][today_string] += 1
                     form_campaign_not_found_count += 1
+
+        skipped_forms.update({"count": len(skipped_forms_list)})
 
         response = {
             "stats": campaign_stats,
@@ -1062,14 +1067,19 @@ class LQASStatsViewSet(viewsets.ViewSet):
 
             districts = set()
             for form in forms:
+                print(form)
                 round_number = form.get("roundNumber")
                 if round_number == "Rnd0" or round_number == "Round1":
                     round_number = "Rnd1"
                 if round_number == "Round2":
                     round_number = "Rnd2"
                 if round_number != "Rnd1" and round_number != "Rnd2":
-                    skipped_forms_list.append(form["_id"])
-                    skipped_forms.update({"count": len(skipped_forms_list)})
+                    try:
+                        skipped_forms_list.append(
+                            {form["_id"]: {"round": form["roundNumber"], "date": form["date_monitored"]}}
+                        )
+                    except KeyError:
+                        skipped_forms_list.append({form["_id"]: {"round": None, "date": form["Date_of_LQAS"]}})
                     continue
                 HH_COUNT = form.get("Count_HH", None)
                 if HH_COUNT is None:
@@ -1172,6 +1182,8 @@ class LQASStatsViewSet(viewsets.ViewSet):
         add_nfm_abs_stats_for_round(campaign_stats, nfm_abs_reasons_per_district_per_campaign, "round_2")
         format_caregiver_stats(campaign_stats, "round_1")
         format_caregiver_stats(campaign_stats, "round_2")
+
+        skipped_forms.update({"count": len(skipped_forms_list)})
 
         response = {
             "stats": campaign_stats,

--- a/plugins/polio/api.py
+++ b/plugins/polio/api.py
@@ -503,6 +503,8 @@ class IMStatsViewSet(viewsets.ViewSet):
         campaigns = Campaign.objects.all()
         config = get_object_or_404(Config, slug="im-config")
         requested_country = request.GET.get("country_id", None)
+        skipped_forms_list = []
+        skipped_forms = {"count": 0, "forms_id": skipped_forms_list}
 
         if requested_country is None:
             return HttpResponseBadRequest
@@ -603,8 +605,10 @@ class IMStatsViewSet(viewsets.ViewSet):
                     round_number = "Rnd1"
                 if round_number == "Round2":
                     round_number = "Rnd2"
-                # FIXME log skipped forms somewhere, accept keys like "Round1" and "Round2"
                 if round_number != "Rnd1" and round_number != "Rnd2":
+                    skipped_forms_list.append(form["_id"])
+                    skipped_forms.update({"count": len(skipped_forms_list)})
+                    print("skipped")
                     continue
                 if form.get("HH", None):
                     if "HH" in stats_types:
@@ -685,6 +689,7 @@ class IMStatsViewSet(viewsets.ViewSet):
             "day_country_not_found": day_country_not_found,
             "form_count": form_count,
             "fully_mapped_form_count": fully_mapped_form_count,
+            "skipped_forms": skipped_forms,
         }
         return JsonResponse(response, safe=False)
 

--- a/plugins/polio/api.py
+++ b/plugins/polio/api.py
@@ -1076,7 +1076,7 @@ class LQASStatsViewSet(viewsets.ViewSet):
                 if round_number != "Rnd1" and round_number != "Rnd2":
                     try:
                         skipped_forms_list.append(
-                            {form["_id"]: {"round": form["roundNumber"], "date": form["date_monitored"]}}
+                            {form["_id"]: {"round": form["roundNumber"], "date": form["Date_of_LQAS"]}}
                         )
                     except KeyError:
                         skipped_forms_list.append({form["_id"]: {"round": None, "date": form["Date_of_LQAS"]}})

--- a/plugins/polio/api.py
+++ b/plugins/polio/api.py
@@ -600,23 +600,24 @@ class IMStatsViewSet(viewsets.ViewSet):
                     continue
                 try:
                     round_number = form["roundNumber"]
-                    if round_number == "Rnd0":
-                        skipped_forms_list.append(
-                            {form["_id"]: {"round": form["roundNumber"], "date": form["date_monitored"]}}
-                        )
-                        unknown_round += 1
-                        continue
-                    if round_number == "MOPUP":
+                    if round_number.upper() == "MOPUP":
                         continue
                 except KeyError:
                     skipped_forms_list.append({form["_id"]: {"round": None, "date": form["date_monitored"]}})
                     no_round_count += 1
                     continue
                 round_number = form["roundNumber"]
-                if round_number == "Round1":
-                    round_number = "Rnd1"
-                if round_number == "Round2":
-                    round_number = "Rnd2"
+                if round_number.endswith("1") or round_number.endswith("2"):
+                    if round_number.endswith("1"):
+                        round_number = "Rnd1"
+                    if round_number.endswith("2"):
+                        round_number = "Rnd2"
+                else:
+                    skipped_forms_list.append(
+                        {form["_id"]: {"round": form["roundNumber"], "date": form["date_monitored"]}}
+                    )
+                    unknown_round += 1
+                    continue
                 if form.get("HH", None):
                     if "HH" in stats_types:
                         for kid in form.get("HH", []):
@@ -1075,20 +1076,25 @@ class LQASStatsViewSet(viewsets.ViewSet):
 
             districts = set()
             for form in forms:
-                round_number = form.get("roundNumber")
-                if round_number == "Round1":
-                    round_number = "Rnd1"
-                if round_number == "Round2":
-                    round_number = "Rnd2"
-                if round_number != "Rnd1" and round_number != "Rnd2":
-                    try:
-                        skipped_forms_list.append(
-                            {form["_id"]: {"round": form["roundNumber"], "date": form["Date_of_LQAS"]}}
-                        )
-                        unknown_round += 1
-                    except KeyError:
-                        skipped_forms_list.append({form["_id"]: {"round": None, "date": form["Date_of_LQAS"]}})
-                        no_round_count += 1
+                try:
+                    round_number = form["roundNumber"]
+                    if round_number.upper() == "MOPUP":
+                        continue
+                except KeyError:
+                    skipped_forms_list.append({form["_id"]: {"round": None, "date": form["Date_of_LQAS"]}})
+                    no_round_count += 1
+                    continue
+                round_number = form["roundNumber"]
+                if round_number.endswith("1") or round_number.endswith("2"):
+                    if round_number.endswith("1"):
+                        round_number = "Rnd1"
+                    if round_number.endswith("2"):
+                        round_number = "Rnd2"
+                else:
+                    skipped_forms_list.append(
+                        {form["_id"]: {"round": form["roundNumber"], "date": form["Date_of_LQAS"]}}
+                    )
+                    unknown_round += 1
                     continue
                 HH_COUNT = form.get("Count_HH", None)
                 if HH_COUNT is None:

--- a/plugins/polio/api.py
+++ b/plugins/polio/api.py
@@ -1067,7 +1067,6 @@ class LQASStatsViewSet(viewsets.ViewSet):
 
             districts = set()
             for form in forms:
-                print(form)
                 round_number = form.get("roundNumber")
                 if round_number == "Rnd0" or round_number == "Round1":
                     round_number = "Rnd1"

--- a/plugins/polio/api.py
+++ b/plugins/polio/api.py
@@ -966,7 +966,7 @@ class LQASStatsViewSet(viewsets.ViewSet):
         config = get_object_or_404(Config, slug="lqas-config")
         requested_country = request.GET.get("country_id", None)
         skipped_forms_list = []
-        skipped_forms = {"count": 0, "forms": skipped_forms_list}
+        skipped_forms = {"count": 0, "forms_id": skipped_forms_list}
 
         if requested_country is None:
             return HttpResponseBadRequest
@@ -1062,9 +1062,8 @@ class LQASStatsViewSet(viewsets.ViewSet):
                     round_number = "Rnd1"
                 if round_number == "Round2":
                     round_number = "Rnd2"
-                # FIXME ignored forms should be logged somewhere
                 if round_number != "Rnd1" and round_number != "Rnd2":
-                    skipped_forms_list.append(form)
+                    skipped_forms_list.append(form["_id"])
                     skipped_forms.update({"count": len(skipped_forms_list)})
                     continue
                 HH_COUNT = form.get("Count_HH", None)

--- a/plugins/polio/api.py
+++ b/plugins/polio/api.py
@@ -960,6 +960,7 @@ class LQASStatsViewSet(viewsets.ViewSet):
     """
     Endpoint used to transform IM (independent monitoring) data from existing ODK forms stored in ONA.
     """
+
     def list(self, request):
         campaigns = Campaign.objects.all()
         config = get_object_or_404(Config, slug="lqas-config")


### PR DESCRIPTION
Add "skipped_forms": skipped_forms to the response which contains a count , skipped form id, round and date.
Add count of invalid rounds and unknown rounds.
Remove auto assign Rdn0 to Rnd1. 

![image](https://user-images.githubusercontent.com/45785235/154523401-0f386f44-9277-4228-87dc-1b5aa0c5453d.png)
![image](https://user-images.githubusercontent.com/45785235/154523586-89278dce-660e-479b-8aca-e067090aaf6c.png)

