### PR TITLE
POLIO-516: get scope from round(LQAS-IM)

### DIFF
--- a/plugins/polio/api.py
+++ b/plugins/polio/api.py
@@ -644,17 +644,17 @@ class IMStatsViewSet(viewsets.ViewSet):
         if stats_types == "HH,OHH":
             im_request_type = ""
 
-        # cached_response = cache.get(
-        #     "{0}-{1}-IM{2}".format(request.user.id, request.query_params["country_id"], im_request_type),
-        #     version=CACHE_VERSION,
-        # )
+        cached_response = cache.get(
+            "{0}-{1}-IM{2}".format(request.user.id, request.query_params["country_id"], im_request_type),
+            version=CACHE_VERSION,
+        )
 
-        # if not request.user.is_anonymous and cached_response and not no_cache:
-        #     response = json.loads(cached_response)
-        #     cached_date = make_aware(datetime.utcfromtimestamp(response["cache_creation_date"]))
+        if not request.user.is_anonymous and cached_response and not no_cache:
+            response = json.loads(cached_response)
+            cached_date = make_aware(datetime.utcfromtimestamp(response["cache_creation_date"]))
 
-        #     if latest_campaign_update and cached_date > latest_campaign_update:
-        #         return JsonResponse(response)
+            if latest_campaign_update and cached_date > latest_campaign_update:
+                return JsonResponse(response)
 
         stats_types = stats_types.split(",")
         config = get_object_or_404(Config, slug="im-config")
@@ -1010,7 +1010,6 @@ def handle_ona_request_with_key(request, key):
                 logger.exception(f"failed parsing of {form}", exc_info=e)
                 failure_count += 1
     print("parsed:", len(res), "failed:", failure_count)
-    # print("all_keys", all_keys)
     res = convert_dicts_to_table(res)
 
     if as_csv:

--- a/plugins/polio/api.py
+++ b/plugins/polio/api.py
@@ -644,17 +644,17 @@ class IMStatsViewSet(viewsets.ViewSet):
         if stats_types == "HH,OHH":
             im_request_type = ""
 
-        cached_response = cache.get(
-            "{0}-{1}-IM{2}".format(request.user.id, request.query_params["country_id"], im_request_type),
-            version=CACHE_VERSION,
-        )
+        # cached_response = cache.get(
+        #     "{0}-{1}-IM{2}".format(request.user.id, request.query_params["country_id"], im_request_type),
+        #     version=CACHE_VERSION,
+        # )
 
-        if not request.user.is_anonymous and cached_response and not no_cache:
-            response = json.loads(cached_response)
-            cached_date = make_aware(datetime.utcfromtimestamp(response["cache_creation_date"]))
+        # if not request.user.is_anonymous and cached_response and not no_cache:
+        #     response = json.loads(cached_response)
+        #     cached_date = make_aware(datetime.utcfromtimestamp(response["cache_creation_date"]))
 
-            if latest_campaign_update and cached_date > latest_campaign_update:
-                return JsonResponse(response)
+        #     if latest_campaign_update and cached_date > latest_campaign_update:
+        #         return JsonResponse(response)
 
         stats_types = stats_types.split(",")
         config = get_object_or_404(Config, slug="im-config")
@@ -807,7 +807,7 @@ class IMStatsViewSet(viewsets.ViewSet):
                 if campaign:
                     campaign_name = campaign.obr_name
                     # FIXME: We refetch the whole list for all submission this is probably a cause of slowness
-                    scope = campaign.get_all_districts().values_list("id", flat=True)
+                    scope = campaign.get_round_districts(round_number).values_list("id", flat=True)
                     campaign_stats[campaign_name]["has_scope"] = len(scope) > 0
                     district = find_district(district_name, region_name, district_dict)
                     if not district:
@@ -1368,7 +1368,7 @@ class LQASStatsViewSet(viewsets.ViewSet):
                             if source_info == "True":
                                 caregiver_counts_dict[source_info_key] += 1
                 # FIXME: We refetch the whole list for all submission this is probably a cause of slowness
-                scope = campaign.get_all_districts().values_list("id", flat=True)
+                scope = campaign.get_round_districts(round_number).values_list("id", flat=True)
                 campaign_stats[campaign_name]["has_scope"] = len(scope) > 0
                 district = find_district(district_name, region_name, district_dict)
                 if not district:

--- a/plugins/polio/api.py
+++ b/plugins/polio/api.py
@@ -80,7 +80,7 @@ from .preparedness.parser import get_preparedness
 
 logger = getLogger(__name__)
 
-CACHE_VERSION = 6
+CACHE_VERSION = 7
 
 
 class CustomFilterBackend(filters.BaseFilterBackend):

--- a/plugins/polio/models.py
+++ b/plugins/polio/models.py
@@ -369,6 +369,14 @@ class Campaign(SoftDeletableModel):
             return OrgUnit.objects.filter(groups__roundScope__round__campaign=self)
         return self.get_campaign_scope_districts()
 
+    def get_round_districts(self, round_number: int):
+        """District from a specific round"""
+        if self.separate_scopes_per_round:
+            return OrgUnit.objects.filter(groups__roundScope__round__number=self).filter(
+                groups__roundScope__round__campaign=self
+            )
+        return self.get_campaign_scope_districts()
+
     def last_surge(self):
         spreadsheet_url = self.surge_spreadsheet_url
         ssi = SpreadSheetImport.last_for_url(spreadsheet_url)


### PR DESCRIPTION
LQA/IM maps were still using campaign scoped maps

## Self proof reading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented


## Changes

- Add `get_round_districts` method to `Campaign` model
- Replace `get_all_districts` with `get_round_district` in `LQASStatsViewSet` and `IMStatsViewSet`


## How to test

- create a campaign with different scopes per round
- Go to LQAS
- show campaign
- The maps should display different scopes for each round (it will appear in grey if there's no LQAS data, so you can see it anyway)
- repeat with IM

## Print screen / video

![Screenshot 2022-09-13 at 12 03 56](https://user-images.githubusercontent.com/38907762/189875340-89640d1c-1168-41af-9534-993e20f725e7.png)

