### PR TITLE
IA-1539: iterate all perms to find landing page

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/users/components/ProtectedRoute.js
+++ b/hat/assets/js/apps/Iaso/domains/users/components/ProtectedRoute.js
@@ -31,7 +31,7 @@ class ProtectedRoute extends Component {
             if (!isAuthorized && isRootUrl) {
                 const newBaseUrl = getFirstAllowedUrl(
                     permissions,
-                    currentUser,
+                    currentUser?.permissions ?? [],
                     allRoutes,
                 );
                 if (newBaseUrl) {

--- a/hat/assets/js/apps/Iaso/domains/users/utils.js
+++ b/hat/assets/js/apps/Iaso/domains/users/utils.js
@@ -88,5 +88,6 @@ export const getFirstAllowedUrl = (
     if (newPath) {
         return newPath.baseUrl;
     }
+    if (untestedPermissions.length === 0) return undefined;
     return getFirstAllowedUrl(rootPermissions, untestedPermissions, routes);
 };

--- a/hat/assets/js/apps/Iaso/domains/users/utils.js
+++ b/hat/assets/js/apps/Iaso/domains/users/utils.js
@@ -71,13 +71,22 @@ export const listMenuPermission = (menuItem, permissions = []) => {
  * @param {Object} user
  * @return {String}
  */
-export const getFirstAllowedUrl = (rootPermissions, user, routes) => {
+export const getFirstAllowedUrl = (
+    rootPermissions,
+    userPermissions,
+    routes,
+) => {
+    const untestedPermissions = [...userPermissions];
     let newRoot;
-    user?.permissions.forEach(p => {
+    userPermissions.forEach((p, i) => {
         if (!newRoot && !rootPermissions.includes(p)) {
             newRoot = p;
+            untestedPermissions.splice(i, 1);
         }
     });
     const newPath = routes.find(p => p.permissions?.some(kp => kp === newRoot));
-    return newPath?.baseUrl;
+    if (newPath) {
+        return newPath.baseUrl;
+    }
+    return getFirstAllowedUrl(rootPermissions, untestedPermissions, routes);
 };


### PR DESCRIPTION
Some profiles were not correctly redirected when they didn't have permission for the landing page

## Self proof reading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [X] Are my typescript files well typed

## Changes

- change `getFirstAllowedUrl` to keep looking for eligible route if the first permission found isn't linked to any routes


## How to test

- create a user without the permission to forms but with the untranslated permission `iaso_beneficiaries` and at least 1 other permission (except the polio ones)
- log in with that user

## Print screen / video

There's no point really, just login and see if you get a the 401 screen

## Notes

The bug happened because of a dangling permission after a migration. Removing that permission is part of another ticket.
Anyway it's good to have a more robust fallback method, because we've had permissions leading to nowhere before.
