### PR TITLE
POLIO-463: Verification score as a number

### DIFF
--- a/plugins/polio/js/src/forms/RiskAssessmentForm.js
+++ b/plugins/polio/js/src/forms/RiskAssessmentForm.js
@@ -39,6 +39,10 @@ export const RiskAssessmentForm = () => {
                             name="verification_score"
                             component={TextInput}
                             className={classes.input}
+                            type="number"
+                            inputProps={{
+                                min: 0,
+                            }}
                         />
                     </Grid>
                 </Grid>


### PR DESCRIPTION
Verification score should be blocked for number data entry only 

## Self proof reading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included

## Changes

adding type and input props to adapt TextInput as a number input

## How to test

Edit a campaign , go to risk tab, verification score input should accept only numbers

## Print screen / video

<img width="674" alt="Screenshot 2022-09-16 at 13 31 03" src="https://user-images.githubusercontent.com/12494624/190629500-301dfb55-d9b8-4ab2-ab51-dbfd41a3b761.png">


