### PR TITLE
POLIO-578: adding prop to static field allowing to hide it or not for export

### DIFF
--- a/plugins/polio/js/src/components/campaignCalendar/Body.js
+++ b/plugins/polio/js/src/components/campaignCalendar/Body.js
@@ -15,6 +15,7 @@ const Body = ({
     firstMonday,
     lastSunday,
     loadingCampaigns,
+    isPdf,
 }) => {
     const classes = useStyles();
     return (
@@ -29,7 +30,10 @@ const Body = ({
                             className={classes.tableRow}
                             key={`row-${campaign.id}}`}
                         >
-                            <StaticFieldsCells campaign={campaign} />
+                            <StaticFieldsCells
+                                campaign={campaign}
+                                isPdf={isPdf}
+                            />
                             {getCells(
                                 campaign,
                                 currentWeekIndex,
@@ -50,6 +54,7 @@ Body.propTypes = {
     firstMonday: PropTypes.object.isRequired,
     lastSunday: PropTypes.object.isRequired,
     loadingCampaigns: PropTypes.bool.isRequired,
+    isPdf: PropTypes.bool.isRequired,
 };
 
 export { Body };

--- a/plugins/polio/js/src/components/campaignCalendar/Head.js
+++ b/plugins/polio/js/src/components/campaignCalendar/Head.js
@@ -10,9 +10,9 @@ import { colSpanTitle } from './constants';
 import { HeadStaticFieldsCells } from './cells/HeadStaticFields';
 import { useStaticFields } from '../../hooks/useStaticFields';
 
-const Head = ({ headers, orders, currentWeekIndex }) => {
+const Head = ({ headers, orders, currentWeekIndex, isPdf }) => {
     const classes = useStyles();
-    const fields = useStaticFields();
+    const fields = useStaticFields(isPdf);
     return (
         <TableHead>
             <TableRow className={classes.tableRow}>
@@ -79,7 +79,7 @@ const Head = ({ headers, orders, currentWeekIndex }) => {
             <TableRow
                 className={classnames(classes.tableRow, classes.tableRowSmall)}
             >
-                <HeadStaticFieldsCells orders={orders} />
+                <HeadStaticFieldsCells orders={orders} isPdf={isPdf} />
                 {headers.weeks.map((week, weekIndex) => (
                     <TableCell
                         className={classnames(
@@ -129,11 +129,11 @@ const Head = ({ headers, orders, currentWeekIndex }) => {
         </TableHead>
     );
 };
-
 Head.propTypes = {
     headers: PropTypes.object.isRequired,
     orders: PropTypes.string.isRequired,
     currentWeekIndex: PropTypes.number.isRequired,
+    isPdf: PropTypes.bool.isRequired,
 };
 
 export { Head };

--- a/plugins/polio/js/src/components/campaignCalendar/cells/HeadStaticFields.js
+++ b/plugins/polio/js/src/components/campaignCalendar/cells/HeadStaticFields.js
@@ -16,7 +16,7 @@ import MESSAGES from '../../../constants/messages';
 import { genUrl } from '../../../utils/routing';
 import { useStaticFields } from '../../../hooks/useStaticFields';
 
-const HeadStaticFieldsCells = ({ orders, router }) => {
+const HeadStaticFieldsCells = ({ orders, router, isPdf }) => {
     const classes = useStyles();
     const { formatMessage } = useSafeIntl();
     const dispatch = useDispatch();
@@ -47,7 +47,7 @@ const HeadStaticFieldsCells = ({ orders, router }) => {
 
         dispatch(replace(url));
     };
-    const fields = useStaticFields();
+    const fields = useStaticFields(isPdf);
     return fields.map(f => {
         const sort = ordersArray.find(o => o.id === f.sortKey);
         const sortActive = Boolean(sort);
@@ -105,6 +105,7 @@ const HeadStaticFieldsCells = ({ orders, router }) => {
 
 HeadStaticFieldsCells.propTypes = {
     orders: PropTypes.string.isRequired,
+    isPdf: PropTypes.bool.isRequired,
 };
 
 const wrappedHeadStaticFieldsCells = withRouter(HeadStaticFieldsCells);

--- a/plugins/polio/js/src/components/campaignCalendar/cells/StaticFields.js
+++ b/plugins/polio/js/src/components/campaignCalendar/cells/StaticFields.js
@@ -8,10 +8,10 @@ import { colSpanTitle } from '../constants';
 import { useStyles } from '../Styles';
 import { useStaticFields } from '../../../hooks/useStaticFields';
 
-const StaticFieldsCells = ({ campaign }) => {
+const StaticFieldsCells = ({ campaign, isPdf }) => {
     const classes = useStyles();
     const defaultCellStyles = [classes.tableCell, classes.tableCellBordered];
-    const fields = useStaticFields();
+    const fields = useStaticFields(isPdf);
     return fields.map(field => (
         <TableCell
             key={field.key}
@@ -33,6 +33,7 @@ const StaticFieldsCells = ({ campaign }) => {
 
 StaticFieldsCells.propTypes = {
     campaign: PropTypes.object.isRequired,
+    isPdf: PropTypes.bool.isRequired,
 };
 
 export { StaticFieldsCells };

--- a/plugins/polio/js/src/components/campaignCalendar/index.js
+++ b/plugins/polio/js/src/components/campaignCalendar/index.js
@@ -42,6 +42,7 @@ const CampaignsCalendar = ({
                         params={params}
                         orders={orders}
                         currentWeekIndex={currentWeekIndex}
+                        isPdf={isPdf}
                     />
                     <Body
                         loadingCampaigns={loadingCampaigns}
@@ -49,6 +50,7 @@ const CampaignsCalendar = ({
                         currentWeekIndex={currentWeekIndex}
                         firstMonday={firstMonday}
                         lastSunday={lastSunday}
+                        isPdf={isPdf}
                     />
                 </Table>
             </TableContainer>

--- a/plugins/polio/js/src/components/campaignCalendar/staticFields.js
+++ b/plugins/polio/js/src/components/campaignCalendar/staticFields.js
@@ -9,6 +9,7 @@ const staticFields = [
         key: 'edit',
         hideHeadTitle: true,
         render: campaign => <EditCampaignCell campaign={campaign} />,
+        exportHide: true,
     },
     {
         key: 'country',

--- a/plugins/polio/js/src/hooks/useStaticFields.js
+++ b/plugins/polio/js/src/hooks/useStaticFields.js
@@ -1,9 +1,12 @@
 import { useSelector } from 'react-redux';
 import { staticFields } from '../components/campaignCalendar/staticFields';
 
-const useStaticFields = () => {
+const useStaticFields = isPdf => {
     const isLogged = useSelector(state => Boolean(state.users.current));
     let fields = [...staticFields];
+    if (isPdf) {
+        fields = fields.filter(f => !f.exportHide);
+    }
     if (!isLogged) {
         fields = fields.filter(f => f.key !== 'edit');
     }


### PR DESCRIPTION
The edit column was still present while exporting a pdf from the calendar page

## Self proof reading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included

## Changes

- add `exportHide` property to static field allowing to hide it while exporting a pdf
- drill down `isPdf` prop to lower level component
- adapt `useStaticField` to filter field with `isPdf` and `exportHide`

## How to test

Go to calendar page and make an export of it, check that the first column has been removed

## Print screen / video

[calendar (65).pdf](https://github.com/BLSQ/iaso/files/9598098/calendar.65.pdf)
