### PR TITLE
IA-1279: Edit instance location in admin is not working

### DIFF
--- a/iaso/admin.py
+++ b/iaso/admin.py
@@ -1,5 +1,3 @@
-import json
-
 from django.contrib.admin import widgets
 from django.contrib.gis import admin, forms
 from django.db import models
@@ -43,6 +41,7 @@ from .models import (
     InstanceLock,
 )
 from .models.microplanning import Team, Planning, Assignment
+from .utils.gis import convert_2d_point_to_3d
 
 
 class OrgUnitAdmin(admin.GeoModelAdmin):
@@ -160,6 +159,12 @@ class InstanceAdmin(admin.GeoModelAdmin):
     inlines = [
         InstanceFileAdminInline,
     ]
+
+    def save_model(self, request, obj, form, change):
+        if obj.location:  # GeoDjango's map return a 2D point, but the database expect a Z value
+            obj.location = convert_2d_point_to_3d(obj.location)
+
+        super().save_model(request, obj, form, change)
 
 
 class InstanceFileAdmin(admin.GeoModelAdmin):

--- a/iaso/utils/gis.py
+++ b/iaso/utils/gis.py
@@ -1,0 +1,12 @@
+from django.contrib.gis.geos import Point
+
+
+def convert_2d_point_to_3d(point: Point) -> Point:
+    """Convert a 2D point to a 3D point
+
+    Return the initial point if it's already 3D
+    """
+    if point.z is None:
+        return Point(x=point.x, y=point.y, z=0, srid=point.srid)
+
+    return point


### PR DESCRIPTION
An exception ("Z dimension is missing") was raised when editing an instance location in the Django admin (by adding/moving the point on the map).

This PR fixes the issue.

## Self proof reading checklist

- [x] Did I use eslint and black formatters

## How to test

Edit an instance location in Django admin, make sure it can save correctly and without any exception.

@ekhalilbsq: as far as I understood the same (or at least a similar) issue might still happen in other places in Iaso. When you encounter one, can you create a JIRA ticket and assign me? thanks!