### PR TITLE
IA-1562 entity admin: the entity type is now more clearly displayed

### DIFF
--- a/iaso/admin.py
+++ b/iaso/admin.py
@@ -279,6 +279,14 @@ class SourceVersionAdmin(admin.ModelAdmin):
 
 
 class EntityAdmin(admin.ModelAdmin):
+    def get_form(self, request, obj=None, **kwargs):
+        # In the <select> for the entity type, we also want to indicate the account name
+        form = super().get_form(request, obj, **kwargs)
+        form.base_fields[
+            "entity_type"
+        ].label_from_instance = lambda entity: f"{entity.name} (Account: {entity.account.name})"
+        return form
+
     readonly_fields = ("created_at",)
     list_display = (
         "id",


### PR DESCRIPTION
When adding/editing an entity in the Django admin site, there is a <select> to allow choosing the entity type. Only the name of the entity type was shown there. It made the thing difficult to use, because it was not possible to know to which account the entity type was linked (it also happens that we have multiple entity types with the same name in different accounts)

It is now fixed, the entries in the <select> look like: "Children under 5 (Account: RDC)"

## Self proof reading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented

## How to test

1) Go to the Django admin site
2) Create a new entity (or edit an existing one)
3) Make sure the account name is clearly visible in the list
4) Make sure the admin page still works as intended

## Print screen / video

**Before the change:**

![Screenshot_20220922_144913](https://user-images.githubusercontent.com/386387/191941330-bf0a2b10-1760-442f-aa1e-1d445f1f633e.png)

**After the change:**

![Screenshot_20220923_122348](https://user-images.githubusercontent.com/386387/191941358-7226452e-efb0-44bb-83e7-22d4eae5ddd8.png)
