### PR TITLE
POLIO-543: disable scope if no round, show tooltip

### DIFF
--- a/plugins/polio/js/src/components/CreateEditDialog.js
+++ b/plugins/polio/js/src/components/CreateEditDialog.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-props-no-spreading */
 /* eslint-disable camelcase */
 import React, { useEffect, useState, useMemo } from 'react';
 import PropTypes from 'prop-types';
@@ -15,9 +16,11 @@ import {
     Tab,
     Tabs,
     Typography,
+    Tooltip,
 } from '@material-ui/core';
 
 import { useSafeIntl, LoadingSpinner } from 'bluesquare-components';
+import { FormattedMessage } from 'react-intl';
 import { convertEmptyStringToNull } from '../utils/convertEmptyStringToNull';
 import { PreparednessForm } from '../forms/PreparednessForm';
 import { useFormValidator } from '../hooks/useFormValidator';
@@ -109,7 +112,9 @@ const CreateEditDialog = ({
             {
                 title: formatMessage(MESSAGES.scope),
                 form: ScopeForm,
-                disabled: !formik.values.initial_org_unit,
+                disabled:
+                    !formik.values.initial_org_unit ||
+                    formik.values.rounds.length === 0,
             },
             {
                 title: formatMessage(MESSAGES.budget),
@@ -128,7 +133,11 @@ const CreateEditDialog = ({
                 form: VaccineManangementForm,
             },
         ];
-    }, [formatMessage, formik.values.initial_org_unit]);
+    }, [
+        formatMessage,
+        formik.values.initial_org_unit,
+        formik.values.rounds.length,
+    ]);
 
     const [selectedTab, setSelectedTab] = useState(0);
 
@@ -182,6 +191,29 @@ const CreateEditDialog = ({
                     scrollButtons="auto"
                 >
                     {tabs.map(({ title, disabled }) => {
+                        if (
+                            disabled &&
+                            title === formatMessage(MESSAGES.scope)
+                        ) {
+                            return (
+                                <Tooltip
+                                    title={
+                                        <FormattedMessage
+                                            {...MESSAGES.scopeUnlockConditions}
+                                        />
+                                    }
+                                >
+                                    {/* the wrapping span is to enable the tooltip while the tab is disabled */}
+                                    <span>
+                                        <Tab
+                                            key={title}
+                                            label={title}
+                                            disabled={disabled || false}
+                                        />
+                                    </span>
+                                </Tooltip>
+                            );
+                        }
                         return (
                             <Tab
                                 key={title}

--- a/plugins/polio/js/src/constants/messages.js
+++ b/plugins/polio/js/src/constants/messages.js
@@ -1536,6 +1536,11 @@ const MESSAGES = defineMessages({
         id: 'iaso.polio.label.shipmentFieldsTogether',
         defaultMessage: 'All shipment fields need to be filled together',
     },
+    scopeUnlockConditions: {
+        id: 'iaso.polio.label.scopeUnlockConditions',
+        defaultMessage:
+            'Select initial region and encode dates for at least one round to unlock Scope tab',
+    },
 });
 
 export default MESSAGES;

--- a/plugins/polio/js/src/constants/translations/en.json
+++ b/plugins/polio/js/src/constants/translations/en.json
@@ -280,6 +280,7 @@
     "iaso.polio.label.round1": "Round 1",
     "iaso.polio.label.round2": "Round 2",
     "iaso.polio.label.school": "At school",
+    "iaso.polio.label.scopeUnlockConditions": "Select initial org. unit and encode dates for at least one round to unlock Scope tab",
     "iaso.polio.label.search": "Search",
     "iaso.polio.label.see": "See",
     "iaso.polio.label.seeFullComment": "See full comment",

--- a/plugins/polio/js/src/constants/translations/fr.json
+++ b/plugins/polio/js/src/constants/translations/fr.json
@@ -290,6 +290,7 @@
     "iaso.polio.label.round1": "Round 1",
     "iaso.polio.label.round2": "Round 2",
     "iaso.polio.label.school": "À l'école",
+    "iaso.polio.label.scopeUnlockConditions": "Veuillez sélectuionner l'unité d'org initiale et encoder les dates d'au moins un round pour activer l'onglet \"Périmètre\"",
     "iaso.polio.label.search": "Recherche",
     "iaso.polio.label.see": "Voir",
     "iaso.polio.label.seeFullComment": "Voir commentaire",


### PR DESCRIPTION
Scope tab was showing basically nothing if no round dates had been entered

## Self proof reading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [X] Are my typescript files well typed
- [X] Did I add translations

## Changes

- Extended the condition to `disable` Scope tab: dates for at least 1 round should be provided
- Wrapped the Scope tab in a tooltip witha message explaining the activation conditions of the tab


## How to test

- go to polio campaigns
- create a new campaign
- try to open the scope tab

## Print screen / video

https://user-images.githubusercontent.com/38907762/192532176-50be5694-4c1a-41a5-9213-bc13112027c8.mov



