### PR TITLE
Always use DEFAULT_FROM_EMAIL

### DIFF
--- a/hat/settings.py
+++ b/hat/settings.py
@@ -28,6 +28,11 @@ from urllib.parse import urlparse
 
 from plugins.wfp.wfp_pkce_generator import generate_pkce
 
+# This should the the naked domain (no http or https prefix) that is
+# hosting Iaso, this is used when sending out emails that need a link
+# back to the Iaso application.
+#
+# This should be the same as the one set on: `/admin/sites/site/1/change/`
 DNS_DOMAIN = os.environ.get("DNS_DOMAIN", "localhost:8081")
 TESTING = os.environ.get("TESTING", "").lower() == "true"
 PLUGINS = os.environ["PLUGINS"].split(",") if os.environ.get("PLUGINS", "") else []

--- a/iaso/api/profiles.py
+++ b/iaso/api/profiles.py
@@ -151,6 +151,7 @@ class ProfilesViewSet(viewsets.ViewSet):
     @staticmethod
     def send_email_invitation(self, profile, email_subject, email_message):
         domain = settings.DNS_DOMAIN
+        from_email = settings.DEFAULT_FROM_EMAIL
 
         token_generator = PasswordResetTokenGenerator()
         token = token_generator.make_token(profile.user)
@@ -164,7 +165,7 @@ class ProfilesViewSet(viewsets.ViewSet):
 
         email_subject_text = email_subject.format(dns_domain=f"{domain}")
 
-        send_mail(email_subject_text, email_message_text, "no-reply@%s" % domain, [profile.user.email])
+        send_mail(email_subject_text, email_message_text, from_email, [profile.user.email])
 
     @staticmethod
     def get_message_by_language(self, request_languange="en"):

--- a/iaso/tests/api/test_profiles.py
+++ b/iaso/tests/api/test_profiles.py
@@ -265,9 +265,10 @@ class ProfileAPITestCase(APITestCase):
         self.assertEqual(response.status_code, 200)
 
         domain = settings.DNS_DOMAIN
+        from_email = settings.DEFAULT_FROM_EMAIL
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].subject, f"Set up a password for your new account on {domain}")
-        self.assertEqual(mail.outbox[0].from_email, "no-reply@%s" % domain)
+        self.assertEqual(mail.outbox[0].from_email, from_email)
         self.assertEqual(mail.outbox[0].to, ["test@test.com"])
 
     def test_create_profile_with_no_password_and_not_send_email(self):

--- a/plugins/polio/api.py
+++ b/plugins/polio/api.py
@@ -251,6 +251,8 @@ Timeline tracker Automated message
         country = campaign.country
 
         domain = settings.DNS_DOMAIN
+        from_email = settings.DEFAULT_FROM_EMAIL
+
         if campaign.creation_email_send_at:
             raise serializers.ValidationError("Notification Email already sent")
         if not (campaign.obr_name and campaign.virus and country and campaign.onset_at):
@@ -281,7 +283,7 @@ Timeline tracker Automated message
         send_mail(
             "New Campaign {}".format(campaign.obr_name),
             email_text,
-            "no-reply@%s" % domain,
+            from_email,
             emails,
         )
         campaign.creation_email_send_at = now()

--- a/plugins/polio/management/commands/weekly_email.py
+++ b/plugins/polio/management/commands/weekly_email.py
@@ -28,6 +28,8 @@ def get_last_preparedness(campaign):
 def send_notification_email(campaign):
     country = campaign.country
     domain = settings.DNS_DOMAIN
+    from_email = settings.DEFAULT_FROM_EMAIL
+
     if not (campaign.obr_name and campaign.virus and country and campaign.onset_at and campaign.deleted_at is None):
         return False
     try:
@@ -88,7 +90,7 @@ Timeline tracker Automated message.
     send_mail(
         "Update on Campaign {}".format(campaign.obr_name),
         email_text,
-        "no-reply@%s" % domain,
+        from_email,
         emails,
     )
 


### PR DESCRIPTION
We're mixing DEFAULT_FROM_EMAIL with `no-reply${settings.DNS_DOMAIN}`, this tries to fix that so that all outgoing email is send from the `DEFAULT_FROM_EMAIL`

I did a search on `no-reply` and changed those instances, the `DNS_DOMAIN` setting is still in use, because it is in use in the bodies of the emails for link generation, e.g.

      <a href="//{{settings.DNS_DOMAIN}}/some/link/here">

So the DNS_DOMAIN should point to the domain that is hosting Iaso, it's unrelated to the email sending bit.
