### PR TITLE
IA-1087 Fix performance problem on history API

### DIFF
--- a/iaso/api/logs.py
+++ b/iaso/api/logs.py
@@ -18,10 +18,10 @@ from iaso.models import OrgUnit, Instance, Form
 def has_access_to(user: User, obj: Union[OrgUnit, Instance, models.Model]):
     if isinstance(obj, OrgUnit):
         ous = OrgUnit.objects.filter_for_user_and_app_id(user, None)
-        return obj in ous
+        return ous.filter(id=obj.id).exists()
     if isinstance(obj, Instance):
         instances = Instance.objects.filter_for_user(user)
-        return user.has_perm("menupermissions.iaso_submissions") and obj in instances
+        return user.has_perm("menupermissions.iaso_submissions") and instances.filter(id=obj.id).exists()
     if isinstance(obj, Form):
         forms = Form.objects.filter_for_user_and_app_id(user)
         return obj in forms

--- a/iaso/models/base.py
+++ b/iaso/models/base.py
@@ -819,15 +819,18 @@ class InstanceQuerySet(models.QuerySet):
 
     def filter_for_user(self, user):
         profile = user.iaso_profile
+        # Do a relative import to avoid an import loop
         from .org_unit import OrgUnit
+
+        new_qs = self
 
         # If user is restricted to some org unit, filter on thoses
         if profile.org_units.exists():
             orgunits = OrgUnit.objects.hierarchy(profile.org_units.all())
 
-            self = self.filter(org_unit__in=orgunits)
-        self = self.filter(project__account=profile.account_id)
-        return self
+            new_qs = new_qs.filter(org_unit__in=orgunits)
+        new_qs = new_qs.filter(project__account=profile.account_id)
+        return new_qs
 
 
 InstanceManager = models.Manager.from_queryset(InstanceQuerySet)

--- a/iaso/models/base.py
+++ b/iaso/models/base.py
@@ -826,7 +826,7 @@ class InstanceQuerySet(models.QuerySet):
             orgunits = OrgUnit.objects.hierarchy(profile.org_units.all())
 
             self = self.filter(org_unit__in=orgunits)
-        self = self.filter(project__account=profile.account)
+        self = self.filter(project__account=profile.account_id)
         return self
 
 


### PR DESCRIPTION
Improve performance on  /api/logs/

## Self proof reading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] My migrations file are included
- [x] Are there enough tests
## Changes
The issue found was that we were checking if an record belonged in a queryset using the 'obj in queryset' pattern But to do this Django retrieved ALL the record in the queryset with all their fields from the Database in the RCI account this mean over 100k record and probably megabyte of data and json to be parsed for the Instance

we switched to the patterns queryset.filter(id=obj.id).exists() which only do one very small database query and that we should use from now on

In InstanceQueryset.filter_for_user we also switched to use 'profile.account_id' instead of 'profile.account' which do one less query because it doesn't retrieve the account from the database.

## How to test

Check that you can still edit Instance and OrgUnit and view the modification. It's important to check with a user this is not a super user !

