### PR TITLE
WC2-54 Last Sync missing in beneficiary details response

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/entities/beneficiaries/config.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/beneficiaries/config.tsx
@@ -207,8 +207,8 @@ export const useBeneficiariesDetailsColumns = (
                 // TODO make sortable
                 // TODO get correct key when implemented on backend
                 sortable: false,
-                id: 'last_sync_at',
-                accessor: 'last_sync_at',
+                id: 'updated_at',
+                accessor: 'updated_at',
                 Cell: DateTimeCell,
             },
             {


### PR DESCRIPTION
Last Sync Field is named updated_at in backend response thereby the value was not found. 
Henceforth the correct name updated_at is used. 

## Self proof reading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are my typescript files well typed
- [x] Did I add translations
- [x] My migrations file are included
- [x] Are there enough tests

## How to test

Go to a beneficiary details and check the last_sync column

## Print screen / video

Upload here print screens or videos showing the changes

