### PR TITLE
IA-1574 optimize getting org unit hierarchy (and optimize fetching Instance under an orgunit)

### DIFF
--- a/iaso/api/logs.py
+++ b/iaso/api/logs.py
@@ -18,10 +18,10 @@ from iaso.models import OrgUnit, Instance, Form
 def has_access_to(user: User, obj: Union[OrgUnit, Instance, models.Model]):
     if isinstance(obj, OrgUnit):
         ous = OrgUnit.objects.filter_for_user_and_app_id(user, None)
-        return obj in ous
+        return ous.filter(id=obj.id).exists()
     if isinstance(obj, Instance):
         instances = Instance.objects.filter_for_user(user)
-        return user.has_perm("menupermissions.iaso_submissions") and obj in instances
+        return user.has_perm("menupermissions.iaso_submissions") and instances.filter(id=obj.id).exists()
     if isinstance(obj, Form):
         forms = Form.objects.filter_for_user_and_app_id(user)
         return obj in forms

--- a/iaso/api/org_unit_types/serializers.py
+++ b/iaso/api/org_unit_types/serializers.py
@@ -53,6 +53,7 @@ class OrgUnitTypeSerializer(DynamicFieldsModelSerializer):
         queryset=Form.objects.all(),
     )
 
+    # Fixme make this directly in db !
     def get_units_count(self, obj: OrgUnitType):
         orgUnits = OrgUnit.objects.filter_for_user_and_app_id(
             self.context["request"].user, self.context["request"].query_params.get("app_id")

--- a/iaso/models/base.py
+++ b/iaso/models/base.py
@@ -819,15 +819,18 @@ class InstanceQuerySet(models.QuerySet):
 
     def filter_for_user(self, user):
         profile = user.iaso_profile
+        # Do a relative import to avoid an import loop
         from .org_unit import OrgUnit
+
+        new_qs = self
 
         # If user is restricted to some org unit, filter on thoses
         if profile.org_units.exists():
             orgunits = OrgUnit.objects.hierarchy(profile.org_units.all())
 
-            self = self.filter(org_unit__in=orgunits)
-        self = self.filter(project__account=profile.account_id)
-        return self
+            new_qs = new_qs.filter(org_unit__in=orgunits)
+        new_qs = new_qs.filter(project__account=profile.account_id)
+        return new_qs
 
 
 InstanceManager = models.Manager.from_queryset(InstanceQuerySet)

--- a/iaso/models/base.py
+++ b/iaso/models/base.py
@@ -729,17 +729,11 @@ class InstanceQuerySet(models.QuerySet):
             queryset = queryset.filter(org_unit_id=org_unit_id)
 
         if org_unit_parent_id:
-            # TODO: attempt to refactor this (so it's cleaner / more efficient and we're not limited to an arbitrary number of parents)
-            queryset = queryset.filter(
-                Q(org_unit__id=org_unit_parent_id)
-                | Q(org_unit__parent__id=org_unit_parent_id)
-                | Q(org_unit__parent__parent__id=org_unit_parent_id)
-                | Q(org_unit__parent__parent__parent__id=org_unit_parent_id)
-                | Q(org_unit__parent__parent__parent__parent__id=org_unit_parent_id)
-                | Q(org_unit__parent__parent__parent__parent__parent__id=org_unit_parent_id)
-                | Q(org_unit__parent__parent__parent__parent__parent__parent__id=org_unit_parent_id)
-                | Q(org_unit__parent__parent__parent__parent__parent__parent__parent__id=org_unit_parent_id)
-            )
+            # Local import to avoid loop
+            from iaso.models import OrgUnit
+
+            parent = OrgUnit.objects.get(id=org_unit_parent_id)
+            queryset = queryset.filter(org_unit__path__descendants=parent.path)
 
         if with_location == "true":
             queryset = queryset.filter(location__isnull=False)

--- a/iaso/models/base.py
+++ b/iaso/models/base.py
@@ -826,7 +826,7 @@ class InstanceQuerySet(models.QuerySet):
             orgunits = OrgUnit.objects.hierarchy(profile.org_units.all())
 
             self = self.filter(org_unit__in=orgunits)
-        self = self.filter(project__account=profile.account)
+        self = self.filter(project__account=profile.account_id)
         return self
 
 

--- a/iaso/utils/expressions.py
+++ b/iaso/utils/expressions.py
@@ -1,0 +1,19 @@
+# taken from django/django/contrib/postgres/expressions.py
+# which was introduced in django 4.1
+# FIXME : When upgrading to django >= 4.1, please remove this file
+# and replace the code that import it with
+# ```from django.contrib.postgres.expressions import ArraySubquery```
+from django.contrib.postgres.fields import ArrayField
+from django.db.models import Subquery
+from django.utils.functional import cached_property
+
+
+class ArraySubquery(Subquery):
+    template = "ARRAY(%(subquery)s)"
+
+    def __init__(self, queryset, **kwargs):
+        super().__init__(queryset, **kwargs)
+
+    @cached_property
+    def output_field(self):
+        return ArrayField(self.query.output_field)

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ requests==2.22.0
 
 # postgresql and sql
 psycopg2-binary==2.8.5
-django-ltree==0.5.2
+django-ltree==0.5.3
 
 # webpack loader
 # This is our custom version of webpack loader to handle S3 better.


### PR DESCRIPTION
Optimize the DB usages for OrgUnitQueryset.hierarchy. which is used to filter on all the descendant of one or more orgunits. Before this necessitate a separate subquery now it does everything in one via  a subquery.

This PR also optimize the query for getting all the Submissions below an instance and allow querying at arbritrary depth

## Self proof reading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] My migrations file are included
- [x] Are there enough tests. (there was coverage for this api before)

## Changes

- Updated django-ltree version to the latest one (0.5.4)
-  vendored some code from django 4.   since we can't update the Django version for now (because we are still on python 3.6)
- Rewrote hierarchy to use a subquery
- Modified the query in Instance


## How to test

These are optimizations so everything should works  the same as before. Try to use all the feature using org unit and see if they still works.
Try using the website with an user whose OrgUnit access is limited.
