### PR TITLE
IA-1564: Orgunit Detail - sort on children tab redirects to infos tab

### DIFF
--- a/hat/assets/js/apps/Iaso/constants/routes.js
+++ b/hat/assets/js/apps/Iaso/constants/routes.js
@@ -5,7 +5,7 @@ import FormsStats from '../domains/forms/stats';
 import { OrgUnits } from '../domains/orgUnits/index.tsx';
 import { Links } from '../domains/links';
 import Runs from '../domains/links/Runs';
-import OrgUnitDetail from '../domains/orgUnits/detail';
+import OrgUnitDetail from '../domains/orgUnits/details';
 import Completeness from '../domains/completeness';
 import Instances from '../domains/instances';
 import CompareSubmissions from '../domains/instances/compare/index.tsx';

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/details.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/details.js
@@ -364,11 +364,6 @@ const OrgUnitDetail = ({ params, router }) => {
         sourcesSelected,
     ]);
 
-    useEffect(() => {
-        if (tab !== params.tab && params.tab) {
-            setTab(params.tab);
-        }
-    }, [tab, params.tab]);
     return (
         <section className={classes.root}>
             <TopBar
@@ -518,7 +513,6 @@ const OrgUnitDetail = ({ params, router }) => {
                                 }
                             >
                                 <SingleTable
-                                    paramsPrefix="childrenParams"
                                     apiParams={{
                                         ...onlyChildrenParams(
                                             'childrenParams',
@@ -527,9 +521,6 @@ const OrgUnitDetail = ({ params, router }) => {
                                         ),
                                     }}
                                     propsToWatch={params.orgUnitId}
-                                    baseUrl={baseUrl}
-                                    endPointPath="orgunits"
-                                    fetchItems={fetchOrgUnitsList}
                                     filters={orgUnitFiltersWithPrefix(
                                         'childrenParams',
                                         true,
@@ -537,6 +528,11 @@ const OrgUnitDetail = ({ params, router }) => {
                                         groups,
                                         orgUnitTypes,
                                     )}
+                                    params={params}
+                                    paramsPrefix="childrenParams"
+                                    baseUrl={baseUrl}
+                                    endPointPath="orgunits"
+                                    fetchItems={fetchOrgUnitsList}
                                     columns={orgUnitsTableColumns(
                                         formatMessage,
                                         classes,
@@ -553,7 +549,6 @@ const OrgUnitDetail = ({ params, router }) => {
                                     apiParams={{
                                         orgUnitId: params.orgUnitId,
                                     }}
-                                    hideGpkg
                                     propsToWatch={params.orgUnitId}
                                     filters={linksFiltersWithPrefix(
                                         'linksParams',
@@ -563,6 +558,7 @@ const OrgUnitDetail = ({ params, router }) => {
                                         algorithms,
                                         sources,
                                     )}
+                                    params={params}
                                     paramsPrefix="linksParams"
                                     baseUrl={baseUrl}
                                     endPointPath="links"
@@ -589,6 +585,7 @@ const OrgUnitDetail = ({ params, router }) => {
                                             />
                                         ) : null
                                     }
+                                    hideGpkg
                                 />
                             </div>
                             {tab === 'comments' && (


### PR DESCRIPTION

Removing useless useEffect

## Self proof reading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests
## Changes
Removed a useEffect causing the problem, not sure that it was very usefull...

## How to test

Open details of an org unit, 
navigate lo links tab, 
change sort on a column, 
go to children tab,
change sort on a column, 
 => tab should still be children, not links or infos


## Print screen / video


https://user-images.githubusercontent.com/12494624/194027444-3425faae-8b84-4962-ba87-8dd308129f15.mov


## Notes

Please test also navigaion between other tabs, i d'ont remember why i put this useEffect