### PR TITLE
Polio 626 polio 627 vaccine tab improvements

### DIFF
--- a/plugins/polio/js/src/constants/translations/fr.json
+++ b/plugins/polio/js/src/constants/translations/fr.json
@@ -258,7 +258,7 @@
     "iaso.polio.label.paymentMode": "Mode de paiement",
     "iaso.polio.label.pending": "En attente",
     "iaso.polio.label.playground": "À la plaine de jeux",
-    "iaso.polio.label.poNumbers": "Nombres PO",
+    "iaso.polio.label.poNumbers": "Numéro de PO",
     "iaso.polio.label.preparednessError": "Erreur dans la génération de la Google sheet de préparation",
     "iaso.polio.label.provinceOption": "PROVINCE",
     "iaso.polio.label.ratioCaregiversInformed": "Ratio parents informés",

--- a/plugins/polio/js/src/forms/RoundVaccinesForm.tsx
+++ b/plugins/polio/js/src/forms/RoundVaccinesForm.tsx
@@ -27,6 +27,8 @@ const DEFAULT_WASTAGE_RATIOS = {
     bOPV2: 1.18,
 };
 
+const DEFAULT_DOSES_PER_VIAL = 50;
+
 export const RoundVaccinesForm: FunctionComponent<Props> = ({
     round,
     roundIndex,
@@ -137,6 +139,34 @@ export const RoundVaccinesForm: FunctionComponent<Props> = ({
                 setFieldValue(
                     `rounds[${roundIndex}].vaccines[${index}].wastage_ratio_forecast`,
                     DEFAULT_WASTAGE_RATIOS[vaccine.name],
+                );
+            }
+        });
+    }, [
+        roundIndex,
+        rounds,
+        setFieldValue,
+        // @ts-ignore
+        touched.rounds,
+        vaccines,
+        vaccines.length,
+    ]);
+
+    // Fill in number of doses with default value when adding vaccine
+    useEffect(() => {
+        vaccines.forEach((vaccine, index) => {
+            const dosesPerVial =
+                rounds[roundIndex].vaccines[index].doses_per_vial;
+            // I'm sorry for this, I really had to null check this value
+            const isTouched = Boolean(
+                // @ts-ignore
+                ((touched?.rounds ?? [])[roundIndex]?.vaccines ?? [])[index]
+                    ?.doses_per_vial,
+            );
+            if (!dosesPerVial && !isTouched) {
+                setFieldValue(
+                    `rounds[${roundIndex}].vaccines[${index}].doses_per_vial`,
+                    DEFAULT_DOSES_PER_VIAL,
                 );
             }
         });


### PR DESCRIPTION
There was a wrong translation and a defauklt value missing in the vaccine tab

## Self proof reading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [X] Are my typescript files well typed
- [X] Did I add translations

## Changes

- Added a `useEffect` to add default value for doses per vial. 
- corrected french translation of PO number


## How to test

- go to a campaign with a clear vaccine tab. 
- add a vaccine -> the doses per vial field should auto fill
- check the translation for PO number. Should be " Numéro de PO"

## Print screen / video

https://user-images.githubusercontent.com/38907762/194870088-1ed9ed61-d159-42cd-bce6-9d4ece531efc.mov

![Screenshot 2022-10-10 at 14 46 00](https://user-images.githubusercontent.com/38907762/194870103-8910eafb-4bed-48b1-84e1-2e68727f4adc.png)

