### PR TITLE
POLIO-637: Filter out test campaigns in the excel export

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -18,3 +18,6 @@ ignore_missing_imports = True
 
 [mypy-responses.*]
 ignore_missing_imports = True
+
+[mypy-openpyxl.*]
+ignore_missing_imports = True

--- a/plugins/polio/api.py
+++ b/plugins/polio/api.py
@@ -8,7 +8,6 @@ from typing import Any, Dict, List, Optional, Union
 from collections import defaultdict
 from functools import lru_cache
 from logging import getLogger
-from typing_extensions import reveal_type
 from openpyxl.writer.excel import save_virtual_workbook  # type: ignore
 
 import requests
@@ -224,7 +223,7 @@ class CampaignViewSet(ModelViewSet):
         current_year = self.get_year(current_date)
 
         params = request.query_params
-        calendar_data = self.get_calendar_data(self, current_year, params)
+        calendar_data = self.get_calendar_data(current_year, params)
         filename = xlsx_file_name("calendar", params)
         xlsx_file = generate_xlsx_campaigns_calendar(filename, calendar_data)
 
@@ -245,13 +244,12 @@ class CampaignViewSet(ModelViewSet):
             today = dt.date.today()
             return today.year
 
-    @staticmethod
     def get_calendar_data(self: Any, year: int, params: Any) -> Any:
         """
         Returns filtered rounds from database
 
             parameters:
-                self (CampaignViewSet): a self CampaignViewSet
+                self: a self
                 year (int): a year int
                 params(dictionary): a params dictionary
             returns:
@@ -275,7 +273,7 @@ class CampaignViewSet(ModelViewSet):
             rounds = rounds.filter(campaign__is_preventive=False).filter(campaign__is_test=False)
         if search:
             rounds = rounds.filter(Q(campaign__obr_name__icontains=search) | Q(campaign__epid__icontains=search))
-        print(rounds)
+
         return self.loop_on_rounds(self, rounds)
 
     @staticmethod

--- a/plugins/polio/api.py
+++ b/plugins/polio/api.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List, Optional, Union
 from collections import defaultdict
 from functools import lru_cache
 from logging import getLogger
+from typing_extensions import reveal_type
 from openpyxl.writer.excel import save_virtual_workbook  # type: ignore
 
 import requests
@@ -223,8 +224,7 @@ class CampaignViewSet(ModelViewSet):
         current_year = self.get_year(current_date)
 
         params = request.query_params
-
-        calendar_data = self.get_calendar_data(self, current_year, request.query_params)
+        calendar_data = self.get_calendar_data(self, current_year, params)
         filename = xlsx_file_name("calendar", params)
         xlsx_file = generate_xlsx_campaigns_calendar(filename, calendar_data)
 
@@ -246,31 +246,50 @@ class CampaignViewSet(ModelViewSet):
             return today.year
 
     @staticmethod
-    def get_calendar_data(self, year, params):
+    def get_calendar_data(self: Any, year: int, params: Any) -> Any:
+        """
+        Returns filtered rounds from database
+
+            parameters:
+                self (CampaignViewSet): a self CampaignViewSet
+                year (int): a year int
+                params(dictionary): a params dictionary
+            returns:
+                rounds (array of dictionary): a rounds of array of dictionaries
+        """
         countries = params.get("countries") if params.get("countries") is not None else None
         campaign_groups = params.get("campaignGroups") if params.get("campaignGroups") is not None else None
         campaign_type = params.get("campaignType") if params.get("campaignType") is not None else None
         order_by = params.get("order") if params.get("order") is not None else None
         search = params.get("search")
         rounds = Round.objects.filter(started_at__year=year)
+        # Test campaigns should not appear in the xlsx calendar
+        rounds = rounds.filter(campaign__is_test=False)
         if countries:
             rounds = rounds.filter(campaign__country_id__in=countries.split(","))
         if campaign_groups:
             rounds = rounds.filter(campaign__group_id__in=campaign_groups.split(","))
         if campaign_type == "preventive":
             rounds = rounds.filter(campaign__is_preventive=True)
-        if campaign_type == "test":
-            rounds = rounds.filter(campaign__is_test=True)
         if campaign_type == "regular":
             rounds = rounds.filter(campaign__is_preventive=False).filter(campaign__is_test=False)
         if search:
             rounds = rounds.filter(Q(campaign__obr_name__icontains=search) | Q(campaign__epid__icontains=search))
-
+        print(rounds)
         return self.loop_on_rounds(self, rounds)
 
     @staticmethod
-    def loop_on_rounds(self, rounds):
-        data_row = []
+    def loop_on_rounds(self: Any, rounds: Any) -> list:
+        """
+        Returns formatted rounds
+
+            parameters:
+                self (CampaignViewSet): a self CampaignViewSet
+                rounds(rounds queryset): rounds queryset
+            returns:
+                rounds (list): list of rounds
+        """
+        data_row: list = []
         for round in rounds:
             if round.campaign is not None:
                 if round.campaign.country is not None:
@@ -291,6 +310,7 @@ class CampaignViewSet(ModelViewSet):
                             else:
                                 data_row[row_index]["rounds"][str(month)] = []
                                 data_row[row_index]["rounds"][str(month)].append(self.get_round(round))
+
         return data_row
 
     @staticmethod

--- a/plugins/polio/export_utils.py
+++ b/plugins/polio/export_utils.py
@@ -1,6 +1,6 @@
-from openpyxl import Workbook  # type: ignore
-from openpyxl.styles import Alignment, Font, PatternFill  # type: ignore
-from openpyxl.styles.borders import Border, Side  # type: ignore
+from openpyxl import Workbook
+from openpyxl.styles import Alignment, Font, PatternFill
+from openpyxl.styles.borders import Border, Side
 import datetime as dt
 import calendar
 from typing import Any, Optional, Union

--- a/plugins/polio/export_utils.py
+++ b/plugins/polio/export_utils.py
@@ -1,6 +1,6 @@
-from openpyxl import Workbook
-from openpyxl.styles import Alignment, Font, PatternFill
-from openpyxl.styles.borders import Border, Side
+from openpyxl import Workbook  # type: ignore
+from openpyxl.styles import Alignment, Font, PatternFill  # type: ignore
+from openpyxl.styles.borders import Border, Side  # type: ignore
 import datetime as dt
 import calendar
 from typing import Any, Optional, Union

--- a/plugins/polio/tests/test_base.py
+++ b/plugins/polio/tests/test_base.py
@@ -430,6 +430,27 @@ class PolioAPITestCase(APITestCase):
         data_dict = excel_data.to_dict()
         self.assertEqual(data_dict["January"][0], self.format_date_to_test(c, round))
 
+    def test_create_calendar_xlsx_sheet_without_test_campaigns(self):
+        """
+        Test campaigns appeared in the XLSX but they should not
+            - This test is to make sure that no test campaign appear again in the XLSX calendar export
+        """
+        org_unit = OrgUnit.objects.create(
+            id=5455,
+            name="Country name",
+            org_unit_type=self.jedi_squad,
+            version=self.star_wars.default_version,
+        )
+        c = Campaign.objects.create(country_id=org_unit.id, obr_name="orb campaign", vacine="vacin", is_test=True)
+        c.rounds.create(number=1, started_at=datetime.date(2022, 1, 1), ended_at=datetime.date(2022, 1, 2))
+
+        response = self.client.get("/api/polio/campaigns/create_calendar_xlsx_sheet/", {"currentDate": "2022-10-01"})
+        self.assertEqual(response.status_code, 200)
+        excel_data = pd.read_excel(response.content, engine="openpyxl", sheet_name="calendar_2022-10-01")
+
+        data_dict = excel_data.to_dict()
+        self.assertEqual(len(data_dict["COUNTRY"]), 0)
+
     @staticmethod
     def format_date_to_test(campaign, round):
         started_at = format_date(round.started_at.strftime("%Y-%m-%d")) if round.started_at is not None else ""


### PR DESCRIPTION
The XLSX calendar export includes test campaigns too.

## Self proof reading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [x] Are there enough tests
## Changes
- Filter rounds base on the campaign is_test boolean field by including only rounds with campaign is_test False


## How to test
- Add a test campaign
- Export calendar as an XLSX file

## Print screen / video
![Peek 2022-10-12 11-41](https://user-images.githubusercontent.com/19631540/195309059-7e3016b6-3899-441b-b2dc-9c2f277fe314.gif)

