### PR TITLE
IA-1591 fix marking data source version as default

### DIFF
--- a/iaso/api/accounts.py
+++ b/iaso/api/accounts.py
@@ -1,3 +1,4 @@
+"""This api is only there so the default version on an account can be modified"""
 from rest_framework.request import Request
 
 from .common import ModelViewSet, HasPermission
@@ -52,4 +53,5 @@ class AccountViewSet(ModelViewSet):
     serializer_class = AccountSerializer
     results_key = "accounts"
     queryset = Account.objects.all()
+    # FIXME: USe a PATCH in the future, it make more sense regarding HTTP method semantic
     http_method_names = ["put"]

--- a/iaso/api/accounts.py
+++ b/iaso/api/accounts.py
@@ -12,7 +12,6 @@ class AccountSerializer(serializers.ModelSerializer):
 
         fields = [
             "id",
-            "name",
             "default_version",
         ]
 

--- a/iaso/tests/api/test_account.py
+++ b/iaso/tests/api/test_account.py
@@ -1,0 +1,101 @@
+from iaso.test import APITestCase
+from iaso import models as m
+
+
+class ProjectsAPITestCase(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.ghi = ghi = m.Account.objects.create(name="Global Health Initiative")
+        cls.wha = wha = m.Account.objects.create(name="Worldwide Health Aid")
+
+        cls.jane = cls.create_user_with_profile(username="janedoe", account=ghi, permissions=["iaso_sources"])
+        cls.john = cls.create_user_with_profile(username="johndoe", account=wha, permissions=["iaso_sources"])
+        cls.jim = cls.create_user_with_profile(username="jimdoe", account=ghi)
+
+        ghi_project = m.Project.objects.create(name="ghi_project", account=ghi)
+        ghi_datasource = m.DataSource.objects.create()
+        ghi_datasource.projects.set([ghi_project])
+        cls.ghi_version = m.SourceVersion.objects.create(data_source=ghi_datasource, number=1)
+
+    def test_account_list_without_auth(self):
+        """GET /projects/ without auth should result in a 403 (before the method not authorized?"""
+        self.client.force_authenticate(self.jim)
+
+        response = self.client.get("/api/accounts/")
+        self.assertJSONResponse(response, 403)
+
+    def test_account_list_with_auth(self):
+        """GET /projects/ with auth should result in a 403 as method is not allowed"""
+        self.client.force_authenticate(self.jane)
+
+        response = self.client.get("/api/accounts/")
+        self.assertJSONResponse(response, 405)
+
+    def test_account_delete_forbidden(self):
+        """DELETE /projects/ with auth should result in a 403 as method is not allowed"""
+        self.client.force_authenticate(self.jane)
+
+        response = self.client.delete("/api/accounts/")
+        self.assertJSONResponse(response, 405)
+
+    def test_account_post_forbidden(self):
+        """POST /projects/ with auth should result in a 403 as method is not allowed"""
+        self.client.force_authenticate(self.jane)
+
+        response = self.client.post("/api/accounts/", {"default_version": self.ghi_version})
+        self.assertJSONResponse(response, 405)
+
+    def test_account_detail_forbidden(self):
+        """POST /projects/ with auth should result in a 403 as method is not allowed"""
+        self.client.force_authenticate(self.jane)
+
+        response = self.client.get(f"/api/accounts/{self.ghi.pk}/")
+        self.assertJSONResponse(response, 405)
+
+    def test_account_set_default_ok(self):
+        """Set a version with an user that has correct perm"""
+
+        self.client.force_authenticate(self.jane)
+        response = self.client.put(f"/api/accounts/{self.ghi.pk}/", {"default_version": self.ghi_version.pk})
+        j = self.assertJSONResponse(response, 200)
+        self.assertEqual(j, {"id": self.ghi.pk, "default_version": self.ghi_version.pk})
+
+        self.ghi.refresh_from_db()
+        self.assertEqual(self.ghi.default_version.id, self.ghi_version.id)
+
+    def test_account_set_default_fail_wrong_account(self):
+        """User try to set default on an account he doesn't belong too"""
+
+        self.client.force_authenticate(self.jane)
+        response = self.client.put(f"/api/accounts/{self.wha.pk}/", {"default_version": self.ghi_version.pk})
+        j = self.assertJSONResponse(response, 403)
+        self.assertEqual(j, {"detail": "You do not have permission to perform this action."})
+
+        # old default version
+        old_version = self.wha.default_version
+        self.wha.refresh_from_db()
+        self.assertEqual(self.wha.default_version, old_version)
+
+        # invert on the other account/user to be sure
+        self.client.force_authenticate(self.john)
+        response = self.client.put(f"/api/accounts/{self.ghi.pk}/", {"default_version": self.ghi_version.pk})
+        j = self.assertJSONResponse(response, 403)
+        self.assertEqual(j, {"detail": "You do not have permission to perform this action."})
+
+        # old default version
+        old_version = self.ghi.default_version
+        self.ghi.refresh_from_db()
+        self.assertEqual(self.ghi.default_version, old_version)
+
+    def test_account_set_default_no_perm(self):
+        """User without source perm cannot modify the default version"""
+        # invert on the other account/user to be sure
+        self.client.force_authenticate(self.jim)
+        response = self.client.put(f"/api/accounts/{self.ghi.pk}/", {"default_version": self.ghi_version.pk})
+        j = self.assertJSONResponse(response, 403)
+        self.assertEqual(j, {"detail": "You do not have permission to perform this action."})
+
+        # old default version
+        old_version = self.ghi.default_version
+        self.ghi.refresh_from_db()
+        self.assertEqual(self.ghi.default_version, old_version)

--- a/iaso/tests/api/test_account.py
+++ b/iaso/tests/api/test_account.py
@@ -25,35 +25,35 @@ class ProjectsAPITestCase(APITestCase):
         self.assertJSONResponse(response, 403)
 
     def test_account_list_with_auth(self):
-        """GET /projects/ with auth should result in a 403 as method is not allowed"""
+        """GET /projects/ with auth should result in a 405 as method is not allowed"""
         self.client.force_authenticate(self.jane)
 
         response = self.client.get("/api/accounts/")
         self.assertJSONResponse(response, 405)
 
     def test_account_delete_forbidden(self):
-        """DELETE /projects/ with auth should result in a 403 as method is not allowed"""
+        """DELETE /projects/ with auth should result in a 405 as method is not allowed"""
         self.client.force_authenticate(self.jane)
 
         response = self.client.delete("/api/accounts/")
         self.assertJSONResponse(response, 405)
 
     def test_account_post_forbidden(self):
-        """POST /projects/ with auth should result in a 403 as method is not allowed"""
+        """POST /projects/ with auth should result in a 405 as method is not allowed"""
         self.client.force_authenticate(self.jane)
 
         response = self.client.post("/api/accounts/", {"default_version": self.ghi_version})
         self.assertJSONResponse(response, 405)
 
     def test_account_detail_forbidden(self):
-        """POST /projects/ with auth should result in a 403 as method is not allowed"""
+        """POST /projects/ with auth should result in a 405 as method is not allowed"""
         self.client.force_authenticate(self.jane)
 
         response = self.client.get(f"/api/accounts/{self.ghi.pk}/")
         self.assertJSONResponse(response, 405)
 
     def test_account_set_default_ok(self):
-        """Set a version with an user that has correct perm"""
+        """Set a version with a user that has correct perm"""
 
         self.client.force_authenticate(self.jane)
         response = self.client.put(f"/api/accounts/{self.ghi.pk}/", {"default_version": self.ghi_version.pk})


### PR DESCRIPTION
The default version for an account couldn't be changed anymore.

I trace this regression back to :
https://github.com/BLSQ/iaso/commit/75a780e0690c45e4fdba9432200cf86c9050cc6a

## Self proof reading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are there enough tests 
## Changes

Fixed the bug by removing the bugging and unused field from the Account Serializer.
Added a log of test around this API endpoint since there wasn't any


## How to test
- On the Web, go on the data source page.
- Open a data source dialog. Mark a version as default if there is none already
- Then check the Default data source checkbox
- Save.

What happened before :
There is one success snackbar and one error one : Respectively the  save on data source edit but the mark as default fail

What should happen now :
 Both request succeed and the source is the new default for the account


In general check there is no regression with the account feature