### PR TITLE
IA-1595: Add missing "not" operator, light jsonlogic refactoring

### DIFF
--- a/iaso/tests/api/test_instances.py
+++ b/iaso/tests/api/test_instances.py
@@ -513,6 +513,43 @@ class InstancesAPITestCase(APITestCase):
         self.assertValidInstanceListData(response_json, expected_length=1)
         self.assertEqual(response_json["instances"][0]["id"], b.id)
 
+    def test_instance_list_by_json_content_not_operator(self):
+        """We do the opposite than test_instance_list_by_json_content(): exclude all the women before 25"""
+        a = self.create_form_instance(
+            form=self.form_1,
+            period="202001",
+            org_unit=self.jedi_council_corruscant,
+            project=self.project,
+            json={"name": "a", "age": 18, "gender": "M"},
+        )
+
+        b = self.create_form_instance(
+            form=self.form_1,
+            period="202001",
+            org_unit=self.jedi_council_corruscant,
+            project=self.project,
+            json={"name": "b", "age": 19, "gender": "F"},
+        )
+
+        c = self.create_form_instance(
+            form=self.form_1,
+            period="202001",
+            org_unit=self.jedi_council_corruscant,
+            project=self.project,
+            json={"name": "c", "age": 30, "gender": "F"},
+        )
+
+        self.client.force_authenticate(self.yoda)
+        json_filters = json.dumps({"!": {"and": [{"==": [{"var": "gender"}, "F"]}, {"<": [{"var": "age"}, 25]}]}})
+        response = self.client.get(f"/api/instances/", {"jsonContent": json_filters})
+
+        response_json = response.json()
+        # We should receive the a and c (+ the instances created in setupTestData), but not the b (because it's a female under 25)
+        received_instances_ids = [instance["id"] for instance in response_json["instances"]]
+        self.assertIn(a.id, received_instances_ids)
+        self.assertIn(c.id, received_instances_ids)
+        self.assertNotIn(b.id, received_instances_ids)
+
     def test_instance_list_by_json_content_nested(self):
         """Search using the instance content (in JSON field) with nested and/or operators"""
         a = self.create_form_instance(

--- a/iaso/tests/utils/test_jsonlogic.py
+++ b/iaso/tests/utils/test_jsonlogic.py
@@ -9,6 +9,12 @@ class JsonLogicTests(TestCase):
         q = jsonlogic_to_q(filters)
         self.assertEqual(str(q), "(AND: ('gender__exact', 'F'), ('age__lt', 25))")
 
+    def test_jsonlogic_to_q_filters_not(self) -> None:
+        """The not operator works as expected"""
+        filters = {"!": {"and": [{"==": [{"var": "gender"}, "F"]}, {"<": [{"var": "age"}, 25]}]}}
+        q = jsonlogic_to_q(filters)
+        self.assertEqual(str(q), "(NOT (AND: ('gender__exact', 'F'), ('age__lt', 25)))")
+
     def test_jsonlogic_to_q_filters_field_prefix(self) -> None:
         """The field_prefix argument is taken into account."""
         filters = {"and": [{"==": [{"var": "gender"}, "F"]}, {"<": [{"var": "age"}, 25]}]}


### PR DESCRIPTION
Explain what problem this PR is resolving

## Self proof reading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are there enough tests

## Changes

As described in https://github.com/BLSQ/iaso/pull/55, the ! (not) operator was not available when searching instances using JsonLogic. It's now implemented.


## How to test

Search instances using the JsonLogic syntax. Make sure the previous search features still work, and that the "!" operator can be used to negate a query.
