### PR TITLE
POLIO_652: use textarea for comments

### DIFF
--- a/hat/assets/js/apps/Iaso/components/forms/TextArea.tsx
+++ b/hat/assets/js/apps/Iaso/components/forms/TextArea.tsx
@@ -1,0 +1,103 @@
+import React, { FunctionComponent, useState } from 'react';
+
+import {
+    // @ts-ignore
+    FormControl,
+    // @ts-ignore
+    commonStyles,
+} from 'bluesquare-components';
+import classnames from 'classnames';
+import { makeStyles, InputLabel } from '@material-ui/core';
+
+type Props = {
+    value?: string;
+    label: string;
+    // eslint-disable-next-line no-unused-vars
+    onChange: (newValue: string) => void;
+    errors?: string[];
+    required?: boolean;
+};
+
+const useStyles = makeStyles(theme => ({
+    inputLabelFocus: {
+        color: theme.palette.primary.main,
+    },
+    inputLabel: {
+        ...commonStyles.inputLabel,
+        top: 13,
+        left: 4,
+        backgroundColor: 'white',
+    },
+    inputLabelShrink: {
+        transform: 'translate(14px, -3px) scale(0.75) !important',
+    },
+    textArea: {
+        width: '100%',
+        minWidth: '100%',
+        maxWidth: '100%',
+        minHeight: '100px',
+        padding: theme.spacing(2),
+        marginTop: theme.spacing(2),
+        outline: 'none',
+        borderRadius: 5,
+        fontSize: 16,
+        fontFamily: '"Roboto", "Arial", sans-serif',
+        // @ts-ignore
+        border: `1px solid rgba(0, 0, 0, 0.23)`,
+        '&:hover': {
+            border: `1px solid rgba(0, 0, 0, 0.87)`,
+        },
+        '&:focus': {
+            border: `1px solid ${theme.palette.primary.main}`,
+        },
+    },
+    errorArea: {
+        border: `1px solid ${theme.palette.error.main}`,
+        '&:focus': {
+            border: `1px solid ${theme.palette.error.main}`,
+        },
+        '&:hover': {
+            border: `1px solid ${theme.palette.error.main}`,
+        },
+    },
+    errorText: { color: theme.palette.error.main },
+}));
+
+export const TextArea: FunctionComponent<Props> = ({
+    value,
+    onChange,
+    label,
+    errors = [],
+    required = false,
+}) => {
+    const classes: Record<string, string> = useStyles();
+    const [focus, setFocus] = useState<boolean>(false);
+    const hasErrors = errors.length > 0;
+
+    return (
+        <FormControl errors={errors}>
+            <InputLabel
+                shrink={Boolean(value)}
+                className={classnames(
+                    classes.inputLabel,
+                    focus && classes.inputLabelFocus,
+                    Boolean(value) && classes.inputLabelShrink,
+                    hasErrors && classes.errorText,
+                )}
+                required={required}
+            >
+                {label}
+            </InputLabel>
+            <textarea
+                onFocus={() => setFocus(true)}
+                onBlur={() => setFocus(false)}
+                className={classnames(
+                    classes.textArea,
+                    hasErrors && classes.errorArea,
+                )}
+                onChange={e => onChange(e.target.value)}
+                value={value}
+            />
+        </FormControl>
+    );
+};

--- a/plugins/polio/js/src/pages/Budget/CreateBudgetStep/CreateBudgetStep.tsx
+++ b/plugins/polio/js/src/pages/Budget/CreateBudgetStep/CreateBudgetStep.tsx
@@ -37,6 +37,7 @@ import { AddMultipleLinks } from '../MultipleLinks/AddMultipleLinks';
 import { useBudgetStepValidation } from '../hooks/validation';
 import { redirectToReplace } from '../../../../../../../hat/assets/js/apps/Iaso/routing/actions';
 import { BUDGET_DETAILS } from '../../../constants/routes';
+import { TextArea } from '../../../../../../../hat/assets/js/apps/Iaso/components/forms/TextArea';
 
 type Props = {
     campaignId: string;
@@ -217,14 +218,11 @@ const CreateBudgetStep: FunctionComponent<Props> = ({
             >
                 {userHasTeam && (
                     <>
-                        <InputComponent
-                            type="text"
-                            keyValue="comment"
-                            multiline
-                            onChange={onChange}
+                        <TextArea
                             value={values.comment}
                             errors={getErrors('comment')}
-                            label={MESSAGES.notes}
+                            label={formatMessage(MESSAGES.notes)}
+                            onChange={newValue => onChange('comment', newValue)}
                             required={requiredFields.includes('comment')}
                         />
                         <InputComponent


### PR DESCRIPTION
The "Comments" filed was multiline, but it wans't obvious to users

## Self proof reading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [X] Are my typescript files well typed

## Changes

- replaced the `InputComponent`of type "text" with the `TextArea` from the upcoming https://github.com/BLSQ/iaso/blob/WC2-60-demo/hat/assets/js/apps/Iaso/components/forms/TextArea.tsx
- Added required and error states to the `TextArea`


## How to test

- Go to Budget details, create a step

## Print screen / video

![Screenshot 2022-10-19 at 16 09 13](https://user-images.githubusercontent.com/38907762/196715942-24459d72-5200-4004-8c9c-c016d15844bc.png)


## Notes

There's a ticket to move the component to bluesquer-components, and replace `InputComponent`'s multiline "text"  input with this new component: https://bluesquare.atlassian.net/browse/IA-1597
