### PR TITLE
POLIO-650 fix listing possible state in filter

### DIFF
--- a/plugins/polio/api.py
+++ b/plugins/polio/api.py
@@ -58,7 +58,6 @@ from plugins.polio.serializers import (
     CountryUsersGroupSerializer,
 )
 from plugins.polio.serializers import SurgePreviewSerializer, CampaignPreparednessSpreadsheetSerializer
-from .budget.api import BudgetCampaignViewSet
 from .forma import (
     FormAStocksViewSetV2,
     make_orgunits_cache,
@@ -2046,10 +2045,11 @@ class BudgetFilesViewset(ModelViewSet):
 router = routers.SimpleRouter()
 router.register(r"polio/orgunits", PolioOrgunitViewSet, basename="PolioOrgunit")
 router.register(r"polio/campaigns", CampaignViewSet, basename="Campaign")
-from .budget.api import BudgetCampaignViewSet, BudgetStepViewSet
+from .budget.api import BudgetCampaignViewSet, BudgetStepViewSet, WorkflowViewSet
 
 router.register(r"polio/budget", BudgetCampaignViewSet, basename="BudgetCampaign")
 router.register(r"polio/budgetsteps", BudgetStepViewSet, basename="BudgetStep")
+router.register(r"polio/workflow", WorkflowViewSet, basename="BudgetWorkflow")
 router.register(r"polio/campaignsgroup", CampaignGroupViewSet, basename="campaigngroup")
 router.register(r"polio/preparedness_dashboard", PreparednessDashboardViewSet, basename="preparedness_dashboard")
 router.register(r"polio/imstats", IMStatsViewSet, basename="imstats")

--- a/plugins/polio/budget/serializers.py
+++ b/plugins/polio/budget/serializers.py
@@ -37,6 +37,10 @@ class NodeSerializer(serializers.Serializer):
     label = serializers.CharField()  # type: ignore
 
 
+class WorkflowSerializer(serializers.Serializer):
+    states = NodeSerializer(many=True, source="nodes")
+
+
 # noinspection PyMethodMayBeStatic
 class CampaignBudgetSerializer(CampaignSerializer, DynamicFieldsModelSerializer):
     class Meta:

--- a/plugins/polio/js/src/pages/Budget/hooks/api/useGetBudget.ts
+++ b/plugins/polio/js/src/pages/Budget/hooks/api/useGetBudget.ts
@@ -1,11 +1,15 @@
 /* eslint-disable camelcase */
 import { useMemo } from 'react';
 import { UseQueryResult } from 'react-query';
+import { groupBy } from 'lodash';
 import { useSnackQuery } from '../../../../../../../../hat/assets/js/apps/Iaso/libs/apiHooks';
 import { getApiParamDateString } from '../../../../../../../../hat/assets/js/apps/Iaso/utils/dates';
 import { getRequest } from '../../../../../../../../hat/assets/js/apps/Iaso/libs/Api';
-import { Optional } from '../../../../../../../../hat/assets/js/apps/Iaso/types/utils';
-import { Budget } from '../../types';
+import {
+    DropdownOptions,
+    Optional,
+} from '../../../../../../../../hat/assets/js/apps/Iaso/types/utils';
+import { Budget, Workflow } from '../../types';
 
 const getBudgets = (params: any) => {
     const filteredParams = Object.entries(params).filter(
@@ -74,5 +78,31 @@ export const useGetBudgetForCampaign = (
         queryFn: () => getBudgetForCampaign(id, params),
         queryKey: ['budget', 'campaign', id],
         options: { enabled: Boolean(id) },
+    });
+};
+
+const getBudgetWorkflow = () => {
+    return getRequest(`/api/polio/workflow/current/`);
+};
+
+export const useGetWorkflowStatesForDropdown = (): UseQueryResult<
+    DropdownOptions<string>[]
+> => {
+    return useSnackQuery({
+        queryFn: () => getBudgetWorkflow(),
+        queryKey: ['budget', 'workflow'],
+        options: {
+            select: (data: Workflow) => {
+                const apiPossibleStates = data?.states ?? [];
+                return Object.entries(groupBy(apiPossibleStates, 'label')).map(
+                    ([label, items]) => {
+                        return {
+                            label,
+                            value: items.map(i => i.key).join(','),
+                        };
+                    },
+                );
+            },
+        },
     });
 };

--- a/plugins/polio/js/src/pages/Budget/index.tsx
+++ b/plugins/polio/js/src/pages/Budget/index.tsx
@@ -1,9 +1,4 @@
-import React, {
-    FunctionComponent,
-    useState,
-    useCallback,
-    useMemo,
-} from 'react';
+import React, { FunctionComponent, useState, useCallback } from 'react';
 import {
     // @ts-ignore
     useSafeIntl,
@@ -24,7 +19,6 @@ import { Pagination } from '@material-ui/lab';
 
 // @ts-ignore
 import TopBar from 'Iaso/components/nav/TopBarComponent';
-import { groupBy } from 'lodash';
 import { TableWithDeepLink } from '../../../../../../hat/assets/js/apps/Iaso/components/tables/TableWithDeepLink';
 
 import { useStyles } from '../../styles/theme';
@@ -37,7 +31,11 @@ import { convertObjectToString } from '../../utils';
 import { BudgetFilters } from './BudgetFilters';
 import { BudgetCard } from './cards/BudgetCard';
 
-import { useBudgetParams, useGetBudgets } from './hooks/api/useGetBudget';
+import {
+    useBudgetParams,
+    useGetBudgets,
+    useGetWorkflowStatesForDropdown,
+} from './hooks/api/useGetBudget';
 import { Budget } from './types';
 
 import { handleTableDeepLink } from '../../../../../../hat/assets/js/apps/Iaso/utils/table';
@@ -89,16 +87,7 @@ export const BudgetList: FunctionComponent<Props> = ({ router }) => {
         },
         [apiParams],
     );
-    // FIXME: should come with right format from backend
-    const possibleStates = useMemo(() => {
-        const apiPossibleStates =
-            (budgets?.results ?? [])[0]?.possible_states ?? [];
-        return Object.entries(groupBy(apiPossibleStates, 'label')).map(
-            ([label, items]) => {
-                return { label, value: items.map(i => i.key).join(',') };
-            },
-        );
-    }, [budgets?.results]);
+    const { data: possibleStates } = useGetWorkflowStatesForDropdown();
 
     return (
         <>

--- a/plugins/polio/js/src/pages/Budget/types.ts
+++ b/plugins/polio/js/src/pages/Budget/types.ts
@@ -64,3 +64,10 @@ export type StepForm = {
     general: Nullable<string[]>;
     attachments: Nullable<string[]>;
 };
+
+export type Workflow = {
+    states: {
+        key: string;
+        label: string;
+    }[];
+};


### PR DESCRIPTION
This fix listing the state in the dropdown filter when there was no list of campaign returned

## Self proof reading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are my typescript files well typed
- [] Are there enough tests.
## Changes

- Add an new endpoint to list possibles states. /polio/workflow/current/
- Use the new endpoint in the front-end


## How to test

General configuration is the same as for the budget workflow feature.
Check if the state are properly listed

## Notes

Filtering on campaign without budget is still broken, this is a known bug.