### PR TITLE
Wc2 96: search parameter doesn't work for /api/entity (list/export/details)

### DIFF
--- a/iaso/api/entity.py
+++ b/iaso/api/entity.py
@@ -6,7 +6,7 @@ from typing import List, Any, Union
 
 import xlsxwriter  # type: ignore
 from django.core.paginator import Paginator
-from django.db.models import Max
+from django.db.models import Max, Q
 from django.http import JsonResponse, HttpResponse, StreamingHttpResponse
 from django.shortcuts import get_object_or_404
 from django_filters.rest_framework import DjangoFilterBackend  # type: ignore

--- a/iaso/tests/test_entities.py
+++ b/iaso/tests/test_entities.py
@@ -246,12 +246,18 @@ class EntityAPITestCase(APITestCase):
         the_result = response.json()["result"][0]
         self.assertEqual(the_result["id"], newly_added_entity.id)
 
-        # Case 2: search by entity UUID
+        # Case 2: search by entity name - make sure it's case-insensitive
+        response = self.client.get("/api/entity/?search=cLiEnT", format="json")
+        self.assertEqual(len(response.json()["result"]), 1)
+        the_result = response.json()["result"][0]
+        self.assertEqual(the_result["id"], newly_added_entity.id)
+
+        # Case 3: search by entity UUID
         response = self.client.get(f"/api/entity/?search={newly_added_entity.uuid}", format="json")
         self.assertEqual(len(response.json()["result"]), 1)
         self.assertEqual(the_result["id"], newly_added_entity.id)
 
-        # Case 3: search by JSON attribute
+        # Case 4: search by JSON attribute
         response = self.client.get(f"/api/entity/?search=age", format="json")
         self.assertEqual(len(response.json()["result"]), 1)
         self.assertEqual(the_result["id"], newly_added_entity.id)

--- a/iaso/tests/test_entities.py
+++ b/iaso/tests/test_entities.py
@@ -1,8 +1,10 @@
+# TODO: check: shouldn't this file be under the "api" subdirectory?
+# TODO: it would be cleaner if tests for the get operations would create the objects they need directly in the database,
+#  rather than making POST calls
+
 import time
 import uuid
 from unittest import mock
-
-from django.core.files import File
 
 from iaso import models as m
 from iaso.models import EntityType, Instance, Entity
@@ -208,6 +210,51 @@ class EntityAPITestCase(APITestCase):
         response = self.client.get(f"/api/entity/{entity.pk}/")
 
         self.assertEqual(response.status_code, 200)
+
+    def test_get_entity_search_filter(self):
+        """
+        Test the 'search' filter of /api/entity
+
+        This parameter allows to filter either by name, UUID or attributes (of the reference form)
+        """
+        self.client.force_authenticate(self.yoda)
+
+        # Let's first create the test data
+        entity_type = EntityType.objects.create(name="Type 1", reference_form=self.form_1)
+
+        instance = Instance.objects.create(
+            org_unit=self.jedi_council_corruscant,
+            form=self.form_1,
+            period="202002",
+            json={"name": "c", "age": 30, "gender": "F"},
+        )
+
+        payload = {
+            "name": "New Client",
+            "entity_type": entity_type.pk,
+            "attributes": instance.uuid,
+            "account": self.yoda.iaso_profile.account.pk,
+        }
+
+        self.client.post("/api/entity/", data=payload, format="json")
+
+        newly_added_entity = Entity.objects.last()
+
+        # Case 1: search by entity name
+        response = self.client.get("/api/entity/?search=Client", format="json")
+        self.assertEqual(len(response.json()["result"]), 1)
+        the_result = response.json()["result"][0]
+        self.assertEqual(the_result["id"], newly_added_entity.id)
+
+        # Case 2: search by entity UUID
+        response = self.client.get(f"/api/entity/?search={newly_added_entity.uuid}", format="json")
+        self.assertEqual(len(response.json()["result"]), 1)
+        self.assertEqual(the_result["id"], newly_added_entity.id)
+
+        # Case 3: search by JSON attribute
+        response = self.client.get(f"/api/entity/?search=age", format="json")
+        self.assertEqual(len(response.json()["result"]), 1)
+        self.assertEqual(the_result["id"], newly_added_entity.id)
 
     def test_get_entity_by_id(self):
         self.client.force_authenticate(self.yoda)


### PR DESCRIPTION
Due to a broken import, the "search" paramter/filter of the list /api/entity endpoint triggered a 500 error.

This fixes the issue and add some tests for this paramter. 

## Self proof reading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are there enough tests

## Changes

Just added an import :)

## How to test

Go to an URL such as `/api/entity/?search=entity_name` and make sure:

- no error 500 is triggered
- the results match the search

## Notes

I added tests for the code I've touched, but IMHO this API is currently poorly tested and many more test functions should also be added if we want to ensure some robustness.
