### PR TITLE
POLIO-664: fix vaccine selection

### DIFF
--- a/plugins/polio/js/src/forms/RoundVaccinesForm.tsx
+++ b/plugins/polio/js/src/forms/RoundVaccinesForm.tsx
@@ -207,7 +207,7 @@ export const RoundVaccinesForm: FunctionComponent<Props> = ({
 
     return (
         <>
-            {vaccines.length > 0 &&
+            {vaccines.length > 1 &&
                 vaccines.map((_vaccine, index) => {
                     return (
                         <RoundVaccineForm


### PR DESCRIPTION
In vaccine tab, selecting he first vaccine would create 2 rows with the same data

## Self proof reading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests
## Changes

- Fixed a mistake in the conditional rendering of `RoundVaccines`


## How to test

- Go to campaigns > create > vaccine management and select a vaccine


