### PR TITLE
Polio 671 step node deletion

### DIFF
--- a/plugins/polio/budget/serializers.py
+++ b/plugins/polio/budget/serializers.py
@@ -251,10 +251,9 @@ class BudgetStepSerializer(serializers.ModelSerializer):
     created_by = UserSerializer()
 
     @swagger_serializer_method(serializer_or_field=serializers.CharField)
-    def get_transition_label(self, budget_step: BudgetStep):
+    def get_transition_label(self, budget_step: BudgetStep) -> str:
         workflow = get_workflow()
-        transition = workflow.get_transition_by_key(budget_step.transition_key)
-        return transition.label
+        return workflow.get_transition_label_safe(budget_step.transition_key)
 
 
 class UpdateBudgetStepSerializer(serializers.ModelSerializer):

--- a/plugins/polio/budget/serializers.py
+++ b/plugins/polio/budget/serializers.py
@@ -77,11 +77,18 @@ class CampaignBudgetSerializer(CampaignSerializer, DynamicFieldsModelSerializer)
 
     def get_current_state(self, campaign: Campaign):
         workflow = get_workflow()
-        node = workflow.get_node_by_key(campaign.budget_current_state_key)
-        return {
-            "key": campaign.budget_current_state_key,
-            "label": node.label,
-        }
+        try:
+            node = workflow.get_node_by_key(campaign.budget_current_state_key)
+        except:
+            return {
+                "key": campaign.budget_current_state_key,
+                "label": campaign.budget_current_state_key,
+            }
+        else:
+            return {
+                "key": campaign.budget_current_state_key,
+                "label": node.label,
+            }
 
     @swagger_serializer_method(serializer_or_field=TransitionSerializer(many=True))
     def get_next_transitions(self, campaign):

--- a/plugins/polio/budget/workflow.py
+++ b/plugins/polio/budget/workflow.py
@@ -55,6 +55,14 @@ class Workflow:
     def get_transition_by_key(self, key) -> Transition:
         return self.transitions_dict[key]
 
+    def get_transition_label_safe(self, key) -> str:
+        """Return the label for this transition key. Or the label itself it the
+        key is not found in the workfloe e.g. it was deleted"""
+        if key in self.transitions_dict:
+            return self.transitions_dict[key].label
+        else:
+            return key
+
     def self_check(self):
         for transition in self.transitions:
             if transition.from_node:


### PR DESCRIPTION
Make the api not crash when it cannot found a node or a step. (When they get  removed or deleted)

## Self proof reading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are there enough tests

## Changes

When we cannot found the transition or node to show the label we return the key itself as a fallback value

## How to test

Use the budget workflow. Then in the workflow definition  the current state of a campaign  and the last step
