### PR TITLE
IA-1588: Make the test suite more resilient to small rounding errors in different environments

### DIFF
--- a/iaso/tests/test_dhis2_ou_importer.py
+++ b/iaso/tests/test_dhis2_ou_importer.py
@@ -123,7 +123,11 @@ class CommandTests(TestCase, DHIS2TestMixin):
 
         # assert location and geometry and parent relationships
         healthcenter = created_orgunits_qs.get(name="Bambara Kaima CHP")
-        self.assertEquals(healthcenter.location.wkt, "POINT Z (-11.3596 8.531700000000001 0)")
+
+        location_coords = healthcenter.location.coords
+        self.assertAlmostEqual(location_coords[0], -11.3596)
+        self.assertAlmostEqual(location_coords[1], 8.5317)
+        self.assertEqual(location_coords[2], 0)
         self.assertEquals(healthcenter.parent.name, "Gorama Mende")
 
         # assert has a simplified geometry
@@ -268,7 +272,10 @@ class TaskTests(TestCase, DHIS2TestMixin):
 
         # assert location and geometry and parent relationships
         healthcenter = created_orgunits_qs.get(name="Bambara Kaima CHP")
-        self.assertEquals(healthcenter.location.wkt, "POINT Z (-11.3596 8.531700000000001 0)")
+        location_coords = healthcenter.location.coords
+        self.assertAlmostEqual(location_coords[0], -11.3596)
+        self.assertAlmostEqual(location_coords[1], 8.5317)
+        self.assertEqual(location_coords[2], 0)
         self.assertEquals(healthcenter.parent.name, "Gorama Mende")
 
         # assert has a simplified geometry


### PR DESCRIPTION
I got some failing Python tests on my machine because of negligible rounding differences (depending of the environment) for GIS coordinates. Example:

`AssertionError: 'POINT Z (-11.3596 8.5317 0)' != 'POINT Z (-11.3596 8.531700000000001 0)'`

## Self proof reading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented

## Changes

I made the tests a bit more lenient (using `assertAlmostEquals` rather than `assertEquals`) for coordinates were some imprecision is normal and negligible.


## How to test

No expected changes of behavior. Make sure Python tests still pass in your environment.