### PR TITLE
POLIO-660 Restrict the history log on campaign to user who have access to the campaign

### DIFF
--- a/iaso/api/logs.py
+++ b/iaso/api/logs.py
@@ -29,7 +29,7 @@ def has_access_to(user: User, obj: Union[OrgUnit, Instance, models.Model]):
     from plugins.polio.models import Campaign
 
     if isinstance(obj, Campaign):
-        return True
+        return Campaign.objects.filter_for_user(user).filter(id=obj.id).exists()
     return False
 
 

--- a/iaso/api/logs.py
+++ b/iaso/api/logs.py
@@ -46,7 +46,7 @@ class LogsViewSet(viewsets.ViewSet):
         - new_value
         - field_diffs
 
-    contentType parameter can be one of:  iaso.orgunit, iaso.form, iaso.instance
+    contentType parameter can be one of:  iaso.orgunit, iaso.form, iaso.instance, polio.campaign
 
     list:
     Returns the list of modifications

--- a/iaso/api/logs.py
+++ b/iaso/api/logs.py
@@ -29,7 +29,10 @@ def has_access_to(user: User, obj: Union[OrgUnit, Instance, models.Model]):
     from plugins.polio.models import Campaign
 
     if isinstance(obj, Campaign):
-        return Campaign.objects.filter_for_user(user).filter(id=obj.id).exists()
+        return (
+            user.has_perm("menupermissions.iaso_polio")
+            and Campaign.objects.filter_for_user(user).filter(id=obj.id).exists()
+        )
     return False
 
 

--- a/plugins/polio/models.py
+++ b/plugins/polio/models.py
@@ -195,7 +195,7 @@ class CampaignQuerySet(models.QuerySet):
             # Restrict Campaign to the OrgUnit on the country he can access
             if user.iaso_profile.org_units.count():
                 org_units = OrgUnit.objects.hierarchy(user.iaso_profile.org_units.all())
-                qs = qs.filter(initial_org_unit__in=org_units)
+                qs = qs.filter(country__in=org_units)
         return qs
 
 

--- a/plugins/polio/models.py
+++ b/plugins/polio/models.py
@@ -195,7 +195,7 @@ class CampaignQuerySet(models.QuerySet):
             # Restrict Campaign to the OrgUnit on the country he can access
             if user.iaso_profile.org_units.count():
                 org_units = OrgUnit.objects.hierarchy(user.iaso_profile.org_units.all())
-                qs = qs.filter(country__in=org_units)
+                qs = qs.filter(Q(country__in=org_units) | Q(initial_org_unit__in=org_units))
         return qs
 
 

--- a/plugins/polio/models.py
+++ b/plugins/polio/models.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 
 from django.contrib.auth.models import User, AnonymousUser
 from django.db import models
-from django.db.models import Count, Manager
+from django.db.models import Count, Manager, Q
 import django.db.models.manager
 
 from django.utils.translation import gettext as _

--- a/plugins/polio/tests/test_api.py
+++ b/plugins/polio/tests/test_api.py
@@ -1,12 +1,12 @@
+from django.contrib.auth.models import User, Permission
 from django.utils.timezone import now
 from rest_framework.test import APIClient
 
+from hat.audit.models import Modification
 from iaso import models as m
 from iaso.models import Account
 from iaso.test import APITestCase
-
 from ..models import Round
-
 from ..preparedness.spreadsheet_manager import *
 
 
@@ -504,3 +504,56 @@ class PreparednessAPITestCase(APITestCase):
         for campaign_round in r:
             self.assertEqual(campaign_round["status"], "not_sync")
         print(r)
+
+
+class TeamAPITestCase(APITestCase):
+    fixtures = ["user.yaml"]
+    c: Campaign
+    user: User
+    country: OrgUnit
+    country2: OrgUnit
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.user = User.objects.get(username="test")
+        cls.country = OrgUnit.objects.create(name="Country A")
+        cls.country2 = OrgUnit.objects.create(name="Country B")
+
+        cls.c = Campaign.objects.create(
+            obr_name="test campaign", account=cls.user.iaso_profile.account, country=cls.country
+        )
+
+    def test_audit_list(self):
+        """Mod a campaign, user can see modification. Limit to another country modification cannot be listed anymore
+        Give access to country in campaign , they can be listed again
+        """
+        self.client.force_authenticate(self.user)
+        self.assertEqual(self.user.is_superuser, False)
+        self.user.user_permissions.add(Permission.objects.get(codename="iaso_polio"))
+
+        payload = {"obr_name": "test2"}
+        response = self.client.patch(f"/api/polio/campaigns/{self.c.id}/", payload, format="json")
+        self.assertJSONResponse(response, 200)
+
+        self.assertEqual(Modification.objects.count(), 1)
+        response = self.client.get(f"/api/logs/?objectId={self.c.id}&contentType=polio.campaign&limit=10")
+        j = self.assertJSONResponse(response, 200)
+        self.assertEqual(len(j["list"]), 1)
+
+        # limit user to the other country. Cannot list
+        p = self.user.iaso_profile
+        p.org_units.set([self.country2])
+        p.save()
+        response = self.client.get(f"/api/logs/?objectId={self.c.id}&contentType=polio.campaign&limit=10")
+        j = self.assertJSONResponse(response, 401)
+        self.assertEqual(j, {"error": "Unauthorized"})
+
+        # limit user to the other country. Cannot list
+        p = self.user.iaso_profile
+        p.org_units.set([self.c.country])
+        p.save()
+        self.client.force_authenticate(self.user)
+
+        response = self.client.get(f"/api/logs/?objectId={self.c.id}&contentType=polio.campaign&limit=10")
+        j = self.assertJSONResponse(response, 200)
+        self.assertEqual(len(j["list"]), 1)


### PR DESCRIPTION
Prevent user who cannot see a campaign to see their history log.

## Self proof reading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented


## Changes

If a user doesn't have access to a campaign because their orgunit access is restricted or they doesn't have the polio permission, doesn't allow him to have access to the campaigns

## How to test

1. Make a campaign on a country
2. Make a modification on it.
3. Create an user which is restricted to that country. (via is profile)
4. Check they have access to the campaign history log in the interface.
5. Keep the url the API use to access it (via the Network tab in your browser debug)
6. Modify the country the user has acces to
7. Check the URL api you keep previously doesn't work.
8. Check that they cannot see the campaign anymore in the campaign list.
