### PR TITLE
Polio 673 hide repeat step from infos

### DIFF
--- a/plugins/polio/js/src/pages/Budget/BudgetDetails/BudgetDetails.tsx
+++ b/plugins/polio/js/src/pages/Budget/BudgetDetails/BudgetDetails.tsx
@@ -89,14 +89,11 @@ export const BudgetDetails: FunctionComponent<Props> = ({ router }) => {
         );
         const toDisplay = new Set(
             regular
-                ?.filter(
-                    transition =>
-                        transition.key !== budgetInfos?.current_state?.key,
-                )
+                ?.filter(transition => !transition.key.includes('repeat'))
                 .map(transition => transition.label),
         );
         return { regular, override, toDisplay };
-    }, [budgetInfos?.current_state?.key, budgetInfos?.next_transitions]);
+    }, [budgetInfos?.next_transitions]);
 
     const { resetPageToOne, columns } = useTableState({
         events: budgetDetails?.results,

--- a/plugins/polio/js/src/pages/Budget/BudgetDetails/BudgetDetailsInfos.tsx
+++ b/plugins/polio/js/src/pages/Budget/BudgetDetails/BudgetDetailsInfos.tsx
@@ -5,7 +5,7 @@ import {
     TableCell,
     TableRow,
 } from '@material-ui/core';
-import React, { FunctionComponent, useMemo } from 'react';
+import React, { FunctionComponent } from 'react';
 // @ts-ignore
 import { useSafeIntl } from 'bluesquare-components';
 import classnames from 'classnames';
@@ -30,11 +30,7 @@ export const BudgetDetailsInfos: FunctionComponent<Props> = ({
     nextSteps = [],
 }) => {
     const { formatMessage } = useSafeIntl();
-    // filtering out repeat steps
-    const [firstStep, ...steps] = useMemo(
-        () => nextSteps.filter(step => !step.includes('repeat')),
-        [nextSteps],
-    );
+    const [firstStep, ...steps] = nextSteps;
     const classes = useStyles();
     return (
         <WidgetPaperComponent title={formatMessage(MESSAGES.budgetStatus)}>

--- a/plugins/polio/js/src/pages/Budget/BudgetDetails/BudgetDetailsInfos.tsx
+++ b/plugins/polio/js/src/pages/Budget/BudgetDetails/BudgetDetailsInfos.tsx
@@ -5,7 +5,7 @@ import {
     TableCell,
     TableRow,
 } from '@material-ui/core';
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, useMemo } from 'react';
 // @ts-ignore
 import { useSafeIntl } from 'bluesquare-components';
 import classnames from 'classnames';
@@ -30,7 +30,11 @@ export const BudgetDetailsInfos: FunctionComponent<Props> = ({
     nextSteps = [],
 }) => {
     const { formatMessage } = useSafeIntl();
-    const [firstStep, ...steps] = nextSteps;
+    // filtering out repeat steps
+    const [firstStep, ...steps] = useMemo(
+        () => nextSteps.filter(step => !step.includes('repeat')),
+        [nextSteps],
+    );
     const classes = useStyles();
     return (
         <WidgetPaperComponent title={formatMessage(MESSAGES.budgetStatus)}>


### PR DESCRIPTION
The BudgetDetailsInfo table showed the "repeat" event as a next step, although it's just a step that's meant for the userto correct a mistake, and not a step that moves the workflow forward

## Self proof reading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests
## Changes

- filtered out the event with "repeat" in their key. That means the fix depends on enforcing a naming convention in the naming of transitions.


## How to test

- Go to a budget as MoH user
- Request a budget
- You should see a button allowiing you to reques the budget (the repeat button), but the "Infos" table shouldn't list it in the next steps line
 
## Print screen / video

![Screenshot 2022-10-21 at 16 59 13](https://user-images.githubusercontent.com/38907762/197227536-ad504d5f-48d7-4e77-aefc-42e143e33b83.png)

## Notes 

Merges in POLIO-648
