### PR TITLE
Polio 676 fix preparedness import chart

### DIFF
--- a/.ebextensions/70_crontab.config
+++ b/.ebextensions/70_crontab.config
@@ -7,7 +7,7 @@ files:
         MAILTO=""
         HOME=/opt/python/current/app/
         PATH=/opt/python/run/venv/bin/python:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-        5 30 * * * ec2-user /opt/python/current/app/scripts/command_in_eb.sh refresh_preparedness_data
+        30 5 * * * ec2-user /opt/python/current/app/scripts/command_in_eb.sh refresh_preparedness_data
   "/etc/cron.d/polio_weekly_email":
     mode: "000644"
     owner: root

--- a/hat/settings.py
+++ b/hat/settings.py
@@ -169,7 +169,7 @@ INSTALLED_APPS = [
 # see https://django-contrib-comments.readthedocs.io/en/latest/custom.htm
 COMMENTS_APP = "iaso"
 
-print("Enabled plugins:", PLUGINS)
+print("Enabled plugins:", PLUGINS, end=" ")
 for plugin_name in PLUGINS:
     INSTALLED_APPS.append(f"plugins.{plugin_name}")
 

--- a/hat/settings.py
+++ b/hat/settings.py
@@ -226,6 +226,10 @@ DB_HOST = os.environ.get("RDS_HOSTNAME", "db")
 DB_PORT = os.environ.get("RDS_PORT", 5432)
 SNS_NOTIFICATION_TOPIC = os.environ.get("SNS_NOTIFICATION_TOPIC", None)
 
+print(
+    "DB_NAME",
+    DB_NAME,
+)
 DATABASES = {
     "default": {
         "ENGINE": "django.contrib.gis.db.backends.postgis",

--- a/plugins/polio/preparedness/parser.py
+++ b/plugins/polio/preparedness/parser.py
@@ -104,6 +104,8 @@ class RoundNumber(str, Enum):
 
 def get_national_level_preparedness(spread: CachedSpread):
     for worksheet in spread.worksheets():
+        if worksheet.is_hidden:
+            continue
         cell = worksheet.find_one_of(
             "Summary of National Level Preparedness",
             "Résumé du niveau de préparation au niveau national ",
@@ -148,6 +150,8 @@ def get_regional_level_preparedness(spread: CachedSpread):
 
     sheet: CachedSheet
     for sheet in spread.worksheets():
+        if sheet.is_hidden:
+            continue
         # detect if we are in a Regional Spreadsheet form the title
         # and find position of the total score box
         cell = sheet.find_one_of(

--- a/plugins/polio/preparedness/spread_cache.py
+++ b/plugins/polio/preparedness/spread_cache.py
@@ -15,6 +15,10 @@ class CachedSpread:
         dict_spread["properties"] = spread._properties
         dict_spread["sheets"] = sheets = []
         for sheet in spread.worksheets():
+            # Google sheet has some kind of special "chart" as a sheet
+            # which will fail import. their sheetType is "OBJECT"
+            if sheet._properties["sheetType"] != "GRID":
+                continue
             dict_sheet = {
                 "title": sheet.title,
                 "id": sheet.id,
@@ -23,6 +27,7 @@ class CachedSpread:
                     value_render_option=gspread.utils.ValueRenderOption.unformatted,
                     date_time_render_option="SERIAL_NUMBER",
                 ),
+                "properties": sheet._properties,
             }
             sheets.append(dict_sheet)
         return CachedSpread(dict_spread)

--- a/plugins/polio/preparedness/spread_cache.py
+++ b/plugins/polio/preparedness/spread_cache.py
@@ -45,6 +45,7 @@ class CachedSheet:
         self.c = cache_dict
         self.values = cache_dict["values"]
         self.formulas = cache_dict["formulas"]
+        self.properties = cache_dict.get("properties", {})
 
     def _cache_get(self, linenum, colnum):
         if linenum >= len(self.values):
@@ -71,6 +72,10 @@ class CachedSheet:
     @property
     def title(self):
         return self.c["title"]
+
+    @property
+    def is_hidden(self) -> bool:
+        return self.properties.get("hidden", False)
 
     def __repr__(self):
         return f'<CachedSheet title="{self.c["title"]}">'


### PR DESCRIPTION
Some preparedness Spreadsheet were not importing, because some  of their worksheet were Special Graph and it was making the gspread library crash. We now skip these sheets

Also we no ignore hidden WorkSheet

## Self proof reading checklist

- [x ] Did I use eslint and black formatters

## Changes
Skip worksheet that are not of GRID type 
Skip worksheet hidden one. This won't take effect retroactively for already imported sheet since we didn't save this meta data at the time
