### PR TITLE
IA-1579 Use flexible site name in the reset  and invitations emails

### DIFF
--- a/README.md
+++ b/README.md
@@ -620,6 +620,18 @@ them reflected in the interface:
 
 ```manage.py compilemessages```
 
+You do not need to manage local for English as it is the default language
+
+If you get an error about `/opt/app` or cannot accessing docker:
+Change in settings.py LOCALE_PATHS to
+```python
+LOCALE_PATHS = [ "hat/locale/"]
+```
+
+And specify --ignore
+```sh
+makemessages --locale=fr --extension txt --extension html --ignore /opt/app --ignore docker --ignore node_modules
+```
 
 Code reloading
 --------------

--- a/README.md
+++ b/README.md
@@ -615,13 +615,6 @@ regenerate the translations:
 This will update `hat/locale/fr/LC_MESSAGES/django.po` with the new strings to
 translate.
 
-After updating it with the translation you need to following command to have
-them reflected in the interface:
-
-```manage.py compilemessages```
-
-You do not need to manage local for English as it is the default language
-
 If you get an error about `/opt/app` or cannot accessing docker:
 Change in settings.py LOCALE_PATHS to
 ```python
@@ -632,6 +625,19 @@ And specify --ignore
 ```sh
 makemessages --locale=fr --extension txt --extension html --ignore /opt/app --ignore docker --ignore node_modules
 ```
+
+
+After updating it with the translation you need to following command to have
+them reflected in the interface:
+
+```manage.py compilemessages```
+
+This is done automatically when you launch the docker image so if new translations
+you just pulled in git don't appear, relaunch the iaso docker.
+
+
+You do not need to manage local for English as it is the default language
+
 
 Code reloading
 --------------

--- a/hat/locale/fr/LC_MESSAGES/django.po
+++ b/hat/locale/fr/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-08-10 12:56+0000\n"
+"POT-Creation-Date: 2022-10-24 15:30+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Olivier Le Thanh Duong <olivier@lethanh.be>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,20 +17,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: hat/templates/iaso/base.html:8 plugins/polio/templates/polio/base.html:13
-msgid "Iaso Dashboard"
-msgstr "Dashboard Iaso"
-
-#: hat/templates/iaso/base.html:34 plugins/polio/templates/polio/base.html:24
-msgid "Welcome to the IASO Dashboard"
-msgstr "Bienvenue dans Iaso"
-
-#: hat/templates/iaso/forgot_password.html:10
-#: hat/templates/iaso/reset_password_confirmation.html:10
+#: hat/templates/iaso/forgot_password.html:9
+#: hat/templates/iaso/reset_password_confirmation.html:9
 msgid "Submit"
 msgstr "Envoyer"
 
-#: hat/templates/iaso/forgot_password.html:11
+#: hat/templates/iaso/forgot_password.html:10
 #: hat/templates/iaso/forgot_password_confirmation.html:10
 msgid "Go back to login"
 msgstr "Retour a la connection"
@@ -51,12 +43,7 @@ msgstr ""
 "Si vous ne recevez pas de courriel, verifiez que vous avez bien entrez votre "
 "addresse d'enregistrement et verifiez votre dossier spam."
 
-#: hat/templates/iaso/login.html:9
-msgid ""
-"An offspring of the <a href=\"https://www.trypelim.org\">Trypelim</a> project"
-msgstr "Né du projet <a href=\"https://www.trypelim.org\">Trypelim</a>."
-
-#: hat/templates/iaso/login.html:16
+#: hat/templates/iaso/login.html:15
 msgid ""
 "Your account doesn't have access to this page. To proceed, please login with "
 "an account that has access.\n"
@@ -66,15 +53,15 @@ msgstr ""
 "avec un autre utilisateur.\n"
 "          "
 
-#: hat/templates/iaso/login.html:21
+#: hat/templates/iaso/login.html:20
 msgid "Please login to see this page."
 msgstr "Veuillez vous connecter pour voir cette page"
 
-#: hat/templates/iaso/login.html:27
+#: hat/templates/iaso/login.html:26
 msgid "Your username and password didn't match. Please try again."
 msgstr "Nom d'utilisateur ou mot de passe incorrect."
 
-#: hat/templates/iaso/login.html:33
+#: hat/templates/iaso/login.html:32
 msgid "Login"
 msgstr "Connexion"
 
@@ -82,7 +69,7 @@ msgstr "Connexion"
 msgid "Forgot password"
 msgstr "Oublié votre mot de passe?"
 
-#: hat/templates/iaso/reset_password_complete.html:10
+#: hat/templates/iaso/reset_password_complete.html:9
 #, python-format
 msgid ""
 "\n"
@@ -101,7 +88,8 @@ msgid ""
 "\n"
 "Hello,\n"
 "\n"
-"A password reset has been request for your Iaso account \"%(username)s\",\n"
+"A password reset has been request for your account \"%(username)s\" on "
+"%(site_name)s }},\n"
 "to proceed please click the link below:\n"
 "\n"
 "%(protocol)s://%(domain)s%(reset_url)s\n"
@@ -114,13 +102,13 @@ msgid ""
 "passwords will be changed.\n"
 "\n"
 "Sincerely,\n"
-"The Iaso Team.\n"
+"The { site_name }} Team.\n"
 msgstr ""
 "\n"
 "Bonjour,\n"
 "\n"
 "Une demande de réinitialisation de mot de passe a été effectuée pour votre "
-"compte Iaso \"%(username)s\",\n"
+"compte \"%(username)s\" sur %(site_name)s }},\n"
 "pour continuer, veuillez clicker sur le lien suivant :\n"
 "\n"
 "%(protocol)s://%(domain)s%(reset_url)s\n"
@@ -131,8 +119,23 @@ msgstr ""
 "Si vous n'avez pas demandé cette réinitialisation, vous pouvez ignorer ce "
 "mail, aucun mot de passe ne sera modifié\n"
 "Sincèrement,\n"
-"L'équipe Iaso.\n"
+"L'équipe { site_name }}.\n"
 
-#: hat/templates/iaso/reset_password_subject.txt:1
-msgid "Iaso password reset"
-msgstr "Réinitialisation du mot de passe Iaso"
+#: hat/templates/iaso/reset_password_subject.txt:2
+#, python-format
+msgid "Password reset on %(site_name)s"
+msgstr "Réinitialisation du mot de passe sur %(site_name)s"
+
+#~ msgid "Iaso password reset"
+#~ msgstr "Réinitialisation du mot de passe Iaso"
+
+#~ msgid "Iaso Dashboard"
+#~ msgstr "Dashboard Iaso"
+
+#~ msgid "Welcome to the IASO Dashboard"
+#~ msgstr "Bienvenue dans Iaso"
+
+#~ msgid ""
+#~ "An offspring of the <a href=\"https://www.trypelim.org\">Trypelim</a> "
+#~ "project"
+#~ msgstr "Né du projet <a href=\"https://www.trypelim.org\">Trypelim</a>."

--- a/hat/templates/iaso/reset_password_email.html
+++ b/hat/templates/iaso/reset_password_email.html
@@ -2,7 +2,7 @@
 {% autoescape off %}{% blocktrans with  username=user.get_username %}
 Hello,
 
-A password reset has been request for your Iaso account "{{ username }}",
+A password reset has been request for your account "{{ username }}" on {{  site_name }} }},
 to proceed please click the link below:
 
 {{ protocol }}://{{ domain }}{{ reset_url }}
@@ -13,5 +13,5 @@ window instead.
 If you did not request a password reset, you can ignore this e-mail - no passwords will be changed.
 
 Sincerely,
-The Iaso Team.
+The { site_name }} Team.
 {% endblocktrans %}{% endautoescape %}

--- a/hat/templates/iaso/reset_password_subject.txt
+++ b/hat/templates/iaso/reset_password_subject.txt
@@ -1,1 +1,3 @@
-{% load i18n %}{% trans "Iaso password reset" %}
+{% load i18n %}{% autoescape off %}
+{% blocktranslate %}Password reset on {{ site_name }}{% endblocktranslate %}
+{% endautoescape %}

--- a/iaso/tests/api/test_profiles.py
+++ b/iaso/tests/api/test_profiles.py
@@ -1,6 +1,7 @@
 import typing
 
 from django.contrib.gis.geos import Polygon, Point, MultiPolygon
+from django.contrib.sites.models import Site
 from django.test import tag
 from django.core import mail
 from iaso.models import Profile
@@ -251,6 +252,9 @@ class ProfileAPITestCase(APITestCase):
         self.assertEqual(org_units[0].name, "Corruscant Jedi Council")
 
     def test_create_profile_with_send_email(self):
+        site = Site.objects.first()
+        site.name = "Iaso Dev"
+        site.save()
         self.client.force_authenticate(self.jim)
         data = {
             "user_name": "userTest",
@@ -264,7 +268,7 @@ class ProfileAPITestCase(APITestCase):
         response = self.client.post("/api/profiles/", data=data, format="json")
         self.assertEqual(response.status_code, 200)
 
-        domain = settings.DNS_DOMAIN
+        domain = site.name
         from_email = settings.DEFAULT_FROM_EMAIL
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].subject, f"Set up a password for your new account on {domain}")


### PR DESCRIPTION
Instead of hardcoding Iaso in the e-mail Subject and Body use the name defined in database so we can easily configure it for each environment

## Self proof reading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Did I add translations
- [x] My migrations file are included
- [x] Are there enough tests
## Changes

* More Consistantly use the Site settings. See Django Sites' Famework  for more information https://docs.djangoproject.com/en/4.1/ref/contrib/sites/
* Changed the text of the Invitation email and reset-email as well.
* The old budget stuff wasn't touched because we remove it in another PR and we already use the new style in the new budget engine.
* Remove some use of DNS_DOMAIN but not all yet. (There was some inconsistance of usage in it, some part of the code were expecting the protocol other not it seems)
* Updated documentation for Django translation handling.

## How to test

* Make sure the Site framework is configured correctly in the Admin, by going to `/admin/sites/site/1/change/`
* Try sending an invitation e-mail and check the result
* Idem for a Reset password e-mail

By default the content of the e-mail will be displayed in the Django terminal log.
