### PR TITLE
POLIO-579: calendar page disable pdf button when map still loading

### DIFF
--- a/plugins/polio/js/src/pages/Calendar.js
+++ b/plugins/polio/js/src/pages/Calendar.js
@@ -133,10 +133,12 @@ const Calendar = ({ params }) => {
     );
 
     useEffect(() => {
-        if (campaigns.length > 0 && filteredCampaigns.length > 0) {
+        if (filteredCampaigns.length > 0) {
             setCalendarAndMapLoaded(true);
+        } else {
+            setCalendarAndMapLoaded(false);
         }
-    }, [campaigns, filteredCampaigns]);
+    }, [filteredCampaigns]);
 
     return (
         <div>

--- a/plugins/polio/js/src/pages/Calendar.js
+++ b/plugins/polio/js/src/pages/Calendar.js
@@ -133,14 +133,10 @@ const Calendar = ({ params }) => {
     );
 
     useEffect(() => {
-        if (
-            campaigns.length > 0 &&
-            filteredCampaigns.length > 0 &&
-            !isLoading
-        ) {
+        if (campaigns.length > 0 && filteredCampaigns.length > 0) {
             setCalendarAndMapLoaded(true);
         }
-    }, [campaigns, filteredCampaigns, isLoading]);
+    }, [campaigns, filteredCampaigns]);
 
     return (
         <div>

--- a/plugins/polio/js/src/pages/Calendar.js
+++ b/plugins/polio/js/src/pages/Calendar.js
@@ -9,7 +9,7 @@ import {
     useSafeIntl,
     LoadingSpinner,
     ExcellSvg,
-    getTableUrl
+    getTableUrl,
 } from 'bluesquare-components';
 import { useSelector } from 'react-redux';
 import TopBar from 'Iaso/components/nav/TopBarComponent';
@@ -48,7 +48,7 @@ const useStyles = makeStyles(theme => ({
     isNotPdf: {
         height: 'calc(100vh - 65px)',
     },
-    exportIcon: { marginRight: '8px' }
+    exportIcon: { marginRight: '8px' },
 }));
 
 const Calendar = ({ params }) => {
@@ -128,7 +128,7 @@ const Calendar = ({ params }) => {
         campaignType: params.campaignType,
         campaignGroups: params.campaignGroups,
         search: params.search,
-        order: params.order
+        order: params.order,
     };
 
     const xlsx_url = getTableUrl(
@@ -137,10 +137,14 @@ const Calendar = ({ params }) => {
     );
 
     useEffect(() => {
-        if (campaigns.length > 0) {
+        if (
+            campaigns.length > 0 &&
+            filteredCampaigns.length > 0 &&
+            !isLoading
+        ) {
             setCalendarAndMapLoaded(true);
         }
-    }, [campaigns]);
+    }, [campaigns, filteredCampaigns, isLoading]);
 
     return (
         <div>
@@ -206,10 +210,7 @@ const Calendar = ({ params }) => {
                                     className="createXlsx"
                                     href={xlsx_url}
                                 >
-                                    <ExcellSvg
-                                        className={classes.exportIcon}
-
-                                    />
+                                    <ExcellSvg className={classes.exportIcon} />
                                     {formatMessage(MESSAGES.exportToExcel)}
                                 </Button>
                             </Box>

--- a/plugins/polio/js/src/pages/Calendar.js
+++ b/plugins/polio/js/src/pages/Calendar.js
@@ -197,7 +197,6 @@ const Calendar = ({ params }) => {
                         <Grid item>
                             <Box mb={2} mt={2}>
                                 <Button
-                                    disabled={!isCalendarAndMapLoaded}
                                     type="button"
                                     color="primary"
                                     variant="contained"

--- a/plugins/polio/js/src/pages/Calendar.js
+++ b/plugins/polio/js/src/pages/Calendar.js
@@ -23,8 +23,6 @@ import {
     getCalendarData,
 } from '../components/campaignCalendar/utils';
 
-import { useGetCalendarXlsx } from '../hooks/useGetCalendarXlsx';
-
 import {
     dateFormat,
     defaultOrder,
@@ -71,8 +69,6 @@ const Calendar = ({ params }) => {
         params.countries,
         params.search,
     ]);
-
-    const { mutate: generateCalendarXlsx } = useGetCalendarXlsx();
 
     const { data: campaigns = [], isLoading } =
         useGetCampaigns(queryOptions).query;


### PR DESCRIPTION
Explain what problem this PR is resolving

## Self proof reading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests
## Changes

- updated the logic inside useEffect to disable pdf and xlsx export buttons if there is no filtered campaigns in the calendar

## How to test

Go to Polio > Calendar
Play with the calendar to see if when there is no data, the buttons are disable and the other way around.

## Print screen / video

https://user-images.githubusercontent.com/25134301/197745763-403a9c8c-8838-400d-8524-a74c22ca07ba.mp4

