### PR TITLE
IA-1608: Query builder crash with possible fields containing a "."

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/forms/hooks/useGetPossibleFields.ts
+++ b/hat/assets/js/apps/Iaso/domains/forms/hooks/useGetPossibleFields.ts
@@ -13,8 +13,13 @@ export const useGetPossibleFields = (formId?: number): Result => {
         Boolean(formId),
         'possible_fields',
     );
+    const possibleFields =
+        currentForm?.possible_fields.map(field => ({
+            ...field,
+            fieldKey: field.name.replace('.', ''),
+        })) || [];
     return {
-        possibleFields: currentForm?.possible_fields || [],
+        possibleFields,
         isFetchingForm,
     };
 };

--- a/hat/assets/js/apps/Iaso/domains/forms/types/forms.ts
+++ b/hat/assets/js/apps/Iaso/domains/forms/types/forms.ts
@@ -54,6 +54,7 @@ export type PossibleField = {
     label: string;
     name: string;
     type: FieldType;
+    fieldKey: string;
 };
 export type ChildrenDescriptor = {
     label: string;

--- a/hat/assets/js/apps/Iaso/domains/instances/components/InstancesFiltersComponent.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/InstancesFiltersComponent.js
@@ -52,6 +52,7 @@ const InstancesFiltersComponent = ({
     params: { formIds },
     params,
     onSearch,
+    possibleFields,
 }) => {
     const dispatch = useDispatch();
     const { formatMessage } = useSafeIntl();
@@ -96,7 +97,7 @@ const InstancesFiltersComponent = ({
         currentForm?.latest_form_version?.version_id, // by default using last form version
         currentForm?.id,
     );
-    const fields = useGetQueryBuildersFields(formId, formDescriptor);
+    const fields = useGetQueryBuildersFields(formDescriptor, possibleFields);
 
     useInstancesFiltersData(formIds, setFetchingOrgUnitTypes);
     const handleSearch = useCallback(() => {
@@ -409,9 +410,14 @@ const InstancesFiltersComponent = ({
     );
 };
 
+InstancesFiltersComponent.defaultProps = {
+    possibleFields: [],
+};
+
 InstancesFiltersComponent.propTypes = {
     params: PropTypes.object.isRequired,
     onSearch: PropTypes.func.isRequired,
+    possibleFields: PropTypes.array,
 };
 
 export default InstancesFiltersComponent;

--- a/hat/assets/js/apps/Iaso/domains/instances/components/InstancesTopBar.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/InstancesTopBar.js
@@ -61,7 +61,11 @@ const InstancesTopBar = ({
             currentUser,
             dispatch,
         );
-        if (JSON.stringify(newTablecols) !== JSON.stringify(tableColumns)) {
+        // TODO this part of the code should be refactored, it leads too infinite loop
+        if (
+            JSON.stringify(newTablecols) !== JSON.stringify(tableColumns) &&
+            newTablecols.length > 1
+        ) {
             setTableColumns(newTablecols);
         }
         setVisibleColumns(cols);

--- a/hat/assets/js/apps/Iaso/domains/instances/components/InstancesTopBar.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/InstancesTopBar.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 
 import { makeStyles, Grid, Tabs, Tab } from '@material-ui/core';
 import { commonStyles, useSafeIntl } from 'bluesquare-components';
@@ -12,7 +12,7 @@ import { getInstancesColumns, getInstancesVisibleColumns } from '../utils';
 import { ColumnsSelectDrawer } from '../../../components/tables/ColumnSelectDrawer';
 import MESSAGES from '../messages';
 import { INSTANCE_METAS_FIELDS } from '../constants';
-import { useCurrentUser } from '../../../utils/usersUtils';
+import { useCurrentUser } from '../../../utils/usersUtils.ts';
 
 const useStyles = makeStyles(theme => ({
     ...commonStyles(theme),
@@ -36,6 +36,7 @@ const InstancesTopBar = ({
     labelKeys,
     possibleFields,
     formDetails,
+    tableColumns,
 }) => {
     const classes = useStyles();
     const dispatch = useDispatch();
@@ -53,15 +54,16 @@ const InstancesTopBar = ({
         if (columns.length > 0) {
             newParams.columns = columns.map(c => c.key).join(',');
         }
-        setTableColumns(
-            getInstancesColumns(
-                formatMessage,
-                cols,
-                params.showDeleted === 'true',
-                currentUser,
-                dispatch,
-            ),
+        const newTablecols = getInstancesColumns(
+            formatMessage,
+            cols,
+            params.showDeleted === 'true',
+            currentUser,
+            dispatch,
         );
+        if (JSON.stringify(newTablecols) !== JSON.stringify(tableColumns)) {
+            setTableColumns(newTablecols);
+        }
         setVisibleColumns(cols);
         if (withRedirect) {
             dispatch(redirectToReplace(baseUrl, newParams));

--- a/hat/assets/js/apps/Iaso/domains/instances/hooks/useGetQueryBuildersFields.ts
+++ b/hat/assets/js/apps/Iaso/domains/instances/hooks/useGetQueryBuildersFields.ts
@@ -1,10 +1,9 @@
 // @ts-ignore
 import { QueryBuilderFields } from 'bluesquare-components';
 
-import { useGetPossibleFields } from '../../forms/hooks/useGetPossibleFields';
 import { formatLabel } from '../utils';
 
-import { FormDescriptor } from '../../forms/types/forms';
+import { FormDescriptor, PossibleField } from '../../forms/types/forms';
 import { getLocaleDateFormat } from '../../../utils/dates';
 
 const findDescriptorInChildren = (field, descriptor) =>
@@ -17,17 +16,16 @@ const findDescriptorInChildren = (field, descriptor) =>
 
 // you can fields examples here: https://codesandbox.io/s/github/ukrbublik/react-awesome-query-builder/tree/master/sandbox?file=/src/demo/config.tsx:1444-1464
 export const useGetQueryBuildersFields = (
-    formId?: number,
     formDescriptor?: FormDescriptor,
+    possibleFields?: PossibleField[],
 ): QueryBuilderFields => {
-    const { possibleFields, isFetchingForm } = useGetPossibleFields(formId);
-    if (isFetchingForm || !possibleFields) return {};
+    if (!possibleFields) return {};
     const Fields: QueryBuilderFields = {};
     possibleFields.forEach(field => {
         switch (field.type) {
             case 'text':
             case 'note': {
-                Fields[field.name] = {
+                Fields[field.fieldKey] = {
                     label: formatLabel(field),
                     type: 'text',
                     excludeOperators: [
@@ -52,7 +50,7 @@ export const useGetQueryBuildersFields = (
                         value: child.name,
                         title: formatLabel(child),
                     })) || [];
-                Fields[field.name] = {
+                Fields[field.fieldKey] = {
                     label: formatLabel(field),
                     type: 'select',
                     excludeOperators: [
@@ -78,8 +76,9 @@ export const useGetQueryBuildersFields = (
             //             value: child.name,
             //             title: formatLabel(child),
             //         })) || [];
-            //     Fields[field.name] = {
+            //     Fields[field.fieldKey] = {
             //         label: formatLabel(field),
+            //         originalKey: field.name,
             //         type: 'multiselect',
             //         excludeOperators: [
             //             'proximity',
@@ -95,7 +94,7 @@ export const useGetQueryBuildersFields = (
             // }
             case 'integer':
             case 'decimal': {
-                Fields[field.name] = {
+                Fields[field.fieldKey] = {
                     label: formatLabel(field),
                     type: 'number',
                     preferWidgets: ['number'],
@@ -103,7 +102,7 @@ export const useGetQueryBuildersFields = (
                 break;
             }
             case 'range': {
-                Fields[field.name] = {
+                Fields[field.fieldKey] = {
                     label: formatLabel(field),
                     type: 'number',
                     preferWidgets: ['number'],
@@ -113,7 +112,7 @@ export const useGetQueryBuildersFields = (
                 break;
             }
             case 'date': {
-                Fields[field.name] = {
+                Fields[field.fieldKey] = {
                     label: formatLabel(field),
                     type: 'date',
                     operators: ['equal', 'not_equal'],
@@ -126,9 +125,10 @@ export const useGetQueryBuildersFields = (
 
             // Not working for now
             // case 'time': {
-            //     Fields[field.name] = {
+            //     Fields[field.fieldKey] = {
             //         label: formatLabel(field),
             //         type: 'time',
+            //         originalKey: field.name,
             //         operators: ['equal', 'not_equal'],
             //         fieldSettings: {
             //             timeFormat: getLocaleDateFormat('LT'),
@@ -137,9 +137,10 @@ export const useGetQueryBuildersFields = (
             //     break;
             // }
             // case 'dateTime': {
-            //     Fields[field.name] = {
+            //     Fields[field.fieldKey] = {
             //         label: formatLabel(field),
             //         type: 'datetime',
+            //         originalKey: field.name,
             //         operators: ['equal', 'not_equal'],
             //         fieldSettings: {
             //             timeFormat: getLocaleDateFormat('LT'),

--- a/hat/assets/js/apps/Iaso/domains/instances/requests.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/requests.js
@@ -6,9 +6,6 @@ import snackMessages from '../../components/snackBars/messages';
 export const fetchFormDetailsForInstance = formId =>
     getRequest(`/api/forms/${formId}/?fields=name,period_type,label_keys,id,org_unit_type_ids`);
 
-export const fetchPossibleFields = async formId =>
-    getRequest(`/api/forms/${formId}/?fields=possible_fields`);
-
 export const fetchInstancesAsDict = url => getRequest(url);
 
 export const fetchInstancesAsSmallDict = url => getRequest(url);

--- a/hat/assets/js/apps/Iaso/domains/instances/utils/jsonLogicParse.ts
+++ b/hat/assets/js/apps/Iaso/domains/instances/utils/jsonLogicParse.ts
@@ -63,7 +63,11 @@ export const parseJson = ({ value, parent, fields }: Props): JSONValue => {
         }
         if (fieldType === 'time') {
             return `${moment
-                .utc(moment.duration(value, 'seconds').as('milliseconds'))
+                .utc(
+                    moment
+                        .duration(value as string, 'seconds')
+                        .as('milliseconds'),
+                )
                 .format(apiTimeFormat)}`;
         }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5626,7 +5626,7 @@
         },
         "node_modules/bluesquare-components": {
             "version": "0.2.0",
-            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#7b3b53530b575fde503b07163134a952c65d935b",
+            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#d2f237486d6569f84e5a7ee1379478ad2da23c7d",
             "license": "Apache-2.0",
             "dependencies": {
                 "@babel/plugin-transform-runtime": "^7.17.0",
@@ -30799,7 +30799,7 @@
             "dev": true
         },
         "bluesquare-components": {
-            "version": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#7b3b53530b575fde503b07163134a952c65d935b",
+            "version": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#d2f237486d6569f84e5a7ee1379478ad2da23c7d",
             "from": "bluesquare-components@github:BLSQ/bluesquare-components",
             "requires": {
                 "@babel/plugin-transform-runtime": "^7.17.0",


### PR DESCRIPTION
Go [here](https://iaso.bluesquare.org/dashboard/forms/submissions/formIds/796/page/1/tab/list/columns/updated_at,period,org_unit__name,status/mapResults/3000)

click on the query builder field and select this value:

<img width="1884" alt="Screenshot 2022-10-26 at 12 11 55" src="https://user-images.githubusercontent.com/12494624/198003907-5a97f597-b174-48ce-9676-0665d08ade74.png">
It leads to a white page.

It seems that possible field name can contain a “.” and is crashing the query builder lib

## Self proof reading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests

## Changes

- update bluesquare-component to remove translation warning
- remove fetchPossibleFields and use use getPossibleFields
- use fieldKey that is more object friendly to possible fields
- replace value when calling the api to put field name again


## How to test

You'll need [this](https://iaso.bluesquare.org/dashboard/forms/list/page/1/search/ACV%20-%20perform)  (pbf_rca account) form  locally.
Best is to create a submission with enketo to ensure filtering is working properly.

After go to submissione search, select the form you just created and try to search on the same field as in production.
It should not crash

## Print screen / video

https://user-images.githubusercontent.com/12494624/198005230-4b600605-f934-414c-aa3d-81ddba39432b.mov


