### PR TITLE
WC2-97: iaso_storages not translated

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/users/messages.js
+++ b/hat/assets/js/apps/Iaso/domains/users/messages.js
@@ -164,6 +164,10 @@ const MESSAGES = defineMessages({
         id: 'iaso.permissions.assignments',
         defaultMessage: 'Assignments',
     },
+    iaso_storages: {
+        id: 'iaso.label.storages',
+        defaultMessage: 'Storages',
+    },
     iaso_entities: {
         id: 'iaso.permissions.entities',
         defaultMessage: 'Beneficiaries',


### PR DESCRIPTION
Adding translation in the messages for iaso_storages
<img width="839" alt="Screenshot 2022-10-28 at 09 58 56" src="https://user-images.githubusercontent.com/12494624/198535539-d8b28383-c681-4cf7-ba60-3765eb10574b.png">
