### PR TITLE
IA-1568-POLIO-638: fix b0PV option, fix vaccinedropdown

### DIFF
--- a/plugins/polio/js/src/forms/RoundVaccineForm.tsx
+++ b/plugins/polio/js/src/forms/RoundVaccineForm.tsx
@@ -1,6 +1,6 @@
 import { Box, Grid } from '@material-ui/core';
-import { Field } from 'formik';
-import React, { FunctionComponent } from 'react';
+import { Field, useFormikContext } from 'formik';
+import React, { FunctionComponent, useMemo } from 'react';
 // @ts-ignore
 import { useSafeIntl } from 'bluesquare-components';
 import { Select, TextInput } from '../components/Inputs';
@@ -39,8 +39,21 @@ export const RoundVaccineForm: FunctionComponent<Props> = ({
     vaccineOptions,
 }) => {
     const { formatMessage } = useSafeIntl();
+    const {
+        // @ts-ignore
+        values: { rounds },
+    } = useFormikContext();
+    const { vaccines } = rounds[roundIndex];
+    const selectedVaccine = vaccines[vaccineIndex];
     const classes: Record<string, string> = useStyles();
     const accessor = `rounds[${roundIndex}].vaccines[${vaccineIndex}]`;
+    const options = useMemo(() => {
+        if (!selectedVaccine?.name) return vaccineOptions;
+        return [
+            ...vaccineOptions,
+            { label: selectedVaccine.name, value: selectedVaccine.name },
+        ];
+    }, [selectedVaccine?.name, vaccineOptions]);
 
     return (
         <>
@@ -50,7 +63,7 @@ export const RoundVaccineForm: FunctionComponent<Props> = ({
                         label={formatMessage(MESSAGES.vaccine)}
                         name={`${accessor}.name`}
                         className={classes.input}
-                        options={vaccineOptions}
+                        options={options}
                         component={Select}
                     />
                 </Box>

--- a/plugins/polio/js/src/forms/RoundVaccineForm.tsx
+++ b/plugins/polio/js/src/forms/RoundVaccineForm.tsx
@@ -43,7 +43,7 @@ export const RoundVaccineForm: FunctionComponent<Props> = ({
         // @ts-ignore
         values: { rounds },
     } = useFormikContext();
-    const { vaccines } = rounds[roundIndex];
+    const { vaccines = [] } = rounds[roundIndex] ?? {};
     const selectedVaccine = vaccines[vaccineIndex];
     const classes: Record<string, string> = useStyles();
     const accessor = `rounds[${roundIndex}].vaccines[${vaccineIndex}]`;

--- a/plugins/polio/js/src/forms/RoundVaccinesForm.tsx
+++ b/plugins/polio/js/src/forms/RoundVaccinesForm.tsx
@@ -141,7 +141,6 @@ export const RoundVaccinesForm: FunctionComponent<Props> = ({
                 vaccinesRef.current &&
                 vaccine?.name !== vaccinesRef?.current?.[index]?.name
             ) {
-                vaccine?.name;
                 setFieldValue(
                     `rounds[${roundIndex}].vaccines[${index}].wastage_ratio_forecast`,
                     DEFAULT_WASTAGE_RATIOS[vaccine.name],

--- a/plugins/polio/js/src/forms/RoundVaccinesForm.tsx
+++ b/plugins/polio/js/src/forms/RoundVaccinesForm.tsx
@@ -137,14 +137,20 @@ export const RoundVaccinesForm: FunctionComponent<Props> = ({
     // Fill in wastage ratio with default value for vaccine when adding vaccine
     useEffect(() => {
         vaccines.forEach((vaccine, index) => {
-            if (vaccine?.name !== vaccinesRef?.current?.[index]?.name) {
+            if (
+                vaccinesRef.current &&
+                vaccine?.name !== vaccinesRef?.current?.[index]?.name
+            ) {
                 vaccine?.name;
                 setFieldValue(
                     `rounds[${roundIndex}].vaccines[${index}].wastage_ratio_forecast`,
                     DEFAULT_WASTAGE_RATIOS[vaccine.name],
                 );
             }
-            if (vaccine?.name !== vaccinesRef?.current?.[index]?.name) {
+            if (
+                vaccinesRef.current &&
+                vaccine?.name !== vaccinesRef?.current?.[index]?.name
+            ) {
                 setFieldValue(
                     `rounds[${roundIndex}].vaccines[${index}].doses_per_vial`,
                     DEFAULT_DOSES_PER_VIAL,


### PR DESCRIPTION
The default value for B0PV vaccine didn't show, and users could select the same vaccine several times

## Self proof reading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [X] Are my typescript files well typed

## Changes

- Fixed the typo that was causing the bug with b0PV default value
- Reset vaccine values to default when selecting another vaccine
- Restrict the dropdown options to unselected vaccines


## How to test

- Go to any campaign -> Vaccine tab and play around

## Print screen / video


https://user-images.githubusercontent.com/38907762/199541208-53c92c78-f413-4cc9-9c8b-38c127104019.mov

