### PR TITLE
IA-1569: show input borders in table cells

### DIFF
--- a/plugins/polio/js/src/forms/ReportingDelays.tsx
+++ b/plugins/polio/js/src/forms/ReportingDelays.tsx
@@ -23,7 +23,6 @@ const useStyles = makeStyles(theme => ({
     title: {
         fontWeight: 'bold',
     },
-    inputFields: { '& .MuiOutlinedInput-notchedOutline': { border: 'none' } },
 }));
 
 type Props = {
@@ -61,7 +60,6 @@ export const ReportingDelays: FunctionComponent<Props> = ({ accessor }) => {
                                 label=""
                                 name={`${accessor}.reporting_delays_hc_to_district`}
                                 component={TextInput}
-                                className={classes.inputFields}
                             />
                         </TableCell>
                     </TableRow>
@@ -74,7 +72,6 @@ export const ReportingDelays: FunctionComponent<Props> = ({ accessor }) => {
                                 label=""
                                 name={`${accessor}.reporting_delays_district_to_region`}
                                 component={TextInput}
-                                className={classes.inputFields}
                             />
                         </TableCell>
                     </TableRow>
@@ -87,7 +84,6 @@ export const ReportingDelays: FunctionComponent<Props> = ({ accessor }) => {
                                 label=""
                                 name={`${accessor}.reporting_delays_region_to_national`}
                                 component={TextInput}
-                                className={classes.inputFields}
                             />
                         </TableCell>
                     </TableRow>


### PR DESCRIPTION
Table cells content is editable for reporting delays, but the UI didn't make it clear

## Self proof reading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [X] Are my typescript files well typed
- 
## Changes

- remove CSS hiding input border for inputs in table cells


## How to test

Go to a campaign's vaccine tab

## Print screen / video

![Screenshot 2022-11-02 at 17 29 57](https://user-images.githubusercontent.com/38907762/199546944-a45ad302-2d03-4091-9fc1-4f7b440475d3.png)

