### PR TITLE
WC2-103: Mising "search on entity or storage id" filter on the the /api/storage (list) API endpoint

### DIFF
--- a/iaso/tests/api/test_storage.py
+++ b/iaso/tests/api/test_storage.py
@@ -63,6 +63,7 @@ class StorageAPITestCase(APITestCase):
             type="SD",
             status="BLACKLISTED",
             status_reason="ABUSE",
+            entity=cls.entity,
         )
 
         # This one should be invisible to the "yoda" user
@@ -444,7 +445,7 @@ class StorageAPITestCase(APITestCase):
                     "storage_type": "SD",
                     "status": {"status": "BLACKLISTED", "reason": "ABUSE", "comment": "", "updated_at": None},
                     "org_unit": None,
-                    "entity": None,
+                    "entity": {"id": self.entity.id, "name": "New Client 3"},
                 },
             ],
         )
@@ -473,7 +474,7 @@ class StorageAPITestCase(APITestCase):
                     "storage_type": "SD",
                     "status": {"status": "BLACKLISTED", "reason": "ABUSE", "comment": "", "updated_at": None},
                     "org_unit": None,
-                    "entity": None,
+                    "entity": {"id": self.entity.id, "name": "New Client 3"},
                 },
             ],
         )
@@ -526,6 +527,41 @@ class StorageAPITestCase(APITestCase):
                     "org_unit": None,
                     "entity": None,
                 },
+            ],
+        )
+
+    def test_list_filter_by_storage_id(self):
+        """The 'search' filter can be used to filter per (customer-chosen) storage ID"""
+        self.client.force_authenticate(self.yoda)
+        response = self.client.get("/api/storage/?search=aNotHeR")
+        received_json = response.json()
+
+        # If the filter was not operational we would get 3 results.
+        # If the filter was not case-insensitive we would get 0 results.
+        self.assertEqual(len(received_json), 2)
+        # We double-check that the results are the ones we expect
+        for entry in received_json:
+            self.assertIn("ANOTHER", entry["storage_id"])
+
+    def test_list_filter_by_entity_id(self):
+        """The 'search' filter can be also be used to search per entity ID"""
+        self.client.force_authenticate(self.yoda)
+        response = self.client.get(f"/api/storage/?search={self.entity.id}")
+        received_json = response.json()
+
+        # If the filter was not operational we would get 3 results.
+        self.assertEqual(
+            received_json,
+            [
+                {
+                    "updated_at": 1580608922.0,
+                    "created_at": 1580608922.0,
+                    "storage_id": "ANOTHER_EXISTING_STORAGE_BLACKLISTED_ABUSE",
+                    "storage_type": "SD",
+                    "status": {"status": "BLACKLISTED", "reason": "ABUSE", "updated_at": None, "comment": ""},
+                    "org_unit": None,
+                    "entity": {"id": self.entity.id, "name": "New Client 3"},
+                }
             ],
         )
 
@@ -1209,7 +1245,7 @@ class StorageAPITestCase(APITestCase):
                         "storage_type": "SD",
                         "status": {"status": "BLACKLISTED", "reason": "ABUSE", "comment": "", "updated_at": None},
                         "org_unit": None,
-                        "entity": None,
+                        "entity": {"id": self.entity.id, "name": "New Client 3"},
                     },
                 ]
             },


### PR DESCRIPTION
In https://bluesquare.atlassian.net/browse/WC2-62, a "search" filter was mentioned for the storage API.

It was skipped in the first PR because we were in a hurry for a demo. This PR adds the missing feature. As a reminder, this search parameter allows to search both within storage IDs and entity IDs

## Self proof reading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are there enough tests

## How to test

Test the API using the search parameter (see usage in `test_storages.py`)