### PR TITLE
WC-98: Logs per device endpoint: added "performed_at" filter

### DIFF
--- a/iaso/api/storage.py
+++ b/iaso/api/storage.py
@@ -1,5 +1,5 @@
 # TODO: need better type annotations in this file
-
+import datetime
 from typing import Tuple
 
 from django.db.models import Prefetch
@@ -333,6 +333,8 @@ def logs_per_device(request, storage_customer_chosen_id: str, storage_type: str)
 
     order = request.GET.get("order", "-performed_at").split(",")
 
+    performed_at_str = request.GET.get("performed_at", None)
+
     device_identity_fields = {
         "customer_chosen_id": storage_customer_chosen_id,
         "type": storage_type,
@@ -353,6 +355,10 @@ def logs_per_device(request, storage_customer_chosen_id: str, storage_type: str)
         log_entries_queryset = log_entries_queryset.filter(status=status)
     if reason is not None:
         log_entries_queryset = log_entries_queryset.filter(status_reason=reason)
+    if performed_at_str is not None:
+        log_entries_queryset = log_entries_queryset.filter(
+            performed_at__date=datetime.datetime.strptime(performed_at_str, "%Y-%m-%d").date()
+        )
 
     device_with_logs = StorageDevice.objects.prefetch_related(
         Prefetch(

--- a/iaso/tests/api/test_storage.py
+++ b/iaso/tests/api/test_storage.py
@@ -969,6 +969,27 @@ class StorageAPITestCase(APITestCase):
             },
         )
 
+    def test_get_logs_for_device_performed_at_filter(self):
+        """The logs per device endpoint can be filtered by date using performed_at"""
+        self.client.force_authenticate(self.yoda)
+
+        # We add a second log with a different performed_at
+        StorageLogEntry.objects.create(
+            id="e4200710-bf82-4d29-a29b-6a042f79ef26",
+            device=self.existing_storage_device,
+            operation_type="WRITE_RECORD",
+            performed_by=self.yoda,
+            performed_at=datetime(2022, 11, 3, 13, 12, 56, 0, tzinfo=timezone.utc),
+            org_unit=self.org_unit,
+        )
+
+        response = self.client.get(f"/api/storage/NFC/EXISTING_STORAGE/logs?performed_at=2022-11-03")
+        self.assertEqual(response.status_code, 200)
+        received_json = response.json()
+        # if the filter didn't worked, we would also receive the log from setupTestData
+        self.assertEqual(len(received_json["logs"]), 1)
+        self.assertEqual(received_json["logs"][0]["id"], "e4200710-bf82-4d29-a29b-6a042f79ef26")
+
     def test_get_logs_for_device_pagination(self):
         """The logs per device endpoint can optionally be paginated"""
         self.client.force_authenticate(self.yoda)


### PR DESCRIPTION
Added a performed_at filter to the "list logs per device" endpoint, as requested by @beygorghor in https://bluesquare.atlassian.net/browse/WC2-98

## Self proof reading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are there enough tests

## How to test

Create a new StorageDevice called superbe_id of type NFC, and add it a few log entries (from Django Admin)

Go to `/api/storage/NFC/superbe_id/logs` and check that you can filter the logs with the performed_at filter, for example: `/api/storage/NFC/superbe_id/logs?performed_at=2022-11-03`

