### PR TITLE
Wc2 104 missing refinements from the storage blacklist api

### DIFF
--- a/iaso/api/storage.py
+++ b/iaso/api/storage.py
@@ -205,8 +205,6 @@ class StorageViewSet(ListModelMixin, viewsets.GenericViewSet):
 
         POST /api/storage/blacklisted/
         """
-        # TODO: permissions: spec mentions "permission to modify storage", what does it mean exactly?
-        #  Clarify then implement
 
         # 1. Get data from request/environment
         user = request.user
@@ -388,7 +386,6 @@ class StorageBlacklistedViewSet(ListModelMixin, viewsets.GenericViewSet):
     queryset = StorageDevice.objects.filter(status=StorageDevice.BLACKLISTED)
     serializer_class = StorageSerializer
 
-    # TODO: check permissions if necessary (everybody can get the list of blacklisted devices accross all accounts, correct?)
     permission_classes = [AllowAny]
     # TODO: according to spec, we should add an "updated_at" field
     # TODO: implement pagination

--- a/iaso/api/storage.py
+++ b/iaso/api/storage.py
@@ -226,7 +226,6 @@ class StorageViewSet(ListModelMixin, viewsets.GenericViewSet):
             # 3. Submitted data is valid, we can now proceed
             status_dict = status_serializer.validated_data
             # 3.1 Update device status
-            # TODO: discuss: what should be done if we try to change the device to the status it's already in?
             device.change_status(
                 new_status=status_dict["status"],
                 reason=status_dict.get("status_reason", ""),
@@ -279,7 +278,6 @@ class StorageLogViewSet(CreateModelMixin, viewsets.GenericViewSet):
 
                 concerned_instances = Instance.objects.filter(uuid__in=log_data["instances"])
 
-                # TODO: refactor this?
                 concerned_orgunit = None
                 if "org_unit_id" in log_data and log_data["org_unit_id"] is not None:
                     try:
@@ -361,7 +359,7 @@ def logs_per_device(request, storage_customer_chosen_id: str, storage_type: str)
     ).get(**device_identity_fields)
 
     if limit_str:
-        # Pagination requested: each page contains the device metadata + a subset of log entries
+        # Pagination as requested: each page contains the device metadata + a subset of log entries
         limit = int(limit_str)
         page_offset = int(page_offset)
         paginator = Paginator(log_entries_queryset, limit)
@@ -387,8 +385,6 @@ class StorageBlacklistedViewSet(ListModelMixin, viewsets.GenericViewSet):
     serializer_class = StorageSerializer
 
     permission_classes = [AllowAny]
-    # TODO: implement pagination
-    # TODO: clarify, then implement the "since" feature -see specs-
 
     def list(self, request):
         """

--- a/iaso/api/storage.py
+++ b/iaso/api/storage.py
@@ -387,7 +387,6 @@ class StorageBlacklistedViewSet(ListModelMixin, viewsets.GenericViewSet):
     serializer_class = StorageSerializer
 
     permission_classes = [AllowAny]
-    # TODO: according to spec, we should add an "updated_at" field
     # TODO: implement pagination
     # TODO: clarify, then implement the "since" feature -see specs-
 

--- a/iaso/tests/api/test_storage.py
+++ b/iaso/tests/api/test_storage.py
@@ -550,6 +550,34 @@ class StorageAPITestCase(APITestCase):
         self.assertFalse(received_json["has_previous"])
         self.assertEqual(received_json["limit"], 1)
 
+    def test_post_blacklisted_storage_permission_denied(self):
+        """POST to /api/storage/blacklisted requires an authenticated user with iaso_storage permissions"""
+        # Case 1: anonymous user
+        response = self.client.post(
+            "/api/storage/blacklisted/",
+            {
+                "storage_id": "EXISTING_STORAGE",
+                "storage_type": "NFC",
+                "storage_status": {"status": "BLACKLISTED", "reason": "DAMAGED", "comment": "not usable anymore"},
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, 403)
+
+        # Case 2: user without iaso_storage permissions
+        self.client.force_authenticate(self.another_user)
+
+        response = self.client.post(
+            "/api/storage/blacklisted/",
+            {
+                "storage_id": "EXISTING_STORAGE",
+                "storage_type": "NFC",
+                "storage_status": {"status": "BLACKLISTED", "reason": "DAMAGED", "comment": "not usable anymore"},
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, 403)
+
     def test_post_blacklisted_storage_ok(self):
         """
         POST /api/storage/blacklisted with correct parameters and permissions does the job:


### PR DESCRIPTION
This ticket was initially to add a few refinements (pagination, filters, permissions) to the storage blacklist API. After careful review with Benjamin, it has been noticed the current behavior was correct and that the refinements could be safely postponed (maybe/nice to have).

Therefore, the corresponding PR only remove some "TODO" comments and add a few tests to make sure we don't break the (current, preexisting) behaviour. 

## Self proof reading checklist

- [x] Did I use eslint and black formatters
- [x] Are there enough tests

## How to test

Not much to test I think.