### PR TITLE
 IA-1618 Submission content filter add support for number in API

### DIFF
--- a/iaso/tests/api/test_instances.py
+++ b/iaso/tests/api/test_instances.py
@@ -486,7 +486,7 @@ class InstancesAPITestCase(APITestCase):
             period="202001",
             org_unit=self.jedi_council_corruscant,
             project=self.project,
-            json={"name": "a", "age": 18, "gender": "M"},
+            json={"name": "a", "age": "18", "gender": "M"},
         )
 
         b = self.create_form_instance(
@@ -494,7 +494,7 @@ class InstancesAPITestCase(APITestCase):
             period="202001",
             org_unit=self.jedi_council_corruscant,
             project=self.project,
-            json={"name": "b", "age": 19, "gender": "F"},
+            json={"name": "b", "age": "19", "gender": "F"},
         )
 
         self.create_form_instance(
@@ -502,7 +502,7 @@ class InstancesAPITestCase(APITestCase):
             period="202001",
             org_unit=self.jedi_council_corruscant,
             project=self.project,
-            json={"name": "c", "age": 30, "gender": "F"},
+            json={"name": "c", "age": "30", "gender": "F"},
         )
 
         self.client.force_authenticate(self.yoda)
@@ -520,7 +520,7 @@ class InstancesAPITestCase(APITestCase):
             period="202001",
             org_unit=self.jedi_council_corruscant,
             project=self.project,
-            json={"name": "a", "age": 18, "gender": "M"},
+            json={"name": "a", "age": "18", "gender": "M"},
         )
 
         b = self.create_form_instance(
@@ -528,7 +528,7 @@ class InstancesAPITestCase(APITestCase):
             period="202001",
             org_unit=self.jedi_council_corruscant,
             project=self.project,
-            json={"name": "b", "age": 19, "gender": "F"},
+            json={"name": "b", "age": "19", "gender": "F"},
         )
 
         c = self.create_form_instance(

--- a/iaso/tests/utils/test_jsonlogic.py
+++ b/iaso/tests/utils/test_jsonlogic.py
@@ -5,37 +5,37 @@ from iaso.utils.jsonlogic import jsonlogic_to_q
 class JsonLogicTests(TestCase):
     def test_jsonlogic_to_q_filters_base(self) -> None:
         """The base case of jsonlogic_to_q works as expected."""
-        filters = {"and": [{"==": [{"var": "gender"}, "F"]}, {"<": [{"var": "age"}, 25]}]}
+        filters = {"and": [{"==": [{"var": "gender"}, "F"]}, {"<": [{"var": "age"}, "25"]}]}
         q = jsonlogic_to_q(filters)
-        self.assertEqual(str(q), "(AND: ('gender__exact', 'F'), ('age__lt', 25))")
+        self.assertEqual(str(q), "(AND: ('gender__exact', 'F'), ('age__lt', '25'))")
 
     def test_jsonlogic_to_q_filters_not(self) -> None:
         """The not operator works as expected"""
-        filters = {"!": {"and": [{"==": [{"var": "gender"}, "F"]}, {"<": [{"var": "age"}, 25]}]}}
+        filters = {"!": {"and": [{"==": [{"var": "gender"}, "F"]}, {"<": [{"var": "age"}, "25"]}]}}
         q = jsonlogic_to_q(filters)
-        self.assertEqual(str(q), "(NOT (AND: ('gender__exact', 'F'), ('age__lt', 25)))")
+        self.assertEqual(str(q), "(NOT (AND: ('gender__exact', 'F'), ('age__lt', '25')))")
 
     def test_jsonlogic_to_q_filters_field_prefix(self) -> None:
         """The field_prefix argument is taken into account."""
-        filters = {"and": [{"==": [{"var": "gender"}, "F"]}, {"<": [{"var": "age"}, 25]}]}
+        filters = {"and": [{"==": [{"var": "gender"}, "F"]}, {"<": [{"var": "age"}, "25"]}]}
         q = jsonlogic_to_q(filters, field_prefix="content__")
-        self.assertEqual(str(q), "(AND: ('content__gender__exact', 'F'), ('content__age__lt', 25))")
+        self.assertEqual(str(q), "(AND: ('content__gender__exact', 'F'), ('content__age__lt', '25'))")
 
     def test_jsonlogic_to_q_filters_field_recursive(self) -> None:
         """And / or operators can be recursively nested."""
         filters = {
             "and": [
                 {"==": [{"var": "gender"}, "F"]},
-                {"or": [{"==": [{"var": "age"}, 20]}, {"==": [{"var": "age"}, 30]}]},
+                {"or": [{"==": [{"var": "age"}, "20"]}, {"==": [{"var": "age"}, "30"]}]},
             ],
         }
 
         q = jsonlogic_to_q(filters)
-        self.assertEqual(str(q), "(AND: ('gender__exact', 'F'), (OR: ('age__exact', 20), ('age__exact', 30)))")
+        self.assertEqual(str(q), "(AND: ('gender__exact', 'F'), (OR: ('age__exact', '20'), ('age__exact', '30')))")
 
     def test_jsonlogic_to_q_filters_field_valueerror(self) -> None:
         """A ValueError is raised in the case of an unknown operator."""
-        filters = {"unknown operator": [{"==": [{"var": "gender"}, "F"]}, {"<": [{"var": "age"}, 25]}]}
+        filters = {"unknown operator": [{"==": [{"var": "gender"}, "F"]}, {"<": [{"var": "age"}, "25"]}]}
         with self.assertRaises(ValueError):
             jsonlogic_to_q(filters)
 

--- a/iaso/utils/jsonlogic.py
+++ b/iaso/utils/jsonlogic.py
@@ -72,9 +72,9 @@ def jsonlogic_to_q(jsonlogic: Dict[str, Any], field_prefix: str = "") -> Q:
     op = list(jsonlogic.keys())[0]
     params = jsonlogic[op]
     if len(params) != 2:
-        raise ValueError(f"Unsuported JsonLogic: {jsonlogic}")
+        raise ValueError(f"Unsupported JsonLogic. Operator {op} take exactly two operands: {jsonlogic}")
     if "var" not in params[0]:
-        raise ValueError(f"Unsuported JsonLogic: {jsonlogic}")
+        raise ValueError(f"Unsupported JsonLogic. First argument must be a variable : {jsonlogic}")
 
     lookups = {
         "==": "exact",
@@ -86,7 +86,9 @@ def jsonlogic_to_q(jsonlogic: Dict[str, Any], field_prefix: str = "") -> Q:
     }
 
     if op not in lookups.keys():
-        raise ValueError(f"Unsuported JsonLogic: {jsonlogic}")
+        raise ValueError(
+            f"Unsupported JsonLogic (unknown operator {op}): {jsonlogic}. Supported operators: f{lookups.keys()}"
+        )
 
     field_name = params[0]["var"]
 

--- a/iaso/utils/jsonlogic.py
+++ b/iaso/utils/jsonlogic.py
@@ -15,6 +15,7 @@ def jsonlogic_to_q(jsonlogic: Dict[str, Any], field_prefix: str = "") -> Q:
 
     :return: A Django Q object.
     """
+
     if "and" in jsonlogic:
         return reduce(
             operator.and_,
@@ -28,17 +29,35 @@ def jsonlogic_to_q(jsonlogic: Dict[str, Any], field_prefix: str = "") -> Q:
 
     elif "!" in jsonlogic:
         return ~jsonlogic_to_q(jsonlogic["!"], field_prefix)
-    elif "==" in jsonlogic:
-        return Q(**{f"{field_prefix}{jsonlogic['=='][0]['var']}__exact": jsonlogic["=="][1]})
-    elif "!=" in jsonlogic:
-        return ~Q(**{f"{field_prefix}{jsonlogic['!='][0]['var']}__exact": jsonlogic["!="][1]})
-    elif ">" in jsonlogic:
-        return Q(**{f"{field_prefix}{jsonlogic['>'][0]['var']}__gt": jsonlogic[">"][1]})
-    elif ">=" in jsonlogic:
-        return Q(**{f"{field_prefix}{jsonlogic['>='][0]['var']}__gte": jsonlogic[">="][1]})
-    elif "<" in jsonlogic:
-        return Q(**{f"{field_prefix}{jsonlogic['<'][0]['var']}__lt": jsonlogic["<"][1]})
-    elif "<=" in jsonlogic:
-        return Q(**{f"{field_prefix}{jsonlogic['<='][0]['var']}__lte": jsonlogic["<="][1]})
-    else:
-        raise ValueError(f"Unknown JsonLogic operator: {jsonlogic}")
+
+    if not jsonlogic.keys():
+        return Q()
+
+    # Binary operators
+    op = list(jsonlogic.keys())[0]
+    params = jsonlogic[op]
+    if len(params) != 2:
+        raise ValueError(f"Unsuported JsonLogic: {jsonlogic}")
+    if "var" not in params[0]:
+        raise ValueError(f"Unsuported JsonLogic: {jsonlogic}")
+
+    lookups = {
+        "==": "exact",
+        "!=": "exact",
+        ">": "gt",
+        ">=": "gte",
+        "<": "lt",
+        "<=": "lte",
+    }
+
+    if op not in lookups.keys():
+        raise ValueError(f"Unsuported JsonLogic: {jsonlogic}")
+
+    field_name = params[0]["var"]
+    lookup = lookups[op]
+    f = f"{field_prefix}{field_name}__{lookup}"
+    q = Q(**{f: params[1]})
+    if op == "!=":
+        # invert the filter
+        q = ~q
+    return q


### PR DESCRIPTION
When querying for Submission content it now works with number. It was not working before because we are storing the number as string in the JSON on the DB. Now we cast them.

We still need to re enable it in the frontend.

## Self proof reading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [x ] Are there enough tests

## Changes

If we receive a number to compare to we force cast the json field value to a   number for comparison

I had to do use arcane django stuff, glaned from their source code, but everything should be sufficiently documented in the comments.

## How to test

We still need to reenable it in the frontend. You can test via the API for now. See the call in the test.
