### PR TITLE
IA-1548: Split requirements.txt into runtime and dev versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -110,7 +110,7 @@ jobs:
             ${{ runner.os }}-venv-
           # Build a virtualenv, but only if it doesn't already exist
       - run: python -v && python -m venv ./venv && . ./venv/bin/activate && pip install -U pip &&
-          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
         if: steps.cache-venv.outputs.cache-hit != 'true'
       - name: Environment info
         run: |

--- a/docker/bundle/Dockerfile
+++ b/docker/bundle/Dockerfile
@@ -41,8 +41,8 @@ RUN apt-get update && apt-get --yes  --no-install-recommends install \
     &&  apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 WORKDIR /opt/app
-COPY requirements.txt /opt/app/requirements.txt
-RUN pip install -r requirements.txt
+COPY requirements-dev.txt /opt/app/requirements-dev.txt
+RUN pip install -r requirements-dev.txt
 
 COPY --from=npmbuilder /opt/app/hat/assets /opt/app/hat/assets
 COPY . /opt/app

--- a/docker/bundle/Dockerfile
+++ b/docker/bundle/Dockerfile
@@ -41,6 +41,7 @@ RUN apt-get update && apt-get --yes  --no-install-recommends install \
     &&  apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 WORKDIR /opt/app
+COPY requirements.txt /opt/app/requirements.txt
 COPY requirements-dev.txt /opt/app/requirements-dev.txt
 RUN pip install -r requirements-dev.txt
 

--- a/docker/django/Dockerfile
+++ b/docker/django/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && apt-get --yes install \
 WORKDIR /opt/app
 
 # install python dependencies
+COPY requirements.txt /opt/app/requirements.txt
 COPY requirements-dev.txt /opt/app/requirements-dev.txt
 RUN pip install --quiet -r requirements-dev.txt
 

--- a/docker/django/Dockerfile
+++ b/docker/django/Dockerfile
@@ -11,8 +11,8 @@ RUN apt-get update && apt-get --yes install \
 WORKDIR /opt/app
 
 # install python dependencies
-COPY requirements.txt /opt/app/requirements.txt
-RUN pip install --quiet -r requirements.txt
+COPY requirements-dev.txt /opt/app/requirements-dev.txt
+RUN pip install --quiet -r requirements-dev.txt
 
 # don't copy app we mount everything afterwards for hot reloading anyway
 #COPY . /opt/app

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 # Specifies only dev-specific requirements
 # But imports the runtime ones too
 
--r ./requirements.txt
+-r requirements.txt
 
 # test and linting
 mypy==0.971

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,27 @@
+# Specifies only dev-specific requirements
+# But imports the runtime ones too
+
+-r requirements.txt
+
+# test and linting
+mypy==0.971
+typed-ast==1.4.2
+flake8==3.7.9
+flake8-mypy==17.8.0
+mock==4.0.1
+redgreenunittest==0.1.1
+responses==0.12.1
+types-dataclasses==0.6.6
+types-requests==2.28.9
+django-stubs==1.9.0
+types-mock==4.0.15
+types-dateparser==1.1.4
+djangorestframework-stubs==1.4.0
+lxml-stubs==0.4.0
+types-jwt==0.1.3
+boto3-stubs==1.24.35
+openpyxl-stubs==0.1.22
+black==21.5b1
+
+pre-commit==2.9.2
+ipython==7.12.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 # Specifies only dev-specific requirements
 # But imports the runtime ones too
 
--r requirements.txt
+-r ./requirements.txt
 
 # test and linting
 mypy==0.971

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,18 +1,19 @@
+# Specifies the requirements necessary to run the application.
+# If you're installing a local development environment, you should use requirements-dev.txt instead.
+
 # django
 django==3.2.15
 django-cors-headers==3.2.1
 djangorestframework==3.11.2
 django-filter==2.4.0
 pandas==1.0.1
-cython==0.29.23
+cython==0.29.23  # Apparently required for Beanstalk deployment?
 pyproj==3.0.1
 geopandas==0.8.0
 Fiona~=1.8.19
 numpy==1.18.1
-Pillow==8.3.2
 django-storages==1.9.1
 boto3==1.12.1
-geopy==1.21.0
 Shapely==1.7.0
 unidecode==1.2.0
 drf-yasg==1.20.0
@@ -32,9 +33,6 @@ django-ltree==0.5.3
 # Use the tar.gz version to install faster
 https://github.com/BLSQ/django-webpack-loader/archive/e94f76d0f8372193f0b662e2a1aba01a9deffb20.tar.gz#egg=django_webpack_loader
 
-# importing tools
-jsonschema==3.2.0
-
 # exporting tools
 xlsxwriter==1.2.7
 beautifulsoup4==4.7.1
@@ -48,30 +46,6 @@ dhis2.py==2.0.2
 # odk-specific libraries
 pyxform==1.1.0
 
-# test and linting
-mypy==0.971
-typed-ast==1.4.2
-flake8==3.7.9
-flake8-mypy==17.8.0
-mock==4.0.1
-redgreenunittest==0.1.1
-responses==0.12.1
-types-dataclasses==0.6.6
-types-requests==2.28.9
-django-stubs==1.9.0
-types-mock==4.0.15
-types-dateparser==1.1.4
-djangorestframework-stubs==1.4.0
-lxml-stubs==0.4.0
-types-jwt==0.1.3
-boto3-stubs==1.24.35
-openpyxl-stubs==0.1.22
-
-
-black==21.5b1
-pre-commit==2.9.2
-
-ipython==7.12.0
 django-extensions==2.2.8
 lxml==4.9.1
 xlrd==1.2.0

--- a/runiasodev.sh
+++ b/runiasodev.sh
@@ -4,7 +4,7 @@
 # You can run the database and webpack with django-compose and it will connect to the by default
 # By running:  django-compose up db webpack
 
-# You will need to create a venv locally by running: venv . && pip install -r requirements.txt
+# You will need to create a venv locally by running: venv . && pip install -r requirements-dev.txt
 
 #source bin/activate
 export SECRET_KEY="secret"


### PR DESCRIPTION
Split requirements.txt into runtime and dev versions, and remove a few unused dependencies.

The goal is to have more clarity into dependencies and limit those who are needed for runtime (smaller Docker images, faster deployment, easier dependency upgrades, ...)

## Self proof reading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are there enough tests

## Changes

To **run** Iaso, we can use `$ pip install -r requirements.txt`. To develop Iaso or run the CI, we need to use `$ pip install -r requirements-dev.txt` instead.

## How to test

Make sure Iaso can still be run in various environments (local dev with and without Docker, CI, staging, ...). I think it should be fine since I've updated Docker files, utility scripts, ...