### PR TITLE
IA-1610 User page  add feature to filter by permission and org unit

### DIFF
--- a/hat/assets/js/apps/Iaso/constants/routes.js
+++ b/hat/assets/js/apps/Iaso/constants/routes.js
@@ -476,6 +476,10 @@ export const usersPath = {
             isRequired: false,
             key: 'search',
         },
+        {
+            isRequired: false,
+            key: 'permissions',
+        },
         ...paginationPathParams.map(p => ({
             ...p,
             isRequired: true,

--- a/hat/assets/js/apps/Iaso/constants/routes.js
+++ b/hat/assets/js/apps/Iaso/constants/routes.js
@@ -480,6 +480,10 @@ export const usersPath = {
             isRequired: false,
             key: 'permissions',
         },
+        {
+            isRequired: false,
+            key: 'location',
+        },
         ...paginationPathParams.map(p => ({
             ...p,
             isRequired: true,

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/messages.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/messages.js
@@ -173,6 +173,10 @@ const MESSAGES = defineMessages({
         defaultMessage: 'Created',
         id: 'iaso.label.created_at',
     },
+    creator: {
+        defaultMessage: 'Created By',
+        id: 'iaso.orgUnits.createdBy',
+    },
     details: {
         defaultMessage: 'Details',
         id: 'iaso.label.details',

--- a/hat/assets/js/apps/Iaso/domains/users/components/Filters.js
+++ b/hat/assets/js/apps/Iaso/domains/users/components/Filters.js
@@ -2,7 +2,7 @@ import React, { useState, useCallback } from 'react';
 import { useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
 
-import { Grid, Button, makeStyles } from '@material-ui/core';
+import { Grid, Button, makeStyles, Box } from '@material-ui/core';
 import SearchIcon from '@material-ui/icons/Search';
 
 import { commonStyles, useSafeIntl } from 'bluesquare-components';
@@ -11,6 +11,8 @@ import InputComponent from 'Iaso/components/forms/InputComponent';
 import { redirectTo } from '../../../routing/actions';
 import MESSAGES from '../messages';
 import { useGetPermissionsDropDown } from '../hooks/useGetPermissionsDropdown.ts';
+import { OrgUnitTreeviewModal } from '../../orgUnits/components/TreeView/OrgUnitTreeviewModal';
+import { useGetOrgUnit } from '../../orgUnits/components/TreeView/requests';
 
 const useStyles = makeStyles(theme => ({
     ...commonStyles(theme),
@@ -24,8 +26,11 @@ const Filters = ({ baseUrl, params }) => {
     const [filters, setFilters] = useState({
         search: params.search,
         permissions: params.permissions,
+        location: params.location,
     });
+    const [initialOrgUnitId, setInitialOrgUnitId] = useState(params?.location);
     const { data: dropdown, isFetching } = useGetPermissionsDropDown();
+    const { data: initialOrgUnit } = useGetOrgUnit(initialOrgUnitId);
 
     const handleSearch = useCallback(() => {
         if (filtersUpdated) {
@@ -42,6 +47,9 @@ const Filters = ({ baseUrl, params }) => {
     const handleChange = useCallback(
         (key, value) => {
             setFiltersUpdated(true);
+            if (key === 'location') {
+                setInitialOrgUnitId(value);
+            }
             setFilters({
                 ...filters,
                 [key]: value,
@@ -87,6 +95,21 @@ const Filters = ({ baseUrl, params }) => {
                         loading={isFetching}
                         onEnterPressed={handleSearchPerms}
                     />
+                </Grid>
+                <Grid item xs={3}>
+                    <Box id="ou-tree-input">
+                        <OrgUnitTreeviewModal
+                            toggleOnLabelClick={false}
+                            titleMessage={MESSAGES.location}
+                            onConfirm={orgUnit =>
+                                handleChange(
+                                    'location',
+                                    orgUnit ? [orgUnit.id] : undefined,
+                                )
+                            }
+                            initialSelection={initialOrgUnit}
+                        />
+                    </Box>
                 </Grid>
             </Grid>
             <Grid

--- a/hat/assets/js/apps/Iaso/domains/users/components/Filters.js
+++ b/hat/assets/js/apps/Iaso/domains/users/components/Filters.js
@@ -72,7 +72,7 @@ const Filters = ({ baseUrl, params }) => {
 
     return (
         <>
-            <Grid container spacing={4}>
+            <Grid container spacing={2}>
                 <Grid item xs={3}>
                     <InputComponent
                         keyValue="search"
@@ -114,7 +114,7 @@ const Filters = ({ baseUrl, params }) => {
             </Grid>
             <Grid
                 container
-                spacing={4}
+                spacing={2}
                 justifyContent="flex-end"
                 alignItems="center"
             >

--- a/hat/assets/js/apps/Iaso/domains/users/components/Filters.js
+++ b/hat/assets/js/apps/Iaso/domains/users/components/Filters.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useCallback } from 'react';
 import { useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
 
@@ -10,6 +10,7 @@ import { commonStyles, useSafeIntl } from 'bluesquare-components';
 import InputComponent from 'Iaso/components/forms/InputComponent';
 import { redirectTo } from '../../../routing/actions';
 import MESSAGES from '../messages';
+import { useGetPermissionsDropDown } from '../hooks/useGetPermissionsDropdown.ts';
 
 const useStyles = makeStyles(theme => ({
     ...commonStyles(theme),
@@ -23,7 +24,9 @@ const Filters = ({ baseUrl, params }) => {
     const [filters, setFilters] = useState({
         search: params.search,
     });
-    const handleSearch = () => {
+    const { data: dropdown, isFetching } = useGetPermissionsDropDown();
+
+    const handleSearch = useCallback(() => {
         if (filtersUpdated) {
             setFiltersUpdated(false);
             const tempParams = {
@@ -33,14 +36,19 @@ const Filters = ({ baseUrl, params }) => {
             tempParams.page = 1;
             dispatch(redirectTo(baseUrl, tempParams));
         }
-    };
-    const handleChange = (key, value) => {
-        setFiltersUpdated(true);
-        setFilters({
-            ...filters,
-            [key]: value,
-        });
-    };
+    }, [baseUrl, dispatch, filters, filtersUpdated, params]);
+
+    const handleChange = useCallback(
+        (key, value) => {
+            setFiltersUpdated(true);
+            setFilters({
+                ...filters,
+                [key]: value,
+            });
+        },
+        [filters],
+    );
+
     return (
         <>
             <Grid container spacing={4}>
@@ -52,6 +60,18 @@ const Filters = ({ baseUrl, params }) => {
                         type="search"
                         label={MESSAGES.search}
                         onEnterPressed={handleSearch}
+                    />
+                </Grid>
+                <Grid item xs={3}>
+                    <InputComponent
+                        keyValue="permissions"
+                        onChange={handleChange}
+                        value={filters.permissions}
+                        type="select"
+                        multi
+                        options={dropdown ?? []}
+                        label={MESSAGES.permissions}
+                        loading={isFetching}
                     />
                 </Grid>
             </Grid>

--- a/hat/assets/js/apps/Iaso/domains/users/components/Filters.js
+++ b/hat/assets/js/apps/Iaso/domains/users/components/Filters.js
@@ -23,6 +23,7 @@ const Filters = ({ baseUrl, params }) => {
     const dispatch = useDispatch();
     const [filters, setFilters] = useState({
         search: params.search,
+        permissions: params.permissions,
     });
     const { data: dropdown, isFetching } = useGetPermissionsDropDown();
 
@@ -49,6 +50,18 @@ const Filters = ({ baseUrl, params }) => {
         [filters],
     );
 
+    const handleSearchPerms = useCallback(() => {
+        if (filtersUpdated) {
+            setFiltersUpdated(false);
+            const tempParams = {
+                ...params,
+                ...filters,
+            };
+            tempParams.page = 1;
+            dispatch(redirectTo(baseUrl, tempParams));
+        }
+    }, [baseUrl, dispatch, filters, filtersUpdated, params]);
+
     return (
         <>
             <Grid container spacing={4}>
@@ -72,6 +85,7 @@ const Filters = ({ baseUrl, params }) => {
                         options={dropdown ?? []}
                         label={MESSAGES.permissions}
                         loading={isFetching}
+                        onEnterPressed={handleSearchPerms}
                     />
                 </Grid>
             </Grid>

--- a/hat/assets/js/apps/Iaso/domains/users/hooks/useGetPermissionsDropdown.ts
+++ b/hat/assets/js/apps/Iaso/domains/users/hooks/useGetPermissionsDropdown.ts
@@ -13,8 +13,8 @@ export const useGetPermissionsDropDown = (): UseQueryResult =>
                 if (!data) return [];
                 return data.permissions.map(permission => {
                     return {
-                        value: permission.id,
-                        label: permission.codename,
+                        value: permission.codename,
+                        label: permission.name,
                     };
                 });
             },

--- a/hat/assets/js/apps/Iaso/domains/users/hooks/useGetPermissionsDropdown.ts
+++ b/hat/assets/js/apps/Iaso/domains/users/hooks/useGetPermissionsDropdown.ts
@@ -1,0 +1,22 @@
+import { UseQueryResult } from 'react-query';
+import { getRequest } from '../../../libs/Api';
+import { useSnackQuery } from '../../../libs/apiHooks';
+import MESSAGES from '../messages';
+
+export const useGetPermissionsDropDown = (): UseQueryResult =>
+    useSnackQuery({
+        queryKey: ['permissions'],
+        queryFn: () => getRequest('/api/permissions/'),
+        snackErrorMsg: MESSAGES.fetchPermissionsError,
+        options: {
+            select: data => {
+                if (!data) return [];
+                return data.permissions.map(permission => {
+                    return {
+                        value: permission.id,
+                        label: permission.codename,
+                    };
+                });
+            },
+        },
+    });

--- a/hat/assets/js/apps/Iaso/domains/users/hooks/useGetProfiles.js
+++ b/hat/assets/js/apps/Iaso/domains/users/hooks/useGetProfiles.js
@@ -15,6 +15,9 @@ export const useGetProfiles = params => {
         if (params.permissions) {
             newParams.permissions = params.permissions;
         }
+        if (params.location) {
+            newParams.location = params.location;
+        }
     }
 
     const searchParams = new URLSearchParams(newParams);

--- a/hat/assets/js/apps/Iaso/domains/users/hooks/useGetProfiles.js
+++ b/hat/assets/js/apps/Iaso/domains/users/hooks/useGetProfiles.js
@@ -1,5 +1,5 @@
 import { getRequest } from 'Iaso/libs/Api';
-import { useSnackQuery } from 'Iaso/libs/apiHooks';
+import { useSnackQuery } from 'Iaso/libs/apiHooks.ts';
 
 export const useGetProfiles = params => {
     let newParams = {};
@@ -11,6 +11,9 @@ export const useGetProfiles = params => {
         };
         if (params.search) {
             newParams.search = params.search;
+        }
+        if (params.permissions) {
+            newParams.permissions = params.permissions;
         }
     }
 

--- a/hat/assets/js/apps/Iaso/domains/users/index.js
+++ b/hat/assets/js/apps/Iaso/domains/users/index.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import { makeStyles, Box, Grid } from '@material-ui/core';
 
 import {
@@ -26,7 +26,7 @@ import MESSAGES from './messages';
 
 import { redirectTo } from '../../routing/actions';
 import { convertObjectToString } from '../../utils';
-import { useCurrentUser } from '../../utils/usersUtils';
+import { useCurrentUser } from '../../utils/usersUtils.ts';
 
 const baseUrl = baseUrls.users;
 
@@ -47,9 +47,12 @@ const Users = ({ params }) => {
     const dispatch = useDispatch();
 
     const { data, isFetching: fetchingProfiles } = useGetProfiles(params);
+
     const { mutate: deleteProfile, isLoading: deletingProfile } =
         useDeleteProfile();
+
     const { mutate: saveProfile, isLoading: savingProfile } = useSaveProfile();
+
     const isLoading = fetchingProfiles || deletingProfile || savingProfile;
 
     useSkipEffectOnMount(() => {

--- a/iaso/api/profiles.py
+++ b/iaso/api/profiles.py
@@ -60,7 +60,7 @@ class ProfilesViewSet(viewsets.ViewSet):
         orders = request.GET.get("order", "user__username").split(",")
         search = request.GET.get("search", None)
         perms = request.GET.get("permissions", None)
-        org_unit = request.GET.get("orgunit", None)
+        location = request.GET.get("location", None)
 
         queryset = self.get_queryset()
         if search:
@@ -69,12 +69,14 @@ class ProfilesViewSet(viewsets.ViewSet):
                 | Q(user__first_name__icontains=search)
                 | Q(user__last_name__icontains=search)
                 | Q(user__iaso_profile__org_units__name__icontains=search)
-                | Q(user__user_permissions__codename__icontains=search)
             ).distinct()
 
         if perms:
             permissions = perms.split(",")
             queryset = queryset.filter(user__user_permissions__codename__in=permissions).distinct()
+
+        if location:
+            queryset = queryset.filter(user__iaso__profile_org_units__pk=location).distinct()
 
         if limit:
             queryset = queryset.order_by(*orders)

--- a/iaso/api/profiles.py
+++ b/iaso/api/profiles.py
@@ -71,8 +71,7 @@ class ProfilesViewSet(viewsets.ViewSet):
             ).distinct()
 
         if perms:
-            perms = perms.split(",")
-            queryset = queryset.filter(user__user_permissions__codename__in=perms).distinct()
+            queryset = queryset.filter(user__user_permissions__codename__icontains=perms).distinct()
 
         if location:
             queryset = queryset.filter(user__iaso_profile__org_units__pk=location).distinct()

--- a/iaso/api/profiles.py
+++ b/iaso/api/profiles.py
@@ -59,7 +59,6 @@ class ProfilesViewSet(viewsets.ViewSet):
         page_offset = request.GET.get("page", 1)
         orders = request.GET.get("order", "user__username").split(",")
         search = request.GET.get("search", None)
-        search_by_ou = request.GET.get("search_by_ou", None)
 
         queryset = self.get_queryset()
         if search:
@@ -68,7 +67,8 @@ class ProfilesViewSet(viewsets.ViewSet):
                 | Q(user__first_name__icontains=search)
                 | Q(user__last_name__icontains=search)
                 | Q(user__iaso_profile__org_units__name__icontains=search)
-            )
+                | Q(user__user_permissions__codename__icontains=search)
+            ).distinct()
 
         if limit:
             queryset = queryset.order_by(*orders)

--- a/iaso/api/profiles.py
+++ b/iaso/api/profiles.py
@@ -59,9 +59,11 @@ class ProfilesViewSet(viewsets.ViewSet):
         page_offset = request.GET.get("page", 1)
         orders = request.GET.get("order", "user__username").split(",")
         search = request.GET.get("search", None)
+        perms = request.GET.get("permissions", None)
 
         queryset = self.get_queryset()
         if search:
+            print("SEARCH")
             queryset = queryset.filter(
                 Q(user__username__icontains=search)
                 | Q(user__first_name__icontains=search)
@@ -69,6 +71,10 @@ class ProfilesViewSet(viewsets.ViewSet):
                 | Q(user__iaso_profile__org_units__name__icontains=search)
                 | Q(user__user_permissions__codename__icontains=search)
             ).distinct()
+
+        if perms:
+            permissions = perms.split(",")
+            queryset = queryset.filter(user__user_permissions__codename__in=permissions).distinct()
 
         if limit:
             queryset = queryset.order_by(*orders)

--- a/iaso/api/profiles.py
+++ b/iaso/api/profiles.py
@@ -59,6 +59,7 @@ class ProfilesViewSet(viewsets.ViewSet):
         page_offset = request.GET.get("page", 1)
         orders = request.GET.get("order", "user__username").split(",")
         search = request.GET.get("search", None)
+        search_by_ou = request.GET.get("search_by_ou", None)
 
         queryset = self.get_queryset()
         if search:
@@ -66,7 +67,10 @@ class ProfilesViewSet(viewsets.ViewSet):
                 Q(user__username__icontains=search)
                 | Q(user__first_name__icontains=search)
                 | Q(user__last_name__icontains=search)
+                | Q(user__iaso_profile__org_units__icontains=search)
             )
+
+
 
         if limit:
             queryset = queryset.order_by(*orders)

--- a/iaso/api/profiles.py
+++ b/iaso/api/profiles.py
@@ -60,10 +60,10 @@ class ProfilesViewSet(viewsets.ViewSet):
         orders = request.GET.get("order", "user__username").split(",")
         search = request.GET.get("search", None)
         perms = request.GET.get("permissions", None)
+        org_unit = request.GET.get("orgunit", None)
 
         queryset = self.get_queryset()
         if search:
-            print("SEARCH")
             queryset = queryset.filter(
                 Q(user__username__icontains=search)
                 | Q(user__first_name__icontains=search)

--- a/iaso/api/profiles.py
+++ b/iaso/api/profiles.py
@@ -67,10 +67,8 @@ class ProfilesViewSet(viewsets.ViewSet):
                 Q(user__username__icontains=search)
                 | Q(user__first_name__icontains=search)
                 | Q(user__last_name__icontains=search)
-                | Q(user__iaso_profile__org_units__icontains=search)
+                | Q(user__iaso_profile__org_units__name__icontains=search)
             )
-
-
 
         if limit:
             queryset = queryset.order_by(*orders)

--- a/iaso/api/profiles.py
+++ b/iaso/api/profiles.py
@@ -68,15 +68,14 @@ class ProfilesViewSet(viewsets.ViewSet):
                 Q(user__username__icontains=search)
                 | Q(user__first_name__icontains=search)
                 | Q(user__last_name__icontains=search)
-                | Q(user__iaso_profile__org_units__name__icontains=search)
             ).distinct()
 
         if perms:
-            permissions = perms.split(",")
-            queryset = queryset.filter(user__user_permissions__codename__in=permissions).distinct()
+            perms = perms.split(",")
+            queryset = queryset.filter(user__user_permissions__codename__in=perms).distinct()
 
         if location:
-            queryset = queryset.filter(user__iaso__profile_org_units__pk=location).distinct()
+            queryset = queryset.filter(user__iaso_profile__org_units__pk=location).distinct()
 
         if limit:
             queryset = queryset.order_by(*orders)

--- a/iaso/tests/api/test_profiles.py
+++ b/iaso/tests/api/test_profiles.py
@@ -361,7 +361,6 @@ class ProfileAPITestCase(APITestCase):
         print(response_data["account"])
         self.assertEqual(response_data["account"]["feature_flags"], [])
 
-
     def test_search_user_by_permissions(self):
         self.client.force_authenticate(self.jane)
 
@@ -379,4 +378,3 @@ class ProfileAPITestCase(APITestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["profiles"][0]["user_name"], "janedoe")
         self.assertEqual(len(response.json()["profiles"]), 1)
-

--- a/iaso/tests/api/test_profiles.py
+++ b/iaso/tests/api/test_profiles.py
@@ -360,3 +360,23 @@ class ProfileAPITestCase(APITestCase):
         self.assertIn("account", response_data)
         print(response_data["account"])
         self.assertEqual(response_data["account"]["feature_flags"], [])
+
+
+    def test_search_user_by_permissions(self):
+        self.client.force_authenticate(self.jane)
+
+        response = self.client.get("/api/profiles/?permissions=iaso_users")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["profiles"][0]["user_name"], "jim")
+        self.assertEqual(len(response.json()["profiles"]), 1)
+
+    def test_search_user_by_org_units(self):
+        self.client.force_authenticate(self.jane)
+        self.jane.iaso_profile.org_units.set([self.jedi_council_corruscant])
+
+        response = self.client.get(f"/api/profiles/?location={self.jedi_council_corruscant.pk}")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["profiles"][0]["user_name"], "janedoe")
+        self.assertEqual(len(response.json()["profiles"]), 1)
+

--- a/iaso/tests/test_create_users_from_csv.py
+++ b/iaso/tests/test_create_users_from_csv.py
@@ -257,7 +257,7 @@ class BulkCreateCsvTestCase(APITestCase):
         print(self.jedi_council.id, self.jedi_council.id, 9999, self.tatooine.id)
 
         self.assertEqual(ou_list, [9999])
-        self.assertEqual(ou_f_list, [self.jedi_council_corruscant.id, self.tatooine.id, 9999])
+        self.assertCountEqual(ou_f_list, [self.jedi_council_corruscant.id, self.tatooine.id, 9999])
         self.assertEqual(response.status_code, 200)
 
     def test_cant_create_user_without_access_to_ou(self):


### PR DESCRIPTION
Allows to search user by org unit and by permissions. 

## Self proof reading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented



## How to test

Play with users / org units and permissions and search for it. 


https://user-images.githubusercontent.com/45785235/200835760-4587f663-c6fd-4b31-a035-f5b689e28b31.mov



## Notes

I don't know if the same search box for everything is a good idea. Maybe the UI should also change ?

I just noticed that there was an update about the UI on the ticket. So it's a draft.  
