### PR TITLE
POLIO-684: fix pdf export button enabled when map still loading

### DIFF
--- a/plugins/polio/js/src/pages/Calendar.js
+++ b/plugins/polio/js/src/pages/Calendar.js
@@ -133,12 +133,16 @@ const Calendar = ({ params }) => {
     );
 
     useEffect(() => {
-        if (filteredCampaigns.length > 0) {
+        if (
+            filteredCampaigns.length > 0 &&
+            mappedCampaigns.length > 0 &&
+            !isLoading
+        ) {
             setCalendarAndMapLoaded(true);
         } else {
             setCalendarAndMapLoaded(false);
         }
-    }, [filteredCampaigns]);
+    }, [filteredCampaigns, mappedCampaigns, isLoading]);
 
     return (
         <div>


### PR DESCRIPTION
Explain what problem this PR is resolving

the pdf export button was not enable even if the map has not loaded. The behavior expected is that the button should only be enable if both calendar and map has finished loading.

## Self proof reading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests
## Changes

- add condition in useEffect to make sure `campaigns` data is fetched and `mappedCampaigns` array is not empty 


## How to test

Go to Polio > Calendar
The pdf export button should only be visible if both calendar table and map  have finished loading.

## Print screen / video

[recording-2022-11-09-17-32-10.webm](https://user-images.githubusercontent.com/25134301/200886771-54379446-8f1e-4063-bd41-9ab0542c4319.webm)
