### PR TITLE
WC2-105: Typo on storage logs (FR): "Auvegarde enregistrement"

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -806,7 +806,7 @@
     "iaso.storages.status.ok": "Ok",
     "iaso.storages.usb": "USB",
     "iaso.storages.writeProfile": "Sauvegarde du profile",
-    "iaso.storages.writeRecord": "Auvegarde enregistrement",
+    "iaso.storages.writeRecord": "Sauvegarde enregistrement",
     "iaso.table.label.close": "Fermer",
     "iaso.table.label.resetSearch": "Vider la recherche",
     "iaso.table.label.search": "Rechercher",


### PR DESCRIPTION
Fix a small typo in FR


## How to test

1) Make sure there are storage devices in the database, and at least on of those storage has log entries of type "write record"
2) Go to the storage page, select the storage device and click the eye icon to see logs
3) make sure the UI is shown in French, and check that the log type is displayed as "Sauvegarde enregisrement" and not "Auvegarde enregistrement" :)

## Print screen / video

**Before**:
![Screenshot_20221108_143232](https://user-images.githubusercontent.com/386387/201071483-45f3040a-2667-452a-adbc-cb4be17eda3f.png)

**After**:
![Screenshot_20221110_114746](https://user-images.githubusercontent.com/386387/201071524-fc773334-c669-41c6-9ea4-6714a6a33cfd.png)