### PR TITLE
WC2-91: Make pagination / order work on beneficiary submissions

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/entities/beneficiaries/config.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/beneficiaries/config.tsx
@@ -190,39 +190,28 @@ export const useBeneficiariesDetailsColumns = (
         () => [
             {
                 Header: formatMessage(MESSAGES.form),
-                // TODO make sortable
-                sortable: false,
-                id: 'form_name',
+                id: 'form__name',
                 accessor: 'form_name',
             },
             {
                 Header: formatMessage(MESSAGES.created_at),
-                // TODO make sortable
-                sortable: false,
                 id: 'created_at',
                 accessor: 'created_at',
                 Cell: DateTimeCell,
             },
             {
                 Header: formatMessage(MESSAGES.last_sync_at),
-                // TODO make sortable
-                // TODO get correct key when implemented on backend
-                sortable: false,
                 id: 'updated_at',
                 accessor: 'updated_at',
                 Cell: DateTimeCell,
             },
             {
                 Header: formatMessage(MESSAGES.OrgUnitName),
-                // TODO make sortable
-                sortable: false,
-                id: 'org_unit.name',
+                id: 'org_unit__name',
                 accessor: 'org_unit.name',
             },
             {
                 Header: formatMessage(MESSAGES.keyInfo),
-                // TODO get correct key when implemented on backend
-                sortable: false,
                 id: 'key_info',
                 accessor: 'key_info',
                 // eslint-disable-next-line no-unused-vars
@@ -232,9 +221,7 @@ export const useBeneficiariesDetailsColumns = (
             },
             {
                 Header: formatMessage(MESSAGES.submitter),
-                // TODO make sortable
-                sortable: false,
-                id: 'created_by.user_name',
+                id: 'created_by',
                 accessor: 'created_by.user_name',
                 Cell: settings => {
                     const { created_by: user } = settings.row.original;

--- a/hat/assets/js/apps/Iaso/domains/entities/beneficiaries/details.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/beneficiaries/details.tsx
@@ -6,8 +6,6 @@ import {
     commonStyles,
     // @ts-ignore
     LoadingSpinner,
-    // @ts-ignore
-    Table,
 } from 'bluesquare-components';
 import { Box, Divider, Grid, makeStyles } from '@material-ui/core';
 import { useDispatch, useSelector } from 'react-redux';
@@ -20,12 +18,12 @@ import { baseUrls } from '../../../constants/urls';
 import { useGetBeneficiary, useGetSubmissions } from './hooks/requests';
 
 import { Beneficiary } from './types/beneficiary';
-import { useResetPageToOne } from '../../../hooks/useResetPageToOne';
 import { useBeneficiariesDetailsColumns } from './config';
 import { CsvButton } from '../../../components/Buttons/CsvButton';
 import { XlsxButton } from '../../../components/Buttons/XslxButton';
 import { BeneficiaryBaseInfo } from './components/BeneficiaryBaseInfo';
 import WidgetPaper from '../../../components/papers/WidgetPaperComponent';
+import { TableWithDeepLink } from '../../../components/tables/TableWithDeepLink';
 
 type Props = {
     router: any;
@@ -56,7 +54,9 @@ const useStyles = makeStyles(theme => ({
         borderTop: 'none',
     },
     titleRow: { fontWeight: 'bold' },
-    fullWith: { width: '100%' },
+    fullWidth: { width: '100%' },
+    infoPaper: { width: '100%', position: 'relative' },
+    infoPaperBox: { minHeight: '100px' },
 }));
 
 // const mapFileContent = (
@@ -78,7 +78,6 @@ export const Details: FunctionComponent<Props> = ({ router }) => {
     // @ts-ignore
     const prevPathname = useSelector(state => state.routerCustom.prevPathname);
     const dispatch = useDispatch();
-    const resetPageToOne = useResetPageToOne({ params });
 
     const {
         data: beneficiary,
@@ -94,8 +93,10 @@ export const Details: FunctionComponent<Props> = ({ router }) => {
         [],
     );
 
-    const { data: submissions, isLoading: isLoadingSubmissions } =
-        useGetSubmissions(entityId);
+    const { data, isLoading: isLoadingSubmissions } = useGetSubmissions(
+        params,
+        entityId,
+    );
     return (
         <>
             <TopBar
@@ -110,14 +111,18 @@ export const Details: FunctionComponent<Props> = ({ router }) => {
                 }}
             />
             <Box className={`${classes.containerFullHeightNoTabPadded}`}>
-                {isLoadingBeneficiary && <LoadingSpinner />}
                 <Grid container spacing={2}>
                     <Grid container item xs={4}>
                         <WidgetPaper
-                            className={classes.fullWith}
+                            className={classes.infoPaper}
                             title={formatMessage(MESSAGES.beneficiaryInfo)}
                         >
-                            <BeneficiaryBaseInfo beneficiary={beneficiary} />
+                            <Box className={classes.infoPaperBox}>
+                                {!beneficiary && <LoadingSpinner absolute />}
+                                <BeneficiaryBaseInfo
+                                    beneficiary={beneficiary}
+                                />
+                            </Box>
                         </WidgetPaper>
                     </Grid>
                     {/* TODO uncomment when edition is possible */}
@@ -140,22 +145,29 @@ export const Details: FunctionComponent<Props> = ({ router }) => {
                 </Grid>
                 <Box mt={2}>
                     <WidgetPaper
-                        className={classes.fullWith}
+                        className={classes.fullWidth}
                         title={formatMessage(MESSAGES.submissions)}
                     >
-                        <Table
-                            elevation={0}
-                            data={submissions ?? []}
-                            columns={columns}
-                            resetPageToOne={resetPageToOne}
-                            count={1}
-                            pages={1}
-                            params={params}
-                            marginBottom={false}
+                        <TableWithDeepLink
                             marginTop={false}
                             countOnTop={false}
+                            elevation={0}
+                            baseUrl={baseUrls.entityDetails}
+                            data={data?.instances ?? []}
+                            pages={data?.pages}
+                            defaultSorted={[{ id: 'id', desc: false }]}
+                            columns={columns}
+                            count={data?.count}
+                            params={params}
+                            onTableParamsChange={p =>
+                                dispatch(
+                                    redirectToReplace(
+                                        baseUrls.entityDetails,
+                                        p,
+                                    ),
+                                )
+                            }
                             extraProps={{
-                                colums: columns,
                                 loading:
                                     isLoadingBeneficiary ||
                                     isLoadingSubmissions,

--- a/hat/assets/js/apps/Iaso/domains/entities/beneficiaries/hooks/requests.ts
+++ b/hat/assets/js/apps/Iaso/domains/entities/beneficiaries/hooks/requests.ts
@@ -16,7 +16,7 @@ import MESSAGES from '../../messages';
 import { makeUrlWithParams } from '../../../../libs/utils';
 
 import { Beneficiary } from '../types/beneficiary';
-import { Pagination } from '../../../../types/table';
+import { Pagination, UrlParams } from '../../../../types/table';
 import {
     Instance,
     PaginatedInstances,
@@ -155,14 +155,8 @@ export const useGetBeneficiary = (
     });
 };
 
-type SubmissionsParams = {
-    pageSize?: string;
-    order?: string;
-    page?: string;
-};
-
 const getSubmissions = (
-    { pageSize, order, page }: SubmissionsParams,
+    { pageSize, order, page }: Partial<UrlParams>,
     entityId?: number,
 ): Promise<PaginatedInstances> => {
     const baseUrl = '/api/instances/';
@@ -178,7 +172,7 @@ const getSubmissions = (
 };
 
 export const useGetSubmissions = (
-    params: SubmissionsParams,
+    params: Partial<UrlParams>,
     entityId?: number,
 ): UseQueryResult<PaginatedInstances, Error> => {
     return useSnackQuery({

--- a/hat/assets/js/apps/Iaso/domains/entities/beneficiaries/hooks/requests.ts
+++ b/hat/assets/js/apps/Iaso/domains/entities/beneficiaries/hooks/requests.ts
@@ -17,7 +17,10 @@ import { makeUrlWithParams } from '../../../../libs/utils';
 
 import { Beneficiary } from '../types/beneficiary';
 import { Pagination } from '../../../../types/table';
-import { Instance } from '../../../instances/types/instance';
+import {
+    Instance,
+    PaginatedInstances,
+} from '../../../instances/types/instance';
 import { DropdownOptions } from '../../../../types/utils';
 import getDisplayName, { Profile } from '../../../../utils/usersUtils';
 import { DropdownTeamsOptions, Team } from '../../../teams/types/team';
@@ -102,7 +105,7 @@ export const useGetBeneficiaryTypesDropdown = (): UseQueryResult<
 > =>
     useSnackQuery({
         queryKey: ['beneficiaryTypes'],
-        queryFn: () => getRequest('/api/entitytype'),
+        queryFn: () => getRequest('/api/entitytype/'),
         options: {
             select: data =>
                 data?.map(
@@ -136,7 +139,7 @@ export const useSaveBeneficiary = (): UseMutationResult =>
     );
 
 const getBeneficiary = (entityId: string | undefined): Promise<Beneficiary> => {
-    return getRequest(`/api/entity/${entityId}`);
+    return getRequest(`/api/entity/${entityId}/`);
 };
 export const useGetBeneficiary = (
     entityId: string | undefined,
@@ -152,23 +155,38 @@ export const useGetBeneficiary = (
     });
 };
 
-const getSubmissions = (id?: number) => {
-    return getRequest(`/api/instances/?entityId=${id}`);
+type SubmissionsParams = {
+    pageSize?: string;
+    order?: string;
+    page?: string;
+};
+
+const getSubmissions = (
+    { pageSize, order, page }: SubmissionsParams,
+    entityId?: number,
+): Promise<PaginatedInstances> => {
+    const baseUrl = '/api/instances/';
+    const apiParams = {
+        limit: pageSize || 20,
+        order,
+        page,
+        entityId,
+    };
+
+    const url = makeUrlWithParams(baseUrl, apiParams);
+    return getRequest(url) as Promise<PaginatedInstances>;
 };
 
 export const useGetSubmissions = (
-    id?: number,
-): UseQueryResult<Instance[], Error> => {
+    params: SubmissionsParams,
+    entityId?: number,
+): UseQueryResult<PaginatedInstances, Error> => {
     return useSnackQuery({
-        queryKey: ['submissionsForEntity', id],
-        queryFn: () => getSubmissions(id),
+        queryKey: ['submissionsForEntity', entityId, params],
+        queryFn: () => getSubmissions(params, entityId),
         options: {
             retry: false,
-            enabled: Boolean(id),
-            select: data => {
-                if (!data) return [];
-                return data.instances;
-            },
+            enabled: Boolean(entityId),
         },
     });
 };
@@ -178,7 +196,7 @@ export const useGetUsersDropDown = (
 ): UseQueryResult<DropdownOptions<number>, Error> => {
     return useSnackQuery(
         ['profiles', team],
-        () => getRequest('/api/profiles'),
+        () => getRequest('/api/profiles/'),
         MESSAGES.projectsError,
         {
             select: data => {
@@ -213,7 +231,7 @@ export const useGetUsersDropDown = (
 };
 
 const getTeams = async (): Promise<Team[]> => {
-    return getRequest('/api/microplanning/teams') as Promise<Team[]>;
+    return getRequest('/api/microplanning/teams/') as Promise<Team[]>;
 };
 
 export const useGetTeamsDropdown = (): UseQueryResult<
@@ -243,7 +261,7 @@ export const useGetTeamsDropdown = (): UseQueryResult<
 };
 
 const getVisitSubmission = (submissionId: string): Promise<any> => {
-    return getRequest(`/api/instances/${submissionId}`);
+    return getRequest(`/api/instances/${submissionId}/`);
 };
 
 export const useGetVisitSubmission = (

--- a/hat/assets/js/apps/Iaso/domains/entities/beneficiaries/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/beneficiaries/index.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent, useState, useMemo } from 'react';
 import { useDispatch } from 'react-redux';
-import { makeStyles, Box, Grid, Tabs, Tab } from '@material-ui/core';
+import { makeStyles, Box, Tabs, Tab } from '@material-ui/core';
 
 import {
     // @ts-ignore

--- a/hat/assets/js/apps/Iaso/domains/instances/types/instance.ts
+++ b/hat/assets/js/apps/Iaso/domains/instances/types/instance.ts
@@ -77,3 +77,6 @@ export type FileContent = {
     logA: Record<string, any>;
     logB: Record<string, any>;
 };
+export interface PaginatedInstances extends Pagination {
+    instances: Instance[];
+}


### PR DESCRIPTION
If you go on a detail of a beneficiary you should be able to order columns and have a pagination working.

For now we have a pagination but it doesn’t work
## Self proof reading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests

## Changes

- use `TableWithDeeplink`
- add pagination params to get request
- move main loader to info paper as table is using is own loader

## How to test

Make sure you have a beneficiary with multiple instances attach to it ( go to admin and assign an entity on each instances details page)
Open the dashboard and visit this beneficiary detail page

Try to ordering columns and pagination features

## Print screen / video

<img width="1661" alt="Screenshot 2022-11-10 at 12 55 07" src="https://user-images.githubusercontent.com/12494624/201093419-c5acc053-43d3-4cd5-bc80-6e0759309b96.png">
<img width="1646" alt="Screenshot 2022-11-10 at 12 54 48" src="https://user-images.githubusercontent.com/12494624/201093423-817ee01f-bbfd-4941-bb5e-f8c6aaadf748.png">
