### PR TITLE
IA-1623: run cypress tests manually

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -145,7 +145,7 @@ jobs:
 
       - name: Mark comment as success
         uses: dkershner6/reaction-action@v1
-        if: success()
+        if: github.event.issue.pull_request && contains(github.event.comment.body, '@cypress') == true && success()
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           reaction: 'hooray'
@@ -153,7 +153,7 @@ jobs:
 
       - name: Comment PR with failure
         uses: actions/github-script@v6
-        if: failure()
+        if: github.event.issue.pull_request && contains(github.event.comment.body, '@cypress') == true && failure()
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -164,5 +164,4 @@ jobs:
               repo,
               body: 'Test failed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
             });
-        if: github.event.issue.pull_request && contains(github.event.comment.body, '@cypress') == true
 

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -142,16 +142,16 @@ jobs:
           CYPRESS_PASSWORD: "test"
           CYPRESS_BASE_URL: "http://localhost:8081"
 
+    if: github.event.issue.pull_request && contains(github.event.comment.body, '@cypress') == true
       - name: Mark comment as success
-        if: github.event.issue.pull_request && contains(github.event.comment.body, '@cypress') == true
         uses: dkershner6/reaction-action@v1
         if: success()
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           reaction: 'hooray'
 
+    if: github.event.issue.pull_request && contains(github.event.comment.body, '@cypress') == true
       - name: Comment PR with failure
-        if: github.event.issue.pull_request && contains(github.event.comment.body, '@cypress') == true
         uses: actions/github-script@v6
         if: failure()
         with:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -142,7 +142,7 @@ jobs:
           CYPRESS_PASSWORD: "test"
           CYPRESS_BASE_URL: "http://localhost:8081"
 
-    if: github.event.issue.pull_request && contains(github.event.comment.body, '@cypress') == true
+      if: github.event.issue.pull_request && contains(github.event.comment.body, '@cypress') == true
       - name: Mark comment as success
         uses: dkershner6/reaction-action@v1
         if: success()
@@ -150,7 +150,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           reaction: 'hooray'
 
-    if: github.event.issue.pull_request && contains(github.event.comment.body, '@cypress') == true
+      if: github.event.issue.pull_request && contains(github.event.comment.body, '@cypress') == true
       - name: Comment PR with failure
         uses: actions/github-script@v6
         if: failure()

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -149,7 +149,6 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           reaction: 'hooray'
-        if: github.event.issue.pull_request && contains(github.event.comment.body, '@cypress') == true
 
       - name: Comment PR with failure
         uses: actions/github-script@v6

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -143,7 +143,7 @@ jobs:
           CYPRESS_BASE_URL: "http://localhost:8081"
 
       if: github.event.issue.pull_request && contains(github.event.comment.body, '@cypress') == true
-      - name: Mark comment as success
+        - name: Mark comment as success
         uses: dkershner6/reaction-action@v1
         if: success()
         with:
@@ -151,7 +151,7 @@ jobs:
           reaction: 'hooray'
 
       if: github.event.issue.pull_request && contains(github.event.comment.body, '@cypress') == true
-      - name: Comment PR with failure
+        - name: Comment PR with failure
         uses: actions/github-script@v6
         if: failure()
         with:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -142,16 +142,16 @@ jobs:
           CYPRESS_PASSWORD: "test"
           CYPRESS_BASE_URL: "http://localhost:8081"
 
-      if: github.event.issue.pull_request && contains(github.event.comment.body, '@cypress') == true
-        - name: Mark comment as success
+
+      - name: Mark comment as success
         uses: dkershner6/reaction-action@v1
         if: success()
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           reaction: 'hooray'
+        if: github.event.issue.pull_request && contains(github.event.comment.body, '@cypress') == true
 
-      if: github.event.issue.pull_request && contains(github.event.comment.body, '@cypress') == true
-        - name: Comment PR with failure
+      - name: Comment PR with failure
         uses: actions/github-script@v6
         if: failure()
         with:
@@ -164,4 +164,5 @@ jobs:
               repo,
               body: 'Test failed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
             });
+        if: github.event.issue.pull_request && contains(github.event.comment.body, '@cypress') == true
 


### PR DESCRIPTION
Explain what problem this PR is resolving

The workflow only handled cypress tests on a PR by commenting with @cypress. It didn't allow to launch a workflow manually on a specific branch

## Self proof reading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests
## Changes

- updated the workflow file to add an event trigger : `workflow_dispatch` allowing to launch cypress tests manually on a specific branch.

## How to test

### Launch the cypress tests on a PR with comment
Add a comment with this body : "@cypress" on the PR you want to test

### Launch the cypress tests on a branch manually 
Go to [actions](https://github.com/BLSQ/iaso/actions) tab > select the workflow "Iaso Cypress manual testing"  > Run workflow (choose the branch you want to run the workflow)

## Print screen / video

![comment](https://user-images.githubusercontent.com/25134301/201105788-c0805345-344a-4413-af15-3337829d0ea0.png)

![workflow_dispatch](https://user-images.githubusercontent.com/25134301/201106251-9c4cae78-a38f-4a91-a673-381ab156fda5.png)
