### PR TITLE
IA-1628: [Form field filter] New version of form creates issues when searching in fields of old version of form

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/instances/compare/hooks/useGetInstanceLogs.ts
+++ b/hat/assets/js/apps/Iaso/domains/instances/compare/hooks/useGetInstanceLogs.ts
@@ -66,23 +66,19 @@ export const useGetInstanceLogDetail = (
 };
 
 const getVersion = (
-    versionId: string | undefined,
-    formId: number | undefined,
+    formId: string | undefined,
 ): Promise<Record<string, any>> => {
-    return getRequest(
-        `/api/formversions/?version_id=${versionId}&form_id=${formId}&fields=descriptor`,
-    );
+    return getRequest(`/api/formversions/?form_id=${formId}&fields=descriptor`);
 };
 export const useGetFormDescriptor = (
-    versionId?: string,
-    formId?: number,
+    formId?: string,
 ): UseQueryResult<Record<string, any> | undefined, Error> => {
-    const queryKey: any[] = ['instanceDescriptor', versionId];
+    const queryKey: any[] = ['instanceDescriptor'];
     return useSnackQuery({
         queryKey,
-        queryFn: () => getVersion(versionId, formId),
+        queryFn: () => getVersion(formId),
         options: {
-            enabled: Boolean(versionId),
+            enabled: Boolean(formId),
             select: (data: FormDescriptor | undefined) => {
                 if (!data) return data;
                 return data.form_versions[0].descriptor;

--- a/hat/assets/js/apps/Iaso/domains/instances/components/InstancesFiltersComponent.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/InstancesFiltersComponent.js
@@ -86,17 +86,8 @@ const InstancesFiltersComponent = ({
         formState.formIds.value?.split(',').length === 1
             ? formState.formIds.value.split(',')[0]
             : undefined;
-    const currentForm = useMemo(() => {
-        if (formId) {
-            return formsList.find(form => parseInt(formId, 10) === form.id);
-        }
-        return undefined;
-    }, [formId, formsList]);
 
-    const { data: formDescriptor } = useGetFormDescriptor(
-        currentForm?.latest_form_version?.version_id, // by default using last form version
-        currentForm?.id,
-    );
+    const { data: formDescriptor } = useGetFormDescriptor(formId);
     const fields = useGetQueryBuildersFields(formDescriptor, possibleFields);
 
     useInstancesFiltersData(formIds, setFetchingOrgUnitTypes);


### PR DESCRIPTION
Example from PEVCameroun on Iaso prod, form [Collecte des données de la FOSA](https://iaso.bluesquare.org/dashboard/forms/detail/formId/735):

In the version 2022110801 of the form there is a question “test_instance” allowing the user to indicate if this form is filled out for test reasons.

In the version 2022111001 of the form, this question was deleted by request of the client.

Now, when we try to find all forms that have test_instance = ‘yes’, we cannot select possible responses anymore, probably because the system takes the options from the lastest version of the form:

{"and":[{"==":[{"var":"test_instance"},"yes"]}]}  works however.

![image-20221110-135211](https://user-images.githubusercontent.com/12494624/201637742-8c64d2a6-316e-43e7-b2df-949aaf875cc2.png)


## Self proof reading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests

## Changes

Removed versionId param from api call to form to get form descriptor

## How to test

Create a new version of an existing form by removing a field (select with options) in the new one.

Launch the subissions search and try to search by the field you removed with the query builder, you should be able to select an option.

## Print screen / video

<img width="1279" alt="Screenshot 2022-11-14 at 11 33 33" src="https://user-images.githubusercontent.com/12494624/201638375-141dec1a-67fc-4c41-8744-fa82d2cd1075.png">


