### PR TITLE
POLIO-681 Mark node as completed when there is an alternative path

### DIFF
--- a/plugins/polio/budget/serializers.py
+++ b/plugins/polio/budget/serializers.py
@@ -220,9 +220,9 @@ class CampaignBudgetSerializer(CampaignSerializer, DynamicFieldsModelSerializer)
             for node in c.nodes:  # Node are already sorted
                 if not node.mandatory:
                     continue
-                node_remaining.add(node.key)
                 if node.key in node_passed_by:
                     continue
+                node_remaining.add(node.key)
                 items.append({"label": node.label})
             # color calculation
             active = len(node_passed_by) > 0

--- a/plugins/polio/budget/serializers.py
+++ b/plugins/polio/budget/serializers.py
@@ -193,9 +193,23 @@ class CampaignBudgetSerializer(CampaignSerializer, DynamicFieldsModelSerializer)
                 to_node_key = transition.to_node
                 if to_node_key in node_dict.keys():
                     # If this is in the category
+                    node = node_dict[to_node_key]
+                    for other_key in node.mark_nodes_as_completed:
+                        if other_key not in node_passed_by:
+                            other_node = node_dict.get(other_key)
+                            items.append(
+                                {
+                                    "label": other_node.label,
+                                    "performed_by": step.created_by,
+                                    "performed_at": step.created_at,
+                                    "step_id": step.id,
+                                }
+                            )
+                            node_passed_by.add(other_key)
+
                     items.append(
                         {
-                            "label": node_dict[to_node_key].label,
+                            "label": node.label,
                             "performed_by": step.created_by,
                             "performed_at": step.created_at,
                             "step_id": step.id,

--- a/plugins/polio/budget/workflow.py
+++ b/plugins/polio/budget/workflow.py
@@ -36,6 +36,9 @@ class Transition:
 class Node:
     label: str
     key: str
+    # Hack for the widget. So we can mark node as completed when passing via other field
+    # must be in the same category
+    mark_nodes_as_completed: List[str] = field(default_factory=list)
     category_key: str = ""
     order: int = 0
     mandatory: bool = False

--- a/plugins/polio/fixtures/budget.yaml
+++ b/plugins/polio/fixtures/budget.yaml
@@ -146,6 +146,7 @@
         order: 13
         mandatory: true
         category_key: country
+        mark_nodes_as_completed: [who_sent_budget, unicef_sent_budget]
       - key: submitted_to_rrt
         label: Submitted to RRT
         order: 21

--- a/plugins/polio/js/src/pages/Budget/BudgetDetails/BudgetDetailsInfos.tsx
+++ b/plugins/polio/js/src/pages/Budget/BudgetDetails/BudgetDetailsInfos.tsx
@@ -232,11 +232,11 @@ export const BudgetDetailsInfos: FunctionComponent<Props> = ({
                 </Grid>
             </Grid>
             {/* temporary hide the budget timeline waiting to fix the workflow process */}
-            {/* {isTabletOrDesktopLayout && (
+            {isTabletOrDesktopLayout && (
                 <Box py={2}>
                     <BudgetTimeline categories={categories} />
                 </Box>
-            )} */}
+            )}
         </WidgetPaperComponent>
     );
 };

--- a/plugins/polio/js/src/pages/Budget/BudgetDetails/BudgetTimeline.tsx
+++ b/plugins/polio/js/src/pages/Budget/BudgetDetails/BudgetTimeline.tsx
@@ -1,12 +1,12 @@
 import { Box, makeStyles, Divider } from '@material-ui/core';
-import React, { FunctionComponent, useState, useEffect } from 'react';
+import React, { FunctionComponent, useState, useEffect, useMemo } from 'react';
 import classnames from 'classnames';
 import Stepper from '@material-ui/core/Stepper';
 import Step from '@material-ui/core/Step';
 import StepLabel from '@material-ui/core/StepLabel';
 import { CheckCircleOutline } from '@material-ui/icons';
 import moment from 'moment';
-import { findLast } from 'lodash';
+import { findLastIndex } from 'lodash';
 import { Categories } from '../types';
 
 type Props = {
@@ -86,23 +86,14 @@ const getColor = category => {
 export const BudgetTimeline: FunctionComponent<Props> = ({
     categories = [],
 }) => {
-    const [activeStep, setActiveStep] = useState(0);
     const classes = useStyles();
 
-    useEffect(() => {
+    const activeStep = useMemo(() => {
         if (categories.length > 0) {
-            // @ts-ignore
-            const lastStepCompleted = findLast(
-                categories,
-                category => !category.completed,
-            );
-
-            const lastStepCompletedIndex = lastStepCompleted
-                ? categories.indexOf(lastStepCompleted)
-                : 0;
-            setActiveStep(lastStepCompletedIndex);
+            return categories.findIndex(category => !category.completed);
         }
-    }, [categories, activeStep]);
+        return 0;
+    }, [categories]);
     return (
         <Stepper
             className={classes.root}
@@ -117,8 +108,9 @@ export const BudgetTimeline: FunctionComponent<Props> = ({
                             classes.step,
                         )}
                         key={category.key}
-                        completed={category.completed}
-                        active={category.active}
+                        // The widget automatically recalculate it so not needed
+                        // completed={category.completed}
+                        // active={category.active}
                     >
                         <StepLabel>
                             <Box>

--- a/plugins/polio/js/src/pages/Budget/BudgetDetails/BudgetTimeline.tsx
+++ b/plugins/polio/js/src/pages/Budget/BudgetDetails/BudgetTimeline.tsx
@@ -6,8 +6,8 @@ import Step from '@material-ui/core/Step';
 import StepLabel from '@material-ui/core/StepLabel';
 import { CheckCircleOutline } from '@material-ui/icons';
 import moment from 'moment';
-import { Categories } from '../types';
 import { findLast } from 'lodash';
+import { Categories } from '../types';
 
 type Props = {
     categories?: Categories;
@@ -97,8 +97,9 @@ export const BudgetTimeline: FunctionComponent<Props> = ({
                 category => !category.completed,
             );
 
-            const lastStepCompletedIndex =
-                categories.indexOf(lastStepCompleted);
+            const lastStepCompletedIndex = lastStepCompleted
+                ? categories.indexOf(lastStepCompleted)
+                : 0;
             setActiveStep(lastStepCompletedIndex);
         }
     }, [categories, activeStep]);


### PR DESCRIPTION
 When we use a diamond to modelize that  a double approval is neeeded, add a way to mark the 'skipped' path as completed
 We do this by adding a mark_nodes_as_completed property on Node

## Self proof reading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are my typescript files well typed
- [] Did I add translations
- [x] My migrations file are included
- [x]  Are there enough tests

## Changes

- Add a `mark_nodes_as_completed` property in the workflow definition. When we pass by a node that has this property mark all the node listed (in the same category) as completed at the same time
- Re active the widget
- Fix crash in it.
- Fix calculation for Active and completed Category

## How to test

See wiki page on wikijs

The workflow definition in the fixture has been updated (for GPEI consolidation) so if you update your database with it you should have a correct workflow.
