### PR TITLE
POLIO-646 & POLIO-647 Attach file to email, use permanent URL

### DIFF
--- a/hat/assets/js/apps/Iaso/libs/utils.tsx
+++ b/hat/assets/js/apps/Iaso/libs/utils.tsx
@@ -2,12 +2,12 @@
  * Get request with params passed as query params
  * Remove undefined params
  * @param {string} url
- * @param {{[p: string]: T}} params
+ * @param {{[p: string]: T}} urlParams
  */
 // url should include closing slash
 export const makeUrlWithParams = (
     url: string,
-    urlParams: Record<string, unknown>,
+    urlParams: Record<string, string>,
 ): string => {
     // @ts-ignore
     const urlSearchParams = new URLSearchParams();

--- a/plugins/polio/budget/api.py
+++ b/plugins/polio/budget/api.py
@@ -2,15 +2,17 @@ from typing import Type
 
 from django.db.models import QuerySet, Max
 from django.http import HttpResponse
+from django.shortcuts import redirect
 from django_filters.rest_framework import DjangoFilterBackend  # type: ignore
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import permissions, filters, status, serializers
 from rest_framework.decorators import action
+from rest_framework.generics import get_object_or_404
 from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
 
 from iaso.api.common import ModelViewSet, DeletionFilterBackend, HasPermission
-from plugins.polio.budget.models import BudgetStep, MailTemplate, get_workflow
+from plugins.polio.budget.models import BudgetStep, MailTemplate, get_workflow, BudgetStepFile
 from plugins.polio.budget.serializers import (
     CampaignBudgetSerializer,
     TransitionToSerializer,
@@ -130,6 +132,19 @@ class BudgetStepViewSet(ModelViewSet):
         "campaign_id": ["exact"],
         "transition_key": ["exact", "in"],
     }
+
+    @action(detail=True, methods=["GET"], url_path="files/(?P<file_pk>[0-9]+)")
+    def files(self, request, pk, file_pk):
+        "Redirect to the static file"
+        # Since on AWS S3 the signed url created (for the media upload files) are only valid a certain amount of time
+        # This is endpoint is used to give a permanent url to the users.
+
+        # Use the queryset to ensure the user has the proper access rights to this step
+        # and keep down the url guessing.
+        step: BudgetStep = self.get_queryset().get(pk=pk)
+        stepFile: BudgetStepFile = get_object_or_404(step.files, pk=file_pk)
+        url = stepFile.file.url
+        return redirect(url, permanent=False)
 
     @action(detail=True, permission_classes=[permissions.IsAdminUser])
     def mail_template(self, request, pk):

--- a/plugins/polio/budget/models.py
+++ b/plugins/polio/budget/models.py
@@ -158,7 +158,7 @@ class MailTemplate(models.Model):
         transition = workflow.get_transition_by_key(step.transition_key)
         attachments = []
         for f in step.files.all():
-            attachments.append({"url": f.file.url, "name": f.filename})
+            attachments.append({"url": f.get_absolute_url(), "name": f.filename})
         for l in step.links.all():
             attachments.append({"url": l.url, "name": l.alias})
 

--- a/plugins/polio/budget/models.py
+++ b/plugins/polio/budget/models.py
@@ -9,6 +9,7 @@ from django.core.mail import EmailMultiAlternatives
 from django.db import models
 from django.template import Engine, TemplateSyntaxError, Context
 from django.utils.translation import ugettext_lazy as _
+from django.urls import reverse
 
 from hat.api.token_authentication import generate_auto_authentication_link
 from iaso.models.microplanning import Team
@@ -59,6 +60,9 @@ class BudgetStepFile(models.Model):
     filename = models.CharField(blank=True, null=True, max_length=100)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
+
+    def get_absolute_url(self):
+        return reverse("BudgetStep-files", kwargs={"pk": self.step_id, "file_pk": self.id})
 
     class Meta:
         verbose_name = "Budget Step File"

--- a/plugins/polio/budget/serializers.py
+++ b/plugins/polio/budget/serializers.py
@@ -335,7 +335,10 @@ class BudgetFileSerializer(serializers.ModelSerializer):
             "id",
             "file",  # url
             "filename",
+            "permanent_url",
         ]
+
+    permanent_url = serializers.URLField(source="get_absolute_url", read_only=True)
 
 
 class BudgetStepSerializer(serializers.ModelSerializer):

--- a/plugins/polio/budget/test.py
+++ b/plugins/polio/budget/test.py
@@ -1,3 +1,4 @@
+import http
 import json
 from io import StringIO
 from typing import List, Dict
@@ -5,7 +6,9 @@ from unittest import skip, mock
 
 from django.contrib.auth.models import User, Permission
 from django.core.exceptions import ValidationError
-from django.template import Template, Engine, Context
+from django.http import HttpResponse
+from django.template import Engine, Context
+from rest_framework import status
 
 from iaso.test import APITestCase
 from plugins.polio.budget.models import BudgetStep, MailTemplate
@@ -152,6 +155,50 @@ class TeamAPITestCase(APITestCase):
         f = j["files"][0]
         self.assertTrue(f["file"].startswith("http"))  # should be an url
         self.assertEqual(f["filename"], fake_file.name)
+
+    def test_step_files(self):
+        "With file and links"
+        self.client.force_login(self.user)
+        prev_budget_step_count = BudgetStep.objects.count()
+        r = self.client.get("/api/polio/budget/")
+        j = self.assertJSONResponse(r, 200)
+        campaigns = j["results"]
+        for c in campaigns:
+            self.assertEqual(c["obr_name"], "test campaign")
+
+        fake_file = StringIO("hello world")
+        fake_file.name = "mon_fichier.txt"
+        r = self.client.post(
+            "/api/polio/budget/transition_to/",
+            data={
+                "transition_key": "submit_budget",
+                "campaign": self.c.id,
+                "comment": "hello world2",
+                "files": [fake_file],
+            },
+        )
+        j = self.assertJSONResponse(r, 201)
+        self.assertEqual(j["result"], "success")
+        step_id = j["id"]
+        s = BudgetStep.objects.get(id=step_id)
+
+        # check that we have only created one step
+        new_budget_step_count = BudgetStep.objects.count()
+        self.assertEqual(prev_budget_step_count + 1, new_budget_step_count)
+
+        self.assertEqual(s.files.count(), 1)
+        r = self.client.get(f"/api/polio/budgetsteps/{s.id}/")
+        j = self.assertJSONResponse(r, 200)
+        f = j["files"][0]
+        self.assertTrue(f["file"].startswith("http"))  # should be an url
+        self.assertEqual(f["filename"], fake_file.name)
+        file_id = s.files.first().id
+        self.assertEqual(f["id"], file_id)
+        self.assertEqual(f["permanent_url"], f"/api/polio/budgetsteps/{s.id}/files/{file_id}/")
+        r = self.client.get(f"/api/polio/budgetsteps/{s.id}/files/{file_id}/")
+        self.assertIsInstance(r, HttpResponse)
+        self.assertEqual(r.status_code, status.HTTP_302_FOUND, r)
+        self.assertTrue(len(r.url) > 0)
 
     def test_transition_to_link(self):
         self.client.force_login(self.user)

--- a/plugins/polio/fixtures/budget.yaml
+++ b/plugins/polio/fixtures/budget.yaml
@@ -1022,3 +1022,14 @@
         displayed_fields: []
         teams_ids_can_transition:
         - 4
+- model: polio.mailtemplate
+  pk: 1
+  fields:
+    slug: base_email
+    subject_template: '{{author_name}} updated the the budget  for campaign {{campaign.obr_name}}'
+    html_template: "{% extends \"base_budget_email.html\" %}\r\n{% block text %}\r\n{{
+      block.super }} \r\n{% endblock %}"
+    text_template: "{% extends \"base_budget_email.txt\" %}\r\n{% block text %}\r\n{{
+      block.super }} \r\n{% endblock %}"
+    created_at: 2022-11-14 16:16:41.233023+00:00
+    updated_at: 2022-11-14 16:16:41.233054+00:00

--- a/plugins/polio/js/src/pages/Budget/CreateBudgetStep/CreateBudgetStep.tsx
+++ b/plugins/polio/js/src/pages/Budget/CreateBudgetStep/CreateBudgetStep.tsx
@@ -108,7 +108,7 @@ const CreateBudgetStep: FunctionComponent<Props> = ({
         const fileLinks = previousStep?.files;
         const filesAsLinks = (fileLinks ?? []).map(fileLink => ({
             alias: fileLink.filename,
-            url: fileLink.file,
+            url: fileLink.permanent_url,
         }));
         const previousStepLinks = previousStep?.links;
         if (!quickTransition) {

--- a/plugins/polio/js/src/pages/Budget/types.ts
+++ b/plugins/polio/js/src/pages/Budget/types.ts
@@ -63,7 +63,11 @@ export type Budget = {
 };
 
 export type LinkWithAlias = { alias: string; url: string };
-export type FileWithName = { file: string; filename: string };
+export type FileWithName = {
+    file: string;
+    filename: string;
+    permanent_url: string;
+};
 
 export type BudgetStep = {
     id: number;

--- a/plugins/polio/templates/base_budget_email.html
+++ b/plugins/polio/templates/base_budget_email.html
@@ -57,6 +57,14 @@ Base file to be reused in the MailTemplate for the budget workflow engine
     </tr>
   {% endif %}
   {% include "_files.html" with attachments=attachments only %}
+  {% if skipped_attachments > 0 %}
+    <tr>
+      <td align="left" style="padding:5px;">
+        <br />
+        {{ skipped_attachments }} file(s) has(have) not been attached to this message due to their size. Please use the link(s)
+        above to view them.
+    </tr>
+  {% endif %}
   <tr>
     <td style="height:20px;padding:0;font-size:0;line-height:0;">&nbsp;</td>
   </tr>
@@ -66,26 +74,26 @@ Base file to be reused in the MailTemplate for the budget workflow engine
     </td>
   <tr>
     {% if buttons %}
-  <tr>
-    <td style="height:20px;padding:0;font-size:0;line-height:0;">&nbsp;</td>
-  </tr>
-  <tr>
-    <td align="left" style="padding:5px;">
-      You can follow up using one of the buttons below:
-    </td>
-  </tr>
-  <tr>
-    <td style="height:20px;padding:0;font-size:0;line-height:0;">&nbsp;</td>
-  </tr>
+      <tr>
+        <td style="height:20px;padding:0;font-size:0;line-height:0;">&nbsp;</td>
+      </tr>
+      <tr>
+        <td align="left" style="padding:5px;">
+          You can follow up using one of the buttons below:
+        </td>
+      </tr>
+      <tr>
+        <td style="height:20px;padding:0;font-size:0;line-height:0;">&nbsp;</td>
+      </tr>
 
-  <table role="presentation"
-         style="width:100%;max-width:600px;border-collapse:collapse;border:0;border-spacing:0;background:#ffffff;">
-    <tr>
-      {% include "_buttons.html" with buttons=buttons only %}
+      <table role="presentation"
+             style="width:100%;max-width:600px;border-collapse:collapse;border:0;border-spacing:0;background:#ffffff;">
+        <tr>
+          {% include "_buttons.html" with buttons=buttons only %}
 
-    </tr>
-  </table>
-  {% endif %}
+        </tr>
+      </table>
+    {% endif %}
 {% endblock content %}
 <table role="presentation" style="width:100%;max-width:600px;">
   <tr>

--- a/plugins/polio/templates/base_budget_email.txt
+++ b/plugins/polio/templates/base_budget_email.txt
@@ -2,8 +2,7 @@
 Base file to be reused in the MailTemplate for the budget workflow engine
 {% endcomment %}
 {% block content %} {% block text %}
-A new budget update has been done on the polio campaign {{ campaign.obr_name }}  by {{ author_name }}
-from team {{ team }}: {{ transition.label }}.
+A new budget update has been done on the polio campaign {{ campaign.obr_name }} by {{ author_name }} from team {{ team }}: {{ transition.label }}.
 {% endblock %}
 {% if comment %}
 The following comment was left:
@@ -13,6 +12,7 @@ The following comment was left:
 {% for attachment in attachments%}{{ forloop.counter }}. {{attachment.name}}: {{attachment.url|safe}}
 {% endfor %}
 {%endif%}
+{% if skipped_attachments > 0 %}{{ skipped_attachments }} file(s) has(have) not been attached to this message due to their size. Please use the link(s) above to view them.{% endif %}
 
 Consult the campaign page for the complet budget history and more information: {{ budget_url|safe }}
 


### PR DESCRIPTION
The URL generated for file that we used for quick transition and in e-mail where expiring so  they were unusable after 15 minutes. We now use a endpoint in iaso to act as a mediator that will redirect to the destination file and that we can share.

Attach file directly to the e-mails if they are less than 500k (the limit was set arbitrary for now on a guess on what server would always accept). Show a message in the template if some file were not attached.

Compared to the initial demand  we do not handle rejected e-mail !

## Self proof reading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are my typescript files well typed
- [] Did I add translations
- [NA ] My migrations file are included
- [] Are there enough tests. Could use more

## Changes

- Add `/file` endpoint on budget step
- add a get_absolute_url on model and a `permanent_url` on API from BugetStepFile to that url.
- Use that url in quickTransition
- Use that url


## How to test
- See wiki page on Budget. Properly set up your mail. Check using SMTPBucket
- Test making a step with one or more files attached.
- Check that there is a mail with the file
- Try the quick transition button

Check again with a file > 1 mb and a smaller file.

