### PR TITLE
Ia 1639 fix cypress ci

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -6,8 +6,8 @@ on:
   workflow_dispatch: {}
   
 concurrency: 
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 env:
   REGISTRY: ghcr.io
@@ -37,15 +37,17 @@ jobs:
           reaction: 'eyes'
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
+      
       - name: Log in to the Container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      
       - name: Build and push Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           push: true
           tags: ghcr.io/blsq/iaso:${{github.sha}}
@@ -124,7 +126,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./node_modules
-          key: node_modules-${{ hashFiles('package-lock.json') }}
+          key: node_modules-20221121-${{ hashFiles('package-lock.json') }}
 
       - name: upgrade npm
         run: |
@@ -133,16 +135,12 @@ jobs:
       - run: npm ci
         if: steps.cache.outputs.cache-hit != 'true'
         
-      - name: install cypress
-        run: npm i cypress@9.5.4
-
       - name: Cypress run
         uses: cypress-io/github-action@v4
         with:
           browser: chrome
           wait-on: 'http://localhost:8081'
           spec: hat/assets/js/cypress/integration/**/*.spec.js
-          install: false
         env:
           CYPRESS_USERNAME: "test"
           CYPRESS_PASSWORD: "test"


### PR DESCRIPTION
Cypress binary was missing when running cypress manually in the CI

## Self proof reading checklist

- [NA] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [NA] Are my typescript files well typed
- [NA] Did I add translations
- [NA] My migrations file are included
- [NA] Are there enough tests
## Changes

- Replaced the caching of node_modules as per [guidelines](https://docs.cypress.io/guides/continuous-integration/introduction#Caching)
- Cached cypress binary and `.npm` folder as in [recommended example](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.github/workflows/single.yml)


## How to test
Run Iaso manual cypress testing in Github actions

## Print screen / video

NA

## Notes

I just fixed the missing binary issue. the tests still take a long time (20min+), but this can probably be optimized further
