### PR TITLE
POLIO-691 Speed up calendar map (campaign shapes) :fire:

### DIFF
--- a/plugins/polio/api.py
+++ b/plugins/polio/api.py
@@ -449,7 +449,7 @@ Timeline tracker Automated message
 
         round_scope_queryset = campaigns.filter(separate_scopes_per_round=True).annotate(
             geom=RawSQL(
-                """select st_asgeojson(st_simplify(st_union(st_buffer(iaso_orgunit.geom::geometry, 0)), 0.01)::geography)
+                """select st_asgeojson(st_simplify(st_union(st_buffer(iaso_orgunit.simplified_geom::geometry, 0)), 0.01)::geography)
 from iaso_orgunit
 right join iaso_group_org_units ON iaso_group_org_units.orgunit_id = iaso_orgunit.id
 right join polio_roundscope ON iaso_group_org_units.group_id =  polio_roundscope.group_id
@@ -461,7 +461,7 @@ where polio_round.campaign_id = polio_campaign.id""",
         # For campaign scope
         campain_scope_queryset = campaigns.filter(separate_scopes_per_round=False).annotate(
             geom=RawSQL(
-                """select st_asgeojson(st_simplify(st_union(st_buffer(iaso_orgunit.geom::geometry, 0)), 0.01)::geography)
+                """select st_asgeojson(st_simplify(st_union(st_buffer(iaso_orgunit.simplified_geom::geometry, 0)), 0.01)::geography)
 from iaso_orgunit
 right join iaso_group_org_units ON iaso_group_org_units.orgunit_id = iaso_orgunit.id
 right join polio_campaignscope ON iaso_group_org_units.group_id =  polio_campaignscope.group_id
@@ -527,9 +527,11 @@ where polio_campaignscope.campaign_id = polio_campaign.id""",
         campaign_scopes = CampaignScope.objects.filter(campaign__in=campaigns.filter(separate_scopes_per_round=False))
         campaign_scopes = campaign_scopes.prefetch_related("campaign")
         campaign_scopes = campaign_scopes.prefetch_related("campaign__country")
+
+        # noinspection SqlResolve
         campaign_scopes = campaign_scopes.annotate(
             geom=RawSQL(
-                """select st_asgeojson(st_simplify(st_union(st_buffer(iaso_orgunit.geom::geometry, 0)), 0.01)::geography)
+                """SELECT st_asgeojson(st_simplify(st_union(st_buffer(iaso_orgunit.simplified_geom::geometry, 0)), 0.01)::geography)
 from iaso_orgunit right join iaso_group_org_units ON iaso_group_org_units.orgunit_id = iaso_orgunit.id
 where group_id = polio_campaignscope.group_id""",
                 [],
@@ -556,9 +558,10 @@ where group_id = polio_campaignscope.group_id""",
         round_scopes = RoundScope.objects.filter(round__campaign__in=campaigns.filter(separate_scopes_per_round=True))
         round_scopes = round_scopes.prefetch_related("round__campaign")
         round_scopes = round_scopes.prefetch_related("round__campaign__country")
+        # noinspection SqlResolve
         round_scopes = round_scopes.annotate(
             geom=RawSQL(
-                """select st_asgeojson(st_simplify(st_union(st_buffer(iaso_orgunit.geom::geometry, 0)), 0.01)::geography)
+                """select st_asgeojson(st_simplify(st_union(st_buffer(iaso_orgunit.simplified_geom::geometry, 0)), 0.01)::geography)
 from iaso_orgunit right join iaso_group_org_units ON iaso_group_org_units.orgunit_id = iaso_orgunit.id
 where group_id = polio_roundscope.group_id""",
                 [],


### PR DESCRIPTION
It was the shapes endpoint that returned the geojson that got very slow. We speed it up From 11 minutes to 9seconds by now used the simplified_geom instead of the geom.

This code is only a port of the fix, we also need to manually run the following command manually to recalculate the simplified_geom on iaso_orgunit for the newly added org unit since the last time it was ran.

update iaso_orgunit set simplified_geom = ST_Simplify(geom::geometry, 0.01, true);

We need a more permanent fix in the futures to keep them up to date, but this is outside the scope of this Hotfix PR.

Explain what problem this PR is resolving

## Self proof reading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests
## Changes

Explain the changes that were made. The idea is not to list exhaustively all the changes made (Github already provides a full diff), but to help the reviewers better understand:
- which specific file changes go together, e.g: when creating a table in the front-end, there usually is a config file that goes with it
- the reasoning behind some changes, e.g: deleted files because they are now redundant
- the behaviour to expect, e.g: tooltip has purple background color because the client likes it so, changed a key in the API response to be consistent with other endpoints


## How to test

Explain how to test your PR.
If a specific config is required explain it here (dataset, account, profile, ...)

## Print screen / video

Upload here print screens or videos showing the changes

## Notes

Things that the reviewers should know: known bugs that are out of the scope of the PR, other trade-offs that were made.
If the PR depends on a PR in bluesquare-components, or merges into another PR (i.o. main), it should also be mentioned here
