### PR TITLE
POLIO-709 Fix file link in e-mail

### DIFF
--- a/plugins/polio/budget/models.py
+++ b/plugins/polio/budget/models.py
@@ -159,7 +159,8 @@ class MailTemplate(models.Model):
         transition = workflow.get_transition_by_key(step.transition_key)
         attachments = []
         for f in step.files.all():
-            attachments.append({"url": f.get_absolute_url(), "name": f.filename})
+            file_url = base_url + f.get_absolute_url()
+            attachments.append({"url": file_url, "name": f.filename})
         for l in step.links.all():
             attachments.append({"url": l.url, "name": l.alias})
 


### PR DESCRIPTION
link to file didn't comprise the domain name so they were useless in e-mail.
Include domain  in e-mail so they link in it works again

Explain what problem this PR is resolving

## Self proof reading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [  ] My migrations file are included
- [] Are there enough tests
## Changes

Include the domain in file link
## How to test
See budget workflow wiki page. Send an event that should generate an e-mail and check it.