### PR TITLE
WC2-106: rename status => storage_status

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/storages/components/Infos.tsx
+++ b/hat/assets/js/apps/Iaso/domains/storages/components/Infos.tsx
@@ -68,7 +68,7 @@ export const Infos: FunctionComponent<Props> = ({ storage }) => {
                     <>
                         {storage && (
                             <>
-                                <StatusCell status={storage.status} />
+                                <StatusCell status={storage.storage_status} />
                                 <Box ml={2} display="inline-block">
                                     <StatusModal storage={storage} />
                                 </Box>

--- a/hat/assets/js/apps/Iaso/domains/storages/config.tsx
+++ b/hat/assets/js/apps/Iaso/domains/storages/config.tsx
@@ -54,8 +54,8 @@ export const useGetColumns = (params: StorageParams): Array<Column> => {
             accessor: 'status',
             id: 'status',
             Cell: settings => {
-                const { status } = settings.row.original;
-                return <StatusCell status={status} />;
+                const { storage_status } = settings.row.original;
+                return <StatusCell status={storage_status} />;
             },
         },
         {

--- a/hat/assets/js/apps/Iaso/domains/storages/types/storages.ts
+++ b/hat/assets/js/apps/Iaso/domains/storages/types/storages.ts
@@ -43,7 +43,7 @@ export type Storage = {
     updated_at: number;
     created_at: number;
     storage_type: 'NFC' | 'USB' | 'SD';
-    status: StorageStatus;
+    storage_status: StorageStatus;
     entity: Entity;
     logs?: Array<Log>;
     org_unit: ShortOrgUnit;


### PR DESCRIPTION
According to this [PR](https://github.com/BLSQ/iaso/pull/146/files), `status` field as been renamed to `storage_status` on storage model
It was provoking a white page on staging

## Self proof reading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests
## Changes

Only rename `StorageStatus` field on type and ts components 

## How to test

Visit storage list and detail page. (with storages 😄 )

