### PR TITLE
WC2-108: disable confirm on status modal

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/storages/components/StatusModal.tsx
+++ b/hat/assets/js/apps/Iaso/domains/storages/components/StatusModal.tsx
@@ -4,6 +4,7 @@ import React, {
     useMemo,
     useCallback,
 } from 'react';
+import isEqual from 'lodash/isEqual';
 
 import {
     // @ts-ignore
@@ -60,8 +61,8 @@ const StatusModal: FunctionComponent<Props> = ({
                 [key]: value,
             };
             if (key === 'status' && value === 'OK') {
-                newStatus.reason = undefined;
-                newStatus.comment = undefined;
+                delete newStatus.reason;
+                delete newStatus.comment;
             }
             setStatus(newStatus);
         },
@@ -76,8 +77,8 @@ const StatusModal: FunctionComponent<Props> = ({
         if (status?.status === 'BLACKLISTED' && !status.reason) {
             return false;
         }
-        return true;
-    }, [status.reason, status?.status]);
+        return !isEqual(status, storage.storage_status);
+    }, [status, storage.storage_status]);
     return (
         <ConfirmCancelModal
             allowConfirm={allowConfirm}


### PR DESCRIPTION
It was possible to save a storage status while nothing has been changed 
It fixes the problem describe on the ticket by blocking user to save twice ok as new status

## Self proof reading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests
## Changes

Comparing state and prop status to allow confirm on the dialog


## How to test

Play like the video on a storage status

## Print screen / video


https://user-images.githubusercontent.com/12494624/203320320-3898998f-8be7-42f4-b739-fbf02d1c1f34.mov


