### PR TITLE
IA-1324 Filter orgunit by depth in hierarchy

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitsFilters.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitsFilters.tsx
@@ -84,6 +84,7 @@ export const OrgUnitFilters: FunctionComponent<Props> = ({
     const [sourceVersionId, setSourceVersionId] = useState<
         number | undefined
     >();
+    const [depth, setDepth] = useState<number | undefined>();
     const [initialOrgUnitId, setInitialOrgUnitId] = useState<
         string | undefined
     >(currentSearch?.levels);
@@ -256,6 +257,14 @@ export const OrgUnitFilters: FunctionComponent<Props> = ({
                             options={versionsDropDown}
                             clearable={false}
                             loading={isFetchingOrgunitTypes}
+                        />
+                        <InputComponent
+                            type="number"
+                            keyValue="depth"
+                            onChange={handleChange}
+                            value={filters?.depth}
+                            label={MESSAGES.depth}
+                            clearable
                         />
                         <Typography
                             className={classes.advancedSettings}

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/messages.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/messages.js
@@ -510,6 +510,11 @@ const MESSAGES = defineMessages({
         id: 'iaso.label.hasNoGeometryAndGps',
         defaultMessage: 'Without geographic data',
     },
+
+    depth: {
+        id: 'iaso.label.depth',
+        defaultMessage: 'Depth',
+    },
 });
 
 export default MESSAGES;

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/messages.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/messages.js
@@ -510,9 +510,8 @@ const MESSAGES = defineMessages({
         id: 'iaso.label.hasNoGeometryAndGps',
         defaultMessage: 'Without geographic data',
     },
-
     depth: {
-        id: 'iaso.label.depth',
+        id: 'iaso.orgUnits.depth',
         defaultMessage: 'Depth',
     },
 });

--- a/iaso/api/org_unit_search.py
+++ b/iaso/api/org_unit_search.py
@@ -37,6 +37,7 @@ def build_org_units_queryset(queryset, params, profile):
     ignore_empty_names = params.get("ignoreEmptyNames", False)
 
     org_unit_type_category = params.get("orgUnitTypeCategory", None)
+    path_depth = params.get("depth", None)
 
     if validation_status != "all":
         queryset = queryset.filter(validation_status=validation_status)
@@ -200,6 +201,9 @@ def build_org_units_queryset(queryset, params, profile):
 
     if ignore_empty_names:
         queryset = queryset.filter(~Q(name=""))
+
+    if path_depth is not None:
+        queryset = queryset.filter(path__depth=path_depth)
 
     queryset = queryset.select_related("version__data_source")
     queryset = queryset.select_related("org_unit_type")

--- a/iaso/tests/api/test_orgunits.py
+++ b/iaso/tests/api/test_orgunits.py
@@ -146,6 +146,33 @@ class OrgUnitAPITestCase(APITestCase):
         self.assertJSONResponse(response, 200)
         self.assertEqual(response.json()["count"], 2)
 
+    def test_org_unit_list_depth(self):
+        """GET /orgunits/ with a search based on refs"""
+
+        self.client.force_authenticate(self.yoda)
+
+        response = self.client.get(
+            '/api/orgunits/?&order=id&page=1&searchTabIndex=0&searches=[{"validation_status":"all","color":"4dd0e1","depth":"2"}]&limit=50'
+        )
+        self.assertJSONResponse(response, 200)
+        self.assertEqual(response.json()["count"], 2)
+
+        response = self.client.get(
+            '/api/orgunits/?&order=id&page=1&searchTabIndex=0&searches=[{"validation_status":"all","color":"4dd0e1","depth":"1"}]&limit=50'
+        )
+        self.assertJSONResponse(response, 200)
+        self.assertEqual(response.json()["count"], 3)
+        response = self.client.get(
+            '/api/orgunits/?&order=id&page=1&searchTabIndex=0&searches=[{"validation_status":"all","color":"4dd0e1","depth":"0"}]&limit=50'
+        )
+        self.assertJSONResponse(response, 200)
+        self.assertEqual(response.json()["count"], 0)
+        response = self.client.get(
+            '/api/orgunits/?&order=id&page=1&searchTabIndex=0&searches=[{"validation_status":"all","color":"4dd0e1","depth":"3"}]&limit=50'
+        )
+        self.assertJSONResponse(response, 200)
+        self.assertEqual(response.json()["count"], 0)
+
     def test_org_unit_search_with_ref(self):
         """GET /orgunits/ with a search based on ids"""
 


### PR DESCRIPTION
Allow user to search org unit at a certain depth in the hierarchy

## Self proof reading checklist

- [x] Did I use eslint and black formatters
- [] Is my code clear enough and well documented
- [NA] Are my typescript files well typed
- [NA] Did I add translations ( Reused existing one)
- [NA] My migrations file are included
- [x] Are there enough tests

## Changes

Added a field in the Org Unit page (hidden under the advanced params) to allow entering a level to filter by.


https://user-images.githubusercontent.com/82500/203359559-4a2154b3-d1c2-4f8f-8d6f-0653d676319e.mp4

