### PR TITLE
Wc2 107 auto blacklist old nfc cards

### DIFF
--- a/iaso/api/storage.py
+++ b/iaso/api/storage.py
@@ -309,7 +309,9 @@ class StorageLogViewSet(CreateModelMixin, viewsets.GenericViewSet):
 
                 performed_at = timestamp_to_utc_datetime(int(log_data["performed_at"]))
 
-                concerned_instances = Instance.objects.filter(uuid__in=log_data["instances"])
+                concerned_instances = Instance.objects.none()
+                if "instances" in log_data:
+                    concerned_instances = Instance.objects.filter(uuid__in=log_data["instances"])
 
                 concerned_orgunit = None
                 if "org_unit_id" in log_data and log_data["org_unit_id"] is not None:

--- a/iaso/models/storage.py
+++ b/iaso/models/storage.py
@@ -117,7 +117,7 @@ class StorageLogEntryManager(models.Manager):
         user: User,
         concerned_orgunit: OrgUnit,
         concerned_entity: Entity,
-        concerned_instances: QuerySet["Instance"],
+        concerned_instances: "QuerySet[Instance]",
     ) -> None:
         """
         Create a new StorageLogEntry, and perform StorageDevice-related operations:

--- a/iaso/models/storage.py
+++ b/iaso/models/storage.py
@@ -117,7 +117,7 @@ class StorageLogEntryManager(models.Manager):
         user: User,
         concerned_orgunit: OrgUnit,
         concerned_entity: Entity,
-        concerned_instances: QuerySet[Instance],
+        concerned_instances: QuerySet["Instance"],
     ) -> None:
         """
         Create a new StorageLogEntry, and perform StorageDevice-related operations:

--- a/iaso/models/storage.py
+++ b/iaso/models/storage.py
@@ -97,6 +97,9 @@ class StorageDevice(models.Model):
             status_comment=comment,
         )
 
+    def __str__(self):
+        return f"{self.customer_chosen_id} ({self.type})"
+
     class Meta:
         unique_together = ("customer_chosen_id", "account", "type")
 
@@ -115,12 +118,15 @@ class StorageLogEntryManager(models.Manager):
         concerned_instances,
     ) -> None:
         """
-        Create a new StorageLogEntry and update the StorageDevice if needed
+        Create a new StorageLogEntry, and perform StorageDevice-related operations:
+
+        - update the device, so it is linked to the org unit and entity referenced in the log entry
+        - if the log entry is of type WRITE_PROFILE to a new Storage device, blacklist old devices for the same entity
 
         This is the preferred method to create new log entries. It is assumed the StorageDevice already exists when this
         method is called.
         """
-        # 2. Create the log entry
+
         log_entry = self.create(
             id=log_id,
             device=device,
@@ -134,10 +140,20 @@ class StorageLogEntryManager(models.Manager):
         log_entry.instances.set(concerned_instances)
 
         # We update the orgunit and entity of the device to reflect what was pushed as the last log
-        # TODO: discuss: should we do that? What if the mobile pushes multiple logs in the wrong "order" for a given device? should we merge data instead?
         device.entity = concerned_entity
         device.org_unit = concerned_orgunit
         device.save()
+
+        # Blacklist old devices for the same entity
+        if operation_type == StorageLogEntry.WRITE_PROFILE:
+            old_devices = StorageDevice.objects.filter(entity=concerned_entity).exclude(id=device.id)
+            for old_device in old_devices:
+                old_device.change_status(
+                    new_status=StorageDevice.BLACKLISTED,
+                    reason=StorageDevice.OTHER,
+                    comment=f"Profile was written on {device.customer_chosen_id} on {performed_at}",
+                    performed_by=user,
+                )
 
 
 class StorageLogEntry(models.Model):

--- a/iaso/tests/api/test_storage.py
+++ b/iaso/tests/api/test_storage.py
@@ -44,6 +44,7 @@ class StorageAPITestCase(APITestCase):
             account=cls.star_wars,
             type="NFC",
             status="OK",
+            entity=cls.entity,
         )
 
         StorageLogEntry.objects.create(
@@ -435,7 +436,7 @@ class StorageAPITestCase(APITestCase):
                     "storage_type": "NFC",
                     "storage_status": {"status": "OK", "updated_at": None},
                     "org_unit": None,
-                    "entity": None,
+                    "entity": {"id": mock.ANY, "name": "New Client 3"},
                 },
                 {
                     "updated_at": 1580608922.0,
@@ -549,7 +550,7 @@ class StorageAPITestCase(APITestCase):
                     "storage_type": "NFC",
                     "storage_status": {"status": "OK", "updated_at": None},
                     "org_unit": None,
-                    "entity": None,
+                    "entity": {"id": mock.ANY, "name": "New Client 3"},
                 },
                 {
                     "updated_at": 1580608922.0,
@@ -588,9 +589,18 @@ class StorageAPITestCase(APITestCase):
         received_json = response.json()
 
         # If the filter was not operational we would get 3 results.
-        self.assertEqual(
+        self.assertListEqual(
             received_json,
             [
+                {
+                    "updated_at": 1580608922.0,
+                    "created_at": 1580608922.0,
+                    "storage_id": "EXISTING_STORAGE",
+                    "storage_type": "NFC",
+                    "storage_status": {"status": "OK", "updated_at": None},
+                    "org_unit": None,
+                    "entity": {"id": mock.ANY, "name": "New Client 3"},
+                },
                 {
                     "updated_at": 1580608922.0,
                     "created_at": 1580608922.0,
@@ -604,7 +614,7 @@ class StorageAPITestCase(APITestCase):
                     },
                     "org_unit": None,
                     "entity": {"id": self.entity.id, "name": "New Client 3"},
-                }
+                },
             ],
         )
 
@@ -759,7 +769,7 @@ class StorageAPITestCase(APITestCase):
         response = self.client.get("/api/storage/NFC/EXISTING_STORAGE/logs")
         self.assertEqual(response.status_code, 200)
         received_json = response.json()
-        self.assertEqual(
+        self.assertDictEqual(
             received_json,
             {
                 "updated_at": 1580608922.0,
@@ -768,7 +778,7 @@ class StorageAPITestCase(APITestCase):
                 "storage_type": "NFC",
                 "storage_status": {"status": "OK", "updated_at": None},
                 "org_unit": None,
-                "entity": None,
+                "entity": {"id": mock.ANY, "name": "New Client 3"},
                 "logs": [
                     {
                         "id": "e4200710-bf82-4d29-a29b-6a042f79ef25",
@@ -805,7 +815,7 @@ class StorageAPITestCase(APITestCase):
                 "storage_type": "NFC",
                 "storage_status": {"status": "OK", "updated_at": None},
                 "org_unit": None,
-                "entity": None,
+                "entity": {"id": mock.ANY, "name": "New Client 3"},
                 "logs": [],
             },
         )
@@ -836,7 +846,7 @@ class StorageAPITestCase(APITestCase):
                 "storage_type": "NFC",
                 "storage_status": {"status": "OK", "updated_at": None},
                 "org_unit": None,
-                "entity": None,
+                "entity": {"id": mock.ANY, "name": "New Client 3"},
                 "logs": [
                     {
                         "id": "e4200710-bf82-4d29-a29b-6a042f79ef26",
@@ -873,7 +883,7 @@ class StorageAPITestCase(APITestCase):
                 "storage_type": "NFC",
                 "storage_status": {"status": "OK", "updated_at": None},
                 "org_unit": None,
-                "entity": None,
+                "entity": {"id": mock.ANY, "name": "New Client 3"},
                 "logs": [
                     {
                         "id": "e4200710-bf82-4d29-a29b-6a042f79ef25",
@@ -906,7 +916,7 @@ class StorageAPITestCase(APITestCase):
                 "storage_type": "NFC",
                 "storage_status": {"status": "OK", "updated_at": None},
                 "org_unit": None,
-                "entity": None,
+                "entity": {"id": mock.ANY, "name": "New Client 3"},
                 "logs": [],
             },
         )
@@ -924,7 +934,7 @@ class StorageAPITestCase(APITestCase):
                 "storage_type": "NFC",
                 "storage_status": {"status": "OK", "updated_at": None},
                 "org_unit": None,
-                "entity": None,
+                "entity": {"id": mock.ANY, "name": "New Client 3"},
                 "logs": [
                     {
                         "id": "e4200710-bf82-4d29-a29b-6a042f79ef25",
@@ -966,7 +976,7 @@ class StorageAPITestCase(APITestCase):
                 "storage_type": "NFC",
                 "storage_status": {"status": "OK", "updated_at": None},
                 "org_unit": None,
-                "entity": None,
+                "entity": {"id": mock.ANY, "name": "New Client 3"},
                 "logs": [
                     {
                         "id": "e4200710-bf82-4d29-a29b-6a042f79ef25",
@@ -1008,7 +1018,7 @@ class StorageAPITestCase(APITestCase):
         response = self.client.get(f"/api/storage/NFC/EXISTING_STORAGE/logs?status=OK")
         self.assertEqual(response.status_code, 200)
         received_json = response.json()
-        self.assertEqual(
+        self.assertDictEqual(
             received_json,
             {
                 "updated_at": 1580608922.0,
@@ -1017,7 +1027,7 @@ class StorageAPITestCase(APITestCase):
                 "storage_type": "NFC",
                 "storage_status": {"status": "OK", "updated_at": None},
                 "org_unit": None,
-                "entity": None,
+                "entity": {"id": mock.ANY, "name": "New Client 3"},
                 "logs": [
                     {
                         "id": "e4200710-bf82-4d29-a29b-6a042f79ef25",
@@ -1050,7 +1060,7 @@ class StorageAPITestCase(APITestCase):
                 "storage_type": "NFC",
                 "storage_status": {"status": "OK", "updated_at": None},
                 "org_unit": None,
-                "entity": None,
+                "entity": {"id": mock.ANY, "name": "New Client 3"},
                 "logs": [],
             },
         )
@@ -1071,7 +1081,7 @@ class StorageAPITestCase(APITestCase):
                 "storage_type": "NFC",
                 "storage_status": {"status": "OK", "updated_at": None},
                 "org_unit": None,
-                "entity": None,
+                "entity": {"id": mock.ANY, "name": "New Client 3"},
                 "logs": [],
             },
         )
@@ -1124,7 +1134,7 @@ class StorageAPITestCase(APITestCase):
                     "storage_type": "NFC",
                     "storage_status": {"status": "OK", "updated_at": None},
                     "org_unit": None,
-                    "entity": None,
+                    "entity": {"id": mock.ANY, "name": "New Client 3"},
                     "logs": [
                         {
                             "id": "e4200710-bf82-4d29-a29b-6a042f79ef25",
@@ -1164,7 +1174,7 @@ class StorageAPITestCase(APITestCase):
                     "storage_type": "NFC",
                     "storage_status": {"status": "OK", "updated_at": None},
                     "org_unit": None,
-                    "entity": None,
+                    "entity": {"id": mock.ANY, "name": "New Client 3"},
                     "logs": [
                         {
                             "id": "e4200710-bf82-4d29-a29b-6a042f79ef26",
@@ -1204,7 +1214,7 @@ class StorageAPITestCase(APITestCase):
                     "storage_type": "NFC",
                     "storage_status": {"status": "OK", "updated_at": None},
                     "org_unit": None,
-                    "entity": None,
+                    "entity": {"id": mock.ANY, "name": "New Client 3"},
                     "logs": [
                         {
                             "id": "e4200710-bf82-4d29-a29b-6a042f79ef25",


### PR DESCRIPTION
New feature for NFC card management:

Given the backend receives a new “WRITE_PROFILE” event
When the entity associated with that event has other cards associated to them
Then those other cards are automatically blacklisted with : 
 - the reason "OTHER" 
 - and the comment "Profile was written on {NEW NFC CARD ID}"

## Self proof reading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are there enough tests

## How to test

Mobile-related endpoint, so difficult to test, two solutions come to mind:

- check the newly added tests in `test_storage.py` make sense and work
- for @bmonjoie: test the interactions directly from the mobile app