### PR TITLE
IA-1652: Django admin teams cannot be edited

### DIFF
--- a/iaso/admin.py
+++ b/iaso/admin.py
@@ -285,11 +285,17 @@ class ExportStatusAdmin(admin.GeoModelAdmin):
     def http_requests(self, instance):
         # Write a get-method for a list of module names in the class Profile
         # return HTML string which will be display in the form
-        return format_html_join(
-            mark_safe("<br/><br/>"),
-            "{} http status: {} url : {} <br/> <ul> <li>sent <pre>{}</pre> </li><li>received <pre>{}</pre></li></ul>",
-            ((line.id, line.http_status, line.url, line.sent, line.received) for line in instance.export_logs.all()),
-        ) or mark_safe("<span>no logs available.</span>")
+        return (
+            format_html_join(
+                mark_safe("<br/><br/>"),
+                "{} http status: {} url : {} <br/> <ul> <li>sent <pre>{}</pre> </li><li>received <pre>{}</pre></li></ul>",
+                (
+                    (line.id, line.http_status, line.url, line.sent, line.received)
+                    for line in instance.export_logs.all()
+                ),
+            )
+            or mark_safe("<span>no logs available.</span>")
+        )
 
 
 @admin_attr_decorator

--- a/iaso/admin.py
+++ b/iaso/admin.py
@@ -285,17 +285,11 @@ class ExportStatusAdmin(admin.GeoModelAdmin):
     def http_requests(self, instance):
         # Write a get-method for a list of module names in the class Profile
         # return HTML string which will be display in the form
-        return (
-            format_html_join(
-                mark_safe("<br/><br/>"),
-                "{} http status: {} url : {} <br/> <ul> <li>sent <pre>{}</pre> </li><li>received <pre>{}</pre></li></ul>",
-                (
-                    (line.id, line.http_status, line.url, line.sent, line.received)
-                    for line in instance.export_logs.all()
-                ),
-            )
-            or mark_safe("<span>no logs available.</span>")
-        )
+        return format_html_join(
+            mark_safe("<br/><br/>"),
+            "{} http status: {} url : {} <br/> <ul> <li>sent <pre>{}</pre> </li><li>received <pre>{}</pre></li></ul>",
+            ((line.id, line.http_status, line.url, line.sent, line.received) for line in instance.export_logs.all()),
+        ) or mark_safe("<span>no logs available.</span>")
 
 
 @admin_attr_decorator
@@ -411,6 +405,7 @@ class TeamAdmin(admin.ModelAdmin):
     )
     list_filter = ("project", "type")
     date_hierarchy = "created_at"
+    readonly_fields = ("path",)
 
 
 @admin_attr_decorator


### PR DESCRIPTION
When editing a team in the django admin, saving gave an error with the Path, which couldn't be corrected from the admin (editing the field doesn’t work)


## Self proof reading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented

## Changes

Made the `path` field read-only in the Admin, just like we did for `OrgUnit`


## How to test

Go in the Django admin section. Check you can freely create and edit teams without getting apath-related error.
