### PR TITLE
IA-1671: add null check on permission

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -661,6 +661,7 @@
     "iaso.periods.start": "Start period",
     "iaso.permissions.assignments": "Assignments",
     "iaso.permissions.completeness": "Data completeness",
+    "iaso.permissions.completeness_stats": "Completeness stats",
     "iaso.permissions.dataTasks": "Tasks",
     "iaso.permissions.entities": "Beneficiaries",
     "iaso.permissions.forms": "Forms",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -658,6 +658,7 @@
     "iaso.periods.start": "Période de début",
     "iaso.permissions.assignments": "Attributions",
     "iaso.permissions.completeness": "Complétude des données",
+    "iaso.permissions.completeness_stats": "Statitiques de complétude",
     "iaso.permissions.dataTasks": "Tâches",
     "iaso.permissions.entities": "Bénéficiaires",
     "iaso.permissions.forms": "Formulaires",

--- a/hat/assets/js/apps/Iaso/domains/users/hooks/useGetPermissionsDropdown.ts
+++ b/hat/assets/js/apps/Iaso/domains/users/hooks/useGetPermissionsDropdown.ts
@@ -17,7 +17,9 @@ export const useGetPermissionsDropDown = (): UseQueryResult => {
                 return data.permissions.map(permission => {
                     return {
                         value: permission.codename,
-                        label: formatMessage(MESSAGES[permission.codename]),
+                        label:
+                            formatMessage(MESSAGES[permission.codename]) ??
+                            permission.codename,
                     };
                 });
             },


### PR DESCRIPTION
If there’s no entry in MESSAGES for the permission codename, the page will crash on a null error

## Self proof reading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests
## Changes

- Added a null check when creating the dropdown list, so if the translation is missing in `MESSAGES`the `codename`is displayed instead


## How to test

- Go to user's page, it shouldn't crash

## Print screen / video

![Screenshot 2022-11-28 at 13 38 39](https://user-images.githubusercontent.com/38907762/204279869-0473f64d-404a-4531-a899-bd1fbab75926.png)


## Notes

The permission that caused the crash was `iaso_beneficiaries` but it should have been removed
