### PR TITLE
IA-1681: Completeness stats API: parameter renamed

### DIFF
--- a/hat/assets/js/apps/Iaso/constants/routes.js
+++ b/hat/assets/js/apps/Iaso/constants/routes.js
@@ -476,7 +476,7 @@ export const completenessStatsPath = {
         ...paginationPathParams,
         {
             isRequired: false,
-            key: 'parentId',
+            key: 'orgUnitId',
         },
         {
             isRequired: false,

--- a/hat/assets/js/apps/Iaso/domains/completenessStats/CompletenessStatsFilters.tsx
+++ b/hat/assets/js/apps/Iaso/domains/completenessStats/CompletenessStatsFilters.tsx
@@ -36,7 +36,7 @@ export const CompletenessStatsFilters: FunctionComponent<Props> = ({
         useGetOrgUnitTypesOptions();
     const { filters, handleSearch, handleChange, filtersUpdated } =
         useFilterState({ baseUrl, params });
-    const [initialOrgUnitId, setInitialOrgUnitId] = useState(params?.parentId);
+    const [initialOrgUnitId, setInitialOrgUnitId] = useState(params?.orgUnitId);
 
     const { data: initialOrgUnit } = useGetOrgUnit(initialOrgUnitId);
 
@@ -65,7 +65,7 @@ export const CompletenessStatsFilters: FunctionComponent<Props> = ({
             const id = orgUnit ? [orgUnit.id] : undefined;
             setInitialOrgUnitId(id);
             setSelectedOrgUnit(orgUnit);
-            handleChange('parentId', id);
+            handleChange('orgUnitId', id);
         },
         [handleChange],
     );
@@ -73,7 +73,7 @@ export const CompletenessStatsFilters: FunctionComponent<Props> = ({
         Math.abs(selectedOrgUnitTypeMaxDepth - selectedOrgUnitDepth) <
         REASONABLE_DEPTH;
 
-    const isOrgUnitTypeDisabled = !filters.parentId;
+    const isOrgUnitTypeDisabled = !filters.orgUnitId;
 
     const showError = !isOrgUnitTypeDisabled && !isReasonableDepth;
 

--- a/hat/assets/js/apps/Iaso/domains/completenessStats/hooks/api/useGetCompletnessStats.ts
+++ b/hat/assets/js/apps/Iaso/domains/completenessStats/hooks/api/useGetCompletnessStats.ts
@@ -5,13 +5,13 @@ import { UrlParams } from '../../../../types/table';
 import { CompletenessApiResponse } from '../../types';
 
 const queryParamsMap = new Map([
-    ['parentId', 'parent_id'],
+    ['orgUnitId', 'org_unit_id'],
     ['orgUnitTypeId', 'org_unit_type_id'],
     ['formId', 'form_id'],
 ]);
 
 export type CompletenessGETParams = UrlParams & {
-    parentId?: string;
+    orgUnitId?: string;
     formId?: string;
     orgUnitTypeId?: string;
 };
@@ -22,7 +22,7 @@ const getCompletenessStats = async (
     params: CompletenessGETParams,
 ): Promise<CompletenessApiResponse> => {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { pageSize, parentId, orgUnitTypeId, formId, ...urlParams } = params;
+    const { pageSize, orgUnitId, orgUnitTypeId, formId, ...urlParams } = params;
     const apiParams = { ...urlParams, limit: pageSize ?? 50 };
     const queryParams = {};
     apiParamsKeys.forEach(apiParamKey => {

--- a/iaso/api/completeness_stats.py
+++ b/iaso/api/completeness_stats.py
@@ -42,12 +42,12 @@ class CompletenessStatsViewSet(viewsets.ViewSet):
         else:
             org_unit_types = None
 
-        parent_org_unit_id_str = request.GET.get("parent_id", None)
+        requested_org_unit_id_str = request.GET.get("org_unit_id", None)
 
-        if parent_org_unit_id_str is not None:
-            parent_org_unit = OrgUnit.objects.get(id=parent_org_unit_id_str)
+        if requested_org_unit_id_str is not None:
+            requested_org_unit = OrgUnit.objects.get(id=requested_org_unit_id_str)
         else:
-            parent_org_unit = None
+            requested_org_unit = None
 
         requested_form_ids = requested_forms.split(",") if requested_forms is not None else []
         profile = request.user.iaso_profile
@@ -63,8 +63,8 @@ class CompletenessStatsViewSet(viewsets.ViewSet):
         org_units = OrgUnit.objects.filter(version=version).filter(
             validation_status="VALID"
         )  # don't forget to think about org unit status
-        if parent_org_unit:
-            org_units = org_units.hierarchy(parent_org_unit)
+        if requested_org_unit:
+            org_units = org_units.hierarchy(requested_org_unit)
 
         top_ous = org_units
 


### PR DESCRIPTION
For the completeness stats table, there was a badly named filter parameter: `parent_id` was used to select the "current" OrgUnit, while the name suggested that the returned rows would actually be the children of the OU.

Since we'll need to implement another feature for the "real" parent_id soon, it's important to rename the existing one to avoid adding more confusion to the confusion.

## Self proof reading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are there enough tests


## How to test

1) Go to the completeness stats table
2) Make sure the "OrgUnit" filter still works