### PR TITLE
IA-1684: pass OUtype Ids to backend

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/completenessStats/hooks/api/useGetCompletnessStats.ts
+++ b/hat/assets/js/apps/Iaso/domains/completenessStats/hooks/api/useGetCompletnessStats.ts
@@ -6,14 +6,14 @@ import { CompletenessApiResponse } from '../../types';
 
 const queryParamsMap = new Map([
     ['parentId', 'parent_id'],
-    ['orgUnitTypeId', 'org_unit_type_id'],
+    ['orgUnitTypeIds', 'org_unit_type_id'],
     ['formId', 'form_id'],
 ]);
 
 export type CompletenessGETParams = UrlParams & {
     parentId?: string;
     formId?: string;
-    orgUnitTypeId?: string;
+    orgUnitTypeIds?: string;
 };
 
 const apiParamsKeys = ['order', 'page', 'limit', 'search'];
@@ -22,7 +22,7 @@ const getCompletenessStats = async (
     params: CompletenessGETParams,
 ): Promise<CompletenessApiResponse> => {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { pageSize, parentId, orgUnitTypeId, formId, ...urlParams } = params;
+    const { pageSize, parentId, orgUnitTypeIds, formId, ...urlParams } = params;
     const apiParams = { ...urlParams, limit: pageSize ?? 50 };
     const queryParams = {};
     apiParamsKeys.forEach(apiParamKey => {


### PR DESCRIPTION
The key used to pass the org unit type ids to the backend was incorrect, so the filter didn't work

## Self proof reading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests
## Changes

- Corrected the typo that prevented sending OU type ids to backend


## How to test

use the filters od completeness stats

## Print screen / video

![Screenshot 2022-11-29 at 20 23 42](https://user-images.githubusercontent.com/38907762/204631852-91bc1046-adba-4d5f-ae3b-1ea1444f9964.png)


