### PR TITLE
IA-1685: enable outype selection with form

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/completenessStats/CompletenessStatsFilters.tsx
+++ b/hat/assets/js/apps/Iaso/domains/completenessStats/CompletenessStatsFilters.tsx
@@ -24,7 +24,7 @@ type Props = {
     params: UrlParams & any;
 };
 
-const REASONABLE_DEPTH = 2;
+const REASONABLE_DEPTH = 3;
 const baseUrl = baseUrls.completenessStats;
 
 export const CompletenessStatsFilters: FunctionComponent<Props> = ({
@@ -54,7 +54,7 @@ export const CompletenessStatsFilters: FunctionComponent<Props> = ({
                         ouType => ouType.original.id === parseInt(ouTypeId, 10),
                     ),
                 )
-                .map(ouType => ouType.original?.depth ?? 0)
+                .map(ouType => ouType?.original?.depth ?? 0)
                 // If the array is empty, we return the same depth as the orgUnit, to avoid showing an error
                 .sort((a, b) => b - a)[0] ?? selectedOrgUnitDepth,
         [filters.orgUnitTypeIds, orgUnitTypes, selectedOrgUnitDepth],
@@ -69,11 +69,12 @@ export const CompletenessStatsFilters: FunctionComponent<Props> = ({
         },
         [handleChange],
     );
-    const isReasonableDepth =
-        Math.abs(selectedOrgUnitTypeMaxDepth - selectedOrgUnitDepth) <
-        REASONABLE_DEPTH;
+    const isReasonableDepth = selectedOrgUnit
+        ? Math.abs(selectedOrgUnitTypeMaxDepth - selectedOrgUnitDepth) <
+          REASONABLE_DEPTH
+        : true;
 
-    const isOrgUnitTypeDisabled = !filters.parentId;
+    const isOrgUnitTypeDisabled = !filters.parentId && !filters.formId;
 
     const showError = !isOrgUnitTypeDisabled && !isReasonableDepth;
 


### PR DESCRIPTION
Users could only select an org unit type if an org unit was selected. they should be able to select ou types with only a form selected



Explain what problem this PR is resolving

## Self proof reading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests
## Changes

- Changed the `disable` condition of the filter button to allow filtering when a form is selected
- Set the value of `isReasonableDepth` to true when no Org unit is selected to prevent error states when selecting only a form
- Increased tolerated level diff bteween Ou and OU type to 3


## How to test

Use filters in completeness stats

## Print screen / video

https://user-images.githubusercontent.com/38907762/204632687-14ce3e5d-74d6-4e0e-bf10-67d2538249e1.mov



