### PR TITLE
Fix IA-1687 Feature flag dropdown on edit Project dialog is sometime empty

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/projects/components/ProjectFeatureFlags.tsx
+++ b/hat/assets/js/apps/Iaso/domains/projects/components/ProjectFeatureFlags.tsx
@@ -19,26 +19,29 @@ type Props = {
     // eslint-disable-next-line no-unused-vars
     setFieldValue: (key: string, value: string) => void;
     currentProject: ProjectForm;
-    featureFlags: Array<FeatureFlag>;
+    featureFlags?: Array<FeatureFlag>;
+    isFetchingFeatureFlag: boolean;
 };
 
 const ProjectFeatureFlags: FunctionComponent<Props> = ({
     setFieldValue,
     currentProject,
     featureFlags,
+    isFetchingFeatureFlag,
 }) => {
     return (
         <InputComponent
             multi
             clearable
             keyValue="feature_flags"
+            loading={isFetchingFeatureFlag}
             onChange={(key, value) =>
                 setFieldValue(key, commaSeparatedIdsToArray(value))
             }
             value={currentProject.feature_flags.value.join(',')}
             errors={currentProject.feature_flags.errors}
             type="select"
-            options={featureFlags.map(fF => ({
+            options={featureFlags?.map(fF => ({
                 label: fF.name,
                 value: fF.id,
             }))}

--- a/hat/assets/js/apps/Iaso/domains/projects/components/ProjectFeatureFlags.tsx
+++ b/hat/assets/js/apps/Iaso/domains/projects/components/ProjectFeatureFlags.tsx
@@ -29,6 +29,14 @@ const ProjectFeatureFlags: FunctionComponent<Props> = ({
     featureFlags,
     isFetchingFeatureFlag,
 }) => {
+    const options = React.useMemo(
+        () =>
+            featureFlags?.map(fF => ({
+                label: fF.name,
+                value: fF.id,
+            })),
+        [featureFlags],
+    );
     return (
         <InputComponent
             multi
@@ -41,10 +49,7 @@ const ProjectFeatureFlags: FunctionComponent<Props> = ({
             value={currentProject.feature_flags.value.join(',')}
             errors={currentProject.feature_flags.errors}
             type="select"
-            options={featureFlags?.map(fF => ({
-                label: fF.name,
-                value: fF.id,
-            }))}
+            options={options}
             label={MESSAGES.featureFlags}
         />
     );

--- a/hat/assets/js/apps/Iaso/domains/projects/components/ProjectsDialog.tsx
+++ b/hat/assets/js/apps/Iaso/domains/projects/components/ProjectsDialog.tsx
@@ -153,8 +153,9 @@ const ProjectsDialog: FunctionComponent<Props> = ({
             project.name &&
             project.name.value !== '' &&
             project.app_id &&
-            project.app_id.value !== '',
-        [project],
+            project.app_id.value !== '' &&
+            !isFetchingFeatureFlags,
+        [project, isFetchingFeatureFlags],
     );
 
     return (

--- a/hat/assets/js/apps/Iaso/domains/projects/components/ProjectsDialog.tsx
+++ b/hat/assets/js/apps/Iaso/domains/projects/components/ProjectsDialog.tsx
@@ -15,10 +15,10 @@ import { ProjectInfos } from './ProjectInfos';
 import { ProjectFeatureFlags } from './ProjectFeatureFlags';
 
 import { Project } from '../types/project';
-import { FeatureFlag } from '../types/featureFlag';
 import { IntlMessage } from '../../../types/intl';
 
 import MESSAGES from '../messages';
+import { useGetFeatureFlags } from '../hooks/requests';
 
 type RenderTriggerProps = {
     openDialog: () => void;
@@ -32,7 +32,6 @@ type Props = {
     initialData?: Project | null;
     // eslint-disable-next-line no-unused-vars
     saveProject: (s: Project) => Promise<any>;
-    featureFlags: Array<FeatureFlag>;
 };
 
 const useStyles = makeStyles(theme => ({
@@ -65,9 +64,10 @@ const ProjectsDialog: FunctionComponent<Props> = ({
         app_id: null,
         feature_flags: [],
     },
-    featureFlags,
     saveProject,
 }) => {
+    const { data: featureFlags, isFetching: isFetchingFeatureFlags } =
+        useGetFeatureFlags();
     const { formatMessage } = useSafeIntl();
     const classes: Record<string, string> = useStyles();
     const initialProject = useCallback(
@@ -210,6 +210,7 @@ const ProjectsDialog: FunctionComponent<Props> = ({
                         }
                         currentProject={project}
                         featureFlags={featureFlags}
+                        isFetchingFeatureFlag={isFetchingFeatureFlags}
                     />
                 )}
             </div>

--- a/hat/assets/js/apps/Iaso/domains/projects/config.tsx
+++ b/hat/assets/js/apps/Iaso/domains/projects/config.tsx
@@ -27,8 +27,6 @@ export const columns = (
     formatMessage: (msg: IntlMessage) => string,
     // eslint-disable-next-line no-unused-vars
     params: Params,
-    featureFlags: Array<FeatureFlag>,
-    // eslint-disable-next-line no-unused-vars
     saveProject: (s: Project) => Promise<any>,
 ): Array<Column> => [
     {
@@ -64,7 +62,6 @@ export const columns = (
                     initialData={settings.row.original}
                     titleMessage={MESSAGES.updateProject}
                     key={settings.row.original.updated_at}
-                    featureFlags={featureFlags}
                     saveProject={saveProject}
                 />
             </section>

--- a/hat/assets/js/apps/Iaso/domains/projects/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/projects/index.tsx
@@ -3,10 +3,15 @@ import { useDispatch } from 'react-redux';
 import { makeStyles, Box, Grid } from '@material-ui/core';
 
 import {
+    // @ts-ignore
     commonStyles,
+    // @ts-ignore
     Table,
+    // @ts-ignore
     LoadingSpinner,
+    // @ts-ignore
     useSafeIntl,
+    // @ts-ignore
     AddButton as AddButtonComponent,
 } from 'bluesquare-components';
 
@@ -39,7 +44,7 @@ export const Projects: FunctionComponent<Props> = ({ params }) => {
 
     const { data, isFetching: fetchingProjects } =
         useGetProjectsPaginated(params);
-    const { data: featureFlags = [] } = useGetFeatureFlags();
+
     const { mutateAsync: saveProject, isLoading: saving } = useSave();
 
     const isLoading = fetchingProjects || saving;
@@ -67,7 +72,6 @@ export const Projects: FunctionComponent<Props> = ({ params }) => {
                                 onClick={openDialog}
                             />
                         )}
-                        featureFlags={featureFlags}
                         saveProject={saveProject}
                     />
                 </Grid>
@@ -75,12 +79,7 @@ export const Projects: FunctionComponent<Props> = ({ params }) => {
                     data={data?.projects ?? []}
                     pages={data?.pages ?? 1}
                     defaultSorted={[{ id: 'name', desc: false }]}
-                    columns={columns(
-                        formatMessage,
-                        params,
-                        featureFlags,
-                        saveProject,
-                    )}
+                    columns={columns(formatMessage, params, saveProject)}
                     count={data?.count ?? 0}
                     baseUrl={baseUrl}
                     params={params}


### PR DESCRIPTION
Fix race condiition between the dialog and the network.

## Self proof reading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are my typescript files well typed
- [NA] Did I add translations
- [NA] My migrations file are included
- [?] Are there enough tests
## Changes

This seems to be caused by a race condition. Between fetching the feature flag list and the dialog generation.
If columns() is called with an empty FeatureFlag it is not updated afterward.

Fixed it by moving the useGetFeatureFlags call to the Dialog itself. Ideally we should in the future move the dialog to the new system so it only make the query when opened.

Also added a loading state on the Input to show it's fetching data.
And added Memo and some more robustness.

## How to test
It was a race condition so the error didn't always happen before.

To reproduce 

1. Go to the project page.
2. Edit an existing project
3. Go to the feature flag tab
4. open the dropdown

To help reproduce locally, you can add a waitFor in the query in useGetFeatureFlags.
```
--- a/hat/assets/js/apps/Iaso/domains/projects/hooks/requests.ts
+++ b/hat/assets/js/apps/Iaso/domains/projects/hooks/requests.ts
@@ -5,6 +5,7 @@ import { useSnackQuery, useSnackMutation } from '../../../libs/apiHooks';
 import { PaginatedProjects } from '../types/paginatedProjects';
 import { FeatureFlag } from '../types/featureFlag';
 import { UrlParams, ApiParams } from '../../../types/table';
+import { waitFor } from '../../../utils';

 export const useGetProjectsPaginated = (
     params: UrlParams,
@@ -33,7 +34,7 @@ export const useGetFeatureFlags = (): UseQueryResult<
     // @ts-ignore
     return useSnackQuery(
         ['featureflags'],
-        () => getRequest('/api/featureflags/'),
+        () => waitFor(20000).then(() => getRequest('/api/featureflags/')),
         undefined,
         {
             // using this here to avoid multiple identical calls
```

