### PR TITLE
IA-1686: fix deep linking

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/completenessStats/CompletenessStatsFilters.tsx
+++ b/hat/assets/js/apps/Iaso/domains/completenessStats/CompletenessStatsFilters.tsx
@@ -54,7 +54,7 @@ export const CompletenessStatsFilters: FunctionComponent<Props> = ({
                         ouType => ouType.original.id === parseInt(ouTypeId, 10),
                     ),
                 )
-                .map(ouType => ouType.original?.depth ?? 0)
+                .map(ouType => ouType?.original?.depth ?? 0)
                 // If the array is empty, we return the same depth as the orgUnit, to avoid showing an error
                 .sort((a, b) => b - a)[0] ?? selectedOrgUnitDepth,
         [filters.orgUnitTypeIds, orgUnitTypes, selectedOrgUnitDepth],


### PR DESCRIPTION
Using deep linking with OU type filter n completeness stats crashed the page

## Self proof reading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests
## Changes

- Add a null check on `ouType` to avoid crash when using deep linking


## How to test

Go to completeness stats, make a search with all 3 filters, copy the url, open it in a new. It should not crash and the filters should have the correct values

## Print screen / video

https://user-images.githubusercontent.com/38907762/204823822-ebccf19c-5be0-4ea5-a4ec-88e1ccc18642.mov


