### PR TITLE
IA-1693: Bulk update count error

### DIFF
--- a/hat/assets/js/apps/Iaso/components/dialogs/ConfirmDialogComponent.js
+++ b/hat/assets/js/apps/Iaso/components/dialogs/ConfirmDialogComponent.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 
 import { Button } from '@material-ui/core';
+import Divider from '@material-ui/core/Divider';
 import Dialog from '@material-ui/core/Dialog';
 import DialogActions from '@material-ui/core/DialogActions';
 import DialogTitle from '@material-ui/core/DialogTitle';
@@ -21,6 +22,7 @@ const ConfirmDialog = ({
     btnVariant,
     btnDisabled,
     btnSize,
+    withDivider,
 }) => {
     const [open, setOpen] = React.useState(false);
 
@@ -57,6 +59,7 @@ const ConfirmDialog = ({
                 }}
             >
                 <DialogTitle>{question}</DialogTitle>
+                {withDivider && <Divider />}
                 {message !== '' && (
                     <DialogContent>
                         <DialogContentText id="alert-dialog-description">
@@ -87,6 +90,7 @@ ConfirmDialog.defaultProps = {
     btnVariant: 'outlined',
     message: '',
     btnSize: 'medium',
+    withDivider: false,
 };
 
 ConfirmDialog.propTypes = {
@@ -98,6 +102,7 @@ ConfirmDialog.propTypes = {
     btnDisabled: PropTypes.bool,
     btnVariant: PropTypes.string,
     btnSize: PropTypes.string,
+    withDivider: PropTypes.bool,
 };
 
 export default ConfirmDialog;

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitsMultiActionsDialog.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitsMultiActionsDialog.tsx
@@ -9,7 +9,6 @@ import {
     Button,
     makeStyles,
     Box,
-    Grid,
     Typography,
 } from '@material-ui/core';
 import {
@@ -20,6 +19,7 @@ import {
     // @ts-ignore
     useSafeIntl,
 } from 'bluesquare-components';
+import ReportIcon from '@material-ui/icons/Report';
 // @ts-ignore
 import { useCurrentUser } from 'Iaso/utils/usersUtils';
 import { useGetOrgUnitTypes } from '../hooks/requests/useGetOrgUnitTypes';
@@ -58,6 +58,14 @@ const useStyles = makeStyles(theme => ({
     action: {
         paddingBottom: theme.spacing(2),
         paddingRight: theme.spacing(2),
+    },
+    warningTitle: {
+        display: 'flex',
+    },
+    warningIcon: {
+        display: 'inline-block',
+        marginLeft: theme.spacing(1),
+        marginRight: theme.spacing(1),
     },
 }));
 
@@ -320,30 +328,31 @@ export const OrgUnitsMultiActionsDialog: FunctionComponent<Props> = ({
                     </Button>
 
                     <ConfirmDialog
+                        withDivider
                         btnMessage={formatMessage(MESSAGES.validate)}
+                        message={
+                            <Box display="flex" justifyContent="center">
+                                <Typography variant="body2" color="error">
+                                    {formatMessage(MESSAGES.bulkChangeCount, {
+                                        count: `${formatThousand(selectCount)}`,
+                                    })}
+                                </Typography>
+                            </Box>
+                        }
                         question={
-                            <Grid direction="column" container>
-                                <Grid item>
-                                    <Box>
-                                        {formatMessage(
-                                            MESSAGES.confirmMultiChange,
-                                        )}
-                                        <>🚨</>
-                                    </Box>
-                                </Grid>
-                                <Grid item>
-                                    <Box>
-                                        <Typography variant="body2">
-                                            {formatMessage(
-                                                MESSAGES.bulkChangeCount,
-                                                {
-                                                    count: `${selectedItems.length}`,
-                                                },
-                                            )}
-                                        </Typography>
-                                    </Box>
-                                </Grid>
-                            </Grid>
+                            <Box className={classes.warningTitle}>
+                                <ReportIcon
+                                    className={classes.warningIcon}
+                                    color="error"
+                                    fontSize="large"
+                                />
+                                {formatMessage(MESSAGES.confirmMultiChange)}
+                                <ReportIcon
+                                    className={classes.warningIcon}
+                                    color="error"
+                                    fontSize="large"
+                                />
+                            </Box>
                         }
                         confirm={() => saveAndReset()}
                         btnDisabled={isSaveDisabled()}

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitsMultiActionsDialog.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitsMultiActionsDialog.tsx
@@ -68,6 +68,10 @@ const useStyles = makeStyles(theme => ({
         marginLeft: theme.spacing(1),
         marginRight: theme.spacing(1),
     },
+    warningMessage: {
+        display: 'flex',
+        justifyContent: 'center',
+    },
 }));
 
 const stringOfIdsToArrayofIds = stringValue =>
@@ -332,13 +336,16 @@ export const OrgUnitsMultiActionsDialog: FunctionComponent<Props> = ({
                         withDivider
                         btnMessage={formatMessage(MESSAGES.validate)}
                         message={
-                            <Box display="flex" justifyContent="center">
-                                <Typography variant="body2" color="error">
-                                    {formatMessage(MESSAGES.bulkChangeCount, {
-                                        count: `${formatThousand(selectCount)}`,
-                                    })}
-                                </Typography>
-                            </Box>
+                            <Typography
+                                variant="body2"
+                                color="error"
+                                component="span"
+                                className={classes.warningMessage}
+                            >
+                                {formatMessage(MESSAGES.bulkChangeCount, {
+                                    count: `${formatThousand(selectCount)}`,
+                                })}
+                            </Typography>
                         }
                         question={
                             <Box className={classes.warningTitle}>

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitsMultiActionsDialog.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitsMultiActionsDialog.tsx
@@ -61,6 +61,7 @@ const useStyles = makeStyles(theme => ({
     },
     warningTitle: {
         display: 'flex',
+        alignItems: 'center',
     },
     warningIcon: {
         display: 'inline-block',


### PR DESCRIPTION
Go to org units, launch a search, select all result, launch bulk update, change the group or something else, validate.

The confirmation dialog is appearing with the wrong total of org units to change. It’s woriking while only selecting a few the org units.
![CleanShot 2022-12-01 at 11 45 20](https://user-images.githubusercontent.com/12494624/205065426-98d3f006-6abc-4867-a237-768d08906cc2.png)

## Self proof reading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included

- [ ] Are there enough tests

## Changes

- Use correct count to display
- review icon and lay-out a bit

## Print screen / video

<img width="630" alt="Screenshot 2022-12-01 at 14 02 30" src="https://user-images.githubusercontent.com/12494624/205067238-9047b29f-7687-4918-91cd-2bba4db99b1c.png">
