### PR TITLE
Display nicer error for user without profile

### DIFF
--- a/hat/dashboard/views.py
+++ b/hat/dashboard/views.py
@@ -1,4 +1,5 @@
 from django.contrib.auth.decorators import login_required
+from django.core.exceptions import ObjectDoesNotExist
 from django.views.decorators.http import require_http_methods
 from django.shortcuts import render
 from django.http.request import HttpRequest
@@ -8,7 +9,12 @@ from hat.__version__ import VERSION
 
 
 def _base_iaso(request: HttpRequest) -> HttpResponse:
-    USER_HOME_PAGE = request.user.iaso_profile.home_page if request.user.is_authenticated else ""
+    try:
+        USER_HOME_PAGE = request.user.iaso_profile.home_page if request.user.is_authenticated else ""
+    except ObjectDoesNotExist:
+        return HttpResponse(
+            f"User {request.user.username} has no iaso_profile. Please contact your administrator.", status=403
+        )
     return render(
         request,
         "iaso/index.html",


### PR DESCRIPTION
For user without profile (eg. super user created by the createsuperuser command) we now display a nice explaination message
We also catch the error so it doesn't trigger sentry and change the return status code to a 403

To test, create a new user via the django admin or the CLI so it doesn't have an attached profile
and log on it
