### PR TITLE
IA-1737: Explicitly set Ubuntu version for GitHub workflows

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -22,7 +22,7 @@ jobs:
       packages: write
       pull-requests: write
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -73,7 +73,7 @@ jobs:
   test_cypress:
     if: ((github.event_name == 'workflow_dispatch') || (contains(github.event.comment.body, '@cypress')))
     timeout-minutes: 60
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: build-image
     permissions:
       contents: read

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       # Merge the workflow_dispatch config with some default for deployment via the on:push
       - name: Set configs

--- a/.github/workflows/e2e_tests_staging.yml
+++ b/.github/workflows/e2e_tests_staging.yml
@@ -6,7 +6,7 @@ env:
 jobs:
   e2etests:
     name: run end2end tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 #    container: cypress/browsers:node16.5.0-chrome94-ff93
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 jobs:
   test_js:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Use node.js 14
@@ -43,7 +43,7 @@ jobs:
           MSG_MINIMAL: true
         if: failure()
   build-and-push-image:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     permissions:
       contents: read
       packages: write
@@ -80,7 +80,7 @@ jobs:
           cache-from: type=registry,ref=ghcr.io/blsq/iaso:buildcache
           cache-to: type=registry,ref=ghcr.io/blsq/iaso:buildcache,mode=max
   test_python:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     services:
       postgres:
         image: mdillon/postgis:10


### PR DESCRIPTION
CI errors such as "Version 3.6 with arch x64 not found" on main

## Changes

Explicitly set the Ubuntu version to 20.04 since "ubuntu-latest" now points to version 22.04 (that doesn't support Python 3.6, same issue than https://github.com/actions/setup-python/issues/544#issuecomment-1320295576).

## How to test

Make sure the different GitHub wokflows (python-test, deploy, ...) work again.