### PR TITLE
IA-1669: Edit org unit: filter groups for ou source 

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitForm.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitForm.js
@@ -39,6 +39,8 @@ const OrgUnitForm = ({
     params,
     baseUrl,
     onResetOrgUnit,
+    isFetchingOrgUnitTypes,
+    isFetchingGroups,
 }) => {
     const [formState, setFieldValue, setFieldErrors, setFormState] =
         useFormState(initialFormState(orgUnit));
@@ -127,6 +129,8 @@ const OrgUnitForm = ({
                 groups={groups}
                 onChangeInfo={handleChangeInfo}
                 resetTrigger={!orgUnitModified}
+                isFetchingOrgUnitTypes={isFetchingOrgUnitTypes}
+                isFetchingGroups={isFetchingGroups}
             />
             <Grid
                 container
@@ -170,6 +174,8 @@ OrgUnitForm.propTypes = {
     onResetOrgUnit: PropTypes.func.isRequired,
     params: PropTypes.object.isRequired,
     baseUrl: PropTypes.string.isRequired,
+    isFetchingOrgUnitTypes: PropTypes.bool.isRequired,
+    isFetchingGroups: PropTypes.bool.isRequired,
 };
 
 export default withStyles(styles)(OrgUnitForm);

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitInfosComponent.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitInfosComponent.js
@@ -236,7 +236,6 @@ const OrgUnitCreationDetails = ({ orgUnit, formatMessage, classes }) => {
                 value={moment.unix(orgUnit.updated_at).format('LTS')}
                 disabled
             />
-           
 
             {!orgUnit.has_geo_json && !latitudeLongitude && (
                 <Grid
@@ -295,6 +294,8 @@ const OrgUnitInfosComponent = ({
     resetTrigger,
     fetchEditUrl,
     params,
+    isFetchingOrgUnitTypes,
+    isFetchingGroups,
 }) => {
     const { mutateAsync: saveOu } = useSaveOrgUnit();
     const classes = useStyles();
@@ -306,14 +307,15 @@ const OrgUnitInfosComponent = ({
     const [setFieldErrors] = useFormState(
         initialFormState(orgUnit, instanceId),
     );
-
+    const showSpeedDialsActions =
+        orgUnit.reference_instance ||
+        (formId === referenceFormId &&
+            formId !== undefined &&
+            referenceFormId !== undefined);
     return (
         <Grid container spacing={4}>
-            {(orgUnit.reference_instance ||
-                (formId === referenceFormId &&
-                    formId !== undefined &&
-                    referenceFormId !== undefined)) && (
-                    <SpeedDialInstanceActions
+            {showSpeedDialsActions && (
+                <SpeedDialInstanceActions
                     speedDialClasses={classes.speedDialTop}
                     actions={Actions(
                         orgUnit,
@@ -352,9 +354,14 @@ const OrgUnitInfosComponent = ({
                     keyValue="org_unit_type_id"
                     onChange={onChangeInfo}
                     required
-                    value={orgUnit.org_unit_type_id.value}
+                    value={
+                        isFetchingOrgUnitTypes
+                            ? undefined
+                            : orgUnit.org_unit_type_id.value
+                    }
                     errors={orgUnit.org_unit_type_id.errors}
                     type="select"
+                    loading={isFetchingOrgUnitTypes}
                     options={orgUnitTypes.map(t => ({
                         label: t.name,
                         value: t.id,
@@ -367,11 +374,8 @@ const OrgUnitInfosComponent = ({
                         onChangeInfo(name, commaSeparatedIdsToArray(value))
                     }
                     multi
-                    value={
-                        orgUnit.groups.value.length > 0
-                            ? orgUnit.groups.value
-                            : null
-                    }
+                    value={isFetchingGroups ? undefined : orgUnit.groups.value}
+                    loading={isFetchingGroups}
                     errors={orgUnit.groups.errors}
                     type="select"
                     options={groups.map(g => ({
@@ -557,6 +561,8 @@ OrgUnitInfosComponent.propTypes = {
     resetTrigger: PropTypes.bool,
     fetchEditUrl: PropTypes.func.isRequired,
     params: PropTypes.object.isRequired,
+    isFetchingOrgUnitTypes: PropTypes.bool.isRequired,
+    isFetchingGroups: PropTypes.bool.isRequired,
 };
 OrgUnitInfosComponent.defaultProps = {
     resetTrigger: false,

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/details.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/details.js
@@ -48,7 +48,7 @@ import {
     getLinksSources,
     getOrgUnitsTree,
 } from './utils';
-import { useCurrentUser } from '../../utils/usersUtils';
+import { useCurrentUser } from '../../utils/usersUtils.ts';
 
 const baseUrl = baseUrls.orgUnitDetails;
 const useStyles = makeStyles(theme => ({
@@ -237,6 +237,8 @@ const OrgUnitDetail = ({ params, router }) => {
         isFetchingDatas,
         originalOrgUnit,
         isFetchingDetail,
+        isFetchingOrgUnitTypes,
+        isFetchingGroups,
     } = useOrgUnitDetailData(isNewOrgunit, params.orgUnitId, setCurrentOrgUnit);
 
     const goToRevision = useCallback(
@@ -419,6 +421,8 @@ const OrgUnitDetail = ({ params, router }) => {
                                 saveOrgUnit={handleSaveOrgUnit}
                                 params={params}
                                 baseUrl={baseUrl}
+                                isFetchingOrgUnitTypes={isFetchingOrgUnitTypes}
+                                isFetchingGroups={isFetchingGroups}
                             />
                         </Box>
                     )}

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/hooks.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/hooks.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import {
     useSnackQuery,
     useSnackMutation,
@@ -24,6 +24,17 @@ export const useOrgUnitDetailData = (
                 onSuccess: ou => setCurrentOrgUnit(ou),
             },
         );
+
+    const groupsUrl = useMemo(() => {
+        const basUrl = '/api/groups/';
+        if (isNewOrgunit) {
+            return `${basUrl}?&defaultVersion=true'`;
+        }
+        if (originalOrgUnit?.source_id) {
+            return `${basUrl}?&dataSource=${originalOrgUnit.source_id}`;
+        }
+        return basUrl;
+    }, [isNewOrgunit, originalOrgUnit?.source_id]);
     const [
         { data: algorithms = [], isFetching: isFetchingAlgorithm },
         { data: algorithmRuns = [], isFetching: isFetchingAlgorithmRuns },
@@ -49,14 +60,7 @@ export const useOrgUnitDetailData = (
         },
         {
             queryKey: ['groups'],
-            queryFn: () =>
-                getRequest(
-                    `/api/groups/${
-                        isNewOrgunit
-                            ? '?&defaultVersion=true'
-                            : `?&dataSource=${originalOrgUnit?.source_id}`
-                    }`,
-                ),
+            queryFn: () => getRequest(groupsUrl),
             snackErrorMsg: MESSAGES.fetchGroupsError,
             options: {
                 select: data => data.groups,

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/hooks.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/hooks.js
@@ -14,6 +14,16 @@ export const useOrgUnitDetailData = (
     orgUnitId,
     setCurrentOrgUnit,
 ) => {
+    const { data: originalOrgUnit, isFetching: isFetchingDetail } =
+        useSnackQuery(
+            ['currentOrgUnit', orgUnitId],
+            () => getRequest(`/api/orgunits/${orgUnitId}/`),
+            MESSAGES.fetchOrgUnitError,
+            {
+                enabled: !isNewOrgunit,
+                onSuccess: ou => setCurrentOrgUnit(ou),
+            },
+        );
     const [
         { data: algorithms = [], isFetching: isFetchingAlgorithm },
         { data: algorithmRuns = [], isFetching: isFetchingAlgorithmRuns },
@@ -42,12 +52,15 @@ export const useOrgUnitDetailData = (
             queryFn: () =>
                 getRequest(
                     `/api/groups/${
-                        isNewOrgunit ? '?&defaultVersion=true' : ''
+                        isNewOrgunit
+                            ? '?&defaultVersion=true'
+                            : `?&dataSource=${originalOrgUnit?.source_id}`
                     }`,
                 ),
             snackErrorMsg: MESSAGES.fetchGroupsError,
             options: {
                 select: data => data.groups,
+                enabled: Boolean(originalOrgUnit),
             },
         },
         {
@@ -114,18 +127,6 @@ export const useOrgUnitDetailData = (
         ? isFetchingPlainSources
         : isFetchingAssociatedDataSources;
 
-    const { data: originalOrgUnit, isFetching: isFetchingDetail } =
-        useSnackQuery(
-            ['currentOrgUnit', orgUnitId],
-            () => getRequest(`/api/orgunits/${orgUnitId}/`),
-            MESSAGES.fetchOrgUnitError,
-            {
-                enabled:
-                    !isNewOrgunit && !isFetchingSources && !isFetchingLinks,
-                onSuccess: ou => setCurrentOrgUnit(ou),
-            },
-        );
-
     return {
         algorithms,
         algorithmRuns,
@@ -144,6 +145,8 @@ export const useOrgUnitDetailData = (
         sources: isNewOrgunit ? sources : associatedDataSources,
         originalOrgUnit,
         isFetchingDetail,
+        isFetchingOrgUnitTypes,
+        isFetchingGroups,
     };
 };
 


### PR DESCRIPTION
In org unit details: When showing an org unit from a given source, proposed groups should be from the same source

## Self proof reading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests
## Changes
Use current org unit source id to filter groups while editing an org unit.

## How to test

Edit an org unit and check that the list of groups are exclusively from the same source as the org unit.


