### PR TITLE
IA-1678: submissions - org units filter state

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/instances/compare/hooks/useGetInstanceLogs.ts
+++ b/hat/assets/js/apps/Iaso/domains/instances/compare/hooks/useGetInstanceLogs.ts
@@ -81,7 +81,7 @@ export const useGetFormDescriptor = (
             enabled: Boolean(formId),
             select: (data: FormDescriptor | undefined) => {
                 if (!data) return data;
-                return data.form_versions[0].descriptor;
+                return data.form_versions[0]?.descriptor;
             },
         },
     });

--- a/hat/assets/js/apps/Iaso/domains/instances/components/InstancesFiltersComponent.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/InstancesFiltersComponent.js
@@ -75,13 +75,8 @@ const InstancesFiltersComponent = ({
     const [initialOrgUnitId, setInitialOrgUnitId] = useState(params?.levels);
     const { data: initialOrgUnit } = useGetOrgUnit(initialOrgUnitId);
     useSkipEffectOnMount(() => {
-        Object.entries(formState).forEach(([key, field]) => {
-            if (
-                (field.value && `${field.value}` !== params[key]) ||
-                (!field.value && params[key])
-            ) {
-                setFormState(key, params[key] || null);
-            }
+        Object.entries(params).forEach(([key, value]) => {
+            setFormState(key, value);
         });
         setInitialOrgUnitId(params?.levels);
     }, [defaultFilters]);

--- a/hat/assets/js/apps/Iaso/domains/instances/components/InstancesFiltersComponent.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/InstancesFiltersComponent.js
@@ -9,6 +9,7 @@ import {
     commonStyles,
     useSafeIntl,
     QueryBuilderInput,
+    useSkipEffectOnMount,
 } from 'bluesquare-components';
 import InputComponent from '../../../components/forms/InputComponent';
 
@@ -71,7 +72,16 @@ const InstancesFiltersComponent = ({
     const [formState, setFormState] = useFormState(
         filterDefault(defaultFilters),
     );
-
+    useSkipEffectOnMount(() => {
+        Object.entries(formState).forEach(([key, field]) => {
+            if (
+                (field.value && `${field.value}` !== params[key]) ||
+                (!field.value && params[key])
+            ) {
+                setFormState(key, params[key] || null);
+            }
+        });
+    }, [defaultFilters]);
     const [initialOrgUnitId, setInitialOrgUnitId] = useState(params?.levels);
     const { data: initialOrgUnit } = useGetOrgUnit(initialOrgUnitId);
 
@@ -200,7 +210,7 @@ const InstancesFiltersComponent = ({
                     <InputComponent
                         keyValue="search"
                         onChange={handleFormChange}
-                        value={formState.search.value || null}
+                        value={formState.search.value || ''}
                         type="search"
                         label={MESSAGES.textSearch}
                         onEnterPressed={() => handleSearch()}

--- a/hat/assets/js/apps/Iaso/domains/instances/components/InstancesFiltersComponent.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/InstancesFiltersComponent.js
@@ -72,6 +72,8 @@ const InstancesFiltersComponent = ({
     const [formState, setFormState] = useFormState(
         filterDefault(defaultFilters),
     );
+    const [initialOrgUnitId, setInitialOrgUnitId] = useState(params?.levels);
+    const { data: initialOrgUnit } = useGetOrgUnit(initialOrgUnitId);
     useSkipEffectOnMount(() => {
         Object.entries(formState).forEach(([key, field]) => {
             if (
@@ -81,9 +83,8 @@ const InstancesFiltersComponent = ({
                 setFormState(key, params[key] || null);
             }
         });
+        setInitialOrgUnitId(params?.levels);
     }, [defaultFilters]);
-    const [initialOrgUnitId, setInitialOrgUnitId] = useState(params?.levels);
-    const { data: initialOrgUnit } = useGetOrgUnit(initialOrgUnitId);
 
     const orgUnitTypes = useSelector(state => state.orgUnits.orgUnitTypes);
     const isInstancesFilterUpdated = useSelector(

--- a/hat/assets/js/apps/Iaso/domains/instances/components/InstancesTopBar.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/InstancesTopBar.js
@@ -98,15 +98,14 @@ const InstancesTopBar = ({
         if (formIds?.length === 1) {
             // if detail loaded
             if (formDetails) {
-                if (possibleFields.length > 0) {
-                    newCols = getInstancesVisibleColumns({
-                        formatMessage,
-                        columns: newColsString,
-                        order: params.order,
-                        defaultOrder,
-                        possibleFields,
-                    });
-                }
+                newCols = getInstancesVisibleColumns({
+                    formatMessage,
+                    columns: newColsString,
+                    order: params.order,
+                    defaultOrder,
+                    possibleFields:
+                        possibleFields.length > 0 ? possibleFields : undefined,
+                });
             } else if (visibleColumns.length > 0) {
                 // remove columns while reloading
                 handleChangeVisibleColmuns([], false);

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitFiltersContainer.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitFiltersContainer.tsx
@@ -8,6 +8,8 @@ import {
     useSafeIntl,
     // @ts-ignore
     DynamicTabs,
+    // @ts-ignore
+    useSkipEffectOnMount,
 } from 'bluesquare-components';
 import React, {
     FunctionComponent,
@@ -17,6 +19,7 @@ import React, {
 } from 'react';
 import classnames from 'classnames';
 
+import { isEqual } from 'lodash';
 import { useCurrentUser } from '../../../utils/usersUtils';
 
 import { SearchButton } from '../../../components/SearchButton';
@@ -39,7 +42,7 @@ import MESSAGES from '../messages';
 
 type Props = {
     params: OrgUnitParams;
-    defaultSearches: [Search];
+    paramsSearches: [Search];
     // eslint-disable-next-line no-unused-vars
     onSearch: (searches: any) => void;
     currentTab: string;
@@ -81,7 +84,7 @@ export const OrgUnitFiltersContainer: FunctionComponent<Props> = ({
     params,
     onSearch,
     currentTab,
-    defaultSearches,
+    paramsSearches,
     orgunitTypes,
     isFetchingOrgunitTypes,
     counts,
@@ -100,7 +103,7 @@ export const OrgUnitFiltersContainer: FunctionComponent<Props> = ({
 
     const [hasLocationLimitError, setHasLocationLimitError] =
         useState<boolean>(false);
-    const [searches, setSearches] = useState<[Search]>(defaultSearches);
+    const [searches, setSearches] = useState<[Search]>(paramsSearches);
     const [textSearchError, setTextSearchError] = useState<boolean>(false);
     const currentSearchIndex = parseInt(params.searchTabIndex, 10);
 
@@ -141,6 +144,13 @@ export const OrgUnitFiltersContainer: FunctionComponent<Props> = ({
         },
         [dispatch],
     );
+
+    // update filter state if search changed in the url
+    useSkipEffectOnMount(() => {
+        if (!isEqual(decodeSearch(decodeURI(params.searches)), searches)) {
+            setSearches(paramsSearches);
+        }
+    }, [params.searches]);
 
     return (
         <>

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitsFilters.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitsFilters.tsx
@@ -84,7 +84,6 @@ export const OrgUnitFilters: FunctionComponent<Props> = ({
     const [sourceVersionId, setSourceVersionId] = useState<
         number | undefined
     >();
-    const [depth, setDepth] = useState<number | undefined>();
     const [initialOrgUnitId, setInitialOrgUnitId] = useState<
         string | undefined
     >(currentSearch?.levels);
@@ -92,6 +91,10 @@ export const OrgUnitFilters: FunctionComponent<Props> = ({
     const [showAdvancedSettings, setShowAdvancedSettings] = useState(false);
 
     const { data: initialOrgUnit } = useGetOrgUnit(initialOrgUnitId);
+
+    useSkipEffectOnMount(() => {
+        setInitialOrgUnitId(currentSearch?.levels);
+    }, [currentSearch?.levels]);
 
     const { data: dataSources, isFetching: isFetchingDataSources } =
         useGetDataSources();

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/hooks/requests/useGetOrgUnits.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/hooks/requests/useGetOrgUnits.ts
@@ -25,15 +25,18 @@ export type Result = Pagination & {
 type Props = {
     params: ApiParams;
     callback?: () => void;
+    isSearchActive: boolean;
 };
 
 type PropsLocation = {
     params: ApiParams;
     searches: Search[];
+    isSearchActive: boolean;
 };
 
 export const useGetOrgUnits = ({
     params,
+    isSearchActive,
     callback = () => null,
 }: Props): UseQueryResult<Result, Error> => {
     const onSuccess = () => callback();
@@ -46,6 +49,12 @@ export const useGetOrgUnits = ({
             staleTime: Infinity,
             keepPreviousData: true,
             onSuccess,
+            select: data => {
+                if (isSearchActive) {
+                    return data;
+                }
+                return undefined;
+            },
         },
     });
 };
@@ -53,7 +62,8 @@ export const useGetOrgUnits = ({
 export const useGetOrgUnitsLocations = ({
     params,
     searches,
-}: PropsLocation): UseQueryResult<Locations, Error> => {
+    isSearchActive,
+}: PropsLocation): UseQueryResult<Locations | undefined, Error> => {
     const queryString = new URLSearchParams(params);
     return useSnackQuery({
         queryKey: ['orgunitslocations'],
@@ -61,7 +71,12 @@ export const useGetOrgUnitsLocations = ({
         options: {
             enabled: false,
             staleTime: Infinity,
-            select: data => mapOrgUnitByLocation(data, searches),
+            select: data => {
+                if (isSearchActive) {
+                    return mapOrgUnitByLocation(data, searches);
+                }
+                return undefined;
+            },
         },
     });
 };

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/index.tsx
@@ -257,7 +257,7 @@ export const OrgUnits: FunctionComponent<Props> = ({ params }) => {
                     params={params}
                     onSearch={onSearch}
                     currentTab={tab}
-                    paramsSearches={searches}
+                    paramsSearches={searches || []}
                     orgunitTypes={orgunitTypes || []}
                     isFetchingOrgunitTypes={isFetchingOrgunitTypes}
                     counts={(!isLoading && orgUnitsData?.counts) || []}

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/index.tsx
@@ -135,6 +135,7 @@ export const OrgUnits: FunctionComponent<Props> = ({ params }) => {
         refetch: fetchOrgUnits,
     } = useGetOrgUnits({
         params: apiParams,
+        isSearchActive,
     });
     const {
         data: orgUnitsDataLocation,
@@ -143,6 +144,7 @@ export const OrgUnits: FunctionComponent<Props> = ({ params }) => {
     } = useGetOrgUnitsLocations({
         params: apiParamsLocations,
         searches,
+        isSearchActive,
     });
     // REQUESTS HOOKS
 
@@ -164,9 +166,11 @@ export const OrgUnits: FunctionComponent<Props> = ({ params }) => {
     );
 
     const handleSearch = useCallback(() => {
-        fetchOrgUnits();
-        fetchOrgUnitsLocations();
-    }, [fetchOrgUnits, fetchOrgUnitsLocations]);
+        if (isSearchActive) {
+            fetchOrgUnits();
+            fetchOrgUnitsLocations();
+        }
+    }, [fetchOrgUnits, fetchOrgUnitsLocations, isSearchActive]);
 
     const onSearch = useCallback(
         newParams => {
@@ -253,7 +257,7 @@ export const OrgUnits: FunctionComponent<Props> = ({ params }) => {
                     params={params}
                     onSearch={onSearch}
                     currentTab={tab}
-                    defaultSearches={searches}
+                    paramsSearches={searches}
                     orgunitTypes={orgunitTypes || []}
                     isFetchingOrgunitTypes={isFetchingOrgunitTypes}
                     counts={(!isLoading && orgUnitsData?.counts) || []}


### PR DESCRIPTION
Repro

Go to forms list

click “view submissions” for a form

Open the side menu

Click “Submissions”

Expected:

Either: Both the filter selection and the table results are preserved

Or: Both the filter selection and the table results are cleared/ reset

Actual

The filter selection is preserved but the table results are updated (diplaying results of an empty search)

## Self proof reading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests
## Changes

- `useSkipEffectOnMount` to watch params and sync filter states with it
- ensure fetching data is not done on org units id isSearchActive not set in the params
- fix a a small issue with forms without possible fields, cols were empty

## How to test

Go to submissions and org units pages, perform seraches and click back the same page in the sidebar

## Print screen / video

https://user-images.githubusercontent.com/12494624/205893782-17ff0559-ddc0-4ecb-92f0-76214050fa6d.mov


https://user-images.githubusercontent.com/12494624/205893883-388e1a1a-4397-4499-b3a6-e3212308d884.mov


