### PR TITLE
Polio 683 : Vaccine tab improvement

### DIFF
--- a/hat/assets/js/apps/Iaso/components/forms/TextArea.tsx
+++ b/hat/assets/js/apps/Iaso/components/forms/TextArea.tsx
@@ -21,6 +21,7 @@ type Props = {
     errors?: string[];
     required?: boolean;
     debounceTime?: number; // debounce time in ms
+    disabled?: boolean;
 };
 
 const useStyles = makeStyles(theme => ({
@@ -73,6 +74,7 @@ export const TextArea: FunctionComponent<Props> = ({
     errors = [],
     required = false,
     debounceTime = 0,
+    disabled = false,
 }) => {
     const classes: Record<string, string> = useStyles();
     const [focus, setFocus] = useState<boolean>(false);
@@ -122,6 +124,7 @@ export const TextArea: FunctionComponent<Props> = ({
                     setTextValue(e.target.value);
                 }}
                 value={textValue}
+                disabled={disabled}
             />
         </FormControl>
     );

--- a/hat/assets/js/apps/Iaso/components/forms/TextArea.tsx
+++ b/hat/assets/js/apps/Iaso/components/forms/TextArea.tsx
@@ -65,6 +65,16 @@ const useStyles = makeStyles(theme => ({
         },
     },
     errorText: { color: theme.palette.error.main },
+    // @ts-ignore
+    disabledLabel: { backgroundColor: theme.palette.ligthGray.background },
+    disabledTextArea: {
+        '&:hover': {
+            // @ts-ignore
+            border: `1px solid rgba(0, 0, 0, 0.23)`,
+        },
+        // @ts-ignore
+        backgroundColor: theme.palette.ligthGray.background,
+    },
 }));
 
 export const TextArea: FunctionComponent<Props> = ({
@@ -94,7 +104,7 @@ export const TextArea: FunctionComponent<Props> = ({
 
     useSkipEffectOnMount(() => {
         if (debouncedValue !== prevDebounced.current) {
-            // Only call onChange if debouncedVAlue has been updated to avoid unwanted overwrites
+            // Only call onChange if debouncedValue has been updated to avoid unwanted overwrites
             prevDebounced.current = debouncedValue;
             onChange(debouncedValue);
         }
@@ -109,6 +119,7 @@ export const TextArea: FunctionComponent<Props> = ({
                     focus && classes.inputLabelFocus,
                     Boolean(value) && classes.inputLabelShrink,
                     hasErrors && classes.errorText,
+                    disabled && classes.disabledLabel,
                 )}
                 required={required}
             >
@@ -119,6 +130,7 @@ export const TextArea: FunctionComponent<Props> = ({
                 className={classnames(
                     classes.textArea,
                     hasErrors && classes.errorArea,
+                    disabled && classes.disabledTextArea,
                 )}
                 onChange={e => {
                     setTextValue(e.target.value);

--- a/hat/assets/js/apps/Iaso/components/forms/TextArea.tsx
+++ b/hat/assets/js/apps/Iaso/components/forms/TextArea.tsx
@@ -74,11 +74,11 @@ export const TextArea: FunctionComponent<Props> = ({
     required = false,
     debounceTime = 0,
 }) => {
-    const prevValue = useRef<Optional<string>>();
-    const prevDebounced = useRef<Optional<string>>();
     const classes: Record<string, string> = useStyles();
     const [focus, setFocus] = useState<boolean>(false);
     const hasErrors = errors.length > 0;
+    const prevValue = useRef<Optional<string>>();
+    const prevDebounced = useRef<Optional<string>>();
     const [textValue, setTextValue] = useState<string>(value ?? '');
     const [debouncedValue] = useDebounce(textValue, debounceTime);
 

--- a/plugins/polio/js/src/components/Inputs/DebouncedTextInput.tsx
+++ b/plugins/polio/js/src/components/Inputs/DebouncedTextInput.tsx
@@ -54,35 +54,27 @@ export const DebouncedTextInput: FunctionComponent<Props> = ({
         },
         [name, setFieldTouched, setFieldValue],
     );
-    const prevValue = useRef();
+    const parsedValue =
+        typeof field?.value === 'number'
+            ? `${field.value}`
+            : field?.value ?? '';
+    const prevValue = useRef<string>();
     const prevDebounced = useRef();
-    const [textValue, setTextValue] = useState(field.value ?? '');
+    const [textValue, setTextValue] = useState(parsedValue);
     const [debouncedValue] = useDebounce(textValue, debounceTime);
-
-    // const handleChangeAndFocus = useCallback(
-    //     e => {
-    //         form?.setFieldTouched(field.name, true);
-    //         field?.onChange(e);
-    //     },
-    //     [form, field],
-    // );
-
-    // const handleChange = useMemo(
-    //     () => (touchOnFocus ? field.onChange : handleChangeAndFocus),
-    //     [field.onChange, handleChangeAndFocus, touchOnFocus],
-    // );
 
     // Reset state when value changes to prevent wrongly persisting the state value
     useEffect(() => {
         if (field.value !== prevValue.current) {
-            setTextValue(field.value ?? '');
+            // using parsedValue to avoid type error
+            setTextValue(parsedValue ?? '');
             prevValue.current = field.value;
         }
-    }, [field.value]);
+    }, [field.value, parsedValue]);
 
     useSkipEffectOnMount(() => {
         if (debouncedValue !== prevDebounced.current) {
-            // Only call onChange if debouncedVAlue has been updated to avoid unwanted overwrites
+            // Only call onChange if debouncedValue has been updated to avoid unwanted overwrites
             prevDebounced.current = debouncedValue;
             onChange(debouncedValue);
         }

--- a/plugins/polio/js/src/components/Inputs/DebouncedTextInput.tsx
+++ b/plugins/polio/js/src/components/Inputs/DebouncedTextInput.tsx
@@ -1,0 +1,106 @@
+import { get } from 'lodash';
+import React, {
+    FunctionComponent,
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+} from 'react';
+import { useDebounce } from 'use-debounce';
+// @ts-ignore
+import { useSkipEffectOnMount } from 'bluesquare-components';
+import InputComponent from '../../../../../../hat/assets/js/apps/Iaso/components/forms/InputComponent';
+
+type Props = {
+    field: any;
+    form: any;
+    label: string;
+    required: boolean;
+    debounceTime?: number;
+    withMarginTop?: boolean;
+    clearable?: boolean;
+    // touchOnFocus?: boolean;
+};
+
+export const DebouncedTextInput: FunctionComponent<Props> = ({
+    field,
+    form,
+    label,
+    required,
+    debounceTime = 0,
+    withMarginTop = false,
+    clearable = false,
+    // touchOnFocus = true,
+}) => {
+    const { name } = field;
+    const {
+        setFieldValue,
+        touched,
+        errors: formErrors,
+        setFieldTouched,
+    } = form;
+    const hasError =
+        form.errors &&
+        Boolean(get(form.errors, field.name) && get(touched, field.name));
+    const errors = useMemo(
+        () => (hasError ? [get(formErrors, name)] : []),
+        [formErrors, hasError, name],
+    );
+    const onChange = useCallback(
+        value => {
+            setFieldTouched(name, true);
+            setFieldValue(name, value);
+        },
+        [name, setFieldTouched, setFieldValue],
+    );
+    const prevValue = useRef();
+    const prevDebounced = useRef();
+    const [textValue, setTextValue] = useState(field.value ?? '');
+    const [debouncedValue] = useDebounce(textValue, debounceTime);
+
+    // const handleChangeAndFocus = useCallback(
+    //     e => {
+    //         form?.setFieldTouched(field.name, true);
+    //         field?.onChange(e);
+    //     },
+    //     [form, field],
+    // );
+
+    // const handleChange = useMemo(
+    //     () => (touchOnFocus ? field.onChange : handleChangeAndFocus),
+    //     [field.onChange, handleChangeAndFocus, touchOnFocus],
+    // );
+
+    // Reset state when value changes to prevent wrongly persisting the state value
+    useEffect(() => {
+        if (field.value !== prevValue.current) {
+            setTextValue(field.value ?? '');
+            prevValue.current = field.value;
+        }
+    }, [field.value]);
+
+    useSkipEffectOnMount(() => {
+        if (debouncedValue !== prevDebounced.current) {
+            // Only call onChange if debouncedVAlue has been updated to avoid unwanted overwrites
+            prevDebounced.current = debouncedValue;
+            onChange(debouncedValue);
+        }
+    }, [debouncedValue, onChange, prevValue.current]);
+
+    return (
+        <InputComponent
+            keyValue={field.name}
+            type="text"
+            withMarginTop={withMarginTop}
+            value={textValue}
+            clearable={clearable}
+            required={required}
+            labelString={label}
+            onChange={(_keyValue, value) => {
+                setTextValue(value);
+            }}
+            errors={errors}
+        />
+    );
+};

--- a/plugins/polio/js/src/components/Inputs/DebouncedTextInput.tsx
+++ b/plugins/polio/js/src/components/Inputs/DebouncedTextInput.tsx
@@ -63,6 +63,11 @@ export const DebouncedTextInput: FunctionComponent<Props> = ({
     const [textValue, setTextValue] = useState(parsedValue);
     const [debouncedValue] = useDebounce(textValue, debounceTime);
 
+    useEffect(() => {
+        prevDebounced.current = parsedValue;
+        // leaving the deps empty because the effect should only run once
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
     // Reset state when value changes to prevent wrongly persisting the state value
     useEffect(() => {
         if (field.value !== prevValue.current) {

--- a/plugins/polio/js/src/components/Inputs/DebouncedTextInput.tsx
+++ b/plugins/polio/js/src/components/Inputs/DebouncedTextInput.tsx
@@ -20,7 +20,6 @@ type Props = {
     debounceTime?: number;
     withMarginTop?: boolean;
     clearable?: boolean;
-    // touchOnFocus?: boolean;
 };
 
 export const DebouncedTextInput: FunctionComponent<Props> = ({
@@ -31,7 +30,6 @@ export const DebouncedTextInput: FunctionComponent<Props> = ({
     debounceTime = 0,
     withMarginTop = false,
     clearable = false,
-    // touchOnFocus = true,
 }) => {
     const { name } = field;
     const {

--- a/plugins/polio/js/src/components/Inputs/MultilineText.tsx
+++ b/plugins/polio/js/src/components/Inputs/MultilineText.tsx
@@ -8,6 +8,7 @@ type Props = {
     label: string;
     required: boolean;
     debounceTime?: number;
+    disabled?: boolean;
 };
 
 export const MultilineText: FunctionComponent<Props> = ({
@@ -16,6 +17,7 @@ export const MultilineText: FunctionComponent<Props> = ({
     label,
     required,
     debounceTime = 0,
+    disabled = false,
 }) => {
     const { name } = field;
     const {
@@ -42,6 +44,7 @@ export const MultilineText: FunctionComponent<Props> = ({
             value={field.value}
             onChange={onChange}
             debounceTime={debounceTime}
+            disabled={disabled}
         />
     );
 };

--- a/plugins/polio/js/src/components/Inputs/SingleSelect.tsx
+++ b/plugins/polio/js/src/components/Inputs/SingleSelect.tsx
@@ -13,7 +13,7 @@ type Props = {
     required?: boolean;
 };
 
-export const MultiSelect: FunctionComponent<Props> = ({
+export const SingleSelect: FunctionComponent<Props> = ({
     options,
     label,
     field,
@@ -31,7 +31,6 @@ export const MultiSelect: FunctionComponent<Props> = ({
             type="select"
             withMarginTop={withMarginTop}
             value={field.value}
-            multi
             options={options}
             clearable={clearable}
             required={required}

--- a/plugins/polio/js/src/components/Inputs/TextInput.js
+++ b/plugins/polio/js/src/components/Inputs/TextInput.js
@@ -1,14 +1,6 @@
-import React, {
-    useState,
-    useEffect,
-    useCallback,
-    useRef,
-    useMemo,
-} from 'react';
+import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
-import { useDebounce } from 'use-debounce';
 import { TextField } from '@material-ui/core';
-import { useSkipEffectOnMount } from 'bluesquare-components';
 import { get } from 'lodash';
 
 export const TextInput = ({
@@ -16,46 +8,19 @@ export const TextInput = ({
     form = {},
     value,
     touchOnFocus = true,
-    debounceTime = 500,
     ...props
 } = {}) => {
-    const prevValue = useRef();
-    const prevDebounced = useRef();
-    const [textValue, setTextValue] = useState(value ?? '');
-    const [debouncedValue] = useDebounce(textValue, debounceTime);
-
     const hasError =
         form.errors &&
         Boolean(get(form.errors, field.name) && get(form.touched, field.name));
 
     const handleChangeAndFocus = useCallback(
-        newValue => {
+        e => {
             form?.setFieldTouched(field.name, true);
-            form.setFieldValue(field.name, newValue);
+            field?.onChange(e);
         },
         [form, field],
     );
-
-    const handleChange = useMemo(
-        () => (touchOnFocus ? field.onChange : handleChangeAndFocus),
-        [field.onChange, handleChangeAndFocus, touchOnFocus],
-    );
-
-    // Reset state when value changes to prevent wrongly persisting the state value
-    useEffect(() => {
-        if (value !== prevValue.current) {
-            setTextValue(value ?? '');
-            prevValue.current = value;
-        }
-    }, [value]);
-
-    useSkipEffectOnMount(() => {
-        if (debouncedValue !== prevDebounced.current) {
-            // Only call onChange if debouncedVAlue has been updated to avoid unwanted overwrites
-            prevDebounced.current = debouncedValue;
-            handleChange(debouncedValue);
-        }
-    }, [debouncedValue, handleChange, prevValue.current, handleChange]);
 
     return (
         <TextField
@@ -73,10 +38,8 @@ export const TextInput = ({
                     : undefined
             }
             onBlur={touchOnFocus ? field.onBlur : undefined}
-            onChange={e => {
-                setTextValue(e.target.value);
-            }}
-            value={textValue}
+            onChange={touchOnFocus ? field.onChange : handleChangeAndFocus}
+            value={field.value ?? value ?? ''}
             error={hasError}
             helperText={hasError ? get(form.errors, field.name) : undefined}
         />
@@ -88,7 +51,6 @@ TextInput.defaultProps = {
     form: {},
     value: undefined,
     touchOnFocus: true,
-    debounceTime: 500,
 };
 
 TextInput.propTypes = {
@@ -96,5 +58,4 @@ TextInput.propTypes = {
     form: PropTypes.object,
     value: PropTypes.any,
     touchOnFocus: PropTypes.bool,
-    debounceTime: PropTypes.number,
 };

--- a/plugins/polio/js/src/components/Inputs/TextInput.js
+++ b/plugins/polio/js/src/components/Inputs/TextInput.js
@@ -35,7 +35,7 @@ export const TextInput = ({
             onFocus={
                 touchOnFocus
                     ? () => form.setFieldTouched(field.name, true)
-                    : undefined
+                    : () => null
             }
             onBlur={touchOnFocus ? field.onBlur : undefined}
             onChange={touchOnFocus ? field.onChange : handleChangeAndFocus}

--- a/plugins/polio/js/src/components/Inputs/TextInput.js
+++ b/plugins/polio/js/src/components/Inputs/TextInput.js
@@ -1,12 +1,27 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { TextField } from '@material-ui/core';
 import { get } from 'lodash';
 
-export const TextInput = ({ field = {}, form = {}, value, ...props } = {}) => {
+export const TextInput = ({
+    field = {},
+    form = {},
+    value,
+    touchOnFocus = true,
+    ...props
+} = {}) => {
     const hasError =
         form.errors &&
         Boolean(get(form.errors, field.name) && get(form.touched, field.name));
+
+    const handleChangeAndFocus = useCallback(
+        e => {
+            form?.setFieldTouched(field.name, true);
+            field?.onChange(e);
+        },
+        [form, field],
+    );
+
     return (
         <TextField
             InputLabelProps={{
@@ -17,7 +32,13 @@ export const TextInput = ({ field = {}, form = {}, value, ...props } = {}) => {
             size="medium"
             {...props}
             {...field}
-            onFocus={() => form.setFieldTouched(field.name, true)}
+            onFocus={
+                touchOnFocus
+                    ? () => form.setFieldTouched(field.name, true)
+                    : undefined
+            }
+            onBlur={touchOnFocus ? field.onBlur : undefined}
+            onChange={touchOnFocus ? field.onChange : handleChangeAndFocus}
             value={field.value ?? value ?? ''}
             error={hasError}
             helperText={hasError ? get(form.errors, field.name) : undefined}
@@ -29,10 +50,12 @@ TextInput.defaultProps = {
     field: {},
     form: {},
     value: undefined,
+    touchOnFocus: true,
 };
 
 TextInput.propTypes = {
     field: PropTypes.object,
     form: PropTypes.object,
     value: PropTypes.any,
+    touchOnFocus: PropTypes.bool,
 };

--- a/plugins/polio/js/src/forms/DestructionForm.tsx
+++ b/plugins/polio/js/src/forms/DestructionForm.tsx
@@ -5,9 +5,9 @@ import React, { FunctionComponent, useEffect, useMemo } from 'react';
 import { useSafeIntl } from 'bluesquare-components';
 import MESSAGES from '../constants/messages';
 import { DateInput } from '../components/Inputs/DateInput';
-import { TextInput } from '../components/Inputs';
 import { useStyles } from '../styles/theme';
 import { MultilineText } from '../components/Inputs/MultilineText';
+import { DebouncedTextInput } from '../components/Inputs/DebouncedTextInput';
 
 type Props = { accessor: string; index: number; roundIndex: number };
 
@@ -69,9 +69,8 @@ export const DestructionForm: FunctionComponent<Props> = ({
                 <Field
                     label={formatMessage(MESSAGES.vialsDestroyed)}
                     name={`${accessor}.destructions[${index}].vials_destroyed`}
-                    component={TextInput}
-                    // don't change the filed.touch value on Focus to avoid the component being in error state on first click
-                    touchOnFocus={false}
+                    component={DebouncedTextInput}
+                    debounceTime={300}
                     className={classes.input}
                 />
             </Grid>

--- a/plugins/polio/js/src/forms/DestructionForm.tsx
+++ b/plugins/polio/js/src/forms/DestructionForm.tsx
@@ -47,12 +47,18 @@ export const DestructionForm: FunctionComponent<Props> = ({
         });
     }, [accessor, fieldValues, index, setFieldTouched]);
 
+    const disableComment = !(
+        values?.round?.[roundIndex]?.destructions?.[index]?.date_report &&
+        values?.round?.[roundIndex]?.destructions?.[index]
+            ?.date_report_received &&
+        values?.round?.[roundIndex]?.destructions?.[index]?.vials_destroyed
+    );
+
     return (
         <Grid container direction="row" spacing={2} item xs={12}>
             <Grid item xs={3}>
                 <Field
                     label={formatMessage(MESSAGES.destructionReceptionDate)}
-                    // fullWidth
                     name={`${accessor}.destructions[${index}].date_report_received`}
                     component={DateInput}
                 />
@@ -81,6 +87,7 @@ export const DestructionForm: FunctionComponent<Props> = ({
                     component={MultilineText}
                     className={classes.input}
                     debounceTime={1000}
+                    disabled={disableComment}
                 />
             </Grid>
         </Grid>

--- a/plugins/polio/js/src/forms/DestructionForm.tsx
+++ b/plugins/polio/js/src/forms/DestructionForm.tsx
@@ -41,6 +41,8 @@ export const DestructionForm: FunctionComponent<Props> = ({
                     label={formatMessage(MESSAGES.vialsDestroyed)}
                     name={`${accessor}.destructions[${index}].vials_destroyed`}
                     component={TextInput}
+                    // don't change the filed.touch value on Focus to avoid the component being in error state on first click
+                    touchOnFocus={false}
                     className={classes.input}
                 />
             </Grid>

--- a/plugins/polio/js/src/forms/DestructionForm.tsx
+++ b/plugins/polio/js/src/forms/DestructionForm.tsx
@@ -1,6 +1,6 @@
 import { Grid } from '@material-ui/core';
-import { Field } from 'formik';
-import React, { FunctionComponent } from 'react';
+import { Field, useFormikContext } from 'formik';
+import React, { FunctionComponent, useEffect, useMemo } from 'react';
 // @ts-ignore
 import { useSafeIntl } from 'bluesquare-components';
 import MESSAGES from '../constants/messages';
@@ -9,14 +9,43 @@ import { TextInput } from '../components/Inputs';
 import { useStyles } from '../styles/theme';
 import { MultilineText } from '../components/Inputs/MultilineText';
 
-type Props = { accessor: string; index: number };
+type Props = { accessor: string; index: number; roundIndex: number };
+
+export const destructionFieldNames = [
+    'date_report_received',
+    'date_report',
+    'vials_destroyed',
+    'comment',
+];
 
 export const DestructionForm: FunctionComponent<Props> = ({
     accessor,
     index,
+    roundIndex,
 }) => {
     const { formatMessage } = useSafeIntl();
     const classes: Record<string, string> = useStyles();
+    const { values = {} as any, setFieldTouched } = useFormikContext();
+    const fieldValues = useMemo(
+        () => values?.rounds?.[roundIndex].destructions?.[index],
+        [index, roundIndex, values?.rounds],
+    );
+    useEffect(() => {
+        // Using every to be able to break the loop
+        destructionFieldNames.every(key => {
+            if (fieldValues[key]) {
+                destructionFieldNames.forEach(name => {
+                    setFieldTouched(
+                        `${accessor}.destructions[${index}].${name}`,
+                        true,
+                    );
+                });
+                // break the loop if any field has a value
+                return false;
+            }
+            return true;
+        });
+    }, [accessor, fieldValues, index, setFieldTouched]);
 
     return (
         <Grid container direction="row" spacing={2} item xs={12}>

--- a/plugins/polio/js/src/forms/DestructionForm.tsx
+++ b/plugins/polio/js/src/forms/DestructionForm.tsx
@@ -33,7 +33,7 @@ export const DestructionForm: FunctionComponent<Props> = ({
     useEffect(() => {
         // Using every to be able to break the loop
         destructionFieldNames.every(key => {
-            if (fieldValues[key]) {
+            if (fieldValues?.[key]) {
                 destructionFieldNames.forEach(name => {
                     setFieldTouched(
                         `${accessor}.destructions[${index}].${name}`,

--- a/plugins/polio/js/src/forms/DestructionsForm.tsx
+++ b/plugins/polio/js/src/forms/DestructionsForm.tsx
@@ -9,19 +9,21 @@ import React, {
 import { useSafeIntl } from 'bluesquare-components';
 import { Box, Button, Grid } from '@material-ui/core';
 import MESSAGES from '../constants/messages';
-import { DestructionForm } from './DestructionForm';
+import { destructionFieldNames, DestructionForm } from './DestructionForm';
 
 type Props = {
     round: any;
     accessor: string;
+    roundIndex: number;
 };
 
 export const DestructionsForm: FunctionComponent<Props> = ({
     round,
     accessor,
+    roundIndex,
 }) => {
     const { formatMessage } = useSafeIntl();
-    const { setFieldValue } = useFormikContext();
+    const { setFieldValue, setFieldTouched } = useFormikContext();
     const { destructions = [] } = round ?? {};
     const [enableRemoveButton, setEnableRemoveButton] =
         useState<boolean>(false);
@@ -37,7 +39,13 @@ export const DestructionsForm: FunctionComponent<Props> = ({
         const newDestructions = [...destructions];
         newDestructions.pop();
         setFieldValue(`${accessor}.destructions`, newDestructions);
-    }, [accessor, setFieldValue, destructions]);
+        destructionFieldNames.forEach(field => {
+            setFieldTouched(
+                `${accessor}.destructions[${newDestructions.length}].${field}`,
+                false,
+            );
+        });
+    }, [destructions, setFieldValue, accessor, setFieldTouched]);
 
     // determine whether to show delete button or not
 
@@ -63,6 +71,7 @@ export const DestructionsForm: FunctionComponent<Props> = ({
                             <DestructionForm
                                 index={index}
                                 accessor={accessor}
+                                roundIndex={roundIndex}
                             />
                         </Box>
                     </Grid>

--- a/plugins/polio/js/src/forms/FormAForm.tsx
+++ b/plugins/polio/js/src/forms/FormAForm.tsx
@@ -25,13 +25,17 @@ export const FormAForm: FunctionComponent<Props> = ({
 }) => {
     const { formatMessage } = useSafeIntl();
     const classes: Record<string, string> = useStyles();
-    const { values = {} as any, setFieldTouched } = useFormikContext();
+    const {
+        values = {} as any,
+        setFieldTouched,
+        setFieldValue,
+    } = useFormikContext();
     const fieldValues = useMemo(
         () => values?.rounds[roundIndex],
         [roundIndex, values?.rounds],
     );
 
-    // Make all fields error by setting touched to true if any other formA field has a value
+    // // Make all fields error by setting touched to true if any other formA field has a value
     useEffect(() => {
         // Using every to be able to break the loop
         formAFieldNames.every(key => {
@@ -46,7 +50,7 @@ export const FormAForm: FunctionComponent<Props> = ({
         });
     }, [accessor, fieldValues, setFieldTouched]);
 
-    // Remove error state if no field has value
+    // // Remove error state if no field has value
     useEffect(() => {
         const isFormAEmpty = formAFieldNames.every(key => !fieldValues[key]);
         if (isFormAEmpty) {
@@ -55,6 +59,25 @@ export const FormAForm: FunctionComponent<Props> = ({
             });
         }
     }, [accessor, fieldValues, setFieldTouched]);
+
+    // // Set TextFields values to null if empty to avoid 400.
+    useEffect(() => {
+        if (fieldValues.forma_usable_vials === '') {
+            setFieldValue(`${accessor}.forma_usable_vials`, null);
+        }
+        if (fieldValues.forma_unusable_vials === '') {
+            setFieldValue(`${accessor}.forma_unusable_vials`, null);
+        }
+        if (fieldValues.forma_missing_vials === '') {
+            setFieldValue(`${accessor}.forma_missing_vials`, null);
+        }
+    }, [
+        accessor,
+        fieldValues.forma_missing_vials,
+        fieldValues.forma_unusable_vials,
+        fieldValues.forma_usable_vials,
+        setFieldValue,
+    ]);
 
     return (
         <>

--- a/plugins/polio/js/src/forms/FormAForm.tsx
+++ b/plugins/polio/js/src/forms/FormAForm.tsx
@@ -101,6 +101,14 @@ export const FormAForm: FunctionComponent<Props> = ({
                 </Grid>
                 <Grid item lg={3} md={6}>
                     <Field
+                        label={formatMessage(MESSAGES.formADate)}
+                        name={`${accessor}.forma_date`}
+                        component={DateInput}
+                        className={classes.input}
+                    />
+                </Grid>
+                <Grid item lg={3} md={6}>
+                    <Field
                         label={formatMessage(MESSAGES.formAUnusableVials)}
                         name={`${accessor}.forma_unusable_vials`}
                         component={DebouncedTextInput}
@@ -123,23 +131,6 @@ export const FormAForm: FunctionComponent<Props> = ({
                         name={`${accessor}.forma_usable_vials`}
                         component={DebouncedTextInput}
                         debounceTime={300}
-                        className={classes.input}
-                    />
-                </Grid>
-            </Grid>
-            <Grid
-                container
-                direction="row"
-                item
-                xs={12}
-                spacing={2}
-                justifyContent="flex-start"
-            >
-                <Grid item lg={3} md={6}>
-                    <Field
-                        label={formatMessage(MESSAGES.formADate)}
-                        name={`${accessor}.forma_date`}
-                        component={DateInput}
                         className={classes.input}
                     />
                 </Grid>

--- a/plugins/polio/js/src/forms/FormAForm.tsx
+++ b/plugins/polio/js/src/forms/FormAForm.tsx
@@ -4,7 +4,7 @@ import { useSafeIntl } from 'bluesquare-components';
 import { Field, useFormikContext } from 'formik';
 import { Grid } from '@material-ui/core';
 import MESSAGES from '../constants/messages';
-import { DateInput, TextInput } from '../components/Inputs';
+import { DateInput } from '../components/Inputs';
 import { useStyles } from '../styles/theme';
 import { MultilineText } from '../components/Inputs/MultilineText';
 import { DebouncedTextInput } from '../components/Inputs/DebouncedTextInput';
@@ -40,7 +40,7 @@ export const FormAForm: FunctionComponent<Props> = ({
     useEffect(() => {
         // Using every to be able to break the loop
         formAFieldNames.every(key => {
-            if (fieldValues[key]) {
+            if (fieldValues?.[key]) {
                 formAFieldNames.forEach(name => {
                     setFieldTouched(`${accessor}.${name}`, true);
                 });
@@ -53,7 +53,7 @@ export const FormAForm: FunctionComponent<Props> = ({
 
     // // Remove error state if no field has value
     useEffect(() => {
-        const isFormAEmpty = formAFieldNames.every(key => !fieldValues[key]);
+        const isFormAEmpty = formAFieldNames.every(key => !fieldValues?.[key]);
         if (isFormAEmpty) {
             formAFieldNames.forEach(key => {
                 setFieldTouched(`${accessor}.${key}`, false);
@@ -63,20 +63,20 @@ export const FormAForm: FunctionComponent<Props> = ({
 
     // // Set TextFields values to null if empty to avoid 400.
     useEffect(() => {
-        if (fieldValues.forma_usable_vials === '') {
+        if (fieldValues?.forma_usable_vials === '') {
             setFieldValue(`${accessor}.forma_usable_vials`, null);
         }
-        if (fieldValues.forma_unusable_vials === '') {
+        if (fieldValues?.forma_unusable_vials === '') {
             setFieldValue(`${accessor}.forma_unusable_vials`, null);
         }
-        if (fieldValues.forma_missing_vials === '') {
+        if (fieldValues?.forma_missing_vials === '') {
             setFieldValue(`${accessor}.forma_missing_vials`, null);
         }
     }, [
         accessor,
-        fieldValues.forma_missing_vials,
-        fieldValues.forma_unusable_vials,
-        fieldValues.forma_usable_vials,
+        fieldValues?.forma_missing_vials,
+        fieldValues?.forma_unusable_vials,
+        fieldValues?.forma_usable_vials,
         setFieldValue,
     ]);
 
@@ -96,9 +96,7 @@ export const FormAForm: FunctionComponent<Props> = ({
                         label={formatMessage(MESSAGES.formAUnusableVials)}
                         name={`${accessor}.forma_unusable_vials`}
                         component={DebouncedTextInput}
-                        // don't change the filed.touch value on Focus to avoid the component being in error state on first click
-                        // touchOnFocus={false}
-                        debounceTime={500}
+                        debounceTime={300}
                         className={classes.input}
                     />
                 </Grid>
@@ -106,9 +104,8 @@ export const FormAForm: FunctionComponent<Props> = ({
                     <Field
                         label={formatMessage(MESSAGES.formAMissingVials)}
                         name={`${accessor}.forma_missing_vials`}
-                        component={TextInput}
-                        // don't change the filed.touch value on Focus to avoid the component being in error state on first click
-                        touchOnFocus={false}
+                        component={DebouncedTextInput}
+                        debounceTime={300}
                         className={classes.input}
                     />
                 </Grid>
@@ -116,9 +113,8 @@ export const FormAForm: FunctionComponent<Props> = ({
                     <Field
                         label={formatMessage(MESSAGES.formAUsableVials)}
                         name={`${accessor}.forma_usable_vials`}
-                        component={TextInput}
-                        // don't change the filed.touch value on Focus to avoid the component being in error state on first click
-                        touchOnFocus={false}
+                        component={DebouncedTextInput}
+                        debounceTime={300}
                         className={classes.input}
                     />
                 </Grid>

--- a/plugins/polio/js/src/forms/FormAForm.tsx
+++ b/plugins/polio/js/src/forms/FormAForm.tsx
@@ -80,6 +80,14 @@ export const FormAForm: FunctionComponent<Props> = ({
         setFieldValue,
     ]);
 
+    const disableComment = !(
+        fieldValues?.forma_missing_vials &&
+        fieldValues?.forma_unusable_vials &&
+        fieldValues?.forma_usable_vials &&
+        fieldValues?.forma_date &&
+        fieldValues?.forma_reception
+    );
+
     return (
         <>
             <Grid container direction="row" item xs={12} spacing={2}>
@@ -142,6 +150,7 @@ export const FormAForm: FunctionComponent<Props> = ({
                         component={MultilineText}
                         className={classes.input}
                         debounceTime={1000}
+                        disabled={disableComment}
                     />
                 </Grid>
             </Grid>

--- a/plugins/polio/js/src/forms/FormAForm.tsx
+++ b/plugins/polio/js/src/forms/FormAForm.tsx
@@ -1,0 +1,129 @@
+import React, { FunctionComponent, useEffect, useMemo } from 'react';
+// @ts-ignore
+import { useSafeIntl } from 'bluesquare-components';
+import { Field, useFormikContext } from 'formik';
+import { Grid } from '@material-ui/core';
+import MESSAGES from '../constants/messages';
+import { DateInput, TextInput } from '../components/Inputs';
+import { useStyles } from '../styles/theme';
+import { MultilineText } from '../components/Inputs/MultilineText';
+
+type Props = { accessor: string; roundIndex: number };
+
+export const formAFieldNames = [
+    'forma_unusable_vials',
+    'forma_missing_vials',
+    'forma_reception',
+    'forma_usable_vials',
+    'forma_date',
+    'forma_comment',
+];
+
+export const FormAForm: FunctionComponent<Props> = ({
+    accessor,
+    roundIndex,
+}) => {
+    const { formatMessage } = useSafeIntl();
+    const classes: Record<string, string> = useStyles();
+    const { values = {} as any, setFieldTouched } = useFormikContext();
+    const fieldValues = useMemo(
+        () => values?.rounds[roundIndex],
+        [roundIndex, values?.rounds],
+    );
+
+    // Make all fields error by setting touched to true if any other formA field has a value
+    useEffect(() => {
+        // Using every to be able to break the loop
+        formAFieldNames.every(key => {
+            if (fieldValues[key]) {
+                formAFieldNames.forEach(name => {
+                    setFieldTouched(`${accessor}.${name}`, true);
+                });
+                // break the loop if any field has a value
+                return false;
+            }
+            return true;
+        });
+    }, [accessor, fieldValues, setFieldTouched]);
+
+    // Remove error state if no field has value
+    useEffect(() => {
+        const isFormAEmpty = formAFieldNames.every(key => !fieldValues[key]);
+        if (isFormAEmpty) {
+            formAFieldNames.forEach(key => {
+                setFieldTouched(`${accessor}.${key}`, false);
+            });
+        }
+    }, [accessor, fieldValues, setFieldTouched]);
+
+    return (
+        <>
+            <Grid container direction="row" item xs={12} spacing={2}>
+                <Grid item lg={3} md={6}>
+                    <Field
+                        label={formatMessage(MESSAGES.formAReception)}
+                        name={`${accessor}.forma_reception`}
+                        component={DateInput}
+                        className={classes.input}
+                    />
+                </Grid>
+                <Grid item lg={3} md={6}>
+                    <Field
+                        label={formatMessage(MESSAGES.formAUnusableVials)}
+                        name={`${accessor}.forma_unusable_vials`}
+                        component={TextInput}
+                        // don't change the filed.touch value on Focus to avoid the component being in error state on first click
+                        touchOnFocus={false}
+                        className={classes.input}
+                    />
+                </Grid>
+                <Grid item lg={3} md={6}>
+                    <Field
+                        label={formatMessage(MESSAGES.formAMissingVials)}
+                        name={`${accessor}.forma_missing_vials`}
+                        component={TextInput}
+                        // don't change the filed.touch value on Focus to avoid the component being in error state on first click
+                        touchOnFocus={false}
+                        className={classes.input}
+                    />
+                </Grid>
+                <Grid item lg={3} md={6}>
+                    <Field
+                        label={formatMessage(MESSAGES.formAUsableVials)}
+                        name={`${accessor}.forma_usable_vials`}
+                        component={TextInput}
+                        // don't change the filed.touch value on Focus to avoid the component being in error state on first click
+                        touchOnFocus={false}
+                        className={classes.input}
+                    />
+                </Grid>
+            </Grid>
+            <Grid
+                container
+                direction="row"
+                item
+                xs={12}
+                spacing={2}
+                justifyContent="flex-start"
+            >
+                <Grid item lg={3} md={6}>
+                    <Field
+                        label={formatMessage(MESSAGES.formADate)}
+                        name={`${accessor}.forma_date`}
+                        component={DateInput}
+                        className={classes.input}
+                    />
+                </Grid>
+                <Grid item lg={3} md={6}>
+                    <Field
+                        label={formatMessage(MESSAGES.formAComment)}
+                        name={`${accessor}.forma_comment`}
+                        component={MultilineText}
+                        className={classes.input}
+                        debounceTime={1000}
+                    />
+                </Grid>
+            </Grid>
+        </>
+    );
+};

--- a/plugins/polio/js/src/forms/FormAForm.tsx
+++ b/plugins/polio/js/src/forms/FormAForm.tsx
@@ -7,6 +7,7 @@ import MESSAGES from '../constants/messages';
 import { DateInput, TextInput } from '../components/Inputs';
 import { useStyles } from '../styles/theme';
 import { MultilineText } from '../components/Inputs/MultilineText';
+import { DebouncedTextInput } from '../components/Inputs/DebouncedTextInput';
 
 type Props = { accessor: string; roundIndex: number };
 
@@ -94,9 +95,10 @@ export const FormAForm: FunctionComponent<Props> = ({
                     <Field
                         label={formatMessage(MESSAGES.formAUnusableVials)}
                         name={`${accessor}.forma_unusable_vials`}
-                        component={TextInput}
+                        component={DebouncedTextInput}
                         // don't change the filed.touch value on Focus to avoid the component being in error state on first click
-                        touchOnFocus={false}
+                        // touchOnFocus={false}
+                        debounceTime={500}
                         className={classes.input}
                     />
                 </Grid>

--- a/plugins/polio/js/src/forms/ReportingDelays.tsx
+++ b/plugins/polio/js/src/forms/ReportingDelays.tsx
@@ -13,7 +13,7 @@ import { useSafeIntl } from 'bluesquare-components';
 import classnames from 'classnames';
 import { Field } from 'formik';
 import MESSAGES from '../constants/messages';
-import { TextInput } from '../components/Inputs';
+import { DebouncedTextInput } from '../components/Inputs/DebouncedTextInput';
 
 const useStyles = makeStyles(theme => ({
     rightCell: {
@@ -59,7 +59,8 @@ export const ReportingDelays: FunctionComponent<Props> = ({ accessor }) => {
                             <Field
                                 label=""
                                 name={`${accessor}.reporting_delays_hc_to_district`}
-                                component={TextInput}
+                                component={DebouncedTextInput}
+                                debounceTime={300}
                             />
                         </TableCell>
                     </TableRow>
@@ -71,7 +72,8 @@ export const ReportingDelays: FunctionComponent<Props> = ({ accessor }) => {
                             <Field
                                 label=""
                                 name={`${accessor}.reporting_delays_district_to_region`}
-                                component={TextInput}
+                                component={DebouncedTextInput}
+                                debounceTime={300}
                             />
                         </TableCell>
                     </TableRow>
@@ -83,7 +85,8 @@ export const ReportingDelays: FunctionComponent<Props> = ({ accessor }) => {
                             <Field
                                 label=""
                                 name={`${accessor}.reporting_delays_region_to_national`}
-                                component={TextInput}
+                                component={DebouncedTextInput}
+                                debounceTime={300}
                             />
                         </TableCell>
                     </TableRow>

--- a/plugins/polio/js/src/forms/RoundVaccineForm.tsx
+++ b/plugins/polio/js/src/forms/RoundVaccineForm.tsx
@@ -3,11 +3,11 @@ import { Field, useFormikContext } from 'formik';
 import React, { FunctionComponent, useMemo } from 'react';
 // @ts-ignore
 import { useSafeIntl } from 'bluesquare-components';
-import { TextInput } from '../components/Inputs';
 import MESSAGES from '../constants/messages';
 import { useStyles } from '../styles/theme';
 import { DropdownOptions } from '../../../../../hat/assets/js/apps/Iaso/types/utils';
 import { SingleSelect } from '../components/Inputs/SingleSelect';
+import { DebouncedTextInput } from '../components/Inputs/DebouncedTextInput';
 
 type Props = {
     vaccineIndex: number;
@@ -86,7 +86,8 @@ export const RoundVaccineForm: FunctionComponent<Props> = ({
                 <Field
                     label={formatMessage(MESSAGES.wastageRatio)}
                     name={`${accessor}.wastage_ratio_forecast`}
-                    component={TextInput} // TODO make NumberInput
+                    component={DebouncedTextInput}
+                    debounceTime={300}
                     className={classes.input}
                 />
             </Grid>

--- a/plugins/polio/js/src/forms/RoundVaccineForm.tsx
+++ b/plugins/polio/js/src/forms/RoundVaccineForm.tsx
@@ -3,10 +3,11 @@ import { Field, useFormikContext } from 'formik';
 import React, { FunctionComponent, useMemo } from 'react';
 // @ts-ignore
 import { useSafeIntl } from 'bluesquare-components';
-import { Select, TextInput } from '../components/Inputs';
+import { TextInput } from '../components/Inputs';
 import MESSAGES from '../constants/messages';
 import { useStyles } from '../styles/theme';
 import { DropdownOptions } from '../../../../../hat/assets/js/apps/Iaso/types/utils';
+import { SingleSelect } from '../components/Inputs/SingleSelect';
 
 type Props = {
     vaccineIndex: number;
@@ -64,7 +65,8 @@ export const RoundVaccineForm: FunctionComponent<Props> = ({
                         name={`${accessor}.name`}
                         className={classes.input}
                         options={options}
-                        component={Select}
+                        clearable={false}
+                        component={SingleSelect}
                     />
                 </Box>
             </Grid>
@@ -75,7 +77,8 @@ export const RoundVaccineForm: FunctionComponent<Props> = ({
                         name={`${accessor}.doses_per_vial`}
                         className={classes.input}
                         options={dosesOptions}
-                        component={Select}
+                        clearable={false}
+                        component={SingleSelect}
                     />
                 </Box>
             </Grid>

--- a/plugins/polio/js/src/forms/RoundVaccinesForm.tsx
+++ b/plugins/polio/js/src/forms/RoundVaccinesForm.tsx
@@ -24,9 +24,9 @@ const DEFAULT_DELAY_DISTRICT = 5;
 const DEFAULT_DELAY_REGION = 7;
 
 const DEFAULT_WASTAGE_RATIOS = {
-    mOPV2: 1.15,
-    nOPV2: 1.33,
-    bOPV: 1.18,
+    mOPV2: '1.15',
+    nOPV2: '1.33',
+    bOPV: '1.18',
 };
 
 const DEFAULT_DOSES_PER_VIAL = 50;

--- a/plugins/polio/js/src/forms/ShipmentForm.tsx
+++ b/plugins/polio/js/src/forms/ShipmentForm.tsx
@@ -42,6 +42,8 @@ export const ShipmentForm: FunctionComponent<Props> = ({ index, accessor }) => {
                         label={formatMessage(MESSAGES.poNumbers)}
                         name={`${accessor}.shipments[${index}].po_numbers`}
                         component={TextInput}
+                        // don't change the filed.touch value on Focus to avoid the component being in error state on first click
+                        touchOnFocus={false}
                         className={classes.input}
                     />
                 </Grid>
@@ -50,6 +52,8 @@ export const ShipmentForm: FunctionComponent<Props> = ({ index, accessor }) => {
                         label={formatMessage(MESSAGES.vialsShipped)}
                         name={`${accessor}.shipments[${index}].vials_received`}
                         component={TextInput}
+                        // don't change the filed.touch value on Focus to avoid the component being in error state on first click
+                        touchOnFocus={false}
                         className={classes.input}
                     />
                 </Grid>

--- a/plugins/polio/js/src/forms/ShipmentForm.tsx
+++ b/plugins/polio/js/src/forms/ShipmentForm.tsx
@@ -57,6 +57,16 @@ export const ShipmentForm: FunctionComponent<Props> = ({
         });
     }, [accessor, fieldValues, index, setFieldTouched]);
 
+    const disableComment = !(
+        values?.round?.[roundIndex]?.shipments?.[index]?.vaccine_name &&
+        values?.round?.[roundIndex]?.shipments?.[index]?.po_numbers &&
+        values?.round?.[roundIndex]?.shipments?.[index]?.vials_received &&
+        values?.round?.[roundIndex]?.shipments?.[index]?.reception_pre_alert &&
+        values?.round?.[roundIndex]?.shipments?.[index]
+            ?.estimated_arrival_date &&
+        values?.round?.[roundIndex]?.shipments?.[index]?.date_reception
+    );
+
     return (
         <>
             <Grid
@@ -127,6 +137,7 @@ export const ShipmentForm: FunctionComponent<Props> = ({
                         component={MultilineText}
                         className={classes.input}
                         debounceTime={1000}
+                        disabled={disableComment}
                     />
                 </Grid>
             </Grid>

--- a/plugins/polio/js/src/forms/ShipmentForm.tsx
+++ b/plugins/polio/js/src/forms/ShipmentForm.tsx
@@ -43,7 +43,7 @@ export const ShipmentForm: FunctionComponent<Props> = ({
     useEffect(() => {
         // Using every to be able to break the loop
         shipmentFieldNames.every(key => {
-            if (fieldValues[key]) {
+            if (fieldValues?.[key]) {
                 shipmentFieldNames.forEach(name => {
                     setFieldTouched(
                         `${accessor}.shipments[${index}].${name}`,

--- a/plugins/polio/js/src/forms/ShipmentForm.tsx
+++ b/plugins/polio/js/src/forms/ShipmentForm.tsx
@@ -1,23 +1,60 @@
 /* eslint-disable camelcase */
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, useEffect, useMemo } from 'react';
 // @ts-ignore
 import { useSafeIntl } from 'bluesquare-components';
 import { Grid } from '@material-ui/core';
-import { Field } from 'formik';
+import { Field, useFormikContext } from 'formik';
 import MESSAGES from '../constants/messages';
 import { useStyles } from '../styles/theme';
-import { DateInput, Select, TextInput } from '../components/Inputs';
+import { DateInput, TextInput } from '../components/Inputs';
 import { polioVaccines } from '../constants/virus';
 import { MultilineText } from '../components/Inputs/MultilineText';
+import { SingleSelect } from '../components/Inputs/SingleSelect';
 
 type Props = {
     index: number;
     accessor: string;
+    roundIndex: number;
 };
 
-export const ShipmentForm: FunctionComponent<Props> = ({ index, accessor }) => {
+export const shipmentFieldNames = [
+    'vaccine_name',
+    'po_numbers',
+    'vials_received',
+    'estimated_arrival_date',
+    'date_reception',
+    'reception_pre_alert',
+    'comment',
+];
+
+export const ShipmentForm: FunctionComponent<Props> = ({
+    index,
+    accessor,
+    roundIndex,
+}) => {
     const classes: Record<string, string> = useStyles();
     const { formatMessage } = useSafeIntl();
+    const { values = {} as any, setFieldTouched } = useFormikContext();
+    const fieldValues = useMemo(
+        () => values?.rounds?.[roundIndex].shipments?.[index],
+        [index, roundIndex, values?.rounds],
+    );
+    useEffect(() => {
+        // Using every to be able to break the loop
+        shipmentFieldNames.every(key => {
+            if (fieldValues[key]) {
+                shipmentFieldNames.forEach(name => {
+                    setFieldTouched(
+                        `${accessor}.shipments[${index}].${name}`,
+                        true,
+                    );
+                });
+                // break the loop if any field has a value
+                return false;
+            }
+            return true;
+        });
+    }, [accessor, fieldValues, index, setFieldTouched]);
 
     return (
         <>
@@ -34,7 +71,8 @@ export const ShipmentForm: FunctionComponent<Props> = ({ index, accessor }) => {
                         name={`${accessor}.shipments[${index}].vaccine_name`}
                         className={classes.input}
                         options={polioVaccines}
-                        component={Select}
+                        clearable={false}
+                        component={SingleSelect}
                     />
                 </Grid>
                 <Grid item md={3}>

--- a/plugins/polio/js/src/forms/ShipmentForm.tsx
+++ b/plugins/polio/js/src/forms/ShipmentForm.tsx
@@ -6,10 +6,11 @@ import { Grid } from '@material-ui/core';
 import { Field, useFormikContext } from 'formik';
 import MESSAGES from '../constants/messages';
 import { useStyles } from '../styles/theme';
-import { DateInput, TextInput } from '../components/Inputs';
+import { DateInput } from '../components/Inputs';
 import { polioVaccines } from '../constants/virus';
 import { MultilineText } from '../components/Inputs/MultilineText';
 import { SingleSelect } from '../components/Inputs/SingleSelect';
+import { DebouncedTextInput } from '../components/Inputs/DebouncedTextInput';
 
 type Props = {
     index: number;
@@ -79,9 +80,8 @@ export const ShipmentForm: FunctionComponent<Props> = ({
                     <Field
                         label={formatMessage(MESSAGES.poNumbers)}
                         name={`${accessor}.shipments[${index}].po_numbers`}
-                        component={TextInput}
-                        // don't change the filed.touch value on Focus to avoid the component being in error state on first click
-                        touchOnFocus={false}
+                        component={DebouncedTextInput}
+                        debounceTime={300}
                         className={classes.input}
                     />
                 </Grid>
@@ -89,9 +89,8 @@ export const ShipmentForm: FunctionComponent<Props> = ({
                     <Field
                         label={formatMessage(MESSAGES.vialsShipped)}
                         name={`${accessor}.shipments[${index}].vials_received`}
-                        component={TextInput}
-                        // don't change the filed.touch value on Focus to avoid the component being in error state on first click
-                        touchOnFocus={false}
+                        component={DebouncedTextInput}
+                        debounceTime={300}
                         className={classes.input}
                     />
                 </Grid>

--- a/plugins/polio/js/src/forms/ShipmentsForm.tsx
+++ b/plugins/polio/js/src/forms/ShipmentsForm.tsx
@@ -8,20 +8,22 @@ import React, {
 // @ts-ignore
 import { useSafeIntl } from 'bluesquare-components';
 import { Box, Button, Grid } from '@material-ui/core';
-import { ShipmentForm } from './ShipmentForm';
+import { shipmentFieldNames, ShipmentForm } from './ShipmentForm';
 import MESSAGES from '../constants/messages';
 
 type Props = {
     round: any;
     accessor: string;
+    roundIndex: number;
 };
 
 export const ShipmentsForm: FunctionComponent<Props> = ({
     round,
     accessor,
+    roundIndex,
 }) => {
     const { formatMessage } = useSafeIntl();
-    const { setFieldValue } = useFormikContext();
+    const { setFieldValue, setFieldTouched } = useFormikContext();
     const { shipments = [] } = round ?? {};
     const [enableRemoveButton, setEnableRemoveButton] =
         useState<boolean>(false);
@@ -36,8 +38,15 @@ export const ShipmentsForm: FunctionComponent<Props> = ({
     const handleRemoveLastShipment = useCallback(() => {
         const newShipments = [...shipments];
         newShipments.pop();
+
         setFieldValue(`${accessor}.shipments`, newShipments);
-    }, [accessor, setFieldValue, shipments]);
+        shipmentFieldNames.forEach(field => {
+            setFieldTouched(
+                `${accessor}.shipments[${newShipments.length}].${field}`,
+                false,
+            );
+        });
+    }, [accessor, setFieldTouched, setFieldValue, shipments]);
 
     // determine whether to show delete button or not
 
@@ -60,7 +69,11 @@ export const ShipmentsForm: FunctionComponent<Props> = ({
                     // eslint-disable-next-line react/no-array-index-key
                     <Grid item xs={12} key={`shipment${index}`}>
                         <Box mt={2}>
-                            <ShipmentForm index={index} accessor={accessor} />
+                            <ShipmentForm
+                                index={index}
+                                accessor={accessor}
+                                roundIndex={roundIndex}
+                            />
                         </Box>
                     </Grid>
                 ))}

--- a/plugins/polio/js/src/forms/VaccineManagementForm.tsx
+++ b/plugins/polio/js/src/forms/VaccineManagementForm.tsx
@@ -19,6 +19,7 @@ import { ReportingDelays } from './ReportingDelays';
 import { RoundVaccinesForm } from './RoundVaccinesForm';
 import { DestructionsForm } from './DestructionsForm';
 import { FormAForm } from './FormAForm';
+import { Campaign } from '../constants/types';
 
 type Props = any;
 
@@ -39,7 +40,7 @@ export const VaccineManagementForm: FunctionComponent<Props> = () => {
     const { formatMessage } = useSafeIntl();
     const {
         values: { rounds = [] },
-    } = useFormikContext<any>(); // TODO add campaign typing
+    } = useFormikContext<Campaign>();
 
     const [currentIndex, setCurrentIndex] = useState<number>(0);
 
@@ -55,7 +56,6 @@ export const VaccineManagementForm: FunctionComponent<Props> = () => {
                     <Grid item>
                         <Box mb={2}>
                             <Tabs
-                                // value={currentRoundNumber}
                                 value={currentIndex}
                                 className={classes.subTabs}
                                 textColor="primary"
@@ -63,8 +63,7 @@ export const VaccineManagementForm: FunctionComponent<Props> = () => {
                             >
                                 {rounds.map((round, index) => (
                                     <Tab
-                                        // eslint-disable-next-line react/no-array-index-key
-                                        key={`${round.number}-${index}`}
+                                        key={`${round.number}-${round.id}`}
                                         className={classes.subTab}
                                         label={
                                             <span>
@@ -80,16 +79,7 @@ export const VaccineManagementForm: FunctionComponent<Props> = () => {
                     </Grid>
                 </Grid>
             )}
-            <Grid
-                key={currentIndex}
-                container
-                spacing={2}
-                // className={classnames(
-                //     round.number !== currentRoundNumber &&
-                //         customClasses.hiddenOpacity,
-                // )}
-            >
-                <Divider style={{ width: '100%' }} />
+            <Grid key={currentIndex} container spacing={2}>
                 {/* First row: vaccine */}
                 <Grid item xs={12}>
                     <Box mt={1} mb={1}>

--- a/plugins/polio/js/src/forms/VaccineManagementForm.tsx
+++ b/plugins/polio/js/src/forms/VaccineManagementForm.tsx
@@ -14,12 +14,12 @@ import classnames from 'classnames';
 import { useSafeIntl } from 'bluesquare-components';
 import { useStyles } from '../styles/theme';
 import MESSAGES from '../constants/messages';
-import { DateInput, TextInput } from '../components/Inputs';
+import { DateInput } from '../components/Inputs';
 import { ShipmentsForm } from './ShipmentsForm';
 import { ReportingDelays } from './ReportingDelays';
 import { RoundVaccinesForm } from './RoundVaccinesForm';
-import { MultilineText } from '../components/Inputs/MultilineText';
 import { DestructionsForm } from './DestructionsForm';
+import { FormAForm } from './FormAForm';
 
 type Props = any;
 
@@ -156,80 +156,7 @@ export const VaccineManagementForm: FunctionComponent<Props> = () => {
                                 </Typography>
                             </Box>
                         </Grid>
-                        <Grid
-                            container
-                            direction="row"
-                            item
-                            xs={12}
-                            spacing={2}
-                        >
-                            <Grid item lg={3} md={6}>
-                                <Field
-                                    label={formatMessage(
-                                        MESSAGES.formAReception,
-                                    )}
-                                    name={`${accessor}.forma_reception`}
-                                    component={DateInput}
-                                    className={classes.input}
-                                />
-                            </Grid>
-                            <Grid item lg={3} md={6}>
-                                <Field
-                                    label={formatMessage(
-                                        MESSAGES.formAUnusableVials,
-                                    )}
-                                    name={`${accessor}.forma_unusable_vials`}
-                                    component={TextInput}
-                                    className={classes.input}
-                                />
-                            </Grid>
-                            <Grid item lg={3} md={6}>
-                                <Field
-                                    label={formatMessage(
-                                        MESSAGES.formAMissingVials,
-                                    )}
-                                    name={`${accessor}.forma_missing_vials`}
-                                    component={TextInput}
-                                    className={classes.input}
-                                />
-                            </Grid>
-                            <Grid item lg={3} md={6}>
-                                <Field
-                                    label={formatMessage(
-                                        MESSAGES.formAUsableVials,
-                                    )}
-                                    name={`${accessor}.forma_usable_vials`}
-                                    component={TextInput}
-                                    className={classes.input}
-                                />
-                            </Grid>
-                        </Grid>
-                        <Grid
-                            container
-                            direction="row"
-                            item
-                            xs={12}
-                            spacing={2}
-                            justifyContent="flex-start"
-                        >
-                            <Grid item lg={3} md={6}>
-                                <Field
-                                    label={formatMessage(MESSAGES.formADate)}
-                                    name={`${accessor}.forma_date`}
-                                    component={DateInput}
-                                    className={classes.input}
-                                />
-                            </Grid>
-                            <Grid item lg={3} md={6}>
-                                <Field
-                                    label={formatMessage(MESSAGES.formAComment)}
-                                    name={`${accessor}.forma_comment`}
-                                    component={MultilineText}
-                                    className={classes.input}
-                                    debounceTime={1000}
-                                />
-                            </Grid>
-                        </Grid>
+                        <FormAForm accessor={accessor} roundIndex={index} />
 
                         {/* fourth row: destruction */}
                         <Divider className={customClasses.marginTop} />

--- a/plugins/polio/js/src/forms/VaccineManagementForm.tsx
+++ b/plugins/polio/js/src/forms/VaccineManagementForm.tsx
@@ -141,7 +141,11 @@ export const VaccineManagementForm: FunctionComponent<Props> = () => {
                             </Box>
                         </Grid>
                         <Grid container item xs={12}>
-                            <ShipmentsForm accessor={accessor} round={round} />
+                            <ShipmentsForm
+                                accessor={accessor}
+                                round={round}
+                                roundIndex={index}
+                            />
                         </Grid>
                         {/* third row: Form A */}
                         <Divider style={{ width: '100%' }} />
@@ -236,7 +240,11 @@ export const VaccineManagementForm: FunctionComponent<Props> = () => {
                                 </Typography>
                             </Box>
                         </Grid>
-                        <DestructionsForm accessor={accessor} round={round} />
+                        <DestructionsForm
+                            accessor={accessor}
+                            round={round}
+                            roundIndex={index}
+                        />
                     </Grid>
                 );
             })}

--- a/plugins/polio/js/src/forms/VaccineManagementForm.tsx
+++ b/plugins/polio/js/src/forms/VaccineManagementForm.tsx
@@ -9,7 +9,6 @@ import {
     Typography,
 } from '@material-ui/core';
 import { Field, useFormikContext } from 'formik';
-import classnames from 'classnames';
 // @ts-ignore
 import { useSafeIntl } from 'bluesquare-components';
 import { useStyles } from '../styles/theme';
@@ -42,16 +41,11 @@ export const VaccineManagementForm: FunctionComponent<Props> = () => {
         values: { rounds = [] },
     } = useFormikContext<any>(); // TODO add campaign typing
 
-    const [currentRoundNumber, setCurrentRoundNumber] = useState(
-        rounds.length > 0 ? rounds[0].number : undefined,
-    );
     const [currentIndex, setCurrentIndex] = useState<number>(0);
 
     const handleRoundTabChange = (_, newValue) => {
-        // setCurrentRoundNumber(newValue);
         setCurrentIndex(newValue);
     };
-    // console.log('render');
     const accessor = `rounds[${currentIndex}]`;
 
     return (
@@ -69,7 +63,8 @@ export const VaccineManagementForm: FunctionComponent<Props> = () => {
                             >
                                 {rounds.map((round, index) => (
                                     <Tab
-                                        key={round.number}
+                                        // eslint-disable-next-line react/no-array-index-key
+                                        key={`${round.number}-${index}`}
                                         className={classes.subTab}
                                         label={
                                             <span>
@@ -173,97 +168,6 @@ export const VaccineManagementForm: FunctionComponent<Props> = () => {
                     roundIndex={currentIndex}
                 />
             </Grid>
-            {/* {rounds.map((round, index) => {
-                const accessor = `rounds[${index}]`;
-                return (
-                    <Grid
-                        key={round.number}
-                        container
-                        spacing={2}
-                        className={classnames(
-                            round.number !== currentRoundNumber &&
-                                customClasses.hiddenOpacity,
-                        )}
-                    >
-                        <Divider style={{ width: '100%' }} />
-                        <Grid item xs={12}>
-                            <Box mt={1} mb={1}>
-                                <Typography variant="button">
-                                    {formatMessage(MESSAGES.vaccines)}
-                                </Typography>
-                            </Box>
-                        </Grid>
-                        <Grid
-                            container
-                            direction="row"
-                            item
-                            xs={12}
-                            spacing={2}
-                            justifyContent="center"
-                        >
-                            <Grid container item lg={6} md={12}>
-                                <RoundVaccinesForm
-                                    roundIndex={index}
-                                    round={round}
-                                />
-                            </Grid>
-                            <Grid item lg={3} md={6}>
-                                <Box mb={1}>
-                                    <ReportingDelays accessor={accessor} />
-                                </Box>
-                            </Grid>
-                            <Grid item lg={3} md={6}>
-                                <Field
-                                    label={formatMessage(
-                                        MESSAGES.dateSignedVrf,
-                                    )}
-                                    fullWidth
-                                    name={`${accessor}.date_signed_vrf_received`}
-                                    component={DateInput}
-                                />
-                            </Grid>
-                        </Grid>
-                        <Divider style={{ width: '100%' }} />
-                        <Grid item xs={12}>
-                            <Box mt={1} mb={1}>
-                                <Typography variant="button">
-                                    {formatMessage(MESSAGES.shipments)}
-                                </Typography>
-                            </Box>
-                        </Grid>
-                        <Grid container item xs={12}>
-                            <ShipmentsForm
-                                accessor={accessor}
-                                round={round}
-                                roundIndex={index}
-                            />
-                        </Grid>
-                        <Divider style={{ width: '100%' }} />
-                        <Grid item xs={12}>
-                            <Box mt={1} mb={1}>
-                                <Typography variant="button">
-                                    {formatMessage(MESSAGES.formA)}
-                                </Typography>
-                            </Box>
-                        </Grid>
-                        <FormAForm accessor={accessor} roundIndex={index} />
-
-                        <Divider className={customClasses.marginTop} />
-                        <Grid item xs={12}>
-                            <Box mt={1} mb={1}>
-                                <Typography variant="button">
-                                    {formatMessage(MESSAGES.destruction)}
-                                </Typography>
-                            </Box>
-                        </Grid>
-                        <DestructionsForm
-                            accessor={accessor}
-                            round={round}
-                            roundIndex={index}
-                        />
-                    </Grid>
-                );
-            })} */}
         </>
     );
 };

--- a/plugins/polio/js/src/forms/VaccineManagementForm.tsx
+++ b/plugins/polio/js/src/forms/VaccineManagementForm.tsx
@@ -45,10 +45,14 @@ export const VaccineManagementForm: FunctionComponent<Props> = () => {
     const [currentRoundNumber, setCurrentRoundNumber] = useState(
         rounds.length > 0 ? rounds[0].number : undefined,
     );
+    const [currentIndex, setCurrentIndex] = useState<number>(0);
 
     const handleRoundTabChange = (_, newValue) => {
-        setCurrentRoundNumber(newValue);
+        // setCurrentRoundNumber(newValue);
+        setCurrentIndex(newValue);
     };
+    // console.log('render');
+    const accessor = `rounds[${currentIndex}]`;
 
     return (
         <>
@@ -57,12 +61,13 @@ export const VaccineManagementForm: FunctionComponent<Props> = () => {
                     <Grid item>
                         <Box mb={2}>
                             <Tabs
-                                value={currentRoundNumber}
+                                // value={currentRoundNumber}
+                                value={currentIndex}
                                 className={classes.subTabs}
                                 textColor="primary"
                                 onChange={handleRoundTabChange}
                             >
-                                {rounds.map(round => (
+                                {rounds.map((round, index) => (
                                     <Tab
                                         key={round.number}
                                         className={classes.subTab}
@@ -72,7 +77,7 @@ export const VaccineManagementForm: FunctionComponent<Props> = () => {
                                                 {round.number}
                                             </span>
                                         }
-                                        value={round.number}
+                                        value={index}
                                     />
                                 ))}
                             </Tabs>
@@ -80,7 +85,95 @@ export const VaccineManagementForm: FunctionComponent<Props> = () => {
                     </Grid>
                 </Grid>
             )}
-            {rounds.map((round, index) => {
+            <Grid
+                key={currentIndex}
+                container
+                spacing={2}
+                // className={classnames(
+                //     round.number !== currentRoundNumber &&
+                //         customClasses.hiddenOpacity,
+                // )}
+            >
+                <Divider style={{ width: '100%' }} />
+                {/* First row: vaccine */}
+                <Grid item xs={12}>
+                    <Box mt={1} mb={1}>
+                        <Typography variant="button">
+                            {formatMessage(MESSAGES.vaccines)}
+                        </Typography>
+                    </Box>
+                </Grid>
+                <Grid
+                    container
+                    direction="row"
+                    item
+                    xs={12}
+                    spacing={2}
+                    justifyContent="center"
+                >
+                    <Grid container item lg={6} md={12}>
+                        <RoundVaccinesForm
+                            roundIndex={currentIndex}
+                            round={rounds[currentIndex]}
+                        />
+                    </Grid>
+                    <Grid item lg={3} md={6}>
+                        <Box mb={1}>
+                            <ReportingDelays accessor={accessor} />
+                        </Box>
+                    </Grid>
+                    <Grid item lg={3} md={6}>
+                        <Field
+                            label={formatMessage(MESSAGES.dateSignedVrf)}
+                            fullWidth
+                            name={`${accessor}.date_signed_vrf_received`}
+                            component={DateInput}
+                        />
+                    </Grid>
+                </Grid>
+                {/* second row: shipments */}
+                <Divider style={{ width: '100%' }} />
+                <Grid item xs={12}>
+                    <Box mt={1} mb={1}>
+                        <Typography variant="button">
+                            {formatMessage(MESSAGES.shipments)}
+                        </Typography>
+                    </Box>
+                </Grid>
+                <Grid container item xs={12}>
+                    <ShipmentsForm
+                        accessor={accessor}
+                        round={rounds[currentIndex]}
+                        roundIndex={currentIndex}
+                    />
+                </Grid>
+                {/* third row: Form A */}
+                <Divider style={{ width: '100%' }} />
+                <Grid item xs={12}>
+                    <Box mt={1} mb={1}>
+                        <Typography variant="button">
+                            {formatMessage(MESSAGES.formA)}
+                        </Typography>
+                    </Box>
+                </Grid>
+                <FormAForm accessor={accessor} roundIndex={currentIndex} />
+
+                {/* fourth row: destruction */}
+                <Divider className={customClasses.marginTop} />
+                <Grid item xs={12}>
+                    <Box mt={1} mb={1}>
+                        <Typography variant="button">
+                            {formatMessage(MESSAGES.destruction)}
+                        </Typography>
+                    </Box>
+                </Grid>
+                <DestructionsForm
+                    accessor={accessor}
+                    round={rounds[currentIndex]}
+                    roundIndex={currentIndex}
+                />
+            </Grid>
+            {/* {rounds.map((round, index) => {
                 const accessor = `rounds[${index}]`;
                 return (
                     <Grid
@@ -93,7 +186,6 @@ export const VaccineManagementForm: FunctionComponent<Props> = () => {
                         )}
                     >
                         <Divider style={{ width: '100%' }} />
-                        {/* First row: vaccine */}
                         <Grid item xs={12}>
                             <Box mt={1} mb={1}>
                                 <Typography variant="button">
@@ -131,7 +223,6 @@ export const VaccineManagementForm: FunctionComponent<Props> = () => {
                                 />
                             </Grid>
                         </Grid>
-                        {/* second row: shipments */}
                         <Divider style={{ width: '100%' }} />
                         <Grid item xs={12}>
                             <Box mt={1} mb={1}>
@@ -147,7 +238,6 @@ export const VaccineManagementForm: FunctionComponent<Props> = () => {
                                 roundIndex={index}
                             />
                         </Grid>
-                        {/* third row: Form A */}
                         <Divider style={{ width: '100%' }} />
                         <Grid item xs={12}>
                             <Box mt={1} mb={1}>
@@ -158,7 +248,6 @@ export const VaccineManagementForm: FunctionComponent<Props> = () => {
                         </Grid>
                         <FormAForm accessor={accessor} roundIndex={index} />
 
-                        {/* fourth row: destruction */}
                         <Divider className={customClasses.marginTop} />
                         <Grid item xs={12}>
                             <Box mt={1} mb={1}>
@@ -174,7 +263,7 @@ export const VaccineManagementForm: FunctionComponent<Props> = () => {
                         />
                     </Grid>
                 );
-            })}
+            })} */}
         </>
     );
 };

--- a/plugins/polio/js/src/hooks/useFormValidator.js
+++ b/plugins/polio/js/src/hooks/useFormValidator.js
@@ -166,12 +166,14 @@ yup.addMethod(
             } = parent;
             if (
                 !value &&
-                (vaccine_name ||
-                    po_numbers ||
-                    vials_received ||
-                    reception_pre_alert ||
-                    estimated_arrival_date ||
-                    date_reception)
+                !(
+                    vaccine_name &&
+                    po_numbers &&
+                    vials_received &&
+                    reception_pre_alert &&
+                    estimated_arrival_date &&
+                    date_reception
+                )
             ) {
                 return createError({
                     path,
@@ -199,12 +201,14 @@ yup.addMethod(
             if (
                 !value &&
                 value !== 0 &&
-                (vaccine_name ||
-                    po_numbers ||
-                    vials_received ||
-                    reception_pre_alert ||
-                    estimated_arrival_date ||
-                    date_reception)
+                !(
+                    vaccine_name &&
+                    po_numbers &&
+                    vials_received &&
+                    reception_pre_alert &&
+                    estimated_arrival_date &&
+                    date_reception
+                )
             ) {
                 return createError({
                     path,
@@ -226,7 +230,7 @@ yup.addMethod(
                 parent;
             if (
                 !value &&
-                (date_report || vials_destroyed || date_report_received)
+                !(date_report && vials_destroyed && date_report_received)
             ) {
                 return createError({
                     path,
@@ -251,7 +255,7 @@ yup.addMethod(
                 if (
                     !value &&
                     value !== 0 &&
-                    (date_report || vials_destroyed || date_report_received)
+                    !(date_report && vials_destroyed && date_report_received)
                 ) {
                     return createError({
                         path,
@@ -282,12 +286,14 @@ yup.addMethod(
             } = parent;
             if (
                 !value &&
-                (vaccine_name ||
-                    po_numbers ||
-                    vials_received ||
-                    reception_pre_alert ||
-                    estimated_arrival_date ||
-                    date_reception)
+                !(
+                    vaccine_name &&
+                    po_numbers &&
+                    vials_received &&
+                    reception_pre_alert &&
+                    estimated_arrival_date &&
+                    date_reception
+                )
             ) {
                 return createError({
                     path,

--- a/plugins/polio/js/src/hooks/useFormValidator.js
+++ b/plugins/polio/js/src/hooks/useFormValidator.js
@@ -105,6 +105,17 @@ yup.addMethod(
             if (
                 !value &&
                 value !== 0 &&
+                !forma_unusable_vials &&
+                !forma_usable_vials &&
+                !forma_missing_vials &&
+                !forma_reception &&
+                !forma_date
+            ) {
+                return true;
+            }
+            if (
+                !value &&
+                value !== 0 &&
                 !(
                     forma_unusable_vials &&
                     forma_usable_vials &&
@@ -135,6 +146,16 @@ yup.addMethod(
                 forma_unusable_vials,
                 forma_date,
             } = parent;
+            if (
+                !value &&
+                !forma_unusable_vials &&
+                !forma_usable_vials &&
+                !forma_missing_vials &&
+                !forma_reception &&
+                !forma_date
+            ) {
+                return true;
+            }
             if (
                 !value &&
                 !(

--- a/plugins/polio/js/src/hooks/useFormValidator.js
+++ b/plugins/polio/js/src/hooks/useFormValidator.js
@@ -105,11 +105,13 @@ yup.addMethod(
             if (
                 !value &&
                 value !== 0 &&
-                (forma_unusable_vials ||
-                    forma_usable_vials ||
-                    forma_missing_vials ||
-                    forma_reception ||
-                    forma_date)
+                !(
+                    forma_unusable_vials &&
+                    forma_usable_vials &&
+                    forma_missing_vials &&
+                    forma_reception &&
+                    forma_date
+                )
             ) {
                 return createError({
                     path,
@@ -135,11 +137,13 @@ yup.addMethod(
             } = parent;
             if (
                 !value &&
-                (forma_unusable_vials ||
-                    forma_usable_vials ||
-                    forma_missing_vials ||
-                    forma_reception ||
-                    forma_date)
+                !(
+                    forma_unusable_vials &&
+                    forma_usable_vials &&
+                    forma_missing_vials &&
+                    forma_reception &&
+                    forma_date
+                )
             ) {
                 return createError({
                     path,

--- a/plugins/polio/js/src/hooks/useFormValidator.js
+++ b/plugins/polio/js/src/hooks/useFormValidator.js
@@ -396,7 +396,10 @@ const useDestructionShape = () => {
 const useVaccineShape = () => {
     const { formatMessage } = useSafeIntl();
     return yup.object().shape({
-        name: yup.string().trim().required(), // TODO restrict string value to vaccines
+        name: yup
+            .string()
+            .trim()
+            .required(formatMessage(MESSAGES.fieldRequired)), // TODO restrict string value to vaccines
         wastage_ratio_forecast: yup
             .number()
             .nullable()


### PR DESCRIPTION
In the vaccine managment tab, saving with an empty Shipment or Destruction would return a 400 and crash the page. Fixing this required fixing some other issues, so there's been some scope creep here

## Self proof reading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [X] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests

## Changes

- Change the validation in `useFormValidator` so that empty `Destruction` and  `Shipment` will block form save
- Improved validation for `Destruction`, `FormA` and `Shipment`. All empty fields will error if one field has a value, thus showing that all fields have to be filled out together (bar `comments`).  `FormA` is a special case since the form itself can't be deleted, as shipments and destrcutions can, so there's some custom code to handle that as well (mainly making sure the payload sent to the back end is correct).
- Add `SingleSelect` input component for better error management (will not be errored by default)
- Add `DebouncedTextInput` to replace `TextInput` in the Vaccine tab to avoid input lag
- Refactor `VaccineManagementForm` to avoid looping through all rounds and improve performance
- Add `disabled `prop`to `TextArea`
- Prevent commenting Form A , destruction, shipment if all mandatory fields are not filled by disabling the input



## How to test

Go to polio campaigns. try editing the vaccine management in a campaign, then try creating a new campaign with vaccine management data.

## Print screen / video

https://user-images.githubusercontent.com/38907762/206246485-75d062dd-a807-4cc2-b2b7-107b2903e2b3.mov

## Note

- I used `DebouncedInput` i.o. updating the existing (custom) `TextInput` of polio because adding the debounce is messing with the validation: since mandatory empty fields are in error, but we only show the error when the field has been `touched`, adding a debounce was messing with  that because of its reliance on `useEffect`. 
Since we plan to refactor the whole form and its API anyway, it seemed more work than was worth.

- TextArea should be updated to:
    - Disable onFocus styling when disabled
    - Be able to receive a helper text (use case: explain the user why the field is disabled)
   I didn't add it to limit scope creep

