### PR TITLE
IA-1751 Enketo couldn't edit some form because of duplicate uuid

### DIFF
--- a/iaso/api/enketo.py
+++ b/iaso/api/enketo.py
@@ -255,7 +255,7 @@ def enketo_form_list(request):
 
     Require a param `formID` which is actually an Instance UUID"""
     form_id_str = request.GET["formID"]
-    i = Instance.objects.exclude(deleted=True).get(uuid=form_id_str)
+    i = Instance.objects.exclude(deleted=True).filter(uuid=form_id_str).order_by("updated_at").last()
     latest_form_version = i.form.latest_version
     # will it work through s3, what about "signing" infos if they expires ?
     downloadurl = public_url_for_enketo(request, "/api/enketo/formDownload/?uuid=%s" % i.uuid)
@@ -283,7 +283,7 @@ def enketo_form_download(request):
     We insert the instance.id In the form definition so the "Form" is unique per instance.
     """
     uuid = request.GET.get("uuid")
-    i = Instance.objects.get(uuid=uuid)
+    i = Instance.objects.filter(uuid=uuid).order_by("updated_at").last()
     xml_string = i.form.latest_version.file.read().decode("utf-8")
     injected_xml = inject_instance_id_in_form(xml_string, i.id)
     return HttpResponse(injected_xml, content_type="application/xml")


### PR DESCRIPTION
When there are two submission with the same uuid we couldn't edit it in enketo

## Changes

Now when there is multiple submission we take the last edited one.
Note that when editing from iaso web we use the uuid to communicate and not the instance id so if the user pick a particular instance to edit another may be edited. Not much we can do without changing the whole logic (which we probably should do). I still don't have any idea how this problem appear in the first place.

## How to test

Duplicate an Instance with the same uuid.
For example In the python shell
```

In [1]: '1ffaafbb-1e76-44f6-85ec-68a9fb220a1b'
Out[1]: '1ffaafbb-1e76-44f6-85ec-68a9fb220a1b'

In [2]: Instance.objects.get(uuid=_1)
Out[2]: <Instance: meh Form-rapide  None>

In [3]: e=Instance.objects.get(uuid=_1)

In [4]: e.id
Out[4]: 44
In [6]: e.id=None

In [7]: e.save()

In [8]: e.id
Out[8]: 53
```
But I'm guessing in can be done in the admin too.

then start Iaso locally with enketo in (see the section in the readme).
And try to edit the submission.
