### PR TITLE
IA-1682: Added parent_org_unit_id filter to completeness stats API

### DIFF
--- a/iaso/api/completeness_stats.py
+++ b/iaso/api/completeness_stats.py
@@ -35,22 +35,27 @@ class CompletenessStatsViewSet(viewsets.ViewSet):
 
     def list(self, request):
         order = request.GET.get("order", "name").split(",")
-        org_unit_type_str = request.query_params.get("org_unit_type_id", None)
+        requested_org_unit_type_str = request.query_params.get("org_unit_type_id", None)
 
         requested_forms_str = request.query_params.get("form_id", None)
         requested_form_ids = requested_forms_str.split(",") if requested_forms_str is not None else []
 
-        if org_unit_type_str is not None:
-            org_unit_types = OrgUnitType.objects.filter(id__in=org_unit_type_str.split(","))
+        if requested_org_unit_type_str is not None:
+            org_unit_types = OrgUnitType.objects.filter(id__in=requested_org_unit_type_str.split(","))
         else:
             org_unit_types = None
 
         requested_org_unit_id_str = request.GET.get("org_unit_id", None)
-
         if requested_org_unit_id_str is not None:
             requested_org_unit = OrgUnit.objects.get(id=requested_org_unit_id_str)
         else:
             requested_org_unit = None
+
+        requested_parent_org_unit_id_str = request.GET.get("parent_org_unit_id", None)
+        if requested_parent_org_unit_id_str is not None:
+            requested_parent_org_unit = OrgUnit.objects.get(id=requested_parent_org_unit_id_str)
+        else:
+            requested_parent_org_unit = None
 
         profile = request.user.iaso_profile
 
@@ -65,8 +70,14 @@ class CompletenessStatsViewSet(viewsets.ViewSet):
         org_units = OrgUnit.objects.filter(version=version).filter(
             validation_status="VALID"
         )  # don't forget to think about org unit status
+
+        # Filtering per org unit: we drop the rows that don't match the requested org_unit
         if requested_org_unit:
             org_units = org_units.hierarchy(requested_org_unit)
+
+        # Filtering per parent org unit: we drop the rows that are not direct children of the requested parent org unit
+        if requested_parent_org_unit:
+            org_units = org_units.filter(parent=requested_parent_org_unit)
 
         top_ous = org_units
 

--- a/iaso/tests/api/test_completeness_stats.py
+++ b/iaso/tests/api/test_completeness_stats.py
@@ -186,7 +186,7 @@ class CompletenessStatsAPITestCase(APITestCase):
         json = response.json()
         # All the rows we get are direct children of the Country (region A and B)
         for result in json["results"]:
-            self.assertEqual(result["parent_org_unit"]["id"], 1)
+            self.assertEqual(result["parent_org_unit"][0]["id"], 1)
 
     def test_pagination(self):
         self.client.force_authenticate(self.user)

--- a/iaso/tests/api/test_completeness_stats.py
+++ b/iaso/tests/api/test_completeness_stats.py
@@ -179,6 +179,15 @@ class CompletenessStatsAPITestCase(APITestCase):
         for result in json["results"]:
             self.assertEqual(result["org_unit"]["id"], 7)
 
+    def test_filter_by_parent_org_unit(self):
+        self.client.force_authenticate(self.user)
+
+        response = self.client.get(f"/api/completeness_stats/?parent_org_unit_id=1")
+        json = response.json()
+        # All the rows we get are direct children of the Country (region A and B)
+        for result in json["results"]:
+            self.assertEqual(result["parent_org_unit"]["id"], 1)
+
     def test_pagination(self):
         self.client.force_authenticate(self.user)
 


### PR DESCRIPTION
Completeness stats API: add a filter allowing to filter data based on the parent org unit. This is not used by the frontend yet, but will soon be.

## Self proof reading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are there enough tests


## How to test

1) Go to /api/completeness_stats/?parent_org_unit_id=<SOME_ORG_UNIT_ID>
2) Make sure all the result returned all concerned org units that are direct children of OU with id=<SOME_ORG_UNIT_ID>
3) Make sure the completeness table still works as before

