### PR TITLE
Ia 1741 missing translation

### DIFF
--- a/hat/assets/js/apps/Iaso/constants/filters.js
+++ b/hat/assets/js/apps/Iaso/constants/filters.js
@@ -638,7 +638,6 @@ export const linksFilters = props => {
         fetchingAlgorithms,
         fetchingSources,
     } = props;
-    console.log('OUTYPES', orgUnitTypes);
     const filters = [
         {
             ...search(),

--- a/hat/assets/js/apps/Iaso/constants/filters.js
+++ b/hat/assets/js/apps/Iaso/constants/filters.js
@@ -432,7 +432,10 @@ export const orgUnitFilters = (
             column: 1,
         },
         {
-            ...orgUnitType({ orgUnitTypes }),
+            ...orgUnitType({
+                orgUnitTypes,
+                labelString: formatMessage(MESSAGES.orgUnitsTypes),
+            }),
             column: 1,
         },
         {

--- a/hat/assets/js/apps/Iaso/constants/filters.js
+++ b/hat/assets/js/apps/Iaso/constants/filters.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { getParamsKey } from 'bluesquare-components';
 import MESSAGES from '../domains/forms/messages';
 import FullStarsSvg from '../components/stars/FullStarsSvgComponent';
-import getDisplayName from '../utils/usersUtils';
+import getDisplayName from '../utils/usersUtils.ts';
 import { usePrettyPeriod } from '../domains/periods/utils';
 import { orgUnitLabelString } from '../domains/orgUnits/utils';
 import { capitalize } from '../utils/index';
@@ -111,23 +111,25 @@ export const orgUnitLevel = (
     value,
 });
 
-export const orgUnitType = (
-    orgunitTypesList,
+export const orgUnitType = ({
+    orgUnitTypes,
     urlKey = 'orgUnitTypeId',
     labelString = '',
     label = MESSAGES.org_unit_type_id,
-) => ({
-    urlKey,
-    isMultiSelect: true,
-    isClearable: true,
-    options: orgunitTypesList.map(t => ({
-        label: t.name,
-        value: t.id,
-    })),
-    label: labelString !== '' ? null : label,
-    type: 'select',
-    labelString,
-});
+}) => {
+    return {
+        urlKey,
+        isMultiSelect: true,
+        isClearable: true,
+        options: orgUnitTypes.map(t => ({
+            label: t.name,
+            value: t.id,
+        })),
+        label: labelString !== '' ? null : label,
+        type: 'select',
+        labelString,
+    };
+};
 
 const renderColoredOption = item => (
     <div>
@@ -430,7 +432,7 @@ export const orgUnitFilters = (
             column: 1,
         },
         {
-            ...orgUnitType(orgUnitTypes),
+            ...orgUnitType({ orgUnitTypes }),
             column: 1,
         },
         {
@@ -636,6 +638,7 @@ export const linksFilters = props => {
         fetchingAlgorithms,
         fetchingSources,
     } = props;
+    console.log('OUTYPES', orgUnitTypes);
     const filters = [
         {
             ...search(),
@@ -647,7 +650,10 @@ export const linksFilters = props => {
             column: 1,
         },
         {
-            ...orgUnitType(orgUnitTypes),
+            ...orgUnitType({
+                orgUnitTypes,
+                labelString: formatMessage(MESSAGES.org_unit_type_id),
+            }),
             loading: fetchingOrgUnitTypes,
             column: 1,
         },


### PR DESCRIPTION
There was no label for the org unit type filter at `/dashboard/orgunits/sources/links/list`

## Self proof reading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [NA] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests
## Changes

- Passed a `labelString` to the filter since the `label` prop didn't seem to function as expected


## How to test

Go to the page, see if the label is there

## Print screen / video

![Screenshot 2022-12-12 at 16 47 47](https://user-images.githubusercontent.com/38907762/207090428-bc19db1d-74f0-4dac-ade0-873dfc5db0bc.png)


## Notes

Things that the reviewers should know: known bugs that are out of the scope of the PR, other trade-offs that were made.
If the PR depends on a PR in bluesquare-components, or merges into another PR (i.o. main), it should also be mentioned he
