### PR TITLE
POLIO-727: remove console error

### DIFF
--- a/plugins/polio/js/src/pages/Budget/BudgetDetails/BudgetTimeline.tsx
+++ b/plugins/polio/js/src/pages/Budget/BudgetDetails/BudgetTimeline.tsx
@@ -1,12 +1,11 @@
 import { Box, makeStyles, Divider } from '@material-ui/core';
-import React, { FunctionComponent, useState, useEffect, useMemo } from 'react';
+import React, { FunctionComponent, useMemo } from 'react';
 import classnames from 'classnames';
 import Stepper from '@material-ui/core/Stepper';
 import Step from '@material-ui/core/Step';
 import StepLabel from '@material-ui/core/StepLabel';
 import { CheckCircleOutline } from '@material-ui/icons';
 import moment from 'moment';
-import { findLastIndex } from 'lodash';
 import { Categories } from '../types';
 
 type Props = {

--- a/plugins/polio/js/src/pages/Budget/MultipleLinks/NamedLink.tsx
+++ b/plugins/polio/js/src/pages/Budget/MultipleLinks/NamedLink.tsx
@@ -77,13 +77,13 @@ export const NamedLink: FunctionComponent<Props> = ({ index }) => {
                 </Grid>
                 {/* IconButton from blsq-comp with url prop doesn't seem to work, so we're using the one from Material UI instead (cf Preparedness) */}
                 <Grid item xs={6}>
+                    {/* TS complains about target and href props which are passed by IconButton to its rroot element (BaseButton) */}
+                    {/* @ts-ignore */}
                     <IconButton
                         target="_blank"
                         variant="outlined"
-                        // @ts-ignore
                         href={links?.[index]?.url ?? ''}
-                        // @ts-ignore
-                        color="action"
+                        color="default"
                         disabled={!links?.[index]?.url}
                     >
                         <OpenInNewIcon />


### PR DESCRIPTION
The link component of CreateBudgetStep was giving PropTypes error in the console, though it worked without problem

## Self proof reading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests
## Changes

- Changed the `color` prop value to `"default"`
- Cleanup some unused imports


## How to test

Go to polio> Budgets, try to create a step. Nothing should have changed. Check the console: it should be empty


