### PR TITLE
IA-1757: remove depth constraint on Org Unit Type fiter

### DIFF
--- a/hat/assets/js/apps/Iaso/constants/routes.js
+++ b/hat/assets/js/apps/Iaso/constants/routes.js
@@ -480,6 +480,10 @@ export const completenessStatsPath = {
         },
         {
             isRequired: false,
+            key: 'parentId',
+        },
+        {
+            isRequired: false,
             key: 'formId',
         },
         {

--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -40,7 +40,6 @@
     "iaso.completeness.title": "Completeness",
     "iaso.completeness.titleDescendants": "Completeness (with descendants)",
     "iaso.completeness.titleDirect": "Completeness (direct)",
-    "iaso.completeness.tooMuchDepth": "Too much depth between parent and type",
     "iaso.completenessStats.title": "Completeness stats",
     "iaso.datasources.addAskTitle": "{title} - Source: {source} - Version: {version}",
     "iaso.datasources.button.label.copy": "Copy",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -455,7 +455,7 @@
     "iaso.label.others": "Others",
     "iaso.label.pages": "Pages",
     "iaso.label.parent": "Parent",
-    "iaso.label.parentOu": "Parent org Unit",
+    "iaso.label.parentOu": "Parent org unit",
     "iaso.label.periods": "Periods",
     "iaso.label.periodsAfterAllowed": "Periods after",
     "iaso.label.periodsBeforeAllowed": "Periods before",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -41,7 +41,6 @@
     "iaso.completeness.title": "Complétude des données",
     "iaso.completeness.titleDirect": "Complétude des données (direct)",
     "iaso.completeness.titleWithDescendants": "Complétude des données (avec niv. inf.)",
-    "iaso.completeness.tooMuchDepth": "La différence de niveau entre le parent et le type est trop grande",
     "iaso.completenessStats.title": "Statistiques de complétude",
     "iaso.datasources.addAskTitle": "{title} - Source: {source} - Version: {version}",
     "iaso.datasources.button.label.copy": "Copier",

--- a/hat/assets/js/apps/Iaso/domains/completenessStats/CompletenessStatsFilters.tsx
+++ b/hat/assets/js/apps/Iaso/domains/completenessStats/CompletenessStatsFilters.tsx
@@ -1,13 +1,5 @@
 import { Box, Grid, useTheme, useMediaQuery } from '@material-ui/core';
-import React, {
-    FunctionComponent,
-    useCallback,
-    useEffect,
-    useMemo,
-    useState,
-} from 'react';
-// @ts-ignore
-import { useSafeIntl } from 'bluesquare-components';
+import React, { FunctionComponent, useCallback, useState } from 'react';
 import { FilterButton } from '../../components/FilterButton';
 import InputComponent from '../../components/forms/InputComponent';
 import { baseUrls } from '../../constants/urls';
@@ -18,19 +10,16 @@ import { useGetOrgUnit } from '../orgUnits/components/TreeView/requests';
 import { useGetFormsOptions } from './hooks/api/useGetFormsOptions';
 import { useGetOrgUnitTypesOptions } from './hooks/api/useGetOrgUnitTypesOptions';
 import MESSAGES from './messages';
-import { commaSeparatedIdsToStringArray } from '../../utils/forms';
 
 type Props = {
     params: UrlParams & any;
 };
 
-const REASONABLE_DEPTH = 2;
 const baseUrl = baseUrls.completenessStats;
 
 export const CompletenessStatsFilters: FunctionComponent<Props> = ({
     params,
 }) => {
-    const { formatMessage } = useSafeIntl();
     const { data: forms, isFetching: fetchingForms } = useGetFormsOptions();
     const { data: orgUnitTypes, isFetching: fetchingTypes } =
         useGetOrgUnitTypesOptions();
@@ -40,56 +29,22 @@ export const CompletenessStatsFilters: FunctionComponent<Props> = ({
 
     const { data: initialOrgUnit } = useGetOrgUnit(initialOrgUnitId);
 
-    const [selectedOrgUnit, setSelectedOrgUnit] = useState(initialOrgUnit);
-    const selectedOrgUnitDepth =
-        (orgUnitTypes ?? []).find(
-            ouType => ouType.original.id === selectedOrgUnit?.org_unit_type_id,
-        )?.original.depth ?? 0;
-
-    const selectedOrgUnitTypeMaxDepth = useMemo(
-        () =>
-            commaSeparatedIdsToStringArray(filters.orgUnitTypeIds)
-                .map(ouTypeId =>
-                    (orgUnitTypes ?? []).find(
-                        ouType => ouType.original.id === parseInt(ouTypeId, 10),
-                    ),
-                )
-                .map(ouType => ouType?.original?.depth ?? 0)
-                // If the array is empty, we return the same depth as the orgUnit, to avoid showing an error
-                .sort((a, b) => b - a)[0] ?? selectedOrgUnitDepth,
-        [filters.orgUnitTypeIds, orgUnitTypes, selectedOrgUnitDepth],
-    );
-
     const handleOrgUnitChange = useCallback(
         orgUnit => {
             const id = orgUnit ? [orgUnit.id] : undefined;
             setInitialOrgUnitId(id);
-            setSelectedOrgUnit(orgUnit);
+            // setSelectedOrgUnit(orgUnit);
             handleChange('orgUnitId', id);
         },
         [handleChange],
     );
-    const isReasonableDepth =
-        Math.abs(selectedOrgUnitTypeMaxDepth - selectedOrgUnitDepth) <
-        REASONABLE_DEPTH;
-
-    const isOrgUnitTypeDisabled = !filters.orgUnitId;
-
-    const showError = !isOrgUnitTypeDisabled && !isReasonableDepth;
 
     const theme = useTheme();
     const isLargeLayout = useMediaQuery(theme.breakpoints.up('md'));
 
-    useEffect(() => {
-        if (isOrgUnitTypeDisabled && filters.orgUnitTypeIds) {
-            handleChange('orgUnitTypeIds', undefined);
-        }
-    }, [filters.orgUnitTypeIds, handleChange, isOrgUnitTypeDisabled]);
-
     return (
         <>
             <Grid container spacing={2}>
-                {/* select forms. Multiselect */}
                 <Grid item xs={12} md={3}>
                     <InputComponent
                         type="select"
@@ -102,7 +57,6 @@ export const CompletenessStatsFilters: FunctionComponent<Props> = ({
                         options={forms ?? []}
                     />
                 </Grid>
-                {/* select parent. Treeview modal */}
                 <Grid item xs={12} md={3}>
                     <Box id="ou-tree-input">
                         <OrgUnitTreeviewModal
@@ -113,7 +67,6 @@ export const CompletenessStatsFilters: FunctionComponent<Props> = ({
                         />
                     </Box>
                 </Grid>
-                {/* select org unit types. Multiselect */}
                 <Grid item xs={12} md={3}>
                     <InputComponent
                         type="select"
@@ -124,17 +77,6 @@ export const CompletenessStatsFilters: FunctionComponent<Props> = ({
                         value={filters.orgUnitTypeIds}
                         loading={fetchingTypes}
                         options={orgUnitTypes ?? []}
-                        disabled={isOrgUnitTypeDisabled}
-                        helperText={
-                            isOrgUnitTypeDisabled
-                                ? formatMessage(MESSAGES.chooseParent)
-                                : undefined
-                        }
-                        errors={
-                            showError
-                                ? [formatMessage(MESSAGES.tooMuchDepth)]
-                                : []
-                        }
                     />
                 </Grid>
                 <Grid
@@ -145,7 +87,7 @@ export const CompletenessStatsFilters: FunctionComponent<Props> = ({
                 >
                     <Box mt={isLargeLayout ? 2 : 0}>
                         <FilterButton
-                            disabled={!filtersUpdated || !isReasonableDepth}
+                            disabled={!filtersUpdated}
                             onFilter={handleSearch}
                         />
                     </Box>

--- a/hat/assets/js/apps/Iaso/domains/completenessStats/CompletenessStatsFilters.tsx
+++ b/hat/assets/js/apps/Iaso/domains/completenessStats/CompletenessStatsFilters.tsx
@@ -25,16 +25,26 @@ export const CompletenessStatsFilters: FunctionComponent<Props> = ({
         useGetOrgUnitTypesOptions();
     const { filters, handleSearch, handleChange, filtersUpdated } =
         useFilterState({ baseUrl, params });
-    const [initialOrgUnitId, setInitialOrgUnitId] = useState(params?.orgUnitId);
 
+    const [initialOrgUnitId, setInitialOrgUnitId] = useState(params?.orgUnitId);
     const { data: initialOrgUnit } = useGetOrgUnit(initialOrgUnitId);
+
+    const [initialParentId, setInitialParentId] = useState(params?.parentId);
+    const { data: initialParent } = useGetOrgUnit(initialParentId);
 
     const handleOrgUnitChange = useCallback(
         orgUnit => {
             const id = orgUnit ? [orgUnit.id] : undefined;
             setInitialOrgUnitId(id);
-            // setSelectedOrgUnit(orgUnit);
             handleChange('orgUnitId', id);
+        },
+        [handleChange],
+    );
+    const handleParentChange = useCallback(
+        orgUnit => {
+            const id = orgUnit ? [orgUnit.id] : undefined;
+            setInitialParentId(id);
+            handleChange('parentId', id);
         },
         [handleChange],
     );
@@ -56,8 +66,6 @@ export const CompletenessStatsFilters: FunctionComponent<Props> = ({
                         loading={fetchingForms}
                         options={forms ?? []}
                     />
-                </Grid>
-                <Grid item xs={12} md={3}>
                     <Box id="ou-tree-input">
                         <OrgUnitTreeviewModal
                             toggleOnLabelClick={false}
@@ -68,6 +76,14 @@ export const CompletenessStatsFilters: FunctionComponent<Props> = ({
                     </Box>
                 </Grid>
                 <Grid item xs={12} md={3}>
+                    <Box id="ou-tree-input-parent">
+                        <OrgUnitTreeviewModal
+                            toggleOnLabelClick={false}
+                            titleMessage={MESSAGES.parent}
+                            onConfirm={handleParentChange}
+                            initialSelection={initialParent}
+                        />
+                    </Box>
                     <InputComponent
                         type="select"
                         multi
@@ -82,7 +98,7 @@ export const CompletenessStatsFilters: FunctionComponent<Props> = ({
                 <Grid
                     container
                     item
-                    xs={isLargeLayout ? 3 : 12}
+                    xs={isLargeLayout ? 6 : 12}
                     justifyContent="flex-end"
                 >
                     <Box mt={isLargeLayout ? 2 : 0}>

--- a/hat/assets/js/apps/Iaso/domains/completenessStats/hooks/api/useGetCompletnessStats.ts
+++ b/hat/assets/js/apps/Iaso/domains/completenessStats/hooks/api/useGetCompletnessStats.ts
@@ -8,6 +8,7 @@ const queryParamsMap = new Map([
     ['orgUnitId', 'org_unit_id'],
     ['orgUnitTypeIds', 'org_unit_type_id'],
     ['formId', 'form_id'],
+    ['parentId', 'parent_org_unit_id'],
 ]);
 
 export type CompletenessGETParams = UrlParams & {
@@ -22,7 +23,8 @@ const getCompletenessStats = async (
     params: CompletenessGETParams,
 ): Promise<CompletenessApiResponse> => {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { pageSize, orgUnitId, orgUnitTypeIds, formId, ...urlParams } = params;
+    const { pageSize, orgUnitId, orgUnitTypeIds, formId, ...urlParams } =
+        params;
     const apiParams = { ...urlParams, limit: pageSize ?? 50 };
     const queryParams = {};
     apiParamsKeys.forEach(apiParamKey => {

--- a/hat/assets/js/apps/Iaso/domains/completenessStats/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/completenessStats/index.tsx
@@ -41,7 +41,7 @@ export const CompletessStats: FunctionComponent<Props> = ({ params }) => {
     return (
         <>
             <TopBar
-                title={formatMessage(MESSAGES.completeness)}
+                title={formatMessage(MESSAGES.completenessStats)}
                 displayBackButton={false}
             />
             <Box p={4} className={classes.container}>

--- a/hat/assets/js/apps/Iaso/domains/completenessStats/messages.ts
+++ b/hat/assets/js/apps/Iaso/domains/completenessStats/messages.ts
@@ -37,10 +37,6 @@ const MESSAGES = defineMessages({
         id: 'iaso.completeness.chooseParent',
         defaultMessage: 'Select a form or a parent org unit to enable',
     },
-    tooMuchDepth: {
-        id: 'iaso.completeness.tooMuchDepth',
-        defaultMessage: 'Too much depth between parent and type',
-    },
 });
 
 export default MESSAGES;

--- a/hat/assets/js/apps/Iaso/domains/completenessStats/messages.ts
+++ b/hat/assets/js/apps/Iaso/domains/completenessStats/messages.ts
@@ -37,6 +37,10 @@ const MESSAGES = defineMessages({
         id: 'iaso.completeness.chooseParent',
         defaultMessage: 'Select a form or a parent org unit to enable',
     },
+    completenessStats: {
+        defaultMessage: 'Completeness Stats',
+        id: 'iaso.completenessStats.title',
+    },
 });
 
 export default MESSAGES;


### PR DESCRIPTION
The OUType filter in completeness stats didn't allow too high a level difference between selected org unit and selected types for performance reasons. The backend has been fixed so the restrictions are unnecessary

Explain what problem this PR is resolving

## Self proof reading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [X] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests
## Changes

- removed translations for removed error
- removed restriction on level difference betwwenn OU and OU Type. Basically revert https://github.com/BLSQ/iaso/pull/205


## How to test

Go to completeness stats. Select org unit types without any other filter -> search
Go to completeness stats. Select a low level OU Type with a high level OU -> search

In both cases you should get reasonably quick results

## Print screen / video

![Screenshot 2022-12-13 at 17 57 26](https://user-images.githubusercontent.com/38907762/207397086-81f2b6d0-6fca-43ac-9e95-c45046ad0f76.png)

