### PR TITLE
IA-1763 add parent org unit filter

### DIFF
--- a/hat/assets/js/apps/Iaso/constants/routes.js
+++ b/hat/assets/js/apps/Iaso/constants/routes.js
@@ -480,6 +480,10 @@ export const completenessStatsPath = {
         },
         {
             isRequired: false,
+            key: 'parentId',
+        },
+        {
+            isRequired: false,
             key: 'formId',
         },
         {

--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -455,7 +455,7 @@
     "iaso.label.others": "Others",
     "iaso.label.pages": "Pages",
     "iaso.label.parent": "Parent",
-    "iaso.label.parentOu": "Parent org Unit",
+    "iaso.label.parentOu": "Parent org unit",
     "iaso.label.periods": "Periods",
     "iaso.label.periodsAfterAllowed": "Periods after",
     "iaso.label.periodsBeforeAllowed": "Periods before",

--- a/hat/assets/js/apps/Iaso/domains/completenessStats/CompletenessStatsFilters.tsx
+++ b/hat/assets/js/apps/Iaso/domains/completenessStats/CompletenessStatsFilters.tsx
@@ -25,16 +25,26 @@ export const CompletenessStatsFilters: FunctionComponent<Props> = ({
         useGetOrgUnitTypesOptions();
     const { filters, handleSearch, handleChange, filtersUpdated } =
         useFilterState({ baseUrl, params });
-    const [initialOrgUnitId, setInitialOrgUnitId] = useState(params?.orgUnitId);
 
+    const [initialOrgUnitId, setInitialOrgUnitId] = useState(params?.orgUnitId);
     const { data: initialOrgUnit } = useGetOrgUnit(initialOrgUnitId);
+
+    const [initialParentId, setInitialParentId] = useState(params?.parentId);
+    const { data: initialParent } = useGetOrgUnit(initialParentId);
 
     const handleOrgUnitChange = useCallback(
         orgUnit => {
             const id = orgUnit ? [orgUnit.id] : undefined;
             setInitialOrgUnitId(id);
-            // setSelectedOrgUnit(orgUnit);
             handleChange('orgUnitId', id);
+        },
+        [handleChange],
+    );
+    const handleParentChange = useCallback(
+        orgUnit => {
+            const id = orgUnit ? [orgUnit.id] : undefined;
+            setInitialParentId(id);
+            handleChange('parentId', id);
         },
         [handleChange],
     );
@@ -56,8 +66,6 @@ export const CompletenessStatsFilters: FunctionComponent<Props> = ({
                         loading={fetchingForms}
                         options={forms ?? []}
                     />
-                </Grid>
-                <Grid item xs={12} md={3}>
                     <Box id="ou-tree-input">
                         <OrgUnitTreeviewModal
                             toggleOnLabelClick={false}
@@ -68,6 +76,14 @@ export const CompletenessStatsFilters: FunctionComponent<Props> = ({
                     </Box>
                 </Grid>
                 <Grid item xs={12} md={3}>
+                    <Box id="ou-tree-input-parent">
+                        <OrgUnitTreeviewModal
+                            toggleOnLabelClick={false}
+                            titleMessage={MESSAGES.parent}
+                            onConfirm={handleParentChange}
+                            initialSelection={initialParent}
+                        />
+                    </Box>
                     <InputComponent
                         type="select"
                         multi
@@ -82,7 +98,7 @@ export const CompletenessStatsFilters: FunctionComponent<Props> = ({
                 <Grid
                     container
                     item
-                    xs={isLargeLayout ? 3 : 12}
+                    xs={isLargeLayout ? 6 : 12}
                     justifyContent="flex-end"
                 >
                     <Box mt={isLargeLayout ? 2 : 0}>

--- a/hat/assets/js/apps/Iaso/domains/completenessStats/hooks/api/useGetCompletnessStats.ts
+++ b/hat/assets/js/apps/Iaso/domains/completenessStats/hooks/api/useGetCompletnessStats.ts
@@ -8,6 +8,7 @@ const queryParamsMap = new Map([
     ['orgUnitId', 'org_unit_id'],
     ['orgUnitTypeIds', 'org_unit_type_id'],
     ['formId', 'form_id'],
+    ['parentId', 'parent_org_unit_id'],
 ]);
 
 export type CompletenessGETParams = UrlParams & {
@@ -22,7 +23,8 @@ const getCompletenessStats = async (
     params: CompletenessGETParams,
 ): Promise<CompletenessApiResponse> => {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { pageSize, orgUnitId, orgUnitTypeIds, formId, ...urlParams } = params;
+    const { pageSize, orgUnitId, orgUnitTypeIds, formId, ...urlParams } =
+        params;
     const apiParams = { ...urlParams, limit: pageSize ?? 50 };
     const queryParams = {};
     apiParamsKeys.forEach(apiParamKey => {

--- a/hat/assets/js/apps/Iaso/domains/completenessStats/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/completenessStats/index.tsx
@@ -41,7 +41,7 @@ export const CompletessStats: FunctionComponent<Props> = ({ params }) => {
     return (
         <>
             <TopBar
-                title={formatMessage(MESSAGES.completeness)}
+                title={formatMessage(MESSAGES.completenessStats)}
                 displayBackButton={false}
             />
             <Box p={4} className={classes.container}>

--- a/hat/assets/js/apps/Iaso/domains/completenessStats/messages.ts
+++ b/hat/assets/js/apps/Iaso/domains/completenessStats/messages.ts
@@ -37,6 +37,10 @@ const MESSAGES = defineMessages({
         id: 'iaso.completeness.chooseParent',
         defaultMessage: 'Select a form or a parent org unit to enable',
     },
+    completenessStats: {
+        defaultMessage: 'Completeness Stats',
+        id: 'iaso.completenessStats.title',
+    },
 });
 
 export default MESSAGES;


### PR DESCRIPTION
Completeness stats table needs a filter on parent org unit

## Self proof reading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [X] Are my typescript files well typed
- [X] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests
## Changes

- Add treeview filter and related state in filter component
- add param to route and pass it to API
- fix translation typo
- reorganise filter layout


## How to test

Go to completeness stats and use the filters

## Print screen / video

https://user-images.githubusercontent.com/38907762/207584678-6aa22ec6-84c3-4de3-a350-3c954a5de13b.mov


