### PR TITLE
IA-1743: add loader for OUtypes

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/forms/components/FormFormComponent.js
+++ b/hat/assets/js/apps/Iaso/domains/forms/components/FormFormComponent.js
@@ -51,6 +51,7 @@ const FormForm = ({ currentForm, setFieldValue }) => {
     const [showAdvancedSettings, setshowAdvancedSettings] = useState(false);
     const allProjects = useSelector(state => state.projects.allProjects);
     const allOrgUnitTypes = useSelector(state => state.orgUnitsTypes.allTypes);
+    const isLoadingOUTypes = (allOrgUnitTypes ?? []).length === 0;
     const setPeriodType = value => {
         setFieldValue('period_type', value);
         if (value === null) {
@@ -216,6 +217,7 @@ const FormForm = ({ currentForm, setFieldValue }) => {
                                 : []
                         }
                         label={MESSAGES.orgUnitsTypes}
+                        loading={isLoadingOUTypes}
                     />
                     {showAdvancedSettings && (
                         <>


### PR DESCRIPTION
OuTypes dropdown list was in error while loading in forms details. project for Alerte voyageur is in error

## Self proof reading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests
## Changes

- Added a boolean based on redux state to get the org unit types drop down in loading state
- The problem with projects seems to be caused by bad data, so no fix.


## How to test

Just load details for a form

## Print screen / video

![Screenshot 2022-12-15 at 11 29 17](https://user-images.githubusercontent.com/38907762/207851337-b7020aae-c89d-4566-b983-c4ba92f35134.png)

