### PR TITLE
IA-1776: Fix pagination in completeness stats table

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/completenessStats/hooks/api/useGetCompletnessStats.ts
+++ b/hat/assets/js/apps/Iaso/domains/completenessStats/hooks/api/useGetCompletnessStats.ts
@@ -25,7 +25,7 @@ const getCompletenessStats = async (
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { pageSize, orgUnitId, orgUnitTypeIds, formId, ...urlParams } =
         params;
-    const apiParams = { ...urlParams, limit: pageSize ?? 50 };
+    const apiParams = { ...urlParams, limit: pageSize ?? 10 };
     const queryParams = {};
     apiParamsKeys.forEach(apiParamKey => {
         const apiParam = apiParams[apiParamKey];

--- a/iaso/api/completeness_stats.py
+++ b/iaso/api/completeness_stats.py
@@ -148,7 +148,7 @@ class CompletenessStatsViewSet(viewsets.ViewSet):
                         ),
                     }
                 )
-        limit = int(request.GET.get("limit", "50"))
+        limit = int(request.GET.get("limit", 10))
         page_offset = int(request.GET.get("page", "1"))
         paginator = Paginator(res, limit)
         if page_offset > paginator.num_pages:

--- a/iaso/tests/api/test_completeness_stats.py
+++ b/iaso/tests/api/test_completeness_stats.py
@@ -104,7 +104,7 @@ class CompletenessStatsAPITestCase(APITestCase):
                 "has_previous": False,
                 "page": 1,
                 "pages": 1,
-                "limit": 50,
+                "limit": 10,
             },
             j,
         )
@@ -210,6 +210,14 @@ class CompletenessStatsAPITestCase(APITestCase):
         self.assertEqual(len(j["results"]), 1)
         self.assertTrue(j["has_next"])
         self.assertFalse(j["has_previous"])
+
+    def test_pagination_default_limit(self):
+        """Test that the default limit parameter is 10"""
+        self.client.force_authenticate(self.user)
+
+        response = self.client.get("/api/completeness_stats/")
+        json = self.assertJSONResponse(response, 200)
+        self.assertEqual(json["limit"], 10)
 
     def test_row_count(self):
         self.client.force_authenticate(self.user)


### PR DESCRIPTION
There were some bugs with the pagination of the completeness table (on initial load/if no explicit page size was chosen by the user, the table loaded 50 results while the table size selector was showing '10 results')

## Self proof reading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [x] Are there enough tests

## Changes

While the bug itself was on the front-end side (requesting 50 rows while showing "10 results" at the bottom of the page), I decided for clarity/consistency to make a small change to the backend so 10 is now also the default there (consistent with the table), and added a test for this specific point.


## How to test

Go to the completeness table, make sure things are consistent between the number of total results (at the top of the table), the number of rows displayed, the "number of results per page" selector, the total number of page, and the state of the navigation buttons (first/previous/next/last). Also play with those buttons and make sure other pages works equally well.
