### PR TITLE
IA-1779: Completeness stats: fix counting bug when a form skipped levels in the hierarchy

### DIFF
--- a/iaso/api/completeness_stats.py
+++ b/iaso/api/completeness_stats.py
@@ -107,7 +107,10 @@ class CompletenessStatsViewSet(viewsets.ViewSet):
                 ou_types_of_form = form.org_unit_types.all()
 
                 # Instance counters for the row OU + all descendants
-                ou_to_fill_with_descendants = org_units.filter(org_unit_type__in=ou_types_of_form).hierarchy(row_ou)
+                ou_to_fill_with_descendants = row_ou.descendants().filter(
+                    org_unit_type__in=ou_types_of_form
+                )  # Apparently .descendants() also includes the row_ou itself
+
                 ou_to_fill_with_descendants_count, ou_filled_with_descendants_count = get_instance_counters(
                     ou_to_fill_with_descendants, form
                 )


### PR DESCRIPTION
Fix a counting bug in completeness stats table. It appeared when a form was targeting multiple OU levels in the hierarchy, with "skipped levels". For example if a given form is targeting both countries (at the top of the hierarchy) ans health facilities (much lower in the hierarchy), the "forms to fill with descendants" / forms filled with descendants" counters were correct on the country and healt facilities row, but were showing incorrect (0/0) values in rows for the intermediate OUs (regions, dictricts, ...)


## Self proof reading checklist
 
- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are there enough tests

## Changes

I also increased the test coverage to make sure this bug doesn't reappear.


## How to test

1) Assign a form to multiple OUs type, and make sure some levels are skipped
2) Go to the completeness table, drill down (using the button in the last column) and make sure the numbers make sense. (The counters "with children" columns are actually consistent with the numbers shown for the child rows )