### PR TITLE
IA-1777: Org Unit tree view multiselect bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5990,7 +5990,7 @@
         },
         "node_modules/bluesquare-components": {
             "version": "0.2.0",
-            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#2b237be9c87411c1287ea585dadce893f6c10fa8",
+            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#66dc4ba755d3da92d68123f442f319691f480155",
             "license": "Apache-2.0",
             "dependencies": {
                 "@babel/plugin-transform-runtime": "^7.17.0",
@@ -34121,7 +34121,7 @@
             "dev": true
         },
         "bluesquare-components": {
-            "version": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#2b237be9c87411c1287ea585dadce893f6c10fa8",
+            "version": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#66dc4ba755d3da92d68123f442f319691f480155",
             "from": "bluesquare-components@github:BLSQ/bluesquare-components",
             "requires": {
                 "@babel/plugin-transform-runtime": "^7.17.0",


### PR DESCRIPTION
unticking an Org unit in Treeview (multiselect mode) would not remove it from the payload sent to the API

## Self proof reading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests
## Changes

- The fix was made on bluesquare-compoenents: https://github.com/BLSQ/bluesquare-components/pull/94


## How to test

- Go to the Admin>Users> Open/create a user -> Location tab
- Select multiple org units then save
- Re-open the same user, remove one or several org units then save
- The org units should be correctly removed

