### PR TITLE
IA-1789: removed required prop from level input

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/orgUnitTypes/components/OrgUnitsTypesDialog.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/orgUnitTypes/components/OrgUnitsTypesDialog.js
@@ -271,7 +271,6 @@ const OrgUnitsTypesDialog = ({
                 errors={formState.depth.errors}
                 type="number"
                 label={MESSAGES.depth}
-                required
             />
 
             <InputComponent


### PR DESCRIPTION
level input was shown as a required field but this input is not mandatory to save org unit type modifications

## Self proof reading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests
## Changes

removed the required prop from level input


## How to test

Go to Orgunit type page >  choose a org unit type from the list > click on edit 
You should not see the asterisk next to the label input

## Print screen / video
![Capture d’écran du 2022-12-22 09-27-11](https://user-images.githubusercontent.com/25134301/209090951-e21c505c-7d5f-406a-865a-cd15850d35f0.png)
