### PR TITLE
POLIO-760 Upgrade Enketo version used for local development

### DIFF
--- a/docker/docker-compose-enketo.yml
+++ b/docker/docker-compose-enketo.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   enketo:
-    image: enketo/enketo-express:3.0.2
+    image: enketo/enketo-express:5.0.0
 #    entrypoint: pm2 start --no-daemon app.js -n enketo
 #    environment:
       # uncomment for more debug output


### PR DESCRIPTION
Instruct docker-compose to use the new image 

This is part of the broader ticket on upgrading Enketo andwas mainly done to check that ware compatible with the new Enketo version and can deploy it on servers. No change in behaviour is expected


## How to test

1. Do a `docker-compose pull` to retrieve the new enketo image.
2. Launch your docker compose with Enketo, see the Enketo sections in the main README.md for instruction on how to do this.
3. Check that you can still create and edit submission. Try with different Form type
