### PR TITLE
IA-1749: adding helperText prop to TextArea component

### DIFF
--- a/hat/assets/js/apps/Iaso/components/forms/TextArea.tsx
+++ b/hat/assets/js/apps/Iaso/components/forms/TextArea.tsx
@@ -9,7 +9,7 @@ import {
     useSkipEffectOnMount,
 } from 'bluesquare-components';
 import classnames from 'classnames';
-import { makeStyles, InputLabel } from '@material-ui/core';
+import { makeStyles, InputLabel, FormHelperText } from '@material-ui/core';
 import { useDebounce } from 'use-debounce';
 import { Optional } from '../../types/utils';
 
@@ -22,6 +22,7 @@ type Props = {
     required?: boolean;
     debounceTime?: number; // debounce time in ms
     disabled?: boolean;
+    helperText?: string;
 };
 
 const useStyles = makeStyles(theme => ({
@@ -85,6 +86,7 @@ export const TextArea: FunctionComponent<Props> = ({
     required = false,
     debounceTime = 0,
     disabled = false,
+    helperText = undefined,
 }) => {
     const classes: Record<string, string> = useStyles();
     const [focus, setFocus] = useState<boolean>(false);
@@ -138,6 +140,7 @@ export const TextArea: FunctionComponent<Props> = ({
                 value={textValue}
                 disabled={disabled}
             />
+            <FormHelperText>{helperText}</FormHelperText>
         </FormControl>
     );
 };

--- a/plugins/polio/js/src/components/Inputs/MultilineText.tsx
+++ b/plugins/polio/js/src/components/Inputs/MultilineText.tsx
@@ -9,6 +9,7 @@ type Props = {
     required: boolean;
     debounceTime?: number;
     disabled?: boolean;
+    helperText?: string;
 };
 
 export const MultilineText: FunctionComponent<Props> = ({
@@ -18,6 +19,7 @@ export const MultilineText: FunctionComponent<Props> = ({
     required,
     debounceTime = 0,
     disabled = false,
+    helperText = undefined,
 }) => {
     const { name } = field;
     const {
@@ -45,6 +47,7 @@ export const MultilineText: FunctionComponent<Props> = ({
             onChange={onChange}
             debounceTime={debounceTime}
             disabled={disabled}
+            helperText={helperText}
         />
     );
 };


### PR DESCRIPTION
Adding a helperText prop to display a message below the textarea if it's disabled because required inputs need to be filled first

## Self proof reading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests
## Changes

- add a helperText prop to TextArea and in MultilineText where TexttArea is used.
