### PR TITLE
IA-1799: restore import and prop-types es-lint rules

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitInfosComponent.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitInfosComponent.js
@@ -1,6 +1,4 @@
-/* eslint-disable import/extensions */
 /* eslint-disable react/jsx-props-no-spreading */
-/* eslint-disable react/prop-types */
 import React from 'react';
 
 import { Box, Button, Grid, DialogContentText } from '@material-ui/core';
@@ -33,7 +31,7 @@ import SpeedDialInstanceActions from '../../instances/components/SpeedDialInstan
 import EnketoIcon from '../../instances/components/EnketoIcon';
 import { userHasPermission } from '../../users/utils';
 import ConfirmCancelDialogComponent from '../../../components/dialogs/ConfirmCancelDialogComponent';
-import { useCurrentUser } from '../../../utils/usersUtils';
+import { useCurrentUser } from '../../../utils/usersUtils.ts';
 import {
     hasFeatureFlag,
     SHOW_LINK_INSTANCE_REFERENCE,


### PR DESCRIPTION
es-lint about import and prop types have been disabled. They should be restored and the errors fixed, especially the prop-types, since it’s not a TS file

## Self proof reading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests

## Changes

- removed disable eslint rules
- add ts extension to ts imports