### PR TITLE
IA-1769: update condition for page LoadingSpinner

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/details.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/details.js
@@ -404,11 +404,8 @@ const OrgUnitDetail = ({ params, router }) => {
                     </Tabs>
                 )}
             </TopBar>
-            {/* {(isFetchingDetail || isFetchingDatas || savingOu) && (
-                <LoadingSpinner />
-            )} */}
 
-            {/* there is already a loader on SingleTable  for the other tabs */}
+            {/* there is already a loader on SingleTable for the other tabs */}
             {(isFetchingDetail || isFetchingDatas || savingOu) &&
                 (tab === 'infos' || tab === 'map' || tab === 'comments') && (
                     <LoadingSpinner />

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/details.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/details.js
@@ -404,9 +404,15 @@ const OrgUnitDetail = ({ params, router }) => {
                     </Tabs>
                 )}
             </TopBar>
-            {(isFetchingDetail || isFetchingDatas || savingOu) && (
+            {/* {(isFetchingDetail || isFetchingDatas || savingOu) && (
                 <LoadingSpinner />
-            )}
+            )} */}
+
+            {/* there is already a loader on SingleTable  for the other tabs */}
+            {(isFetchingDetail || isFetchingDatas || savingOu) &&
+                (tab === 'infos' || tab === 'map' || tab === 'comments') && (
+                    <LoadingSpinner />
+                )}
             {currentOrgUnit && (
                 <section>
                     {tab === 'infos' && (


### PR DESCRIPTION
There were two `LoadingSpinner` components which overlapped (one global for the page, the other coming from `SingleTable` component)

https://user-images.githubusercontent.com/25134301/210803714-9c994718-cc8e-42b0-b713-4f9675916c38.mov


## Self proof reading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests
## Changes

- add a condition to show global `LoadingSpinner` only on tabs where there is no `SingleTable`


## How to test

Go to Orgunits list > Select a row and see details > Click on each tab and force refresh
You should see only one `LoadingSpinner` on each tab

## Print screen / video
[recording-2023-01-05-15-30-06.webm](https://user-images.githubusercontent.com/25134301/210803617-58e27930-8327-4c33-a327-d153c1d9e6f6.webm)


