### PR TITLE
POLIO-735: change vaccine selected by default

### DIFF
--- a/plugins/polio/js/src/components/Inputs/ScopeInput.tsx
+++ b/plugins/polio/js/src/components/Inputs/ScopeInput.tsx
@@ -62,7 +62,7 @@ export const ScopeInput: FunctionComponent<Props> = ({
     setPage,
 }) => {
     const [selectRegion, setSelectRegion] = useState(false);
-    const [selectedVaccine, setSelectedVaccine] = useState<string>('mOPV2');
+    const [selectedVaccine, setSelectedVaccine] = useState<string>('nOPV2');
     const [, , helpers] = useField(field.name);
     const { formatMessage } = useSafeIntl();
     const { value: scopes = [] } = field;


### PR DESCRIPTION
Most of the campaigns today use nOPV2 vaccine. When creating a campaign and about to encode a scope, the radio button by default is on mOPV2 (green) vaccine. This should be on nOPV2

## Self proof reading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests
## Changes

- changed value of `selectedVaccine` in `ScopeInput`


## How to test

-> Go to Campaigns 
-> Then Either create a new one or edit an existing campaign with a scope
-> Go on Scope tab 
-> nOPV2 is now the selected vaccine by default

## Print screen / video

Upload here print screens or videos showing the changes
![Capture d’écran du 2023-01-05 15-57-12](https://user-images.githubusercontent.com/25134301/210809807-f17824bd-3033-427f-a01c-8cf89d1e3f5b.png)
