### PR TITLE
Polio-732  POLIO-628 Editing OrgUnit belonging in invalid group (because of source version)

### DIFF
--- a/iaso/api/org_units.py
+++ b/iaso/api/org_units.py
@@ -60,7 +60,8 @@ class OrgUnitViewSet(viewsets.ViewSet):
 
     GET /api/orgunits/
     GET /api/orgunits/<id>
-    POST /api/orgunits/
+    POST /api/orgunits/ Create org units, used by mobile app
+    POST /api/orgunits/create_org_unit Create org unit, used by web app
     PATCH /api/orgunits/<id>
     """
 
@@ -422,9 +423,13 @@ class OrgUnitViewSet(viewsets.ViewSet):
         if "groups" in request.data:
             new_groups = []
             groups = request.data["groups"]
+            current_groups_ids = list(org_unit.groups.all().values_list("id", flat=True))
             for group_id in groups:
                 temp_group = get_object_or_404(Group, id=group_id)
-                if temp_group.source_version and temp_group.source_version != org_unit.version:
+                #  fix bug where if an org unit was already in a group it failed
+                if group_id not in current_groups_ids and (
+                    temp_group.source_version and temp_group.source_version != org_unit.version
+                ):
                     errors.append({"errorKey": "groups", "errorMessage": _("Group must be in the same source version")})
                     continue
                 new_groups.append(temp_group)

--- a/iaso/api/org_units.py
+++ b/iaso/api/org_units.py
@@ -424,7 +424,7 @@ class OrgUnitViewSet(viewsets.ViewSet):
             groups = request.data["groups"]
             for group_id in groups:
                 temp_group = get_object_or_404(Group, id=group_id)
-                if temp_group.source_version != org_unit.version:
+                if temp_group.source_version and temp_group.source_version != org_unit.version:
                     errors.append({"errorKey": "groups", "errorMessage": _("Group must be in the same source version")})
                     continue
                 new_groups.append(temp_group)

--- a/iaso/tests/api/test_orgunits.py
+++ b/iaso/tests/api/test_orgunits.py
@@ -762,10 +762,9 @@ class OrgUnitAPITestCase(APITestCase):
         self.assertEqual(ou.geom.wkt, MultiPolygon(Polygon([(0, 0), (0, 1), (1, 1), (0, 0)])).wkt)
 
     def test_edit_org_unit_edit_bad_group_fail(self):
-        """FIXME this test Document current behaviour but we want to change how to handle this
-
-        If a org unit already has a bad group we can't edit it anymore from the interface
-        we should just not have this case"""
+        """Check for a previous bug if an org unit is already member of a bad group
+        it couldn't be  edited anymore from the interface
+        """
 
         old_ou = m.OrgUnit.objects.create(
             name="hey",
@@ -776,6 +775,7 @@ class OrgUnitAPITestCase(APITestCase):
         # group on wrong version
         bad_group = m.Group.objects.create(name="bad")
         old_ou.groups.set([bad_group, good_group])
+        old_modification_date = old_ou.updated_at
 
         self.old_counts = self.counts()
 
@@ -785,23 +785,25 @@ class OrgUnitAPITestCase(APITestCase):
 
         group_ids = [g["id"] for g in data["groups"]]
         data["groups"] = group_ids
+        data["name"] = "new name"
         response = self.client.patch(
             f"/api/orgunits/{old_ou.id}/",
             format="json",
             data=data,
         )
-        self.assertJSONResponse(response, 400)
-        self.assertNoCreation()
+        self.assertJSONResponse(response, 200)
+        self.assertCreated({Modification: 1})
         ou = m.OrgUnit.objects.get(id=old_ou.id)
-        # Verify Nothing has changed
+        # Verify group was not modified but the rest was modified
         self.assertQuerysetEqual(
             ou.groups.all().order_by("name"), ["<Group:  | Evil Empire  1 >", "<Group: bad | None >"]
         )
         self.assertEqual(ou.id, old_ou.id)
-        self.assertEqual(ou.name, old_ou.name)
+        self.assertEqual(ou.name, "new name")
         self.assertEqual(ou.parent, old_ou.parent)
         self.assertEqual(ou.created_at, old_ou.created_at)
-        self.assertEqual(ou.updated_at, old_ou.updated_at)
+
+        self.assertNotEqual(ou.updated_at, old_modification_date)
 
     def test_edit_with_apply_directly_instance_gps_into_org_unit(self):
         """Retrieve a orgunit data and push instance_gps_to_org_unit"""

--- a/plugins/polio/serializers.py
+++ b/plugins/polio/serializers.py
@@ -714,8 +714,8 @@ class CampaignSerializer(serializers.ModelSerializer):
                     if len(source_version_ids) != 1:
                         raise serializers.ValidationError("All orgunit should be in the same source version")
                     source_version_id = list(source_version_ids)[0]
-                name = f"scope for round {round.number} campaign {instance.obr_name} - {vaccine}"
-                scope, created = round.scopes.get_or_create(vaccine=vaccine)
+                name = f"scope for round {round_instance.number} campaign {instance.obr_name} - {vaccine}"
+                scope, created = round_instance.scopes.get_or_create(vaccine=vaccine)
                 if not scope.group:
                     scope.group = Group.objects.create(name=name)
                 else:

--- a/plugins/polio/serializers.py
+++ b/plugins/polio/serializers.py
@@ -608,12 +608,25 @@ class CampaignSerializer(serializers.ModelSerializer):
 
         campaign.grouped_campaigns.set(grouped_campaigns)
 
+        # noinspection DuplicatedCode
         for scope in campaign_scopes:
             vaccine = scope.get("vaccine")
             org_units = scope.get("group", {}).get("org_units")
             scope, created = campaign.scopes.get_or_create(vaccine=vaccine)
+            source_version_id = None
+            name = f"scope for campaign {campaign.obr_name} - {vaccine}"
+            if org_units:
+                source_version_ids = set([ou.version_id for ou in org_units])
+                if len(source_version_ids) != 1:
+                    raise serializers.ValidationError("All orgunit should be in the same source version")
+                source_version_id = list(source_version_ids)[0]
             if not scope.group:
-                scope.group = Group.objects.create(name="hidden roundScope")
+                scope.group = Group.objects.create(name=name, source_version_id=source_version_id)
+            else:
+                scope.group.source_version_id = source_version_id
+                scope.group.name = name
+                scope.group.save()
+
             scope.group.org_units.set(org_units)
 
         for round_data in rounds:
@@ -621,12 +634,26 @@ class CampaignSerializer(serializers.ModelSerializer):
             round_serializer = RoundSerializer(data={**round_data, "campaign": campaign.id})
             round_serializer.is_valid(raise_exception=True)
             round = round_serializer.save()
+
             for scope in scopes:
+
                 vaccine = scope.get("vaccine")
                 org_units = scope.get("group", {}).get("org_units")
+                source_version_id = None
+                if org_units:
+                    source_version_ids = set([ou.version_id for ou in org_units])
+                    if len(source_version_ids) != 1:
+                        raise serializers.ValidationError("All orgunit should be in the same source version")
+                    source_version_id = list(source_version_ids)[0]
+                name = f"scope for round {round.number} campaign {campaign.obr_name} - {vaccine}"
                 scope, created = round.scopes.get_or_create(vaccine=vaccine)
                 if not scope.group:
-                    scope.group = Group.objects.create(name="hidden roundScope")
+                    scope.group = Group.objects.create(name=name)
+                else:
+                    scope.group.source_version_id = source_version_id
+                    scope.group.name = name
+                    scope.group.save()
+
                 scope.group.org_units.set(org_units)
 
         log_campaign_modification(campaign, None, self.context["request"].user)
@@ -641,8 +668,20 @@ class CampaignSerializer(serializers.ModelSerializer):
             vaccine = scope.get("vaccine")
             org_units = scope.get("group", {}).get("org_units")
             scope, created = instance.scopes.get_or_create(vaccine=vaccine)
+            source_version_id = None
+            name = f"scope for campaign {instance.obr_name} - {vaccine}"
+            if org_units:
+                source_version_ids = set([ou.version_id for ou in org_units])
+                if len(source_version_ids) != 1:
+                    raise serializers.ValidationError("All orgunit should be in the same source version")
+                source_version_id = list(source_version_ids)[0]
             if not scope.group:
-                scope.group = Group.objects.create(name="hidden roundScope")
+                scope.group = Group.objects.create(name=name, source_version_id=source_version_id)
+            else:
+                scope.group.source_version_id = source_version_id
+                scope.group.name = name
+                scope.group.save()
+
             scope.group.org_units.set(org_units)
 
         round_instances = []
@@ -669,9 +708,21 @@ class CampaignSerializer(serializers.ModelSerializer):
             for scope in scopes:
                 vaccine = scope.get("vaccine")
                 org_units = scope.get("group", {}).get("org_units")
-                scope, created = round_instance.scopes.get_or_create(vaccine=vaccine)
+                source_version_id = None
+                if org_units:
+                    source_version_ids = set([ou.version_id for ou in org_units])
+                    if len(source_version_ids) != 1:
+                        raise serializers.ValidationError("All orgunit should be in the same source version")
+                    source_version_id = list(source_version_ids)[0]
+                name = f"scope for round {round.number} campaign {instance.obr_name} - {vaccine}"
+                scope, created = round.scopes.get_or_create(vaccine=vaccine)
                 if not scope.group:
-                    scope.group = Group.objects.create(name="hidden roundScope")
+                    scope.group = Group.objects.create(name=name)
+                else:
+                    scope.group.source_version_id = source_version_id
+                    scope.group.name = name
+                    scope.group.save()
+
                 scope.group.org_units.set(org_units)
         instance.rounds.set(round_instances)
 

--- a/plugins/polio/tests/test_api.py
+++ b/plugins/polio/tests/test_api.py
@@ -391,6 +391,79 @@ class PolioAPITestCase(APITestCase):
         r = self.assertJSONResponse(response, 200)
         self.assertEqual(len(r["rounds"]), 0)
 
+    def test_create_campaign_with_scopes(self):
+        self.client.force_authenticate(self.yoda)
+        self.assertEqual(Campaign.objects.count(), 0)
+
+        payload = {
+            "account": self.account.pk,
+            "obr_name": "obr_name",
+            "scopes": [
+                {"vaccine": "bOPV", "group": {"org_units": [self.org_unit.id]}},
+                {"vaccine": "mOPV2", "group": {"org_units": [self.child_org_unit.id]}},
+            ],
+            "rounds": [
+                {
+                    "number": 1,
+                    "started_at": "2021-02-01",
+                    "ended_at": "2021-02-20",
+                },
+                {
+                    "number": 2,
+                    "started_at": "2021-04-01",
+                    "ended_at": "2021-04-20",
+                },
+            ],
+        }
+
+        response = self.client.post("/api/polio/campaigns/", payload, format="json")
+
+        self.assertEqual(response.status_code, 201, response.content)
+        self.assertEqual(Campaign.objects.count(), 1)
+        c = Campaign.objects.first()
+        self.assertEqual(c.obr_name, "obr_name")
+        rounds = c.rounds.all().order_by("number")
+        self.assertEqual(2, rounds.count())
+        self.assertQuerysetEqual(rounds, [1, 2], lambda r: r.number)
+        first_round = c.rounds.filter(number=1).first()
+        self.assertQuerysetEqual(c.scopes.get(vaccine="bOPV").group.org_units.all(), [self.org_unit])
+        self.assertEqual(c.scopes.get(vaccine="bOPV").group.source_version, self.org_unit.version)
+        self.assertQuerysetEqual(c.scopes.get(vaccine="mOPV2").group.org_units.all(), [self.child_org_unit])
+        # check via the api
+        response = self.client.get(f"/api/polio/campaigns/{c.id}/", format="json")
+        r = self.assertJSONResponse(response, 200)
+        self.assertNotEqual(r["round_one"], None, r)
+        # self.assertHasField(r["round_one"], "started_at", r)
+        self.assertEqual(r["round_one"]["started_at"], "2021-02-01", r)
+        self.assertEqual(len(r["rounds"]), 2)
+        self.assertNotEqual(r["round_two"], None, r)
+        self.assertEqual(r["round_two"]["started_at"], "2021-04-01", r)
+        round_one = list(filter(lambda r: r["number"] == 1, r["rounds"]))[0]
+
+        scope_bOPV = c.scopes.get(vaccine="bOPV")
+        scope_mOPV2 = c.scopes.get(vaccine="mOPV2")
+        self.assertEqual(
+            r["scopes"],
+            [
+                {
+                    "vaccine": "bOPV",
+                    "group": {
+                        "name": scope_bOPV.group.name,
+                        "id": scope_bOPV.group.id,
+                        "org_units": [o.id for o in scope_bOPV.group.org_units.all()],
+                    },
+                },
+                {
+                    "vaccine": "mOPV2",
+                    "group": {
+                        "name": scope_mOPV2.group.name,
+                        "id": scope_mOPV2.group.id,
+                        "org_units": [o.id for o in scope_mOPV2.group.org_units.all()],
+                    },
+                },
+            ],
+        )
+
     def test_create_campaign_with_round_scopes(self):
         self.client.force_authenticate(self.yoda)
         self.assertEqual(Campaign.objects.count(), 0)
@@ -445,7 +518,7 @@ class PolioAPITestCase(APITestCase):
                 {
                     "vaccine": "bOPV",
                     "group": {
-                        "name": "hidden roundScope",
+                        "name": "scope for round 1 campaign obr_name - bOPV",
                         "id": first_round.scopes.get(vaccine="bOPV").group.id,
                         "org_units": [o.id for o in first_round.scopes.get(vaccine="bOPV").group.org_units.all()],
                     },
@@ -453,7 +526,7 @@ class PolioAPITestCase(APITestCase):
                 {
                     "vaccine": "mOPV2",
                     "group": {
-                        "name": "hidden roundScope",
+                        "name": "scope for round 1 campaign obr_name - mOPV2",
                         "id": first_round.scopes.get(vaccine="mOPV2").group.id,
                         "org_units": [o.id for o in first_round.scopes.get(vaccine="mOPV2").group.org_units.all()],
                     },


### PR DESCRIPTION
Fix root cause by Campaign Scope and in general

## Self proof reading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests
## Changes
One of the cause of this was that that the group for Campaign scope in polio were not created with the proper source version. This is now fixed at creation and edition.

We also fix this in the org unit API by allowing other field to be edited if the groups membership didn't change and by bypassing the check for empty group.

Note that we don't fix the fact that the group are not displayed properly in the org unit detail and that if you change the group membership you will remove the org unit from the  campaign scope!

## How to test
0. Have the  `polio` plugin enabled.
1. Create/Edit a campaign and put an org unit in the scope
2. Try to edit the org unit in it's detail page.
