### PR TITLE
Polio 773 Speed up Campaign list and calendar

### DIFF
--- a/plugins/polio/api.py
+++ b/plugins/polio/api.py
@@ -41,6 +41,7 @@ from plugins.polio.serializers import (
     serialize_campaign,
     log_campaign_modification,
     ListCampaignSerializer,
+    CalendarCampaignSerializer,
 )
 from plugins.polio.serializers import (
     CountryUsersGroupSerializer,
@@ -93,6 +94,14 @@ class PolioOrgunitViewSet(ModelViewSet):
 
 
 class CampaignViewSet(ModelViewSet):
+    """Main endpoint for campaign.
+
+    GET (Anonymously too)
+    POST
+    PATCH
+    See swagger for Parameters
+    """
+
     results_key = "campaigns"
     remove_results_key_if_paginated = True
     filter_backends = [
@@ -129,9 +138,19 @@ class CampaignViewSet(ModelViewSet):
         if self.request.user.is_authenticated:
             if self.request.query_params.get("fieldset") == "list" and self.request.method in permissions.SAFE_METHODS:
                 return ListCampaignSerializer
+            if (
+                self.request.query_params.get("fieldset") == "calendar"
+                and self.request.method in permissions.SAFE_METHODS
+            ):
+                return CalendarCampaignSerializer
 
             return CampaignSerializer
         else:
+            if (
+                self.request.query_params.get("fieldset") == "calendar"
+                and self.request.method in permissions.SAFE_METHODS
+            ):
+                return CalendarCampaignSerializer
             return AnonymousCampaignSerializer
 
     def filter_queryset(self, queryset):

--- a/plugins/polio/api.py
+++ b/plugins/polio/api.py
@@ -40,6 +40,7 @@ from plugins.polio.serializers import (
     CampaignGroupSerializer,
     serialize_campaign,
     log_campaign_modification,
+    ListCampaignSerializer,
 )
 from plugins.polio.serializers import (
     CountryUsersGroupSerializer,
@@ -126,6 +127,9 @@ class CampaignViewSet(ModelViewSet):
 
     def get_serializer_class(self):
         if self.request.user.is_authenticated:
+            if self.request.query_params.get("fieldset") == "list" and self.request.method in permissions.SAFE_METHODS:
+                return ListCampaignSerializer
+
             return CampaignSerializer
         else:
             return AnonymousCampaignSerializer

--- a/plugins/polio/js/src/components/CreateEditDialog.js
+++ b/plugins/polio/js/src/components/CreateEditDialog.js
@@ -47,14 +47,13 @@ import { CAMPAIGN_HISTORY_URL } from '../constants/routes';
 
 import { useStyles } from '../styles/theme';
 import MESSAGES from '../constants/messages';
+import { useGetCampaign } from '../hooks/useGetCampaign';
 
-const CreateEditDialog = ({
-    isOpen,
-    onClose,
-    selectedCampaign,
-    isFetching,
-}) => {
+const CreateEditDialog = ({ isOpen, onClose, campaignId }) => {
     const { mutate: saveCampaign } = useSaveCampaign();
+    const { data: selectedCampaign, isFetching: isFetching } = useGetCampaign(
+        isOpen && campaignId,
+    );
 
     const { data: campaignLogs } = useGetCampaignLogs(
         selectedCampaign?.id,
@@ -307,15 +306,13 @@ const CreateEditDialog = ({
 };
 
 CreateEditDialog.defaultProps = {
-    isFetching: false,
     selectedCampaign: undefined,
 };
 
 CreateEditDialog.propTypes = {
     isOpen: PropTypes.bool.isRequired,
     onClose: PropTypes.func.isRequired,
-    selectedCampaign: PropTypes.object,
-    isFetching: PropTypes.bool,
+    campaignId: PropTypes.string,
 };
 
 // There's naming conflict with component in Iaso

--- a/plugins/polio/js/src/components/campaignCalendar/cells/EditCampaignCell.js
+++ b/plugins/polio/js/src/components/campaignCalendar/cells/EditCampaignCell.js
@@ -18,7 +18,7 @@ const EditCampaignCell = ({ campaign }) => {
                 size="small"
             />
             <CreateEditDialog
-                selectedCampaign={campaign.original.id}
+                campaignId={campaign.original.id}
                 isOpen={dialogOpen}
                 onClose={() => setDialogOpen(false)}
             />

--- a/plugins/polio/js/src/components/campaignCalendar/cells/EditCampaignCell.js
+++ b/plugins/polio/js/src/components/campaignCalendar/cells/EditCampaignCell.js
@@ -18,7 +18,7 @@ const EditCampaignCell = ({ campaign }) => {
                 size="small"
             />
             <CreateEditDialog
-                selectedCampaign={campaign.original}
+                selectedCampaign={campaign.original.id}
                 isOpen={dialogOpen}
                 onClose={() => setDialogOpen(false)}
             />

--- a/plugins/polio/js/src/components/campaignCalendar/cells/RoundCell.js
+++ b/plugins/polio/js/src/components/campaignCalendar/cells/RoundCell.js
@@ -68,7 +68,7 @@ const RoundCell = ({ colSpan, campaign, round }) => {
             )}
             {isLogged && (
                 <CreateEditDialog
-                    selectedCampaign={campaign.original}
+                    campaignId={campaign.original.id}
                     isOpen={dialogOpen}
                     onClose={() => setDialogOpen(false)}
                 />

--- a/plugins/polio/js/src/hooks/useGetCampaign.js
+++ b/plugins/polio/js/src/hooks/useGetCampaign.js
@@ -1,0 +1,13 @@
+import { getRequest } from 'Iaso/libs/Api';
+import { useSnackQuery } from 'Iaso/libs/apiHooks';
+
+export const useGetCampaign = campaignId => {
+    return useSnackQuery(
+        ['polio', 'campaigns', campaignId],
+        () => getRequest(`/api/polio/campaigns/${campaignId}`),
+        undefined,
+        {
+            enabled: Boolean(campaignId),
+        },
+    );
+};

--- a/plugins/polio/js/src/hooks/useGetCampaigns.js
+++ b/plugins/polio/js/src/hooks/useGetCampaigns.js
@@ -27,6 +27,7 @@ export const useGetCampaigns = (
             // Ugly fix to prevent the full list of campaigns showing when waiting for the value of countries
             enabled: options.enabled ?? true,
             last_budget_event__status: options.last_budget_event__status,
+            fieldset: options.fieldset ?? undefined,
         }),
         [
             options.campaignGroups,
@@ -109,6 +110,7 @@ export const useCampaignParams = params => {
             campaignGroups: params.campaignGroups,
             show_test: showTest,
             last_budget_event__status: params.last_budget_event__status,
+            fieldset: 'list',
         };
     }, [params]);
 };

--- a/plugins/polio/js/src/pages/Calendar.js
+++ b/plugins/polio/js/src/pages/Calendar.js
@@ -62,6 +62,7 @@ const Calendar = ({ params }) => {
             search: params.search,
             campaignType: params.campaignType,
             campaignGroups: params.campaignGroups,
+            fieldset: 'calendar',
         };
     }, [
         orders,

--- a/plugins/polio/js/src/pages/Dashboard.js
+++ b/plugins/polio/js/src/pages/Dashboard.js
@@ -273,9 +273,8 @@ const Dashboard = ({ router }) => {
                 displayBackButton={false}
             />
             <CreateEditDialog
-                selectedCampaign={selectedCampaign}
+                campaignId={selectedCampaign?.id}
                 isOpen={isCreateEditDialogOpen}
-                isFetching={isFetching}
                 onClose={closeCreateEditDialog}
             />
             <ConfirmDialog

--- a/plugins/polio/serializers.py
+++ b/plugins/polio/serializers.py
@@ -721,6 +721,72 @@ class ListCampaignSerializer(CampaignSerializer):
         read_only_fields = fields
 
 
+class CalendarCampaignSerializer(CampaignSerializer):
+    """This serializer contains juste enough data for the Calendar view in the web ui. Read only.
+    Used by both anonymous and non anonymous user"""
+
+    class NestedListRoundSerializer(RoundSerializer):
+        class NestedScopeSerializer(RoundScopeSerializer):
+            class NestedGroupSerializer(GroupSerializer):
+                class Meta:
+                    model = Group
+                    fields = ["id"]
+
+            class Meta:
+                model = RoundScope
+                fields = ["group", "vaccine"]
+
+            group = NestedGroupSerializer()
+
+        class Meta:
+            model = Round
+            fields = [
+                "id",
+                "number",
+                "started_at",
+                "ended_at",
+                "scopes",
+            ]
+
+    class NestedScopeSerializer(CampaignScopeSerializer):
+        class NestedGroupSerializer(GroupSerializer):
+            class Meta:
+                model = Group
+                fields = ["id"]
+
+        class Meta:
+            model = CampaignScope
+            fields = ["group", "vaccine"]
+
+        group = NestedGroupSerializer()
+
+    rounds = NestedListRoundSerializer(many=True, required=False)
+    scopes = NestedScopeSerializer(many=True, required=False)
+
+    class Meta:
+        model = Campaign
+        fields = [
+            "id",
+            "epid",
+            "obr_name",
+            "account",
+            "cvdpv2_notified_at",
+            "top_level_org_unit_name",
+            "top_level_org_unit_id",
+            "rounds",
+            "is_preventive",
+            "general_status",
+            "grouped_campaigns",
+            "separate_scopes_per_round",
+            "scopes",
+            # displayed in RoundPopper
+            "risk_assessment_status",
+            "budget_status",
+            "vaccines",
+        ]
+        read_only_fields = fields
+
+
 class SmallCampaignSerializer(CampaignSerializer):
     class Meta:
         model = Campaign

--- a/plugins/polio/serializers.py
+++ b/plugins/polio/serializers.py
@@ -689,6 +689,38 @@ class CampaignSerializer(serializers.ModelSerializer):
         read_only_fields = ["last_surge", "preperadness_sync_status", "creation_email_send_at", "group"]
 
 
+class ListCampaignSerializer(CampaignSerializer):
+    "This serializer contains juste enough data for the List view in the web ui"
+
+    class NestedListRoundSerializer(RoundSerializer):
+        class Meta:
+            model = Round
+            fields = [
+                "id",
+                "number",
+                "started_at",
+                "ended_at",
+            ]
+
+    rounds = NestedListRoundSerializer(many=True, required=False)
+
+    class Meta:
+        model = Campaign
+        fields = [
+            "id",
+            "epid",
+            "obr_name",
+            "account",
+            "cvdpv2_notified_at",
+            "top_level_org_unit_name",
+            "top_level_org_unit_id",
+            "rounds",
+            "general_status",
+            "grouped_campaigns",
+        ]
+        read_only_fields = fields
+
+
 class SmallCampaignSerializer(CampaignSerializer):
     class Meta:
         model = Campaign


### PR DESCRIPTION
This PR speed up getting the campaign list and calendar by  only fetching the data needed for display and  when opening the edition dialog fetching the full campaign data from the server.

When combined with https://github.com/BLSQ/iaso/pull/281 the calendar get A LOT faster. See branch `POLIO-630-773-merge` if you want to test both together


## Changes

This is accomplished by in the backend adding a parameter to the API `fieldset` which tell which field of field to return. I considered using a Dynamic and that the frontend send the list of field it wanted but with the nested model it quickly got complicated. For now the value can either by `list` or `calendar`.

On the Frontend, we now pass the campaignId  instead of the full campaign data to CreateEditDialog and the dialog fetch the data when opened, via a new hook `getCampaign`. When we call getCampaigns (with s) we now pass the proper fieldset argument when needed.

## How to test

Regular polio setup. Test the list, edition of campaign, calendar, embeddedCalendar.

No particular set up is needed and there is no change to the data model. No change in comportement is expected except that it should be a lot faster.

https://user-images.githubusercontent.com/82500/211307849-2cae6bfd-e7f5-4ee8-983b-e1ef957e8ee9.mp4


