### PR TITLE
IA-1815: add source info in org unit creation details

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitCreationDetails.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitCreationDetails.tsx
@@ -19,6 +19,7 @@ import {
 } from 'bluesquare-components';
 import WidgetPaper from '../../../components/papers/WidgetPaperComponent';
 import { OrgUnit } from '../types/orgUnit';
+import { useCurrentUser } from '../../../utils/usersUtils';
 import MESSAGES from '../messages';
 
 const useStyles = makeStyles(theme => ({
@@ -65,6 +66,8 @@ export const OrgUnitCreationDetails: FunctionComponent<Props> = ({
         orgUnit.latitude && orgUnit.longitude ? latitude + longitude : false;
     const orgUnitCreatedAt = moment.unix(orgUnit.created_at).format('LTS');
     const orgUnitUpdatedAt = moment.unix(orgUnit.updated_at).format('LTS');
+    const currentUser = useCurrentUser();
+    const { account } = currentUser;
 
     return (
         <>
@@ -75,7 +78,10 @@ export const OrgUnitCreationDetails: FunctionComponent<Props> = ({
                     <TableBody>
                         <Row
                             label={formatMessage(MESSAGES.source)}
-                            value={orgUnit.source ?? '-'}
+                            value={
+                                orgUnit.source ??
+                                account.default_version?.data_source.name
+                            }
                             dataTestId="source"
                         />
                         <Row


### PR DESCRIPTION
source info was missing in org unit creation details
## Self proof reading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests
## Changes

import the `useCurrentUser` hook to get the source value


## Print screen / video
![Capture d’écran du 2023-01-11 12-23-27](https://user-images.githubusercontent.com/25134301/211794124-3c87c18f-7afe-429c-a81b-59ff0f6244ea.png)
