### PR TITLE
IA-1810: Submissions details start, end, today fields

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/instances/components/InstanceFileContentRich.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/InstanceFileContentRich.js
@@ -102,7 +102,6 @@ function getDisplayedValue(descriptor, data, activeLocale) {
     if (value === undefined) {
         return textPlaceholder;
     }
-
     switch (descriptor.type) {
         case 'select_one':
         case 'select one': {
@@ -187,9 +186,6 @@ function FormChild({ descriptor, data, showQuestionKey, showNote }) {
                     showQuestionKey={showQuestionKey}
                 />
             );
-        case 'start':
-        case 'end':
-        case 'today':
         case 'deviceid':
         case 'subscriberid':
         case 'simserial':
@@ -426,8 +422,8 @@ function Label({ descriptor, value, tooltip, showQuestionKey }) {
             {showQuestionKey
                 ? showNameHint && (
                       <div className={classes.tableCellLabelName}>
-                          {descriptor.name}
-                      </div>
+                    {descriptor.name}
+                </div>
                   )
                 : null}
         </div>


### PR DESCRIPTION
Start, end , today type of field were not present on a detail of a submission.

## Self proof reading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests
## Changes

I moved those field from meta to form field

## How to test

You need a form using thos types: `start`, `end` and `today` like this:
[form_a_2021100801.xls](https://github.com/BLSQ/iaso/files/10392365/form_a_2021100801.xls)
Create a submission wiht this form and go to the detail of it, those field should display a value.

## Print screen / video

<img width="1263" alt="Screenshot 2023-01-11 at 13 37 24" src="https://user-images.githubusercontent.com/12494624/211808079-62baef3f-a8a7-456c-a30a-e6c6f9950814.png">

