### PR TITLE
IA-1817: Org Unit page: Back arrow return to 404 when loading from url

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitCreationDetails.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitCreationDetails.tsx
@@ -36,7 +36,6 @@ type RowProps = {
 };
 
 const Row: FunctionComponent<RowProps> = ({ label, value, dataTestId }) => {
-    console.log('test', moment.unix(1633954017.188993).format('LTS'));
     const classes: Record<string, string> = useStyles();
     return (
         <TableRow>

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/details.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/details.js
@@ -47,6 +47,7 @@ import {
     getAliasesArrayFromString,
     getLinksSources,
     getOrgUnitsTree,
+    getOrgUnitsUrl,
 } from './utils';
 import { useCurrentUser } from '../../utils/usersUtils.ts';
 
@@ -108,7 +109,6 @@ const tabs = [
 const OrgUnitDetail = ({ params, router }) => {
     const classes = useStyles();
     const dispatch = useDispatch();
-
     const { mutateAsync: saveOu, isLoading: savingOu } = useSaveOrgUnit();
     const queryClient = useQueryClient();
     const { formatMessage } = useSafeIntl();
@@ -365,7 +365,6 @@ const OrgUnitDetail = ({ params, router }) => {
         isNewOrgunit,
         sourcesSelected,
     ]);
-
     return (
         <section className={classes.root}>
             <TopBar
@@ -378,9 +377,7 @@ const OrgUnitDetail = ({ params, router }) => {
                         }, 300);
                     } else {
                         dispatch(
-                            redirectTo(baseUrls.orgUnits, {
-                                accountId: params.accountId,
-                            }),
+                            redirectTo(getOrgUnitsUrl(params.accountId), {}),
                         );
                     }
                 }}

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/utils.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/utils.js
@@ -1,5 +1,11 @@
 import React from 'react';
-import { textPlaceholder, useSafeIntl } from 'bluesquare-components';
+
+import { textPlaceholder, useSafeIntl, createUrl } from 'bluesquare-components';
+import { getChipColors } from '../../constants/chipColors';
+import { baseUrls } from '../../constants/urls';
+
+import { locationLimitMax } from './constants/orgUnitConstants';
+
 import OrgUnitPopupComponent from './components/OrgUnitPopupComponent';
 import MarkersListComponent from '../../components/maps/markers/MarkersListComponent';
 import {
@@ -278,3 +284,19 @@ export const compareGroupVersions = (a, b) => {
     }
     return comparison;
 };
+
+export const getOrgUnitsUrl = accountId =>
+    `${baseUrls.orgUnits}${createUrl(
+        {
+            accountId,
+            locationLimit: locationLimitMax,
+            order: 'id',
+            pageSize: 50,
+            page: 1,
+            searchTabIndex: 0,
+            searches: `[{"validation_status":"all", "color":"${getChipColors(
+                0,
+            ).replace('#', '')}"}]`,
+        },
+        '',
+    )}`;

--- a/hat/assets/js/apps/Iaso/routing/redirections.js
+++ b/hat/assets/js/apps/Iaso/routing/redirections.js
@@ -8,13 +8,11 @@ import {
 
 import { cloneDeep } from 'lodash';
 import { baseUrls } from '../constants/urls';
-import { getChipColors } from '../constants/chipColors';
-
-import { locationLimitMax } from '../domains/orgUnits/constants/orgUnitConstants';
 import Page404 from '../components/errors/Page404';
 
 import { defaultSorted as storageDefaultSort } from '../domains/storages/config.tsx';
 import { defaultSorted as workflowDefaultSort } from '../domains/workflows/config.tsx';
+import { getOrgUnitsUrl } from '../domains/orgUnits/utils';
 
 const getRedirections = overrideLanding => {
     const getPaginationParams = (order = 'id', pageSize = 20) =>
@@ -26,14 +24,7 @@ const getRedirections = overrideLanding => {
         },
         {
             path: `${baseUrls.orgUnits}`,
-            to: `${
-                baseUrls.orgUnits
-            }/locationLimit/${locationLimitMax}${getPaginationParams(
-                undefined,
-                50,
-            )}/searchTabIndex/0/searches/[{"validation_status":"all", "color":"${getChipColors(
-                0,
-            ).replace('#', '')}"}]`,
+            to: getOrgUnitsUrl(),
         },
         {
             path: `${baseUrls.mappings}`,


### PR DESCRIPTION
If you go directly on the org unit creation page url. e.g 

 https://iaso-staging.bluesquare.org/dashboard/orgunits/detail/accountId/8/orgUnitId/0
then press the back arrow in the top bar it goes to 

  https://iaso-staging.bluesquare.org/dashboard/orgunits/list/accountId/8 
which return a 404 (from react router)

## Self proof reading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests
- 
## Changes

Dedicated function to create org units list url.
Using it in redirections and back button on org units list.


## How to test

Open an org unit on a a new tab. Refresh the page and then go back.
You should arrive on org units list page.
Same while creating an org unit.

## Print screen / video


https://user-images.githubusercontent.com/12494624/211839377-30605857-281e-4583-8b0c-8efc091e4ff9.mov

