### PR TITLE
IA-1781: Completeness stats: don't show lines when "with descendants" count would be 0/0

### DIFF
--- a/iaso/api/completeness_stats.py
+++ b/iaso/api/completeness_stats.py
@@ -125,26 +125,27 @@ class CompletenessStatsViewSet(viewsets.ViewSet):
                 if row_ou.parent is not None:
                     parent_data = (row_ou.parent.as_dict_for_completeness_stats(),)
 
-                res.append(
-                    {
-                        "parent_org_unit": parent_data,
-                        "org_unit_type": row_ou.org_unit_type.as_dict_for_completeness_stats(),
-                        "org_unit": row_ou.as_dict_for_completeness_stats(),
-                        "form": form.as_dict_for_completeness_stats(),
-                        # Those counts target the row org unit and all of its descendants
-                        "forms_filled": ou_filled_with_descendants_count,
-                        "forms_to_fill": ou_to_fill_with_descendants_count,
-                        "completeness_ratio": formatted_percentage(
-                            part=ou_filled_with_descendants_count, total=ou_to_fill_with_descendants_count
-                        ),
-                        # Those counts strictly/directly target the row org unit (no descendants included)
-                        "forms_filled_direct": ou_filled_direct_count,
-                        "forms_to_fill_direct": ou_to_fill_direct_count,
-                        "completeness_ratio_direct": formatted_percentage(
-                            part=ou_filled_direct_count, total=ou_to_fill_direct_count
-                        ),
-                    }
-                )
+                if ou_to_fill_with_descendants_count > 0:
+                    res.append(
+                        {
+                            "parent_org_unit": parent_data,
+                            "org_unit_type": row_ou.org_unit_type.as_dict_for_completeness_stats(),
+                            "org_unit": row_ou.as_dict_for_completeness_stats(),
+                            "form": form.as_dict_for_completeness_stats(),
+                            # Those counts target the row org unit and all of its descendants
+                            "forms_filled": ou_filled_with_descendants_count,
+                            "forms_to_fill": ou_to_fill_with_descendants_count,
+                            "completeness_ratio": formatted_percentage(
+                                part=ou_filled_with_descendants_count, total=ou_to_fill_with_descendants_count
+                            ),
+                            # Those counts strictly/directly target the row org unit (no descendants included)
+                            "forms_filled_direct": ou_filled_direct_count,
+                            "forms_to_fill_direct": ou_to_fill_direct_count,
+                            "completeness_ratio_direct": formatted_percentage(
+                                part=ou_filled_direct_count, total=ou_to_fill_direct_count
+                            ),
+                        }
+                    )
         limit = int(request.GET.get("limit", 10))
         page_offset = int(request.GET.get("page", "1"))
         paginator = Paginator(res, limit)

--- a/iaso/tests/api/test_completeness_stats.py
+++ b/iaso/tests/api/test_completeness_stats.py
@@ -256,12 +256,12 @@ class CompletenessStatsAPITestCase(APITestCase):
         self.client.force_authenticate(self.user)
 
         # We request a form/OU combination that has no forms to fill.
-        response = self.client.get(f"/api/completeness_stats/?org_unit_id=3&form_id={self.form_hs_2.id}")
+        response = self.client.get(f"/api/completeness_stats/?org_unit_id=2&form_id={self.form_hs_2.id}")
         json = response.json()
         # 0 forms to fill: the percentage should be returned as N/A and not as 0% or as a division error :)
         row = json["results"][0]
-        self.assertEqual(row["forms_to_fill"], 0)
-        self.assertEqual(row["completeness_ratio"], "N/A")
+        self.assertEqual(row["forms_to_fill_direct"], 0)
+        self.assertEqual(row["completeness_ratio_direct"], "N/A")
 
     def test_counts_include_current_ou_and_children(self):
         """The forms_to_fill/forms_filled counts include the forms for the OU and all its children"""
@@ -361,3 +361,14 @@ class CompletenessStatsAPITestCase(APITestCase):
             self.assertEqual(result_as["forms_filled"], 0)
             self.assertEqual(result_as["forms_to_fill_direct"], 1)
             self.assertEqual(result_as["forms_filled_direct"], 0)
+
+    def test_no_rows_if_form_not_for_ou_and_descendants(self):
+        """
+        The API exclude the rows that qre not relevant because the form is not for the OU and its descendants.
+
+        Those lines would have 0/0 in the "count with descendants" column and would pollute the table.
+        """
+        self.client.force_authenticate(self.user)
+        response = self.client.get(f"/api/completeness_stats/?form_id={self.form_hs_4.id}&parent_org_unit_id=2")
+        json = response.json()
+        self.assertEqual(json["results"], [])


### PR DESCRIPTION
In the current version of the completeness table, we often have rows that shows a “0/0“ value in the “# Forms filled (with descendants)“ column. 

This means the form of the row is not configured to  target OU type of the row's OU, nor any of its descendants.
Since the whole purpose of the completeness table is to show progress/percentages for a OrgUnit/Form combination, listing those 0/0 rows is just adding noise to the table, since the combination is not relevant.

After applying this PR, those rows are simply not returned anymore.

Please note that each row has two counters: "with descendants" and "direct". The ones with 0/0 in the "direct count" columns can be returned if there is something targeting their children (this allows the drilldown). 


## Self proof reading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are there enough tests

## How to test

Use the completeness table to show a given OU and form, and make sure the form configuration make it non-applicable to the requested OUs nor any of its descendants.

=> The returned table should now be empty.
