### PR TITLE
Ia 1764 submissions reset

### DIFF
--- a/hat/assets/js/apps/Iaso/components/filters/DatesRange.js
+++ b/hat/assets/js/apps/Iaso/components/filters/DatesRange.js
@@ -4,7 +4,12 @@ import { makeStyles } from '@material-ui/core/styles';
 import { KeyboardDatePicker } from '@material-ui/pickers';
 
 import { Grid, useTheme, useMediaQuery, Box } from '@material-ui/core';
-import { injectIntl, IconButton, FormControl } from 'bluesquare-components';
+import {
+    injectIntl,
+    IconButton,
+    FormControl,
+    useSkipEffectOnMount,
+} from 'bluesquare-components';
 import EventIcon from '@material-ui/icons/Event';
 import MESSAGES from './messages';
 import {
@@ -88,6 +93,16 @@ const DatesRange = ({
         },
         [blockInvalidDates, onChangeDate],
     );
+    useSkipEffectOnMount(() => {
+        if (from !== dateFrom) {
+            setFrom(dateFrom);
+        }
+    }, [dateFrom]);
+    useSkipEffectOnMount(() => {
+        if (to !== dateTo) {
+            setTo(dateTo);
+        }
+    }, [dateTo]);
     // Converting the displayedDateFormat to this one onChange to avoid a nasty bug in Firefox
     return (
         <Grid container spacing={useCurrentBreakPointSpacing(xs, sm, md, lg)}>

--- a/hat/assets/js/apps/Iaso/domains/instances/components/InstancesFiltersComponent.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/InstancesFiltersComponent.js
@@ -79,6 +79,7 @@ const InstancesFiltersComponent = ({
         delete filters.pageSize;
         delete filters.order;
         delete filters.page;
+        filters.showDeleted = filters.showDeleted === 'true';
         return filters;
     }, [params]);
     const [formState, setFormState] = useFormState(
@@ -88,7 +89,11 @@ const InstancesFiltersComponent = ({
     const { data: initialOrgUnit } = useGetOrgUnit(initialOrgUnitId);
     useSkipEffectOnMount(() => {
         Object.entries(params).forEach(([key, value]) => {
-            setFormState(key, value);
+            if (key === 'showDeleted') {
+                setFormState(key, value === 'true');
+            } else {
+                setFormState(key, value);
+            }
         });
         setInitialOrgUnitId(params?.levels);
     }, [defaultFilters]);


### PR DESCRIPTION
Date Fields filter remain after clicking on "Submissions" menu item.
Show only deleted was not working properly

## Self proof reading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests

## Changes

- Refresh date range component from and to state while props are changing
- parse showDeleted value from params to a boolean


## How to test

Open submissions page:
- check that the checkbox show deleted is working properly
- fill up every filters and make sure they are reset if you click again on submissions in the sidebar menu

## Print screen / video

https://user-images.githubusercontent.com/12494624/212298609-331bebe5-4122-44b0-8e99-0694578148f9.mov


