### PR TITLE
IA-1816: groups dropdown empty at first load

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitCreationDetails.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitCreationDetails.tsx
@@ -36,7 +36,6 @@ type RowProps = {
 };
 
 const Row: FunctionComponent<RowProps> = ({ label, value, dataTestId }) => {
-    console.log('test', moment.unix(1633954017.188993).format('LTS'));
     const classes: Record<string, string> = useStyles();
     return (
         <TableRow>

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/hooks.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/hooks.js
@@ -28,7 +28,7 @@ export const useOrgUnitDetailData = (
     const groupsUrl = useMemo(() => {
         const basUrl = '/api/groups/';
         if (isNewOrgunit) {
-            return `${basUrl}?&defaultVersion=true'`;
+            return `${basUrl}?&defaultVersion=true`;
         }
         if (originalOrgUnit?.source_id) {
             return `${basUrl}?&dataSource=${originalOrgUnit.source_id}`;
@@ -64,7 +64,6 @@ export const useOrgUnitDetailData = (
             snackErrorMsg: MESSAGES.fetchGroupsError,
             options: {
                 select: data => data.groups,
-                enabled: Boolean(originalOrgUnit),
             },
         },
         {


### PR DESCRIPTION
groups select was empy when creating a new orgunit

## Self proof reading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests
## Changes

- remove blocking condition to fetch groups if new orgunit

## How to test

Go to Orgunits > Create
You should be able to select options in groups select filter

## Print screen / video

[recording-2023-01-13-11-46-07.webm](https://user-images.githubusercontent.com/25134301/212302476-1d5e8f20-f79f-4fce-9c93-d19524c421ed.webm)
