### PR TITLE
Aggregate handle dhis 2.38 exceptions

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/instances/components/InstanceDetailsExportRequests.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/InstanceDetailsExportRequests.js
@@ -38,7 +38,7 @@ const InstanceDetailsExportRequests = ({
         {currentInstance.export_statuses &&
             currentInstance.export_statuses.length > 0 && <Divider />}
         {currentInstance.export_statuses.map((exportStatus, index) => (
-            <>
+            <React.Fragment key={index}>
                 <InstanceDetailsField
                     label={formatMessage(MESSAGES.exportStatus)}
                     value={exportStatus.status}
@@ -66,7 +66,7 @@ const InstanceDetailsExportRequests = ({
                 {index !== currentInstance.export_statuses.length - 1 && (
                     <Divider />
                 )}
-            </>
+            </React.Fragment>
         ))}
     </WidgetPaper>
 );

--- a/iaso/dhis2/datavalue_exporter.py
+++ b/iaso/dhis2/datavalue_exporter.py
@@ -70,6 +70,11 @@ class AggregateHandler(BaseHandler):
                 descriptions.append(response["message"])
         if "conflicts" in response:
             descriptions = [m["value"] for m in response["conflicts"]]
+
+        # 2.38 nesting conflicts in response
+        if "response" in response and "conflicts" in response["response"]:
+            descriptions = [m["value"] for m in response["response"]["conflicts"]]
+
         descriptions = uniquify(descriptions)
         if len(descriptions) > 0:
             self.logger.warn(

--- a/iaso/dhis2/datavalue_exporter.py
+++ b/iaso/dhis2/datavalue_exporter.py
@@ -68,10 +68,12 @@ class AggregateHandler(BaseHandler):
                 descriptions.append(response["description"])
             if "message" in response:
                 descriptions.append(response["message"])
+
+        # version < 2.38, a normal payload is sent with 200
         if "conflicts" in response:
             descriptions = [m["value"] for m in response["conflicts"]]
 
-        # 2.38 nesting conflicts in response
+        # 2.38 nesting conflicts in response with 409
         if "response" in response and "conflicts" in response["response"]:
             descriptions = [m["value"] for m in response["response"]["conflicts"]]
 

--- a/iaso/tests/fixtures/dhis2/datavalues-error-bad-type.json
+++ b/iaso/tests/fixtures/dhis2/datavalues-error-bad-type.json
@@ -1,0 +1,57 @@
+{
+    "httpStatus": "Conflict",
+    "httpStatusCode": 409,
+    "status": "WARNING",
+    "message": "One more conflicts encountered, please check import summary.",
+    "response": {
+        "responseType": "ImportSummary",
+        "status": "WARNING",
+        "importOptions": {
+            "idSchemes": {},
+            "dryRun": false,
+            "async": false,
+            "importStrategy": "CREATE_AND_UPDATE",
+            "mergeMode": "REPLACE",
+            "reportMode": "FULL",
+            "skipExistingCheck": false,
+            "sharing": false,
+            "skipNotifications": false,
+            "skipAudit": false,
+            "datasetAllowsPeriods": false,
+            "strictPeriods": false,
+            "strictDataElements": false,
+            "strictCategoryOptionCombos": false,
+            "strictAttributeOptionCombos": false,
+            "strictOrganisationUnits": false,
+            "requireCategoryOptionCombo": false,
+            "requireAttributeOptionCombo": false,
+            "skipPatternValidation": false,
+            "ignoreEmptyCollection": false,
+            "force": false,
+            "firstRowIsHeader": false,
+            "skipLastUpdated": false,
+            "mergeDataValues": false,
+            "skipCache": false
+        },
+        "description": "Import process completed successfully",
+        "importCount": {
+            "imported": 0,
+            "updated": 355,
+            "ignored": 1,
+            "deleted": 0
+        },
+        "conflicts": [
+            {
+                "object": "nymNRxmnj4z",
+                "objects": {
+                    "dataElement": "nymNRxmnj4z",
+                    "value": "value_not_integer"
+                },
+                "value": "Value must match data element's `nymNRxmnj4z` type constraints: Data value is not an integer",
+                "errorCode": "E7619",
+                "property": "value"
+            }
+        ],
+        "dataSetComplete": "false"
+    }
+}

--- a/iaso/tests/tests_aggregate_exporter.py
+++ b/iaso/tests/tests_aggregate_exporter.py
@@ -471,7 +471,7 @@ class DataValueExporterTests(TestCase):
         self.expect_logs(ERRORED)
 
         self.assertEquals(
-            "ERROR while processing page 1/1 : Data element: FC3nR54yGUx must be assigned through data sets to organisation unit: t3kZ5ksd8IR",
+            "ERROR while processing page 1/1 : Value must match data element's `nymNRxmnj4z` type constraints: Data value is not an integer",
             context.exception.message,
         )
         instance.refresh_from_db()

--- a/iaso/tests/tests_aggregate_exporter.py
+++ b/iaso/tests/tests_aggregate_exporter.py
@@ -440,6 +440,44 @@ class DataValueExporterTests(TestCase):
         self.assertIsNone(instance.last_export_success_at)
 
     @responses.activate
+    def test_aggregate_export_handle_dhis2_errors_238_and_higher(self):
+        instance = self.build_instance(self.form)
+
+        with self.assertRaises(InstanceExportError) as context:
+            mapping_version = MappingVersion(
+                name="aggregate", json=build_form_mapping(), form_version=self.form_version, mapping=self.mapping
+            )
+            mapping_version.save()
+
+            # dhis2 2.38 now return a bad request (vs 200 previously)
+            # the payload is wrapped in "response" field
+            responses.add(
+                responses.POST,
+                "https://dhis2.com/api/dataValueSets",
+                json=load_dhis2_fixture("datavalues-error-bad-type.json"),
+                status=409,
+            )
+
+            export_request = ExportRequestBuilder().build_export_request(
+                filters={
+                    "period_ids": ",".join(["201801"]),
+                    "form_id": self.form.id,
+                    "org_unit_id": instance.org_unit.id,
+                },
+                launcher=self.user,
+            )
+            DataValueExporter().export_instances(export_request)
+
+        self.expect_logs(ERRORED)
+
+        self.assertEquals(
+            "ERROR while processing page 1/1 : Data element: FC3nR54yGUx must be assigned through data sets to organisation unit: t3kZ5ksd8IR",
+            context.exception.message,
+        )
+        instance.refresh_from_db()
+        self.assertIsNone(instance.last_export_success_at)
+
+    @responses.activate
     def test_aggregate_export_continue_on_dhis2_errors(self):
         self.setUpFormQuality()
         # setup


### PR DESCRIPTION

Dhis2 2.38 changed the http code in case of imports with warnings

## Changes

The good news is that the current code was already a bit considering this as an exception
I just had to adapt a bit the parsing of the conflicts field because the payload changed a bit too.


## How to test

- seed on a 2.38 version : 
`docker-compose run --rm iaso manage seed_test_data --mode=seed --dhis2version=2.38`
- test the export of a single submission of the quantity form
- then change in dhis2 the data element type from Number to Integer (https://play.dhis2.org/2.38.2.1/dhis-web-maintenance/index.html#/edit/dataElementSection/dataElement/nymNRxmnj4z) 
- modify the submission json via django admin to have decimals (something like 
  via something like http://localhost:8081/admin/iaso/instance/56359/change/
![image](https://user-images.githubusercontent.com/371692/212319663-1d281268-d7fe-45f1-a9a0-cbaede3bc1de.png)
- test the export of the modified, verify the error messages looks like this
![image](https://user-images.githubusercontent.com/371692/212318633-3f28f565-aff2-4b2b-8036-523a4599267e.png)

