### PR TITLE
POLIO-743 number of days since notification date in automatic email to gpei coordinator does not show

### DIFF
--- a/plugins/polio/management/commands/weekly_email.py
+++ b/plugins/polio/management/commands/weekly_email.py
@@ -39,11 +39,15 @@ def send_notification_email(campaign):
     emails = [user.email for user in users if user.email]
     if not emails:
         return False
-    day_number = (now().date() - campaign.cvdpv_notified_at).days if campaign.cvdpv_notified_at else ""
+    day_number = (
+        (now().date() - campaign.cvdpv_notified_at).days
+        if campaign.cvdpv_notified_at
+        else "{Error: No cVDPV notification available. Enter a notification date in order to have the days count.}"
+    )
     onset_days = (
         (campaign.cvdpv_notified_at - campaign.onset_at).days
         if campaign.onset_at and campaign.cvdpv_notified_at
-        else ""
+        else "{Error: No cVDPV notification available. Enter a notification date in order to have the days count.}"
     )
     try:
         first_round = campaign.rounds.earliest("number")

--- a/plugins/polio/management/commands/weekly_email.py
+++ b/plugins/polio/management/commands/weekly_email.py
@@ -47,7 +47,7 @@ def send_notification_email(campaign):
     onset_days = (
         (campaign.cvdpv_notified_at - campaign.onset_at).days
         if campaign.onset_at and campaign.cvdpv_notified_at
-        else "{Error: No cVDPV notification available. Enter a notification date in order to have the days count.}"
+        else "{Error: No cVDPV notification or campaign on set available. Enter a date in order to have the days count.}"
     )
     try:
         first_round = campaign.rounds.earliest("number")

--- a/plugins/polio/tests/test_base.py
+++ b/plugins/polio/tests/test_base.py
@@ -27,7 +27,7 @@ from iaso.test import APITestCase, TestCase
 
 from plugins.polio.management.commands.weekly_email import send_notification_email
 from ..api import CACHE_VERSION
-from ..models import Config
+from ..models import Config, Round
 
 from ..preparedness.calculator import get_preparedness_score
 from ..preparedness.exceptions import InvalidFormatError
@@ -310,6 +310,7 @@ class PolioAPITestCase(APITestCase):
             country=self.org_unit,
             onset_at=now(),
             account=self.account,
+            cvdpv_notified_at=datetime.date(2022, 9, 12),
         )
 
         country_user_grp = CountryUsersGroup(country=self.org_unit)
@@ -326,6 +327,39 @@ class PolioAPITestCase(APITestCase):
         campaign_active.save()
 
         self.assertEqual(send_notification_email(campaign_deleted), False)
+        self.assertEqual(send_notification_email(campaign_active), True)
+
+    def test_weekly_mail_content_active_campaign(self):
+
+        round = Round.objects.create(
+            started_at=datetime.date(2022, 9, 12),
+            number=1,
+        )
+
+        campaign_active = Campaign(
+            obr_name="active campaign",
+            detection_status="PENDING",
+            virus="ABC",
+            country=self.org_unit,
+            onset_at=now().date(),
+            account=self.account,
+            cvdpv_notified_at=datetime.date(2022, 9, 12),
+            vacine="mOPV2",
+        )
+
+        round.campaign = campaign_active
+        campaign_active.rounds.set([round])
+
+        country_user_grp = CountryUsersGroup(country=self.org_unit)
+        country_user_grp.save()
+
+        users = User.objects.all()
+        country_user_grp.users.set(users)
+
+        self.luke.email = "luketest@lukepoliotest.io"
+        self.luke.save()
+        campaign_active.save()
+
         self.assertEqual(send_notification_email(campaign_active), True)
 
     def create_multiple_campaigns(self, count: int) -> None:

--- a/plugins/polio/tests/test_base.py
+++ b/plugins/polio/tests/test_base.py
@@ -310,7 +310,6 @@ class PolioAPITestCase(APITestCase):
             country=self.org_unit,
             onset_at=now(),
             account=self.account,
-            cvdpv_notified_at=datetime.date(2022, 9, 12),
         )
 
         country_user_grp = CountryUsersGroup(country=self.org_unit)

--- a/plugins/polio/tests/test_base.py
+++ b/plugins/polio/tests/test_base.py
@@ -293,6 +293,41 @@ class PolioAPITestCase(APITestCase):
         self.assertEqual(send_notification_email(campaign_deleted), False)
         self.assertEqual(send_notification_email(campaign_active), True)
 
+    def test_sweekly_mail_content(self):
+        campaign_deleted = Campaign(
+            obr_name="deleted_campaign",
+            detection_status="PENDING",
+            virus="ABC",
+            country=self.org_unit,
+            onset_at=now(),
+            account=self.account,
+        )
+
+        campaign_active = Campaign(
+            obr_name="active campaign",
+            detection_status="PENDING",
+            virus="ABC",
+            country=self.org_unit,
+            onset_at=now(),
+            account=self.account,
+        )
+
+        country_user_grp = CountryUsersGroup(country=self.org_unit)
+        country_user_grp.save()
+
+        users = User.objects.all()
+        country_user_grp.users.set(users)
+
+        self.luke.email = "luketest@lukepoliotest.io"
+        self.luke.save()
+
+        campaign_deleted.save()
+        campaign_deleted.delete()
+        campaign_active.save()
+
+        self.assertEqual(send_notification_email(campaign_deleted), False)
+        self.assertEqual(send_notification_email(campaign_active), True)
+
     def create_multiple_campaigns(self, count: int) -> None:
         for n in range(count):
             payload = {

--- a/plugins/polio/tests/test_base.py
+++ b/plugins/polio/tests/test_base.py
@@ -293,7 +293,7 @@ class PolioAPITestCase(APITestCase):
         self.assertEqual(send_notification_email(campaign_deleted), False)
         self.assertEqual(send_notification_email(campaign_active), True)
 
-    def test_sweekly_mail_content(self):
+    def test_weekly_mail_content(self):
         campaign_deleted = Campaign(
             obr_name="deleted_campaign",
             detection_status="PENDING",


### PR DESCRIPTION
After checking everything the calculation seems to work when the cVDVP date is correctly filled. 
After a small talk with Laure we agreed to add an error message if the cVDVP is empty.

For the preparedness Olivier has  some code update to do as we discussed. 

## Self proof reading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are there enough tests

<img width="1293" alt="image" src="https://user-images.githubusercontent.com/45785235/212330375-43368a19-be1d-480e-b119-467ceac70872.png">
