### PR TITLE
IA-1818: fix version number not showing if is equal to 0

### DIFF
--- a/hat/assets/js/apps/Iaso/components/nav/CurrentUser/index.tsx
+++ b/hat/assets/js/apps/Iaso/components/nav/CurrentUser/index.tsx
@@ -119,6 +119,7 @@ export const CurrentUserInfos: FunctionComponent<Props> = ({
                         <span>
                             {`${
                                 (defaultSourceVersion.version &&
+                                    defaultSourceVersion.version.number >= 0 &&
                                     defaultSourceVersion.version.number) ||
                                 '-'
                             }`}

--- a/hat/assets/js/apps/Iaso/components/nav/CurrentUser/index.tsx
+++ b/hat/assets/js/apps/Iaso/components/nav/CurrentUser/index.tsx
@@ -118,10 +118,10 @@ export const CurrentUserInfos: FunctionComponent<Props> = ({
                         </span>
                         <span>
                             {`${
-                                (defaultSourceVersion.version &&
-                                    defaultSourceVersion.version.number >= 0 &&
-                                    defaultSourceVersion.version.number) ||
-                                '-'
+                                defaultSourceVersion.version &&
+                                defaultSourceVersion.version.number >= 0
+                                    ? defaultSourceVersion.version.number
+                                    : '-'
                             }`}
                         </span>
                     </div>


### PR DESCRIPTION
Current user tool tip doesn't display correct Source version number if number is 0


- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests
## Changes

- update condition to display version number