### PR TITLE
POLIO-470: Budget filters: add country filter

### DIFF
--- a/plugins/polio/js/config.js
+++ b/plugins/polio/js/config.js
@@ -235,6 +235,10 @@ const routes = [
                 isRequired: false,
                 key: 'roundStartTo',
             },
+            {
+                isRequired: false,
+                key: 'countries',
+            },
         ],
     },
     {

--- a/plugins/polio/js/src/hooks/useGetCampaigns.js
+++ b/plugins/polio/js/src/hooks/useGetCampaigns.js
@@ -34,6 +34,7 @@ export const useGetCampaigns = (
             options.campaignType,
             options.countries,
             options.enabled,
+            options.fieldset,
             options.last_budget_event__status,
             options.order,
             options.page,

--- a/plugins/polio/js/src/pages/Budget/BudgetFilters.tsx
+++ b/plugins/polio/js/src/pages/Budget/BudgetFilters.tsx
@@ -9,6 +9,7 @@ import { BUDGET } from '../../constants/routes';
 import { UrlParams } from '../../../../../../hat/assets/js/apps/Iaso/types/table';
 import { BudgetStatus } from '../../constants/types';
 import { DropdownOptions } from '../../../../../../hat/assets/js/apps/Iaso/types/utils';
+import { useGetCountries } from '../../hooks/useGetCountries';
 
 type Props = {
     params: UrlParams & {
@@ -35,6 +36,8 @@ export const BudgetFilters: FunctionComponent<Props> = ({
         useFilterState({ baseUrl, params });
     const theme = useTheme();
     const isXSLayout = useMediaQuery(theme.breakpoints.down('xs'));
+    const { data, isFetching: isFetchingCountries } = useGetCountries();
+    const countriesList = (data && data.orgUnits) || [];
     return (
         <Box mb={4}>
             <Grid container spacing={isXSLayout ? 0 : 2}>
@@ -59,7 +62,23 @@ export const BudgetFilters: FunctionComponent<Props> = ({
                         label={MESSAGES.status}
                     />
                 </Grid>
-                <Grid container item xs={12} md={6} justifyContent="flex-end">
+                <Grid item xs={12} sm={6} md={3}>
+                    <InputComponent
+                        loading={isFetchingCountries}
+                        keyValue="countries"
+                        multi
+                        clearable
+                        onChange={handleChange}
+                        value={filters.countries}
+                        type="select"
+                        options={countriesList.map(c => ({
+                            label: c.name,
+                            value: c.id,
+                        }))}
+                        label={MESSAGES.country}
+                    />
+                </Grid>
+                <Grid container item xs={12} md={3} justifyContent="flex-end">
                     <Box mt={2}>
                         <FilterButton
                             disabled={!filtersUpdated}

--- a/plugins/polio/js/src/pages/Budget/hooks/api/useGetBudget.ts
+++ b/plugins/polio/js/src/pages/Budget/hooks/api/useGetBudget.ts
@@ -32,6 +32,7 @@ export const useGetBudgets = (options: any): any => {
         order: options.order,
         search: options.search,
         budget_current_state_key__in: options.budget_current_state_key__in,
+        country__id__in: options.country__id__in,
         fields: 'id,obr_name,country_name,current_state,cvdpv2_notified_at,possible_states,budget_last_updated_at',
     };
 
@@ -51,12 +52,14 @@ export const useBudgetParams = params => {
             roundStartFrom: getApiParamDateString(params.roundStartFrom),
             roundStartTo: getApiParamDateString(params.roundStartTo),
             budget_current_state_key__in: params.current_state__key,
+            country__id__in: params?.countries,
         };
     }, [
         params.current_state__key,
         params?.order,
         params?.page,
         params?.pageSize,
+        params?.countries,
         params.roundStartFrom,
         params.roundStartTo,
         params.search,


### PR DESCRIPTION
Allow to filter budget by countries

## Self proof reading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests

## Changes

Adding new multi select on budget filters.
Adapt existing hooks to use this param
Api was already working


## How to test

Go to budget page and try to filter the by countries

## Print screen / video

<img width="1651" alt="Screenshot 2023-01-17 at 12 55 50" src="https://user-images.githubusercontent.com/12494624/212893307-f8a55917-a14f-4eb7-9aca-3c1091beec8a.png">

<img width="844" alt="Screenshot 2023-01-17 at 12 55 31" src="https://user-images.githubusercontent.com/12494624/212893315-ed41299b-2fea-41ca-8eff-ce5b7e4d5f90.png">
