### PR TITLE
POLIO-780 Crash when encoding campaign scope

### DIFF
--- a/plugins/polio/js/src/forms/ScopeForm.tsx
+++ b/plugins/polio/js/src/forms/ScopeForm.tsx
@@ -80,7 +80,7 @@ export const ScopeForm: FunctionComponent = () => {
     }, [currentTab, rounds, scopePerRound, sortedRounds, values.scopes]);
 
     const filteredDistricts = useMemo(() => {
-        if (districtShapes) {
+        if (districtShapes && regionShapes) {
             let filtered: FilteredDistricts[] = districtShapes.map(district => {
                 return {
                     ...cloneDeep(district),


### PR DESCRIPTION
Happened with the Botswana campaign
Attempt to FIX POLIO-780.
I made the change from the error on production since I can't reproduce it locally and can't manage to reproduce consistently in production I assume this is a concurrency error following the order in which the server respond to the request. Nevertheless this check was necessary.

## How to test
didn't manage to reproduce it locally. We can probably check in prod.

## Notes
I think this  problem was not detected in typescript because I didn't do the typing properly in : `plugins/polio/js/src/hooks/useGetGeoJson.ts` If someone want to look into it?
