### PR TITLE
WC-118: fix back arrow not working on storage details

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/storages/components/LogsFilters.tsx
+++ b/hat/assets/js/apps/Iaso/domains/storages/components/LogsFilters.tsx
@@ -28,7 +28,7 @@ type Props = {
 const baseUrl = baseUrls.storageDetail;
 export const LogsFilters: FunctionComponent<Props> = ({ params }) => {
     const { filters, handleSearch, handleChange, filtersUpdated } =
-        useFilterState({ baseUrl, params });
+        useFilterState({ baseUrl, params, saveSearchInHistory: false });
     const { formatMessage }: { formatMessage: IntlFormatMessage } =
         useSafeIntl();
     const operationTypes = useGetOperationsTypes();

--- a/hat/assets/js/apps/Iaso/domains/storages/details.tsx
+++ b/hat/assets/js/apps/Iaso/domains/storages/details.tsx
@@ -7,7 +7,7 @@ import {
 } from 'bluesquare-components';
 // @ts-ignore
 import { Box, Divider, Grid, makeStyles } from '@material-ui/core';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import TopBar from '../../components/nav/TopBarComponent';
 import { Infos } from './components/Infos';
 import { TableWithDeepLink } from '../../components/tables/TableWithDeepLink';
@@ -31,13 +31,23 @@ import { useGetDetailsColumns } from './config';
 
 type Props = {
     params: StorageDetailsParams;
+    router: Router;
+};
+type State = {
+    routerCustom: RouterCustom;
+};
+type RouterCustom = {
+    prevPathname: string | undefined;
 };
 
+type Router = {
+    goBack: () => void;
+};
 const useStyles = makeStyles(theme => ({
     ...commonStyles(theme),
 }));
 
-export const Details: FunctionComponent<Props> = ({ params }) => {
+export const Details: FunctionComponent<Props> = ({ params, router }) => {
     const { formatMessage } = useSafeIntl();
     const { data, isFetching } = useGetStorageLogs(params);
     const { url: apiUrl } = useGetApiParams(params);
@@ -45,13 +55,14 @@ export const Details: FunctionComponent<Props> = ({ params }) => {
     const storageDetail = data?.results;
 
     const classes: Record<string, string> = useStyles();
-
+    const prevPathname: string | undefined = useSelector(
+        (state: State) => state.routerCustom.prevPathname,
+    );
     const dispatch = useDispatch();
 
     const columns = useGetDetailsColumns();
 
     const storageDetailLogs = storageDetail?.logs ?? [];
-
     return (
         <>
             <TopBar
@@ -60,7 +71,11 @@ export const Details: FunctionComponent<Props> = ({ params }) => {
                 }`}
                 displayBackButton
                 goBack={() => {
-                    dispatch(redirectToReplace(baseUrls.storages, {}));
+                    if (prevPathname) {
+                        router.goBack();
+                    } else {
+                        dispatch(redirectToReplace(baseUrls.storages, {}));
+                    }
                 }}
             />
             <Box className={`${classes.containerFullHeightNoTabPadded}`}>

--- a/hat/assets/js/apps/Iaso/domains/storages/details.tsx
+++ b/hat/assets/js/apps/Iaso/domains/storages/details.tsx
@@ -7,7 +7,7 @@ import {
 } from 'bluesquare-components';
 // @ts-ignore
 import { Box, Divider, Grid, makeStyles } from '@material-ui/core';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import TopBar from '../../components/nav/TopBarComponent';
 import { Infos } from './components/Infos';
 import { TableWithDeepLink } from '../../components/tables/TableWithDeepLink';
@@ -31,23 +31,13 @@ import { useGetDetailsColumns } from './config';
 
 type Props = {
     params: StorageDetailsParams;
-    router: Router;
-};
-type State = {
-    routerCustom: RouterCustom;
-};
-type RouterCustom = {
-    prevPathname: string | undefined;
 };
 
-type Router = {
-    goBack: () => void;
-};
 const useStyles = makeStyles(theme => ({
     ...commonStyles(theme),
 }));
 
-export const Details: FunctionComponent<Props> = ({ params, router }) => {
+export const Details: FunctionComponent<Props> = ({ params }) => {
     const { formatMessage } = useSafeIntl();
     const { data, isFetching } = useGetStorageLogs(params);
     const { url: apiUrl } = useGetApiParams(params);
@@ -55,14 +45,13 @@ export const Details: FunctionComponent<Props> = ({ params, router }) => {
     const storageDetail = data?.results;
 
     const classes: Record<string, string> = useStyles();
-    const prevPathname: string | undefined = useSelector(
-        (state: State) => state.routerCustom.prevPathname,
-    );
+
     const dispatch = useDispatch();
 
     const columns = useGetDetailsColumns();
 
     const storageDetailLogs = storageDetail?.logs ?? [];
+
     return (
         <>
             <TopBar
@@ -71,11 +60,7 @@ export const Details: FunctionComponent<Props> = ({ params, router }) => {
                 }`}
                 displayBackButton
                 goBack={() => {
-                    if (prevPathname) {
-                        router.goBack();
-                    } else {
-                        dispatch(redirectToReplace(baseUrls.storages, {}));
-                    }
+                    dispatch(redirectToReplace(baseUrls.storages, {}));
                 }}
             />
             <Box className={`${classes.containerFullHeightNoTabPadded}`}>


### PR DESCRIPTION
When you changed filters on storage details and then clicked on the back arrow, the navigation dint work well because you were redirect to last url withouth the filters params though the back arrow should redirect to the storages list

## Self proof reading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests
## Changes

- removed router from params
- use `redirectToReplace` instead to force redirect to storage list


## How to test

Go to Storages > choose a element from the list and see detail 
Then change the filters, apply them 
Use the back arrow 
It should lead to the storages list page

## Print screen / video

[recording-2023-01-19-13-07-19.webm](https://user-images.githubusercontent.com/25134301/213439971-495e3295-4e5e-4e78-a907-2ef0bc12e094.webm)

