### PR TITLE
IA-1837: remove 403 error for users without submission permission

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/orgUnitMap/OrgUnitMapComponent.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/orgUnitMap/OrgUnitMapComponent.js
@@ -446,7 +446,10 @@ class OrgUnitMapComponent extends Component {
                                     });
                                 }}
                             />
-                            {userHasPermission('iaso_submissions') && (
+                            {userHasPermission(
+                                'iaso_submissions',
+                                this.props.currentUser,
+                            ) && (
                                 <FormsFilterComponent
                                     currentOrgUnit={currentOrgUnit}
                                     formsSelected={formsSelected}

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/orgUnitMap/OrgUnitMapComponent.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/orgUnitMap/OrgUnitMapComponent.js
@@ -55,6 +55,7 @@ import {
     EDIT_GEO_JSON_RIGHT,
     EDIT_CATCHMENT_RIGHT,
 } from '../../../../utils/featureFlags';
+import { userHasPermission } from '../../../users/utils';
 
 export const zoom = 5;
 export const padding = [75, 75];
@@ -445,25 +446,27 @@ class OrgUnitMapComponent extends Component {
                                     });
                                 }}
                             />
-                            <FormsFilterComponent
-                                currentOrgUnit={currentOrgUnit}
-                                formsSelected={formsSelected}
-                                setFormsSelected={forms => {
-                                    this.setState({ formsSelected: forms });
-                                    fitToBounds({
-                                        padding,
-                                        currentTile,
-                                        orgUnit: currentOrgUnit,
-                                        orgUnitTypesSelected,
-                                        sourcesSelected,
-                                        formsSelected: forms,
-                                        editLocationEnabled: location.edit,
-                                        locationGroup,
-                                        catchmentGroup,
-                                        map: this.map.leafletElement,
-                                    });
-                                }}
-                            />
+                            {userHasPermission('iaso_submissions') && (
+                                <FormsFilterComponent
+                                    currentOrgUnit={currentOrgUnit}
+                                    formsSelected={formsSelected}
+                                    setFormsSelected={forms => {
+                                        this.setState({ formsSelected: forms });
+                                        fitToBounds({
+                                            padding,
+                                            currentTile,
+                                            orgUnit: currentOrgUnit,
+                                            orgUnitTypesSelected,
+                                            sourcesSelected,
+                                            formsSelected: forms,
+                                            editLocationEnabled: location.edit,
+                                            locationGroup,
+                                            catchmentGroup,
+                                            map: this.map.leafletElement,
+                                        });
+                                    }}
+                                />
+                            )}
                         </>
                     }
                     editOptionComponent={

--- a/hat/assets/js/apps/Iaso/domains/users/components/ProtectedRoute.js
+++ b/hat/assets/js/apps/Iaso/domains/users/components/ProtectedRoute.js
@@ -57,7 +57,7 @@ const ProtectedRoute = ({
                 allRoutes,
             );
             if (newBaseUrl) {
-                dispatch(redirectTo(newBaseUrl, {}));
+                dispatch(redirectToReplace(newBaseUrl, {}));
             }
         }
     }, [


### PR DESCRIPTION
When user with permission for org units but not for submissions accessed org unit details, there would be a request to /api/instances/ which would (logically) result !ini a 403, triggering the display of an error  snack bar

## Self proof reading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests
## Changes

- Hide `FormsFilterComponent` for users without `iaso_submissions` permission
- Fixed an import error in `ProtectedRoute`


## How to test

- create a user with only permission to org units
- go to an org unit’s details
- The filter on forms submission should not be displayed

## Print screen / video

![Screenshot 2023-01-19 at 15 01 21](https://user-images.githubusercontent.com/38907762/213462045-398c4fec-f8c4-44fa-b5ba-c6e78b672555.png)


## Notes

Merge into IA-1820
