### PR TITLE
IA 1839 text alignment in submissions

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/instances/config.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/config.js
@@ -3,17 +3,22 @@ import orderBy from 'lodash/orderBy';
 
 import { INSTANCE_METAS_FIELDS } from './constants';
 import MESSAGES from './messages';
-import ActionTableColumnComponent from "./components/ActionTableColumnComponent";
+import ActionTableColumnComponent from './components/ActionTableColumnComponent';
 
-export const actionTableColumn = (formatMessage = () => ({}), user, dispatch) => {
-
+export const actionTableColumn = (
+    formatMessage = () => ({}),
+    user,
+    dispatch,
+) => {
     return {
         Header: formatMessage(MESSAGES.actions),
         accessor: 'actions',
         resizable: false,
         sortable: false,
         width: 150,
-        Cell: settings => <ActionTableColumnComponent settings={settings} user={user}/>
+        Cell: settings => (
+            <ActionTableColumnComponent settings={settings} user={user} />
+        ),
     };
 };
 
@@ -21,19 +26,20 @@ const instancesTableColumns = (formatMessage = () => ({})) => {
     const columns = [];
     let metaFields = INSTANCE_METAS_FIELDS.filter(f => Boolean(f.tableOrder));
     metaFields = orderBy(metaFields, [f => f.tableOrder], ['asc']);
-    metaFields.forEach(f =>
+    metaFields.forEach(f => {
         columns.push({
             Header: formatMessage(MESSAGES[f.key]),
             accessor: f.accessor || f.key,
             sortable: f.sortable !== false,
+            align: f.key.includes('name') ? 'left' : 'center',
             Cell:
                 f.Cell ||
                 (settings =>
                     f.render
                         ? f.render(settings.row.original[f.key])
                         : settings.row.original[f.key]),
-        }),
-    );
+        });
+    });
     return columns;
 };
 

--- a/hat/assets/js/apps/Iaso/domains/instances/index.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/index.js
@@ -33,7 +33,7 @@ import { InstancesTopBar as TopBar } from './components/InstancesTopBar';
 import DownloadButtonsComponent from '../../components/DownloadButtonsComponent';
 import InstancesMap from './components/InstancesMapComponent';
 import InstancesFiltersComponent from './components/InstancesFiltersComponent';
-import { CreateReAssignDialogComponent } from './components/CreateReAssignDialogComponent';
+import { CreateReAssignDialogComponent } from './components/CreateReAssignDialogComponent.tsx';
 
 import { baseUrls } from '../../constants/urls';
 
@@ -43,7 +43,6 @@ import snackMessages from '../../components/snackBars/messages';
 import { TableWithDeepLink } from '../../components/tables/TableWithDeepLink';
 import { PaginatedInstanceFiles } from './components/PaginatedInstancesFiles';
 import { useGetPossibleFields } from '../forms/hooks/useGetPossibleFields.ts';
-import UpdateIcon from '@material-ui/icons/Update';
 
 const baseUrl = baseUrls.instances;
 


### PR DESCRIPTION
The text in “Form” column in Forms page is aligned left. In submissions it is centered. The styling should be aligned. Since we made changes elsewhere to change alignment from ‘center’ to ‘left’, the alignment will be changed in submissions (center → left)

Related JIRA tickets : IA-1839

## Self proof reading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests

## Changes

- Align text left in instances columns if the accessor includes `"name"`


## How to test

Go to Forms then go to submissions. the form name should be aligned left in both cases



## Notes
merges in IA-1811
