### PR TITLE
IA-1290: remove TS error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5996,7 +5996,7 @@
         },
         "node_modules/bluesquare-components": {
             "version": "0.2.0",
-            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#e659861ea6f56ad815ea32455bffcf2a2f07403b",
+            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#86049c2a2ce488733efa462df8fdb48d53196bd5",
             "license": "Apache-2.0",
             "dependencies": {
                 "@babel/plugin-transform-runtime": "^7.17.0",
@@ -34132,7 +34132,7 @@
             "dev": true
         },
         "bluesquare-components": {
-            "version": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#e659861ea6f56ad815ea32455bffcf2a2f07403b",
+            "version": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#86049c2a2ce488733efa462df8fdb48d53196bd5",
             "from": "bluesquare-components@github:BLSQ/bluesquare-components",
             "requires": {
                 "@babel/plugin-transform-runtime": "^7.17.0",


### PR DESCRIPTION
named imports made the TS compiler complain, though the code was working fine

Related JIRA tickets : IA-1290

## Self proof reading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests

## Changes
- Update dep to bluesquare-components after https://github.com/BLSQ/bluesquare-components/pull/100 was merged

## How to test

Open vs code, look for a file with `// @ts-ignore` above an import from bluesquare-components. Remove the comment. The ts compiler should not show any errors

## Print screen / video

Upload here print screens or videos showing the changes

## Notes

Depends on https://github.com/BLSQ/bluesquare-components/pull/100
