### PR TITLE
POLIO-782: fix preparedness round 0

### DIFF
--- a/plugins/polio/js/src/forms/PreparednessForm.js
+++ b/plugins/polio/js/src/forms/PreparednessForm.js
@@ -50,7 +50,11 @@ export const PreparednessForm = () => {
             },
         );
     };
-    const [currentTab, setCurrentTab] = useState('1');
+    const defaultRoundNumber = Number.isInteger(sortedRounds[0]?.number)
+        ? `${sortedRounds[0]?.number}`
+        : '1';
+
+    const [currentTab, setCurrentTab] = useState(defaultRoundNumber);
 
     const handleChangeTab = (event, newValue) => {
         setCurrentTab(newValue);


### PR DESCRIPTION
User could not generate or paste preparedness url if campaign had only a round 0

Related JIRA tickets :  POLIO-782

## Self proof reading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests

## Changes

- replaced the default round number of `'1'` with a string value calculated from actual rounds

## How to test

Create a polio campaign with only a round 0. Go to preparedness tab. You should see the all preparedness fields

## Print screen / video

![Screenshot 2023-01-20 at 12 24 28](https://user-images.githubusercontent.com/38907762/213684206-edca400e-183b-4b36-b6f3-21ec2925c284.png)

## Notes

Until the PR is merged, the problem can be avoided by adding a round 1 to the campaign
