### PR TITLE
POLIO-789: fix csv download

### DIFF
--- a/plugins/polio/js/src/components/Buttons/PageActionWithLink.tsx
+++ b/plugins/polio/js/src/components/Buttons/PageActionWithLink.tsx
@@ -1,0 +1,30 @@
+import React, { FunctionComponent } from 'react';
+import { Button } from '@material-ui/core';
+import { Link } from 'react-router';
+import { useStyles } from '../../styles/theme';
+
+type Props = {
+    url: string;
+    icon: any;
+};
+
+export const PageActionWithLink: FunctionComponent<Props> = ({
+    icon: Icon,
+    children,
+    url,
+}) => {
+    const classes: Record<string, string> = useStyles();
+    return (
+        <Link download href={url}>
+            <Button
+                variant="contained"
+                color="primary"
+                className={classes.pageAction}
+                component="div"
+            >
+                <Icon className={classes.buttonIcon} />
+                {children}
+            </Button>
+        </Link>
+    );
+};

--- a/plugins/polio/js/src/hooks/useGetCampaigns.js
+++ b/plugins/polio/js/src/hooks/useGetCampaigns.js
@@ -27,14 +27,12 @@ export const useGetCampaigns = (
             // Ugly fix to prevent the full list of campaigns showing when waiting for the value of countries
             enabled: options.enabled ?? true,
             last_budget_event__status: options.last_budget_event__status,
-            fieldset: options.fieldset ?? undefined,
         }),
         [
             options.campaignGroups,
             options.campaignType,
             options.countries,
             options.enabled,
-            options.fieldset,
             options.last_budget_event__status,
             options.order,
             options.page,
@@ -69,16 +67,21 @@ export const useGetCampaigns = (
     // adding the params to the queryKey to make sure it fetches when the query changes
     return {
         // eslint-disable-next-line no-return-assign
-        exportToCSV: () =>
-            (window.location.href = `${getURL({
-                ...params,
-                limit: undefined,
-                page: undefined,
-                format: 'csv',
-            })}`),
+        exportToCSV: `${getURL({
+            ...params,
+            limit: undefined,
+            page: undefined,
+            format: 'csv',
+        })}`,
         query: useSnackQuery(
             effectiveQueryKey,
-            () => getRequest(getURL(params)),
+            () =>
+                getRequest(
+                    getURL({
+                        ...params,
+                        fieldset: options.fieldset ?? undefined,
+                    }),
+                ),
             undefined,
             {
                 cacheTime: Infinity,

--- a/plugins/polio/js/src/pages/Dashboard.js
+++ b/plugins/polio/js/src/pages/Dashboard.js
@@ -30,6 +30,7 @@ import { genUrl } from '../utils/routing';
 import { convertObjectToString } from '../utils';
 import { DASHBOARD_BASE_URL } from '../constants/routes';
 import { useSingleTableParams } from '../../../../../hat/assets/js/apps/Iaso/components/tables/SingleTable';
+import { PageActionWithLink } from '../components/Buttons/PageActionWithLink.tsx';
 
 const Dashboard = ({ router }) => {
     const { params } = router;
@@ -299,9 +300,9 @@ const Dashboard = ({ router }) => {
                     >
                         {formatMessage(MESSAGES.create)}
                     </PageAction>
-                    <PageAction icon={DownloadIcon} onClick={exportToCSV}>
+                    <PageActionWithLink icon={DownloadIcon} url={exportToCSV}>
                         {formatMessage(MESSAGES.csv)}
-                    </PageAction>
+                    </PageActionWithLink>
                     <ImportLineListDialog
                         renderTrigger={({ openDialog }) => (
                             <PageAction


### PR DESCRIPTION
download url was incorrect

Related JIRA tickets : POLIO-789

## Self proof reading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [X] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests

## Changes

- Changed `useGetCampaigns` so that the `fieldset` parameter is only added to the `query` (and not to `exportToCsv`)
- Changed `exportToCsv` so that it returns the url i.o. handling the download
- Created `PageActionWithLink` which handles the  `exportToCsv`url. This allows the displaying of the url on hover

## How to test

Go to polio campaigns and play with CSV button

## Print screen / video

https://user-images.githubusercontent.com/38907762/214286955-4713e34e-b37c-45b0-88b4-881b9423f866.mov
