### PR TITLE
IA-1852: cell create a warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5996,7 +5996,7 @@
         },
         "node_modules/bluesquare-components": {
             "version": "0.2.0",
-            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#86049c2a2ce488733efa462df8fdb48d53196bd5",
+            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#4bf2d992bb036aff6decfcf6e74454f700d0668d",
             "license": "Apache-2.0",
             "dependencies": {
                 "@babel/plugin-transform-runtime": "^7.17.0",
@@ -34132,7 +34132,7 @@
             "dev": true
         },
         "bluesquare-components": {
-            "version": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#86049c2a2ce488733efa462df8fdb48d53196bd5",
+            "version": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#4bf2d992bb036aff6decfcf6e74454f700d0668d",
             "from": "bluesquare-components@github:BLSQ/bluesquare-components",
             "requires": {
                 "@babel/plugin-transform-runtime": "^7.17.0",


### PR DESCRIPTION
Last change on cell errorBoundary is displaying a warning in the console

![214074441-8b85cdbe-b2fe-45e8-b231-a293bb53b263](https://user-images.githubusercontent.com/12494624/214614025-1a883140-f6b6-473b-9eee-b2785b215c3e.png)

Related JIRA tickets : IA-1852

## Self proof reading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests

## Changes

upgrade blusquare-components

## How to test

Open Forms page and check the console


