### PR TITLE
IA-1855: fix docker M1 support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,7 @@ services:
     image: iaso
     ports:
       - "8081:8081"
-    volumes:
-      &hat_volumes
+    volumes: &hat_volumes
       - ./manage.py:/opt/app/manage.py
       - ./hat:/opt/app/hat
       - ./iaso:/opt/app/iaso
@@ -30,11 +29,9 @@ services:
       - ./notebooks:/opt/notebooks
       # Optional Used to load dev bluesquare-components JS. See `Live Bluesquare components` in doc
       - ../bluesquare-components:/opt/bluesquare-components
-    links:
-      &hat_links
+    links: &hat_links
       - db
-    environment:
-      &hat_environment
+    environment: &hat_environment
       PREPAREDNESS_TEMPLATE_ID:
       PREPAREDNESS_TEMPLATE_FR_ID:
       PLUGINS:
@@ -65,16 +62,17 @@ services:
       ENKETO_API_TOKEN: AZE78974654azeAZE
       ENKETO_URL: http://enketo:8005/
       EMAIL_BACKEND: "django.core.mail.backends.console.EmailBackend"
-      LIVE_COMPONENTS: # Limit logging in dev to not overflow terminal
-    logging:
-      &iaso_logging
+      LIVE_COMPONENTS:
+    # Limit logging in dev to not overflow terminal
+    logging: &iaso_logging
       driver: "json-file"
       options:
         max-size: "5k"
     command: start_dev
 
   db:
-    image: iaso/postgis
+    image:
+      iaso/postgis
     # Workaround until there is a stable Postgis image for Apple Silicon
     build: docker/db
     logging: *iaso_logging
@@ -89,7 +87,6 @@ services:
   # the webpack dev server
   webpack:
     image: iaso-webpack
-    platform: linux/amd64
     build:
       context: .
       dockerfile: docker/webpack/Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,8 @@ services:
     image: iaso
     ports:
       - "8081:8081"
-    volumes: &hat_volumes
+    volumes:
+      &hat_volumes
       - ./manage.py:/opt/app/manage.py
       - ./hat:/opt/app/hat
       - ./iaso:/opt/app/iaso
@@ -29,9 +30,11 @@ services:
       - ./notebooks:/opt/notebooks
       # Optional Used to load dev bluesquare-components JS. See `Live Bluesquare components` in doc
       - ../bluesquare-components:/opt/bluesquare-components
-    links: &hat_links
+    links:
+      &hat_links
       - db
-    environment: &hat_environment
+    environment:
+      &hat_environment
       PREPAREDNESS_TEMPLATE_ID:
       PREPAREDNESS_TEMPLATE_FR_ID:
       PLUGINS:
@@ -62,17 +65,16 @@ services:
       ENKETO_API_TOKEN: AZE78974654azeAZE
       ENKETO_URL: http://enketo:8005/
       EMAIL_BACKEND: "django.core.mail.backends.console.EmailBackend"
-      LIVE_COMPONENTS:
-    # Limit logging in dev to not overflow terminal
-    logging: &iaso_logging
+      LIVE_COMPONENTS: # Limit logging in dev to not overflow terminal
+    logging:
+      &iaso_logging
       driver: "json-file"
       options:
         max-size: "5k"
     command: start_dev
 
   db:
-    image:
-      iaso/postgis
+    image: iaso/postgis
     # Workaround until there is a stable Postgis image for Apple Silicon
     build: docker/db
     logging: *iaso_logging
@@ -87,6 +89,7 @@ services:
   # the webpack dev server
   webpack:
     image: iaso-webpack
+    platform: linux/amd64
     build:
       context: .
       dockerfile: docker/webpack/Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,6 +87,7 @@ services:
   # the webpack dev server
   webpack:
     image: iaso-webpack
+    platform: linux/amd64
     build:
       context: .
       dockerfile: docker/webpack/Dockerfile

--- a/docker/webpack/Dockerfile
+++ b/docker/webpack/Dockerfile
@@ -1,5 +1,4 @@
 FROM node:14-bullseye-slim
-
 ENV PROJECT_ROOT /opt
 
 WORKDIR /opt/app

--- a/docker/webpack/Dockerfile
+++ b/docker/webpack/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:14.17.0-stretch-slim
+FROM node:14-bullseye-slim
+
 ENV PROJECT_ROOT /opt
 
 WORKDIR /opt/app


### PR DESCRIPTION
docker build was failing at `npm ci `step

## Self proof reading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests

## Changes

- updated the debian version in Dockerfile
- updated the platform for webpack in docker-compose.yml
