### PR TITLE
IA-1592 Restrict user to set default_source_version to version linked to his …

### DIFF
--- a/iaso/api/accounts.py
+++ b/iaso/api/accounts.py
@@ -59,7 +59,7 @@ class AccountViewSet(ModelViewSet):
     def update(self, request: Request, *args, **kwargs):
         default_version = request.data["default_version"]
         version = get_object_or_404(SourceVersion, pk=default_version)
-        project = Project.objects.get(account=request.user.iaso_profile.account)
+        project = Project.objects.get(account=request.user.iaso_profile.account)  # type: ignore
         if project not in version.data_source.projects.all():
             raise serializers.ValidationError({"Error": "Account not allowed to access this default_source"})
         return super().update(request, args, kwargs)

--- a/iaso/api/accounts.py
+++ b/iaso/api/accounts.py
@@ -20,15 +20,16 @@ class AccountSerializer(serializers.ModelSerializer):
         default_version = validated_data.pop("default_version", None)
         user = self.context["request"].user
         if default_version is not None:
-            sourceVersion = get_object_or_404(
+            source_version = get_object_or_404(
                 SourceVersion,
                 id=default_version.id,
                 number=default_version.number,
             )
-            project = Project.objects.get(account=user.iaso_profile.account)  # type: ignore
-            if project not in sourceVersion.data_source.projects.all():
-                raise serializers.ValidationError({"Error": "Account not allowed to access this default_source"})
-            account.default_version = sourceVersion
+            projects = source_version.data_source.projects.all()
+            for p in projects:
+                if user.iaso_profile.account != p.account:
+                    raise serializers.ValidationError({"Error": "Account not allowed to access this default_source"})
+            account.default_version = source_version
             account.save()
 
         return account

--- a/iaso/tests/api/test_account.py
+++ b/iaso/tests/api/test_account.py
@@ -2,7 +2,7 @@ from iaso.test import APITestCase
 from iaso import models as m
 
 
-class ProjectsAPITestCase(APITestCase):
+class AccountAPITestCase(APITestCase):
     @classmethod
     def setUpTestData(cls):
         cls.ghi = ghi = m.Account.objects.create(name="Global Health Initiative")
@@ -18,6 +18,9 @@ class ProjectsAPITestCase(APITestCase):
         cls.ghi_version = m.SourceVersion.objects.create(data_source=ghi_datasource, number=1)
 
         wha_project = m.Project.objects.create(name="gha_project", account=wha)
+        wha_datasource = m.DataSource.objects.create(name="wha datasource")
+        wha_datasource.projects.set([wha_project])
+        cls.wha_version = m.SourceVersion.objects.create(data_source=wha_datasource, number=1)
 
     def test_account_list_without_auth(self):
         """GET /projects/ without auth should result in a 403 (before the method not authorized?"""
@@ -81,8 +84,8 @@ class ProjectsAPITestCase(APITestCase):
         # invert on the other account/user to be sure
         self.client.force_authenticate(self.john)
         response = self.client.put(f"/api/accounts/{self.ghi.pk}/", {"default_version": self.ghi_version.pk})
-        j = self.assertJSONResponse(response, 400)
-        self.assertEqual(j, {"Error": "Account not allowed to access this default_source"})
+        j = self.assertJSONResponse(response, 403)
+        self.assertEqual(j, {"detail": "You do not have permission to perform this action."})
 
         # old default version
         old_version = self.ghi.default_version
@@ -101,3 +104,10 @@ class ProjectsAPITestCase(APITestCase):
         old_version = self.ghi.default_version
         self.ghi.refresh_from_db()
         self.assertEqual(self.ghi.default_version, old_version)
+
+    def test_cant_assign_source_version_from_different_account(self):
+
+        self.client.force_authenticate(self.jane)
+        response = self.client.put(f"/api/accounts/{self.ghi.pk}/", {"default_version": self.wha_version.pk})
+        j = self.assertJSONResponse(response, 400)
+        self.assertEqual(j, {"Error": "Account not allowed to access this default_source"})

--- a/iaso/tests/api/test_account.py
+++ b/iaso/tests/api/test_account.py
@@ -17,6 +17,8 @@ class ProjectsAPITestCase(APITestCase):
         ghi_datasource.projects.set([ghi_project])
         cls.ghi_version = m.SourceVersion.objects.create(data_source=ghi_datasource, number=1)
 
+        wha_project = m.Project.objects.create(name="gha_project", account=wha)
+
     def test_account_list_without_auth(self):
         """GET /projects/ without auth should result in a 403 (before the method not authorized?"""
         self.client.force_authenticate(self.jim)
@@ -79,8 +81,8 @@ class ProjectsAPITestCase(APITestCase):
         # invert on the other account/user to be sure
         self.client.force_authenticate(self.john)
         response = self.client.put(f"/api/accounts/{self.ghi.pk}/", {"default_version": self.ghi_version.pk})
-        j = self.assertJSONResponse(response, 403)
-        self.assertEqual(j, {"detail": "You do not have permission to perform this action."})
+        j = self.assertJSONResponse(response, 400)
+        self.assertEqual(j, {"Error": "Account not allowed to access this default_source"})
 
         # old default version
         old_version = self.ghi.default_version

--- a/iaso/tests/api/test_account.py
+++ b/iaso/tests/api/test_account.py
@@ -17,7 +17,8 @@ class AccountAPITestCase(APITestCase):
         ghi_datasource.projects.set([ghi_project])
         cls.ghi_version = m.SourceVersion.objects.create(data_source=ghi_datasource, number=1)
 
-        wha_project = m.Project.objects.create(name="gha_project", account=wha)
+        wha_project = m.Project.objects.create(name="wha_project", account=wha)
+        wha_second_project = m.Project.objects.create(name="wha_second_project", account=wha)
         wha_datasource = m.DataSource.objects.create(name="wha datasource")
         wha_datasource.projects.set([wha_project])
         cls.wha_version = m.SourceVersion.objects.create(data_source=wha_datasource, number=1)


### PR DESCRIPTION
When doing a PUT request at   /api/accounts/{the account id}/ with  {"default_version": the_version_id_from_other_account}
it was possible to set a version from another account. It is not longer possible. 

Related JIRA tickets : IA-1592

## Self proof reading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are there enough tests

## How to test

Create two account

Create a Data source and a version inside one of the account.

Log on the other account, make an API call to  PUT /api/accounts/{the account id}/ with 

{"default_version": the_version_id_from_other_account}
What happen

Request fail and the account is not modified. The error received from the API should contain the field and the error.
