### PR TITLE
POLIO-791: HOTFIX change allowConfirm condition

### DIFF
--- a/plugins/polio/js/src/pages/Budget/CreateBudgetStep/CreateBudgetStep.tsx
+++ b/plugins/polio/js/src/pages/Budget/CreateBudgetStep/CreateBudgetStep.tsx
@@ -173,6 +173,7 @@ const CreateBudgetStep: FunctionComponent<Props> = ({
         messages: MESSAGES,
         formatMessage,
     });
+
     const attachmentErrors = useMemo(() => {
         const anyFieldTouched = Object.values(touched).find(value => value);
         const attachmentsErrors = [errors.attachments] ?? [];
@@ -201,9 +202,12 @@ const CreateBudgetStep: FunctionComponent<Props> = ({
         touched.links,
         values,
     ]);
-    const allowConfirm = !quickTransition
-        ? isValid && !isEqual(values, initialValues)
-        : isValid;
+
+    const allowConfirm =
+        quickTransition || requiredFields.length === 0
+            ? isValid
+            : isValid && !isEqual(values, initialValues);
+
     return (
         <FormikProvider value={formik}>
             <ConfirmCancelModal

--- a/plugins/polio/js/src/pages/Budget/hooks/validation.ts
+++ b/plugins/polio/js/src/pages/Budget/hooks/validation.ts
@@ -75,7 +75,7 @@ addMethod(
 export const useBudgetStepValidation = (
     errors: ValidationError = {},
     payload: any,
-    requiredFields: string[] = ['links', 'comment'],
+    requiredFields: string[] = [],
 ): ObjectSchema<any> => {
     const { formatMessage } = useSafeIntl();
     const fieldRequired = formatMessage(MESSAGES.requiredField);


### PR DESCRIPTION
when no field was required users still had to make a change to be able to confirm the step creation

Related JIRA tickets : POLIO-791

## Self proof reading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests

## Changes
- Changes the `allowConfirm`condition in `CreateBudgetStep` so that when `requiredFields` are empty, we only check for fields validity

## How to test

 You need your Db setup with this config: https://drive.google.com/drive/u/0/folders/1ua4yzyFOGayweQVNKP0hyBNDKhQrPlx1

You need your polio app to be configured for the budget tool, cf wiki: https://wiki.bluesquare.org/en/Dev-team/product-management/iaso/polio_budget_workflow

Then, just go to a budget and try , eg to `Request Budget`. You should be able to save the modal without making any changes to it

## Print screen / video

https://user-images.githubusercontent.com/38907762/215096768-0cadae63-2884-4dc1-83e0-6b3f1e519c65.mov

