### PR TITLE
IA-1766 adding account in entity type list for add workflow dajngo admin

### DIFF
--- a/iaso/admin.py
+++ b/iaso/admin.py
@@ -468,6 +468,14 @@ class StorageDeviceAdmin(admin.ModelAdmin):
 class WorkflowAdmin(admin.ModelAdmin):
     readonly_fields = ("created_at", "updated_at")
 
+    def get_form(self, request, obj=None, **kwargs):
+        # In the <select> for the entity type, we also want to indicate the account name
+        form = super().get_form(request, obj, **kwargs)
+        form.base_fields[
+            "entity_type"
+        ].label_from_instance = lambda entity: f"{entity.name} (Account: {entity.account.name})"
+        return form
+
     def get_queryset(self, request):
         return Workflow.objects_include_deleted.all()
 


### PR DESCRIPTION
Add account name in entity type dropdown while editing a workflow in the admin (otherwise you cannot differentiate between entity type with same name but different account)

Related JIRA tickets : IA-1766

## Self proof reading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented

## Changes

Override de default admin form to rewrite entity type display and add account name

## How to test

Got to /admin
Add a workflow
Choose from entity type dropdown

## Print screen / video

<img width="611" alt="Screenshot 2023-02-02 at 16 05 40" src="https://user-images.githubusercontent.com/383344/216361461-2760d754-c0b0-4fce-a4ab-285ff71b1b3c.png">

