### PR TITLE
IA-1887 Submissions Search on Period type Day gets 500

### DIFF
--- a/iaso/periods.py
+++ b/iaso/periods.py
@@ -238,8 +238,8 @@ class MonthPeriod(Period):
 
 class DayPeriod(Period):
 
-    LOWER_BOUND = None
-    HIGHER_BOUND = None
+    LOWER_BOUND = "20000101"
+    HIGHER_BOUND = "20301231"
 
     @staticmethod
     def from_parts(year, month, day):


### PR DESCRIPTION
On form submissions page, If you don't provide a start or a end period ...
It's taking the lower bound or higher bound of the period type instead, but this was None for day period type.
Then it was making a 500 Error.


Related JIRA tickets : IA-1887

## Self proof reading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented

## Changes

Copied the behaviour for Month period and extrapolated it to Day


## How to test

Go to /dashboard/forms/submissions/
In the filters above on the right,
Choose "Periodicity" > Day
Then enter only a start or a end date (not both).
It should work as expected and not return a 500

## Print screen / video


https://user-images.githubusercontent.com/383344/217005283-896b0bc7-2d44-401d-aabf-c0b18cb37b75.mov



## Notes

In `iaso/api/instance_filters.py` we have this comment :

```python
# as a compromise for now to limit the performance impact when we search for higher level we don't include
#  the day periods
```

Not really sure what it means but it's still working ?


Also, in `iaso/periods.py` we have the LOWER_BOUND and HIGHER_BOUND of the periods hardcoded like this (for example for year period) : 

```python
LOWER_BOUND = "2000"
HIGHER_BOUND = "2030"
```

It's gonna stop working after 2030 ! Maybe we should make it dynamic, like `current year + X`

It has been reported in IA-1894
