### PR TITLE
IA-1893 planning fit to bounds

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/assignments/components/AssignmentsMap.tsx
+++ b/hat/assets/js/apps/Iaso/domains/assignments/components/AssignmentsMap.tsx
@@ -105,6 +105,7 @@ export const AssignmentsMap: FunctionComponent<Props> = ({
 }) => {
     const mapContainer: any = useRef();
     const map: any = useRef();
+    const [fitted, setFitted] = useState<boolean>(false);
     const [selectedLocation, setSelectedLocation] = useState<
         OrgUnitShape | OrgUnitMarker | undefined
     >(undefined);
@@ -179,13 +180,13 @@ export const AssignmentsMap: FunctionComponent<Props> = ({
         });
     };
 
+    const isLoading = isFetchingLocations || isFetchingParentLocations;
     useEffect(() => {
-        if (!isFetchingLocations && !isFetchingParentLocations && locations) {
+        if (!isLoading && locations && !fitted) {
+            setFitted(true);
             fitToBounds(locations, parentLocations);
         }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [isFetchingLocations, locations, isFetchingParentLocations]);
-    const isLoading = isFetchingLocations || isFetchingParentLocations;
+    }, [isLoading, locations, parentLocations]);
     return (
         <section ref={mapContainer}>
             <Box position="relative">

--- a/hat/assets/js/apps/Iaso/domains/assignments/hooks/requests/useGetAssignments.ts
+++ b/hat/assets/js/apps/Iaso/domains/assignments/hooks/requests/useGetAssignments.ts
@@ -15,7 +15,7 @@ export type AssignmentsResult = {
 };
 
 const getAssignments = async (options: Option): Promise<AssignmentApi[]> => {
-    const url = makeUrlWithParams('/api/microplanning/assignments', options);
+    const url = makeUrlWithParams('/api/microplanning/assignments/', options);
     return getRequest(url) as Promise<AssignmentApi[]>;
 };
 

--- a/hat/assets/js/apps/Iaso/domains/assignments/hooks/requests/useGetOrgUnitParentLocations.ts
+++ b/hat/assets/js/apps/Iaso/domains/assignments/hooks/requests/useGetOrgUnitParentLocations.ts
@@ -19,7 +19,7 @@ export const useGetOrgUnitParentLocations = ({
     orgUnitParentIds,
     baseOrgunitType,
 }: Props): UseQueryResult<OrgUnitShape[], Error> => {
-    const params = {
+    const params: Record<string, any> = {
         validation_status: 'VALID',
         asLocation: true,
         limit: 5000,
@@ -31,7 +31,7 @@ export const useGetOrgUnitParentLocations = ({
         orgUnitTypeId: baseOrgunitType,
     };
 
-    const url = makeUrlWithParams('/api/orgunits', params);
+    const url = makeUrlWithParams('/api/orgunits/', params);
 
     return useSnackQuery(
         ['geo_json', params, baseOrgunitType],

--- a/hat/assets/js/apps/Iaso/domains/assignments/hooks/requests/useGetOrgUnits.ts
+++ b/hat/assets/js/apps/Iaso/domains/assignments/hooks/requests/useGetOrgUnits.ts
@@ -169,20 +169,20 @@ export const useGetOrgUnits = ({
     currentType,
     order,
 }: Props): UseQueryResult<Locations, Error> => {
-    const params = {
+    const params: Record<string, any> = {
         validation_status: 'VALID',
         asLocation: true,
         limit: 5000,
-        order,
-        orgUnitParentIds: orgUnitParentIds?.join(','),
         geography: 'any',
         onlyDirectChildren: false,
         page: 1,
-        orgUnitTypeId: baseOrgunitType,
         withParents: true,
+        order,
+        orgUnitParentIds: orgUnitParentIds?.join(','),
+        orgUnitTypeId: baseOrgunitType,
     };
 
-    const url = makeUrlWithParams('/api/orgunits', params);
+    const url = makeUrlWithParams('/api/orgunits/', params);
 
     const select = useCallback(
         (orgUnits: OrgUnit[]) => {

--- a/hat/assets/js/apps/Iaso/domains/assignments/hooks/requests/useGetOrgUnitsByParent.ts
+++ b/hat/assets/js/apps/Iaso/domains/assignments/hooks/requests/useGetOrgUnitsByParent.ts
@@ -31,7 +31,7 @@ export const useGetOrgUnitsByParent = ({
     currentType,
     selectedItem,
 }: Props): UseQueryResult<ChildrenOrgUnits, Error> => {
-    const params = {
+    const params: Record<string, any> = {
         validation_status: 'all',
         order: 'id',
         orgUnitParentId,
@@ -39,7 +39,7 @@ export const useGetOrgUnitsByParent = ({
         orgUnitTypeId: baseOrgunitType,
     };
 
-    const url = makeUrlWithParams('/api/orgunits', params);
+    const url = makeUrlWithParams('/api/orgunits/', params);
 
     return useSnackQuery(
         ['geo_json', params, baseOrgunitType],

--- a/hat/assets/js/apps/Iaso/domains/assignments/hooks/requests/useGetPlanning.ts
+++ b/hat/assets/js/apps/Iaso/domains/assignments/hooks/requests/useGetPlanning.ts
@@ -4,7 +4,7 @@ import { getRequest } from '../../../../libs/Api';
 import { Planning } from '../../types/planning';
 
 const getPlanning = (planningId: string): Promise<Planning> => {
-    return getRequest(`/api/microplanning/planning/${planningId}`);
+    return getRequest(`/api/microplanning/planning/${planningId}/`);
 };
 export const useGetPlanning = (
     planningId: string | undefined,

--- a/hat/assets/js/apps/Iaso/domains/assignments/hooks/requests/useGetTeams.ts
+++ b/hat/assets/js/apps/Iaso/domains/assignments/hooks/requests/useGetTeams.ts
@@ -10,7 +10,9 @@ import { Teams, DropdownTeamsOptions, Team } from '../../types/team';
 import { getColor } from '../../constants/colors';
 
 const getTeams = async (ancestor: number): Promise<Teams> => {
-    const url = makeUrlWithParams('/api/microplanning/teams', { ancestor });
+    const url = makeUrlWithParams('/api/microplanning/teams/', {
+        ancestor: `${ancestor}`,
+    });
     return getRequest(url) as Promise<Teams>;
 };
 

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/hooks/useGetOrgUnitsTableColumns.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/hooks/useGetOrgUnitsTableColumns.tsx
@@ -17,7 +17,6 @@ import { Search } from '../types/search';
 import { Column } from '../../../types/table';
 import { IntlFormatMessage } from '../../../types/intl';
 import { ActionCell } from '../components/ActionCell';
-import getDisplayName from '../../../utils/usersUtils';
 
 const useStyles = makeStyles(theme => ({
     ...commonStyles(theme),


### PR DESCRIPTION
While navigating to planning detail view on map tab, map was zooming automatically on each action done on the filters.


https://user-images.githubusercontent.com/12494624/217009465-25d4ce48-9879-491a-9016-4807a2324bb4.mov



Related JIRA tickets : IA-1893

## Self proof reading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests

## Changes

- remove 301 redirections while calling the API
- launch only fit to bound while the map is loaded

## How to test

Explain how to test your PR.
Visit the map of assignation of a planning and play with teams / users

## Print screen / video



Uploading Screen Recording 2023-02-06 at 16.06.31.mov…

