### PR TITLE
IA-1895: restore iaso_planning and iaso_assignments perms

### DIFF
--- a/hat/assets/js/apps/Iaso/constants/routes.js
+++ b/hat/assets/js/apps/Iaso/constants/routes.js
@@ -832,7 +832,7 @@ export const planningPath = {
 export const assignmentsPath = {
     baseUrl: baseUrls.assignments,
     // FIXME use planning permissions when they exist
-    permissions: ['iaso_assignments'],
+    permissions: ['iaso_planning'],
     component: props => <Assignments {...props} />,
     params: [
         {

--- a/iaso/api/permissions.py
+++ b/iaso/api/permissions.py
@@ -33,13 +33,6 @@ class PermissionsViewSet(viewsets.ViewSet):
         if "polio" not in settings.PLUGINS:
             perms = perms.exclude(codename__startswith="iaso_polio")
 
-        # TODO Remove once this is in prod
-        perms = (
-            perms.exclude(codename__startswith="iaso_planning")
-            # .exclude(codename__startswith="iaso_teams")
-            .exclude(codename__startswith="iaso_assignments")
-        )
-
         result = []
         for permission in perms:
             result.append({"id": permission.id, "name": _(permission.name), "codename": permission.codename})


### PR DESCRIPTION
`iaso_assignments` and `iaso_planning` where not available trough the api

Related JIRA tickets : IA-1895

## Self proof reading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests

## Changes

remove exclude from api/permissions.py

## How to test

create a user

give him the planning permission through the admin

 try to view a precise planning


