### PR TITLE
POLIO-802 Make Email optional in bulk create users

### DIFF
--- a/iaso/api/bulk_create_users.py
+++ b/iaso/api/bulk_create_users.py
@@ -106,7 +106,7 @@ class BulkCreateUserFromCsvViewSet(ModelViewSet):
                             raise serializers.ValidationError(
                                 {
                                     "error": "Operation aborted. Invalid Email at row : {0}. Fix the error and try "
-                                             "again.".format(i)
+                                    "again.".format(i)
                                 }
                             )
 

--- a/iaso/tests/fixtures/test_user_bulk_create_no_mail.csv
+++ b/iaso/tests/fixtures/test_user_bulk_create_no_mail.csv
@@ -1,0 +1,4 @@
+username,password,email,first_name,last_name,orgunit,,,profile_language
+broly,yOdnjdln8!,biobroly@bluesquarehub.com,broly,bio,9999,,,fr
+ferdinand,dEF80s:ghd,fdzepplin@bluesquarehub.com,ferdinand,von Zepplin,"Coruscant Jedi Council, 9999, Tatooine",,,fr
+rsfg,frdgEF73f9!,,feesf,dsfsf,"Tatooine, Dagobah",,,FR

--- a/iaso/tests/test_create_users_from_csv.py
+++ b/iaso/tests/test_create_users_from_csv.py
@@ -93,6 +93,16 @@ class BulkCreateCsvTestCase(APITestCase):
             response.json()["error"], "Operation aborted. Invalid Email at row : 3. Fix the error and try again."
         )
 
+    def test_upload_without_mail_must_work(self):
+        self.client.force_authenticate(self.yoda)
+        self.sw_source.projects.set([self.project])
+
+        with open("iaso/tests/fixtures/test_user_bulk_create_no_mail.csv") as csv_users:
+            response = self.client.post(f"/api/bulkcreateuser/", {"file": csv_users})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["Accounts created"], 3)
+
     def test_upload_invalid_orgunit_id(self):
         self.client.force_authenticate(self.yoda)
         self.sw_source.projects.set([self.project])
@@ -253,8 +263,6 @@ class BulkCreateCsvTestCase(APITestCase):
 
         for ou in ferdinand_ou:
             ou_f_list.append(ou.id)
-
-        print(self.jedi_council.id, self.jedi_council.id, 9999, self.tatooine.id)
 
         self.assertEqual(ou_list, [9999])
         self.assertCountEqual(ou_f_list, [self.jedi_council_corruscant.id, self.tatooine.id, 9999])


### PR DESCRIPTION
An email address was required while creating users in bulk. It has been removed. 

Related JIRA tickets : POLIO-802

## Self proof reading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] My migrations file are included
- [x] Are there enough tests

To test: 

/api/bulkcreateuser

Upload a csv file containing the user data in the django admin. Check the files from the test and follow the template.
