### PR TITLE
IA-1891: Planning view list tab sort by assignments

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/assignments/components/AssignmentsListTab.tsx
+++ b/hat/assets/js/apps/Iaso/domains/assignments/components/AssignmentsListTab.tsx
@@ -14,7 +14,7 @@ import {
     AssignmentUnit,
 } from '../types/locations';
 import { useColumns } from '../configs/AssignmentsListTabColumns';
-import { DropdownTeamsOptions, SubTeam, User } from '../types/team';
+import { DropdownTeamsOptions, SubTeam, User, Team } from '../types/team';
 import { Profile } from '../../../utils/usersUtils';
 
 import { baseUrls } from '../../../constants/urls';
@@ -53,6 +53,7 @@ type Props = {
     teams: DropdownTeamsOptions[];
     profiles: Profile[];
     selectedItem: SubTeam | User | undefined;
+    currentTeam?: Team;
 };
 
 const baseUrl = baseUrls.assignments;
@@ -65,8 +66,15 @@ export const AssignmentsListTab: FunctionComponent<Props> = ({
     profiles,
     selectedItem,
     params,
+    currentTeam,
 }: Props) => {
-    const columns = useColumns({ orgUnits, assignments, teams, profiles });
+    const columns = useColumns({
+        orgUnits,
+        assignments,
+        teams,
+        profiles,
+        currentTeam,
+    });
     const dispatch = useDispatch();
     return (
         <Paper>

--- a/hat/assets/js/apps/Iaso/domains/assignments/configs/AssignmentsListTabColumns.tsx
+++ b/hat/assets/js/apps/Iaso/domains/assignments/configs/AssignmentsListTabColumns.tsx
@@ -7,7 +7,7 @@ import {
 
 import { AssignmentsApi } from '../types/assigment';
 import { AssignmentUnit } from '../types/locations';
-import { DropdownTeamsOptions } from '../types/team';
+import { DropdownTeamsOptions, Team } from '../types/team';
 import { Column } from '../../../types/table';
 
 import { getOrgUnitAssignation } from '../utils';
@@ -23,6 +23,7 @@ type Props = {
     assignments: AssignmentsApi;
     teams: DropdownTeamsOptions[] | undefined;
     profiles: Profile[] | undefined;
+    currentTeam?: Team;
 };
 
 const getParentCount = (orgUnit: AssignmentUnit, count = 0): number => {
@@ -38,9 +39,9 @@ export const useColumns = ({
     assignments,
     teams,
     profiles,
+    currentTeam,
 }: Props): Column[] => {
     const { formatMessage } = useSafeIntl();
-
     const firstOrgunit: AssignmentUnit = orgUnits[0];
     const parentCount: number = firstOrgunit ? getParentCount(firstOrgunit) : 0;
     return useMemo(() => {
@@ -77,9 +78,13 @@ export const useColumns = ({
                     },
                 });
             });
+        // assignment__team__name
         const assignationColumn: Column = {
             Header: formatMessage(MESSAGES.assignment),
-            id: 'assignment',
+            id:
+                currentTeam?.type === 'TEAM_OF_TEAMS'
+                    ? 'assignment__team__name'
+                    : 'assignment__user__username',
             Cell: settings => {
                 return (
                     <UsersTeamsCell
@@ -96,5 +101,12 @@ export const useColumns = ({
         };
         columns.push(assignationColumn);
         return columns;
-    }, [assignments, formatMessage, profiles, teams, parentCount]);
+    }, [
+        formatMessage,
+        parentCount,
+        currentTeam?.type,
+        assignments,
+        teams,
+        profiles,
+    ]);
 };

--- a/hat/assets/js/apps/Iaso/domains/assignments/configs/AssignmentsListTabColumns.tsx
+++ b/hat/assets/js/apps/Iaso/domains/assignments/configs/AssignmentsListTabColumns.tsx
@@ -80,7 +80,6 @@ export const useColumns = ({
         const assignationColumn: Column = {
             Header: formatMessage(MESSAGES.assignment),
             id: 'assignment',
-            sortable: false,
             Cell: settings => {
                 return (
                     <UsersTeamsCell

--- a/hat/assets/js/apps/Iaso/domains/assignments/hooks/requests/useSaveAssignment.ts
+++ b/hat/assets/js/apps/Iaso/domains/assignments/hooks/requests/useSaveAssignment.ts
@@ -1,4 +1,4 @@
-import { UseMutationResult } from 'react-query';
+import { UseMutationResult, useQueryClient } from 'react-query';
 import { postRequest, patchRequest } from '../../../../libs/Api';
 import { useSnackMutation } from '../../../../libs/apiHooks';
 
@@ -16,13 +16,14 @@ export const saveAssignment = async (
     return postRequest(endpoint, body);
 };
 
-export const useSaveAssignment = (
-    callback: () => void = () => null,
-): UseMutationResult => {
-    const onSuccess = () => callback();
+export const useSaveAssignment = (): UseMutationResult => {
+    const queryClient = useQueryClient();
+    const onSuccess = () => {
+        queryClient.invalidateQueries('orgUnits');
+        queryClient.invalidateQueries('assignmentsList');
+    };
     return useSnackMutation({
         mutationFn: (data: SaveAssignmentQuery) => saveAssignment(data),
-        invalidateQueryKey: ['assignmentsList'],
         options: { onSuccess },
         showSucessSnackBar: false,
     });
@@ -33,13 +34,14 @@ const saveBulkAssignments = (data: SaveAssignmentQuery) => {
     return postRequest(url, data);
 };
 
-export const useBulkSaveAssignments = (
-    callback: () => void = () => null,
-): UseMutationResult => {
-    const onSuccess = () => callback();
+export const useBulkSaveAssignments = (): UseMutationResult => {
+    const queryClient = useQueryClient();
+    const onSuccess = () => {
+        queryClient.invalidateQueries('orgUnits');
+        queryClient.invalidateQueries('assignmentsList');
+    };
     return useSnackMutation({
         mutationFn: saveBulkAssignments,
-        invalidateQueryKey: ['assignmentsList'],
         options: { onSuccess },
         showSucessSnackBar: false,
     });

--- a/hat/assets/js/apps/Iaso/domains/assignments/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/assignments/index.tsx
@@ -16,7 +16,7 @@ import {
     LoadingSpinner,
 } from 'bluesquare-components';
 
-import { redirectTo } from '../../routing/actions';
+import { redirectTo, redirectToReplace } from '../../routing/actions';
 import { baseUrls } from '../../constants/urls';
 
 import TopBar from '../../components/nav/TopBarComponent';
@@ -188,6 +188,30 @@ export const Assignments: FunctionComponent<Props> = ({ params }) => {
     }, [currentTeamId, teams]);
 
     useEffect(() => {
+        if (params.order) {
+            const redirect = (to: string): void => {
+                const tempParams = {
+                    ...params,
+                    order: `${params.order?.startsWith('-') ? '-' : ''}${to}`,
+                };
+                dispatch(redirectToReplace(baseUrl, tempParams));
+            };
+            if (
+                params.order?.includes('assignment__team__name') &&
+                currentTeam?.type === 'TEAM_OF_USERS'
+            ) {
+                redirect('assignment__user__username');
+            }
+            if (
+                params.order?.includes('assignment__user__username') &&
+                currentTeam?.type === 'TEAM_OF_TEAMS'
+            ) {
+                redirect('assignment__team__name');
+            }
+        }
+    }, [params, currentTeam?.type, dispatch]);
+
+    useEffect(() => {
         if (planning && currentTeam) {
             if (currentTeam.type === 'TEAM_OF_USERS') {
                 setSelectedItem(currentTeam.users_details[0]);
@@ -299,6 +323,7 @@ export const Assignments: FunctionComponent<Props> = ({ params }) => {
                                             params={params}
                                             teams={teams || []}
                                             profiles={profiles}
+                                            currentTeam={currentTeam}
                                             orgUnits={orgUnits?.all || []}
                                             handleSaveAssignment={
                                                 handleSaveAssignment

--- a/iaso/api/microplanning.py
+++ b/iaso/api/microplanning.py
@@ -517,7 +517,7 @@ class AssignmentViewSet(AuditMixin, ModelViewSet):
         PublishingStatusFilterBackend,
         DeletionFilterBackend,
     ]
-    ordering_fields = ["id", "name", "started_at", "ended_at"]
+    ordering_fields = ["id", "team__name"]
     filterset_fields = {
         "planning": ["exact"],
         "team": ["exact"],

--- a/iaso/api/microplanning.py
+++ b/iaso/api/microplanning.py
@@ -517,7 +517,7 @@ class AssignmentViewSet(AuditMixin, ModelViewSet):
         PublishingStatusFilterBackend,
         DeletionFilterBackend,
     ]
-    ordering_fields = ["id", "team__name"]
+    ordering_fields = ["id", "team__name", "user__username"]
     filterset_fields = {
         "planning": ["exact"],
         "team": ["exact"],


### PR DESCRIPTION
 Be able to sort org units by assignment column.

Related JIRA tickets : IA-1891

## Self proof reading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests

## Changes

- adding filters in microplanning.py
- remove sortable:false from assignment column
- dynamic sort/order depending on current team type


## How to test

View a planning by clicking on a planning in list view
Select tab List
Make sure you have some assignents
Try to sort on the last column (with a team of users and a team of team)

## Print screen / video


https://user-images.githubusercontent.com/12494624/217469677-0716090c-bfa3-460d-9e2f-fb27867b98b7.mov


