### PR TITLE
IA-1878: fix Org Unit location limit filter

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitFiltersContainer.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitFiltersContainer.tsx
@@ -1,14 +1,11 @@
+/* eslint-disable react/no-array-index-key */
 import { Box, makeStyles, Button, AppBar } from '@material-ui/core';
 import Add from '@material-ui/icons/Add';
 import { useDispatch } from 'react-redux';
 import {
-    // @ts-ignore
     commonStyles,
-    // @ts-ignore
     useSafeIntl,
-    // @ts-ignore
     DynamicTabs,
-    // @ts-ignore
     useSkipEffectOnMount,
 } from 'bluesquare-components';
 import React, {
@@ -100,21 +97,24 @@ export const OrgUnitFiltersContainer: FunctionComponent<Props> = ({
         () => currentUser?.account?.default_version?.data_source,
         [currentUser],
     );
-
     const [hasLocationLimitError, setHasLocationLimitError] =
         useState<boolean>(false);
     const [searches, setSearches] = useState<[Search]>(paramsSearches);
+    const [locationLimit, setLocationLimit] = useState<number>(
+        parseInt(params.locationLimit, 10),
+    );
     const [textSearchError, setTextSearchError] = useState<boolean>(false);
     const currentSearchIndex = parseInt(params.searchTabIndex, 10);
 
     const handleSearch = useCallback(() => {
         const tempParams = {
             ...params,
+            locationLimit,
             page: 1,
             searches,
         };
         onSearch(tempParams);
-    }, [params, searches, onSearch]);
+    }, [params, locationLimit, searches, onSearch]);
 
     const handleChangeColor = useCallback(
         (color: string, searchIndex: number) => {
@@ -208,10 +208,11 @@ export const OrgUnitFiltersContainer: FunctionComponent<Props> = ({
                             setSearches={setSearches}
                             onChangeColor={handleChangeColor}
                             currentTab={currentTab}
-                            params={params}
                             setHasLocationLimitError={setHasLocationLimitError}
                             orgunitTypes={orgunitTypes}
                             isFetchingOrgunitTypes={isFetchingOrgunitTypes}
+                            locationLimit={locationLimit}
+                            setLocationLimit={setLocationLimit}
                         />
                     </Box>
                 ))}

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitsFilters.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitsFilters.tsx
@@ -1,5 +1,12 @@
+import React, {
+    FunctionComponent,
+    useState,
+    useEffect,
+    useMemo,
+    Dispatch,
+    useCallback,
+} from 'react';
 import { Grid, Box, Typography, makeStyles, Divider } from '@material-ui/core';
-import React, { FunctionComponent, useState, useEffect, useMemo } from 'react';
 import {
     // @ts-ignore
     commonStyles,
@@ -24,7 +31,6 @@ import { useCurrentUser } from '../../../utils/usersUtils';
 import { useGetOrgUnit } from './TreeView/requests';
 
 import { IntlFormatMessage } from '../../../types/intl';
-import { OrgUnitParams } from '../types/orgUnit';
 import { Search } from '../types/search';
 import { DropdownOptions } from '../../../types/utils';
 
@@ -32,16 +38,17 @@ import MESSAGES from '../messages';
 
 type Props = {
     searches: [Search];
+    locationLimit: number;
+    setLocationLimit: Dispatch<React.SetStateAction<number>>;
     searchIndex: number;
     currentSearch: Search;
     // eslint-disable-next-line no-unused-vars
-    setTextSearchError: (hasError: boolean) => void;
+    setTextSearchError: Dispatch<React.SetStateAction<boolean>>;
     onSearch: () => void;
     // eslint-disable-next-line no-unused-vars
     onChangeColor: (color: string, index: number) => void;
     setSearches: React.Dispatch<React.SetStateAction<[Search]>>;
     currentTab: string;
-    params: OrgUnitParams;
     setHasLocationLimitError: React.Dispatch<React.SetStateAction<boolean>>;
     orgunitTypes: DropdownOptions<string>[];
     isFetchingOrgunitTypes: boolean;
@@ -70,10 +77,11 @@ export const OrgUnitFilters: FunctionComponent<Props> = ({
     setTextSearchError,
     setSearches,
     currentTab,
-    params,
     setHasLocationLimitError,
     orgunitTypes,
     isFetchingOrgunitTypes,
+    locationLimit,
+    setLocationLimit,
 }) => {
     const classes: Record<string, string> = useStyles();
     const { formatMessage }: { formatMessage: IntlFormatMessage } =
@@ -129,6 +137,13 @@ export const OrgUnitFilters: FunctionComponent<Props> = ({
     const currentColor = filters?.color
         ? `#${filters.color}`
         : getChipColors(searchIndex);
+
+    const handleLocationLimitChange = useCallback(
+        (key: string, value: number) => {
+            setLocationLimit(value);
+        },
+        [setLocationLimit],
+    );
 
     // Splitting this effect from the one below, so we can use the deps array
     useEffect(() => {
@@ -335,8 +350,8 @@ export const OrgUnitFilters: FunctionComponent<Props> = ({
                         <Box mt={2}>
                             <LocationLimit
                                 keyValue="locationLimit"
-                                onChange={handleChange}
-                                value={params.locationLimit}
+                                onChange={handleLocationLimitChange}
+                                value={locationLimit}
                                 setHasError={setHasLocationLimitError}
                             />
                         </Box>


### PR DESCRIPTION
In Org units list, it was impossible to edit the value of the location limit filter

Related JIRA tickets : IA-1878

## Self proof reading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests

## Changes

 - Add a `[locationLimit, setLocationLimit]`state to `OrgUnitsFilterContainer`
 - Use these values to make a `handleLocationLimit` callback for the filter
 - Update `OrgUnitsFilterContainer`'s `onSearch` accordingly
 - Remove now useless `params`  prop from `OrgUnitsFilter`

## How to test

- Go to Org units, make a search, click on Map tab
- Change the value of location limit and click 'Search'
- The results should be updated
- Try with other filters (eg search) they should still work as expected

## Print screen / video

https://user-images.githubusercontent.com/38907762/217510375-96e4b6bb-d00a-4606-aecd-b5b08bd4cbed.mov

