### PR TITLE
IA-1899 : org unit api call optimization

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/index.tsx
@@ -203,7 +203,7 @@ export const OrgUnits: FunctionComponent<Props> = ({ params }) => {
     );
     // TABS
 
-    // onload, if searchActive is true => set launch search
+    // onload, if searchActive is true and cache empty => set launch search
     useEffect(() => {
         if (isSearchActive) {
             const cachedOrgUnits = queryClient.getQueryData(['orgunits']);
@@ -214,16 +214,6 @@ export const OrgUnits: FunctionComponent<Props> = ({ params }) => {
                 handleSearch();
             }
         }
-        // return () => {
-        // queryClient
-        //     .getQueryCache()
-        //     .findAll(['orgunits'])
-        //     .forEach(query => query.setData(undefined));
-        // queryClient
-        //     .getQueryCache()
-        //     .findAll(['orgunitslocations'])
-        //     .forEach(query => query.setData(undefined));
-        // };
     }, [handleSearch, isSearchActive, queryClient]);
 
     // trigger search on order, page size and page

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/index.tsx
@@ -206,20 +206,25 @@ export const OrgUnits: FunctionComponent<Props> = ({ params }) => {
     // onload, if searchActive is true => set launch search
     useEffect(() => {
         if (isSearchActive) {
-            handleSearch();
+            const cachedOrgUnits = queryClient.getQueryData(['orgunits']);
+            const cachedLocations = queryClient.getQueryData([
+                'orgunitslocations',
+            ]);
+            if (!cachedOrgUnits || !cachedLocations) {
+                handleSearch();
+            }
         }
-        return () => {
-            queryClient
-                .getQueryCache()
-                .findAll(['orgunits'])
-                .forEach(query => query.setData(undefined));
-            queryClient
-                .getQueryCache()
-                .findAll(['orgunitslocations'])
-                .forEach(query => query.setData(undefined));
-        };
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
+        // return () => {
+        // queryClient
+        //     .getQueryCache()
+        //     .findAll(['orgunits'])
+        //     .forEach(query => query.setData(undefined));
+        // queryClient
+        //     .getQueryCache()
+        //     .findAll(['orgunitslocations'])
+        //     .forEach(query => query.setData(undefined));
+        // };
+    }, [handleSearch, isSearchActive, queryClient]);
 
     // trigger search on order, page size and page
     useSkipEffectOnMount(() => {
@@ -263,6 +268,7 @@ export const OrgUnits: FunctionComponent<Props> = ({ params }) => {
                     counts={(!isLoading && orgUnitsData?.counts) || []}
                     setDeletedTab={setDeletedTab}
                 />
+
                 {tab === 'list' &&
                     orgUnitsData &&
                     orgUnitsData?.orgunits?.length > 0 && (


### PR DESCRIPTION
When navigation from org units list to create or deatils view, then back to list, the API calls fetching org units and locations would be triggered, even though there's data in react-query' cache. For big searches, that would considerably slow down the UI

Related JIRA tickets : IA-1899

## Self proof reading checklist

- [X] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests

## Changes

- Updated `useEffect` that `refetch` on mount so that it would only fetch if caches are empty, and removed the cleanup function emptying the cache on unmount

## How to test
Go to org units list. Lauche one or several search(es). Go to create screen then back. The page should load instantly (no loading spinner)
Do the same with org list -> org units detail -> org units list

## Print screen / video


https://user-images.githubusercontent.com/38907762/217648147-813d33fa-76bb-4594-9b30-8b622edafcb4.mov


