### PR TITLE
POLIO-814: Timeline UI polish

### DIFF
--- a/plugins/polio/js/src/pages/Budget/types.ts
+++ b/plugins/polio/js/src/pages/Budget/types.ts
@@ -8,22 +8,24 @@ export type Timeline = {
     categories: Categories;
 };
 
+export type Item = {
+    label: string;
+    step_id?: number;
+    performed_at?: string; // datetime
+    performed_by?: {
+        username;
+        first_name;
+        last_name;
+    };
+};
+
 export type Categories = {
     key: string;
     label: string;
     color: string; // css string
     active: boolean;
     completed: boolean;
-    items: {
-        label: string;
-        step_id?: number;
-        performed_at?: string; // datetime
-        performed_by?: {
-            username;
-            first_name;
-            last_name;
-        }; // User
-    }[];
+    items: Item[];
 }[];
 
 export type NextTransition = {


### PR DESCRIPTION
Latest step in timeline should be bold

Related JIRA tickets : POLIO-814

## Self proof reading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [X] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests

## Changes
- Add `Item` type
- Find latest step in API payload and style it

## How to test

Go to a budget details see if the latest step is bold

## Print screen / video

![Screenshot 2023-02-08 at 23 15 39](https://user-images.githubusercontent.com/38907762/217663565-0d6b197c-674d-4b35-909e-152f046f8732.png)

## Notes

The colors of the progress bar on the screen shot are wrong because I used override steps and this branch is  based on main  (which doesn't have yet POLIO-798 and POLIO-799)
