### PR TITLE
WC2-153: enable workflow name edit for any state

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/entities/entityTypes/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/entityTypes/index.tsx
@@ -3,15 +3,10 @@ import { useDispatch } from 'react-redux';
 import { makeStyles, Box, Grid } from '@material-ui/core';
 
 import {
-    // @ts-ignore
     commonStyles,
-    // @ts-ignore
     Table,
-    // @ts-ignore
     LoadingSpinner,
-    // @ts-ignore
     useSafeIntl,
-    // @ts-ignore
     AddButton as AddButtonComponent,
 } from 'bluesquare-components';
 

--- a/hat/assets/js/apps/Iaso/domains/workflows/components/WorkflowBaseInfo.tsx
+++ b/hat/assets/js/apps/Iaso/domains/workflows/components/WorkflowBaseInfo.tsx
@@ -56,13 +56,10 @@ export const WorkflowBaseInfo: FunctionComponent<Props> = ({
             <Divider />
             <Table size="small">
                 <TableBody>
-                    {workflowVersion?.status &&
-                        workflowVersion?.status !== 'DRAFT' && (
-                            <Row
-                                label={formatMessage(MESSAGES.name)}
-                                value={workflowVersion?.name}
-                            />
-                        )}
+                    <Row
+                        label={formatMessage(MESSAGES.name)}
+                        value={workflowVersion?.name}
+                    />
                     <Row
                         label={formatMessage(MESSAGES.type)}
                         value={workflowVersion?.entity_type.name}

--- a/hat/assets/js/apps/Iaso/domains/workflows/components/WorkflowBaseInfo.tsx
+++ b/hat/assets/js/apps/Iaso/domains/workflows/components/WorkflowBaseInfo.tsx
@@ -52,12 +52,8 @@ export const WorkflowBaseInfo: FunctionComponent<Props> = ({
     const { formatMessage } = useSafeIntl();
     return (
         <>
-            {workflowVersion?.status === 'DRAFT' && (
-                <>
-                    <DetailsForm workflowVersion={workflowVersion} />
-                    <Divider />
-                </>
-            )}
+            <DetailsForm workflowVersion={workflowVersion} />
+            <Divider />
             <Table size="small">
                 <TableBody>
                     {workflowVersion?.status &&
@@ -106,6 +102,7 @@ export const WorkflowBaseInfo: FunctionComponent<Props> = ({
                 <>
                     <Divider />
                     <Box p={2} display="flex" justifyContent="flex-end">
+                        {/* @ts-ignore */}
                         <PublishVersionModal
                             workflowVersion={workflowVersion}
                             invalidateQueryKey="workflowVersion"

--- a/hat/assets/js/apps/Iaso/domains/workflows/details.tsx
+++ b/hat/assets/js/apps/Iaso/domains/workflows/details.tsx
@@ -10,6 +10,8 @@ import {
     LoadingSpinner,
     // @ts-ignore
     formatThousand,
+    // @ts-ignore
+    Column,
     SortableTable,
     useHumanReadableJsonLogic,
 } from 'bluesquare-components';
@@ -199,7 +201,9 @@ export const Details: FunctionComponent<Props> = ({ router }) => {
                                         <SortableTable
                                             items={followUps}
                                             onChange={handleSortChange}
-                                            columns={followUpsColumns}
+                                            columns={
+                                                followUpsColumns as Column[]
+                                            }
                                         />
                                     )}
                                     {workflowVersion.status !== 'DRAFT' && (
@@ -226,6 +230,7 @@ export const Details: FunctionComponent<Props> = ({ router }) => {
                                         {formatMessage(MESSAGES.saveOrder)}
                                     </Button>
                                 </Box>
+                                {/* @ts-ignore */}
                                 <AddFollowUpsModal
                                     fields={fields}
                                     versionId={versionId}
@@ -276,6 +281,7 @@ export const Details: FunctionComponent<Props> = ({ router }) => {
                         />
                         {workflowVersion?.status === 'DRAFT' && (
                             <Box m={2} textAlign="right">
+                                {/* @ts-ignore */}
                                 <AddChangeModal
                                     versionId={versionId}
                                     changes={workflowVersion?.changes || []}


### PR DESCRIPTION
Enable changing the name of a workflow even after it's been published

Related JIRA tickets :  WC2-153

## Self proof reading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests

## Changes

- removed condition on name edition
- fixed some ts errors

## How to test

- Beneficiary types > workflows
- Make sure you have published and unpublished workflows
- Edit the name for both published and unpublished
- You should get a 200 and the workflow table should be updated

## Print screen / video


https://user-images.githubusercontent.com/38907762/218063226-3bbc7f50-8eb0-430b-a9a9-b63b3cbfe3d5.mov


