### PR TITLE
IA-1900 submission crash because form label

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/forms/fields/hooks/useGetFormDescriptor.ts
+++ b/hat/assets/js/apps/Iaso/domains/forms/fields/hooks/useGetFormDescriptor.ts
@@ -1,7 +1,7 @@
 import { UseQueryResult } from 'react-query';
 import { getRequest } from '../../../../libs/Api';
 import { useSnackQuery } from '../../../../libs/apiHooks';
-import { FormDescriptor } from '../../../forms/types/forms';
+import { FormDescriptor } from '../../types/forms';
 
 type FormVersions = {
     descriptor: FormDescriptor;

--- a/hat/assets/js/apps/Iaso/domains/forms/fields/hooks/useGetQueryBuildersFields.ts
+++ b/hat/assets/js/apps/Iaso/domains/forms/fields/hooks/useGetQueryBuildersFields.ts
@@ -39,17 +39,20 @@ export const useGetQueryBuildersFields = (
             if (currentField.useListValues) {
                 // We will take the last found value in the form descriptors list
                 formDescriptors?.forEach(formDescriptor => {
-                    const listValues =
-                        findDescriptorInChildren(
-                            field,
-                            formDescriptor,
-                        )?.children?.map(child => ({
-                            value: child.name,
-                            title: formatLabel(child),
-                        })) || [];
-                    fields[field.fieldKey].fieldSettings = {
-                        listValues,
-                    };
+                    const descriptor = findDescriptorInChildren(
+                        field,
+                        formDescriptor,
+                    );
+                    if (descriptor?.children) {
+                        const listValues =
+                            descriptor.children.map(child => ({
+                                value: child.name,
+                                title: formatLabel(child),
+                            })) || [];
+                        fields[field.fieldKey].fieldSettings = {
+                            listValues,
+                        };
+                    }
                 });
             }
         }

--- a/hat/assets/js/apps/Iaso/domains/forms/fields/hooks/useGetQueryBuildersFields.ts
+++ b/hat/assets/js/apps/Iaso/domains/forms/fields/hooks/useGetQueryBuildersFields.ts
@@ -15,7 +15,7 @@ const findDescriptorInChildren = (field, descriptor) =>
     }, null);
 
 export const useGetQueryBuildersFields = (
-    formDescriptor?: FormDescriptor,
+    formDescriptors?: FormDescriptor[],
     possibleFields?: PossibleField[],
 ): QueryBuilderFields => {
     if (!possibleFields) return {};
@@ -35,16 +35,22 @@ export const useGetQueryBuildersFields = (
                 ...currentField.queryBuilder,
                 label: formatLabel(field),
             };
+            // in case the field needs a list of values to display
             if (currentField.useListValues) {
-                const listValues =
-                    findDescriptorInChildren(
-                        field,
-                        formDescriptor,
-                    )?.children?.map(child => ({
-                        value: child.name,
-                        title: formatLabel(child),
-                    })) || [];
-                currentField.queryBuilder.fieldSettings = { listValues };
+                // We will take the last found value in the form descriptors list
+                formDescriptors?.forEach(formDescriptor => {
+                    const listValues =
+                        findDescriptorInChildren(
+                            field,
+                            formDescriptor,
+                        )?.children?.map(child => ({
+                            value: child.name,
+                            title: formatLabel(child),
+                        })) || [];
+                    fields[field.fieldKey].fieldSettings = {
+                        listValues,
+                    };
+                });
             }
         }
     });

--- a/hat/assets/js/apps/Iaso/domains/instances/components/InstancesFiltersComponent.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/InstancesFiltersComponent.js
@@ -31,7 +31,7 @@ import { Period } from '../../periods/models.ts';
 import { INSTANCE_STATUSES } from '../constants';
 import { setInstancesFilterUpdated } from '../actions';
 
-import { useGetFormDescriptor } from '../compare/hooks/useGetInstanceLogs.ts';
+import { useGetFormDescriptor } from '../../forms/fields/hooks/useGetFormDescriptor.ts';
 import { useGetForms, useInstancesFiltersData } from '../hooks';
 import { getInstancesFilterValues, useFormState } from '../../../hooks/form';
 import { useGetQueryBuildersFields } from '../../forms/fields/hooks/useGetQueryBuildersFields.ts';

--- a/hat/assets/js/apps/Iaso/domains/instances/utils/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/utils/index.tsx
@@ -61,7 +61,7 @@ const KeyValueFields: FunctionComponent<KeyValueFieldsProps> = ({ entry }) => (
 );
 
 type Field = {
-    label?: string;
+    label?: string | Record<string, string>;
     name: string;
 };
 type Locales = {
@@ -76,28 +76,37 @@ const localizeLabel = (field: Field): string => {
     const locale: string = getCookie('django_language') ?? 'en';
     const localeKey = labelLocales[locale] ?? labelLocales.en;
 
-    let localeOptions: Field;
+    let localeOptions: Record<string, string> = { [localeKey]: field.name };
     if (typeof field === 'object') {
-        const singleToDoubleQuotes: string = (field.label || '').replaceAll(
-            "'",
-            '"',
-        );
-        const wrongDoubleQuotes = /(?:[a-zA-Z])"(?=[a-zA-Z])/g;
-        const formattedLabel: string = singleToDoubleQuotes.replace(
-            wrongDoubleQuotes,
-            "'",
-        );
-        try {
-            localeOptions = JSON.parse(formattedLabel);
-        } catch (e) {
-            // some fields are using single quotes. Logging just for info, this can be deleted if it clutters the console
-            console.warn('Error parsing JSON', formattedLabel, e);
-            return field.name;
+        // console.log('BUG!', field.label);
+        if (typeof field.label === 'string') {
+            const singleToDoubleQuotes: string = (field.label || '').replaceAll(
+                "'",
+                '"',
+            );
+            const wrongDoubleQuotes = /(?:[a-zA-Z])"(?=[a-zA-Z])/g;
+            const formattedLabel: string = singleToDoubleQuotes.replace(
+                wrongDoubleQuotes,
+                "'",
+            );
+            try {
+                localeOptions = JSON.parse(formattedLabel);
+            } catch (e) {
+                // some fields are using single quotes. Logging just for info, this can be deleted if it clutters the console
+                console.warn('Error parsing JSON', formattedLabel, e);
+                return field.name;
+            }
+        } else if (
+            typeof field.label === 'object' &&
+            !Array.isArray(field.label)
+        ) {
+            // console.log('JSON', field.label);
+            localeOptions = field.label;
         }
     } else {
         localeOptions = field;
     }
-    return localeOptions[localeKey] ?? field.name;
+    return localeOptions[localeKey];
 };
 
 /**

--- a/hat/assets/js/apps/Iaso/domains/workflows/details.tsx
+++ b/hat/assets/js/apps/Iaso/domains/workflows/details.tsx
@@ -29,7 +29,7 @@ import { useGetWorkflowVersion } from './hooks/requests/useGetWorkflowVersions';
 import { useGetQueryBuildersFields } from '../forms/fields/hooks/useGetQueryBuildersFields';
 import { useGetQueryBuilderListToReplace } from '../forms/fields/hooks/useGetQueryBuilderListToReplace';
 
-import { useGetFormDescriptor } from './hooks/requests/useGetFormDescriptor';
+import { useGetFormDescriptor } from '../forms/fields/hooks/useGetFormDescriptor';
 import { useBulkUpdateWorkflowFollowUp } from './hooks/requests/useBulkUpdateWorkflowFollowUp';
 
 import { WorkflowVersionDetail, WorkflowParams, FollowUps } from './types';


### PR DESCRIPTION
Query builder was crashing while using this form

[collecte_des_donnees_de_la_fosa_2022051302.xlsx](https://github.com/BLSQ/iaso/files/10721416/collecte_des_donnees_de_la_fosa_2022051302.xlsx)

![image](https://user-images.githubusercontent.com/12494624/218438749-317f8557-1028-4abc-ba11-4f8245d03933.png)

Related JIRA tickets : IA-1900

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests

## Changes

- fix `localizeLabel` to support this form
- parse multiple form descriptors to use last known value of a field

## How to test

Create a new form with the XLSX.
Go to to submissions list and filter with this form.
Query builder should work properly especially for `select_one` fields.
Try also to edit a workflow version in draft mode and play with the query builder, again double check the list of values possible on `select_one` type of field.

You can also add a version to a form and add a field, delete a field, change type of a field.
Check that the query builder is behaving correctly.

