### PR TITLE
IA-1889: Depth parameter remains in URL even when no value - causes error

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitsFilters.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitsFilters.tsx
@@ -8,11 +8,8 @@ import React, {
 } from 'react';
 import { Grid, Box, Typography, makeStyles, Divider } from '@material-ui/core';
 import {
-    // @ts-ignore
     commonStyles,
-    // @ts-ignore
     useSafeIntl,
-    // @ts-ignore
     useSkipEffectOnMount,
 } from 'bluesquare-components';
 
@@ -124,8 +121,12 @@ export const OrgUnitFilters: FunctionComponent<Props> = ({
         }
         const newFilters: Record<string, unknown> = {
             ...filters,
-            [key]: value,
         };
+        if ((!value || value === '') && newFilters[key]) {
+            delete newFilters[key];
+        } else {
+            newFilters[key] = value;
+        }
         if (newFilters.source && newFilters.version) {
             delete newFilters.source;
         }


### PR DESCRIPTION
On org units search page
 - fill up a filter
 - click on search 
 - empty this filter
 - re-click on search
 => the filter remains in the url as null or an empty string :
`{"validation_status":"all","color":"f4511e","source":218,"depth":""}`

Org unit api is crashing with an empty string on `depth`

Related JIRA tickets : IA-1889

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests

## Changes

Remove existing filter state if the new value of this filter is `null`, `undefined` or an empty string

## How to test

On org units search page
 - fill up a filter
 - click on search 
 - empty this filter
 - re-click on search
 - check that the value of the filter is not in the url anymore
 
## Print screen / video


https://user-images.githubusercontent.com/12494624/218728183-b1039ed3-3c69-4df7-9dfb-d1b7b7e2ddc5.mov

