### PR TITLE
IA-1423: Planing view, list tab, order reset

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/assignments/configs/AssignmentsListTabColumns.tsx
+++ b/hat/assets/js/apps/Iaso/domains/assignments/configs/AssignmentsListTabColumns.tsx
@@ -78,7 +78,6 @@ export const useColumns = ({
                     },
                 });
             });
-        // assignment__team__name
         const assignationColumn: Column = {
             Header: formatMessage(MESSAGES.assignment),
             id:

--- a/hat/assets/js/apps/Iaso/domains/assignments/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/assignments/index.tsx
@@ -11,6 +11,7 @@ import {
     commonStyles,
     useSafeIntl,
     LoadingSpinner,
+    useSkipEffectOnMount,
 } from 'bluesquare-components';
 
 import { redirectTo, redirectToReplace } from '../../routing/actions';
@@ -208,6 +209,18 @@ export const Assignments: FunctionComponent<Props> = ({ params }) => {
             }
         }
     }, [params, currentTeam?.type, dispatch]);
+
+    useSkipEffectOnMount(() => {
+        // Change order if baseOrgunitType or team changed and current order is on a parent column that will probably disappear
+        if (params.order?.includes('parent__name')) {
+            dispatch(
+                redirectToReplace(baseUrl, {
+                    ...params,
+                    order: 'name',
+                }),
+            );
+        }
+    }, [params.baseOrgunitType, params.team]);
 
     useEffect(() => {
         if (planning && currentTeam) {


### PR DESCRIPTION
Go to to planning list

Click on view View planning eye icon

Make sure you have assignations on at least 2 levels (Country, province, regions)

Assign teams or user to this level of org unit.

Click on list tab.

Sort on a parent column.

Change current team or base org unit type, order is still on a column that doesn’t exist anymore


https://user-images.githubusercontent.com/12494624/218738154-2a15be29-e4d4-4b5c-b4c0-36894fcc5917.mov


Related JIRA tickets : IA-1423

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests

## Changes

`useSkipEffectOnMount` to watch `baseOrgunitType` and `team`, if `order` is using a `parent__name` => reset it to `name`

## How to test

repeat previous proccess

Change current team or base org unit type, order should be set to name

## Print screen / video

https://user-images.githubusercontent.com/12494624/218738112-c844273a-cb23-4cb4-aada-a9c2098b3fa8.mov


