### PR TITLE
POLIO-824: update pv notification date

### DIFF
--- a/plugins/polio/js/src/constants/messages.js
+++ b/plugins/polio/js/src/constants/messages.js
@@ -262,11 +262,11 @@ const MESSAGES = defineMessages({
     },
     pv2_notification_date: {
         id: 'iaso.polio.form.label.pv2_notification_date',
-        defaultMessage: 'PV2 notification date',
+        defaultMessage: 'PV notification date',
     },
     pv2_notified_at: {
         id: 'iaso.polio.form.label.pv2_notification_date',
-        defaultMessage: 'PV2 notification date',
+        defaultMessage: 'PV notification date',
     },
     threelevelCall: {
         id: 'iaso.polio.form.label.threelevelCall',

--- a/plugins/polio/js/src/constants/translations/en.json
+++ b/plugins/polio/js/src/constants/translations/en.json
@@ -93,7 +93,7 @@
     "iaso.polio.form.label.pleaseSaveCampaign": "Please save the Campaign before selecting scope.",
     "iaso.polio.form.label.preventive": "Preventive campaign",
     "iaso.polio.form.label.preventive.short": "Preventive",
-    "iaso.polio.form.label.pv2_notification_date": "PV2 notification date",
+    "iaso.polio.form.label.pv2_notification_date": "PV notification date",
     "iaso.polio.form.label.ratioChildrenMissedInAndOutOfHousehold": "% children missed IN+OUT OF household",
     "iaso.polio.form.label.ratioChildrenMissedInHousehold": "% children missed IN household",
     "iaso.polio.form.label.ratioChildrenMissedOutOfHousehold": "% children missed OUT OF household",

--- a/plugins/polio/js/src/constants/translations/fr.json
+++ b/plugins/polio/js/src/constants/translations/fr.json
@@ -92,7 +92,7 @@
     "iaso.polio.form.label.pleaseSaveCampaign": "SVP enregistrer la campagne avant de sélectionner le périmètre",
     "iaso.polio.form.label.preventive": "Campagne préventive",
     "iaso.polio.form.label.preventive.short": "Préventive",
-    "iaso.polio.form.label.pv2_notification_date": "Date de notification PV2",
+    "iaso.polio.form.label.pv2_notification_date": "Date de notification PV",
     "iaso.polio.form.label.ratioChildrenMissedInAndOutOfHousehold": "% d'enfants manqués DANS+EN DEHORS des ménages",
     "iaso.polio.form.label.ratioChildrenMissedInHousehold": "% d'enfants manqués DANS les ménages",
     "iaso.polio.form.label.ratioChildrenMissedOutOfHousehold": "% d'enfants manqués EN DEHORS des ménages",


### PR DESCRIPTION
“PV2” dates back from the beginning of the project where the platform was supposed to address only cvdpv2 outbreak responses

Related JIRA tickets : IA-XXX, WC2-XXX, POLIO-XXX

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [x] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests

## Changes

Updated the translation

## How to test

- Go to campaigns 
- Edit a campaign
- Go to Basic Info and Detection tabs. You should see "PV notification date"

## Print screen / video

https://user-images.githubusercontent.com/25134301/219064815-345362c5-732c-4da2-bbae-c80e435834f7.mov
