### PR TITLE
IA-1916 entity mandatory field

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/entities/entityTypes/components/EntityTypesDialog.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/entityTypes/components/EntityTypesDialog.tsx
@@ -20,7 +20,7 @@ import { baseUrls } from '../../../../constants/urls';
 
 import { useGetForms } from '../hooks/requests/forms';
 import { useTranslatedErrors } from '../../../../libs/validation';
-import { useGetPossibleFields } from '../../../forms/hooks/useGetPossibleFields';
+import { useGetPossibleFieldsForEntityTypes } from '../../../forms/hooks/useGetPossibleFields';
 import MESSAGES from '../messages';
 
 type RenderTriggerProps = {
@@ -134,9 +134,11 @@ export const EntityTypesDialog: FunctionComponent<Props> = ({
     });
     const isNew = !initialData?.id;
     const { data: formsList, isFetching: isFetchingForms } = useGetForms(isNew);
-    const { possibleFields, isFetchingForm } = useGetPossibleFields(
-        isOpen ? values?.reference_form : undefined,
-    );
+    const { possibleFields, isFetchingForm } =
+        useGetPossibleFieldsForEntityTypes({
+            formId: values?.reference_form,
+            enabled: isOpen,
+        });
     return (
         <FormikProvider value={formik}>
             {/* @ts-ignore */}
@@ -158,10 +160,12 @@ export const EntityTypesDialog: FunctionComponent<Props> = ({
                 dialogProps={{
                     classNames: classes.dialog,
                 }}
-                onOpen={() => setIsOpen(true)}
+                onOpen={() => {
+                    resetForm();
+                    setIsOpen(true);
+                }}
                 onClosed={() => {
                     setIsOpen(false);
-                    resetForm();
                 }}
             >
                 {!isNew && (

--- a/hat/assets/js/apps/Iaso/domains/entities/entityTypes/components/EntityTypesDialog.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/entityTypes/components/EntityTypesDialog.tsx
@@ -137,7 +137,6 @@ export const EntityTypesDialog: FunctionComponent<Props> = ({
     const { possibleFields, isFetchingForm } = useGetPossibleFields(
         isOpen ? values?.reference_form : undefined,
     );
-
     return (
         <FormikProvider value={formik}>
             {/* @ts-ignore */}

--- a/hat/assets/js/apps/Iaso/domains/entities/entityTypes/components/EntityTypesDialog.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/entityTypes/components/EntityTypesDialog.tsx
@@ -137,6 +137,7 @@ export const EntityTypesDialog: FunctionComponent<Props> = ({
     const { possibleFields, isFetchingForm } = useGetPossibleFields(
         isOpen ? values?.reference_form : undefined,
     );
+    console.log('forms', formsList);
     return (
         <FormikProvider value={formik}>
             {/* @ts-ignore */}

--- a/hat/assets/js/apps/Iaso/domains/entities/entityTypes/components/EntityTypesDialog.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/entityTypes/components/EntityTypesDialog.tsx
@@ -60,8 +60,8 @@ export const EntityTypesDialog: FunctionComponent<Props> = ({
         id: undefined,
         name: undefined,
         reference_form: undefined,
-        fields_detail_info_view: [],
-        fields_list_view: [],
+        fields_detail_info_view: undefined,
+        fields_list_view: undefined,
     },
     saveEntityType,
 }) => {
@@ -82,6 +82,16 @@ export const EntityTypesDialog: FunctionComponent<Props> = ({
                     .number()
                     .nullable()
                     .required(formatMessage(MESSAGES.referenceFormRequired)),
+                fields_list_view: yup
+                    .array()
+                    .of(yup.string())
+                    .nullable()
+                    .required(),
+                fields_detail_info_view: yup
+                    .array()
+                    .of(yup.string())
+                    .nullable()
+                    .required(),
             }),
         );
 
@@ -194,6 +204,7 @@ export const EntityTypesDialog: FunctionComponent<Props> = ({
                     <InputComponent
                         type="select"
                         multi
+                        required
                         disabled={isFetchingForm || !values.reference_form}
                         keyValue="fields_list_view"
                         onChange={(key, value) =>
@@ -214,6 +225,7 @@ export const EntityTypesDialog: FunctionComponent<Props> = ({
                     <InputComponent
                         type="select"
                         multi
+                        required
                         disabled={isFetchingForm || !values.reference_form}
                         loading={isFetchingForm}
                         keyValue="fields_detail_info_view"

--- a/hat/assets/js/apps/Iaso/domains/entities/entityTypes/components/EntityTypesDialog.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/entityTypes/components/EntityTypesDialog.tsx
@@ -137,7 +137,6 @@ export const EntityTypesDialog: FunctionComponent<Props> = ({
     const { possibleFields, isFetchingForm } = useGetPossibleFields(
         isOpen ? values?.reference_form : undefined,
     );
-    console.log('forms', formsList);
     return (
         <FormikProvider value={formik}>
             {/* @ts-ignore */}

--- a/hat/assets/js/apps/Iaso/domains/entities/entityTypes/components/EntityTypesDialog.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/entityTypes/components/EntityTypesDialog.tsx
@@ -159,7 +159,10 @@ export const EntityTypesDialog: FunctionComponent<Props> = ({
                     classNames: classes.dialog,
                 }}
                 onOpen={() => setIsOpen(true)}
-                onClosed={() => setIsOpen(false)}
+                onClosed={() => {
+                    setIsOpen(false);
+                    resetForm();
+                }}
             >
                 {!isNew && (
                     <Box className={classes.view}>

--- a/hat/assets/js/apps/Iaso/domains/entities/entityTypes/hooks/requests/forms.ts
+++ b/hat/assets/js/apps/Iaso/domains/entities/entityTypes/hooks/requests/forms.ts
@@ -30,11 +30,15 @@ export const useGetForms = (
 ): UseQueryResult<Form[], Error> => {
     return useSnackQuery({
         queryKey: ['forms'],
-        queryFn: () => getRequest('/api/forms/?fields=id,name'),
+        queryFn: () =>
+            getRequest('/api/forms/?fields=id,name,latest_form_version'),
         options: {
             staleTime: 60000,
             enabled,
-            select: data => data?.forms,
+            select: data =>
+                data?.forms.filter(form =>
+                    Boolean(form.latest_form_version?.xls_file),
+                ),
         },
     });
 };

--- a/hat/assets/js/apps/Iaso/domains/forms/hooks/useGetPossibleFields.ts
+++ b/hat/assets/js/apps/Iaso/domains/forms/hooks/useGetPossibleFields.ts
@@ -1,11 +1,25 @@
 import { useMemo } from 'react';
 import { useGetForm } from '../../entities/entityTypes/hooks/requests/forms';
 
-import { PossibleField } from '../types/forms';
+import { Form, PossibleField } from '../types/forms';
 
 type Result = {
     possibleFields: PossibleField[];
     isFetchingForm: boolean;
+};
+
+const usePossibleFields = (isFetchingForm: boolean, form?: Form) => {
+    return useMemo(() => {
+        const possibleFields =
+            form?.possible_fields?.map(field => ({
+                ...field,
+                fieldKey: field.name.replace('.', ''),
+            })) || [];
+        return {
+            possibleFields,
+            isFetchingForm,
+        };
+    }, [form?.possible_fields, isFetchingForm]);
 };
 
 export const useGetPossibleFields = (formId?: number): Result => {
@@ -14,15 +28,19 @@ export const useGetPossibleFields = (formId?: number): Result => {
         Boolean(formId),
         'possible_fields',
     );
-    return useMemo(() => {
-        const possibleFields =
-            currentForm?.possible_fields?.map(field => ({
-                ...field,
-                fieldKey: field.name.replace('.', ''),
-            })) || [];
-        return {
-            possibleFields,
-            isFetchingForm,
-        };
-    }, [currentForm?.possible_fields, isFetchingForm]);
+    return usePossibleFields(isFetchingForm, currentForm);
+};
+export const useGetPossibleFieldsForEntityTypes = ({
+    formId,
+    enabled = true,
+}: {
+    formId?: number;
+    enabled?: boolean;
+}): Result => {
+    const { data: currentForm, isFetching: isFetchingForm } = useGetForm(
+        formId,
+        enabled,
+        'possible_fields',
+    );
+    return usePossibleFields(isFetchingForm, currentForm);
 };

--- a/hat/assets/js/apps/Iaso/domains/forms/hooks/useGetPossibleFields.ts
+++ b/hat/assets/js/apps/Iaso/domains/forms/hooks/useGetPossibleFields.ts
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useGetForm } from '../../entities/entityTypes/hooks/requests/forms';
 
 import { PossibleField } from '../types/forms';
@@ -13,13 +14,15 @@ export const useGetPossibleFields = (formId?: number): Result => {
         Boolean(formId),
         'possible_fields',
     );
-    const possibleFields =
-        currentForm?.possible_fields?.map(field => ({
-            ...field,
-            fieldKey: field.name.replace('.', ''),
-        })) || [];
-    return {
-        possibleFields,
-        isFetchingForm,
-    };
+    return useMemo(() => {
+        const possibleFields =
+            currentForm?.possible_fields?.map(field => ({
+                ...field,
+                fieldKey: field.name.replace('.', ''),
+            })) || [];
+        return {
+            possibleFields,
+            isFetchingForm,
+        };
+    }, [currentForm?.possible_fields, isFetchingForm]);
 };


### PR DESCRIPTION
In entity types create/edit modal, the `List fields` and `Details info fields` need to be made mandatory to prevent bugs with the mobile app

Related JIRA tickets : IA-1916

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [X] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests

## Changes

- Added validator for both fields
- Marked them as required
- Changed the default value in `intialState` fromm `[]` to `undefined` to enable the validation check
- Filtered out forms without XLS version to avoid users having no fields to choose from after having selected a reference form when creating an entity type
- Fixed `usePossibleFields` so it fetches the fields when user changes selection in UI
- Fixed Dialog so it would reset `onClose` to avoid keeping the values after a `Create`
- **UPDATE 2023/02/17**: add `useGetPossibleFieldsForEntityTypes` to remove glitch on close (see below in comments thtread and code review).

## How to test

Go to Beneficiary Types
Create a Beneficiary: you shouldn't be able to save unless all fields have a value

## Print screen / video

https://user-images.githubusercontent.com/38907762/219353290-04a94906-bd96-4984-ba74-029d2fec036f.mov

