### PR TITLE
IA-1908-missing-json-widget-for-instances-admin FIX

### DIFF
--- a/iaso/admin.py
+++ b/iaso/admin.py
@@ -215,6 +215,7 @@ class InstanceAdmin(admin.GeoModelAdmin):
     formfield_overrides = {
         models.TextField: {"widget": widgets.AdminTextInputWidget},
         geomodels.PointField: {"widget": forms.OSMWidget},  # type: ignore
+        models.JSONField: {"widget": IasoJSONEditorWidget},
     }
     inlines = [
         InstanceFileAdminInline,


### PR DESCRIPTION
In Django admin for instances, the JSON field was not displayed with the new widget.
This small PR fixes it.

Related JIRA tickets : IA-1908

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented

## Changes

Add formfield_overrides on Instances admin



## How to test

Go to /admin/iaso/instance/

## Print screen / video

![image](https://user-images.githubusercontent.com/383344/219379332-763a6130-b391-45c1-98bb-50d1ac113364.png)
