### PR TITLE
Polio 841 block budget tab edition

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
                 "@types/react": "^17.0.36",
                 "@types/react-dom": "^17.0.9",
                 "babel-plugin-formatjs": "^10.3.4",
-                "bluesquare-components": "github:BLSQ/bluesquare-components",
+                "bluesquare-components": "github:BLSQ/bluesquare-components#POLIO-841_add_disabled-prop",
                 "classnames": "^2.2.6",
                 "color": "^3.1.2",
                 "dom-to-pdf": "^0.3.1",
@@ -6017,7 +6017,7 @@
         },
         "node_modules/bluesquare-components": {
             "version": "0.2.0",
-            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#23cbd770616695dce5e2ba429740e8fb54966723",
+            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#fa0665b1b48518699f62ffee212dee0c0e9edaf1",
             "license": "Apache-2.0",
             "dependencies": {
                 "@babel/plugin-transform-runtime": "^7.17.0",
@@ -34187,8 +34187,8 @@
             "dev": true
         },
         "bluesquare-components": {
-            "version": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#23cbd770616695dce5e2ba429740e8fb54966723",
-            "from": "bluesquare-components@github:BLSQ/bluesquare-components",
+            "version": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#fa0665b1b48518699f62ffee212dee0c0e9edaf1",
+            "from": "bluesquare-components@github:BLSQ/bluesquare-components#POLIO-841_add_disabled-prop",
             "requires": {
                 "@babel/plugin-transform-runtime": "^7.17.0",
                 "@babel/preset-typescript": "^7.16.7",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
         "@types/react": "^17.0.36",
         "@types/react-dom": "^17.0.9",
         "babel-plugin-formatjs": "^10.3.4",
-        "bluesquare-components": "github:BLSQ/bluesquare-components",
+        "bluesquare-components": "github:BLSQ/bluesquare-components#POLIO-841_add_disabled-prop",
         "classnames": "^2.2.6",
         "color": "^3.1.2",
         "dom-to-pdf": "^0.3.1",

--- a/plugins/polio/budget/serializers.py
+++ b/plugins/polio/budget/serializers.py
@@ -324,7 +324,6 @@ class CampaignBudgetSerializer(CampaignSerializer, DynamicFieldsModelSerializer)
             for uncancelled_node in uncancelled_mandatory_nodes_passed:
                 uncancelled_mandatory_nodes_labels.append(uncancelled_node["label"])
             unique_nodes_passed = set(uncancelled_mandatory_nodes_labels)
-            print("unique_nodes", unique_nodes_passed)
             if len(unique_nodes_passed) == len(mandatory_nodes):
                 section["completed"] = True
                 section["active"] = False

--- a/plugins/polio/js/src/components/CreateEditDialog.js
+++ b/plugins/polio/js/src/components/CreateEditDialog.js
@@ -92,6 +92,7 @@ const CreateEditDialog = ({ isOpen, onClose, campaignId }) => {
         is_preventive: false,
         is_test: false,
         enable_send_weekly_email: true,
+        has_data_in_budget_tool: false,
     };
 
     // Merge inplace default values with the one we get from the campaign.

--- a/plugins/polio/js/src/components/Inputs/DateInput.js
+++ b/plugins/polio/js/src/components/Inputs/DateInput.js
@@ -8,7 +8,7 @@ import { apiDateFormat } from 'Iaso/utils/dates.ts';
 import MESSAGES from '../../constants/messages';
 import { isTouched } from '../../utils';
 
-export const DateInput = ({ field, form, label, required }) => {
+export const DateInput = ({ field, form, label, required, disabled }) => {
     const hasError =
         form.errors &&
         Boolean(get(form.errors, field.name) && isTouched(form.touched));
@@ -17,6 +17,7 @@ export const DateInput = ({ field, form, label, required }) => {
             <DatePicker
                 label={label}
                 required={required}
+                disabled={disabled}
                 clearMessage={MESSAGES.clear}
                 currentDate={field.value || null}
                 errors={hasError ? [get(form.errors, field.name)] : []}
@@ -33,6 +34,7 @@ export const DateInput = ({ field, form, label, required }) => {
 };
 DateInput.defaultProps = {
     required: false,
+    disabled: false,
 };
 
 DateInput.propTypes = {
@@ -40,4 +42,5 @@ DateInput.propTypes = {
     form: PropTypes.object.isRequired,
     label: PropTypes.string.isRequired,
     required: PropTypes.bool,
+    disabled: PropTypes.bool,
 };

--- a/plugins/polio/js/src/constants/messages.js
+++ b/plugins/polio/js/src/constants/messages.js
@@ -2046,6 +2046,10 @@ const MESSAGES = defineMessages({
         id: 'iaso.polio.form.label.date',
         defaultMessage: 'Date',
     },
+    editionDisabled: {
+        id: 'iaso.polio.form.label.editionDisabled',
+        defaultMessage: 'Edition disabled',
+    },
 });
 
 export default MESSAGES;

--- a/plugins/polio/js/src/constants/translations/en.json
+++ b/plugins/polio/js/src/constants/translations/en.json
@@ -66,6 +66,7 @@
     "iaso.polio.form.label.districtsFailingLqas": "Districts failing LQAS",
     "iaso.polio.form.label.districtsPassingLqas": "Districts passing LQAS",
     "iaso.polio.form.label.dosesRequested": "Doses Requested",
+    "iaso.polio.form.label.editionDisabled": "Edition disabled",
     "iaso.polio.form.label.eomg": "EOMG Group",
     "iaso.polio.form.label.epid": "EPID",
     "iaso.polio.form.label.feedback_sent_to_gpei": "Feedback sent to GPEI coordinator",

--- a/plugins/polio/js/src/constants/translations/fr.json
+++ b/plugins/polio/js/src/constants/translations/fr.json
@@ -65,6 +65,7 @@
     "iaso.polio.form.label.districtsFailingLqas": "Districts ayant échoué le LQAS",
     "iaso.polio.form.label.districtsPassingLqas": "Districts ayant réussi le LQAS",
     "iaso.polio.form.label.dosesRequested": "Nombre de doses nécessaires",
+    "iaso.polio.form.label.editionDisabled": "Edition désactivée",
     "iaso.polio.form.label.eomg": "Groupe EOMG",
     "iaso.polio.form.label.epid": "EPID",
     "iaso.polio.form.label.feedback_sent_to_gpei": "Feedback envoyé au coordinateur GPEI",

--- a/plugins/polio/js/src/forms/BudgetForm.js
+++ b/plugins/polio/js/src/forms/BudgetForm.js
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 import React, { useMemo } from 'react';
 import { Grid, Typography, Box, Divider } from '@material-ui/core';
 import { Field, useFormikContext } from 'formik';
@@ -90,7 +91,7 @@ export const BudgetForm = () => {
     const { touched, errors } = useFormikContext();
 
     const { values } = useFormikContext();
-    const { rounds = [] } = values;
+    const { rounds = [], has_data_in_budget_tool: disableEdition } = values;
 
     const totalCostPerChild = useMemo(() => {
         let totalCost = 0;
@@ -121,15 +122,19 @@ export const BudgetForm = () => {
         touched,
     );
 
+    const title = disableEdition
+        ? `${formatMessage(MESSAGES.budgetApproval)}: ${formatMessage(
+              MESSAGES.editionDisabled,
+          )}`
+        : formatMessage(MESSAGES.budgetApproval);
+
     return (
         <>
             <Grid container spacing={2}>
                 <Grid container direction="row" item spacing={2}>
                     <Grid xs={12} md={6} item>
                         <Box mb={2}>
-                            <Typography variant="button">
-                                {formatMessage(MESSAGES.budgetApproval)}
-                            </Typography>
+                            <Typography variant="button">{title}</Typography>
                         </Box>
                         <Box mb={2}>
                             <Divider style={{ height: '1px', width: '100%' }} />
@@ -162,6 +167,7 @@ export const BudgetForm = () => {
                         <Field
                             name="budget_status"
                             component={BudgetStatusField}
+                            disabled={disableEdition}
                         />
                     </Box>
                     <Box mt={2}>
@@ -179,6 +185,7 @@ export const BudgetForm = () => {
                                         name={`${node}${WORKFLOW_SUFFIX}`}
                                         component={DateInput}
                                         fullWidth
+                                        disabled={disableEdition}
                                     />
                                 </Box>
                             );
@@ -197,6 +204,7 @@ export const BudgetForm = () => {
                                         name={`${node}${WORKFLOW_SUFFIX}`}
                                         component={DateInput}
                                         fullWidth
+                                        disabled={disableEdition}
                                     />
                                 </Box>
                             );
@@ -211,6 +219,7 @@ export const BudgetForm = () => {
                         <Field
                             name="budget_responsible"
                             component={ResponsibleField}
+                            disabled={disableEdition}
                         />
                     </Box>
                     <Box mt={2}>
@@ -228,6 +237,7 @@ export const BudgetForm = () => {
                                         name={`${node}${WORKFLOW_SUFFIX}`}
                                         component={DateInput}
                                         fullWidth
+                                        disabled={disableEdition}
                                     />
                                 </Box>
                             );
@@ -248,6 +258,7 @@ export const BudgetForm = () => {
                                         name={`${node}${WORKFLOW_SUFFIX}`}
                                         component={DateInput}
                                         fullWidth
+                                        disabled={disableEdition}
                                     />
                                 </Box>
                             );

--- a/plugins/polio/serializers.py
+++ b/plugins/polio/serializers.py
@@ -561,6 +561,7 @@ class CampaignSerializer(serializers.ModelSerializer):
     )
     # Account is filed per default the one of the connected user that update it
     account: Field = serializers.PrimaryKeyRelatedField(default=CurrentAccountDefault(), read_only=True)
+    has_data_in_budget_tool = serializers.SerializerMethodField(read_only=True)
 
     def get_top_level_org_unit_name(self, campaign):
         if campaign.country:
@@ -580,6 +581,11 @@ class CampaignSerializer(serializers.ModelSerializer):
             elif round.started_at and now_utc >= round.started_at:
                 return _("Round {} started").format(round.number)
         return _("Preparing")
+
+    def get_has_data_in_budget_tool(self, campaign):
+        if len(list(campaign.budget_steps.filter(created_at__isnull=False))) > 0:
+            return True
+        return False
 
     # group = GroupSerializer(required=False, allow_null=True)
     scopes = CampaignScopeSerializer(many=True, required=False)

--- a/plugins/polio/serializers.py
+++ b/plugins/polio/serializers.py
@@ -583,7 +583,7 @@ class CampaignSerializer(serializers.ModelSerializer):
         return _("Preparing")
 
     def get_has_data_in_budget_tool(self, campaign):
-        if len(list(campaign.budget_steps.filter(created_at__isnull=False))) > 0:
+        if campaign.budget_steps.all() :
             return True
         return False
 

--- a/plugins/polio/serializers.py
+++ b/plugins/polio/serializers.py
@@ -583,7 +583,7 @@ class CampaignSerializer(serializers.ModelSerializer):
         return _("Preparing")
 
     def get_has_data_in_budget_tool(self, campaign):
-        if campaign.budget_steps.all() :
+        if campaign.budget_steps.all():
             return True
         return False
 


### PR DESCRIPTION
Block edition in budget tab if there is data in budget tool

Related JIRA tickets : POLIO-841

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [X] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests

## Changes

- Check `Campaign.budget_steps` to see if a campaign has a data from the budget tool
- Update serializer to return  boolean `has_data_in_budget_tool`
- Update `BudgetForm` to disable budget related fields if `has_data_in_budget_tool` is `true`
    - The `ExpandableItems`  remain expandable because we will display the data from the tool (that's another PR)
    - Added a mention that edition is disabled in the tab title 

## How to test

- You need at least 1 campaign that has data in teh budget tool
- Go to campaigns
- Open the campaign, go to the Budget tab
- Budget related fields should not be editable
- Try again with a campaogn with no budget data
- It should be editable

## Print screen / video

![Screenshot 2023-02-16 at 16 13 11](https://user-images.githubusercontent.com/38907762/219408658-8a82f2e4-0acc-463f-962a-033084775a1d.png)

## Notes 

Depends on https://github.com/BLSQ/bluesquare-components/pull/103
