### PR TITLE
IA-1548-split-requirements-txt-in-dev-prod-sections

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -111,7 +111,7 @@ jobs:
             ${{ runner.os }}-venv-
           # Build a virtualenv, but only if it doesn't already exist
       - run: python -v && python -m venv ./venv && . ./venv/bin/activate && pip install -U pip &&
-          pip install -r requirements.txt
+          pip install -r requirements.txt && pip install -r requirements-dev.txt
         if: steps.cache-venv.outputs.cache-hit != 'true'
       - name: Environment info
         run: |

--- a/docker/bundle/Dockerfile
+++ b/docker/bundle/Dockerfile
@@ -46,7 +46,9 @@ RUN apt-get update && apt-get --yes  --no-install-recommends install \
 
 WORKDIR /opt/app
 COPY requirements.txt /opt/app/requirements.txt
+COPY requirements-dev.txt /opt/app/requirements-dev.txt
 RUN pip install -r requirements.txt
+RUN pip install -r requirements-dev.txt
 
 COPY --from=npmbuilder /opt/app/hat/assets /opt/app/hat/assets
 COPY . /opt/app

--- a/docker/django/Dockerfile
+++ b/docker/django/Dockerfile
@@ -12,7 +12,9 @@ WORKDIR /opt/app
 
 # install python dependencies
 COPY requirements.txt /opt/app/requirements.txt
+COPY requirements-dev.txt /opt/app/requirements-dev.txt
 RUN pip install --quiet -r requirements.txt
+RUN pip install --quiet -r requirements-dev.txt
 
 # don't copy app we mount everything afterwards for hot reloading anyway
 #COPY . /opt/app

--- a/iaso/admin.py
+++ b/iaso/admin.py
@@ -6,7 +6,8 @@ from django.contrib.gis.db import models as geomodels
 from django.db import models
 from django.utils.html import format_html_join, format_html
 from django.utils.safestring import mark_safe
-from typing_extensions import Protocol
+from typing import Protocol
+
 
 from django_json_widget.widgets import JSONEditorWidget  # type: ignore
 

--- a/plugins/polio/budget/workflow.py
+++ b/plugins/polio/budget/workflow.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 from django.db.models import Q, QuerySet
 
 # Move to typing import Literal when upgrading to python 3.8
-from typing_extensions import Literal
+from typing import Literal
 
 import plugins.polio.models
 from iaso.models.microplanning import Team, TeamType

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,25 @@
+types-jsonschema==3.2.0
+
+mypy==0.971
+typed-ast==1.4.2
+flake8==3.7.9
+flake8-mypy==17.8.0
+mock==4.0.1
+redgreenunittest==0.1.1
+responses==0.12.1
+types-dataclasses==0.6.6
+types-requests==2.28.9
+
+types-mock==4.0.15
+types-dateparser==1.1.4
+djangorestframework-stubs==1.4.0
+lxml-stubs==0.4.0
+types-jwt==0.1.3
+boto3-stubs==1.24.35
+openpyxl-stubs==0.1.22
+
+
+# temporary till we upgrade black version
+click==8.0.3
+black==21.5b1
+pre-commit==2.9.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ https://github.com/BLSQ/django-webpack-loader/archive/e94f76d0f8372193f0b662e2a1
 
 # importing tools
 jsonschema==3.2.0
-types-jsonschema==3.2.0
+
 
 # exporting tools
 xlsxwriter==1.2.7
@@ -49,29 +49,6 @@ dhis2.py==2.0.2
 # odk-specific libraries
 pyxform==1.1.0
 
-# test and linting
-mypy==0.971
-typed-ast==1.4.2
-flake8==3.7.9
-flake8-mypy==17.8.0
-mock==4.0.1
-redgreenunittest==0.1.1
-responses==0.12.1
-types-dataclasses==0.6.6
-types-requests==2.28.9
-django-stubs==1.9.0
-types-mock==4.0.15
-types-dateparser==1.1.4
-djangorestframework-stubs==1.4.0
-lxml-stubs==0.4.0
-types-jwt==0.1.3
-boto3-stubs==1.24.35
-openpyxl-stubs==0.1.22
-
-# temporary till we upgrade black version
-click==8.0.3
-black==21.5b1
-pre-commit==2.9.2
 
 ipython==7.12.0
 django-extensions==2.2.8
@@ -95,6 +72,7 @@ django-sql-dashboard~=1.1
 django-allauth==0.50.0
 
 
-# mypy
-django-stubs==1.9.0
 django-json-widget==1.1.1
+
+# Seems to be required to run the project
+django-stubs==1.9.0

--- a/runiasodev.sh
+++ b/runiasodev.sh
@@ -4,7 +4,7 @@
 # You can run the database and webpack with django-compose and it will connect to the by default
 # By running:  django-compose up db webpack
 
-# You will need to create a venv locally by running: venv . && pip install -r requirements.txt
+# You will need to create a venv locally by running: venv . && pip install -r requirements.txt && pip install -r requirements-dev.txt
 
 #source bin/activate
 export SECRET_KEY="secret"


### PR DESCRIPTION
Split requirements in order to have a lighter production image and allow devs to add whatever to requirements-dev.txt

Related JIRA tickets : IA-1548

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented

## Changes

Split requirements into `requirements.txt` and `requirements-dev.txt`

Corrected the docker images and github actions 

Tested locally with a fresh virtual env until it works only with r`equirements.txt`

`requirements-dev.txt` DOES NOT include `requirements.txt` so you need to install both for local development.

## How to test

We need to make sure that the github action still work.
That the staging still works and it doesn't break the prod environments obviously.

## Notes

@olethanh I'm not sure how the staging and deploy things work. Can you check that I only include requirements.txt for those and requirements-dev.txt for github actions (which do tests and mypy and format checking)
