### PR TITLE
POLIO-840 self auth file links

### DIFF
--- a/plugins/polio/budget/models.py
+++ b/plugins/polio/budget/models.py
@@ -1,3 +1,4 @@
+from functools import reduce
 import logging
 from typing import Union
 
@@ -166,20 +167,22 @@ class MailTemplate(models.Model):
             node = workflow.get_node_by_key(node_key)
 
         attachments = []
-        override = step.transition_key == "override"
-        for f in step.files.all():
-            file_url = base_url + f.get_absolute_url()
-            attachments.append({"url": file_url, "name": f.filename})
-        for l in step.links.all():
-            attachments.append({"url": l.url, "name": l.alias})
-
         skipped_attachements = 0
+        override = step.transition_key == "override"
+        total_file_size = reduce(
+            lambda file1, file2: file1 + file2, list(map(lambda f: f.file.size, list(step.files.all())))
+        )
+
         for f in step.files.all():
-            # only attach file smaller than 500k
-            if f.file.size < 1024 * 500:
+            # only attach files if total is less than 5MB
+            if total_file_size < 1024 * 5000:
                 msg.attach(f.filename, f.file.read())
             else:
-                skipped_attachements += 1
+                skipped_attachements = len(list(step.files.all()))
+                file_url = base_url + f.get_absolute_url()
+                attachments.append({"url": generate_auto_authentication_link(file_url, receiver), "name": f.filename})
+        for l in step.links.all():
+            attachments.append({"url": l.url, "name": l.alias})
 
         context = Context(
             {
@@ -215,7 +218,6 @@ class MailTemplate(models.Model):
         msg.body = text_content
 
         msg.attach_alternative(html_content, "text/html")
-
         return msg
 
 

--- a/plugins/polio/templates/base_budget_email.html
+++ b/plugins/polio/templates/base_budget_email.html
@@ -90,7 +90,7 @@ Base file to be reused in the MailTemplate for the budget workflow engine
     <tr>
       <td align="left" style="padding:5px;">
         <br />
-        {{ skipped_attachments }} file(s) has(have) not been attached to this message due to their size. Please use the link(s)
+        {{ skipped_attachments }} file(s) has(have) not been attached because total file size exceeds 5MB. Please use the link(s)
         above to view them.
     </tr>
   {% endif %}


### PR DESCRIPTION
File links in polio budget emails required authentication and need to be replaced with self authenticated links

Related JIRA tickets :  POLIO-840

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests

## Changes

- Use `generate_auto_authentication_link` to make attachment links self-auth
- Change the condition for not directly attaching a file from file size < 500k to total files size < 5MB
- Update the message in `base_budget_email.html` to reflect the changes 

## How to test

- [configure your localhost to use smtp bucket](https://wiki.bluesquare.org/en/Dev-team/product-management/iaso/email)
- Go to campaign
- Add a step with files for a total >5MB
- Go to smtp bucket and find your email
- Hover over an attachment link: you should see the auth token in the url

## Print screen / video
![Screenshot 2023-02-17 at 11 44 48](https://user-images.githubusercontent.com/38907762/219623263-c440fce1-d99d-46b2-ad89-fcb17229ae36.png)


## Notes

The link in smtp bucket won't work because the domain is example.com. Replacing it with localhost will not work either, because the redirection will be refused by django. **We should test on staging after merge for confirmation that it works as intended**
