### PR TITLE
IA-1904: fix target of link too large

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/forms/components/FormFormComponent.js
+++ b/hat/assets/js/apps/Iaso/domains/forms/components/FormFormComponent.js
@@ -30,8 +30,6 @@ const styles = theme => ({
     },
     linkToChangesLog: {
         color: theme.palette.primary.main,
-        textAlign: 'right',
-        flex: '1',
         cursor: 'pointer',
     },
 });
@@ -328,7 +326,7 @@ const FormForm = ({ currentForm, setFieldValue }) => {
                 </Grid>
             </Grid>
             {currentForm.id.value && (
-                <Grid justifyContent="space-between" container spacing={2}>
+                <Grid justifyContent="flex-end" container spacing={2}>
                     <Typography
                         className={classes.linkToChangesLog}
                         variant="overline"


### PR DESCRIPTION
Link was taking the entire width of the parent, the target of the link was too large

Related JIRA tickets : [IA-1904](https://bluesquare.atlassian.net/browse/IA-1904?atlOrigin=eyJpIjoiNWNiM2M0N2IxMmI3NDJlN2IwNmJhYTk5ZGFhZWFiMmMiLCJwIjoiaiJ9)

https://user-images.githubusercontent.com/25134301/219683011-fa406864-f47a-4872-b000-5587dc617d33.mov

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests


## Print screen / video

https://user-images.githubusercontent.com/25134301/219683249-2a16debf-6adc-44c2-8b30-53d2f1003e47.mov


[IA-1904]: https://bluesquare.atlassian.net/browse/IA-1904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ