### PR TITLE
POLIO-851: HOTFIX 500 on budget

### DIFF
--- a/plugins/polio/budget/models.py
+++ b/plugins/polio/budget/models.py
@@ -169,9 +169,11 @@ class MailTemplate(models.Model):
         attachments = []
         skipped_attachements = 0
         override = step.transition_key == "override"
-        total_file_size = reduce(
-            lambda file1, file2: file1 + file2, list(map(lambda f: f.file.size, list(step.files.all())))
-        )
+        total_file_size = 0
+        if len(list(step.files.all())) > 0:
+            total_file_size = reduce(
+                lambda file1, file2: file1 + file2, list(map(lambda f: f.file.size, list(step.files.all())))
+            )
 
         for f in step.files.all():
             # only attach files if total is less than 5MB


### PR DESCRIPTION
When saving a budget step without attachment: 500 because reduce function has no starting value

Related JIRA tickets : IA-XXX, WC2-XXX, POLIO-XXX

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests

## Changes

- use reducer only if files not empty

## How to test

Go to polio budget, crate a step without files attached: backend should not crash


