### PR TITLE
IA-1921 Add permissions to /api/task

### DIFF
--- a/iaso/api/tasks/__init__.py
+++ b/iaso/api/tasks/__init__.py
@@ -1,7 +1,7 @@
 from rest_framework import permissions, serializers
 
 from iaso.models import Task
-from ..common import ModelViewSet, TimestampField, UserSerializer
+from ..common import ModelViewSet, TimestampField, UserSerializer, HasPermission
 
 
 class TaskSerializer(serializers.ModelSerializer):
@@ -46,7 +46,7 @@ class TaskSourceViewSet(ModelViewSet):
     PATCH /api/tasks/<id>
     """
 
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [permissions.IsAuthenticated, HasPermission("menupermissions.iaso_data_tasks")]
     serializer_class = TaskSerializer
     results_key = "tasks"
     queryset = Task.objects.all()

--- a/iaso/api/tasks/__init__.py
+++ b/iaso/api/tasks/__init__.py
@@ -46,7 +46,7 @@ class TaskSourceViewSet(ModelViewSet):
     PATCH /api/tasks/<id>
     """
 
-    permission_classes = [permissions.IsAuthenticated, HasPermission("menupermissions.iaso_data_tasks")]
+    permission_classes = [permissions.IsAuthenticated, HasPermission("menupermissions.iaso_data_tasks")]  # type: ignore
     serializer_class = TaskSerializer
     results_key = "tasks"
     queryset = Task.objects.all()

--- a/iaso/tests/api/test_copy_version.py
+++ b/iaso/tests/api/test_copy_version.py
@@ -22,7 +22,9 @@ class CopyVersionTestCase(APITestCase):
         source.projects.add(cls.project)
         OrgUnit.objects.create(version=old_version, name="Myagi", org_unit_type=unit_type, source_ref="nomercy")
         cls.source = source
-        cls.johnny = cls.create_user_with_profile(username="johnny", account=account, permissions=["iaso_sources"])
+        cls.johnny = cls.create_user_with_profile(
+            username="johnny", account=account, permissions=["iaso_sources", "iaso_data_tasks"]
+        )
         cls.miguel = cls.create_user_with_profile(username="miguel", account=account, permissions=[])
 
     def test_copy_version(self):

--- a/iaso/tests/api/test_copy_version.py
+++ b/iaso/tests/api/test_copy_version.py
@@ -26,6 +26,12 @@ class CopyVersionTestCase(APITestCase):
             username="johnny", account=account, permissions=["iaso_sources", "iaso_data_tasks"]
         )
         cls.miguel = cls.create_user_with_profile(username="miguel", account=account, permissions=[])
+        cls.user_with_data_sources_perms = cls.create_user_with_profile(
+            username="user_with_data_sources_perms", account=account, permissions=["iaso_sources"]
+        )
+        cls.user_with_data_tasks_perms = cls.create_user_with_profile(
+            username="user_with_data_tasks_perms", account=account, permissions=["iaso_data_tasks"]
+        )
 
     def test_copy_version(self):
         """Copying a version through the api"""
@@ -75,6 +81,18 @@ class CopyVersionTestCase(APITestCase):
         self.client.force_authenticate(self.miguel)
         response = self.client.post("/api/copyversion/", data={}, format="json")
         self.assertEqual(response.status_code, 403)
+
+    def test_user_with_only_data_sources_permissions(self):
+        # user needs  both data_sources and data_tasks permissions
+        self.client.force_authenticate(self.user_with_data_sources_perms)
+        response = self.client.post("/api/copyversion/", data={}, format="json")
+        self.assertEqual(response.status_code, 400)
+
+    def test_user_with_only_data_tasks_permissions(self):
+        # user needs  both data_sources and data_tasks permissions
+        self.client.force_authenticate(self.user_with_data_sources_perms)
+        response = self.client.post("/api/copyversion/", data={}, format="json")
+        self.assertEqual(response.status_code, 400)
 
     def test_self_copy(self):
         self.client.force_authenticate(self.johnny)

--- a/iaso/tests/api/test_org_units_bulk_update.py
+++ b/iaso/tests/api/test_org_units_bulk_update.py
@@ -95,11 +95,15 @@ class OrgUnitsBulkUpdateAPITestCase(APITestCase):
             validation_status=m.OrgUnit.VALIDATION_VALID,
         )
 
-        cls.yoda = cls.create_user_with_profile(username="yoda", account=star_wars, permissions=["iaso_org_units"])
+        cls.yoda = cls.create_user_with_profile(
+            username="yoda", account=star_wars, permissions=["iaso_org_units", "iaso_data_tasks"]
+        )
         cls.luke = cls.create_user_with_profile(
             username="luke", account=star_wars, permissions=["iaso_org_units"], org_units=[cls.jedi_council_endor]
         )
-        cls.raccoon = cls.create_user_with_profile(username="raccoon", account=marvel, permissions=["iaso_org_units"])
+        cls.raccoon = cls.create_user_with_profile(
+            username="raccoon", account=marvel, permissions=["iaso_org_units", "iaso_data_tasks"]
+        )
 
         cls.form_1 = m.Form.objects.create(name="Hydroponics study", period_type=m.MONTH, single_per_period=True)
 

--- a/iaso/tests/api/test_tasks.py
+++ b/iaso/tests/api/test_tasks.py
@@ -1,0 +1,41 @@
+from beanstalk_worker.services import TestTaskService
+from iaso.test import APITestCase
+from ...models import OrgUnit, OrgUnitType, Account, Project, SourceVersion, DataSource, Task
+
+
+class IasoTasksTestCase(APITestCase):
+    @classmethod
+    def setUp(cls):
+        source = DataSource.objects.create(name="Valley Championship")
+        old_version = SourceVersion.objects.create(number=1, data_source=source)
+        cls.new_version = SourceVersion.objects.create(number=2, data_source=source)
+
+        account = Account(name="Cobra Kai", default_version=cls.new_version)
+        account.save()
+
+        cls.project = Project(name="The Show", app_id="com.cobrakai.show", account=account)
+        cls.project.save()
+
+        unit_type = OrgUnitType(name="Dojo", short_name="dojo")
+        unit_type.save()
+        cls.project.unit_types.add(unit_type)
+        source.projects.add(cls.project)
+        OrgUnit.objects.create(version=old_version, name="Myagi", org_unit_type=unit_type, source_ref="nomercy")
+        cls.source = source
+        cls.johnny = cls.create_user_with_profile(
+            username="johnny", account=account, permissions=["iaso_sources", "iaso_data_tasks"]
+        )
+        cls.miguel = cls.create_user_with_profile(username="miguel", account=account, permissions=[])
+
+    def test_tasks_authoziration_access(self):
+        self.client.force_authenticate(self.miguel)
+        response = self.client.get("/api/tasks/")
+        self.assertEqual(response.status_code, 403)
+
+    def test_tasks_authoziration_access(self):
+        """
+        Both permissions iaso_sources and iaso_data_tasks are required to access tasks.
+        """
+        self.client.force_authenticate(self.johnny)
+        response = self.client.get("/api/tasks/")
+        self.assertEqual(response.status_code, 200)

--- a/iaso/tests/api/test_tasks.py
+++ b/iaso/tests/api/test_tasks.py
@@ -32,7 +32,7 @@ class IasoTasksTestCase(APITestCase):
         response = self.client.get("/api/tasks/")
         self.assertEqual(response.status_code, 403)
 
-    def test_tasks_authoziration_access(self):
+    def test_tasks_user_can_access(self):
         """
         Both permissions iaso_sources and iaso_data_tasks are required to access tasks.
         """

--- a/iaso/tests/api/test_tasks.py
+++ b/iaso/tests/api/test_tasks.py
@@ -16,11 +16,11 @@ class IasoTasksTestCase(APITestCase):
         cls.project = Project(name="The Show", app_id="com.cobrakai.show", account=account)
         cls.project.save()
 
-        unit_type = OrgUnitType(name="Dojo", short_name="dojo")
-        unit_type.save()
-        cls.project.unit_types.add(unit_type)
+        org_unit_type = OrgUnitType(name="Dojo", short_name="dojo")
+        org_unit_type.save()
+        cls.project.unit_types.add(org_unit_type)
         source.projects.add(cls.project)
-        OrgUnit.objects.create(version=old_version, name="Myagi", org_unit_type=unit_type, source_ref="nomercy")
+        OrgUnit.objects.create(version=old_version, name="Myagi", org_unit_type=org_unit_type, source_ref="nomercy")
         cls.source = source
         cls.johnny = cls.create_user_with_profile(
             username="johnny", account=account, permissions=["iaso_sources", "iaso_data_tasks"]

--- a/iaso/tests/api/test_tasks.py
+++ b/iaso/tests/api/test_tasks.py
@@ -38,7 +38,7 @@ class IasoTasksTestCase(APITestCase):
         """
         self.client.force_authenticate(self.johnny)
 
-        Task.objects.create(
+        task = Task.objects.create(
             progress_value=1,
             end_value=1,
             account=self.johnny.iaso_profile.account,
@@ -51,6 +51,6 @@ class IasoTasksTestCase(APITestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["tasks"][0]["name"], "The best task")
         self.assertEqual(response.json()["tasks"][0]["status"], "Success")
-        self.assertEqual(response.json()["tasks"][0]["id"], 1)
+        self.assertEqual(response.json()["tasks"][0]["id"], task.id)
         self.assertEqual(response.json()["tasks"][0]["end_value"], 1)
         self.assertEqual(response.json()["tasks"][0]["launcher"]["username"], "johnny")


### PR DESCRIPTION
Task permissions were missing to /api/task in the backend
Related JIRA tickets : IA-1921

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] Did I add translations
- [x] My migrations file are included
- [x] Are there enough tests

## Changes

permissions to api/task, tests

## How to test

Create a profile without the task permission and you should get a 403 if you go to 
/api/tasks
or tasks from iaso menu admin

which was not the case before.
