### PR TITLE
IA-1896: Error planningAndOrgUnit is wrongly displayed

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/plannings/CreateEditPlanning/CreateEditPlanning.tsx
+++ b/hat/assets/js/apps/Iaso/domains/plannings/CreateEditPlanning/CreateEditPlanning.tsx
@@ -328,6 +328,7 @@ export const CreateEditPlanning: FunctionComponent<Props> = ({
                                         MESSAGES.selectOrgUnit,
                                     )}
                                     name="selectedOrgUnit"
+                                    errors={getErrors('selectedOrgUnit')}
                                 />
                             </Box>
                         </Grid>

--- a/plugins/polio/js/src/components/Inputs/OrgUnitsSelect.js
+++ b/plugins/polio/js/src/components/Inputs/OrgUnitsSelect.js
@@ -5,7 +5,20 @@ import { OrgUnitTreeviewModal } from 'Iaso/domains/orgUnits/components/TreeView/
 import { useGetOrgUnit } from 'Iaso/domains/orgUnits/components/TreeView/requests';
 import { isTouched } from '../../utils';
 
-export const OrgUnitsLevels = ({ field, form, label, required, clearable }) => {
+const getErrors = (touched, formErrors) => {
+    const { name } = formErrors;
+
+    return isTouched(touched) && formErrors?.[name] ? [formErrors[name]] : [];
+};
+
+export const OrgUnitsLevels = ({
+    field,
+    form,
+    label,
+    required,
+    clearable,
+    errors: backendErrors,
+}) => {
     const { name } = field;
     const {
         setFieldValue,
@@ -15,8 +28,7 @@ export const OrgUnitsLevels = ({ field, form, label, required, clearable }) => {
         values,
     } = form;
     const initialOrgUnitId = values[name];
-    const errors =
-        isTouched(touched) && formErrors?.[name] ? [formErrors[name]] : [];
+    const errors = backendErrors ?? getErrors(touched, formErrors);
     const { data: initialOrgUnit, isLoading } = useGetOrgUnit(initialOrgUnitId);
     return (
         <Box position="relative">
@@ -55,6 +67,7 @@ export const OrgUnitsLevels = ({ field, form, label, required, clearable }) => {
 OrgUnitsLevels.defaultProps = {
     required: false,
     clearable: true,
+    errors: undefined,
 };
 
 OrgUnitsLevels.propTypes = {
@@ -71,4 +84,5 @@ OrgUnitsLevels.propTypes = {
     label: PropTypes.string.isRequired,
     required: PropTypes.bool,
     clearable: PropTypes.bool,
+    errors: PropTypes.arrayOf(PropTypes.string),
 };

--- a/plugins/polio/js/src/components/Inputs/OrgUnitsSelect.tsx
+++ b/plugins/polio/js/src/components/Inputs/OrgUnitsSelect.tsx
@@ -1,23 +1,24 @@
-import React from 'react';
+import React, { FunctionComponent } from 'react';
+import { FormikProps, FieldInputProps } from 'formik';
 import { CircularProgress, Box } from '@material-ui/core';
-import PropTypes from 'prop-types';
-import { OrgUnitTreeviewModal } from 'Iaso/domains/orgUnits/components/TreeView/OrgUnitTreeviewModal';
-import { useGetOrgUnit } from 'Iaso/domains/orgUnits/components/TreeView/requests';
+import { useGetOrgUnit } from '../../../../../../hat/assets/js/apps/Iaso/domains/orgUnits/components/TreeView/requests';
+import { OrgUnitTreeviewModal } from '../../../../../../hat/assets/js/apps/Iaso/domains/orgUnits/components/TreeView/OrgUnitTreeviewModal';
 import { isTouched } from '../../utils';
 
-const getErrors = (touched, formErrors) => {
-    const { name } = formErrors;
-
-    return isTouched(touched) && formErrors?.[name] ? [formErrors[name]] : [];
+type Props = {
+    field: FieldInputProps<string>;
+    form: FormikProps<Record<string, any>>;
+    label: string;
+    required: boolean;
+    clearable: boolean;
 };
 
-export const OrgUnitsLevels = ({
+export const OrgUnitsLevels: FunctionComponent<Props> = ({
     field,
     form,
     label,
     required,
     clearable,
-    errors: backendErrors,
 }) => {
     const { name } = field;
     const {
@@ -28,8 +29,10 @@ export const OrgUnitsLevels = ({
         values,
     } = form;
     const initialOrgUnitId = values[name];
-    const errors = backendErrors ?? getErrors(touched, formErrors);
+    const errors =
+        isTouched(touched) && formErrors?.[name] ? [formErrors[name]] : [];
     const { data: initialOrgUnit, isLoading } = useGetOrgUnit(initialOrgUnitId);
+
     return (
         <Box position="relative">
             <OrgUnitTreeviewModal
@@ -62,27 +65,4 @@ export const OrgUnitsLevels = ({
             )}
         </Box>
     );
-};
-
-OrgUnitsLevels.defaultProps = {
-    required: false,
-    clearable: true,
-    errors: undefined,
-};
-
-OrgUnitsLevels.propTypes = {
-    field: PropTypes.shape({
-        name: PropTypes.string,
-    }).isRequired,
-    form: PropTypes.shape({
-        setFieldValue: PropTypes.func.isRequired,
-        values: PropTypes.object.isRequired,
-        errors: PropTypes.object,
-        touched: PropTypes.object.isRequired,
-        setFieldTouched: PropTypes.func.isRequired,
-    }).isRequired,
-    label: PropTypes.string.isRequired,
-    required: PropTypes.bool,
-    clearable: PropTypes.bool,
-    errors: PropTypes.arrayOf(PropTypes.string),
 };

--- a/plugins/polio/js/src/components/Inputs/OrgUnitsSelect.tsx
+++ b/plugins/polio/js/src/components/Inputs/OrgUnitsSelect.tsx
@@ -24,6 +24,7 @@ export const OrgUnitsLevels: FunctionComponent<Props> = ({
     const {
         setFieldValue,
         touched,
+        // @ts-ignore
         errors: formErrors,
         setFieldTouched,
         values,
@@ -45,6 +46,7 @@ export const OrgUnitsLevels: FunctionComponent<Props> = ({
                 initialSelection={initialOrgUnit}
                 showStatusIconInTree={false}
                 showStatusIconInPicker={false}
+                // @ts-ignore
                 errors={errors}
                 required={required}
                 clearable={clearable}

--- a/plugins/polio/js/src/components/Inputs/OrgUnitsSelect.tsx
+++ b/plugins/polio/js/src/components/Inputs/OrgUnitsSelect.tsx
@@ -9,16 +9,16 @@ type Props = {
     field: FieldInputProps<string>;
     form: FormikProps<Record<string, any>>;
     label: string;
-    required: boolean;
-    clearable: boolean;
+    required?: boolean;
+    clearable?: boolean;
 };
 
 export const OrgUnitsLevels: FunctionComponent<Props> = ({
     field,
     form,
     label,
-    required,
-    clearable,
+    required = false,
+    clearable = true,
 }) => {
     const { name } = field;
     const {
@@ -45,8 +45,7 @@ export const OrgUnitsLevels: FunctionComponent<Props> = ({
                 initialSelection={initialOrgUnit}
                 showStatusIconInTree={false}
                 showStatusIconInPicker={false}
-                // @ts-ignore
-                errors={errors}
+                errors={errors as string[]}
                 required={required}
                 clearable={clearable}
             />

--- a/plugins/polio/js/src/components/Inputs/OrgUnitsSelect.tsx
+++ b/plugins/polio/js/src/components/Inputs/OrgUnitsSelect.tsx
@@ -24,7 +24,6 @@ export const OrgUnitsLevels: FunctionComponent<Props> = ({
     const {
         setFieldValue,
         touched,
-        // @ts-ignore
         errors: formErrors,
         setFieldTouched,
         values,

--- a/plugins/polio/js/src/forms/BaseInfoForm.js
+++ b/plugins/polio/js/src/forms/BaseInfoForm.js
@@ -6,7 +6,7 @@ import { useSafeIntl } from 'bluesquare-components';
 import { useStyles } from '../styles/theme';
 import { SendEmailButton } from '../components/Buttons/SendEmailButton';
 import { polioViruses } from '../constants/virus.ts';
-import { OrgUnitsLevels } from '../components/Inputs/OrgUnitsSelect';
+import { OrgUnitsLevels } from '../components/Inputs/OrgUnitsSelect.tsx';
 import {
     BooleanInput,
     DateInput,


### PR DESCRIPTION
Errors were not passed to OrgUnitSelect component, therefore the message was not displayed when the input was in error state.
![Capture d’écran 2023-02-07 à 11 07 49](https://user-images.githubusercontent.com/25134301/221538751-121f7a33-3fd7-4575-a999-5c3252f0a922.png)

Related JIRA tickets : [IA-1896](https://bluesquare.atlassian.net/browse/IA-1896?atlOrigin=eyJpIjoiYTE1OTljYjlhYTJjNDQ4ZWI0ZjI1ZDRmODA1YmFlZWIiLCJwIjoiaiJ9)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests

## Changes

- add a prop `errors` to `OrgUnitSelect` component

## How to test

- Go to planning
- Create new planning
- Fill the form - the orgunit type of the org unit you selected must not be in the same project you selected

## Print screen / video

[Upload here print screens or videos showing the changes](https://user-images.githubusercontent.com/25134301/221545053-70db52a7-e54a-43b0-b166-4e92476e2ed3.mov)

[IA-1896]: https://bluesquare.atlassian.net/browse/IA-1896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ