### PR TITLE
IA-1670 ou appear as their own children

### DIFF
--- a/iaso/api/org_unit_search.py
+++ b/iaso/api/org_unit_search.py
@@ -25,6 +25,8 @@ def build_org_units_queryset(queryset, params, profile):
     group = params.get("group", None)
     version = params.get("version", None)
     default_version = params.get("defaultVersion", None)
+    direct_children = params.get("onlyDirectChildren", False)
+    direct_children = False if direct_children == "false" else True
 
     org_unit_parent_id = params.get("orgUnitParentId", None)
     org_unit_parent_ids = params.get("orgUnitParentIds", None)
@@ -204,6 +206,9 @@ def build_org_units_queryset(queryset, params, profile):
 
     if path_depth is not None:
         queryset = queryset.filter(path__depth=path_depth)
+
+    if not direct_children:
+        queryset = queryset.exclude(pk=org_unit_parent_id)
 
     queryset = queryset.select_related("version__data_source")
     queryset = queryset.select_related("org_unit_type")

--- a/iaso/api/org_unit_search.py
+++ b/iaso/api/org_unit_search.py
@@ -25,7 +25,7 @@ def build_org_units_queryset(queryset, params, profile):
     group = params.get("group", None)
     version = params.get("version", None)
     default_version = params.get("defaultVersion", None)
-    direct_children = params.get("onlyDirectChildren", False)
+    direct_children = params.get("onlyDirectChildren", None)
     direct_children = False if direct_children == "false" else True
 
     org_unit_parent_id = params.get("orgUnitParentId", None)

--- a/iaso/tests/api/test_orgunits.py
+++ b/iaso/tests/api/test_orgunits.py
@@ -1006,20 +1006,6 @@ class OrgUnitAPITestCase(APITestCase):
     def test_org_unit_search_only_direct_children_true(self):
         self.client.force_authenticate(self.yoda)
 
-        jedi_squad_endor_2_children = m.OrgUnit.objects.create(
-            org_unit_type=self.jedi_council,
-            parent=self.jedi_squad_endor_2,
-            version=self.sw_version_2,
-            name="Endor Jedi Squad 2 Children",
-            geom=self.mock_multipolygon,
-            simplified_geom=self.mock_multipolygon,
-            catchment=self.mock_multipolygon,
-            location=self.mock_point,
-            validation_status=m.OrgUnit.VALIDATION_VALID,
-        )
-
-        jedi_squad_endor_2_children.save()
-
         response = self.client.get(
             f"/api/orgunits/?&parent_id={self.jedi_council_endor.pk}&limit=10&page=1&order=name&validation_status=all&onlyDirectChildren=true"
         )

--- a/iaso/tests/api/test_orgunits.py
+++ b/iaso/tests/api/test_orgunits.py
@@ -837,12 +837,10 @@ class OrgUnitAPITestCase(APITestCase):
         self.assertEqual(ou.as_dict()["altitude"], form_altitude)
 
     def test_create_org_unit_from_different_level_from_mobile(self):
-
         self.client.force_authenticate(self.yoda)
 
         ou_type = OrgUnitType.objects.create(name="Test_type")
         org_unit_parent = OrgUnit.objects.create(name="A_new_OU")
-
         count_of_orgunits = OrgUnit.objects.all().count()
 
         data = [

--- a/iaso/tests/api/test_orgunits.py
+++ b/iaso/tests/api/test_orgunits.py
@@ -1006,6 +1006,20 @@ class OrgUnitAPITestCase(APITestCase):
     def test_org_unit_search_only_direct_children_true(self):
         self.client.force_authenticate(self.yoda)
 
+        jedi_squad_endor_2_children = m.OrgUnit.objects.create(
+            org_unit_type=self.jedi_council,
+            parent=self.jedi_squad_endor_2,
+            version=self.sw_version_2,
+            name="Endor Jedi Squad 2 Children",
+            geom=self.mock_multipolygon,
+            simplified_geom=self.mock_multipolygon,
+            catchment=self.mock_multipolygon,
+            location=self.mock_point,
+            validation_status=m.OrgUnit.VALIDATION_VALID,
+        )
+
+        jedi_squad_endor_2_children.save()
+
         response = self.client.get(
             f"/api/orgunits/?&parent_id={self.jedi_council_endor.pk}&limit=10&page=1&order=name&validation_status=all&onlyDirectChildren=true"
         )

--- a/iaso/tests/api/test_orgunits.py
+++ b/iaso/tests/api/test_orgunits.py
@@ -21,7 +21,7 @@ class OrgUnitAPITestCase(APITestCase):
         sw_source.projects.add(cls.project)
         cls.sw_source = sw_source
         cls.sw_version_1 = sw_version_1 = m.SourceVersion.objects.create(data_source=sw_source, number=1)
-        sw_version_2 = m.SourceVersion.objects.create(data_source=sw_source, number=2)
+        cls.sw_version_2 = m.SourceVersion.objects.create(data_source=sw_source, number=2)
         star_wars.default_version = sw_version_1
         star_wars.save()
 
@@ -105,21 +105,9 @@ class OrgUnitAPITestCase(APITestCase):
             validation_status=m.OrgUnit.VALIDATION_VALID,
         )
 
-        cls.jedi_squad_endor_2_children = m.OrgUnit.objects.create(
-            org_unit_type=cls.jedi_council,
-            parent=cls.jedi_squad_endor_2,
-            version=sw_version_2,
-            name="Endor Jedi Squad 2 Children",
-            geom=cls.mock_multipolygon,
-            simplified_geom=cls.mock_multipolygon,
-            catchment=cls.mock_multipolygon,
-            location=cls.mock_point,
-            validation_status=m.OrgUnit.VALIDATION_VALID,
-        )
-
         cls.jedi_council_brussels = m.OrgUnit.objects.create(
             org_unit_type=cls.jedi_council,
-            version=sw_version_2,
+            version=cls.sw_version_2,
             name="Brussels Jedi Council",
             geom=cls.mock_multipolygon,
             simplified_geom=cls.mock_multipolygon,
@@ -985,8 +973,22 @@ class OrgUnitAPITestCase(APITestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(orgunits, count_of_orgunits + 9)
 
-    def test_org_unit_search_only_direct_children(self):
+    def test_org_unit_search_only_direct_children_false(self):
         self.client.force_authenticate(self.yoda)
+
+        jedi_squad_endor_2_children = m.OrgUnit.objects.create(
+            org_unit_type=self.jedi_council,
+            parent=self.jedi_squad_endor_2,
+            version=self.sw_version_2,
+            name="Endor Jedi Squad 2 Children",
+            geom=self.mock_multipolygon,
+            simplified_geom=self.mock_multipolygon,
+            catchment=self.mock_multipolygon,
+            location=self.mock_point,
+            validation_status=m.OrgUnit.VALIDATION_VALID,
+        )
+
+        jedi_squad_endor_2_children.save()
 
         response = self.client.get(
             f"/api/orgunits/?&orgUnitParentId={self.jedi_council_endor.pk}&limit=10&page=1&order=name&validation_status=all&onlyDirectChildren=false"
@@ -998,5 +1000,35 @@ class OrgUnitAPITestCase(APITestCase):
         self.assertEqual(response.json()["count"], 3)
 
         ids_in_response = [ou["id"] for ou in org_units]
-        ou_ids_list = [self.jedi_squad_endor.pk, self.jedi_squad_endor_2.pk, self.jedi_squad_endor_2_children.pk]
+        ou_ids_list = [self.jedi_squad_endor.pk, self.jedi_squad_endor_2.pk, jedi_squad_endor_2_children.pk]
+        self.assertEqual(sorted(ids_in_response), sorted(ou_ids_list))
+
+    def test_org_unit_search_only_direct_children_true(self):
+        self.client.force_authenticate(self.yoda)
+
+        jedi_squad_endor_2_children = m.OrgUnit.objects.create(
+            org_unit_type=self.jedi_council,
+            parent=self.jedi_squad_endor_2,
+            version=self.sw_version_2,
+            name="Endor Jedi Squad 2 Children",
+            geom=self.mock_multipolygon,
+            simplified_geom=self.mock_multipolygon,
+            catchment=self.mock_multipolygon,
+            location=self.mock_point,
+            validation_status=m.OrgUnit.VALIDATION_VALID,
+        )
+
+        jedi_squad_endor_2_children.save()
+
+        response = self.client.get(
+            f"/api/orgunits/?&parent_id={self.jedi_council_endor.pk}&limit=10&page=1&order=name&validation_status=all&onlyDirectChildren=true"
+        )
+
+        org_units = response.json()["orgunits"]
+
+        self.assertJSONResponse(response, 200)
+        self.assertEqual(response.json()["count"], 2)
+
+        ids_in_response = [ou["id"] for ou in org_units]
+        ou_ids_list = [self.jedi_squad_endor.pk, self.jedi_squad_endor_2.pk]
         self.assertEqual(sorted(ids_in_response), sorted(ou_ids_list))

--- a/iaso/tests/api/test_orgunits.py
+++ b/iaso/tests/api/test_orgunits.py
@@ -998,11 +998,16 @@ class OrgUnitAPITestCase(APITestCase):
         self.assertEqual(response.json()["count"], 3)
 
         ids_in_response = [ou["id"] for ou in org_units]
+
+        # list of all the indirect children of the jedi_council_endor OU
         ou_ids_list = [self.jedi_squad_endor.pk, self.jedi_squad_endor_2.pk, jedi_squad_endor_2_children.pk]
+
         self.assertEqual(sorted(ids_in_response), sorted(ou_ids_list))
 
     def test_org_unit_search_only_direct_children_true(self):
         self.client.force_authenticate(self.yoda)
+
+        # this ou in the children of the children of the parent so it must not appear in the response.
 
         jedi_squad_endor_2_children = m.OrgUnit.objects.create(
             org_unit_type=self.jedi_council,
@@ -1028,5 +1033,7 @@ class OrgUnitAPITestCase(APITestCase):
         self.assertEqual(response.json()["count"], 2)
 
         ids_in_response = [ou["id"] for ou in org_units]
+
+        # list of all direct children of the jedi_council_endor OU
         ou_ids_list = [self.jedi_squad_endor.pk, self.jedi_squad_endor_2.pk]
         self.assertEqual(sorted(ids_in_response), sorted(ou_ids_list))


### PR DESCRIPTION
If you don't hit the checkbox Only Direct children in org unit search tab children, atm the org unit you are looking the children for will be in the result. 

There is some strange things with this checkbox. If the checkbox is check the paremeter for the parent org unit is "parent_id" if not the parameter  is "orgUnitParentId", I'm not sure why. The parameter "onlyDirectChildren" is sent in both case respectively true or false.

Nevertheless, the parameter "onlyDirectChildren" was appearing in org_unit.py but unused and was missing in org_unit_search.py so I added it. I also added some tests.  

Related JIRA tickets : IA-1670

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [x] Did I add translations
- [x] My migrations file are included
- [x] Are there enough tests


## How to test

With the current version : 
Go to org unit, search for a org unit with children. 
Go to the children tab and search with the "only direct children" box unchecked
You will find the org unit as its own children in the list. 

With my PR: 
Do the same but you won't find the org unit as its own children.

Do the same and the org unit
