### PR TITLE
POLIO-869: Display RA status and Budget Status in the same format(capitalized)

### DIFF
--- a/hat/assets/js/apps/Iaso/utils/index.js
+++ b/hat/assets/js/apps/Iaso/utils/index.js
@@ -1,8 +1,12 @@
 import { createContext } from 'react';
 import pluginsConfigs from '../../../../../../plugins';
 
-export const capitalize = (text, keepEndCase = false) =>
-    text
+export const capitalize = (text, keepEndCase = false) => {
+    if (!text) {
+        return text;
+    }
+
+    return text
         .split(' ')
         .map(
             word =>
@@ -10,6 +14,8 @@ export const capitalize = (text, keepEndCase = false) =>
                 (keepEndCase ? word.slice(1) : word.slice(1).toLowerCase()),
         )
         .join(' ');
+}
+
 
 export const formatThousand = number => {
     if (number) {
@@ -81,8 +87,8 @@ export const waitFor = delay =>
 
 export const fakeResponse =
     response =>
-    async (isError = false) => {
-        if (isError) throw new Error('mock request failed');
-        await waitFor(200);
-        return response;
-    };
+        async (isError = false) => {
+            if (isError) throw new Error('mock request failed');
+            await waitFor(200);
+            return response;
+        };

--- a/plugins/polio/js/src/components/campaignCalendar/popper/RoundPopper.js
+++ b/plugins/polio/js/src/components/campaignCalendar/popper/RoundPopper.js
@@ -16,6 +16,7 @@ import { useSelector } from 'react-redux';
 import MESSAGES from '../../../constants/messages';
 import { useStyles } from '../Styles';
 import { CsvButton } from '../../../../../../../hat/assets/js/apps/Iaso/components/Buttons/CsvButton.tsx';
+import { capitalize } from '../../../../../../../hat/assets/js/apps/Iaso/utils/index';
 
 const groupsForCampaignRound = (campaign, round) => {
     if (!campaign.separate_scopes_per_round) {
@@ -81,13 +82,13 @@ const RoundPopper = ({
                             <FormattedMessage {...MESSAGES.raStatus} />:
                         </Grid>
                         <Grid item sm={6} container justifyContent="flex-start">
-                            {campaign.original.risk_assessment_status}
+                            {capitalize(campaign.original.risk_assessment_status)}
                         </Grid>
                         <Grid item sm={6} container justifyContent="flex-end">
                             <FormattedMessage {...MESSAGES.budgetStatus} />:
                         </Grid>
                         <Grid item sm={6} container justifyContent="flex-start">
-                            {campaign.original.budget_status}
+                            {capitalize(campaign.original.budget_status)}
                         </Grid>
                         <Grid item sm={6} container justifyContent="flex-end">
                             <FormattedMessage {...MESSAGES.vaccine} />:


### PR DESCRIPTION
Explain what problem this PR is resolving

RA Status and Budget Status in the calendar show in different format

Related JIRA tickets :  [POLIO-869](https://bluesquare.atlassian.net/browse/POLIO-869)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] Did I add translations
- [ ] My migrations file are included
- [ ] Are there enough tests

## Changes
- Capitalize the RA status and the Budget status 

## How to test
1. Polio --> Calendar 
2. And click on one round
3. Check in the round popup if the RA status and Budget status have same format

## Print screen / video
![Peek 2023-03-06 16-25](https://user-images.githubusercontent.com/19631540/223138044-da52e0c2-d640-48b8-ad18-8485221c4078.gif)


[POLIO-869]: https://bluesquare.atlassian.net/browse/POLIO-869?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ