### PR TITLE
WC2-176 : Change frontend, backend, update tests

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/workflows/components/changes/Modal.tsx
+++ b/hat/assets/js/apps/Iaso/domains/workflows/components/changes/Modal.tsx
@@ -44,8 +44,8 @@ const mapChange = (change?: Change): Mapping[] => {
     let mapArray: Mapping[] = [];
     if (change?.mapping) {
         mapArray = Object.entries(change.mapping).map(([key, value]) => ({
-            target: key,
-            source: value,
+            target: value,
+            source: key,
         }));
     }
     return mapArray;
@@ -101,7 +101,7 @@ const Modal: FunctionComponent<Props> = ({
         const mappingObject = {};
         mappingArray.forEach(mapping => {
             if (mapping.target && mapping.source) {
-                mappingObject[mapping.target] = mapping.source;
+                mappingObject[mapping.source] = mapping.target;
             }
         });
         saveChange({

--- a/hat/assets/js/cypress/fixtures/workflows/details.json
+++ b/hat/assets/js/cypress/fixtures/workflows/details.json
@@ -21,8 +21,8 @@
                 "name": "FORM_2"
             },
             "mapping": {
-                "first_name": "firstName",
-                "last_name": "LastName"
+                "firstName": "first_name",
+                "LastName": "last_name"
             },
             "created_at": "2023-01-31T11:04:21.120249Z",
             "updated_at": "2023-01-31T11:04:21.120270Z"
@@ -34,7 +34,7 @@
                 "name": "FORM_3"
             },
             "mapping": {
-                "last_name": "name"
+                "name": "last_name"
             },
             "created_at": "2023-01-31T11:04:21.127004Z",
             "updated_at": "2023-01-31T11:04:21.127041Z"

--- a/hat/assets/js/cypress/integration/13 - workflows/details.spec.js
+++ b/hat/assets/js/cypress/integration/13 - workflows/details.spec.js
@@ -1,33 +1,33 @@
 /// <reference types="cypress" />
 
-import superUser from '../../fixtures/profiles/me/superuser.json';
-import details from '../../fixtures/workflows/details.json';
+import superUser from '../../fixtures/profiles/me/superuser.json'
+import details from '../../fixtures/workflows/details.json'
 
-const siteBaseUrl = Cypress.env('siteBaseUrl');
-const baseUrl = `${siteBaseUrl}/dashboard/workflows/details/entityTypeId/3/versionId/12`;
+const siteBaseUrl = Cypress.env('siteBaseUrl')
+const baseUrl = `${siteBaseUrl}/dashboard/workflows/details/entityTypeId/3/versionId/12`
 
-let interceptFlag = false;
+let interceptFlag = false
 const mockPage = () => {
-    cy.login();
-    cy.intercept('GET', '/sockjs-node/**');
+    cy.login()
+    cy.intercept('GET', '/sockjs-node/**')
     cy.intercept('GET', '/api/profiles/me/**', {
         fixture: 'profiles/me/superuser.json',
-    }).as('getProfile');
+    }).as('getProfile')
     cy.intercept('GET', '/api/workflowversions/12/', {
         fixture: 'workflows/details.json',
-    }).as('getDetails');
+    }).as('getDetails')
     cy.intercept('GET', '/api/forms/7/?fields=possible_fields', {
         fixture: 'workflows/possible_fields.json',
-    }).as('getPossibleFields');
+    }).as('getPossibleFields')
     cy.intercept('GET', '/api/formversions/?form_id=7&fields=descriptor', {
         fixture: 'workflows/descriptor.json',
-    }).as('getDescriptor');
+    }).as('getDescriptor')
 
     cy.intercept('GET', '/api/forms/?fields=id,name', {
         fixture: 'forms/list.json',
-    }).as('getForms');
-};
-const name = 'mario';
+    }).as('getForms')
+}
+const name = 'mario'
 
 describe('Workflows details', () => {
     it('page should not be accessible if user does not have permission', () => {
@@ -35,126 +35,124 @@ describe('Workflows details', () => {
             ...superUser,
             permissions: [],
             is_superuser: false,
-        };
-        mockPage();
-        cy.intercept('GET', '/api/profiles/me/**', fakeUser);
-        cy.visit(baseUrl);
-        const errorCode = cy.get('#error-code');
-        errorCode.should('contain', '401');
-    });
+        }
+        mockPage()
+        cy.intercept('GET', '/api/profiles/me/**', fakeUser)
+        cy.visit(baseUrl)
+        const errorCode = cy.get('#error-code')
+        errorCode.should('contain', '401')
+    })
     it('with PUBLISHED or UNPUBLISHED status should not be able to publish; create, delete, change order or edit follow-ups and create, edit, delete changes', () => {
         const testStatus = status => {
-            mockPage();
+            mockPage()
             const fixture = {
                 ...details,
                 status,
-            };
+            }
             cy.intercept(
                 {
                     pathname: '/api/workflowversions/12/',
                     method: 'GET',
                 },
                 fixture,
-            ).as('getDetails');
-            cy.visit(baseUrl);
+            ).as('getDetails')
+            cy.visit(baseUrl)
 
             cy.wait([
                 '@getDetails',
                 '@getDescriptor',
                 '@getPossibleFields',
             ]).then(() => {
-                cy.log('Publish');
+                cy.log('Publish')
                 cy.get('[data-test="publish-workflow-button"]').should(
                     'not.exist',
-                );
-                cy.log('Create follow-up');
-                cy.get('[data-test="create-follow-ups"]').should('not.exist');
+                )
+                cy.log('Create follow-up')
+                cy.get('[data-test="create-follow-ups"]').should('not.exist')
 
-                cy.log('Edit and delete follow-up');
+                cy.log('Edit and delete follow-up')
                 cy.get('[data-test="follow-ups"]')
                     .find('table tbody tr')
                     .eq(0)
                     .find('td')
                     .last()
                     .find('button')
-                    .should('not.exist');
+                    .should('not.exist')
 
-                cy.log('Change order');
+                cy.log('Change order')
                 cy.get('[data-test="follow-ups"]')
                     .find('table tbody tr')
                     .eq(0)
                     .find('td')
                     .eq(0)
-                    .should('contain', '1');
+                    .should('contain', '1')
                 cy.get('[data-test="reset-follow-up-order"]').should(
                     'not.exist',
-                );
-                cy.get('[data-test="save-follow-up-order"]').should(
-                    'not.exist',
-                );
+                )
+                cy.get('[data-test="save-follow-up-order"]').should('not.exist')
 
-                cy.log('Create change');
-                cy.get('[data-test="create-change"]').should('not.exist');
+                cy.log('Create change')
+                cy.get('[data-test="create-change"]').should('not.exist')
 
-                cy.log('Edit and delete change');
+                cy.log('Edit and delete change')
                 cy.get('[data-test="changes"]')
                     .find('table tbody tr')
                     .eq(0)
                     .find('td')
                     .last()
                     .find('button')
-                    .should('not.exist');
-            });
-        };
-        testStatus('PUBLISHED');
-        testStatus('UNPUBLISHED');
-    });
+                    .should('not.exist')
+            })
+        }
+        testStatus('PUBLISHED')
+        testStatus('UNPUBLISHED')
+    })
     describe('with any status', () => {
         beforeEach(() => {
-            mockPage();
-            cy.visit(baseUrl);
-        });
+            mockPage()
+            cy.visit(baseUrl)
+        })
         it('should display correct infos values', () => {
             cy.get('[data-test="workflow-base-info"]')
                 .as('tableInfos')
-                .should('be.visible');
+                .should('be.visible')
             cy.get('@tableInfos')
                 .find('tr')
                 .eq(0)
                 .find('td')
                 .eq(1)
-                .should('contain', details.entity_type.name);
+                .should('contain', details.entity_type.name)
             cy.get('@tableInfos')
                 .find('tr')
                 .eq(1)
                 .find('td')
                 .eq(1)
-                .should('contain', details.reference_form.name);
+                .should('contain', details.reference_form.name)
             cy.get('@tableInfos')
                 .find('tr')
                 .eq(2)
                 .find('td')
                 .eq(1)
-                .should('contain', details.version_id);
+                .should('contain', details.version_id)
             cy.get('@tableInfos')
                 .find('tr')
                 .eq(3)
                 .find('td')
                 .eq(1)
-                .should('contain', 'Draft');
-        });
+                .should('contain', 'Draft')
+        })
         it('should be possible to edit and save name', () => {
-            cy.get('[data-test="save-name-button"]').as('saveButton');
+            cy.get('[data-test="save-name-button"]').as('saveButton')
             cy.get('@saveButton')
                 .invoke('attr', 'disabled')
-                .should('equal', 'disabled');
+                .should('equal', 'disabled')
 
-            cy.fillTextField('#input-text-name', name);
+            cy.fillTextField('#input-text-name', name)
             cy.get('@saveButton')
                 .invoke('attr', 'disabled')
-                .should('equal', undefined);
+                .should('equal', undefined)
 
-            interceptFlag = false;
+            interceptFlag = false
 
             cy.intercept(
                 {
@@ -162,157 +160,143 @@ describe('Workflows details', () => {
                     pathname: '/api/workflowversions/12',
                 },
                 req => {
-                    interceptFlag = true;
+                    interceptFlag = true
                     req.reply({
                         statusCode: 200,
                         body: {},
-                    });
+                    })
                 },
-            ).as('saveVersion');
+            ).as('saveVersion')
 
-            cy.get('@saveButton').click();
+            cy.get('@saveButton').click()
             cy.wait('@saveVersion').then(xhr => {
-                cy.wrap(xhr.request.body).its('name').should('eq', name);
-                cy.wrap(interceptFlag).should('eq', true);
-            });
-        });
+                cy.wrap(xhr.request.body).its('name').should('eq', name)
+                cy.wrap(interceptFlag).should('eq', true)
+            })
+        })
         it('should display correct follow-ups', () => {
-            cy.get('[data-test="follow-ups"]')
-                .find('table')
-                .as('followUpTable');
-            cy.get('@followUpTable').should('be.visible');
+            cy.get('[data-test="follow-ups"]').find('table').as('followUpTable')
+            cy.get('@followUpTable').should('be.visible')
             cy.get('@followUpTable')
                 .find('tbody')
                 .find('tr')
-                .should('have.length', 2);
+                .should('have.length', 2)
 
             cy.get('@followUpTable')
                 .find('tbody')
                 .find('tr')
                 .eq(0)
-                .as('firstRow');
+                .as('firstRow')
 
             cy.get('@followUpTable')
                 .find('tbody')
                 .find('tr')
                 .eq(1)
-                .as('secondRow');
+                .as('secondRow')
 
             cy.get('@firstRow')
                 .find('td')
                 .eq(1)
-                .should('contain', 'Last name = last_name_value');
-            cy.get('@firstRow').find('td').eq(2).should('contain', 'FORM_2');
-            cy.get('@firstRow')
-                .find('td')
-                .eq(3)
-                .should('contain', '01/02/2023');
-            cy.get('@firstRow')
-                .find('td')
-                .eq(4)
-                .should('contain', '01/02/2023');
+                .should('contain', 'Last name = last_name_value')
+            cy.get('@firstRow').find('td').eq(2).should('contain', 'FORM_2')
+            cy.get('@firstRow').find('td').eq(3).should('contain', '01/02/2023')
+            cy.get('@firstRow').find('td').eq(4).should('contain', '01/02/2023')
 
             cy.get('@secondRow')
                 .find('td')
                 .eq(1)
-                .should('contain', 'Gender = Male AND Entity Group = Group A');
-            cy.get('@secondRow').find('td').eq(2).should('contain', 'FORM_3');
+                .should('contain', 'Gender = Male AND Entity Group = Group A')
+            cy.get('@secondRow').find('td').eq(2).should('contain', 'FORM_3')
             cy.get('@secondRow')
                 .find('td')
                 .eq(3)
-                .should('contain', '31/01/2023');
+                .should('contain', '31/01/2023')
             cy.get('@secondRow')
                 .find('td')
                 .eq(4)
-                .should('contain', '13/02/2023');
-        });
+                .should('contain', '13/02/2023')
+        })
         it('should display correct changes', () => {
-            cy.get('[data-test="changes"]').find('table').as('changesTable');
-            cy.get('@changesTable').should('be.visible');
+            cy.get('[data-test="changes"]').find('table').as('changesTable')
+            cy.get('@changesTable').should('be.visible')
             cy.get('@changesTable')
                 .find('tbody')
                 .find('tr')
-                .should('have.length', 2);
+                .should('have.length', 2)
 
             cy.get('@changesTable')
                 .find('tbody')
                 .find('tr')
                 .eq(0)
-                .as('firstRow');
+                .as('firstRow')
             cy.get('@changesTable')
                 .find('tbody')
                 .find('tr')
                 .eq(1)
-                .as('secondRow');
+                .as('secondRow')
 
-            cy.get('@firstRow').find('td').eq(0).should('contain', 'FORM_2');
+            cy.get('@firstRow').find('td').eq(0).should('contain', 'FORM_2')
             cy.get('@firstRow')
                 .find('td')
                 .eq(1)
                 .should(
                     'contain',
-                    'first_name => firstName, last_name => LastName',
-                );
-            cy.get('@firstRow')
-                .find('td')
-                .eq(2)
-                .should('contain', '31/01/2023');
-            cy.get('@firstRow')
-                .find('td')
-                .eq(3)
-                .should('contain', '31/01/2023');
+                    'firstName => first_name, LastName => last_name',
+                )
+            cy.get('@firstRow').find('td').eq(2).should('contain', '31/01/2023')
+            cy.get('@firstRow').find('td').eq(3).should('contain', '31/01/2023')
 
-            cy.get('@secondRow').find('td').eq(0).should('contain', 'FORM_3');
+            cy.get('@secondRow').find('td').eq(0).should('contain', 'FORM_3')
             cy.get('@secondRow')
                 .find('td')
                 .eq(1)
-                .should('contain', 'last_name => name');
+                .should('contain', 'name => last_name')
             cy.get('@secondRow')
                 .find('td')
                 .eq(2)
-                .should('contain', '31/01/2023');
+                .should('contain', '31/01/2023')
             cy.get('@secondRow')
                 .find('td')
                 .eq(3)
-                .should('contain', '31/01/2023');
-        });
-    });
+                .should('contain', '31/01/2023')
+        })
+    })
     describe('with DRAFT status', () => {
         beforeEach(() => {
-            mockPage();
-            cy.visit(baseUrl);
-        });
+            mockPage()
+            cy.visit(baseUrl)
+        })
         it('should be possible to publish', () => {
-            interceptFlag = false;
+            interceptFlag = false
             cy.intercept(
                 {
                     method: 'PATCH',
                     pathname: '/api/workflowversions/12/',
                 },
                 req => {
-                    interceptFlag = true;
+                    interceptFlag = true
                     req.reply({
                         statusCode: 200,
                         body: {},
-                    });
+                    })
                 },
-            ).as('publishVersion');
+            ).as('publishVersion')
             cy.get('[data-test="publish-workflow-button"')
                 .should('be.visible')
-                .click();
+                .click()
             cy.get('[data-test="publish-workflow-version"]').should(
                 'be.visible',
-            );
-            cy.get('[data-test="confirm-button"]').click();
+            )
+            cy.get('[data-test="confirm-button"]').click()
             cy.wait('@publishVersion').then(xhr => {
                 cy.wrap(xhr.request.body)
                     .its('status')
-                    .should('eq', 'PUBLISHED');
-                cy.wrap(interceptFlag).should('eq', true);
-            });
-        });
+                    .should('eq', 'PUBLISHED')
+                cy.wrap(interceptFlag).should('eq', true)
+            })
+        })
         it('should create a follow-up', () => {
-            interceptFlag = false;
+            interceptFlag = false
             cy.intercept(
                 {
                     method: 'POST',
@@ -322,13 +306,13 @@ describe('Workflows details', () => {
                     },
                 },
                 req => {
-                    interceptFlag = true;
+                    interceptFlag = true
                     req.reply({
                         statusCode: 200,
                         body: {},
-                    });
+                    })
                 },
-            ).as('addFollowUp');
+            ).as('addFollowUp')
 
             cy.wait([
                 '@getDetails',
@@ -337,53 +321,53 @@ describe('Workflows details', () => {
             ]).then(() => {
                 cy.get('[data-test="create-follow-ups"')
                     .should('be.visible')
-                    .click();
-                cy.get('[data-test="follow-up-modal"]').should('be.visible');
-                cy.get('[data-test="confirm-button"]').as('saveButton');
+                    .click()
+                cy.get('[data-test="follow-up-modal"]').should('be.visible')
+                cy.get('[data-test="confirm-button"]').as('saveButton')
                 cy.get('@saveButton')
                     .invoke('attr', 'disabled')
-                    .should('equal', 'disabled');
-                cy.testInputValue('#forms', '');
-                cy.get('.query-builder button').eq(0).click();
-                cy.get('.query-builder .MuiInputBase-input').click();
-                cy.get('[role="option"]').eq(0).click();
-                cy.get('.widget--widget input[type="text"]').type(name);
-                cy.fillSingleSelect('#forms', 0);
+                    .should('equal', 'disabled')
+                cy.testInputValue('#forms', '')
+                cy.get('.query-builder button').eq(0).click()
+                cy.get('.query-builder .MuiInputBase-input').click()
+                cy.get('[role="option"]').eq(0).click()
+                cy.get('.widget--widget input[type="text"]').type(name)
+                cy.fillSingleSelect('#forms', 0)
 
                 cy.get('@saveButton')
                     .invoke('attr', 'disabled')
-                    .should('equal', undefined);
-                cy.get('@saveButton').click();
+                    .should('equal', undefined)
+                cy.get('@saveButton').click()
                 cy.wait('@addFollowUp').then(xhr => {
-                    cy.wrap(xhr.request.body).its('order').should('eq', 2);
+                    cy.wrap(xhr.request.body).its('order').should('eq', 2)
                     cy.wrap(xhr.request.body.condition.and[0]['=='][0])
                         .its('var')
-                        .should('eq', 'first_name');
+                        .should('eq', 'first_name')
                     cy.wrap(xhr.request.body.condition.and[0]['=='][1]).should(
                         'eq',
                         name,
-                    );
-                    cy.wrap(xhr.request.body.form_ids[0]).should('eq', 1);
-                    cy.wrap(interceptFlag).should('eq', true);
-                });
-            });
-        });
+                    )
+                    cy.wrap(xhr.request.body.form_ids[0]).should('eq', 1)
+                    cy.wrap(interceptFlag).should('eq', true)
+                })
+            })
+        })
         it('should edit a follow-up', () => {
             // TO-DO: test query builder properly, point here is to test edit feature
-            interceptFlag = false;
+            interceptFlag = false
             cy.intercept(
                 {
                     method: 'POST',
                     pathname: '/api/workflowfollowups/bulkupdate/',
                 },
                 req => {
-                    interceptFlag = true;
+                    interceptFlag = true
                     req.reply({
                         statusCode: 200,
                         body: {},
-                    });
+                    })
                 },
-            ).as('editFollowUp');
+            ).as('editFollowUp')
 
             cy.wait([
                 '@getDetails',
@@ -391,7 +375,7 @@ describe('Workflows details', () => {
                 '@getPossibleFields',
                 '@getProfile',
             ]).then(() => {
-                cy.wait(500);
+                cy.wait(500)
                 cy.get('[data-test="follow-ups"]')
                     .find('table tbody tr')
                     .eq(0)
@@ -399,52 +383,52 @@ describe('Workflows details', () => {
                     .last()
                     .find('button')
                     .first()
-                    .click();
-                cy.get('[data-test="follow-up-modal"').should('be.visible');
+                    .click()
+                cy.get('[data-test="follow-up-modal"').should('be.visible')
 
-                cy.get('[data-test="confirm-button"]').as('saveButton');
-                cy.testMultiSelect('#forms', [{ name: 'FORM 1' }]);
-                cy.get('.query-builder button').eq(0).click();
-                cy.get('.query-builder .MuiInputBase-input').eq(0).click();
-                cy.get('[role="option"]').eq(2).click();
+                cy.get('[data-test="confirm-button"]').as('saveButton')
+                cy.testMultiSelect('#forms', [{ name: 'FORM 1' }])
+                cy.get('.query-builder button').eq(0).click()
+                cy.get('.query-builder .MuiInputBase-input').eq(0).click()
+                cy.get('[role="option"]').eq(2).click()
                 cy.get('.widget--widget input[type="text"]')
                     .type('{selectall}')
-                    .type(name);
-                cy.fillSingleSelect('#forms', 0);
+                    .type(name)
+                cy.fillSingleSelect('#forms', 0)
 
                 cy.get('@saveButton')
                     .invoke('attr', 'disabled')
-                    .should('equal', undefined);
-                cy.get('@saveButton').click();
+                    .should('equal', undefined)
+                cy.get('@saveButton').click()
                 cy.wait('@editFollowUp').then(xhr => {
-                    cy.wrap(xhr.request.body[0]).its('order').should('eq', 0);
+                    cy.wrap(xhr.request.body[0]).its('order').should('eq', 0)
                     cy.wrap(xhr.request.body[0].condition['!'].and[0]['=='][0])
                         .its('var')
-                        .should('eq', 'last_name');
+                        .should('eq', 'last_name')
                     cy.wrap(
                         xhr.request.body[0].condition['!'].and[0]['=='][1],
-                    ).should('eq', name);
-                    cy.wrap(xhr.request.body[0].form_ids[0]).should('eq', 2);
-                    cy.wrap(xhr.request.body[0].form_ids[1]).should('eq', 1);
-                    cy.wrap(interceptFlag).should('eq', true);
-                });
-            });
-        });
+                    ).should('eq', name)
+                    cy.wrap(xhr.request.body[0].form_ids[0]).should('eq', 2)
+                    cy.wrap(xhr.request.body[0].form_ids[1]).should('eq', 1)
+                    cy.wrap(interceptFlag).should('eq', true)
+                })
+            })
+        })
         it('should delete a follow-up', () => {
-            interceptFlag = false;
+            interceptFlag = false
             cy.intercept(
                 {
                     method: 'delete',
                     pathname: '/api/workflowfollowups/1/',
                 },
                 req => {
-                    interceptFlag = true;
+                    interceptFlag = true
                     req.reply({
                         statusCode: 200,
                         body: {},
-                    });
+                    })
                 },
-            ).as('deleteFollowUp');
+            ).as('deleteFollowUp')
 
             cy.wait('@getDetails').then(() => {
                 cy.get('[data-test="follow-ups"]')
@@ -454,19 +438,19 @@ describe('Workflows details', () => {
                     .last()
                     .find('button')
                     .last()
-                    .click();
+                    .click()
 
                 cy.get(
                     '[data-test="delete-dialog-delete-workflow-follow-up-1"]',
-                ).should('be.visible');
-                cy.get('[data-test="confirm-button"]').click();
+                ).should('be.visible')
+                cy.get('[data-test="confirm-button"]').click()
                 cy.wait('@deleteFollowUp').then(() => {
-                    cy.wrap(interceptFlag).should('eq', true);
-                });
-            });
-        });
+                    cy.wrap(interceptFlag).should('eq', true)
+                })
+            })
+        })
         it('should create a change', () => {
-            interceptFlag = false;
+            interceptFlag = false
             cy.intercept(
                 {
                     method: 'POST',
@@ -476,13 +460,13 @@ describe('Workflows details', () => {
                     },
                 },
                 req => {
-                    interceptFlag = true;
+                    interceptFlag = true
                     req.reply({
                         statusCode: 200,
                         body: {},
-                    });
+                    })
                 },
-            ).as('addChange');
+            ).as('addChange')
 
             cy.wait([
                 '@getDetails',
@@ -491,65 +475,65 @@ describe('Workflows details', () => {
             ]).then(() => {
                 cy.intercept('GET', '/api/forms/1/?fields=possible_fields', {
                     fixture: 'workflows/possible_fields.json',
-                });
-                cy.get('[data-test="create-change"]').click();
-                cy.get('[data-test="change-modal"]').should('be.visible');
-                cy.get('[data-test="confirm-button"]').as('saveButton');
+                })
+                cy.get('[data-test="create-change"]').click()
+                cy.get('[data-test="change-modal"]').should('be.visible')
+                cy.get('[data-test="confirm-button"]').as('saveButton')
                 cy.get('@saveButton')
                     .invoke('attr', 'disabled')
-                    .should('equal', 'disabled');
-                cy.testInputValue('#forms', '');
-                cy.fillSingleSelect('#forms', 0);
+                    .should('equal', 'disabled')
+                cy.testInputValue('#forms', '')
+                cy.fillSingleSelect('#forms', 0)
                 cy.get('[data-test="change-modal"]')
                     .find('table tbody tr')
-                    .should('have.length', 0);
-                cy.get('[data-test="create-change-button"]').click();
+                    .should('have.length', 0)
+                cy.get('[data-test="create-change-button"]').click()
                 cy.get('[data-test="change-modal"]')
                     .find('table tbody tr')
-                    .should('have.length', 1);
+                    .should('have.length', 1)
 
                 cy.get('[data-test="change-modal"]')
                     .find('table tbody tr td')
                     .eq(0)
                     .find('#source')
-                    .click();
-                cy.get('#source-option-1').click();
+                    .click()
+                cy.get('#source-option-1').click()
                 cy.get('[data-test="change-modal"]')
                     .find('table tbody tr td')
                     .eq(1)
                     .find('#target')
-                    .click();
-                cy.get('#target-option-1').click();
+                    .click()
+                cy.get('#target-option-1').click()
 
                 cy.get('@saveButton')
                     .invoke('attr', 'disabled')
-                    .should('equal', undefined);
-                cy.get('@saveButton').click();
+                    .should('equal', undefined)
+                cy.get('@saveButton').click()
                 cy.wait('@addChange').then(xhr => {
                     // {"form":67,"mapping":{"registration_id":"nom"}}
-                    cy.wrap(xhr.request.body).its('form').should('eq', 1);
+                    cy.wrap(xhr.request.body).its('form').should('eq', 1)
                     cy.wrap(xhr.request.body.mapping)
                         .its('middle_names')
-                        .should('eq', 'middle_names');
-                    cy.wrap(interceptFlag).should('eq', true);
-                });
-            });
-        });
+                        .should('eq', 'middle_names')
+                    cy.wrap(interceptFlag).should('eq', true)
+                })
+            })
+        })
         it('should edit a change', () => {
-            interceptFlag = false;
+            interceptFlag = false
             cy.intercept(
                 {
                     method: 'PUT',
                     pathname: '/api/workflowchanges/1/',
                 },
                 req => {
-                    interceptFlag = true;
+                    interceptFlag = true
                     req.reply({
                         statusCode: 200,
                         body: {},
-                    });
+                    })
                 },
-            ).as('editChange');
+            ).as('editChange')
 
             cy.wait([
                 '@getDetails',
@@ -559,11 +543,11 @@ describe('Workflows details', () => {
             ]).then(() => {
                 cy.intercept('GET', '/api/forms/2/?fields=possible_fields', {
                     fixture: 'workflows/possible_fields_source.json',
-                });
+                })
 
                 cy.intercept('GET', '/api/forms/?fields=id,name', {
                     fixture: 'forms/list.json',
-                });
+                })
                 cy.get('[data-test="changes"]')
                     .find('table tbody tr')
                     .eq(0)
@@ -571,20 +555,20 @@ describe('Workflows details', () => {
                     .last()
                     .find('button')
                     .first()
-                    .click();
-                cy.get('[data-test="change-modal"').should('be.visible');
+                    .click()
+                cy.get('[data-test="change-modal"').should('be.visible')
 
-                cy.get('[data-test="confirm-button"]').as('saveButton');
+                cy.get('[data-test="confirm-button"]').as('saveButton')
 
-                cy.testInputValue('#forms', 'FORM 1');
+                cy.testInputValue('#forms', 'FORM 1')
 
                 cy.intercept('GET', '/api/forms/4/?fields=possible_fields', {
                     fixture: 'workflows/possible_fields_source.json',
-                }).as('getSourcePossibleFields');
+                }).as('getSourcePossibleFields')
 
-                cy.log('Should display correct infos');
+                cy.log('Should display correct infos')
 
-                cy.log('on first row');
+                cy.log('on first row')
                 cy.get('[data-test="change-modal"]')
                     .find('table tbody tr')
                     .eq(0)
@@ -592,7 +576,7 @@ describe('Workflows details', () => {
                     .eq(0)
                     .find('#source')
                     .invoke('attr', 'value')
-                    .should('contain', 'First name');
+                    .should('contain', 'First name')
 
                 cy.get('[data-test="change-modal"]')
                     .find('table tbody tr')
@@ -601,8 +585,8 @@ describe('Workflows details', () => {
                     .eq(0)
                     .find('#source')
                     .invoke('attr', 'value')
-                    .should('contain', 'Last name');
-                cy.log('on second row');
+                    .should('contain', 'Last name')
+                cy.log('on second row')
                 cy.get('[data-test="change-modal"]')
                     .find('table tbody tr')
                     .eq(0)
@@ -610,7 +594,7 @@ describe('Workflows details', () => {
                     .eq(1)
                     .find('#target')
                     .invoke('attr', 'value')
-                    .should('contain', 'First name');
+                    .should('contain', 'First name')
 
                 cy.get('[data-test="change-modal"]')
                     .find('table tbody tr')
@@ -619,15 +603,15 @@ describe('Workflows details', () => {
                     .eq(1)
                     .find('#target')
                     .invoke('attr', 'value')
-                    .should('contain', 'Last name');
+                    .should('contain', 'Last name')
 
-                cy.log('Sources should be empty by changing source form');
-                cy.fillSingleSelect('#forms', 2);
+                cy.log('Sources should be empty by changing source form')
+                cy.fillSingleSelect('#forms', 2)
                 cy.get('@saveButton')
                     .invoke('attr', 'disabled')
-                    .should('equal', 'disabled');
+                    .should('equal', 'disabled')
                 cy.wait('@getSourcePossibleFields').then(() => {
-                    cy.wait(200);
+                    cy.wait(200)
                     cy.get('[data-test="change-modal"]')
                         .find('table tbody tr')
                         .eq(0)
@@ -636,9 +620,9 @@ describe('Workflows details', () => {
                         .find('#source')
                         .as('source')
                         .invoke('attr', 'value')
-                        .should('eq', '');
-                    cy.get('@source').click();
-                    cy.get('#source-option-1').click();
+                        .should('eq', '')
+                    cy.get('@source').click()
+                    cy.get('#source-option-1').click()
 
                     cy.get('[data-test="change-modal"]')
                         .find('table tbody tr')
@@ -648,18 +632,18 @@ describe('Workflows details', () => {
                         .find('#source')
                         .as('source')
                         .invoke('attr', 'value')
-                        .should('eq', '');
-                    cy.get('@source').click();
+                        .should('eq', '')
+                    cy.get('@source').click()
                     cy.log(
                         'Selected source should not be present in options list',
-                    );
-                    cy.get('#source-popup').should('not.contain', 'Last name');
-                    cy.get('#source-option-1').click();
+                    )
+                    cy.get('#source-popup').should('not.contain', 'Last name')
+                    cy.get('#source-option-1').click()
 
-                    cy.log("Save should be disabled if type does'nt match");
+                    cy.log("Save should be disabled if type does'nt match")
                     cy.get('@saveButton')
                         .invoke('attr', 'disabled')
-                        .should('equal', 'disabled');
+                        .should('equal', 'disabled')
 
                     cy.get('[data-test="change-modal"]')
                         .find('table tbody tr')
@@ -669,43 +653,43 @@ describe('Workflows details', () => {
                         .find('#target')
                         .as('target')
                         .invoke('attr', 'value')
-                        .should('eq', '');
-                    cy.get('@target').click();
-                    cy.get('#target-popup').should('not.contain', 'Type: text');
-                    cy.get('#target-option-0').click();
+                        .should('eq', '')
+                    cy.get('@target').click()
+                    cy.get('#target-popup').should('not.contain', 'Type: text')
+                    cy.get('#target-option-0').click()
                     cy.get('@saveButton')
                         .invoke('attr', 'disabled')
-                        .should('equal', undefined);
+                        .should('equal', undefined)
 
-                    cy.get('@saveButton').click();
+                    cy.get('@saveButton').click()
                     cy.wait('@editChange').then(xhr => {
-                        cy.wrap(xhr.request.body).its('form').should('eq', 4);
+                        cy.wrap(xhr.request.body).its('form').should('eq', 4)
                         cy.wrap(xhr.request.body.mapping)
-                            .its('first_name')
-                            .should('eq', 'LastName');
+                            .its('LastName')
+                            .should('eq', 'first_name')
                         cy.wrap(xhr.request.body.mapping)
-                            .its('age')
-                            .should('eq', 'Age');
-                        cy.wrap(interceptFlag).should('eq', true);
-                    });
-                });
-            });
-        });
+                            .its('Age')
+                            .should('eq', 'age')
+                        cy.wrap(interceptFlag).should('eq', true)
+                    })
+                })
+            })
+        })
         it('should delete a change', () => {
-            interceptFlag = false;
+            interceptFlag = false
             cy.intercept(
                 {
                     method: 'delete',
                     pathname: '/api/workflowchanges/1/',
                 },
                 req => {
-                    interceptFlag = true;
+                    interceptFlag = true
                     req.reply({
                         statusCode: 200,
                         body: {},
-                    });
+                    })
                 },
-            ).as('deleteChange');
+            ).as('deleteChange')
 
             cy.wait([
                 '@getDetails',
@@ -714,7 +698,7 @@ describe('Workflows details', () => {
             ]).then(() => {
                 cy.intercept('GET', '/api/forms/7/?fields=possible_fields', {
                     fixture: 'workflows/possible_fields_source.json',
-                });
+                })
                 cy.get('[data-test="changes"]')
                     .find('table tbody tr')
                     .eq(0)
@@ -722,20 +706,20 @@ describe('Workflows details', () => {
                     .last()
                     .find('button')
                     .last()
-                    .click();
+                    .click()
 
                 cy.get(
                     '[data-test="delete-dialog-delete-workflow-change-1"]',
-                ).should('be.visible');
-                cy.get('[data-test="confirm-button"]').click();
+                ).should('be.visible')
+                cy.get('[data-test="confirm-button"]').click()
                 cy.wait('@deleteChange').then(() => {
-                    cy.wrap(interceptFlag).should('eq', true);
-                });
-            });
-        });
+                    cy.wrap(interceptFlag).should('eq', true)
+                })
+            })
+        })
 
         // TO-DO: implement drag & drop behaviour  with cypress => https://github.com/clauderic/dnd-kit/blob/master/cypress/support/commands.ts
-        it.skip('should change order of follow-ups and save it', () => {});
-        it.skip('should reset order of follow-ups', () => {});
-    });
-});
+        it.skip('should change order of follow-ups and save it', () => {})
+        it.skip('should reset order of follow-ups', () => {})
+    })
+})

--- a/iaso/api/workflows/serializers.py
+++ b/iaso/api/workflows/serializers.py
@@ -111,22 +111,22 @@ class WorkflowChangeCreateSerializer(serializers.Serializer):
         if len(mapping.values()) != len(list(set(mapping.values()))):
             raise serializers.ValidationError(f"Mapping cannot have two identical values")
 
-        for key, value in mapping.items():
+        for _source, _target in mapping.items():
 
-            q = find_question_by_name(value, s_questions)
+            q = find_question_by_name(_source, s_questions)
             if q is None:
-                raise serializers.ValidationError(f"Question {value} does not exist in source form")
+                raise serializers.ValidationError(f"Question {_source} does not exist in source form")
             else:
                 s_type = q["type"]
 
-            q = find_question_by_name(key, r_questions)
+            q = find_question_by_name(_target, r_questions)
             if q is None:
-                raise serializers.ValidationError(f"Question {key} does not exist in reference form")
+                raise serializers.ValidationError(f"Question {_target} does not exist in reference/target form")
             else:
                 r_type = q["type"]
 
             if s_type != r_type:
-                raise serializers.ValidationError(f"Question {key} and {value} do not have the same type")
+                raise serializers.ValidationError(f"Question {_source} and {_target} do not have the same type")
 
         return mapping
 

--- a/iaso/tests/api/workflows/test_workflows_changes.py
+++ b/iaso/tests/api/workflows/test_workflows_changes.py
@@ -3,6 +3,8 @@ from iaso.tests.api.workflows.base import BaseWorkflowsAPITestCase
 
 BASE_API = "/api/workflowchanges/"
 
+import pprint
+
 
 class WorkflowsChangesAPITestCase(BaseWorkflowsAPITestCase):
     def test_workflow_create_change_without_auth(self):
@@ -86,7 +88,7 @@ class WorkflowsChangesAPITestCase(BaseWorkflowsAPITestCase):
         )
         assert response.data["form"][0].code == "invalid"
 
-        assert "Question data does not exist in source form" in str(response.data["mapping"][0])
+        assert "Question fake does not exist in source form" in str(response.data["mapping"][0])
         assert response.data["mapping"][0].code == "invalid"
 
     def test_should_field_not_exist_on_reference_form(self):
@@ -101,7 +103,7 @@ class WorkflowsChangesAPITestCase(BaseWorkflowsAPITestCase):
         )
 
         self.assertJSONResponse(response, 400)
-        assert "Question XXXX does not exist in reference form" in str(response.data["mapping"][0])
+        assert "Question XXXX does not exist in source form" in str(response.data["mapping"][0])
         assert response.data["mapping"][0].code == "invalid"
 
     def test_delete_non_existing_should_fail(self):


### PR DESCRIPTION
In workflow changes, the order of the field mappings was reversed between web and mobile.
This reverses it in web frontend and backend.

Related JIRA tickets : WC2-176

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are there enough tests

## Changes

Reversed the order of the mapping Source Field > Target Field in frontend
Reversed the order of the mapping Source Field > Target Field in backend
Fixed the API tests to take it into account

## How to test

Go to Beneficiary type > Workflow and add or edit changes in a workflow
Verify that the order is correct.

(See video below)

## Print screen / video


https://user-images.githubusercontent.com/383344/223390845-977b6910-7dee-4e39-8fe8-626a8070797f.mov
