### PR TITLE
Allow pagination of mobile OrgUnit API

### DIFF
--- a/iaso/api/mobile/entity.py
+++ b/iaso/api/mobile/entity.py
@@ -13,7 +13,7 @@ from iaso.api.common import (
     DeletionFilterBackend,
     TimestampField,
 )
-from iaso.api.query_params import LIMIT
+from iaso.api.query_params import LIMIT, PAGE
 from iaso.models import Entity, Instance, OrgUnit, FormVersion
 from iaso.utils.jsonlogic import jsonlogic_to_q
 
@@ -21,6 +21,7 @@ from iaso.utils.jsonlogic import jsonlogic_to_q
 class LargeResultsSetPagination(PageNumberPagination):
     page_size = 1000
     page_size_query_param = LIMIT
+    page_query_param = PAGE
     max_page_size = 1000
 
 
@@ -108,7 +109,7 @@ class MobileEntityViewSet(ModelViewSet):
 
     details = /api/mobile/entities/uuid
 
-    sample usage: /api/mobile/entities/?limit_date=2022-12-29&{LIMIT}=1&page=1
+    sample usage: /api/mobile/entities/?limit_date=2022-12-29&{LIMIT}=1&{PAGE}=1
 
     """
 

--- a/iaso/api/mobile/entity.py
+++ b/iaso/api/mobile/entity.py
@@ -13,13 +13,14 @@ from iaso.api.common import (
     DeletionFilterBackend,
     TimestampField,
 )
+from iaso.api.query_params import LIMIT
 from iaso.models import Entity, Instance, OrgUnit, FormVersion
 from iaso.utils.jsonlogic import jsonlogic_to_q
 
 
 class LargeResultsSetPagination(PageNumberPagination):
     page_size = 1000
-    page_size_query_param = "page_size"
+    page_size_query_param = LIMIT
     max_page_size = 1000
 
 
@@ -97,7 +98,7 @@ class MobileEntitySerializer(serializers.ModelSerializer):
 
 
 class MobileEntityViewSet(ModelViewSet):
-    """Entity API for mobile
+    f"""Entity API for mobile
 
     list: /api/mobile/entities
 
@@ -107,7 +108,7 @@ class MobileEntityViewSet(ModelViewSet):
 
     details = /api/mobile/entities/uuid
 
-    sample usage: /api/mobile/entities/?limit_date=2022-12-29&limit=1&page=1
+    sample usage: /api/mobile/entities/?limit_date=2022-12-29&{LIMIT}=1&page=1
 
     """
 

--- a/iaso/api/mobile/org_units.py
+++ b/iaso/api/mobile/org_units.py
@@ -20,7 +20,7 @@ class MobileOrgUnitsSetPagination(Paginator):
     page_size = None  # None to disable pagination by default.
 
     def get_page_number(self, request):
-        return request.query_params.get(self.page_query_param, 1)
+        return int(request.query_params.get(self.page_query_param, 1))
 
 
 class MobileOrgUnitSerializer(ModelSerializer):
@@ -116,6 +116,10 @@ class MobileOrgUnitViewSet(ModelViewSet):
     Optionally, {PAGE} and {LIMIT} parameters can be passed to paginate the results.
 
     GET /api/mobile/orgunits?{PAGE}=1&{LIMIT}=100
+
+    You can also request the Geo Shape by adding the `shapes=1` to your query parameters.
+
+    GET /api/mobile/orgunits?shapes=1
     """
 
     permission_classes = [HasOrgUnitPermission]

--- a/iaso/api/mobile/org_units.py
+++ b/iaso/api/mobile/org_units.py
@@ -135,9 +135,7 @@ class MobileOrgUnitViewSet(ModelViewSet):
         )
         include_geo_json = self.check_include_geo_json()
         if include_geo_json:
-            queryset = queryset.annotate(
-                geo_json=RawSQL("ST_AsGeoJson(COALESCE(simplified_geom, geom, location))::json", [])
-            )
+            queryset = queryset.annotate(geo_json=RawSQL("ST_AsGeoJson(COALESCE(simplified_geom, geom))::json", []))
         return queryset
 
     def get_serializer_context(self) -> Dict[str, Any]:

--- a/iaso/api/mobile/org_units.py
+++ b/iaso/api/mobile/org_units.py
@@ -65,7 +65,7 @@ class MobileOrgUnitViewSet(viewsets.ViewSet):
         if not app_id:
             return Response()
 
-        queryset = self.get_queryset().prefetch_related("parent", "org_unit_type")
+        queryset = self.get_queryset().order_by("path").prefetch_related("parent", "org_unit_type")
         queryset = queryset.select_related("org_unit_type")
         response = {}
 

--- a/iaso/api/mobile/org_units.py
+++ b/iaso/api/mobile/org_units.py
@@ -9,12 +9,12 @@ from rest_framework.response import Response
 from hat.api.export_utils import timestamp_to_utc_datetime
 from iaso.api.common import get_timestamp
 from iaso.api.common import safe_api_import
-from iaso.api.query_params import APP_ID, PAGE_SIZE, PAGE
+from iaso.api.query_params import APP_ID, LIMIT, PAGE
 from iaso.models import OrgUnit, Project
 
 
 class MobileOrgUnitsSetPagination(PageNumberPagination):
-    page_size_query_param = PAGE_SIZE
+    page_size_query_param = LIMIT
     page_query_param = PAGE
     page_size = None  # None to disable pagination by default.
 
@@ -48,9 +48,9 @@ class MobileOrgUnitViewSet(viewsets.ViewSet):
     GET /api/mobile/orgunits/
     POST /api/mobile/orgunits/
 
-    Optionally, {PAGE} and {PAGE_SIZE} parameters can be passed to paginate the results.
+    Optionally, {PAGE} and {LIMIT} parameters can be passed to paginate the results.
 
-    GET /api/mobile/orgunits?{PAGE}=1&{PAGE_SIZE}=100
+    GET /api/mobile/orgunits?{PAGE}=1&{LIMIT}=100
     """
 
     permission_classes = [HasOrgUnitPermission]

--- a/iaso/api/query_params.py
+++ b/iaso/api/query_params.py
@@ -1,4 +1,4 @@
 APP_ID = "app_id"
 APP_VERSION = "app_version"
-PAGE_SIZE = "page_size"
+LIMIT = "limit"
 PAGE = "page"

--- a/iaso/api/query_params.py
+++ b/iaso/api/query_params.py
@@ -1,2 +1,4 @@
 APP_ID = "app_id"
 APP_VERSION = "app_version"
+PAGE_SIZE = "page_size"
+PAGE = "page"

--- a/iaso/models/org_unit.py
+++ b/iaso/models/org_unit.py
@@ -372,11 +372,9 @@ class OrgUnit(TreeModel):
             "aliases": self.aliases,
         }
 
-    def get_valid_parent_id(self, default_to_none: bool = True):
+    def get_valid_parent_id(self):
         return (
-            self.parent_id
-            if self.parent is None or self.parent.validation_status == OrgUnit.VALIDATION_VALID
-            else (self.parent.get_valid_parent_id(default_to_none) if default_to_none is not True else None)
+            self.parent_id if self.parent is None or self.parent.validation_status == OrgUnit.VALIDATION_VALID else None
         )
 
     def as_dict(self, with_groups=True):

--- a/iaso/models/org_unit.py
+++ b/iaso/models/org_unit.py
@@ -368,6 +368,7 @@ class OrgUnit(TreeModel):
             "longitude": self.location.x if self.location else None,
             "altitude": self.location.z if self.location else None,
             "reference_instance_id": self.reference_instance_id if self.reference_instance else None,
+            "uuid": self.uuid,
             "aliases": self.aliases,
         }
 

--- a/iaso/models/org_unit.py
+++ b/iaso/models/org_unit.py
@@ -358,7 +358,7 @@ class OrgUnit(TreeModel):
         return {
             "name": self.name,
             "id": self.id,
-            "parent_id": self.get_valid_parent_id(),
+            "parent_id": self.parent_id,
             "org_unit_type_id": self.org_unit_type_id,
             "org_unit_type_name": self.org_unit_type.name if self.org_unit_type else None,
             "validation_status": self.validation_status if self.org_unit_type else None,
@@ -368,14 +368,8 @@ class OrgUnit(TreeModel):
             "longitude": self.location.x if self.location else None,
             "altitude": self.location.z if self.location else None,
             "reference_instance_id": self.reference_instance_id if self.reference_instance else None,
-            "uuid": self.uuid,
             "aliases": self.aliases,
         }
-
-    def get_valid_parent_id(self):
-        return (
-            self.parent_id if self.parent is None or self.parent.validation_status == OrgUnit.VALIDATION_VALID else None
-        )
 
     def as_dict(self, with_groups=True):
         res = {

--- a/iaso/models/org_unit.py
+++ b/iaso/models/org_unit.py
@@ -374,7 +374,7 @@ class OrgUnit(TreeModel):
     def get_valid_parent_id(self, default_to_none: bool = True):
         return (
             self.parent_id
-            if self.parent_id is None or self.parent.validation_status == OrgUnit.VALIDATION_VALID
+            if self.parent is None or self.parent.validation_status == OrgUnit.VALIDATION_VALID
             else (self.parent.get_valid_parent_id(default_to_none) if default_to_none is not True else None)
         )
 

--- a/iaso/models/org_unit.py
+++ b/iaso/models/org_unit.py
@@ -358,7 +358,7 @@ class OrgUnit(TreeModel):
         return {
             "name": self.name,
             "id": self.id,
-            "parent_id": self.parent_id,
+            "parent_id": self.get_valid_parent_id(),
             "org_unit_type_id": self.org_unit_type_id,
             "org_unit_type_name": self.org_unit_type.name if self.org_unit_type else None,
             "validation_status": self.validation_status if self.org_unit_type else None,
@@ -370,6 +370,13 @@ class OrgUnit(TreeModel):
             "reference_instance_id": self.reference_instance_id if self.reference_instance else None,
             "aliases": self.aliases,
         }
+
+    def get_valid_parent_id(self, default_to_none: bool = True):
+        return (
+            self.parent_id
+            if self.parent_id is None or self.parent.validation_status == OrgUnit.VALIDATION_VALID
+            else (self.parent.get_valid_parent_id(default_to_none) if default_to_none is not True else None)
+        )
 
     def as_dict(self, with_groups=True):
         res = {

--- a/iaso/tests/api/test_mobile_orgunits.py
+++ b/iaso/tests/api/test_mobile_orgunits.py
@@ -1,0 +1,125 @@
+from iaso.api.query_params import APP_ID, PAGE_SIZE, PAGE
+from iaso.models import Account, OrgUnit, OrgUnitType, Project, SourceVersion, DataSource
+from iaso.test import APITestCase
+
+BASE_URL = "/api/mobile/orgunits/"
+
+
+class MobileOrgUnitAPITestCase(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.account = account = Account.objects.create(name="Dragon Ball")
+        cls.project = project = Project.objects.create(name="Saiyans", app_id="dragon.ball.saiyans", account=account)
+        cls.user = user = cls.create_user_with_profile(username="user", account=account, permissions=["iaso_org_units"])
+        cls.sw_source = sw_source = DataSource.objects.create(name="Vegeta Planet")
+        sw_source.projects.add(project)
+        cls.sw_version = sw_version = SourceVersion.objects.create(data_source=sw_source, number=1)
+        account.default_version = sw_version
+        account.save()
+
+        cls.warriors = warriors = OrgUnitType.objects.create(name="Warriors")
+        warriors.projects.add(project)
+
+        cls.super_saiyans = super_saiyans = OrgUnitType.objects.create(name="Super Saiyans")
+        super_saiyans.projects.add(project)
+        warriors.sub_unit_types.add(super_saiyans)
+
+        cls.on_earth = on_earth = OrgUnitType.objects.create(name="Born on Earth")
+        on_earth.projects.add(project)
+        super_saiyans.sub_unit_types.add(on_earth)
+
+        cls.bardock = bardock = OrgUnit.objects.create(
+            parent=None,
+            org_unit_type=warriors,
+            version=sw_version,
+            name="Bardock",
+            validation_status=OrgUnit.VALIDATION_VALID,
+        )
+
+        cls.raditz = raditz = OrgUnit.objects.create(
+            parent=bardock,
+            org_unit_type=super_saiyans,
+            version=sw_version,
+            name="Raditz",
+            validation_status=OrgUnit.VALIDATION_VALID,
+        )
+
+        cls.goku = goku = OrgUnit.objects.create(
+            parent=bardock,
+            org_unit_type=super_saiyans,
+            version=sw_version,
+            name="Son Goku",
+            validation_status=OrgUnit.VALIDATION_REJECTED,
+        )
+
+        cls.gohan = OrgUnit.objects.create(
+            parent=goku,
+            org_unit_type=on_earth,
+            version=sw_version,
+            name="Son Gohan",
+            validation_status=OrgUnit.VALIDATION_VALID,
+        )
+
+        cls.goten = OrgUnit.objects.create(
+            parent=goku,
+            org_unit_type=on_earth,
+            version=sw_version,
+            name="Son Goten",
+            validation_status=OrgUnit.VALIDATION_VALID,
+        )
+
+        user.iaso_profile.org_units.set([raditz, goku])
+
+    def test_org_unit_have_correct_parent_id_without_limit(self):
+        self.client.force_authenticate(self.user)
+
+        response = self.client.get(BASE_URL, data={APP_ID: "dragon.ball.saiyans"})
+        self.assertJSONResponse(response, 200)
+        self.assertEqual([self.raditz.id, self.goku.id], response.json()["roots"])
+        self.assertNotIn("count", response.json())
+        self.assertNotIn("next", response.json())
+        self.assertNotIn("previous", response.json())
+        self.assertEqual(len(response.json()["orgUnits"]), 4)
+        self.assertEqual(response.json()["orgUnits"][0]["name"], "Bardock")
+        self.assertEqual(response.json()["orgUnits"][0]["parent_id"], None)
+        self.assertEqual(response.json()["orgUnits"][1]["name"], "Raditz")
+        self.assertEqual(response.json()["orgUnits"][1]["parent_id"], self.bardock.id)
+        self.assertEqual(response.json()["orgUnits"][2]["name"], "Son Gohan")
+        self.assertEqual(response.json()["orgUnits"][2]["parent_id"], None)
+        self.assertEqual(response.json()["orgUnits"][3]["name"], "Son Goten")
+        self.assertEqual(response.json()["orgUnits"][3]["parent_id"], None)
+
+    def test_org_unit_have_correct_parent_id_with_limit(self):
+        self.client.force_authenticate(self.user)
+
+        response = self.client.get(BASE_URL, data={APP_ID: "dragon.ball.saiyans", PAGE_SIZE: 1, PAGE: 1})
+        self.assertJSONResponse(response, 200)
+        self.assertEqual(response.json()["count"], 4)
+        self.assertEqual(response.json()["next"], 2)
+        self.assertEqual(response.json()["previous"], None)
+        self.assertEqual([self.raditz.id, self.goku.id], response.json()["roots"])
+        self.assertEqual(len(response.json()["orgUnits"]), 1)
+        self.assertEqual(response.json()["orgUnits"][0]["name"], "Bardock")
+        self.assertEqual(response.json()["orgUnits"][0]["parent_id"], None)
+
+        response = self.client.get(BASE_URL, data={APP_ID: "dragon.ball.saiyans", PAGE_SIZE: 1, PAGE: 2})
+        self.assertJSONResponse(response, 200)
+        self.assertEqual(response.json()["count"], 4)
+        self.assertEqual(response.json()["next"], 3)
+        self.assertEqual(response.json()["previous"], 1)
+        self.assertNotIn("roots", response.json())
+        self.assertEqual(len(response.json()["orgUnits"]), 1)
+        self.assertEqual(response.json()["orgUnits"][0]["name"], "Raditz")
+        self.assertEqual(response.json()["orgUnits"][0]["parent_id"], self.bardock.id)
+
+        response = self.client.get(BASE_URL, data={APP_ID: "dragon.ball.saiyans", PAGE_SIZE: 2, PAGE: 2})
+        self.assertJSONResponse(response, 200)
+        self.assertEqual(response.json()["count"], 4)
+        self.assertEqual(response.json()["next"], None)
+        self.assertEqual(response.json()["previous"], 1)
+        self.assertNotIn("roots", response.json())
+        self.assertEqual(len(response.json()["orgUnits"]), 2)
+        self.assertEqual(response.json()["orgUnits"][0]["name"], "Son Gohan")
+        self.assertEqual(response.json()["orgUnits"][0]["parent_id"], None)
+        self.assertEqual(response.json()["orgUnits"][1]["name"], "Son Goten")
+        self.assertEqual(response.json()["orgUnits"][1]["parent_id"], None)

--- a/iaso/tests/api/test_mobile_orgunits.py
+++ b/iaso/tests/api/test_mobile_orgunits.py
@@ -28,6 +28,13 @@ class MobileOrgUnitAPITestCase(APITestCase):
         on_earth.projects.add(project)
         super_saiyans.sub_unit_types.add(on_earth)
 
+        cls.raditz = raditz = OrgUnit.objects.create(
+            org_unit_type=super_saiyans,
+            version=sw_version,
+            name="Raditz",
+            validation_status=OrgUnit.VALIDATION_VALID,
+        )
+
         cls.bardock = bardock = OrgUnit.objects.create(
             parent=None,
             org_unit_type=warriors,
@@ -36,13 +43,8 @@ class MobileOrgUnitAPITestCase(APITestCase):
             validation_status=OrgUnit.VALIDATION_VALID,
         )
 
-        cls.raditz = raditz = OrgUnit.objects.create(
-            parent=bardock,
-            org_unit_type=super_saiyans,
-            version=sw_version,
-            name="Raditz",
-            validation_status=OrgUnit.VALIDATION_VALID,
-        )
+        raditz.parent = bardock
+        raditz.save()
 
         cls.goku = goku = OrgUnit.objects.create(
             parent=bardock,

--- a/iaso/tests/api/test_mobile_orgunits.py
+++ b/iaso/tests/api/test_mobile_orgunits.py
@@ -1,4 +1,4 @@
-from iaso.api.query_params import APP_ID, PAGE_SIZE, PAGE
+from iaso.api.query_params import APP_ID, LIMIT, PAGE
 from iaso.models import Account, OrgUnit, OrgUnitType, Project, SourceVersion, DataSource
 from iaso.test import APITestCase
 
@@ -94,7 +94,7 @@ class MobileOrgUnitAPITestCase(APITestCase):
     def test_org_unit_have_correct_parent_id_with_limit(self):
         self.client.force_authenticate(self.user)
 
-        response = self.client.get(BASE_URL, data={APP_ID: "dragon.ball.saiyans", PAGE_SIZE: 1, PAGE: 1})
+        response = self.client.get(BASE_URL, data={APP_ID: "dragon.ball.saiyans", LIMIT: 1, PAGE: 1})
         self.assertJSONResponse(response, 200)
         self.assertEqual(response.json()["count"], 4)
         self.assertEqual(response.json()["next"], 2)
@@ -104,7 +104,7 @@ class MobileOrgUnitAPITestCase(APITestCase):
         self.assertEqual(response.json()["orgUnits"][0]["name"], "Bardock")
         self.assertEqual(response.json()["orgUnits"][0]["parent_id"], None)
 
-        response = self.client.get(BASE_URL, data={APP_ID: "dragon.ball.saiyans", PAGE_SIZE: 1, PAGE: 2})
+        response = self.client.get(BASE_URL, data={APP_ID: "dragon.ball.saiyans", LIMIT: 1, PAGE: 2})
         self.assertJSONResponse(response, 200)
         self.assertEqual(response.json()["count"], 4)
         self.assertEqual(response.json()["next"], 3)
@@ -114,7 +114,7 @@ class MobileOrgUnitAPITestCase(APITestCase):
         self.assertEqual(response.json()["orgUnits"][0]["name"], "Raditz")
         self.assertEqual(response.json()["orgUnits"][0]["parent_id"], self.bardock.id)
 
-        response = self.client.get(BASE_URL, data={APP_ID: "dragon.ball.saiyans", PAGE_SIZE: 2, PAGE: 2})
+        response = self.client.get(BASE_URL, data={APP_ID: "dragon.ball.saiyans", LIMIT: 2, PAGE: 2})
         self.assertJSONResponse(response, 200)
         self.assertEqual(response.json()["count"], 4)
         self.assertEqual(response.json()["next"], None)

--- a/iaso/tests/api/test_mobile_orgunits.py
+++ b/iaso/tests/api/test_mobile_orgunits.py
@@ -97,9 +97,7 @@ class MobileOrgUnitAPITestCase(APITestCase):
 
         response = self.client.get(BASE_URL, data={APP_ID: BASE_APP_ID, LIMIT: 1, PAGE: 1})
         self.assertJSONResponse(response, 200)
-        self.assertEqual(response.json()["count"], 4)
-        self.assertEqual(response.json()["next"], self.get_page_url(1, 2))
-        self.assertEqual(response.json()["previous"], None)
+        self.assert_page(response.json(), count=4, limit=1, page=1, pages=4, has_next=True, has_previous=False)
         self.assertEqual([self.raditz.id, self.goku.id], response.json()["roots"])
         self.assertEqual(len(response.json()["orgUnits"]), 1)
         self.assertEqual(response.json()["orgUnits"][0]["name"], "Bardock")
@@ -107,9 +105,7 @@ class MobileOrgUnitAPITestCase(APITestCase):
 
         response = self.client.get(BASE_URL, data={APP_ID: BASE_APP_ID, LIMIT: 1, PAGE: 2})
         self.assertJSONResponse(response, 200)
-        self.assertEqual(response.json()["count"], 4)
-        self.assertEqual(response.json()["next"], self.get_page_url(1, 3))
-        self.assertEqual(response.json()["previous"], self.get_page_url(1, 1))
+        self.assert_page(response.json(), count=4, limit=1, page=2, pages=4, has_next=True, has_previous=True)
         self.assertNotIn("roots", response.json())
         self.assertEqual(len(response.json()["orgUnits"]), 1)
         self.assertEqual(response.json()["orgUnits"][0]["name"], "Raditz")
@@ -117,9 +113,7 @@ class MobileOrgUnitAPITestCase(APITestCase):
 
         response = self.client.get(BASE_URL, data={APP_ID: BASE_APP_ID, LIMIT: 2, PAGE: 2})
         self.assertJSONResponse(response, 200)
-        self.assertEqual(response.json()["count"], 4)
-        self.assertEqual(response.json()["next"], None)
-        self.assertEqual(response.json()["previous"], self.get_page_url(2, 1))
+        self.assert_page(response.json(), count=4, limit=2, page=2, pages=2, has_next=False, has_previous=True)
         self.assertNotIn("roots", response.json())
         self.assertEqual(len(response.json()["orgUnits"]), 2)
         self.assertEqual(response.json()["orgUnits"][0]["name"], "Son Gohan")
@@ -127,8 +121,10 @@ class MobileOrgUnitAPITestCase(APITestCase):
         self.assertEqual(response.json()["orgUnits"][1]["name"], "Son Goten")
         self.assertEqual(response.json()["orgUnits"][1]["parent_id"], None)
 
-    @staticmethod
-    def get_page_url(limit: int, page: int):
-        if page == 1:
-            return f"http://testserver/api/mobile/orgunits/?{APP_ID}={BASE_APP_ID}&{LIMIT}={limit}"
-        return f"http://testserver/api/mobile/orgunits/?{APP_ID}={BASE_APP_ID}&{LIMIT}={limit}&{PAGE}={page}"
+    def assert_page(self, json, count: int, limit: int, page: int, pages: int, has_next: bool, has_previous: bool):
+        self.assertEqual(json["count"], count)
+        self.assertEqual(json["limit"], limit)
+        self.assertEqual(json["page"], page)
+        self.assertEqual(json["pages"], pages)
+        self.assertEqual(json["has_next"], has_next)
+        self.assertEqual(json["has_previous"], has_previous)


### PR DESCRIPTION
We received a complaint that some devices cannot synchronize OrgUnits when they are too many.
As we couldn't reproduce, the assumptions are:
 - The list is too big in memory
 - The filtering that is done to remove the `parent_id` value of children for which the parent hasn't been returned is too consuming.

This PR allows 2 new parameters: `page_size`and `page`, to process the OrgUnit in smaller chunks.
Since we won't be able to remove the `parent_id` of children without parents with only part of the data, the removal is now done in the backend.

Therefore, this addresses both assumptions while still being backward compatible.

Related JIRA tickets: IA-1914

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new string have been introduced in the frontend
- [ ] My migrations file are included
- [X] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

The `/api/mobile/orgunits` endpoint is now capable of returning a paginated list.
The `parent_id` value of OrgUnits with a parent that has a `REJECTED` status is now set to `None`.

## How to test

Call `/api/mobile/orgunits?app_id=...` **before** applying the changes.
Call `/api/mobile/orgunits?app_id=...` **after** applying the changes.
The results should be the same

Then, call `/api/mobile/orgunits?app_id=...` with a `page_size` and `page` parameters and ensure the right chunk of the data has been returned.
