### PR TITLE
POLIO-864: hide test campaign for non admin users

### DIFF
--- a/plugins/polio/js/src/forms/BaseInfoForm.js
+++ b/plugins/polio/js/src/forms/BaseInfoForm.js
@@ -17,6 +17,8 @@ import { MultiSelect } from '../components/Inputs/MultiSelect.tsx';
 import MESSAGES from '../constants/messages';
 import { EmailListForCountry } from '../components/EmailListForCountry/EmailListForCountry';
 import { useGetGroupedCampaigns } from '../hooks/useGetGroupedCampaigns.ts';
+import { useCurrentUser } from '../../../../../hat/assets/js/apps/Iaso/utils/usersUtils.ts';
+import { userHasPermission } from '../../../../../hat/assets/js/apps/Iaso/domains/users/utils';
 
 export const baseInfoFormFields = [
     'epid',
@@ -40,6 +42,7 @@ export const BaseInfoForm = () => {
     const classes = useStyles();
 
     const { formatMessage } = useSafeIntl();
+    const currentUser = useCurrentUser();
     const { data: groupedCampaigns } = useGetGroupedCampaigns();
     const groupedCampaignsOptions = useMemo(
         () =>
@@ -133,12 +136,14 @@ export const BaseInfoForm = () => {
                         name="is_preventive"
                         component={BooleanInput}
                     />
-                    <Field
-                        className={classes.input}
-                        label={formatMessage(MESSAGES.testCampaign)}
-                        name="is_test"
-                        component={BooleanInput}
-                    />
+                    {userHasPermission('iaso_polio_config', currentUser) && (
+                        <Field
+                            className={classes.input}
+                            label={formatMessage(MESSAGES.testCampaign)}
+                            name="is_test"
+                            component={BooleanInput}
+                        />
+                    )}
                     <SendEmailButton />
                     <Field
                         className={classes.input}


### PR DESCRIPTION
hide test campaign for non admin users in main polio form

Related JIRA tickets :POLIO-864

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new string have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- Hide the option in the form is the user is nor super user or doesn't have `iaso_polio_config` permission (which is the admin permission for non-budget polio)

## How to test

- Go to polio as super user
- open or create a campaign
- Go to Base info tab
- You should see the check box for test campaigns
- Create a user without the "Polio admin" permission
- log in as this user
-  go to campaigns and open one
-  you shoudl not see the checkbox

## Print screen / video


https://user-images.githubusercontent.com/38907762/223700710-c93c1a39-c3c1-4b52-b229-f147fde54166.mov




