### PR TITLE
IA-1972 runiasodev sh script only launch dev server

### DIFF
--- a/runiasodev.sh
+++ b/runiasodev.sh
@@ -22,5 +22,10 @@ export PLUGINS="polio"
 set  -o allexport
 source .env
 
-./manage.py runserver
+# like this we can run any manage.py command and by default it will run the dev server
+if (( $# > 0 )); then
+    ./manage.py $@
+else
+    ./manage.py runserver
+fi
 set  +o allexport

--- a/runiasodev.sh
+++ b/runiasodev.sh
@@ -24,7 +24,7 @@ source .env
 
 # like this we can run any manage.py command and by default it will run the dev server
 if (( $# > 0 )); then
-    ./manage.py $@
+    ./manage.py "$@"
 else
     ./manage.py runserver
 fi


### PR DESCRIPTION
With the current `runiasodev.sh` script you can only launch the django devserver. This allows to run any django management command by giving an additional parameter to `runiasodev.sh`

Related JIRA tickets : IA-1972

## Self proofreading checklist

- [x] Is my code clear enough and well documented

## Changes

On `runiasodev.sh` was modified.

## How to test

You can try `runiasodev.sh showmigrations` for example.
