### PR TITLE
WC2-175: Storages, beneficiaries, move export buttons up

### DIFF
--- a/hat/assets/js/apps/Iaso/components/DownloadButtonsComponent.tsx
+++ b/hat/assets/js/apps/Iaso/components/DownloadButtonsComponent.tsx
@@ -21,12 +21,14 @@ type Props = {
     csvUrl?: string;
     xlsxUrl?: string;
     gpkgUrl?: string;
+    disabled?: boolean;
 };
 
 const DownloadButtonsComponent: FunctionComponent<Props> = ({
     csvUrl,
     xlsxUrl,
     gpkgUrl,
+    disabled = false,
 }) => {
     const classes = useDownloadButtonStyles();
     return (
@@ -37,6 +39,7 @@ const DownloadButtonsComponent: FunctionComponent<Props> = ({
                 className={classes.button}
                 color="primary"
                 href={csvUrl}
+                disabled={disabled}
             >
                 <CsvSvg />
                 CSV
@@ -47,6 +50,7 @@ const DownloadButtonsComponent: FunctionComponent<Props> = ({
                 className={classes.button}
                 color="primary"
                 href={xlsxUrl}
+                disabled={disabled}
             >
                 <ExcellSvg className={classes.icon} />
                 XLSX
@@ -58,6 +62,7 @@ const DownloadButtonsComponent: FunctionComponent<Props> = ({
                     className={classes.button}
                     color="primary"
                     href={gpkgUrl}
+                    disabled={disabled}
                 >
                     <PublicIcon className={classes.icon} />
                     GPKG

--- a/hat/assets/js/apps/Iaso/domains/entities/beneficiaries/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/beneficiaries/index.tsx
@@ -120,7 +120,14 @@ export const Beneficiaries: FunctionComponent<Props> = ({ params }) => {
             </TopBar>
             <Box p={4} className={classes.container}>
                 <Filters params={params} types={types || []} />
-
+                {!isFetching && (
+                    <Box display="flex" justifyContent="flex-end">
+                        <DownloadButtonsComponent
+                            csvUrl={`${apiUrl}&csv=true`}
+                            xlsxUrl={`${apiUrl}&xlsx=true`}
+                        />
+                    </Box>
+                )}
                 <Box position="relative" width="100%" mt={2}>
                     <Box
                         width="100%"
@@ -161,10 +168,6 @@ export const Beneficiaries: FunctionComponent<Props> = ({ params }) => {
                                 onTableParamsChange={p =>
                                     dispatch(redirectTo(baseUrl, p))
                                 }
-                            />
-                            <DownloadButtonsComponent
-                                csvUrl={`${apiUrl}&csv=true`}
-                                xlsxUrl={`${apiUrl}&xlsx=true`}
                             />
                         </Box>
                     )}

--- a/hat/assets/js/apps/Iaso/domains/entities/beneficiaries/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/beneficiaries/index.tsx
@@ -120,14 +120,13 @@ export const Beneficiaries: FunctionComponent<Props> = ({ params }) => {
             </TopBar>
             <Box p={4} className={classes.container}>
                 <Filters params={params} types={types || []} />
-                {!isFetching && (
-                    <Box display="flex" justifyContent="flex-end">
-                        <DownloadButtonsComponent
-                            csvUrl={`${apiUrl}&csv=true`}
-                            xlsxUrl={`${apiUrl}&xlsx=true`}
-                        />
-                    </Box>
-                )}
+                <Box display="flex" justifyContent="flex-end">
+                    <DownloadButtonsComponent
+                        csvUrl={`${apiUrl}&csv=true`}
+                        xlsxUrl={`${apiUrl}&xlsx=true`}
+                        disabled={isFetching}
+                    />
+                </Box>
                 <Box position="relative" width="100%" mt={2}>
                     <Box
                         width="100%"

--- a/hat/assets/js/apps/Iaso/domains/storages/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/storages/index.tsx
@@ -44,14 +44,13 @@ export const Storages: FunctionComponent<Props> = ({ params }) => {
             />
             <Box className={classes.containerFullHeightNoTabPadded}>
                 <Filters params={apiParams} />
-                {!isFetching && (
-                    <Box display="flex" justifyContent="flex-end" mt={2}>
-                        <DownloadButtonsComponent
-                            csvUrl={`${apiUrl}&csv=true`}
-                            xlsxUrl={`${apiUrl}&xlsx=true`}
-                        />
-                    </Box>
-                )}
+                <Box display="flex" justifyContent="flex-end" mt={2}>
+                    <DownloadButtonsComponent
+                        csvUrl={`${apiUrl}&csv=true`}
+                        xlsxUrl={`${apiUrl}&xlsx=true`}
+                        disabled={isFetching}
+                    />
+                </Box>
                 <TableWithDeepLink
                     baseUrl={baseUrl}
                     data={data?.results ?? []}

--- a/hat/assets/js/apps/Iaso/domains/storages/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/storages/index.tsx
@@ -44,6 +44,14 @@ export const Storages: FunctionComponent<Props> = ({ params }) => {
             />
             <Box className={classes.containerFullHeightNoTabPadded}>
                 <Filters params={apiParams} />
+                {!isFetching && (
+                    <Box display="flex" justifyContent="flex-end" mt={2}>
+                        <DownloadButtonsComponent
+                            csvUrl={`${apiUrl}&csv=true`}
+                            xlsxUrl={`${apiUrl}&xlsx=true`}
+                        />
+                    </Box>
+                )}
                 <TableWithDeepLink
                     baseUrl={baseUrl}
                     data={data?.results ?? []}
@@ -56,11 +64,6 @@ export const Storages: FunctionComponent<Props> = ({ params }) => {
                         dispatch(redirectToReplace(baseUrl, p))
                     }
                     extraProps={{ loading: isFetching }}
-                />
-
-                <DownloadButtonsComponent
-                    csvUrl={`${apiUrl}&csv=true`}
-                    xlsxUrl={`${apiUrl}&xlsx=true`}
                 />
             </Box>
         </>


### PR DESCRIPTION
Move export buttons before page result on those two pages

Related JIRA tickets : WC2-175

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new string have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

Moved and wrap buttons component before table on both pages

## How to test



Explain how to test your PR.

Visit Beneficiaries and storage page, check export buttons

## Print screen / video
![Screenshot 2023-03-08 at 14 28 40](https://user-images.githubusercontent.com/12494624/223726154-97a70027-6ab2-4a6f-bda4-9494511ad592.png)
![Screenshot 2023-03-08 at 14 28 33](https://user-images.githubusercontent.com/12494624/223726159-ce412813-dcad-408d-94db-73ea5d9219db.png)
