### PR TITLE
Polio 874 remove email alert if no data

### DIFF
--- a/plugins/polio/preparedness/warning_email.py
+++ b/plugins/polio/preparedness/warning_email.py
@@ -15,7 +15,7 @@ from plugins.polio.preparedness.summary import get_or_set_preparedness_cache_for
 
 def valid_indicator(x):
     if x is None:
-            return True
+        return True
     if isinstance(x, str):
         return x.strip() in ["NA", "N/A"]
     if not isinstance(x, (int, float)):

--- a/plugins/polio/preparedness/warning_email.py
+++ b/plugins/polio/preparedness/warning_email.py
@@ -14,9 +14,9 @@ from plugins.polio.preparedness.summary import get_or_set_preparedness_cache_for
 
 
 def valid_indicator(x):
-    if isinstance(x, str):
-        if x is None:
+    if x is None:
             return True
+    if isinstance(x, str):
         return x.strip() in ["NA", "N/A"]
     if not isinstance(x, (int, float)):
         return False

--- a/plugins/polio/preparedness/warning_email.py
+++ b/plugins/polio/preparedness/warning_email.py
@@ -15,6 +15,8 @@ from plugins.polio.preparedness.summary import get_or_set_preparedness_cache_for
 
 def valid_indicator(x):
     if isinstance(x, str):
+        if x is None:
+            return True
         return x.strip() in ["NA", "N/A"]
     if not isinstance(x, (int, float)):
         return False


### PR DESCRIPTION
When fields have no data they are included in the error email (false positive)

Related JIRA tickets :  POLIO-874

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new string have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- Changed `valid_indicator` to return `True` if its argument is `None`

## How to test

- Create a campaign with round dates in the future
- Either use the preparedness sheet linked in the ticket, or generate a new one
- If generating a new one: delete data in several cells
- in the terminal, run`docker-compose run iaso manage refresh_preparedness_data <obr-name>`
- The output should show you an email with no errors (see screenshot). Such emails are printed out in the console, but not sent. If the list of errors is not empty, there's a bug in this PR.


## Print screen / video

![Screenshot 2023-03-08 at 14 37 47](https://user-images.githubusercontent.com/38907762/223727253-42ba48b9-ccd0-4c3d-b9a9-ebc05c389a46.png)

