### PR TITLE
IA-1152 storage, team, orgunits deletion problems

### DIFF
--- a/iaso/management/commands/delete_accounts.py
+++ b/iaso/management/commands/delete_accounts.py
@@ -14,7 +14,7 @@ from django.db.models.functions import Cast
 from hat.audit.models import Modification
 from iaso.models import Account, OrgUnitType, CommentIaso, StoragePassword, StorageDevice, StorageLogEntry
 from iaso.models import BulkCreateUserCsvFile
-from iaso.models import ExportLog
+from iaso.models import ExportLog, ExportRequest
 from iaso.models.base import DataSource, ExternalCredentials, Instance, Mapping, Profile, InstanceFile
 from iaso.models.base import Task, QUEUED, KILLED
 from iaso.models.entity import Entity, EntityType
@@ -24,6 +24,7 @@ from iaso.models.org_unit import OrgUnit
 from iaso.models.pages import Page
 from iaso.models.project import Project
 
+from django_sql_dashboard.models import Dashboard
 
 def flatten(l):
     return [item for sublist in l for item in sublist]
@@ -356,6 +357,12 @@ class Command(BaseCommand):
             f.org_unit_types.clear()
             print("deleting hard", f.name)
             f.delete_hard()
+
+        print("sql dashboard", Dashboard.objects.all().delete())
+        
+        cursor.execute(
+                    "delete from iaso_exportrequest where id not in ( select export_request_id from iaso_exportstatus )"
+                )
 
         print("******* Deleting Modification (might take a while too)")
 

--- a/iaso/management/commands/delete_accounts.py
+++ b/iaso/management/commands/delete_accounts.py
@@ -12,7 +12,7 @@ from django.db.models import TextField
 from django.db.models.functions import Cast
 
 from hat.audit.models import Modification
-from iaso.models import Account, OrgUnitType, CommentIaso
+from iaso.models import Account, OrgUnitType, CommentIaso, StoragePassword, StorageDevice, StorageLogEntry
 from iaso.models import BulkCreateUserCsvFile
 from iaso.models import ExportLog
 from iaso.models.base import DataSource, ExternalCredentials, Instance, Mapping, Profile, InstanceFile
@@ -109,55 +109,69 @@ class Command(BaseCommand):
 
         projects = Project.objects.filter(account=account)
         for project in projects:
-            Form.objects.raw(
-                f"delete vector_control_apiimport where headers->>'QUERY_STRING' like 'app_id={project.app_id}%'"
-            )
-            forms = Form.objects_include_deleted.filter(projects__in=[project])
+            try:
+                Form.objects.raw(
+                    f"delete vector_control_apiimport where headers->>'QUERY_STRING' like 'app_id={project.app_id}%'"
+                )
+                forms = Form.objects_include_deleted.filter(projects__in=[project])
 
-            print(
-                "OrgUnit remove reference_instance",
-                OrgUnit.objects.filter(reference_instance__in=Instance.objects.filter(project=project)).update(
-                    reference_instance=None
-                ),
-            )
-            print("Instance update", Instance.objects.filter(project=project).update(entity=None))
-            print("Entity", Entity.objects.filter(account=account).delete())
-            print("EntityType", EntityType.objects.filter(account=account).delete())
-            print(
-                "InstanceFile delete",
-                InstanceFile.objects.filter(instance__in=Instance.objects.filter(project=project)).delete(),
-            )
-            print("Instance delete", Instance.objects.filter(project=project).delete())
-            print("InstanceFile delete", InstanceFile.objects.filter(instance__form__in=forms).delete())
-            print("Instance delete", Instance.objects.filter(form__in=forms).delete())
-            print("Mapping", Mapping.objects.filter(form__in=forms).delete())
-            print("Forms", [f.name for f in forms])
-            for f in forms:
-                try:
-                    print("Instance delete", Instance.objects.filter(form__in=forms).delete())
-                    f.delete_hard()
-                except:
-                    print("can't hard delete form ", f, "soft deleting")
-                    f.delete()
+                print(
+                    "OrgUnit remove reference_instance",
+                    OrgUnit.objects.filter(reference_instance__in=Instance.objects.filter(project=project)).update(
+                        reference_instance=None
+                    ),
+                )
+                print("Instance update", Instance.objects.filter(project=project).update(entity=None))
+                print("Entity", Entity.objects.filter(account=account).delete())
+                print("EntityType", EntityType.objects.filter(account=account).delete())
+                print(
+                    "InstanceFile delete",
+                    InstanceFile.objects.filter(instance__in=Instance.objects.filter(project=project)).delete(),
+                )
+                print("Instance delete", Instance.objects.filter(project=project).delete())
+                print("InstanceFile delete", InstanceFile.objects.filter(instance__form__in=forms).delete())
+                print("Instance delete", Instance.objects.filter(form__in=forms).delete())
+                print("Mapping", Mapping.objects.filter(form__in=forms).delete())
+                print("Forms", [f.name for f in forms])
+                for f in forms:
+                    try:
+                        print("Instance delete", Instance.objects.filter(form__in=forms).delete())
+                        f.delete_hard()
+                    except:
+                        print("can't hard delete form ", f, "soft deleting")
+                        f.delete()
 
-            print(
-                "Assignment",
-                Assignment.objects.filter(team__in=Team.objects.filter(project=project)).delete(),
-            )
-            print("Planning", Planning.objects.filter(project=project).delete())
-            print(
-                "Team children",
-                Team.objects.filter(parent__in=Team.objects.filter(project=project)).delete(),
-            )
-            print("Team", Team.objects.filter(project=project).delete())
+                print(
+                    "Assignment",
+                    Assignment.objects.filter(team__in=Team.objects.filter(project=project)).delete(),
+                )
+                print("Planning", Planning.objects.filter(project=project).delete())
+                print("Teams with parents")
 
-            datasources = project.data_sources.all()
-            for data_source in datasources:
-                print("missing related datasource", datasources)
-                print(InstanceFile.objects.filter(instance__org_unit__version__in=data_source.versions.all()).delete())
-                print(Instance.objects.filter(org_unit__version__in=data_source.versions.all()).delete())
-            print("datasources", datasources.delete())
-            print("project", project.delete())
+                teams = [t for t in Team.objects.order_by("path").all()]
+                teams.sort(key=lambda x: str(x.path).count("."), reverse=True)
+                # delete leafs before parents
+                for team in teams:
+                    print("Hard delete team", team, team.path)
+                    team.delete_hard()
+
+                datasources = project.data_sources.all()
+                for data_source in datasources:
+                    print("missing related datasource", datasources)
+                    print(
+                        InstanceFile.objects.filter(instance__org_unit__version__in=data_source.versions.all()).delete()
+                    )
+                    print(Instance.objects.filter(org_unit__version__in=data_source.versions.all()).delete())
+                print("deleting datasources might take awhile")
+                print("datasources", datasources.delete())
+                print("StoragePassword", StoragePassword.objects.filter(project=project).delete())
+                print("project", project.delete())
+            except Exception as err:
+                # Sometimes the "delete by project" don't because there are multiple projects sharing a common pyramid
+                # the statements outside this will try to take care of it
+                # that's why I'm catching the error, and give a chance to the next project and the code below
+                traceback.print_exception(type(err), err, err.__traceback__)
+                print("can't delete project", project, err, traceback.format_exc())
 
         forms = Form.objects_include_deleted.filter(projects__account=account)
         forms.delete()
@@ -186,6 +200,12 @@ class Command(BaseCommand):
             "Instance last_modified_by",
             Instance.objects.filter(last_modified_by__in=User.objects.filter(iaso_profile__account=account)).delete(),
         )
+
+        print(
+            "StorageLogEntry",
+            StorageLogEntry.objects.filter(device__in=StorageDevice.objects.filter(account=account)).delete(),
+        )
+        print("StorageDevice", StorageDevice.objects.filter(account=account).delete())
 
         print("Users", User.objects.filter(iaso_profile__account=account).delete())
 

--- a/iaso/management/commands/delete_accounts.py
+++ b/iaso/management/commands/delete_accounts.py
@@ -26,6 +26,7 @@ from iaso.models.project import Project
 
 from django_sql_dashboard.models import Dashboard
 
+
 def flatten(l):
     return [item for sublist in l for item in sublist]
 
@@ -359,10 +360,10 @@ class Command(BaseCommand):
             f.delete_hard()
 
         print("sql dashboard", Dashboard.objects.all().delete())
-        
+
         cursor.execute(
-                    "delete from iaso_exportrequest where id not in ( select export_request_id from iaso_exportstatus )"
-                )
+            "delete from iaso_exportrequest where id not in ( select export_request_id from iaso_exportstatus )"
+        )
 
         print("******* Deleting Modification (might take a while too)")
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -30,3 +30,6 @@ ignore_missing_imports = True
 
 [mypy-gspread.*]
 ignore_missing_imports = True
+
+[mypy-django_sql_dashboard.*]
+ignore_missing_imports = True


### PR DESCRIPTION
Produce tenant, adaptation for new models

Related JIRA tickets : [IA-1152](https://bluesquare.atlassian.net/browse/IA-1152)

## Self proofreading checklist


## Changes


   - teams :  the previous code only worked for "a team with a parent team", but the model allows much more deep nested levels : https://github.com/BLSQ/iaso/pull/433/files#diff-17cc21a7dcf6f0e29f91ccaeab14c9a708b87e990dbc0420730c3765aec8bff1R153-R158 
   - export request were not handled, now we only keep the one with export status/instances that are left in the db
   - dashboard sql : all deleted by default
   - StorageDevice, StorageLogEntry, StoragePassword are now handled
   - added a big try catch in the for project loop because some projects share some datasource/orgunits

## How to test

trust me or https://github.com/BLSQ/ops-runbooks/blob/main/local-hosting/iaso-produce-tenant-dump.md


[IA-1152]: https://bluesquare.atlassian.net/browse/IA-1152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ