### PR TITLE
IA-1326 Fix issue with EMPTY GEOM

### DIFF
--- a/iaso/gpkg/import_gpkg.py
+++ b/iaso/gpkg/import_gpkg.py
@@ -1,3 +1,4 @@
+import math
 import sqlite3
 from copy import deepcopy
 from typing import Dict, List, Optional, Tuple, Union
@@ -56,7 +57,12 @@ def convert_to_geography(geom_type: str, coordinates: list):
     geom_type = geom_type.lower()
     geom: Union[Point, MultiPolygon]
     if geom_type == "point":
+        if any(math.isnan(coordinate) for coordinate in coordinates):
+            # the lib return Nan for empty point, we don't want to store it in that case
+            # and geom.empty don't work at that point (it only work after we get it back from the db).
+            return None
         # For some reason point in iaso are in 3D
+
         if len(coordinates) == 2:
             geom = Point(*coordinates, z=0)  # type: ignore
         else:
@@ -67,6 +73,8 @@ def convert_to_geography(geom_type: str, coordinates: list):
         geom = MultiPolygon(*[Polygon(*coord) for coord in coordinates])
     else:
         raise Exception(f"Unhandled geom type {geom_type}")
+    if geom.empty:
+        return None
     return geom
 
 

--- a/iaso/models/org_unit.py
+++ b/iaso/models/org_unit.py
@@ -292,6 +292,11 @@ class OrgUnit(TreeModel):
                                     would be a burden, but the path needs to be set afterwards
         :param force_recalculate: use with caution - used to force recalculation of paths
         """
+        # work around https://code.djangoproject.com/ticket/33787
+        # where we had empty Z point in the database but couldn't save the OrgUnit back.
+        # because it was missing a dimension
+        if self.location is not None and self.location.empty:
+            self.location = None
 
         if skip_calculate_path:
             super().save(*args, **kwargs)

--- a/iaso/tests/models/test_org_unit.py
+++ b/iaso/tests/models/test_org_unit.py
@@ -1,3 +1,4 @@
+from django.contrib.gis.geos import Point
 from django.db import InternalError, connections
 
 from iaso import models as m
@@ -233,3 +234,15 @@ class OrgUnitModelDbTestCase(TestCase):
             "Constraint violation iaso_group_org_units_same_source_version_constraint",
         ):
             orgunit.groups.set([group])
+
+    def test_empty_geom(self):
+        #  regression test for IA-1326
+        ou = m.OrgUnit.objects.create(name="test", location=Point(float("nan"), float("nan"), z=0))
+
+        # DB return an empty 2D point, and not POINT Z EMPTY which is 3D
+        ous = m.OrgUnit.objects.filter(id=ou.id).extra(select={"raw_location": "ST_AsEWKT(location)"})
+        self.assertEqual("SRID=4326;POINT EMPTY", ous.first().raw_location)
+
+        ou.refresh_from_db()
+        ou.name = "test2"
+        ou.save()


### PR DESCRIPTION
we had OrgUnit with empty geom in the database that could not be edited anymore because they had the issue `Column has Z dimension but geometry does not`

they were created via the GPKG import or directly in the database by inserting a POINT Z EMPTY, but they couldn't be edited anymore from django because we got a 2d empty point in return.

After discussion with the geo type we decided that it's better to replace empty point with `null` value in database.

So this patch fix the issue by:
replacing Empty geom with None during GPKG import
Allow editing existing org unit by fixing their value in the save()



Related JIRA tickets : IA-1326

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [NA] Are my typescript files well typed
- [NA] New translations have been added or updated if new string have been introduced in the frontend
- [NA] My migrations file are included
- [x] Are there enough tests
- [NA] Documentation has been included (for new feature)

## How to test

Ask the geo team

## Notes
Don't know if we should bother doing a DB data migration for all the existing orgunit? It might help for bulk_update operation or other stuff that skip the save(), not sure if we have any. But on the other hand the migration might block because of the group trigger like the one which added source_updated_at