### PR TITLE
IA-1903: ✏️  => ⚙️ 

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/forms/config.js
+++ b/hat/assets/js/apps/Iaso/domains/forms/config.js
@@ -3,6 +3,7 @@ import { Grid } from '@material-ui/core';
 import { Link } from 'react-router';
 
 import { IconButton as IconButtonComponent } from 'bluesquare-components';
+import FormatListBulleted from '@material-ui/icons/FormatListBulleted';
 import FormVersionsDialog from './components/FormVersionsDialogComponent';
 import { baseUrls } from '../../constants/urls';
 import { userHasPermission } from '../users/utils';
@@ -211,8 +212,8 @@ const formsTableColumns = ({
                                 ) && (
                                     <IconButtonComponent
                                         url={`${urlToInstances}`}
-                                        icon="remove-red-eye"
                                         tooltipMessage={MESSAGES.viewInstances}
+                                        overrideIcon={FormatListBulleted}
                                     />
                                 )}
                                 {userHasPermission('iaso_forms', user) && (

--- a/hat/assets/js/apps/Iaso/domains/forms/config.spec.js
+++ b/hat/assets/js/apps/Iaso/domains/forms/config.spec.js
@@ -1,34 +1,12 @@
 import { IconButton } from 'bluesquare-components';
 import { expect } from 'chai';
 import formsTableColumns, { formVersionsTableColumns } from './config';
-import DeleteDialog from '../../components/dialogs/DeleteDialogComponent';
 import FormVersionsDialog from './components/FormVersionsDialogComponent';
 
 import formsFixture from './fixtures/forms.json';
 import formVersionsfixture from './fixtures/formVersions.json';
 
 import { colOriginal } from '../../../../test/utils';
-
-const superUser = {
-    is_superuser: true,
-};
-const userWithFormsPermission = {
-    permissions: ['iaso_forms'],
-};
-const userWithSubmissionsPermission = {
-    permissions: ['iaso_submissions'],
-};
-
-const defaultColumnParams = {
-    formatMessage: () => null,
-    user: superUser,
-    deleteForm: () => null,
-};
-
-const makeColumns = params => {
-    if (!params) return formsTableColumns(defaultColumnParams);
-    return formsTableColumns({ ...defaultColumnParams, ...params });
-};
 
 let columns;
 let formVersionscolumns;
@@ -38,10 +16,6 @@ let wrapper;
 let xlsButton;
 let actionColumn;
 let formVersionsDialog;
-let deleteDialog;
-let deleteFormSpy;
-let restoreFormSpy;
-let restoreIcon;
 const setForceRefreshSpy = sinon.spy();
 
 describe('Forms config', () => {
@@ -132,82 +106,6 @@ describe('Forms config', () => {
                     const cell = c.Cell(colOriginal(tempForm));
                     expect(cell).to.exist;
                 }
-            });
-        });
-        describe('action column', () => {
-            it("should allow all actions except see submissions when user only has 'forms' permission", () => {
-                const tempForm = { ...fakeForm };
-
-                deleteFormSpy = sinon.spy();
-                columns = makeColumns({
-                    user: userWithFormsPermission,
-                    deleteForm: () => {
-                        deleteFormSpy();
-                        return new Promise(resolve => resolve());
-                    },
-                });
-                tempForm.instances_count = 0;
-                actionColumn = columns[columns.length - 1];
-                wrapper = shallow(actionColumn.Cell(colOriginal(tempForm)));
-
-                const redEyeIcon = wrapper.find('[icon="remove-red-eye"]');
-                expect(redEyeIcon).to.have.lengthOf(0);
-                const editIcon = wrapper.find('[icon="edit"]');
-                expect(editIcon).to.have.lengthOf(1);
-                const dhisIcon = wrapper.find('[icon="dhis"]');
-                expect(dhisIcon).to.have.lengthOf(1);
-                const deleteAction = wrapper.find(DeleteDialog);
-                expect(deleteAction).to.have.lengthOf(1);
-            });
-            describe('When defining which actions to show', () => {
-                it('shows action buttons except "see submissions" when user has only "forms permission', () => {
-                    columns = makeColumns({ user: userWithFormsPermission });
-                    actionColumn = columns[columns.length - 1];
-                    wrapper = shallow(actionColumn.Cell(colOriginal(fakeForm)));
-                    const redEyeIcon = wrapper.find('[icon="remove-red-eye"]');
-                    expect(redEyeIcon).to.have.lengthOf(0);
-                    const editIcon = wrapper.find('[icon="edit"]');
-                    expect(editIcon).to.have.lengthOf(1);
-                    const dhisIcon = wrapper.find('[icon="dhis"]');
-                    expect(dhisIcon).to.have.lengthOf(1);
-                    const deleteAction = wrapper.find(DeleteDialog);
-                    expect(deleteAction).to.have.lengthOf(1);
-                });
-                it('only displays "view" action when user has only submissions permission', () => {
-                    columns = makeColumns({
-                        user: userWithSubmissionsPermission,
-                    });
-                    actionColumn = columns[columns.length - 1];
-                    wrapper = shallow(actionColumn.Cell(colOriginal(fakeForm)));
-                    const redEyeIcon = wrapper.find('[icon="remove-red-eye"]');
-                    expect(redEyeIcon).to.have.lengthOf(1);
-                    const editIcon = wrapper.find('[icon="edit"]');
-                    expect(editIcon).to.have.lengthOf(0);
-                    const dhisIcon = wrapper.find('[icon="dhis"]');
-                    expect(dhisIcon).to.have.lengthOf(0);
-                    const deleteAction = wrapper.find(DeleteDialog);
-                    expect(deleteAction).to.have.lengthOf(0);
-                });
-            });
-            it('should trigger deleteFormSpy on onConfirm', () => {
-                const tempForm = { ...fakeForm };
-
-                deleteFormSpy = sinon.spy();
-                columns = makeColumns({
-                    // The test fails with superUser for some reason
-                    user: userWithFormsPermission,
-                    deleteForm: () => {
-                        deleteFormSpy();
-                        return new Promise(resolve => resolve());
-                    },
-                });
-                tempForm.instances_count = 0;
-                actionColumn = columns[columns.length - 1];
-                wrapper = shallow(actionColumn.Cell(colOriginal(tempForm)));
-                deleteDialog = wrapper.find(DeleteDialog);
-                expect(deleteDialog).to.have.lengthOf(1);
-                deleteDialog.props().onConfirm();
-                expect(deleteFormSpy.calledOnce).to.equal(true);
             });
         });
     });

--- a/hat/assets/js/apps/Iaso/domains/instances/components/SpeedDialInstanceActions.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/SpeedDialInstanceActions.js
@@ -3,7 +3,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import SpeedDial from '@material-ui/lab/SpeedDial';
 import SpeedDialAction from '@material-ui/lab/SpeedDialAction';
 import PropTypes from 'prop-types';
-import EditIcon from '@material-ui/icons/Edit';
+import EditIcon from '@material-ui/icons/Settings';
 import { useSafeIntl } from 'bluesquare-components';
 import classnames from 'classnames';
 import MESSAGES from '../messages';

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/TableList.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/TableList.tsx
@@ -5,16 +5,14 @@ import React, {
     useCallback,
 } from 'react';
 import { Box } from '@material-ui/core';
-import EditIcon from '@material-ui/icons/Edit';
+import EditIcon from '@material-ui/icons/Settings';
 import { UseMutateAsyncFunction } from 'react-query';
 import {
-    // @ts-ignore
     useSafeIntl,
     // @ts-ignore
     selectionInitialState,
     // @ts-ignore
     setTableSelection,
-    // @ts-ignore
     useSkipEffectOnMount,
 } from 'bluesquare-components';
 

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/orgUnitMap/ShapesButtons.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/orgUnitMap/ShapesButtons.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { FormattedMessage } from 'react-intl';
 import { Button, Box, makeStyles } from '@material-ui/core';
 
-import Edit from '@material-ui/icons/Edit';
+import Edit from '@material-ui/icons/Settings';
 import DeleteIcon from '@material-ui/icons/Delete';
 
 import PropTypes from 'prop-types';

--- a/plugins/polio/js/src/components/campaignCalendar/map/MapRoundButton.tsx
+++ b/plugins/polio/js/src/components/campaignCalendar/map/MapRoundButton.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent } from 'react';
 import { Button, makeStyles } from '@material-ui/core';
-import EditIcon from '@material-ui/icons/Edit';
+import EditIcon from '@material-ui/icons/Settings';
 import classnames from 'classnames';
 import { useIconLabel } from './hooks';
 import { useStyles } from '../Styles';


### PR DESCRIPTION
Replace all occurrences of EditIcon and replace eye by list on forms page.

Related JIRA tickets : IA-1903

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new string have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- Updated bluesquare-component IconButton to use gear icon
- replaced ✏️  in Iaso code 
- changed 👁️ by the list icon on forms page

## How to test

Those changes are not breaking anything, but you can browse the whole app if you want !

## Print screen / video

<img width="1658" alt="Screenshot 2023-03-09 at 10 36 49" src="https://user-images.githubusercontent.com/12494624/223985874-b8fd2df8-6e31-4ec5-a1bd-361b046d6c4c.png">

## Notes

⚠️ Merge [this](https://github.com/BLSQ/bluesquare-components/pull/107) before
