### PR TITLE
IA-1974 download csv

### DIFF
--- a/django_sql_dashboard_export/README.md
+++ b/django_sql_dashboard_export/README.md
@@ -1,0 +1,5 @@
+Django app.
+
+Add an export for saved SQL dashboard.
+
+In a separate app for loading dependencies reason.

--- a/django_sql_dashboard_export/apps.py
+++ b/django_sql_dashboard_export/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class DjangoSqlDashboardExportConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "django_sql_dashboard_export"

--- a/django_sql_dashboard_export/templates/django_sql_dashboard/widgets/_base_widget.html
+++ b/django_sql_dashboard_export/templates/django_sql_dashboard/widgets/_base_widget.html
@@ -1,0 +1,8 @@
+<div class="query-results">
+  {% block widget_results %}{% endblock %}
+{%  if saved_dashboard  %}
+  <p>
+      <a href="export/?index={{ result.index }}&format=csv" >Download as CSV 📉</a>
+  </p>
+{% endif %}
+</div>

--- a/django_sql_dashboard_export/templates/django_sql_dashboard/widgets/default.html
+++ b/django_sql_dashboard_export/templates/django_sql_dashboard/widgets/default.html
@@ -1,0 +1,113 @@
+{% load django_sql_dashboard %}<div class="query-results" id="query-results-{{ result.index }}">
+  {% if saved_dashboard %}<details><summary style="cursor: pointer;">SQL query</summary><pre class="sql">{{ result.sql }}</pre>{% else %}<textarea
+    name="sql"
+    rows="{{ result.textarea_rows }}"
+  >{{ result.sql|default:"" }}</textarea>{% endif %}
+  {% if not saved_dashboard %}<p>
+    <input
+      class="btn"
+      type="submit"
+      value="Run quer{% if query_results|length > 1 %}ies{% else %}y{% endif %}"
+    />
+  </p>{% else %}</details>{% endif %}
+  {% if result.truncated %}
+    <p class="results-truncated">
+      Results were truncated
+      {% if user_can_export_data and not saved_dashboard %}
+        <input
+          class="btn"
+          style="font-size: 0.6rem"
+          type="submit"
+          name="export_csv_{{ result.index }}"
+          value="Export all as CSV"
+        />
+        <input
+          class="btn"
+          style="font-size: 0.6rem"
+          type="submit"
+          name="export_tsv_{{ result.index }}"
+          value="Export all as TSV"
+        />
+      {% endif %}
+    </p>
+  {% else %}
+    <p>{{ result.row_lists|length }} row{{ result.row_lists|length|pluralize }}</p>
+  {% endif %}
+  {% if result.error %}
+  <p style="background-color: pink; padding: 1em; margin: 1em 0">
+    {{ result.error }}
+  </p>
+  {% endif %}
+  <table>
+    <thead>
+      <tr>
+        {% for column in result.column_details %}
+          <th alt="{{ column.name }}"
+            {% if user_can_execute_sql and column.is_unambiguous and not too_long_so_use_post %}
+              data-count-url="{% url 'django_sql_dashboard-index' %}?sql={% filter sign_sql|urlencode %}select "{{ column.name }}", count(*) as n from ({{ result.sql|safe }}) as results group by "{{ column.name }}" order by n desc{% endfilter %}{{ result.extra_qs }}"
+              data-sort-asc-url="{% url 'django_sql_dashboard-index' %}?sql={% filter sign_sql|urlencode %}{{ column.sort_sql|safe }}{% endfilter %}{{ result.extra_qs }}"
+              data-sort-desc-url="{% url 'django_sql_dashboard-index' %}?sql={% filter sign_sql|urlencode %}{{ column.sort_desc_sql|safe }}{% endfilter %}{{ result.extra_qs }}"
+              data-count-distinct-url="{% url 'django_sql_dashboard-index' %}?sql={% filter sign_sql|urlencode %}select count(distinct "{{ column.name }}") from ({{ result.sql|safe }}) as results{% endfilter %}{{ result.extra_qs }}"
+            {% endif %}>{{ column.name }}</th>
+        {% endfor %}
+      </tr>
+    </thead>
+    <tbody>
+      {% for row in result.row_lists %}
+      <tr>
+        {% for item in row %}
+        <td>{% if item is None %}<span class="null">- null -</span>{% else %}{{ item|format_cell }}{% endif %}</td>
+        {% endfor %}
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  <details style="margin-top: 1em;"><summary style="font-size: 0.7em; margin-bottom: 0.5em; cursor: pointer;">Copy and export data</summary>
+    <textarea id="copyable-{{ result.index }}" style="height: 10em">{{ result|sql_dashboard_tsv }}</textarea>
+    {% if user_can_export_data and not saved_dashboard %}
+      <div class="export-buttons">
+        <input
+          class="btn"
+          type="submit"
+          name="export_csv_{{ result.index }}"
+          value="Export all as CSV"
+        />
+        <input
+          class="btn"
+          type="submit"
+          name="export_tsv_{{ result.index }}"
+          value="Export all as TSV"
+        />
+      </div>
+    {% endif %}
+  </details>
+  <p>Duration: {{ result.duration_ms|floatformat:2 }}ms</p>
+  {%  if saved_dashboard  %}
+  <p>
+      <a href="export/?index={{ result.index }}&format=csv" >Download as CSV 📉</a>
+  </p>
+{% endif %}
+  <!-- templates considered: {{ result.templates|join:", " }} -->
+  <script>
+  (function() {
+    var ta = document.querySelector("#copyable-{{ result.index }}");
+    var button = document.createElement("button");
+    button.className = "copyable-copy-button btn";
+    button.style.fontSize = '0.6em';
+    button.innerHTML = "Copy to clipboard";
+    button.onclick = (ev) => {
+      ev.preventDefault();
+      ta.select();
+      document.execCommand("copy");
+      button.innerHTML = "Copied!";
+      setTimeout(() => {
+          button.innerHTML = "Copy to clipboard";
+      }, 1500);
+    };
+    var p = document.createElement('p');
+    p.style.marginTop = '0.2em';
+    ta.insertAdjacentElement("afterend", p);
+    p.insertAdjacentElement("afterbegin", button);
+  })();
+  </script>
+</div>

--- a/django_sql_dashboard_export/tests.py
+++ b/django_sql_dashboard_export/tests.py
@@ -1,0 +1,47 @@
+from django.test import TestCase
+from django_sql_dashboard.models import Dashboard, DashboardQuery
+
+
+class ExportTestCase(TestCase):
+    databases = ["dashboard", "default"]
+
+    def test_download_csv(self):
+        dashboard = Dashboard.objects.create(
+            slug="my_dashboard", title="My little dashboard for export", view_policy=Dashboard.ViewPolicies.UNLISTED
+        )
+        query = DashboardQuery.objects.create(sql="select 1 as a, 'hello' as b", dashboard=dashboard)
+
+        r = self.client.get(f"/explore/my_dashboard/export/?index={query._order}&format=csv")
+        self.assertEqual(r.status_code, 200)
+        content = r.getvalue()
+        self.assertEqual(content, b"a,b\r\n1,hello\r\n")
+        self.assertEqual(r.headers["Content-Type"], "text/csv")
+        self.assertEqual(r.headers["Content-Disposition"], 'attachment; filename="my_dashboard_0.csv"')
+
+        self.assertEqual(content.decode("ascii"), "a,b\r\n1,hello\r\n")
+
+    def test_download_tsv(self):
+        dashboard = Dashboard.objects.create(
+            slug="my_dashboard", title="My little dashboard for export", view_policy=Dashboard.ViewPolicies.UNLISTED
+        )
+        query = DashboardQuery.objects.create(sql="select 1 as a, 'hello' as b", dashboard=dashboard)
+
+        r = self.client.get(f"/explore/my_dashboard/export/?index={query._order}&format=tsv")
+        self.assertEqual(r.status_code, 200)
+        content = r.getvalue()
+        self.assertEqual(r.headers["Content-Type"], "text/tab-separated-values")
+        self.assertEqual(r.headers["Content-Disposition"], 'attachment; filename="my_dashboard_0.tsv"')
+        self.assertEqual(content.decode("ascii"), """a\tb\r\n1\thello\r\n""")
+
+        self.assertEqual(content, b"a\tb\r\n1\thello\r\n")
+
+    def test_download_no_perm(self):
+        dashboard = Dashboard.objects.create(
+            slug="my_dashboard", title="My little dashboard for export", view_policy=Dashboard.ViewPolicies.PRIVATE
+        )
+        query = DashboardQuery.objects.create(sql="select 1 as a, 'hello' as b", dashboard=dashboard)
+
+        r = self.client.get(f"/explore/my_dashboard/export/?index={query._order}&format=csv")
+        self.assertEqual(r.status_code, 403)
+        content = r.getvalue()
+        self.assertEqual(content, b"You cannot access this dashboard")

--- a/django_sql_dashboard_export/tests.py
+++ b/django_sql_dashboard_export/tests.py
@@ -3,7 +3,7 @@ from django_sql_dashboard.models import Dashboard, DashboardQuery
 
 
 class ExportTestCase(TestCase):
-    databases = ["dashboard", "default"]
+    databases = {"dashboard", "default"}
 
     def test_download_csv(self):
         dashboard = Dashboard.objects.create(

--- a/django_sql_dashboard_export/views.py
+++ b/django_sql_dashboard_export/views.py
@@ -4,13 +4,22 @@ from io import StringIO
 from django.conf import settings
 from django.db import connections
 from django.http import HttpResponseForbidden, StreamingHttpResponse
-
-from django.shortcuts import render, get_object_or_404
+from django.shortcuts import get_object_or_404
+from django.views.decorators.http import require_safe
 from django_sql_dashboard.models import Dashboard
 from django_sql_dashboard.utils import extract_named_parameters
 
-
+# Changed to get to enable permalinking
+@require_safe
 def export_sql_results_for_dashboard(request, slug):
+    """Export a saved SQL Dashboard as a file
+
+    Parameters:
+        * index: Which query from the dashboard to export
+        * format: 'csv' or 'tsv'
+    """
+    if not getattr(settings, "DASHBOARD_ENABLE_FULL_EXPORT", None):
+        return HttpResponseForbidden("The export feature is not enabled")
     ## copy pasted from the report, to extract
     dashboard = get_object_or_404(Dashboard, slug=slug)
     # Can current user see it, based on view_policy?

--- a/django_sql_dashboard_export/views.py
+++ b/django_sql_dashboard_export/views.py
@@ -1,0 +1,97 @@
+import csv
+from io import StringIO
+
+from django.conf import settings
+from django.db import connections
+from django.http import HttpResponseForbidden, StreamingHttpResponse
+
+from django.shortcuts import render, get_object_or_404
+from django_sql_dashboard.models import Dashboard
+from django_sql_dashboard.utils import extract_named_parameters
+
+
+def export_sql_results_for_dashboard(request, slug):
+    ## copy pasted from the report, to extract
+    dashboard = get_object_or_404(Dashboard, slug=slug)
+    # Can current user see it, based on view_policy?
+    view_policy = dashboard.view_policy
+    owner = dashboard.owned_by
+    denied = HttpResponseForbidden("You cannot access this dashboard")
+    denied["cache-control"] = "private"
+    if view_policy == Dashboard.ViewPolicies.PRIVATE:
+        if request.user != owner:
+            return denied
+    elif view_policy == Dashboard.ViewPolicies.LOGGEDIN:
+        if not request.user.is_authenticated:
+            return denied
+    elif view_policy == Dashboard.ViewPolicies.GROUP:
+        if (not request.user.is_authenticated) or not (
+            request.user == owner or request.user.groups.filter(pk=dashboard.view_group_id).exists()
+        ):
+            return denied
+    elif view_policy == Dashboard.ViewPolicies.STAFF:
+        if (not request.user.is_authenticated) or (request.user != owner and not request.user.is_staff):
+            return denied
+    elif view_policy == Dashboard.ViewPolicies.SUPERUSER:
+        if (not request.user.is_authenticated) or (request.user != owner and not request.user.is_superuser):
+            return denied
+
+    format = request.GET.get("format", "csv")
+    sql_index = request.GET.get("index", 1)
+    assert format in ("csv", "tsv")  # TODO put nicer message
+
+    dashboard_query = get_object_or_404(dashboard.queries, _order=sql_index)
+    sql = dashboard_query.sql
+    parameter_values = {parameter: request.GET.get(parameter, "") for parameter in extract_named_parameters(sql)}
+    alias = getattr(settings, "DASHBOARD_DB_ALIAS", "dashboard")
+    # Decide on filename
+    filename = f"{dashboard.slug}_{sql_index}"
+    filename_plus_ext = f"{filename}.{format}"
+
+    connection = connections[alias]
+    connection.cursor()  # To initialize connection
+    cursor = connection.create_cursor(name="c" + filename.replace("-", "_"))
+
+    csvfile = StringIO()
+    csvwriter = csv.writer(
+        csvfile,
+        dialect={
+            "csv": csv.excel,
+            "tsv": csv.excel_tab,
+        }[format],
+    )
+
+    def read_and_flush():
+        csvfile.seek(0)
+        data = csvfile.read()
+        csvfile.seek(0)
+        csvfile.truncate()
+        return data
+
+    def rows():
+        try:
+            cursor.execute(sql, parameter_values)
+            done_header = False
+            while True:
+                records = cursor.fetchmany(size=2000)
+                if not done_header:
+                    csvwriter.writerow([r.name for r in cursor.description])
+                    yield read_and_flush()
+                    done_header = True
+                if not records:
+                    break
+                for record in records:
+                    csvwriter.writerow(record)
+                    yield read_and_flush()
+        finally:
+            cursor.close()
+
+    response = StreamingHttpResponse(
+        rows(),
+        content_type={
+            "csv": "text/csv",
+            "tsv": "text/tab-separated-values",
+        }[format],
+    )
+    response["Content-Disposition"] = 'attachment; filename="' + filename_plus_ext + '"'
+    return response

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - ./hat:/opt/app/hat
       - ./iaso:/opt/app/iaso
       - ./beanstalk_worker:/opt/app/beanstalk_worker
+      - ./django_sql_dashboard_export:/opt/app/django_sql_dashboard_export
       - ./media:/opt/app/media
       - ./plugins:/opt/app/plugins
       - ./scripts:/opt/app/scripts

--- a/hat/settings.py
+++ b/hat/settings.py
@@ -16,6 +16,7 @@ import hashlib
 import html
 import os
 import re
+import sys
 import urllib.parse
 from datetime import timedelta
 from typing import Dict, Any
@@ -199,7 +200,7 @@ CORS_ALLOW_CREDENTIALS = False
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
-        "DIRS": ["./hat/templates"],
+        "DIRS": ["./hat/templates", "./django_sql_dashboard_export/templates"],
         "APP_DIRS": True,
         "OPTIONS": {
             "context_processors": [
@@ -262,8 +263,17 @@ if os.environ.get("DB_READONLY_USERNAME"):
     }
 
     INSTALLED_APPS.append("django_sql_dashboard")
+    INSTALLED_APPS.append("django_sql_dashboard_export")
     # https://django-sql-dashboard.datasette.io/en/stable/setup.html#additional-settings
     DASHBOARD_ENABLE_FULL_EXPORT = True  # allow csv export on /explore
+elif "test" in sys.argv and DEBUG:
+    DATABASES["dashboard"] = DATABASES["default"]
+
+    INSTALLED_APPS.append("django_sql_dashboard")
+    INSTALLED_APPS.append("django_sql_dashboard_export")
+    # https://django-sql-dashboard.datasette.io/en/stable/setup.html#additional-settings
+    DASHBOARD_ENABLE_FULL_EXPORT = True  # allow csv export on /explore
+
 
 DATABASES["worker"] = DATABASES["default"].copy()
 DATABASE_ROUTERS = [

--- a/hat/settings.py
+++ b/hat/settings.py
@@ -267,6 +267,7 @@ if os.environ.get("DB_READONLY_USERNAME"):
     # https://django-sql-dashboard.datasette.io/en/stable/setup.html#additional-settings
     DASHBOARD_ENABLE_FULL_EXPORT = True  # allow csv export on /explore
 elif "test" in sys.argv and DEBUG:
+    # For when running unit test
     DATABASES["dashboard"] = DATABASES["default"]
 
     INSTALLED_APPS.append("django_sql_dashboard")

--- a/hat/urls.py
+++ b/hat/urls.py
@@ -10,7 +10,7 @@ from drf_yasg.views import get_schema_view
 from rest_framework import permissions
 
 from iaso.views import page, health
-from django_sql_dashboard_export.views import export_sql_results_for_dashboard
+
 
 admin.site.site_header = "Administration de Iaso"
 admin.site.site_title = "Iaso"
@@ -80,6 +80,8 @@ if settings.BEANSTALK_WORKER or settings.DEBUG:
     urlpatterns.append(path("tasks/", include("beanstalk_worker.urls")))
 
 if apps.is_installed("django_sql_dashboard"):
+    from django_sql_dashboard_export.views import export_sql_results_for_dashboard
+
     urlpatterns.append(path("explore/", include(django_sql_dashboard.urls)))
     urlpatterns.append(path("explore/<slug>/export/", export_sql_results_for_dashboard))
 

--- a/hat/urls.py
+++ b/hat/urls.py
@@ -1,4 +1,5 @@
 import django_sql_dashboard  # type: ignore
+from django.apps import apps
 from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin, auth
@@ -9,6 +10,7 @@ from drf_yasg.views import get_schema_view
 from rest_framework import permissions
 
 from iaso.views import page, health
+from django_sql_dashboard_export.views import export_sql_results_for_dashboard
 
 admin.site.site_header = "Administration de Iaso"
 admin.site.site_title = "Iaso"
@@ -77,8 +79,9 @@ urlpatterns = urlpatterns + [
 if settings.BEANSTALK_WORKER or settings.DEBUG:
     urlpatterns.append(path("tasks/", include("beanstalk_worker.urls")))
 
-if settings.DATABASES.get("dashboard"):
+if apps.is_installed("django_sql_dashboard"):
     urlpatterns.append(path("explore/", include(django_sql_dashboard.urls)))
+    urlpatterns.append(path("explore/<slug>/export/", export_sql_results_for_dashboard))
 
 urlpatterns.append(path("dashboard/", include("hat.dashboard.urls")))
 


### PR DESCRIPTION
Previously the sql dashboard at /explore didn't permit to download CSV export for saved dashboard. Now it can.
I made this work  as a permalink so we can link and reuse them somewhere else. Also I made a big prominent button.

Special care still need to be had, as for sharing regular SQL dashboard since this could leak data

Related JIRA tickets : IA-1974

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [NA] Are my typescript files well typed
- [NA] New translations have been added or updated if new string have been introduced in the frontend
- [NA] My migrations file are included
- [x] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes
I had to add a new app to prevent  import order issue and to keep code a bit clean.


## How to test

* Go to /explore create dashboard try differend sql query and  to download them as csv.
* try different sharing type and log in with different user  to check the permission

## Print screen / video

https://user-images.githubusercontent.com/82500/224717473-317802af-8bca-44b9-9563-c5e0ddb481f2.mp4



## Notes

We could probably upstream this at some point