### PR TITLE
POLIO-889:add missing arg to get_url_content in IM

### DIFF
--- a/plugins/polio/api.py
+++ b/plugins/polio/api.py
@@ -830,7 +830,12 @@ class IMStatsViewSet(viewsets.ViewSet):
                 .prefetch_related("parent")
             )
             district_dict = _build_district_cache(districts_qs)
-            forms = get_url_content(country_config["url"], country_config["login"], country_config["password"])
+            forms = get_url_content(
+                country_config["url"],
+                country_config["login"],
+                country_config["password"],
+                minutes=country_config.get("minutes", 60 * 24 * 10),
+            )
             debug_response = set()
             for form in forms:
                 form_count += 1


### PR DESCRIPTION
All IM requests return a 500

Related JIRA tickets : POLIO-889

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new string have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- Added a default value to the `minutes` arg. Copied the value used in LQAS.

## How to test

- Go to any IM page
- Select a country
- You shouldn't get a 500

## Print screen / video

![Screenshot 2023-03-14 at 17 16 05](https://user-images.githubusercontent.com/38907762/225069393-a3d5396c-a969-474c-a8a8-ce7744f61c16.png)

## Notes

This branch is just one commit ahead from the v1.194 release, so it can be deployed as a hotfix if needed
