### PR TITLE
Polio-856 budget email template for submitter team

### DIFF
--- a/plugins/polio/budget/models.py
+++ b/plugins/polio/budget/models.py
@@ -143,9 +143,11 @@ class MailTemplate(models.Model):
 
         workflow = get_workflow()
         transitions = next_transitions(workflow.transitions, campaign.budget_current_state_key)
+        # filter out repeat steps. I do it here so it's easy to remove
+        filtered_transitions = [transition for transition in transitions if "repeat" not in transition.key.split("_")]
 
         buttons = []
-        for transition in transitions:
+        for transition in filtered_transitions:
             transition_url_template = "/quickTransition/{transition_key}/previousStep/{step_id}"
             button_url = campaign_url + transition_url_template.format(transition_key=transition.key, step_id=step.id)
             # link that will auto auth

--- a/plugins/polio/templates/submitter_email.html
+++ b/plugins/polio/templates/submitter_email.html
@@ -1,0 +1,71 @@
+{% comment %}
+Base file to be reused in the MailTemplate for the budget workflow engine
+{% endcomment %}
+<!DOCTYPE HTML>
+<html lang={{ LANGUAGE_CODE }} xmlns="http://www.w3.org/1999/xhtml" xmlns:o="urn:schemas-microsoft-com:office:office">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="x-apple-disable-message-reformatting">
+  <meta http-equiv="Content-Type" content="text/html charset=UTF-8" />
+  <title></title>
+  <!--[if mso]>
+  <noscript>
+    <xml>
+      <o:OfficeDocumentSettings>
+        <o:PixelsPerInch>96</o:PixelsPerInch>
+      </o:OfficeDocumentSettings>
+    </xml>
+  </noscript>
+  <![endif]-->
+  <style>
+      table, td, div, h1, p {
+          font-family: Arial, sans-serif;
+      }
+
+      {% comment %} table, td {border:2px solid #000000 !important;} {% endcomment %}
+  </style>
+</head>
+<body style="margin:0;padding:0;width:100%;max-width:800px">
+{% block content %}
+  <table role="presentation"
+         style="width:100%;max-width:600px;border-collapse:collapse;border:0;border-spacing:0;background:#ffffff;">
+
+  <tr>
+    <td align="left" style="padding:5px;">
+        Thank you for your submission.
+    </td>
+  </tr>
+  <tr>
+    <td align="left" style="padding:5px;">
+      The NEW status of the POLIO campaign <strong>{{ campaign.obr_name }}</strong> has been updated to:  <strong>{{ node.label }}</strong> 
+    </td>
+  </tr>
+   <tr>
+    <td style="height:20px;padding:5px;font-size:0;line-height:0;">&nbsp;</td>
+  </tr>
+  <tr>
+    <td align="left" style="padding:5px;">
+        For additional information, please, consult the <a href="{{ budget_url }}">campaign page</a>.
+    </td>
+  <tr>
+ 
+{% endblock content %}
+<table role="presentation" style="width:100%;max-width:600px;">
+  <tr>
+    <td style="height:20px;padding:0;font-size:0;line-height:0;">&nbsp;</td>
+  </tr>
+  <tr>
+    <td align="left" style="padding:5px;">
+      <hr>
+    </td>
+  </tr>
+  <tr>
+    <td align="left" style="padding:5px;">
+      This is an automated email from <a href="{{ site_url }}">{{ site_name }}</a>
+    </td>
+  </tr>
+</table>
+</table>
+</body>
+</html>

--- a/plugins/polio/templates/submitter_email.txt
+++ b/plugins/polio/templates/submitter_email.txt
@@ -1,0 +1,11 @@
+{% block content %} {% block text %}
+Thank you for your submission.
+The NEW status of the POLIO campaign {{ campaign.obr_name }} has been updated to:{{ node.label }}
+{% endblock %}
+
+For additional information, please, consult the campaign page : {{ budget_url|safe }}
+
+{% endblock content %}
+
+============
+This is an automated email from {{ site_name }} - {{ site_url }}


### PR DESCRIPTION
We need a specific email without buttons for the team that created a step

Related JIRA tickets : POLIO-856

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new string have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- Add `submitter_email.html` and `submitter_email.txt`
- Filter out repeat steps in `MailTemplate.render_for_step`. This will avoid users to see the repeat step if they are both in the team that created the step and in another team (in which case they'll receive the normal email with buttons as well as the `submitter_email`, so that's why the repeat step is filtered out)

## How to test

Yay, setup time!

- You need a polio DB configured for budget: [wiki](https://wiki.bluesquare.org/en/Dev-team/product-management/iaso/polio_budget_workflow)
- You need to configure your backend to use smtp bucket: [wiki](https://wiki.bluesquare.org/en/Dev-team/product-management/iaso/email)
- You need to use [this config](https://drive.google.com/file/d/1c6s-_iDVs8Sk9j4XLH2oDpyNqUEiqwtq/view?usp=share_link) in the django admin

- Then (finally!), you can go to the campaign you want to edit and  create a step
- Then go to SMTP bucket. You should have 2 emails:
    - The `base_email` with the buttons for the next steps (but no repeat step)
    - The `submitter_email` 
    - Both emails should also have a txt version as fallback ("Raw" tab in smtp bucket)

## Print screen / video

base email:
![Screenshot 2023-03-15 at 18 03 23](https://user-images.githubusercontent.com/38907762/225385847-f4043518-92bf-4dd8-a41c-6b5aae5b71e1.png)


submitter email
![Screenshot 2023-03-15 at 18 02 57](https://user-images.githubusercontent.com/38907762/225385889-5f25569d-6b64-425b-bd85-c562fc2a82a3.png)



## Notes

Once this PR is merged, replace the config with [this one](https://drive.google.com/file/d/1c6s-_iDVs8Sk9j4XLH2oDpyNqUEiqwtq/view?usp=share_link).

The mail templates should also be updated in the django admin to include the `submitter_email`.
This should nbe done on campaigns-staging and staging