### PR TITLE
[IA-1982] Polio scopes should only show org units in valid status

### DIFF
--- a/plugins/polio/forma.py
+++ b/plugins/polio/forma.py
@@ -274,9 +274,9 @@ def get_forma_scope_df(campaigns):
             if districts.count() == 0:
                 logger.info(f"skipping {campaign}, no scope")
                 continue
-            facilities = OrgUnit.objects.filter(parent__in=districts)
-            regions = OrgUnit.objects.filter(parents_q(districts)).filter(path__depth=2)
-            countries = OrgUnit.objects.filter(parents_q(districts)).filter(path__depth=1)
+            facilities = OrgUnit.objects.filter(parent__in=districts).filter(status="VALID")
+            regions = OrgUnit.objects.filter(parents_q(districts)).filter(path__depth=2).filter(status="VALID")
+            countries = OrgUnit.objects.filter(parents_q(districts)).filter(path__depth=1).filter(status="VALID")
 
             for ous in [districts, facilities, regions, countries]:
                 scope_df = DataFrame.from_records(

--- a/plugins/polio/models.py
+++ b/plugins/polio/models.py
@@ -474,19 +474,25 @@ class Campaign(SoftDeletableModel):
 
     def get_districts_for_round(self, round):
         if self.separate_scopes_per_round:
-            districts = OrgUnit.objects.filter(groups__roundScope__round=round).distinct()
+            districts = (
+                OrgUnit.objects.filter(groups__roundScope__round=round).filter(validation_status="VALID").distinct()
+            )
         else:
             districts = self.get_campaign_scope_districts()
         return districts
 
     def get_campaign_scope_districts(self):
         # Get districts on campaign scope, make only sense if separate_scopes_per_round=True
-        return OrgUnit.objects.filter(groups__campaignScope__campaign=self)
+        return OrgUnit.objects.filter(groups__campaignScope__campaign=self).filter(validation_status="VALID")
 
     def get_all_districts(self):
         """District from all round merged as one"""
         if self.separate_scopes_per_round:
-            return OrgUnit.objects.filter(groups__roundScope__round__campaign=self).distinct()
+            return (
+                OrgUnit.objects.filter(groups__roundScope__round__campaign=self)
+                .filter(validation_status="VALID")
+                .distinct()
+            )
         return self.get_campaign_scope_districts()
 
     def last_surge(self):


### PR DESCRIPTION
To allow to hide some org units for polio, the scopes api should hide org units in status others than VALID
IA-1982


## Self proofreading checklist

- [x ] Did I use eslint and black formatters
- [ x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new string have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes
Just filtered on the status everywhere in the scope API

