### PR TITLE
Polio-879 move budget tab field

### DIFF
--- a/plugins/polio/js/src/constants/budget.ts
+++ b/plugins/polio/js/src/constants/budget.ts
@@ -29,10 +29,10 @@ export const RRT_REVIEW = [
     'submitted_to_rrt',
     'feedback_sent_to_gpei',
     're_submitted_to_rrt',
-    'submitted_to_orpg_operations1',
 ];
 
 export const ORPG_REVIEW = [
+    'submitted_to_orpg_operations1',
     'feedback_sent_to_rrt1',
     'submitted_to_orpg_wider',
     'submitted_to_orpg_operations2',


### PR DESCRIPTION
The input field Submitted to ORPG Ops(1) was not in the right section

Related JIRA tickets : POLIO-879

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new string have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- Updated the constant that defines the fields order

## How to test

Go to any polio campaign
Open the budget tab

## Print screen / video

![Screenshot 2023-03-16 at 13 20 28](https://user-images.githubusercontent.com/38907762/225615871-fef91263-7206-4e9e-a5d6-6e6c36de76c9.png)


## Notes

Merges into POLIO-849

Done in pair coding with @hakifran 
