### PR TITLE
POLIO-869: use translation for statuses

### DIFF
--- a/plugins/polio/js/src/components/campaignCalendar/popper/RoundPopper.js
+++ b/plugins/polio/js/src/components/campaignCalendar/popper/RoundPopper.js
@@ -11,6 +11,7 @@ import {
     Box,
 } from '@material-ui/core';
 import CloseIcon from '@material-ui/icons/Close';
+import { useSafeIntl } from 'bluesquare-components';
 
 import { useSelector } from 'react-redux';
 import MESSAGES from '../../../constants/messages';
@@ -42,6 +43,7 @@ const RoundPopper = ({
     round,
 }) => {
     const classes = useStyles();
+    const { formatMessage } = useSafeIntl();
     // We don't want to show the edit button if there is no connected user
     const isLogged = useSelector(state => Boolean(state.users.current));
     const id = open ? `campaign-popover-${campaign.id}-${round.id}` : undefined;
@@ -81,13 +83,24 @@ const RoundPopper = ({
                             <FormattedMessage {...MESSAGES.raStatus} />:
                         </Grid>
                         <Grid item sm={6} container justifyContent="flex-start">
-                            {campaign.original.risk_assessment_status}
+                            {campaign.original.risk_assessment_status
+                                ? formatMessage(
+                                      MESSAGES[
+                                          campaign.original
+                                              .risk_assessment_status
+                                      ],
+                                  )
+                                : ''}
                         </Grid>
                         <Grid item sm={6} container justifyContent="flex-end">
                             <FormattedMessage {...MESSAGES.budgetStatus} />:
                         </Grid>
                         <Grid item sm={6} container justifyContent="flex-start">
-                            {campaign.original.budget_status}
+                            {campaign.original.budget_status
+                                ? formatMessage(
+                                      MESSAGES[campaign.original.budget_status],
+                                  )
+                                : ''}
                         </Grid>
                         <Grid item sm={6} container justifyContent="flex-end">
                             <FormattedMessage {...MESSAGES.vaccine} />:

--- a/plugins/polio/js/src/components/campaignCalendar/popper/RoundPopper.js
+++ b/plugins/polio/js/src/components/campaignCalendar/popper/RoundPopper.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 
@@ -49,7 +49,10 @@ const RoundPopper = ({
     const id = open ? `campaign-popover-${campaign.id}-${round.id}` : undefined;
     const groupIds = groupsForCampaignRound(campaign, round).join(',');
     const url = `/api/orgunits/?csv=true&group=${groupIds}&app_id=com.poliooutbreaks.app`;
-
+    const getMessage = useCallback(
+        key => (MESSAGES[key] ? formatMessage(MESSAGES[key]) : key),
+        [formatMessage],
+    );
     return (
         <Popper
             id={id}
@@ -83,19 +86,15 @@ const RoundPopper = ({
                             <FormattedMessage {...MESSAGES.raStatus} />:
                         </Grid>
                         <Grid item sm={6} container justifyContent="flex-start">
-                            {formatMessage(
-                                MESSAGES[
-                                    campaign.original.risk_assessment_status
-                                ],
-                            ) ?? campaign.original.risk_assessment_status}
+                            {getMessage(
+                                campaign.original.risk_assessment_status,
+                            )}
                         </Grid>
                         <Grid item sm={6} container justifyContent="flex-end">
                             <FormattedMessage {...MESSAGES.budgetStatus} />:
                         </Grid>
                         <Grid item sm={6} container justifyContent="flex-start">
-                            {formatMessage(
-                                MESSAGES[campaign.original.budget_status],
-                            ) ?? campaign.original.budget_status}
+                            {getMessage(campaign.original.budget_status)}
                         </Grid>
                         <Grid item sm={6} container justifyContent="flex-end">
                             <FormattedMessage {...MESSAGES.vaccine} />:

--- a/plugins/polio/js/src/components/campaignCalendar/popper/RoundPopper.js
+++ b/plugins/polio/js/src/components/campaignCalendar/popper/RoundPopper.js
@@ -83,24 +83,19 @@ const RoundPopper = ({
                             <FormattedMessage {...MESSAGES.raStatus} />:
                         </Grid>
                         <Grid item sm={6} container justifyContent="flex-start">
-                            {campaign.original.risk_assessment_status
-                                ? formatMessage(
-                                      MESSAGES[
-                                          campaign.original
-                                              .risk_assessment_status
-                                      ],
-                                  )
-                                : ''}
+                            {formatMessage(
+                                MESSAGES[
+                                    campaign.original.risk_assessment_status
+                                ],
+                            ) ?? campaign.original.risk_assessment_status}
                         </Grid>
                         <Grid item sm={6} container justifyContent="flex-end">
                             <FormattedMessage {...MESSAGES.budgetStatus} />:
                         </Grid>
                         <Grid item sm={6} container justifyContent="flex-start">
-                            {campaign.original.budget_status
-                                ? formatMessage(
-                                      MESSAGES[campaign.original.budget_status],
-                                  )
-                                : ''}
+                            {formatMessage(
+                                MESSAGES[campaign.original.budget_status],
+                            ) ?? campaign.original.budget_status}
                         </Grid>
                         <Grid item sm={6} container justifyContent="flex-end">
                             <FormattedMessage {...MESSAGES.vaccine} />:


### PR DESCRIPTION
Keys for Budget status and Risk assessement status were not formatted in polio calendar

Related JIRA tickets : POLIO-869

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new string have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- use pass the statuses through `formatMessage`

## How to test

go to polio calendar
click on a round in the calendar (table)

## Print screen / video
![Screenshot 2023-03-16 at 13 40 56](https://user-images.githubusercontent.com/38907762/225620689-baebb69d-21fe-44ce-ab84-eabca1c1d5eb.png)


## Notes

Done in pair coding with @hakifran 
