### PR TITLE
IA-1984: Planning show org units without geo location

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/assignments/hooks/requests/useGetOrgUnits.ts
+++ b/hat/assets/js/apps/Iaso/domains/assignments/hooks/requests/useGetOrgUnits.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { UseQueryResult } from 'react-query';
 // @ts-ignore
 import { getRequest } from 'Iaso/libs/Api';
@@ -7,7 +7,7 @@ import { useSnackQuery } from 'Iaso/libs/apiHooks';
 
 import { makeUrlWithParams } from '../../../../libs/utils';
 
-import { OrgUnit } from '../../../orgUnits/types/orgUnit';
+import { OrgUnit, PaginatedOrgUnits } from '../../../orgUnits/types/orgUnit';
 
 import { BaseLocation, Locations } from '../../types/locations';
 import { Profile } from '../../../../utils/usersUtils';
@@ -48,7 +48,6 @@ const mapLocation = ({
             selected: [],
             unselected: [],
         },
-        all: [],
     };
     if (!orgUnits) return locations;
     orgUnits.forEach((orgUnit: OrgUnit) => {
@@ -63,7 +62,6 @@ const mapLocation = ({
                         ...baseLocation,
                         geoJson: orgUnit.geo_json,
                     };
-                    locations.all.push(shape);
                     locations.shapes.all.push(shape);
                     const orgUnitAssignation = getOrgUnitAssignation(
                         assignments,
@@ -105,7 +103,6 @@ const mapLocation = ({
                         latitude: orgUnit.latitude,
                         longitude: orgUnit.longitude,
                     };
-                    locations.all.push(marker);
                     locations.markers.all.push(marker);
                     const orgUnitAssignation = getOrgUnitAssignation(
                         assignments,
@@ -171,21 +168,22 @@ export const useGetOrgUnits = ({
     order,
     search,
 }: Props): UseQueryResult<Locations, Error> => {
-    const params: Record<string, any> = {
-        validation_status: 'VALID',
-        asLocation: true,
-        limit: 5000,
-        geography: 'any',
-        onlyDirectChildren: false,
-        page: 1,
-        withParents: true,
-        order,
-        orgUnitParentIds: orgUnitParentIds?.join(','),
-        orgUnitTypeId: baseOrgunitType,
-        search,
-    };
-
-    const url = makeUrlWithParams('/api/orgunits/', params);
+    const params: Record<string, any> = useMemo(
+        () => ({
+            validation_status: 'VALID',
+            asLocation: true,
+            limit: 5000,
+            geography: 'any',
+            onlyDirectChildren: false,
+            page: 1,
+            withParents: true,
+            order,
+            orgUnitParentIds: orgUnitParentIds?.join(','),
+            orgUnitTypeId: baseOrgunitType,
+            search,
+        }),
+        [baseOrgunitType, order, orgUnitParentIds, search],
+    );
 
     const select = useCallback(
         (orgUnits: OrgUnit[]) => {
@@ -213,16 +211,76 @@ export const useGetOrgUnits = ({
             currentType,
         ],
     );
-    return useSnackQuery(
-        ['orgUnits', params, baseOrgunitType],
-        () => getRequest(url),
-        undefined,
-        {
+    return useSnackQuery({
+        queryKey: ['orgUnits', params, baseOrgunitType],
+        queryFn: () => getRequest(makeUrlWithParams('/api/orgunits/', params)),
+        options: {
             enabled:
                 Boolean(params.orgUnitParentIds) && Boolean(baseOrgunitType),
             staleTime: 1000 * 60 * 15, // in MS
             cacheTime: 1000 * 60 * 5,
             select,
         },
+    });
+};
+
+type ListProps = {
+    orgUnitParentIds: number[] | undefined;
+    baseOrgunitType: string | undefined;
+    order?: string;
+    search?: string;
+};
+
+export const useGetOrgUnitsList = ({
+    orgUnitParentIds,
+    baseOrgunitType,
+    order,
+    search,
+}: ListProps): UseQueryResult<OrgUnit[], Error> => {
+    const params: Record<string, any> = useMemo(
+        () => ({
+            validation_status: 'VALID',
+            limit: 5000,
+            onlyDirectChildren: false,
+            page: 1,
+            withParents: true,
+            order,
+            orgUnitParentIds: orgUnitParentIds?.join(','),
+            orgUnitTypeId: baseOrgunitType,
+            search,
+        }),
+        [baseOrgunitType, order, orgUnitParentIds, search],
     );
+
+    const select = useCallback(
+        (data: PaginatedOrgUnits) => {
+            if (baseOrgunitType && orgUnitParentIds) {
+                const list: OrgUnit[] = [];
+                data.orgunits.forEach((orgUnit: OrgUnit) => {
+                    if (!orgUnitParentIds.find(ou => ou === orgUnit.id)) {
+                        if (
+                            parseInt(baseOrgunitType, 10) ===
+                            orgUnit.org_unit_type_id
+                        ) {
+                            list.push(orgUnit);
+                        }
+                    }
+                });
+                return list;
+            }
+            return [];
+        },
+        [baseOrgunitType, orgUnitParentIds],
+    );
+    return useSnackQuery({
+        queryKey: ['orgUnitsList', params, baseOrgunitType],
+        queryFn: () => getRequest(makeUrlWithParams('/api/orgunits/', params)),
+        options: {
+            enabled:
+                Boolean(params.orgUnitParentIds) && Boolean(baseOrgunitType),
+            staleTime: 1000 * 60 * 15, // in MS
+            cacheTime: 1000 * 60 * 5,
+            select,
+        },
+    });
 };

--- a/hat/assets/js/apps/Iaso/domains/assignments/hooks/requests/useSaveAssignment.ts
+++ b/hat/assets/js/apps/Iaso/domains/assignments/hooks/requests/useSaveAssignment.ts
@@ -21,6 +21,7 @@ export const useSaveAssignment = (): UseMutationResult => {
     const onSuccess = () => {
         queryClient.invalidateQueries('orgUnits');
         queryClient.invalidateQueries('assignmentsList');
+        queryClient.invalidateQueries('orgUnitsList');
     };
     return useSnackMutation({
         mutationFn: (data: SaveAssignmentQuery) => saveAssignment(data),
@@ -39,6 +40,7 @@ export const useBulkSaveAssignments = (): UseMutationResult => {
     const onSuccess = () => {
         queryClient.invalidateQueries('orgUnits');
         queryClient.invalidateQueries('assignmentsList');
+        queryClient.invalidateQueries('orgUnitsList');
     };
     return useSnackMutation({
         mutationFn: saveBulkAssignments,

--- a/hat/assets/js/apps/Iaso/domains/assignments/hooks/useGetAssignmentData.ts
+++ b/hat/assets/js/apps/Iaso/domains/assignments/hooks/useGetAssignmentData.ts
@@ -15,7 +15,7 @@ import {
 } from './requests/useSaveAssignment';
 import { useGetOrgUnitTypes } from './requests/useGetOrgUnitTypes';
 import { useGetOrgUnitsByParent } from './requests/useGetOrgUnitsByParent';
-import { useGetOrgUnits } from './requests/useGetOrgUnits';
+import { useGetOrgUnits, useGetOrgUnitsList } from './requests/useGetOrgUnits';
 import { useGetOrgUnitParentIds } from './useGetOrgUnitParentIds';
 import { useGetPlanning } from './requests/useGetPlanning';
 import {
@@ -24,6 +24,7 @@ import {
 } from './requests/useGetAssignments';
 
 import { useBoundState } from '../../../hooks/useBoundState';
+import { OrgUnit } from '../../orgUnits/types/orgUnit';
 
 type Props = {
     planningId: string;
@@ -48,8 +49,10 @@ type Result = {
     orgunitTypes: DropdownOptions<string>[] | undefined;
     childrenOrgunits: ChildrenOrgUnits | undefined;
     orgUnits: Locations | undefined;
+    orgUnitsList: OrgUnit[] | undefined;
     sidebarData: SubTeam[] | User[] | undefined;
     isFetchingOrgUnits: boolean;
+    isFetchingOrgUnitsList: boolean;
     isLoadingPlanning: boolean;
     isSaving: boolean;
     isFetchingOrgunitTypes: boolean;
@@ -134,7 +137,18 @@ export const useGetAssignmentData = ({
             order,
             search,
         });
-
+    const { data: orgUnitsList, isFetching: isFetchingOrgUnitsList } =
+        useGetOrgUnitsList({
+            orgUnitParentIds: useGetOrgUnitParentIds({
+                currentTeam,
+                allAssignments,
+                planning,
+                isLoadingAssignments,
+            }),
+            baseOrgunitType,
+            order,
+            search,
+        });
     const [orgUnits] = useBoundState<Locations | undefined>(
         undefined,
         dataOrgUnits,
@@ -184,8 +198,10 @@ export const useGetAssignmentData = ({
             orgunitTypes,
             childrenOrgunits,
             orgUnits,
+            orgUnitsList,
             sidebarData,
             isFetchingOrgUnits,
+            isFetchingOrgUnitsList,
             isLoadingPlanning,
             isSaving: isBulkSaving || isSaving,
             isFetchingOrgunitTypes,
@@ -203,12 +219,14 @@ export const useGetAssignmentData = ({
         isBulkSaving,
         isFetchingChildrenOrgunits,
         isFetchingOrgUnits,
+        isFetchingOrgUnitsList,
         isFetchingOrgunitTypes,
         isLoadingAssignments,
         isLoadingPlanning,
         isSaving,
         isTeamsFetched,
         orgUnits,
+        orgUnitsList,
         orgunitTypes,
         planning,
         profiles,

--- a/hat/assets/js/apps/Iaso/domains/assignments/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/assignments/index.tsx
@@ -86,8 +86,10 @@ export const Assignments: FunctionComponent<Props> = ({ params }) => {
         orgunitTypes,
         childrenOrgunits,
         orgUnits,
+        orgUnitsList,
         sidebarData,
         isFetchingOrgUnits,
+        isFetchingOrgUnitsList,
         isLoadingPlanning,
         isSaving,
         isFetchingOrgunitTypes,
@@ -335,14 +337,13 @@ export const Assignments: FunctionComponent<Props> = ({ params }) => {
                                             teams={teams || []}
                                             profiles={profiles}
                                             currentTeam={currentTeam}
-                                            orgUnits={orgUnits?.all || []}
+                                            orgUnits={orgUnitsList || []}
                                             handleSaveAssignment={
                                                 handleSaveAssignment
                                             }
                                             isFetchingOrgUnits={
                                                 isLoadingAssignments ||
-                                                isFetchingOrgUnits ||
-                                                !orgUnits
+                                                isFetchingOrgUnitsList
                                             }
                                             selectedItem={selectedItem}
                                         />

--- a/hat/assets/js/apps/Iaso/domains/assignments/types/locations.ts
+++ b/hat/assets/js/apps/Iaso/domains/assignments/types/locations.ts
@@ -32,7 +32,6 @@ type Selection<T> = {
 export type Locations = {
     shapes: Selection<OrgUnitShape>;
     markers: Selection<OrgUnitMarker>;
-    all: Array<OrgUnitShape | OrgUnitMarker>;
 };
 
 export type AssignmentUnit = OrgUnitShape | OrgUnitMarker | OrgUnit;

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/types/orgUnit.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/types/orgUnit.ts
@@ -1,5 +1,5 @@
 import { ReactNode } from 'react';
-import { UrlParams } from '../../../types/table';
+import { UrlParams, Pagination } from '../../../types/table';
 import { Shape } from './shapes';
 import { Nullable } from '../../../types/utils';
 import { Instance } from '../../instances/types/instance';
@@ -66,6 +66,9 @@ export type OrgUnit = {
     reference_instance_id: Nullable<number>;
     reference_instance: Instance;
 };
+export interface PaginatedOrgUnits extends Pagination {
+    orgunits: OrgUnit[];
+}
 
 export type OrgUnitParams = UrlParams & {
     locationLimit: string;


### PR DESCRIPTION
While navigating to a planning, the tab list of org units should also display org units without locations.

Related JIRA tickets : IA-1984

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are my typescript files well typed
- [ ] New translations have been added or updated if new string have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

Make a separate call to fetch org units list, including org unit without geo location

## How to test

Use a polio Data base using shapes with COUNTRY,REGIONS , DISTRICT, VILLAGES

Make sure you have at least a master team parent of another team of users.

Go to org units page and create an org unit without geo location, children of a COUNTRY and with REGION  as org unit type.
<img width="1916" alt="Screenshot 2023-03-17 at 10 48 04" src="https://user-images.githubusercontent.com/12494624/225870705-d002641e-7b4b-4588-b7c6-94bdb82a70ae.png">

Create a planning using the same COUNTRY (here GABON)
Make sure it's also using the master team.
<img width="1118" alt="Screenshot 2023-03-17 at 10 45 58" src="https://user-images.githubusercontent.com/12494624/225870036-7aec6381-90c7-4dc2-afd4-832e7ba065a7.png">

Open the view planning page and select REGION as base org unit type.
<img width="1918" alt="Screenshot 2023-03-17 at 10 41 05" src="https://user-images.githubusercontent.com/12494624/225870783-fbc767d1-3cc0-44b8-ba8b-804468e58a26.png">
You should see a map with list of REGIONS of GABON.
<img width="1887" alt="Screenshot 2023-03-17 at 10 50 05" src="https://user-images.githubusercontent.com/12494624/225870950-29ed03d1-a921-4530-8965-7d0f6425f7ab.png">

Click on list tab, the REGION we just created should be present (here CHILDREN WITHOUT LOCATION)
<img width="1920" alt="Screenshot 2023-03-17 at 10 51 51" src="https://user-images.githubusercontent.com/12494624/225871383-5aeb722e-bf07-46f8-a694-d93ec187ebfa.png">


