### PR TITLE
WC2-189: change traces_sample_rate value

### DIFF
--- a/hat/settings.py
+++ b/hat/settings.py
@@ -416,7 +416,11 @@ except Exception as e:
 
 if SENTRY_URL:
     sentry_sdk.init(
-        SENTRY_URL, traces_sample_rate=0.1, integrations=[DjangoIntegration()], send_default_pii=True, release=VERSION
+        SENTRY_URL,
+        traces_sample_rate=os.environ.get("SENTRY_TRACES_SAMPLE_RATE", 0.1),
+        integrations=[DjangoIntegration()],
+        send_default_pii=True,
+        release=VERSION,
     )
 
 # Workers configuration

--- a/hat/settings.py
+++ b/hat/settings.py
@@ -415,11 +415,11 @@ except Exception as e:
     VERSION = "undetected_version"
 
 if SENTRY_URL:
-    traces_sample_rate = os.environ.get("SENTRY_TRACES_SAMPLE_RATE", "0.1")
+    traces_sample_rate_str: str = os.environ.get("SENTRY_TRACES_SAMPLE_RATE", "0.1")
     try:
-        traces_sample_rate = float(traces_sample_rate)
+        traces_sample_rate = float(traces_sample_rate_str)
     except ValueError:
-        raise Exception(f"Error wrong SENTRY_TRACES_SAMPLE_RATE value {traces_sample_rate}, should be float")
+        raise Exception(f"Error wrong SENTRY_TRACES_SAMPLE_RATE value {traces_sample_rate_str}, should be float")
 
     sentry_sdk.init(
         SENTRY_URL,

--- a/hat/settings.py
+++ b/hat/settings.py
@@ -415,9 +415,15 @@ except Exception as e:
     VERSION = "undetected_version"
 
 if SENTRY_URL:
+    traces_sample_rate = os.environ.get("SENTRY_TRACES_SAMPLE_RATE", "0.1")
+    try:
+        traces_sample_rate = float(traces_sample_rate)
+    except ValueError:
+        raise Exception(f"Error wrong SENTRY_TRACES_SAMPLE_RATE value {traces_sample_rate}, should be float")
+
     sentry_sdk.init(
         SENTRY_URL,
-        traces_sample_rate=os.environ.get("SENTRY_TRACES_SAMPLE_RATE", 0.1),
+        traces_sample_rate=traces_sample_rate,
         integrations=[DjangoIntegration()],
         send_default_pii=True,
         release=VERSION,


### PR DESCRIPTION
WFP required to be able to change `traces_sample_rate` in settings.py.

Related JIRA tickets : WC2-189

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new string have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

Adding `SENTRY_TRACES_SAMPLE_RATE ` env variable to `settings.py`

## How to test

Not sure if we can test it before deploying it to wfp server. Matteao is adding the env variable on their side.
