### PR TITLE
IA-1985: submission detail infos text overflows

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -403,7 +403,7 @@
     "iaso.label.images": "Images",
     "iaso.label.infos": "Infos",
     "iaso.label.instanceLocks": "Instance locks",
-    "iaso.label.instanceStatus": "status",
+    "iaso.label.instanceStatus": "Status",
     "iaso.label.instanceStatus.duplicatedSingle": "duplicated",
     "iaso.label.instanceStatus.duplicateMulti": "Duplicated",
     "iaso.label.instanceStatus.error": "Error(s)",

--- a/hat/assets/js/apps/Iaso/domains/instances/components/InstanceDetailsField.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/InstanceDetailsField.js
@@ -17,6 +17,9 @@ const styles = theme => ({
         position: 'relative',
         top: 2,
     },
+    value: {
+        wordBreak: 'break-all',
+    },
 });
 
 const InstanceDetailsField = ({
@@ -54,6 +57,7 @@ const InstanceDetailsField = ({
                     variant="body1"
                     color="inherit"
                     title={valueTitle !== '' ? valueTitle : value}
+                    className={classes.value}
                 >
                     {renderValue && renderValue(value)}
                     {!renderValue && (value || textPlaceholder)}


### PR DESCRIPTION
IMEI id value in `InstanceDetailsField` overflowed from its container, it should go next line 

Related JIRA tickets : [IA-1985](https://bluesquare.atlassian.net/browse/IA-1985?atlOrigin=eyJpIjoiMjRiNmIxMTlhNGFjNDg5MzhlNTY2NzZiNTFkYzFhM2EiLCJwIjoiaiJ9)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new string have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- add `word-break: break-all` to force text stay in its container box

## How to test

- Go to Submissions
- view details of a submission

## Print screen / video

<img width="719" alt="Capture d’écran 2023-03-21 à 11 28 22" src="https://user-images.githubusercontent.com/25134301/226580245-7ab01980-9335-48d4-94ba-0a2a4e32d502.png">



[IA-1985]: https://bluesquare.atlassian.net/browse/IA-1985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ