### PR TITLE
WC2-187: move create version button

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/forms/components/FormVersionsComponent.js
+++ b/hat/assets/js/apps/Iaso/domains/forms/components/FormVersionsComponent.js
@@ -41,6 +41,25 @@ const FormVersionsComponent = ({
             >
                 <FormattedMessage {...MESSAGES.versions} />
             </Typography>
+            <Box
+                mb={2}
+                justifyContent="flex-end"
+                alignItems="center"
+                display="flex"
+            >
+                <FormVersionsDialog
+                    formId={formId}
+                    periodType={periodType}
+                    titleMessage={MESSAGES.createFormVersion}
+                    renderTrigger={({ openDialog }) => (
+                        <AddButtonComponent
+                            onClick={openDialog}
+                            message={MESSAGES.createFormVersion}
+                        />
+                    )}
+                    onConfirmed={() => setForceRefresh(true)}
+                />
+            </Box>
             <SingleTable
                 isFullHeight={false}
                 baseUrl={baseUrl}
@@ -79,22 +98,6 @@ const FormVersionsComponent = ({
                 forceRefresh={forceRefresh}
                 onForceRefreshDone={() => setForceRefresh(false)}
             />
-            <Box
-                mt={2}
-                justifyContent="flex-end"
-                alignItems="center"
-                display="flex"
-            >
-                <FormVersionsDialog
-                    formId={formId}
-                    periodType={periodType}
-                    titleMessage={MESSAGES.createFormVersion}
-                    renderTrigger={({ openDialog }) => (
-                        <AddButtonComponent onClick={openDialog} />
-                    )}
-                    onConfirmed={() => setForceRefresh(true)}
-                />
-            </Box>
         </Box>
     );
 };


### PR DESCRIPTION
Move create button  for  form versions from  under table to above to be inline with iaso design

Related JIRA tickets : WC2-187

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new string have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- Moved the button
- Changed the message to make clear that the button creates a version

## How to test

Go to forms list click on the gear icon for any form

## Print screen / video
![Screenshot 2023-03-21 at 14 52 14](https://user-images.githubusercontent.com/38907762/226627497-9292a335-a233-42cb-a9dc-a9d001005289.png)




