### PR TITLE
IA-1995 fix completness page dropdown for form

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/completenessStats/hooks/api/useGetFormsOptions.ts
+++ b/hat/assets/js/apps/Iaso/domains/completenessStats/hooks/api/useGetFormsOptions.ts
@@ -3,12 +3,16 @@ import { getRequest } from '../../../../libs/Api';
 import { useSnackQuery } from '../../../../libs/apiHooks';
 
 export const useGetFormsOptions = (
-    additionalFields?: string,
+    additionalFields?: string[],
 ): UseQueryResult => {
+    const fields = ['name', 'id'];
+    if (additionalFields) {
+        fields.push(...additionalFields);
+    }
     const params = {
         all: 'true',
         order: 'name',
-        fields: `name,id,${additionalFields ?? ''}`,
+        fields: fields.join(','),
     };
     const queryString = new URLSearchParams(params);
 

--- a/hat/assets/js/apps/Iaso/domains/entities/duplicates/list/DuplicatesFilters.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/duplicates/list/DuplicatesFilters.tsx
@@ -76,7 +76,7 @@ export const DuplicatesFilters: FunctionComponent<Props> = ({ params }) => {
         useGetBeneficiaryTypesDropdown();
 
     const { data: formsDropdown, isFetching: isFetchingForms } =
-        useGetFormsOptions('possible_fields');
+        useGetFormsOptions(['possible_fields']);
 
     const selectedForm = useMemo(() => {
         return (formsDropdown as any[])


### PR DESCRIPTION
Was broken when downloading values for the form
because of an empty fields parameter


Related JIRA tickets : IA-1995

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are my typescript files well typed
- [NA] New translations have been added or updated if new string have been introduced in the frontend
- [NA] My migrations file are included
- [obviously not or this would have been found] Are there enough tests
- [NA] Documentation has been included (for new feature)

## Changes

Now take an array as an arg. so it doesn't add an empty field name to the list

## How to test

open completeness page

