### PR TITLE
IA-1994: add missing validation icon

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitInfos.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitInfos.tsx
@@ -53,6 +53,7 @@ const getParentOrgUnit = (orgUnit: OrgUnit): Partial<OrgUnit> =>
         source_id: orgUnit.parent.source_id,
         parent: orgUnit.parent.parent,
         parent_name: orgUnit.parent.parent_name,
+        validation_status: orgUnit.parent.validation_status,
     };
 
 type Props = {


### PR DESCRIPTION
validation status icon wasn't showing in the `TruncatedTreeview` in `OrgUnitInfos`

Related JIRA tickets : IA-1994

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new string have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- The status wasn't passed when reformatting data with `getParentOrgUnit`. I added it

## How to test

Go to the details of any org unit, check that all org units in the parent input field have an icon

## Print screen / video

![Screenshot 2023-03-23 at 09 09 17](https://user-images.githubusercontent.com/38907762/227143082-a7f79937-6b2f-4982-b12a-c62b795ab550.png)


