### PR TITLE
WC2-179 calculate fields are not available in the forms workflow config

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/workflows/components/changes/SourceCell.tsx
+++ b/hat/assets/js/apps/Iaso/domains/workflows/components/changes/SourceCell.tsx
@@ -31,6 +31,7 @@ const supportedOptionsTypes = [
     'start',
     'end',
     'today',
+    'calculate',
 ];
 
 export const SourceCell: FunctionComponent<Props> = ({

--- a/hat/assets/js/apps/Iaso/domains/workflows/components/changes/TargetCell.tsx
+++ b/hat/assets/js/apps/Iaso/domains/workflows/components/changes/TargetCell.tsx
@@ -46,7 +46,9 @@ export const TargetCell: FunctionComponent<Props> = ({
         if (sourceKey && sourceType) {
             // only use target option of the same type as the source
             newOptions = newOptions.filter(
-                option => option.type === sourceType,
+                option =>
+                    option.type === sourceType ||
+                    (option.type === 'text' && sourceType === 'calculate'),
             );
         }
         // remove already selected options

--- a/iaso/api/workflows/serializers.py
+++ b/iaso/api/workflows/serializers.py
@@ -128,13 +128,11 @@ class WorkflowChangeCreateSerializer(serializers.Serializer):
             else:
                 r_type = q["type"]
 
-            print("r_type", r_type)
-            print("s_type", s_type)
-
-            if s_type == CALCULATE_TYPE and r_type != TEXT_TYPE:
-                raise serializers.ValidationError(
-                    f"Question {_source} is a 'calculate' question and cannot only be mapped to 'string' type, found : {r_type}"
-                )
+            if s_type == CALCULATE_TYPE:
+                if r_type != TEXT_TYPE:
+                    raise serializers.ValidationError(
+                        f"Question {_source} is a 'calculate' question and cannot only be mapped to 'string' type, found : {r_type}"
+                    )
             elif s_type != r_type:
                 raise serializers.ValidationError(f"Question {_source} and {_target} do not have the same type")
 

--- a/iaso/api/workflows/serializers.py
+++ b/iaso/api/workflows/serializers.py
@@ -12,6 +12,9 @@ from iaso.models import (
 )
 from iaso.models.workflow import WorkflowVersionsStatus
 
+CALCULATE_TYPE = "calculate"
+TEXT_TYPE = "text"
+
 
 class FormNestedSerializer(serializers.ModelSerializer):
     class Meta:
@@ -125,7 +128,14 @@ class WorkflowChangeCreateSerializer(serializers.Serializer):
             else:
                 r_type = q["type"]
 
-            if s_type != r_type:
+            print("r_type", r_type)
+            print("s_type", s_type)
+
+            if s_type == CALCULATE_TYPE and r_type != TEXT_TYPE:
+                raise serializers.ValidationError(
+                    f"Question {_source} is a 'calculate' question and cannot only be mapped to 'string' type, found : {r_type}"
+                )
+            elif s_type != r_type:
                 raise serializers.ValidationError(f"Question {_source} and {_target} do not have the same type")
 
         return mapping


### PR DESCRIPTION
Add possibility to create a "change" in a entity_type workflow that maps a "calculate" field (always) to a "text" field.

Related JIRA tickets : WC2-179

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented

## Changes

In the backend API for worfklow changes we add a special case for "calculate" fields.
In the frontend we modify so that if a calculate field is selected on one side it only shows text fields on the other dropdown.

## How to test

Open a entity type workflow (you will need a form with calculate fields) and select that form and try to map it

## Print screen / video

https://user-images.githubusercontent.com/383344/227157727-97a6afe6-25cd-40cc-9255-8c20db83e0fe.mov
