### PR TITLE
Polio 884 remove scopes from csv

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -403,7 +403,7 @@
     "iaso.label.images": "Images",
     "iaso.label.infos": "Infos",
     "iaso.label.instanceLocks": "Instance locks",
-    "iaso.label.instanceStatus": "status",
+    "iaso.label.instanceStatus": "Status",
     "iaso.label.instanceStatus.duplicatedSingle": "duplicated",
     "iaso.label.instanceStatus.duplicateMulti": "Duplicated",
     "iaso.label.instanceStatus.error": "Error(s)",

--- a/hat/assets/js/apps/Iaso/domains/forms/components/FormVersionsComponent.js
+++ b/hat/assets/js/apps/Iaso/domains/forms/components/FormVersionsComponent.js
@@ -41,6 +41,25 @@ const FormVersionsComponent = ({
             >
                 <FormattedMessage {...MESSAGES.versions} />
             </Typography>
+            <Box
+                mb={2}
+                justifyContent="flex-end"
+                alignItems="center"
+                display="flex"
+            >
+                <FormVersionsDialog
+                    formId={formId}
+                    periodType={periodType}
+                    titleMessage={MESSAGES.createFormVersion}
+                    renderTrigger={({ openDialog }) => (
+                        <AddButtonComponent
+                            onClick={openDialog}
+                            message={MESSAGES.createFormVersion}
+                        />
+                    )}
+                    onConfirmed={() => setForceRefresh(true)}
+                />
+            </Box>
             <SingleTable
                 isFullHeight={false}
                 baseUrl={baseUrl}
@@ -79,22 +98,6 @@ const FormVersionsComponent = ({
                 forceRefresh={forceRefresh}
                 onForceRefreshDone={() => setForceRefresh(false)}
             />
-            <Box
-                mt={2}
-                justifyContent="flex-end"
-                alignItems="center"
-                display="flex"
-            >
-                <FormVersionsDialog
-                    formId={formId}
-                    periodType={periodType}
-                    titleMessage={MESSAGES.createFormVersion}
-                    renderTrigger={({ openDialog }) => (
-                        <AddButtonComponent onClick={openDialog} />
-                    )}
-                    onConfirmed={() => setForceRefresh(true)}
-                />
-            </Box>
         </Box>
     );
 };

--- a/hat/assets/js/apps/Iaso/domains/instances/components/InstanceDetailsField.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/InstanceDetailsField.js
@@ -17,6 +17,9 @@ const styles = theme => ({
         position: 'relative',
         top: 2,
     },
+    value: {
+        wordBreak: 'break-all',
+    },
 });
 
 const InstanceDetailsField = ({
@@ -54,6 +57,7 @@ const InstanceDetailsField = ({
                     variant="body1"
                     color="inherit"
                     title={valueTitle !== '' ? valueTitle : value}
+                    className={classes.value}
                 >
                     {renderValue && renderValue(value)}
                     {!renderValue && (value || textPlaceholder)}

--- a/plugins/polio/api.py
+++ b/plugins/polio/api.py
@@ -28,10 +28,11 @@ from rest_framework import routers, filters, viewsets, serializers, permissions,
 from rest_framework.decorators import action
 from rest_framework.request import Request
 from rest_framework.response import Response
-from iaso.api.common import ModelViewSet, DeletionFilterBackend, CONTENT_TYPE_XLSX, CONTENT_TYPE_CSV
+from iaso.api.common import CSVExportMixin, ModelViewSet, DeletionFilterBackend, CONTENT_TYPE_XLSX, CONTENT_TYPE_CSV
 from iaso.models import OrgUnit
 from plugins.polio.serializers import (
     CountryUsersGroupSerializer,
+    ExportCampaignSerializer,
 )
 from plugins.polio.serializers import (
     OrgUnitSerializer,
@@ -92,7 +93,7 @@ class PolioOrgunitViewSet(ModelViewSet):
         return OrgUnit.objects.filter_for_user_and_app_id(self.request.user, self.request.query_params.get("app_id"))
 
 
-class CampaignViewSet(ModelViewSet):
+class CampaignViewSet(ModelViewSet, CSVExportMixin):
     """Main endpoint for campaign.
 
     GET (Anonymously too)
@@ -132,6 +133,8 @@ class CampaignViewSet(ModelViewSet):
     # in this case we use a restricted serializer with less field
     # notably not the url that we want to remain private.
     permission_classes = [permissions.IsAuthenticatedOrReadOnly]
+    exporter_serializer_class = ExportCampaignSerializer
+    export_filename = "campaigns_list_{date}.csv"
 
     def get_serializer_class(self):
         if self.request.user.is_authenticated:

--- a/plugins/polio/js/src/hooks/useGetCampaigns.ts
+++ b/plugins/polio/js/src/hooks/useGetCampaigns.ts
@@ -78,7 +78,6 @@ const useGetCampaignsOptions = (
             enabled: options.enabled ?? true,
             last_budget_event__status: options.last_budget_event__status,
             fieldset: asCsv ? undefined : options.fieldset ?? undefined,
-            format: asCsv ? 'csv' : undefined,
         }),
         [
             asCsv,
@@ -128,7 +127,7 @@ export const useGetCampaigns = (
 
 export const useGetCampaignsAsCsv = (
     options: Options = {},
-    url = '/api/polio/campaigns/',
+    url = '/api/polio/campaigns/export_csv/',
 ): string => {
     const params = useGetCampaignsOptions(options, true);
     return `${getURL(params, url)}`;

--- a/plugins/polio/serializers.py
+++ b/plugins/polio/serializers.py
@@ -1041,8 +1041,6 @@ class ExportCampaignSerializer(CampaignSerializer):
                     "wastage_ratio_forecast",
                 ]
 
-      
-
         class Meta:
             model = Round
             fields = [
@@ -1084,11 +1082,12 @@ class ExportCampaignSerializer(CampaignSerializer):
                 "forma_date",
                 "forma_comment",
             ]
+
         scopes = NestedRoundScopeSerializer(many=True, required=False)
         vaccines = NestedRoundVaccineSerializer(many=True, required=False)
         shipments = NestedShipmentSerializer(many=True, required=False)
         destructions = NestedDestructionSerializer(many=True, required=False)
-        
+
     class ExportCampaignScopeSerializer(CampaignScopeSerializer):
         class Meta:
             model = CampaignScope

--- a/plugins/polio/serializers.py
+++ b/plugins/polio/serializers.py
@@ -1000,3 +1000,173 @@ class CampaignGroupSerializer(serializers.ModelSerializer):
 
     campaigns = CampaignNameSerializer(many=True, read_only=True)
     campaigns_ids = serializers.PrimaryKeyRelatedField(many=True, queryset=Campaign.objects.all(), source="campaigns")
+
+
+class ExportCampaignSerializer(CampaignSerializer):
+    class NestedRoundSerializer(RoundSerializer):
+        class NestedRoundScopeSerializer(RoundScopeSerializer):
+            class Meta:
+                model = RoundScope
+                fields = ["vaccine"]
+
+        class NestedShipmentSerializer(ShipmentSerializer):
+            class Meta:
+                model = Shipment
+                fields = [
+                    "vaccine_name",
+                    "po_numbers",
+                    "vials_received",
+                    "estimated_arrival_date",
+                    "reception_pre_alert",
+                    "date_reception",
+                    "comment",
+                ]
+
+        class NestedDestructionSerializer(DestructionSerializer):
+            class Meta:
+                model = Destruction
+                fields = [
+                    "vials_destroyed",
+                    "date_report_received",
+                    "date_report",
+                    "comment",
+                ]
+
+        class NestedRoundVaccineSerializer(RoundVaccineSerializer):
+            class Meta:
+                model = RoundVaccine
+                fields = [
+                    "name",
+                    "doses_per_vial",
+                    "wastage_ratio_forecast",
+                ]
+
+      
+
+        class Meta:
+            model = Round
+            fields = [
+                "scopes",
+                "vaccines",
+                "shipments",
+                "destructions",
+                "number",
+                "started_at",
+                "ended_at",
+                "mop_up_started_at",
+                "mop_up_ended_at",
+                "im_started_at",
+                "im_ended_at",
+                "lqas_started_at",
+                "lqas_ended_at",
+                "target_population",
+                "doses_requested",
+                "cost",
+                "im_percentage_children_missed_in_household",
+                "im_percentage_children_missed_out_household",
+                "im_percentage_children_missed_in_plus_out_household",
+                "awareness_of_campaign_planning",
+                "main_awareness_problem",
+                "lqas_district_passing",
+                "lqas_district_failing",
+                "preparedness_spreadsheet_url",
+                "preparedness_sync_status",
+                "date_signed_vrf_received",
+                "date_destruction",
+                "vials_destroyed",
+                "reporting_delays_hc_to_district",
+                "reporting_delays_district_to_region",
+                "reporting_delays_region_to_national",
+                "forma_reception",
+                "forma_missing_vials",
+                "forma_usable_vials",
+                "forma_unusable_vials",
+                "forma_date",
+                "forma_comment",
+            ]
+        scopes = NestedRoundScopeSerializer(many=True, required=False)
+        vaccines = NestedRoundVaccineSerializer(many=True, required=False)
+        shipments = NestedShipmentSerializer(many=True, required=False)
+        destructions = NestedDestructionSerializer(many=True, required=False)
+        
+    class ExportCampaignScopeSerializer(CampaignScopeSerializer):
+        class Meta:
+            model = CampaignScope
+            fields = ["vaccine"]
+
+    rounds = NestedRoundSerializer(many=True, required=False)
+    scopes = ExportCampaignScopeSerializer(many=True, required=False)
+
+    class Meta:
+        model = Campaign
+        fields = [
+            "obr_name",
+            "rounds",
+            "scopes",
+            "gpei_coordinator",
+            "gpei_email",
+            "description",
+            "initial_org_unit",
+            "country",
+            "creation_email_send_at",
+            "onset_at",
+            "three_level_call_at",
+            "cvdpv_notified_at",
+            "cvdpv2_notified_at",
+            "pv_notified_at",
+            "pv2_notified_at",
+            "virus",
+            "vacine",
+            "detection_status",
+            "detection_responsible",
+            "detection_first_draft_submitted_at",
+            "detection_rrt_oprtt_approval_at",
+            "risk_assessment_status",
+            "risk_assessment_responsible",
+            "investigation_at",
+            "risk_assessment_first_draft_submitted_at",
+            "risk_assessment_rrt_oprtt_approval_at",
+            "ag_nopv_group_met_at",
+            "dg_authorized_at",
+            "verification_score",
+            "doses_requested",
+            "surge_spreadsheet_url",
+            "country_name_in_surge_spreadsheet",
+            "budget_status",
+            "is_test",
+            "budget_current_state_key",
+            "budget_current_state_label",
+            "who_sent_budget_at_WFEDITABLE",
+            "unicef_sent_budget_at_WFEDITABLE",
+            "gpei_consolidated_budgets_at_WFEDITABLE",
+            "submitted_to_rrt_at_WFEDITABLE",
+            "feedback_sent_to_gpei_at_WFEDITABLE",
+            "re_submitted_to_rrt_at_WFEDITABLE",
+            "submitted_to_orpg_operations1_at_WFEDITABLE",
+            "feedback_sent_to_rrt1_at_WFEDITABLE",
+            "re_submitted_to_orpg_operations1_at_WFEDITABLE",
+            "submitted_to_orpg_wider_at_WFEDITABLE",
+            "submitted_to_orpg_operations2_at_WFEDITABLE",
+            "feedback_sent_to_rrt2_at_WFEDITABLE",
+            "re_submitted_to_orpg_operations2_at_WFEDITABLE",
+            "submitted_for_approval_at_WFEDITABLE",
+            "feedback_sent_to_orpg_operations_unicef_at_WFEDITABLE",
+            "feedback_sent_to_orpg_operations_who_at_WFEDITABLE",
+            "approved_by_who_at_WFEDITABLE",
+            "approved_by_unicef_at_WFEDITABLE",
+            "approved_at_WFEDITABLE",
+            "approval_confirmed_at_WFEDITABLE",
+            "who_disbursed_to_co_at",
+            "who_disbursed_to_moh_at",
+            "unicef_disbursed_to_co_at",
+            "unicef_disbursed_to_moh_at",
+            "eomg",
+            "no_regret_fund_amount",
+            "payment_mode",
+            "created_at",
+            "updated_at",
+            "district_count",
+            "is_preventive",
+            "enable_send_weekly_email",
+        ]
+        read_only_fields = fields


### PR DESCRIPTION
CSV export of campaigns had too many columns

Related JIRA tickets :  POLIO-884

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new string have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- Use `CSVExportMixin`  to manage csv export and create specific endpoint (as opposed as just passing `format=csv` to the regular endpoint)
- Remove `round_one` and `round_two` from the export
- Remove `groups` from the scopes for the export (still exporting the vaccine though)
- Add Missing fields from the Vaccine management tab to the export: destructions, vaccines (for rounds) and shipments
- Changed the url used by the front-end to do the export

## How to test

- Go to polio
- click the csv button:
     - The csv should not have so many columns that Excel, LibreOffice, whatever complains about it
     - You should not have the `round_one` and `round_two`fields
     - If scope exists either at campign or round level, you should only have the vaccine field in the csv 
     - If you have active filters, they should apply to the results in the csv (eg: filter by country)

## Print screen / video

https://user-images.githubusercontent.com/38907762/227534511-7cd114f0-15d6-4846-ac42-7c5a93876fb2.mov


## Notes

Merges into https://github.com/BLSQ/iaso/pull/471
