### PR TITLE
WC2-195: Workflow follow-ups, add greater_or_equal and less_or_equal operators

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/forms/fields/hooks/useGetQueryBuildersFields.ts
+++ b/hat/assets/js/apps/Iaso/domains/forms/fields/hooks/useGetQueryBuildersFields.ts
@@ -17,12 +17,13 @@ const findDescriptorInChildren = (field, descriptor) =>
 export const useGetQueryBuildersFields = (
     formDescriptors?: FormDescriptor[],
     possibleFields?: PossibleField[],
+    configFields: Field[] = iasoFields,
 ): QueryBuilderFields => {
     if (!possibleFields || !formDescriptors) return {};
     // you can fields examples here: https://codesandbox.io/s/github/ukrbublik/react-awesome-query-builder/tree/master/sandbox?file=/src/demo/config.tsx:1444-1464
     const fields: QueryBuilderFields = {};
     possibleFields.forEach(field => {
-        const currentField: Field | undefined = iasoFields.find(
+        const currentField: Field | undefined = configFields.find(
             iasoField =>
                 iasoField.type === field.type || iasoField.alias === field.type,
         );

--- a/hat/assets/js/apps/Iaso/domains/workflows/config/followUps.tsx
+++ b/hat/assets/js/apps/Iaso/domains/workflows/config/followUps.tsx
@@ -12,10 +12,32 @@ import { Column } from '../../../types/table';
 
 import { FollowUpActionCell } from '../components/followUps/ActionCell';
 import { WorkflowVersionDetail } from '../types';
+import { iasoFields, Field } from '../../forms/fields/constants';
 
 interface FollowUpsColumns extends Column {
     accessor: string;
 }
+
+export const getConfigFields = (): Field[] => {
+    const configFields = [...iasoFields];
+    if (configFields[2].queryBuilder?.operators) {
+        configFields[2].queryBuilder.operators = [
+            'equal',
+            'not_equal',
+            'greater_or_equal',
+            'less_or_equal',
+        ];
+    }
+    if (configFields[3].queryBuilder?.operators) {
+        configFields[3].queryBuilder.operators = [
+            'equal',
+            'not_equal',
+            'greater_or_equal',
+            'less_or_equal',
+        ];
+    }
+    return configFields;
+};
 
 export const useGetFollowUpsColumns = (
     getHumanReadableJsonLogic: (

--- a/hat/assets/js/apps/Iaso/domains/workflows/details.tsx
+++ b/hat/assets/js/apps/Iaso/domains/workflows/details.tsx
@@ -42,7 +42,7 @@ import { AddChangeModal } from './components/changes/Modal';
 import WidgetPaper from '../../components/papers/WidgetPaperComponent';
 import { TableWithDeepLink } from '../../components/tables/TableWithDeepLink';
 import { useGetChangesColumns } from './config/changes';
-import { useGetFollowUpsColumns } from './config/followUps';
+import { useGetFollowUpsColumns, getConfigFields } from './config/followUps';
 import { useGetPossibleFields } from '../forms/hooks/useGetPossibleFields';
 
 type Router = {
@@ -123,6 +123,7 @@ export const Details: FunctionComponent<Props> = ({ router }) => {
     const fields = useGetQueryBuildersFields(
         formDescriptors,
         targetPossibleFields,
+        getConfigFields(),
     );
     const queryBuilderListToReplace = useGetQueryBuilderListToReplace();
     const getHumanReadableJsonLogic = useHumanReadableJsonLogic(


### PR DESCRIPTION
Workflow follow-up query builder can use more operators than supported in the back-end.

Related JIRA tickets : WC2-195

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are my typescript files well typed
- [ ] New translations have been added or updated if new string have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

Override number and integer fields for workflows

## How to test

Beneficiary-types => workflows versions => edit a workflow in draft.
Create a new follow-up and try to use a `number` or `integer` field, you should be able to use <= and >= .

## Print screen / video
<img width="1244" alt="Screenshot 2023-03-27 at 14 24 34" src="https://user-images.githubusercontent.com/12494624/227959520-7fbc92cb-4077-4f4b-9d2b-6c2b00608b17.png">

