### PR TITLE
POLIO-914: Fix for emails still being sent multiple times

### DIFF
--- a/beanstalk_worker/views.py
+++ b/beanstalk_worker/views.py
@@ -95,11 +95,6 @@ def task_launcher(request, task_name: str, user_name: str):
         created_at__gte=time_threshold,
     ).count()
 
-    print("task_name", task_name)
-    print("the_user", the_user)
-    print("time_threshold", time_threshold)
-    print("Running tasks count", running_tasks_count)
-
     if running_tasks_count > 0:
         return JsonResponse(
             {

--- a/beanstalk_worker/views.py
+++ b/beanstalk_worker/views.py
@@ -99,9 +99,9 @@ def task_launcher(request, task_name: str, user_name: str):
         return JsonResponse(
             {
                 "status": "fail",
-                "error": f"Error while launching the task {task_name} - already running for this user and in the last 24 hours",
+                "error": f"Error while launching the task {task_name} - already running for this user and in the last 12 hours",
             },
-            status=http.HTTPStatus.FORBIDDEN,
+            status=http.HTTPStatus.OK,
         )
 
     call_args = {"user": the_user}

--- a/beanstalk_worker/views.py
+++ b/beanstalk_worker/views.py
@@ -113,7 +113,7 @@ def task_launcher(request, task_name: str, user_name: str):
             call_args = {**call_args, **request.GET}
 
         the_task = the_task_fn(**call_args)
-        return JsonResponse({"status": "success", "task": the_task.as_dict()}, status=http.HTTPStatus.CREATED)
+        return JsonResponse({"status": "success", "task": the_task.as_dict()}, status=http.HTTPStatus.OK)
 
     except Exception as e:
         logger.exception(e)

--- a/beanstalk_worker/views.py
+++ b/beanstalk_worker/views.py
@@ -86,7 +86,7 @@ def task_launcher(request, task_name: str, user_name: str):
             status=http.HTTPStatus.BAD_REQUEST,
         )
 
-    time_threshold = timezone.now() - timedelta(hours=24)
+    time_threshold = timezone.now() - timedelta(hours=12)
     running_tasks_count = Task.objects.filter(
         launcher=the_user,
         params__method=task_fn_str,

--- a/iaso/tests/test_task_launcher.py
+++ b/iaso/tests/test_task_launcher.py
@@ -37,7 +37,7 @@ class TaskLauncher(APITestCase):
 
     def test_with_ok_username_ok_taskname_should_succeed(self):
         res = self.client.get("/tasks/launch_task/iaso.tests.test_task_launcher.fake_empty_task/test_task_user/")
-        res_json = self.assertJSONResponse(res, 201)
+        res_json = self.assertJSONResponse(res, 200)
 
         print(res_json)
 
@@ -51,7 +51,7 @@ class TaskLauncher(APITestCase):
         res = self.client.get(
             "/tasks/launch_task/iaso.tests.test_task_launcher.fake_empty_task/test_task_user/?a=1&b=2"
         )
-        res_json = self.assertJSONResponse(res, 201)
+        res_json = self.assertJSONResponse(res, 200)
 
         print(res_json)
 
@@ -69,9 +69,7 @@ class TaskLauncher(APITestCase):
             data={"a": "1", "b": "2"},
         )
 
-        res_json = self.assertJSONResponse(res, 201)
-
-        print(res_json)
+        res_json = self.assertJSONResponse(res, 200)
 
         assert res_json["status"] == "success"
         assert res_json["task"]["id"] > 0


### PR DESCRIPTION
Emails are still sent multiple times.
The problem is that the cron system from EBS relaunches the task, thinking they are failed or expired while they are still running.
This will block it from resending the same task if it's less than 12 hours old and still QUEUED or RUNNING.


Related JIRA tickets : POLIO-914

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented

## Changes

Added a check that there are no running tasks that fit the criteria and if yes then block from launching a new task.

## How to test

If you are in DEBUG mode,  you can visit a URL like :

`http://127.0.0.1:8000/tasks/launch_task/plugins.polio.tasks.weekly_email.send_email/<your_username>/`

It should work on first time you visit and then block on second try. If you go in django admin and change the status or delete the created Task it should work again ...

