### PR TITLE
POLIO-848 Add round number on preparedness api

### DIFF
--- a/plugins/polio/preparedness/summary.py
+++ b/plugins/polio/preparedness/summary.py
@@ -116,6 +116,7 @@ def _make_prep(c: Campaign, round: Round):
         "campaign_obr_name": c.obr_name,
         "indicators": {},
         "round": f"Round{round.number}",
+        "round_number": round.number,
         "round_id": round.id,
         "round_start": round.started_at,
         "round_end": round.ended_at,


### PR DESCRIPTION
This is so join can be done directly in the PowerBI

Related JIRA tickets : POLIO-848

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)


## How to test

New round_number field on preparedness_dashboard api  should be present. Beware of the cache.
