### PR TITLE
POLIO-882: update field key for campaign automatic email

### DIFF
--- a/plugins/polio/tasks/weekly_email.py
+++ b/plugins/polio/tasks/weekly_email.py
@@ -78,6 +78,7 @@ Ci-dessous un résumé des informations de la campagne {c.obr_name} disponibles 
 * Type de vaccin                    : {c.vaccines}
 * Population cible                  : {target_population} 
 * Statut de l'évaluation du risque  : {c.get_risk_assessment_status_display() or 'Pending'}
+* Date de soumission du budget      : {c.submitted_to_rrt_at_WFEDITABLE}
 * Jours entre date de détection et de notification   : {onset_days}
 * Jours entre dates de notification et de passage 1 : {round1_days}
 * Prep. national                 : {preparedness.get('national_score') if preparedness else ''}
@@ -99,6 +100,7 @@ Segue em baixo um resumo das informações da campanha {c.obr_name} disponíveis
 * Tipo de vacina: {c.vaccines}
 * População-alvo: {target_population}
 * Estado da avaliação de risco: {c.get_risk_assessment_status_display() or 'Pending'}
+* Data de envio do orçamento:   {c.submitted_to_rrt_at_WFEDITABLE}
 * Dias entre a data de detecção e a data de notificação: {onset_days}
 * Dias entre a data de notificação e as datas da primeira ronda: {round1_days}
 * Prep. nacional: {preparedness.get('national_score') if preparedness else ''}
@@ -121,6 +123,7 @@ If there are missing data or dates; visit {url} to update
 * Vaccine Type                   : {c.vaccines}
 * Target population              : {target_population} 
 * RA Status                      : {c.get_risk_assessment_status_display() or 'Pending'}
+* Date Budget Submitted          : {c.submitted_to_rrt_at_WFEDITABLE}
 * OnSet to Notification (Days)   : {onset_days}
 * Round 1 to Notification (Days) : {round1_days}
 * Prep. national                 : {preparedness.get('national_score') if preparedness else ''}


### PR DESCRIPTION
`budget_submitted_at` was obselete and needed to be replaced by `submitted_to_rrt_at_WFEDITABLE`

Related JIRA tickets : [POLIO-882](https://bluesquare.atlassian.net/browse/POLIO-882?atlOrigin=eyJpIjoiMmY5ZTdlYjU3MTU3NGFkYzhmYTk4ZWI0NWE1NzQ2YWUiLCJwIjoiaiJ9)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new string have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## How to test

See this [PR](https://github.com/BLSQ/iaso/pull/468)
You need to have at least an OBR name, a initial region and a virus selected to test sending the email

## Print screen / video

[Upload here print screens or videos showing the changes](https://user-images.githubusercontent.com/25134301/228577081-5af8ed89-bcb1-4b8e-814a-4cb77570e52a.mov)


[POLIO-882]: https://bluesquare.atlassian.net/browse/POLIO-882?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ