### PR TITLE
POLIO-898: replace budget status input

### DIFF
--- a/plugins/polio/js/src/components/CreateEditDialog.js
+++ b/plugins/polio/js/src/components/CreateEditDialog.js
@@ -93,6 +93,7 @@ const CreateEditDialog = ({ isOpen, onClose, campaignId }) => {
         is_test: false,
         enable_send_weekly_email: true,
         has_data_in_budget_tool: false,
+        budget_current_state_key: '-',
     };
 
     // Merge inplace default values with the one we get from the campaign.

--- a/plugins/polio/js/src/components/Inputs/DateInput.js
+++ b/plugins/polio/js/src/components/Inputs/DateInput.js
@@ -8,7 +8,14 @@ import { apiDateFormat } from 'Iaso/utils/dates.ts';
 import MESSAGES from '../../constants/messages';
 import { isTouched } from '../../utils';
 
-export const DateInput = ({ field, form, label, required, disabled }) => {
+export const DateInput = ({
+    field,
+    form,
+    label,
+    required,
+    disabled,
+    onChange = () => {},
+}) => {
     const hasError =
         form.errors &&
         Boolean(get(form.errors, field.name) && isTouched(form.touched));
@@ -22,6 +29,7 @@ export const DateInput = ({ field, form, label, required, disabled }) => {
                 currentDate={field.value || null}
                 errors={hasError ? [get(form.errors, field.name)] : []}
                 onChange={date => {
+                    onChange(field.name, date);
                     form.setFieldTouched(field.name, true);
                     form.setFieldValue(
                         field.name,
@@ -35,6 +43,7 @@ export const DateInput = ({ field, form, label, required, disabled }) => {
 DateInput.defaultProps = {
     required: false,
     disabled: false,
+    onChange: () => {},
 };
 
 DateInput.propTypes = {
@@ -43,4 +52,5 @@ DateInput.propTypes = {
     label: PropTypes.string.isRequired,
     required: PropTypes.bool,
     disabled: PropTypes.bool,
+    onChange: PropTypes.func,
 };

--- a/plugins/polio/js/src/components/Inputs/StatusField.js
+++ b/plugins/polio/js/src/components/Inputs/StatusField.js
@@ -4,7 +4,6 @@ import { useSafeIntl, useTranslatedOptions } from 'bluesquare-components';
 import { Select } from './Select';
 import MESSAGES from '../../constants/messages';
 import { RA_STATUSES } from '../../constants/statuses.ts';
-import { BUDGET_STATES } from '../../constants/budget.ts';
 
 const statuses = [
     {
@@ -42,24 +41,6 @@ const RABudgetstatuses = RA_STATUSES.map(state => ({
 export const RABudgetStatusField = props => {
     const { formatMessage } = useSafeIntl();
     const options = useTranslatedOptions(RABudgetstatuses);
-
-    return (
-        <Select
-            label={formatMessage(MESSAGES.status)}
-            options={options}
-            {...props}
-        />
-    );
-};
-
-const budgetStatuses = BUDGET_STATES.map(state => ({
-    value: state,
-    label: MESSAGES[state],
-}));
-
-export const BudgetStatusField = props => {
-    const { formatMessage } = useSafeIntl();
-    const options = useTranslatedOptions(budgetStatuses);
 
     return (
         <Select

--- a/plugins/polio/js/src/forms/BudgetForm.js
+++ b/plugins/polio/js/src/forms/BudgetForm.js
@@ -51,6 +51,16 @@ const findBudgetStateIndex = values => {
     return -1;
 };
 
+const findNewBudgetState = (fieldIndex, values) => {
+    for (let i = fieldIndex - 1; i >= 0; i -= 1) {
+        const key = `${BUDGET_STATES[i]}${WORKFLOW_SUFFIX}`;
+        if (values[key]) {
+            return BUDGET_STATES[i];
+        }
+    }
+    return null;
+};
+
 export const budgetFormFields = rounds => {
     return [
         'budget_status_at_WFEDITABLE',
@@ -132,23 +142,17 @@ export const BudgetForm = () => {
             const fieldIndex = BUDGET_STATES.findIndex(
                 budgetState => budgetState === fieldKey,
             );
-            console.log('click', fieldIndex, computedBudgetStatusIndex);
             if (fieldIndex > computedBudgetStatusIndex && value) {
-                console.log('setting value', fieldKey);
                 setFieldValue('budget_status', fieldKey);
                 setFieldValue('budget_current_state_key', fieldKey);
             } else if (!value && fieldIndex >= computedBudgetStatusIndex) {
-                // Need to fall back on next available status
-                console.log('removing value');
-                setFieldValue('budget_status', null);
-                setFieldValue('budget_current_state_key', '-');
+                const newBudgetState = findNewBudgetState(fieldIndex, values);
+                setFieldValue('budget_status', newBudgetState);
+                setFieldValue(
+                    'budget_current_state_key',
+                    newBudgetState ?? '-',
+                );
             }
-
-            // if (computedBudgetStatus !== values.budget_status) {
-            //     console.log('updating', computedBudgetStatus, values.budget_status);
-            //     setFieldValue('budget_status', computedBudgetStatus);
-            //     setFieldValue('budget_current_state_key', computedBudgetStatus);
-            // }
         },
         [setFieldValue, values],
     );
@@ -164,7 +168,6 @@ export const BudgetForm = () => {
         : values.budget_status ?? values.budget_current_state_key;
     return (
         <Grid container spacing={2} direction="row">
-            {/* Budget: xs={12} md={6} */}
             <Grid
                 container
                 item
@@ -296,7 +299,6 @@ export const BudgetForm = () => {
                     </Grid>
                 </Grid>
             </Grid>
-            {/* Funds release xs={12} md={3} */}
             <Grid container item xs={12} md={4} lg={3}>
                 <Grid item xs={12}>
                     <Box mb={2} textAlign="center">
@@ -353,7 +355,6 @@ export const BudgetForm = () => {
                     />
                 </Grid>
             </Grid>
-            {/* cost per child xs={12} md={3} */}
             <Grid container item xs={12} md={4} lg={3}>
                 <Grid item xs={12}>
                     <Box mb={2} textAlign="center">

--- a/plugins/polio/js/src/forms/BudgetForm.js
+++ b/plugins/polio/js/src/forms/BudgetForm.js
@@ -1,17 +1,11 @@
 /* eslint-disable camelcase */
 import React, { useMemo } from 'react';
-import { Grid, Typography, Box, Divider } from '@material-ui/core';
+import { Grid, Typography, Box, Divider, Paper } from '@material-ui/core';
 import { Field, useFormikContext } from 'formik';
 import { useSafeIntl } from 'bluesquare-components';
 import { useStyles } from '../styles/theme';
 import MESSAGES from '../constants/messages';
-import {
-    DateInput,
-    ResponsibleField,
-    BudgetStatusField,
-    TextInput,
-    PaymentField,
-} from '../components/Inputs';
+import { DateInput, TextInput, PaymentField } from '../components/Inputs';
 import {
     BUDGET_REQUEST,
     RRT_REVIEW,
@@ -128,146 +122,141 @@ export const BudgetForm = () => {
         : formatMessage(MESSAGES.budgetApproval);
 
     return (
-        <>
-            <Grid container spacing={2}>
-                <Grid container direction="row" item spacing={2}>
-                    <Grid xs={12} md={6} item>
-                        <Box mb={2}>
-                            <Typography variant="button">{title}</Typography>
-                        </Box>
-                        <Box mb={2}>
-                            <Divider style={{ height: '1px', width: '100%' }} />
-                        </Box>
-                    </Grid>
-                    <Grid xs={12} md={3} item>
-                        <Box mb={2}>
-                            <Typography variant="button">
-                                {formatMessage(MESSAGES.fundsRelease)}
-                            </Typography>
-                        </Box>
-                        <Box mb={2}>
-                            <Divider style={{ height: '1px', width: '100%' }} />
-                        </Box>
-                    </Grid>
-                    <Grid xs={12} md={3} item>
-                        <Box mb={2}>
-                            <Typography variant="button">
-                                {formatMessage(MESSAGES.costPerChild)}
-                            </Typography>
-                        </Box>
-                        <Box mb={2}>
-                            <Divider style={{ height: '1px', width: '100%' }} />
-                        </Box>
-                    </Grid>
-                </Grid>
-
-                <Grid item md={3}>
-                    <Box mb={2}>
-                        <Field
-                            name="budget_status"
-                            component={BudgetStatusField}
-                            disabled={disableEdition}
-                        />
+        <Grid container spacing={2} direction="row">
+            {/* Budget: xs={12} md={6} */}
+            <Grid container item xs={12} md={6} spacing={2} direction="column">
+                <Grid item>
+                    <Box mb={2} ml={2}>
+                        <Typography variant="button">{title}</Typography>
                     </Box>
-                    <Box mt={2}>
-                        <Divider style={{ height: '1px', width: '100%' }} />
-                    </Box>
-                    <ExpandableItem
-                        label={formatMessage(MESSAGES.budgetRequest)}
-                        preventCollapse={hasRequestFieldsError}
-                    >
-                        {BUDGET_REQUEST.map((node, index) => {
-                            return (
-                                <Box mt={index === 0 ? 2 : 0} key={node}>
-                                    <Field
-                                        label={formatMessage(MESSAGES[node])}
-                                        name={`${node}${WORKFLOW_SUFFIX}`}
-                                        component={DateInput}
-                                        fullWidth
-                                        disabled={disableEdition}
-                                    />
-                                </Box>
-                            );
-                        })}
-                    </ExpandableItem>
-                    <Divider style={{ height: '1px', width: '100%' }} />
-                    <ExpandableItem
-                        label={formatMessage(MESSAGES.RRTReview)}
-                        preventCollapse={hasRRTReviewError}
-                    >
-                        {RRT_REVIEW.map((node, index) => {
-                            return (
-                                <Box mt={index === 0 ? 2 : 0} key={node}>
-                                    <Field
-                                        label={formatMessage(MESSAGES[node])}
-                                        name={`${node}${WORKFLOW_SUFFIX}`}
-                                        component={DateInput}
-                                        fullWidth
-                                        disabled={disableEdition}
-                                    />
-                                </Box>
-                            );
-                        })}
-                    </ExpandableItem>
-                    <Box mb={2}>
-                        <Divider style={{ height: '1px', width: '100%' }} />
-                    </Box>
-                </Grid>
-                <Grid item md={3}>
-                    <Box mb={2} style={{ visibility: 'hidden' }}>
-                        <Field
-                            name="budget_responsible"
-                            component={ResponsibleField}
-                            disabled
-                        />
-                    </Box>
-                    <Box mt={2}>
-                        <Divider style={{ height: '1px', width: '100%' }} />
-                    </Box>
-                    <ExpandableItem
-                        label={formatMessage(MESSAGES.ORPGReview)}
-                        preventCollapse={hasORPGReviewError}
-                    >
-                        {ORPG_REVIEW.map((node, index) => {
-                            return (
-                                <Box mt={index === 0 ? 2 : 0} key={node}>
-                                    <Field
-                                        label={formatMessage(MESSAGES[node])}
-                                        name={`${node}${WORKFLOW_SUFFIX}`}
-                                        component={DateInput}
-                                        fullWidth
-                                        disabled={disableEdition}
-                                    />
-                                </Box>
-                            );
-                        })}
-                    </ExpandableItem>
                     <Box>
-                        <Divider style={{ height: '1px', width: '100%' }} />
+                        <Divider />
                     </Box>
-                    <ExpandableItem
-                        label={formatMessage(MESSAGES.approval)}
-                        preventCollapse={hasApprovalFieldsError}
-                    >
-                        {REVIEW_FOR_APPROVAL.map((node, index) => {
-                            return (
-                                <Box mt={index === 0 ? 2 : 0} key={node}>
-                                    <Field
-                                        label={formatMessage(MESSAGES[node])}
-                                        name={`${node}${WORKFLOW_SUFFIX}`}
-                                        component={DateInput}
-                                        fullWidth
-                                        disabled={disableEdition}
-                                    />
-                                </Box>
-                            );
-                        })}
-                    </ExpandableItem>
+                </Grid>
+                <Grid item>
+                    <Box mb={2} px={2} py={2}>
+                        <Typography variant="button">
+                            {' '}
+                            {`${formatMessage(MESSAGES.status)}: ${
+                                formatMessage(
+                                    MESSAGES[values.budget_current_state_key],
+                                ) ?? values.budget_current_state_key
+                            }`}
+                        </Typography>
+                    </Box>
+                    <Box>
+                        <Divider />
+                    </Box>
+                </Grid>
+                <Grid container direction="row" item>
+                    <Grid item xs={12} md={6}>
+                        <ExpandableItem
+                            label={formatMessage(MESSAGES.budgetRequest)}
+                            preventCollapse={hasRequestFieldsError}
+                        >
+                            {BUDGET_REQUEST.map((node, index) => {
+                                return (
+                                    <Box mt={index === 0 ? 2 : 0} key={node}>
+                                        <Field
+                                            label={formatMessage(
+                                                MESSAGES[node],
+                                            )}
+                                            name={`${node}${WORKFLOW_SUFFIX}`}
+                                            component={DateInput}
+                                            fullWidth
+                                            disabled={disableEdition}
+                                        />
+                                    </Box>
+                                );
+                            })}
+                        </ExpandableItem>
+                        <Divider style={{ height: '1px', width: '100%' }} />
+                        <ExpandableItem
+                            label={formatMessage(MESSAGES.RRTReview)}
+                            preventCollapse={hasRRTReviewError}
+                        >
+                            {RRT_REVIEW.map((node, index) => {
+                                return (
+                                    <Box mt={index === 0 ? 2 : 0} key={node}>
+                                        <Field
+                                            label={formatMessage(
+                                                MESSAGES[node],
+                                            )}
+                                            name={`${node}${WORKFLOW_SUFFIX}`}
+                                            component={DateInput}
+                                            fullWidth
+                                            disabled={disableEdition}
+                                        />
+                                    </Box>
+                                );
+                            })}
+                        </ExpandableItem>
+                        <Box mb={2}>
+                            <Divider />
+                        </Box>
+                    </Grid>
+
+                    <Grid item xs={12} md={6}>
+                        <ExpandableItem
+                            label={formatMessage(MESSAGES.ORPGReview)}
+                            preventCollapse={hasORPGReviewError}
+                        >
+                            {ORPG_REVIEW.map((node, index) => {
+                                return (
+                                    <Box mt={index === 0 ? 2 : 0} key={node}>
+                                        <Field
+                                            label={formatMessage(
+                                                MESSAGES[node],
+                                            )}
+                                            name={`${node}${WORKFLOW_SUFFIX}`}
+                                            component={DateInput}
+                                            fullWidth
+                                            disabled={disableEdition}
+                                        />
+                                    </Box>
+                                );
+                            })}
+                        </ExpandableItem>
+                        <Box>
+                            <Divider />
+                        </Box>
+                        <ExpandableItem
+                            label={formatMessage(MESSAGES.approval)}
+                            preventCollapse={hasApprovalFieldsError}
+                        >
+                            {REVIEW_FOR_APPROVAL.map((node, index) => {
+                                return (
+                                    <Box mt={index === 0 ? 2 : 0} key={node}>
+                                        <Field
+                                            label={formatMessage(
+                                                MESSAGES[node],
+                                            )}
+                                            name={`${node}${WORKFLOW_SUFFIX}`}
+                                            component={DateInput}
+                                            fullWidth
+                                            disabled={disableEdition}
+                                        />
+                                    </Box>
+                                );
+                            })}
+                        </ExpandableItem>
+                        <Box mb={2}>
+                            <Divider style={{ height: '1px', width: '100%' }} />
+                        </Box>
+                    </Grid>
+                </Grid>
+            </Grid>
+            {/* Funds release xs={12} md={3} */}
+            <Grid container item xs={12} md={3}>
+                <Grid item xs={12}>
+                    <Box mb={2}>
+                        <Typography variant="button">
+                            {formatMessage(MESSAGES.fundsRelease)}
+                        </Typography>
+                    </Box>
                     <Box mb={2}>
                         <Divider style={{ height: '1px', width: '100%' }} />
                     </Box>
-                </Grid>
-                <Grid item md={3}>
                     <Box mb={2}>
                         <Field
                             name="payment_mode"
@@ -313,7 +302,18 @@ export const BudgetForm = () => {
                         className={classes.input}
                     />
                 </Grid>
-                <Grid xs={12} md={3} item>
+            </Grid>
+            {/* cost per child xs={12} md={3} */}
+            <Grid container item xs={12} md={3}>
+                <Grid item xs={12}>
+                    <Box mb={2}>
+                        <Typography variant="button">
+                            {formatMessage(MESSAGES.costPerChild)}
+                        </Typography>
+                    </Box>
+                    <Box mb={2}>
+                        <Divider style={{ height: '1px', width: '100%' }} />
+                    </Box>
                     {rounds.map((round, i) => {
                         const roundData = getRoundData(round);
                         return (
@@ -347,6 +347,6 @@ export const BudgetForm = () => {
                     </Typography>
                 </Grid>
             </Grid>
-        </>
+        </Grid>
     );
 };


### PR DESCRIPTION
Update budget tab so that budget status is computed directly from dates input by user to avoid inconsistency between status and filled out fields

Related JIRA tickets : POLIO-898

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new string have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- Rework the grid structure of the budget tab to accommodate the removal of the `BudgetStatus` input and work better on smaller screens
- If budget exists in budget tool, the value of status is taken directly from the API
- Else: loop through `BUDGET_STATES` starting from the end and take the first formik `field` with a value
- When filling a field, we check if it is "later" in he workflow, if yes, we update the status
- When clearing the field of the current status, we check in other fields for a value

## How to test

- Go to polio. 
- Edit or create a campaign
- Go to budget tab
- In the Budget section of the tab, add and remove dates in the various fields. See if the budget state updates correctly

## Print screen / video


https://user-images.githubusercontent.com/38907762/228578417-ff2a753d-efbe-478d-abaa-e6ad9fa1fb23.mov
