### PR TITLE
POLIO-912: make initial_org_unit required and refactor dialog tab to allow an icon

### DIFF
--- a/plugins/polio/js/src/components/CreateEditDialog.js
+++ b/plugins/polio/js/src/components/CreateEditDialog.js
@@ -314,7 +314,6 @@ const CreateEditDialog = ({ isOpen, onClose, campaignId }) => {
 };
 
 CreateEditDialog.defaultProps = {
-    selectedCampaign: undefined,
     campaignId: undefined,
 };
 
@@ -322,7 +321,6 @@ CreateEditDialog.propTypes = {
     isOpen: PropTypes.bool.isRequired,
     onClose: PropTypes.func.isRequired,
     campaignId: PropTypes.string,
-    selectedCampaign: PropTypes.object,
 };
 
 // There's naming conflict with component in Iaso

--- a/plugins/polio/js/src/components/Inputs/OrgUnitsSelect.tsx
+++ b/plugins/polio/js/src/components/Inputs/OrgUnitsSelect.tsx
@@ -14,9 +14,7 @@ type Props = {
     errors?: string[];
 };
 
-const getErrors = (touched, formErrors) => {
-    const { name } = formErrors;
-
+const getErrors = (touched, formErrors, name) => {
     return isTouched(touched) && formErrors?.[name] ? [formErrors[name]] : [];
 };
 
@@ -37,7 +35,7 @@ export const OrgUnitsLevels: FunctionComponent<Props> = ({
         values,
     } = form;
     const initialOrgUnitId = values[name];
-    const errors = backendErrors ?? getErrors(touched, formErrors);
+    const errors = backendErrors ?? getErrors(touched, formErrors, name);
     const { data: initialOrgUnit, isLoading } = useGetOrgUnit(initialOrgUnitId);
 
     return (

--- a/plugins/polio/js/src/components/MainDialog/PolioDialogTab.tsx
+++ b/plugins/polio/js/src/components/MainDialog/PolioDialogTab.tsx
@@ -1,0 +1,66 @@
+import React, { FunctionComponent, ReactNode, useCallback } from 'react';
+import { useSafeIntl } from 'bluesquare-components';
+import { Tab, Tooltip } from '@material-ui/core';
+import InfoIcon from '@material-ui/icons/Info';
+
+import classnames from 'classnames';
+import MESSAGES from '../../constants/messages';
+import { useStyles } from '../../styles/theme';
+
+type Tab = {
+    title: string;
+    form: ReactNode;
+    hasTabError: boolean;
+    key: string;
+    disabled?: boolean;
+};
+
+type Props = {
+    value: number;
+    title: string;
+    hasTabError: boolean;
+    disabled: boolean;
+    // eslint-disable-next-line no-unused-vars
+    handleChange: (_event: any, newValue: number) => void;
+};
+
+export const PolioDialogTab: FunctionComponent<Props> = ({
+    value,
+    title,
+    hasTabError,
+    disabled,
+    handleChange,
+}) => {
+    const { formatMessage } = useSafeIntl();
+    const classes: Record<string, string> = useStyles();
+    const onChange = useCallback(() => {
+        if (!disabled) {
+            handleChange(undefined, value);
+        }
+    }, [disabled, handleChange, value]);
+    return (
+        <Tab
+            label={title}
+            onClick={onChange}
+            className={classnames(
+                classes.tab,
+                hasTabError && classes.tabError,
+                disabled && classes.tabDisabled,
+            )}
+            disableFocusRipple={disabled}
+            disableRipple={disabled}
+            icon={
+                (disabled && title === formatMessage(MESSAGES.scope) && (
+                    <Tooltip
+                        title={formatMessage(MESSAGES.scopeUnlockConditions)}
+                    >
+                        <InfoIcon
+                            fontSize="small"
+                            className={classes.tabIcon}
+                        />
+                    </Tooltip>
+                )) || <></>
+            }
+        />
+    );
+};

--- a/plugins/polio/js/src/components/MainDialog/PolioDialogTabs.tsx
+++ b/plugins/polio/js/src/components/MainDialog/PolioDialogTabs.tsx
@@ -1,100 +1,54 @@
-/* eslint-disable react/jsx-props-no-spreading */
 import React, { FunctionComponent, ReactNode } from 'react';
-import { useSafeIntl } from 'bluesquare-components';
-import { makeStyles, Tab, Tabs, Tooltip } from '@material-ui/core';
-import { FormattedMessage } from 'react-intl';
-import MESSAGES from '../../constants/messages';
+import { Tab, Tabs } from '@material-ui/core';
 import { useStyles } from '../../styles/theme';
+import { PolioDialogTab } from './PolioDialogTab';
+
+type Tab = {
+    title: string;
+    form: ReactNode;
+    hasTabError: boolean;
+    key: string;
+    disabled?: boolean;
+};
 
 type Props = {
     selectedTab: number;
     // eslint-disable-next-line no-unused-vars
     handleChange: (_event: any, newValue: number) => void;
-    tabs: {
-        title: string;
-        form: ReactNode;
-        hasTabError: boolean;
-        key: string;
-        disabled?: boolean;
-    }[];
+    tabs: Tab[];
 };
-
-const useTabErrorStyles = makeStyles(theme => {
-    return {
-        tabError: {
-            color: `${theme.palette.error.main} !important`,
-        },
-        pointer: {
-            pointerEvents: 'auto',
-        },
-    };
-});
 
 export const PolioDialogTabs: FunctionComponent<Props> = ({
     selectedTab,
     handleChange,
     tabs,
 }) => {
-    const { formatMessage } = useSafeIntl();
-    const tabErrorClasses = useTabErrorStyles();
     const classes: Record<string, string> = useStyles();
+
     return (
         <Tabs
             value={selectedTab}
             className={classes.tabs}
             textColor="primary"
-            onChange={handleChange}
             aria-label="disabled tabs example"
             variant="scrollable"
             scrollButtons="auto"
         >
-            {tabs.map(({ title, disabled, hasTabError = false, key }) => {
-                if (disabled && title === formatMessage(MESSAGES.scope)) {
-                    return (
-                        <Tab
-                            key={key}
-                            classes={
-                                hasTabError
-                                    ? {
-                                          textColorPrimary:
-                                              tabErrorClasses.tabError,
-                                          selected: tabErrorClasses.tabError,
-                                      }
-                                    : undefined
-                            }
-                            label={
-                                <Tooltip
-                                    key={key}
-                                    title={
-                                        <FormattedMessage
-                                            {...MESSAGES.scopeUnlockConditions}
-                                        />
-                                    }
-                                >
-                                    <span>{title}</span>
-                                </Tooltip>
-                            }
-                            disabled={disabled || false}
-                        />
-                    );
-                }
-                return (
-                    <Tab
+            {tabs.map(
+                (
+                    { title, disabled = false, hasTabError = false, key },
+                    index,
+                ) => (
+                    <PolioDialogTab
                         key={key}
-                        label={title}
-                        disabled={disabled || false}
-                        classes={
-                            hasTabError
-                                ? {
-                                      textColorPrimary:
-                                          tabErrorClasses.tabError,
-                                      selected: tabErrorClasses.tabError,
-                                  }
-                                : undefined
-                        }
+                        title={title}
+                        disabled={disabled}
+                        hasTabError={hasTabError}
+                        handleChange={handleChange}
+                        value={index}
                     />
-                );
-            })}
+                ),
+            )}
         </Tabs>
     );
 };

--- a/plugins/polio/js/src/constants/translations/fr.json
+++ b/plugins/polio/js/src/constants/translations/fr.json
@@ -359,7 +359,7 @@
     "iaso.polio.label.school": "À l'école",
     "iaso.polio.label.scope_per_round": "Périmètre séparé par round",
     "iaso.polio.label.scopes": "Périmètres",
-    "iaso.polio.label.scopeUnlockConditions": "Veuillez sélectuionner l'unité d'org initiale et encoder les dates d'au moins un round pour activer l'onglet \"Périmètre\"",
+    "iaso.polio.label.scopeUnlockConditions": "Veuillez sélectionner l'unité d'org initiale et encoder les dates d'au moins un round pour activer l'onglet \"Périmètre\"",
     "iaso.polio.label.search": "Recherche",
     "iaso.polio.label.searchInScopeOrAllDistricts": "Recherche des districts dans scope",
     "iaso.polio.label.see": "Voir",

--- a/plugins/polio/js/src/forms/BaseInfoForm.js
+++ b/plugins/polio/js/src/forms/BaseInfoForm.js
@@ -126,6 +126,7 @@ export const BaseInfoForm = () => {
                             label={formatMessage(MESSAGES.selectOrgUnit)}
                             component={OrgUnitsLevels}
                             clearable={false}
+                            required
                         />
                     </Box>
                 </Grid>

--- a/plugins/polio/js/src/hooks/useFormValidator.js
+++ b/plugins/polio/js/src/hooks/useFormValidator.js
@@ -555,6 +555,7 @@ export const useFormValidator = () => {
     return yup.object().shape({
         epid: yup.string().nullable(),
         obr_name: yup.string().trim().required(),
+        initial_org_unit: yup.number().positive().integer().required(),
         grouped_campaigns: yup.array(yup.number()).nullable(),
         description: yup.string().nullable(),
         onset_at: yup.date().nullable(),

--- a/plugins/polio/js/src/styles/theme.js
+++ b/plugins/polio/js/src/styles/theme.js
@@ -205,4 +205,24 @@ export const useStyles = makeStyles(() => ({
         position: 'relative',
         left: -16,
     },
+    tab: {
+        '& .MuiTab-wrapper': {
+            display: 'flex',
+            flexDirection: 'row-reverse',
+        },
+    },
+    tabError: {
+        color: `${theme.palette.error.main} !important`,
+    },
+    tabDisabled: {
+        color: `${theme.palette.text.disabled} !important`,
+        cursor: 'default',
+    },
+    tabIcon: {
+        position: 'relative',
+        top: 1,
+        left: theme.spacing(0.5),
+        color: theme.palette.primary.main,
+        cursor: 'pointer',
+    },
 }));


### PR DESCRIPTION
- Initial org unit field is necessary to create a campaign though it was not required
- It was not clear that you need at least dates filled on one round to access the Scope tab

Related JIRA tickets : [POLIO-912](https://bluesquare.atlassian.net/browse/POLIO-912?atlOrigin=eyJpIjoiN2RjM2Q5M2EzZjMxNGU4YThhYjEyMjlmNDA1NzM5MTIiLCJwIjoiaiJ9)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are my typescript files well typed
- [ ] New translations have been added or updated if new string have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- add yup validation on initial_org_unit and make it required + add required prop to the Select input
- refactor dialog tab to allow an icon

## How to test

 - Go to Polio > Campaigns
 - Create a new campaign
 -  Scope tab should be disabled and an icon is displayed above the tab title. On hover you can see a popover showing info to enable the tab
 - Fill/ Select a value for required fields (Obr Name, initial region) and choose a start date and end date for at least one round to access Scope tab

## Print screen / video

https://user-images.githubusercontent.com/25134301/228619877-c3b07e02-8fb7-4d33-888f-02b97654dd2f.mov


[POLIO-912]: https://bluesquare.atlassian.net/browse/POLIO-912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ