### PR TITLE
IA-2037 Add link to submission from form details

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/forms/components/FormFormComponent.js
+++ b/hat/assets/js/apps/Iaso/domains/forms/components/FormFormComponent.js
@@ -16,6 +16,10 @@ import { fetchAllOrgUnitTypes } from '../../orgUnits/orgUnitTypes/actions';
 import { formatLabel } from '../../instances/utils/index.tsx';
 import { periodTypeOptions } from '../../periods/constants';
 import MESSAGES from '../messages';
+import { Link } from 'react-router';
+import { History } from '@material-ui/icons';
+import FormatListBulleted from '@material-ui/icons/FormatListBulleted';
+import { DisplayIfUserHasPerm } from '../../../components/DisplayIfUserHasPerm';
 
 const styles = theme => ({
     radio: {
@@ -28,9 +32,11 @@ const styles = theme => ({
         flex: '1',
         cursor: 'pointer',
     },
-    linkToChangesLog: {
-        color: theme.palette.primary.main,
-        cursor: 'pointer',
+    // Align the icon with the text
+    linkWithIcon: {
+        display: 'flex',
+        alignItems: 'center',
+        gap: '0.5em',
     },
 });
 
@@ -39,10 +45,6 @@ const formatBooleanForRadio = value => {
     if (value === true) return 'true';
     if (value === false) return 'false';
     return null;
-};
-
-const redirectToChangesLog = url => {
-    window.open(url);
 };
 
 const FormForm = ({ currentForm, setFieldValue }) => {
@@ -327,13 +329,23 @@ const FormForm = ({ currentForm, setFieldValue }) => {
             </Grid>
             {currentForm.id.value && (
                 <Grid justifyContent="flex-end" container spacing={2}>
-                    <Typography
-                        className={classes.linkToChangesLog}
-                        variant="overline"
-                        onClick={() => redirectToChangesLog(logsUrl)}
-                    >
-                        {intl.formatMessage(MESSAGES.formChangeLog)}
-                    </Typography>
+                    <DisplayIfUserHasPerm permission={'iaso_submissions'}>
+                        <Grid item>
+                            <Link
+                                className={classes.linkWithIcon}
+                                href={`/dashboard/forms/submissions/formIds/${currentForm.id.value}/tab/list`}
+                            >
+                                <FormatListBulleted />
+                                {intl.formatMessage(MESSAGES.records)}
+                            </Link>
+                        </Grid>
+                    </DisplayIfUserHasPerm>
+                    <Grid item>
+                        <Link href={logsUrl} className={classes.linkWithIcon}>
+                            <History />
+                            {intl.formatMessage(MESSAGES.formChangeLog)}
+                        </Link>
+                    </Grid>
                 </Grid>
             )}
         </>


### PR DESCRIPTION
When playing with form, it was bothering me having to go back to the list view all the time to see the submission link so I added one directly on the Form page beside the history one.

Took the opportunity to also alter the  the history link  as to make it behave like a link and have them consistant in style

I extracted this from the completeness branch as to not make it too enormous.

Related JIRA tickets : IA-2037

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [NA] Are my typescript files well typed
- [Reused existing] New translations have been added or updated if new string have been introduced in the frontend
- [NA] My migrations file are included
- [? probably not] Are there enough tests
- [NA] Documentation has been included (for new feature)


## How to test

* On the Form page you should have a link if the Form is not in creation.
* Test with a user without the submission permission to check if the link is correctly hidden.

![image](https://user-images.githubusercontent.com/82500/228831524-a9e2c468-35fc-4427-9c4b-30091ba4c549.png)
