### PR TITLE
POLIO-932: HOTFIX: remove duplicate http on links

### DIFF
--- a/plugins/polio/js/src/pages/Budget/hooks/api/useSaveBudgetStep.tsx
+++ b/plugins/polio/js/src/pages/Budget/hooks/api/useSaveBudgetStep.tsx
@@ -25,18 +25,8 @@ const postBudgetStep = (body: Payload): Promise<BudgetStep> => {
     );
     const { links }: { links?: LinkWithAlias[] } = filteredParams;
     if (links) {
-        const filteredLinks = links
-            .filter(link => link.alias && link.url)
-            .map(({ alias, url }) => {
-                return {
-                    alias,
-                    url:
-                        !url.startsWith('http://') ||
-                        !url.startsWith('https://')
-                            ? `https://${url}`
-                            : url,
-                };
-            });
+        const filteredLinks = links.filter(link => link.alias && link.url);
+
         filteredParams.links = filteredLinks;
     }
     const requestBody: PostRequestBody = {


### PR DESCRIPTION
POLIO-932
Remove code that added http in front of links as it was buggy and broke links

Related JIRA tickets : POLIO-932

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new string have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- remove `.map`  in `useSaveBudgetStep`

## How to test
With a working budget config:
- create a step with an atttached link
-  save 
- open the link in budget details table
- it should work


## Notes

deployed on campaigns-staging as hotfix
