### PR TITLE
POLIO-933 IA-2041 update email text

### DIFF
--- a/plugins/polio/budget/models.py
+++ b/plugins/polio/budget/models.py
@@ -168,7 +168,7 @@ class MailTemplate(models.Model):
             )
         # buttons is never empty, so the text accompanying the buttons in the email would always show, even when no buttons are displayed
         # So we check if there are allowed buttons
-        show_buttons = list(filter(lambda x:x.allowed), buttons)
+        show_buttons = list(filter(lambda x: x.allowed), buttons)
         transition = workflow.get_transition_by_key(step.transition_key)
         if transition.key != "override":
             node = workflow.get_node_by_key(transition.to_node)

--- a/plugins/polio/budget/models.py
+++ b/plugins/polio/budget/models.py
@@ -168,7 +168,7 @@ class MailTemplate(models.Model):
             )
         # buttons is never empty, so the text accompanying the buttons in the email would always show, even when no buttons are displayed
         # So we check if there are allowed buttons
-        show_buttons = list(filter(lambda x: x.allowed), buttons)
+        show_buttons = list(filter(lambda x: x["allowed"], buttons))
         transition = workflow.get_transition_by_key(step.transition_key)
         if transition.key != "override":
             node = workflow.get_node_by_key(transition.to_node)

--- a/plugins/polio/budget/models.py
+++ b/plugins/polio/budget/models.py
@@ -166,6 +166,9 @@ class MailTemplate(models.Model):
                     "allowed": can_user_transition(transition, receiver, campaign),
                 }
             )
+        # buttons is never empty, so the text accompanying the buttons in the email would always show, even when no buttons are displayed
+        # So we check if there are allowed buttons
+        show_buttons = list(filter(lambda x:x.allowed), buttons)
         transition = workflow.get_transition_by_key(step.transition_key)
         if transition.key != "override":
             node = workflow.get_node_by_key(transition.to_node)
@@ -197,7 +200,7 @@ class MailTemplate(models.Model):
             {
                 "author": step.created_by,
                 "author_name": step.created_by.get_full_name() or step.created_by.username,
-                "buttons": buttons,
+                "buttons": buttons if show_buttons else None,
                 "node": node,
                 "team": step.created_by_team,
                 "step": step,

--- a/plugins/polio/budget/models.py
+++ b/plugins/polio/budget/models.py
@@ -145,6 +145,7 @@ class MailTemplate(models.Model):
         campaign_url = (
             f"{base_url}/dashboard/polio/budget/details/campaignName/{campaign.obr_name}/campaignId/{campaign.id}"
         )
+        self_auth_campaign_url = generate_auto_authentication_link(campaign_url, receiver)
 
         workflow = get_workflow()
         transitions = next_transitions(workflow.transitions, campaign.budget_current_state_key)
@@ -205,7 +206,7 @@ class MailTemplate(models.Model):
                 "team": step.created_by_team,
                 "step": step,
                 "campaign": campaign,
-                "budget_url": campaign_url,
+                "budget_url": self_auth_campaign_url,
                 "site_url": base_url,
                 "site_name": site.name,
                 "comment": step.comment,


### PR DESCRIPTION
Text telling user to use buttons below"  would show even when there were no buttons displayed

Related JIRA tickets :  POLIO-933, IA-2041

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new string have been introduced in the frontend
- [ ] My migrations file are included
- [X] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes
- Since the list of buttons always contained buttons and the interface just hid those that had the property `allowed` set to `False` the text was always displayed. So I added a condition to see if there's a button to display
- Make campaign url link self-auth in `base_budget_email`

## How to test

-  Set up your env to use smtp bucket
-  make sure you use the latest budget config
- have your env configured for budget
- Configure different users for ORPG, RRT and GPEI. they can sahre the same email address, but it shoud be different users
- go to a budget
- go through the workflow until you reach "Submitted to ORPG ops"
- request a feedback from RRT
- Check the email sent to GPEI coordinator. It should have no buttons and no text mentioning them
- self auth campaign link: the link to the campaign itself ("consult campaign page") should be self auth now

## Screenshot
![Screenshot 2023-03-31 at 10 47 32](https://user-images.githubusercontent.com/38907762/229074066-afdfca7e-25e2-4515-ba14-c007d030d8c1.png)

