### PR TITLE
POLIO-925: fix display good date format + no geojson

### DIFF
--- a/plugins/polio/js/src/components/campaignHistory/CampaignLogDetail.tsx
+++ b/plugins/polio/js/src/components/campaignHistory/CampaignLogDetail.tsx
@@ -13,7 +13,7 @@ import ErrorPaperComponent from '../../../../../../hat/assets/js/apps/Iaso/compo
 
 import MESSAGES from '../../constants/messages';
 
-import { config } from './config';
+import { useGetConfig } from './config';
 import { useGetMapLog } from './useGetMapLog';
 import { Head } from './Head';
 
@@ -33,6 +33,7 @@ export const CampaignLogDetail: FunctionComponent<Props> = ({ logId }) => {
     } = useGetCampaignLogDetail(initialLogDetail, logId);
 
     const { formatMessage } = useSafeIntl();
+    const config = useGetConfig();
     const getMapLog = useGetMapLog(config);
 
     if (isLoading)

--- a/plugins/polio/js/src/components/campaignHistory/config.tsx
+++ b/plugins/polio/js/src/components/campaignHistory/config.tsx
@@ -4,7 +4,7 @@ import moment from 'moment';
 import { upperCase } from 'lodash';
 import { Link } from 'react-router';
 import { Box } from '@material-ui/core';
-import { useSafeIntl } from 'bluesquare-components';
+import { IntlFormatMessage, useSafeIntl } from 'bluesquare-components';
 import { GeoJsonMap } from '../../../../../../hat/assets/js/apps/Iaso/components/maps/GeoJsonMapComponent';
 import MESSAGES from '../../constants/messages';
 import { useGetOrgUnitDetail } from '../../../../../../hat/assets/js/apps/Iaso/domains/orgUnits/hooks/requests/useGetOrgUnitDetail';
@@ -20,7 +20,7 @@ const OrgUnitLink = ({ orgUnitId }): ReactElement<OrgUnitLinkProps> => {
     return <LinkToOrgUnit orgUnit={currentOrgUnit} />;
 };
 
-const convertBoolean = (value: boolean, formatMessage) => {
+const convertBoolean = (value: boolean, formatMessage: IntlFormatMessage) => {
     return value ? formatMessage(MESSAGES.yes) : formatMessage(MESSAGES.no);
 };
 

--- a/plugins/polio/js/src/components/campaignHistory/config.tsx
+++ b/plugins/polio/js/src/components/campaignHistory/config.tsx
@@ -110,6 +110,7 @@ export const config: Record<string, any> = [
     },
     {
         key: 'onset_at',
+        getLogValue: log => convertDate(log.onset_at),
     },
     {
         key: 'cvdpv2_notified_at',
@@ -614,11 +615,12 @@ export const config: Record<string, any> = [
             if (hasGeoJson) {
                 return <GeoJsonMap geoJson={log.geojson} />;
             }
-            return null;
+            return <FormattedMessage {...MESSAGES.noGeojson} />;
         },
     },
     {
         key: 'creation_email_send_at',
+        getLogValue: log => convertDate(log.creation_email_send_at),
     },
     // DEPRECATED FIELDS ?
     // {

--- a/plugins/polio/js/src/components/campaignHistory/config.tsx
+++ b/plugins/polio/js/src/components/campaignHistory/config.tsx
@@ -4,7 +4,7 @@ import moment from 'moment';
 import { upperCase } from 'lodash';
 import { Link } from 'react-router';
 import { Box } from '@material-ui/core';
-import { FormattedMessage } from 'react-intl';
+import { useSafeIntl } from 'bluesquare-components';
 import { GeoJsonMap } from '../../../../../../hat/assets/js/apps/Iaso/components/maps/GeoJsonMapComponent';
 import MESSAGES from '../../constants/messages';
 import { useGetOrgUnitDetail } from '../../../../../../hat/assets/js/apps/Iaso/domains/orgUnits/hooks/requests/useGetOrgUnitDetail';
@@ -20,625 +20,637 @@ const OrgUnitLink = ({ orgUnitId }): ReactElement<OrgUnitLinkProps> => {
     return <LinkToOrgUnit orgUnit={currentOrgUnit} />;
 };
 
+const convertBoolean = (value: boolean, formatMessage) => {
+    return value ? formatMessage(MESSAGES.yes) : formatMessage(MESSAGES.no);
+};
+
 const convertDate = (value: string, format = 'L') => {
     return value ? moment(value).format(format) : '--';
 };
-
-const convertBoolean = (value: boolean) => {
-    return value ? (
-        <FormattedMessage {...MESSAGES.yes} />
-    ) : (
-        <FormattedMessage {...MESSAGES.no} />
-    );
-};
-
-export const config: Record<string, any> = [
-    // Global
-    {
-        key: 'id',
-    },
-    {
-        key: 'created_at',
-        getLogValue: log => convertDate(log.created_at, 'LTS'),
-    },
-    {
-        key: 'updated_at',
-        getLogValue: log => convertDate(log.updated_at, 'LTS'),
-    },
-    {
-        key: 'deleted_at',
-        getLogValue: log => convertDate(log.deleted_at, 'LTS'),
-    },
-    {
-        key: 'account',
-    },
-    // Base Info
-    {
-        key: 'epid',
-    },
-    {
-        key: 'obr_name',
-    },
-    {
-        key: 'group',
-        type: 'object',
-        childrenLabel: MESSAGES.group,
-        children: [
-            {
-                key: 'id',
-            },
-            {
-                key: 'org_units',
-                getLogValue: log =>
-                    log.org_units.map((ouId, index) => {
-                        const lastArrayItem =
-                            log.org_units[log.org_units.length - 1];
-                        return (
-                            <Box key={ouId} display="inline-block">
-                                <Link
-                                    target="_blank"
-                                    href={`/dashboard/orgunits/detail/orgUnitId/${ouId}`}
-                                >
-                                    {ouId}
-                                </Link>
-                                {log.org_units[index] !== lastArrayItem && ','}
-                            </Box>
-                        );
-                    }),
-            },
-        ],
-    },
-    {
-        key: 'eomg',
-    },
-    {
-        key: 'description',
-    },
-    {
-        key: 'gpei_coordinator',
-    },
-    {
-        key: 'gpei_email',
-    },
-    {
-        key: 'country',
-        getLogValue: log => <OrgUnitLink orgUnitId={log.country} />,
-    },
-    {
-        key: 'initial_org_unit',
-        getLogValue: log => <OrgUnitLink orgUnitId={log.initial_org_unit} />,
-    },
-    {
-        key: 'onset_at',
-        getLogValue: log => convertDate(log.onset_at),
-    },
-    {
-        key: 'cvdpv2_notified_at',
-        getLogValue: log => convertDate(log.cvdpv2_notified_at),
-    },
-    {
-        key: 'virus',
-    },
-    {
-        key: 'vacine',
-    },
-    {
-        key: 'is_preventive',
-        getLogValue: log => convertBoolean(log.is_preventive),
-    },
-    {
-        key: 'is_test',
-        getLogValue: log => convertBoolean(log.is_test),
-    },
-    {
-        key: 'enable_send_weekly_email',
-        getLogValue: log => convertBoolean(log.enable_send_weekly_email),
-    },
-    {
-        key: 'pv_notified_at',
-        getLogValue: log => convertDate(log.pv_notified_at),
-    },
-    {
-        key: 'three_level_call_at',
-        getLogValue: log => convertDate(log.three_level_call_at),
-    },
-    // Detection
-    {
-        key: 'detection_status',
-    },
-    {
-        key: 'detection_responsible',
-    },
-    // Risk assessment
-    {
-        key: 'risk_assessment_status',
-    },
-    {
-        key: 'verification_score',
-    },
-    {
-        key: 'investigation_at',
-        getLogValue: log => convertDate(log.investigation_at),
-    },
-    {
-        key: 'risk_assessment_first_draft_submitted_at',
-        getLogValue: log =>
-            convertDate(log.risk_assessment_first_draft_submitted_at),
-    },
-    {
-        key: 'risk_assessment_rrt_oprtt_approval_at',
-        getLogValue: log =>
-            convertDate(log.risk_assessment_rrt_oprtt_approval_at),
-    },
-    {
-        key: 'ag_nopv_group_met_at',
-        getLogValue: log => convertDate(log.ag_nopv_group_met_at),
-    },
-    {
-        key: 'dg_authorized_at',
-        getLogValue: log => convertDate(log.dg_authorized_at),
-    },
-    {
-        key: 'risk_assessment_responsible',
-    },
-    // Budget
-    {
-        key: 'budget_status',
-        getLogValue: log => upperCase(log.budget_status),
-    },
-    {
-        key: 'budget_current_state_label',
-    },
-    // Budget request
-    {
-        key: 'who_sent_budget',
-        getLogValue: log => convertDate(log.who_sent_budget_at_WFEDITABLE),
-    },
-    {
-        key: 'unicef_sent_budget',
-        getLogValue: log =>
-            convertDate(log.unicef_sent_budget_at_WFEDITABLE, 'L'),
-    },
-    {
-        key: 'gpei_consolidated_budgets',
-        getLogValue: log =>
-            convertDate(log.gpei_consolidated_budgets_at_WFEDITABLE, 'L'),
-    },
-    // RRT review
-    {
-        key: 'submitted_to_rrt',
-        getLogValue: log =>
-            convertDate(log.submitted_to_rrt_at_WFEDITABLE, 'L'),
-    },
-    {
-        key: 'feedback_sent_to_gpei',
-        getLogValue: log =>
-            convertDate(log.feedback_sent_to_gpei_at_WFEDITABLE, 'L'),
-    },
-    {
-        key: 're_submitted_to_rrt',
-        getLogValue: log =>
-            convertDate(log.re_submitted_to_rrt_at_WFEDITABLE, 'L'),
-    },
-    // ORPG review
-    {
-        key: 'submitted_to_orpg_operations1',
-        getLogValue: log =>
-            convertDate(log.submitted_to_orpg_operations1_at_WFEDITABLE, 'L'),
-    },
-    {
-        key: 'feedback_sent_to_rrt1',
-        getLogValue: log =>
-            convertDate(log.feedback_sent_to_rrt1_at_WFEDITABLE, 'L'),
-    },
-    {
-        key: 're_submitted_to_orpg_operations1',
-        getLogValue: log =>
-            convertDate(
-                log.re_submitted_to_orpg_operations1_at_WFEDITABLE,
-                'L',
+export const useGetConfig = (): Record<string, any> => {
+    const { formatMessage } = useSafeIntl();
+    return [
+        // Global
+        {
+            key: 'id',
+        },
+        {
+            key: 'created_at',
+            getLogValue: log => convertDate(log.created_at, 'LTS'),
+        },
+        {
+            key: 'updated_at',
+            getLogValue: log => convertDate(log.updated_at, 'LTS'),
+        },
+        {
+            key: 'deleted_at',
+            getLogValue: log => convertDate(log.deleted_at, 'LTS'),
+        },
+        {
+            key: 'account',
+        },
+        // Base Info
+        {
+            key: 'epid',
+        },
+        {
+            key: 'obr_name',
+        },
+        {
+            key: 'group',
+            type: 'object',
+            childrenLabel: MESSAGES.group,
+            children: [
+                {
+                    key: 'id',
+                },
+                {
+                    key: 'org_units',
+                    getLogValue: log =>
+                        log.org_units.map((ouId, index) => {
+                            const lastArrayItem =
+                                log.org_units[log.org_units.length - 1];
+                            return (
+                                <Box key={ouId} display="inline-block">
+                                    <Link
+                                        target="_blank"
+                                        href={`/dashboard/orgunits/detail/orgUnitId/${ouId}`}
+                                    >
+                                        {ouId}
+                                    </Link>
+                                    {log.org_units[index] !== lastArrayItem &&
+                                        ','}
+                                </Box>
+                            );
+                        }),
+                },
+            ],
+        },
+        {
+            key: 'eomg',
+        },
+        {
+            key: 'description',
+        },
+        {
+            key: 'gpei_coordinator',
+        },
+        {
+            key: 'gpei_email',
+        },
+        {
+            key: 'country',
+            getLogValue: log => <OrgUnitLink orgUnitId={log.country} />,
+        },
+        {
+            key: 'initial_org_unit',
+            getLogValue: log => (
+                <OrgUnitLink orgUnitId={log.initial_org_unit} />
             ),
-    },
-    {
-        key: 'submitted_to_orpg_wider',
-        getLogValue: log =>
-            convertDate(log.submitted_to_orpg_wider_at_WFEDITABLE, 'L'),
-    },
-    {
-        key: 'submitted_to_orpg_operations2',
-        getLogValue: log =>
-            convertDate(log.submitted_to_orpg_operations2_at_WFEDITABLE, 'L'),
-    },
-    {
-        key: 'feedback_sent_to_rrt2',
-        getLogValue: log =>
-            convertDate(log.feedback_sent_to_rrt2_at_WFEDITABLE, 'L'),
-    },
-    {
-        key: 're_submitted_to_orpg_operations2',
-        getLogValue: log =>
-            convertDate(
-                log.re_submitted_to_orpg_operations2_at_WFEDITABLE,
-                'L',
-            ),
-    },
-    // APPROVAL
-    {
-        key: 'submitted_for_approval',
-        getLogValue: log =>
-            convertDate(log.submitted_for_approval_at_WFEDITABLE, 'L'),
-    },
-    {
-        key: 'feedback_sent_to_orpg_operations_unicef',
-        getLogValue: log =>
-            convertDate(
-                log.feedback_sent_to_orpg_operations_unicef_at_WFEDITABLE,
-                'L',
-            ),
-    },
-    {
-        key: 'feedback_sent_to_orpg_operations_who',
-        getLogValue: log =>
-            convertDate(
-                log.feedback_sent_to_orpg_operations_who_at_WFEDITABLE,
-                'L',
-            ),
-    },
-    {
-        key: 'approved_by_who',
-        getLogValue: log => convertDate(log.approved_by_who_at_WFEDITABLE),
-    },
-    {
-        key: 'approved_by_unicef',
-        getLogValue: log => convertDate(log.approved_by_unicefat_WFEDITABLE),
-    },
-    {
-        key: 'approved',
-        getLogValue: log => convertDate(log.approved_at_WFEDITABLE),
-    },
-    {
-        key: 'approval_confirmed',
-        getLogValue: log => convertDate(log.approval_confirmed_at_WFEDITABLE),
-    },
-    {
-        key: 'payment_mode',
-    },
-    {
-        key: 'who_disbursed_to_co_at',
-        getLogValue: log => convertDate(log.who_disbursed_to_co_at),
-    },
-    {
-        key: 'unicef_disbursed_to_co_at',
-        getLogValue: log => convertDate(log.unicef_disbursed_to_co_at),
-    },
-    {
-        key: 'district_count',
-    },
-    {
-        key: 'no_regret_fund_amount',
-    },
-    {
-        key: 'budget_submitted_at',
-        getLogValue: log => convertDate(log.budget_submitted_at),
-    },
-    // Preparedness
-    {
-        key: 'preparedness_spreadsheet_url',
-    },
-    {
-        key: 'surge_spreadsheet_url',
-    },
-    {
-        key: 'preperadness_sync_status',
-    },
-    // Scopes
-    {
-        key: 'scopes',
-        type: 'array',
-        childrenLabel: MESSAGES.scope,
-        children: [
-            {
-                key: 'id',
-            },
-            {
-                key: 'group',
-                type: 'object',
-                childrenLabel: MESSAGES.group,
-                children: [
-                    {
-                        key: 'id',
-                    },
-                    {
-                        key: 'org_units',
-                        getLogValue: log =>
-                            log.org_units.map((ouId, index) => {
-                                const lastArrayItem =
-                                    log.org_units[log.org_units.length - 1];
-                                return (
-                                    <Box key={ouId} display="inline-block">
-                                        <Link
-                                            target="_blank"
-                                            href={`/dashboard/orgunits/detail/orgUnitId/${ouId}`}
-                                        >
-                                            {ouId}
-                                        </Link>
-                                        {log.org_units[index] !==
-                                            lastArrayItem && ','}
-                                    </Box>
-                                );
-                            }),
-                    },
-                ],
-            },
-        ],
-    },
-    {
-        key: 'separate_scopes_per_round',
-        getLogValue: log => convertBoolean(log.separate_scopes_per_round),
-    },
-    // Rounds
-    {
-        key: 'rounds',
-        type: 'array',
-        childrenLabel: MESSAGES.round,
-        children: [
-            {
-                key: 'id',
-            },
-            {
-                key: 'cost',
-            },
-            {
-                key: 'number',
-            },
-            {
-                key: 'started_at',
-                getLogValue: log => convertDate(log.started_at),
-            },
-            {
-                key: 'ended_at',
-                getLogValue: log => convertDate(log.ended_at),
-            },
-            {
-                key: 'mop_up_started_at',
-                getLogValue: log => convertDate(log.mop_up_started_at),
-            },
-            {
-                key: 'mop_up_ended_at',
-                getLogValue: log => convertDate(log.mop_up_ended_at),
-            },
-            {
-                key: 'im_started_at',
-                getLogValue: log => convertDate(log.im_started_at),
-            },
-            {
-                key: 'im_ended_at',
-                getLogValue: log => convertDate(log.im_ended_at),
-            },
-            {
-                key: 'lqas_started_at',
-                getLogValue: log => convertDate(log.lqas_started_at),
-            },
-            {
-                key: 'lqas_ended_at',
-                getLogValue: log => convertDate(log.lqas_ended_at),
-            },
-            {
-                key: 'lqas_district_passing',
-            },
-            {
-                key: 'lqas_district_failing',
-            },
-            {
-                key: 'main_awareness_problem',
-            },
-            {
-                key: 'im_percentage_children_missed_in_household',
-            },
-            {
-                key: 'im_percentage_children_missed_out_household',
-            },
-            {
-                key: 'awareness_of_campaign_planning',
-            },
-            {
-                key: 'scopes',
-                type: 'array',
-                childrenLabel: MESSAGES.scope,
-                children: [
-                    {
-                        key: 'id',
-                    },
-                    {
-                        key: 'group',
-                        type: 'object',
-                        childrenLabel: MESSAGES.group,
-                        children: [
-                            {
-                                key: 'id',
-                            },
-                            {
-                                key: 'org_units',
-                                getLogValue: log =>
-                                    log.org_units.map((ouId, index) => {
-                                        const lastArrayItem =
-                                            log.org_units[
-                                                log.org_units.length - 1
-                                            ];
-                                        return (
+        },
+        {
+            key: 'onset_at',
+            getLogValue: log => convertDate(log.onset_at),
+        },
+        {
+            key: 'cvdpv2_notified_at',
+            getLogValue: log => convertDate(log.cvdpv2_notified_at),
+        },
+        {
+            key: 'virus',
+        },
+        {
+            key: 'vacine',
+        },
+        {
+            key: 'is_preventive',
+            getLogValue: log =>
+                convertBoolean(log.is_preventive, formatMessage),
+        },
+        {
+            key: 'is_test',
+            getLogValue: log => convertBoolean(log.is_test, formatMessage),
+        },
+        {
+            key: 'enable_send_weekly_email',
+            getLogValue: log =>
+                convertBoolean(log.enable_send_weekly_email, formatMessage),
+        },
+        {
+            key: 'pv_notified_at',
+            getLogValue: log => convertDate(log.pv_notified_at),
+        },
+        {
+            key: 'three_level_call_at',
+            getLogValue: log => convertDate(log.three_level_call_at),
+        },
+        // Detection
+        {
+            key: 'detection_status',
+        },
+        {
+            key: 'detection_responsible',
+        },
+        // Risk assessment
+        {
+            key: 'risk_assessment_status',
+        },
+        {
+            key: 'verification_score',
+        },
+        {
+            key: 'investigation_at',
+            getLogValue: log => convertDate(log.investigation_at),
+        },
+        {
+            key: 'risk_assessment_first_draft_submitted_at',
+            getLogValue: log =>
+                convertDate(log.risk_assessment_first_draft_submitted_at),
+        },
+        {
+            key: 'risk_assessment_rrt_oprtt_approval_at',
+            getLogValue: log =>
+                convertDate(log.risk_assessment_rrt_oprtt_approval_at),
+        },
+        {
+            key: 'ag_nopv_group_met_at',
+            getLogValue: log => convertDate(log.ag_nopv_group_met_at),
+        },
+        {
+            key: 'dg_authorized_at',
+            getLogValue: log => convertDate(log.dg_authorized_at),
+        },
+        {
+            key: 'risk_assessment_responsible',
+        },
+        // Budget
+        {
+            key: 'budget_status',
+            getLogValue: log => upperCase(log.budget_status),
+        },
+        {
+            key: 'budget_current_state_label',
+        },
+        // Budget request
+        {
+            key: 'who_sent_budget',
+            getLogValue: log => convertDate(log.who_sent_budget_at_WFEDITABLE),
+        },
+        {
+            key: 'unicef_sent_budget',
+            getLogValue: log =>
+                convertDate(log.unicef_sent_budget_at_WFEDITABLE, 'L'),
+        },
+        {
+            key: 'gpei_consolidated_budgets',
+            getLogValue: log =>
+                convertDate(log.gpei_consolidated_budgets_at_WFEDITABLE, 'L'),
+        },
+        // RRT review
+        {
+            key: 'submitted_to_rrt',
+            getLogValue: log =>
+                convertDate(log.submitted_to_rrt_at_WFEDITABLE, 'L'),
+        },
+        {
+            key: 'feedback_sent_to_gpei',
+            getLogValue: log =>
+                convertDate(log.feedback_sent_to_gpei_at_WFEDITABLE, 'L'),
+        },
+        {
+            key: 're_submitted_to_rrt',
+            getLogValue: log =>
+                convertDate(log.re_submitted_to_rrt_at_WFEDITABLE, 'L'),
+        },
+        // ORPG review
+        {
+            key: 'submitted_to_orpg_operations1',
+            getLogValue: log =>
+                convertDate(
+                    log.submitted_to_orpg_operations1_at_WFEDITABLE,
+                    'L',
+                ),
+        },
+        {
+            key: 'feedback_sent_to_rrt1',
+            getLogValue: log =>
+                convertDate(log.feedback_sent_to_rrt1_at_WFEDITABLE, 'L'),
+        },
+        {
+            key: 're_submitted_to_orpg_operations1',
+            getLogValue: log =>
+                convertDate(
+                    log.re_submitted_to_orpg_operations1_at_WFEDITABLE,
+                    'L',
+                ),
+        },
+        {
+            key: 'submitted_to_orpg_wider',
+            getLogValue: log =>
+                convertDate(log.submitted_to_orpg_wider_at_WFEDITABLE, 'L'),
+        },
+        {
+            key: 'submitted_to_orpg_operations2',
+            getLogValue: log =>
+                convertDate(
+                    log.submitted_to_orpg_operations2_at_WFEDITABLE,
+                    'L',
+                ),
+        },
+        {
+            key: 'feedback_sent_to_rrt2',
+            getLogValue: log =>
+                convertDate(log.feedback_sent_to_rrt2_at_WFEDITABLE, 'L'),
+        },
+        {
+            key: 're_submitted_to_orpg_operations2',
+            getLogValue: log =>
+                convertDate(
+                    log.re_submitted_to_orpg_operations2_at_WFEDITABLE,
+                    'L',
+                ),
+        },
+        // APPROVAL
+        {
+            key: 'submitted_for_approval',
+            getLogValue: log =>
+                convertDate(log.submitted_for_approval_at_WFEDITABLE, 'L'),
+        },
+        {
+            key: 'feedback_sent_to_orpg_operations_unicef',
+            getLogValue: log =>
+                convertDate(
+                    log.feedback_sent_to_orpg_operations_unicef_at_WFEDITABLE,
+                    'L',
+                ),
+        },
+        {
+            key: 'feedback_sent_to_orpg_operations_who',
+            getLogValue: log =>
+                convertDate(
+                    log.feedback_sent_to_orpg_operations_who_at_WFEDITABLE,
+                    'L',
+                ),
+        },
+        {
+            key: 'approved_by_who',
+            getLogValue: log => convertDate(log.approved_by_who_at_WFEDITABLE),
+        },
+        {
+            key: 'approved_by_unicef',
+            getLogValue: log =>
+                convertDate(log.approved_by_unicefat_WFEDITABLE),
+        },
+        {
+            key: 'approved',
+            getLogValue: log => convertDate(log.approved_at_WFEDITABLE),
+        },
+        {
+            key: 'approval_confirmed',
+            getLogValue: log =>
+                convertDate(log.approval_confirmed_at_WFEDITABLE),
+        },
+        {
+            key: 'payment_mode',
+        },
+        {
+            key: 'who_disbursed_to_co_at',
+            getLogValue: log => convertDate(log.who_disbursed_to_co_at),
+        },
+        {
+            key: 'unicef_disbursed_to_co_at',
+            getLogValue: log => convertDate(log.unicef_disbursed_to_co_at),
+        },
+        {
+            key: 'district_count',
+        },
+        {
+            key: 'no_regret_fund_amount',
+        },
+        {
+            key: 'budget_submitted_at',
+            getLogValue: log => convertDate(log.budget_submitted_at),
+        },
+        // Preparedness
+        {
+            key: 'preparedness_spreadsheet_url',
+        },
+        {
+            key: 'surge_spreadsheet_url',
+        },
+        {
+            key: 'preperadness_sync_status',
+        },
+        // Scopes
+        {
+            key: 'scopes',
+            type: 'array',
+            childrenLabel: MESSAGES.scope,
+            children: [
+                {
+                    key: 'id',
+                },
+                {
+                    key: 'group',
+                    type: 'object',
+                    childrenLabel: MESSAGES.group,
+                    children: [
+                        {
+                            key: 'id',
+                        },
+                        {
+                            key: 'org_units',
+                            getLogValue: log =>
+                                log.org_units.map((ouId, index) => {
+                                    const lastArrayItem =
+                                        log.org_units[log.org_units.length - 1];
+                                    return (
+                                        <Box key={ouId} display="inline-block">
                                             <Link
                                                 target="_blank"
                                                 href={`/dashboard/orgunits/detail/orgUnitId/${ouId}`}
                                             >
                                                 {ouId}
-                                                {log.org_units[index] !==
-                                                    lastArrayItem && ','}
                                             </Link>
-                                        );
-                                    }),
-                            },
-                        ],
-                    },
-                ],
-            },
-            {
-                key: 'campaign',
-            },
-            // Vaccines
-            {
-                key: 'vaccines',
-                type: 'array',
-                childrenLabel: MESSAGES.vaccine,
-                children: [
-                    {
-                        key: 'id',
-                    },
-                    {
-                        key: 'dosesPerVial',
-                    },
-                    {
-                        key: 'name',
-                    },
-                    {
-                        key: 'round',
-                    },
-                    {
-                        key: 'wastageRatio',
-                    },
-                ],
-            },
-            {
-                key: 'reporting_delays_hc_to_district',
-            },
-            {
-                key: 'reporting_delays_district_to_region',
-            },
-            {
-                key: 'reporting_delays_region_to_national',
-            },
-            {
-                key: 'shipments',
-                type: 'array',
-                childrenLabel: MESSAGES.shipment,
-                children: [
-                    {
-                        key: 'id',
-                    },
-                    {
-                        key: 'round',
-                    },
-                    {
-                        key: 'po_numbers',
-                    },
-                    {
-                        key: 'vaccine_name',
-                    },
-                    {
-                        key: 'receptionVaccineArrivalReport',
-                        getLogValue: log => convertDate(log.date_reception),
-                    },
-                    {
-                        key: 'vials_received',
-                    },
-                    {
-                        key: 'receptionPreAlert',
-                        getLogValue: log =>
-                            convertDate(log.reception_pre_alert),
-                    },
-                    {
-                        key: 'estimatedDateOfArrival',
-                        getLogValue: log =>
-                            convertDate(log.estimated_arrival_date),
-                    },
-                    {
-                        key: 'comment',
-                    },
-                ],
-            },
-            {
-                key: 'forma_reception',
-                getLogValue: log => convertDate(log.forma_reception),
-            },
-            {
-                key: 'forma_date',
-                getLogValue: log => convertDate(log.forma_date),
-            },
-            {
-                key: 'forma_unusable_vials',
-            },
-            {
-                key: 'forma_usable_vials',
-            },
-            {
-                key: 'forma_missing_vials',
-            },
-            {
-                key: 'forma_comment',
-            },
-            // Destructions
-            {
-                key: 'destructions',
-                type: 'array',
-                childrenLabel: MESSAGES.destruction,
-                children: [
-                    {
-                        key: 'id',
-                    },
-                    {
-                        key: 'round',
-                    },
-                    {
-                        key: 'destructionReceptionDate',
-                        getLogValue: log =>
-                            convertDate(log.date_report_received),
-                    },
-                    {
-                        key: 'destructionReportDate',
-                        getLogValue: log => convertDate(log.date_report),
-                    },
-                    {
-                        key: 'vials_destroyed',
-                    },
-                    {
-                        key: 'comment',
-                    },
-                ],
-            },
-        ],
-    },
-    {
-        key: 'geojson',
-        getLogValue: log => {
-            const hasGeoJson =
-                log.geojson !== undefined && log.geojson.length > 0;
-
-            if (hasGeoJson) {
-                return <GeoJsonMap geoJson={log.geojson} />;
-            }
-            return <FormattedMessage {...MESSAGES.noGeojson} />;
+                                            {log.org_units[index] !==
+                                                lastArrayItem && ','}
+                                        </Box>
+                                    );
+                                }),
+                        },
+                    ],
+                },
+            ],
         },
-    },
-    {
-        key: 'creation_email_send_at',
-        getLogValue: log => convertDate(log.creation_email_send_at),
-    },
-    // DEPRECATED FIELDS ?
-    // {
-    //     key: 'last_budget_event',
-    // },
-    // {
-    //     key: 'pv2_notified_at',
-    //     getLogValue: log => convertDate(log.pv2_notified_at),
-    // },
-    // {
-    //     key: 'detection_rrt_oprtt_approval_at',
+        {
+            key: 'separate_scopes_per_round',
+            getLogValue: log =>
+                convertBoolean(log.separate_scopes_per_round, formatMessage),
+        },
+        // Rounds
+        {
+            key: 'rounds',
+            type: 'array',
+            childrenLabel: MESSAGES.round,
+            children: [
+                {
+                    key: 'id',
+                },
+                {
+                    key: 'cost',
+                },
+                {
+                    key: 'number',
+                },
+                {
+                    key: 'started_at',
+                    getLogValue: log => convertDate(log.started_at),
+                },
+                {
+                    key: 'ended_at',
+                    getLogValue: log => convertDate(log.ended_at),
+                },
+                {
+                    key: 'mop_up_started_at',
+                    getLogValue: log => convertDate(log.mop_up_started_at),
+                },
+                {
+                    key: 'mop_up_ended_at',
+                    getLogValue: log => convertDate(log.mop_up_ended_at),
+                },
+                {
+                    key: 'im_started_at',
+                    getLogValue: log => convertDate(log.im_started_at),
+                },
+                {
+                    key: 'im_ended_at',
+                    getLogValue: log => convertDate(log.im_ended_at),
+                },
+                {
+                    key: 'lqas_started_at',
+                    getLogValue: log => convertDate(log.lqas_started_at),
+                },
+                {
+                    key: 'lqas_ended_at',
+                    getLogValue: log => convertDate(log.lqas_ended_at),
+                },
+                {
+                    key: 'lqas_district_passing',
+                },
+                {
+                    key: 'lqas_district_failing',
+                },
+                {
+                    key: 'main_awareness_problem',
+                },
+                {
+                    key: 'im_percentage_children_missed_in_household',
+                },
+                {
+                    key: 'im_percentage_children_missed_out_household',
+                },
+                {
+                    key: 'awareness_of_campaign_planning',
+                },
+                {
+                    key: 'scopes',
+                    type: 'array',
+                    childrenLabel: MESSAGES.scope,
+                    children: [
+                        {
+                            key: 'id',
+                        },
+                        {
+                            key: 'group',
+                            type: 'object',
+                            childrenLabel: MESSAGES.group,
+                            children: [
+                                {
+                                    key: 'id',
+                                },
+                                {
+                                    key: 'org_units',
+                                    getLogValue: log =>
+                                        log.org_units.map((ouId, index) => {
+                                            const lastArrayItem =
+                                                log.org_units[
+                                                    log.org_units.length - 1
+                                                ];
+                                            return (
+                                                <Link
+                                                    target="_blank"
+                                                    href={`/dashboard/orgunits/detail/orgUnitId/${ouId}`}
+                                                >
+                                                    {ouId}
+                                                    {log.org_units[index] !==
+                                                        lastArrayItem && ','}
+                                                </Link>
+                                            );
+                                        }),
+                                },
+                            ],
+                        },
+                    ],
+                },
+                {
+                    key: 'campaign',
+                },
+                // Vaccines
+                {
+                    key: 'vaccines',
+                    type: 'array',
+                    childrenLabel: MESSAGES.vaccine,
+                    children: [
+                        {
+                            key: 'id',
+                        },
+                        {
+                            key: 'dosesPerVial',
+                        },
+                        {
+                            key: 'name',
+                        },
+                        {
+                            key: 'round',
+                        },
+                        {
+                            key: 'wastageRatio',
+                        },
+                    ],
+                },
+                {
+                    key: 'reporting_delays_hc_to_district',
+                },
+                {
+                    key: 'reporting_delays_district_to_region',
+                },
+                {
+                    key: 'reporting_delays_region_to_national',
+                },
+                {
+                    key: 'shipments',
+                    type: 'array',
+                    childrenLabel: MESSAGES.shipment,
+                    children: [
+                        {
+                            key: 'id',
+                        },
+                        {
+                            key: 'round',
+                        },
+                        {
+                            key: 'po_numbers',
+                        },
+                        {
+                            key: 'vaccine_name',
+                        },
+                        {
+                            key: 'receptionVaccineArrivalReport',
+                            getLogValue: log => convertDate(log.date_reception),
+                        },
+                        {
+                            key: 'vials_received',
+                        },
+                        {
+                            key: 'receptionPreAlert',
+                            getLogValue: log =>
+                                convertDate(log.reception_pre_alert),
+                        },
+                        {
+                            key: 'estimatedDateOfArrival',
+                            getLogValue: log =>
+                                convertDate(log.estimated_arrival_date),
+                        },
+                        {
+                            key: 'comment',
+                        },
+                    ],
+                },
+                {
+                    key: 'forma_reception',
+                    getLogValue: log => convertDate(log.forma_reception),
+                },
+                {
+                    key: 'forma_date',
+                    getLogValue: log => convertDate(log.forma_date),
+                },
+                {
+                    key: 'forma_unusable_vials',
+                },
+                {
+                    key: 'forma_usable_vials',
+                },
+                {
+                    key: 'forma_missing_vials',
+                },
+                {
+                    key: 'forma_comment',
+                },
+                // Destructions
+                {
+                    key: 'destructions',
+                    type: 'array',
+                    childrenLabel: MESSAGES.destruction,
+                    children: [
+                        {
+                            key: 'id',
+                        },
+                        {
+                            key: 'round',
+                        },
+                        {
+                            key: 'destructionReceptionDate',
+                            getLogValue: log =>
+                                convertDate(log.date_report_received),
+                        },
+                        {
+                            key: 'destructionReportDate',
+                            getLogValue: log => convertDate(log.date_report),
+                        },
+                        {
+                            key: 'vials_destroyed',
+                        },
+                        {
+                            key: 'comment',
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            key: 'geojson',
+            getLogValue: log => {
+                const hasGeoJson =
+                    log.geojson !== undefined && log.geojson.length > 0;
 
-    //     getLogValue: log =>
-    //         convertDate(log.detection_rrt_oprtt_approval_at_WFEDITABLE, 'L'),
-    // },
-    // {
-    //     key: 'detection_first_draft_submitted_at',
-    //     getLogValue: log =>
-    //         convertDate(log.detection_first_draft_submitted_at_WFEDITABLE, 'L'),
-    // },
-];
+                if (hasGeoJson) {
+                    return <GeoJsonMap geoJson={log.geojson} />;
+                }
+                return formatMessage(MESSAGES.noGeojson);
+            },
+        },
+        {
+            key: 'creation_email_send_at',
+            getLogValue: log => convertDate(log.creation_email_send_at),
+        },
+        // DEPRECATED FIELDS ?
+        // {
+        //     key: 'last_budget_event',
+        // },
+        // {
+        //     key: 'pv2_notified_at',
+        //     getLogValue: log => convertDate(log.pv2_notified_at),
+        // },
+        // {
+        //     key: 'detection_rrt_oprtt_approval_at',
+
+        //     getLogValue: log =>
+        //         convertDate(log.detection_rrt_oprtt_approval_at_WFEDITABLE, 'L'),
+        // },
+        // {
+        //     key: 'detection_first_draft_submitted_at',
+        //     getLogValue: log =>
+        //         convertDate(log.detection_first_draft_submitted_at_WFEDITABLE, 'L'),
+        // },
+    ];
+};

--- a/plugins/polio/js/src/constants/messages.js
+++ b/plugins/polio/js/src/constants/messages.js
@@ -9,6 +9,10 @@ const MESSAGES = defineMessages({
         id: 'iaso.polio.label.geojson',
         defaultMessage: 'Geojson',
     },
+    noGeojson: {
+        id: 'iaso.label.hasNoGeometryAndGps',
+        defaultMessage: 'Without geographic data',
+    },
     selectOrgUnit: {
         id: 'iaso.polio.label.selectOrgUnit',
         defaultMessage: 'Select intial region',

--- a/plugins/polio/js/src/hooks/useGetCampaignFieldLabel.ts
+++ b/plugins/polio/js/src/hooks/useGetCampaignFieldLabel.ts
@@ -2,7 +2,6 @@
 // @ts-ignore
 
 import { useSafeIntl } from 'bluesquare-components';
-import { IntlMessage } from '../../../../../hat/assets/js/apps/Iaso/types/intl';
 
 import MESSAGES from '../constants/messages';
 


### PR DESCRIPTION
Date of onset is now displayed in format `DD/MM/YYYY` as the other date fields
Geojson show clear message if there is now Scope

https://user-images.githubusercontent.com/25134301/229091007-abe6ea0d-7afd-4b2b-b731-7ad8f47a378a.mov


Related JIRA tickets : [POLIO-925](https://bluesquare.atlassian.net/browse/POLIO-925?atlOrigin=eyJpIjoiYmUwOGRjZWYyMmNlNGQ4NjgxYTM4ZjQ4OTIwM2I2NmQiLCJwIjoiaiJ9)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are my typescript files well typed
- [ ] New translations have been added or updated if new string have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- pass `getLogValue` to onset_at and creation_email_send_at to convert date and display it in good format
- show explicit message if no geographic data for geojon instead of displaying empty placeholder

## How to test

- Go to Campaign
- Click on a campaign 
- Add/Change value of **Date of onset** field in Base Info Tab, check if date is displayed in format DD/MM/YYYY
- Check if there is no scope, Geojson value should be "Without geographic data"
 

## Print screen / video

https://user-images.githubusercontent.com/25134301/229087584-b445f883-27b1-4ce0-96ac-67a9a5c178b1.mov

[POLIO-925]: https://bluesquare.atlassian.net/browse/POLIO-925?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ