### PR TITLE
IA-2042 Polio weekly email relax precondition for campaign

### DIFF
--- a/iaso/management/commands/dhis2_ou_importer.py
+++ b/iaso/management/commands/dhis2_ou_importer.py
@@ -45,6 +45,9 @@ class FakeTask:
     def report_progress_and_stop_if_killed(self, progress_value=None, progress_message=None, end_value=None):
         self.logger.info(progress_message, progress_value, "/", end_value)
 
+    def report_success(self, message):
+        self.logger.info(message)
+
 
 def parse_type_dict(org_unit_type_file_name):
     type_dict = dict()

--- a/plugins/polio/management/commands/test_send_email.py
+++ b/plugins/polio/management/commands/test_send_email.py
@@ -1,13 +1,42 @@
 from django.core.management.base import BaseCommand
+from django.utils.timezone import now
+
+from iaso.management.commands.command_logger import CommandLogger
+from iaso.management.commands.dhis2_ou_importer import FakeTask
 from plugins.polio.models import Campaign
-from plugins.polio.tasks.weekly_email import send_notification_email
+from plugins.polio.tasks.weekly_email import send_notification_email, send_email
+from logging import getLogger
+
+logger = getLogger(__name__)
 
 
 class Command(BaseCommand):
-    help = "Send campaign automatic email to GPEI coordinator"
+    help = """Send campaigns automatic email to GPEI coordinator
+    (to use for dev debguging)"""
 
     def handle(self, *args, **options):
-        # replace obr_name value by one you set locally in a campaign
-        my_campaign = Campaign.objects.get(obr_name="GAM-65DS-06-2023")
-        print(my_campaign)
-        send_notification_email(my_campaign)
+        campaigns = Campaign.objects.exclude(enable_send_weekly_email=False)
+        total = campaigns.count()
+        email_sent = 0
+        iaso_logger = CommandLogger(self.stdout)
+        task = FakeTask(iaso_logger)
+
+        for i, campaign in enumerate(campaigns):
+
+            task.report_progress_and_stop_if_killed(
+                progress_value=i,
+                end_value=total,
+                progress_message=f"Campaign {campaign.pk} started",
+            )
+
+            latest_round_end = campaign.rounds.order_by("ended_at").last()
+            if latest_round_end and latest_round_end.ended_at and latest_round_end.ended_at > now().date():
+                print(f"Campaign {campaign} is finished, skipping")
+                continue
+            print(f"Email for {campaign.obr_name}")
+            status = send_notification_email(campaign)
+            if not status:
+                logger.info(f"... skipped")
+            else:
+                email_sent += 1
+        task.report_success(f"Finished sending {email_sent} weekly-email(s)")

--- a/plugins/polio/tasks/weekly_email.py
+++ b/plugins/polio/tasks/weekly_email.py
@@ -29,7 +29,8 @@ def send_notification_email(campaign):
     domain = settings.DNS_DOMAIN
     from_email = settings.DEFAULT_FROM_EMAIL
 
-    if not (campaign.obr_name and campaign.virus and country and campaign.onset_at and campaign.deleted_at is None):
+    if not (campaign.obr_name and country and campaign.deleted_at is None):
+        print(f"Campaign {campaign} skipped because of missing fields")
         return False
     try:
         cug = CountryUsersGroup.objects.get(country=country)
@@ -56,7 +57,7 @@ def send_notification_email(campaign):
         first_round = None
     round1_days = (
         (first_round.started_at - campaign.onset_at).days
-        if first_round and first_round.started_at and campaign.cvdpv2_notified_at
+        if first_round and first_round.started_at and campaign.onset_at
         else ""
     )
     c = campaign


### PR DESCRIPTION
 Relax the requirement for sending the reminded e-mail as some mail were not send while the users were expecting them

Remove the onset_at and virus requirement as they are often not set.


Related JIRA tickets : IA-2042

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [NA] My migrations file are included
- [No] Are there enough tests

## Changes



## How to test

Need to have the proper polio setup with mail.
I have adapted the test_send_email command to replicate the logic of the weekly_email and loop through all the campaigns
