### PR TITLE
WC2-179 Fix calculate types can't be mapped to calculate types

### DIFF
--- a/iaso/api/workflows/serializers.py
+++ b/iaso/api/workflows/serializers.py
@@ -129,9 +129,10 @@ class WorkflowChangeCreateSerializer(serializers.Serializer):
                 r_type = q["type"]
 
             if s_type == CALCULATE_TYPE:
-                if r_type != TEXT_TYPE:
+                if r_type != TEXT_TYPE and r_type != CALCULATE_TYPE:
                     raise serializers.ValidationError(
-                        f"Question {_source} is a 'calculate' question and cannot only be mapped to 'string' type, found : {r_type}"
+                        f"Question {_source} is a 'calculate' question and cannot only be mapped to 'string' or "
+                        f"'calculate' type, found : {r_type}"
                     )
             elif s_type != r_type:
                 raise serializers.ValidationError(f"Question {_source} and {_target} do not have the same type")


### PR DESCRIPTION
There was an oversight in the previous PR that forgot to allow calculate types to target other calculate types

Related JIRA tickets : WC2-179

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented

## Changes

The calculate type can now be mapped to other calculate types

## How to test

In the workflow admin, add a change that takes a calculate type and targets another calculate type.
Save and it should work.