### PR TITLE
IA-2036: update user guide link in sidemenu

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/app/components/SidebarMenuComponent.js
+++ b/hat/assets/js/apps/Iaso/domains/app/components/SidebarMenuComponent.js
@@ -84,7 +84,7 @@ const localizedManualUrl = (locale, account) => {
     if (locale === 'fr' && account === 'RDC') {
         return 'https://docs.google.com/document/d/1lKyhbKDLZpHtAsf3K6pRs0_EAXWdSDsL76Ohv0cyZQc/edit';
     }
-    return 'https://docs.google.com/document/d/1qHCRIiYgbZYAKMqxXYOjBGL_nzlSDPhOLykiKXaw8fw/edit';
+    return 'https://docs.google.com/document/d/12eXaHgQ0egNp1SMS86gv_X2j5vhpohU_Usagq4u_FAw/edit';
 };
 
 const SidebarMenu = ({


### PR DESCRIPTION
The current user guide is an old version from 2021, replaced it by the new one from 2022

Related JIRA tickets : [IA-2036](https://bluesquare.atlassian.net/browse/IA-2036?atlOrigin=eyJpIjoiOWE2YmViZWE2OTQxNDM1Yzk4NzUxNmZiYTVmMzA3MzQiLCJwIjoiaiJ9)

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new string have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)


https://user-images.githubusercontent.com/25134301/229164201-bc4f32e5-d508-4b8b-be0d-c24c6e0a7bdc.mov



[IA-2036]: https://bluesquare.atlassian.net/browse/IA-2036?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ