### PR TITLE
WC-201: Worflow follow up condition not displayed

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/workflows/components/followUps/Table.tsx
+++ b/hat/assets/js/apps/Iaso/domains/workflows/components/followUps/Table.tsx
@@ -49,6 +49,7 @@ export const FollowUpsTable: FunctionComponent<Props> = ({
                 params={params}
                 extraProps={{
                     isLoading,
+                    followUpsColumns,
                 }}
             />
             <Box display="flex" justifyContent="flex-end" pr={2} pb={2} mt={-2}>


### PR DESCRIPTION
Condition are not visible while visiting a non DRAFT workflow version

<img width="1658" alt="Screenshot 2023-04-04 at 11 37 24" src="https://user-images.githubusercontent.com/12494624/229752730-c417d36f-8574-4113-a084-b896ce659795.png">


Related JIRA tickets : WC2-201

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new string have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

Pass columns in extra props to rerender table while updating fields

## How to test

Open a worflow version wiht condition in follow ups, human readable condition should be visible while on a non DRAFT version

## Print screen / video

<img width="1674" alt="Screenshot 2023-04-04 at 11 37 39" src="https://user-images.githubusercontent.com/12494624/229752573-17921235-17ee-4a1c-8abb-e4c272dac997.png">

