### PR TITLE
Script to automatically update translation file with stub value so it is easier to translate

### DIFF
--- a/hat/assets/README.rst
+++ b/hat/assets/README.rst
@@ -178,9 +178,12 @@ or
 Translations
 ============
 
-Translations are extracted on the first webpack build. Just like the django
-translation strings; translations are downloaded for every `Travis CI <https://travis-ci.com>`__
-build, and uploaded on the ``development`` branch.
+Run `./scripts/update_trads.py` it will automatically extract translations and populate the translation json with the new ones.
+
+Then search for CHECKME in your editor for the string to validate and translate. Remove the CHECKME when you check them.
+
+Re run the script until all strings are translated.
+
 
 Set up VSCode for front-end development
 =======================================

--- a/scripts/update_trads.py
+++ b/scripts/update_trads.py
@@ -19,6 +19,7 @@ TODO: Add the check in CI
 
 import json
 import sys
+import typing
 from collections import OrderedDict, defaultdict
 import os
 
@@ -58,6 +59,7 @@ if __name__ == "__main__":
 
     # keep trace of what we set in previous traduction file. so we can detect properly
     # if a plugin reuse a translation from the main file
+    previous_trad: typing.DefaultDict[str, typing.Dict[str, str]]
     previous_trad = defaultdict(dict)
     for path in paths:
         trad_dir = path["translations_dir"]

--- a/scripts/update_trads.py
+++ b/scripts/update_trads.py
@@ -1,0 +1,96 @@
+#!python3
+"""Update the translation json files
+
+Run the npm formats command to extract the translation from the code
+Add them to the traduction file if not present.
+Add a CHECKME on the new added traduction so they can be found easily
+Count the number of CHECKME and missing trad so we can check the translation is complete.
+
+To use:
+ - run it
+ - search for CHECKME in your editor. Check these string, remove the CHECKME
+ - re run it. If it's say it's ok that's good.
+ - commit
+ - success
+
+TODO: Remove old trad?
+TODO: Add the check in CI
+"""
+
+import json
+import sys
+from collections import OrderedDict, defaultdict
+import os
+
+
+def extract_translations(path, trad_dir):
+    print(f"Extracting translations for {path}...")
+    extracted_name = "extracted_translation.json"
+    extracted_path = trad_dir + extracted_name
+
+    extract_cmd = (
+        f"./node_modules/.bin/formatjs extract --out-file '{extracted_path}' '{path}**/*.{{js,tsx,ts}}' --format=simple"
+    )
+    os.system(extract_cmd)
+
+    extracted = json.load(open(extracted_path, encoding="utf8"))
+    print(f"Translations extracted {len(extracted)}")
+    return extracted
+
+
+# command to manually extracd trad
+# ./node_modules/.bin/formatjs extract --out-file 'extracted.json' './hat/assets/js/apps/Iaso/**/*.[js]sx?' --format=simple
+
+
+# expect the "main" dir to be before the plugin
+paths = [
+    {
+        "source_files": "./hat/assets/js/apps/Iaso/",
+        "translations_dir": "hat/assets/js/apps/Iaso/domains/app/translations/",
+    },
+    {"source_files": "./plugins/polio/js/", "translations_dir": "plugins/polio/js/src/constants/translations/"},
+]
+if __name__ == "__main__":
+    if os.getcwd().endswith("scripts"):  # we are in the script directory, go up a level
+        os.chdir("..")
+
+    missing_translations = 0
+
+    # keep trace of what we set in previous traduction file. so we can detect properly
+    # if a plugin reuse a translation from the main file
+    previous_trad = defaultdict(dict)
+    for path in paths:
+        trad_dir = path["translations_dir"]
+        extracted = extract_translations(path["source_files"], trad_dir)
+
+        added_trad = 0
+        for lang in ["en", "fr"]:
+            original_name = trad_dir + lang + ".json"
+            original = json.load(open(original_name, encoding="utf8"))
+            previous_trad_for_lang = previous_trad[lang]
+
+            for new_key, value in extracted.items():
+                if (
+                    new_key not in original.keys()
+                    and not new_key.startswith("blsq")
+                    and new_key not in previous_trad_for_lang
+                ):
+                    added_trad += 1
+                    missing_translations += 1
+                    # ADD CHECKME so we can see the new strings easily
+                    original[new_key] = value + " CHECKME"
+                elif "CHECKME" in original.get(new_key, ""):
+                    missing_translations += 1
+
+            print(f"Translations added: {added_trad} for {lang}")
+            previous_trad_for_lang.update(original)
+            # somehow try to replicate VSCODE bizarre keys ordering
+            sorted_dict = OrderedDict(sorted(original.items(), key=lambda x: x[0].lower().replace("_", "!")))
+            with (open(original_name, "w+", encoding="utf8")) as file_write:
+                # ensure_ascii is necessary othewhise it didn't properly encode unicode, not sure why.
+                json.dump(sorted_dict, fp=file_write, indent=4, ensure_ascii=False)
+    if missing_translations:
+        print("Please translate the translation containing CHECKME and remove it.")
+        sys.exit(f"Translations to check : {missing_translations}")
+    else:
+        print("All translations are up to date")


### PR DESCRIPTION
If you run `./scripts/update_trads.py` it will automatically extract translations and populate the translation json with the new ones

Example run
```
olivier:~/Projects/blsq/iaso] update_trads_script+* 1 ± ./scripts/update_trads.py
Extracting translations for ./hat/assets/js/apps/Iaso/...
[@formatjs/cli] [WARN] [FormatJS CLI] Duplicate message id: "iaso.snackBar.fetchMappingsError", but the `description` and/or `defaultMessage` are different.[@formatjs/cli] [WARN] [FormatJS CLI] Duplicate message id: "iaso.label.dateFrom", 
[...]]
Translations extracted 971
Translations added: 0 for en
Translations added: 0 for fr
Extracting translations for ./plugins/polio/js/...
[@formatjs/cli] [WARN] [FormatJS CLI] Duplicate message id: "iaso.polio.form.label.verificationScore", but the `description` and/or `defaultMessage` are different.[@formatjs/cli] [WARN] [FormatJS CLI] Duplicate message id: "iaso.polio.table.label.status", but the `description` and/or `defaultMessage` are different.[@formatjs/cli] [WARN] [FormatJS CLI] Duplicate message id: "iaso.polio.form.label.rrtOprttApproval", but the `description` and/or `defaultMessage` are different.
Translations extracted 480
Translations added: 9 for en
Translations added: 16 for fr
Please translate the translation containing CHECKME and remove it.
Translations to check : 16
```

For example:
```diff
diff --git a/plugins/polio/js/src/constants/translations/en.json b/plugins/polio/js/src/constants/translations/en.json
index 1abee4f6a..181f5a191 100644
--- a/plugins/polio/js/src/constants/translations/en.json
+++ b/plugins/polio/js/src/constants/translations/en.json
@@ -47,6 +47,7 @@
     "iaso.polio.form.label.APPROVED": "Approved",
     "iaso.polio.form.label.approved_by_unicef": "Approved by UNICEF",
     "iaso.polio.form.label.approved_by_who": "Approved by WHO",
+    "iaso.polio.form.label.approved_by_who_at_WFEDITABLE": "Date of approval by WHO CHECKME",
     "iaso.polio.form.label.awarenessCampaignPlanning": "Awareness of campaign planning (%)",
     "iaso.polio.form.label.budget_submitted_at": "Budget Submitted At",
     "iaso.polio.form.label.budgetApproval": "Budget Approval",
[...]
```


## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are my typescript files well typed
- [Curious that you ask..] New translations have been added or updated if new strings have been introduced in the frontend
- [NA] My migrations file are included
- [x] Are there enough tests
- [x] Documentation has been included (for new feature)

## Changes

Explain the changes that were made. The idea is not to list exhaustively all the changes made (GitHub already provides a full diff), but to help the reviewers better understand:
- which specific file changes go together, e.g: when creating a table in the front-end, there usually is a config file that goes with it
- the reasoning behind some changes, e.g: deleted files because they are now redundant
- the behaviour to expect, e.g: tooltip has purple background color because the client likes it so, changed a key in the API response to be consistent with other endpoints

## How to test
Just run it. If you merge the polio-940 branch all trad should be ok.
Otherwise it should modify the file.

## Print screen / video

See the magnificent console output above

## Notes

The goal afterward would be to have this run in the CI so we don't have untranslated strings.