### PR TITLE
POLIO-955: change label test campaign

### DIFF
--- a/plugins/polio/js/src/constants/messages.js
+++ b/plugins/polio/js/src/constants/messages.js
@@ -1272,7 +1272,7 @@ const MESSAGES = defineMessages({
     },
     is_test: {
         id: 'iaso.polio.label.testCampaign',
-        defaultMessage: 'Test campaign',
+        defaultMessage: 'Test campaigns/On hold status',
     },
     testCampaigns: {
         id: 'iaso.polio.label.testCampaigns',

--- a/plugins/polio/js/src/constants/translations/en.json
+++ b/plugins/polio/js/src/constants/translations/en.json
@@ -382,7 +382,7 @@
     "iaso.polio.label.submission": "Submission",
     "iaso.polio.label.submitted": "Submitted",
     "iaso.polio.label.Teachers_Student": "Teachers",
-    "iaso.polio.label.testCampaign": "Test campaign",
+    "iaso.polio.label.testCampaign": "Test campaign/On hold status",
     "iaso.polio.label.testCampaigns": "Test campaigns",
     "iaso.polio.label.toSubmit": "To submit",
     "iaso.polio.label.Tot_child_Absent_HH": "Child absent",

--- a/plugins/polio/js/src/constants/translations/fr.json
+++ b/plugins/polio/js/src/constants/translations/fr.json
@@ -389,7 +389,7 @@
     "iaso.polio.label.submission": "Soumission",
     "iaso.polio.label.submitted": "Soumis",
     "iaso.polio.label.Teachers_Student": "Professeurs",
-    "iaso.polio.label.testCampaign": "Campagne de test",
+    "iaso.polio.label.testCampaign": "Campagnes de test/en pause",
     "iaso.polio.label.testCampaigns": "Campagnes de test",
     "iaso.polio.label.toSubmit": "À soumettre",
     "iaso.polio.label.Tot_child_Absent_HH": "Enfant absent",


### PR DESCRIPTION
in Base Info tab `is_test` checkbox label was not up to date 

![Capture d’écran 2023-04-12 à 13 30 07](https://user-images.githubusercontent.com/25134301/231465810-8310fa0f-d44d-4e67-810b-a0ef9ecb81f9.png)

Related JIRA tickets : [POLIO-955](https://bluesquare.atlassian.net/browse/POLIO-955?atlOrigin=eyJpIjoiYzE2ZWQwMWU0ZjUzNGUzNGIzM2Q1YmI0MzkyMzI3OTUiLCJwIjoiaiJ9)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [x] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- changed label in messages
- updated translations

## How to test

-Go to Campaigns
- Create or Edit a campaign
- Go to Base Info tab : you should see "Test campaign/on hold status" instead of "Test campaign"

## Print screen / video

![Capture d’écran 2023-04-12 à 15 00 42](https://user-images.githubusercontent.com/25134301/231466343-0a64fd75-4641-44e6-8b45-d93e80dbb70b.png)

[POLIO-955]: https://bluesquare.atlassian.net/browse/POLIO-955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ