### PR TITLE
IA-1989: submission soft delete action

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/instances/actions.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/actions.js
@@ -3,7 +3,6 @@ import {
     postRequest,
     putRequest,
     patchRequest,
-    deleteRequest,
 } from 'Iaso/libs/Api';
 import { enqueueSnackbar } from '../../redux/snackBarsReducer';
 import { errorSnackBar, succesfullSnackBar } from '../../constants/snackBars';
@@ -59,40 +58,6 @@ export const fetchInstanceDetail = instanceId => dispatch => {
         .then(res => {
             dispatch(setInstancesFetching(false));
             return res;
-        });
-};
-
-export const softDeleteInstance = currentInstance => dispatch => {
-    dispatch(setInstancesFetching(true));
-    deleteRequest(`/api/instances/${currentInstance.id}`)
-        .then(() => {
-            dispatch(fetchInstanceDetail(currentInstance.id));
-        })
-        .catch(err =>
-            dispatch(
-                enqueueSnackbar(errorSnackBar('fetchInstanceError', null, err)),
-            ),
-        )
-        .then(() => {
-            dispatch(setInstancesFetching(false));
-        });
-};
-
-export const restoreInstance = currentInstance => dispatch => {
-    dispatch(setInstancesFetching(true));
-    patchRequest(`/api/instances/${currentInstance.id}/`, { deleted: false })
-        .then(() => {
-            dispatch(fetchInstanceDetail(currentInstance.id));
-        })
-        .catch(err =>
-            dispatch(
-                enqueueSnackbar(
-                    errorSnackBar('restoreInstanceError', null, err),
-                ),
-            ),
-        )
-        .then(() => {
-            dispatch(setInstancesFetching(false));
         });
 };
 

--- a/hat/assets/js/apps/Iaso/domains/instances/components/SpeedDialInstance.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/SpeedDialInstance.tsx
@@ -1,15 +1,7 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import React, { FunctionComponent } from 'react';
-import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 
-import {
-    fetchEditUrl as fetchEditUrlAction,
-    fetchInstanceDetail as fetchInstanceDetailAction,
-    restoreInstance as restoreInstanceAction,
-    setCurrentInstance as setCurrentInstanceAction,
-    softDeleteInstance as softDeleteAction,
-} from '../actions';
+import { LoadingSpinner } from 'bluesquare-components';
 import SpeedDialInstanceActions from './SpeedDialInstanceActions';
 import { userHasPermission } from '../../users/utils';
 import {
@@ -27,12 +19,14 @@ import {
     useLockAction,
 } from '../hooks/speedDialActions';
 import { useGetFormDefForInstance } from '../hooks/speeddials';
+import {
+    useDeleteInstance,
+    useRestoreInstance,
+} from '../hooks/requests/useDeleteInstance';
+import { useGetEnketoUrl } from '../../registry/hooks/useGetEnketoUrl';
 
 type Props = {
     currentInstance: Instance;
-    fetchEditUrl: CallableFunction;
-    softDelete: CallableFunction;
-    restoreInstance: CallableFunction;
     params: {
         instanceId: string;
         referenceFormId?: string;
@@ -96,16 +90,22 @@ const SpeedDialInstance: FunctionComponent<Props> = props => {
         referenceFormId: referenceFormId ? parseInt(referenceFormId, 10) : null,
     });
 
+    const { mutate: softDeleteInstance, isLoading: isDeleting } =
+        useDeleteInstance();
+    const { mutate: restoreInstance, isLoading: isRestoring } =
+        useRestoreInstance();
+    const getEnketoUrl = useGetEnketoUrl(window.location.href, currentInstance);
     const onActionSelected = action => {
-        if (action.id === 'instanceEditAction' && props.currentInstance) {
-            props.fetchEditUrl(props.currentInstance, window.location);
-        }
-
-        if (action.id === 'instanceDeleteAction' && props.currentInstance) {
-            props.softDelete(props.currentInstance);
-        }
-        if (action.id === 'instanceRestoreAction' && props.currentInstance) {
-            props.restoreInstance(props.currentInstance);
+        if (currentInstance) {
+            if (action.id === 'instanceEditAction') {
+                getEnketoUrl();
+            }
+            if (action.id === 'instanceDeleteAction') {
+                softDeleteInstance(currentInstance.id);
+            }
+            if (action.id === 'instanceRestoreAction') {
+                restoreInstance(currentInstance.id);
+            }
         }
     };
 
@@ -122,25 +122,14 @@ const SpeedDialInstance: FunctionComponent<Props> = props => {
     }
 
     return currentInstance?.can_user_modify ? (
-        <SpeedDialInstanceActions
-            actions={actions}
-            onActionSelected={action => onActionSelected(action)}
-        />
+        <>
+            {(isDeleting || isRestoring) && <LoadingSpinner />}
+            <SpeedDialInstanceActions
+                actions={actions}
+                onActionSelected={action => onActionSelected(action)}
+            />
+        </>
     ) : null;
 };
 
-const MapStateToProps = () => ({});
-const MapDispatchToProps = dispatch => ({
-    ...bindActionCreators(
-        {
-            fetchInstanceDetail: fetchInstanceDetailAction,
-            fetchEditUrl: fetchEditUrlAction,
-            softDelete: softDeleteAction,
-            restoreInstance: restoreInstanceAction,
-            setCurrentInstance: setCurrentInstanceAction,
-        },
-        dispatch,
-    ),
-});
-
-export default connect(MapStateToProps, MapDispatchToProps)(SpeedDialInstance);
+export default SpeedDialInstance;

--- a/hat/assets/js/apps/Iaso/domains/instances/components/SpeedDialInstanceActions.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/SpeedDialInstanceActions.js
@@ -12,7 +12,7 @@ const useStyles = makeStyles(theme => ({
     speedDial: {
         position: 'absolute',
         zIndex: 1000000,
-        top: theme.spacing(6.5),
+        bottom: theme.spacing(2),
         right: theme.spacing(2),
     },
     fab: {
@@ -48,7 +48,7 @@ const SpeedDialInstanceActions = props => {
                 onClose={handleClose}
                 onOpen={handleOpen}
                 open={open}
-                direction="left"
+                direction="up"
                 FabProps={{ className: classes.fab }}
             >
                 {actions.map(action => (

--- a/hat/assets/js/apps/Iaso/domains/instances/hooks/requests/useDeleteInstance.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/hooks/requests/useDeleteInstance.tsx
@@ -1,0 +1,22 @@
+import { UseMutationResult } from 'react-query';
+import { deleteRequest, patchRequest } from '../../../../libs/Api';
+import { useSnackMutation } from '../../../../libs/apiHooks';
+
+const deleteInstance = async (instanceId: string): Promise<any> => {
+    return deleteRequest(`/api/instances/${instanceId}/`);
+};
+export const useDeleteInstance = (): UseMutationResult =>
+    useSnackMutation({
+        mutationFn: deleteInstance,
+        invalidateQueryKey: 'instance',
+    });
+
+const restoreInstance = async (instanceId: string): Promise<any> =>
+    patchRequest(`/api/instances/${instanceId}/`, { deleted: false });
+
+export const useRestoreInstance = (): UseMutationResult =>
+    useSnackMutation({
+        mutationFn: restoreInstance,
+        invalidateQueryKey: 'instance',
+        showSucessSnackBar: true,
+    });


### PR DESCRIPTION
The delete button on instance does not trigger a refresh of the content, and I need to refresh the page to have the banner showing that the submission is deleted to show up. This refresh should not be necessary

Related JIRA tickets : IA-1989

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- Remove redux actions and use react-query hook to delete, restore and fetch enketo url actions
- moved speed dial to the bottom of the page

## How to test

- Edit a submission with enketo switched on
- soft delete it 
- you should see a loader an then the banner showing the submission has been soft deleted

## Print screen / video

https://user-images.githubusercontent.com/12494624/231741408-f6577a07-cf54-4007-9ee4-bbe741d0fb31.mov


## Notes

⚠️ Restore is leading to a crash locally for me, on staging it's very slow, another ticket has been made : https://bluesquare.atlassian.net/browse/IA-2052
