### PR TITLE
POLIO-947: remove Responsible field from Risk Assessment tab

### DIFF
--- a/plugins/polio/js/src/constants/messages.js
+++ b/plugins/polio/js/src/constants/messages.js
@@ -1878,6 +1878,10 @@ const MESSAGES = defineMessages({
         id: 'iaso.polio.label.creation_email_send_at',
         defaultMessage: 'Email creation date',
     },
+    risk_assessment_responsible: {
+        id: 'iaso.polio.label.risk_assessment_responsible',
+        defaultMessage: 'Risk assessment responsible',
+    },
     detection_rrt_oprtt_approval_at: {
         id: 'iaso.polio.label.detection_rrt_oprtt_approval_at',
         defaultMessage: 'Detection rrt oprtt oprtt',

--- a/plugins/polio/js/src/constants/messages.js
+++ b/plugins/polio/js/src/constants/messages.js
@@ -1878,10 +1878,6 @@ const MESSAGES = defineMessages({
         id: 'iaso.polio.label.creation_email_send_at',
         defaultMessage: 'Email creation date',
     },
-    risk_assessment_responsible: {
-        id: 'iaso.polio.label.risk_assessment_responsible',
-        defaultMessage: 'Risk assessment responsible',
-    },
     detection_rrt_oprtt_approval_at: {
         id: 'iaso.polio.label.detection_rrt_oprtt_approval_at',
         defaultMessage: 'Detection rrt oprtt oprtt',

--- a/plugins/polio/js/src/constants/translations/en.json
+++ b/plugins/polio/js/src/constants/translations/en.json
@@ -344,6 +344,7 @@
     "iaso.polio.label.restoreWarning": "Are you sure you want to restore this campaign?",
     "iaso.polio.label.review": "Review",
     "iaso.polio.label.reviewedByRrt": "Reviewed by RRT",
+    "iaso.polio.label.risk_assessment_responsible": "Risk assessment responsible",
     "iaso.polio.label.risk_assessment_status": "Risk assessment",
     "iaso.polio.label.round": "Round",
     "iaso.polio.label.round.number": "Round number",

--- a/plugins/polio/js/src/constants/translations/en.json
+++ b/plugins/polio/js/src/constants/translations/en.json
@@ -344,7 +344,6 @@
     "iaso.polio.label.restoreWarning": "Are you sure you want to restore this campaign?",
     "iaso.polio.label.review": "Review",
     "iaso.polio.label.reviewedByRrt": "Reviewed by RRT",
-    "iaso.polio.label.risk_assessment_responsible": "Risk assessment responsible",
     "iaso.polio.label.risk_assessment_status": "Risk assessment",
     "iaso.polio.label.round": "Round",
     "iaso.polio.label.round.number": "Round number",

--- a/plugins/polio/js/src/constants/translations/fr.json
+++ b/plugins/polio/js/src/constants/translations/fr.json
@@ -351,6 +351,7 @@
     "iaso.polio.label.restoreWarning": "Etes-vous sûr(e) de vouloir restaurer cette campagne?",
     "iaso.polio.label.review": "Evaluation",
     "iaso.polio.label.reviewedByRrt": "Revu par RRT",
+    "iaso.polio.label.risk_assessment_responsible": "Responsable de l'évaluation du risque",
     "iaso.polio.label.risk_assessment_status": "Evaluation du risque",
     "iaso.polio.label.round": "Round",
     "iaso.polio.label.round.number": "Round number",

--- a/plugins/polio/js/src/constants/translations/fr.json
+++ b/plugins/polio/js/src/constants/translations/fr.json
@@ -351,7 +351,6 @@
     "iaso.polio.label.restoreWarning": "Etes-vous sûr(e) de vouloir restaurer cette campagne?",
     "iaso.polio.label.review": "Evaluation",
     "iaso.polio.label.reviewedByRrt": "Revu par RRT",
-    "iaso.polio.label.risk_assessment_responsible": "Responsable de l'évaluation du risque",
     "iaso.polio.label.risk_assessment_status": "Evaluation du risque",
     "iaso.polio.label.round": "Round",
     "iaso.polio.label.round.number": "Round number",

--- a/plugins/polio/js/src/forms/RiskAssessmentForm.js
+++ b/plugins/polio/js/src/forms/RiskAssessmentForm.js
@@ -8,7 +8,6 @@ import { DateInput, TextInput, NumberInput } from '../components/Inputs';
 
 export const riskAssessmentFormFields = [
     'risk_assessment_status',
-    'risk_assessment_responsible',
     'verification_score',
     'investigation_at',
     'three_level_call_at',

--- a/plugins/polio/js/src/forms/RiskAssessmentForm.js
+++ b/plugins/polio/js/src/forms/RiskAssessmentForm.js
@@ -4,12 +4,7 @@ import { Field, useFormikContext } from 'formik';
 import { useSafeIntl } from 'bluesquare-components';
 import { useStyles } from '../styles/theme';
 import MESSAGES from '../constants/messages';
-import {
-    DateInput,
-    ResponsibleField,
-    TextInput,
-    NumberInput,
-} from '../components/Inputs';
+import { DateInput, TextInput, NumberInput } from '../components/Inputs';
 
 export const riskAssessmentFormFields = [
     'risk_assessment_status',
@@ -128,22 +123,6 @@ export const RiskAssessmentForm = () => {
                             <Divider style={{ width: '50%' }} />
                         </Box>
                     </Grid>
-                    <Grid xs={12} md={6} item>
-                        <Field
-                            name="risk_assessment_responsible"
-                            component={ResponsibleField}
-                        />
-                    </Grid>
-                    <Grid xs={12} md={6} item>
-                        <Field
-                            label={formatMessage(MESSAGES.verificationScore)}
-                            name="verification_score"
-                            component={NumberInput}
-                            className={classes.input}
-                            min={0}
-                            max={20}
-                        />
-                    </Grid>
                 </Grid>
                 <Grid item md={6}>
                     <Field
@@ -187,6 +166,16 @@ export const RiskAssessmentForm = () => {
                         fullWidth
                         onChange={updateDGAuthorized}
                     />
+                    <Box mt={2}>
+                        <Field
+                            label={formatMessage(MESSAGES.verificationScore)}
+                            name="verification_score"
+                            component={NumberInput}
+                            className={classes.input}
+                            min={0}
+                            max={20}
+                        />
+                    </Box>
                 </Grid>
                 <Grid item md={6}>
                     {rounds.map((round, i) => {
@@ -221,15 +210,15 @@ export const RiskAssessmentForm = () => {
                                 key={round.number}
                                 label={`${formatMessage(
                                     MESSAGES.dosesRequested,
-                                )} ${formatMessage(MESSAGES.round)} ${round.number
-                                    }`}
+                                )} ${formatMessage(MESSAGES.round)} ${
+                                    round.number
+                                }`}
                                 name={`rounds[${i}].doses_requested`}
                                 component={TextInput}
                                 className={classes.input}
                             />
                         );
                     })}
-
                 </Grid>
             </Grid>
         </>


### PR DESCRIPTION
Remove unecesseray responsible select field in Risk Assessment tab

Related JIRA tickets : [POLIO-947](https://bluesquare.atlassian.net/browse/POLIO-947?atlOrigin=eyJpIjoiNjM3NDg2OGEzYWJmNDVjYThiOWM3ZDhlODA0N2VkYmMiLCJwIjoiaiJ9)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [x] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- removed `ResponsibleField`
- switch Verification score field to fix layout

## How to test

- Go to Campaigns
- Create or edit a campaign
- Go to Risk Assessment Tab: you should not see the responsible select field 

## Print screen / video
![Capture d’écran 2023-04-14 à 13 23 23](https://user-images.githubusercontent.com/25134301/232031191-7c2a73d7-d95e-46b6-8c47-a61023cb7465.png)

[POLIO-947]: https://bluesquare.atlassian.net/browse/POLIO-947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ