### PR TITLE
POLIO-948: temporary hide dg auth and ag/nopv group fields

### DIFF
--- a/plugins/polio/js/src/forms/RiskAssessmentForm.js
+++ b/plugins/polio/js/src/forms/RiskAssessmentForm.js
@@ -152,7 +152,8 @@ export const RiskAssessmentForm = () => {
                         fullWidth
                         onChange={updateRRTApproval}
                     />
-                    <Field
+                    {/* temporary hiding those fields but should not be removed as we will need them at a later stage */}
+                    {/* <Field
                         label={formatMessage(MESSAGES.ag_nopv_group_met_at)}
                         name="ag_nopv_group_met_at"
                         component={DateInput}
@@ -164,7 +165,7 @@ export const RiskAssessmentForm = () => {
                         component={DateInput}
                         fullWidth
                         onChange={updateDGAuthorized}
-                    />
+                    /> */}
                     <Box mt={2}>
                         <Field
                             label={formatMessage(MESSAGES.verificationScore)}


### PR DESCRIPTION
These fields will be moved to Vaccine Management tab. For now, we can hide them as we will need them again at a later stage

Related JIRA tickets : [POLIO-948](https://bluesquare.atlassian.net/browse/POLIO-948?atlOrigin=eyJpIjoiZjcwMDBkNWIwNTg2NDBlM2I5MGJiYjE4NzhiMzY0MzIiLCJwIjoiaiJ9)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## How to test

- Go to Campaings
- Create or edit a campaign
- Go to Risk Assessment tab :  you should not see "Dg Authorization" and "Ag/noPV group" fields

## Print screen / video

<img width="1398" alt="Capture d’écran 2023-04-14 à 19 00 57" src="https://user-images.githubusercontent.com/25134301/232109857-64b6777d-96e4-4f95-8b3e-a2b2df21c357.png">


[POLIO-948]: https://bluesquare.atlassian.net/browse/POLIO-948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ