### PR TITLE
POLIO-948-949: update RA status logic + hide dg auth and ag/nopv group fields

### DIFF
--- a/plugins/polio/js/src/forms/RiskAssessmentForm.js
+++ b/plugins/polio/js/src/forms/RiskAssessmentForm.js
@@ -24,24 +24,30 @@ export const RiskAssessmentForm = () => {
     const { rounds = [] } = values;
     const updateFirstDraftSubmission = useCallback(
         (fieldName, date) => {
-            if (
-                date &&
-                !values.risk_assessment_rrt_oprtt_approval_at &&
-                !values.dg_authorized_at
-            ) {
+            if (date && !values.risk_assessment_rrt_oprtt_approval_at) {
                 setFieldValue('risk_assessment_status', 'SUBMITTED');
             }
-            if (
-                !date &&
-                !values.risk_assessment_rrt_oprtt_approval_at &&
-                !values.dg_authorized_at
-            ) {
+            if (!date && !values.risk_assessment_rrt_oprtt_approval_at) {
                 setFieldValue('risk_assessment_status', 'TO_SUBMIT');
             }
+            // if (
+            //     date &&
+            //     !values.risk_assessment_rrt_oprtt_approval_at &&
+            //     !values.dg_authorized_at
+            // ) {
+            //     setFieldValue('risk_assessment_status', 'SUBMITTED');
+            // }
+            // if (
+            //     !date &&
+            //     !values.risk_assessment_rrt_oprtt_approval_at &&
+            //     !values.dg_authorized_at
+            // ) {
+            //     setFieldValue('risk_assessment_status', 'TO_SUBMIT');
+            // }
         },
         [
             setFieldValue,
-            values.dg_authorized_at,
+            // values.dg_authorized_at,
             values.risk_assessment_rrt_oprtt_approval_at,
         ],
     );

--- a/plugins/polio/js/src/forms/RiskAssessmentForm.js
+++ b/plugins/polio/js/src/forms/RiskAssessmentForm.js
@@ -13,8 +13,8 @@ export const riskAssessmentFormFields = [
     'outbreak_declaration_date',
     'risk_assessment_first_draft_submitted_at',
     'risk_assessment_rrt_oprtt_approval_at',
-    'ag_nopv_group_met_at',
-    'dg_authorized_at',
+    // 'ag_nopv_group_met_at',
+    // 'dg_authorized_at',
 ];
 
 export const RiskAssessmentForm = () => {
@@ -47,63 +47,74 @@ export const RiskAssessmentForm = () => {
     );
     const updateRRTApproval = useCallback(
         (fieldName, date) => {
-            if (date && !values.dg_authorized_at) {
-                setFieldValue('risk_assessment_status', 'REVIEWED');
-            }
-            if (
-                !date &&
-                values.risk_assessment_first_draft_submitted_at &&
-                !values.dg_authorized_at
-            ) {
-                setFieldValue('risk_assessment_status', 'SUBMITTED');
-            }
-            if (
-                !date &&
-                !values.risk_assessment_first_draft_submitted_at &&
-                !values.dg_authorized_at
-            ) {
-                setFieldValue('risk_assessment_status', 'TO_SUBMIT');
-            }
-        },
-        [
-            setFieldValue,
-            values.dg_authorized_at,
-            values.risk_assessment_first_draft_submitted_at,
-        ],
-    );
-    const updateDGAuthorized = useCallback(
-        (fieldName, date) => {
             if (date) {
                 setFieldValue('risk_assessment_status', 'APPROVED');
             }
-            if (
-                !date &&
-                values.risk_assessment_rrt_oprtt_approval_at &&
-                !values.risk_assessment_first_draft_submitted_at
-            ) {
-                setFieldValue('risk_assessment_status', 'REVIEWED');
-            }
-            if (
-                !date &&
-                !values.risk_assessment_rrt_oprtt_approval_at &&
-                values.risk_assessment_first_draft_submitted_at
-            ) {
+
+            if (!date && values.risk_assessment_first_draft_submitted_at) {
                 setFieldValue('risk_assessment_status', 'SUBMITTED');
             }
-            if (
-                !date &&
-                !values.risk_assessment_rrt_oprtt_approval_at &&
-                !values.risk_assessment_first_draft_submitted_at
-            ) {
+
+            if (!date && !values.risk_assessment_first_draft_submitted_at) {
                 setFieldValue('risk_assessment_status', 'TO_SUBMIT');
             }
+            // if (date && !values.dg_authorized_at) {
+            //     setFieldValue('risk_assessment_status', 'REVIEWED');
+            // }
+            // if (
+            //     !date &&
+            //     values.risk_assessment_first_draft_submitted_at &&
+            //     !values.dg_authorized_at
+            // ) {
+            //     setFieldValue('risk_assessment_status', 'SUBMITTED');
+            // }
+            // if (
+            //     !date &&
+            //     !values.risk_assessment_first_draft_submitted_at &&
+            //     !values.dg_authorized_at
+            // ) {
+            //     setFieldValue('risk_assessment_status', 'TO_SUBMIT');
+            // }
         },
         [
             setFieldValue,
+            // values.dg_authorized_at,
             values.risk_assessment_first_draft_submitted_at,
-            values.risk_assessment_rrt_oprtt_approval_at,
         ],
     );
+    // const updateDGAuthorized = useCallback(
+    //     (fieldName, date) => {
+    //         if (date) {
+    //             setFieldValue('risk_assessment_status', 'APPROVED');
+    //         }
+    //         if (
+    //             !date &&
+    //             values.risk_assessment_rrt_oprtt_approval_at &&
+    //             !values.risk_assessment_first_draft_submitted_at
+    //         ) {
+    //             setFieldValue('risk_assessment_status', 'REVIEWED');
+    //         }
+    //         if (
+    //             !date &&
+    //             !values.risk_assessment_rrt_oprtt_approval_at &&
+    //             values.risk_assessment_first_draft_submitted_at
+    //         ) {
+    //             setFieldValue('risk_assessment_status', 'SUBMITTED');
+    //         }
+    //         if (
+    //             !date &&
+    //             !values.risk_assessment_rrt_oprtt_approval_at &&
+    //             !values.risk_assessment_first_draft_submitted_at
+    //         ) {
+    //             setFieldValue('risk_assessment_status', 'TO_SUBMIT');
+    //         }
+    //     },
+    //     [
+    //         setFieldValue,
+    //         values.risk_assessment_first_draft_submitted_at,
+    //         values.risk_assessment_rrt_oprtt_approval_at,
+    //     ],
+    // );
     const status = values.risk_assessment_status
         ? formatMessage(MESSAGES[values.risk_assessment_status])
         : formatMessage(MESSAGES.TO_SUBMIT);
@@ -152,19 +163,20 @@ export const RiskAssessmentForm = () => {
                         fullWidth
                         onChange={updateRRTApproval}
                     />
-                    <Field
+                    {/* temporary hiding those fields but should not be removed as we will need them at a later sta
+                    {/* <Field
                         label={formatMessage(MESSAGES.ag_nopv_group_met_at)}
                         name="ag_nopv_group_met_at"
                         component={DateInput}
                         fullWidth
-                    />
-                    <Field
+                    /> */}
+                    {/* <Field
                         label={formatMessage(MESSAGES.dgAuthorization)}
                         name="dg_authorized_at"
                         component={DateInput}
                         fullWidth
                         onChange={updateDGAuthorized}
-                    />
+                    /> */}
                     <Box mt={2}>
                         <Field
                             label={formatMessage(MESSAGES.verificationScore)}


### PR DESCRIPTION
These fields will be moved to Vaccine Management tab. For now, we can hide them as we will need them again at a later stage. Moreover the risk assessment status should depend on RRT/ORPG Approval date now and no more on DG Authorized

Related JIRA tickets: 
-  [POLIO-948](https://bluesquare.atlassian.net/browse/POLIO-948?atlOrigin=eyJpIjoiZjcwMDBkNWIwNTg2NDBlM2I5MGJiYjE4NzhiMzY0MzIiLCJwIjoiaiJ9)
- [POLIO-949](https://bluesquare.atlassian.net/browse/POLIO-949?atlOrigin=eyJpIjoiYzk3OTllNDY2ZDBiNGE3NWIxYWQ3ZWFkYTQxMTY0YTQiLCJwIjoiaiJ9)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## How to test

- Go to Campaings
- Create or edit a campaign
- Go to Risk Assessment tab :  you should not see "Dg Authorization" and "Ag/noPV group" fields
- Play with dates to make sure status updates correctly. Now when there is a RRT/ORPG Approval date, the Risk Assessment status should be "Approved"

## Print screen / video

https://user-images.githubusercontent.com/25134301/232454371-7e6279ed-8e62-4b5c-9015-c23928553d83.mov

[POLIO-948]: https://bluesquare.atlassian.net/browse/POLIO-948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[POLIO-949]: https://bluesquare.atlassian.net/browse/POLIO-949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ