### PR TITLE
Registry improvements: IA-2058 IA-2061 IA-2062 IA-2057

### DIFF
--- a/hat/assets/js/apps/Iaso/components/papers/WidgetPaperComponent.tsx
+++ b/hat/assets/js/apps/Iaso/components/papers/WidgetPaperComponent.tsx
@@ -1,19 +1,20 @@
-import React, { useState } from 'react';
-import PropTypes from 'prop-types';
+import React, { useState, FunctionComponent, ReactElement } from 'react';
+
 import {
-    withStyles,
     Paper,
     Divider,
     Typography,
     Grid,
     Collapse,
     Box,
+    makeStyles,
 } from '@material-ui/core';
 import ExpandLess from '@material-ui/icons/ExpandLess';
 import ExpandMore from '@material-ui/icons/ExpandMore';
 
-const styles = theme => ({
+const useStyles = makeStyles(theme => ({
     root: {
+        // @ts-ignore
         backgroundColor: theme.palette.ligthGray.background,
         marginBottom: theme.spacing(4),
         '&:last-child': {
@@ -49,22 +50,35 @@ const styles = theme => ({
         marginLeft: 'auto',
         marginTop: theme.spacing(1),
     },
-});
+}));
 
-const WidgetPaper = ({
-    classes,
-    title,
-    children,
-    padded,
+type Props = {
+    title: string;
+    children: ReactElement;
+    isExpanded?: boolean;
+    expandable?: boolean;
+    id?: string;
+    padded?: boolean;
+    IconButton?: FunctionComponent;
+    iconButtonProps?: Record<string, any>;
+    showHeader?: boolean;
+    className?: string;
+    elevation?: number;
+};
+export const WidgetPaper: FunctionComponent<Props> = ({
     IconButton,
     iconButtonProps,
-    expandable,
-    isExpanded,
-    id,
-    showHeader,
-    className,
+    title,
+    children,
+    id = '',
+    padded = false,
+    expandable = false,
+    showHeader = true,
+    isExpanded = true,
+    className = '',
     elevation = 1,
 }) => {
+    const classes: Record<string, string> = useStyles();
     const [open, setOpen] = useState(isExpanded);
     const handleClick = () => {
         if (expandable) {
@@ -127,7 +141,7 @@ const WidgetPaper = ({
 
             <Collapse in={open} timeout="auto" unmountOnExit>
                 <div
-                    className={padded ? classes.padded : null}
+                    className={padded ? classes.padded : undefined}
                     id={id ? `${id}-body` : undefined}
                 >
                     {children}
@@ -137,31 +151,4 @@ const WidgetPaper = ({
     );
 };
 
-WidgetPaper.defaultProps = {
-    padded: false,
-    IconButton: null,
-    iconButtonProps: {},
-    expandable: false,
-    isExpanded: true,
-    id: undefined,
-    showHeader: true,
-    className: '',
-    elevation: 1,
-};
-
-WidgetPaper.propTypes = {
-    classes: PropTypes.object.isRequired,
-    title: PropTypes.string.isRequired,
-    children: PropTypes.node.isRequired,
-    padded: PropTypes.bool,
-    IconButton: PropTypes.any,
-    iconButtonProps: PropTypes.object,
-    expandable: PropTypes.bool,
-    isExpanded: PropTypes.bool,
-    id: PropTypes.string,
-    showHeader: PropTypes.bool,
-    className: PropTypes.string,
-    elevation: PropTypes.number,
-};
-
-export default withStyles(styles)(WidgetPaper);
+export default WidgetPaper;

--- a/hat/assets/js/apps/Iaso/components/papers/WidgetPaperComponent.tsx
+++ b/hat/assets/js/apps/Iaso/components/papers/WidgetPaperComponent.tsx
@@ -1,4 +1,4 @@
-import React, { useState, FunctionComponent, ReactElement } from 'react';
+import React, { useState, FunctionComponent } from 'react';
 
 import {
     Paper,
@@ -54,7 +54,6 @@ const useStyles = makeStyles(theme => ({
 
 type Props = {
     title: string;
-    children: ReactElement;
     isExpanded?: boolean;
     expandable?: boolean;
     id?: string;

--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -661,6 +661,7 @@
     "iaso.orgUnits.dataSources": "Data Sources",
     "iaso.orgUnits.depth": "Level",
     "iaso.orgUnits.depthInfos": "Level of the type in the hierarchy: province (1)> zone (2)> aire (3)> village (4)",
+    "iaso.orgUnits.edit": "Edit org unit",
     "iaso.orgUnits.editGroups": "Edit groups",
     "iaso.orgUnits.editOrgUnitType": "Edit org unit type",
     "iaso.orgUnits.editValidation": "Edit validation",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -25,6 +25,7 @@
     "iaso.assignment.count": "Nombre d'assignations",
     "iaso.assignment.inAnotherTeam": "dans une autre équipe",
     "iaso.assignment.label": "Affectation",
+    "iaso.orgUnits.edit": "Editer unité d'organisation",
     "iaso.assignment.map.disabled": "Déjà assigné",
     "iaso.assignment.map.parent": "Parent",
     "iaso.assignment.map.unselected": "Non assigné",

--- a/hat/assets/js/apps/Iaso/domains/instances/components/InstanceDetailsExportRequests.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/InstanceDetailsExportRequests.js
@@ -8,7 +8,7 @@ import {
     IconButton as IconButtonComponent,
 } from 'bluesquare-components';
 import MESSAGES from '../messages';
-import WidgetPaper from '../../../components/papers/WidgetPaperComponent';
+import WidgetPaper from '../../../components/papers/WidgetPaperComponent.tsx';
 import InstanceDetailsField from './InstanceDetailsField';
 
 const formatUnixTimestamp = unix =>

--- a/hat/assets/js/apps/Iaso/domains/registry/details.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/details.tsx
@@ -120,7 +120,7 @@ export const Details: FunctionComponent<Props> = ({ router }) => {
                             <WidgetPaper
                                 id="form-contents"
                                 className={classes.paper}
-                                title={formatMessage(MESSAGES.submission)}
+                                title={orgUnit.reference_instance.form_name}
                                 IconButton={
                                     userHasPermission(
                                         'iaso_update_submission',

--- a/hat/assets/js/apps/Iaso/domains/registry/details.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/details.tsx
@@ -92,7 +92,14 @@ export const Details: FunctionComponent<Props> = ({ router }) => {
                         {orgUnit && (
                             <WidgetPaper
                                 className={classes.paper}
-                                title={orgUnit?.name ?? ''}
+                                title={orgUnit.name ?? ''}
+                                IconButton={IconButton}
+                                iconButtonProps={{
+                                    url: `${baseUrls.orgUnitDetails}/orgUnitId/${orgUnit.id}`,
+                                    color: 'secondary',
+                                    icon: 'edit',
+                                    tooltipMessage: MESSAGES.editOrgUnit,
+                                }}
                             >
                                 <OrgUnitMap
                                     orgUnit={orgUnit}

--- a/hat/assets/js/apps/Iaso/domains/registry/hooks/useGetInstances.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/hooks/useGetInstances.tsx
@@ -21,6 +21,7 @@ export const useGetInstances = (
         order: params.order || getSort(defaultSorted),
         page: params.page || 1,
         showDeleted: false,
+        orgUnitParentId: params.orgUnitId,
     };
     const url = makeUrlWithParams('/api/instances/', apiParams);
     return useSnackQuery({

--- a/hat/assets/js/apps/Iaso/domains/registry/hooks/useGetOrgUnit.ts
+++ b/hat/assets/js/apps/Iaso/domains/registry/hooks/useGetOrgUnit.ts
@@ -29,7 +29,7 @@ export const useGetOrgUnitsChildren = (
     orgUnitTypes: OrgunitTypes,
 ): UseQueryResult<OrgUnit[], Error> => {
     const params: Record<string, any> = {
-        validation_status: 'all',
+        validation_status: 'VALID',
         withShapes: true,
         orgUnitParentId,
         onlyDirectChildren: true,

--- a/hat/assets/js/apps/Iaso/domains/registry/messages.ts
+++ b/hat/assets/js/apps/Iaso/domains/registry/messages.ts
@@ -81,6 +81,10 @@ const MESSAGES = defineMessages({
         defaultMessage: 'See',
         id: 'iaso.label.see',
     },
+    editOrgUnit: {
+        defaultMessage: 'Edit org unit',
+        id: 'iaso.orgUnits.edit',
+    },
 });
 
 export default MESSAGES;


### PR DESCRIPTION
Small improvements on registry domain

Related JIRA tickets : IA-2058 IA-2061 IA-2062 IA-2057

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- IA-2058: Submissions should be filtered only for children of current ou
- IA-2062: display form name instead of submission
- IA-2061: display only valid org units on the map
- IA-2057: link to org unit details

## How to test

Make sure this [config](https://github.com/BLSQ/iaso/pull/472)  is working
Open the details for an org unit with submissions


## Print screen / video

<img width="1894" alt="Screenshot 2023-04-18 at 09 25 31" src="https://user-images.githubusercontent.com/12494624/232703276-3ef87511-2fbf-4335-8327-6f3e41cf8983.png">

