### PR TITLE
IA-2067: make tooltip text visible

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/instances/components/SpeedDialInstanceActions.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/SpeedDialInstanceActions.js
@@ -11,7 +11,6 @@ import MESSAGES from '../messages';
 const useStyles = makeStyles(theme => ({
     speedDial: {
         position: 'absolute',
-        zIndex: 1000000,
         bottom: theme.spacing(2),
         right: theme.spacing(2),
     },


### PR DESCRIPTION
In instances `Speeddial` the tooltip text was displayed under the icons

Explain what problem this PR is resolving

Related JIRA tickets : IA-2067

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- removed the z-index value in styles

## How to test

Go to any submission detail, click on the speed dial button, then hover over one of the action buttons

## Print screen / video

![Screenshot 2023-04-18 at 10 21 51](https://user-images.githubusercontent.com/38907762/232718385-b83b6d3a-44b8-4cf2-8a6d-d992b983bccd.png)



