### PR TITLE
IA-2051: fix dynamic tab bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6019,7 +6019,7 @@
         },
         "node_modules/bluesquare-components": {
             "version": "0.2.0",
-            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#525df51102012e80bf25582aebd7f18518ce3efc",
+            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#9555c0a16dbb4e5155927b734d41f5cb77b13d85",
             "license": "Apache-2.0",
             "dependencies": {
                 "@babel/plugin-transform-runtime": "^7.17.0",
@@ -34207,7 +34207,7 @@
             "dev": true
         },
         "bluesquare-components": {
-            "version": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#525df51102012e80bf25582aebd7f18518ce3efc",
+            "version": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#9555c0a16dbb4e5155927b734d41f5cb77b13d85",
             "from": "bluesquare-components@github:BLSQ/bluesquare-components",
             "requires": {
                 "@babel/plugin-transform-runtime": "^7.17.0",


### PR DESCRIPTION
While creating 10 searches of org units on the same page, on smaller screen close button of each tab is wrongly placed.

![Screenshot 2023-04-13 at 17 57 59](https://user-images.githubusercontent.com/12494624/231817368-51be2c4e-21ed-4877-a0ab-b59dbe1d2f9a.png)

Related JIRA tickets : IA-2051

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

update package-lock to integrate the solution from https://github.com/BLSQ/bluesquare-components/pull/114

## How to test

Go to org units, open as many search tabs as possible


