### PR TITLE
POLIO-974: add max value for % covered target population

### DIFF
--- a/plugins/polio/js/src/hooks/useFormValidator.js
+++ b/plugins/polio/js/src/hooks/useFormValidator.js
@@ -544,7 +544,12 @@ const useRoundShape = () => {
         shipments: yup.array(shipment).nullable(),
         vaccines: yup.array(vaccine).nullable(),
         destructions: yup.array(destruction).nullable(),
-        percentage_covered_target_population: yup.number().nullable().min(0).integer(),
+        percentage_covered_target_population: yup
+            .number()
+            .nullable()
+            .min(0)
+            .max(100)
+            .integer(),
     });
 };
 


### PR DESCRIPTION
There was no max value for the percentage covered target population fields in Risk Assesment tab.

Related JIRA tickets : [POLIO-074](https://bluesquare.atlassian.net/browse/POLIO-974?atlOrigin=eyJpIjoiZjU4YzEzMWMwYmExNGRiNGJhMTY5M2Q5NTk0ZjJmMDQiLCJwIjoiaiJ9)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- add max value in yup validation

## How to test

- Go to campaigns
-  Create or edit a campaign
- Go to Risk Assessment tab :  try to add a value > 100, the field should switch in error state

## Print screen / video

https://user-images.githubusercontent.com/25134301/232797942-0f7e77c3-693d-407e-9bd6-9ffcf0f58b36.mov


