### PR TITLE
POLIO-976: fix missing translations + error validation

### DIFF
--- a/plugins/polio/js/src/constants/messages.js
+++ b/plugins/polio/js/src/constants/messages.js
@@ -215,6 +215,10 @@ const MESSAGES = defineMessages({
         id: 'iaso.polio.form.validator.error.positiveInteger',
         defaultMessage: 'Please use a positive integer',
     },
+    positiveRangeInteger: {
+        id: 'iaso.polio.form.validator.error.positiveRangeInteger',
+        defaultMessage: 'Please use a positive integer between 0 and 100',
+    },
     positiveNumber: {
         id: 'iaso.polio.form.validator.error.positiveNumber',
         defaultMessage: 'Please use a positive number',

--- a/plugins/polio/js/src/constants/translations/en.json
+++ b/plugins/polio/js/src/constants/translations/en.json
@@ -137,6 +137,7 @@
     "iaso.polio.form.validator.error.endDateBeforeStartDate": "End date can't be before start date",
     "iaso.polio.form.validator.error.positiveInteger": "Please use a positive integer",
     "iaso.polio.form.validator.error.positiveNumber": "Please use a positive number",
+    "iaso.polio.form.validator.error.positiveRangeInteger": "Please use a positive integer between 0 and 100",
     "iaso.polio.form.validator.error.startDateAfterEndDate": "Start date can't be after end date",
     "iaso.polio.form.validator.error.startDateBeforePreviousEndDate": "Start date can't be before or equal previous round end date",
     "iaso.polio.forms.deleteRound": "Delete round",

--- a/plugins/polio/js/src/constants/translations/fr.json
+++ b/plugins/polio/js/src/constants/translations/fr.json
@@ -138,6 +138,7 @@
     "iaso.polio.form.validator.error.endDateBeforeStartDate": "La date de fin ne peut être avant la date de début",
     "iaso.polio.form.validator.error.positiveInteger": "Veuillez remplir avec un nombre entier positif",
     "iaso.polio.form.validator.error.positiveNumber": "Veuillez remplir avec un nombre positif",
+    "iaso.polio.form.validator.error.positiveRangeInteger": "Veuillez remplir avec un nombre entier positif entre 0 et 100",
     "iaso.polio.form.validator.error.startDateAfterEndDate": "La date de début ne peut pas être après la date de fin",
     "iaso.polio.form.validator.error.startDateBeforePreviousEndDate": "La date de début ne peut être avant ou égal à la date de fin du round précédent",
     "iaso.polio.forms.deleteRound": "Effacer round",

--- a/plugins/polio/js/src/hooks/useFormValidator.js
+++ b/plugins/polio/js/src/hooks/useFormValidator.js
@@ -458,7 +458,12 @@ const useRoundShape = () => {
                 yup.ref('lqas_started_at'),
                 formatMessage(MESSAGES.endDateBeforeStartDate),
             ),
-        target_population: yup.number().nullable().min(0).integer(),
+        target_population: yup
+            .number()
+            .nullable()
+            .min(0)
+            .integer()
+            .typeError(formatMessage(MESSAGES.positiveInteger)),
         cost: yup.number().nullable().min(0).integer(),
         lqas_district_passing: yup
             .number()
@@ -544,7 +549,18 @@ const useRoundShape = () => {
         shipments: yup.array(shipment).nullable(),
         vaccines: yup.array(vaccine).nullable(),
         destructions: yup.array(destruction).nullable(),
-        percentage_covered_target_population: yup.number().nullable().min(0).integer(),
+        percentage_covered_target_population: yup
+            .number()
+            .nullable()
+            .min(0)
+            .integer()
+            .typeError(formatMessage(MESSAGES.positiveRangeInteger)),
+        doses_requested: yup
+            .number()
+            .nullable()
+            .integer()
+            .min(0)
+            .typeError(formatMessage(MESSAGES.positiveInteger)),
     });
 };
 
@@ -559,8 +575,14 @@ export const useFormValidator = () => {
         initial_org_unit: yup.number().positive().integer().required(),
         grouped_campaigns: yup.array(yup.number()).nullable(),
         description: yup.string().nullable(),
-        onset_at: yup.date().nullable(),
-        outbreak_declaration_date: yup.date().nullable(),
+        onset_at: yup
+            .date()
+            .nullable()
+            .typeError(formatMessage(MESSAGES.invalidDate)),
+        outbreak_declaration_date: yup
+            .date()
+            .nullable()
+            .typeError(formatMessage(MESSAGES.invalidDate)),
 
         cvdpv_notified_at: yup.date().nullable(),
         cvdpv2_notified_at: yup.date().nullable(),
@@ -570,11 +592,26 @@ export const useFormValidator = () => {
         detection_first_draft_submitted_at: yup.date().nullable(),
         detection_rrt_oprtt_approval_at: yup.date().nullable(),
 
-        investigation_at: yup.date().nullable(),
-        risk_assessment_first_draft_submitted_at: yup.date().nullable(),
-        risk_assessment_rrt_oprtt_approval_at: yup.date().nullable(),
-        ag_nopv_group_met_at: yup.date().nullable(),
-        dg_authorized_at: yup.date().nullable(),
+        investigation_at: yup
+            .date()
+            .nullable()
+            .typeError(formatMessage(MESSAGES.invalidDate)),
+        risk_assessment_first_draft_submitted_at: yup
+            .date()
+            .nullable()
+            .typeError(formatMessage(MESSAGES.invalidDate)),
+        risk_assessment_rrt_oprtt_approval_at: yup
+            .date()
+            .nullable()
+            .typeError(formatMessage(MESSAGES.invalidDate)),
+        ag_nopv_group_met_at: yup
+            .date()
+            .nullable()
+            .typeError(formatMessage(MESSAGES.invalidDate)),
+        dg_authorized_at: yup
+            .date()
+            .nullable()
+            .typeError(formatMessage(MESSAGES.invalidDate)),
         // Budget tab
         who_sent_budget_at_WFEDITABLE: yup.date().nullable(),
         unicef_sent_budget_at_WFEDITABLE: yup.date().nullable(),


### PR DESCRIPTION
Missing translations and missing yup validation in Risk Assessment tab

Related JIRA tickets : [POLIO-976](https://bluesquare.atlassian.net/browse/POLIO-976?atlOrigin=eyJpIjoiNDAwNTlkNDk1NWNhNGQyZmI2ZDdlYzlhMTkwZGNiZDIiLCJwIjoiaiJ9)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [x] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)


## How to test

- Go to Campaigns
- Create or edit a campaign
- Go on Risk Assessment tab: play with fields, put them in error state. Check if error messages are correct

[POLIO-976]: https://bluesquare.atlassian.net/browse/POLIO-976?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ