### PR TITLE
IA-2040: Workflow editor

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/workflows/components/changes/MappingTable.tsx
+++ b/hat/assets/js/apps/Iaso/domains/workflows/components/changes/MappingTable.tsx
@@ -147,16 +147,18 @@ export const MappingTable: FunctionComponent<Props> = ({
             target: undefined,
             source: undefined,
         });
+        setIsTouched(true);
         setMappingArray(newMappings);
-    }, [mappingArray, setMappingArray]);
+    }, [mappingArray, setIsTouched, setMappingArray]);
 
     const handleDelete = useCallback(
         (index: number) => {
             const newMappings = cloneDeep(mappingArray);
             newMappings.splice(index, 1);
+            setIsTouched(true);
             setMappingArray(newMappings);
         },
-        [mappingArray, setMappingArray],
+        [mappingArray, setIsTouched, setMappingArray],
     );
 
     const sourceOptions = useMemo(

--- a/hat/assets/js/apps/Iaso/domains/workflows/components/changes/Modal.tsx
+++ b/hat/assets/js/apps/Iaso/domains/workflows/components/changes/Modal.tsx
@@ -145,7 +145,6 @@ const Modal: FunctionComponent<Props> = ({
     const allowConfirm =
         isTouched &&
         isValidMapping &&
-        Boolean(form) &&
         mappingArray.length > 0 &&
         !mappingArray.find(mapping => !mapping.target || !mapping.source);
 


### PR DESCRIPTION
When removing a condition in a follow up, confirm button does not activate
To reproduce, open a follow up, and then click on the trashcan, the confirm button never activates

Related JIRA tickets : IA-2040

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

Confirm should be disabled if:

- user changes source or version form and fields mappings are not correct anymore
- a source or a target field is empty
- the list of mapping is empty

I fixed the bug on add and on delete to activate the button

## How to test

Open a follow up, and then click on the trashcan, the confirm button should activate

## Print screen / video


https://user-images.githubusercontent.com/12494624/233043650-2a031394-1bac-4376-983f-4a0ee9ad8679.mov

