### PR TITLE
IA-2076: Completeness stats permissions issues

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/completenessStats/CompletenessStatsFilters.tsx
+++ b/hat/assets/js/apps/Iaso/domains/completenessStats/CompletenessStatsFilters.tsx
@@ -148,7 +148,7 @@ export const CompletenessStatsFilters: FunctionComponent<Props> = ({
                         options={groups}
                         loading={isFetchingGroups}
                     />
-                    <DisplayIfUserHasPerm permission="iaso.permissions.planning">
+                    <DisplayIfUserHasPerm permission="iaso_planning">
                         <InputComponent
                             type="select"
                             multi

--- a/iaso/api/groups.py
+++ b/iaso/api/groups.py
@@ -69,7 +69,7 @@ class GroupsViewSet(ModelViewSet):
 
     permission_classes = [
         permissions.IsAuthenticated,
-        HasPermission("menupermissions.iaso_org_units"),  # type: ignore
+        HasPermission("menupermissions.iaso_org_units", "menupermissions.iaso_completeness_stats"),  # type: ignore
         HasGroupPermission,
     ]
     serializer_class = GroupSerializer


### PR DESCRIPTION
On completeness stats page:
- planning filter only visible if you are super admin
- you need groups permissions also

Related JIRA tickets : IA-2076

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- adding `iaso_completeness_stats` to groups api
- fix typo un stats filter

## How to test

Create a user with only `iaso_completeness_stats` permissions, login with it and go to stats page
You should see groups and not planning filters
Add `iaso_planning` to this user, then go back on stats page, you should see planning filter

