### PR TITLE
IA-2069 Download CSV in /explore/ dashboard return an empty CSV on a named parameter request

### DIFF
--- a/django_sql_dashboard_export/templates/django_sql_dashboard/widgets/default.html
+++ b/django_sql_dashboard_export/templates/django_sql_dashboard/widgets/default.html
@@ -84,7 +84,7 @@
   <p>Duration: {{ result.duration_ms|floatformat:2 }}ms</p>
   {%  if saved_dashboard  %}
   <p>
-      <a href="export/?index={{ result.index }}&format=csv" >Download as CSV 📉</a>
+      <a id="download_as_csv" href="export/?index={{ result.index }}&format=csv" >Download as CSV 📉</a>
   </p>
 {% endif %}
   <!-- templates considered: {{ result.templates|join:", " }} -->
@@ -109,5 +109,13 @@
     ta.insertAdjacentElement("afterend", p);
     p.insertAdjacentElement("afterbegin", button);
   })();
+
+  //otherwise the parameters from the URL are not passed to the download link
+  window.addEventListener('load', function() { 
+    const urlParams = new URLSearchParams(window.location.search);
+    const current_url = document.getElementById('download_as_csv').getAttribute('href');
+    document.getElementById('download_as_csv').setAttribute('href', current_url + '&' + urlParams.toString());
+  });
+
   </script>
 </div>

--- a/django_sql_dashboard_export/tests.py
+++ b/django_sql_dashboard_export/tests.py
@@ -20,6 +20,23 @@ class ExportTestCase(TestCase):
 
         self.assertEqual(content.decode("ascii"), "a,b\r\n1,hello\r\n")
 
+    def test_download_csv_with_query_param(self):
+        dashboard = Dashboard.objects.create(
+            slug="my_dashboard",
+            title="My little dashboard for export with q param",
+            view_policy=Dashboard.ViewPolicies.UNLISTED,
+        )
+        query = DashboardQuery.objects.create(sql="select 1 as a, %(BValue)s as b", dashboard=dashboard)
+
+        r = self.client.get(f"/explore/my_dashboard/export/?index={query._order}&format=csv&BValue=hello")
+        self.assertEqual(r.status_code, 200)
+        content = r.getvalue()
+        self.assertEqual(content, b"a,b\r\n1,hello\r\n")
+        self.assertEqual(r.headers["Content-Type"], "text/csv")
+        self.assertEqual(r.headers["Content-Disposition"], 'attachment; filename="my_dashboard_0.csv"')
+
+        self.assertEqual(content.decode("ascii"), "a,b\r\n1,hello\r\n")
+
     def test_download_tsv(self):
         dashboard = Dashboard.objects.create(
             slug="my_dashboard", title="My little dashboard for export", view_policy=Dashboard.ViewPolicies.UNLISTED


### PR DESCRIPTION
When you create a dashboards from a query with named parameters...
It works but when you try to export the data as CSV you get an empty CSV files with the column names but no datas.

Example of such query : 

```SQL
SELECT * FROM iaso_profile INNER join auth_user ON iaso_profile.user_id = auth_user.id WHERE auth_user.username = %(Username)s
```


Related JIRA tickets : IA-2069

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are there enough tests

## Changes

The problem was that the parameters of the query are in the URL as get params and the /export/ endpoint expect them as get params as well.

But the link "Download as CSV" at the bottom is hardcoded and doesn't transmit those parameters to the /export/ endpoint.

This is implemented as a custom widget form django-sql-dashboard app, as a django template and some views. But the template doesn't have does GET params, so I had to add a little bit of JS that copies thoses params from the page URL to the HREF of the "Download as CSV" link.

I also added a test case for an export of a query with named parameters.

## How to test

Create a new dashboard with named arguments (see above for an example).
Save it and give it a name.
Visit it and enter a value for your param, then run the query.
When you click on the "Download as CSV" at the bottom it should give a valid CSV file with datas.

## Print screen / video

https://user-images.githubusercontent.com/383344/233595495-64a24d5b-03af-4715-9148-a0de422bb146.mov



