### PR TITLE
IA-2063: Register, add button to create a children

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -773,6 +773,7 @@
     "iaso.queryBuilder.supportedTypeFields": "Supported type of fields",
     "iaso.queryBuilder.title": "Query builder",
     "iaso.queryBuilder.xlsQuestionsTypesLink": "Possible questions types",
+    "iaso.registry.addOrgUnitChildren": "Add children org unit",
     "iaso.registry.seeRegistry": "See registry",
     "iaso.registry.title": "Registry",
     "iaso.registry.withLocation": "With point",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -773,7 +773,7 @@
     "iaso.queryBuilder.supportedTypeFields": "Supported type of fields",
     "iaso.queryBuilder.title": "Query builder",
     "iaso.queryBuilder.xlsQuestionsTypesLink": "Possible questions types",
-    "iaso.registry.addOrgUnitChildren": "Add new children org unit",
+    "iaso.registry.addOrgUnitChild": "Add new child org unit",
     "iaso.registry.seeRegistry": "See registry",
     "iaso.registry.title": "Registry",
     "iaso.registry.withLocation": "With point",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -773,7 +773,7 @@
     "iaso.queryBuilder.supportedTypeFields": "Supported type of fields",
     "iaso.queryBuilder.title": "Query builder",
     "iaso.queryBuilder.xlsQuestionsTypesLink": "Possible questions types",
-    "iaso.registry.addOrgUnitChildren": "Add children org unit",
+    "iaso.registry.addOrgUnitChildren": "Add new children org unit",
     "iaso.registry.seeRegistry": "See registry",
     "iaso.registry.title": "Registry",
     "iaso.registry.withLocation": "With point",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -761,7 +761,7 @@
     "iaso.queryBuilder.supportedTypeFields": "Type de champ supportés",
     "iaso.queryBuilder.title": "Query builder",
     "iaso.queryBuilder.xlsQuestionsTypesLink": "Types des questions possible",
-    "iaso.registry.addOrgUnitChildren": "Ajouter une unité d'org.",
+    "iaso.registry.addOrgUnitChildren": "Ajouter une nouvelle sous unité d'org.",
     "iaso.registry.seeRegistry": "Voir le registre",
     "iaso.registry.title": "Registre",
     "iaso.registry.withLocation": "Avec point",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -761,7 +761,7 @@
     "iaso.queryBuilder.supportedTypeFields": "Type de champ supportés",
     "iaso.queryBuilder.title": "Query builder",
     "iaso.queryBuilder.xlsQuestionsTypesLink": "Types des questions possible",
-    "iaso.registry.addOrgUnitChildren": "Ajouter une nouvelle sous unité d'org.",
+    "iaso.registry.addOrgUnitChild": "Ajouter une nouvelle sous unité d'org.",
     "iaso.registry.seeRegistry": "Voir le registre",
     "iaso.registry.title": "Registre",
     "iaso.registry.withLocation": "Avec point",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -761,6 +761,7 @@
     "iaso.queryBuilder.supportedTypeFields": "Type de champ supportés",
     "iaso.queryBuilder.title": "Query builder",
     "iaso.queryBuilder.xlsQuestionsTypesLink": "Types des questions possible",
+    "iaso.registry.addOrgUnitChildren": "Ajouter une unité d'org.",
     "iaso.registry.seeRegistry": "Voir le registre",
     "iaso.registry.title": "Registre",
     "iaso.registry.withLocation": "Avec point",

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/details.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/details.js
@@ -245,7 +245,13 @@ const OrgUnitDetail = ({ params, router }) => {
         isFetchingDetail,
         isFetchingOrgUnitTypes,
         isFetchingGroups,
-    } = useOrgUnitDetailData(isNewOrgunit, params.orgUnitId, setCurrentOrgUnit);
+        parentOrgUnit,
+    } = useOrgUnitDetailData(
+        isNewOrgunit,
+        params.orgUnitId,
+        setCurrentOrgUnit,
+        params.levels,
+    );
 
     const goToRevision = useCallback(
         (orgUnitRevision, onSuccess) => {
@@ -310,11 +316,17 @@ const OrgUnitDetail = ({ params, router }) => {
     );
 
     useEffect(() => {
-        if (isNewOrgunit) {
-            setCurrentOrgUnit(initialOrgUnit);
+        if (isNewOrgunit && !currentOrgUnit) {
+            if (params.levels && parentOrgUnit) {
+                setCurrentOrgUnit({
+                    ...initialOrgUnit,
+                    parent: parentOrgUnit,
+                });
+            } else if (!params.levels) {
+                setCurrentOrgUnit(initialOrgUnit);
+            }
         }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
+    }, [parentOrgUnit, isNewOrgunit, params.levels, currentOrgUnit]);
 
     // Set levels params in the url
     useEffect(() => {

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/hooks.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/hooks.js
@@ -13,6 +13,7 @@ export const useOrgUnitDetailData = (
     isNewOrgunit,
     orgUnitId,
     setCurrentOrgUnit,
+    levels,
 ) => {
     const { data: originalOrgUnit, isFetching: isFetchingDetail } =
         useSnackQuery(
@@ -24,7 +25,6 @@ export const useOrgUnitDetailData = (
                 onSuccess: ou => setCurrentOrgUnit(ou),
             },
         );
-
     const groupsUrl = useMemo(() => {
         const basUrl = '/api/groups/';
         if (isNewOrgunit) {
@@ -47,6 +47,7 @@ export const useOrgUnitDetailData = (
             isFetching: isFetchingAssociatedDataSources,
         },
         { data: sources = [], isFetching: isFetchingPlainSources },
+        { data: parentOrgUnit },
     ] = useSnackQueries([
         {
             queryKey: ['algorithms'],
@@ -124,6 +125,17 @@ export const useOrgUnitDetailData = (
                 enabled: !isNewOrgunit,
             },
         },
+        {
+            queryKey: ['parentOrgUnit', orgUnitId],
+            queryFn: () => getRequest(`/api/orgunits/${levels}/`),
+            snackErrorMsg: MESSAGES.fetchOrgUnitError,
+            options: {
+                enabled:
+                    Boolean(levels) &&
+                    isNewOrgunit &&
+                    levels.split(',').length === 1,
+            },
+        },
     ]);
 
     const isFetchingSources = isNewOrgunit
@@ -150,6 +162,7 @@ export const useOrgUnitDetailData = (
         isFetchingDetail,
         isFetchingOrgUnitTypes,
         isFetchingGroups,
+        parentOrgUnit,
     };
 };
 

--- a/hat/assets/js/apps/Iaso/domains/registry/components/MapLegend.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/MapLegend.tsx
@@ -1,0 +1,101 @@
+import React, {
+    FunctionComponent,
+    Dispatch,
+    SetStateAction,
+    useCallback,
+} from 'react';
+import { Paper, makeStyles, Box } from '@material-ui/core';
+import { cloneDeep } from 'lodash';
+import CheckIcon from '@material-ui/icons/Check';
+
+import { Legend } from '../hooks/useGetLegendOptions';
+
+const useStyles = makeStyles(theme => ({
+    root: {
+        position: 'absolute', // assuming you have a parent relative
+        zIndex: 500,
+        top: 'auto',
+        left: 'auto',
+        right: theme.spacing(1),
+        bottom: theme.spacing(3),
+        width: 'auto',
+    },
+    option: {
+        cursor: 'pointer',
+    },
+    activeOption: {
+        cursor: 'pointer',
+    },
+    roundColor: {
+        borderRadius: 20,
+        height: 20,
+        width: 20,
+        display: 'inline-block',
+        marginRight: theme.spacing(1),
+    },
+    mapLegendLabel: {
+        textAlign: 'right',
+        display: 'inline-block',
+        verticalAlign: 'top',
+    },
+    checkIcon: {
+        color: 'white',
+    },
+}));
+
+type Props = {
+    options: Array<Legend> | undefined;
+    setOptions: Dispatch<SetStateAction<Legend[]>>;
+};
+
+export const MapLegend: FunctionComponent<Props> = ({
+    options,
+    setOptions,
+}) => {
+    const classes = useStyles();
+    const handleClick = useCallback(
+        (optionIndex: number): void => {
+            const newOptions = cloneDeep(options);
+            if (newOptions && newOptions[optionIndex]) {
+                newOptions[optionIndex].active =
+                    !newOptions[optionIndex].active;
+                setOptions(newOptions);
+            }
+        },
+        [options, setOptions],
+    );
+
+    return (
+        <Paper elevation={1} className={classes.root}>
+            <Box p={2}>
+                {options &&
+                    options.map((option, i) => (
+                        <Box
+                            key={option.value}
+                            mb={i + 1 === options.length ? 0 : 1}
+                            onClick={() => handleClick(i)}
+                            role="button"
+                            tabIndex={0}
+                            className={classes.option}
+                        >
+                            <span
+                                className={classes.roundColor}
+                                style={{ backgroundColor: option.color }}
+                            >
+                                {option.active && (
+                                    <CheckIcon
+                                        fontSize="small"
+                                        className={classes.checkIcon}
+                                    />
+                                )}
+                            </span>
+
+                            <span className={classes.mapLegendLabel}>
+                                {option.label}
+                            </span>
+                        </Box>
+                    ))}
+            </Box>
+        </Paper>
+    );
+};

--- a/hat/assets/js/apps/Iaso/domains/registry/components/MapLegend.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/MapLegend.tsx
@@ -22,9 +22,8 @@ const useStyles = makeStyles(theme => ({
     },
     option: {
         cursor: 'pointer',
-    },
-    activeOption: {
-        cursor: 'pointer',
+        display: 'flex',
+        alignItems: 'center',
     },
     roundColor: {
         borderRadius: 20,

--- a/hat/assets/js/apps/Iaso/domains/registry/components/MapLegend.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/MapLegend.tsx
@@ -5,7 +5,6 @@ import React, {
     useCallback,
 } from 'react';
 import { Paper, makeStyles, Box } from '@material-ui/core';
-import { cloneDeep } from 'lodash';
 import CheckIcon from '@material-ui/icons/Check';
 
 import { Legend } from '../hooks/useGetLegendOptions';
@@ -54,8 +53,8 @@ export const MapLegend: FunctionComponent<Props> = ({
     const classes = useStyles();
     const handleClick = useCallback(
         (optionIndex: number): void => {
-            const newOptions = cloneDeep(options);
-            if (newOptions && newOptions[optionIndex]) {
+            const newOptions = [...(options || [])];
+            if (newOptions?.[optionIndex]) {
                 newOptions[optionIndex].active =
                     !newOptions[optionIndex].active;
                 setOptions(newOptions);

--- a/hat/assets/js/apps/Iaso/domains/registry/components/OrgUnitChildrenMap.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/OrgUnitChildrenMap.tsx
@@ -14,7 +14,7 @@ import {
     ScaleControl,
     Tooltip,
 } from 'react-leaflet';
-import { useSafeIntl } from 'bluesquare-components';
+import { LoadingSpinner, useSafeIntl } from 'bluesquare-components';
 import { Box, useTheme } from '@material-ui/core';
 
 import { useGetOrgUnitsMapChildren } from '../hooks/useGetOrgUnit';
@@ -85,7 +85,12 @@ export const OrgUnitChildrenMap: FunctionComponent<Props> = ({
         }
         return options;
     }, [formatMessage, orgUnit, subOrgUnitTypes, theme.palette.secondary.main]);
-    if (isFetching) return null;
+    if (isFetching)
+        return (
+            <Box position="relative" height={500}>
+                <LoadingSpinner absolute />
+            </Box>
+        );
     return (
         <Box position="relative">
             <MapLegend

--- a/hat/assets/js/apps/Iaso/domains/registry/components/OrgUnitPaper.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/OrgUnitPaper.tsx
@@ -124,7 +124,7 @@ export const OrgUnitPaper: FunctionComponent<Props> = ({
                             url={`${baseUrls.orgUnitDetails}/orgUnitId/0/levels/${orgUnit.id}`}
                             color="secondary"
                             overrideIcon={AddIcon}
-                            tooltipMessage={MESSAGES.addOrgUnitChildren}
+                            tooltipMessage={MESSAGES.addOrgUnitChild}
                         />
                         <IconButton
                             url={`${baseUrls.orgUnitDetails}/orgUnitId/${orgUnit.id}`}

--- a/hat/assets/js/apps/Iaso/domains/registry/components/OrgUnitPaper.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/OrgUnitPaper.tsx
@@ -1,14 +1,23 @@
 import React, { FunctionComponent, useCallback, useState } from 'react';
 import { useDispatch } from 'react-redux';
-import { makeStyles, Tabs, Tab, Box } from '@material-ui/core';
+import {
+    makeStyles,
+    Tabs,
+    Tab,
+    Box,
+    Paper,
+    Grid,
+    Typography,
+    Divider,
+} from '@material-ui/core';
 import { commonStyles, IconButton, useSafeIntl } from 'bluesquare-components';
 import classnames from 'classnames';
+import AddIcon from '@material-ui/icons/Add';
 
 import MESSAGES from '../messages';
 
 import { baseUrls } from '../../../constants/urls';
 
-import WidgetPaper from '../../../components/papers/WidgetPaperComponent';
 import { OrgUnitChildrenMap } from './OrgUnitChildrenMap';
 
 import { redirectToReplace } from '../../../routing/actions';
@@ -29,6 +38,29 @@ const useStyles = makeStyles(theme => ({
     ...commonStyles(theme),
     paper: {
         width: '100%',
+        // @ts-ignore
+        backgroundColor: theme.palette.ligthGray.background,
+        marginBottom: theme.spacing(4),
+        '&:last-child': {
+            marginBottom: 0,
+        },
+    },
+    title: {
+        [theme.breakpoints.down('md')]: {
+            fontSize: '1.4rem',
+        },
+    },
+    paperTitle: {
+        padding: theme.spacing(2),
+        display: 'flex',
+    },
+    paperTitleButtonContainer: {
+        position: 'relative',
+    },
+    paperTitleButton: {
+        position: 'absolute',
+        right: -theme.spacing(1),
+        top: -theme.spacing(1),
     },
     hiddenOpacity: {
         position: 'absolute',
@@ -69,17 +101,42 @@ export const OrgUnitPaper: FunctionComponent<Props> = ({
         [dispatch, params],
     );
     return (
-        <WidgetPaper
-            className={classes.paper}
-            title={orgUnit.name ?? ''}
-            IconButton={IconButton}
-            iconButtonProps={{
-                url: `${baseUrls.orgUnitDetails}/orgUnitId/${orgUnit.id}`,
-                color: 'secondary',
-                icon: 'edit',
-                tooltipMessage: MESSAGES.editOrgUnit,
-            }}
-        >
+        <Paper elevation={1} className={classes.paper}>
+            <Box className={classes.paperTitle}>
+                <Grid xs={8} item>
+                    <Typography
+                        color="primary"
+                        variant="h5"
+                        className={classes.title}
+                    >
+                        {orgUnit.name ?? ''}
+                    </Typography>
+                </Grid>
+                <Grid
+                    xs={4}
+                    item
+                    container
+                    justifyContent="flex-end"
+                    className={classes.paperTitleButtonContainer}
+                >
+                    <Box className={classes.paperTitleButton}>
+                        <IconButton
+                            url={`${baseUrls.orgUnitDetails}/orgUnitId/0/levels/${orgUnit.id}`}
+                            color="secondary"
+                            overrideIcon={AddIcon}
+                            tooltipMessage={MESSAGES.addOrgUnitChildren}
+                        />
+                        <IconButton
+                            url={`${baseUrls.orgUnitDetails}/orgUnitId/${orgUnit.id}`}
+                            color="secondary"
+                            icon="edit"
+                            tooltipMessage={MESSAGES.editOrgUnit}
+                        />
+                    </Box>
+                </Grid>
+
+                <Divider />
+            </Box>
             <Tabs
                 value={tab}
                 classes={{
@@ -114,6 +171,6 @@ export const OrgUnitPaper: FunctionComponent<Props> = ({
                     />
                 </Box>
             </Box>
-        </WidgetPaper>
+        </Paper>
     );
 };

--- a/hat/assets/js/apps/Iaso/domains/registry/hooks/useGetLegendOptions.ts
+++ b/hat/assets/js/apps/Iaso/domains/registry/hooks/useGetLegendOptions.ts
@@ -1,0 +1,39 @@
+import { useSafeIntl } from 'bluesquare-components';
+import { useTheme } from '@material-ui/core';
+
+import { OrgUnit } from '../../orgUnits/types/orgUnit';
+import { OrgunitTypes } from '../../orgUnits/types/orgunitTypes';
+
+import MESSAGES from '../messages';
+
+export type Legend = {
+    value: string;
+    label: string;
+    color: string; // has to be an hexa color
+    active?: boolean;
+};
+export const useGetlegendOptions = (
+    orgUnit: OrgUnit,
+    subOrgUnitTypes: OrgunitTypes,
+): (() => Legend[]) => {
+    const { formatMessage } = useSafeIntl();
+    const theme = useTheme();
+    const getLegendOptions = (): Legend[] => {
+        const options = subOrgUnitTypes.map(subOuType => ({
+            value: `${subOuType.id}`,
+            label: subOuType.name,
+            color: subOuType.color || '',
+            active: true,
+        }));
+        if (orgUnit) {
+            options.unshift({
+                value: `${orgUnit.id}`,
+                label: formatMessage(MESSAGES.selectedOrgUnit),
+                color: theme.palette.secondary.main,
+                active: true,
+            });
+        }
+        return options;
+    };
+    return getLegendOptions;
+};

--- a/hat/assets/js/apps/Iaso/domains/registry/messages.ts
+++ b/hat/assets/js/apps/Iaso/domains/registry/messages.ts
@@ -105,6 +105,10 @@ const MESSAGES = defineMessages({
         defaultMessage: 'Without geography',
         id: 'iaso.label.noGeographicalData',
     },
+    addOrgUnitChildren: {
+        defaultMessage: 'Add children org unit',
+        id: 'iaso.registry.addOrgUnitChildren',
+    },
 });
 
 export default MESSAGES;

--- a/hat/assets/js/apps/Iaso/domains/registry/messages.ts
+++ b/hat/assets/js/apps/Iaso/domains/registry/messages.ts
@@ -106,7 +106,7 @@ const MESSAGES = defineMessages({
         id: 'iaso.label.noGeographicalData',
     },
     addOrgUnitChildren: {
-        defaultMessage: 'Add children org unit',
+        defaultMessage: 'Add children new org unit',
         id: 'iaso.registry.addOrgUnitChildren',
     },
 });

--- a/hat/assets/js/apps/Iaso/domains/registry/messages.ts
+++ b/hat/assets/js/apps/Iaso/domains/registry/messages.ts
@@ -105,9 +105,9 @@ const MESSAGES = defineMessages({
         defaultMessage: 'Without geography',
         id: 'iaso.label.noGeographicalData',
     },
-    addOrgUnitChildren: {
-        defaultMessage: 'Add children new org unit',
-        id: 'iaso.registry.addOrgUnitChildren',
+    addOrgUnitChild: {
+        defaultMessage: 'Add new child org unit',
+        id: 'iaso.registry.addOrgUnitChild',
     },
 });
 

--- a/hat/assets/js/apps/Iaso/utils/mapUtils.ts
+++ b/hat/assets/js/apps/Iaso/utils/mapUtils.ts
@@ -217,7 +217,7 @@ export type Bounds = {
     _northEast: LatLng;
     _southWest: LatLng;
     // eslint-disable-next-line no-unused-vars
-    extend: (bounds: Bounds) => Bounds;
+    extend?: (bounds: Bounds) => Bounds;
 };
 type BoundsOptions = {
     padding: number[];

--- a/hat/assets/js/apps/Iaso/utils/mapUtils.ts
+++ b/hat/assets/js/apps/Iaso/utils/mapUtils.ts
@@ -217,7 +217,7 @@ export type Bounds = {
     _northEast: LatLng;
     _southWest: LatLng;
     // eslint-disable-next-line no-unused-vars
-    extend?: (bounds: Bounds) => Bounds;
+    extend: (bounds: Bounds) => Bounds;
 };
 type BoundsOptions = {
     padding: number[];


### PR DESCRIPTION


Add a button to create a new org unit as the children of the current one.
Related JIRA tickets : IA-2063

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- accept levels as default param for parent while creating a org unit
- fetch parent info end set it as parent to the new org unit
- custom paper component for registry
- add link to create children org unit with current org unit as level in the url
- placeholder on map while loading list of children

## How to test

Go to register for an existing org unit.
You should see a + button nearby the name of the org unit, if you click on it you should arrive on the org unit creation page with the org unit selected in registry as parent 

## Print screen / video


https://user-images.githubusercontent.com/12494624/233610010-6f303b2b-9d17-4000-ad6a-3e0259e85455.mov



## Notes

⚠️ Current base is this [PR](https://github.com/BLSQ/iaso/pull/535)