### PR TITLE
IA-2074: registry toggle types

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/registry/components/MapLegend.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/MapLegend.tsx
@@ -1,0 +1,101 @@
+import React, {
+    FunctionComponent,
+    Dispatch,
+    SetStateAction,
+    useCallback,
+} from 'react';
+import { Paper, makeStyles, Box } from '@material-ui/core';
+import { cloneDeep } from 'lodash';
+import CheckIcon from '@material-ui/icons/Check';
+
+import { Legend } from '../hooks/useGetLegendOptions';
+
+const useStyles = makeStyles(theme => ({
+    root: {
+        position: 'absolute', // assuming you have a parent relative
+        zIndex: 500,
+        top: 'auto',
+        left: 'auto',
+        right: theme.spacing(1),
+        bottom: theme.spacing(3),
+        width: 'auto',
+    },
+    option: {
+        cursor: 'pointer',
+    },
+    activeOption: {
+        cursor: 'pointer',
+    },
+    roundColor: {
+        borderRadius: 20,
+        height: 20,
+        width: 20,
+        display: 'inline-block',
+        marginRight: theme.spacing(1),
+    },
+    mapLegendLabel: {
+        textAlign: 'right',
+        display: 'inline-block',
+        verticalAlign: 'top',
+    },
+    checkIcon: {
+        color: 'white',
+    },
+}));
+
+type Props = {
+    options: Array<Legend> | undefined;
+    setOptions: Dispatch<SetStateAction<Legend[]>>;
+};
+
+export const MapLegend: FunctionComponent<Props> = ({
+    options,
+    setOptions,
+}) => {
+    const classes = useStyles();
+    const handleClick = useCallback(
+        (optionIndex: number): void => {
+            const newOptions = cloneDeep(options);
+            if (newOptions && newOptions[optionIndex]) {
+                newOptions[optionIndex].active =
+                    !newOptions[optionIndex].active;
+                setOptions(newOptions);
+            }
+        },
+        [options, setOptions],
+    );
+
+    return (
+        <Paper elevation={1} className={classes.root}>
+            <Box p={2}>
+                {options &&
+                    options.map((option, i) => (
+                        <Box
+                            key={option.value}
+                            mb={i + 1 === options.length ? 0 : 1}
+                            onClick={() => handleClick(i)}
+                            role="button"
+                            tabIndex={0}
+                            className={classes.option}
+                        >
+                            <span
+                                className={classes.roundColor}
+                                style={{ backgroundColor: option.color }}
+                            >
+                                {option.active && (
+                                    <CheckIcon
+                                        fontSize="small"
+                                        className={classes.checkIcon}
+                                    />
+                                )}
+                            </span>
+
+                            <span className={classes.mapLegendLabel}>
+                                {option.label}
+                            </span>
+                        </Box>
+                    ))}
+            </Box>
+        </Paper>
+    );
+};

--- a/hat/assets/js/apps/Iaso/domains/registry/components/MapLegend.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/MapLegend.tsx
@@ -22,9 +22,8 @@ const useStyles = makeStyles(theme => ({
     },
     option: {
         cursor: 'pointer',
-    },
-    activeOption: {
-        cursor: 'pointer',
+        display: 'flex',
+        alignItems: 'center',
     },
     roundColor: {
         borderRadius: 20,

--- a/hat/assets/js/apps/Iaso/domains/registry/components/MapLegend.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/MapLegend.tsx
@@ -5,7 +5,6 @@ import React, {
     useCallback,
 } from 'react';
 import { Paper, makeStyles, Box } from '@material-ui/core';
-import { cloneDeep } from 'lodash';
 import CheckIcon from '@material-ui/icons/Check';
 
 import { Legend } from '../hooks/useGetLegendOptions';
@@ -54,8 +53,8 @@ export const MapLegend: FunctionComponent<Props> = ({
     const classes = useStyles();
     const handleClick = useCallback(
         (optionIndex: number): void => {
-            const newOptions = cloneDeep(options);
-            if (newOptions && newOptions[optionIndex]) {
+            const newOptions = [...(options || [])];
+            if (newOptions?.[optionIndex]) {
                 newOptions[optionIndex].active =
                     !newOptions[optionIndex].active;
                 setOptions(newOptions);

--- a/hat/assets/js/apps/Iaso/domains/registry/hooks/useGetLegendOptions.ts
+++ b/hat/assets/js/apps/Iaso/domains/registry/hooks/useGetLegendOptions.ts
@@ -1,0 +1,39 @@
+import { useSafeIntl } from 'bluesquare-components';
+import { useTheme } from '@material-ui/core';
+
+import { OrgUnit } from '../../orgUnits/types/orgUnit';
+import { OrgunitTypes } from '../../orgUnits/types/orgunitTypes';
+
+import MESSAGES from '../messages';
+
+export type Legend = {
+    value: string;
+    label: string;
+    color: string; // has to be an hexa color
+    active?: boolean;
+};
+export const useGetlegendOptions = (
+    orgUnit: OrgUnit,
+    subOrgUnitTypes: OrgunitTypes,
+): (() => Legend[]) => {
+    const { formatMessage } = useSafeIntl();
+    const theme = useTheme();
+    const getLegendOptions = (): Legend[] => {
+        const options = subOrgUnitTypes.map(subOuType => ({
+            value: `${subOuType.id}`,
+            label: subOuType.name,
+            color: subOuType.color || '',
+            active: true,
+        }));
+        if (orgUnit) {
+            options.unshift({
+                value: `${orgUnit.id}`,
+                label: formatMessage(MESSAGES.selectedOrgUnit),
+                color: theme.palette.secondary.main,
+                active: true,
+            });
+        }
+        return options;
+    };
+    return getLegendOptions;
+};

--- a/hat/assets/js/apps/Iaso/utils/mapUtils.ts
+++ b/hat/assets/js/apps/Iaso/utils/mapUtils.ts
@@ -217,7 +217,7 @@ export type Bounds = {
     _northEast: LatLng;
     _southWest: LatLng;
     // eslint-disable-next-line no-unused-vars
-    extend: (bounds: Bounds) => Bounds;
+    extend?: (bounds: Bounds) => Bounds;
 };
 type BoundsOptions = {
     padding: number[];

--- a/hat/assets/js/apps/Iaso/utils/mapUtils.ts
+++ b/hat/assets/js/apps/Iaso/utils/mapUtils.ts
@@ -217,7 +217,7 @@ export type Bounds = {
     _northEast: LatLng;
     _southWest: LatLng;
     // eslint-disable-next-line no-unused-vars
-    extend?: (bounds: Bounds) => Bounds;
+    extend: (bounds: Bounds) => Bounds;
 };
 type BoundsOptions = {
     padding: number[];


### PR DESCRIPTION
This should be interactive and allow to toggle on and off the org units shown on the map

Related JIRA tickets : IA-2074,

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- change legend to accept active prop
- custom map legend component toggling active org unit
- show / hide active org units
- refactor fit to bounds to fit only active org units

## How to test

Open a registry for an org unit whit su b org units (with geo locations)
You should be able to show/hide those children types

## Print screen / video


https://user-images.githubusercontent.com/12494624/233645142-bac5d4a9-a8ec-47ae-9179-d9cb095e55f3.mov



## Notes

⚠️ Curent base is this [PR](https://github.com/BLSQ/iaso/pull/537)
