### PR TITLE
POLIO-967: Remove vaccine type colors from default calendar assigned colors

### DIFF
--- a/plugins/polio/js/src/constants/campaignsColors.js
+++ b/plugins/polio/js/src/constants/campaignsColors.js
@@ -16,20 +16,20 @@ import {
 } from '@material-ui/core/colors';
 
 const colors = [
-    teal[500],
+    teal[800],
     lightGreen[800],
     purple[800],
     blue[800],
-    amber[500],
-    lime[500],
-    brown[500],
-    grey[500],
-    cyan[500],
-    blueGrey[500],
-    pink[500],
-    indigo[500],
+    amber[800],
+    lime[800],
+    brown[800],
+    grey[800],
+    cyan[800],
+    blueGrey[800],
+    pink[800],
+    indigo[800],
     yellow[800],
-    deepOrange[700],
+    deepOrange[800],
 ];
 
 const getCampaignColor = (i, reverse = false) => {

--- a/plugins/polio/js/src/constants/campaignsColors.js
+++ b/plugins/polio/js/src/constants/campaignsColors.js
@@ -3,7 +3,6 @@ import {
     purple,
     indigo,
     blue,
-    lightBlue,
     cyan,
     teal,
     lightGreen,
@@ -20,9 +19,8 @@ const colors = [
     teal[500],
     lightGreen[800],
     purple[800],
-    blue[500],
+    blue[800],
     amber[500],
-    lightBlue[500],
     lime[500],
     brown[500],
     grey[500],
@@ -30,7 +28,7 @@ const colors = [
     blueGrey[500],
     pink[500],
     indigo[500],
-    yellow[500],
+    yellow[800],
     deepOrange[700],
 ];
 


### PR DESCRIPTION
Campaigns colors w'ere sometimes too close to vaccine colors

Related JIRA tickets : POLIO-967

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

removing colors too close to vaccine colors

## How to test

Open calendar page with lots of campaigns, check that campaigns colors are not matching the vaccine colors

## Print screen / video

<img width="1340" alt="Screenshot 2023-04-21 at 15 31 24" src="https://user-images.githubusercontent.com/12494624/233648668-bea738bd-c40d-424e-a017-52c6049d6a7d.png">

