### PR TITLE
IA-2073: add breadcrumbs to registry

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/LinkToOrgUnit.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/LinkToOrgUnit.tsx
@@ -15,11 +15,13 @@ import MESSAGES from '../../assignments/messages';
 type Props = {
     orgUnit?: OrgUnit | ShortOrgUnit;
     useIcon?: boolean;
+    className?: string;
 };
 
 export const LinkToOrgUnit: FunctionComponent<Props> = ({
     orgUnit,
     useIcon = false,
+    className = '',
 }) => {
     const user = useCurrentUser();
     if (userHasPermission('iaso_org_units', user) && orgUnit) {
@@ -33,7 +35,11 @@ export const LinkToOrgUnit: FunctionComponent<Props> = ({
                 />
             );
         }
-        return <Link to={url}>{orgUnit.name}</Link>;
+        return (
+            <Link className={className} to={url}>
+                {orgUnit.name}
+            </Link>
+        );
     }
     return <>{orgUnit ? orgUnit.name : '-'}</>;
 };

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/LinkToOrgUnit.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/LinkToOrgUnit.tsx
@@ -19,7 +19,7 @@ type Props = {
 
 export const LinkToOrgUnit: FunctionComponent<Props> = ({
     orgUnit,
-    useIcon,
+    useIcon = false,
 }) => {
     const user = useCurrentUser();
     if (userHasPermission('iaso_org_units', user) && orgUnit) {
@@ -36,8 +36,4 @@ export const LinkToOrgUnit: FunctionComponent<Props> = ({
         return <Link to={url}>{orgUnit.name}</Link>;
     }
     return <>{orgUnit ? orgUnit.name : '-'}</>;
-};
-
-LinkToOrgUnit.defaultProps = {
-    useIcon: false,
 };

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/breadcrumbs/OrgUnitBreadcrumbs.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/breadcrumbs/OrgUnitBreadcrumbs.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent, useMemo } from 'react';
-import { Breadcrumbs } from '@material-ui/core';
+import { Breadcrumbs, makeStyles } from '@material-ui/core';
 import { OrgUnit } from '../../types/orgUnit';
 import { LinkToOrgUnit } from '../LinkToOrgUnit';
 
@@ -39,6 +39,13 @@ export const useOrgUnitBreadCrumbs = ({
     }, [orgUnit, showOnlyParents]);
 };
 
+const useStyles = makeStyles(theme => {
+    return {
+        // @ts-ignore
+        link: { color: theme.palette.mediumGray.main },
+    };
+});
+
 type Props = {
     separator?: string;
     orgUnit: OrgUnit;
@@ -50,11 +57,14 @@ export const OrgUnitBreadcrumbs: FunctionComponent<Props> = ({
     orgUnit,
     showOnlyParents,
 }) => {
+    const { link } = useStyles();
     const breadcrumbs = useOrgUnitBreadCrumbs({ orgUnit, showOnlyParents });
     return (
         <Breadcrumbs separator={separator}>
             {breadcrumbs.map(ou => {
-                return <LinkToOrgUnit orgUnit={ou} key={ou.id} />;
+                return (
+                    <LinkToOrgUnit orgUnit={ou} key={ou.id} className={link} />
+                );
             })}
         </Breadcrumbs>
     );

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/breadcrumbs/OrgUnitBreadcrumbs.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/breadcrumbs/OrgUnitBreadcrumbs.tsx
@@ -1,0 +1,41 @@
+import React, { FunctionComponent, useMemo } from 'react';
+import { Breadcrumbs } from '@material-ui/core';
+import { OrgUnit } from '../../types/orgUnit';
+import { LinkToOrgUnit } from '../LinkToOrgUnit';
+
+export const getBreadcrumbs = (
+    orgUnit?: OrgUnit,
+    list: OrgUnit[] = [],
+): OrgUnit[] => {
+    if (!orgUnit) return list;
+    if (!orgUnit.parent) {
+        list.push(orgUnit);
+        return list;
+    }
+    list.push(orgUnit.parent);
+    return getBreadcrumbs(orgUnit.parent, list);
+};
+
+export const useOrgUnitBreadCrumbs = (orgUnit?: OrgUnit): OrgUnit[] => {
+    return useMemo(() => {
+        return getBreadcrumbs(orgUnit).reverse();
+    }, [orgUnit]);
+};
+
+type Props = {
+    separator?: string;
+    breadcrumbs: OrgUnit[];
+};
+
+export const OrgUnitBreadcrumbs: FunctionComponent<Props> = ({
+    separator = '>',
+    breadcrumbs,
+}) => {
+    return (
+        <Breadcrumbs separator={separator}>
+            {breadcrumbs.map(ou => {
+                return <LinkToOrgUnit orgUnit={ou} key={ou.id} />;
+            })}
+        </Breadcrumbs>
+    );
+};

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/breadcrumbs/OrgUnitBreadcrumbs.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/breadcrumbs/OrgUnitBreadcrumbs.tsx
@@ -3,34 +3,54 @@ import { Breadcrumbs } from '@material-ui/core';
 import { OrgUnit } from '../../types/orgUnit';
 import { LinkToOrgUnit } from '../LinkToOrgUnit';
 
-export const getBreadcrumbs = (
-    orgUnit?: OrgUnit,
-    list: OrgUnit[] = [],
-): OrgUnit[] => {
+type BreadCrumbsArgs = {
+    orgUnit?: OrgUnit;
+    list?: OrgUnit[];
+    showOnlyParents?: boolean;
+};
+
+export const getBreadcrumbs = ({
+    orgUnit,
+    list = [],
+    showOnlyParents = false,
+}: BreadCrumbsArgs): OrgUnit[] => {
     if (!orgUnit) return list;
-    if (!orgUnit.parent) {
+    if (list.length === 0 && !showOnlyParents) {
         list.push(orgUnit);
+    }
+    if (!orgUnit.parent) {
         return list;
     }
     list.push(orgUnit.parent);
-    return getBreadcrumbs(orgUnit.parent, list);
+    return getBreadcrumbs({ orgUnit: orgUnit.parent, list, showOnlyParents });
 };
 
-export const useOrgUnitBreadCrumbs = (orgUnit?: OrgUnit): OrgUnit[] => {
+type UseOrgUnitBreadCrumbsArgs = {
+    orgUnit?: OrgUnit;
+    showOnlyParents?: boolean;
+};
+
+export const useOrgUnitBreadCrumbs = ({
+    orgUnit,
+    showOnlyParents,
+}: UseOrgUnitBreadCrumbsArgs): OrgUnit[] => {
     return useMemo(() => {
-        return getBreadcrumbs(orgUnit).reverse();
-    }, [orgUnit]);
+        return getBreadcrumbs({ orgUnit, showOnlyParents }).reverse();
+    }, [orgUnit, showOnlyParents]);
 };
 
 type Props = {
     separator?: string;
-    breadcrumbs: OrgUnit[];
+    orgUnit: OrgUnit;
+    showOnlyParents?: boolean;
 };
 
 export const OrgUnitBreadcrumbs: FunctionComponent<Props> = ({
     separator = '>',
-    breadcrumbs,
+    orgUnit,
+    showOnlyParents,
 }) => {
+    const breadcrumbs = useOrgUnitBreadCrumbs({ orgUnit, showOnlyParents });
     return (
         <Breadcrumbs separator={separator}>
             {breadcrumbs.map(ou => {

--- a/hat/assets/js/apps/Iaso/domains/registry/details.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/details.tsx
@@ -52,7 +52,10 @@ const useStyles = makeStyles(theme => ({
 
 const getBreadcrumbs = (orgUnit?: OrgUnit, list: OrgUnit[] = []): OrgUnit[] => {
     if (!orgUnit) return list;
-    if (!orgUnit.parent) return list;
+    if (!orgUnit.parent) {
+        list.push(orgUnit);
+        return list;
+    }
     list.push(orgUnit.parent);
     return getBreadcrumbs(orgUnit.parent, list);
 };
@@ -105,7 +108,12 @@ export const Details: FunctionComponent<Props> = ({ router }) => {
                             <Box mb={2}>
                                 <Breadcrumbs separator=">">
                                     {breadcrumbs.map(ou => {
-                                        return <LinkToOrgUnit orgUnit={ou} />;
+                                        return (
+                                            <LinkToOrgUnit
+                                                orgUnit={ou}
+                                                key={ou.id}
+                                            />
+                                        );
                                     })}
                                 </Breadcrumbs>
                             </Box>

--- a/hat/assets/js/apps/Iaso/domains/registry/details.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/details.tsx
@@ -50,12 +50,10 @@ const useStyles = makeStyles(theme => ({
     },
 }));
 
-const getBreadcrumbs = (orgUnit?: OrgUnit, list: any[] = []): any[] => {
+const getBreadcrumbs = (orgUnit?: OrgUnit, list: OrgUnit[] = []): OrgUnit[] => {
     if (!orgUnit) return list;
     if (!orgUnit.parent) return list;
-    list.push({
-        orgUnit: orgUnit.parent,
-    });
+    list.push(orgUnit.parent);
     return getBreadcrumbs(orgUnit.parent, list);
 };
 
@@ -106,12 +104,8 @@ export const Details: FunctionComponent<Props> = ({ router }) => {
                         {orgUnit && (
                             <Box mb={2}>
                                 <Breadcrumbs separator=">">
-                                    {breadcrumbs.map(breadcrumb => {
-                                        return (
-                                            <LinkToOrgUnit
-                                                orgUnit={breadcrumb.orgUnit}
-                                            />
-                                        );
+                                    {breadcrumbs.map(ou => {
+                                        return <LinkToOrgUnit orgUnit={ou} />;
                                     })}
                                 </Breadcrumbs>
                             </Box>

--- a/hat/assets/js/apps/Iaso/domains/registry/details.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/details.tsx
@@ -5,7 +5,7 @@ import {
     IconButton,
     LoadingSpinner,
 } from 'bluesquare-components';
-import { Box, Grid, makeStyles } from '@material-ui/core';
+import { Box, Grid, makeStyles, Breadcrumbs } from '@material-ui/core';
 import { orderBy } from 'lodash';
 import TopBar from '../../components/nav/TopBarComponent';
 import MESSAGES from './messages';
@@ -28,6 +28,8 @@ import { OrgunitTypes } from '../orgUnits/types/orgunitTypes';
 import { RegistryDetailParams } from './types';
 
 import { userHasPermission } from '../users/utils';
+import { OrgUnit } from '../orgUnits/types/orgUnit';
+import { LinkToOrgUnit } from '../orgUnits/components/LinkToOrgUnit';
 
 type Router = {
     goBack: () => void;
@@ -48,6 +50,15 @@ const useStyles = makeStyles(theme => ({
     },
 }));
 
+const getBreadcrumbs = (orgUnit?: OrgUnit, list: any[] = []): any[] => {
+    if (!orgUnit) return list;
+    if (!orgUnit.parent) return list;
+    list.push({
+        orgUnit: orgUnit.parent,
+    });
+    return getBreadcrumbs(orgUnit.parent, list);
+};
+
 export const Details: FunctionComponent<Props> = ({ router }) => {
     const {
         params: { orgUnitId, accountId },
@@ -58,6 +69,9 @@ export const Details: FunctionComponent<Props> = ({ router }) => {
     const goBack = useGoBack(router, baseUrls.registry, { accountId });
 
     const { data: orgUnit, isFetching } = useGetOrgUnit(orgUnitId);
+    const breadcrumbs = useMemo(() => {
+        return getBreadcrumbs(orgUnit).reverse();
+    }, [orgUnit]);
 
     const subOrgUnitTypes: OrgunitTypes = useMemo(() => {
         const options =
@@ -89,6 +103,19 @@ export const Details: FunctionComponent<Props> = ({ router }) => {
                 {isFetching && <LoadingSpinner />}
                 <Grid container spacing={2}>
                     <Grid item xs={12} md={5}>
+                        {orgUnit && (
+                            <Box mb={2}>
+                                <Breadcrumbs separator=">">
+                                    {breadcrumbs.map(breadcrumb => {
+                                        return (
+                                            <LinkToOrgUnit
+                                                orgUnit={breadcrumb.orgUnit}
+                                            />
+                                        );
+                                    })}
+                                </Breadcrumbs>
+                            </Box>
+                        )}
                         {orgUnit && (
                             <WidgetPaper
                                 className={classes.paper}

--- a/hat/assets/js/apps/Iaso/domains/registry/details.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/details.tsx
@@ -89,12 +89,12 @@ export const Details: FunctionComponent<Props> = ({ router }) => {
             <Box className={`${classes.containerFullHeightNoTabPadded}`}>
                 {isFetching && <LoadingSpinner />}
                 <Grid container spacing={2}>
+                    {orgUnit && (
+                        <Grid item xs={12}>
+                            <OrgUnitBreadcrumbs orgUnit={orgUnit} />
+                        </Grid>
+                    )}
                     <Grid item xs={12} md={5}>
-                        {orgUnit && (
-                            <Box mb={2}>
-                                <OrgUnitBreadcrumbs orgUnit={orgUnit} />
-                            </Box>
-                        )}
                         {orgUnit && (
                             <WidgetPaper
                                 className={classes.paper}

--- a/hat/assets/js/apps/Iaso/domains/registry/details.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/details.tsx
@@ -28,10 +28,7 @@ import { OrgunitTypes } from '../orgUnits/types/orgunitTypes';
 import { RegistryDetailParams } from './types';
 
 import { userHasPermission } from '../users/utils';
-import {
-    OrgUnitBreadcrumbs,
-    useOrgUnitBreadCrumbs,
-} from '../orgUnits/components/breadcrumbs/OrgUnitBreadcrumbs';
+import { OrgUnitBreadcrumbs } from '../orgUnits/components/breadcrumbs/OrgUnitBreadcrumbs';
 
 type Router = {
     goBack: () => void;
@@ -62,7 +59,6 @@ export const Details: FunctionComponent<Props> = ({ router }) => {
     const goBack = useGoBack(router, baseUrls.registry, { accountId });
 
     const { data: orgUnit, isFetching } = useGetOrgUnit(orgUnitId);
-    const breadcrumbs = useOrgUnitBreadCrumbs(orgUnit);
 
     const subOrgUnitTypes: OrgunitTypes = useMemo(() => {
         const options =
@@ -96,7 +92,7 @@ export const Details: FunctionComponent<Props> = ({ router }) => {
                     <Grid item xs={12} md={5}>
                         {orgUnit && (
                             <Box mb={2}>
-                                <OrgUnitBreadcrumbs breadcrumbs={breadcrumbs} />
+                                <OrgUnitBreadcrumbs orgUnit={orgUnit} />
                             </Box>
                         )}
                         {orgUnit && (

--- a/hat/assets/js/apps/Iaso/domains/registry/details.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/details.tsx
@@ -5,7 +5,7 @@ import {
     IconButton,
     LoadingSpinner,
 } from 'bluesquare-components';
-import { Box, Grid, makeStyles, Breadcrumbs } from '@material-ui/core';
+import { Box, Grid, makeStyles } from '@material-ui/core';
 import { orderBy } from 'lodash';
 import TopBar from '../../components/nav/TopBarComponent';
 import MESSAGES from './messages';
@@ -28,8 +28,10 @@ import { OrgunitTypes } from '../orgUnits/types/orgunitTypes';
 import { RegistryDetailParams } from './types';
 
 import { userHasPermission } from '../users/utils';
-import { OrgUnit } from '../orgUnits/types/orgUnit';
-import { LinkToOrgUnit } from '../orgUnits/components/LinkToOrgUnit';
+import {
+    OrgUnitBreadcrumbs,
+    useOrgUnitBreadCrumbs,
+} from '../orgUnits/components/breadcrumbs/OrgUnitBreadcrumbs';
 
 type Router = {
     goBack: () => void;
@@ -50,16 +52,6 @@ const useStyles = makeStyles(theme => ({
     },
 }));
 
-const getBreadcrumbs = (orgUnit?: OrgUnit, list: OrgUnit[] = []): OrgUnit[] => {
-    if (!orgUnit) return list;
-    if (!orgUnit.parent) {
-        list.push(orgUnit);
-        return list;
-    }
-    list.push(orgUnit.parent);
-    return getBreadcrumbs(orgUnit.parent, list);
-};
-
 export const Details: FunctionComponent<Props> = ({ router }) => {
     const {
         params: { orgUnitId, accountId },
@@ -70,9 +62,7 @@ export const Details: FunctionComponent<Props> = ({ router }) => {
     const goBack = useGoBack(router, baseUrls.registry, { accountId });
 
     const { data: orgUnit, isFetching } = useGetOrgUnit(orgUnitId);
-    const breadcrumbs = useMemo(() => {
-        return getBreadcrumbs(orgUnit).reverse();
-    }, [orgUnit]);
+    const breadcrumbs = useOrgUnitBreadCrumbs(orgUnit);
 
     const subOrgUnitTypes: OrgunitTypes = useMemo(() => {
         const options =
@@ -106,16 +96,7 @@ export const Details: FunctionComponent<Props> = ({ router }) => {
                     <Grid item xs={12} md={5}>
                         {orgUnit && (
                             <Box mb={2}>
-                                <Breadcrumbs separator=">">
-                                    {breadcrumbs.map(ou => {
-                                        return (
-                                            <LinkToOrgUnit
-                                                orgUnit={ou}
-                                                key={ou.id}
-                                            />
-                                        );
-                                    })}
-                                </Breadcrumbs>
+                                <OrgUnitBreadcrumbs breadcrumbs={breadcrumbs} />
                             </Box>
                         )}
                         {orgUnit && (


### PR DESCRIPTION
Add breadcrumbs that link to the parent org units of the org unit shown in registry

Related JIRA tickets : IA-2073

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [X] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- Add a recursive function to make a list of the org unit's ancestors
- Pass the list to  MUI's `Breadcrumbs`
- use `LinkToOrgUnit` to link to the org unit details

## How to test

- Go to OrgUnits>Registry
- Select an org unit
- Go to details
-  Test the breadcrumbs that appear above the map


## Print screen / video

![Screenshot 2023-04-21 at 17 30 24](https://user-images.githubusercontent.com/38907762/233676272-f7a4ebb2-e4ee-470d-9a02-b9a69f671a50.png)


