### PR TITLE
IA-2098: make breadcrumbs link to registry

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/LinkToOrgUnit.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/LinkToOrgUnit.tsx
@@ -16,16 +16,23 @@ type Props = {
     orgUnit?: OrgUnit | ShortOrgUnit;
     useIcon?: boolean;
     className?: string;
+    toRegistry: boolean;
 };
 
 export const LinkToOrgUnit: FunctionComponent<Props> = ({
     orgUnit,
     useIcon = false,
     className = '',
+    toRegistry = false,
 }) => {
     const user = useCurrentUser();
-    if (userHasPermission('iaso_org_units', user) && orgUnit) {
-        const url = `/${baseUrls.orgUnitDetails}/orgUnitId/${orgUnit.id}`;
+    const hasPermission = toRegistry
+        ? userHasPermission('iaso_registry', user)
+        : userHasPermission('iaso_org_units', user);
+    if (hasPermission && orgUnit) {
+        const url = toRegistry
+            ? `/${baseUrls.registryDetail}/orgUnitId/${orgUnit.id}`
+            : `/${baseUrls.orgUnitDetails}/orgUnitId/${orgUnit.id}`;
         if (useIcon) {
             return (
                 <IconButtonComponent

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/breadcrumbs/OrgUnitBreadcrumbs.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/breadcrumbs/OrgUnitBreadcrumbs.tsx
@@ -50,12 +50,14 @@ type Props = {
     separator?: string;
     orgUnit: OrgUnit;
     showOnlyParents?: boolean;
+    showRegistry?: boolean;
 };
 
 export const OrgUnitBreadcrumbs: FunctionComponent<Props> = ({
     separator = '>',
     orgUnit,
     showOnlyParents,
+    showRegistry = false,
 }) => {
     const { link } = useStyles();
     const breadcrumbs = useOrgUnitBreadCrumbs({ orgUnit, showOnlyParents });
@@ -63,7 +65,12 @@ export const OrgUnitBreadcrumbs: FunctionComponent<Props> = ({
         <Breadcrumbs separator={separator}>
             {breadcrumbs.map(ou => {
                 return (
-                    <LinkToOrgUnit orgUnit={ou} key={ou.id} className={link} />
+                    <LinkToOrgUnit
+                        orgUnit={ou}
+                        key={ou.id}
+                        className={link}
+                        toRegistry={showRegistry}
+                    />
                 );
             })}
         </Breadcrumbs>

--- a/hat/assets/js/apps/Iaso/domains/registry/details.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/details.tsx
@@ -86,7 +86,11 @@ export const Details: FunctionComponent<Props> = ({ router }) => {
                 <Grid container spacing={2}>
                     {orgUnit && (
                         <Grid item xs={12}>
-                            <OrgUnitBreadcrumbs orgUnit={orgUnit} />
+                            <OrgUnitBreadcrumbs
+                                orgUnit={orgUnit}
+                                showRegistry
+                                showOnlyParents
+                            />
                         </Grid>
                     )}
                     <Grid item xs={12} md={6}>


### PR DESCRIPTION


linked to OU details i.o registry

Related JIRA tickets : IA-2098

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- update LinkToOrgUnit to link to either org unit details or registy
- OrgUnitBreadcrumbs in registry details now only shows parent OUs

## How to test

- go to registry, select a top PU: no breadcrumbs should display
- select an OU deeper in the pyramid and test breadcrumbs

## Print screen / video


https://user-images.githubusercontent.com/38907762/234047256-64ba90d1-8c75-4f81-8ecc-b5739219678b.mov


