### PR TITLE
IA-2086: Calculate fields render

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/entities/hooks/useGetFieldValue.ts
+++ b/hat/assets/js/apps/Iaso/domains/entities/hooks/useGetFieldValue.ts
@@ -20,6 +20,7 @@ export const useGetFieldValue = (): ((
     const getValue = (fieldKey, fileContent, type): string => {
         switch (type) {
             case 'text':
+            case 'calculate':
             case 'integer':
             case 'decimal':
             case 'select one':


### PR DESCRIPTION
seen at https://dev.coda.go.wfp.org/dashboard/entities/list/accountId/1/entityTypeIds/7/order/last_saved_instance/pageSize/20/page/1

The program value is not displayed because it’s a calculate (while there is a program and it is a string
![3f52d01d-ddb9-4d8b-9459-9d49ba2f53a4](https://user-images.githubusercontent.com/12494624/234227242-0ad31fbe-03f6-45ca-8c14-2f04b174bfa6.png)


Related JIRA tickets : IA-2086

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

allow calculate field render

## How to test

Make sure you complete the entities creation  (cf doc [here](https://github.com/BLSQ/iaso/blob/main/docs/pages/dev/how_to/create_entities_in_web_ui/create_entities_in_web_ui.md)) with this form using calculate fields: 
[test_child_registration_2023041401.xlsx](https://github.com/BLSQ/iaso/files/11320715/test_child_registration_2023041401.xlsx)
While viewing entities list or detail, you should be able to see calculate fields in column or info. (You can edit program value in the admin by editing json of the instance).

## Print screen / video

<img width="618" alt="Screenshot 2023-04-25 at 10 55 23" src="https://user-images.githubusercontent.com/12494624/234228267-0a8e92c8-4791-416f-bc40-0bcb3ee5c1bf.png">
<img width="1624" alt="Screenshot 2023-04-25 at 10 55 15" src="https://user-images.githubusercontent.com/12494624/234228272-98d95884-182b-4cfd-9a53-570e2f91869c.png">


