### PR TITLE
IA-2065: Submissions: Default column selection breaks when selecting show only deleted

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/instances/components/ColumnSelect.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/ColumnSelect.tsx
@@ -109,10 +109,7 @@ export const ColumnSelect: FunctionComponent<Props> = ({
         order: params.order,
         defaultOrder,
     });
-    const getInstancesColumns = useGetInstancesColumns(
-        params.showDeleted === 'true',
-        getActionCell,
-    );
+    const getInstancesColumns = useGetInstancesColumns(getActionCell);
     const handleChangeVisibleColmuns = cols => {
         const columns = cols.filter(c => c.active);
         const newParams: Params = {

--- a/hat/assets/js/apps/Iaso/domains/instances/utils/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/utils/index.tsx
@@ -163,7 +163,6 @@ const renderValue = (settings: Setting<Instance>, c: VisibleColumn) => {
 };
 
 export const useGetInstancesColumns = (
-    showDeleted = false,
     // eslint-disable-next-line no-unused-vars
     getActionCell: RenderCell = settings => (
         <ActionTableColumnComponent settings={settings} />
@@ -176,10 +175,6 @@ export const useGetInstancesColumns = (
         () => [...instancesTableColumns(formatMessage)],
         [formatMessage],
     );
-    if (showDeleted) {
-        metasColumns.shift();
-    }
-
     const getInstancesColumns = useCallback(
         (visibleColumns: VisibleColumn[]) => {
             let tableColumns: Column[] = [];


### PR DESCRIPTION
**Go to submissions**

 tick “Show only deleted” and click search

**Expected:**

The displayed submissions change but the columns stay the same

**Actual:**

Only 3 columns are displayed

When unticking the box, the columns don’t revert back to the default selection. 

https://user-images.githubusercontent.com/12494624/234251233-1ef2b7f1-cc12-4100-b9df-fc427f176762.mov

Related JIRA tickets : IA-2065

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

Remove useless unshift

## How to test

Open submission page un tick and un tick show deleted checkbox (don't forget to press on search too)

## Print screen / video


https://user-images.githubusercontent.com/12494624/234251610-eaf48ba2-afcd-4123-9428-31ce965ac73b.mov



