### PR TITLE
IA-2056: registry part 3

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -778,6 +778,7 @@
     "iaso.registry.noInstance": "No submission found for this org unit",
     "iaso.registry.referenceInstance": "reference submission",
     "iaso.registry.seeRegistry": "See registry",
+    "iaso.registry.showNames": "Show names",
     "iaso.registry.title": "Registry",
     "iaso.registry.withLocation": "With point",
     "iaso.registry.withShape": "With territory",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -766,6 +766,7 @@
     "iaso.registry.noInstance": "Aucune soumission trouvée pour cette unité d'org.",
     "iaso.registry.referenceInstance": "soumission de référence",
     "iaso.registry.seeRegistry": "Voir le registre",
+    "iaso.registry.showNames": "Voir les noms",
     "iaso.registry.title": "Registre",
     "iaso.registry.withLocation": "Avec point",
     "iaso.registry.withShape": "Avec territoire",

--- a/hat/assets/js/apps/Iaso/domains/instances/components/LinkToInstance.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/LinkToInstance.tsx
@@ -1,18 +1,35 @@
 import React, { FunctionComponent } from 'react';
 
+import { IconButton as IconButtonComponent } from 'bluesquare-components';
 import { Link } from 'react-router';
-// @ts-ignore
 import { userHasPermission } from '../../users/utils';
 import { baseUrls } from '../../../constants/urls';
 import { useCurrentUser } from '../../../utils/usersUtils';
+import MESSAGES from '../../assignments/messages';
 
 type Props = {
     instanceId: string;
+    useIcon?: boolean;
+    color?: string;
 };
-export const LinkToInstance: FunctionComponent<Props> = ({ instanceId }) => {
+export const LinkToInstance: FunctionComponent<Props> = ({
+    instanceId,
+    useIcon = false,
+    color = 'inherit',
+}) => {
     const user = useCurrentUser();
     if (userHasPermission('iaso_submissions', user)) {
         const formUrl = `/${baseUrls.instanceDetail}/instanceId/${instanceId}`;
+        if (useIcon) {
+            return (
+                <IconButtonComponent
+                    icon="remove-red-eye"
+                    url={formUrl}
+                    tooltipMessage={MESSAGES.details}
+                    color={color}
+                />
+            );
+        }
         return <Link to={formUrl}>{instanceId}</Link>;
     }
     return <>{instanceId}</>;

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/LinkToOrgUnit.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/LinkToOrgUnit.tsx
@@ -2,7 +2,10 @@ import React, { FunctionComponent } from 'react';
 import { useDispatch } from 'react-redux';
 import { makeStyles } from '@material-ui/core';
 import classNames from 'classnames';
-import { IconButton as IconButtonComponent } from 'bluesquare-components';
+import {
+    IconButton as IconButtonComponent,
+    useKeyPressListener,
+} from 'bluesquare-components';
 
 import { Link } from 'react-router';
 import { userHasPermission } from '../../users/utils';
@@ -19,6 +22,8 @@ type Props = {
     useIcon?: boolean;
     className?: string;
     replace?: boolean;
+    iconSize?: 'small' | 'medium' | 'large' | 'default' | 'inherit';
+    size?: 'small' | 'medium' | 'large' | 'default' | 'inherit';
 };
 
 const useStyles = makeStyles(() => ({
@@ -32,14 +37,19 @@ export const LinkToOrgUnit: FunctionComponent<Props> = ({
     useIcon = false,
     className = '',
     replace = false,
+    iconSize = 'medium',
+    size = 'medium',
 }) => {
     const user = useCurrentUser();
+    const targetBlankEnabled = useKeyPressListener('Meta');
     const classes: Record<string, string> = useStyles();
     const dispatch = useDispatch();
     if (userHasPermission('iaso_org_units', user) && orgUnit) {
         const url = `/${baseUrls.orgUnitDetails}/orgUnitId/${orgUnit.id}`;
         const handleClick = () => {
-            if (replace) {
+            if (targetBlankEnabled) {
+                window.open(`/dashboard${url}`, '_blank');
+            } else if (replace) {
                 dispatch(redirectToReplace(url));
             } else {
                 dispatch(redirectTo(url));
@@ -51,6 +61,8 @@ export const LinkToOrgUnit: FunctionComponent<Props> = ({
                     onClick={handleClick}
                     icon="remove-red-eye"
                     tooltipMessage={MESSAGES.details}
+                    iconSize={iconSize}
+                    size={size}
                 />
             );
         }
@@ -63,5 +75,6 @@ export const LinkToOrgUnit: FunctionComponent<Props> = ({
             </Link>
         );
     }
+    if (useIcon) return null;
     return <>{orgUnit ? orgUnit.name : '-'}</>;
 };

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/breadcrumbs/OrgUnitBreadcrumbs.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/breadcrumbs/OrgUnitBreadcrumbs.tsx
@@ -2,6 +2,7 @@ import React, { FunctionComponent, useMemo } from 'react';
 import { Breadcrumbs, makeStyles } from '@material-ui/core';
 import { OrgUnit } from '../../types/orgUnit';
 import { LinkToOrgUnit } from '../LinkToOrgUnit';
+import { LinkToRegistry } from '../../../registry/components/LinkToRegistry';
 
 type BreadCrumbsArgs = {
     orgUnit?: OrgUnit;
@@ -63,16 +64,23 @@ export const OrgUnitBreadcrumbs: FunctionComponent<Props> = ({
     const breadcrumbs = useOrgUnitBreadCrumbs({ orgUnit, showOnlyParents });
     return (
         <Breadcrumbs separator={separator}>
-            {breadcrumbs.map(ou => {
-                return (
+            {breadcrumbs.map(ou =>
+                showRegistry ? (
+                    <LinkToRegistry
+                        orgUnit={ou}
+                        key={ou.id}
+                        className={link}
+                        replace
+                    />
+                ) : (
                     <LinkToOrgUnit
                         orgUnit={ou}
                         key={ou.id}
                         className={link}
-                        toRegistry={showRegistry}
+                        replace
                     />
-                );
-            })}
+                ),
+            )}
         </Breadcrumbs>
     );
 };

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/types/orgunitTypes.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/types/orgunitTypes.ts
@@ -31,6 +31,7 @@ export type OrgunitType = {
     reference_form: any;
     projects: Project[];
     color?: string;
+    count?: number;
 };
 
 export type OrgunitTypes = OrgunitType[];

--- a/hat/assets/js/apps/Iaso/domains/registry/components/ActionCell.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/ActionCell.tsx
@@ -5,6 +5,8 @@ import MESSAGES from '../messages';
 
 import EnketoIcon from '../../instances/components/EnketoIcon';
 
+import { LinkToInstance } from '../../instances/components/LinkToInstance';
+
 import { useGetEnketoUrl } from '../hooks/useGetEnketoUrl';
 
 type Props = {
@@ -24,6 +26,7 @@ export const ActionCell: FunctionComponent<Props> = ({ settings }) => {
                 overrideIcon={EnketoIcon}
                 tooltipMessage={MESSAGES.editOnEnketo}
             />
+            <LinkToInstance instanceId={settings.row.original.id} useIcon />
         </section>
     );
 };

--- a/hat/assets/js/apps/Iaso/domains/registry/components/Instances.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/Instances.tsx
@@ -5,7 +5,6 @@ import React, {
     useCallback,
 } from 'react';
 import { Box, Tabs, Tab, Grid } from '@material-ui/core';
-import { useSkipEffectOnMount } from 'bluesquare-components';
 import { useDispatch } from 'react-redux';
 
 import InputComponent from '../../../components/forms/InputComponent';
@@ -40,7 +39,17 @@ export const Instances: FunctionComponent<Props> = ({
 }) => {
     const [tableColumns, setTableColumns] = useState<Column[]>([]);
     const { formIds, tab } = params;
-    const [currentType, setCurrentType] = useState<OrgunitType | undefined>();
+    const currentType: OrgunitType | undefined = useMemo(() => {
+        if (subOrgUnitTypes.length > 0) {
+            if (tab) {
+                const existingType: OrgunitType | undefined =
+                    subOrgUnitTypes.find(subType => `${subType.id}` === tab);
+                return existingType || subOrgUnitTypes[0];
+            }
+            return subOrgUnitTypes[0];
+        }
+        return undefined;
+    }, [subOrgUnitTypes, tab]);
 
     const dispatch = useDispatch();
 
@@ -63,7 +72,6 @@ export const Instances: FunctionComponent<Props> = ({
 
     const handleChangeTab = useCallback(
         (newType: OrgunitType) => {
-            setCurrentType(newType);
             dispatch(
                 redirectToReplace(baseUrls.registryDetail, {
                     ...params,
@@ -74,17 +82,6 @@ export const Instances: FunctionComponent<Props> = ({
         [dispatch, params],
     );
 
-    useSkipEffectOnMount(() => {
-        if (subOrgUnitTypes?.length > 0 && !currentType) {
-            if (tab) {
-                setCurrentType(
-                    subOrgUnitTypes.find(subType => `${subType.id}` === tab),
-                );
-            } else {
-                setCurrentType(subOrgUnitTypes[0]);
-            }
-        }
-    }, [subOrgUnitTypes]);
     const currentForm: Form | undefined = useMemo(() => {
         return formsList?.find(f => `${f.value}` === formIds)?.original;
     }, [formIds, formsList]);

--- a/hat/assets/js/apps/Iaso/domains/registry/components/Instances.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/Instances.tsx
@@ -96,7 +96,7 @@ export const Instances: FunctionComponent<Props> = ({
                         {subOrgUnitTypes.map(subType => (
                             <Tab
                                 value={subType}
-                                label={subType.name}
+                                label={`${subType.name} (${subType.count})`}
                                 key={subType.id}
                             />
                         ))}

--- a/hat/assets/js/apps/Iaso/domains/registry/components/LinkToRegistry.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/LinkToRegistry.tsx
@@ -1,7 +1,10 @@
 import React, { FunctionComponent } from 'react';
 import { useDispatch } from 'react-redux';
 import { makeStyles } from '@material-ui/core';
-import { IconButton as IconButtonComponent } from 'bluesquare-components';
+import {
+    IconButton as IconButtonComponent,
+    useKeyPressListener,
+} from 'bluesquare-components';
 import MenuBookIcon from '@material-ui/icons/MenuBook';
 import { Link } from 'react-router';
 import classNames from 'classnames';
@@ -19,6 +22,8 @@ type Props = {
     useIcon?: boolean;
     className?: string;
     replace?: boolean;
+    iconSize?: 'small' | 'medium' | 'large' | 'default' | 'inherit';
+    size?: 'small' | 'medium' | 'large' | 'default' | 'inherit';
 };
 
 const useStyles = makeStyles(() => ({
@@ -26,19 +31,26 @@ const useStyles = makeStyles(() => ({
         cursor: 'pointer',
     },
 }));
+
 export const LinkToRegistry: FunctionComponent<Props> = ({
     orgUnit,
     useIcon = false,
     className = '',
     replace = false,
+    iconSize = 'medium',
+    size = 'medium',
 }) => {
     const user = useCurrentUser();
+
+    const targetBlankEnabled = useKeyPressListener('Meta');
     const classes: Record<string, string> = useStyles();
     const dispatch = useDispatch();
     if (userHasPermission('iaso_registry', user) && orgUnit) {
         const url = `/${baseUrls.registryDetail}/orgUnitId/${orgUnit?.id}`;
         const handleClick = () => {
-            if (replace) {
+            if (targetBlankEnabled) {
+                window.open(`/dashboard${url}`, '_blank');
+            } else if (replace) {
                 dispatch(redirectToReplace(url));
             } else {
                 dispatch(redirectTo(url));
@@ -50,6 +62,8 @@ export const LinkToRegistry: FunctionComponent<Props> = ({
                     onClick={handleClick}
                     overrideIcon={MenuBookIcon}
                     tooltipMessage={MESSAGES.seeRegistry}
+                    iconSize={iconSize}
+                    size={size}
                 />
             );
         }
@@ -62,5 +76,6 @@ export const LinkToRegistry: FunctionComponent<Props> = ({
             </Link>
         );
     }
+    if (useIcon) return null;
     return <>{orgUnit ? orgUnit.name : '-'}</>;
 };

--- a/hat/assets/js/apps/Iaso/domains/registry/components/LinkToRegistry.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/LinkToRegistry.tsx
@@ -1,18 +1,18 @@
 import React, { FunctionComponent } from 'react';
 import { useDispatch } from 'react-redux';
 import { makeStyles } from '@material-ui/core';
-import classNames from 'classnames';
 import { IconButton as IconButtonComponent } from 'bluesquare-components';
-
+import MenuBookIcon from '@material-ui/icons/MenuBook';
 import { Link } from 'react-router';
+import classNames from 'classnames';
+
 import { userHasPermission } from '../../users/utils';
 import { baseUrls } from '../../../constants/urls';
 import { useCurrentUser } from '../../../utils/usersUtils';
-import { OrgUnit, ShortOrgUnit } from '../types/orgUnit';
-
+import { OrgUnit, ShortOrgUnit } from '../../orgUnits/types/orgUnit';
 import { redirectTo, redirectToReplace } from '../../../routing/actions';
 
-import MESSAGES from '../../assignments/messages';
+import MESSAGES from '../messages';
 
 type Props = {
     orgUnit?: OrgUnit | ShortOrgUnit;
@@ -26,8 +26,7 @@ const useStyles = makeStyles(() => ({
         cursor: 'pointer',
     },
 }));
-
-export const LinkToOrgUnit: FunctionComponent<Props> = ({
+export const LinkToRegistry: FunctionComponent<Props> = ({
     orgUnit,
     useIcon = false,
     className = '',
@@ -36,8 +35,8 @@ export const LinkToOrgUnit: FunctionComponent<Props> = ({
     const user = useCurrentUser();
     const classes: Record<string, string> = useStyles();
     const dispatch = useDispatch();
-    if (userHasPermission('iaso_org_units', user) && orgUnit) {
-        const url = `/${baseUrls.orgUnitDetails}/orgUnitId/${orgUnit.id}`;
+    if (userHasPermission('iaso_registry', user) && orgUnit) {
+        const url = `/${baseUrls.registryDetail}/orgUnitId/${orgUnit?.id}`;
         const handleClick = () => {
             if (replace) {
                 dispatch(redirectToReplace(url));
@@ -49,8 +48,8 @@ export const LinkToOrgUnit: FunctionComponent<Props> = ({
             return (
                 <IconButtonComponent
                     onClick={handleClick}
-                    icon="remove-red-eye"
-                    tooltipMessage={MESSAGES.details}
+                    overrideIcon={MenuBookIcon}
+                    tooltipMessage={MESSAGES.seeRegistry}
                 />
             );
         }

--- a/hat/assets/js/apps/Iaso/domains/registry/components/MapPopUp.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/MapPopUp.tsx
@@ -1,25 +1,20 @@
 import React, { FunctionComponent, useRef } from 'react';
 import { Popup } from 'react-leaflet';
-import { Link } from 'react-router';
 
-import {
-    Card,
-    CardContent,
-    Button,
-    Grid,
-    Box,
-    makeStyles,
-} from '@material-ui/core';
+import { Card, CardContent, Box, makeStyles, Divider } from '@material-ui/core';
 
 import {
     useSafeIntl,
     commonStyles,
     mapPopupStyles,
+    IconButton,
 } from 'bluesquare-components';
-import { baseUrls } from '../../../constants/urls';
 
 import MESSAGES from '../messages';
 import { OrgUnit } from '../../orgUnits/types/orgUnit';
+import { LinkToRegistry } from './LinkToRegistry';
+import PopupItemComponent from '../../../components/maps/popups/PopupItemComponent';
+import { LinkToOrgUnit } from '../../orgUnits/components/LinkToOrgUnit';
 
 type Props = {
     orgUnit: OrgUnit;
@@ -28,14 +23,19 @@ type Props = {
 const useStyles = makeStyles(theme => ({
     ...commonStyles(theme),
     ...mapPopupStyles(theme),
-    actionBox: {
-        padding: theme.spacing(1, 0, 0, 0),
+    popupCardContent: {
+        ...mapPopupStyles(theme).popupCardContent,
+        margin: theme.spacing(2),
     },
-    linkButton: {
-        color: 'inherit',
-        textDecoration: 'none',
-        display: 'flex',
-        '&:hover': { textDecoration: 'none' },
+    popup: {
+        ...mapPopupStyles(theme).popup,
+        '& .leaflet-popup-content': {
+            ...mapPopupStyles(theme).popup['& .leaflet-popup-content'],
+            width: '300px !important',
+        },
+        '& a.leaflet-popup-close-button': {
+            display: 'none',
+        },
     },
 }));
 
@@ -47,31 +47,46 @@ export const MapPopUp: FunctionComponent<Props> = ({ orgUnit }) => {
     return (
         <Popup className={classes.popup} ref={popup}>
             <Card className={classes.popupCard}>
-                <CardContent className={classes.popupCardContent}>
-                    {orgUnit.name}
-                    <Box className={classes.actionBox}>
-                        <Grid
-                            container
-                            spacing={0}
-                            justifyContent="flex-end"
-                            alignItems="center"
-                        >
-                            <Link
-                                target="_blank"
-                                to={`${baseUrls.registryDetail}/orgunitId/${orgUnit.id}`}
-                                className={classes.linkButton}
-                            >
-                                <Button
-                                    className={classes.marginLeft}
-                                    variant="outlined"
-                                    color="primary"
-                                    size="small"
-                                >
-                                    {formatMessage(MESSAGES.see)}
-                                </Button>
-                            </Link>
-                        </Grid>
+                <Box display="flex" justifyContent="flex-end" px={1} py="4px">
+                    <Box mr="auto">
+                        <LinkToOrgUnit
+                            orgUnit={orgUnit}
+                            useIcon
+                            iconSize="small"
+                            size="small"
+                        />
+                        <LinkToRegistry
+                            orgUnit={orgUnit}
+                            replace
+                            useIcon
+                            iconSize="small"
+                            size="small"
+                        />
                     </Box>
+                    <IconButton
+                        onClick={() =>
+                            popup.current.leafletElement.options.leaflet.map.closePopup()
+                        }
+                        icon="clear"
+                        tooltipMessage={MESSAGES.close}
+                        iconSize="small"
+                        size="small"
+                    />
+                </Box>
+                <Divider />
+                <CardContent className={classes.popupCardContent}>
+                    <PopupItemComponent
+                        label={formatMessage(MESSAGES.name)}
+                        value={orgUnit.name}
+                    />
+                    <PopupItemComponent
+                        label={formatMessage(MESSAGES.type)}
+                        value={orgUnit.org_unit_type_name}
+                    />
+                    <PopupItemComponent
+                        label={formatMessage(MESSAGES.source)}
+                        value={orgUnit.source}
+                    />
                 </CardContent>
             </Card>
         </Popup>

--- a/hat/assets/js/apps/Iaso/domains/registry/components/MapPopUp.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/MapPopUp.tsx
@@ -49,12 +49,14 @@ export const MapPopUp: FunctionComponent<Props> = ({ orgUnit }) => {
             <Card className={classes.popupCard}>
                 <Box display="flex" justifyContent="flex-end" px={1} py="4px">
                     <Box mr="auto">
-                        <LinkToOrgUnit
-                            orgUnit={orgUnit}
-                            useIcon
-                            iconSize="small"
-                            size="small"
-                        />
+                        <Box display="inline-block" mr={1}>
+                            <LinkToOrgUnit
+                                orgUnit={orgUnit}
+                                useIcon
+                                iconSize="small"
+                                size="small"
+                            />
+                        </Box>
                         <LinkToRegistry
                             orgUnit={orgUnit}
                             replace

--- a/hat/assets/js/apps/Iaso/domains/registry/components/MapToggleTooltips.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/MapToggleTooltips.tsx
@@ -13,11 +13,14 @@ const useStyles = makeStyles(theme => ({
     root: {
         position: 'absolute', // assuming you have a parent relative
         zIndex: 500,
-        top: 'auto',
+        bottom: 'auto',
         right: 'auto',
-        left: theme.spacing(1),
-        bottom: theme.spacing(4),
+        left: theme.spacing(6),
+        top: 10,
         width: 'auto',
+    },
+    label: {
+        fontSize: 12,
     },
 }));
 
@@ -34,16 +37,21 @@ export const MapToggleTooltips: FunctionComponent<Props> = ({
     const { formatMessage } = useSafeIntl();
     return (
         <Paper elevation={1} className={classes.root}>
-            <Box p={1}>
+            <Box pl={2}>
                 <FormControlLabel
                     control={
                         <Switch
+                            size="small"
                             checked={showTooltip}
                             onChange={() => setShowTooltip(!showTooltip)}
                             color="primary"
                         />
                     }
-                    label={formatMessage(MESSAGES.showNames)}
+                    label={
+                        <span className={classes.label}>
+                            {formatMessage(MESSAGES.showNames)}
+                        </span>
+                    }
                 />
             </Box>
         </Paper>

--- a/hat/assets/js/apps/Iaso/domains/registry/components/MapToggleTooltips.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/MapToggleTooltips.tsx
@@ -1,0 +1,51 @@
+import React, { FunctionComponent, Dispatch, SetStateAction } from 'react';
+import {
+    Paper,
+    makeStyles,
+    Box,
+    FormControlLabel,
+    Switch,
+} from '@material-ui/core';
+import { useSafeIntl } from 'bluesquare-components';
+import MESSAGES from '../messages';
+
+const useStyles = makeStyles(theme => ({
+    root: {
+        position: 'absolute', // assuming you have a parent relative
+        zIndex: 500,
+        top: 'auto',
+        right: 'auto',
+        left: theme.spacing(1),
+        bottom: theme.spacing(4),
+        width: 'auto',
+    },
+}));
+
+type Props = {
+    showTooltip: boolean;
+    setShowTooltip: Dispatch<SetStateAction<boolean>>;
+};
+
+export const MapToggleTooltips: FunctionComponent<Props> = ({
+    showTooltip,
+    setShowTooltip,
+}) => {
+    const classes = useStyles();
+    const { formatMessage } = useSafeIntl();
+    return (
+        <Paper elevation={1} className={classes.root}>
+            <Box p={1}>
+                <FormControlLabel
+                    control={
+                        <Switch
+                            checked={showTooltip}
+                            onChange={() => setShowTooltip(!showTooltip)}
+                            color="primary"
+                        />
+                    }
+                    label={formatMessage(MESSAGES.showNames)}
+                />
+            </Box>
+        </Paper>
+    );
+};

--- a/hat/assets/js/apps/Iaso/domains/registry/components/OrgUnitChildrenList.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/OrgUnitChildrenList.tsx
@@ -6,18 +6,14 @@ import { useDispatch } from 'react-redux';
 import { redirectToReplace } from '../../../routing/actions';
 import { baseUrls } from '../../../constants/urls';
 
-import { OrgUnit } from '../../orgUnits/types/orgUnit';
-import { OrgunitTypes } from '../../orgUnits/types/orgunitTypes';
-
 import { RegistryDetailParams } from '../types';
-
-import { useGetOrgUnitsListChildren } from '../hooks/useGetOrgUnit';
 import { useGetOrgUnitsListColumns } from '../config';
+import { OrgUnitListChildren } from '../hooks/useGetOrgUnit';
 
 type Props = {
-    orgUnit: OrgUnit;
-    subOrgUnitTypes: OrgunitTypes;
     params: RegistryDetailParams;
+    orgUnitChildren?: OrgUnitListChildren;
+    isFetchingChildren: boolean;
 };
 export const defaultSorted = [{ id: 'name', desc: true }];
 const useStyles = makeStyles(theme => ({
@@ -49,16 +45,11 @@ const useStyles = makeStyles(theme => ({
 }));
 
 export const OrgUnitChildrenList: FunctionComponent<Props> = ({
-    orgUnit,
-    subOrgUnitTypes,
     params,
+    orgUnitChildren,
+    isFetchingChildren,
 }) => {
     const dispatch = useDispatch();
-    const { data, isFetching } = useGetOrgUnitsListChildren(
-        `${orgUnit.id}`,
-        subOrgUnitTypes,
-        params,
-    );
 
     const classes: Record<string, string> = useStyles();
     const columns = useGetOrgUnitsListColumns();
@@ -67,15 +58,15 @@ export const OrgUnitChildrenList: FunctionComponent<Props> = ({
             <Table
                 marginTop={false}
                 marginBottom={false}
-                data={data?.orgunits || []}
-                pages={data?.pages || 0}
+                data={orgUnitChildren?.orgunits || []}
+                pages={orgUnitChildren?.pages || 0}
                 defaultSorted={defaultSorted}
                 paramsPrefix="orgUnitList"
                 columns={columns}
-                count={data?.count || 0}
+                count={orgUnitChildren?.count || 0}
                 baseUrl={baseUrls.registryDetail}
                 params={params}
-                extraProps={{ loading: isFetching }}
+                extraProps={{ loading: isFetchingChildren }}
                 elevation={0}
                 onTableParamsChange={p => {
                     dispatch(redirectToReplace(baseUrls.registryDetail, p));

--- a/hat/assets/js/apps/Iaso/domains/registry/components/OrgUnitChildrenMap.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/OrgUnitChildrenMap.tsx
@@ -28,6 +28,8 @@ import { OrgunitTypes } from '../../orgUnits/types/orgunitTypes';
 
 import { Legend, useGetlegendOptions } from '../hooks/useGetLegendOptions';
 
+import { MapToggleTooltips } from './MapToggleTooltips';
+
 import TILES from '../../../constants/mapTiles';
 import {
     circleColorMarkerOptions,
@@ -65,6 +67,7 @@ export const OrgUnitChildrenMap: FunctionComponent<Props> = ({
         getlegendOptions(),
     );
     const [currentTile, setCurrentTile] = useState<Tile>(TILES.osm);
+    const [showTooltip, setShowTooltip] = useState<boolean>(false);
 
     const optionsObject = useMemo(
         () => keyBy(legendOptions, 'value'),
@@ -104,6 +107,10 @@ export const OrgUnitChildrenMap: FunctionComponent<Props> = ({
         );
     return (
         <Box position="relative">
+            <MapToggleTooltips
+                showTooltip={showTooltip}
+                setShowTooltip={setShowTooltip}
+            />
             <MapLegend options={legendOptions} setOptions={setLegendOptions} />
             <TilesSwitch
                 currentTile={currentTile}
@@ -142,7 +149,9 @@ export const OrgUnitChildrenMap: FunctionComponent<Props> = ({
                                         color: theme.palette.secondary.main,
                                     })}
                                 >
-                                    <Tooltip>{orgUnit.name}</Tooltip>
+                                    <Tooltip permanent={showTooltip}>
+                                        {orgUnit.name}
+                                    </Tooltip>
                                 </GeoJSON>
                             </Pane>
                         )}
@@ -153,7 +162,9 @@ export const OrgUnitChildrenMap: FunctionComponent<Props> = ({
                                     longitude: orgUnit.longitude,
                                 }}
                                 TooltipComponent={() => (
-                                    <Tooltip>{orgUnit.name}</Tooltip>
+                                    <Tooltip permanent={showTooltip}>
+                                        {orgUnit.name}
+                                    </Tooltip>
                                 )}
                                 markerProps={() => ({
                                     ...circleColorMarkerOptions(
@@ -190,6 +201,11 @@ export const OrgUnitChildrenMap: FunctionComponent<Props> = ({
                                                 <MapPopUp
                                                     orgUnit={childrenOrgUnit}
                                                 />
+                                                <Tooltip
+                                                    permanent={showTooltip}
+                                                >
+                                                    {childrenOrgUnit.name}
+                                                </Tooltip>
                                             </GeoJSON>
                                         );
                                     }
@@ -222,6 +238,13 @@ export const OrgUnitChildrenMap: FunctionComponent<Props> = ({
                                                     orgUnit: childrenOrgUnit,
                                                 })}
                                                 key={childrenOrgUnit.id}
+                                                TooltipComponent={() => (
+                                                    <Tooltip
+                                                        permanent={showTooltip}
+                                                    >
+                                                        {childrenOrgUnit.name}
+                                                    </Tooltip>
+                                                )}
                                                 markerProps={() => ({
                                                     ...circleColorMarkerOptions(
                                                         subType.color || '',

--- a/hat/assets/js/apps/Iaso/domains/registry/components/OrgUnitChildrenMap.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/OrgUnitChildrenMap.tsx
@@ -148,11 +148,7 @@ export const OrgUnitChildrenMap: FunctionComponent<Props> = ({
                                     style={() => ({
                                         color: theme.palette.secondary.main,
                                     })}
-                                >
-                                    <Tooltip permanent={showTooltip}>
-                                        {orgUnit.name}
-                                    </Tooltip>
-                                </GeoJSON>
+                                />
                             </Pane>
                         )}
                         {orgUnit.latitude && orgUnit.longitude && (
@@ -161,11 +157,6 @@ export const OrgUnitChildrenMap: FunctionComponent<Props> = ({
                                     latitude: orgUnit.latitude,
                                     longitude: orgUnit.longitude,
                                 }}
-                                TooltipComponent={() => (
-                                    <Tooltip permanent={showTooltip}>
-                                        {orgUnit.name}
-                                    </Tooltip>
-                                )}
                                 markerProps={() => ({
                                     ...circleColorMarkerOptions(
                                         theme.palette.secondary.main,

--- a/hat/assets/js/apps/Iaso/domains/registry/components/OrgUnitInstances.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/OrgUnitInstances.tsx
@@ -5,7 +5,14 @@ import {
     LoadingSpinner,
     useSafeIntl,
 } from 'bluesquare-components';
-import { Box, makeStyles, Paper, Typography } from '@material-ui/core';
+import {
+    Box,
+    makeStyles,
+    Paper,
+    Typography,
+    Grid,
+    Divider,
+} from '@material-ui/core';
 import moment from 'moment';
 import { useDispatch } from 'react-redux';
 import ErrorOutlineIcon from '@material-ui/icons/ErrorOutline';
@@ -18,7 +25,6 @@ import { useGetEnketoUrl } from '../hooks/useGetEnketoUrl';
 import { useCurrentUser } from '../../../utils/usersUtils';
 
 import InputComponent from '../../../components/forms/InputComponent';
-import WidgetPaper from '../../../components/papers/WidgetPaperComponent';
 import InstanceFileContent from '../../instances/components/InstanceFileContent';
 import EnketoIcon from '../../instances/components/EnketoIcon';
 
@@ -30,6 +36,7 @@ import {
 
 import { OrgUnit } from '../../orgUnits/types/orgUnit';
 import { RegistryDetailParams } from '../types';
+import { LinkToInstance } from '../../instances/components/LinkToInstance';
 
 type Props = {
     orgUnit: OrgUnit;
@@ -59,6 +66,18 @@ const useStyles = makeStyles(theme => ({
     emptyPaperIcon: {
         display: 'inline-block',
         marginRight: theme.spacing(1),
+    },
+    paperTitle: {
+        padding: theme.spacing(2),
+        display: 'flex',
+    },
+    paperTitleButtonContainer: {
+        position: 'relative',
+    },
+    paperTitleButton: {
+        position: 'absolute',
+        right: -theme.spacing(1),
+        top: -theme.spacing(1),
     },
 }));
 
@@ -145,35 +164,59 @@ export const OrgUnitInstances: FunctionComponent<Props> = ({
                 </Box>
             )}
             {currentInstance && (
-                <WidgetPaper
-                    id="form-contents"
-                    className={classes.paper}
-                    elevation={1}
-                    title={`${currentInstance.form_name}${
-                        currentInstance.id === orgUnit.reference_instance?.id
-                            ? ` (${formatMessage(MESSAGES.referenceInstance)})`
-                            : ''
-                    }`}
-                    IconButton={
-                        userHasPermission(
-                            'iaso_update_submission',
-                            currentUser,
-                        ) && IconButton
-                    }
-                    iconButtonProps={{
-                        onClick: () => getEnketoUrl(),
-                        overrideIcon: EnketoIcon,
-                        color: 'secondary',
-                        tooltipMessage: MESSAGES.editOnEnketo,
-                    }}
-                >
+                <Paper elevation={1} className={classes.paper}>
+                    <Grid container className={classes.paperTitle}>
+                        <Grid xs={8} item>
+                            <Typography
+                                color="primary"
+                                variant="h5"
+                                className={classes.title}
+                            >
+                                {`${currentInstance.form_name}${
+                                    currentInstance.id ===
+                                    orgUnit.reference_instance?.id
+                                        ? ` (${formatMessage(
+                                              MESSAGES.referenceInstance,
+                                          )})`
+                                        : ''
+                                }`}
+                            </Typography>
+                        </Grid>
+                        <Grid
+                            xs={4}
+                            item
+                            container
+                            justifyContent="flex-end"
+                            className={classes.paperTitleButtonContainer}
+                        >
+                            <Box className={classes.paperTitleButton}>
+                                {userHasPermission(
+                                    'iaso_update_submission',
+                                    currentUser,
+                                ) && (
+                                    <IconButton
+                                        onClick={() => getEnketoUrl()}
+                                        overrideIcon={EnketoIcon}
+                                        color="secondary"
+                                        tooltipMessage={MESSAGES.editOnEnketo}
+                                    />
+                                )}
+                                <LinkToInstance
+                                    instanceId={`${currentInstance.id}`}
+                                    useIcon
+                                    color="secondary"
+                                />
+                            </Box>
+                        </Grid>
+                    </Grid>
+                    <Divider />
                     <Box className={classes.formContents}>
                         <InstanceFileContent
                             instance={currentInstance}
                             showQuestionKey={false}
                         />
                     </Box>
-                </WidgetPaper>
+                </Paper>
             )}
         </Box>
     );

--- a/hat/assets/js/apps/Iaso/domains/registry/components/OrgUnitInstances.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/OrgUnitInstances.tsx
@@ -150,8 +150,9 @@ export const OrgUnitInstances: FunctionComponent<Props> = ({
                     className={classes.paper}
                     elevation={1}
                     title={`${currentInstance.form_name}${
-                        currentInstance.id === orgUnit.reference_instance?.id &&
-                        ` (${formatMessage(MESSAGES.referenceInstance)})`
+                        currentInstance.id === orgUnit.reference_instance?.id
+                            ? ` (${formatMessage(MESSAGES.referenceInstance)})`
+                            : ''
                     }`}
                     IconButton={
                         userHasPermission(

--- a/hat/assets/js/apps/Iaso/domains/registry/components/OrgUnitPaper.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/OrgUnitPaper.tsx
@@ -107,7 +107,7 @@ export const OrgUnitPaper: FunctionComponent<Props> = ({
     );
     return (
         <Paper elevation={1} className={classes.paper}>
-            <Box className={classes.paperTitle}>
+            <Grid container className={classes.paperTitle}>
                 <Grid xs={8} item>
                     <Typography
                         color="primary"
@@ -134,14 +134,13 @@ export const OrgUnitPaper: FunctionComponent<Props> = ({
                         <IconButton
                             url={`${baseUrls.orgUnitDetails}/orgUnitId/${orgUnit.id}`}
                             color="secondary"
-                            icon="edit"
+                            icon="remove-red-eye"
                             tooltipMessage={MESSAGES.editOrgUnit}
                         />
                     </Box>
                 </Grid>
-
-                <Divider />
-            </Box>
+            </Grid>
+            <Divider />
             <Tabs
                 value={tab}
                 classes={{

--- a/hat/assets/js/apps/Iaso/domains/registry/components/OrgUnitPaper.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/OrgUnitPaper.tsx
@@ -26,12 +26,15 @@ import { OrgUnit } from '../../orgUnits/types/orgUnit';
 import { OrgUnitChildrenList } from './OrgUnitChildrenList';
 
 import { RegistryDetailParams, OrgUnitListTab } from '../types';
+import { OrgUnitListChildren } from '../hooks/useGetOrgUnit';
 import { OrgunitTypes } from '../../orgUnits/types/orgunitTypes';
 
 type Props = {
     orgUnit: OrgUnit;
     subOrgUnitTypes: OrgunitTypes;
     params: RegistryDetailParams;
+    orgUnitChildren?: OrgUnitListChildren;
+    isFetchingChildren: boolean;
 };
 
 const useStyles = makeStyles(theme => ({
@@ -81,6 +84,8 @@ export const OrgUnitPaper: FunctionComponent<Props> = ({
     orgUnit,
     subOrgUnitTypes,
     params,
+    orgUnitChildren,
+    isFetchingChildren,
 }) => {
     const classes: Record<string, string> = useStyles();
     const [tab, setTab] = useState<OrgUnitListTab>(
@@ -165,9 +170,9 @@ export const OrgUnitPaper: FunctionComponent<Props> = ({
                     )}
                 >
                     <OrgUnitChildrenList
-                        orgUnit={orgUnit}
-                        subOrgUnitTypes={subOrgUnitTypes}
                         params={params}
+                        orgUnitChildren={orgUnitChildren}
+                        isFetchingChildren={isFetchingChildren}
                     />
                 </Box>
             </Box>

--- a/hat/assets/js/apps/Iaso/domains/registry/config.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/config.tsx
@@ -1,18 +1,19 @@
 import React, { ReactElement } from 'react';
-import { IconButton, useSafeIntl } from 'bluesquare-components';
+import { useSafeIntl } from 'bluesquare-components';
 import { Tooltip, Box } from '@material-ui/core';
 import LocationOnIcon from '@material-ui/icons/LocationOn';
 import LocationDisabledIcon from '@material-ui/icons/LocationDisabled';
 import AccountTreeIcon from '@material-ui/icons/AccountTree';
 import MapIcon from '@material-ui/icons/Map';
 
-import { baseUrls } from '../../constants/urls';
 import { IntlFormatMessage } from '../../types/intl';
 
 import { InstanceMetasField } from '../instances/components/ColumnSelect';
 import { Instance } from '../instances/types/instance';
 import { OrgUnit } from '../orgUnits/types/orgUnit';
 import { Column } from '../../types/table';
+
+import { LinkToRegistry } from './components/LinkToRegistry';
 
 import MESSAGES from './messages';
 import ShapeSvg from '../../components/svg/ShapeSvgComponent';
@@ -124,7 +125,7 @@ export const useGetOrgUnitsListColumns = (): Column[] => {
                             arrow
                             title={formatMessage(MESSAGES.withShape)}
                         >
-                            <Box>
+                            <Box mt="6px">
                                 <ShapeSvg fontSize="small" color="primary" />
                             </Box>
                         </Tooltip>
@@ -136,7 +137,7 @@ export const useGetOrgUnitsListColumns = (): Column[] => {
                             arrow
                             title={formatMessage(MESSAGES.withLocation)}
                         >
-                            <Box>
+                            <Box mt="6px">
                                 <LocationOnIcon
                                     fontSize="small"
                                     color="primary"
@@ -150,7 +151,7 @@ export const useGetOrgUnitsListColumns = (): Column[] => {
                         arrow
                         title={formatMessage(MESSAGES.noGeographicalData)}
                     >
-                        <Box>
+                        <Box mt="6px">
                             <LocationDisabledIcon
                                 fontSize="small"
                                 color="error"
@@ -170,12 +171,10 @@ export const useGetOrgUnitsListColumns = (): Column[] => {
             sortable: false,
             width: 50,
             Cell: settings => (
-                <IconButton
-                    icon="remove-red-eye"
-                    url={`${baseUrls.registryDetail}/orgunitId/${settings.row.original.id}`}
-                    tooltipMessage={MESSAGES.see}
-                    iconSize="small"
-                    color="primary"
+                <LinkToRegistry
+                    orgUnit={settings.row.original}
+                    replace
+                    useIcon
                 />
             ),
         },

--- a/hat/assets/js/apps/Iaso/domains/registry/config.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/config.tsx
@@ -3,7 +3,6 @@ import { useSafeIntl } from 'bluesquare-components';
 import { Tooltip, Box } from '@material-ui/core';
 import LocationOnIcon from '@material-ui/icons/LocationOn';
 import LocationDisabledIcon from '@material-ui/icons/LocationDisabled';
-import AccountTreeIcon from '@material-ui/icons/AccountTree';
 import MapIcon from '@material-ui/icons/Map';
 
 import { IntlFormatMessage } from '../../types/intl';
@@ -17,6 +16,7 @@ import { LinkToRegistry } from './components/LinkToRegistry';
 
 import MESSAGES from './messages';
 import ShapeSvg from '../../components/svg/ShapeSvgComponent';
+import { LinkToOrgUnit } from '../orgUnits/components/LinkToOrgUnit';
 
 export const defaultSorted = [{ id: 'org_unit__name', desc: false }];
 
@@ -162,20 +162,28 @@ export const useGetOrgUnitsListColumns = (): Column[] => {
             },
         },
         {
-            Header: (
-                <Box position="relative" top={4} left={2}>
-                    <AccountTreeIcon fontSize="small" color="inherit" />
-                </Box>
-            ),
+            Header: formatMessage(MESSAGES.actions),
             id: 'see',
             sortable: false,
             width: 50,
             Cell: settings => (
-                <LinkToRegistry
-                    orgUnit={settings.row.original}
-                    replace
-                    useIcon
-                />
+                <>
+                    <Box display="inline-block" mr={1}>
+                        <LinkToOrgUnit
+                            orgUnit={settings.row.original}
+                            useIcon
+                            size="small"
+                            iconSize="small"
+                        />
+                    </Box>
+                    <LinkToRegistry
+                        orgUnit={settings.row.original}
+                        replace
+                        useIcon
+                        size="small"
+                        iconSize="small"
+                    />
+                </>
             ),
         },
     ];

--- a/hat/assets/js/apps/Iaso/domains/registry/details.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/details.tsx
@@ -55,7 +55,6 @@ export const Details: FunctionComponent<Props> = ({ router }) => {
             })) || [];
         return orderBy(options, [f => f.depth], ['asc']);
     }, [orgUnit]);
-
     return (
         <>
             <TopBar
@@ -66,7 +65,7 @@ export const Details: FunctionComponent<Props> = ({ router }) => {
             <Box className={`${classes.containerFullHeightNoTabPadded}`}>
                 {isFetching && <LoadingSpinner />}
 
-                {orgUnit && (
+                {!isFetching && orgUnit && (
                     <Grid container spacing={2}>
                         {orgUnit && (
                             <Grid item xs={12}>

--- a/hat/assets/js/apps/Iaso/domains/registry/details.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/details.tsx
@@ -13,7 +13,10 @@ import { useGoBack } from '../../routing/useGoBack';
 import { baseUrls } from '../../constants/urls';
 import { getOtChipColors } from '../../constants/chipColors';
 
-import { useGetOrgUnit } from './hooks/useGetOrgUnit';
+import {
+    useGetOrgUnit,
+    useGetOrgUnitListChildren,
+} from './hooks/useGetOrgUnit';
 
 import { Instances } from './components/Instances';
 import { OrgUnitPaper } from './components/OrgUnitPaper';
@@ -46,15 +49,24 @@ export const Details: FunctionComponent<Props> = ({ router }) => {
     const goBack = useGoBack(router, baseUrls.registry, { accountId });
 
     const { data: orgUnit, isFetching } = useGetOrgUnit(orgUnitId);
-
+    const { data: orgUnitChildren, isFetching: isFetchingChildren } =
+        useGetOrgUnitListChildren(
+            orgUnitId,
+            params,
+            orgUnit?.org_unit_type?.sub_unit_types,
+        );
     const subOrgUnitTypes: OrgunitTypes = useMemo(() => {
         const options =
             orgUnit?.org_unit_type?.sub_unit_types.map((subType, index) => ({
                 ...subType,
                 color: getOtChipColors(index) as string,
+                count: (orgUnitChildren?.orgunits || []).filter(
+                    subOrgUnit => subOrgUnit.org_unit_type_id === subType.id,
+                ).length,
             })) || [];
         return orderBy(options, [f => f.depth], ['asc']);
-    }, [orgUnit]);
+    }, [orgUnit, orgUnitChildren]);
+
     return (
         <>
             <TopBar
@@ -81,6 +93,8 @@ export const Details: FunctionComponent<Props> = ({ router }) => {
                                 orgUnit={orgUnit}
                                 subOrgUnitTypes={subOrgUnitTypes}
                                 params={params}
+                                orgUnitChildren={orgUnitChildren}
+                                isFetchingChildren={isFetchingChildren}
                             />
                         </Grid>
                         <Grid

--- a/hat/assets/js/apps/Iaso/domains/registry/hooks/useGetOrgUnit.ts
+++ b/hat/assets/js/apps/Iaso/domains/registry/hooks/useGetOrgUnit.ts
@@ -22,15 +22,15 @@ export const useGetOrgUnit = (
     });
 };
 
-type ResultList = Pagination & {
+export type OrgUnitListChildren = Pagination & {
     orgunits: OrgUnit[];
 };
 
-export const useGetOrgUnitsListChildren = (
+export const useGetOrgUnitListChildren = (
     orgUnitParentId: string,
-    orgUnitTypes: OrgunitTypes,
     params: RegistryDetailParams,
-): UseQueryResult<ResultList, Error> => {
+    orgUnitTypes?: OrgunitTypes,
+): UseQueryResult<OrgUnitListChildren, Error> => {
     let order = '-name';
     if (params.orgUnitListOrder) {
         if (params.orgUnitListOrder === 'location') {
@@ -49,7 +49,7 @@ export const useGetOrgUnitsListChildren = (
         order,
         page: params.orgUnitListPage || '1',
     };
-    if (orgUnitTypes?.length > 0) {
+    if (orgUnitTypes && orgUnitTypes.length > 0) {
         apiParams.orgUnitTypeId = orgUnitTypes
             .map(orgunitType => orgunitType.id)
             .join(',');
@@ -61,6 +61,7 @@ export const useGetOrgUnitsListChildren = (
         queryFn: () => getRequest(url),
         options: {
             keepPreviousData: true,
+            enabled: Boolean(orgUnitParentId),
             select: data => {
                 if (!data) return undefined;
                 const orgunits: OrgUnit[] = data.orgunits.filter(

--- a/hat/assets/js/apps/Iaso/domains/registry/messages.ts
+++ b/hat/assets/js/apps/Iaso/domains/registry/messages.ts
@@ -129,6 +129,10 @@ const MESSAGES = defineMessages({
         id: 'iaso.label.close',
         defaultMessage: 'Close',
     },
+    actions: {
+        defaultMessage: 'Actions',
+        id: 'iaso.label.actions',
+    },
 });
 
 export default MESSAGES;

--- a/hat/assets/js/apps/Iaso/domains/registry/messages.ts
+++ b/hat/assets/js/apps/Iaso/domains/registry/messages.ts
@@ -117,6 +117,10 @@ const MESSAGES = defineMessages({
         defaultMessage: 'reference submission',
         id: 'iaso.registry.referenceInstance',
     },
+    showNames: {
+        defaultMessage: 'Show names',
+        id: 'iaso.registry.showNames',
+    },
 });
 
 export default MESSAGES;

--- a/hat/assets/js/apps/Iaso/domains/registry/messages.ts
+++ b/hat/assets/js/apps/Iaso/domains/registry/messages.ts
@@ -121,6 +121,14 @@ const MESSAGES = defineMessages({
         defaultMessage: 'Show names',
         id: 'iaso.registry.showNames',
     },
+    source: {
+        defaultMessage: 'Source',
+        id: 'iaso.forms.source',
+    },
+    close: {
+        id: 'iaso.label.close',
+        defaultMessage: 'Close',
+    },
 });
 
 export default MESSAGES;


### PR DESCRIPTION
Multiple improvements on registry 

Related JIRA tickets : IA-2111, IA-2108, IA-2107, IA-2105, IA-2106

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- Review of navigation using replace for `LinkForRegistry` (refactor of `LinkToOrgUnit`)
- Allow to toggle tooltip for children org units
- Review preselected sub org unit type logic
- display count of sub org units tin tabs
- link to submissions everywhere

## How to test

Go to registry page for an org unit, play with the navigation and come back, check that all required features are working


## Print screen / video

https://user-images.githubusercontent.com/12494624/234879571-e2f50a32-79a8-4e2f-abbe-cc5904ee6069.mov






