### PR TITLE
IA-2056:  registry part 4

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -245,6 +245,8 @@
     "iaso.instance.delete": "Delete instance(s)",
     "iaso.instance.deleteCount": "Delete {count} instance(s)",
     "iaso.instance.deleteInstanceWarning": "This operation can still be undone",
+    "iaso.instance.deleteText": "Undelete is possible on submission detail page",
+    "iaso.instance.deleteTitle": "Are you sure you want to delete this submission?",
     "iaso.instance.device": "IMEI device",
     "iaso.instance.dialog.editGpsFromInstanceTitle": "Are you sure you want to push GPS from submission to the org unit. ?",
     "iaso.instance.dialog.linkOffOrgUnitToInstanceReferenceTitle": "Are you sure you want to unlink this reference submission from the orgUnit ?",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -242,6 +242,8 @@
     "iaso.instance.delete": "Effacer une(des) soumission(s)",
     "iaso.instance.deleteCount": "Effacer {count} soumission(s)",
     "iaso.instance.deleteInstanceWarning": "Cette opération peut toujours être annulée.",
+    "iaso.instance.deleteText": "Restaurer la soumission est possible sur la page detail",
+    "iaso.instance.deleteTitle": "Êtes-vous certain de vouloir effacer cette soumission?",
     "iaso.instance.device": "IMEI appareil",
     "iaso.instance.dialog.editGpsFromInstanceTitle": "Voulez-vous vraiment pousser les GPS de la soumission à l'unité organisation ?",
     "iaso.instance.dialog.linkOffOrgUnitToInstanceReferenceTitle": "Êtes-vous sûr de vouloir dissocier cette soumission de référence de l'orgUnit ?",

--- a/hat/assets/js/apps/Iaso/domains/instances/hooks/requests/useDeleteInstance.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/hooks/requests/useDeleteInstance.tsx
@@ -5,10 +5,12 @@ import { useSnackMutation } from '../../../../libs/apiHooks';
 const deleteInstance = async (instanceId: string): Promise<any> => {
     return deleteRequest(`/api/instances/${instanceId}/`);
 };
-export const useDeleteInstance = (): UseMutationResult =>
+export const useDeleteInstance = (
+    invalidateQueryKey = 'instance',
+): UseMutationResult =>
     useSnackMutation({
         mutationFn: deleteInstance,
-        invalidateQueryKey: 'instance',
+        invalidateQueryKey,
     });
 
 const restoreInstance = async (instanceId: string): Promise<any> =>

--- a/hat/assets/js/apps/Iaso/domains/registry/components/ActionCell.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/ActionCell.tsx
@@ -2,30 +2,49 @@ import React, { FunctionComponent } from 'react';
 import { IconButton as IconButtonComponent } from 'bluesquare-components';
 
 import MESSAGES from '../messages';
+import { userHasPermission } from '../../users/utils';
+import { useCurrentUser } from '../../../utils/usersUtils';
 
 import EnketoIcon from '../../instances/components/EnketoIcon';
+import DeleteDialog from '../../../components/dialogs/DeleteDialogComponent';
 
 import { LinkToInstance } from '../../instances/components/LinkToInstance';
 
 import { useGetEnketoUrl } from '../hooks/useGetEnketoUrl';
+import { useDeleteInstance } from '../../instances/hooks/requests/useDeleteInstance';
 
 type Props = {
     settings: any;
 };
 
 export const ActionCell: FunctionComponent<Props> = ({ settings }) => {
+    const user = useCurrentUser();
     const getEnketoUrl = useGetEnketoUrl(
         window.location.href,
         settings.row.original,
     );
-
+    const { mutate: softDeleteInstance } =
+        useDeleteInstance('registry-instances');
     return (
         <section>
-            <IconButtonComponent
-                onClick={() => getEnketoUrl()}
-                overrideIcon={EnketoIcon}
-                tooltipMessage={MESSAGES.editOnEnketo}
-            />
+            {userHasPermission('iaso_update_submission', user) && (
+                <>
+                    <IconButtonComponent
+                        onClick={() => getEnketoUrl()}
+                        overrideIcon={EnketoIcon}
+                        tooltipMessage={MESSAGES.editOnEnketo}
+                    />
+
+                    <DeleteDialog
+                        keyName={`instance-${settings.row.original.id}`}
+                        titleMessage={MESSAGES.deleteTitle}
+                        message={MESSAGES.deleteText}
+                        onConfirm={() =>
+                            softDeleteInstance(settings.row.original.id)
+                        }
+                    />
+                </>
+            )}
             <LinkToInstance instanceId={settings.row.original.id} useIcon />
         </section>
     );

--- a/hat/assets/js/apps/Iaso/domains/registry/components/Instances.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/Instances.tsx
@@ -7,6 +7,7 @@ import React, {
 import { Box, Tabs, Tab, Grid } from '@material-ui/core';
 import { useDispatch } from 'react-redux';
 
+import DownloadButtonsComponent from '../../../components/DownloadButtonsComponent';
 import InputComponent from '../../../components/forms/InputComponent';
 import { TableWithDeepLink } from '../../../components/tables/TableWithDeepLink';
 import { ColumnSelect } from '../../instances/components/ColumnSelect';
@@ -20,7 +21,7 @@ import { Column } from '../../../types/table';
 import { Form } from '../../forms/types/forms';
 
 import { useGetForms } from '../hooks/useGetForms';
-import { useGetInstances } from '../hooks/useGetInstances';
+import { useGetInstanceApi, useGetInstances } from '../hooks/useGetInstances';
 
 import MESSAGES from '../messages';
 import { baseUrls } from '../../../constants/urls';
@@ -54,6 +55,8 @@ export const Instances: FunctionComponent<Props> = ({
     const dispatch = useDispatch();
 
     const { data: formsList, isFetching: isFetchingForms } = useGetForms();
+
+    const { url: apiUrl } = useGetInstanceApi(params, currentType?.id);
     const { data, isFetching: isFetchingList } = useGetInstances(
         params,
         currentType?.id,
@@ -146,6 +149,20 @@ export const Instances: FunctionComponent<Props> = ({
                                         )}
                                     />
                                 )}
+                                <Box
+                                    display="flex"
+                                    justifyContent="flex-end"
+                                    width="100%"
+                                    mt={2}
+                                >
+                                    <DownloadButtonsComponent
+                                        csvUrl={`${apiUrl}&csv=true`}
+                                        xlsxUrl={`${apiUrl}&xlsx=true`}
+                                        disabled={
+                                            isFetchingList || data?.count === 0
+                                        }
+                                    />
+                                </Box>
                             </Grid>
                         </Grid>
                         <TableWithDeepLink

--- a/hat/assets/js/apps/Iaso/domains/registry/hooks/useGetInstances.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/hooks/useGetInstances.tsx
@@ -11,20 +11,49 @@ import { makeUrlWithParams } from '../../../libs/utils';
 import { RegistryDetailParams } from '../types';
 import { defaultSorted } from '../config';
 
+type ApiParams = {
+    orgUnitTypeId?: number;
+    form_ids?: string;
+    limit: string;
+    order: string;
+    page: string;
+    showDeleted: false;
+    orgUnitParentId: string;
+};
+
+type InstanceApi = {
+    url: string;
+    apiParams: ApiParams;
+};
+
+export const useGetInstanceApi = (
+    params: RegistryDetailParams,
+    orgUnitTypeId?: number,
+): InstanceApi => {
+    const apiParams: ApiParams = {
+        orgUnitTypeId,
+        form_ids: params.formIds,
+        limit: params.pageSize || '20',
+        order: params.order || getSort(defaultSorted),
+        page: params.page || '1',
+        showDeleted: false,
+        orgUnitParentId: params.orgUnitId,
+    };
+    const url = makeUrlWithParams(
+        '/api/instances/',
+        apiParams as Record<string, any>,
+    );
+    return {
+        apiParams,
+        url,
+    };
+};
+
 export const useGetInstances = (
     params: RegistryDetailParams,
     orgUnitTypeId?: number,
 ): UseQueryResult<PaginatedInstances, Error> => {
-    const apiParams: Record<string, any> = {
-        orgUnitTypeId,
-        form_ids: params.formIds,
-        limit: params.pageSize || 20,
-        order: params.order || getSort(defaultSorted),
-        page: params.page || 1,
-        showDeleted: false,
-        orgUnitParentId: params.orgUnitId,
-    };
-    const url = makeUrlWithParams('/api/instances/', apiParams);
+    const { apiParams, url } = useGetInstanceApi(params, orgUnitTypeId);
     return useSnackQuery({
         queryKey: ['registry-instances', apiParams],
         queryFn: () => getRequest(url),

--- a/hat/assets/js/apps/Iaso/domains/registry/messages.ts
+++ b/hat/assets/js/apps/Iaso/domains/registry/messages.ts
@@ -133,6 +133,14 @@ const MESSAGES = defineMessages({
         defaultMessage: 'Actions',
         id: 'iaso.label.actions',
     },
+    deleteTitle: {
+        id: 'iaso.instance.deleteTitle',
+        defaultMessage: 'Are you sure you want to delete this submission?',
+    },
+    deleteText: {
+        id: 'iaso.instance.deleteText',
+        defaultMessage: 'Undelete is possible on submission detail page',
+    },
 });
 
 export default MESSAGES;


### PR DESCRIPTION
Allow to delete a submission , export buttons for submissions

Related JIRA tickets : IA-2109, IA-2110

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- added confirm dialog to soft delete a submission
- split `useGetInstances` into hokks to get download url
- use `downloadButtonComponent` to export submissions

## How to test

Go to registry page, check that you can delete and export subimssions

## Print screen / video


https://user-images.githubusercontent.com/12494624/234899204-63b4540a-2500-4c15-a00a-9ff2ff6e3b2d.mov


