### PR TITLE
POLIO-957-975: change text automatic campaign email + Stop sending automatic emails after the last round start date of the campaign

### DIFF
--- a/plugins/polio/management/commands/test_send_email.py
+++ b/plugins/polio/management/commands/test_send_email.py
@@ -22,7 +22,6 @@ class Command(BaseCommand):
         task = FakeTask(iaso_logger)
 
         for i, campaign in enumerate(campaigns):
-
             task.report_progress_and_stop_if_killed(
                 progress_value=i,
                 end_value=total,
@@ -30,7 +29,7 @@ class Command(BaseCommand):
             )
 
             latest_round_end = campaign.rounds.order_by("ended_at").last()
-            if latest_round_end and latest_round_end.ended_at and latest_round_end.ended_at > now().date():
+            if latest_round_end and latest_round_end.ended_at and latest_round_end.ended_at < now().date():
                 print(f"Campaign {campaign} is finished, skipping")
                 continue
             print(f"Email for {campaign.obr_name}")

--- a/plugins/polio/tasks/weekly_email.py
+++ b/plugins/polio/tasks/weekly_email.py
@@ -61,10 +61,13 @@ def send_notification_email(campaign):
     c = campaign
     url = f"https://{domain}/dashboard/polio/list/campaignId/{campaign.id}"
 
-    next_round_date = next_round.started_at if next_round else None
-    next_round_number = next_round.number if next_round else None
-    next_round_preparedness_spreadsheet_url = next_round.preparedness_spreadsheet_url if next_round else None
-    next_round_days_left = (next_round.started_at - now().date()).days if next_round and next_round.started_at else ""
+    if next_round:
+        next_round_date = next_round.started_at if next_round else ""
+        next_round_number = next_round.number if next_round else ""
+        next_round_preparedness_spreadsheet_url = next_round.preparedness_spreadsheet_url if next_round else ""
+        next_round_days_left = (
+            (next_round.started_at - now().date()).days if next_round and next_round.started_at else ""
+        )
     # format thousand
     target_population = f"{first_round.target_population:,}" if first_round and first_round.target_population else ""
 

--- a/plugins/polio/tasks/weekly_email.py
+++ b/plugins/polio/tasks/weekly_email.py
@@ -60,7 +60,10 @@ def send_notification_email(campaign):
 
     c = campaign
     url = f"https://{domain}/dashboard/polio/list/campaignId/{campaign.id}"
-
+    next_round_date = ""
+    next_round_number = ""
+    next_round_preparedness_spreadsheet_url = ""
+    next_round_days_left = ""
     if next_round:
         next_round_date = next_round.started_at if next_round else ""
         next_round_number = next_round.number if next_round else ""

--- a/plugins/polio/tasks/weekly_email.py
+++ b/plugins/polio/tasks/weekly_email.py
@@ -62,6 +62,8 @@ def send_notification_email(campaign):
     url = f"https://{domain}/dashboard/polio/list/campaignId/{campaign.id}"
 
     next_round_date = next_round.started_at if next_round else None
+    next_round_number = next_round.number if next_round else None
+    next_round_preparedness_spreadsheet_url = next_round.preparedness_spreadsheet_url if next_round else None
     next_round_days_left = (next_round.started_at - now().date()).days if next_round and next_round.started_at else ""
     # format thousand
     target_population = f"{first_round.target_population:,}" if first_round and first_round.target_population else ""
@@ -76,12 +78,12 @@ Statut hebdomadaire: Il reste {next_round_days_left} jours avant le début de la
 Ci-dessous un résumé des informations de la campagne {c.obr_name} disponibles dans la plateforme. Pour plus de détails, cliquez ici: https://afro-rrt-who.hub.arcgis.com/pages/country-summary. S'il manque des données ou s'il y a des mises à jour à effectuer, cliquez ici {url} pour mettre à jour.
 
 * Date de notification              : {c.cvdpv2_notified_at}
-* Date du prochain round (Round {next_round.number})          : {next_round_date if campaign.rounds else None}
+* Date du prochain round (Round {next_round_number})          : {next_round_date if campaign.rounds else None}
 * Type de vaccin                    : {c.vaccines}
 * Population cible                  : {target_population} 
 * RA Date de l'approbation RRT/ORPG  : {c.risk_assessment_rrt_oprtt_approval_at}
 * Date de soumission du budget      : {c.submitted_to_rrt_at_WFEDITABLE}
-* Lien vers la preperadness google sheet du Round {next_round.number if next_round else None} : {next_round.preparedness_spreadsheet_url if next_round else None}
+* Lien vers la preperadness google sheet du Round {next_round_number} : {next_round_preparedness_spreadsheet_url}
 * Prep. national                 : {preparedness.get('national_score') if preparedness else ''}
 * Prep. régional                 : {preparedness.get('regional_score') if preparedness else ''}
 * Prep. district                 : {preparedness.get('district_score') if preparedness else ''}
@@ -97,12 +99,12 @@ Estado semanal: passaram-se {next_round_days_left} dias desde a data de notifica
 Segue em baixo um resumo das informações da campanha {c.obr_name} disponíveis na plataforma. Para mais detalhes, clique em: https://afro-rrt-who.hub.arcgis.com/pages/country-summary . Se faltarem dados ou houverem atualizações a serem feitas, por favor clique em {url} para atualizar.
 
 * Data de notificação: {c.cvdpv2_notified_at}
-* Proxima ronda (Round {next_round.number}) data: {next_round_date if campaign.rounds else None}
+* Proxima ronda (Round {next_round_number}) data: {next_round_date if campaign.rounds else None}
 * Tipo de vacina: {c.vaccines}
 * População-alvo: {target_population}
 * RA Data de aprovação RRT/ORPG: {c.risk_assessment_rrt_oprtt_approval_at}
 * Data de envio do orçamento:   {c.submitted_to_rrt_at_WFEDITABLE}
-* Link to {next_round.number if next_round else None}  preparedness Google sheet: {next_round.preparedness_spreadsheet_url if next_round else None}
+* Link to {next_round_number}  preparedness Google sheet: {next_round_preparedness_spreadsheet_url}
 * Prep. nacional: {preparedness.get('national_score') if preparedness else ''}
 * Prep. regional: {preparedness.get('regional_score') if preparedness else ''}
 * Prep. distrital: {preparedness.get('district_score') if preparedness else ''}
@@ -119,12 +121,12 @@ Below is the summary of the campaign {c.obr_name}. For more details, visit https
 If there are missing data or dates; visit {url} to update
 
 * Notification date              : {c.cvdpv2_notified_at}
-* Next round (Round {next_round.number}) date: {next_round_date if campaign.rounds else None}
+* Next round (Round {next_round_number}) date: {next_round_date if campaign.rounds else None}
 * Vaccine Type                   : {c.vaccines}
 * Target population              : {target_population} 
 * RA RRT/ORPG approval date      : {c.risk_assessment_rrt_oprtt_approval_at}
 * Date Budget Submitted          : {c.submitted_to_rrt_at_WFEDITABLE}
-* Link to Round {next_round.number if next_round else None} preparedness Google sheet: {next_round.preparedness_spreadsheet_url if next_round else None}
+* Link to Round {next_round_number if next_round else None} preparedness Google sheet: {next_round_preparedness_spreadsheet_url}
 * Prep. national                 : {preparedness.get('national_score') if preparedness else ''}
 * Prep. regional                 : {preparedness.get('regional_score') if preparedness else ''}
 * Prep. district                 : {preparedness.get('district_score') if preparedness else ''}

--- a/plugins/polio/tasks/weekly_email.py
+++ b/plugins/polio/tasks/weekly_email.py
@@ -41,16 +41,7 @@ def send_notification_email(campaign):
     emails = [user.email for user in users if user.email]
     if not emails:
         return False
-    # day_number = (
-    #     (now().date() - campaign.cvdpv2_notified_at).days
-    #     if campaign.cvdpv2_notified_at
-    #     else "{Error: No cVDPV notification available. Enter a notification date in order to have the days count.}"
-    # )
-    # onset_days = (
-    #     (campaign.cvdpv2_notified_at - campaign.onset_at).days
-    #     if campaign.onset_at and campaign.cvdpv2_notified_at
-    #     else "{Error: No cVDPV notification or campaign on set available. Enter a date in order to have the days count.}"
-    # )
+
     try:
         first_round = campaign.rounds.earliest("number")
         next_round = campaign.rounds.filter(started_at__gte=now().date()).order_by("started_at").first()
@@ -80,7 +71,7 @@ def send_notification_email(campaign):
     if lang == "fr":
         email_text = f"""Cher·ère coordinateur.rice de la GPEI – {country.name},
 
-Statut hebdomadaire: Il reste {next_round_days_left} jours avant le début de la campagne. 
+Statut hebdomadaire: Il reste {next_round_days_left} jours avant le début du prochain round. 
 Ci-dessous un résumé des informations de la campagne {c.obr_name} disponibles dans la plateforme. Pour plus de détails, cliquez ici: https://afro-rrt-who.hub.arcgis.com/pages/country-summary. S'il manque des données ou s'il y a des mises à jour à effectuer, cliquez ici {url} pour mettre à jour.
 
 * Date de notification              : {c.cvdpv2_notified_at}
@@ -89,7 +80,7 @@ Ci-dessous un résumé des informations de la campagne {c.obr_name} disponibles 
 * Population cible                  : {target_population} 
 * RA Date de l'approbation RRT/ORPG  : {c.risk_assessment_rrt_oprtt_approval_at}
 * Date de soumission du budget      : {c.submitted_to_rrt_at_WFEDITABLE}
-* Lien vers la preperadness google sheet du Round {next_round_number} : {next_round_preparedness_spreadsheet_url}
+* Lien vers la preparedness google sheet du Round {next_round_number} : {next_round_preparedness_spreadsheet_url}
 * Prep. national                 : {preparedness.get('national_score') if preparedness else ''}
 * Prep. régional                 : {preparedness.get('regional_score') if preparedness else ''}
 * Prep. district                 : {preparedness.get('district_score') if preparedness else ''}
@@ -101,7 +92,7 @@ Ceci est un message automatique.
     elif lang == "pt":
         email_text = f"""Prezado(a) coordenador(a) da GPEI – {country.name},
 
-Estado semanal: passaram-se {next_round_days_left} dias desde a data de notificação da campanha.
+Estado semanal: Faltam {next_round_days_left} dias para o início da próxima ronda.
 Segue em baixo um resumo das informações da campanha {c.obr_name} disponíveis na plataforma. Para mais detalhes, clique em: https://afro-rrt-who.hub.arcgis.com/pages/country-summary . Se faltarem dados ou houverem atualizações a serem feitas, por favor clique em {url} para atualizar.
 
 * Data de notificação: {c.cvdpv2_notified_at}
@@ -109,8 +100,8 @@ Segue em baixo um resumo das informações da campanha {c.obr_name} disponíveis
 * Tipo de vacina: {c.vaccines}
 * População-alvo: {target_population}
 * RA Data de aprovação RRT/ORPG: {c.risk_assessment_rrt_oprtt_approval_at}
-* Data de envio do orçamento:   {c.submitted_to_rrt_at_WFEDITABLE}
-* Link to {next_round_number}  preparedness Google sheet: {next_round_preparedness_spreadsheet_url}
+* Data de envio do orçamento:  {c.submitted_to_rrt_at_WFEDITABLE}
+* Link to {next_round_number} preparedness Google sheet: {next_round_preparedness_spreadsheet_url}
 * Prep. nacional: {preparedness.get('national_score') if preparedness else ''}
 * Prep. regional: {preparedness.get('regional_score') if preparedness else ''}
 * Prep. distrital: {preparedness.get('district_score') if preparedness else ''}
@@ -122,7 +113,7 @@ Esta é uma mensagem automática.
     else:
         email_text = f"""Dear GPEI coordinator – {country.name},
 
-Weekly status update: Today is day {next_round_days_left} to Round {next_round.number} start date.
+Weekly status update: Today is day {next_round_days_left} to Round {next_round_number} start date.
 Below is the summary of the campaign {c.obr_name}. For more details, visit https://afro-rrt-who.hub.arcgis.com/pages/country-summary
 If there are missing data or dates; visit {url} to update
 

--- a/plugins/polio/tasks/weekly_email.py
+++ b/plugins/polio/tasks/weekly_email.py
@@ -131,7 +131,7 @@ If there are missing data or dates; visit {url} to update
 * Next round (Round {next_round.number}) date: {next_round_date if campaign.rounds else None}
 * Vaccine Type                   : {c.vaccines}
 * Target population              : {target_population} 
-* RA RRT/ORPG approval date      : {c.get_risk_assessment_status_display() or 'Pending'}
+* RA RRT/ORPG approval date      : {c.risk_assessment_rrt_oprtt_approval_at}
 * Date Budget Submitted          : {c.submitted_to_rrt_at_WFEDITABLE}
 * Link to Round {next_round.number if next_round else None} preparedness Google sheet: {next_round.preparedness_spreadsheet_url if next_round else None}
 * Prep. national                 : {preparedness.get('national_score') if preparedness else ''}

--- a/plugins/polio/tasks/weekly_email.py
+++ b/plugins/polio/tasks/weekly_email.py
@@ -53,20 +53,23 @@ def send_notification_email(campaign):
     # )
     try:
         first_round = campaign.rounds.earliest("number")
+        next_round = campaign.rounds.filter(started_at__gte=now().date()).order_by("started_at").first()
     except Round.DoesNotExist:
         first_round = None
+        next_round = None
 
     c = campaign
     url = f"https://{domain}/dashboard/polio/list/campaignId/{campaign.id}"
 
-    # next round
-    next_round = campaign.rounds.filter(started_at__gte=now().date()).order_by("started_at").first()
     next_round_date = next_round.started_at
     next_round_days_left = (next_round.started_at - now().date()).days if next_round and next_round.started_at else ""
     # format thousand
     target_population = f"{first_round.target_population:,}" if first_round and first_round.target_population else ""
 
     preparedness = get_last_preparedness(campaign)
+
+    print(next_round)
+    print(next_round.started_at)
 
     # French
     if lang == "fr":
@@ -93,7 +96,7 @@ Ceci est un message automatique.
     elif lang == "pt":
         email_text = f"""Prezado(a) coordenador(a) da GPEI – {country.name},
 
-Estado semanal: passaram-se {next_round_days} dias desde a data de notificação da campanha.
+Estado semanal: passaram-se {next_round_days_left} dias desde a data de notificação da campanha.
 Segue em baixo um resumo das informações da campanha {c.obr_name} disponíveis na plataforma. Para mais detalhes, clique em: https://afro-rrt-who.hub.arcgis.com/pages/country-summary . Se faltarem dados ou houverem atualizações a serem feitas, por favor clique em {url} para atualizar.
 
 * Data de notificação: {c.cvdpv2_notified_at}
@@ -114,7 +117,7 @@ Esta é uma mensagem automática.
     else:
         email_text = f"""Dear GPEI coordinator – {country.name},
 
-Weekly status update: Today is day {next_round_days} to Round {next_round.number} start date.
+Weekly status update: Today is day {next_round_days_left} to Round {next_round.number} start date.
 Below is the summary of the campaign {c.obr_name}. For more details, visit https://afro-rrt-who.hub.arcgis.com/pages/country-summary
 If there are missing data or dates; visit {url} to update
 

--- a/plugins/polio/tasks/weekly_email.py
+++ b/plugins/polio/tasks/weekly_email.py
@@ -61,15 +61,12 @@ def send_notification_email(campaign):
     c = campaign
     url = f"https://{domain}/dashboard/polio/list/campaignId/{campaign.id}"
 
-    next_round_date = next_round.started_at
+    next_round_date = next_round.started_at if next_round else None
     next_round_days_left = (next_round.started_at - now().date()).days if next_round and next_round.started_at else ""
     # format thousand
     target_population = f"{first_round.target_population:,}" if first_round and first_round.target_population else ""
 
     preparedness = get_last_preparedness(campaign)
-
-    print(next_round)
-    print(next_round.started_at)
 
     # French
     if lang == "fr":
@@ -162,8 +159,8 @@ def send_email(task=None):
             progress_message=f"Campaign {campaign.pk} started",
         )
 
-        latest_round_end = campaign.rounds.order_by("ended_at").last()
-        if latest_round_end and latest_round_end.ended_at and latest_round_end.ended_at < now().date():
+        latest_round_start = campaign.rounds.order_by("started_at").last()
+        if latest_round_start and latest_round_start.started_at and latest_round_start.started_at < now().date():
             print(f"Campaign {campaign} is finished, skipping")
             continue
         logger.info(f"Email for {campaign.obr_name}")

--- a/plugins/polio/tasks/weekly_email.py
+++ b/plugins/polio/tasks/weekly_email.py
@@ -62,13 +62,8 @@ def send_notification_email(campaign):
     # next round
     next_round =  campaign.rounds.filter(started_at__gte=now().date()).order_by("started_at").first()
     next_round_date = next_round.started_at
-    next_round_days = (
-        (next_round.started_at - campaign.onset_at).days
-        if next_round and next_round.started_at and campaign.onset_at
-        else ""
-    )
     next_round_days_left = (
-        ((next_round.started_at) - (now().date())).days
+        (next_round.started_at - now().date()).days
         if next_round and next_round.started_at
         else ""
     )

--- a/plugins/polio/tasks/weekly_email.py
+++ b/plugins/polio/tasks/weekly_email.py
@@ -60,13 +60,9 @@ def send_notification_email(campaign):
     url = f"https://{domain}/dashboard/polio/list/campaignId/{campaign.id}"
 
     # next round
-    next_round =  campaign.rounds.filter(started_at__gte=now().date()).order_by("started_at").first()
+    next_round = campaign.rounds.filter(started_at__gte=now().date()).order_by("started_at").first()
     next_round_date = next_round.started_at
-    next_round_days_left = (
-        (next_round.started_at - now().date()).days
-        if next_round and next_round.started_at
-        else ""
-    )
+    next_round_days_left = (next_round.started_at - now().date()).days if next_round and next_round.started_at else ""
     # format thousand
     target_population = f"{first_round.target_population:,}" if first_round and first_round.target_population else ""
 
@@ -164,7 +160,7 @@ def send_email(task=None):
         )
 
         latest_round_end = campaign.rounds.order_by("ended_at").last()
-        if latest_round_end and latest_round_end.ended_at and latest_round_end.ended_at <  now().date():
+        if latest_round_end and latest_round_end.ended_at and latest_round_end.ended_at < now().date():
             print(f"Campaign {campaign} is finished, skipping")
             continue
         logger.info(f"Email for {campaign.obr_name}")

--- a/plugins/polio/tasks/weekly_email.py
+++ b/plugins/polio/tasks/weekly_email.py
@@ -61,6 +61,7 @@ def send_notification_email(campaign):
         else ""
     )
     c = campaign
+    print(c)
     url = f"https://{domain}/dashboard/polio/list/campaignId/{campaign.id}"
     # format thousand
     target_population = f"{first_round.target_population:,}" if first_round and first_round.target_population else ""
@@ -126,7 +127,8 @@ If there are missing data or dates; visit {url} to update
 * RA Status                      : {c.get_risk_assessment_status_display() or 'Pending'}
 * Date Budget Submitted          : {c.submitted_to_rrt_at_WFEDITABLE}
 * OnSet to Notification (Days)   : {onset_days}
-* Round 1 to Notification (Days) : {round1_days}
+* Notification to Round 1 (Days) : {round1_days}
+* 
 * Prep. national                 : {preparedness.get('national_score') if preparedness else ''}
 * Prep. regional                 : {preparedness.get('regional_score') if preparedness else ''}
 * Prep. district                 : {preparedness.get('district_score') if preparedness else ''}


### PR DESCRIPTION
- Automatic weekly campaign email template was obsolete
- Mail was sent still when last round has started

Related JIRA tickets :
 -  [POLIO-957](https://bluesquare.atlassian.net/browse/POLIO-957?atlOrigin=eyJpIjoiY2VkYWM1ZWFiYTAxNGM5YmE3OWY4NWIxMDcyYWNkMTEiLCJwIjoiaiJ9)
- [POLIO-975](https://bluesquare.atlassian.net/browse/POLIO-975?atlOrigin=eyJpIjoiNmZhNzNhYWM1ZTQ2NDAwYzk1YjlmOGQ0N2EwOTJhNzkiLCJwIjoiaiJ9)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- calculate number of days between last round start date and current date
- remove unnecessary values from email
- fix logic to send email 

## How to test

-  you have to assign your email to the country linked to the campaign you want to test  
- you need to test it locally, you can use the debugger and Python console

## Print screen / video

https://user-images.githubusercontent.com/25134301/235147880-0d9049b4-2d95-4168-8179-94c931c9fbe2.mov

[POLIO-957]: https://bluesquare.atlassian.net/browse/POLIO-957?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[POLIO-975]: https://bluesquare.atlassian.net/browse/POLIO-975?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ