### PR TITLE
IA-2118: registry map fullscreen

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/registry/components/MapToggleFullscreen.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/MapToggleFullscreen.tsx
@@ -1,0 +1,64 @@
+import React, { FunctionComponent, Dispatch, SetStateAction } from 'react';
+import { Paper, makeStyles, Box } from '@material-ui/core';
+import FullscreenIcon from '@material-ui/icons/Fullscreen';
+import FullscreenExitIcon from '@material-ui/icons/FullscreenExit';
+
+const useStyles = makeStyles(() => ({
+    root: {
+        position: 'absolute', // assuming you have a parent relative
+        zIndex: 1100,
+        bottom: 'auto',
+        right: 'auto',
+        left: 10,
+        top: 132,
+        padding: 0,
+        borderRadius: 0,
+        boxShadow: 'none',
+        height: 34,
+        width: 34,
+        borderLeft: '2px solid rgba(0,0,0,0.2)',
+        borderRight: '2px solid rgba(0,0,0,0.2)',
+        borderBottom: '2px solid rgba(0,0,0,0.2)',
+        borderBottomLeftRadius: 4,
+        borderBottomRightRadius: 4,
+        backgroundColor: 'transparent',
+    },
+    box: {
+        borderTop: '1px solid rgba(0,0,0,0.2)',
+        backgroundColor: 'white',
+        cursor: 'pointer',
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        borderBottomLeftRadius: 4,
+        borderBottomRightRadius: 4,
+        '&:hover': {
+            backgroundColor: '#f4f4f4',
+        },
+    },
+}));
+
+type Props = {
+    isMapFullScreen: boolean;
+    setIsMapFullScreen: Dispatch<SetStateAction<boolean>>;
+};
+
+export const MapToggleFullscreen: FunctionComponent<Props> = ({
+    isMapFullScreen,
+    setIsMapFullScreen,
+}) => {
+    const classes = useStyles();
+    return (
+        <Paper elevation={1} className={classes.root}>
+            <Box
+                onClick={() => setIsMapFullScreen(!isMapFullScreen)}
+                className={classes.box}
+            >
+                {!isMapFullScreen && <FullscreenIcon fontSize="small" />}
+                {isMapFullScreen && <FullscreenExitIcon fontSize="small" />}
+            </Box>
+        </Paper>
+    );
+};


### PR DESCRIPTION
Allow to see maps in full screen (or at least larger) in the registry

Related JIRA tickets : IA-2118

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- local state to toggle fullscreen
- fake toolbar zoom button to toggle fullscreen

## How to test

Open a registry page, click on the fullscreen icon on the map

## Print screen / video

https://user-images.githubusercontent.com/12494624/235170120-93809894-3d5e-4fae-b2f8-1e6c5653d8bf.mov




