### PR TITLE
IA-2121 Fix slow treeview

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/TreeView/requests.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/TreeView/requests.js
@@ -6,7 +6,7 @@ import { errorSnackBar } from '../../../../constants/snackBars';
 
 export const getChildrenData = (id, validationStatus = 'all') => {
     return getRequest(
-        `/api/orgunits/?&parent_id=${id}&validation_status=${validationStatus}&treeSearch=true&ignoreEmptyNames=true`,
+        `/api/orgunits/treesearch/?&parent_id=${id}&validation_status=${validationStatus}&ignoreEmptyNames=true`,
     )
         .then(response => {
             return response.orgunits.map(orgUnit => {
@@ -32,11 +32,11 @@ export const getChildrenData = (id, validationStatus = 'all') => {
 const makeUrl = (id, type, validationStatus = 'all') => {
     if (id) {
         if (type === 'version')
-            return `/api/orgunits/?&rootsForUser=true&version=${id}&validation_status=${validationStatus}&treeSearch=true&ignoreEmptyNames=true`;
+            return `/api/orgunits/treesearch/?&rootsForUser=true&version=${id}&validation_status=${validationStatus}&ignoreEmptyNames=true`;
         if (type === 'source')
-            return `/api/orgunits/?&rootsForUser=true&source=${id}&validation_status=${validationStatus}&treeSearch=true&ignoreEmptyNames=true`;
+            return `/api/orgunits/treesearch/?&rootsForUser=true&source=${id}&validation_status=${validationStatus}&ignoreEmptyNames=true`;
     }
-    return `/api/orgunits/?&rootsForUser=true&defaultVersion=true&validation_status=${validationStatus}&treeSearch=true&ignoreEmptyNames=true`;
+    return `/api/orgunits/treesearch/?&rootsForUser=true&defaultVersion=true&validation_status=${validationStatus}&ignoreEmptyNames=true`;
 };
 
 // mapping the request result here i.o in the useRootData hook to keep the hook more generic

--- a/hat/assets/js/cypress/integration/06 - orgUnits tabs/detailInfosTab.spec.js
+++ b/hat/assets/js/cypress/integration/06 - orgUnits tabs/detailInfosTab.spec.js
@@ -192,7 +192,7 @@ describe('infos tab', () => {
     it('should save new infos', () => {
         cy.intercept(
             'GET',
-            `/api/orgunits/?&rootsForUser=true&source=${orgUnit.source_id}&validation_status=all&treeSearch=true&ignoreEmptyNames=true`,
+            `/api/orgunits/treesearch/?&rootsForUser=true&source=${orgUnit.source_id}&validation_status=all&ignoreEmptyNames=true`,
             {
                 fixture: 'orgunits/list.json',
             },

--- a/hat/assets/js/cypress/integration/07 - entities/list.spec.js
+++ b/hat/assets/js/cypress/integration/07 - entities/list.spec.js
@@ -88,7 +88,7 @@ describe('Entities', () => {
 
         cy.intercept(
             'GET',
-            '/api/orgunits/?&rootsForUser=true&defaultVersion=true&validation_status=all&treeSearch=true&ignoreEmptyNames=true',
+            '/api/orgunits/treesearch/?&rootsForUser=true&defaultVersion=true&validation_status=all&ignoreEmptyNames=true',
             {
                 fixture: 'orgunits/list.json',
             },

--- a/hat/assets/js/cypress/integration/11 - submissions/list.spec.js
+++ b/hat/assets/js/cypress/integration/11 - submissions/list.spec.js
@@ -283,7 +283,7 @@ describe('Submissions', () => {
     it('change filters should deep link and call api with correct params', () => {
         cy.intercept(
             'GET',
-            '/api/orgunits/?&rootsForUser=true&defaultVersion=true&validation_status=all&treeSearch=true&ignoreEmptyNames=true',
+            '/api/orgunits/treesearch/?&rootsForUser=true&defaultVersion=true&validation_status=all&ignoreEmptyNames=true',
             {
                 fixture: 'orgunits/list.json',
             },

--- a/iaso/api/org_units.py
+++ b/iaso/api/org_units.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.contrib.gis.geos import Point
 from django.contrib.gis.geos import Polygon, GEOSGeometry, MultiPolygon
 from django.core.paginator import Paginator
-from django.db.models import Q, IntegerField, Value
+from django.db.models import Q, IntegerField, Value, Count
 from django.http import StreamingHttpResponse, HttpResponse
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
@@ -21,7 +21,7 @@ from iaso.api.common import safe_api_import, CONTENT_TYPE_XLSX, CONTENT_TYPE_CSV
 from iaso.api.org_unit_search import build_org_units_queryset, annotate_query
 from iaso.api.serializers import OrgUnitSmallSearchSerializer, OrgUnitSearchSerializer, OrgUnitTreeSearchSerializer
 from iaso.gpkg import org_units_to_gpkg_bytes
-from iaso.models import OrgUnit, OrgUnitType, Group, Project, SourceVersion, Form, Instance
+from iaso.models import OrgUnit, OrgUnitType, Group, Project, SourceVersion, Form, Instance, DataSource
 from iaso.utils import geojson_queryset
 
 
@@ -101,7 +101,6 @@ class OrgUnitViewSet(viewsets.ViewSet):
         with_shapes = request.GET.get("withShapes", None)
         as_location = request.GET.get("asLocation", None)
         small_search = request.GET.get("smallSearch", None)
-        tree_search = request.GET.get("treeSearch", None)
 
         if as_location:
             queryset = queryset.filter(Q(location__isnull=False) | Q(simplified_geom__isnull=False))
@@ -163,9 +162,6 @@ class OrgUnitViewSet(viewsets.ViewSet):
                 }
 
                 return Response(res)
-            elif tree_search:
-                org_units = OrgUnitTreeSearchSerializer(queryset, many=True).data
-                return Response({"orgunits": org_units})
             elif with_shapes:
                 org_units = []
                 for unit in queryset:
@@ -295,6 +291,57 @@ class OrgUnitViewSet(viewsets.ViewSet):
         filename = f"org_units-{timezone.now().strftime('%Y-%m-%d-%H-%M')}.gpkg"
         response["Content-Disposition"] = f"attachment; filename={filename}"
 
+        return response
+
+    @action(methods=["GET"], detail=False)
+    def treesearch(self, request, **kwargs):
+        queryset = self.get_queryset().order_by("name")
+        params = request.GET
+        parent_id = params.get("parent_id")
+        validation_status = params.get("validation_status")
+        roots_for_user = params.get("rootsForUser", None)
+        source = params.get("source", None)
+        version = params.get("version", None)
+        ignore_empty_names = params.get("ignoreEmptyNames", False)
+        default_version = params.get("defaultVersion", None)
+        if not request.user.is_anonymous:
+            profile = request.user.iaso_profile
+        else:
+            profile = None
+
+        if source:
+            source = DataSource.objects.get(id=source)
+            if source.default_version:
+                queryset = queryset.filter(version=source.default_version)
+            else:
+                queryset = queryset.filter(version__data_source_id=source)
+
+        if version:
+            queryset = queryset.filter(version=version)
+
+        if default_version == "true" and profile is not None:
+            queryset = queryset.filter(version=profile.account.default_version)
+
+        if roots_for_user:
+            org_unit_for_profile = request.user.iaso_profile.org_units.only("id")
+            if org_unit_for_profile:
+                queryset = queryset.filter(id__in=org_unit_for_profile)
+            else:
+                queryset = queryset.filter(parent__isnull=True)
+
+        if parent_id:
+            get_object_or_404(self.get_queryset().only("id"), id=parent_id)
+            queryset = queryset.filter(parent=parent_id)
+
+        if validation_status != "all":
+            queryset = queryset.filter(validation_status=validation_status)
+        if ignore_empty_names:
+            queryset = queryset.filter(~Q(name=""))
+
+        queryset = queryset.only("id", "name", "validation_status", "version", "org_unit_type", "parent")
+        queryset = queryset.annotate(children_count=Count("orgunit__id"))
+        org_units = OrgUnitTreeSearchSerializer(queryset, many=True).data
+        response = Response({"orgunits": org_units})
         return response
 
     def partial_update(self, request, pk=None):

--- a/iaso/api/serializers.py
+++ b/iaso/api/serializers.py
@@ -186,13 +186,16 @@ class OrgUnitSearchSerializer(OrgUnitSerializer):
         ]
 
 
-class OrgUnitTreeSearchSerializer(OrgUnitSerializer):
+# noinspection PyMethodMayBeStatic
+class OrgUnitTreeSearchSerializer(TimestampSerializerMixin, serializers.ModelSerializer):
+    # If in a subclass this will correctly use the subclass own serializer
+
     has_children = serializers.SerializerMethodField()
 
-    # probably a way to optimize that
-    def get_has_children(self, org_unit):
-        return org_unit.children().exists() if org_unit.path else False
+    @classmethod
+    def get_has_children(cls, org_unit):
+        return org_unit.children_count > 0
 
     class Meta:
         model = OrgUnit
-        fields = ["id", "name", "parent", "has_children", "validation_status", "org_unit_type_id"]
+        fields = ["id", "name", "validation_status", "has_children"]


### PR DESCRIPTION
Explain what problem this PR is resolving

Related JIRA tickets : IA-2121 

The treeview was slowly loading due to 
- loading too much data (geometries were loaded, while not needed)
- a non optimal way to find out if an org unit has children 

This PR fixes this by making a new endpoint for the treeview that only fetches the exactly needed data and use simple aggregation to find if an org unit has children (instead of relying on string comparisons on the path)

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

Explain the changes that were made. The idea is not to list exhaustively all the changes made (GitHub already provides a full diff), but to help the reviewers better understand:
- which specific file changes go together, e.g: when creating a table in the front-end, there usually is a config file that goes with it
- the reasoning behind some changes, e.g: deleted files because they are now redundant
- the behaviour to expect, e.g: tooltip has purple background color because the client likes it so, changed a key in the API response to be consistent with other endpoints

## How to test

Explain how to test your PR.
If a specific config is required explain it here (dataset, account, profile, ...)

## Print screen / video

Upload here print screens or videos showing the changes

## Notes

Things that the reviewers should know: known bugs that are out of the scope of the PR, other trade-offs that were made.
If the PR depends on a PR in bluesquare-components, or merges into another PR (i.o. main), it should also be mentioned here
