### PR TITLE
IA-2115: Org uit details fi to bounds

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/forms/components/OrgUnitTypeFilterComponent.js
+++ b/hat/assets/js/apps/Iaso/domains/forms/components/OrgUnitTypeFilterComponent.js
@@ -43,7 +43,6 @@ const OrgUnitTypeFilterComponent = props => {
     const {
         orgUnitTypesSelected,
         setOrgUnitTypesSelected,
-        fitToBounds,
         orgUnitTypes,
         currentOrgUnit,
     } = props;
@@ -78,7 +77,6 @@ const OrgUnitTypeFilterComponent = props => {
     const hanldeOnChange = selection => {
         if (!selection) {
             setOrgUnitTypesSelected([]);
-            fitToBounds();
         } else {
             updateOrgUnitTypesSelected(selection);
         }
@@ -149,7 +147,6 @@ OrgUnitTypeFilterComponent.propTypes = {
     orgUnitTypes: PropTypes.array,
     orgUnitTypesSelected: PropTypes.array,
     setOrgUnitTypesSelected: PropTypes.func.isRequired,
-    fitToBounds: PropTypes.func.isRequired,
     currentOrgUnit: PropTypes.object.isRequired,
 };
 

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/SourcesFilterComponent.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/SourcesFilterComponent.js
@@ -13,7 +13,6 @@ import { getSourcesWithoutCurrentSource } from '../utils';
 import MESSAGES from '../../forms/messages';
 
 const SourcesFilterComponent = ({
-    fitToBounds,
     sourcesSelected,
     setSourcesSelected,
     currentSources,
@@ -52,7 +51,6 @@ const SourcesFilterComponent = ({
             setIsLoading(false);
             setSourcesSelected(fullSources || []);
         }
-        fitToBounds();
     };
     return (
         <Box m={4}>
@@ -87,7 +85,6 @@ SourcesFilterComponent.defaultProps = {
 };
 
 SourcesFilterComponent.propTypes = {
-    fitToBounds: PropTypes.func.isRequired,
     sourcesSelected: PropTypes.array.isRequired,
     setSourcesSelected: PropTypes.func.isRequired,
     currentSources: PropTypes.array.isRequired,

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/orgUnitMap/OrgUnitMap/OrgUnitMap.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/orgUnitMap/OrgUnitMap/OrgUnitMap.tsx
@@ -99,6 +99,7 @@ export const OrgUnitMap: FunctionComponent<Props> = ({
     const didLocationInitialize = useRef(false);
     const didCatchmentInitialize = useRef(false);
     const [isCreatingMarker, setIsCreatingMarker] = useState<boolean>(false);
+    const [isMapFitted, setIsMapFitted] = useState<boolean>(false);
     // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
     const [state, setStateField, _, setState] = useFormState(
         initialState(currentUser),
@@ -109,7 +110,7 @@ export const OrgUnitMap: FunctionComponent<Props> = ({
         fetchInstanceDetail,
         fetchSubOrgUnitDetail,
     } = useRedux();
-
+    // console.log('state', state);
     const setAncestor = useCallback(() => {
         const ancestor = getAncestorWithGeojson(currentOrgUnit);
         if (ancestor) {
@@ -145,10 +146,6 @@ export const OrgUnitMap: FunctionComponent<Props> = ({
             padding,
             currentTile,
             orgUnit: currentOrgUnit,
-            orgUnitTypesSelected: state.orgUnitTypesSelected.value,
-            sourcesSelected,
-            formsSelected: state.formsSelected.value,
-            editLocationEnabled: state.location.value.edit,
             locationGroup: state.locationGroup.value,
             catchmentGroup: state.catchmentGroup.value,
             map: map.current.leafletElement,
@@ -157,13 +154,9 @@ export const OrgUnitMap: FunctionComponent<Props> = ({
     }, [
         currentTile,
         currentOrgUnit,
-        state.orgUnitTypesSelected.value,
-        state.formsSelected.value,
-        state.location.value.edit,
         state.locationGroup.value,
         state.catchmentGroup.value,
         state.ancestorWithGeoJson.value,
-        sourcesSelected,
     ]);
 
     const toggleEditShape = useCallback(
@@ -371,12 +364,20 @@ export const OrgUnitMap: FunctionComponent<Props> = ({
         }
     });
 
-    useSkipEffectOnMount(() => {
-        fitToBounds();
+    useEffect(() => {
+        if (
+            ((currentOrgUnit && !currentOrgUnit.parent) ||
+                (currentOrgUnit.parent && state.ancestorWithGeoJson.value)) &&
+            !isMapFitted
+        ) {
+            fitToBounds();
+            setIsMapFitted(true);
+        }
     }, [
-        sourcesSelected,
-        state.orgUnitTypesSelected.value,
-        state.formsSelected.value,
+        currentOrgUnit,
+        state.ancestorWithGeoJson.value,
+        fitToBounds,
+        isMapFitted,
     ]);
 
     useSkipEffectOnMount(() => {
@@ -425,14 +426,12 @@ export const OrgUnitMap: FunctionComponent<Props> = ({
                             loadingSelectedSources={loadingSelectedSources}
                             currentOrgUnit={currentOrgUnit}
                             currentSources={sources}
-                            fitToBounds={fitToBounds}
                             sourcesSelected={sourcesSelected}
                             setSourcesSelected={setSourcesSelected}
                         />
                         <OrgUnitTypeFilterComponent
                             currentOrgUnit={currentOrgUnit}
                             orgUnitTypes={orgUnitTypes}
-                            fitToBounds={fitToBounds}
                             orgUnitTypesSelected={
                                 state.orgUnitTypesSelected.value
                             }

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/orgUnitMap/fitToBounds.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/orgUnitMap/fitToBounds.js
@@ -36,7 +36,7 @@ const fitToBounds = ({
             }
             bounds = otherBounds.extend(bounds);
             map.fitBounds(bounds, {
-                maxZoom: 10,
+                maxZoom: currentTile.maxZoom,
                 padding,
                 animate: false,
             });

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/orgUnitMap/fitToBounds.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/orgUnitMap/fitToBounds.js
@@ -1,27 +1,15 @@
 import L from 'leaflet';
-import { mapOrgUnitByLocation } from '../../../../utils/mapUtils';
 
 const fitToBounds = ({
     padding,
     currentTile,
     orgUnit,
-    orgUnitTypesSelected,
-    sourcesSelected,
-    formsSelected,
-    editLocationEnabled,
     locationGroup,
     catchmentGroup,
     map,
     ancestorWithGeoJson,
 }) => {
     if (map) {
-        const mappedOrgUnitTypesSelected = mapOrgUnitByLocation(
-            orgUnitTypesSelected || [],
-        );
-        const mappedSourcesSelected = mapOrgUnitByLocation(
-            sourcesSelected || [],
-        );
-
         const groups = [];
         const locations = [];
         let shapesBounds;
@@ -29,40 +17,7 @@ const fitToBounds = ({
             const tempBounds = L.geoJSON(ancestorWithGeoJson.geo_json);
             shapesBounds = tempBounds.getBounds();
         }
-        mappedOrgUnitTypesSelected.forEach(ot => {
-            ot.orgUnits.locations.forEach(o => {
-                locations.push(L.latLng(o.latitude, o.longitude));
-            });
-            ot.orgUnits.shapes.forEach(o => {
-                const tempBounds = L.geoJSON(o.geo_json);
-                if (shapesBounds) {
-                    shapesBounds = shapesBounds.extend(tempBounds.getBounds());
-                } else {
-                    shapesBounds = tempBounds.getBounds();
-                }
-            });
-        });
 
-        mappedSourcesSelected.forEach(s => {
-            s.orgUnits.locations.forEach(o => {
-                locations.push(L.latLng(o.latitude, o.longitude));
-            });
-            s.orgUnits.shapes.forEach(o => {
-                const tempBounds = L.geoJSON(o.geo_json);
-                if (shapesBounds) {
-                    shapesBounds = shapesBounds.extend(tempBounds.getBounds());
-                } else {
-                    shapesBounds = tempBounds.getBounds();
-                }
-            });
-        });
-        if (!editLocationEnabled && formsSelected) {
-            formsSelected.forEach(f => {
-                f.instances.forEach(i => {
-                    locations.push(L.latLng(i.latitude, i.longitude));
-                });
-            });
-        }
         const locationsBounds = L.latLngBounds(locations);
         const otherBounds = locationsBounds.extend(shapesBounds);
         if (orgUnit.geo_json) {


### PR DESCRIPTION
Fi to bounds feature on this page was not working well.

It was using, forms, org unit types and sources value to try to fit on the map, but those value where always empty (need leaflet upgrade or `useRef`)

Now the map should only fit once while you have a current org unit and / or a parent with a shape or a point

Related JIRA tickets : IA-2115

 

https://user-images.githubusercontent.com/12494624/235629563-d43cb58f-7c9f-4823-a7a3-505c4534a1ff.mp4



## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- remove fit to bounds from sources and org unit types
- remove forms, sources and org unit types form fi to bounds computation, was not working at all
- local state to fit only once when current org unit and parent shapes or point are loaded

## How to test

- create an org unit with a parent (having a shape)
-  zoom a bit on the map
-  add a location marker and save
- the map should not zoom automatically to the first point

## Print screen / video


Uploading Screen Recording 2023-05-02 at 11.26.33.mov…




