### PR TITLE
IA-2123 filter org unit status registry

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/registry/components/Instances.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/Instances.tsx
@@ -61,7 +61,7 @@ export const Instances: FunctionComponent<Props> = ({
 
     const { data: formsList, isFetching: isFetchingForms } = useGetForms();
 
-    const { url: apiUrl } = useGetInstanceApi(params, currentType?.id);
+    const { url: apiUrl } = useGetInstanceApi(params, currentType?.id, 'VALID');
     const { data, isFetching: isFetchingList } = useGetInstances(
         params,
         currentType?.id,

--- a/hat/assets/js/apps/Iaso/domains/registry/hooks/useGetInstances.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/hooks/useGetInstances.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 import { UseQueryResult } from 'react-query';
 // @ts-ignore
 import { getSort } from 'bluesquare-components';
@@ -19,6 +20,7 @@ type ApiParams = {
     page: string;
     showDeleted: false;
     orgUnitParentId: string;
+    org_unit_status?: 'VALID' | 'NEW' | 'REJECTED';
 };
 
 type InstanceApi = {
@@ -29,6 +31,7 @@ type InstanceApi = {
 export const useGetInstanceApi = (
     params: RegistryDetailParams,
     orgUnitTypeId?: number,
+    orgUnitStatus?: 'VALID' | 'NEW' | 'REJECTED',
 ): InstanceApi => {
     const apiParams: ApiParams = {
         orgUnitTypeId,
@@ -38,6 +41,7 @@ export const useGetInstanceApi = (
         page: params.page || '1',
         showDeleted: false,
         orgUnitParentId: params.orgUnitId,
+        org_unit_status: orgUnitStatus,
     };
     const url = makeUrlWithParams(
         '/api/instances/',
@@ -53,7 +57,11 @@ export const useGetInstances = (
     params: RegistryDetailParams,
     orgUnitTypeId?: number,
 ): UseQueryResult<PaginatedInstances, Error> => {
-    const { apiParams, url } = useGetInstanceApi(params, orgUnitTypeId);
+    const { apiParams, url } = useGetInstanceApi(
+        params,
+        orgUnitTypeId,
+        'VALID',
+    );
     return useSnackQuery({
         queryKey: ['registry-instances', apiParams],
         queryFn: () => getRequest(url),

--- a/iaso/api/instances.py
+++ b/iaso/api/instances.py
@@ -298,6 +298,7 @@ class InstancesViewSet(viewsets.ViewSet):
         csv_format = request.GET.get("csv", None)
         xlsx_format = request.GET.get("xlsx", None)
         filters = parse_instance_filters(request.GET)
+        org_unit_status = request.GET.get("org_unit_status", None)  # "NEW", "VALID", "REJECTED"
 
         file_export = False
         if csv_format is not None or xlsx_format is not None:
@@ -323,6 +324,9 @@ class InstancesViewSet(viewsets.ViewSet):
         #       exports, paginated or not, as small dict or not)
         #  - 2) the limit and asSmallDict parameters are independent from each other (the consumer can choose to use
         #       one, both or None and get predictable results)
+        if org_unit_status:
+            queryset = queryset.filter(org_unit__validation_status=org_unit_status)
+
         if not file_export:
             if limit:
                 limit = int(limit)

--- a/iaso/tests/api/test_instances.py
+++ b/iaso/tests/api/test_instances.py
@@ -42,16 +42,27 @@ class InstancesAPITestCase(APITestCase):
         cls.jedi_council = m.OrgUnitType.objects.create(name="Jedi Council", short_name="Cnc")
 
         cls.jedi_council_corruscant = m.OrgUnit.objects.create(
-            name="Coruscant Jedi Council", source_ref="jedi_council_corruscant_ref", version=sw_version
+            name="Coruscant Jedi Council",
+            source_ref="jedi_council_corruscant_ref",
+            version=sw_version,
+            validation_status="VALID",
         )
         cls.ou_top_1 = m.OrgUnit.objects.create(
-            name="ou_top_1", source_ref="jedi_council_corruscant_ref", version=sw_version
+            name="ou_top_1",
+            source_ref="jedi_council_corruscant_ref",
+            version=sw_version,
         )
         cls.ou_top_2 = m.OrgUnit.objects.create(
-            name="ou_top_2", source_ref="jedi_council_corruscant_ref", parent=cls.ou_top_1, version=sw_version
+            name="ou_top_2",
+            source_ref="jedi_council_corruscant_ref",
+            parent=cls.ou_top_1,
+            version=sw_version,
         )
         cls.ou_top_3 = m.OrgUnit.objects.create(
-            name="ou_top_3", source_ref="jedi_council_corruscant_ref", parent=cls.ou_top_2, version=sw_version
+            name="ou_top_3",
+            source_ref="jedi_council_corruscant_ref",
+            parent=cls.ou_top_2,
+            version=sw_version,
         )
         cls.jedi_council_endor = m.OrgUnit.objects.create(
             name="Endor Jedi Council", source_ref="jedi_council_endor_ref"
@@ -431,6 +442,21 @@ class InstancesAPITestCase(APITestCase):
         self.assertJSONResponse(response, 200)
 
         self.assertValidInstanceListData(response.json(), 4)
+
+    def test_instance_filter_by_org_unit_status(self):
+        """GET /instances/?org_unit_status={status}"""
+
+        self.client.force_authenticate(self.yoda)
+
+        response = self.client.get(f"/api/instances/?org_unit_status=VALID")
+        self.assertJSONResponse(response, 200)
+
+        self.assertValidInstanceListData(response.json(), 6)
+
+        response = self.client.get(f"/api/instances/?org_unit_status=REJECTED")
+        self.assertJSONResponse(response, 200)
+
+        self.assertValidInstanceListData(response.json(), 0)
 
     def test_instance_list_by_form_id_ok_soft_deleted(self):
         """GET /instances/?form_id=form_id"""


### PR DESCRIPTION
List view in registry wasn't filtering by org unit status

Related JIRA tickets : IA-2123

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [X] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [X] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- Add filter on org unit status in instances api backend (+test)
- Add param in front-end query. this will also impact csv and xlsx exports.

## How to test

Go to registry
Choose an org unit
In the submissions' table, select an org unit and change its status to "NEW" or "REJECTED"
Go back to registry: the submissions for the org unit you just changed shouldn't appear

## Print screen / video


https://user-images.githubusercontent.com/38907762/235680847-b26aeed2-a814-4c76-81b8-99b3e02b0e26.mov




