### PR TITLE
IA-2012: Form parsing issue

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/instances/utils/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/utils/index.tsx
@@ -82,20 +82,22 @@ const localizeLabel = (field: Field): string => {
     let localeOptions: Record<string, string> = { [localeKey]: field.name };
     if (typeof field === 'object') {
         if (typeof field.label === 'string') {
-            const singleToDoubleQuotes: string = (field.label || '').replaceAll(
-                "'",
-                '"',
+            // Replacing all single quotes used as apostrophe into html entities, and put it back after replacing other single quotes into double quotes
+            const apostrophe = /(?<=[\p{Letter}])'(?=[\p{Letter}])/gu;
+            let label: string = (field.label || '').replaceAll(
+                apostrophe,
+                '&apos;',
             );
-            const wrongDoubleQuotes = /(?:[a-zA-Z])"(?=[a-zA-Z])/g;
-            const formattedLabel: string = singleToDoubleQuotes.replace(
-                wrongDoubleQuotes,
-                "'",
-            );
+            label = label.replaceAll("'", '"');
+            label = label.replaceAll('&apos;', "'");
+            const wrongDoubleQuotes = /(?<=[\p{Letter}])"(?=[\p{Letter}])/gu;
+            label = label.replace(wrongDoubleQuotes, "'");
+
             try {
-                localeOptions = JSON.parse(formattedLabel);
+                localeOptions = JSON.parse(label);
             } catch (e) {
                 // some fields are using single quotes. Logging just for info, this can be deleted if it clutters the console
-                console.warn('Error parsing JSON', formattedLabel, e);
+                console.warn('Error parsing JSON', label, e);
                 return field.name;
             }
         } else if (


### PR DESCRIPTION
While using this form, i have a warning while looking the detail of a submission.

<img width="632" alt="Screenshot 2023-03-27 at 16 08 02" src="https://user-images.githubusercontent.com/12494624/235898166-a572b3db-37ad-4fbf-9f8d-6e1ade87127f.png">

[microplan_localite_2022112301 (3).xlsx](https://github.com/BLSQ/iaso/files/11405392/microplan_localite_2022112301.3.xlsx)

This was due to the `localizeLabel` function that was replacing all single quote into double quote, ignoring single quotes used as punctuation.

Related JIRA tickets : IA-2012

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

Replace single quote in words by html entities to avoid parsing issue

## How to test

Create a form with the XLS file and open submissions page for this form, even without submission.
Make sure Iaso is in french
You should not have a warning in the console.
Open column selection, you should see translation for `nombre_ecole_maternel_publique` 
