### PR TITLE
IA-1598: org unit search validation status

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitsFilters.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitsFilters.tsx
@@ -321,6 +321,7 @@ export const OrgUnitFilters: FunctionComponent<Props> = ({
                 />
                 <InputComponent
                     type="select"
+                    clearable={false}
                     keyValue="validation_status"
                     onChange={handleChange}
                     value={filters?.validation_status}


### PR DESCRIPTION
In the OU list, choose for a given validation status (such as new, or validated)

Run the search

Click on the X to erase the term searched for in the validation status window

Run the search again

Result: empty search result

Expected result: validation status should be considered as ‘All’ by default as is the case for other search windows.

Actually All should probably not even be in the list.
Related JIRA tickets : IA-1598

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

Following Martin remarks, i'm leaving it like that, but i removed the clearable option on the status dropdown to avoid inconsistent search


## How to test

search an org unit, you should not be able to remove a status in the dropdown

## Print screen / video


https://user-images.githubusercontent.com/12494624/235914817-6de98333-b8ce-4d87-91b7-39b0494c844e.mov

