### PR TITLE
WC2-214 Fix for failing azure pipeline deployment for WFP

### DIFF
--- a/docker/bundle/Dockerfile
+++ b/docker/bundle/Dockerfile
@@ -2,7 +2,7 @@
 # Then transfert it in the filan django image
 ############ NPM Builder ######################################################################
 
-FROM node:14.19.1-stretch-slim as npmbuilder
+FROM node:14-bullseye-slim as npmbuilder
 ENV PROJECT_ROOT /opt
 
 WORKDIR /opt/app


### PR DESCRIPTION
The deployment to WFP servers was failing due to an error when Building the docker image about the debian "stretch" release not existing in debian repos.

After investigation we found out that this version is officially unsupported by debian and has been moved to archive.debian.org

We update the "bundle" Dockerfile to use the newer debian version as base for nodejs.

Related JIRA tickets : WC2-214


## Changes

Switch to `node:14-bullseye-slim` as the base for the Node docker image.

## How to test

This was already tested in the azure pipeline of WFP directly via the develop branch and it's working

<img width="822" alt="Screenshot 2023-05-04 at 10 13 25" src="https://user-images.githubusercontent.com/383344/236148897-8cc1efc1-da6d-47bc-9850-68533bf011d5.png">

We are re-integrating those changes in main via this PR.
