### PR TITLE
IA-2137 IA-2138 completeness stats status filter backend &  default to new

### DIFF
--- a/iaso/api/completeness_stats.py
+++ b/iaso/api/completeness_stats.py
@@ -164,7 +164,7 @@ class ParamSerializer(serializers.Serializer):
     )
 
     org_unit_validation_status = serializers.CharField(
-        default="NEW,VALID",
+        default="VALID",
         help_text="Filter org unit on theses validation status"
         " (both for returned orgunit and count), can specify multiple status, separated by a ','",
     )

--- a/iaso/api/completeness_stats.py
+++ b/iaso/api/completeness_stats.py
@@ -91,6 +91,7 @@ class Params(TypedDict):
     order: List[str]
     org_unit_group: Optional[Group]
     without_submissions: bool
+    org_unit_validation_status: List[str]
 
 
 class PrimaryKeysRelatedField(serializers.ManyRelatedField):
@@ -162,6 +163,19 @@ class ParamSerializer(serializers.Serializer):
         help_text="Filter the orgunit used for count on this group",
     )
 
+    org_unit_validation_status = serializers.CharField(
+        default="NEW,VALID",
+        help_text="Filter org unit on theses validation status"
+        " (both for returned orgunit and count), can specify multiple status, separated by a ','",
+    )
+
+    def validate_org_unit_validation_status(self, statuses):
+        statuses = statuses.split(",")
+        for status in statuses:
+            if status not in (OrgUnit.VALIDATION_VALID, OrgUnit.VALIDATION_NEW, OrgUnit.VALIDATION_REJECTED):
+                raise serializers.ValidationError("Invalid status")
+        return statuses
+
     def validate_order(self, order):
         return order.split(",")
 
@@ -205,6 +219,7 @@ class CompletenessStatsV2ViewSet(viewsets.ViewSet):
         form_qs = params["forms"]
         period = params.get("period", None)
         planning = params.get("planning", None)
+        org_unit_validation_status = params["org_unit_validation_status"]
 
         instance_qs = Instance.objects.all()
         if period:
@@ -219,9 +234,7 @@ class CompletenessStatsV2ViewSet(viewsets.ViewSet):
         profile = request.user.iaso_profile  # type: ignore
 
         org_units: OrgUnitQuerySet
-        org_units = OrgUnit.objects.filter(
-            validation_status__in=(OrgUnit.VALIDATION_NEW, OrgUnit.VALIDATION_VALID)
-        )  # type: ignore
+        org_units = OrgUnit.objects.filter(validation_status__in=org_unit_validation_status)  # type: ignore
         # Calculate the ou for which we want reporting `top_ous`
         #  We only want ou to which user has access
         #   if no params we return the top ou for the default source
@@ -265,10 +278,9 @@ class CompletenessStatsV2ViewSet(viewsets.ViewSet):
         # End calculation of top ous
         top_ous = top_ous.prefetch_related("org_unit_type", "parent")
 
+        # Orgunit on which we count the Submissions
         orgunit_qs: OrgUnitQuerySet
-        orgunit_qs = OrgUnit.objects.filter(
-            validation_status__in=(OrgUnit.VALIDATION_NEW, OrgUnit.VALIDATION_VALID)
-        )  # type: ignore
+        orgunit_qs = OrgUnit.objects.filter(validation_status__in=org_unit_validation_status)  # type: ignore
         org_unit_group = params.get("org_unit_group")
         if org_unit_group:
             orgunit_qs = orgunit_qs.filter(groups__id=org_unit_group.id)

--- a/iaso/tests/api/test_completeness_stats.py
+++ b/iaso/tests/api/test_completeness_stats.py
@@ -541,9 +541,9 @@ class CompletenessStatsAPITestCase(APITestCase):
         )
 
         j = self.assertJSONResponse(response, 200)
-        self.assertEqual(len(j["results"]), 4)
+        self.assertEqual(len(j["results"]), 3)
 
-        # should default to false so same number of result if params is not present
+        # should default to false so same number of result if par modiié leams is not present
         response = self.client.get(
             f"/api/v2/completeness_stats/",
             {
@@ -553,7 +553,7 @@ class CompletenessStatsAPITestCase(APITestCase):
         )
 
         j = self.assertJSONResponse(response, 200)
-        self.assertEqual(len(j["results"]), 4)
+        self.assertEqual(len(j["results"]), 3)
 
         # If we filter it should be two
         response = self.client.get(
@@ -566,7 +566,7 @@ class CompletenessStatsAPITestCase(APITestCase):
         )
 
         j = self.assertJSONResponse(response, 200)
-        self.assertEqual(len(j["results"]), 2)
+        self.assertEqual(len(j["results"]), 1)
         for r in j["results"]:
             # check that the result have effectly zero submission
             ou = r["org_unit"]["id"]

--- a/iaso/tests/api/test_completeness_stats.py
+++ b/iaso/tests/api/test_completeness_stats.py
@@ -163,7 +163,7 @@ class CompletenessStatsAPITestCase(APITestCase):
     def test_base_row_listing(self):
         self.client.force_authenticate(self.user)
 
-        response = self.client.get("/api/v2/completeness_stats/")
+        response = self.client.get("/api/v2/completeness_stats/", {"org_unit_validation_status": "VALID,NEW"})
         j = self.assertJSONResponse(response, 200)
         expected_result = {
             "forms": [
@@ -372,20 +372,25 @@ class CompletenessStatsAPITestCase(APITestCase):
         self.client.force_authenticate(self.user)
 
         response_with_filter = self.client.get(
-            f"/api/v2/completeness_stats/?org_unit_type_id={self.org_unit_type_country.id}"
+            f"/api/v2/completeness_stats/?org_unit_type_id={self.org_unit_type_country.id}",
+            {"org_unit_validation_status": "VALID,NEW"},
         )
 
         json = self.assertJSONResponse(response_with_filter, 200)
         results_with_filter = json["results"]
         self.assertEqual(len(results_with_filter), 2)
-        response_without_filter = self.client.get(f"/api/v2/completeness_stats/")
+        response_without_filter = self.client.get(
+            f"/api/v2/completeness_stats/", {"org_unit_validation_status": "VALID,NEW"}
+        )
         results_without_filter = self.assertJSONResponse(response_without_filter, 200)["results"]
         self.assertListEqual(results_with_filter, results_without_filter)
 
     def test_filter_by_parent_org_unit(self):
         self.client.force_authenticate(self.user)
 
-        response = self.client.get(f"/api/v2/completeness_stats/?parent_org_unit_id=1")
+        response = self.client.get(
+            f"/api/v2/completeness_stats/?parent_org_unit_id=1&org_unit_validation_status=VALID,NEW"
+        )
         json = response.json()
         # All the rows we get are direct children of the Country (region A and B)
         self.assertEqual(len(json["results"]), 3)
@@ -399,7 +404,7 @@ class CompletenessStatsAPITestCase(APITestCase):
     def test_pagination(self):
         self.client.force_authenticate(self.user)
 
-        response = self.client.get("/api/v2/completeness_stats/?page=1&limit=1")
+        response = self.client.get("/api/v2/completeness_stats/?page=1&limit=1&org_unit_validation_status=VALID,NEW")
         j = self.assertJSONResponse(response, 200)
         self.assertEqual(j["count"], 2)
         self.assertEqual(j["page"], 1)
@@ -413,14 +418,14 @@ class CompletenessStatsAPITestCase(APITestCase):
         """Test that the default limit parameter is 10"""
         self.client.force_authenticate(self.user)
 
-        response = self.client.get("/api/v2/completeness_stats/")
+        response = self.client.get("/api/v2/completeness_stats/", {"org_unit_validation_status": "VALID,NEW"})
         json = self.assertJSONResponse(response, 200)
         self.assertEqual(json["limit"], 10)
 
     def test_row_count(self):
         self.client.force_authenticate(self.user)
 
-        response = self.client.get(f"/api/v2/completeness_stats/")
+        response = self.client.get(f"/api/v2/completeness_stats/", {"org_unit_validation_status": "VALID,NEW"})
         json = response.json()
         # Two OU, 3 forms => 2 rows
         self.assertEqual(len(json["results"]), 2)
@@ -446,7 +451,9 @@ class CompletenessStatsAPITestCase(APITestCase):
         self.client.force_authenticate(self.user)
 
         # We filter to get only the district A.A
-        response = self.client.get(f"/api/v2/completeness_stats/?parent_org_unit_id=4")
+        response = self.client.get(
+            f"/api/v2/completeness_stats/?parent_org_unit_id=4", {"org_unit_validation_status": "VALID,NEW"}
+        )
         j = self.assertJSONResponse(response, 200)
         self.assertEqual(len(j["results"]), 2)
 
@@ -459,7 +466,11 @@ class CompletenessStatsAPITestCase(APITestCase):
         self.as_abb_ou.save()
         response = self.client.get(
             f"/api/v2/completeness_stats/",
-            {"parent_org_unit_id": self.as_abb_ou.parent.id, "form_id": self.form_hs_4.id},
+            {
+                "parent_org_unit_id": self.as_abb_ou.parent.id,
+                "form_id": self.form_hs_4.id,
+                "org_unit_validation_status": "VALID,NEW",
+            },
         )
 
         j = self.assertJSONResponse(response, 200)
@@ -488,7 +499,11 @@ class CompletenessStatsAPITestCase(APITestCase):
 
         response = self.client.get(
             f"/api/v2/completeness_stats/",
-            {"parent_org_unit_id": self.as_abb_ou.parent.id, "form_id": self.form_hs_4.id},
+            {
+                "parent_org_unit_id": self.as_abb_ou.parent.id,
+                "form_id": self.form_hs_4.id,
+                "org_unit_validation_status": "VALID,NEW",
+            },
         )
 
         j = self.assertJSONResponse(response, 200)


### PR DESCRIPTION
IA-2138 Status filter default to VALID
IA-2137 Completeness stats add a parameter in backend to filter on orgunit status


## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are my typescript files well typed
- [x] New translations have been added or updated if new strings have been introduced in the frontend
- [x] My migrations file are included
- [x] Are there enough tests
- [x] Documentation has been included (for new feature)

## Changes

Add a parameter org_unit_validation_status on `/api/v2/completeness_stats/`

## How to test
For the default you can check by switching a OU status
For the parametr no UI yet.

