### PR TITLE
IA-2141: missing submissions is wrong

### DIFF
--- a/hat/assets/js/apps/Iaso/constants/routes.js
+++ b/hat/assets/js/apps/Iaso/constants/routes.js
@@ -477,6 +477,7 @@ export const registryDetailPath = {
         },
         ...paginationPathParams,
         ...paginationPathParamsWithPrefix('orgUnitList'),
+        ...paginationPathParamsWithPrefix('missingSubmissions'),
     ],
 };
 

--- a/hat/assets/js/apps/Iaso/domains/instances/hooks/requests/useDeleteInstance.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/hooks/requests/useDeleteInstance.tsx
@@ -7,10 +7,14 @@ const deleteInstance = async (instanceId: string): Promise<any> => {
 };
 export const useDeleteInstance = (
     invalidateQueryKey = 'instance',
+    onSuccess: () => void,
 ): UseMutationResult =>
     useSnackMutation({
         mutationFn: deleteInstance,
         invalidateQueryKey,
+        options: {
+            onSuccess: onSuccess || (() => undefined),
+        },
     });
 
 const restoreInstance = async (instanceId: string): Promise<any> =>

--- a/hat/assets/js/apps/Iaso/domains/instances/hooks/requests/useDeleteInstance.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/hooks/requests/useDeleteInstance.tsx
@@ -7,13 +7,13 @@ const deleteInstance = async (instanceId: string): Promise<any> => {
 };
 export const useDeleteInstance = (
     invalidateQueryKey = 'instance',
-    onSuccess: () => void,
+    onSuccess: () => void = () => undefined,
 ): UseMutationResult =>
     useSnackMutation({
         mutationFn: deleteInstance,
         invalidateQueryKey,
         options: {
-            onSuccess: onSuccess || (() => undefined),
+            onSuccess,
         },
     });
 

--- a/hat/assets/js/apps/Iaso/domains/registry/components/ActionCell.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/ActionCell.tsx
@@ -1,4 +1,5 @@
 import React, { FunctionComponent } from 'react';
+import { useQueryClient } from 'react-query';
 import { IconButton as IconButtonComponent } from 'bluesquare-components';
 
 import MESSAGES from '../messages';
@@ -19,12 +20,19 @@ type Props = {
 
 export const ActionCell: FunctionComponent<Props> = ({ settings }) => {
     const user = useCurrentUser();
+
+    const queryClient = useQueryClient();
     const getEnketoUrl = useGetEnketoUrl(
         window.location.href,
         settings.row.original,
     );
-    const { mutate: softDeleteInstance } =
-        useDeleteInstance('registry-instances');
+    const onSuccess = () => {
+        queryClient.invalidateQueries('registry-orgunits-without-instances');
+    };
+    const { mutate: softDeleteInstance } = useDeleteInstance(
+        'registry-instances',
+        onSuccess,
+    );
     return (
         <section>
             <LinkToInstance instanceId={settings.row.original.id} useIcon />

--- a/hat/assets/js/apps/Iaso/domains/registry/components/Instances.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/Instances.tsx
@@ -21,7 +21,6 @@ import { OrgunitTypeRegistry } from '../types/orgunitTypes';
 import { RegistryDetailParams } from '../types';
 import { Column } from '../../../types/table';
 import { Form } from '../../forms/types/forms';
-import { OrgUnit } from '../../orgUnits/types/orgUnit';
 
 import { useGetForms } from '../hooks/useGetForms';
 import { useGetInstanceApi, useGetInstances } from '../hooks/useGetInstances';
@@ -31,6 +30,7 @@ import { baseUrls } from '../../../constants/urls';
 import { defaultSorted, INSTANCE_METAS_FIELDS } from '../config';
 import { userHasPermission } from '../../users/utils';
 import { useCurrentUser } from '../../../utils/usersUtils';
+import { useGetEmptyInstanceOrgUnits } from '../hooks/useGetEmptyInstanceOrgUnits';
 
 type Props = {
     isLoading: boolean;
@@ -66,18 +66,12 @@ export const Instances: FunctionComponent<Props> = ({
         params,
         currentType?.id,
     );
-    const OrgUnitsWithoutCurrentForm: OrgUnit[] = useMemo(
-        () =>
-            (data &&
-                currentType?.orgUnits.filter(
-                    orgUnit =>
-                        !data.instances.find(
-                            instance => instance.org_unit.id === orgUnit.id,
-                        ),
-                )) ||
-            [],
-        [currentType?.orgUnits, data],
+
+    const { data: orgUnitsWithoutCurrentForm } = useGetEmptyInstanceOrgUnits(
+        params,
+        currentType?.id,
     );
+
     const handleFilterChange = useCallback(
         (key: string, value: number | string) => {
             dispatch(
@@ -186,7 +180,8 @@ export const Instances: FunctionComponent<Props> = ({
                                     width="100%"
                                     mt={2}
                                 >
-                                    {OrgUnitsWithoutCurrentForm.length > 0 &&
+                                    {orgUnitsWithoutCurrentForm &&
+                                        orgUnitsWithoutCurrentForm.count > 0 &&
                                         userHasPermission(
                                             'iaso_update_submission',
                                             currentUser,
@@ -194,12 +189,11 @@ export const Instances: FunctionComponent<Props> = ({
                                             <MissingInstanceDialog
                                                 formId={formIds}
                                                 missingOrgUnits={
-                                                    OrgUnitsWithoutCurrentForm
+                                                    orgUnitsWithoutCurrentForm.results
                                                 }
                                                 params={params}
                                                 iconProps={{
-                                                    missingOrgUnits:
-                                                        OrgUnitsWithoutCurrentForm,
+                                                    count: orgUnitsWithoutCurrentForm.count,
                                                     params,
                                                 }}
                                                 defaultOpen={

--- a/hat/assets/js/apps/Iaso/domains/registry/components/Instances.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/Instances.tsx
@@ -67,10 +67,10 @@ export const Instances: FunctionComponent<Props> = ({
         currentType?.id,
     );
 
-    const { data: orgUnitsWithoutCurrentForm } = useGetEmptyInstanceOrgUnits(
-        params,
-        currentType?.id,
-    );
+    const {
+        data: orgUnitsWithoutCurrentForm,
+        isFetching: isFetchingOrgUnitsWithoutCurrentForm,
+    } = useGetEmptyInstanceOrgUnits(params, currentType?.id);
 
     const handleFilterChange = useCallback(
         (key: string, value: number | string) => {
@@ -187,9 +187,12 @@ export const Instances: FunctionComponent<Props> = ({
                                             currentUser,
                                         ) && (
                                             <MissingInstanceDialog
+                                                isFetching={
+                                                    isFetchingOrgUnitsWithoutCurrentForm
+                                                }
                                                 formId={formIds}
-                                                missingOrgUnits={
-                                                    orgUnitsWithoutCurrentForm.results
+                                                missingOrgUnitsData={
+                                                    orgUnitsWithoutCurrentForm
                                                 }
                                                 params={params}
                                                 iconProps={{

--- a/hat/assets/js/apps/Iaso/domains/registry/components/MissingInstanceButton.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/MissingInstanceButton.tsx
@@ -4,7 +4,6 @@ import { useSafeIntl } from 'bluesquare-components';
 import { Button, Tooltip, makeStyles } from '@material-ui/core';
 import VisibilityIcon from '@material-ui/icons/Visibility';
 
-import { OrgUnit } from '../../orgUnits/types/orgUnit';
 import { RegistryDetailParams } from '../types';
 
 import MESSAGES from '../messages';
@@ -13,7 +12,7 @@ import { redirectToReplace } from '../../../routing/actions';
 
 type Props = {
     params: RegistryDetailParams;
-    missingOrgUnits: OrgUnit[];
+    count: number;
     onClick: () => void;
 };
 const useStyles = makeStyles(theme => ({
@@ -38,7 +37,7 @@ const useStyles = makeStyles(theme => ({
 }));
 
 export const MissingInstanceButton: FunctionComponent<Props> = ({
-    missingOrgUnits,
+    count,
     onClick,
     params,
 }) => {
@@ -58,7 +57,7 @@ export const MissingInstanceButton: FunctionComponent<Props> = ({
         <Tooltip
             arrow
             title={formatMessage(MESSAGES.missingSubmissionCount, {
-                count: missingOrgUnits.length,
+                count,
             })}
         >
             <Button

--- a/hat/assets/js/apps/Iaso/domains/registry/components/MissingInstanceDialog.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/MissingInstanceDialog.tsx
@@ -25,14 +25,17 @@ import { redirectToReplace } from '../../../routing/actions';
 import { RegistryDetailParams } from '../types';
 import { baseUrls } from '../../../constants/urls';
 import MESSAGES from '../messages';
-import { CompletenessStats } from '../../completenessStats/types';
+import { CompletenessApiResponse } from '../../completenessStats/types';
+
+import { defaultSorted } from '../hooks/useGetEmptyInstanceOrgUnits';
 
 type Props = {
-    missingOrgUnits: CompletenessStats[];
+    missingOrgUnitsData: CompletenessApiResponse;
     isOpen: boolean;
     closeDialog: () => void;
     params: RegistryDetailParams;
     formId?: string;
+    isFetching: boolean;
 };
 const useStyles = makeStyles(theme => ({
     ...commonStyles(theme),
@@ -60,6 +63,18 @@ const useStyles = makeStyles(theme => ({
         '& .pagination-count': {
             marginRight: theme.spacing(2),
         },
+        '& .pagination-previous + div': {
+            marginLeft: theme.spacing(2),
+        },
+        '& .pagination-previous + div + div': {
+            marginRight: theme.spacing(2),
+        },
+        '& .MuiTablePagination-toolbar': {
+            padding: theme.spacing(1),
+        },
+        '& .pagination-row-select': {
+            marginLeft: theme.spacing(2),
+        },
     },
     action: {
         paddingBottom: theme.spacing(2),
@@ -68,11 +83,12 @@ const useStyles = makeStyles(theme => ({
 }));
 
 const MissingInstanceDialog: FunctionComponent<Props> = ({
-    missingOrgUnits,
+    missingOrgUnitsData,
     closeDialog,
     isOpen,
     params,
     formId,
+    isFetching,
 }) => {
     const dispatch = useDispatch();
     const classes: Record<string, string> = useStyles();
@@ -89,7 +105,7 @@ const MissingInstanceDialog: FunctionComponent<Props> = ({
     return (
         <Dialog
             fullWidth
-            maxWidth="xs"
+            maxWidth="sm"
             open={isOpen}
             classes={{
                 paper: classes.paper,
@@ -106,16 +122,15 @@ const MissingInstanceDialog: FunctionComponent<Props> = ({
                 <Table
                     marginTop={false}
                     marginBottom={false}
-                    data={missingOrgUnits}
-                    pages={0}
-                    defaultSorted={[{ id: 'name', desc: true }]}
+                    data={missingOrgUnitsData.results}
+                    pages={missingOrgUnitsData.pages}
+                    defaultSorted={defaultSorted}
                     columns={[
                         {
                             Header: formatMessage(MESSAGES.name),
                             id: 'name',
                             accessor: 'name',
                             align: 'left',
-                            sortable: false,
                         },
                         {
                             Header: formatMessage(MESSAGES.add),
@@ -141,10 +156,14 @@ const MissingInstanceDialog: FunctionComponent<Props> = ({
                             },
                         },
                     ]}
-                    count={missingOrgUnits.length}
+                    extraProps={{ loading: isFetching }}
+                    paramsPrefix="missingSubmissions"
+                    count={missingOrgUnitsData.count}
                     params={params}
-                    showPagination={false}
                     elevation={0}
+                    onTableParamsChange={p => {
+                        dispatch(redirectToReplace(baseUrls.registryDetail, p));
+                    }}
                 />
             </DialogContent>
             <DialogActions className={classes.action}>

--- a/hat/assets/js/apps/Iaso/domains/registry/components/MissingInstanceDialog.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/MissingInstanceDialog.tsx
@@ -17,8 +17,6 @@ import {
 } from 'bluesquare-components';
 import EnketoIcon from '../../instances/components/EnketoIcon';
 
-import { OrgUnit } from '../../orgUnits/types/orgUnit';
-
 import { useGetCreateInstance } from '../hooks/useGetCreateInstance';
 
 import { MissingInstanceButton } from './MissingInstanceButton';
@@ -27,9 +25,10 @@ import { redirectToReplace } from '../../../routing/actions';
 import { RegistryDetailParams } from '../types';
 import { baseUrls } from '../../../constants/urls';
 import MESSAGES from '../messages';
+import { CompletenessStats } from '../../completenessStats/types';
 
 type Props = {
-    missingOrgUnits: OrgUnit[];
+    missingOrgUnits: CompletenessStats[];
     isOpen: boolean;
     closeDialog: () => void;
     params: RegistryDetailParams;
@@ -129,7 +128,8 @@ const MissingInstanceDialog: FunctionComponent<Props> = ({
                                     <IconButton
                                         onClick={() =>
                                             creteInstance(
-                                                settings.row.original.id,
+                                                settings.row.original.org_unit
+                                                    .id,
                                             )
                                         }
                                         overrideIcon={EnketoIcon}

--- a/hat/assets/js/apps/Iaso/domains/registry/hooks/useGetEmptyInstanceOrgUnits.ts
+++ b/hat/assets/js/apps/Iaso/domains/registry/hooks/useGetEmptyInstanceOrgUnits.ts
@@ -29,9 +29,9 @@ export const useGetEmptyInstanceOrgUnits = (
     const apiParams: ApiParams = {
         org_unit_type_ids: orgUnitTypeId,
         form_id: params.formIds,
-        limit: params.pageSize || '20',
-        order: params.order || getSort(defaultSorted),
-        page: params.page || '1',
+        limit: params.missingSubmissionsPageSize || '10',
+        order: params.missingSubmissionsOrder || getSort(defaultSorted),
+        page: params.missingSubmissionsPage || '1',
         parent_org_unit_id: params.orgUnitId,
         without_submissions: true,
     };
@@ -46,6 +46,7 @@ export const useGetEmptyInstanceOrgUnits = (
             enabled: Boolean(orgUnitTypeId && params.formIds),
             staleTime: 1000 * 60 * 15, // in MS
             cacheTime: 1000 * 60 * 5,
+            keepPreviousData: true,
         },
     });
 };

--- a/hat/assets/js/apps/Iaso/domains/registry/hooks/useGetEmptyInstanceOrgUnits.ts
+++ b/hat/assets/js/apps/Iaso/domains/registry/hooks/useGetEmptyInstanceOrgUnits.ts
@@ -1,0 +1,51 @@
+/* eslint-disable camelcase */
+import { UseQueryResult } from 'react-query';
+// @ts-ignore
+import { getSort } from 'bluesquare-components';
+
+import { useSnackQuery } from '../../../libs/apiHooks';
+import { getRequest } from '../../../libs/Api';
+
+import { makeUrlWithParams } from '../../../libs/utils';
+
+import { RegistryDetailParams } from '../types';
+import { CompletenessApiResponse } from '../../completenessStats/types';
+
+type ApiParams = {
+    org_unit_type_ids?: number;
+    form_id?: string;
+    limit: string;
+    order: string;
+    page: string;
+    parent_org_unit_id: string;
+    without_submissions: boolean;
+};
+export const defaultSorted = [{ id: 'orgunit__name', desc: false }];
+
+export const useGetEmptyInstanceOrgUnits = (
+    params: RegistryDetailParams,
+    orgUnitTypeId?: number,
+): UseQueryResult<CompletenessApiResponse, Error> => {
+    const apiParams: ApiParams = {
+        org_unit_type_ids: orgUnitTypeId,
+        form_id: params.formIds,
+        limit: params.pageSize || '20',
+        order: params.order || getSort(defaultSorted),
+        page: params.page || '1',
+        parent_org_unit_id: params.orgUnitId,
+        without_submissions: true,
+    };
+    const url = makeUrlWithParams(
+        '/api/v2/completeness_stats/',
+        apiParams as Record<string, any>,
+    );
+    return useSnackQuery({
+        queryKey: ['registry-orgunits-without-instances', apiParams],
+        queryFn: () => getRequest(url),
+        options: {
+            enabled: Boolean(orgUnitTypeId && params.formIds),
+            staleTime: 1000 * 60 * 15, // in MS
+            cacheTime: 1000 * 60 * 5,
+        },
+    });
+};

--- a/hat/assets/js/apps/Iaso/domains/registry/types/index.ts
+++ b/hat/assets/js/apps/Iaso/domains/registry/types/index.ts
@@ -16,4 +16,7 @@ export type RegistryDetailParams = UrlParams & {
     missingSubmissionVisible?: 'true';
     showTooltip?: 'true';
     isFullScreen?: 'true';
+    missingSubmissionsPageSize?: string;
+    missingSubmissionsOrder?: string;
+    missingSubmissionsPage?: string;
 };

--- a/iaso/api/completeness_stats.py
+++ b/iaso/api/completeness_stats.py
@@ -205,7 +205,7 @@ class CompletenessStatsV2ViewSet(viewsets.ViewSet):
 
     permission_classes = [
         permissions.IsAuthenticated,
-        HasPermission("menupermissions.iaso_completeness_stats"),  # type: ignore
+        HasPermission("menupermissions.iaso_completeness_stats", "menupermissions.iaso_registry"),  # type: ignore
     ]  # type: ignore
 
     # @swagger_auto_schema(query_serializer=ParamSerializer())


### PR DESCRIPTION
On registry details page, missing submissions for org unit children is using a paginated result to compute missing items.

Setting `pageSize` param in the url to 1 is affecting the missing submissions count
https://iaso.bluesquare.org/dashboard/orgunits/registry/details/accountId/20/orgUnitId/1049936/formIds/740/pageSize/200/page/1

Related JIRA tickets : IA-2141

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- Use completeness api to get org unit without submission for a specific form + adding permission to completeness api for registry
- hook to get missing submissions
- pagination, order and deep-link table dialog

## How to test

- get a submission linked to an org unit
- get the parent of this org unit
- open this parent in registry
- at the bottom of the page, if you select the org unit type of your org unit, you should see your submission
- if there are more than one children for this parent org unit, and no submission of the same form, the red butotn should be visible, indicating the correct count of org units, same while clicking on it.
- Test pagination, order, refresh

## Print screen / video



https://user-images.githubusercontent.com/12494624/236815297-17e4cb15-8663-4d87-8cfd-f086911134e2.mov



