### PR TITLE
IA-2078: from completeness stats table link back to ou linked submissions

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/completenessStats/hooks/useCompletenessStatsColumns.tsx
+++ b/hat/assets/js/apps/Iaso/domains/completenessStats/hooks/useCompletenessStatsColumns.tsx
@@ -205,10 +205,7 @@ export const useCompletenessStatsColumns = (
             accessor: 'actions',
             sortable: false,
             Cell: settings => {
-                const { data: orgunit } = useGetOrgUnitDetail(
-                    settings.row.original.id,
-                );
-                const orgunitName = orgunit?.name;
+                const orgunitName = settings.row.original.org_unit.name;
                 return (
                     <>
                         {!settings.row.original.is_root && (

--- a/hat/assets/js/apps/Iaso/domains/completenessStats/hooks/useCompletenessStatsColumns.tsx
+++ b/hat/assets/js/apps/Iaso/domains/completenessStats/hooks/useCompletenessStatsColumns.tsx
@@ -204,6 +204,7 @@ export const useCompletenessStatsColumns = (
             accessor: 'actions',
             sortable: false,
             Cell: settings => {
+                const orgunitName = settings.row.original.name.toLowerCase();
                 return (
                     <>
                         {!settings.row.original.is_root && (
@@ -238,10 +239,18 @@ export const useCompletenessStatsColumns = (
                                 overrideIcon={ArrowUpward}
                             />
                         )}
+                        {settings.row.original.form_stats && (
+                            <IconButtonComponent
+                                id={`form-link-${settings.row.original.id}`}
+                                url={`/${baseUrls.instances}/accountId/${params.accountId}/page/1/tab/list/search/${orgunitName}`}
+                                icon="remove-red-eye"
+                                tooltipMessage={MESSAGES.viewInstances}
+                            />
+                        )}
                     </>
                 );
             },
         });
         return columns;
-    }, [dispatch, formatMessage, redirectionParams, completenessStats]);
+    }, [dispatch, formatMessage, redirectionParams, completenessStats, params]);
 };

--- a/hat/assets/js/apps/Iaso/domains/completenessStats/hooks/useCompletenessStatsColumns.tsx
+++ b/hat/assets/js/apps/Iaso/domains/completenessStats/hooks/useCompletenessStatsColumns.tsx
@@ -19,6 +19,7 @@ import {
     FormStatRow,
 } from '../types';
 import { Column } from '../../../types/table';
+import { useGetOrgUnitDetail } from '../../orgUnits/hooks/requests/useGetOrgUnitDetail';
 
 const baseUrl = `${baseUrls.completenessStats}`;
 
@@ -204,7 +205,10 @@ export const useCompletenessStatsColumns = (
             accessor: 'actions',
             sortable: false,
             Cell: settings => {
-                const orgunitName = settings.row.original.name.toLowerCase();
+                const { data: orgunit } = useGetOrgUnitDetail(
+                    settings.row.original.id,
+                );
+                const orgunitName = orgunit?.name;
                 return (
                     <>
                         {!settings.row.original.is_root && (

--- a/hat/assets/js/apps/Iaso/domains/completenessStats/hooks/useCompletenessStatsColumns.tsx
+++ b/hat/assets/js/apps/Iaso/domains/completenessStats/hooks/useCompletenessStatsColumns.tsx
@@ -213,14 +213,8 @@ export const useCompletenessStatsColumns = (
             Cell: settings => {
                 const formStats = settings.row.original.form_stats;
                 const orgunitId = settings.row.original.org_unit.id;
-                let hasFormSubmissions = false;
-                Object.entries(formStats).forEach(
-                    // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
-                    ([_key, value]: [string, Record<string, any>]) => {
-                        if (value.itself_has_instances > 0) {
-                            hasFormSubmissions = true;
-                        }
-                    },
+                const hasFormSubmissions = Object.values(formStats).some(
+                    stat => stat.itself_has_instances > 0,
                 );
 
                 return (

--- a/hat/assets/js/apps/Iaso/domains/completenessStats/messages.ts
+++ b/hat/assets/js/apps/Iaso/domains/completenessStats/messages.ts
@@ -78,6 +78,10 @@ const MESSAGES = defineMessages({
             'No descendant OrgUnit is expected to fill that form. Check the Form config if this is unexpected',
         id: 'iaso.completenessStats.descendantsNoSubmissionExpected',
     },
+    viewInstances: {
+        defaultMessage: 'View instances',
+        id: 'iaso.forms.viewInstances',
+    },
 });
 
 export default MESSAGES;

--- a/hat/assets/js/apps/Iaso/domains/completenessStats/types.ts
+++ b/hat/assets/js/apps/Iaso/domains/completenessStats/types.ts
@@ -41,4 +41,5 @@ export type CompletenessRouterParams = UrlParams & {
     period?: string;
     groupId?: string;
     parentId?: string;
+    accountId?: string;
 };


### PR DESCRIPTION
Add a link in actions column to access the organization unit linked submissions

Related JIRA tickets : [IA-2078](https://bluesquare.atlassian.net/browse/IA-2078?atlOrigin=eyJpIjoiZjAzYjcxZWMwZThlNDk1YjkzMzU2ODI4Y2M3NTI4NmMiLCJwIjoiaiJ9)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- add a `IconButtonComponent` in actions column to link to the organization unit linked submissions
- add message for icon
- update types

## How to test

- Go to Completeness Stats
- If there is at least one submission linked to the form, you should see the eye icon in the action column
- Make sure the link is working

## Print screen / video

https://github.com/BLSQ/iaso/assets/25134301/a46539f5-2188-454b-86e0-96c0cb622c33

[IA-2078]: https://bluesquare.atlassian.net/browse/IA-2078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ