### PR TITLE
Ia 2136 dhsi2 mappings exlude versions from deleted forms

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/mappings/components/CreateMappingVersionDialogComponent.js
+++ b/hat/assets/js/apps/Iaso/domains/mappings/components/CreateMappingVersionDialogComponent.js
@@ -148,12 +148,14 @@ const CreateMappingVersionDialogComponent = ({
                                 ? formatMessage(MESSAGES.dataset)
                                 : formatMessage(MESSAGES.program)
                         }
-                        mapOptions={options =>
-                            options.map(o => ({
-                                name: `${o.name} (${o.periodType} ${o.id})`,
-                                id: o.id,
-                            }))
-                        }
+                        mapOptions={options => {
+                            return options
+                                .filter(o => o !== undefined)
+                                .map(o => ({
+                                    name: `${o.name} (${o.periodType} ${o.id})`,
+                                    id: o.id,
+                                }));
+                        }}
                         dataSourceId={source}
                         onChange={(name, val) => {
                             setDataset(val);

--- a/hat/assets/js/apps/Iaso/domains/mappings/components/IasoSearchComponent.js
+++ b/hat/assets/js/apps/Iaso/domains/mappings/components/IasoSearchComponent.js
@@ -34,7 +34,7 @@ const IasoSearchComponent = props => {
                     fetch(
                         `/api/${resourceName}.json?search_name=${input.input}${
                             fields ? `&fields=${fields}` : ''
-                        }&hide_deleted=True`,
+                        }`,
                     )
                         .then(resp => resp.json())
                         .then(f => {

--- a/hat/assets/js/apps/Iaso/domains/mappings/components/IasoSearchComponent.js
+++ b/hat/assets/js/apps/Iaso/domains/mappings/components/IasoSearchComponent.js
@@ -34,7 +34,7 @@ const IasoSearchComponent = props => {
                     fetch(
                         `/api/${resourceName}.json?search_name=${input.input}${
                             fields ? `&fields=${fields}` : ''
-                        }`,
+                        }&hide_deleted=True`,
                     )
                         .then(resp => resp.json())
                         .then(f => {
@@ -46,7 +46,7 @@ const IasoSearchComponent = props => {
                         }),
                 200,
             ),
-        [],
+        [collectionName, fields, mapOptions, resourceName],
     );
     React.useEffect(() => {
         setInputValue(defaultValue);

--- a/iaso/api/form_versions.py
+++ b/iaso/api/form_versions.py
@@ -180,6 +180,9 @@ class FormVersionsViewSet(ModelViewSet):
             profile = self.request.user.iaso_profile
             queryset = FormVersion.objects.filter(form__projects__account=profile.account)
 
+        hide_deleted = self.request.query_params.get("hide_deleted", None)
+        if hide_deleted == "True":
+            queryset = queryset.filter(form__deleted_at=None)
         search_name = self.request.query_params.get("search_name", None)
         if search_name:
             queryset = queryset.filter(form__name__icontains=search_name)

--- a/iaso/api/form_versions.py
+++ b/iaso/api/form_versions.py
@@ -180,9 +180,8 @@ class FormVersionsViewSet(ModelViewSet):
             profile = self.request.user.iaso_profile
             queryset = FormVersion.objects.filter(form__projects__account=profile.account)
 
-        hide_deleted = self.request.query_params.get("hide_deleted", None)
-        if hide_deleted == "True":
-            queryset = queryset.filter(form__deleted_at=None)
+        # We don't send versions for deleted forms
+        queryset = queryset.filter(form__deleted_at=None)
         search_name = self.request.query_params.get("search_name", None)
         if search_name:
             queryset = queryset.filter(form__name__icontains=search_name)


### PR DESCRIPTION
Form versions drop down  for DHIOS2 mappings was showing versions for deleted forms

Related JIRA tickets : IA-2136

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- filter out versions for deleted forms in formversions API
- Refactor map function in `CreateDHIS2Mapping` to filter out `undefined`options and remove console error

## How to test
-  Go to Forms. Pick a form with versions and delete it
-  Go to Forms > DHIS2 Mappings
-  Click Create
-  Go to the Form Version field and TYPE SOMETHING to make the dropdown appear. The versions for the deleted form should not be there
- Go back to Forms and undelete the form you deleted
- Go back to DHIS2 Mapping and reapeat the steps to show the drop down options. Versions for the undeleted for should appear


## Print screen / video

https://user-images.githubusercontent.com/38907762/236800191-71966b78-0340-4d34-b678-4d5e4d833b0a.mov


