### PR TITLE
IA2-2090: Completeness stats dead cells should not be sortable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6019,7 +6019,7 @@
         },
         "node_modules/bluesquare-components": {
             "version": "0.2.0",
-            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#9555c0a16dbb4e5155927b734d41f5cb77b13d85",
+            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#2dbb52d440806aad7b749bd68654250e77578a91",
             "license": "Apache-2.0",
             "dependencies": {
                 "@babel/plugin-transform-runtime": "^7.17.0",
@@ -34207,7 +34207,7 @@
             "dev": true
         },
         "bluesquare-components": {
-            "version": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#9555c0a16dbb4e5155927b734d41f5cb77b13d85",
+            "version": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#2dbb52d440806aad7b749bd68654250e77578a91",
             "from": "bluesquare-components@github:BLSQ/bluesquare-components",
             "requires": {
                 "@babel/plugin-transform-runtime": "^7.17.0",


### PR DESCRIPTION
While clicking on a cell without text in the completeness stats table, the dashboard is trying to sort data with a placeholder name and is crashing the api.

Those cells should not be sortable at all.

Related JIRA tickets : IA-2090

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

merged @codeKameleon PR on blusquare-components

## How to test

Open completeness stats page, head cells without text should not be sortable

## Print screen / video


https://github.com/BLSQ/iaso/assets/12494624/b29e5c1e-7a62-4ee4-a729-fa40cba822de

