### PR TITLE
IA-2150 fix timeout on derrived instance generation

### DIFF
--- a/.platform/nginx/conf.d/increase_timeout.conf
+++ b/.platform/nginx/conf.d/increase_timeout.conf
@@ -1,3 +1,3 @@
-proxy_read_timeout 300;
-proxy_connect_timeout 300;
-proxy_send_timeout 300;
+proxy_read_timeout 900;
+proxy_connect_timeout 900;
+proxy_send_timeout 900;


### PR DESCRIPTION
by increasing the general timeout
The corresponding modification has been done on the load balancer for prod This is a short term fix, the generation should be moved in a background task
