### PR TITLE
IA-2025: submission detail show planning

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/instances/constants.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/constants.js
@@ -53,14 +53,18 @@ export const INSTANCE_METAS_FIELDS = [
             if (data.planning_id) {
                 return (
                     <LinkToPlanning
-                        planningId={data.planning_id}
-                        planningName={data.planning_name}
+                        planning={{
+                            id: data.planning_id,
+                            name: data.planning_name,
+                            team: data.team_id,
+                        }}
                     />
                 );
             }
             return '--';
         },
     },
+
     {
         key: 'version',
         accessor: 'formVersion',

--- a/hat/assets/js/apps/Iaso/domains/instances/constants.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/constants.js
@@ -7,6 +7,7 @@ import { usePrettyPeriod } from '../periods/utils';
 import { OrgUnitLabel } from '../orgUnits/utils';
 import MESSAGES from './messages';
 import { LinkToForm } from '../forms/components/LinkToForm.tsx';
+import { LinkToPlanning } from '../plannings/components/LinkToPlanning.tsx';
 import getDisplayName from '../../utils/usersUtils.ts';
 
 export const INSTANCE_STATUS_READY = 'READY';
@@ -43,6 +44,21 @@ export const INSTANCE_METAS_FIELDS = [
             return (
                 <LinkToForm formId={data.form_id} formName={data.form_name} />
             );
+        },
+    },
+    {
+        key: 'planning',
+        type: 'info',
+        renderValue: data => {
+            if (data.planning_id) {
+                return (
+                    <LinkToPlanning
+                        planningId={data.planning_id}
+                        planningName={data.planning_name}
+                    />
+                );
+            }
+            return '--';
         },
     },
     {

--- a/hat/assets/js/apps/Iaso/domains/instances/messages.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/messages.js
@@ -538,6 +538,10 @@ const MESSAGES = defineMessages({
         id: 'iaso.label.created_by',
         defaultMessage: 'Created  by',
     },
+    planning: {
+        id: 'iaso.label.planning',
+        defaultMessage: 'Planning',
+    },
 });
 
 export default MESSAGES;

--- a/hat/assets/js/apps/Iaso/domains/plannings/components/LinkToPlanning.tsx
+++ b/hat/assets/js/apps/Iaso/domains/plannings/components/LinkToPlanning.tsx
@@ -1,0 +1,26 @@
+import React, { FunctionComponent } from 'react';
+
+import { Link } from 'react-router';
+import { userHasPermission } from '../../users/utils';
+import { baseUrls } from '../../../constants/urls';
+import { useCurrentUser } from '../../../utils/usersUtils';
+import { useGetPlanning } from '../../assignments/hooks/requests/useGetPlanning';
+
+type Props = {
+    planningId: string | undefined;
+    planningName: unknown;
+};
+
+export const LinkToPlanning: FunctionComponent<Props> = ({
+    planningId,
+    planningName,
+}) => {
+    const user = useCurrentUser();
+    const { data: planning } = useGetPlanning(planningId);
+
+    if (userHasPermission('iaso_planning', user)) {
+        const planningUrl = `/${baseUrls.assignments}/planningId/${planningId}/team/${planning?.team}`;
+        return <Link to={planningUrl}>{planningName}</Link>;
+    }
+    return <>{planningName}</>;
+};

--- a/hat/assets/js/apps/Iaso/domains/plannings/components/LinkToPlanning.tsx
+++ b/hat/assets/js/apps/Iaso/domains/plannings/components/LinkToPlanning.tsx
@@ -8,7 +8,7 @@ import { useGetPlanning } from '../../assignments/hooks/requests/useGetPlanning'
 
 type Props = {
     planningId: string | undefined;
-    planningName: unknown;
+    planningName: string;
 };
 
 export const LinkToPlanning: FunctionComponent<Props> = ({

--- a/hat/assets/js/apps/Iaso/domains/plannings/components/LinkToPlanning.tsx
+++ b/hat/assets/js/apps/Iaso/domains/plannings/components/LinkToPlanning.tsx
@@ -4,23 +4,18 @@ import { Link } from 'react-router';
 import { userHasPermission } from '../../users/utils';
 import { baseUrls } from '../../../constants/urls';
 import { useCurrentUser } from '../../../utils/usersUtils';
-import { useGetPlanning } from '../../assignments/hooks/requests/useGetPlanning';
+import { Planning } from '../../assignments/types/planning';
 
 type Props = {
-    planningId: string | undefined;
-    planningName: string;
+    planning: Planning;
 };
 
-export const LinkToPlanning: FunctionComponent<Props> = ({
-    planningId,
-    planningName,
-}) => {
+export const LinkToPlanning: FunctionComponent<Props> = ({ planning }) => {
     const user = useCurrentUser();
-    const { data: planning } = useGetPlanning(planningId);
 
     if (userHasPermission('iaso_planning', user)) {
-        const planningUrl = `/${baseUrls.assignments}/planningId/${planningId}/team/${planning?.team}`;
-        return <Link to={planningUrl}>{planningName}</Link>;
+        const planningUrl = `/${baseUrls.assignments}/planningId/${planning.id}/team/${planning.team}`;
+        return <Link to={planningUrl}>{planning.name}</Link>;
     }
-    return <>{planningName}</>;
+    return <>{planning.name}</>;
 };

--- a/iaso/admin.py
+++ b/iaso/admin.py
@@ -203,6 +203,7 @@ class InstanceAdmin(admin.GeoModelAdmin):
                     "last_modified_by",
                     "created_by",
                     "form_version",
+                    "planning",
                 )
             },
         ),

--- a/iaso/models/base.py
+++ b/iaso/models/base.py
@@ -1039,6 +1039,8 @@ class Instance(models.Model):
             "longitude": self.location.x if self.location else None,
             "altitude": self.location.z if self.location else None,
             "period": self.period,
+            "planning_id": self.planning.id if self.planning else None,
+            "planning_name": self.planning.name if self.planning else None,
             "file_content": file_content,
             "files": [f.file.url if f.file else None for f in self.instancefile_set.filter(deleted=False)],
             "status": getattr(self, "status", None),

--- a/iaso/models/base.py
+++ b/iaso/models/base.py
@@ -1041,6 +1041,7 @@ class Instance(models.Model):
             "period": self.period,
             "planning_id": self.planning.id if self.planning else None,
             "planning_name": self.planning.name if self.planning else None,
+            "team_id": self.planning.team_id if self.planning else None,
             "file_content": file_content,
             "files": [f.file.url if f.file else None for f in self.instancefile_set.filter(deleted=False)],
             "status": getattr(self, "status", None),


### PR DESCRIPTION
Show which planning the submission belong to

Related JIRA tickets : IA-2025

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- add planning id and name in instance model
- create new component LinkToPlanning 
- add translations

## How to test

- Go to submissions list
- See details of one submission
- If a planning is linked to the submission, it should appear in the `InstanceDetailsInfos`

## Print screen / video

https://github.com/BLSQ/iaso/assets/25134301/871176a5-84c0-4622-8fad-a753c62a940e

