### PR TITLE
IA-2139: add orgunit status filter in completeness stats

### DIFF
--- a/hat/assets/js/apps/Iaso/constants/routes.js
+++ b/hat/assets/js/apps/Iaso/constants/routes.js
@@ -637,6 +637,10 @@ export const completenessStatsPath = {
             isRequired: false,
             key: 'groupId',
         },
+        {
+            isRequired: false,
+            key: 'orgunitValidationStatus',
+        },
     ],
 };
 

--- a/hat/assets/js/apps/Iaso/domains/completenessStats/CompletenessStatsFilters.tsx
+++ b/hat/assets/js/apps/Iaso/domains/completenessStats/CompletenessStatsFilters.tsx
@@ -161,6 +161,7 @@ export const CompletenessStatsFilters: FunctionComponent<Props> = ({
                         />
                     </DisplayIfUserHasPerm>
                 </Grid>
+
                 <Grid item xs={12} md={3}>
                     <Box id="ou-tree-input-parent">
                         <OrgUnitTreeviewModal
@@ -170,6 +171,29 @@ export const CompletenessStatsFilters: FunctionComponent<Props> = ({
                             initialSelection={initialParent}
                         />
                     </Box>
+                    <InputComponent
+                        type="select"
+                        clearable={false}
+                        multi
+                        keyValue="orgunitValidationStatus"
+                        onChange={handleChange}
+                        value={filters.orgunitValidationStatus}
+                        label={MESSAGES.validationStatus}
+                        options={[
+                            {
+                                label: formatMessage(MESSAGES.new),
+                                value: 'NEW',
+                            },
+                            {
+                                label: formatMessage(MESSAGES.validated),
+                                value: 'VALID',
+                            },
+                            {
+                                label: formatMessage(MESSAGES.rejected),
+                                value: 'REJECTED',
+                            },
+                        ]}
+                    />
                 </Grid>
 
                 <Grid item xs={12} md={3}>

--- a/hat/assets/js/apps/Iaso/domains/completenessStats/CompletenessStatsFilters.tsx
+++ b/hat/assets/js/apps/Iaso/domains/completenessStats/CompletenessStatsFilters.tsx
@@ -110,6 +110,23 @@ export const CompletenessStatsFilters: FunctionComponent<Props> = ({
         [handleChange],
     );
 
+    const orgUnitStatusOptions = useMemo(() => {
+        return [
+            {
+                label: formatMessage(MESSAGES.new),
+                value: 'NEW',
+            },
+            {
+                label: formatMessage(MESSAGES.validated),
+                value: 'VALID',
+            },
+            {
+                label: formatMessage(MESSAGES.rejected),
+                value: 'REJECTED',
+            },
+        ];
+    }, [formatMessage]);
+
     return (
         <>
             <Grid container spacing={2}>
@@ -179,20 +196,7 @@ export const CompletenessStatsFilters: FunctionComponent<Props> = ({
                         onChange={handleChange}
                         value={filters.orgunitValidationStatus}
                         label={MESSAGES.validationStatus}
-                        options={[
-                            {
-                                label: formatMessage(MESSAGES.new),
-                                value: 'NEW',
-                            },
-                            {
-                                label: formatMessage(MESSAGES.validated),
-                                value: 'VALID',
-                            },
-                            {
-                                label: formatMessage(MESSAGES.rejected),
-                                value: 'REJECTED',
-                            },
-                        ]}
+                        options={orgUnitStatusOptions}
                     />
                 </Grid>
 

--- a/hat/assets/js/apps/Iaso/domains/completenessStats/hooks/api/useGetCompletnessStats.ts
+++ b/hat/assets/js/apps/Iaso/domains/completenessStats/hooks/api/useGetCompletnessStats.ts
@@ -10,6 +10,7 @@ const queryParamsMap = new Map([
     ['parentId', 'parent_org_unit_id'],
     ['planningId', 'planning_id'],
     ['groupId', 'org_unit_group_id'],
+    ['orgunitValidationStatus', 'org_unit_validation_status'],
 ]);
 
 const apiParamsKeys = ['order', 'page', 'limit', 'search', 'period'];

--- a/hat/assets/js/apps/Iaso/domains/completenessStats/messages.ts
+++ b/hat/assets/js/apps/Iaso/domains/completenessStats/messages.ts
@@ -78,6 +78,22 @@ const MESSAGES = defineMessages({
             'No descendant OrgUnit is expected to fill that form. Check the Form config if this is unexpected',
         id: 'iaso.completenessStats.descendantsNoSubmissionExpected',
     },
+    rejected: {
+        defaultMessage: 'Rejected',
+        id: 'iaso.forms.rejected',
+    },
+    new: {
+        defaultMessage: 'New',
+        id: 'iaso.forms.new',
+    },
+    validated: {
+        defaultMessage: 'Validated',
+        id: 'iaso.forms.validated',
+    },
+    validationStatus: {
+        defaultMessage: 'Validation status',
+        id: 'iaso.forms.validationStatus',
+    },
 });
 
 export default MESSAGES;

--- a/hat/assets/js/apps/Iaso/domains/completenessStats/types.ts
+++ b/hat/assets/js/apps/Iaso/domains/completenessStats/types.ts
@@ -38,6 +38,7 @@ export type FormStatRow = {
 export type CompletenessRouterParams = UrlParams & {
     formId?: string;
     orgUnitTypeIds?: string;
+    orgunitValidationStatus: 'NEW' | 'VALID' | 'REJECTED';
     period?: string;
     groupId?: string;
     parentId?: string;


### PR DESCRIPTION
Allow to filter by org unit validation status

Related JIRA tickets : IA-2139

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- add org unit validation status multi select in filters
- add org unit validation status to query params
- add org unit validation status to route params
- update types

## How to test

- Go to completenessStats
- Play the validation status filter

## Print screen / video

https://github.com/BLSQ/iaso/assets/25134301/5086198b-68f2-4079-b197-28d07d9e47c8