### PR TITLE
POLIO-1019: fix missing translations risk assessment tab

### DIFF
--- a/plugins/polio/js/src/hooks/useFormValidator.js
+++ b/plugins/polio/js/src/hooks/useFormValidator.js
@@ -461,7 +461,7 @@ const useRoundShape = () => {
         target_population: yup
             .number()
             .nullable()
-            .min(0)
+            .min(0, formatMessage(MESSAGES.positiveInteger))
             .integer()
             .typeError(formatMessage(MESSAGES.positiveInteger)),
         cost: yup.number().nullable().min(0).integer(),
@@ -552,15 +552,15 @@ const useRoundShape = () => {
         percentage_covered_target_population: yup
             .number()
             .nullable()
-            .min(0)
-            .max(100)
             .integer()
-            .typeError(formatMessage(MESSAGES.positiveRangeInteger)),
+            .min(0, formatMessage(MESSAGES.positiveRangeInteger))
+            .max(100, formatMessage(MESSAGES.positiveRangeInteger))
+            .typeError(formatMessage(MESSAGES.positiveInteger)),
         doses_requested: yup
             .number()
             .nullable()
             .integer()
-            .min(0)
+            .min(0, formatMessage(MESSAGES.positiveInteger))
             .typeError(formatMessage(MESSAGES.positiveInteger)),
     });
 };


### PR DESCRIPTION
Missing and mixed translations in yup validation for risk assessment tab

https://github.com/BLSQ/iaso/assets/25134301/878ffb1f-502e-4528-afa3-6435170c4fa5


Related JIRA tickets : POLIO-1019

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- add custom error messages for fields with percentage value
- add consistency in error message content

## How to test

- Go to campaigns
- Create or edit a campaign
- Play with the fields in the second colum
- Check if error validation is working well and if the right message appears 

## Print screen / video

https://github.com/BLSQ/iaso/assets/25134301/4395cde8-3a99-4cbd-ae3f-96e235279f73

## Notes

⚠️ I did a mistake when creating the ticket and creating the branch (I deleted the old ticket, there is no more IA-2101 ticket + I added the link to this PR in the Jira ticket) 