### PR TITLE
Limit downloads to roots for user on mobile.

### DIFF
--- a/iaso/api/mobile/entity.py
+++ b/iaso/api/mobile/entity.py
@@ -96,7 +96,7 @@ class MobileEntitySerializer(serializers.ModelSerializer):
             try:
                 if not inst.json:
                     continue
-                FormVersion.objects.get(version_id=inst.json.get("_version"), form_id=inst.form.id)
+                FormVersion.objects.get(version_id=inst.json.get("_version"), form_id=inst.form_id)
                 ok_instances.append(inst)
             except FormVersion.DoesNotExist:
                 pass

--- a/iaso/api/mobile/org_units.py
+++ b/iaso/api/mobile/org_units.py
@@ -137,7 +137,7 @@ class MobileOrgUnitViewSet(ModelViewSet):
 
         if user and not user.is_anonymous:
             limit_download_to_roots = Project.objects.get_for_user_and_app_id(user, app_id).has_feature(
-                "LIMIT_OU_DOWNLOAD_TO_ROOTS"
+                FeatureFlag.LIMIT_OU_DOWNLOAD_TO_ROOTS
             )
 
         if limit_download_to_roots:

--- a/iaso/api/mobile/org_units.py
+++ b/iaso/api/mobile/org_units.py
@@ -131,20 +131,19 @@ class MobileOrgUnitViewSet(ModelViewSet):
 
     def get_queryset(self):
         user = self.request.user
+        app_id = self.request.query_params.get(APP_ID)
 
         limit_download_to_roots = False
+
         if user and not user.is_anonymous:
-            account = user.iaso_profile.account
-            limit_download_to_roots = "LIMIT_OU_DOWNLOAD_TO_ROOTS" in account.feature_flags.values_list(
-                "code", flat=True
+            limit_download_to_roots = Project.objects.get_for_user_and_app_id(user, app_id).has_feature(
+                "LIMIT_OU_DOWNLOAD_TO_ROOTS"
             )
 
         if limit_download_to_roots:
-            org_units = OrgUnit.objects.filter_for_user_and_app_id(
-                self.request.user, self.request.query_params.get(APP_ID)
-            )
+            org_units = OrgUnit.objects.filter_for_user_and_app_id(self.request.user, app_id)
         else:
-            org_units = OrgUnit.objects.filter_for_user_and_app_id(None, self.request.query_params.get(APP_ID))
+            org_units = OrgUnit.objects.filter_for_user_and_app_id(None, app_id)
         queryset = (
             org_units.filter(validation_status=OrgUnit.VALIDATION_VALID)
             .order_by("path")

--- a/iaso/api/mobile/org_units.py
+++ b/iaso/api/mobile/org_units.py
@@ -11,7 +11,7 @@ from rest_framework.serializers import ModelSerializer, JSONField
 from hat.api.export_utils import timestamp_to_utc_datetime
 from iaso.api.common import get_timestamp, TimestampField, ModelViewSet, Paginator, safe_api_import
 from iaso.api.query_params import APP_ID, LIMIT, PAGE
-from iaso.models import OrgUnit, Project
+from iaso.models import OrgUnit, Project, FeatureFlag
 
 
 class MobileOrgUnitsSetPagination(Paginator):

--- a/iaso/migrations/0206_add_feature_flag_LIMIT_OU_DOWNLOAD_TO_ROOTS.py
+++ b/iaso/migrations/0206_add_feature_flag_LIMIT_OU_DOWNLOAD_TO_ROOTS.py
@@ -1,0 +1,25 @@
+from django.db import migrations
+
+
+def create_feature_flags(apps, schema_editor):
+    FeatureFlag = apps.get_model("iaso", "FeatureFlag")
+    x = FeatureFlag.objects.create(
+        code="LIMIT_OU_DOWNLOAD_TO_ROOTS",
+        name="Mobile: Limit download of orgunit to what the user has access to",
+    )
+
+
+def destroy_feature_flags(apps, schema_editor):
+    FeatureFlag = apps.get_model("iaso", "FeatureFlag")
+    FeatureFlag.objects.filter(code="LIMIT_OU_DOWNLOAD_TO_ROOTS").delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("iaso", "0205_merge_20230504_1352"),
+    ]
+
+    operations = [
+        migrations.RunPython(create_feature_flags, destroy_feature_flags),
+    ]

--- a/iaso/models/base.py
+++ b/iaso/models/base.py
@@ -1265,6 +1265,7 @@ class FeatureFlag(models.Model):
     TAKE_GPS_ON_FORM = "TAKE_GPS_ON_FORM"
     REQUIRE_AUTHENTICATION = "REQUIRE_AUTHENTICATION"
     FORMS_AUTO_UPLOAD = "FORMS_AUTO_UPLOAD"
+    LIMIT_OU_DOWNLOAD_TO_ROOTS = "LIMIT_OU_DOWNLOAD_TO_ROOTS"
 
     FEATURE_FLAGS = {
         (INSTANT_EXPORT, "Instant export", _("Immediate export of instances to DHIS2")),
@@ -1283,6 +1284,13 @@ class FeatureFlag(models.Model):
             "",
             _(
                 "Saving a form as finalized on mobile triggers an upload attempt immediately + everytime network becomes available"
+            ),
+        ),
+        (
+            LIMIT_OU_DOWNLOAD_TO_ROOTS,
+            "Mobile: Limit download of orgunit to what the user has access to",
+            _(
+                "Mobile: Limit download of orgunit to what the user has access to",
             ),
         ),
     }


### PR DESCRIPTION
Adding a feature flag that specify that the mobile app should only download org units under the roots of the user.

Explain what problem this PR is resolving

Related JIRA tickets : IA-XXX, WC2-XXX, POLIO-XXX

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

Explain the changes that were made. The idea is not to list exhaustively all the changes made (GitHub already provides a full diff), but to help the reviewers better understand:
- which specific file changes go together, e.g: when creating a table in the front-end, there usually is a config file that goes with it
- the reasoning behind some changes, e.g: deleted files because they are now redundant
- the behaviour to expect, e.g: tooltip has purple background color because the client likes it so, changed a key in the API response to be consistent with other endpoints

## How to test

Explain how to test your PR.
If a specific config is required explain it here (dataset, account, profile, ...)

## Print screen / video

Upload here print screens or videos showing the changes

## Notes

Things that the reviewers should know: known bugs that are out of the scope of the PR, other trade-offs that were made.
If the PR depends on a PR in bluesquare-components, or merges into another PR (i.o. main), it should also be mentioned here
