### PR TITLE
Run the CI on the main branch as well

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,11 @@ name: Iaso Automated CI testing
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review]
+  push:
+    # Run On push (or merge) on main.  This populates the cache and avoid the issue where we have undetected migrations
+    # conflict following subsequent merge
+    branches:
+      - main
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
This populates the cache and avoid the issue where we have undetected migrations conflict following subsequent merges
