### PR TITLE
WC2-194: link beneficiary page to duplicates page

### DIFF
--- a/hat/assets/js/apps/Iaso/constants/routes.js
+++ b/hat/assets/js/apps/Iaso/constants/routes.js
@@ -885,10 +885,7 @@ export const entityDuplicatesPath = {
             isRequired: false,
             key: 'accountId',
         },
-        ...paginationPathParams.map(p => ({
-            ...p,
-            isRequired: true,
-        })),
+
         {
             isRequired: false,
             key: 'search',
@@ -942,6 +939,10 @@ export const entityDuplicatesPath = {
             isRequired: false,
             key: 'entity_id',
         },
+        ...paginationPathParams.map(p => ({
+            ...p,
+            isRequired: true,
+        })),
     ],
 };
 export const entityDuplicatesDetailsPath = {

--- a/hat/assets/js/apps/Iaso/constants/routes.js
+++ b/hat/assets/js/apps/Iaso/constants/routes.js
@@ -929,10 +929,7 @@ export const entityDuplicatesPath = {
             isRequired: false,
             key: 'ignored',
         },
-        {
-            isRequired: false,
-            key: 'entity',
-        },
+
         {
             isRequired: false,
             key: 'fields',
@@ -940,6 +937,10 @@ export const entityDuplicatesPath = {
         {
             isRequired: false,
             key: 'form',
+        },
+        {
+            isRequired: false,
+            key: 'entity_id',
         },
     ],
 };

--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -143,6 +143,8 @@
     "iaso.entities.male": "Male",
     "iaso.entities.program": "Program",
     "iaso.entities.registrationDate": "Registration date",
+    "iaso.entities.seeDuplicate": "See duplicate",
+    "iaso.entities.seeDuplicates": "See duplicates",
     "iaso.entities.title": "Entities",
     "iaso.entities.type": "Type",
     "iaso.entities.typeNotSupported": "Type not supported yet: {type}",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -140,6 +140,8 @@
     "iaso.entities.male": "Masculin",
     "iaso.entities.program": "Programme",
     "iaso.entities.registrationDate": "Date d'enregistrement",
+    "iaso.entities.seeDuplicate": "Voir doublon",
+    "iaso.entities.seeDuplicates": "Voir doublons",
     "iaso.entities.title": "Entités",
     "iaso.entities.type": "Type",
     "iaso.entities.typeNotSupported": "Type non supporté: {type}",

--- a/hat/assets/js/apps/Iaso/domains/entities/config.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/config.tsx
@@ -8,6 +8,7 @@ import {
 
 import moment from 'moment';
 import _ from 'lodash';
+import FileCopyIcon from '@material-ui/icons/FileCopy';
 import { LinkToOrgUnit } from '../orgUnits/components/LinkToOrgUnit';
 import {
     DateCell,
@@ -111,16 +112,33 @@ export const useColumns = (
             accessor: 'actions',
             resizable: false,
             sortable: false,
-            Cell: (settings): ReactElement => (
+            Cell: (settings): ReactElement => {
                 // TODO: limit to user permissions
-                <>
-                    <IconButtonComponent
-                        url={`/${baseUrls.entityDetails}/entityId/${settings.row.original.id}`}
-                        icon="remove-red-eye"
-                        tooltipMessage={MESSAGES.see}
-                    />
-                </>
-            ),
+                return (
+                    <>
+                        <IconButtonComponent
+                            url={`/${baseUrls.entityDetails}/entityId/${settings.row.original.id}`}
+                            icon="remove-red-eye"
+                            tooltipMessage={MESSAGES.see}
+                        />
+                        {settings.row.original.duplicates.length === 1 && (
+                            <IconButtonComponent
+                                url={`/${baseUrls.entityDuplicateDetails}/entities/${settings.row.original.id},${settings.row.original.duplicates[0]}/`}
+                                overrideIcon={FileCopyIcon}
+                                tooltipMessage={MESSAGES.seeDuplicate}
+                            />
+                        )}
+                        {/* When there's more than one dupe for the entity */}
+                        {settings.row.original.duplicates.length > 1 && (
+                            <IconButtonComponent
+                                url={`/${baseUrls.entityDuplicates}/order/id/pageSize/50/page/1/entity_id/${settings.row.original.id}/`}
+                                overrideIcon={FileCopyIcon}
+                                tooltipMessage={MESSAGES.seeDuplicates}
+                            />
+                        )}
+                    </>
+                );
+            },
         });
         return columns;
     }, [

--- a/hat/assets/js/apps/Iaso/domains/entities/details.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/details.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, useMemo } from 'react';
 import {
     // @ts-ignore
     useSafeIntl,
@@ -7,7 +7,7 @@ import {
     // @ts-ignore
     LoadingSpinner,
 } from 'bluesquare-components';
-import { Box, Divider, Grid, makeStyles } from '@material-ui/core';
+import { Box, Button, Divider, Grid, makeStyles } from '@material-ui/core';
 import { useDispatch, useSelector } from 'react-redux';
 import TopBar from '../../components/nav/TopBarComponent';
 import MESSAGES from './messages';
@@ -59,6 +59,15 @@ export const Details: FunctionComponent<Props> = ({ router }) => {
         params,
         entityId,
     );
+
+    const duplicates = useMemo(() => {
+        return beneficiary?.duplicates ?? [];
+    }, [beneficiary]);
+
+    const duplicateUrl =
+        duplicates.length === 1
+            ? `/dashboard/${baseUrls.entityDuplicateDetails}/entities/${entityId},${duplicates[0]}/`
+            : `/dashboard/${baseUrls.entityDuplicates}/order/id/pageSize/50/page/1/entity_id/${entityId}/`;
     return (
         <>
             <TopBar
@@ -87,6 +96,19 @@ export const Details: FunctionComponent<Props> = ({ router }) => {
                             </Box>
                         </WidgetPaper>
                     </Grid>
+                    {duplicates.length > 0 && (
+                        <Grid container item xs={8} justifyContent="flex-end">
+                            <Box>
+                                <Button
+                                    variant="contained"
+                                    color="primary"
+                                    href={duplicateUrl}
+                                >
+                                    {formatMessage(MESSAGES.seeDuplicates)}
+                                </Button>
+                            </Box>
+                        </Grid>
+                    )}
                     {/* TODO uncomment when edition is possible */}
                     {/* <Grid container item xs={1}>
                         <Box ml={2}>

--- a/hat/assets/js/apps/Iaso/domains/entities/details.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/details.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useMemo } from 'react';
+import React, { FunctionComponent, useCallback, useMemo } from 'react';
 import {
     // @ts-ignore
     useSafeIntl,
@@ -9,10 +9,10 @@ import {
 } from 'bluesquare-components';
 import { Box, Button, Divider, Grid, makeStyles } from '@material-ui/core';
 import { useDispatch, useSelector } from 'react-redux';
+import { Link } from 'react-router';
 import TopBar from '../../components/nav/TopBarComponent';
 import MESSAGES from './messages';
-
-import { redirectToReplace } from '../../routing/actions';
+import { redirectTo, redirectToReplace } from '../../routing/actions';
 import { baseUrls } from '../../constants/urls';
 
 import { useGetBeneficiary, useGetSubmissions } from './hooks/requests';
@@ -64,10 +64,14 @@ export const Details: FunctionComponent<Props> = ({ router }) => {
         return beneficiary?.duplicates ?? [];
     }, [beneficiary]);
 
-    const duplicateUrl =
-        duplicates.length === 1
-            ? `/dashboard/${baseUrls.entityDuplicateDetails}/entities/${entityId},${duplicates[0]}/`
-            : `/dashboard/${baseUrls.entityDuplicates}/order/id/pageSize/50/page/1/entity_id/${entityId}/`;
+    const onClickDuplicateButton = useCallback(() => {
+        const duplicateUrl =
+            duplicates.length === 1
+                ? `${baseUrls.entityDuplicateDetails}/entities/${entityId},${duplicates[0]}/`
+                : `${baseUrls.entityDuplicates}/order/id/pageSize/50/page/1/entity_id/${entityId}/`;
+        dispatch(redirectTo(duplicateUrl));
+    }, [dispatch, duplicates, entityId]);
+
     return (
         <>
             <TopBar
@@ -99,13 +103,15 @@ export const Details: FunctionComponent<Props> = ({ router }) => {
                     {duplicates.length > 0 && (
                         <Grid container item xs={8} justifyContent="flex-end">
                             <Box>
-                                <Button
-                                    variant="contained"
-                                    color="primary"
-                                    href={duplicateUrl}
-                                >
-                                    {formatMessage(MESSAGES.seeDuplicates)}
-                                </Button>
+                                <Link>
+                                    <Button
+                                        variant="contained"
+                                        color="primary"
+                                        onClick={onClickDuplicateButton}
+                                    >
+                                        {formatMessage(MESSAGES.seeDuplicates)}
+                                    </Button>
+                                </Link>
                             </Box>
                         </Grid>
                     )}

--- a/hat/assets/js/apps/Iaso/domains/entities/duplicates/hooks/api/useGetDuplicates.ts
+++ b/hat/assets/js/apps/Iaso/domains/entities/duplicates/hooks/api/useGetDuplicates.ts
@@ -48,6 +48,7 @@ export type DuplicatesGETParams = {
         form?: any;
         fields?: any;
         ignored?: boolean;
+        entity?: string;
     };
 };
 
@@ -97,7 +98,8 @@ export const useGetDuplicateDetails = ({
         queryFn: () => getDuplicatesDetails(queryString),
         options: {
             select: data => {
-                if (!data) return { fields: [], descriptor1: {}, descriptor2: {} };
+                if (!data)
+                    return { fields: [], descriptor1: {}, descriptor2: {} };
 
                 const fields_result = data.fields.map(row => {
                     return {

--- a/hat/assets/js/apps/Iaso/domains/entities/messages.ts
+++ b/hat/assets/js/apps/Iaso/domains/entities/messages.ts
@@ -25,6 +25,14 @@ const MESSAGES = defineMessages({
         id: 'iaso.pages.errors.name',
         defaultMessage: 'Name is required',
     },
+    seeDuplicate: {
+        id: 'iaso.entities.seeDuplicate',
+        defaultMessage: 'See duplicate',
+    },
+    seeDuplicates: {
+        id: 'iaso.entities.seeDuplicates',
+        defaultMessage: 'See duplicates',
+    },
     cancel: {
         id: 'iaso.label.cancel',
         defaultMessage: 'Cancel',

--- a/hat/assets/js/apps/Iaso/domains/entities/types/beneficiary.ts
+++ b/hat/assets/js/apps/Iaso/domains/entities/types/beneficiary.ts
@@ -33,4 +33,5 @@ export type Beneficiary = {
     submitter: string;
     instances: Record<string, any>[];
     program?: string;
+    duplicates: number[];
 };

--- a/iaso/api/deduplication/entity.py
+++ b/iaso/api/deduplication/entity.py
@@ -219,8 +219,10 @@ class EntityDuplicateViewSet(viewsets.GenericViewSet):
 
     def list(self, request: Request, *args, **kwargs):
         # """Override to return responses with {"result_key": data} structure"""
-
+        entity_id = self.request.GET.get("entity_id", None)
         queryset = self.filter_queryset(self.get_queryset())
+        if entity_id:
+            queryset = queryset.filter(Q(entity1__id=entity_id) | Q(entity2__id=entity_id))
 
         page = self.paginate_queryset(queryset)
         if page is not None:

--- a/iaso/api/entity.py
+++ b/iaso/api/entity.py
@@ -123,10 +123,12 @@ class EntityTypeViewSet(ModelViewSet):
 
 def get_duplicates(entity):
     results = []
-    if entity.duplicates1.count() > 0:
-        results = results + list(map(lambda x: x.entity2.id, entity.duplicates1.all()))
-    elif entity.duplicates2.count() > 0:
-        results = results + list(map(lambda x: x.entity1.id, entity.duplicates2.all()))
+    e1qs = entity.duplicates1.filter(validation_status="PENDING")
+    e2qs = entity.duplicates2.filter(validation_status="PENDING")
+    if e1qs.count() > 0:
+        results = results + list(map(lambda x: x.entity2.id, e1qs.all()))
+    elif e2qs.count() > 0:
+        results = results + list(map(lambda x: x.entity1.id, e2qs.all()))
     return results
 
 

--- a/iaso/api/entity.py
+++ b/iaso/api/entity.py
@@ -69,12 +69,14 @@ class EntitySerializer(serializers.ModelSerializer):
             "instances",
             "submitter",
             "org_unit",
+            "duplicates",
         ]
 
     entity_type_name = serializers.SerializerMethodField()
     attributes = serializers.SerializerMethodField()
     submitter = serializers.SerializerMethodField()
     org_unit = serializers.SerializerMethodField()
+    duplicates = serializers.SerializerMethodField()
 
     def get_attributes(self, entity: Entity):
         if entity.attributes:
@@ -93,6 +95,9 @@ class EntitySerializer(serializers.ModelSerializer):
         except AttributeError:
             submitter = None
         return submitter
+
+    def get_duplicates(self, entity: Entity):
+        return get_duplicates(entity)
 
     @staticmethod
     def get_entity_type_name(obj: Entity):


### PR DESCRIPTION
Add Buttons in benefiaryt list and details to see duplicates

Related JIRA tickets : WC2-194

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- Change endpoints to return a `duplicates`field, which is an array of entity ids
- If the array has 1 element: redirect to the details of the duplicate
- If the array has more than 1 element: redirect to the list of duplicates, filtered by id of the "source" entity

## How to test

1. Create 2 sets of duplicates, as simple and a double (a "triplicate"):
- Single duplicate
    - Select a form
    - Create 2 instances of that form, with at least 1 fields (eg name) where the answers differ very little (eg:"John" vs "Jon")
    - In the Django admin, create 2 Entities, each linked to one of the instances you created
- Double:
    - Same thing but with one more submission and one more instance
    - Make sure they are 2 different sets, i.e: you won't get 5 entities matched as duplicates by the algorithm
2. Run the matching algorithm: 
- Start a task manager ( ctrl+F in README for more info)
- Go to `/api/entityduplicates_analyzes/`
- Using the Django API interface, POST a request:
```json
{
    "algorithm":"inverse", 
    "parameters":{}, 
    "fields":[<form fields to match>], 
    "entity_type_id":<entity type of the entities created earlier>
}
```
3. Test the feature
Once the task has finished running, go to Beneficiaries >List
- The Entities created earlier should have an additional icon in the "action" column
- In the details view they should have a "See Duplicates" button in the top right corner

## Print screen / video


https://github.com/BLSQ/iaso/assets/38907762/667ab642-07d5-4db2-8f77-d48cf3c341dd



## Notes

Merges into the dev branch for Deduplication.
Improves the code from the [demo](https://github.com/BLSQ/iaso/tree/WFP-demo-15-05-2023) of 15/05/2023
Was demoed to the client so it should go in the next release
**The failing Python test comes from the parent branch, so don't let it prevent you from reviewing**
