### PR TITLE
IA-2170: head cell with header info is not sortable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6019,7 +6019,7 @@
         },
         "node_modules/bluesquare-components": {
             "version": "0.2.0",
-            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#2cbfa2b4f693a0c6eff9f00cf0bf4dca1508782d",
+            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#21d83841d0acf0f6010484ba31b7b728556ba2d2",
             "license": "Apache-2.0",
             "dependencies": {
                 "@babel/plugin-transform-runtime": "^7.17.0",
@@ -34207,7 +34207,7 @@
             "dev": true
         },
         "bluesquare-components": {
-            "version": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#2cbfa2b4f693a0c6eff9f00cf0bf4dca1508782d",
+            "version": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#21d83841d0acf0f6010484ba31b7b728556ba2d2",
             "from": "bluesquare-components@github:BLSQ/bluesquare-components",
             "requires": {
                 "@babel/plugin-transform-runtime": "^7.17.0",


### PR DESCRIPTION
Depth columns on org unit types page is not sortable and should be

Related JIRA tickets : IA-2170

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

upgraded blsq-components

## How to test
Try to sort depth column in org unit type page

