### PR TITLE
Wc2 232 entities return 502 on coda dev environment

### DIFF
--- a/iaso/api/mobile/entity.py
+++ b/iaso/api/mobile/entity.py
@@ -137,12 +137,12 @@ class MobileEntityViewSet(ModelViewSet):
 
     """
 
-    results_key = "entities"
+    results_key = "results"
     remove_results_key_if_paginated = True
     filter_backends = [filters.OrderingFilter, DjangoFilterBackend, DeletionFilterBackend]
     pagination_class = LargeResultsSetPagination
     permission_classes = [permissions.IsAuthenticated, HasPermission("menupermissions.iaso_entities")]  # type: ignore
-    results_key = "entities"
+
 
     def pagination_class(self):
         return MobileEntitiesSetPagination(self.results_key)
@@ -188,4 +188,4 @@ class MobileEntityViewSet(ModelViewSet):
             "instances__form__form_versions",
             "attributes__form__form_versions",
         )
-        return queryset
+        return queryset.order_by("id")

--- a/iaso/api/mobile/entity.py
+++ b/iaso/api/mobile/entity.py
@@ -143,7 +143,6 @@ class MobileEntityViewSet(ModelViewSet):
     pagination_class = LargeResultsSetPagination
     permission_classes = [permissions.IsAuthenticated, HasPermission("menupermissions.iaso_entities")]  # type: ignore
 
-
     def pagination_class(self):
         return MobileEntitiesSetPagination(self.results_key)
 

--- a/iaso/api/mobile/entity.py
+++ b/iaso/api/mobile/entity.py
@@ -62,7 +62,7 @@ class MobileEntityAttributesSerializer(serializers.ModelSerializer):
     created_at = TimestampField()
     updated_at = TimestampField()
 
-    def get_form_version_id(self, obj: Instance):
+    def get_form_version_id(self, obj):
         if obj.json is None:
             return None
         possible_form_versions = self.context.get("possible_form_versions")
@@ -90,7 +90,7 @@ class MobileEntitySerializer(serializers.ModelSerializer):
     defining_instance_id = serializers.CharField(read_only=True, source="attributes.uuid")
     entity_type_id = serializers.CharField(read_only=True, source="entity_type.id")
 
-    def get_instances(self, entity: Entity):
+    def get_instances(self, entity):
         possible_form_versions = self.context.get("possible_form_versions")
         ok_instances = []
 
@@ -140,7 +140,6 @@ class MobileEntityViewSet(ModelViewSet):
     results_key = "results"
     remove_results_key_if_paginated = True
     filter_backends = [filters.OrderingFilter, DjangoFilterBackend, DeletionFilterBackend]
-    pagination_class = LargeResultsSetPagination
     permission_classes = [permissions.IsAuthenticated, HasPermission("menupermissions.iaso_entities")]  # type: ignore
 
     def pagination_class(self):
@@ -162,6 +161,7 @@ class MobileEntityViewSet(ModelViewSet):
             key = "%s|%s" % (version.version_id, str(version.form_id))
             possible_form_versions_dict[key] = version.id
         context["possible_form_versions"] = possible_form_versions_dict
+
         return context
 
     def get_queryset(self):

--- a/iaso/api/mobile/entity.py
+++ b/iaso/api/mobile/entity.py
@@ -3,6 +3,7 @@ from rest_framework import filters, serializers
 from rest_framework.pagination import PageNumberPagination
 from rest_framework import permissions
 from rest_framework.exceptions import ParseError, AuthenticationFailed, NotFound
+from iaso.api.common import Paginator
 
 
 from iaso.api.common import DeletionFilterBackend, ModelViewSet, TimestampField, HasPermission
@@ -61,11 +62,12 @@ class MobileEntityAttributesSerializer(serializers.ModelSerializer):
     created_at = TimestampField()
     updated_at = TimestampField()
 
-    @staticmethod
-    def get_form_version_id(obj: Instance):
+    def get_form_version_id(self, obj: Instance):
         if obj.json is None:
             return None
-        return FormVersion.objects.get(version_id=obj.json.get("_version"), form_id=obj.form.id).id  # type: ignore
+        possible_form_versions = self.context.get("possible_form_versions")
+        key = "%s|%s" % (obj.json.get("_version"), str(obj.form.id))
+        return possible_form_versions.get(key)
 
 
 class MobileEntitySerializer(serializers.ModelSerializer):
@@ -88,24 +90,36 @@ class MobileEntitySerializer(serializers.ModelSerializer):
     defining_instance_id = serializers.CharField(read_only=True, source="attributes.uuid")
     entity_type_id = serializers.CharField(read_only=True, source="entity_type.id")
 
-    @staticmethod
-    def get_instances(entity: Entity):
+    def get_instances(self, entity: Entity):
+        possible_form_versions = self.context.get("possible_form_versions")
         ok_instances = []
 
-        for inst in entity.instances.filter(deleted=False):
-            try:
+        for inst in entity.instances.all():
+            if inst.deleted == False:
                 if not inst.json:
                     continue
-                FormVersion.objects.get(version_id=inst.json.get("_version"), form_id=inst.form_id)
-                ok_instances.append(inst)
-            except FormVersion.DoesNotExist:
-                pass
 
-        return MobileEntityAttributesSerializer(ok_instances, many=True).data  # type: ignore
+                key = "%s|%s" % (inst.json.get("_version"), str(inst.form_id))
+                form_version = possible_form_versions.get(key, None)
+
+                if form_version is not None:
+                    ok_instances.append(inst)
+
+        return MobileEntityAttributesSerializer(entity.instances, many=True, context=self.context).data  # type: ignore
 
     @staticmethod
     def get_entity_type_name(obj: Entity):
         return obj.entity_type.name if obj.entity_type else None
+
+
+class MobileEntitiesSetPagination(Paginator):
+    page_size_query_param = LIMIT
+    page_query_param = PAGE
+    page_size = 1000
+    max_page_size = 1000
+
+    def get_page_number(self, request):
+        return int(request.query_params.get(self.page_query_param, 1))
 
 
 class MobileEntityViewSet(ModelViewSet):
@@ -128,11 +142,28 @@ class MobileEntityViewSet(ModelViewSet):
     filter_backends = [filters.OrderingFilter, DjangoFilterBackend, DeletionFilterBackend]
     pagination_class = LargeResultsSetPagination
     permission_classes = [permissions.IsAuthenticated, HasPermission("menupermissions.iaso_entities")]  # type: ignore
+    results_key = "entities"
+
+    def pagination_class(self):
+        return MobileEntitiesSetPagination(self.results_key)
 
     lookup_field = "uuid"
 
     def get_serializer_class(self):
         return MobileEntitySerializer
+
+    def get_serializer_context(self):
+        context = super().get_serializer_context()
+        user = self.request.user
+        possible_form_versions = FormVersion.objects.filter(
+            form__projects__account=user.iaso_profile.account
+        ).distinct()
+        possible_form_versions_dict = {}
+        for version in possible_form_versions:
+            key = "%s|%s" % (version.version_id, str(version.form_id))
+            possible_form_versions_dict[key] = version.id
+        context["possible_form_versions"] = possible_form_versions_dict
+        return context
 
     def get_queryset(self):
         user = self.request.user
@@ -141,7 +172,7 @@ class MobileEntityViewSet(ModelViewSet):
         if not app_id:
             raise ParseError("app_id is required")
 
-        queryset = get_queryset_for_user_and_app_id(user, app_id)
+        queryset = get_queryset_for_user_and_app_id(user, app_id).filter(deleted_at__isnull=True)
 
         queryset = filter_for_mobile_entity(queryset, self.request)
 
@@ -151,4 +182,10 @@ class MobileEntityViewSet(ModelViewSet):
             if orgunits and len(orgunits) > 0:
                 queryset = queryset.filter(instances__org_unit__in=orgunits)
 
+        queryset = queryset.select_related("entity_type").prefetch_related(
+            "instances__org_unit",
+            "attributes__org_unit",
+            "instances__form__form_versions",
+            "attributes__form__form_versions",
+        )
         return queryset

--- a/iaso/models/entity.py
+++ b/iaso/models/entity.py
@@ -103,12 +103,11 @@ class EntityQuerySet(models.QuerySet):
             queryset=Instance.objects.filter(
                 deleted=False, org_unit__validation_status=OrgUnit.VALIDATION_VALID
             ).exclude(file=""),
-            to_attr="non_deleted_instances",
         )
 
         self = self.filter(attributes__isnull=False).filter(instances__isnull=False)
 
-        self = self.prefetch_related(p).prefetch_related("non_deleted_instances__form")
+        self = self.prefetch_related(p).prefetch_related("instances__form")
 
         return self
 

--- a/iaso/models/entity.py
+++ b/iaso/models/entity.py
@@ -128,8 +128,9 @@ class EntityQuerySet(models.QuerySet):
                 if project.account is None:
                     raise ProjectNotFoundError(f"Project Account is None for app_id {app_id}")  # Should be a 401
 
-                self = self.filter(account=project.account, instances__project=project, attributes__project=project)
-
+                self = self.filter(
+                    account=project.account, instances__project=project, attributes__project=project
+                ).distinct("id")
             except Project.DoesNotExist:
                 raise ProjectNotFoundError(f"Project Not Found for app_id {app_id}")
 

--- a/iaso/tests/api/test_entities.py
+++ b/iaso/tests/api/test_entities.py
@@ -697,7 +697,7 @@ class EntityAPITestCase(APITestCase):
         self.assertEqual(response_json.get("results")[0].get("entity_type_id"), str(entity_type.id))
         self.assertEqual(len(response_json.get("results")[0].get("instances")), 1)
         self.assertEqual(response_json.get("results")[1].get("entity_type_id"), str(entity_type.id))
-        self.assertEqual(len(response_json.get("results")[1].get("instances")), 1)
+        self.assertEqual(len(response_json.get("results")[1].get("instances")), 0)
 
     def test_access_respect_appid_mobile(self):
         self.client.force_authenticate(self.yoda)


### PR DESCRIPTION
Wc2 232 entities return 502 on coda dev environment

- [x] Did I use eslint and black formatters
- [x ] Is my code clear enough and well documented

## Changes
there were multiple problems:
- the API was returning 970 entities while there were 29 entities in the database in my case (a missing distinct)
- after solving the previous problem, the api was still making 450+ sql requests to build the response:
     - I fixed that by adding a few prefetch_related
     - caching the possible form_version that have not been deleted to use that to filter the answers (instead of doing one sql request for any such test)

