### PR TITLE
Fixing an issue with black in pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,4 +5,5 @@ repos:
     rev: 21.5b1
     hooks:
     - id: black
+      additional_dependencies: ['click<8.1']
       language_version: python3


### PR DESCRIPTION
When running the current version of black in the pre-commit hook, it installs an incompatible version of "click".

https://stackoverflow.com/questions/71769191/

## Changes

I added some configuration to force an older version of "click" which is compatible with the version of black we are using.
