### PR TITLE
Fix XML file is malformed

### DIFF
--- a/iaso/api/forms.py
+++ b/iaso/api/forms.py
@@ -1,6 +1,7 @@
 import typing
 from copy import copy
 from datetime import timedelta
+from xml.sax.saxutils import escape
 
 from django.db.models import Max, Q, Count
 from django.http import StreamingHttpResponse, HttpResponse
@@ -353,9 +354,9 @@ class FormsViewSet(ModelViewSet):
         for attachment in attachments:
             media_files.append(
                 f"""<mediaFile>
-    <filename>{attachment.name}</filename>
+    <filename>{escape(attachment.name)}</filename>
     <hash>md5:{attachment.md5}</hash>
-    <downloadUrl>{attachment.file.url}</downloadUrl>
+    <downloadUrl>{escape(attachment.file.url)}</downloadUrl>
 </mediaFile>"""
             )
 

--- a/iaso/migrations/0207_formattachment.py
+++ b/iaso/migrations/0207_formattachment.py
@@ -6,7 +6,6 @@ import iaso.models.forms
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("iaso", "0206_add_feature_flag_LIMIT_OU_DOWNLOAD_TO_ROOTS"),
     ]


### PR DESCRIPTION
The URL on the server contains `&` and it's making the XML malformed.

Related JIRA tickets : IA-2157

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [X] Are there enough tests

## Changes

Make use of the [`escape`](https://wiki.python.org/moin/EscapingXml) function to fix the XML
