### PR TITLE
POLIO-1038: update campaign history config: fix missing keys and duplicates

### DIFF
--- a/plugins/polio/js/src/components/campaignHistory/config.tsx
+++ b/plugins/polio/js/src/components/campaignHistory/config.tsx
@@ -186,14 +186,6 @@ export const useGetConfig = (): Record<string, any> => {
             getLogValue: log => convertDate(log.three_level_call_at),
         },
         {
-            key: 'outbreak_declaration_date',
-            getLogValue: log => convertDate(log.outbreak_declaration_date),
-        },
-        {
-            key: 'outbreak_declaration_date',
-            getLogValue: log => convertDate(log.outbreak_declaration_date),
-        },
-        {
             key: 'risk_assessment_rrt_oprtt_approval_at',
             getLogValue: log =>
                 convertDate(log.risk_assessment_rrt_oprtt_approval_at),
@@ -506,6 +498,9 @@ export const useGetConfig = (): Record<string, any> => {
                 {
                     key: 'lqas_ended_at',
                     getLogValue: log => convertDate(log.lqas_ended_at),
+                },
+                {
+                    key: 'percentage_covered_target_population',
                 },
                 {
                     key: 'lqas_district_passing',


### PR DESCRIPTION
There was a key missing in campaign log history (percentage covered target population) and errors because duplicates keys

Related JIRA tickets : POLIO-1038

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [x] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- added percentage_covered_target_population in config
- removed duplicates

## How to test

- Go to campaigns
- Create or edit a campaign
- Check if when adding or updating percentage covered target population value, you should be able to see it in Round tab (in campaign log history
