### PR TITLE
POLIO-1030 Change preparedness score formatting in email

### DIFF
--- a/plugins/polio/tasks/weekly_email.py
+++ b/plugins/polio/tasks/weekly_email.py
@@ -46,7 +46,7 @@ def send_notification_email(campaign):
         preparedness = get_or_set_preparedness_cache_for_round(campaign, next_round)
         if preparedness and preparedness.get("indicators", {}).get("status_score"):
             prep_summary = preparedness["indicators"]["status_score"]
-            format = lambda x: "{:.1f}".format(x) if isinstance(x, (int, float)) else "N/A"
+            format = lambda x: "{:.2f}%".format(x * 10) if isinstance(x, (int, float)) else "N/A"
             prep_national = format(prep_summary.get("national"))
             prep_regional = format(prep_summary.get("regions"))
             prep_district = format(prep_summary.get("districts"))


### PR DESCRIPTION
Change the score display from 10 based to percentage like it is in the frontend


Related JIRA tickets : POLIO-1030

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [NA] Are my typescript files well typed
- [NA] New translations have been added or updated if new strings have been introduced in the frontend
- [NA] My migrations file are included
- [no] Are there enough tests
- [na] Documentation has be4en included (for new feature)

## Changes

## How to test

see previous pr on this.

## Print screen / video
sample email
```
Dear GPEI coordinator – CAMEROON,

Weekly status update: Today is day 122 to Round 0 start date.
Below is the summary of the campaign test prep cameroon. For more details, visit https://afro-rrt-who.hub.arcgis.com/pages/country-summary
If there are missing data or dates; visit https://localhost:8081/dashboard/polio/list/campaignId/a2aaaba3-2382-4135-adda-e811fc639250 to update

* Notification date              : None
* Next round (Round 0) date: 2023-10-01
* Vaccine Type                   : 
* Target population              :  
* RA RRT/ORPG approval date      : None
* Date Budget Submitted          : None
* Link to Round 0 preparedness Google sheet: https://docs.google.com/spreadsheets/d/1cEZKEGHY7rW1bslsy2TKNWhvZ0GJgFksmRKJD-pgk0A/edit?pli=1#gid=2072139853
* Prep. national                 : 51.11%
* Prep. regional                 : 95.48%
* Prep. district                 : 94.06%

For guidance on updating: contact RRT team
Timeline tracker Automated message.
```
