### PR TITLE
IA-2119 filter users with no type assigned

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -986,6 +986,7 @@
     "iaso.users.filter.searchUser": "Search user",
     "iaso.users.isSuperUser": "User is a super admin and has all rights",
     "iaso.users.label.homePage": "Home page",
+    "iaso.users.label.noTypeAssigned": "No org unit type assigned",
     "iaso.users.newPassword": "New password",
     "iaso.users.ouChildrenCheckbox": "Users with access to children org unit",
     "iaso.users.ouParentCheckbox": "Users with access to parent org unit",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -973,6 +973,7 @@
     "iaso.users.filter.searchUser": "Rechercher un utilisateur",
     "iaso.users.isSuperUser": "L'utilisateur est administrateur et a tous les droits.",
     "iaso.users.label.homePage": "Page d'accueil",
+    "iaso.users.label.noTypeAssigned": "Aucun type d'unité d'org assigné",
     "iaso.users.newPassword": "Nouveau mot de passe",
     "iaso.users.ouChildrenCheckbox": "Utilisateurs avec accès aux unités d'organisations enfants",
     "iaso.users.ouParentCheckbox": "Utilisateurs avec accès aux unités d'organisations parents",

--- a/hat/assets/js/apps/Iaso/domains/users/components/Filters.js
+++ b/hat/assets/js/apps/Iaso/domains/users/components/Filters.js
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useMemo } from 'react';
 import { useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
 
@@ -15,7 +15,7 @@ import SearchIcon from '@material-ui/icons/Search';
 import { commonStyles, useSafeIntl } from 'bluesquare-components';
 
 import InputComponent from 'Iaso/components/forms/InputComponent';
-import { redirectTo } from '../../../routing/actions';
+import { redirectTo } from '../../../routing/actions.ts';
 import MESSAGES from '../messages';
 import { useGetPermissionsDropDown } from '../hooks/useGetPermissionsDropdown.ts';
 import { useGetOrgUnitTypes } from '../../orgUnits/hooks/requests/useGetOrgUnitTypes.ts';
@@ -48,8 +48,18 @@ const Filters = ({ baseUrl, params }) => {
     const [initialOrgUnitId, setInitialOrgUnitId] = useState(params?.location);
     const { data: dropdown, isFetching } = useGetPermissionsDropDown();
     const { data: initialOrgUnit } = useGetOrgUnit(initialOrgUnitId);
-    const { data: orgUnitTypeDropdown, isFetching: isFetchingOuTypes } =
+    const { data: orgUnitTypes, isFetching: isFetchingOuTypes } =
         useGetOrgUnitTypes();
+
+    const orgUnitTypeDropdown = useMemo(() => {
+        if (!orgUnitTypes?.length) return orgUnitTypes;
+        const options = [...orgUnitTypes];
+        options.push({
+            value: 'unassigned',
+            label: formatMessage(MESSAGES.noTypeAssigned),
+        });
+        return options;
+    }, [formatMessage, orgUnitTypes]);
 
     const theme = useTheme();
     const isLargeLayout = useMediaQuery(theme.breakpoints.up('md'));

--- a/hat/assets/js/apps/Iaso/domains/users/index.js
+++ b/hat/assets/js/apps/Iaso/domains/users/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
 import { makeStyles, Box, Grid } from '@material-ui/core';
@@ -9,7 +9,6 @@ import {
     LoadingSpinner,
     AddButton as AddButtonComponent,
     useSafeIntl,
-    useSkipEffectOnMount,
 } from 'bluesquare-components';
 
 import TopBar from '../../components/nav/TopBarComponent';
@@ -24,8 +23,7 @@ import { useSaveProfile } from './hooks/useSaveProfile';
 import usersTableColumns from './config';
 import MESSAGES from './messages';
 
-import { redirectTo } from '../../routing/actions';
-import { convertObjectToString } from '../../utils/dataManipulation.ts';
+import { redirectTo } from '../../routing/actions.ts';
 import { useCurrentUser } from '../../utils/usersUtils.ts';
 import { BulkImportUsersDialog } from './components/BulkImportDialog/BulkImportDialog.tsx';
 
@@ -38,12 +36,6 @@ const useStyles = makeStyles(theme => ({
 const Users = ({ params }) => {
     const classes = useStyles();
     const currentUser = useCurrentUser();
-    const [resetPageToOne, setResetPageToOne] = useState(
-        convertObjectToString({
-            pageSize: params.pageSize,
-            search: params.search,
-        }),
-    );
     const { formatMessage } = useSafeIntl();
     const dispatch = useDispatch();
 
@@ -55,15 +47,6 @@ const Users = ({ params }) => {
     const { mutate: saveProfile, isLoading: savingProfile } = useSaveProfile();
 
     const isLoading = fetchingProfiles || deletingProfile || savingProfile;
-
-    useSkipEffectOnMount(() => {
-        setResetPageToOne(
-            convertObjectToString({
-                pageSize: params.pageSize,
-                search: params.search,
-            }),
-        );
-    }, [params.pageSize, params.search]);
 
     return (
         <>
@@ -111,7 +94,11 @@ const Users = ({ params }) => {
                     count={data?.count ?? 0}
                     baseUrl={baseUrl}
                     params={params}
-                    resetPageToOne={resetPageToOne}
+                    // resetPageToOne={resetPageToOne}
+                    extraProps={{
+                        pageSize: params.pageSize,
+                        search: params.search,
+                    }}
                     redirectTo={(b, p) => dispatch(redirectTo(b, p))}
                 />
             </Box>

--- a/hat/assets/js/apps/Iaso/domains/users/messages.js
+++ b/hat/assets/js/apps/Iaso/domains/users/messages.js
@@ -306,6 +306,10 @@ const MESSAGES = defineMessages({
         id: 'iaso.label.close',
         defaultMessage: 'Close',
     },
+    noTypeAssigned: {
+        id: 'iaso.users.label.noTypeAssigned',
+        defaultMessage: 'No org unit type assigned',
+    },
 });
 
 export default MESSAGES;

--- a/iaso/api/profiles.py
+++ b/iaso/api/profiles.py
@@ -130,7 +130,10 @@ class ProfilesViewSet(viewsets.ViewSet):
                 queryset = queryset_current | queryset_parent | queryset_children
 
         if org_unit_type:
-            queryset = queryset.filter(user__iaso_profile__org_units__org_unit_type__pk=org_unit_type).distinct()
+            if org_unit_type == "unassigned":
+                queryset = queryset.filter(user__iaso_profile__org_units__org_unit_type__pk=None).distinct()
+            else:
+                queryset = queryset.filter(user__iaso_profile__org_units__org_unit_type__pk=org_unit_type).distinct()
 
         if limit:
             queryset = queryset.order_by(*orders)


### PR DESCRIPTION
At the moment, filters effectively allow to find the list of all users associated to Provinces, Health zones, Health areas or any existing OU type. However, they don’t allow finding users that are not associated to any OU type.

Use case : In the situation below, among the 284 existing users, 10 of them seem to not be associated to any OU type and therefore currently have access to any OU. I want to be able to check that all of these are part of the admin team or if any user was just missed while adding geographic restrictions. At the moment this isn’t possible without reviewing all of them individually.

Related JIRA tickets : IA-2119

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- Change api so `org_unit_type`can be `"unassigned", and return users with no org unit type assigned
- Add new option to org unit types filter 
- Remove `resetPageToOne`state and props to users table (cleanup unrelated to the ticket)

## How to test

 - Go to users
 - Use the org unit types filter to find users with a type assigned
 - Use the org unit types filter and select "No org unit type assigned"
 - The users from the first search should not appear in the results

## Print screen / video

https://github.com/BLSQ/iaso/assets/38907762/804af207-2b30-4908-82eb-f3626d4b5a70


