### PR TITLE
IA-2216 Django gettext deprecation warning

### DIFF
--- a/hat/settings.py
+++ b/hat/settings.py
@@ -24,7 +24,7 @@ from urllib.parse import urlparse
 
 import sentry_sdk
 from django.core.exceptions import ImproperlyConfigured
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from sentry_sdk.integrations.django import DjangoIntegration
 
 from plugins.wfp.wfp_pkce_generator import generate_pkce

--- a/iaso/api/comment.py
+++ b/iaso/api/comment.py
@@ -2,7 +2,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.sites.models import Site
 from django.utils.encoding import smart_str
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers, mixins, permissions
 from rest_framework.exceptions import ValidationError, PermissionDenied
 from rest_framework.pagination import LimitOffsetPagination

--- a/iaso/models/base.py
+++ b/iaso/models/base.py
@@ -22,7 +22,7 @@ from django.db import models
 from django.db.models import Q, FilteredRelation, Count
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from hat.audit.models import log_modification, INSTANCE_API
 from iaso.models.data_source import SourceVersion, DataSource

--- a/iaso/models/comment.py
+++ b/iaso/models/comment.py
@@ -1,6 +1,6 @@
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django_comments.abstracts import CommentAbstractModel  # type: ignore
 
 

--- a/iaso/models/device.py
+++ b/iaso/models/device.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 from django.conf import settings
 from django.contrib.gis.db.models import PointField
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class Device(models.Model):

--- a/iaso/models/forms.py
+++ b/iaso/models/forms.py
@@ -7,7 +7,7 @@ from django.contrib.postgres.fields import ArrayField, CITextField
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.db import models, transaction
 from django.utils.html import strip_tags
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .project import Project
 from .. import periods

--- a/iaso/models/org_unit.py
+++ b/iaso/models/org_unit.py
@@ -10,7 +10,7 @@ from django.contrib.postgres.indexes import GistIndex
 from django.db import models, transaction
 from django.db.models import QuerySet
 from django.db.models.expressions import RawSQL
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django_ltree.fields import PathField  # type: ignore
 from django_ltree.models import TreeModel  # type: ignore
 

--- a/iaso/models/pages.py
+++ b/iaso/models/pages.py
@@ -1,6 +1,6 @@
 from django.contrib.auth.models import User
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from iaso.models import Account
 

--- a/plugins/polio/budget/models.py
+++ b/plugins/polio/budget/models.py
@@ -10,7 +10,7 @@ from django.core.mail import EmailMultiAlternatives
 from django.db import models
 from django.template import Engine, TemplateSyntaxError, Context
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from hat.api.token_authentication import generate_auto_authentication_link
 from iaso.utils.models.soft_deletable import SoftDeletableModel


### PR DESCRIPTION
ugettext_lazy was an alias for gettext_lazy, it is deprecated in our version of Django and will be removed from the next, so in preparation of a future upgrade this PR correct the usage.

Related JIRA tickets : IA-2216

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [NA] Are my typescript files well typed
- [NA] New translations have been added or updated if new strings have been introduced in the frontend
- [NA] My migrations file are included
- [NA] Are there enough tests
- [NA] Documentation has been included (for new feature)

## Changes

Just did a mass replace


## How to test

No change in behavior expected
