### PR TITLE
Upgrade dependencie ipython

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,6 +613,11 @@ SHOW_NAME_WITH_LOGO="<'yes' or 'no'>"
 Contributing
 ============
 
+If you are not using the Docker container for development, please ensure that
+you are using the supported Python version on your local machine. At the time of
+writing, the supported version is 3.8, but it's always a good idea to check the
+system requirements section for the most up-to-date information.
+
 Code formatting
 ---------------
 
@@ -734,6 +739,7 @@ External service dependencies:
 * Enketo > 4.0
 * Access to an SMTP server to send e-mail.
 
+Currently supported version of Python is 3.8.
 
 The PostgreSQL database server and Enketo server can both be deployed in Docker on the same physical machine, it is advised to double the recommended values in that case.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,3 +11,12 @@ exclude = '''
   | src/django-webpack-loader
 )/
 '''
+
+
+[project]
+name= "Iaso"
+readme = "README.md"
+requires-python = "~=3.8"
+
+[project.urls]
+Repository = "https://github.com/BLSQ/"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
+# Iaso requires Python 3.8 to ensure compatibility with the server environment.
+# Please take note of this requirement when updating or upgrading dependencies.
+# (Please update this notice if the required Python version changes.)
+
 # django
 django==3.2.15
 django-cors-headers==3.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,7 +51,7 @@ dhis2.py==2.0.2
 pyxform==1.1.0
 
 
-ipython==7.12.0
+ipython==8.12.2
 django-extensions==2.2.8
 lxml==4.9.1
 xlrd==1.2.0


### PR DESCRIPTION
hopefully this should fix the crash in the shell in the live server when doing tab completion.
This is the last version supported by Python 3.8

