### PR TITLE
IA-2218: Remove "Close" message from the map once a pop-up is closed

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/registry/components/MapPopUp.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/MapPopUp.tsx
@@ -1,13 +1,20 @@
 import React, { FunctionComponent, useRef } from 'react';
 import { Popup, useMap } from 'react-leaflet';
 
-import { Card, CardContent, Box, makeStyles, Divider } from '@material-ui/core';
+import ClearIcon from '@material-ui/icons/Clear';
+import {
+    Card,
+    CardContent,
+    Box,
+    makeStyles,
+    Divider,
+    IconButton,
+} from '@material-ui/core';
 
 import {
     useSafeIntl,
     commonStyles,
     mapPopupStyles,
-    IconButton,
 } from 'bluesquare-components';
 
 import MESSAGES from '../messages';
@@ -66,12 +73,11 @@ export const MapPopUp: FunctionComponent<Props> = ({ orgUnit }) => {
                         />
                     </Box>
                     <IconButton
-                        onClick={() => map.closePopup(popup.current)}
-                        icon="clear"
-                        tooltipMessage={MESSAGES.close}
-                        iconSize="small"
                         size="small"
-                    />
+                        onClick={() => map.closePopup(popup.current)}
+                    >
+                        <ClearIcon />
+                    </IconButton>
                 </Box>
                 <Divider />
                 <CardContent className={classes.popupCardContent}>


### PR DESCRIPTION
On the map displayed in the registry, the closing message stays displayed on the map after actually closing pop-ups.

One would expect these messages to disappear automatically once the pop-up is closed or if the mouse isn’t over the closing cross anymore.

Related JIRA tickets : IA-2218

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

use IconButton from material ui to avoid issue

## How to test

Explain how to test your PR.
If a specific config is required explain it here (dataset, account, profile, ...)

## Print screen / video

https://github.com/BLSQ/iaso/assets/12494624/7c5cc6da-98c2-449c-82ee-674f90f74e82


## Notes

⚠️ Issue is present only on firefox
