### PR TITLE
IA-1931: fix(actions): Take a ref for the triggered action to run the cypress tests

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -3,7 +3,13 @@ name: Iaso Cypress manual testing
 on:
   issue_comment:
     types: [created]
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      ref:
+        type: string
+        description: 'Branch to test'
+        required: true  
+  
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -24,10 +30,17 @@ jobs:
 
     runs-on: ubuntu-20.04
     steps:
-      - name: Checkout repository
+      - name: Checkout repository (dispatch)
         uses: actions/checkout@v3
+        if: github.event_name == 'workflow_dispatch'
         with:
-          fetch-depth: 0
+          ref: ${{ github.event.inputs.ref }}
+      
+      - name: Checkout repository (comment)
+        uses: actions/checkout@v3
+        if: github.event_name != 'workflow_dispatch'
+        with:
+          ref: ${{ github.sha }}
 
       - name: Mark comment as seen
         if: github.event_name != 'workflow_dispatch'
@@ -50,7 +63,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           push: true
-          tags: ghcr.io/blsq/iaso:${{github.sha}}
+          tags: ghcr.io/blsq/iaso:${{ github.event.inputs.ref || github.sha }}
           target: dev
           file: docker/bundle/Dockerfile
           cache-from: type=registry,ref=ghcr.io/blsq/iaso:buildcache
@@ -92,7 +105,7 @@ jobs:
         # needed because the postgres container does not provide a health check
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
       iaso:
-        image: ghcr.io/blsq/iaso:${{ github.sha }}
+        image: ghcr.io/blsq/iaso:${{ github.event.inputs.ref || github.sha }}
         env:
           TEST_PROD: true
           IASO_ENVIRONMENT: development
@@ -110,10 +123,17 @@ jobs:
         ports:
           - 8081:8081
     steps:
-      - name: Checkout repository
+      - name: Checkout repository (dispatch)
         uses: actions/checkout@v3
+        if: github.event_name == 'workflow_dispatch'
         with:
-          fetch-depth: 0
+          ref: ${{ github.event.inputs.ref }}
+      
+      - name: Checkout repository (comment)
+        uses: actions/checkout@v3
+        if: github.event_name != 'workflow_dispatch'
+        with:
+          ref: ${{ github.sha }}
 
       - name: Use node.js 14
         uses: actions/setup-node@v2


### PR DESCRIPTION
Launching cypress test directly on a PR with the comment @cypress is not working properly.

To reproduce, take a branche were tests are passing, checkout the branch,  make a test fail, push and relaunch the tests. They will pass…

Related JIRA tickets : IA-1931

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes
A parameter has been added to the inputs of the manual workflow to select the ref to checkout to build the image and run the tests. It fixes the problem where the workflow would checkout the main branch all the times


## How to test

Needs to be merged on main to test