### PR TITLE
IA-2184 Make Form Attachment works with Enketo

### DIFF
--- a/docker/enketo/config/config.json
+++ b/docker/enketo/config/config.json
@@ -1,6 +1,13 @@
 {
     "app name": "Enketo for iaso dev",
     "encryption key": "Test encryption key do not use in prod",
+    "ip filtering": {
+        "comment": "modification necessary for attachment download",
+        "allowIPAddressList": [],
+        "allowMetaIPAddress": false,
+        "allowPrivateIPAddress": true,
+        "denyAddressList": []
+    },
     "linked form and data server": {
         "api key": "AZE78974654azeAZE",
         "name": "Iaso Dev",

--- a/docker/enketo/config/config.json
+++ b/docker/enketo/config/config.json
@@ -2,10 +2,10 @@
     "app name": "Enketo for iaso dev",
     "encryption key": "Test encryption key do not use in prod",
     "ip filtering": {
-        "comment": "modification necessary for attachment download",
         "allowIPAddressList": [],
         "allowMetaIPAddress": false,
         "allowPrivateIPAddress": true,
+        "comment": "modification necessary for attachment download",
         "denyAddressList": []
     },
     "linked form and data server": {

--- a/iaso/api/enketo.py
+++ b/iaso/api/enketo.py
@@ -270,7 +270,11 @@ def enketo_form_list(request):
 
     latest_form_version = i.form.latest_version
     downloadurl = public_url_for_enketo(request, "/api/enketo/formDownload/?uuid=%s" % i.uuid)
-    manifest_url = public_url_for_enketo(request, f"/api/forms/{i.form_id}/manifest/")
+    # Only add a manifest if we actually have attachment so it doesn't make more unecessary request
+    if i.form.attachments.exists():
+        manifest_url = public_url_for_enketo(request, f"/api/forms/{i.form_id}/manifest/")
+    else:
+        manifest_url = None
 
     if request.method == "GET":
         xforms = to_xforms_xml(

--- a/iaso/api/enketo.py
+++ b/iaso/api/enketo.py
@@ -2,7 +2,7 @@ from logging import getLogger
 from uuid import uuid4
 
 from bs4 import BeautifulSoup as Soup  # type: ignore
-from django.http import HttpResponse, JsonResponse, HttpResponseRedirect
+from django.http import HttpResponse, JsonResponse, HttpResponseRedirect, HttpRequest
 from django.shortcuts import get_object_or_404
 from django.utils.translation import gettext as _
 from rest_framework import permissions
@@ -30,7 +30,7 @@ from iaso.models import User
 logger = getLogger(__name__)
 
 
-def public_url_for_enketo(request, path):
+def public_url_for_enketo(request: HttpRequest, path):
     """Utility function, used for giving Enketo an url by which they can contact our Iaso server,
     so they can download form definitions"""
 
@@ -256,6 +256,8 @@ def enketo_edit_url(request, instance_uuid):
 def enketo_form_list(request):
     """Called by Enketo to get the list of form.
 
+    Implement https://docs.getodk.org/openrosa-form-list/#the-manifest-document
+
     Require a param `formID` which is actually an Instance UUID"""
     form_id_str = request.GET["formID"]
     try:
@@ -264,16 +266,18 @@ def enketo_form_list(request):
         logger.exception("Instance duplicate  uuid when editing")
         # Prioritize instance with a json content, and then the more recently updated
         i = Instance.objects.exclude(deleted=True).filter(uuid=form_id_str).order_by("json", "-updated_at").first()
+    assert i is not None
 
     latest_form_version = i.form.latest_version
-    # will it work through s3, what about "signing" infos if they expires ?
     downloadurl = public_url_for_enketo(request, "/api/enketo/formDownload/?uuid=%s" % i.uuid)
+    manifest_url = public_url_for_enketo(request, f"/api/forms/{i.form_id}/manifest/")
 
     if request.method == "GET":
         xforms = to_xforms_xml(
             i.form,
             download_url=downloadurl,
             version=latest_form_version.version_id,
+            manifest_url=manifest_url,
             md5checksum=calculate_file_md5(latest_form_version.file),
             new_form_id=form_id_str,
         )

--- a/iaso/enketo/enketo_xml.py
+++ b/iaso/enketo/enketo_xml.py
@@ -25,7 +25,7 @@ def inject_instance_id_in_form(xml_str, instance_id):
     return instance_xml.decode("utf-8")
 
 
-def to_xforms_xml(form, download_url, version, md5checksum, new_form_id=None):
+def to_xforms_xml(form, download_url, manifest_url, version, md5checksum, new_form_id=None):
     # create XML
     ns = {"xmlns": "http://openrosa.org/xforms/xformsList"}
     root = etree.Element("xforms", ns)
@@ -65,6 +65,11 @@ def to_xforms_xml(form, download_url, version, md5checksum, new_form_id=None):
     form_url = etree.Element("downloadUrl")
     form_url.text = download_url
     xform.append(form_url)
+
+    if manifest_url:
+        form_url = etree.Element("manifestUrl")
+        form_url.text = manifest_url
+        xform.append(form_url)
 
     xforms_xml = etree.tostring(root, pretty_print=False, encoding="UTF-8")
     return xforms_xml.decode("utf-8")

--- a/iaso/tests/api/test_forms_attachment.py
+++ b/iaso/tests/api/test_forms_attachment.py
@@ -231,15 +231,19 @@ class FormAttachmentsAPITestCase(APITestCase):
         response = self.client.get(MANIFEST_URL.format(form_id=self.form_2.id))
         content = self.assertXMLResponse(response, 200)
         self.assertEqual(
-            b'<?xml version="1.0" encoding="UTF-8"?>\n<manifest '
-            b'xmlns="http://openrosa.org/xforms/xformsManifest">\n<mediaFile>\n    <filename>first '
-            b"attachment</filename>\n    <hash>md5:test1</hash>\n    "
-            b"<downloadUrl>"
-            + self.attachment1.file.url.encode("ascii")
-            + b"</downloadUrl>\n</mediaFile>\n<mediaFile>\n    "
-            b"<filename>second attachment</filename>\n    <hash>md5:test2</hash>\n    "
-            b"<downloadUrl>" + self.attachment2.file.url.encode("ascii") + b"</downloadUrl>\n</mediaFile>\n</manifest>",
-            content,
+            str(
+                b'<?xml version="1.0" encoding="UTF-8"?>\n<manifest '
+                b'xmlns="http://openrosa.org/xforms/xformsManifest">\n<mediaFile>\n    <filename>first '
+                b"attachment</filename>\n    <hash>md5:test1</hash>\n    "
+                b"<downloadUrl>http://testserver"
+                + self.attachment1.file.url.encode("ascii")
+                + b"</downloadUrl>\n</mediaFile>\n<mediaFile>\n    "
+                b"<filename>second attachment</filename>\n    <hash>md5:test2</hash>\n    "
+                b"<downloadUrl>http://testserver"
+                + self.attachment2.file.url.encode("ascii")
+                + b"</downloadUrl>\n</mediaFile>\n</manifest>"
+            ),
+            str(content),
         )
 
     def test_form_attachments_with_invalid_character(self):
@@ -260,7 +264,7 @@ class FormAttachmentsAPITestCase(APITestCase):
             b'<?xml version="1.0" encoding="UTF-8"?>\n<manifest '
             b'xmlns="http://openrosa.org/xforms/xformsManifest">\n<mediaFile>\n    <filename>&lt;&amp;&gt;.png'
             b"</filename>\n    <hash>md5:test1</hash>\n    "
-            b"<downloadUrl>"
+            b"<downloadUrl>http://testserver"
             + escape(attachment.file.url).encode("ascii")
             + b"</downloadUrl>\n</mediaFile>\n</manifest>",
             content,

--- a/iaso/tests/enketo/test_enketo_lib.py
+++ b/iaso/tests/enketo/test_enketo_lib.py
@@ -27,7 +27,11 @@ class EnketoLibTests(TestCase):
         form = m.Form.objects.create(name="name < with entity", form_id="odk_form_id")
         m.FormVersion.objects.create(form=form, version_id="2012010601")
         xml = to_xforms_xml(
-            form=form, version="2019559126", download_url="https://xlsform/odk_form_id.xml", md5checksum="857564sdf"
+            form=form,
+            version="2019559126",
+            download_url="https://xlsform/odk_form_id.xml",
+            md5checksum="857564sdf",
+            manifest_url=None,
         )
         expectedXforms = [
             '<xforms xmlns="http://openrosa.org/xforms/xformsList">',


### PR DESCRIPTION
The form attachment feature was added for the mobi84le but didn't work with enketo, this implement it.

Related JIRA tickets : IA-2184

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [NA] Are my typescript files well typed
- [NA] New translations have been added or updated if new strings have been introduced in the frontend
- [NA] My migrations file are included
- [no] Are there enough tests
- [no] Documentation has been included (for new feature)

## Changes

- Pass the manifest url via the formDownload endpoint so enketo know to retreive the attachment. (in mobile the app construct it)
- Had to make a hack in the manifest endpoint to always have absolute uri, with the enketo domain hack for docker.
- Modification in enketo settings so it would download the attachement properly without a security error. This should only be needed in local

## How to test

- Ask Benjamin for the proper file (the xlsform and the csv)
- Launch your docker with Enketo. See the doc in the readme if you don't know how.
- Create a new form with the file (Form version + attachment)
- Create submissions
