### PR TITLE
IA-2232 Fix duplicate orgunit in registry missing submissions

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/registry/hooks/useGetEmptyInstanceOrgUnits.ts
+++ b/hat/assets/js/apps/Iaso/domains/registry/hooks/useGetEmptyInstanceOrgUnits.ts
@@ -20,7 +20,7 @@ type ApiParams = {
     parent_org_unit_id: string;
     without_submissions: boolean;
 };
-export const defaultSorted = [{ id: 'orgunit__name', desc: false }];
+export const defaultSorted = [{ id: 'name', desc: false }];
 
 export const useGetEmptyInstanceOrgUnits = (
     params: RegistryDetailParams,

--- a/iaso/api/completeness_stats.py
+++ b/iaso/api/completeness_stats.py
@@ -294,6 +294,12 @@ class CompletenessStatsV2ViewSet(viewsets.ViewSet):
         # Transform the order parameter to handle the json properly
         converted_orders: List[Union[str, OrderBy]] = []
         for order in orders:
+            # There is an issue with using orgunit__name as it does a supplementary outer join that duplicate lines
+            # and break pagination
+            if order == "orgunit__name" or order == "-orgunit__name":
+                raise serializers.ValidationError(
+                    {"order": ["Sorting by `orgunit__name` is not supported, please use `name` instead"]}
+                )
             if not (order.startswith("form_stats") or order.startswith("-form_stats")):
                 converted_orders.append(order)
             else:


### PR DESCRIPTION
Related JIRA tickets : IA-2232

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are my typescript files well typed
- [x] New translations have been added or updated if new strings have been introduced in the frontend
- [x] My migrations file are included
- [x] Are there enough tests
- [x] Documentation has been included (for new feature)

## Changes
This is an error in the completeness stats endpoint, I have found out that the trigger  is using : `order=orgunit__name` Which do a supplementary outer join . which duplicate row and produce inconsistent count result. This mean there are a lot of rows but only the first two are taken.

For the moment I found a fix by changing the paramter to order=name in the frontend

But they are probably other parameter that will cause this problem, so we will probably need a better fix in the long term.
  I checked `order by parent__name` don’t trigger it.

I tried to fix this using a distinct but this cause other issues, and don't prevent the join

This error is reproducible directly from the stock data of seed_test_data.

## How to test

To reproduce the error
-
Do the seed data import
Go to registry
Sierra Leone -> Western Area -> Event Tracker
Missing Submission(s)

What happen:

Rural Western Area is listed twice

What should happen:

It should list: Freetown and Rural Western Area.
