### PR TITLE
IA-2226 treeview bug

### DIFF
--- a/hat/assets/js/apps/Iaso/hooks/useObjectState.ts
+++ b/hat/assets/js/apps/Iaso/hooks/useObjectState.ts
@@ -41,7 +41,6 @@ export const recursiveReducer = (state, fieldDict): Record<string, any> => {
  * Example:
  * const [state, setState] = useObjectState(initialState)
  * setState({name: "Bond"})
- * The `dictReducer` uses immer so it's safe to use with complex objects
  * You can update nested objects as well, but it's not type safe in the sens that you can add fields to the state
  * that didn't previously exist
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
                 "color": "^3.1.2",
                 "dom-to-pdf": "^0.3.1",
                 "formik": "^2.2.9",
-                "immer": "^9.0.19",
                 "leaflet": "^1.9.3",
                 "leaflet-draw": "^1.0.4",
                 "leaflet.markercluster": "^1.4.1",
@@ -52,7 +51,6 @@
                 "redux-thunk": "^2.3.0",
                 "typescript": "^4.5.2",
                 "use-debounce": "^7.0.0",
-                "use-immer": "^0.8.1",
                 "video.js": "^7.20.3",
                 "yup": "^0.32.9"
             },
@@ -6028,7 +6026,7 @@
         },
         "node_modules/bluesquare-components": {
             "version": "0.2.0",
-            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#a452e04a690468f17674d0cec842daa46bc6e3a6",
+            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#8610084ba02c0ebdb102a9f689768ca708a3682d",
             "license": "Apache-2.0",
             "dependencies": {
                 "@babel/plugin-transform-runtime": "^7.17.0",
@@ -14685,15 +14683,6 @@
             "dev": true,
             "engines": {
                 "node": ">= 4"
-            }
-        },
-        "node_modules/immer": {
-            "version": "9.0.19",
-            "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.19.tgz",
-            "integrity": "sha512-eY+Y0qcsB4TZKwgQzLaE/lqYMlKhv5J9dyd2RhhtGhNo2njPXDqU9XPfcNfa3MIDsdtZt5KlkIsirlo4dHsWdQ==",
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/immer"
             }
         },
         "node_modules/immutable": {
@@ -28132,15 +28121,6 @@
                 "react": ">=16.8.0"
             }
         },
-        "node_modules/use-immer": {
-            "version": "0.8.1",
-            "resolved": "https://registry.npmjs.org/use-immer/-/use-immer-0.8.1.tgz",
-            "integrity": "sha512-OfTFf1pL+ICjjcLPn9+ZnaJO/Yg4MBzYZtACEe2mZ/W2A5col28PNUnwowOAaBuOogACOK/37TU17KgsIhUpOw==",
-            "peerDependencies": {
-                "immer": ">=2.0.0",
-                "react": "^16.8.0 || ^17.0.1 || ^18.0.0"
-            }
-        },
         "node_modules/util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -34203,7 +34183,7 @@
             "dev": true
         },
         "bluesquare-components": {
-            "version": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#a452e04a690468f17674d0cec842daa46bc6e3a6",
+            "version": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#8610084ba02c0ebdb102a9f689768ca708a3682d",
             "from": "bluesquare-components@github:BLSQ/bluesquare-components",
             "requires": {
                 "@babel/plugin-transform-runtime": "^7.17.0",
@@ -40540,11 +40520,6 @@
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
             "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
             "dev": true
-        },
-        "immer": {
-            "version": "9.0.19",
-            "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.19.tgz",
-            "integrity": "sha512-eY+Y0qcsB4TZKwgQzLaE/lqYMlKhv5J9dyd2RhhtGhNo2njPXDqU9XPfcNfa3MIDsdtZt5KlkIsirlo4dHsWdQ=="
         },
         "immutable": {
             "version": "3.8.2",
@@ -50655,12 +50630,6 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-7.0.0.tgz",
             "integrity": "sha512-4fvxEEs7ztdNMh+c497HAgysdq2+Ascem6EaDANGlCIap1JzqfL03Xw8xkYc2lShfXm4uO6PA6V5zcXN7gJdFA==",
-            "requires": {}
-        },
-        "use-immer": {
-            "version": "0.8.1",
-            "resolved": "https://registry.npmjs.org/use-immer/-/use-immer-0.8.1.tgz",
-            "integrity": "sha512-OfTFf1pL+ICjjcLPn9+ZnaJO/Yg4MBzYZtACEe2mZ/W2A5col28PNUnwowOAaBuOogACOK/37TU17KgsIhUpOw==",
             "requires": {}
         },
         "util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
         "redux-thunk": "^2.3.0",
         "typescript": "^4.5.2",
         "use-debounce": "^7.0.0",
-        "use-immer": "^0.8.1",
         "video.js": "^7.20.3",
         "yup": "^0.32.9"
     },

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
         "color": "^3.1.2",
         "dom-to-pdf": "^0.3.1",
         "formik": "^2.2.9",
-        "immer": "^9.0.19",
         "leaflet": "^1.9.3",
         "leaflet-draw": "^1.0.4",
         "leaflet.markercluster": "^1.4.1",


### PR DESCRIPTION
Un selecetable treeview leaves were hidden, confusing users


Related JIRA tickets : IA-2226, IA-1357

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [X] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes
- The change was made to the treeview in [bluesquare-components](https://github.com/BLSQ/bluesquare-components/pull/123)
- removed unused dependency to `immer` and updated related comment in `useObjectState.ts`

## How to test

- Update package.json to use branch `IA-2226_show_unselectable_treview_leaf`  for bluesquare-compoenents
- Go to Submissions, select a form with restrictions on org unit types (in my DB: CODA-Registration) and click "Search"
- Click "Create"
- Check the treeview: unselectable leaf nodes should appear but be greyed out and unselectable, as opposed as previously, when they were hidden

## Print screen / video

![Screenshot 2023-06-13 at 11 12 06](https://github.com/BLSQ/iaso/assets/38907762/67827e59-31af-474e-8b66-68e969747aa4)


## Notes

⚠️ Depends on https://github.com/BLSQ/bluesquare-components/pull/123. Once the PR is merged, the package.lock should be updated on this branch before merging
