### PR TITLE
WC2-226: Fix 500 when there is no `email` field in the response

### DIFF
--- a/plugins/wfp_auth/views.py
+++ b/plugins/wfp_auth/views.py
@@ -105,7 +105,10 @@ class WFP2Adapter(Auth0OAuth2Adapter):
         extra_data_get = requests.get(self.profile_url, params={"access_token": token})
         extra_data_get.raise_for_status()
         extra_data: ExtraData = extra_data_get.json()
-        email = extra_data["email"].lower().strip()
+        try:
+            email = extra_data["email"].lower().strip()
+        except KeyError:
+            email = extra_data["sub"].lower().strip()
         # the sub is the email, wfp verify it so let's trust this
         uid = extra_data["sub"].lower().strip()
         account = Account.objects.get(name=self.settings["IASO_ACCOUNT_NAME"])


### PR DESCRIPTION
When connecting using a WFP account, the `email` value is not returned. Instead, it can be found in `sub`.

Related JIRA tickets : WC2-226

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented

## Changes

When connecting using a WFP account, the `email` value is not returned. Instead, it can be found in `sub`.

## How to test

Connect using a WFP account 
