### PR TITLE
Ia 2197 table row bug

### DIFF
--- a/docs/pages/dev/reference/front-end_guidelines/front-end_guidelines.md
+++ b/docs/pages/dev/reference/front-end_guidelines/front-end_guidelines.md
@@ -175,11 +175,51 @@ Props:
 - `isCircle`: not required, display marker as a circle or not
 - `onContextmenu`: not required, method applied while right clicking on the marker on the map
 
+
+### Tables
+
+Most tables we use need to support filters and deep linking. We have a `TableWithDeepLinking` component for that purpose, which is a wrapper on the `Table` from Bluesuare-components.
+
+The typical props to pass are:
+- `data`: the table data. Usually originate s from a `react-query` hook
+- `page`: the current page. Usually returned by the API
+- `pageSize`: the amount of rows to display on each page. Also comes from the API
+- `count`: the total amount of items in the page. From the API
+- `pages: total number of pages. From the API
+- `baseUrl`: the baseUrl the table will redirect to 
+- `params`: the params of the current location. `TableWithDeepLink` will combine them with `baseUrl`to redirect to the correct location
+- `extraProps`: an object. The `loading` key will be used to manage the table's loading state. Other values will force a table re-render when they change (similar to `useEffect` deps array), which can be useful in some situations
+- `columns`: an array of objects of type `Column` (imported from bluesquare-components). It's usually defined in a custom hook in order to easily handle translations.
+
+**Note: `useDeleteTableRow`** 
+When performing `DELETE` operations from the table that will reduce the amount of table rows, we can run into a pagination bug. To avoid it, use `useDeleteTableRow` in the `useDelete<whatever>` hook that will return the delete function:
+
+```javascript
+export const useDeleteWhatever = (
+    params: Record<string, any>,
+    count: number,
+): UseMutationResult => {
+    const onSuccess = useDeleteTableRow({
+        params,
+        pageKey: 'whateverPage', // optional, will default to "page"
+        pageSizeKey: 'whateverPageSize', //optional, will default to "pageSize"
+        count,
+        invalidateQueries: ['whatever'], // optional
+        baseUrl: baseUrls.whatever,
+    });
+    return useSnackMutation({
+        mutationFn: deleteWhatever,
+        options: { onSuccess },
+    });
+};
+```
+
+
 ## Remarks
 
 - order translations by alphanumeric
 - spacing is by default theme.spacing(2)
 - do not use Grid everywhere or too much
-- all tha call to the api without query params should end by '/'
+- all the calls to the api without query params should end by '/'
 - prefer `type?:string` to `type: string | undefined`
 - prefer `const myVar = otherValue??"placeholder` to `let myVar = "placeholder" if(otherVAlue){myVar = otherValue}`

--- a/hat/assets/js/apps/Iaso/components/tables/TableWithDeepLink.tsx
+++ b/hat/assets/js/apps/Iaso/components/tables/TableWithDeepLink.tsx
@@ -1,6 +1,9 @@
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, useCallback } from 'react';
 import { Table, TableComponentProps } from 'bluesquare-components';
+import { useQueryClient } from 'react-query';
+import { useDispatch } from 'react-redux';
 import { handleTableDeepLink } from '../../utils/table';
+import { redirectToReplace } from '../../routing/actions';
 
 type TableWithDeepLinkProps = TableComponentProps & {
     baseUrl: string;
@@ -14,4 +17,50 @@ export const TableWithDeepLink: FunctionComponent<TableWithDeepLinkProps> = ({
         // eslint-disable-next-line react/jsx-props-no-spreading
         <Table {...props} onTableParamsChange={handleTableDeepLink(baseUrl)} />
     );
+};
+
+type UseDeleteTableRowArgs = {
+    params: Record<string, any>;
+    pageKey?: string;
+    pageSizeKey?: string;
+    count: number;
+    invalidateQueries?: string[];
+    baseUrl: string;
+};
+
+export const useDeleteTableRow = ({
+    params,
+    pageKey = 'page',
+    pageSizeKey = 'pageSize',
+    count,
+    invalidateQueries,
+    baseUrl,
+}: UseDeleteTableRowArgs): (() => void) => {
+    const queryClient = useQueryClient();
+    const dispatch = useDispatch();
+    return useCallback(() => {
+        const page = parseInt(params[pageKey], 10);
+        const pageSize = parseInt(params[pageSizeKey], 10);
+        const newCount = count - 1;
+        // If count falls into the range of the previous page, redirect to that page
+        if (newCount <= (page - 1) * pageSize && page > 1) {
+            const newParams = {
+                ...params,
+                [pageKey]: `${page - 1}`,
+            };
+            dispatch(redirectToReplace(baseUrl, newParams));
+        }
+        if (invalidateQueries) {
+            queryClient.invalidateQueries(invalidateQueries);
+        }
+    }, [
+        baseUrl,
+        count,
+        dispatch,
+        invalidateQueries,
+        pageKey,
+        pageSizeKey,
+        params,
+        queryClient,
+    ]);
 };

--- a/hat/assets/js/apps/Iaso/domains/forms/components/FormAttachments.tsx
+++ b/hat/assets/js/apps/Iaso/domains/forms/components/FormAttachments.tsx
@@ -26,7 +26,7 @@ export const FormAttachments: FunctionComponent<Props> = ({ params }) => {
         params.formId,
     );
     const dispatch = useDispatch();
-    const columns = useGetColumns();
+    const columns = useGetColumns(params, attachments?.count ?? 0);
     return (
         <Box>
             <Box

--- a/hat/assets/js/apps/Iaso/domains/forms/config/attachments.tsx
+++ b/hat/assets/js/apps/Iaso/domains/forms/config/attachments.tsx
@@ -1,17 +1,19 @@
 import React, { ReactElement, useMemo } from 'react';
 import { Link } from 'react-router';
-import { useSafeIntl, IconButton } from 'bluesquare-components';
+import { useSafeIntl, IconButton, Column } from 'bluesquare-components';
 import GetAppIcon from '@material-ui/icons/GetApp';
 
-import { Column } from '../../../types/table';
 import MESSAGES from '../messages';
 import { DateTimeCell } from '../../../components/Cells/DateTimeCell';
 import DeleteDialog from '../../../components/dialogs/DeleteDialogComponent';
 import { useDeleteAttachment } from '../hooks/useDeleteAttachment';
 
-export const useGetColumns = (): Column[] => {
+export const useGetColumns = (params, count): Column[] => {
     const { formatMessage } = useSafeIntl();
-    const { mutateAsync: deleteAttachment } = useDeleteAttachment();
+    const { mutateAsync: deleteAttachment } = useDeleteAttachment(
+        params,
+        count,
+    );
     return useMemo(
         () => [
             {

--- a/hat/assets/js/apps/Iaso/domains/forms/detail.js
+++ b/hat/assets/js/apps/Iaso/domains/forms/detail.js
@@ -13,7 +13,7 @@ import {
     LoadingSpinner,
     useSafeIntl,
 } from 'bluesquare-components';
-import { redirectToReplace } from '../../routing/actions';
+import { redirectToReplace } from '../../routing/actions.ts';
 
 import TopBar from '../../components/nav/TopBarComponent';
 import MESSAGES from './messages';

--- a/hat/assets/js/apps/Iaso/domains/forms/hooks/useDeleteAttachment.tsx
+++ b/hat/assets/js/apps/Iaso/domains/forms/hooks/useDeleteAttachment.tsx
@@ -1,13 +1,36 @@
-import { UseMutationResult } from 'react-query';
+import { UseMutationResult, useQueryClient } from 'react-query';
+import { useDispatch } from 'react-redux';
 import { deleteRequest } from '../../../libs/Api';
 import { useSnackMutation } from '../../../libs/apiHooks';
+import { redirectToReplace } from '../../../routing/actions';
+import { baseUrls } from '../../../constants/urls';
 
 const deleteAttachment = (id: number) =>
     deleteRequest(`/api/formattachments/${id}`);
 
-export const useDeleteAttachment = (): UseMutationResult => {
+export const useDeleteAttachment = (
+    params: any,
+    count: number,
+): UseMutationResult => {
+    const queryClient = useQueryClient();
+    const dispatch = useDispatch();
+    const { attachmentsPage, attachmentsPageSize } = params;
+    const onSuccess = () => {
+        const page = parseInt(attachmentsPage, 10);
+        const pageSize = parseInt(attachmentsPageSize, 10);
+        const newCount = count - 1;
+        if (newCount / pageSize > 1) {
+            const newParams = {
+                ...params,
+                attachmentsPage: `${page - 1}`,
+            };
+            dispatch(redirectToReplace(baseUrls.formDetail, newParams));
+        }
+        queryClient.invalidateQueries(['formAttachments']);
+    };
     return useSnackMutation({
         mutationFn: deleteAttachment,
-        invalidateQueryKey: ['formAttachments'],
+        options: { onSuccess },
+        // invalidateQueryKey: ['formAttachments'],
     });
 };

--- a/hat/assets/js/apps/Iaso/domains/forms/hooks/useDeleteAttachment.tsx
+++ b/hat/assets/js/apps/Iaso/domains/forms/hooks/useDeleteAttachment.tsx
@@ -1,36 +1,26 @@
-import { UseMutationResult, useQueryClient } from 'react-query';
-import { useDispatch } from 'react-redux';
+import { UseMutationResult } from 'react-query';
 import { deleteRequest } from '../../../libs/Api';
 import { useSnackMutation } from '../../../libs/apiHooks';
-import { redirectToReplace } from '../../../routing/actions';
 import { baseUrls } from '../../../constants/urls';
+import { useDeleteTableRow } from '../../../components/tables/TableWithDeepLink';
 
 const deleteAttachment = (id: number) =>
     deleteRequest(`/api/formattachments/${id}`);
 
 export const useDeleteAttachment = (
-    params: any,
+    params: Record<string, any>,
     count: number,
 ): UseMutationResult => {
-    const queryClient = useQueryClient();
-    const dispatch = useDispatch();
-    const { attachmentsPage, attachmentsPageSize } = params;
-    const onSuccess = () => {
-        const page = parseInt(attachmentsPage, 10);
-        const pageSize = parseInt(attachmentsPageSize, 10);
-        const newCount = count - 1;
-        if (newCount / pageSize > 1) {
-            const newParams = {
-                ...params,
-                attachmentsPage: `${page - 1}`,
-            };
-            dispatch(redirectToReplace(baseUrls.formDetail, newParams));
-        }
-        queryClient.invalidateQueries(['formAttachments']);
-    };
+    const onSuccess = useDeleteTableRow({
+        params,
+        pageKey: 'attachmentsPage',
+        pageSizeKey: 'attachmentsPageSize',
+        count,
+        invalidateQueries: ['formAttachments'],
+        baseUrl: baseUrls.formDetail,
+    });
     return useSnackMutation({
         mutationFn: deleteAttachment,
         options: { onSuccess },
-        // invalidateQueryKey: ['formAttachments'],
     });
 };

--- a/hat/assets/js/apps/Iaso/domains/forms/hooks/useGetAttachments.tsx
+++ b/hat/assets/js/apps/Iaso/domains/forms/hooks/useGetAttachments.tsx
@@ -1,11 +1,10 @@
 /* eslint-disable camelcase */
 import { UseQueryResult } from 'react-query';
-
+import { Pagination } from 'bluesquare-components';
 import { useSnackQuery } from '../../../libs/apiHooks';
 import { getRequest } from '../../../libs/Api';
 import { FormAttachment, FormParams } from '../types/forms';
 import { makeUrlWithParams } from '../../../libs/utils';
-import { Pagination } from '../../../types/table';
 
 export interface FormAttachmentsApiResult extends Pagination {
     results: FormAttachment[];


### PR DESCRIPTION
When deleting the last row of  page in a table with deep link, the url wasn't correctly updated which resulted in a 404

Related JIRA tickets : IA-2197

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [X] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [x] Documentation has been included (for new feature)

## Changes

- Add `useDeleteTableRow` hook
- Update front-end guidelines with `Table` use and intsructions to use `useDeleteTableRow`
- Fix bug in forms attachment

## How to test

Go to Forms > Attachments

- Add attachments to any forms until you have 6 forms
- Change the number of displayed results to 5, in order to have 2 pages
- Go to page 2
- Delete the only attachment

## Print screen / video

Upload here print screens or videos showing the changes

## Notes

The bug was spotted in Forms> Attachments, but is present all over the code base where deep linked tables have deletable rows. This PR is to fix the orginal bug, and to make the solution available for future tables. Fixing the existing ones should be part of another ticket:https://bluesquare.atlassian.net/browse/IA-2240
