### PR TITLE
IA-2248: data source versions pagination not working properly

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/dataSources/components/VersionsDialog.js
+++ b/hat/assets/js/apps/Iaso/domains/dataSources/components/VersionsDialog.js
@@ -26,7 +26,7 @@ import DialogComponent from '../../../components/dialogs/DialogComponent';
 import MESSAGES from '../messages';
 import { AddTask } from './AddTaskComponent';
 import { ImportGeoPkgDialog } from './ImportGeoPkgDialog';
-import { AddNewEmptyVersion } from './AddNewEmptyVersion';
+import { AddNewEmptyVersion } from './AddNewEmptyVersion.tsx';
 import { DateTimeCell } from '../../../components/Cells/DateTimeCell';
 import { EditSourceVersion } from './EditSourceVersion.tsx';
 
@@ -174,7 +174,6 @@ const VersionsDialog = ({ renderTrigger, source, forceRefreshParent }) => {
     const [rowsPerPage, setRowsPerPage] = useState(10);
     const [sortBy, setSortBy] = useState('asc');
     const [sortFocus, setSortFocus] = useState('number');
-    const [resetPageToOne, setResetPageToOne] = useState(`${rowsPerPage}`);
     const dataForTable = useMemo(
         () => source?.versions ?? [],
         [source?.versions],
@@ -198,7 +197,6 @@ const VersionsDialog = ({ renderTrigger, source, forceRefreshParent }) => {
             handleSort(params.order.replace('-', ''));
         }
         if (params.pageSize) {
-            setResetPageToOne(`${params.pageSize}`);
             setRowsPerPage(parseInt(params.pageSize, 10));
         }
         if (params.page) {
@@ -242,7 +240,7 @@ const VersionsDialog = ({ renderTrigger, source, forceRefreshParent }) => {
     const params = useMemo(
         () => ({
             pageSize: rowsPerPage,
-            page,
+            page: page + 1,
         }),
         [rowsPerPage, page],
     );
@@ -276,7 +274,7 @@ const VersionsDialog = ({ renderTrigger, source, forceRefreshParent }) => {
                 data={sortedData}
                 columns={tableColumns(source, forceRefreshParent)}
                 params={params}
-                resetPageToOne={resetPageToOne}
+                page={page}
                 pages={pages}
                 elevation={0}
                 count={source?.versions.length ?? 0}


### PR DESCRIPTION
On the versions list of the data sources page, the page number isn’t properly updated after clicking on arrows:

Clicking on the “next” arrow shows me results 11 to 20 but keeps page number 1/3 (instead of 2/3)

Clicking on the “to the end” arrow shows me results 21 to 23 but indicates page number 2/3 (instead of 3/3)

Related JIRA tickets : IA-2248

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

use correct page number for the table

## How to test

Find a data sources with at least 5 versions, open the versions dialog, change rows per page settings to 5, try to go to the second page, page number should be 2

## Print screen / video


https://github.com/BLSQ/iaso/assets/12494624/f5f45420-ae40-43de-b4be-3195d18563d8


