### PR TITLE
IA--2194: Move the map tile selector to the top right hand corner

### DIFF
--- a/hat/assets/js/apps/Iaso/components/maps/GeoJsonMapComponent.tsx
+++ b/hat/assets/js/apps/Iaso/components/maps/GeoJsonMapComponent.tsx
@@ -8,7 +8,7 @@ import { commonStyles } from 'bluesquare-components';
 import tiles from '../../constants/mapTiles';
 
 import { GeoJson } from './types';
-import { TilesSwitchDialog, Tile } from './tools/TilesSwitchDialog';
+import { Tile } from './tools/TilesSwitchDialog';
 import { CustomZoomControl } from './tools/CustomZoomControl';
 import { CustomTileLayer } from './tools/CustomTileLayer';
 import { Bounds } from '../../utils/map/mapUtils';
@@ -42,10 +42,6 @@ export const GeoJsonMap: FunctionComponent<Props> = ({ geoJson }) => {
 
     return (
         <div className={classes.mapContainer}>
-            <TilesSwitchDialog
-                currentTile={currentTile}
-                setCurrentTile={setCurrentTile}
-            />
             <MapContainer
                 doubleClickZoom
                 scrollWheelZoom={false}
@@ -62,7 +58,10 @@ export const GeoJsonMap: FunctionComponent<Props> = ({ geoJson }) => {
                     boundsOptions={boundsOptions}
                 />
                 <ScaleControl imperial={false} />
-                <CustomTileLayer currentTile={currentTile} />
+                <CustomTileLayer
+                    currentTile={currentTile}
+                    setCurrentTile={setCurrentTile}
+                />
 
                 <GeoJSON
                     // @ts-ignore TODO: fix this type problem

--- a/hat/assets/js/apps/Iaso/components/maps/GeoJsonMapComponent.tsx
+++ b/hat/assets/js/apps/Iaso/components/maps/GeoJsonMapComponent.tsx
@@ -8,7 +8,7 @@ import { commonStyles } from 'bluesquare-components';
 import tiles from '../../constants/mapTiles';
 
 import { GeoJson } from './types';
-import { Tile } from './tools/TilesSwitchDialog';
+import { Tile } from './tools/TilesSwitchControl';
 import { CustomZoomControl } from './tools/CustomZoomControl';
 import { CustomTileLayer } from './tools/CustomTileLayer';
 import { Bounds } from '../../utils/map/mapUtils';

--- a/hat/assets/js/apps/Iaso/components/maps/MarkerMapComponent.tsx
+++ b/hat/assets/js/apps/Iaso/components/maps/MarkerMapComponent.tsx
@@ -10,7 +10,7 @@ import { CustomTileLayer } from './tools/CustomTileLayer';
 
 import tiles from '../../constants/mapTiles';
 import MarkerComponent from './markers/MarkerComponent';
-import { TilesSwitchDialog, Tile } from './tools/TilesSwitchDialog';
+import { Tile } from './tools/TilesSwitchDialog';
 import { CustomZoomControl } from './tools/CustomZoomControl';
 
 const useStyles = makeStyles(theme => ({
@@ -49,10 +49,6 @@ export const MarkerMap: FunctionComponent<Props> = ({
     if (!latitude || !longitude) return null;
     return (
         <div className={classes.mapContainer}>
-            <TilesSwitchDialog
-                currentTile={currentTile}
-                setCurrentTile={setCurrentTile}
-            />
             <MapContainer
                 doubleClickZoom={false}
                 scrollWheelZoom={false}
@@ -69,7 +65,10 @@ export const MarkerMap: FunctionComponent<Props> = ({
                     boundsOptions={boundsOptions}
                 />
                 <ScaleControl imperial={false} />
-                <CustomTileLayer currentTile={currentTile} />
+                <CustomTileLayer
+                    currentTile={currentTile}
+                    setCurrentTile={setCurrentTile}
+                />
                 <MarkerComponent
                     item={{
                         latitude,

--- a/hat/assets/js/apps/Iaso/components/maps/MarkerMapComponent.tsx
+++ b/hat/assets/js/apps/Iaso/components/maps/MarkerMapComponent.tsx
@@ -10,7 +10,7 @@ import { CustomTileLayer } from './tools/CustomTileLayer';
 
 import tiles from '../../constants/mapTiles';
 import MarkerComponent from './markers/MarkerComponent';
-import { Tile } from './tools/TilesSwitchDialog';
+import { Tile } from './tools/TilesSwitchControl';
 import { CustomZoomControl } from './tools/CustomZoomControl';
 
 const useStyles = makeStyles(theme => ({

--- a/hat/assets/js/apps/Iaso/components/maps/tools/CustomTileLayer.tsx
+++ b/hat/assets/js/apps/Iaso/components/maps/tools/CustomTileLayer.tsx
@@ -1,12 +1,17 @@
 import React, { FunctionComponent, useRef, useEffect, RefObject } from 'react';
 import { TileLayer, useMap } from 'react-leaflet';
-import { Tile } from './TilesSwitchDialog';
+import { Tile, TilesSwitchDialog } from './TilesSwitchDialog';
 
 type Props = {
     currentTile: Tile;
+    // eslint-disable-next-line no-unused-vars
+    setCurrentTile: (newTile: Tile) => void;
 };
 
-export const CustomTileLayer: FunctionComponent<Props> = ({ currentTile }) => {
+export const CustomTileLayer: FunctionComponent<Props> = ({
+    currentTile,
+    setCurrentTile,
+}) => {
     const ref: RefObject<any> = useRef(null);
     const map: any = useMap();
     useEffect(() => {
@@ -19,11 +24,17 @@ export const CustomTileLayer: FunctionComponent<Props> = ({ currentTile }) => {
         }
     }, [currentTile, map]);
     return (
-        <TileLayer
-            ref={ref}
-            url={currentTile.url}
-            // @ts-ignore TODO: fix this type problem
-            attribution={currentTile.attribution || ''}
-        />
+        <>
+            <TileLayer
+                ref={ref}
+                url={currentTile.url}
+                // @ts-ignore TODO: fix this type problem
+                attribution={currentTile.attribution || ''}
+            />
+            <TilesSwitchDialog
+                currentTile={currentTile}
+                setCurrentTile={setCurrentTile}
+            />
+        </>
     );
 };

--- a/hat/assets/js/apps/Iaso/components/maps/tools/CustomTileLayer.tsx
+++ b/hat/assets/js/apps/Iaso/components/maps/tools/CustomTileLayer.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent, useRef, useEffect, RefObject } from 'react';
 import { TileLayer, useMap } from 'react-leaflet';
-import { Tile, TilesSwitchDialog } from './TilesSwitchDialog';
+import { Tile, TilesSwitchControl } from './TilesSwitchControl';
 
 type Props = {
     currentTile: Tile;
@@ -31,7 +31,7 @@ export const CustomTileLayer: FunctionComponent<Props> = ({
                 // @ts-ignore TODO: fix this type problem
                 attribution={currentTile.attribution || ''}
             />
-            <TilesSwitchDialog
+            <TilesSwitchControl
                 currentTile={currentTile}
                 setCurrentTile={setCurrentTile}
             />

--- a/hat/assets/js/apps/Iaso/components/maps/tools/TileSwitchComponent.js
+++ b/hat/assets/js/apps/Iaso/components/maps/tools/TileSwitchComponent.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
@@ -7,7 +7,6 @@ import { makeStyles } from '@material-ui/core';
 import RadioButtonChecked from '@material-ui/icons/RadioButtonChecked';
 import RadioButtonUnchecked from '@material-ui/icons/RadioButtonUnchecked';
 import Box from '@material-ui/core/Box';
-import Typography from '@material-ui/core/Typography';
 
 import PropTypes from 'prop-types';
 import { commonStyles, useSafeIntl } from 'bluesquare-components';
@@ -21,7 +20,7 @@ const useStyles = makeStyles(theme => ({
     ...commonStyles(theme),
     ...innerDrawerStyles(theme),
     list: {
-        padding: theme.spacing(0, 0, 2, 0),
+        padding: 0,
     },
     icon: {
         marginRight: theme.spacing(1),
@@ -48,48 +47,41 @@ function TileSwitchComponent(props) {
     const { formatMessage } = useSafeIntl();
     const classes = useStyles();
     return (
-        <>
-            <Box px={2} className={classes.innerDrawerToolbar} component="div">
-                <Typography variant="subtitle1">
-                    {formatMessage(MESSAGES.layersTitle)}
-                </Typography>
-            </Box>
-            <Box py={2} component="div">
-                <List className={classes.list}>
-                    {Object.keys(tiles).map(key => {
-                        const tile = tiles[key];
-                        const isCurrentTile = currentTile.url === tile.url;
-                        return (
-                            <ListItem
-                                selected={isCurrentTile}
-                                className={classes.listItem}
-                                key={key}
-                                button
-                                onClick={() => props.setCurrentTile(tile)}
-                            >
-                                {isCurrentTile && (
-                                    <RadioButtonChecked
-                                        color="primary"
-                                        className={classes.icon}
-                                    />
-                                )}
-                                {!isCurrentTile && (
-                                    <RadioButtonUnchecked
-                                        className={classes.icon}
-                                    />
-                                )}
-                                <ListItemText
-                                    primary={formatMessage(MESSAGES[key])}
-                                    classes={{
-                                        primary: classes.item,
-                                    }}
+        <Box py={2} component="div">
+            <List className={classes.list}>
+                {Object.keys(tiles).map(key => {
+                    const tile = tiles[key];
+                    const isCurrentTile = currentTile.url === tile.url;
+                    return (
+                        <ListItem
+                            selected={isCurrentTile}
+                            className={classes.listItem}
+                            key={key}
+                            button
+                            onClick={() => props.setCurrentTile(tile)}
+                        >
+                            {isCurrentTile && (
+                                <RadioButtonChecked
+                                    color="primary"
+                                    className={classes.icon}
                                 />
-                            </ListItem>
-                        );
-                    })}
-                </List>
-            </Box>
-        </>
+                            )}
+                            {!isCurrentTile && (
+                                <RadioButtonUnchecked
+                                    className={classes.icon}
+                                />
+                            )}
+                            <ListItemText
+                                primary={formatMessage(MESSAGES[key])}
+                                classes={{
+                                    primary: classes.item,
+                                }}
+                            />
+                        </ListItem>
+                    );
+                })}
+            </List>
+        </Box>
     );
 }
 

--- a/hat/assets/js/apps/Iaso/components/maps/tools/TilesSwitchControl.tsx
+++ b/hat/assets/js/apps/Iaso/components/maps/tools/TilesSwitchControl.tsx
@@ -71,7 +71,7 @@ type Props = {
     setCurrentTile: (newTile: Tile) => void;
 };
 
-export const TilesSwitchDialog: FunctionComponent<Props> = ({
+export const TilesSwitchControl: FunctionComponent<Props> = ({
     currentTile,
     setCurrentTile,
 }) => {

--- a/hat/assets/js/apps/Iaso/components/maps/tools/TilesSwitchDialog.tsx
+++ b/hat/assets/js/apps/Iaso/components/maps/tools/TilesSwitchDialog.tsx
@@ -1,17 +1,14 @@
 import React, { FunctionComponent, useState } from 'react';
-import { Dialog, DialogActions, Button, makeStyles } from '@material-ui/core';
-// @ts-ignore
-import { useSafeIntl } from 'bluesquare-components';
+import { Box, makeStyles, Typography } from '@material-ui/core';
+import { IconButton, useSafeIntl } from 'bluesquare-components';
 import Layers from '@material-ui/icons/Layers';
 
+import classNames from 'classnames';
 import TileSwitch from './TileSwitchComponent';
 
 import MESSAGES from '../messages';
 
 const useStyles = makeStyles(theme => ({
-    tileSwitchContainer: {
-        marginBottom: -theme.spacing(4),
-    },
     legendLayers: {
         position: 'absolute',
         right: theme.spacing(1),
@@ -19,18 +16,48 @@ const useStyles = makeStyles(theme => ({
         zIndex: 500,
         borderRadius: 4,
         border: '2px solid rgba(0,0,0,0.2)',
+        minHeight: 28,
+        minWidth: 28,
+    },
+    iconContainer: {
+        position: 'absolute',
+        paddingRight: theme.spacing(0.5),
+        paddingTop: theme.spacing(1),
+        top: 0,
+        right: 0,
+        backgroundColor: 'white',
     },
     barButton: {
         display: 'flex',
-        position: 'relative',
+        position: 'absolute',
         backgroundColor: 'white',
         borderRadius: '4px',
         padding: '2px',
         cursor: 'pointer',
         outline: 'none',
+        top: 0,
+        right: 0,
         boxShadow: 'none',
         // @ts-ignore
         color: `${theme.textColor}! important`,
+    },
+    container: {
+        backgroundColor: 'white',
+        position: 'relative',
+        transition: 'width .1s ease-in-out, height .1s ease-in-out',
+        overflow: 'hidden',
+    },
+    open: {
+        width: 235,
+        height: 240,
+    },
+    closed: {
+        width: 0,
+        height: 0,
+    },
+    title: {
+        paddingLeft: theme.spacing(1),
+        paddingTop: theme.spacing(1),
     },
 }));
 export type Tile = {
@@ -59,35 +86,49 @@ export const TilesSwitchDialog: FunctionComponent<Props> = ({
 
     return (
         <>
-            <Dialog
-                open={tilePopup}
-                onClose={(_, reason) => {
-                    if (reason === 'backdropClick') {
-                        toggleTilePopup();
-                    }
-                }}
-            >
-                <div className={classes.tileSwitchContainer}>
-                    <TileSwitch
-                        setCurrentTile={newtile => setCurrentTile(newtile)}
-                        currentTile={currentTile}
-                    />
-                </div>
-                <DialogActions>
-                    <Button onClick={() => toggleTilePopup()} color="primary">
-                        {formatMessage(MESSAGES.close)}
-                    </Button>
-                </DialogActions>
-            </Dialog>
             <div className={classes.legendLayers}>
-                <span
-                    className={classes.barButton}
-                    role="button"
-                    tabIndex={0}
-                    onClick={() => toggleTilePopup()}
+                {!tilePopup && (
+                    <span
+                        className={classes.barButton}
+                        role="button"
+                        tabIndex={0}
+                        onClick={() => toggleTilePopup()}
+                    >
+                        <Layers fontSize="small" />
+                    </span>
+                )}
+
+                <Box
+                    className={classNames(
+                        tilePopup ? classes.open : classes.closed,
+                        classes.container,
+                    )}
                 >
-                    <Layers fontSize="small" />
-                </span>
+                    {tilePopup && (
+                        <Box width={235}>
+                            <Typography
+                                variant="subtitle1"
+                                className={classes.title}
+                            >
+                                {formatMessage(MESSAGES.layersTitle)}
+                            </Typography>
+                            <Box className={classes.iconContainer}>
+                                <IconButton
+                                    size="small"
+                                    onClick={() => toggleTilePopup()}
+                                    icon="clear"
+                                    tooltipMessage={MESSAGES.close}
+                                />
+                            </Box>
+                            <TileSwitch
+                                setCurrentTile={newtile =>
+                                    setCurrentTile(newtile)
+                                }
+                                currentTile={currentTile}
+                            />
+                        </Box>
+                    )}
+                </Box>
             </div>
         </>
     );

--- a/hat/assets/js/apps/Iaso/domains/assignments/components/AssignmentsMap.tsx
+++ b/hat/assets/js/apps/Iaso/domains/assignments/components/AssignmentsMap.tsx
@@ -12,7 +12,7 @@ import { LoadingSpinner } from 'bluesquare-components';
 
 import { Locations, OrgUnitMarker, OrgUnitShape } from '../types/locations';
 
-import { Tile } from '../../../components/maps/tools/TilesSwitchDialog';
+import { Tile } from '../../../components/maps/tools/TilesSwitchControl';
 import { MapLegend } from './MapLegend';
 import { MapInfo } from './MapInfo';
 import MarkersListComponent from '../../../components/maps/markers/MarkersListComponent';

--- a/hat/assets/js/apps/Iaso/domains/assignments/components/AssignmentsMap.tsx
+++ b/hat/assets/js/apps/Iaso/domains/assignments/components/AssignmentsMap.tsx
@@ -8,17 +8,11 @@ import {
 } from 'react-leaflet';
 
 import { Box } from '@material-ui/core';
-import {
-    // @ts-ignore
-    LoadingSpinner,
-} from 'bluesquare-components';
+import { LoadingSpinner } from 'bluesquare-components';
 
 import { Locations, OrgUnitMarker, OrgUnitShape } from '../types/locations';
 
-import {
-    Tile,
-    TilesSwitchDialog,
-} from '../../../components/maps/tools/TilesSwitchDialog';
+import { Tile } from '../../../components/maps/tools/TilesSwitchDialog';
 import { MapLegend } from './MapLegend';
 import { MapInfo } from './MapInfo';
 import MarkersListComponent from '../../../components/maps/markers/MarkersListComponent';
@@ -176,10 +170,6 @@ export const AssignmentsMap: FunctionComponent<Props> = ({
     return (
         <section ref={mapContainer}>
             <Box position="relative">
-                <TilesSwitchDialog
-                    currentTile={currentTile}
-                    setCurrentTile={setCurrentTile}
-                />
                 <MapLegend />
                 <MapInfo />
                 {selectedLocation && (
@@ -216,7 +206,10 @@ export const AssignmentsMap: FunctionComponent<Props> = ({
                         fitOnLoad
                     />
                     <ScaleControl imperial={false} />
-                    <CustomTileLayer currentTile={currentTile} />
+                    <CustomTileLayer
+                        currentTile={currentTile}
+                        setCurrentTile={setCurrentTile}
+                    />
                     {locations && (
                         <>
                             <Pane name="shapes-unselected-already-assigned">

--- a/hat/assets/js/apps/Iaso/domains/entities/components/ListMap.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/components/ListMap.tsx
@@ -3,7 +3,7 @@ import { MapContainer, Pane, ScaleControl } from 'react-leaflet';
 import { Box, useTheme, makeStyles } from '@material-ui/core';
 import MarkerClusterGroup from 'react-leaflet-markercluster';
 import { LoadingSpinner, commonStyles } from 'bluesquare-components';
-import { Tile } from '../../../components/maps/tools/TilesSwitchDialog';
+import { Tile } from '../../../components/maps/tools/TilesSwitchControl';
 import { PopupComponent as Popup } from './Popup';
 
 import MarkersListComponent from '../../../components/maps/markers/MarkersListComponent';

--- a/hat/assets/js/apps/Iaso/domains/entities/components/ListMap.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/components/ListMap.tsx
@@ -3,10 +3,7 @@ import { MapContainer, Pane, ScaleControl } from 'react-leaflet';
 import { Box, useTheme, makeStyles } from '@material-ui/core';
 import MarkerClusterGroup from 'react-leaflet-markercluster';
 import { LoadingSpinner, commonStyles } from 'bluesquare-components';
-import {
-    Tile,
-    TilesSwitchDialog,
-} from '../../../components/maps/tools/TilesSwitchDialog';
+import { Tile } from '../../../components/maps/tools/TilesSwitchDialog';
 import { PopupComponent as Popup } from './Popup';
 
 import MarkersListComponent from '../../../components/maps/markers/MarkersListComponent';
@@ -80,10 +77,6 @@ export const ListMap: FunctionComponent<Props> = ({
     return (
         <section className={classes.mapContainer}>
             <Box position="relative">
-                <TilesSwitchDialog
-                    currentTile={currentTile}
-                    setCurrentTile={setCurrentTile}
-                />
                 {isLoading && <LoadingSpinner absolute />}
                 <MapContainer
                     isLoading={isLoading}
@@ -99,7 +92,10 @@ export const ListMap: FunctionComponent<Props> = ({
                     boundsOptions={boundsOptions}
                 >
                     <ScaleControl imperial={false} />
-                    <CustomTileLayer currentTile={currentTile} />
+                    <CustomTileLayer
+                        currentTile={currentTile}
+                        setCurrentTile={setCurrentTile}
+                    />
                     <CustomZoomControl
                         bounds={bounds}
                         boundsOptions={boundsOptions}

--- a/hat/assets/js/apps/Iaso/domains/instances/components/InstancesMap/InstancesMap.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/InstancesMap/InstancesMap.tsx
@@ -23,7 +23,7 @@ import { setCurrentInstance } from '../../actions';
 import { fetchInstanceDetail } from '../../../../utils/requests';
 import { Instance } from '../../types/instance';
 import { InstancePopup } from '../InstancePopUp/InstancePopUp';
-import { Tile } from '../../../../components/maps/tools/TilesSwitchDialog';
+import { Tile } from '../../../../components/maps/tools/TilesSwitchControl';
 import { CustomTileLayer } from '../../../../components/maps/tools/CustomTileLayer';
 import { CustomZoomControl } from '../../../../components/maps/tools/CustomZoomControl';
 import { MapToggleCluster } from '../../../../components/maps/tools/MapToggleCluster';

--- a/hat/assets/js/apps/Iaso/domains/instances/components/InstancesMap/InstancesMap.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/InstancesMap/InstancesMap.tsx
@@ -23,10 +23,7 @@ import { setCurrentInstance } from '../../actions';
 import { fetchInstanceDetail } from '../../../../utils/requests';
 import { Instance } from '../../types/instance';
 import { InstancePopup } from '../InstancePopUp/InstancePopUp';
-import {
-    TilesSwitchDialog,
-    Tile,
-} from '../../../../components/maps/tools/TilesSwitchDialog';
+import { Tile } from '../../../../components/maps/tools/TilesSwitchDialog';
 import { CustomTileLayer } from '../../../../components/maps/tools/CustomTileLayer';
 import { CustomZoomControl } from '../../../../components/maps/tools/CustomZoomControl';
 import { MapToggleCluster } from '../../../../components/maps/tools/MapToggleCluster';
@@ -96,10 +93,6 @@ export const InstancesMap: FunctionComponent<Props> = ({
                 isClusterActive={isClusterActive}
                 setIsClusterActive={setIsClusterActive}
             />
-            <TilesSwitchDialog
-                currentTile={currentTile}
-                setCurrentTile={setCurrentTile}
-            />
             <MapContainer
                 scrollWheelZoom={false}
                 maxZoom={currentTile.maxZoom}
@@ -112,7 +105,10 @@ export const InstancesMap: FunctionComponent<Props> = ({
                 keyboard={false}
             >
                 <ScaleControl imperial={false} />
-                <CustomTileLayer currentTile={currentTile} />
+                <CustomTileLayer
+                    currentTile={currentTile}
+                    setCurrentTile={setCurrentTile}
+                />
                 <CustomZoomControl
                     bounds={bounds}
                     boundsOptions={boundsOptions}

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitsMap.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitsMap.tsx
@@ -18,7 +18,7 @@ import {
 import InnerDrawer from '../../../components/nav/InnerDrawer';
 import OrgUnitPopupComponent from './OrgUnitPopupComponent';
 import ErrorPaperComponent from '../../../components/papers/ErrorPaperComponent';
-import { Tile } from '../../../components/maps/tools/TilesSwitchDialog';
+import { Tile } from '../../../components/maps/tools/TilesSwitchControl';
 import MarkersListComponent from '../../../components/maps/markers/MarkersListComponent';
 import { OrgUnitsMapComments } from './orgUnitMap/OrgUnitsMapComments';
 import { innerDrawerStyles } from '../../../components/nav/InnerDrawer/styles';

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitsMap.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitsMap.tsx
@@ -7,7 +7,7 @@ import {
     Tooltip,
     ScaleControl,
 } from 'react-leaflet';
-import { Grid, makeStyles,Box } from '@material-ui/core';
+import { Grid, makeStyles, Box } from '@material-ui/core';
 import {
     useSafeIntl,
     commonStyles,
@@ -18,10 +18,7 @@ import {
 import InnerDrawer from '../../../components/nav/InnerDrawer';
 import OrgUnitPopupComponent from './OrgUnitPopupComponent';
 import ErrorPaperComponent from '../../../components/papers/ErrorPaperComponent';
-import {
-    Tile,
-    TilesSwitchDialog,
-} from '../../../components/maps/tools/TilesSwitchDialog';
+import { Tile } from '../../../components/maps/tools/TilesSwitchDialog';
 import MarkersListComponent from '../../../components/maps/markers/MarkersListComponent';
 import { OrgUnitsMapComments } from './orgUnitMap/OrgUnitsMapComments';
 import { innerDrawerStyles } from '../../../components/nav/InnerDrawer/styles';
@@ -234,10 +231,6 @@ export const OrgUnitsMap: FunctionComponent<Props> = ({
                         isClusterActive={isClusterActive}
                         setIsClusterActive={setIsClusterActive}
                     />
-                    <TilesSwitchDialog
-                        currentTile={currentTile}
-                        setCurrentTile={setCurrentTile}
-                    />
                     <MapContainer
                         doubleClickZoom={false}
                         scrollWheelZoom={false}
@@ -252,7 +245,10 @@ export const OrgUnitsMap: FunctionComponent<Props> = ({
                         trackResize
                     >
                         <ScaleControl imperial={false} />
-                        <CustomTileLayer currentTile={currentTile} />
+                        <CustomTileLayer
+                            currentTile={currentTile}
+                            setCurrentTile={setCurrentTile}
+                        />
                         <CustomZoomControl
                             bounds={bounds}
                             boundsOptions={boundsOptions}

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/orgUnitMap/OrgUnitMap/OrgUnitMap.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/orgUnitMap/OrgUnitMap/OrgUnitMap.tsx
@@ -43,7 +43,7 @@ import { CurrentOrgUnitMarker } from './CurrentOrgUnitMarker';
 import { SelectedMarkers } from './SelectedMarkers';
 import { buttonsInitialState } from './constants';
 import { CustomTileLayer } from '../../../../../components/maps/tools/CustomTileLayer';
-import { Tile } from '../../../../../components/maps/tools/TilesSwitchDialog';
+import { Tile } from '../../../../../components/maps/tools/TilesSwitchControl';
 import tiles from '../../../../../constants/mapTiles';
 import { CustomZoomControl } from '../../../../../components/maps/tools/CustomZoomControl';
 

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/orgUnitMap/OrgUnitMap/OrgUnitMap.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/orgUnitMap/OrgUnitMap/OrgUnitMap.tsx
@@ -43,10 +43,7 @@ import { CurrentOrgUnitMarker } from './CurrentOrgUnitMarker';
 import { SelectedMarkers } from './SelectedMarkers';
 import { buttonsInitialState } from './constants';
 import { CustomTileLayer } from '../../../../../components/maps/tools/CustomTileLayer';
-import {
-    Tile,
-    TilesSwitchDialog,
-} from '../../../../../components/maps/tools/TilesSwitchDialog';
+import { Tile } from '../../../../../components/maps/tools/TilesSwitchDialog';
 import tiles from '../../../../../constants/mapTiles';
 import { CustomZoomControl } from '../../../../../components/maps/tools/CustomZoomControl';
 
@@ -469,10 +466,6 @@ export const OrgUnitMap: FunctionComponent<Props> = ({
                         },
                     ]}
                 />
-                <TilesSwitchDialog
-                    currentTile={currentTile}
-                    setCurrentTile={setCurrentTile}
-                />
                 <MapContainer
                     key={currentOrgUnit.id}
                     // @ts-ignore TODO: fix this type problem
@@ -494,7 +487,10 @@ export const OrgUnitMap: FunctionComponent<Props> = ({
                         fitOnLoad
                     />
                     <ScaleControl imperial={false} />
-                    <CustomTileLayer currentTile={currentTile} />
+                    <CustomTileLayer
+                        currentTile={currentTile}
+                        setCurrentTile={setCurrentTile}
+                    />
                     {!state.location.value.edit &&
                         state.ancestorWithGeoJson.value && (
                             <Pane

--- a/hat/assets/js/apps/Iaso/domains/registry/components/OrgUnitChildrenMap.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/OrgUnitChildrenMap.tsx
@@ -18,7 +18,7 @@ import classNames from 'classnames';
 
 import { keyBy } from 'lodash';
 
-import { Tile } from '../../../components/maps/tools/TilesSwitchDialog';
+import { Tile } from '../../../components/maps/tools/TilesSwitchControl';
 import { MapLegend } from './MapLegend';
 import CircleMarkerComponent from '../../../components/maps/markers/CircleMarkerComponent';
 

--- a/hat/assets/js/apps/Iaso/domains/registry/components/OrgUnitChildrenMap.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/OrgUnitChildrenMap.tsx
@@ -18,10 +18,7 @@ import classNames from 'classnames';
 
 import { keyBy } from 'lodash';
 
-import {
-    Tile,
-    TilesSwitchDialog,
-} from '../../../components/maps/tools/TilesSwitchDialog';
+import { Tile } from '../../../components/maps/tools/TilesSwitchDialog';
 import { MapLegend } from './MapLegend';
 import CircleMarkerComponent from '../../../components/maps/markers/CircleMarkerComponent';
 
@@ -166,10 +163,7 @@ export const OrgUnitChildrenMap: FunctionComponent<Props> = ({
             )}
         >
             <MapLegend options={legendOptions} setOptions={setLegendOptions} />
-            <TilesSwitchDialog
-                currentTile={currentTile}
-                setCurrentTile={setCurrentTile}
-            />
+
             <MapContainer
                 maxZoom={currentTile.maxZoom}
                 style={{
@@ -199,7 +193,10 @@ export const OrgUnitChildrenMap: FunctionComponent<Props> = ({
                     fitOnLoad
                 />
                 <ScaleControl imperial={false} />
-                <CustomTileLayer currentTile={currentTile} />
+                <CustomTileLayer
+                    currentTile={currentTile}
+                    setCurrentTile={setCurrentTile}
+                />
 
                 {isOrgUnitActive && (
                     <>


### PR DESCRIPTION
Today the Modal is in the middle, it could be a bit more on the right hand corner 

Related JIRA tickets : IA-2194

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- move / rename dialog to select current tile
- small css animation

## How to test

open any map, play with the selection of the current tile

## Print screen / video


https://github.com/BLSQ/iaso/assets/12494624/605e020b-3228-449d-80dd-cecbb43016f9

