### PR TITLE
POLIO-1065: LQAS/IM maps colors

### DIFF
--- a/plugins/polio/js/src/pages/IM/constants.ts
+++ b/plugins/polio/js/src/pages/IM/constants.ts
@@ -14,25 +14,31 @@ export const IN_SCOPE = 'inScope';
 
 export const imDistrictColors = {
     [IM_PASS]: {
-        color: OK_COLOR,
+        color: '#5e5e5e',
         weight: '2',
         opacity: '1',
+        fillColor: OK_COLOR,
+        fillOpacity: 0.8,
         zIndex: 999,
     },
     [IM_WARNING]: {
-        color: WARNING_COLOR,
+        color: '#5e5e5e',
         weight: '2',
         opacity: '1',
+        fillColor: WARNING_COLOR,
+        fillOpacity: 0.8,
         zIndex: 999,
     },
     [IM_FAIL]: {
-        color: FAIL_COLOR,
+        color: '#5e5e5e',
         weight: '2',
         opacity: '1',
+        fillColor: FAIL_COLOR,
+        fillOpacity: 0.8,
         zIndex: 999,
     },
     [IN_SCOPE]: {
-        color: 'grey',
+        color: '#5e5e5e',
         opacity: '1',
         fillColor: 'grey',
         weight: '2',
@@ -42,25 +48,31 @@ export const imDistrictColors = {
 
 export const lqasDistrictColors = {
     [LQAS_PASS]: {
-        color: OK_COLOR,
+        color: '#5e5e5e',
         weight: '2',
         opacity: '1',
+        fillColor: OK_COLOR,
+        fillOpacity: 0.8,
         zIndex: 999,
     },
     [LQAS_DISQUALIFIED]: {
-        color: WARNING_COLOR,
+        color: '#5e5e5e',
+        fillColor: WARNING_COLOR,
+        fillOpacity: 0.8,
         weight: '2',
         opacity: '1',
         zIndex: 999,
     },
     [LQAS_FAIL]: {
-        color: FAIL_COLOR,
+        color: '#5e5e5e',
+        fillColor: FAIL_COLOR,
+        fillOpacity: 0.8,
         weight: '2',
         opacity: '1',
         zIndex: 999,
     },
     [IN_SCOPE]: {
-        color: 'grey',
+        color: '#5e5e5e',
         opacity: '1',
         fillColor: 'grey',
         weight: '2',


### PR DESCRIPTION
The opacity of the shapes in LQAS/IM maps was too low, so the client couldn't really see them, especially green shapes over forest areas

Related JIRA tickets :  POLIO-1065

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- add a fillColor and set it's opacity to 0.8
- Change border color to use the same color everywhere, so the shapes are more visible

## How to test

Go to LQAs and IM maps and select a campaign

## Print screen / video
LQAS
![Screenshot 2023-06-19 at 12 02 13](https://github.com/BLSQ/iaso/assets/38907762/34fb33eb-21ae-40e3-bd12-5df221d03638)

IM

![Screenshot 2023-06-19 at 12 03 02](https://github.com/BLSQ/iaso/assets/38907762/d2e01fd3-2512-4880-a0ee-451feaa68afb)


