### PR TITLE
IA-2245: add filename format for GPKG export

### DIFF
--- a/iaso/api/org_units.py
+++ b/iaso/api/org_units.py
@@ -191,7 +191,11 @@ class OrgUnitViewSet(viewsets.ViewSet):
                 queryset = queryset.select_related("org_unit_type")
                 return Response({"orgUnits": [unit.as_dict_for_mobile() for unit in queryset]})
         elif gpkg_format:
-            return self.list_to_gpkg(queryset)
+            user_account_name = profile.account.name if profile else ""
+            environment = settings.ENVIRONMENT
+            filename = "org_units"
+            filename = "%s-%s-%s-%s" % (environment, user_account_name, filename, strftime("%Y-%m-%d-%H-%M", gmtime()))
+            return self.list_to_gpkg(queryset, filename)
         else:
             # When filtering the org units by group, the values_list will return the groups also filtered.
             #  In order to get the all groups independently of filters, we should get the groups
@@ -287,9 +291,9 @@ class OrgUnitViewSet(viewsets.ViewSet):
             response["Content-Disposition"] = "attachment; filename=%s" % filename
             return response
 
-    def list_to_gpkg(self, queryset):
+    def list_to_gpkg(self, queryset, filename):
         response = HttpResponse(org_units_to_gpkg_bytes(queryset), content_type="application/octet-stream")
-        filename = f"org_units-{timezone.now().strftime('%Y-%m-%d-%H-%M')}.gpkg"
+        filename = f"{filename}-{timezone.now().strftime('%Y-%m-%d-%H-%M')}.gpkg"
         response["Content-Disposition"] = f"attachment; filename={filename}"
 
         return response

--- a/iaso/api/org_units.py
+++ b/iaso/api/org_units.py
@@ -293,7 +293,7 @@ class OrgUnitViewSet(viewsets.ViewSet):
 
     def list_to_gpkg(self, queryset, filename):
         response = HttpResponse(org_units_to_gpkg_bytes(queryset), content_type="application/octet-stream")
-        filename = f"{filename}-{timezone.now().strftime('%Y-%m-%d-%H-%M')}.gpkg"
+        filename = f"{filename}.gpkg"
         response["Content-Disposition"] = f"attachment; filename={filename}"
 
         return response


### PR DESCRIPTION
when exporting org units as gpckg, the name wasn't formatted correctly

Related JIRA tickets : IA-2245

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- Added the filename for gpckg export in api/org_units.py

## How to test

- Go to Org units in web UI, perform a search
- click the gpckg button
- The filename should include the environment and the account name

## Print screen / video

![Screenshot 2023-06-21 at 10 30 45](https://github.com/BLSQ/iaso/assets/38907762/13348c9c-06c8-451c-98c7-0366b1aa841a)



