### PR TITLE
IA-2196: add clustering on registry map

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/registry/components/MapTooltip.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/MapTooltip.tsx
@@ -1,0 +1,23 @@
+import React, { FunctionComponent } from 'react';
+import { Tooltip } from 'react-leaflet';
+
+type Props = {
+    label: string;
+    pane: string;
+    permanent: boolean;
+};
+
+export const MapToolTip: FunctionComponent<Props> = ({
+    label,
+    permanent,
+    pane,
+}) => {
+    return (
+        <>
+            {/* @ts-ignore TODO: fix this type problem */}
+            <Tooltip permanent={permanent} pane={pane}>
+                {label}
+            </Tooltip>
+        </>
+    );
+};

--- a/hat/assets/js/apps/Iaso/domains/registry/components/MapTooltip.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/MapTooltip.tsx
@@ -4,7 +4,7 @@ import { Tooltip } from 'react-leaflet';
 type Props = {
     label: string;
     pane: string;
-    permanent: boolean;
+    permanent?: boolean;
 };
 
 export const MapToolTip: FunctionComponent<Props> = ({
@@ -13,11 +13,12 @@ export const MapToolTip: FunctionComponent<Props> = ({
     pane,
 }) => {
     return (
-        <>
-            {/* @ts-ignore TODO: fix this type problem */}
-            <Tooltip permanent={permanent} pane={pane}>
-                {label}
-            </Tooltip>
-        </>
+        <Tooltip
+            // @ts-ignore TODO: fix this type problem
+            permanent={permanent}
+            pane={pane}
+        >
+            {label}
+        </Tooltip>
     );
 };

--- a/hat/assets/js/apps/Iaso/domains/registry/components/OrgUnitChildrenMap.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/OrgUnitChildrenMap.tsx
@@ -257,7 +257,6 @@ export const OrgUnitChildrenMap: FunctionComponent<Props> = ({
                                                 />
                                                 {showTooltip && (
                                                     <MapToolTip
-                                                        // @ts-ignore TODO: fix this type problem
                                                         permanent
                                                         pane="popupPane"
                                                         label={
@@ -266,9 +265,7 @@ export const OrgUnitChildrenMap: FunctionComponent<Props> = ({
                                                     />
                                                 )}
                                                 {!showTooltip && (
-                                                    // @ts-ignore TODO: fix this type problem
                                                     <MapToolTip
-                                                        // @ts-ignore TODO: fix this type problem
                                                         pane="popupPane"
                                                         label={
                                                             childrenOrgUnit.name

--- a/hat/assets/js/apps/Iaso/domains/registry/components/OrgUnitChildrenMap.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/OrgUnitChildrenMap.tsx
@@ -316,10 +316,10 @@ export const OrgUnitChildrenMap: FunctionComponent<Props> = ({
                                                     popupProps={location => ({
                                                         orgUnit: location,
                                                     })}
-                                                    tooltipProps={() => ({
+                                                    tooltipProps={e => ({
                                                         permanent: showTooltip,
                                                         pane: 'popupPane',
-                                                        label: childrenOrgUnit.name,
+                                                        label: e.name,
                                                     })}
                                                     PopupComponent={MapPopUp}
                                                     TooltipComponent={

--- a/hat/assets/js/apps/Iaso/domains/registry/components/OrgUnitChildrenMap.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/OrgUnitChildrenMap.tsx
@@ -15,8 +15,15 @@ import {
 import { LoadingSpinner } from 'bluesquare-components';
 import { Box, useTheme, makeStyles } from '@material-ui/core';
 import classNames from 'classnames';
-
 import { keyBy } from 'lodash';
+import MarkerClusterGroup from 'react-leaflet-markercluster';
+import {
+    circleColorMarkerOptions,
+    getOrgUnitBounds,
+    getOrgUnitsBounds,
+    mergeBounds,
+    clusterCustomMarker,
+} from '../../../utils/map/mapUtils';
 
 import {
     Tile,
@@ -32,20 +39,17 @@ import { Legend, useGetlegendOptions } from '../hooks/useGetLegendOptions';
 
 import { MapToggleTooltips } from './MapToggleTooltips';
 import { MapToggleFullscreen } from './MapToggleFullscreen';
+import { PopupComponent as Popup } from '../../entities/components/Popup';
 
 import TILES from '../../../constants/mapTiles';
-import {
-    circleColorMarkerOptions,
-    getOrgUnitBounds,
-    getOrgUnitsBounds,
-    mergeBounds,
-} from '../../../utils/map/mapUtils';
 import { MapPopUp } from './MapPopUp';
 import { RegistryDetailParams } from '../types';
 import { redirectToReplace } from '../../../routing/actions';
 import { baseUrls } from '../../../constants/urls';
 import { CustomTileLayer } from '../../../components/maps/tools/CustomTileLayer';
 import { CustomZoomControl } from '../../../components/maps/tools/CustomZoomControl';
+import { ExtraColumn } from '../../entities/types/fields';
+import MarkersListComponent from '../../../components/maps/markers/MarkersListComponent';
 
 type Props = {
     orgUnit: OrgUnit;
@@ -216,17 +220,29 @@ export const OrgUnitChildrenMap: FunctionComponent<Props> = ({
                             </Pane>
                         )}
                         {orgUnit.latitude && orgUnit.longitude && (
-                            <CircleMarkerComponent
-                                item={{
-                                    latitude: orgUnit.latitude,
-                                    longitude: orgUnit.longitude,
-                                }}
-                                markerProps={() => ({
-                                    ...circleColorMarkerOptions(
-                                        theme.palette.secondary.main,
-                                    ),
-                                })}
-                            />
+                            <>
+                                <Pane name="markers">
+                                    <MarkerClusterGroup
+                                        iconCreateFunction={clusterCustomMarker}
+                                    >
+                                        <MarkersListComponent
+                                            items={orgUnitChildren || []}
+                                            markerProps={() => ({
+                                                ...circleColorMarkerOptions(
+                                                    theme.palette.primary.main,
+                                                ),
+                                                radius: 12,
+                                            })}
+                                            popupProps={location => ({
+                                                location,
+                                                extraColumns,
+                                            })}
+                                            PopupComponent={Popup}
+                                            isCircle
+                                        />
+                                    </MarkerClusterGroup>
+                                </Pane>
+                            </>
                         )}
                     </>
                 )}


### PR DESCRIPTION
There was no clustering implemented yet in Registry

Related JIRA tickets : IA-2196

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- Add new component `MapTooltip` component to pass a label prop
- Use `MarkerClusterGroup` and `MarkerListComponent` for clustering

## How to test

- Make sure you have created a few orgunits with location (give similar coordinates for all the orgunits) with the same parent (and the right orgunit types)
- Go to registry and search for the parent
- Open the map
- You should see a circle with the number of orgunits. When you click on it, you will see a circle for each orgunit and you should see the org unit name when you hover the circle.

## Print screen / video

https://github.com/BLSQ/iaso/assets/25134301/f783da46-d1c0-48cf-8048-6dfe04e9d944



## Notes


