### PR TITLE
IA-2251 fix  form attachment not working in enketo prod

### DIFF
--- a/iaso/api/enketo.py
+++ b/iaso/api/enketo.py
@@ -272,7 +272,10 @@ def enketo_form_list(request):
     downloadurl = public_url_for_enketo(request, "/api/enketo/formDownload/?uuid=%s" % i.uuid)
     # Only add a manifest if we actually have attachment so it doesn't make more unecessary request
     if i.form.attachments.exists():
-        manifest_url = public_url_for_enketo(request, f"/api/forms/{i.form_id}/manifest/")
+        # pass the app_id so it can be accessed anonymously from Enketo
+        project = i.form.projects.first()
+        app_id = project.app_id if project else ""
+        manifest_url = public_url_for_enketo(request, f"/api/forms/{i.form_id}/manifest/?app_id={app_id}")
     else:
         manifest_url = None
 

--- a/iaso/tests/api/test_forms_attachment.py
+++ b/iaso/tests/api/test_forms_attachment.py
@@ -14,6 +14,8 @@ MANIFEST_URL = "/api/forms/{form_id}/manifest/"
 
 
 class FormAttachmentsAPITestCase(APITestCase):
+    project_1: m.Project
+
     @classmethod
     def setUpTestData(cls):
         time = cls.now = now()
@@ -279,3 +281,13 @@ class FormAttachmentsAPITestCase(APITestCase):
             self.assertEqual("text/xml", response["Content-Type"], response.content)
 
         return response.content
+
+    def test_manifest_anonymous_app_id(self):
+        f"""GET {BASE_URL} via app id"""
+
+        response = self.client.get(
+            MANIFEST_URL.format(form_id=self.form_2.id),
+            headers={"Content-Type": "application/json"},
+            data={"app_id": self.project_1.app_id},
+        )
+        self.assertXMLResponse(response, 200)


### PR DESCRIPTION
The problem was that the API responded as needing an authentification I think the issue wasn't visible in local since it was on the same domain name ? The behaviour was modified so Enketo now pass the app_id (we pass it in the app definition) like the mobile does, and which allow accessing without auth


Related JIRA tickets : IA-2251

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [NA] Are my typescript files well typed
- [NA] New translations have been added or updated if new strings have been introduced in the frontend
- [NA] My migrations file are included
- [x] Are there enough tests
- [NA] Documentation has been included (for new feature)

## Changes

Modify the manifest url to include the app_id.

## How to test

use  a Form with an attachement. You can copy this one https://iaso-staging.bluesquare.org/api/forms/153/manifest/
Make a submission via Enketo
