### PR TITLE
IA-2259 Separate Version for orgunit type api with allow_creating_sub_unit_types

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/assignments/hooks/requests/useGetOrgUnitTypes.ts
+++ b/hat/assets/js/apps/Iaso/domains/assignments/hooks/requests/useGetOrgUnitTypes.ts
@@ -8,7 +8,7 @@ import { DropdownOptions } from '../../../../types/utils';
 import { OrgunitTypesApi } from '../../../orgUnits/types/orgunitTypes';
 
 const getOrgunitTypes = (): Promise<OrgunitTypesApi> => {
-    return getRequest('/api/orgunittypes/');
+    return getRequest('/api/v2/orgunittypes/');
 };
 
 export const useGetOrgUnitTypes = (): UseQueryResult<

--- a/hat/assets/js/apps/Iaso/domains/dataSources/requests.js
+++ b/hat/assets/js/apps/Iaso/domains/dataSources/requests.js
@@ -38,7 +38,7 @@ export const postGeoPkg = async request => {
 };
 
 const getOrgUnitTypes = async () => {
-    return getRequest('/api/orgunittypes/');
+    return getRequest('/api/v2/orgunittypes/');
 };
 
 export const useOrgUnitTypes = () => {

--- a/hat/assets/js/apps/Iaso/domains/instances/index.spec.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/index.spec.js
@@ -10,7 +10,7 @@ import { withQueryClientProvider } from '../../../../test/utils';
 const formId = 1;
 const requests = [
     {
-        url: '/api/orgunittypes/',
+        url: '/api/v2/orgunittypes/',
         body: {
             orgUnitTypes: [],
         },

--- a/hat/assets/js/apps/Iaso/domains/links/index.spec.js
+++ b/hat/assets/js/apps/Iaso/domains/links/index.spec.js
@@ -8,7 +8,7 @@ import { renderWithStore } from '../../../../test/utils/redux';
 
 const requests = [
     {
-        url: '/api/orgunittypes/',
+        url: '/api/v2/orgunittypes/',
         body: {
             orgUnitTypes: [],
         },

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/hooks.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/hooks.js
@@ -77,7 +77,7 @@ export const useOrgUnitDetailData = (
         },
         {
             queryKey: ['orgUnitTypes'],
-            queryFn: () => getRequest('/api/orgunittypes/'),
+            queryFn: () => getRequest('/api/v2/orgunittypes/'),
             snackErrorMsg: MESSAGES.fetchOrgUnitTypesError,
             options: {
                 select: data =>

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/hooks/requests/useGetOrgUnitTypes.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/hooks/requests/useGetOrgUnitTypes.ts
@@ -9,7 +9,7 @@ import { OrgunitTypesApi } from '../../types/orgunitTypes';
 import { staleTime } from '../../config';
 
 const getOrgunitTypes = (): Promise<OrgunitTypesApi> => {
-    return getRequest('/api/orgunittypes/');
+    return getRequest('/api/v2/orgunittypes/');
 };
 
 export const useGetOrgUnitTypes = (): UseQueryResult<

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/orgUnitTypes/hooks/useDeleteOrgUnitType.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/orgUnitTypes/hooks/useDeleteOrgUnitType.ts
@@ -3,7 +3,7 @@ import { deleteRequest } from '../../../../libs/Api';
 import { useSnackMutation } from '../../../../libs/apiHooks';
 
 const deleteOrgUnitType = (id: number) =>
-    deleteRequest(`/api/orgunittypes/${id}/`);
+    deleteRequest(`/api/v2/orgunittypes/${id}/`);
 
 export const useDeleteOrgUnitType = (): UseMutationResult => {
     return useSnackMutation({

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/orgUnitTypes/hooks/useGetOrgUnitTypes.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/orgUnitTypes/hooks/useGetOrgUnitTypes.ts
@@ -15,7 +15,7 @@ const getOrgUnitTypes = async (
     if (pageSize) {
         params.limit = pageSize;
     }
-    const url = makeUrlWithParams('/api/orgunittypes/', params);
+    const url = makeUrlWithParams('/api/v2/orgunittypes/', params);
     return getRequest(url) as Promise<PaginatedOrgUnitTypes>;
 };
 

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/orgUnitTypes/hooks/useGetOrgUnitTypesDropdownOptions.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/orgUnitTypes/hooks/useGetOrgUnitTypesDropdownOptions.ts
@@ -8,7 +8,7 @@ import { DropdownOptions } from '../../../../types/utils';
 import { OrgunitTypesApi } from '../../types/orgunitTypes';
 
 const getOrgunitTypes = (): Promise<OrgunitTypesApi> => {
-    return getRequest('/api/orgunittypes/');
+    return getRequest('/api/v2/orgunittypes/');
 };
 
 export const useGetOrgUnitTypesDropdownOptions = (): UseQueryResult<

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/orgUnitTypes/hooks/useSaveOrgUnitType.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/orgUnitTypes/hooks/useSaveOrgUnitType.ts
@@ -5,13 +5,13 @@ import { useSnackMutation } from '../../../../libs/apiHooks';
 import { OrgunitType } from '../../types/orgunitTypes';
 
 const patchOrgUniType = async (body: Partial<OrgunitType>) => {
-    const url = `/api/orgunittypes/${body.id}/`;
+    const url = `/api/v2/orgunittypes/${body.id}/`;
     return patchRequest(url, body);
 };
 
 const postOrgUnitType = async (body: OrgunitType) => {
     return postRequest({
-        url: '/api/orgunittypes/',
+        url: '/api/v2/orgunittypes/',
         data: body,
     });
 };

--- a/hat/assets/js/apps/Iaso/domains/registry/hooks/useGetOrgUnitType.ts
+++ b/hat/assets/js/apps/Iaso/domains/registry/hooks/useGetOrgUnitType.ts
@@ -11,7 +11,7 @@ export const useGetOrgUnitType = (
     const queryKey: any[] = ['orgUnitType', orgUnitTypeId];
     return useSnackQuery({
         queryKey,
-        queryFn: () => getRequest(`/api/orgunittypes/${orgUnitTypeId}/`),
+        queryFn: () => getRequest(`/api/v2/orgunittypes/${orgUnitTypeId}/`),
         options: {
             retry: false,
             enabled: Boolean(orgUnitTypeId),

--- a/hat/assets/js/apps/Iaso/domains/users/index.spec.js
+++ b/hat/assets/js/apps/Iaso/domains/users/index.spec.js
@@ -21,7 +21,7 @@ const requests = [
         },
     },
     {
-        url: '/api/orgunittypes/',
+        url: '/api/v2/orgunittypes/',
         body: {
             orgUnitTypes: [],
         },

--- a/hat/assets/js/apps/Iaso/utils/requests.js
+++ b/hat/assets/js/apps/Iaso/utils/requests.js
@@ -28,7 +28,7 @@ export const fetchSubOrgUnitsByType = (dispatch, params, orgUnitType) =>
         });
 
 export const fetchOrgUnitsTypes = dispatch =>
-    getRequest('/api/orgunittypes/')
+    getRequest('/api/v2/orgunittypes/')
         .then(res => res.orgUnitTypes)
         .catch(error => {
             dispatch(

--- a/hat/assets/js/cypress/integration/02 - forms/details.spec.js
+++ b/hat/assets/js/cypress/integration/02 - forms/details.spec.js
@@ -31,7 +31,7 @@ describe('Forms details', () => {
         cy.login();
         cy.intercept('GET', '/sockjs-node/**');
         cy.intercept('GET', '/api/profiles/me/**', superUser);
-        cy.intercept('GET', '/api/orgunittypes/**', orgUnitTypes);
+        cy.intercept('GET', '/api/v2/orgunittypes/**', orgUnitTypes);
         cy.intercept('GET', '/api/projects/**', projects);
         // TODO paramatrise form_id
         cy.intercept(

--- a/hat/assets/js/cypress/integration/02 - forms/list.spec.js
+++ b/hat/assets/js/cypress/integration/02 - forms/list.spec.js
@@ -43,7 +43,7 @@ const goToPage = (
         }).as('getForms');
     }
 
-    cy.intercept('GET', '/api/orgunittypes/**', {
+    cy.intercept('GET', '/api/v2/orgunittypes/**', {
         fixture: 'orgunittypes/list.json',
     }).as('getTypes');
     cy.intercept('GET', '/api/projects/**', {

--- a/hat/assets/js/cypress/integration/08 - orgUnitTypes/list.spec.js
+++ b/hat/assets/js/cypress/integration/08 - orgUnitTypes/list.spec.js
@@ -19,7 +19,7 @@ describe('Org unit types', () => {
     beforeEach(() => {
         cy.login();
         cy.intercept('GET', '/sockjs-node/**');
-        cy.intercept('GET', '/api/orgunittypes/', outypesList);
+        cy.intercept('GET', '/api/v2/orgunittypes/', outypesList);
         interceptList.forEach(i => {
             cy.intercept('GET', `/api/${i}/**`, {
                 fixture: `${i}/list.json`,
@@ -27,7 +27,7 @@ describe('Org unit types', () => {
         });
         cy.intercept(
             {
-                pathname: '/api/orgunittypes/**',
+                pathname: '/api/v2/orgunittypes/**',
                 query: {
                     order: 'name',
                     limit: '20',
@@ -40,7 +40,7 @@ describe('Org unit types', () => {
         ).as('getOrgUnitTypes');
         cy.intercept(
             {
-                pathname: '/api/orgunittypes/**',
+                pathname: '/api/v2/orgunittypes/**',
                 query: {
                     order: 'name',
                     limit: '20',
@@ -73,7 +73,7 @@ describe('Org unit types', () => {
             });
             testPagination({
                 baseUrl,
-                apiPath: '/api/orgunittypes/**',
+                apiPath: '/api/v2/orgunittypes/**',
                 apiKey: 'orgUnitTypes',
                 withSearch: false,
                 fixture: orgUnitTypes,

--- a/hat/assets/js/cypress/integration/11 - submissions/list.spec.js
+++ b/hat/assets/js/cypress/integration/11 - submissions/list.spec.js
@@ -96,7 +96,7 @@ const goToPage = (
     interceptFlag = false;
     cy.intercept('GET', '/sockjs-node/**');
     cy.intercept('GET', '/api/profiles/me/**', fakeUser);
-    cy.intercept('GET', '/api/orgunittypes', {
+    cy.intercept('GET', '/api/v2/orgunittypes/', {
         fixture: 'orgunittypes/list.json',
     });
     cy.intercept(

--- a/hat/assets/js/cypress/integration/12 - datasources/list.spec.js
+++ b/hat/assets/js/cypress/integration/12 - datasources/list.spec.js
@@ -58,7 +58,7 @@ const sourcesPage2 = makePaginatedResponse({
 describe('Data sources', () => {
     beforeEach(() => {
         cy.login();
-        cy.intercept('GET', '/api/orgunittypes/', orgUnitTypes).as(
+        cy.intercept('GET', '/api/v2/orgunittypes/', orgUnitTypes).as(
             'orgUnitTypes',
         );
         cy.intercept('GET', '/api/projects/', projects).as('projects');

--- a/hat/webpack.dev.js
+++ b/hat/webpack.dev.js
@@ -67,9 +67,9 @@ module.exports = {
         },
         host: '0.0.0.0',
         port: 3000,
-        // It suppress error shown in console, so it has to be set to false.
+        // It suppresses error shown in console, so it has to be set to false.
         quiet: false,
-        // It suppress everything except error, so it has to be set to false as well
+        // It suppresses everything except error, so it has to be set to false as well
         // to see success build.
         stats: {
             // Config for minimal console.log mess.

--- a/iaso/api/org_unit_types/serializers.py
+++ b/iaso/api/org_unit_types/serializers.py
@@ -1,5 +1,4 @@
 import typing
-from pprint import pprint
 
 from django.db.models import Q
 from rest_framework import serializers
@@ -24,7 +23,120 @@ def get_parents(type_id):
     return parents_ids
 
 
-class OrgUnitTypeSerializer(DynamicFieldsModelSerializer):
+# Kept for the mobile
+class OrgUnitTypeSerializerV1(DynamicFieldsModelSerializer):
+    """
+    V1 kept for mobile where sub_types is actually `allow_creating_sub_unit_types`
+    """
+
+    class Meta:
+        model = OrgUnitType
+        fields = [
+            "id",
+            "name",
+            "short_name",
+            "depth",
+            "projects",
+            "project_ids",
+            "sub_unit_types",
+            "sub_unit_type_ids",
+            "created_at",
+            "updated_at",
+            "units_count",
+            "reference_form",
+            "reference_form_id",
+        ]
+        read_only_fields = ["id", "projects", "sub_unit_types", "created_at", "updated_at", "units_count"]
+
+    projects = ProjectSerializer(many=True, read_only=True)
+    project_ids = serializers.PrimaryKeyRelatedField(
+        source="projects", write_only=True, many=True, queryset=Project.objects.all(), allow_empty=False
+    )
+    sub_unit_types = serializers.SerializerMethodField(read_only=True)
+    sub_unit_type_ids = serializers.PrimaryKeyRelatedField(
+        source="allow_creating_sub_unit_types",
+        write_only=True,
+        many=True,
+        allow_empty=True,
+        queryset=OrgUnitType.objects.all(),
+    )
+    created_at = TimestampField(read_only=True)
+    updated_at = TimestampField(read_only=True)
+    units_count = serializers.SerializerMethodField(read_only=True)
+    reference_form = serializers.SerializerMethodField(read_only=True)
+    reference_form_id: serializers.PrimaryKeyRelatedField = serializers.PrimaryKeyRelatedField(
+        source="reference_form",
+        write_only=True,
+        required=False,
+        many=False,
+        allow_null=True,
+        queryset=Form.objects.all(),
+    )
+
+    # Fixme make this directly in db !
+    def get_units_count(self, obj: OrgUnitType):
+        orgUnits = OrgUnit.objects.filter_for_user_and_app_id(
+            self.context["request"].user, self.context["request"].query_params.get("app_id")
+        ).filter(Q(validated=True) & Q(org_unit_type__id=obj.id))
+        orgunits_count = orgUnits.count()
+        return orgunits_count
+
+    def get_reference_form(self, obj: OrgUnitType):
+        form_def = Form.objects.filter_for_user_and_app_id(
+            self.context["request"].user, self.context["request"].query_params.get("app_id")
+        ).filter(id=obj.reference_form_id)
+        return FormSerializer(
+            form_def.first(),
+            fields=["id", "form_id", "created_at", "updated_at", "projects"],
+            many=False,
+            context=self.context,
+        ).data
+
+    def get_sub_unit_types(self, obj: OrgUnitType):
+        # Filter sub unit types to show only visible items for the current app id
+        unit_types = obj.allow_creating_sub_unit_types.all()
+        app_id = self.context["request"].query_params.get("app_id")
+        if app_id is not None:
+            unit_types = unit_types.filter(projects__app_id=app_id)
+
+        return OrgUnitTypeSerializerV1(
+            unit_types,
+            fields=["id", "name", "short_name", "depth", "created_at", "updated_at"],
+            many=True,
+            context=self.context,
+        ).data
+
+    def validate(self, data: typing.Mapping):
+        parents = get_parents(self.context["request"].data.get("id", None))
+        # validate sub org unit type
+        sub_types_errors = []
+        for sub_type in data.get("sub_unit_types", []):
+            if sub_type.id in parents:
+                sub_types_errors.append(sub_type.name)
+        if len(sub_types_errors) > 0:
+            raise serializers.ValidationError({"sub_unit_type_ids": sub_types_errors})
+        # validate sub org unit type allowed to be created
+        create_sub_types_errors = []
+        for sub_type in data.get("allow_creating_sub_unit_types", []):
+            if sub_type.id in parents:
+                create_sub_types_errors.append(sub_type.name)
+        if len(create_sub_types_errors) > 0:
+            raise serializers.ValidationError({"allow_creating_sub_unit_type_ids": create_sub_types_errors})
+        # validate projects (access check)
+        for project in data.get("projects", []):
+            if self.context["request"].user.iaso_profile.account != project.account:
+                raise serializers.ValidationError({"project_ids": "Invalid project ids"})
+        # validate if form is linked to the right project
+        reference_form = data.get("reference_form", None)
+        if reference_form:
+            projects_form = Form.objects.filter(id=reference_form.id, projects__in=data.get("projects", []))
+            if not projects_form:
+                raise serializers.ValidationError({"reference_form_id": "Invalid reference form id"})
+
+        return data
+
+
+class OrgUnitTypeSerializerV2(DynamicFieldsModelSerializer):
     """This one is a bit cryptic: sub_unit_types is only needed for "root" org unit types
     (the ones returned by the viewset queryset), and they need to be filtered by app_id,
     hence the SerializerMethodField()"""
@@ -105,7 +217,7 @@ class OrgUnitTypeSerializer(DynamicFieldsModelSerializer):
         if app_id is not None:
             unit_types = unit_types.filter(projects__app_id=app_id)
 
-        return OrgUnitTypeSerializer(
+        return OrgUnitTypeSerializerV2(
             unit_types,
             fields=["id", "name", "short_name", "depth", "created_at", "updated_at"],
             many=True,
@@ -119,7 +231,7 @@ class OrgUnitTypeSerializer(DynamicFieldsModelSerializer):
         if app_id is not None:
             unit_types = unit_types.filter(projects__app_id=app_id)
 
-        return OrgUnitTypeSerializer(
+        return OrgUnitTypeSerializerV2(
             unit_types,
             fields=["id", "name", "short_name", "depth", "created_at", "updated_at"],
             many=True,

--- a/iaso/api/org_unit_types/viewsets.py
+++ b/iaso/api/org_unit_types/viewsets.py
@@ -8,8 +8,12 @@ from ..common import ModelViewSet
 
 
 class OrgUnitTypeViewSet(ModelViewSet):
-    """Org unit types API
+    """Org unit types API (deprecated)
 
+    This endpoint it deprecated, Use /v2/orgunittypes/ instead, this is kept only  for compatiblity with the mobile
+    application
+
+    Confusingly in this version  `sub_unit_types` map to allow_creating_sub_unit_types.
     This API is open to anonymous users.
 
     GET /api/orgunittypes/
@@ -45,7 +49,7 @@ class OrgUnitTypeViewSetV2(ModelViewSet):
 
     This API is open to anonymous users.
 
-    GET /api/orgunittypes/
+    GET /api/v2/orgunittypes/
     """
 
     permission_classes = [permissions.IsAuthenticatedOrReadOnly]

--- a/iaso/api/org_unit_types/viewsets.py
+++ b/iaso/api/org_unit_types/viewsets.py
@@ -3,7 +3,7 @@ from rest_framework import status, permissions
 from rest_framework.response import Response
 
 from iaso.models import OrgUnitType
-from .serializers import OrgUnitTypeSerializer
+from .serializers import OrgUnitTypeSerializerV1, OrgUnitTypeSerializerV2
 from ..common import ModelViewSet
 
 
@@ -16,7 +16,7 @@ class OrgUnitTypeViewSet(ModelViewSet):
     """
 
     permission_classes = [permissions.IsAuthenticatedOrReadOnly]
-    serializer_class = OrgUnitTypeSerializer
+    serializer_class = OrgUnitTypeSerializerV1
     results_key = "orgUnitTypes"
     http_method_names = ["get", "post", "patch", "put", "delete", "head", "options", "trace"]
 
@@ -25,6 +25,39 @@ class OrgUnitTypeViewSet(ModelViewSet):
         if t.orgunit_set.count() > 0:
             return Response("You can't delete a type that still has org units", status=status.HTTP_401_UNAUTHORIZED)
         return super(OrgUnitTypeViewSet, self).destroy(request, pk)
+
+    def get_queryset(self):
+        queryset = OrgUnitType.objects.filter_for_user_and_app_id(
+            self.request.user, self.request.query_params.get("app_id")
+        )
+
+        search = self.request.query_params.get("search", None)
+        if search:
+            queryset = queryset.filter(Q(name__icontains=search) | Q(short_name__icontains=search))
+
+        orders = self.request.query_params.get("order", "name").split(",")
+
+        return queryset.order_by("depth").distinct().order_by(*orders)
+
+
+class OrgUnitTypeViewSetV2(ModelViewSet):
+    """Org unit types API
+
+    This API is open to anonymous users.
+
+    GET /api/orgunittypes/
+    """
+
+    permission_classes = [permissions.IsAuthenticatedOrReadOnly]
+    serializer_class = OrgUnitTypeSerializerV2
+    results_key = "orgUnitTypes"
+    http_method_names = ["get", "post", "patch", "put", "delete", "head", "options", "trace"]
+
+    def destroy(self, request, pk):
+        t = OrgUnitType.objects.get(pk=pk)
+        if t.orgunit_set.count() > 0:
+            return Response("You can't delete a type that still has org units", status=status.HTTP_401_UNAUTHORIZED)
+        return super(OrgUnitTypeViewSetV2, self).destroy(request, pk)
 
     def get_queryset(self):
         queryset = OrgUnitType.objects.filter_for_user_and_app_id(

--- a/iaso/migrations/0217_fill_allow_creating_sub_unit_types.py
+++ b/iaso/migrations/0217_fill_allow_creating_sub_unit_types.py
@@ -1,0 +1,17 @@
+from django.db import migrations
+
+
+def fill_allow_creating_sub_unit_types(apps, schema_editor):
+    OrgUnitType = apps.get_model("iaso", "OrgUnitType")
+    # don't override
+    out_without_allow_creating_sub_unit_types = OrgUnitType.objects.filter(allow_creating_sub_unit_types=None)
+    for out in out_without_allow_creating_sub_unit_types:
+        out.allow_creating_sub_unit_types.set(out.sub_unit_types.all())
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("iaso", "0216_merge_20230614_0839"),
+    ]
+
+    operations = [migrations.RunPython(fill_allow_creating_sub_unit_types, migrations.RunPython.noop)]

--- a/iaso/tests/api/test_org_unit_types_v2.py
+++ b/iaso/tests/api/test_org_unit_types_v2.py
@@ -1,0 +1,300 @@
+import typing
+
+from iaso import models as m
+from iaso.test import APITestCase
+
+
+class OrgUnitTypesAPITestCase(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        ghi = m.Account.objects.create(name="Global Health Initiative")
+        wha = m.Account.objects.create(name="Worldwide Health Aid")
+        cls.ead = m.Project.objects.create(name="End All Diseases", account=ghi)
+        cls.esd = m.Project.objects.create(name="End Some Diseases", account=wha)
+
+        cls.jane = cls.create_user_with_profile(username="janedoe", account=ghi, permissions=["iaso_forms"])
+        cls.reference_form = m.Form.objects.create(
+            name="Hydroponics study", period_type=m.MONTH, single_per_period=True
+        )
+        cls.reference_form_update = m.Form.objects.create(
+            name="Reference form update", period_type=m.MONTH, single_per_period=True
+        )
+        cls.reference_form_wrong_project = m.Form.objects.create(
+            name="Reference form with wrong project", period_type=m.MONTH, single_per_period=True
+        )
+        cls.org_unit_type_1 = m.OrgUnitType.objects.create(
+            name="Plop", short_name="Pl", reference_form_id=cls.reference_form_update.id
+        )
+        cls.org_unit_type_2 = m.OrgUnitType.objects.create(name="Boom", short_name="Bo")
+        cls.ead.unit_types.set([cls.org_unit_type_1, cls.org_unit_type_2])
+
+        cls.ead.forms.add(cls.reference_form)
+        cls.ead.forms.add(cls.reference_form_update)
+        cls.ead.save()
+
+        cls.esd.forms.add(cls.reference_form_wrong_project)
+        cls.esd.save()
+
+    def test_org_unit_types_list_without_auth_or_app_id(self):
+        """GET /orgunittypes/ without auth or app id should result in a 200 empty response"""
+
+        response = self.client.get("/api/v2/orgunittypes/")
+        self.assertJSONResponse(response, 200)
+        self.assertValidOrgUnitTypeListData(response.json(), 0)
+
+    def test_org_unit_types_list_with_auth(self):
+        """GET /orgunittypes/ without auth or app id should result in a 200 empty response"""
+
+        self.client.force_authenticate(self.jane)
+        response = self.client.get("/api/v2/orgunittypes/")
+        self.assertJSONResponse(response, 200)
+
+        response_data = response.json()
+        self.assertValidOrgUnitTypeListData(response_data, 2)
+        for org_unit_type_data in response_data["orgUnitTypes"]:
+            self.assertEqual(len(org_unit_type_data["projects"]), 1)
+
+    def test_org_unit_types_retrieve_without_auth_or_app_id(self):
+        """GET /orgunittypes/<org_unit_type_id>/ without auth or app id should result in a 200 empty response"""
+
+        response = self.client.get(f"/api/v2/orgunittypes/{self.org_unit_type_1.id}/")
+        self.assertJSONResponse(response, 404)
+
+    def test_org_unit_types_retrieve_ok(self):
+        """GET /orgunittypes/<org_unit_type_id>/ happy path"""
+
+        self.client.force_authenticate(self.jane)
+        response = self.client.get(f"/api/v2/orgunittypes/{self.org_unit_type_1.id}/")
+        self.assertJSONResponse(response, 200)
+        self.assertValidOrgUnitTypeData(response.json())
+
+    def test_org_unit_type_create_no_auth(self):
+        """POST /orgunittypes/ without auth: 403"""
+
+        response = self.client.post("/api/v2/orgunittypes/", data={}, format="json")
+        self.assertJSONResponse(response, 403)
+
+    def test_org_unit_type_create_invalid(self):
+        """POST /orgunittypes/ without project ids: invalid"""
+
+        self.client.force_authenticate(self.jane)
+        response = self.client.post(
+            "/api/v2/orgunittypes/", data={"name": "", "depth": 1, "project_ids": []}, format="json"
+        )
+        self.assertJSONResponse(response, 400)
+        self.assertHasError(response.json(), "name", "This field may not be blank.")
+        self.assertHasError(response.json(), "short_name", "This field is required.")
+        self.assertHasError(response.json(), "project_ids", "This list may not be empty.")
+
+    def test_org_unit_type_create_invalid_wrong_project(self):
+        """POST /orgunittypes/ without project ids: invalid"""
+
+        self.client.force_authenticate(self.jane)
+        response = self.client.post(
+            "/api/v2/orgunittypes/",
+            data={
+                "name": "Bimbam",
+                "short_name": "Bi",
+                "depth": 1,
+                "project_ids": [self.esd.id],
+                "sub_unit_type_ids": [],
+                "allow_creating_sub_unit_type_ids": [],
+            },
+            format="json",
+        )
+        self.assertJSONResponse(response, 400)
+        self.assertHasError(response.json(), "project_ids", "Invalid project ids")
+
+    def test_org_unit_type_create_with_not_existing_reference_form_ok(self):
+        """POST /orgunittypes/ with auth: 201 OK"""
+
+        self.client.force_authenticate(self.jane)
+        response = self.client.post(
+            "/api/v2/orgunittypes/",
+            data={
+                "name": "Bimbam",
+                "short_name": "Bi",
+                "depth": 1,
+                "project_ids": [self.ead.id],
+                "sub_unit_type_ids": [],
+                "allow_creating_sub_unit_type_ids": [],
+                "reference_form_id": 100,
+            },
+            format="json",
+        )
+        self.assertJSONResponse(response, 400)
+        self.assertHasError(response.json(), "reference_form_id", 'Invalid pk "100" - object does not exist.')
+
+    def test_org_unit_type_create_with_reference_form_ok(self):
+        """POST /orgunittypes/ with auth: 201 OK"""
+
+        self.client.force_authenticate(self.jane)
+        response = self.client.post(
+            "/api/v2/orgunittypes/",
+            data={
+                "name": "Bimbam",
+                "short_name": "Bi",
+                "depth": 1,
+                "project_ids": [self.ead.id],
+                "sub_unit_type_ids": [],
+                "allow_creating_sub_unit_type_ids": [],
+                "reference_form_id": self.reference_form.id,
+            },
+            format="json",
+        )
+
+        org_unit_type_data = response.json()
+        self.assertJSONResponse(response, 201)
+        self.assertValidOrgUnitTypeData(org_unit_type_data)
+        self.assertEqual(self.reference_form.id, org_unit_type_data["reference_form"]["id"])
+
+    def test_org_unit_type_create_with_reference_form_wrong_project(self):
+        """POST /orgunittypes/ with Invalid reference form id"""
+
+        self.client.force_authenticate(self.jane)
+        response = self.client.post(
+            "/api/v2/orgunittypes/",
+            data={
+                "name": "Bimbam",
+                "short_name": "Bi",
+                "depth": 1,
+                "project_ids": [self.ead.id],
+                "sub_unit_type_ids": [],
+                "allow_creating_sub_unit_type_ids": [],
+                "reference_form_id": self.reference_form_wrong_project.id,
+            },
+            format="json",
+        )
+
+        self.assertJSONResponse(response, 400)
+        self.assertHasError(response.json(), "reference_form_id", "Invalid reference form id")
+
+    def test_org_unit_type_create_ok(self):
+        """POST /orgunittypes/ with auth: 201 OK"""
+
+        self.client.force_authenticate(self.jane)
+        response = self.client.post(
+            "/api/v2/orgunittypes/",
+            data={
+                "name": "Bimbam",
+                "short_name": "Bi",
+                "depth": 1,
+                "project_ids": [self.ead.id],
+                "sub_unit_type_ids": [],
+                "allow_creating_sub_unit_type_ids": [],
+            },
+            format="json",
+        )
+
+        org_unit_type_data = response.json()
+        self.assertJSONResponse(response, 201)
+        self.assertValidOrgUnitTypeData(org_unit_type_data)
+        self.assertEqual(1, len(org_unit_type_data["projects"]))
+
+    def test_org_unit_type_create_with_sub_unit_types_ok(self):
+        """POST /orgunittypes/ with auth: 201 OK"""
+
+        self.client.force_authenticate(self.jane)
+        response = self.client.post(
+            "/api/v2/orgunittypes/",
+            data={
+                "name": "Bimbam",
+                "short_name": "Bi",
+                "depth": 1,
+                "project_ids": [self.ead.id],
+                "sub_unit_type_ids": [self.org_unit_type_1.id, self.org_unit_type_2.id],
+                "allow_creating_sub_unit_type_ids": [],
+            },
+            format="json",
+        )
+        self.assertJSONResponse(response, 201)
+
+        org_unit_type_data = response.json()
+        self.assertValidOrgUnitTypeData(org_unit_type_data)
+        self.assertEqual(1, len(org_unit_type_data["projects"]))
+        self.assertEqual(2, len(org_unit_type_data["sub_unit_types"]))
+
+    def test_org_unit_type_update_ok(self):
+        """PUT /orgunittypes/<org_unit_type_id>: 200 OK"""
+
+        self.client.force_authenticate(self.jane)
+        response = self.client.put(
+            f"/api/v2/orgunittypes/{self.org_unit_type_1.id}/",
+            data={
+                "name": "Plop updated",
+                "short_name": "Bi",
+                "depth": 1,
+                "project_ids": [self.ead.id],
+                "sub_unit_type_ids": [],
+                "allow_creating_sub_unit_type_ids": [],
+            },
+            format="json",
+        )
+        self.assertJSONResponse(response, 200)
+        self.assertValidOrgUnitTypeData(response.json())
+
+    def test_org_unit_type_update_with_reference_form_id_ok(self):
+        """PUT /orgunittypes/<org_unit_type_id>: 200 OK"""
+
+        self.client.force_authenticate(self.jane)
+        response = self.client.put(
+            f"/api/v2/orgunittypes/{self.org_unit_type_1.id}/",
+            data={
+                "name": "Plop updated",
+                "short_name": "Bi",
+                "depth": 1,
+                "project_ids": [self.ead.id],
+                "sub_unit_type_ids": [],
+                "allow_creating_sub_unit_type_ids": [],
+                "reference_form_id": self.reference_form_update.id,
+            },
+            format="json",
+        )
+        self.assertJSONResponse(response, 200)
+        self.assertValidOrgUnitTypeData(response.json())
+
+    def test_org_unit_type_partial_update_ok(self):
+        """PATCH /orgunittypes/<org_unit_type_id>/: 200 OK"""
+
+        self.client.force_authenticate(self.jane)
+        response = self.client.patch(
+            f"/api/v2/orgunittypes/{self.org_unit_type_1.id}/", data={"short_name": "P"}, format="json"
+        )
+        self.assertJSONResponse(response, 200)
+        self.assertValidOrgUnitTypeData(response.json())
+        self.org_unit_type_1.refresh_from_db()
+        self.assertEqual("P", self.org_unit_type_1.short_name)
+
+    def test_org_unit_type_delete_ok(self):
+        """DELETE /orgunittypes/<org_unit_type_id>: 200 OK"""
+
+        self.client.force_authenticate(self.jane)
+        response = self.client.delete(f"/api/v2/orgunittypes/{self.org_unit_type_1.id}/", format="json")
+        self.assertJSONResponse(response, 204)
+
+    def assertValidOrgUnitTypeListData(self, list_data: typing.Mapping, expected_length: int, paginated: bool = False):
+        self.assertValidListData(
+            list_data=list_data, expected_length=expected_length, results_key="orgUnitTypes", paginated=paginated
+        )
+
+        for org_unit_type_data in list_data["orgUnitTypes"]:
+            self.assertValidOrgUnitTypeData(org_unit_type_data)
+
+    # noinspection DuplicatedCode
+    def assertValidOrgUnitTypeData(self, org_unit_type_data):
+        self.assertHasField(org_unit_type_data, "id", int)
+        self.assertHasField(org_unit_type_data, "name", str)
+        self.assertHasField(org_unit_type_data, "short_name", str)
+        self.assertHasField(org_unit_type_data, "depth", int, optional=True)
+        self.assertHasField(org_unit_type_data, "projects", list, optional=True)
+        self.assertHasField(org_unit_type_data, "sub_unit_types", list, optional=True)
+        self.assertHasField(org_unit_type_data, "created_at", float)
+        self.assertHasField(org_unit_type_data, "reference_form", dict, optional=True)
+
+        if "projects" in org_unit_type_data:
+            for project_data in org_unit_type_data["projects"]:
+                self.assertValidProjectData(project_data)
+
+        if "sub_unit_types" in org_unit_type_data:
+            for sub_org_unit_type_data in org_unit_type_data["sub_unit_types"]:
+                self.assertValidOrgUnitTypeData(sub_org_unit_type_data)

--- a/iaso/tests/test_api.py
+++ b/iaso/tests/test_api.py
@@ -330,8 +330,15 @@ class BasicAPITestCase(APITestCase):
             exception_contains_string="Could not find project for user",
         )
 
-    def test_fetch_org_unit_type(self):
+    def test_fetch_org_unit_type_v1(self):
         """Fetch Org Unit Types through the API"""
+        out = OrgUnitType.objects.get(name="Hospital")
+        cds = OrgUnitType.objects.get(name="CDS", short_name="CDS")
+        out.allow_creating_sub_unit_types.set([cds])
+
+        out.sub_unit_types.clear()
+        out.save()
+
         c = APIClient()
 
         response = c.get(
@@ -343,6 +350,36 @@ class BasicAPITestCase(APITestCase):
 
         response = c.get(
             "/api/orgunittypes/?app_id=org.inconnus.spectacle", accept="application/json"
+        )  # this should have 2 results
+        json_response = json.loads(response.content)
+        org_unit_types = json_response["orgUnitTypes"]
+        self.assertEqual(len(org_unit_types), 2)
+
+        found = False
+        for org_unit_type_data in org_unit_types:
+            self.assertValidOrgUnitTypeData(org_unit_type_data)
+            if org_unit_type_data["name"] == "Hospital":
+                self.assertLess(org_unit_type_data["created_at"], org_unit_type_data["updated_at"])
+                self.assertEqual(len(org_unit_type_data["sub_unit_types"]), 1)
+                for sub_org_unit_type_data in org_unit_type_data["sub_unit_types"]:
+                    self.assertValidOrgUnitTypeData(sub_org_unit_type_data)
+                found = True
+
+        self.assertTrue(found)
+
+    def test_fetch_org_unit_type_v2(self):
+        """Fetch Org Unit Types through the API"""
+        c = APIClient()
+
+        response = c.get(
+            "/api/v2/orgunittypes/?app_id=com.pascallegitimus.iaso", accept="application/json"
+        )  # this should have 0 result
+        json_response = json.loads(response.content)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(json_response["orgUnitTypes"]), 0)
+
+        response = c.get(
+            "/api/v2/orgunittypes/?app_id=org.inconnus.spectacle", accept="application/json"
         )  # this should have 2 results
         json_response = json.loads(response.content)
         org_unit_types = json_response["orgUnitTypes"]

--- a/iaso/urls.py
+++ b/iaso/urls.py
@@ -60,6 +60,7 @@ from .api.mobile.org_units import MobileOrgUnitViewSet
 from .api.mobile.reports import MobileReportsViewSet
 from .api.mobile.storage import MobileStoragePasswordViewSet
 from .api.org_unit_types import OrgUnitTypeViewSet
+from .api.org_unit_types.viewsets import OrgUnitTypeViewSetV2
 from .api.org_units import OrgUnitViewSet
 from .api.pages import PagesViewSet
 from .api.periods import PeriodsViewSet
@@ -88,6 +89,7 @@ router = routers.DefaultRouter()
 router.register(r"orgunits", OrgUnitViewSet, basename="orgunits")
 
 router.register(r"orgunittypes", OrgUnitTypeViewSet, basename="orgunittypes")
+router.register(r"v2/orgunittypes", OrgUnitTypeViewSetV2, basename="orgunittypes")
 router.register(r"apps", AppsViewSet, basename="apps")
 router.register(r"projects", ProjectsViewSet, basename="projects")
 router.register(r"instances", InstancesViewSet, basename="instances")


### PR DESCRIPTION
Confusingly the V2 is the current behavior with the new allow_creating_sub_unit_types field (separate from sub_unit_types)
the existing url is with the new behavior where we map sub_unit_types to allow_creating_sub_unit_types.
so the mobile application don't need any update to alter the url.


Add a Data migration  to fill allow_creating_sub_unit_types so there is no loss of functionality for mobile application users.

The current behavior will be that allow_creating_sub_unit_types is used on mobile to restrict which org unit can be created
and sub_unit_types is used on web to control which type are displayed

Related JIRA tickets : IA-2259

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [na] Are my typescript files well typed
- [na] New translations have been added or updated if new strings have been introduced in the frontend
- [x] My migrations file are included
- [x] Are there enough tests
- [x] Documentation has been included (for new feature)

## Changes

- See summary, but add /v2/ with current behaviour and modified existing url with new behaviour for mobile.
- Ensure there is tests for both version
- Modified the frontend to use the new url
- Added doc

## How to test


## Notes

The web and external API user should from now on only use the /v2/ endpoint.

At some point we should restrict the action on the current url to only
what the mobile app support, to reduce the amount of code needed for
maintenance. but we need to ensure this won't be problematic for external users

