### PR TITLE
Polio 1076 date history bugs

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -1,4 +1,5 @@
 {
+    "blsq.buttons.label.close": "Close",
     "blsq.label.clickOrDragFile": "Drag files or click to select",
     "blsq.label.clicktoOpenFileSelect": "Click to open file selection",
     "blsq.label.dropHere": "Drop files here",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -1,4 +1,5 @@
 {
+    "blsq.buttons.label.close": "Fermer",
     "blsq.label.clickOrDragFile": "Déposez des fichiers ou cliquez pour ouvrir la sélection de fichiers",
     "blsq.label.clicktoOpenFileSelect": "Cliquer pour sélectionner des fichiers",
     "blsq.label.dropHere": "Déposez les fichiers ici",

--- a/plugins/polio/js/src/components/Rounds/ReasonForDelayModal/hooks/reasons.ts
+++ b/plugins/polio/js/src/components/Rounds/ReasonForDelayModal/hooks/reasons.ts
@@ -17,7 +17,7 @@ export type ReasonForDelay =
     | 'VACCINES_NOT_ARRIVED_IN_COUNTRY';
 
 export const reasonsForDateChange: ReasonForDelay[] = [
-    'INITIAL_DATA',
+    // 'INITIAL_DATA', // users should not have access to that option in the dropdown
     'ENCODING_ERROR',
     'PUBLIC_HOLIDAY',
     'OTHER_ACTIVITIES',

--- a/plugins/polio/serializers.py
+++ b/plugins/polio/serializers.py
@@ -379,7 +379,12 @@ class RoundSerializer(serializers.ModelSerializer):
             new_datelog = updated_datelogs[-1]
             datelog = None
             if has_datelog:
-                last_entry = instance.datelogs.order_by("-created_at").last()
+                last_entry = instance.datelogs.order_by("-created_at").first()
+                # if instance.datelogs.count() >= len(updated_datelogs) it means there was an update that was missed between input and confirmation
+                # This could lead to errors in the log with the previous_started_at and previous_ended_at fields
+                if len(updated_datelogs) >= instance.datelogs.count():
+                    new_datelog["previous_started_at"] = last_entry.started_at
+                    new_datelog["previous_ended_at"] = last_entry.ended_at
                 if (
                     new_datelog["reason"] != last_entry.reason
                     or new_datelog["started_at"] != last_entry.started_at

--- a/plugins/polio/serializers.py
+++ b/plugins/polio/serializers.py
@@ -376,6 +376,7 @@ class RoundSerializer(serializers.ModelSerializer):
 
         has_datelog = instance.datelogs.count() > 0
         if updated_datelogs:
+            new_datelog = updated_datelogs[-1]
             datelog = None
             if has_datelog:
                 last_entry = instance.datelogs.order_by("-created_at").last()
@@ -388,7 +389,6 @@ class RoundSerializer(serializers.ModelSerializer):
             else:
                 datelog = RoundDateHistoryEntry.objects.create(round=instance, reason="INITIAL_DATA", modified_by=user)
             if datelog is not None:
-                new_datelog = updated_datelogs[-1]
                 datelog_serializer = RoundDateHistoryEntrySerializer(instance=datelog, data=new_datelog)
                 datelog_serializer.is_valid(raise_exception=True)
                 datelog_instance = datelog_serializer.save()


### PR DESCRIPTION
Solve a bug that caused last round history entry to be duplicated on every campaign save; and another one that caused errors in the log history when saving without having the latest data (eg: someone else made a change while a user was editing)

POLIO-1076

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- Add a check to see if the data sent by the front-end (PUT request) is different from the latest entry in the round history. Don't create a history entry if not
- Get `previous_staretd_at` and `previous_ended_at`from the last entry in DB if the history in DB is >= the history sent by frontend.

## How to test

- Go to polio campaigns, open a campaign
- Make a change to any field, except round dates and save
- re-open the campaign
- check the any round history: no new entry should have been created 

- Open polio campaigns in another tab.
- In both tab with the same campaign open, choose a round and update the dates. 
- Save the campaign in the first tab, then in the second
- Re-open the campaign, see that the round history log is correct

## Print screen / video

https://github.com/BLSQ/iaso/assets/38907762/b67873a6-e596-4583-a6ec-96cfc73b0bb7


