### PR TITLE
WC2-242: Duplicate empty fields

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/entities/duplicates/hooks/api/useGetDuplicates.ts
+++ b/hat/assets/js/apps/Iaso/domains/entities/duplicates/hooks/api/useGetDuplicates.ts
@@ -81,8 +81,11 @@ const getFieldStatus = (base, compare): 'diff' | 'identical' => {
     if (base !== compare) return 'diff';
     return 'identical';
 };
-const getMergedEntityStatus = (final): 'dropped' | 'identical' => {
-    if (!final) return 'dropped';
+const getMergedEntityStatus = (
+    final: 'dropped' | 'identical',
+    fieldsEmpty: boolean,
+) => {
+    if (!final && !fieldsEmpty) return 'dropped';
     return 'identical';
 };
 
@@ -125,7 +128,10 @@ export const useGetDuplicateDetails = ({
                         final: {
                             value: row.final.value,
                             id: row.final.id,
-                            status: getMergedEntityStatus(row.final.value),
+                            status: getMergedEntityStatus(
+                                row.final.value,
+                                !row.entity1.value && !row.entity2.value,
+                            ),
                         },
                     };
                 });


### PR DESCRIPTION
Blank fields when comparing two beneficiaries.

If you have an empty field in both entities you cannot merge the duplicate

Related JIRA tickets : WC2-242

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

Mark field has fixed if both entities fields are empty

## How to test

Edit the instances of a duplicate to set an empty string has value
Try to merge it

## Print screen / video


https://github.com/BLSQ/iaso/assets/12494624/3b27167d-9ac7-498a-89b7-7984ee1addc8


