### PR TITLE
POLIO 1077:  sort teams by id number by default

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/teams/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/teams/index.tsx
@@ -35,6 +35,8 @@ export const Teams: FunctionComponent<Props> = ({ params }) => {
     const { formatMessage } = useSafeIntl();
     const { data, isFetching } = useGetTeams(apiParams);
     const { mutate: deleteTeam } = useDeleteTeam();
+    const defaultSorted = [{ id: 'id', desc: true }];
+
     return (
         <>
             <TopBar
@@ -50,7 +52,7 @@ export const Teams: FunctionComponent<Props> = ({ params }) => {
                     baseUrl={baseUrl}
                     data={data?.results ?? []}
                     pages={data?.pages ?? 1}
-                    defaultSorted={[{ id: 'name', desc: false }]}
+                    defaultSorted={defaultSorted}
                     columns={teamColumns(formatMessage, deleteTeam)}
                     count={data?.count ?? 0}
                     params={apiParams}

--- a/hat/assets/js/apps/Iaso/routing/redirections.tsx
+++ b/hat/assets/js/apps/Iaso/routing/redirections.tsx
@@ -4,13 +4,13 @@ import { Redirect, Route } from 'react-router';
 import { getSort } from 'bluesquare-components';
 
 import { cloneDeep } from 'lodash';
+import React from 'react';
 import { baseUrls } from '../constants/urls';
 import Page404 from '../components/errors/Page404';
 
 import { defaultSorted as storageDefaultSort } from '../domains/storages/config';
 import { defaultSorted as workflowDefaultSort } from '../domains/workflows/config/index';
 import { getOrgUnitsUrl } from '../domains/orgUnits/utils';
-import React from 'react';
 
 type Redirection =
     | { path: string; to: any; component: undefined }
@@ -68,7 +68,7 @@ const getRedirections: (overrideLanding: boolean) => Redirection[] =
             },
             {
                 path: `${baseUrls.teams}`,
-                to: `${baseUrls.teams}${getPaginationParams('name')}`,
+                to: `${baseUrls.teams}${getPaginationParams('id')}`,
             },
             {
                 path: `${baseUrls.storages}`,


### PR DESCRIPTION
Teams were sorted by name but should be sorted by Id by default

Related JIRA tickets : POLIO-1077

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- update order param value in redirection from name to id
- set default sort by id in `TableWithDeepLink` component

## How to test

- Open sidemenu
- Click on Admin > Teams
- You should see teams list result sorted by Id's
- Check that params are correct in url


## Print screen / video

https://github.com/BLSQ/iaso/assets/25134301/dba0c3a2-23bc-4e25-bc17-61401e4810af


