### PR TITLE
WC2-241: Error 500 in deduplication

### DIFF
--- a/iaso/api/deduplication/entity_duplicate.py
+++ b/iaso/api/deduplication/entity_duplicate.py
@@ -528,6 +528,18 @@ class EntityDuplicateViewSet(viewsets.GenericViewSet):
         version1 = duplicate.entity1.attributes.get_form_version()
         version2 = duplicate.entity2.attributes.get_form_version()
 
+        if version1 is None:
+            return Response(
+                status=status.HTTP_404_NOT_FOUND,
+                data={"error": f"No form version for attibutes of entity {duplicate.entity1.pk}"},
+            )
+
+        if version2 is None:
+            return Response(
+                status=status.HTTP_404_NOT_FOUND,
+                data={"error": f"No form version for attibutes of entity {duplicate.entity2.pk}"},
+            )
+
         return_data = {
             "fields": fields_data,
             "descriptor1": version1.get_or_save_form_descriptor(),

--- a/iaso/api/deduplication/filters.py
+++ b/iaso/api/deduplication/filters.py
@@ -3,15 +3,14 @@ from datetime import datetime
 from functools import reduce
 from itertools import combinations
 
-from django.db.models import Q
+from django.db.models import Q, TextField
 from django.db.models.expressions import RawSQL
+from django.db.models.functions import Cast
 from django.utils import timezone
 from rest_framework import filters
 
 from iaso.models import OrgUnit
 from iaso.models.deduplication import ValidationStatus
-from django.db.models import TextField
-from django.db.models.functions import Cast
 
 
 class EntityIdFilterBackend(filters.BaseFilterBackend):

--- a/iaso/tests/api/deduplication/test_entities_deduplication.py
+++ b/iaso/tests/api/deduplication/test_entities_deduplication.py
@@ -8,9 +8,8 @@ from django.db import connection
 import iaso.models.base as base
 from beanstalk_worker.services import TestTaskService
 from iaso import models as m
-from iaso.test import APITestCase
-
 from iaso.models.deduplication import ValidationStatus
+from iaso.test import APITestCase
 
 
 def create_instance_and_entity(cls, entity_name, instance_json, form_version, orgunit=None, entity_type=None):
@@ -543,15 +542,12 @@ class EntitiesDuplicationAPITestCase(APITestCase):
         task_service = TestTaskService()
         task_service.run_all()
 
-        
         resp = self.client.get(f"/api/entityduplicates/?search=iaso")
 
         resp_json = resp.json()
 
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(len(resp_json["results"]), 6)
-
-
 
     def test_detail_empty_form_version_correct_error(self):
         self.client.force_authenticate(self.user_with_default_ou_rw)
@@ -573,14 +569,13 @@ class EntitiesDuplicationAPITestCase(APITestCase):
         # we need to have some duplicates in DB
 
         duplicate = m.EntityDuplicate.objects.first()
-       
+
         # we need to remove the version from the json to test this case
         orig_json = duplicate.entity1.attributes.json
         orig_version_id = orig_json["_version"]
         del orig_json["_version"]
         duplicate.entity1.attributes.json = orig_json
         duplicate.entity1.attributes.save()
-
 
         resp = self.client.get(f"/api/entityduplicates/detail/?entities={duplicate.entity1.id},{duplicate.entity2.id}")
 
@@ -590,5 +585,3 @@ class EntitiesDuplicationAPITestCase(APITestCase):
         orig_json["_version"] = orig_version_id
         duplicate.entity1.attributes.json = orig_json
         duplicate.entity1.attributes.save()
-
-        


### PR DESCRIPTION
Fix 2 bugs : 

WC2-241 : Error 500 when one of the attributes instances of entities didn't have a propre form_version (based on "_version" in the JSON.

WC2-240 : Problem when using the search, it was only searching in and entity name and not in the attributes json content.

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are there enough tests

## Changes

Handle the case when the form_version of one of the 2 entities cannot be found.
In the search filter, we search in the JSON content as well as in the entity name.


## How to test

For WC2-240 : You can test the search functionality using the web frontend, it should find even in the entities attributes instance json fields (not only the entities name).

For WC2-241 : You can delete the key "_version" in the JSON of the instance used as attributes of an entity and then ask for the details of the related entity duplicate and it should return an 404 error with a proper message and not a 500.

(Check the tests added to the PR to see examples)

