### PR TITLE
IA-2207: Adding /api/mobile/metadata/lastupdates endpoint

### DIFF
--- a/iaso/api/mobile/metadata/last_updates.py
+++ b/iaso/api/mobile/metadata/last_updates.py
@@ -1,0 +1,75 @@
+from django.db.models import Max
+from django.shortcuts import get_object_or_404
+from drf_yasg import openapi
+from drf_yasg.utils import swagger_auto_schema
+from rest_framework import status, permissions
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.viewsets import ViewSet
+
+from iaso.api.query_params import APP_ID
+from iaso.models import Form, FormVersion, OrgUnit, OrgUnitType, Project
+
+
+class LastUpdatesViewSet(ViewSet):
+    """Metadata Last Updates
+
+    This API is open to anonymous users:
+
+    /api/mobile/metadata/lastupdates/
+
+    `GET /api/mobile/metadata/lastupdates/?app_id=some.app.id`
+    """
+
+    permission_classes = [permissions.IsAuthenticatedOrReadOnly]
+    http_method_names = ["get", "head", "options"]
+    lookup_url_kwarg = [APP_ID]
+
+    app_id_param = openapi.Parameter(
+        name=APP_ID,
+        in_=openapi.IN_QUERY,
+        required=True,
+        description="Application id",
+        type=openapi.TYPE_STRING,
+    )
+
+    @swagger_auto_schema(
+        responses={
+            200: "provides the latest updated dates",
+            404: "project for given app id doesn't exist",
+        },
+        manual_parameters=[app_id_param],
+    )
+    def list(self, request: Request):
+        app_id = request.query_params.get(APP_ID)
+
+        forms = Form.objects
+        form_versions = FormVersion.objects
+        org_units = OrgUnit.objects
+        org_unit_types = OrgUnitType.objects
+        if app_id is not None:
+            get_object_or_404(Project, app_id=app_id)  # Just checking the app_id exists
+            forms = forms.filter_for_user_and_app_id(user=request.user, app_id=app_id)
+            form_versions = form_versions.filter(form__in=forms)
+            org_units = org_units.filter_for_user_and_app_id(user=request.user, app_id=app_id)
+            org_unit_types = org_unit_types.filter_for_user_and_app_id(user=request.user, app_id=app_id)
+
+        return Response(
+            data={
+                "forms": self.max_date(forms, form_versions),
+                "org_units": self.max_date(org_units, org_unit_types),
+            },
+            status=status.HTTP_200_OK,
+        )
+
+    @staticmethod
+    def max_date(left, right):
+        left_updated_at = left.aggregate(Max("updated_at"))["updated_at__max"]
+        right_updated_at = right.aggregate(Max("updated_at"))["updated_at__max"]
+        if left_updated_at and right_updated_at:
+            return max(left_updated_at, right_updated_at).timestamp()
+        if left_updated_at:
+            return left_updated_at.timestamp()
+        if right_updated_at:
+            return right_updated_at.timestamp()
+        return None

--- a/iaso/api/mobile/metadata/last_updates.py
+++ b/iaso/api/mobile/metadata/last_updates.py
@@ -3,6 +3,7 @@ from django.shortcuts import get_object_or_404
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import status, permissions
+from rest_framework.exceptions import ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
@@ -36,12 +37,15 @@ class LastUpdatesViewSet(ViewSet):
     @swagger_auto_schema(
         responses={
             200: "provides the latest updated dates",
+            400: f"parameter '{APP_ID}' was not provided",
             404: "project for given app id doesn't exist",
         },
         manual_parameters=[app_id_param],
     )
     def list(self, request: Request):
         app_id = request.query_params.get(APP_ID)
+        if app_id is None or app_id == "":
+            raise ValidationError(f"parameters '{APP_ID}' is required")
 
         forms = Form.objects
         form_versions = FormVersion.objects

--- a/iaso/models/org_unit.py
+++ b/iaso/models/org_unit.py
@@ -87,6 +87,9 @@ class OrgUnitTypeQuerySet(models.QuerySet):
         return queryset
 
 
+OrgUnitTypeManager = models.Manager.from_queryset(OrgUnitTypeQuerySet)
+
+
 class OrgUnitType(models.Model):
     """A type of org unit, such as a country, a province, a district, a health facility, etc.
 
@@ -111,7 +114,7 @@ class OrgUnitType(models.Model):
     projects = models.ManyToManyField("Project", related_name="unit_types", blank=False)
     depth = models.PositiveSmallIntegerField(null=True, blank=True)
 
-    objects = OrgUnitTypeQuerySet.as_manager()
+    objects = OrgUnitTypeManager()
 
     def __str__(self):
         return "%s" % self.name

--- a/iaso/tests/api/test_metadata_lastupdates.py
+++ b/iaso/tests/api/test_metadata_lastupdates.py
@@ -1,0 +1,128 @@
+from datetime import datetime
+from unittest import mock
+from unittest.mock import patch
+
+from iaso import models as m
+from iaso.test import APITestCase
+from django.utils.timezone import now
+
+
+class MetadataLastUpdatesTestCase(APITestCase):
+    @classmethod
+    @mock.patch("django.utils.timezone.now", lambda: datetime(1970, 1, 1, 0, 0, 1))
+    def setUpTestData(cls):
+        n = cls.now = now()
+        star_wars = m.Account.objects.create(name="Star Wars")
+        sw_source = cls.sw_source = m.DataSource.objects.create(name="Galactic Empire")
+        sw_version = m.SourceVersion.objects.create(data_source=sw_source, number=1)
+        star_wars.default_version = sw_version
+        star_wars.save()
+        with patch("django.utils.timezone.now", lambda: datetime(1970, 1, 1, 0, 0, 7)):
+            jedi_council = cls.jedi_council = m.OrgUnitType.objects.create(name="Jedi Council", short_name="Cnc")
+        jedi_academy = cls.jedi_academy = m.OrgUnitType.objects.create(name="Jedi Academy", short_name="Aca")
+        project_1 = cls.project_1 = m.Project.objects.create(
+            name="Hydroponic gardens", app_id="stars.empire.agriculture.hydroponics", account=star_wars
+        )
+        project_2 = cls.project_2 = m.Project.objects.create(
+            name="New Land Speeder concept", app_id="stars.empire.agriculture.land_speeder", account=star_wars
+        )
+        sw_source.projects.add(project_1)
+        sw_source.projects.add(project_2)
+        sw_source.save()
+
+        with patch("django.utils.timezone.now", lambda: datetime(1970, 1, 1, 0, 0, 1)):
+            form_1 = cls.form_1 = m.Form.objects.create(name="Hydroponics study", created_at=n)
+        with patch("django.utils.timezone.now", lambda: datetime(1970, 1, 1, 0, 0, 2)):
+            form_2 = cls.form_2 = m.Form.objects.create(
+                name="Hydroponic public survey",
+                form_id="sample2",
+                device_field="deviceid",
+                location_field="geoloc",
+                period_type="QUARTER",
+                single_per_period=True,
+                created_at=n,
+            )
+        with patch("django.utils.timezone.now", lambda: datetime(1970, 1, 1, 0, 0, 5)):
+            form_version = cls.form_version = form_2.form_versions.create(
+                file=cls.create_file_mock(name="testf1.xml"), version_id="2020022401"
+            )
+        with patch("django.utils.timezone.now", lambda: datetime(1970, 1, 1, 0, 0, 3)):
+            form_3 = cls.form_3 = m.Form.objects.create(name="form3", created_at=n)
+        with patch("django.utils.timezone.now", lambda: datetime(1970, 1, 1, 0, 0, 4)):
+            form_4 = cls.form_4 = m.Form.objects.create(name="form4", created_at=n)
+
+        with patch("django.utils.timezone.now", lambda: datetime(1970, 1, 1, 0, 0, 1)):
+            ou_1 = cls.ou_1 = m.OrgUnit.objects.create(name="OU1", org_unit_type=jedi_council, version=sw_version)
+        with patch("django.utils.timezone.now", lambda: datetime(1970, 1, 1, 0, 0, 4)):
+            ou_2 = cls.ou_2 = m.OrgUnit.objects.create(name="OU2", org_unit_type=jedi_council, version=sw_version)
+        with patch("django.utils.timezone.now", lambda: datetime(1970, 1, 1, 0, 0, 2)):
+            ou_3 = cls.ou_3 = m.OrgUnit.objects.create(name="OU3", org_unit_type=jedi_academy, version=sw_version)
+        with patch("django.utils.timezone.now", lambda: datetime(1970, 1, 1, 0, 0, 3)):
+            ou_4 = cls.ou_4 = m.OrgUnit.objects.create(name="OU4", org_unit_type=jedi_academy, version=sw_version)
+
+        cls.yoda = cls.create_user_with_profile(
+            username="yoda", account=star_wars, permissions=["iaso_forms"], org_units=[ou_3]
+        )
+
+        project_1.unit_types.add(jedi_council)
+        project_1.forms.add(form_1)
+        project_1.forms.add(form_2)
+        project_1.save()
+        project_2.unit_types.add(jedi_academy)
+        project_2.forms.add(form_3)
+        project_2.forms.add(form_4)
+        project_2.save()
+
+        assert jedi_council.updated_at.timestamp() == 7.0, f"updated at: {jedi_council.updated_at.timestamp()}"
+        assert jedi_academy.updated_at.timestamp() == 1.0, f"updated at: {jedi_academy.updated_at.timestamp()}"
+        assert form_1.updated_at.timestamp() == 1.0, f"updated at: {form_1.updated_at.timestamp()}"
+        assert form_2.updated_at.timestamp() == 2.0, f"updated at: {form_2.updated_at.timestamp()}"
+        assert form_3.updated_at.timestamp() == 3.0, f"updated at: {form_3.updated_at.timestamp()}"
+        assert form_4.updated_at.timestamp() == 4.0, f"updated at: {form_4.updated_at.timestamp()}"
+        assert form_version.updated_at.timestamp() == 5.0, f"updated at: {form_version.updated_at.timestamp()}"
+        assert ou_1.updated_at.timestamp() == 1.0, f"updated at: {ou_1.updated_at.timestamp()}"
+        assert ou_2.updated_at.timestamp() == 4.0, f"updated at: {ou_2.updated_at.timestamp()}"
+        assert ou_3.updated_at.timestamp() == 2.0, f"updated at: {ou_3.updated_at.timestamp()}"
+        assert ou_4.updated_at.timestamp() == 3.0, f"updated at: {ou_4.updated_at.timestamp()}"
+
+    def test_last_updates_without_auth_and_app_id(self):
+        """GET /api/mobile/metadata/lastupdates/"""
+
+        response = self.client.get("/api/mobile/metadata/lastupdates/")
+        self.assertJSONResponse(response, 200)
+
+        self.assertEqual(response.json()["forms"], 5.0)  # form version
+        self.assertEqual(response.json()["org_units"], 7.0)  # highest org unit type
+
+    def test_last_updates_without_auth_but_app_id(self):
+        """GET /api/mobile/metadata/lastupdates/?app_id=stars.empire.agriculture.land_speeder"""
+
+        response = self.client.get(f"/api/mobile/metadata/lastupdates/?app_id={self.project_2.app_id}")
+        self.assertJSONResponse(response, 200)
+
+        self.assertEqual(response.json()["forms"], 4.0)  # highest form for project 2
+        self.assertEqual(response.json()["org_units"], 3.0)  # highest org unit for project 2
+
+    def test_last_updates_with_wrong_app_id(self):
+        """GET /api/mobile/metadata/lastupdates/?app_id=WRONG"""
+
+        response = self.client.get(f"/api/mobile/metadata/lastupdates/?app_id=WRONG")
+        self.assertJSONResponse(response, 404)
+
+    def test_last_updates_with_auth_but_no_app_id(self):
+        """GET /api/mobile/metadata/lastupdates/: authenticated"""
+
+        self.client.force_authenticate(self.yoda)
+        response = self.client.get(f"/api/mobile/metadata/lastupdates/")
+
+        self.assertEqual(response.json()["forms"], 5.0)  # form version
+        self.assertEqual(response.json()["org_units"], 7.0)  # highest org unit type
+
+    def test_last_updates_with_auth_and_app_id(self):
+        """GET /api/mobile/metadata/lastupdates/: authenticated"""
+
+        self.client.force_authenticate(self.yoda)
+        response = self.client.get(f"/api/mobile/metadata/lastupdates/?app_id={self.project_2.app_id}")
+
+        self.assertEqual(response.json()["forms"], 4.0)  # highest form for project 2
+        self.assertEqual(response.json()["org_units"], 2.0)  # highest org unit in the ones available to the user

--- a/iaso/tests/api/test_metadata_lastupdates.py
+++ b/iaso/tests/api/test_metadata_lastupdates.py
@@ -86,13 +86,10 @@ class MetadataLastUpdatesTestCase(APITestCase):
         assert ou_4.updated_at.timestamp() == 3.0, f"updated at: {ou_4.updated_at.timestamp()}"
 
     def test_last_updates_without_auth_and_app_id(self):
-        """GET /api/mobile/metadata/lastupdates/"""
+        """GET /api/mobile/metadata/lastupdates/: returns 400 for missing app id"""
 
         response = self.client.get("/api/mobile/metadata/lastupdates/")
-        self.assertJSONResponse(response, 200)
-
-        self.assertEqual(response.json()["forms"], 5.0)  # form version
-        self.assertEqual(response.json()["org_units"], 7.0)  # highest org unit type
+        self.assertJSONResponse(response, 400)
 
     def test_last_updates_without_auth_but_app_id(self):
         """GET /api/mobile/metadata/lastupdates/?app_id=stars.empire.agriculture.land_speeder"""
@@ -104,25 +101,24 @@ class MetadataLastUpdatesTestCase(APITestCase):
         self.assertEqual(response.json()["org_units"], 3.0)  # highest org unit for project 2
 
     def test_last_updates_with_wrong_app_id(self):
-        """GET /api/mobile/metadata/lastupdates/?app_id=WRONG"""
+        """GET /api/mobile/metadata/lastupdates/?app_id=WRONG: returns 404 for invalid app id"""
 
         response = self.client.get(f"/api/mobile/metadata/lastupdates/?app_id=WRONG")
         self.assertJSONResponse(response, 404)
 
     def test_last_updates_with_auth_but_no_app_id(self):
-        """GET /api/mobile/metadata/lastupdates/: authenticated"""
+        """GET /api/mobile/metadata/lastupdates/: authenticated but returns 400 for missing app id"""
 
         self.client.force_authenticate(self.yoda)
         response = self.client.get(f"/api/mobile/metadata/lastupdates/")
-
-        self.assertEqual(response.json()["forms"], 5.0)  # form version
-        self.assertEqual(response.json()["org_units"], 7.0)  # highest org unit type
+        self.assertJSONResponse(response, 400)
 
     def test_last_updates_with_auth_and_app_id(self):
-        """GET /api/mobile/metadata/lastupdates/: authenticated"""
+        """GET /api/mobile/metadata/lastupdates/: authenticated with app id"""
 
         self.client.force_authenticate(self.yoda)
         response = self.client.get(f"/api/mobile/metadata/lastupdates/?app_id={self.project_2.app_id}")
+        self.assertJSONResponse(response, 200)
 
         self.assertEqual(response.json()["forms"], 4.0)  # highest form for project 2
         self.assertEqual(response.json()["org_units"], 2.0)  # highest org unit in the ones available to the user

--- a/iaso/urls.py
+++ b/iaso/urls.py
@@ -53,6 +53,7 @@ from .api.links import LinkViewSet
 from .api.logs import LogsViewSet
 from .api.mapping_versions import MappingVersionsViewSet
 from .api.mappings import MappingsViewSet
+from iaso.api.mobile.metadata.last_updates import LastUpdatesViewSet
 from .api.microplanning import TeamViewSet, PlanningViewSet, AssignmentViewSet, MobilePlanningViewSet
 from .api.mobile.entity import MobileEntityViewSet
 from .api.mobile.entity_type import MobileEntityTypesViewSet
@@ -156,6 +157,8 @@ router.register(r"userroles", UserRolesViewSet, basename="userroles")
 router.register(r"datastore", DataStoreViewSet, basename="datastore")
 router.register(r"validationstatus", ValidationStatusViewSet, basename="validationstatus")
 
+router.register(r"mobile/metadata/lastupdates", LastUpdatesViewSet, basename="lastupdates")
+
 router.registry.extend(plugins_router.registry)
 
 urlpatterns: URLList = [
@@ -202,7 +205,6 @@ urlpatterns = urlpatterns + [
     path("dhis2/<dhis2_slug>/login/", dhis2_callback, name="dhis2_callback"),
     path("token_auth/", token_auth),
 ]
-
 
 for dhis2_resource in DHIS2_VIEWSETS:
     append_datasources_subresource(dhis2_resource, dhis2_resource.resource, urlpatterns)


### PR DESCRIPTION
The mobile application needs a way to know that Forms and OrgUnits have changed.
This endpoint adds the date of the last time the Forms (or FormVersions) and OrgUnits (or OrgUnitTypes) have been updated.
Allowing the mobile application to check with the last time it synchronized the data.

Related JIRA tickets : IA-2207

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [X] Are there enough tests

## Changes

This PR adds a new endpoint: `/api/mobile/metadata/lastupdates/` which provides two fields: `forms` and `org_units`.
`forms` provides the latest timestamp of a modification in the forms or the form versions.
`org_units` provides the latest timestamp of a modification in the org units or the org unit types.

The endpoint takes into account the `app_id` query parameter and if the user is logged in.

## How to test

Go to `/api/mobile/metadata/lastupdates/?app_id=...` and check the timestamps. Make a modification in either of the models tracked (see description) and ensure the timestamp has been updated accordingly.
