### PR TITLE
Hotfix Load all data from ONA

### DIFF
--- a/plugins/polio/helpers.py
+++ b/plugins/polio/helpers.py
@@ -38,7 +38,7 @@ def get_url_content(url, login, password, minutes, prefer_cache: bool = False):
             logger.info(f"fetched {len(response.content)} bytes")
             cached_response.save()
             content = response.json()
-            empty = (len(content) == 0)
+            empty = len(content) == 0
             j.extend(response.json())
             page = page + 1
     else:

--- a/plugins/polio/helpers.py
+++ b/plugins/polio/helpers.py
@@ -34,13 +34,14 @@ def get_url_content(url, login, password, minutes, prefer_cache: bool = False):
             logger.info("paginated_url: " + paginated_url)
             response = requests.get(paginated_url, auth=(login, password))
             response.raise_for_status()
-            cached_response.content = response.text
-            logger.info(f"fetched {len(response.content)} bytes")
-            cached_response.save()
+
             content = response.json()
             empty = len(content) == 0
             j.extend(response.json())
             page = page + 1
+        cached_response.content = json.dumps(j)
+        logger.info(f"fetched {len(response.content)} bytes")
+        cached_response.save()
     else:
         logger.info(f"using cache for {url}")
         j = json.loads(cached_response.content)


### PR DESCRIPTION
when there are more than 10000 form

Ona is silently paging the data for polio, with a default limit of 10000 items. This PR will load the additional pages by batches of 10000 untils there is no data. 



## Self proofreading checklist

- [ x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are there enough tests

