### PR TITLE
POLIO-1081: Calendar vaccine colors

### DIFF
--- a/plugins/polio/js/src/components/campaignCalendar/Styles.js
+++ b/plugins/polio/js/src/components/campaignCalendar/Styles.js
@@ -81,7 +81,6 @@ export const useStyles = makeStyles(theme => ({
         borderBottom: `1px solid ${theme.palette.ligthGray.border}`,
     },
     round: {
-        color: theme.palette.common.white,
         fontSize: 12,
     },
     campaign: {
@@ -192,5 +191,13 @@ export const useStyles = makeStyles(theme => ({
     },
     mapLegendText: {
         fontWeight: 'bold',
+    },
+    coloredBox: {
+        position: 'absolute',
+        zIndex: 0,
+        height: '100%',
+        width: '100%',
+        top: 0,
+        left: 0,
     },
 }));

--- a/plugins/polio/js/src/components/campaignCalendar/cells/RoundCell.js
+++ b/plugins/polio/js/src/components/campaignCalendar/cells/RoundCell.js
@@ -1,15 +1,16 @@
-import React, { useState, useContext, useCallback } from 'react';
+import React, { useState, useContext, useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
-import { TableCell } from '@material-ui/core';
+import { TableCell, Box } from '@material-ui/core';
 
-import { isEqual } from 'lodash';
+import { isEqual, uniq } from 'lodash';
+import { useSelector } from 'react-redux';
 import { PolioCreateEditDialog as CreateEditDialog } from '../../CreateEditDialog';
 import { RoundPopper } from '../popper/RoundPopper';
 import { useStyles } from '../Styles';
 import { RoundPopperContext } from '../contexts/RoundPopperContext.tsx';
-import { useSelector } from 'react-redux';
+import { polioVaccines } from '../../../constants/virus.ts';
 
 const RoundCell = ({ colSpan, campaign, round }) => {
     const classes = useStyles();
@@ -39,12 +40,41 @@ const RoundCell = ({ colSpan, campaign, round }) => {
     const defaultCellStyles = [classes.tableCell, classes.tableCellBordered];
     const open = self && isEqual(self, anchorEl);
     const isLogged = useSelector(state => Boolean(state.users.current));
+    const vaccinesList = useMemo(
+        () =>
+            uniq(
+                campaign.separateScopesPerRound
+                    ? round.scopes.map(scope => scope.vaccine)
+                    : campaign.scopes.map(scope => scope.vaccine),
+            ),
+        [campaign.scopes, campaign.separateScopesPerRound, round.scopes],
+    );
+    const getVaccineColor = useCallback(
+        vaccine =>
+            polioVaccines.find(polioVaccine => polioVaccine.value === vaccine)
+                ?.color || campaign.color,
+        [campaign.color],
+    );
     return (
         <TableCell
             className={classnames(defaultCellStyles, classes.round)}
-            style={{ backgroundColor: campaign.color }}
             colSpan={colSpan}
         >
+            <Box
+                className={classes.coloredBox}
+                style={{ backgroundColor: campaign.color }}
+            >
+                {vaccinesList.map(vaccine => (
+                    <span
+                        key={`${campaign.uuid}-${round.number}-${vaccine}`}
+                        style={{
+                            backgroundColor: getVaccineColor(vaccine),
+                            display: 'block',
+                            height: `${100 / vaccinesList.length}%`,
+                        }}
+                    />
+                ))}
+            </Box>
             <span
                 onClick={handleClick}
                 role="button"

--- a/plugins/polio/js/src/components/campaignCalendar/map/CalendarMapPanesMerged.tsx
+++ b/plugins/polio/js/src/components/campaignCalendar/map/CalendarMapPanesMerged.tsx
@@ -22,7 +22,7 @@ export const CalendarMapPanesMerged: FunctionComponent<Props> = ({
             {mergedShapes?.map(mergedShape => {
                 return (
                     <GeoJSON
-                        key={`${mergedShape.properties.id}-${mergedShape.cache}`}
+                        key={`${mergedShape.properties.id}-${mergedShape.properties.vaccine}-${mergedShape.cache}`}
                         data={mergedShape}
                         style={() =>
                             getGeoJsonStyle(


### PR DESCRIPTION
Use vaccine color in the background of a round on the calendar.


Related JIRA tickets : POLIO-1081

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- Get list of vaccines used for the campaign or the round scope
- use this list to display a background splitted into vaccine colors
- fixed a key issue un the map 

## How to test

load calendar page with visible campaigns, make sure you have multiple vaccines on campaign scopes or round scope

## Print screen / video

![Screenshot 2023-06-30 at 09 19 04](https://github.com/BLSQ/iaso/assets/12494624/2b088639-f85c-4696-b995-7a53b5f59d3e)

