### PR TITLE
IA-2283: Crash in the user column  in the asignemnt table for microplanning

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/assignments/utils.ts
+++ b/hat/assets/js/apps/Iaso/domains/assignments/utils.ts
@@ -87,15 +87,20 @@ export const getTeamUserName = (
     let fullItem;
     let displayString = '';
     if (selectedItem) {
+        displayString = '';
         if (currentTeam?.type === 'TEAM_OF_USERS') {
             fullItem = profiles.find(
                 profile => profile.user_id === selectedItem.id,
             );
-            displayString = getDisplayName(fullItem);
+            if (fullItem) {
+                displayString = getDisplayName(fullItem);
+            }
         }
         if (currentTeam?.type === 'TEAM_OF_TEAMS') {
             fullItem = teams.find(team => team.original.id === selectedItem.id);
-            displayString = fullItem.label;
+            if (fullItem) {
+                displayString = fullItem.label;
+            }
         }
     }
     return displayString;


### PR DESCRIPTION
In prod, we have 292 profiles, the component has time render before getting the full list, this is creating an issue while searching for a specific profile

Related JIRA tickets : IA-2283

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- prevent compute of display name if profiles list is empty

## How to test

Not sure how to test, if you provide an empty list for profiles, the cell is crashing


