### PR TITLE
POLIO-847 API Add a field on round  districts_count_calculated

### DIFF
--- a/plugins/polio/models.py
+++ b/plugins/polio/models.py
@@ -231,6 +231,10 @@ class Round(models.Model):
     def get_item_by_key(self, key):
         return getattr(self, key)
 
+    @property
+    def districts_count_calculated(self):
+        return self.campaign.get_districts_for_round(self).count()
+
 
 class CampaignQuerySet(models.QuerySet):
     def filter_for_user(self, user: Union[User, AnonymousUser]):

--- a/plugins/polio/serializers.py
+++ b/plugins/polio/serializers.py
@@ -337,6 +337,7 @@ class RoundSerializer(serializers.ModelSerializer):
     shipments = ShipmentSerializer(many=True, required=False)
     destructions = DestructionSerializer(many=True, required=False)
     datelogs = RoundDateHistoryEntrySerializer(many=True, required=False)
+    districts_count_calculated = serializers.IntegerField(read_only=True)
 
     @atomic
     def create(self, validated_data):

--- a/plugins/polio/tests/test_api.py
+++ b/plugins/polio/tests/test_api.py
@@ -398,6 +398,7 @@ class PolioAPITestCase(APITestCase):
         payload = {
             "account": self.account.pk,
             "obr_name": "obr_name",
+            "separate_scopes_per_round": False,
             "scopes": [
                 {"vaccine": "bOPV", "group": {"org_units": [self.org_unit.id]}},
                 {"vaccine": "mOPV2", "group": {"org_units": [self.child_org_unit.id]}},
@@ -434,9 +435,11 @@ class PolioAPITestCase(APITestCase):
         self.assertNotEqual(r["round_one"], None, r)
         # self.assertHasField(r["round_one"], "started_at", r)
         self.assertEqual(r["round_one"]["started_at"], "2021-02-01", r)
+        self.assertEqual(r["round_one"]["districts_count_calculated"], 2, r["round_one"])
         self.assertEqual(len(r["rounds"]), 2)
         self.assertNotEqual(r["round_two"], None, r)
         self.assertEqual(r["round_two"]["started_at"], "2021-04-01", r)
+        self.assertEqual(r["round_two"]["districts_count_calculated"], 2, r["round_two"])
 
         scope_bOPV = c.scopes.get(vaccine="bOPV")
         scope_mOPV2 = c.scopes.get(vaccine="mOPV2")
@@ -470,6 +473,7 @@ class PolioAPITestCase(APITestCase):
             "account": self.account.pk,
             "obr_name": "obr_name",
             "detection_status": "PENDING",
+            "separate_scopes_per_round": True,
             "rounds": [
                 {
                     "number": 1,
@@ -505,9 +509,11 @@ class PolioAPITestCase(APITestCase):
         self.assertNotEqual(r["round_one"], None, r)
         # self.assertHasField(r["round_one"], "started_at", r)
         self.assertEqual(r["round_one"]["started_at"], "2021-02-01", r)
+        self.assertEqual(r["round_one"]["districts_count_calculated"], 2, r["round_one"])
         self.assertEqual(len(r["rounds"]), 2)
         self.assertNotEqual(r["round_two"], None, r)
         self.assertEqual(r["round_two"]["started_at"], "2021-04-01", r)
+        self.assertEqual(r["round_two"]["districts_count_calculated"], 0, r["round_two"])
         round_one = list(filter(lambda r: r["number"] == 1, r["rounds"]))[0]
 
         self.assertEqual(


### PR DESCRIPTION
 with the count of district.

This is to ease the calculation in PowerBI

Related JIRA tickets : POLIO-847

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [na] Are my typescript files well typed
- [na] New translations have been added or updated if new strings have been introduced in the frontend
- [na] My migrations file are included
- [x] Are there enough tests
- [na] Documentation has been included (for new feature)


## How to test

Check by hand if what the API is returing in `/api/polio/campaigns/` for the new field is consistant with the number of district configured in the round. Try with and without separate scope per round.
