### PR TITLE
POLIO-1082 wrong vaccine scope

### DIFF
--- a/plugins/polio/js/src/components/campaignCalendar/cells/RoundCell.js
+++ b/plugins/polio/js/src/components/campaignCalendar/cells/RoundCell.js
@@ -54,12 +54,7 @@ const RoundCell = ({ colSpan, campaign, round }) => {
         campaign.separateScopesPerRound,
         round.vaccine_names,
     ]);
-    // const getVaccineColor = useCallback(
-    //     vaccine =>
-    //         polioVaccines.find(polioVaccine => polioVaccine.value === vaccine)
-    //             ?.color || '#bcbcbc',
-    //     [campaign.color],
-    // );
+
     return (
         <TableCell
             className={classnames(defaultCellStyles, classes.round)}

--- a/plugins/polio/js/src/components/campaignCalendar/cells/RoundCell.js
+++ b/plugins/polio/js/src/components/campaignCalendar/cells/RoundCell.js
@@ -12,6 +12,10 @@ import { useStyles } from '../Styles';
 import { RoundPopperContext } from '../contexts/RoundPopperContext.tsx';
 import { polioVaccines } from '../../../constants/virus.ts';
 
+const getVaccineColor = vaccine =>
+    polioVaccines.find(polioVaccine => polioVaccine.value === vaccine)?.color ||
+    '#bcbcbc';
+
 const RoundCell = ({ colSpan, campaign, round }) => {
     const classes = useStyles();
     const [dialogOpen, setDialogOpen] = useState(false);
@@ -50,12 +54,12 @@ const RoundCell = ({ colSpan, campaign, round }) => {
         campaign.separateScopesPerRound,
         round.vaccine_names,
     ]);
-    const getVaccineColor = useCallback(
-        vaccine =>
-            polioVaccines.find(polioVaccine => polioVaccine.value === vaccine)
-                ?.color || campaign.color,
-        [campaign.color],
-    );
+    // const getVaccineColor = useCallback(
+    //     vaccine =>
+    //         polioVaccines.find(polioVaccine => polioVaccine.value === vaccine)
+    //             ?.color || '#bcbcbc',
+    //     [campaign.color],
+    // );
     return (
         <TableCell
             className={classnames(defaultCellStyles, classes.round)}

--- a/plugins/polio/js/src/components/campaignCalendar/cells/RoundCell.js
+++ b/plugins/polio/js/src/components/campaignCalendar/cells/RoundCell.js
@@ -4,7 +4,7 @@ import classnames from 'classnames';
 
 import { TableCell, Box } from '@material-ui/core';
 
-import { isEqual, uniq } from 'lodash';
+import { isEqual } from 'lodash';
 import { useSelector } from 'react-redux';
 import { PolioCreateEditDialog as CreateEditDialog } from '../../CreateEditDialog';
 import { RoundPopper } from '../popper/RoundPopper';
@@ -40,19 +40,16 @@ const RoundCell = ({ colSpan, campaign, round }) => {
     const defaultCellStyles = [classes.tableCell, classes.tableCellBordered];
     const open = self && isEqual(self, anchorEl);
     const isLogged = useSelector(state => Boolean(state.users.current));
-    const vaccinesList = useMemo(
-        () =>
-            uniq(
-                campaign.separateScopesPerRound
-                    ? round.scopes
-                          .filter(scope => scope.group.org_units.length > 0)
-                          .map(scope => scope.vaccine)
-                    : campaign.scopes
-                          .filter(scope => scope.group.org_units.length > 0)
-                          .map(scope => scope.vaccine),
-            ),
-        [campaign.scopes, campaign.separateScopesPerRound, round.scopes],
-    );
+    const vaccinesList = useMemo(() => {
+        const list = campaign.separateScopesPerRound
+            ? round.vaccine_names?.split(',') ?? []
+            : campaign.vaccines?.split(',') ?? [];
+        return list.map(vaccineName => vaccineName.trim());
+    }, [
+        campaign.separateScopesPerRound,
+        campaign.vaccines,
+        round.vaccine_names,
+    ]);
     const getVaccineColor = useCallback(
         vaccine =>
             polioVaccines.find(polioVaccine => polioVaccine.value === vaccine)

--- a/plugins/polio/js/src/components/campaignCalendar/cells/RoundCell.js
+++ b/plugins/polio/js/src/components/campaignCalendar/cells/RoundCell.js
@@ -44,8 +44,12 @@ const RoundCell = ({ colSpan, campaign, round }) => {
         () =>
             uniq(
                 campaign.separateScopesPerRound
-                    ? round.scopes.map(scope => scope.vaccine)
-                    : campaign.scopes.map(scope => scope.vaccine),
+                    ? round.scopes
+                          .filter(scope => scope.group.org_units.length > 0)
+                          .map(scope => scope.vaccine)
+                    : campaign.scopes
+                          .filter(scope => scope.group.org_units.length > 0)
+                          .map(scope => scope.vaccine),
             ),
         [campaign.scopes, campaign.separateScopesPerRound, round.scopes],
     );

--- a/plugins/polio/js/src/components/campaignCalendar/cells/RoundCell.js
+++ b/plugins/polio/js/src/components/campaignCalendar/cells/RoundCell.js
@@ -43,11 +43,11 @@ const RoundCell = ({ colSpan, campaign, round }) => {
     const vaccinesList = useMemo(() => {
         const list = campaign.separateScopesPerRound
             ? round.vaccine_names?.split(',') ?? []
-            : campaign.vaccines?.split(',') ?? [];
+            : campaign.original.vaccines?.split(',') ?? [];
         return list.map(vaccineName => vaccineName.trim());
     }, [
+        campaign.original.vaccines,
         campaign.separateScopesPerRound,
-        campaign.vaccines,
         round.vaccine_names,
     ]);
     const getVaccineColor = useCallback(

--- a/plugins/polio/serializers.py
+++ b/plugins/polio/serializers.py
@@ -887,14 +887,7 @@ class CalendarCampaignSerializer(CampaignSerializer):
 
         class Meta:
             model = Round
-            fields = [
-                "id",
-                "number",
-                "started_at",
-                "ended_at",
-                "scopes",
-                "vaccine_names"
-            ]
+            fields = ["id", "number", "started_at", "ended_at", "scopes", "vaccine_names"]
 
     class NestedScopeSerializer(CampaignScopeSerializer):
         class NestedGroupSerializer(GroupSerializer):

--- a/plugins/polio/serializers.py
+++ b/plugins/polio/serializers.py
@@ -874,7 +874,7 @@ class CalendarCampaignSerializer(CampaignSerializer):
             class NestedGroupSerializer(GroupSerializer):
                 class Meta:
                     model = Group
-                    fields = ["id","org_units"]
+                    fields = ["id", "org_units"]
 
             class Meta:
                 model = RoundScope
@@ -896,7 +896,7 @@ class CalendarCampaignSerializer(CampaignSerializer):
         class NestedGroupSerializer(GroupSerializer):
             class Meta:
                 model = Group
-                fields = ["id","org_units"]
+                fields = ["id", "org_units"]
 
         class Meta:
             model = CampaignScope

--- a/plugins/polio/serializers.py
+++ b/plugins/polio/serializers.py
@@ -877,7 +877,7 @@ class CalendarCampaignSerializer(CampaignSerializer):
             class NestedGroupSerializer(GroupSerializer):
                 class Meta:
                     model = Group
-                    fields = ["id", "org_units"]
+                    fields = ["id"]
 
             class Meta:
                 model = RoundScope
@@ -893,13 +893,14 @@ class CalendarCampaignSerializer(CampaignSerializer):
                 "started_at",
                 "ended_at",
                 "scopes",
+                "vaccine_names"
             ]
 
     class NestedScopeSerializer(CampaignScopeSerializer):
         class NestedGroupSerializer(GroupSerializer):
             class Meta:
                 model = Group
-                fields = ["id", "org_units"]
+                fields = ["id"]
 
         class Meta:
             model = CampaignScope

--- a/plugins/polio/serializers.py
+++ b/plugins/polio/serializers.py
@@ -874,7 +874,7 @@ class CalendarCampaignSerializer(CampaignSerializer):
             class NestedGroupSerializer(GroupSerializer):
                 class Meta:
                     model = Group
-                    fields = ["id"]
+                    fields = ["id","org_units"]
 
             class Meta:
                 model = RoundScope
@@ -896,7 +896,7 @@ class CalendarCampaignSerializer(CampaignSerializer):
         class NestedGroupSerializer(GroupSerializer):
             class Meta:
                 model = Group
-                fields = ["id"]
+                fields = ["id","org_units"]
 
         class Meta:
             model = CampaignScope


### PR DESCRIPTION
The color code in the calendar was wrong if users had input a scope for a vaccine then deleted it

Related JIRA tickets :POLIO-1082

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- add "org_units"  to the `Group` fields returned by the `CalendarCampaignSerializer`
- filter out scopes without org units in the front end

## How to test

Explain how to test your PR.

Go to calendar, edit a campaign to add, then remove a vaccine scope: the calendar should update accordingly

## Print screen / video


https://github.com/BLSQ/iaso/assets/38907762/7fb867da-96e5-43a3-aaeb-6a35faec2b4e



## Notes
depends on https://github.com/BLSQ/iaso/pull/683
