### PR TITLE
WC2-239 similarity score ranking does not work

### DIFF
--- a/iaso/api/deduplication/entity_duplicate.py
+++ b/iaso/api/deduplication/entity_duplicate.py
@@ -12,7 +12,7 @@ from django.utils.text import slugify
 from django_filters.rest_framework import DjangoFilterBackend  # type: ignore
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
-from rest_framework import filters, permissions, serializers, status, viewsets
+from rest_framework import permissions, serializers, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -402,11 +402,12 @@ class EntityDuplicateViewSet(viewsets.GenericViewSet):
         dedup_filters.FormFilterBackend,
         dedup_filters.OrgUnitFilterBackend,
         dedup_filters.StartEndDateFilterBackend,
-        filters.OrderingFilter,
+        dedup_filters.CustomOrderingFilter,
         DjangoFilterBackend,
+        # filters.OrderingFilter,
     ]
 
-    ordering_fields = ["created_at", "similarity_score", "id"]
+    ordering_fields = ["created_at", "similarity_score", "id", "similarity_star"]
     remove_results_key_if_paginated = False
     results_key = "results"
     permission_classes = [permissions.IsAuthenticated, HasPermission("menupermissions.iaso_entity_duplicates_read")]  # type: ignore

--- a/iaso/api/deduplication/filters.py
+++ b/iaso/api/deduplication/filters.py
@@ -9,6 +9,7 @@ from iaso.models import OrgUnit
 from datetime import datetime
 from django.utils import timezone
 from iaso.models.deduplication import ValidationStatus
+from rest_framework.filters import OrderingFilter
 
 
 class EntityIdFilterBackend(filters.BaseFilterBackend):
@@ -215,3 +216,19 @@ class IgnoredMergedFilterBackend(filters.BaseFilterBackend):
             queryset = queryset.filter(qs[0])
 
         return queryset
+
+
+class CustomOrderingFilter(OrderingFilter):
+    def get_ordering(self, request, queryset, view):
+        ordering = super().get_ordering(request, queryset, view)
+        if ordering:
+            new_ordering = []
+            for field in ordering:
+                if field == "similarity_star":  # fix bug because frontend is using the stars not the score
+                    new_ordering.append("similarity_score")
+                elif field == "-similarity_star":
+                    new_ordering.append("-similarity_score")
+                else:
+                    new_ordering.append(field)
+            return new_ordering
+        return ordering


### PR DESCRIPTION
In the entity duplicates list if you were trying to sort by similarity stars it was not working.

Related JIRA tickets : WC2-239

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
frontend

## Changes

The problem was that `similarity_star` is not a real field but a computed one for the frontend. So I did a custom ordering filter that filters on `similarity_score` when `similarity_star` is given otherwise acts normally.


## How to test

In the dashboard, go to to entity duplicates and try to sort the list by similarity star.

## Print screen / video

https://github.com/BLSQ/iaso/assets/383344/eca67f7d-8294-48bd-9127-117c6693d8ba

