### PR TITLE
Configure the server URL for local use with an environment variable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,6 +64,7 @@ services:
       WFP_AUTH_CLIENT_ID:
       WFP_AUTH_ACCOUNT:
       WFP_EMAIL_RECIPIENTS_NEW_ACCOUNT:
+      SERVER_URL:
     # Limit logging in dev to not overflow terminal
     logging: &iaso_logging
       driver: "json-file"

--- a/hat/settings.py
+++ b/hat/settings.py
@@ -355,6 +355,7 @@ AWS_S3_REGION_NAME = os.getenv("AWS_S3_REGION_NAME", "eu-central-1")
 AWS_ACCESS_KEY_ID = os.getenv("AWS_ACCESS_KEY_ID")
 AWS_SECRET_ACCESS_KEY = os.getenv("AWS_SECRET_ACCESS_KEY")
 
+MEDIA_URL_PREFIX = "/media/"
 if USE_S3:
     # https://django-storages.readthedocs.io/en/latest/backends/amazon-S3.html
     AWS_S3_OBJECT_PARAMETERS = {"CacheControl": "max-age=86400"}
@@ -389,7 +390,8 @@ if USE_S3:
 
     DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
 else:
-    MEDIA_URL = "/media/"
+    SERVER_URL = os.environ.get("SERVER_URL", "")
+    MEDIA_URL = SERVER_URL + MEDIA_URL_PREFIX
     STATIC_URL = "/static/"
     STATIC_ROOT = os.path.join(BASE_DIR, "static")
     MEDIA_ROOT = os.path.join(BASE_DIR, "media")

--- a/hat/urls.py
+++ b/hat/urls.py
@@ -88,4 +88,4 @@ if apps.is_installed("django_sql_dashboard"):
 
 urlpatterns.append(path("dashboard/", include("hat.dashboard.urls")))
 
-urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+urlpatterns += static(settings.MEDIA_URL_PREFIX, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
Allow to configure the server URL for local use with an environment variable

TODO: Update the wiki when merged

## Self-proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented

## Changes

The current configuration for local use requires the user to modify several files.
Also, it is not foolproof as new media won't be served correctly (like the form attachments).
This solution will allow to easily configure the local environment, without modifying code, and, therefore, without the risk of committing local configuration.

## How to test

Launch ngrok, copy the URL, and add it into your `.env` file like so:
```
SERVER_URL=<copied URL>
```

Launch docker and go to the form API, the URLs should be absolute instead of relative.
