### PR TITLE
POLIO-1089:skip rejected OU,improve string format

### DIFF
--- a/plugins/polio/api.py
+++ b/plugins/polio/api.py
@@ -1377,15 +1377,11 @@ class OrgUnitsPerCampaignViewset(viewsets.ViewSet):
 def find_district(district_name, region_name, district_dict):
     district_name_lower = district_name.lower() if district_name else None
     district_list = district_dict.get(district_name_lower)
-    # if district_name_lower == "boromo" or district_name_lower=="bousse" or district_name_lower=="toma":
-    #     print(district_name, region_name, len(district_list))
     if district_list and len(district_list) == 1:
         return district_list[0]
     elif district_list and len(district_list) > 1:
         for di in district_list:
             parent_aliases_lower = [alias.lower().strip() for alias in di.parent.aliases] if di.parent.aliases else []
-            if district_name_lower == "boromo" or district_name_lower=="bousse" or district_name_lower=="toma":
-                print(district_name_lower, di.name,di.parent.name.lower().strip(), parent_aliases_lower)
             if di.parent.name.lower().strip() == region_name.lower().strip() or (
                 di.parent.aliases and region_name.lower().strip() in parent_aliases_lower
             ):
@@ -1698,7 +1694,7 @@ class LQASStatsViewSet(viewsets.ViewSet):
             cache.set(
                 "{0}-{1}-LQAS".format(request.user.id, request.query_params["country_id"]),
                 json.dumps(response),
-                1,
+                3600,
                 version=CACHE_VERSION,
             )
         return JsonResponse(response, safe=False)

--- a/plugins/polio/api.py
+++ b/plugins/polio/api.py
@@ -1444,8 +1444,7 @@ class LQASStatsViewSet(viewsets.ViewSet):
         unknown_round = 0
         skipped_forms = {"count": 0, "no_round": 0, "unknown_round": unknown_round, "forms_id": skipped_forms_list}
 
-        find_lqas_im_campaign_cached = find_lqas_im_campaign
-        # find_lqas_im_campaign_cached = lru_cache(maxsize=None)(find_lqas_im_campaign)
+        find_lqas_im_campaign_cached = lru_cache(maxsize=None)(find_lqas_im_campaign)
 
         base_stats = lambda: {
             "total_child_fmd": 0,

--- a/plugins/polio/api.py
+++ b/plugins/polio/api.py
@@ -1434,7 +1434,7 @@ class LQASStatsViewSet(viewsets.ViewSet):
     """
 
     def list(self, request):
-        no_cache = request.GET.get("no_cache", "true") == "true"
+        no_cache = request.GET.get("no_cache", "false") == "true"
         requested_country = request.GET.get("country_id", None)
         if requested_country is None:
             return HttpResponseBadRequest
@@ -1693,7 +1693,7 @@ class LQASStatsViewSet(viewsets.ViewSet):
             cache.set(
                 "{0}-{1}-LQAS".format(request.user.id, request.query_params["country_id"]),
                 json.dumps(response),
-                1,
+                3600,
                 version=CACHE_VERSION,
             )
         return JsonResponse(response, safe=False)

--- a/plugins/polio/serializers.py
+++ b/plugins/polio/serializers.py
@@ -313,6 +313,7 @@ class RoundDateHistoryEntrySerializer(serializers.ModelSerializer):
         ]
 
     modified_by = UserSerializer(required=False, read_only=True)
+    round = serializers.PrimaryKeyRelatedField(read_only=True, many=False)
 
     def validate(self, data):
         if not data["reason"]:

--- a/plugins/polio/serializers.py
+++ b/plugins/polio/serializers.py
@@ -313,7 +313,7 @@ class RoundDateHistoryEntrySerializer(serializers.ModelSerializer):
         ]
 
     modified_by = UserSerializer(required=False, read_only=True)
-    round = serializers.PrimaryKeyRelatedField(read_only=True, many=False)
+    round : Round = serializers.PrimaryKeyRelatedField(read_only=True, many=False)
 
     def validate(self, data):
         if not data["reason"]:

--- a/plugins/polio/serializers.py
+++ b/plugins/polio/serializers.py
@@ -313,7 +313,7 @@ class RoundDateHistoryEntrySerializer(serializers.ModelSerializer):
         ]
 
     modified_by = UserSerializer(required=False, read_only=True)
-    round: Round = serializers.PrimaryKeyRelatedField(read_only=True, many=False)
+    round: Field = serializers.PrimaryKeyRelatedField(read_only=True, many=False)
 
     def validate(self, data):
         if not data["reason"]:

--- a/plugins/polio/serializers.py
+++ b/plugins/polio/serializers.py
@@ -313,7 +313,7 @@ class RoundDateHistoryEntrySerializer(serializers.ModelSerializer):
         ]
 
     modified_by = UserSerializer(required=False, read_only=True)
-    round : Round = serializers.PrimaryKeyRelatedField(read_only=True, many=False)
+    round: Round = serializers.PrimaryKeyRelatedField(read_only=True, many=False)
 
     def validate(self, data):
         if not data["reason"]:


### PR DESCRIPTION
lqas/im API could sometimes return the district id of a deleted org unit of there were 1 valid and 1 rejected version of the org unit, or not show the district at all (same conditions). It also couldn't match all parent alias names when trying to match region names

Related JIRA tickets :  POLIO-1089

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- filter out NEW and REJECTED org units when getting queryset
- strip and convert parent aliases to lower case for better name matching

## How to test

- You need a DB with the same org unit ids as prod
- test name matching: replicate TOG-39DS-06-022 from polio prod: there should be no "district not found" (as opposed to "golfe" in current polio prod)
- rejected org units: I couldn't replicate locally the case where a district is returned with the id of its rejected version (my datasource is outdated). The other bug can be tested by replication locally the campaign ZMB-30DS-02-2022 and creating a rejected version of a district in scope, eg Luangwa. It should not appear in the response when you're on main, but should appear when testing this branch. 

IMPORTANT: don't forget to set the cache time to 1 or comment out caching code when testing.

## Print screen / video
Not visible in the UI, you should compare json from API responses from main and from the branch


