### PR TITLE
IA-2285: User/User roles: make permissions list scrollable

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/userRoles/components/PermissionsSwitches.tsx
+++ b/hat/assets/js/apps/Iaso/domains/userRoles/components/PermissionsSwitches.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo } from 'react';
-import { FormControlLabel, Switch } from '@material-ui/core';
+import { Box, FormControlLabel, Switch, makeStyles } from '@material-ui/core';
 // @ts-ignore
 import { useSafeIntl, LoadingSpinner } from 'bluesquare-components';
 
@@ -7,6 +7,15 @@ import MESSAGES from '../messages';
 import { useSnackQuery } from '../../../libs/apiHooks';
 import { getRequest } from '../../../libs/Api';
 import { Permission } from '../types/userRoles';
+
+const styles = () => ({
+    tableStyle: {
+        maxHeight: '75vh',
+        overflow: 'scroll',
+    },
+});
+
+const useStyles = makeStyles(styles);
 
 type Props = {
     userRolePermissions: Permission[];
@@ -19,6 +28,7 @@ export const PermissionsSwitches: React.FunctionComponent<Props> = ({
     handleChange,
 }) => {
     const { formatMessage } = useSafeIntl();
+    const classes = useStyles();
     const { data, isLoading } = useSnackQuery<{ permissions: Permission[] }>(
         ['permissions'],
         () => getRequest('/api/permissions/'),
@@ -52,7 +62,7 @@ export const PermissionsSwitches: React.FunctionComponent<Props> = ({
     );
 
     return (
-        <>
+        <Box className={classes.tableStyle}>
             {isLoading && <LoadingSpinner />}
 
             {permissions
@@ -88,6 +98,6 @@ export const PermissionsSwitches: React.FunctionComponent<Props> = ({
                         />
                     </div>
                 ))}
-        </>
+        </Box>
     );
 };

--- a/hat/assets/js/apps/Iaso/domains/users/components/PermissionsSwitches.tsx
+++ b/hat/assets/js/apps/Iaso/domains/users/components/PermissionsSwitches.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Typography, makeStyles } from '@material-ui/core';
+import { Box, Typography, makeStyles } from '@material-ui/core';
 import {
     useSafeIntl,
     LoadingSpinner,
@@ -19,6 +19,10 @@ const styles = theme => ({
     },
     tableCellStyle: {
         border: '1px solid grey',
+    },
+    tableStyle: {
+        maxHeight: '75vh',
+        overflow: 'scroll',
     },
 });
 
@@ -89,11 +93,13 @@ const PermissionsSwitches: React.FunctionComponent<Props> = ({
             )}
 
             {!isSuperUser && (
-                <Table
-                    columns={columns}
-                    data={permissionsData}
-                    showPagination={false}
-                />
+                <Box className={classes.tableStyle}>
+                    <Table
+                        columns={columns}
+                        data={permissionsData}
+                        showPagination={false}
+                    />
+                </Box>
             )}
         </>
     );


### PR DESCRIPTION
Explain what problem this PR is resolving
- Make the permissions list scrollable on edit or create user and user role
Related JIRA tickets : [IA-2285](https://bluesquare.atlassian.net/browse/IA-2285)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes
- wrap the table with box and apply maxHeight and OverFlow scoll style

## How to test
- Go to user and user role liste
- Create or edit a user on a user role
- The permission list should be scrollable

## Print screen / video
![Peek 2023-07-11 12-05](https://github.com/BLSQ/iaso/assets/19631540/dd99c27e-e627-4350-81eb-542e8427be6d)



[IA-2285]: https://bluesquare.atlassian.net/browse/IA-2285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ