### PR TITLE
IA-2303: Submissions column crash

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -334,6 +334,7 @@
     "iaso.instance.warningSoftDeletedExport": "If this instance was exported, this doesn't mean these data has been deleted from dhis2.",
     "iaso.instances.editLocationWithInstanceGps": "Push GPS from submission",
     "iaso.instances.forceExport": "Force Export",
+    "iaso.instances.label.created_by__username": "Created by",
     "iaso.instances.showDeleted": "Show only deleted",
     "iaso.label.accuracy": "Accuracy",
     "iaso.label.actions": "Action(s)",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -331,6 +331,7 @@
     "iaso.instance.warningSoftDeletedExport": "Si l'soumission a été exportée précédemment, les données dans dhis2 sont sans doute toujours présentes.",
     "iaso.instances.editLocationWithInstanceGps": "Pousser le GPS à partir de la soumission",
     "iaso.instances.forceExport": "Forcer l'export des soumissions déjà exportées",
+    "iaso.instances.label.created_by__username": "Crée par",
     "iaso.instances.showDeleted": "Montrer seulement les soumissions effacées",
     "iaso.label.accuracy": "Précision",
     "iaso.label.actions": "Action(s)",

--- a/hat/assets/js/apps/Iaso/domains/instances/config.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/config.js
@@ -9,10 +9,10 @@ const instancesTableColumns = (formatMessage = () => ({})) => {
     metaFields = orderBy(metaFields, [f => f.tableOrder], ['asc']);
     metaFields.forEach(f => {
         columns.push({
-            Header: formatMessage(MESSAGES[f.key]),
+            Header: formatMessage(MESSAGES[f.key]) ?? f.key,
             accessor: f.accessor || f.key,
             sortable: f.sortable !== false,
-            align: f.key.includes('name') ? 'left' : 'center',
+            align: 'center',
             Cell:
                 f.Cell ||
                 (settings =>

--- a/hat/assets/js/apps/Iaso/domains/instances/messages.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/messages.js
@@ -554,6 +554,10 @@ const MESSAGES = defineMessages({
         id: 'iaso.label.planning',
         defaultMessage: 'Planning',
     },
+    created_by__username: {
+        id: 'iaso.instances.label.created_by__username',
+        defaultMessage: 'Created by',
+    },
 });
 
 export default MESSAGES;


### PR DESCRIPTION
Submissions table crashed when trying to show created_by__username column

Related JIRA tickets : IA-2023

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes
- Add a check to make `Header`value for `metasColumns` null safe
- Add missing translation for `created_by__username`

## How to test

Go to submission, pick a form click Search
click  "visible comumns" button
select  Created by
It shouldn't crash

## Print screen / video


https://github.com/BLSQ/iaso/assets/38907762/6f95ed85-ed5d-4d0c-bde1-c3c8ea906d94



