### PR TITLE
IA-2288: pass refresh param to API query

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/entities/duplicates/hooks/api/useGetDuplicates.ts
+++ b/hat/assets/js/apps/Iaso/domains/entities/duplicates/hooks/api/useGetDuplicates.ts
@@ -51,17 +51,19 @@ export type DuplicatesGETParams = {
         merged?: boolean;
         entity?: string;
     };
+    refresh: string | undefined;
 };
 
 export const useGetDuplicates = ({
     params,
+    refresh,
 }: DuplicatesGETParams): UseQueryResult<
     DuplicatesList | DuplicateData[],
     any
 > => {
     const queryString = new URLSearchParams(formatParams(params)).toString();
     return useSnackQuery({
-        queryKey: ['entityDuplicates', queryString],
+        queryKey: ['entityDuplicates', queryString, refresh],
         queryFn: () => getDuplicates(queryString),
     });
 };

--- a/hat/assets/js/apps/Iaso/domains/entities/duplicates/list/AnalyseAction.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/duplicates/list/AnalyseAction.tsx
@@ -5,14 +5,23 @@ import Autorenew from '@material-ui/icons/Autorenew';
 import InfoOutlinedIcon from '@material-ui/icons/InfoOutlined';
 
 import { useSafeIntl } from 'bluesquare-components';
-import { useGetLatestAnalysis, useStartAnalyse } from '../hooks/api/analyzes';
+import { useStartAnalyse } from '../hooks/api/analyzes';
 import { AnalysisTooltipTitle } from './AnalysisTooltipTitle';
 import MESSAGES from '../messages';
+import { Analysis } from '../types';
 
-export const AnalyseAction: FunctionComponent = () => {
+type Props = {
+    latestAnalysis: Analysis | undefined;
+    isFetchingLatestAnalysis: boolean;
+};
+
+export const AnalyseAction: FunctionComponent<Props> = ({
+    latestAnalysis,
+    isFetchingLatestAnalysis,
+}) => {
     const { formatMessage } = useSafeIntl();
-    const { data: latestAnalysis, isFetching: isFetchingLatestAnalysis } =
-        useGetLatestAnalysis();
+    // const { data: latestAnalysis, isFetching: isFetchingLatestAnalysis } =
+    //     useGetLatestAnalysis();
 
     const { mutateAsync: startAnalyse, isLoading: isSaving } =
         useStartAnalyse();

--- a/hat/assets/js/apps/Iaso/domains/entities/duplicates/list/Duplicates.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/duplicates/list/Duplicates.tsx
@@ -17,6 +17,7 @@ import { starsStyleForTable } from '../../../../components/stars/StarsComponent'
 import { useDuplicationTableColumns } from './useDuplicationTableColumns';
 import { DuplicatesList } from '../types';
 import { AnalyseAction } from './AnalyseAction';
+import { useGetLatestAnalysis } from '../hooks/api/analyzes';
 
 type Params = PaginationParams & DuplicatesGETParams;
 
@@ -37,7 +38,12 @@ const useStyles = makeStyles(theme => {
 export const Duplicates: FunctionComponent<Props> = ({ params }) => {
     const { formatMessage } = useSafeIntl();
     const classes: Record<string, string> = useStyles();
-    const { data, isFetching } = useGetDuplicates({ params });
+    const { data: latestAnalysis, isFetching: isFetchingLatestAnalysis } =
+        useGetLatestAnalysis();
+    const { data, isFetching } = useGetDuplicates({
+        params,
+        refresh: latestAnalysis?.finished_at,
+    });
     const dispatch = useDispatch();
     const columns = useDuplicationTableColumns();
     const { results, pages, count } = (data as DuplicatesList) ?? {
@@ -53,7 +59,10 @@ export const Duplicates: FunctionComponent<Props> = ({ params }) => {
                 displayBackButton={false}
             />
             <Box className={classes.containerFullHeightNoTabPadded}>
-                <AnalyseAction />
+                <AnalyseAction
+                    latestAnalysis={latestAnalysis}
+                    isFetchingLatestAnalysis={isFetchingLatestAnalysis}
+                />
                 <DuplicatesFilters params={params} />
                 <Box className={classes.table}>
                     <TableWithDeepLink
@@ -65,7 +74,9 @@ export const Duplicates: FunctionComponent<Props> = ({ params }) => {
                         count={count ?? 0}
                         baseUrl={baseUrl}
                         params={params}
-                        extraProps={{ loading: isFetching }}
+                        extraProps={{
+                            loading: isFetching,
+                        }}
                         onTableParamsChange={p =>
                             dispatch(redirectTo(baseUrl, p))
                         }


### PR DESCRIPTION
When relaunching an analyze, users needed to refresh the page to see the updated results in the table

Related JIRA tickets : IA-2288

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- Move the fetching of analyzes to `Duplicates.tsx`
- add `latest_analyze.finished_at` to the query key

## How to test

- You need enketo and the task worker running
- Create 2 new duplicates : go to Enketo, fill 2 forms, then in django admin create 2 entities, one for each form
- Go to duplicates screen
- Launch analyze
- The table should refresh automatically

## Print screen / video

https://github.com/BLSQ/iaso/assets/38907762/57e5d52e-1383-427f-99ea-4abc6ae4f006

