### PR TITLE
Polio-1097 remove lqas disqualified

### DIFF
--- a/plugins/polio/js/src/components/LQAS-IM/LqasSummary.tsx
+++ b/plugins/polio/js/src/components/LQAS-IM/LqasSummary.tsx
@@ -34,7 +34,6 @@ const useStyles = makeStyles(style);
 const getRatePassedColors = (ratePassed, classes) => {
     if (!ratePassed) return '';
     if (parseFloat(ratePassed) >= 80) return classes.pass;
-    if (parseFloat(ratePassed) >= 50) return classes.warning;
     return classes.fail;
 };
 
@@ -46,12 +45,7 @@ export const LqasSummary: FunctionComponent<Props> = ({
     const { formatMessage } = useSafeIntl();
     const classes = useStyles();
     const summary = useMemo(() => {
-        // eslint-disable-next-line no-unused-vars
-        const [passed, failed, _disqualified] = getLqasStatsForRound(
-            data,
-            campaign,
-            round,
-        );
+        const [passed, failed] = getLqasStatsForRound(data, campaign, round);
         const evaluated: number = passed.length + failed.length;
         const ratePassed: string = convertStatToPercent(
             passed.length,

--- a/plugins/polio/js/src/pages/LQAS/index.js
+++ b/plugins/polio/js/src/pages/LQAS/index.js
@@ -97,7 +97,7 @@ export const Lqas = ({ router }) => {
                     {selectedRounds.map((rnd, index) => (
                         <Grid item xs={6} key={`round_${rnd}_${index}`}>
                             <MapContainer
-                                round={parseInt(rnd, 10)} // parsing the rnd because it willl be a string when coming from params
+                                round={parseInt(rnd, 10)} // parsing the rnd because it will be a string when coming from params
                                 campaign={campaign}
                                 campaigns={campaigns}
                                 country={country}

--- a/plugins/polio/js/src/pages/LQAS/utils.ts
+++ b/plugins/polio/js/src/pages/LQAS/utils.ts
@@ -1,13 +1,13 @@
 import { IntlFormatMessage } from 'bluesquare-components';
 import MESSAGES from '../../constants/messages';
-import { LQAS_PASS, LQAS_FAIL, LQAS_DISQUALIFIED } from '../IM/constants';
+import { LQAS_PASS, LQAS_FAIL } from '../IM/constants';
 import {
     LqasImDistrictDataWithNameAndRegion,
     ConvertedLqasImData,
     LqasImCampaign,
     LqasImDistrictData,
 } from '../../constants/types';
-import { OK_COLOR, WARNING_COLOR, FAIL_COLOR } from '../../styles/constants';
+import { OK_COLOR, FAIL_COLOR } from '../../styles/constants';
 import { makeLegendItem } from '../../utils';
 import {
     accessArrayRound,
@@ -23,9 +23,10 @@ export const determineStatusForDistrict = district => {
         if (marked > 56) {
             return LQAS_PASS;
         }
-        return LQAS_FAIL;
+        // return LQAS_FAIL;
     }
-    return LQAS_DISQUALIFIED;
+    return LQAS_FAIL;
+    // return LQAS_DISQUALIFIED;
 };
 
 export const getLqasStatsForRound = (
@@ -44,12 +45,13 @@ export const getLqasStatsForRound = (
         return determineStatusForDistrict(district);
     });
     const passed = allStatuses.filter(status => status === LQAS_PASS);
-    const disqualified = allStatuses.filter(
-        status => status === LQAS_DISQUALIFIED,
-    );
+    // const disqualified = allStatuses.filter(
+    //     status => status === LQAS_DISQUALIFIED,
+    // );
     const failed = allStatuses.filter(status => status === LQAS_FAIL);
 
-    return [passed, failed, disqualified];
+    return [passed, failed];
+    // return [passed, failed, disqualified];
 };
 
 export const makeLqasMapLegendItems =
@@ -63,7 +65,7 @@ export const makeLqasMapLegendItems =
         value: string;
         color: any;
     }[] => {
-        const [passed, failed, disqualified] = getLqasStatsForRound(
+        const [passed, failed] = getLqasStatsForRound(
             lqasData,
             campaign,
             round,
@@ -78,13 +80,13 @@ export const makeLqasMapLegendItems =
             value: failed?.length,
             message: formatMessage(MESSAGES.failing),
         });
-        const disqualifiedLegendItem = makeLegendItem({
-            color: WARNING_COLOR,
-            value: disqualified?.length,
-            message: formatMessage(MESSAGES.disqualified),
-        });
+        // const disqualifiedLegendItem = makeLegendItem({
+        //     color: WARNING_COLOR,
+        //     value: disqualified?.length,
+        //     message: formatMessage(MESSAGES.disqualified),
+        // });
 
-        return [passedLegendItem, disqualifiedLegendItem, failedLegendItem];
+        return [passedLegendItem, failedLegendItem];
     };
 
 export const getLqasStatsWithStatus = ({ data, campaign, round }) => {

--- a/plugins/polio/js/src/pages/LQAS/utils.ts
+++ b/plugins/polio/js/src/pages/LQAS/utils.ts
@@ -23,10 +23,8 @@ export const determineStatusForDistrict = district => {
         if (marked > 56) {
             return LQAS_PASS;
         }
-        // return LQAS_FAIL;
     }
     return LQAS_FAIL;
-    // return LQAS_DISQUALIFIED;
 };
 
 export const getLqasStatsForRound = (
@@ -45,13 +43,9 @@ export const getLqasStatsForRound = (
         return determineStatusForDistrict(district);
     });
     const passed = allStatuses.filter(status => status === LQAS_PASS);
-    // const disqualified = allStatuses.filter(
-    //     status => status === LQAS_DISQUALIFIED,
-    // );
     const failed = allStatuses.filter(status => status === LQAS_FAIL);
 
     return [passed, failed];
-    // return [passed, failed, disqualified];
 };
 
 export const makeLqasMapLegendItems =
@@ -80,11 +74,6 @@ export const makeLqasMapLegendItems =
             value: failed?.length,
             message: formatMessage(MESSAGES.failing),
         });
-        // const disqualifiedLegendItem = makeLegendItem({
-        //     color: WARNING_COLOR,
-        //     value: disqualified?.length,
-        //     message: formatMessage(MESSAGES.disqualified),
-        // });
 
         return [passedLegendItem, failedLegendItem];
     };


### PR DESCRIPTION
Remove disqualified status from LQAS.

Related JIRA tickets : POLIO-1097

⚠️Merges in to https://github.com/BLSQ/iaso/tree/POLIO-1006_use_new_lqas_endpoint

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- remove all code in LQAS that relates to the status "disqualified"

## How to test
- Setup your local env for this PR https://github.com/BLSQ/iaso/pull/705
- Go to LQAS, choose a country and a campaign
- Go to polio prod select the same country and campaign
- Yellow districts should have turned red

## Print screen / video

PROD
![Screenshot 2023-07-12 at 11 29 29](https://github.com/BLSQ/iaso/assets/38907762/00d7e54e-1aaa-4a26-9f67-b996184218db)

AFTER CHANGE
![Screenshot 2023-07-12 at 11 29 36](https://github.com/BLSQ/iaso/assets/38907762/77e571be-72bb-429f-ad4f-cccc6178d998)


