### PR TITLE
POLIO-1098: add key prop to map

### DIFF
--- a/plugins/polio/js/src/components/LQAS-IM/LqasImMap.js
+++ b/plugins/polio/js/src/components/LQAS-IM/LqasImMap.js
@@ -27,7 +27,7 @@ import {
     defaultShapeStyle,
 } from '../../utils/index';
 import MESSAGES from '../../constants/messages';
-import { useGetGeoJson } from '../../hooks/useGetGeoJson';
+import { useGetGeoJson } from '../../hooks/useGetGeoJson.ts';
 import { ScopeAndDNFDisclaimer } from './ScopeAndDNFDisclaimer.tsx';
 
 const defaultShapes = [];
@@ -132,6 +132,7 @@ export const LqasImMap = ({
                     <LoadingSpinner fixed={false} absolute />
                 )}
                 <MapComponent
+                    key={countryId}
                     name={`LQASIMMap${round}-${type}`}
                     backgroundLayer={regionShapes}
                     mainLayer={mainLayer}


### PR DESCRIPTION
Map wasn't refitting to bounds on country change

Related JIRA tickets : POLIO-1098

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- Add the country id as `key` prop to the map to force rerender on country change

## How to test

Go to LQAS and IM, change selected country using teh select box. The map should center on the selected country

## Print screen / video


https://github.com/BLSQ/iaso/assets/38907762/5ee947f4-2c49-4191-9540-0507f1fafa74


