### PR TITLE
IA-2333: registry clustering bugs

### DIFF
--- a/hat/assets/js/apps/Iaso/components/maps/markers/CircleMarkerComponent.js
+++ b/hat/assets/js/apps/Iaso/components/maps/markers/CircleMarkerComponent.js
@@ -18,7 +18,6 @@ const CircleMarkerComponent = props => {
         tooltipProps,
         onContextmenu,
     } = props;
-
     if (
         !item ||
         !item.latitude ||

--- a/hat/assets/js/apps/Iaso/domains/registry/components/OrgUnitChildrenMap.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/OrgUnitChildrenMap.tsx
@@ -175,7 +175,6 @@ export const OrgUnitChildrenMap: FunctionComponent<Props> = ({
                 bounds={bounds}
                 boundsOptions={boundsOptions}
                 trackResize
-                // key={`registry-${orgUnit.id}-${showTooltip}`}
             >
                 <MapToggleTooltips
                     showTooltip={showTooltip}


### PR DESCRIPTION
On registry page, while having markers has children:

- Toggle a subtype is not working on markers.
- Colors is not the correct one
- Toggle label visibility is also not working 


Related JIRA tickets : IA-2333

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- adapt clustering by sub org unit types
- use sub unit type color
- force cluster rerender to display label

## How to test

Go to registry detail page with markers has children, play with the legend to show and hide those markers
Toggle label visibility.
Check that clustering is using the correct colors

## Print screen / video

https://github.com/BLSQ/iaso/assets/12494624/fb07cf9d-b4e5-4abb-a937-8e9e34b531ec


