### PR TITLE
IA-2273: Planning markers color

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/assignments/components/AssignmentsMap.tsx
+++ b/hat/assets/js/apps/Iaso/domains/assignments/components/AssignmentsMap.tsx
@@ -166,7 +166,13 @@ export const AssignmentsMap: FunctionComponent<Props> = ({
     };
 
     const isLoading = isFetchingLocations || isFetchingParentLocations;
-
+    const markersColors = useMemo(
+        () =>
+            (locations?.markers.selected || [])
+                .map(marker => `${marker.color}_${marker.id}`)
+                .join('-'),
+        [locations?.markers.selected],
+    );
     return (
         <section ref={mapContainer}>
             <Box position="relative">
@@ -325,11 +331,12 @@ export const AssignmentsMap: FunctionComponent<Props> = ({
                             </Pane>
                             <Pane name="markers-selected">
                                 <MarkersListComponent
+                                    key={markersColors}
                                     items={locations.markers.selected || []}
-                                    onMarkerClick={shape => onClick(shape)}
-                                    markerProps={shape => ({
+                                    onMarkerClick={marker => onClick(marker)}
+                                    markerProps={marker => ({
                                         ...circleColorMarkerOptions(
-                                            shape.color,
+                                            marker.color,
                                         ),
                                     })}
                                     onContextmenu={(event, marker) =>


### PR DESCRIPTION
Changing color of user on a planning team page doesn't update marker color.

Related JIRA tickets : IA-2273

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

refresh cluster while changing colors

## How to test

Find a planning using markers, try to change team color

## Print screen / video

https://github.com/BLSQ/iaso/assets/12494624/35a2eed1-6d46-4975-8343-090178bd30e8



