### PR TITLE
IA-2335: Remove prefix from user role name on UserDialog

### DIFF
--- a/iaso/api/user_roles.py
+++ b/iaso/api/user_roles.py
@@ -4,7 +4,6 @@ from django.shortcuts import get_object_or_404
 from rest_framework import permissions, serializers
 from django.contrib.auth.models import Permission, Group
 from django.db.models import Q, QuerySet
-from rest_framework.response import Response
 from iaso.models import UserRole
 from .common import TimestampField, ModelViewSet
 

--- a/iaso/models/base.py
+++ b/iaso/models/base.py
@@ -1398,16 +1398,23 @@ class UserRole(models.Model):
     def as_short_dict(self):
         return {
             "id": self.id,
-            "name": self.group.name,
+            "name": self.remove_user_role_name_prefix(self.group.name),
             "group_id": self.group.id,
             "created_at": self.created_at,
             "updated_at": self.updated_at,
         }
 
+    # This method will remove a given prefix from a string
+    def remove_user_role_name_prefix(self, str):
+        prefix = str.split("_")[0] + "_"
+        if str.startswith(prefix):
+            return str[len(prefix) :]
+        return str
+
     def as_dict(self):
         return {
             "id": self.id,
-            "name": self.group.name,
+            "name": self.remove_user_role_name_prefix(self.group.name),
             "group_id": self.group.id,
             "permissions": list(
                 self.group.permissions.filter(codename__startswith="iaso_").values_list("codename", flat=True)


### PR DESCRIPTION
Explain what problem this PR is resolving
- Because of the account_id added as prefix on user role name, when editing or creating a user the prefix is displayed on user role name
Related JIRA tickets : [IA-2335](https://bluesquare.atlassian.net/browse/IA-2335)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes
- Created a method to remove the prefix from user role name
## How to test
- Go in user liste
- Edit or create a new user
- Link the user to a user role 
- See if the the user role name contains account_id as prefix
## Print screen / video
![Screenshot from 2023-07-20 08-58-21](https://github.com/BLSQ/iaso/assets/19631540/4e77cead-22ea-499c-b2a6-b3f805a8b378)


[IA-2335]: https://bluesquare.atlassian.net/browse/IA-2335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ