### PR TITLE
POLIO-1114: LQAS afro map round number bug

### DIFF
--- a/plugins/polio/helpers.py
+++ b/plugins/polio/helpers.py
@@ -100,19 +100,6 @@ def reduce_to_country_status(total, current):
     return total
 
 
-def get_latest_round_number(country_data):
-    data_for_all_rounds = sorted(country_data["rounds"], key=lambda round: round["number"], reverse=True)
-    return data_for_all_rounds[0]["number"] if data_for_all_rounds else None
-
-
-def get_penultimate_round_number(country_data):
-    data_for_all_rounds = sorted(country_data["rounds"], key=lambda round: round["number"], reverse=True)
-    if data_for_all_rounds:
-        if len(data_for_all_rounds) > 1:
-            return data_for_all_rounds[1]["number"]
-    return None
-
-
 def get_data_for_round(country_data, roundNumber):
     data_for_all_rounds = sorted(country_data["rounds"], key=lambda round: round["number"], reverse=True)
     return next((round for round in data_for_all_rounds if round["number"] == roundNumber), {"data": {}})

--- a/plugins/polio/tests/test_lqas_map.py
+++ b/plugins/polio/tests/test_lqas_map.py
@@ -10,7 +10,6 @@ from plugins.polio.helpers import (
     calculate_country_status,
     determine_status_for_district,
     get_data_for_round,
-    get_latest_round_number,
     reduce_to_country_status,
 )
 from plugins.polio.models import Campaign, CampaignScope, Round, RoundScope
@@ -340,14 +339,6 @@ class PolioLqasAfroMapTestCase(APITestCase):
         total = reduce_to_country_status(total, inScope)
         self.assertEqual(total["total"], 5)
         self.assertEqual(total["passed"], 2)
-
-    def test_get_latest_round_number(self):
-        country_data = self.country1_data_store_content["stats"][self.campaign_1.obr_name]
-        number_found = get_latest_round_number(country_data)
-        self.assertEqual(number_found, 2)
-        country_data = {"rounds": []}
-        number_found = get_latest_round_number(country_data)
-        self.assertEqual(number_found, None)
 
     def test_get_data_for_round(self):
         country_data = self.country1_data_store_content["stats"][self.campaign_1.obr_name]


### PR DESCRIPTION
Global view on LQAs afro map was computing round number from datastore payload, which was buggy for rounds without data

Related JIRA tickets : POLIO-1114

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- In `LQASIMGlobalMapViewSet`, compute round number from campaigns i.o. datastore.

## How to test

See ticket POLIO-1114

## Print screen / video

BEFORE

https://github.com/BLSQ/iaso/assets/38907762/9850fd86-ce58-4789-8a64-36d765cb7893

AFTER

https://github.com/BLSQ/iaso/assets/38907762/24a4ad34-663a-45e0-827e-95c4d443a12d

