### PR TITLE
IA-2275: Planning assignments count is wrong

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/assignments/components/AssignmentsSidebar.tsx
+++ b/hat/assets/js/apps/Iaso/domains/assignments/components/AssignmentsSidebar.tsx
@@ -16,6 +16,8 @@ import { Profile } from '../../../utils/usersUtils';
 
 import { useColumns } from '../configs/AssignmentsMapTabColumns';
 
+import { AssignmentUnit } from '../types/locations';
+
 type Props = {
     data: SubTeam[] | User[];
     assignments: AssignmentsApi;
@@ -30,6 +32,8 @@ type Props = {
     selectedItem: SubTeam | User | undefined;
     // eslint-disable-next-line no-unused-vars
     setSelectedItem: (newSelectedTeam: SubTeam) => void;
+    orgUnits: Array<AssignmentUnit>;
+    isLoadingAssignments: boolean;
 };
 
 export const Sidebar: FunctionComponent<Props> = ({
@@ -44,6 +48,8 @@ export const Sidebar: FunctionComponent<Props> = ({
     currentTeam,
     selectedItem,
     setSelectedItem,
+    orgUnits,
+    isLoadingAssignments,
 }) => {
     const columns = useColumns({
         assignments,
@@ -53,6 +59,8 @@ export const Sidebar: FunctionComponent<Props> = ({
         selectedItem,
         setSelectedItem,
         currentTeam,
+        orgUnits,
+        isLoadingAssignments,
     });
     return (
         <Paper>
@@ -74,6 +82,7 @@ export const Sidebar: FunctionComponent<Props> = ({
                         profiles,
                         assignments,
                         loading: !currentTeam,
+                        orgUnits,
                     }}
                 />
             </Box>

--- a/hat/assets/js/apps/Iaso/domains/assignments/configs/AssignmentsMapTabColumns.tsx
+++ b/hat/assets/js/apps/Iaso/domains/assignments/configs/AssignmentsMapTabColumns.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useCallback } from 'react';
 import { Box, Radio } from '@material-ui/core';
 import { Theme, useTheme } from '@material-ui/core/styles';
 import { useSafeIntl, Column, IntlFormatMessage } from 'bluesquare-components';
@@ -9,6 +9,7 @@ import { AssignmentsApi } from '../types/assigment';
 import { DropdownTeamsOptions, SubTeam, User, Team } from '../types/team';
 
 import { Profile } from '../../../utils/usersUtils';
+import { AssignmentUnit } from '../types/locations';
 
 import { getTeamUserName } from '../utils';
 
@@ -26,6 +27,8 @@ type Props = {
     // eslint-disable-next-line no-unused-vars
     setSelectedItem: (newSelectedTeam: SubTeam) => void;
     currentTeam: Team | undefined;
+    orgUnits: Array<AssignmentUnit>;
+    isLoadingAssignments: boolean;
 };
 
 export const useColumns = ({
@@ -36,10 +39,47 @@ export const useColumns = ({
     selectedItem,
     setSelectedItem,
     currentTeam,
+    orgUnits,
+    isLoadingAssignments,
 }: Props): Column[] => {
     const { formatMessage }: { formatMessage: IntlFormatMessage } =
         useSafeIntl();
     const theme: Theme = useTheme();
+    const getAssignationsCount = useCallback(
+        (rowId: number): number | string => {
+            if (isLoadingAssignments) {
+                return '';
+            }
+            return assignments.filter(assignment => {
+                if (currentTeam?.type === 'TEAM_OF_TEAMS') {
+                    return (
+                        assignment.team === rowId &&
+                        orgUnits.some(
+                            orgUnit => orgUnit.id === assignment.org_unit,
+                        )
+                    );
+                }
+                return (
+                    assignment.user === rowId &&
+                    orgUnits.some(orgUnit => orgUnit.id === assignment.org_unit)
+                );
+            }).length;
+        },
+        [assignments, currentTeam?.type, isLoadingAssignments, orgUnits],
+    );
+
+    const getFullItem = useCallback(
+        (rowId: number): undefined | DropdownTeamsOptions | Profile => {
+            if (currentTeam?.type === 'TEAM_OF_USERS') {
+                return profiles.find(profile => profile.user_id === rowId);
+            }
+            if (currentTeam?.type === 'TEAM_OF_TEAMS') {
+                return teams.find(team => team.original.id === rowId);
+            }
+            return undefined;
+        },
+        [currentTeam?.type, profiles, teams],
+    );
     return useMemo(() => {
         return [
             {
@@ -89,43 +129,27 @@ export const useColumns = ({
                 id: 'color',
                 accessor: 'color',
                 Cell: settings => {
-                    let fullItem;
-                    if (currentTeam?.type === 'TEAM_OF_USERS') {
-                        fullItem = profiles.find(
-                            profile =>
-                                profile.user_id === settings.row.original.id,
-                        );
-                    }
-                    if (currentTeam?.type === 'TEAM_OF_TEAMS') {
-                        fullItem = teams.find(
-                            team =>
-                                team.original.id === settings.row.original.id,
-                        );
-                    }
+                    const fullItem = getFullItem(settings.row.original.id);
                     return (
-                        <>
-                            <Box display="flex" justifyContent="center">
-                                <ColorPicker
-                                    currentColor={
-                                        fullItem?.color ??
-                                        theme.palette.grey[500]
-                                    }
-                                    colors={colors.filter(
-                                        color =>
-                                            !fullItem ||
-                                            (fullItem &&
-                                                color !== fullItem.color),
-                                    )}
-                                    displayLabel={false}
-                                    onChangeColor={color =>
-                                        setItemColor(
-                                            color,
-                                            settings.row.original.id,
-                                        )
-                                    }
-                                />
-                            </Box>
-                        </>
+                        <Box display="flex" justifyContent="center">
+                            <ColorPicker
+                                currentColor={
+                                    fullItem?.color ?? theme.palette.grey[500]
+                                }
+                                colors={colors.filter(
+                                    color =>
+                                        !fullItem ||
+                                        (fullItem && color !== fullItem.color),
+                                )}
+                                displayLabel={false}
+                                onChangeColor={color =>
+                                    setItemColor(
+                                        color,
+                                        settings.row.original.id,
+                                    )
+                                }
+                            />
+                        </Box>
                     );
                 },
             },
@@ -137,29 +161,17 @@ export const useColumns = ({
                 Cell: settings => {
                     return (
                         <div>
-                            {
-                                assignments.filter(assignment => {
-                                    if (currentTeam?.type === 'TEAM_OF_TEAMS') {
-                                        return (
-                                            assignment.team ===
-                                            settings.row.original.id
-                                        );
-                                    }
-                                    return (
-                                        assignment.user ===
-                                        settings.row.original.id
-                                    );
-                                }).length
-                            }
+                            {getAssignationsCount(settings.row.original.id)}
                         </div>
                     );
                 },
             },
         ];
     }, [
-        assignments,
         currentTeam,
         formatMessage,
+        getAssignationsCount,
+        getFullItem,
         profiles,
         selectedItem?.id,
         setItemColor,

--- a/hat/assets/js/apps/Iaso/domains/assignments/configs/AssignmentsMapTabColumns.tsx
+++ b/hat/assets/js/apps/Iaso/domains/assignments/configs/AssignmentsMapTabColumns.tsx
@@ -47,9 +47,6 @@ export const useColumns = ({
     const theme: Theme = useTheme();
     const getAssignationsCount = useCallback(
         (rowId: number): number | string => {
-            if (isLoadingAssignments) {
-                return '';
-            }
             return assignments.filter(assignment => {
                 if (currentTeam?.type === 'TEAM_OF_TEAMS') {
                     return (
@@ -65,7 +62,7 @@ export const useColumns = ({
                 );
             }).length;
         },
-        [assignments, currentTeam?.type, isLoadingAssignments, orgUnits],
+        [assignments, currentTeam?.type, orgUnits],
     );
 
     const getFullItem = useCallback(
@@ -161,7 +158,8 @@ export const useColumns = ({
                 Cell: settings => {
                     return (
                         <div>
-                            {getAssignationsCount(settings.row.original.id)}
+                            {!isLoadingAssignments &&
+                                getAssignationsCount(settings.row.original.id)}
                         </div>
                     );
                 },
@@ -172,6 +170,7 @@ export const useColumns = ({
         formatMessage,
         getAssignationsCount,
         getFullItem,
+        isLoadingAssignments,
         profiles,
         selectedItem?.id,
         setItemColor,

--- a/hat/assets/js/apps/Iaso/domains/assignments/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/assignments/index.tsx
@@ -108,7 +108,6 @@ export const Assignments: FunctionComponent<Props> = ({ params }) => {
         search: params.search,
         selectedItem,
     });
-
     const isLoading =
         isLoadingPlanning || isSaving || isFetchingChildrenOrgunits;
 
@@ -146,7 +145,7 @@ export const Assignments: FunctionComponent<Props> = ({ params }) => {
                 ...params,
                 baseOrgunitType: newBaseOrgUnitType,
             };
-            dispatch(redirectTo(baseUrl, newParams));
+            dispatch(redirectTo(baseUrl, newParams as Record<string, any>));
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [assignments]);
@@ -182,7 +181,12 @@ export const Assignments: FunctionComponent<Props> = ({ params }) => {
                             ...params,
                             baseOrgunitType: newBaseOrgUnitType,
                         };
-                        dispatch(redirectTo(baseUrl, newParams));
+                        dispatch(
+                            redirectTo(
+                                baseUrl,
+                                newParams as Record<string, any>,
+                            ),
+                        );
                     }
                 }
             }
@@ -287,6 +291,7 @@ export const Assignments: FunctionComponent<Props> = ({ params }) => {
                                     data={sidebarData || []}
                                     assignments={assignments}
                                     selectedItem={selectedItem}
+                                    orgUnits={orgUnitsList || []}
                                     setSelectedItem={setSelectedItem}
                                     currentTeam={currentTeam}
                                     setItemColor={setItemColor}
@@ -295,6 +300,10 @@ export const Assignments: FunctionComponent<Props> = ({ params }) => {
                                     orgunitTypes={orgunitTypes || []}
                                     isFetchingOrgUnitTypes={
                                         isFetchingOrgunitTypes
+                                    }
+                                    isLoadingAssignments={
+                                        isLoadingAssignments ||
+                                        isFetchingOrgUnitsList
                                     }
                                 />
                             </Grid>

--- a/hat/assets/js/apps/Iaso/utils/usersUtils.ts
+++ b/hat/assets/js/apps/Iaso/utils/usersUtils.ts
@@ -10,6 +10,7 @@ export type Profile = {
     email: string;
     language?: null | undefined | string;
     user_id: number;
+    color?: string;
 };
 
 export type User = {


### PR DESCRIPTION
Count of assignments on planning details page is not correct:


![image (23)](https://github.com/BLSQ/iaso/assets/12494624/741a39c4-951d-496a-8fd4-0830bbb207c4)

Related JIRA tickets : IA-2275
## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- remove assignments to other sub org units of wrong type
- pass it to a `useCallBack`, same for color cumputation

## How to test

Visit details page of a planning containing assignments.
Check that the "Assignments count" columns is matching the count of assigned org units in the list on the right


## Print screen / video
![Screenshot 2023-07-24 at 10 39 58](https://github.com/BLSQ/iaso/assets/12494624/3459d7b6-023b-4f46-82f6-19ed5cdb29b7)

