### PR TITLE
IA-1787 Instances in multiple projects are counted multiple times in the submissions count

### DIFF
--- a/iaso/api/forms.py
+++ b/iaso/api/forms.py
@@ -246,9 +246,11 @@ class FormsViewSet(ModelViewSet):
                         & ~Q(instances__device__test_device=True)
                         & ~Q(instances__deleted=True)
                         & Q(instances__org_unit__in=orgunits)
+                        & Q(projects__in=self.request.user.iaso_profile.projects.all())
                     ),
                 )
             )
+            print(queryset)
         else:
             queryset = queryset.annotate(
                 instances_count=Count(
@@ -258,7 +260,7 @@ class FormsViewSet(ModelViewSet):
                     ),
                 )
             )
-
+        print(queryset.query)
         from_date = self.request.query_params.get("date_from", None)
         if from_date:
             queryset = queryset.filter(

--- a/iaso/api/forms.py
+++ b/iaso/api/forms.py
@@ -246,11 +246,9 @@ class FormsViewSet(ModelViewSet):
                         & ~Q(instances__device__test_device=True)
                         & ~Q(instances__deleted=True)
                         & Q(instances__org_unit__in=orgunits)
-                        & Q(projects__in=self.request.user.iaso_profile.projects.all())
-                    ),
+                    ), distinct=True
                 )
             )
-            print(queryset)
         else:
             queryset = queryset.annotate(
                 instances_count=Count(
@@ -260,7 +258,6 @@ class FormsViewSet(ModelViewSet):
                     ),
                 )
             )
-        print(queryset.query)
         from_date = self.request.query_params.get("date_from", None)
         if from_date:
             queryset = queryset.filter(

--- a/iaso/api/forms.py
+++ b/iaso/api/forms.py
@@ -235,7 +235,6 @@ class FormsViewSet(ModelViewSet):
             profile = self.request.user.iaso_profile
         else:
             profile = False
-
         if profile and profile.org_units.exists():
             orgunits = OrgUnit.objects.hierarchy(profile.org_units.all())
             queryset = queryset.annotate(
@@ -246,7 +245,8 @@ class FormsViewSet(ModelViewSet):
                         & ~Q(instances__device__test_device=True)
                         & ~Q(instances__deleted=True)
                         & Q(instances__org_unit__in=orgunits)
-                    ), distinct=True
+                    ),
+                    distinct=True,
                 )
             )
         else:

--- a/iaso/models/forms.py
+++ b/iaso/models/forms.py
@@ -44,7 +44,7 @@ class FormQuerySet(models.QuerySet):
         queryset = self.all()
 
         if user.is_authenticated:
-            queryset = queryset.filter(projects__account=user.iaso_profile.account).distinct()
+            queryset = queryset.filter(projects__account=user.iaso_profile.account)
 
         if app_id is not None:  # mobile app
             try:

--- a/iaso/models/forms.py
+++ b/iaso/models/forms.py
@@ -44,7 +44,7 @@ class FormQuerySet(models.QuerySet):
         queryset = self.all()
 
         if user.is_authenticated:
-            queryset = queryset.filter(projects__account=user.iaso_profile.account)
+            queryset = queryset.filter(projects__account=user.iaso_profile.account).distinct()
 
         if app_id is not None:  # mobile app
             try:

--- a/iaso/tests/api/test_forms.py
+++ b/iaso/tests/api/test_forms.py
@@ -573,8 +573,8 @@ class FormsAPITestCase(APITestCase):
 
     def test_instance_not_in_same_project_are_not_counted(self):
         """
-        This test ensures that the instance count on list form does not take into account the instances in other
-        projects using the same forms.
+        This test ensure that the instance count on list form is not multiplied by the number of projects with
+        instances linked to the same form.
         """
 
         self.client.force_authenticate(self.yoda)
@@ -587,6 +587,13 @@ class FormsAPITestCase(APITestCase):
         self.assertEqual(0, response.json()["forms"][1]["instances_count"])
 
         with open("iaso/tests/fixtures/hydroponics_test_upload.xml") as instance_file:
+            instance_1 = Instance.objects.create(
+                form=self.form_2,
+                period="202001",
+                org_unit=self.jedi_council_corruscant,
+                project=self.project_2,
+            )
+            instance_1.file.save("hydroponics_test_upload.xml", File(instance_file))
             instance_2 = Instance.objects.create(
                 form=self.form_2,
                 period="202001",
@@ -599,5 +606,4 @@ class FormsAPITestCase(APITestCase):
 
         self.assertJSONResponse(response, 200)
         self.assertValidFormListData(response.json(), 2)
-        self.assertEqual(0, response.json()["forms"][1]["instances_count"])
-        print(response.json())
+        self.assertEqual(2, response.json()["forms"][0]["instances_count"])


### PR DESCRIPTION
The submission count was wrong has the instance count was somehow multiplied by the number of projects. This fix it and test it.

Related JIRA tickets : IA-1787

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

Changes are straightforward. Added a distinct after the query filter as each time a filter was True the Count() is adding it to the total.

## How to test

Have a form with multiple instances from multiple projects. 
For example if you have 2 instances, in different projects you should have 2 submissions for the form. But the list will show 4.
With the fix you will have the correct count. 

