### PR TITLE
POLIO-1119: Display OBR name and Round number on Tooltip in LQAS Afro map

### DIFF
--- a/plugins/polio/api.py
+++ b/plugins/polio/api.py
@@ -1827,7 +1827,12 @@ class LQASIMGlobalMapViewSet(LqasAfroViewset):
 
                 result = {
                     "id": int(country_id),
-                    "data": {"campaign": latest_campaign.obr_name, **stats, "country_name": org_unit.name},
+                    "data": {
+                        "campaign": latest_campaign.obr_name,
+                        **stats,
+                        "country_name": org_unit.name,
+                        "round_number": round_number,
+                    },
                     "geo_json": shapes,
                     "status": calculate_country_status(stats, scope, round_number),
                 }
@@ -1966,6 +1971,7 @@ class LQASIMZoominMapViewSet(LqasAfroViewset):
                             "campaign": latest_campaign.obr_name,
                             **district_stats,
                             "district_name": district.name,
+                            "round_number": round_number,
                         },
                         "geo_json": shapes,
                         "status": determine_status_for_district(district_stats),

--- a/plugins/polio/js/src/components/MapComponent/Tooltip.tsx
+++ b/plugins/polio/js/src/components/MapComponent/Tooltip.tsx
@@ -1,0 +1,44 @@
+import React, { FunctionComponent } from 'react';
+import { Tooltip as LeafletTooltip } from 'react-leaflet';
+import { get } from 'lodash';
+
+import { Shape } from '../../constants/types';
+import { findBackgroundShape } from './utils';
+
+type Props = {
+    backgroundLayer?: Shape[];
+    tooltipLabels?: { main: string; background: string };
+    shape: Shape;
+    tooltipFieldKey?: string;
+};
+
+export const Tooltip: FunctionComponent<Props> = ({
+    backgroundLayer,
+    tooltipLabels,
+    shape,
+    tooltipFieldKey = 'name',
+}) => {
+    return (
+        // @ts-ignore
+        <LeafletTooltip title={shape.name} pane="popupPane">
+            {(backgroundLayer?.length ?? 0) > 0 && (
+                <span>
+                    {tooltipLabels &&
+                        `${tooltipLabels.background}: ${findBackgroundShape(
+                            shape,
+                            // backgroundLayer cannot be undefined because this code will only run if it is not.
+                            // @ts-ignore
+                            backgroundLayer,
+                        )} > `}
+                    {/* {!tooltipLabels &&
+                                                `${get(shape, tooltipFieldKey)}`} */}
+                </span>
+            )}
+            <span>
+                {tooltipLabels &&
+                    `${tooltipLabels.main}: ${get(shape, tooltipFieldKey)}`}
+                {!tooltipLabels && `${get(shape, tooltipFieldKey)}`}
+            </span>
+        </LeafletTooltip>
+    );
+};

--- a/plugins/polio/js/src/constants/types.ts
+++ b/plugins/polio/js/src/constants/types.ts
@@ -422,6 +422,7 @@ export type Shape = {
     short_name: string;
     source_id: number;
     source_name: string;
+    data?: Record<string, any>;
 };
 
 export type MapColor = {

--- a/plugins/polio/js/src/pages/LQAS/LqasAfroOverview/Map/LqasAfroMapPanesContainer.tsx
+++ b/plugins/polio/js/src/pages/LQAS/LqasAfroOverview/Map/LqasAfroMapPanesContainer.tsx
@@ -10,6 +10,7 @@ import {
 } from '../hooks/useAfroMapShapes';
 import { defaultShapeStyle } from '../../../../utils';
 import { AfroMapParams, RoundSelection, Side } from '../types';
+import { LqasAfroTooltip } from './LqasAfroTooltip';
 
 const getMainLayerStyle = shape => {
     return lqasDistrictColors[shape.status] ?? defaultShapeStyle;
@@ -103,7 +104,12 @@ export const LqasAfroMapPanesContainer: FunctionComponent<Props> = ({
                     mainLayer={mapShapes}
                     getMainLayerStyle={getMainLayerStyle}
                     name={`LQAS-Map-country-view-${paramsAsString}`}
-                    tooltipFieldKey="data.country_name"
+                    customTooltip={shape => (
+                        <LqasAfroTooltip
+                            shape={shape}
+                            name={shape.data?.country_name}
+                        />
+                    )}
                 />
             )}
             {!showCountries && (
@@ -114,7 +120,12 @@ export const LqasAfroMapPanesContainer: FunctionComponent<Props> = ({
                     getMainLayerStyle={getMainLayerStyle}
                     getBackgroundLayerStyle={getBackgroundLayerStyle}
                     name={`LQAS-Map-zooomin-view-${paramsAsString}`}
-                    tooltipFieldKey="data.district_name"
+                    customTooltip={shape => (
+                        <LqasAfroTooltip
+                            shape={shape}
+                            name={shape.data?.district_name}
+                        />
+                    )}
                 />
             )}
         </>

--- a/plugins/polio/js/src/pages/LQAS/LqasAfroOverview/Map/LqasAfroTooltip.tsx
+++ b/plugins/polio/js/src/pages/LQAS/LqasAfroOverview/Map/LqasAfroTooltip.tsx
@@ -1,0 +1,47 @@
+import React, { FunctionComponent } from 'react';
+import { Tooltip } from 'react-leaflet';
+import { makeStyles, Box } from '@material-ui/core';
+
+import { useSafeIntl } from 'bluesquare-components';
+import { Shape } from '../../../../constants/types';
+import MESSAGES from '../../../../constants/messages';
+
+type Props = {
+    name: string;
+    shape: Shape;
+};
+
+const useStyles = makeStyles(() => ({
+    label: {
+        fontWeight: 'bold',
+    },
+}));
+
+export const LqasAfroTooltip: FunctionComponent<Props> = ({ name, shape }) => {
+    const { formatMessage } = useSafeIntl();
+    const classes: Record<string, string> = useStyles();
+    return (
+        // @ts-ignore
+        <Tooltip title={shape.name} pane="popupPane">
+            <Box display="block">
+                <span className={classes.label}>{name}</span>
+            </Box>
+            {shape.data?.campaign && (
+                <Box display="block">
+                    <span className={classes.label}>
+                        {formatMessage(MESSAGES.obrName)}:{' '}
+                    </span>
+                    {shape.data.campaign}
+                </Box>
+            )}
+            {shape.data?.round_number && (
+                <Box display="block">
+                    <span className={classes.label}>
+                        {formatMessage(MESSAGES.round)}:{' '}
+                    </span>
+                    {shape.data.round_number}
+                </Box>
+            )}
+        </Tooltip>
+    );
+};


### PR DESCRIPTION
When hovering on the country (and then districts when zoomed in), have the OBR name and Round number showing

Related JIRA tickets : POLIO-1119
## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

create custom tooltip to display info correctly + api to get round

## How to test

Open LQAS Afro map displaying data.
Hover a country and check that OBR name and round number are displayed.
Zoom to district and make the same thing

## Print screen / video



https://github.com/BLSQ/iaso/assets/12494624/0ca1e264-9890-47aa-81e3-a193c1087412

