### PR TITLE
IA-2355 problem with outdated reference to libpoppler97

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -108,7 +108,7 @@ jobs:
         with:
           python-version: 3.8
       - name: Install GDAL
-        run: sudo apt install libpoppler97 gdal-bin
+        run: sudo apt install libpoppler97=0.86.1-0ubuntu1.2 gdal-bin
       - uses: actions/cache@v2
         id: cache-venv
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -108,7 +108,7 @@ jobs:
         with:
           python-version: 3.8
       - name: Install GDAL
-        run: sudo apt install gdal-bin
+        run: sudo apt install libpoppler97==0.86.1-0ubuntu1.2 gdal-bin
       - uses: actions/cache@v2
         id: cache-venv
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -108,7 +108,7 @@ jobs:
         with:
           python-version: 3.8
       - name: Install GDAL
-        run: sudo apt install libpoppler97==0.86.1-0ubuntu1.2 gdal-bin
+        run: sudo apt install libpoppler97=0.86.1-0ubuntu1.2 gdal-bin
       - uses: actions/cache@v2
         id: cache-venv
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -108,7 +108,7 @@ jobs:
         with:
           python-version: 3.8
       - name: Install GDAL
-        run: sudo apt install libpoppler97=0.86.1-0ubuntu1.2 gdal-bin
+        run: sudo apt install libpoppler97 gdal-bin
       - uses: actions/cache@v2
         id: cache-venv
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -108,7 +108,7 @@ jobs:
         with:
           python-version: 3.8
       - name: Install GDAL
-        run: sudo apt install libpoppler97=0.86.1-0ubuntu1.2 gdal-bin
+        run: sudo apt-get update && sudo apt install gdal-bin #libpoppler97=0.86.1-0ubuntu1.2
       - uses: actions/cache@v2
         id: cache-venv
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -108,7 +108,7 @@ jobs:
         with:
           python-version: 3.8
       - name: Install GDAL
-        run: sudo apt-get update && sudo apt install gdal-bin #libpoppler97=0.86.1-0ubuntu1.2
+        run: sudo apt-get update && sudo apt install gdal-bin 
       - uses: actions/cache@v2
         id: cache-venv
         with:


### PR DESCRIPTION
During running python tests in github actions, a step before running the tests install the ubuntu package `gdal-bin`.

Problem is that the gdal-bin package is trying to install a subpackage called libpoppler97
Its trying to download [libpoppler97_0.86.1-0ubuntu1.1_amd64.deb](http://azure.archive.ubuntu.com/ubuntu/pool/main/p/poppler/libpoppler97_0.86.1-0ubuntu1.1_amd64.deb)

But this package doesn't exist anymore (for security reasons ?)
And has been replace by 
[libpoppler97_0.86.1-0ubuntu1.2_amd64.deb](http://azure.archive.ubuntu.com/ubuntu/pool/main/p/poppler/libpoppler97_0.86.1-0ubuntu1.2_amd64.deb)

(**1.2** instead of **1.1** at the end ..)

This modifies the github workflow action to force the install of second package before installing `gdal-bin`


Related JIRA tickets : IA-2355

## Self proofreading checklist

- [x] Doesn't apply

## Changes

Modification of a github action script.

## How to test

If you push in the branch and the python tests are working it means it's OK

