### PR TITLE
IA-2326: change duplicated instance wording

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -463,7 +463,7 @@
     "iaso.label.infos": "Infos",
     "iaso.label.instanceLocks": "Instance locks",
     "iaso.label.instanceStatus": "Status",
-    "iaso.label.instanceStatus.duplicatedMulti": "Duplicated",
+    "iaso.label.instanceStatus.duplicatedMulti": "Error (duplicated)",
     "iaso.label.instanceStatus.duplicatedSingle": "duplicated",
     "iaso.label.instanceStatus.duplicateMulti": "Duplicated",
     "iaso.label.instanceStatus.error": "Error(s)",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -461,7 +461,7 @@
     "iaso.label.infos": "Infos",
     "iaso.label.instanceLocks": "Verrous sur l'instance",
     "iaso.label.instanceStatus": "Statut",
-    "iaso.label.instanceStatus.duplicatedMulti": "Dupliquées",
+    "iaso.label.instanceStatus.duplicatedMulti": "Erreur (dupliquée)",
     "iaso.label.instanceStatus.duplicatedSingle": "dupliquée",
     "iaso.label.instanceStatus.error": "erreur(s)",
     "iaso.label.instanceStatus.errorMulti": "Erreurs",

--- a/hat/assets/js/apps/Iaso/domains/instances/constants.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/constants.js
@@ -152,7 +152,7 @@ export const INSTANCE_METAS_FIELDS = [
     {
         key: 'status',
         render: value =>
-            value ? (
+            value && MESSAGES[value.toLowerCase()] ? (
                 <FormattedMessage {...MESSAGES[value.toLowerCase()]} />
             ) : (
                 '-'

--- a/hat/assets/js/apps/Iaso/domains/instances/messages.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/messages.js
@@ -223,7 +223,7 @@ const MESSAGES = defineMessages({
         id: 'iaso.label.instanceStatus.errorMulti',
     },
     duplicated: {
-        defaultMessage: 'Duplicated',
+        defaultMessage: 'Error (duplicated)',
         id: 'iaso.label.instanceStatus.duplicatedMulti',
     },
     exported: {


### PR DESCRIPTION
On the submission tab, we have the “Status” Filter with 3 choices : 

Ready

Errors

Exported

While in the table below, we also have the value “duplicated”
If we filter on “errors”, this filter currently filters on “duplicated” ==> This is quite confusing…

(observed on the instance iaso  “SPSS RDC”, on the “localisation et photo” form)

Related JIRA tickets : IA-2326
## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

adapt wording with "Error (duplicated)

## How to test

search for errored submissions and try to find duplicated ones

## Print screen / video
![Screenshot 2023-08-09 at 14 53 24](https://github.com/BLSQ/iaso/assets/12494624/01fa5fab-bd0b-4863-9364-a135dccadb0f)
![Screenshot 2023-08-09 at 14 53 15](https://github.com/BLSQ/iaso/assets/12494624/d962e9c6-cfcc-4bcd-8d1c-78a1539a8344)

