### PR TITLE
 IA-2360: Validate Feature Flags when project is updated

### DIFF
--- a/iaso/admin.py
+++ b/iaso/admin.py
@@ -268,7 +268,7 @@ class ProjectAdmin(admin.ModelAdmin):
 
 @admin_attr_decorator
 class FeatureFlagAdmin(admin.ModelAdmin):
-    list_display = ("code", "name")
+    list_display = ("code", "name", "requires_authentication")
 
 
 @admin_attr_decorator

--- a/iaso/api/feature_flags.py
+++ b/iaso/api/feature_flags.py
@@ -8,7 +8,7 @@ class FeatureFlagsSerializer(serializers.ModelSerializer):
     class Meta:
         model = FeatureFlag
 
-        fields = ["id", "code", "name", "description", "created_at", "updated_at"]
+        fields = ["id", "code", "name", "requires_authentication", "description", "created_at", "updated_at"]
 
     created_at = TimestampField(read_only=True)
     updated_at = TimestampField(read_only=True)

--- a/iaso/migrations/0227_featureflag_requires_authentication.py
+++ b/iaso/migrations/0227_featureflag_requires_authentication.py
@@ -1,0 +1,27 @@
+from django.db import migrations, models
+
+
+def set_requires_authentication_to_feature_flags(apps, schema_editor):
+    model = apps.get_model("iaso", "FeatureFlag")
+    set_requires_authentication(model, "PLANNING")
+
+
+def set_requires_authentication(model, code):
+    feature_flag = model.objects.get(code=code)
+    feature_flag.requires_authentication = True
+    feature_flag.save()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("iaso", "0226_merge_20230724_1245"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="featureflag",
+            name="requires_authentication",
+            field=models.BooleanField(default=False),
+        ),
+        migrations.RunPython(set_requires_authentication_to_feature_flags),
+    ]

--- a/iaso/models/base.py
+++ b/iaso/models/base.py
@@ -1351,6 +1351,7 @@ class FeatureFlag(models.Model):
         (
             TAKE_GPS_ON_FORM,
             "Mobile: take GPS on new form",
+            False,
             _("GPS localization on start of instance on mobile"),
         ),
         (
@@ -1361,12 +1362,14 @@ class FeatureFlag(models.Model):
         (
             FORMS_AUTO_UPLOAD,
             "",
+            False,
             _(
                 "Saving a form as finalized on mobile triggers an upload attempt immediately + everytime network becomes available"
             ),
         ),
         (
             LIMIT_OU_DOWNLOAD_TO_ROOTS,
+            False,
             "Mobile: Limit download of orgunit to what the user has access to",
             _(
                 "Mobile: Limit download of orgunit to what the user has access to",
@@ -1376,6 +1379,7 @@ class FeatureFlag(models.Model):
 
     code = models.CharField(max_length=100, null=False, blank=False, unique=True)
     name = models.CharField(max_length=100, null=False, blank=False)
+    requires_authentication = models.BooleanField(default=False)
     description = models.TextField(blank=True)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)


### PR DESCRIPTION
Some Feature Flags won't work without the 'REQUIRE_AUTHENTICATION' one added alongside. 
Therefore, we mark those as requiring authentication and we validate on project creation/update.

Related JIRA tickets: IA-2360

## Self-proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [X] My migrations file are included
- [X] Are there enough tests

## Changes

A new field was added on the model `feature_flag` called `requires_authentication`.
This allows us to check when the project is created/updated that the `REQUIRE_AUTHENTICATION` feature flag is also present or it raises a 400.

## How to test

1. Go into the project edition screen.
1. Try to create or update a project 
1. In the feature flag screen, add "Planning" only
1. Save and you should see an error
1. Add "REQUIRE_AUTHENTICATION" (might have to be added in the admin first, I don't think there is a migration for it)
1. Save and it should work
