### PR TITLE
HOTFIX: fix round history bug with round 0

### DIFF
--- a/plugins/polio/js/src/components/Rounds/RoundDates/RoundDates.tsx
+++ b/plugins/polio/js/src/components/Rounds/RoundDates/RoundDates.tsx
@@ -14,6 +14,7 @@ import { RoundDatesHistoryModal } from '../RoundDatesHistory/RoundDatesHistoryMo
 
 type Props = {
     roundIndex: number;
+    roundNumber: number;
     setParentFieldValue: (
         // eslint-disable-next-line no-unused-vars
         field: string,
@@ -27,6 +28,7 @@ type Props = {
 
 export const RoundDates: FunctionComponent<Props> = ({
     roundIndex,
+    roundNumber,
     setParentFieldValue,
     parentFieldValue,
     // TODO pass parentFieldValue to allow spreading
@@ -36,11 +38,21 @@ export const RoundDates: FunctionComponent<Props> = ({
         values: { rounds = [] },
         initialValues,
     } = useFormikContext<Campaign>();
+    // const currentStartDate = rounds.find(
+    //     round => round.number === roundNumber,
+    // )?.started_at;
+    // const currentEndDate = rounds.find(
+    //     round => round.number === roundNumber,
+    // )?.ended_at;
     const currentStartDate = rounds?.[roundIndex]?.started_at;
     const currentEndDate = rounds?.[roundIndex]?.ended_at;
+    // For initial data, wee need to perform a find, because if we're adding round 0
+    // We'll be addinga round at the start of the rounds array which will lead to index related errors
     const hasInitialData = Boolean(
-        initialValues.rounds?.[roundIndex]?.started_at &&
-            initialValues.rounds?.[roundIndex]?.ended_at,
+        initialValues.rounds.find(round => round.number === roundNumber)
+            ?.started_at &&
+            initialValues.rounds.find(round => round.number === roundNumber)
+                ?.ended_at,
     );
     const save = ({ startDate, endDate, reason }, helpers) => {
         setParentFieldValue(`rounds[${roundIndex}]`, {

--- a/plugins/polio/js/src/components/Rounds/RoundDates/RoundDates.tsx
+++ b/plugins/polio/js/src/components/Rounds/RoundDates/RoundDates.tsx
@@ -38,12 +38,6 @@ export const RoundDates: FunctionComponent<Props> = ({
         values: { rounds = [] },
         initialValues,
     } = useFormikContext<Campaign>();
-    // const currentStartDate = rounds.find(
-    //     round => round.number === roundNumber,
-    // )?.started_at;
-    // const currentEndDate = rounds.find(
-    //     round => round.number === roundNumber,
-    // )?.ended_at;
     const currentStartDate = rounds?.[roundIndex]?.started_at;
     const currentEndDate = rounds?.[roundIndex]?.ended_at;
     // For initial data, wee need to perform a find, because if we're adding round 0

--- a/plugins/polio/js/src/forms/RoundForm.tsx
+++ b/plugins/polio/js/src/forms/RoundForm.tsx
@@ -24,6 +24,7 @@ export const RoundForm: FunctionComponent<Props> = ({ roundNumber }) => {
             <Grid container spacing={2}>
                 <Grid xs={12} md={6} item>
                     <RoundDates
+                        roundNumber={roundNumber}
                         roundIndex={roundIndex}
                         setParentFieldValue={setFieldValue}
                         parentFieldValue={rounds[roundIndex]}

--- a/plugins/polio/serializers.py
+++ b/plugins/polio/serializers.py
@@ -356,6 +356,9 @@ class RoundSerializer(serializers.ModelSerializer):
         destructions = validated_data.pop("destructions", [])
         started_at = validated_data.get("started_at", None)
         ended_at = validated_data.get("ended_at", None)
+        datelogs = validated_data.get("datelogs", None)
+        if datelogs:
+            raise serializers.ValidationError({"datelogs": "Cannot have modification history for new round"})
         round = Round.objects.create(**validated_data)
         if started_at is not None or ended_at is not None:
             datelog = RoundDateHistoryEntry.objects.create(round=round, reason="INITIAL_DATA", modified_by=user)


### PR DESCRIPTION
Polio users get 500 when adding round 0

Related JIRA tickets :  POLIO-1139

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [X] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- prevent users to create datelog when adding round 0
- backend: raise error when receiving datelogs on create

## How to test

Explain how to test your PR.
If a specific config is required explain it here (dataset, account, profile, ...)

## Print screen / video

BEFORE
![Screenshot 2023-08-21 at 14 53 29](https://github.com/BLSQ/iaso/assets/38907762/374026e0-fc13-4e35-b7b0-0bfe98f90753)


AFTER 

![Screenshot 2023-08-21 at 14 56 31](https://github.com/BLSQ/iaso/assets/38907762/5d05fc88-5aaa-44e4-ab52-22c4004e9763)


## Notes

CAN BE DEPLOYED AS HOTFIX
