### PR TITLE
HOTFIX/POLIO-1140: send all countries for IM

### DIFF
--- a/plugins/polio/api.py
+++ b/plugins/polio/api.py
@@ -2036,20 +2036,29 @@ class CountriesWithLqasIMConfigViewSet(ModelViewSet):
 
     def get_queryset(self):
         category = self.request.query_params.get("category")
-        configs = Config.objects.filter(slug=f"{category}-config").first().content
-        country_ids = []
-        for config in configs:
-            if JsonDataStore.objects.filter(slug=f"{category}_{config['country_id']}").exists():
-                country_ids.append(config["country_id"])
-            else:
-                continue
+        # For lqas, we filter out the countries with no datastore
+        if category == "lqas":
+            configs = Config.objects.filter(slug=f"{category}-config").first().content
+            country_ids = []
+            for config in configs:
+                if JsonDataStore.objects.filter(slug=f"{category}_{config['country_id']}").exists():
+                    country_ids.append(config["country_id"])
+                else:
+                    continue
 
-        return (
-            OrgUnit.objects.filter_for_user_and_app_id(self.request.user, self.request.query_params.get("app_id"))
-            .filter(validation_status="VALID")
-            .filter(org_unit_type__category="COUNTRY")
-            .filter(id__in=country_ids)
-        )
+            return (
+                OrgUnit.objects.filter_for_user_and_app_id(self.request.user, self.request.query_params.get("app_id"))
+                .filter(validation_status="VALID")
+                .filter(org_unit_type__category="COUNTRY")
+                .filter(id__in=country_ids)
+            )
+        # For IM we send all countries. We'll align with LQAS when the datastores are configured for IM as well
+        else:
+            return (
+                OrgUnit.objects.filter_for_user_and_app_id(self.request.user, self.request.query_params.get("app_id"))
+                .filter(validation_status="VALID")
+                .filter(org_unit_type__category="COUNTRY")
+            )
 
 
 router = routers.SimpleRouter()

--- a/plugins/polio/js/src/components/Rounds/RoundDates/RoundDates.tsx
+++ b/plugins/polio/js/src/components/Rounds/RoundDates/RoundDates.tsx
@@ -14,6 +14,7 @@ import { RoundDatesHistoryModal } from '../RoundDatesHistory/RoundDatesHistoryMo
 
 type Props = {
     roundIndex: number;
+    roundNumber: number;
     setParentFieldValue: (
         // eslint-disable-next-line no-unused-vars
         field: string,
@@ -27,6 +28,7 @@ type Props = {
 
 export const RoundDates: FunctionComponent<Props> = ({
     roundIndex,
+    roundNumber,
     setParentFieldValue,
     parentFieldValue,
     // TODO pass parentFieldValue to allow spreading
@@ -36,11 +38,21 @@ export const RoundDates: FunctionComponent<Props> = ({
         values: { rounds = [] },
         initialValues,
     } = useFormikContext<Campaign>();
+    // const currentStartDate = rounds.find(
+    //     round => round.number === roundNumber,
+    // )?.started_at;
+    // const currentEndDate = rounds.find(
+    //     round => round.number === roundNumber,
+    // )?.ended_at;
     const currentStartDate = rounds?.[roundIndex]?.started_at;
     const currentEndDate = rounds?.[roundIndex]?.ended_at;
+    // For initial data, wee need to perform a find, because if we're adding round 0
+    // We'll be addinga round at the start of the rounds array which will lead to index related errors
     const hasInitialData = Boolean(
-        initialValues.rounds?.[roundIndex]?.started_at &&
-            initialValues.rounds?.[roundIndex]?.ended_at,
+        initialValues.rounds.find(round => round.number === roundNumber)
+            ?.started_at &&
+            initialValues.rounds.find(round => round.number === roundNumber)
+                ?.ended_at,
     );
     const save = ({ startDate, endDate, reason }, helpers) => {
         setParentFieldValue(`rounds[${roundIndex}]`, {

--- a/plugins/polio/js/src/components/Rounds/RoundDates/RoundDates.tsx
+++ b/plugins/polio/js/src/components/Rounds/RoundDates/RoundDates.tsx
@@ -38,12 +38,6 @@ export const RoundDates: FunctionComponent<Props> = ({
         values: { rounds = [] },
         initialValues,
     } = useFormikContext<Campaign>();
-    // const currentStartDate = rounds.find(
-    //     round => round.number === roundNumber,
-    // )?.started_at;
-    // const currentEndDate = rounds.find(
-    //     round => round.number === roundNumber,
-    // )?.ended_at;
     const currentStartDate = rounds?.[roundIndex]?.started_at;
     const currentEndDate = rounds?.[roundIndex]?.ended_at;
     // For initial data, wee need to perform a find, because if we're adding round 0

--- a/plugins/polio/js/src/forms/RoundForm.tsx
+++ b/plugins/polio/js/src/forms/RoundForm.tsx
@@ -24,6 +24,7 @@ export const RoundForm: FunctionComponent<Props> = ({ roundNumber }) => {
             <Grid container spacing={2}>
                 <Grid xs={12} md={6} item>
                     <RoundDates
+                        roundNumber={roundNumber}
                         roundIndex={roundIndex}
                         setParentFieldValue={setFieldValue}
                         parentFieldValue={rounds[roundIndex]}

--- a/plugins/polio/serializers.py
+++ b/plugins/polio/serializers.py
@@ -356,6 +356,9 @@ class RoundSerializer(serializers.ModelSerializer):
         destructions = validated_data.pop("destructions", [])
         started_at = validated_data.get("started_at", None)
         ended_at = validated_data.get("ended_at", None)
+        datelogs = validated_data.get("datelogs", None)
+        if datelogs:
+            raise serializers.ValidationError({"datelogs": "Cannot have modification history for new round"})
         round = Round.objects.create(**validated_data)
         if started_at is not None or ended_at is not None:
             datelog = RoundDateHistoryEntry.objects.create(round=round, reason="INITIAL_DATA", modified_by=user)


### PR DESCRIPTION
Country dropdown list on IM page was empty

Related JIRA tickets : POLIO-1140

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- Updated `get_queryset` in `CountriesWithLqasIMConfigViewSet` so that it only filters out countries without json data store  for lqas, as there's no datastore yet for IM.

## How to test

Go to IM (any), click on "countries". Drop down list should not be empty

## Print screen / video
BEFORE

![Screenshot 2023-08-21 at 15 25 13](https://github.com/BLSQ/iaso/assets/38907762/d8c62727-826f-4f33-8d52-1aca3e6b36f4)

AFTER

![Screenshot 2023-08-21 at 15 24 40](https://github.com/BLSQ/iaso/assets/38907762/31eb992b-7a78-4d3c-bd69-62c4ccd73390)


## Notes
Can be deployed as hotfix
