### PR TITLE
IA-2377: Fix issue in users management

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/users/components/PermissionsSwitches.tsx
+++ b/hat/assets/js/apps/Iaso/domains/users/components/PermissionsSwitches.tsx
@@ -16,6 +16,7 @@ import { Permission } from '../../userRoles/types/userRoles';
 import { useGetUserRolesDropDown } from '../hooks/useGetUserRolesDropDown';
 import { userHasPermission } from '../utils';
 import * as Permissions from '../../../utils/permissions';
+import { useCurrentUser } from '../../../utils/usersUtils';
 
 const canAssignPermission = (user, permission): boolean => {
     if (userHasPermission(Permissions.USERS_ADMIN, user)) {
@@ -86,10 +87,10 @@ const PermissionsSwitches: React.FunctionComponent<Props> = ({
         }
         handleChange(newUserPerms);
     };
-
+    const loggedInUser = useCurrentUser();
     const allPermissions =
         data?.permissions?.filter(permission =>
-            canAssignPermission(currentUser, permission),
+            canAssignPermission(loggedInUser, permission),
         ) ?? [];
     const userPermissions = currentUser.user_permissions.value;
     const { data: userRoles, isFetching } = useGetUserRolesDropDown();

--- a/hat/menupermissions/models.py
+++ b/hat/menupermissions/models.py
@@ -178,5 +178,5 @@ class CustomPermissionSupport(models.Model):
 
     @staticmethod
     def assert_right_to_assign(user, permission_codename: str):
-        if user.has_perm(USERS_MANAGED) and permission_codename == _USERS_ADMIN:
-            raise PermissionDenied(f"User with {USERS_MANAGED} cannot grant {USERS_ADMIN} permission")
+        if not user.has_perm(USERS_ADMIN) and permission_codename == _USERS_ADMIN:
+            raise PermissionDenied(f"Only users with {USERS_ADMIN} permission can grant {USERS_ADMIN} permission")

--- a/iaso/tasks/profiles_bulk_update.py
+++ b/iaso/tasks/profiles_bulk_update.py
@@ -30,38 +30,38 @@ def update_single_profile_from_bulk(
 ):
     """Used within the context of a bulk operation"""
     original_copy = deepcopy(profile)
-    accound_id = user.iaso_profile.account.id
+    account_id = user.iaso_profile.account.id
     if roles_id_added is not None:
         for role_id in roles_id_added:
-            role = get_object_or_404(UserRole, id=role_id, account_id=accound_id)
-            if role.account.id == accound_id:
-                if user.has_perm(permission.USERS_MANAGED):
+            role = get_object_or_404(UserRole, id=role_id, account_id=account_id)
+            if role.account.id == account_id:
+                if not user.has_perm(permission.USERS_ADMIN):
                     for p in role.group.permissions.all():
                         CustomPermissionSupport.assert_right_to_assign(user, p.codename)
                 role.iaso_profile.add(profile)
     if roles_id_removed is not None:
         for role_id in roles_id_removed:
-            role = get_object_or_404(UserRole, id=role_id, account_id=accound_id)
-            if role.account.id == accound_id:
+            role = get_object_or_404(UserRole, id=role_id, account_id=account_id)
+            if role.account.id == account_id:
                 role.iaso_profile.remove(profile)
 
     if projects_ids_added is not None:
-        if user.has_perm(permission.USERS_MANAGED):
+        if not user.has_perm(permission.USERS_ADMIN):
             raise PermissionDenied(
-                f"User with permission {permission.USERS_MANAGED} cannot changed project " f"attributions"
+                f"User with permission {permission.USERS_MANAGED} cannot changed project attributions"
             )
         for project_id in projects_ids_added:
             project = Project.objects.get(pk=project_id)
-            if project.account and project.account.id == accound_id:
+            if project.account and project.account.id == account_id:
                 project.iaso_profile.add(profile)
     if projects_ids_removed is not None:
-        if user.has_perm(permission.USERS_MANAGED):
+        if not user.has_perm(permission.USERS_ADMIN):
             raise PermissionDenied(
-                f"User with permission {permission.USERS_MANAGED} cannot changed project " f"attributions"
+                f"User with permission {permission.USERS_MANAGED} cannot changed project attributions"
             )
         for project_id in projects_ids_removed:
             project = Project.objects.get(pk=project_id)
-            if project.account and project.account.id == accound_id:
+            if project.account and project.account.id == account_id:
                 project.iaso_profile.remove(profile)
 
     if language is not None:
@@ -153,7 +153,7 @@ def profiles_bulk_update(
     # FIXME Task don't handle rollback properly if task is killed by user or other error
     with transaction.atomic():
         managed_org_units = None
-        if user and user.has_perm(permission.USERS_MANAGED):
+        if user and not user.has_perm(permission.USERS_ADMIN):
             managed_org_units = OrgUnit.objects.hierarchy(user.iaso_profile.org_units.all()).values_list(
                 "id", flat=True
             )


### PR DESCRIPTION
Super-admins have both user admin and user management rights.
Since the code was checking for user management rights, the restrictions were also applied to admins.

Related JIRA ticket: IA-2377

## Self-proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [X] Are there enough tests

## Changes

The endpoints are protected with a check that the user has either the user admin or user management permission. Therefore, instead of checking if the user has user management permission before applying the restrictions, we check if the user doesn't have user admin permissions.

## How to test

Login with a super user and try to assign the user admin permission to a user
