### PR TITLE
Polio 1141 refresh dashboard api

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/dataSources/components/AddTaskComponent.js
+++ b/hat/assets/js/apps/Iaso/domains/dataSources/components/AddTaskComponent.js
@@ -8,7 +8,7 @@ import MESSAGES from '../messages';
 import ConfirmCancelDialogComponent from '../../../components/dialogs/ConfirmCancelDialogComponent';
 import { EditableTextFields } from '../../../components/forms/EditableTextFields';
 import { Checkboxes } from '../../../components/forms/Checkboxes';
-import { redirectTo } from '../../../routing/actions';
+import { redirectTo } from '../../../routing/actions.ts';
 import { baseUrls } from '../../../constants/urls';
 import { sendDhisOuImporterRequest } from '../requests';
 import { useFormState } from '../../../hooks/form';

--- a/hat/assets/js/apps/Iaso/domains/dataSources/components/DataSourceDialogComponent.js
+++ b/hat/assets/js/apps/Iaso/domains/dataSources/components/DataSourceDialogComponent.js
@@ -1,12 +1,11 @@
 import React, { useState, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { Box, Button, Grid, Typography } from '@material-ui/core';
-import { useSelector } from 'react-redux';
 
 import { LoadingSpinner, useSafeIntl } from 'bluesquare-components';
 import { merge } from 'lodash';
-import { useGetProjectsDropdownOptions } from '../../projects/hooks/requests';
 import { FormattedMessage } from 'react-intl';
+import { useGetProjectsDropdownOptions } from '../../projects/hooks/requests.ts';
 import ConfirmCancelDialogComponent from '../../../components/dialogs/ConfirmCancelDialogComponent';
 import InputComponent from '../../../components/forms/InputComponent';
 import MESSAGES from '../messages';
@@ -23,7 +22,7 @@ const ProjectSelectorIds = ({
     fieldHasBeenChanged,
 }) => {
     const { formatMessage } = useSafeIntl();
-    const {data: projects, isFetching} = useGetProjectsDropdownOptions();
+    const { data: projects, isFetching } = useGetProjectsDropdownOptions();
     const allErrors = [...errors];
     if (value.length === 0 && fieldHasBeenChanged) {
         allErrors.unshift(formatMessage(MESSAGES.emptyProjectsError));

--- a/iaso/test.py
+++ b/iaso/test.py
@@ -190,3 +190,14 @@ class APITestCase(BaseAPITestCase, IasoTestCaseMixin):
         self.assertHasField(project_data, "created_at", float)
         self.assertHasField(project_data, "updated_at", float)
         self.assertHasField(project_data, "needs_authentication", bool)
+
+    def assertValidTaskAndInDB(self, jr, status="QUEUED", name=None):
+        task_dict = jr["task"]
+        self.assertEqual(task_dict["status"], status, task_dict)
+
+        task = m.Task.objects.get(id=task_dict["id"])
+        self.assertTrue(task)
+        if name:
+            self.assertEqual(task.name, name)
+
+        return task

--- a/iaso/tests/api/test_task_dhis2_ou_importer.py
+++ b/iaso/tests/api/test_task_dhis2_ou_importer.py
@@ -157,14 +157,3 @@ class ApiDhis2ouimporterTestCase(APITestCase):
         self.assertEqual(task.params["kwargs"]["url"], "override url")
         self.assertEqual(task.params["kwargs"]["login"], None)
         self.assertEqual(task.params["kwargs"]["password"], "override pwd")
-
-    def assertValidTaskAndInDB(self, jr, status="QUEUED", name=None):
-        task_dict = jr["task"]
-        self.assertEqual(task_dict["status"], status, task_dict)
-
-        task = m.Task.objects.get(id=task_dict["id"])
-        self.assertTrue(task)
-        if name:
-            self.assertEqual(task.name, name)
-
-        return task

--- a/plugins/polio/api.py
+++ b/plugins/polio/api.py
@@ -32,6 +32,7 @@ from requests import HTTPError
 from iaso.api.serializers import OrgUnitDropdownSerializer
 from iaso.models.data_store import JsonDataStore
 from iaso.utils import geojson_queryset
+from plugins.polio.tasks.api.create_refresh_preparedness_data import RefreshPreparednessLaucherViewSet
 from rest_framework import routers, filters, viewsets, serializers, permissions, status
 from rest_framework.decorators import action
 from rest_framework.request import Request
@@ -2085,3 +2086,4 @@ router.register(r"polio/lqasim/countries", CountriesWithLqasIMConfigViewSet, bas
 router.register(r"polio/lqasmap/global", LQASIMGlobalMapViewSet, basename="lqasmapglobal")
 router.register(r"polio/lqasmap/zoomin", LQASIMZoominMapViewSet, basename="lqasmapzoomin")
 router.register(r"polio/lqasmap/zoominbackground", LQASIMZoominMapBackgroundViewSet, basename="lqasmapzoominbackground")
+router.register(r"tasks/create/refreshpreparedness", RefreshPreparednessLaucherViewSet, basename="refresh_preparedness")

--- a/plugins/polio/js/src/forms/PreparednessConfig.js
+++ b/plugins/polio/js/src/forms/PreparednessConfig.js
@@ -24,7 +24,7 @@ import {
 import MESSAGES from '../constants/messages';
 import { PreparednessSummary } from './PreparednessSummary';
 
-export const PreparednessConfig = ({ roundNumber }) => {
+export const PreparednessConfig = ({ roundNumber, campaignName }) => {
     const classes = useStyles();
     const { formatMessage } = useSafeIntl();
     const { values, setFieldValue, dirty } = useFormikContext();
@@ -57,11 +57,14 @@ export const PreparednessConfig = ({ roundNumber }) => {
     const previewMutation = useFetchPreparedness();
 
     const refreshData = () => {
-        previewMutation.mutate(preparedness_spreadsheet_url, {
-            onSuccess: data => {
-                setFieldValue(lastKey, data);
+        previewMutation.mutate(
+            { googleSheetURL: preparedness_spreadsheet_url, campaignName },
+            {
+                onSuccess: data => {
+                    setFieldValue(lastKey, data);
+                },
             },
-        });
+        );
     };
 
     const generateSpreadsheet = () => {

--- a/plugins/polio/js/src/forms/PreparednessForm.js
+++ b/plugins/polio/js/src/forms/PreparednessForm.js
@@ -48,7 +48,10 @@ export const PreparednessForm = () => {
                         key={round.number}
                         className={classes.tabPanel}
                     >
-                        <PreparednessConfig roundNumber={round.number} />
+                        <PreparednessConfig
+                            roundNumber={round.number}
+                            campaignName={values.obr_name}
+                        />
                     </TabPanel>
                 ))}
             </TabContext>

--- a/plugins/polio/js/src/hooks/useGetPreparednessData.js
+++ b/plugins/polio/js/src/hooks/useGetPreparednessData.js
@@ -1,7 +1,7 @@
-import { useSnackMutation } from 'Iaso/libs/apiHooks';
-import { postRequest } from 'Iaso/libs/Api';
-import { useSnackQuery } from 'Iaso/libs/apiHooks';
-import { getRequest } from 'Iaso/libs/Api';
+/* eslint-disable camelcase */
+// @ts-ignore
+import { useSnackMutation, useSnackQuery } from 'Iaso/libs/apiHooks.ts';
+import { postRequest, getRequest } from 'Iaso/libs/Api';
 
 export const useGetPreparednessData = (campaignId, roundKey) => {
     const url = `/api/polio/campaigns/${campaignId}/preparedness?round=${roundKey}`;
@@ -15,16 +15,20 @@ export const useGetPreparednessData = (campaignId, roundKey) => {
     );
 };
 
+const refreshPreparedness = ({ googleSheetURL, campaignName }) => {
+    // launch task to refresh endpoint for preparedness dashboard
+    postRequest('/api/tasks/create/refreshpreparedness/', {
+        obr_name: campaignName,
+    });
+    return postRequest('/api/polio/campaigns/preview_preparedness/', {
+        google_sheet_url: googleSheetURL,
+    });
+};
+
 // This retrieve data but since it contact data from an external service this is
 // implemented as a post. This fetch and parse the Google spreadsheet
 export const useFetchPreparedness = () => {
-    return useSnackMutation(
-        googleSheetURL =>
-            postRequest('/api/polio/campaigns/preview_preparedness/', {
-                google_sheet_url: googleSheetURL,
-            }),
-        null,
-    );
+    return useSnackMutation(refreshPreparedness, null);
 };
 
 export const useGeneratePreparednessSheet = campaign_id => {

--- a/plugins/polio/tasks/api/create_refresh_preparedness_data.py
+++ b/plugins/polio/tasks/api/create_refresh_preparedness_data.py
@@ -1,4 +1,3 @@
-import logging
 from plugins.polio.models import Campaign
 from plugins.polio.tasks.refresh_preparedness_data import refresh_data
 
@@ -7,11 +6,7 @@ from rest_framework.response import Response
 
 from iaso.api.common import HasPermission
 from iaso.api.tasks import TaskSerializer
-from iaso.models import DataSource
-from iaso.tasks.dhis2_ou_importer import dhis2_ou_importer
 from hat.menupermissions import models as permission
-
-logger = logging.getLogger(__name__)
 
 
 class RefreshPreparednessLaucherSerializer(serializers.Serializer):

--- a/plugins/polio/tasks/api/create_refresh_preparedness_data.py
+++ b/plugins/polio/tasks/api/create_refresh_preparedness_data.py
@@ -1,0 +1,42 @@
+import logging
+from plugins.polio.models import Campaign
+from plugins.polio.tasks.refresh_preparedness_data import refresh_data
+
+from rest_framework import viewsets, permissions, serializers
+from rest_framework.response import Response
+
+from iaso.api.common import HasPermission
+from iaso.api.tasks import TaskSerializer
+from iaso.models import DataSource
+from iaso.tasks.dhis2_ou_importer import dhis2_ou_importer
+from hat.menupermissions import models as permission
+
+logger = logging.getLogger(__name__)
+
+
+class RefreshPreparednessLaucherSerializer(serializers.Serializer):
+    obr_name = serializers.CharField(max_length=200, required=True)
+
+    def validate(self, attrs):
+        validated_data = super().validate(attrs)
+        request = self.context["request"]
+        user = request.user
+        try:
+            Campaign.objects.filter_for_user(user).get(obr_name=attrs["obr_name"])
+        except Campaign.DoesNotExist:
+            raise serializers.ValidationError("Invalid campaign name")
+        return validated_data
+
+
+# noinspection PyMethodMayBeStatic
+class RefreshPreparednessLaucherViewSet(viewsets.ViewSet):
+    permission_classes = [permissions.IsAuthenticated, HasPermission(permission.POLIO)]  # type: ignore
+    serializer_class = RefreshPreparednessLaucherSerializer
+
+    def create(self, request):
+        serializer = RefreshPreparednessLaucherSerializer(data=request.data, context={"request": request})
+        serializer.is_valid(raise_exception=True)
+        data = serializer.validated_data
+
+        task = refresh_data(campaigns=[data["obr_name"]], user=request.user)
+        return Response({"task": TaskSerializer(instance=task).data})

--- a/plugins/polio/tasks/api/create_refresh_preparedness_data.py
+++ b/plugins/polio/tasks/api/create_refresh_preparedness_data.py
@@ -30,7 +30,7 @@ class RefreshPreparednessLaucherSerializer(serializers.Serializer):
 
 # noinspection PyMethodMayBeStatic
 class RefreshPreparednessLaucherViewSet(viewsets.ViewSet):
-    permission_classes = [permissions.IsAuthenticated, HasPermission(permission.POLIO)]  # type: ignore
+    permission_classes = [permissions.IsAuthenticated, HasPermission(permission.POLIO, permission.POLIO_CONFIG)]  # type: ignore
     serializer_class = RefreshPreparednessLaucherSerializer
 
     def create(self, request):

--- a/plugins/polio/tests/test_refresh_preparedness_data.py
+++ b/plugins/polio/tests/test_refresh_preparedness_data.py
@@ -1,0 +1,57 @@
+from iaso import models as m
+from iaso.test import APITestCase
+from plugins.polio.models import Campaign
+
+
+class RefreshPreparednessTestCase(APITestCase):
+    @classmethod
+    def setUp(cls):
+        cls.url = "/api/tasks/create/refreshpreparedness/"
+        cls.account = account = m.Account.objects.create(name="test account")
+        cls.other_account = m.Account.objects.create(name="other account")
+        cls.user = cls.create_user_with_profile(username="test user", account=account, permissions=["iaso_polio"])
+        cls.campaign = Campaign.objects.create(obr_name="right_campaign", account=account)
+        cls.wrong_campaign = Campaign.objects.create(obr_name="wrong_campaign", account=cls.other_account)
+
+    def test_no_perm(self):
+        user_no_perm = self.create_user_with_profile(username="test user2", account=self.account, permissions=[])
+        self.client.force_authenticate(user_no_perm)
+        response = self.client.post(
+            self.url,
+            format="json",
+            data={"obr_name": self.campaign.obr_name},
+        )
+        jr = self.assertJSONResponse(response, 403)
+        self.assertEqual({"detail": "You do not have permission to perform this action."}, jr)
+
+    def test_wrong_obr_name(self):
+        self.client.force_authenticate(self.user)
+        response = self.client.post(
+            self.url,
+            format="json",
+            data={"obr_name": "Bleh"},
+        )
+        jr = self.assertJSONResponse(response, 400)
+        self.assertEqual({"non_field_errors": ["Invalid campaign name"]}, jr)
+
+    def test_wrong_account(self):
+        self.client.force_authenticate(self.user)
+        response = self.client.post(
+            self.url,
+            format="json",
+            data={"obr_name": self.wrong_campaign.obr_name},
+        )
+        jr = self.assertJSONResponse(response, 400)
+        self.assertEqual({"non_field_errors": ["Invalid campaign name"]}, jr)
+
+    def test_ok(self):
+        self.client.force_authenticate(self.user)
+        response = self.client.post(
+            self.url,
+            format="json",
+            data={"obr_name": self.campaign.obr_name},
+        )
+        jr = self.assertJSONResponse(response, 200)
+        task = self.assertValidTaskAndInDB(jr)
+        self.assertEqual(task.launcher, self.user)
+        self.assertEqual(task.params["kwargs"]["obr_name"], self.campaign.obr_name)

--- a/plugins/polio/tests/test_refresh_preparedness_data.py
+++ b/plugins/polio/tests/test_refresh_preparedness_data.py
@@ -54,4 +54,4 @@ class RefreshPreparednessTestCase(APITestCase):
         jr = self.assertJSONResponse(response, 200)
         task = self.assertValidTaskAndInDB(jr)
         self.assertEqual(task.launcher, self.user)
-        self.assertEqual(task.params["kwargs"]["obr_name"], self.campaign.obr_name)
+        self.assertEqual(task.params["kwargs"]["campaigns"], [self.campaign.obr_name])


### PR DESCRIPTION
refreshing prepâredness data from the Ui doesn't update the endpoint used for the powerBi dashboards

Related JIRA tickets :  POLIO-1141

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [X] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [X] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- Add endpoint to launch `refresh_data` and pass it an `obr_name` (to avoid refreshing all campaigns, which takes about an hour)
- Update front-end code to post on new endpoint when clicking "refresh" button.

## How to test

- Start a worker (see README for the command)
- Go to polio
- Find or create a campaign wit at least 1 round in the future
- Select campaign go to preparedness tab
- Select the future round and click "generate spreadsheet"
- Open the sheet in a new tab. Fill in some values
- Go back to polio,  and click "Refresh preparedness data"
- When the data has finished refreshing, go to Tasks
- You should see a `refresh_data` task with a timestamp matchiing your refresh (see video)

You can also open the browser inspector and check that a call to `tasks/create/refreshpreparedness` is made when you click "Refresh preparedness data".

## Print screen / video

https://github.com/BLSQ/iaso/assets/38907762/b068481d-a429-401b-8217-155fd4f38d14



