### PR TITLE
POLIO-1156 Proposed temporary fix

### DIFF
--- a/plugins/polio/preparedness/client.py
+++ b/plugins/polio/preparedness/client.py
@@ -23,7 +23,7 @@ class QuotaLimiter:
     """This class allow limiting the number of call to an API within the allowed quota.
 
     Just call the function, and then it will wait before returning if we are over the rate.
-    The limit on the Google sheet API is 60 call per seconds per project, we will limit to half that
+    The limit on the Google sheet API is 60 call per minute per project, we will limit to half that
     because we may not be the only sessions using the API Key"""
 
     RANGE_SECONDS = 60

--- a/plugins/polio/preparedness/summary.py
+++ b/plugins/polio/preparedness/summary.py
@@ -145,7 +145,7 @@ def _make_prep(c: Campaign, round: Round):
     return campaign_prep
 
 
-TIMEOUT_PREPAREDNESS = 60 * 60 * 24
+TIMEOUT_PREPAREDNESS = 60 * 60 * 24 * 365 * 5  # 5 years timeout
 "set as 24h since we run the cron once per day"
 
 

--- a/plugins/polio/tasks/refresh_preparedness_data.py
+++ b/plugins/polio/tasks/refresh_preparedness_data.py
@@ -20,6 +20,8 @@ def refresh_data(
     started_at = datetime.now()
     if date_filter is None:
         date_filter = now() - timedelta(days=180)
+    elif type(date_filter) == str:
+        date_filter = datetime.fromisoformat(date_filter)
 
     round_qs = Round.objects.filter(preparedness_spreadsheet_url__isnull=False).prefetch_related("campaign")
     round_qs = round_qs.filter(started_at__gte=date_filter)

--- a/plugins/polio/tasks/refresh_preparedness_data.py
+++ b/plugins/polio/tasks/refresh_preparedness_data.py
@@ -14,11 +14,15 @@ logger = logging.getLogger(__name__)
 @task_decorator(task_name="refresh_data")
 def refresh_data(
     campaigns=None,
+    date_filter=None,
     task=None,
 ):
     started_at = datetime.now()
+    if date_filter is None:
+        date_filter = now() - timedelta(days=180)
+
     round_qs = Round.objects.filter(preparedness_spreadsheet_url__isnull=False).prefetch_related("campaign")
-    round_qs = round_qs.filter(started_at__gte=now() - timedelta(days=180))
+    round_qs = round_qs.filter(started_at__gte=date_filter)
     round_qs = round_qs.exclude(campaign__isnull=True)
     round_qs = round_qs.filter(campaign__deleted_at__isnull=True)
     round_qs = round_qs.order_by("-started_at")


### PR DESCRIPTION
We are seeing performance issues on campaigns installation (POLIO Outbreaks).
After analysis they seem to be related to the preparedness dashboard which implies a lot of computations and fetching from google sheets API.


Related JIRA tickets : POLIO-1156

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented

## Changes

We propose a "quick" fix that should fix the performance issues. Basically we are not expiring our cache after 24h and we are gonna launch a manual task to cache the results of old campaigns too (until now only the campaigns rounds not older than 180 days where cached).

## Notes

Every night a task is launch by cron to refresh the data in cache (data of the last 180 days)
After that fix we are gonna launch a manual task which will put in cache all available data (not only 180 days). The task has been modified to allow for an optional parameter to override this 180 days
