### PR TITLE
POLIO-1162: Fix LQAS Afro Map district view

### DIFF
--- a/plugins/polio/api.py
+++ b/plugins/polio/api.py
@@ -77,6 +77,7 @@ from .helpers import (
     CustomFilterBackend,
     calculate_country_status,
     determine_status_for_district,
+    make_safe_bbox,
 )
 from .vaccines_email import send_vaccines_notification_email
 from .models import (
@@ -1754,7 +1755,7 @@ class LQASIMGlobalMapViewSet(LqasAfroViewset):
 
     def get_queryset(self):
         # TODO see if we need to filter per user as with Campaign
-        return OrgUnit.objects.filter(org_unit_type__category="COUNTRY").exclude(simplified_geom=None)
+        return OrgUnit.objects.filter(org_unit_type__category="COUNTRY").exclude(simplified_geom__isnull=True)
 
     def list(self, request):
         results = []
@@ -1860,8 +1861,8 @@ class LQASIMZoominMapViewSet(LqasAfroViewset):
 
     def get_queryset(self):
         bounds = json.loads(self.request.GET.get("bounds", None))
-        bounds_as_polygon = Polygon.from_bbox(
-            (
+        bounds_as_polygon = Polygon(
+            make_safe_bbox(
                 bounds["_southWest"]["lng"],
                 bounds["_southWest"]["lat"],
                 bounds["_northEast"]["lng"],
@@ -1871,7 +1872,7 @@ class LQASIMZoominMapViewSet(LqasAfroViewset):
         # TODO see if we need to filter per user as with Campaign
         return (
             OrgUnit.objects.filter(org_unit_type__category="COUNTRY")
-            .exclude(simplified_geom=None)
+            .exclude(simplified_geom__isnull=True)
             .filter(simplified_geom__intersects=bounds_as_polygon)
         )
 
@@ -1880,8 +1881,8 @@ class LQASIMZoominMapViewSet(LqasAfroViewset):
         requested_round = self.request.GET.get("round", "latest")
         queryset = self.get_queryset()
         bounds = json.loads(request.GET.get("bounds", None))
-        bounds_as_polygon = Polygon.from_bbox(
-            (
+        bounds_as_polygon = Polygon(
+            make_safe_bbox(
                 bounds["_southWest"]["lng"],
                 bounds["_southWest"]["lat"],
                 bounds["_northEast"]["lng"],
@@ -1930,7 +1931,7 @@ class LQASIMZoominMapViewSet(LqasAfroViewset):
             districts = (
                 scope.filter(org_unit_type__category="DISTRICT")
                 .filter(parent__parent=org_unit.id)
-                .exclude(simplified_geom=None)
+                .exclude(simplified_geom__isnull=True)
                 .filter(simplified_geom__intersects=bounds_as_polygon)
             )
             data_for_country = data_store.content
@@ -1994,8 +1995,8 @@ class LQASIMZoominMapBackgroundViewSet(ModelViewSet):
 
     def get_queryset(self):
         bounds = json.loads(self.request.GET.get("bounds", None))
-        bounds_as_polygon = Polygon.from_bbox(
-            (
+        bounds_as_polygon = Polygon(
+            make_safe_bbox(
                 bounds["_southWest"]["lng"],
                 bounds["_southWest"]["lat"],
                 bounds["_northEast"]["lng"],
@@ -2005,7 +2006,7 @@ class LQASIMZoominMapBackgroundViewSet(ModelViewSet):
         # TODO see if we need to filter per user as with Campaign
         return (
             OrgUnit.objects.filter(org_unit_type__category="COUNTRY")
-            .exclude(simplified_geom=None)
+            .exclude(simplified_geom__isnull=True)
             .filter(simplified_geom__intersects=bounds_as_polygon)
         )
 

--- a/plugins/polio/helpers.py
+++ b/plugins/polio/helpers.py
@@ -126,6 +126,13 @@ def calculate_country_status(country_data, scope, roundNumber):
     return "3lqasFail"
 
 
+# Using this custom function because Polygon.from_bbox will change the bounding box if the longitude coordinates cover more than 180°
+# which will cause hard to track bugs
+# This very plain solution required investigation from 3 people and cause the utterance of many curse words.
+def make_safe_bbox(x_min, y_min, x_max, y_max):
+    return ((x_min, y_min), (x_max, y_min), (x_max, y_max), (x_min, y_max), (x_min, y_min))
+
+
 class LqasAfroViewset(ModelViewSet):
     def compute_reference_dates(self):
         start_date_after = self.request.GET.get("startDate", None)

--- a/plugins/polio/helpers.py
+++ b/plugins/polio/helpers.py
@@ -128,7 +128,7 @@ def calculate_country_status(country_data, scope, roundNumber):
 
 # Using this custom function because Polygon.from_bbox will change the bounding box if the longitude coordinates cover more than 180°
 # which will cause hard to track bugs
-# This very plain solution required investigation from 3 people and cause the utterance of many curse words.
+# This very plain solution required investigation from 3 people and caused the utterance of many curse words.
 def make_safe_bbox(x_min, y_min, x_max, y_max):
     return ((x_min, y_min), (x_max, y_min), (x_max, y_max), (x_min, y_max), (x_min, y_min))
 


### PR DESCRIPTION
When switching the map to "distrcit" view without zooming in, the API would return an empty list on big screens

Related JIRA tickets :POLIO-1162

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- The culprit was `Polygon.from_bbox` which would change the bounds when longitude would cover more than 180°. 
- Add `make_safe_bounds` function and use it to generate a tuple that is used to create the `Polygon`

## How to test

Go to Afro map and chack the "District" radio button

## Print screen / video

![Screenshot 2023-08-29 at 10 16 07](https://github.com/BLSQ/iaso/assets/38907762/672d5341-36a5-4ef0-9244-cd47d3617353)


##Notes

Thanks @edarchis  who actually found the solution of this one
