### PR TITLE
IA-2364 Make list of users downloadable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+# Tests.
+# =============================================================================
+
+.PHONY: dbshell drop-test-db test
+
+# make test
+# make test TARGET=iaso.tests.api.test_profiles.ProfileAPITestCase
+test:
+	docker-compose exec iaso ./manage.py test \
+	--noinput --keepdb --failfast --settings=hat.settings_test \
+	$(TARGET)
+
+# When the migration history is changed, we need to drop the DB before running the tests suite with `--keepdb`.
+drop-test-db:
+	docker-compose exec db psql -U postgres -c "drop database if exists test_iaso"
+
+dbshell:
+	docker-compose exec iaso ./manage.py dbshell

--- a/hat/assets/js/apps/Iaso/domains/users/hooks/useGetProfiles.js
+++ b/hat/assets/js/apps/Iaso/domains/users/hooks/useGetProfiles.js
@@ -2,8 +2,10 @@ import { getRequest } from 'Iaso/libs/Api';
 import { useSnackQuery } from 'Iaso/libs/apiHooks.ts';
 import { makeUrlWithParams } from '../../../libs/utils.tsx';
 
-export const useGetProfiles = params => {
-    const newParams = params
+
+export const useGetProfilesApiParams = params => {
+
+    const apiParams = params
         ? {
               limit: params.pageSize,
               order: params.order,
@@ -20,9 +22,18 @@ export const useGetProfiles = params => {
         : {};
 
     const url = makeUrlWithParams(`/api/profiles/`, {
-        ...newParams,
+        ...apiParams,
         managedUsersOnly: 'true',
     });
 
-    return useSnackQuery(['profiles', newParams], () => getRequest(url));
+    return {
+        url,
+        apiParams,
+    };
+
+};
+
+export const useGetProfiles = params => {
+    const { url, apiParams } = useGetProfilesApiParams(params);
+    return useSnackQuery(['profiles', apiParams], () => getRequest(url));
 };

--- a/hat/assets/js/apps/Iaso/domains/users/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/users/index.tsx
@@ -22,16 +22,17 @@ import Filters from './components/Filters';
 import { AddUsersDialog } from './components/UsersDialog';
 
 import { baseUrls } from '../../constants/urls';
-import { useGetProfiles } from './hooks/useGetProfiles';
+import { useGetProfilesApiParams, useGetProfiles } from './hooks/useGetProfiles';
 import { useDeleteProfile } from './hooks/useDeleteProfile';
 import { useSaveProfile } from './hooks/useSaveProfile';
 
 import { usersTableColumns } from './config';
 import MESSAGES from './messages';
 
+import DownloadButtonsComponent from '../../components/DownloadButtonsComponent';
+import { BulkImportUsersDialog } from './components/BulkImportDialog/BulkImportDialog';
 import { redirectTo } from '../../routing/actions';
 import { useCurrentUser } from '../../utils/usersUtils';
-import { BulkImportUsersDialog } from './components/BulkImportDialog/BulkImportDialog';
 
 import { Selection } from '../orgUnits/types/selection';
 import { Profile } from '../teams/types/profile';
@@ -103,6 +104,8 @@ export const Users: FunctionComponent<Props> = ({ params }) => {
     const isLoading =
         fetchingProfiles || deletingProfile || savingProfile || savingProfiles;
 
+    const apiParams = useGetProfilesApiParams(params);
+
     return (
         <>
             {isLoading && <LoadingSpinner />}
@@ -142,6 +145,11 @@ export const Users: FunctionComponent<Props> = ({ params }) => {
                             {/* @ts-ignore */}
                             <BulkImportUsersDialog />
                         </Box>
+                        <DownloadButtonsComponent
+                            csvUrl={`${apiParams.url}&csv=true`}
+                            xlsxUrl={`${apiParams.url}&xlsx=true`}
+                            disabled={isLoading}
+                        />
                     </Grid>
                 )}
                 <Table

--- a/hat/settings_test.py
+++ b/hat/settings_test.py
@@ -4,4 +4,4 @@ from .settings import *  # noqa: F401,F403
 # Django serializes the whole database into a SQL string at the start of a test run, which can take a few seconds.
 # https://docs.djangoproject.com/en/3.2/topics/testing/overview/#test-case-serialized-rollback
 # Fixed in Django 4.0 https://code.djangoproject.com/ticket/32446
-DATABASES["default"]["TEST"] = {"SERIALIZE": False}
+DATABASES["default"]["TEST"] = {"SERIALIZE": False}  # type: ignore

--- a/hat/settings_test.py
+++ b/hat/settings_test.py
@@ -1,0 +1,7 @@
+from .settings import *  # noqa: F401,F403
+
+# Disable Database Serialization to speed up tests (Django < 4.0).
+# Django serializes the whole database into a SQL string at the start of a test run, which can take a few seconds.
+# https://docs.djangoproject.com/en/3.2/topics/testing/overview/#test-case-serialized-rollback
+# Fixed in Django 4.0 https://code.djangoproject.com/ticket/32446
+DATABASES["default"]["TEST"] = {"SERIALIZE": False}

--- a/iaso/api/bulk_create_users.py
+++ b/iaso/api/bulk_create_users.py
@@ -19,7 +19,7 @@ from iaso.models import BulkCreateUserCsvFile, Profile, OrgUnit, UserRole, Proje
 from hat.menupermissions import models as permission
 
 
-COLUMNS_LIST = [
+BULK_CREATE_USER_COLUMNS_LIST = [
     "username",
     "password",
     "email",
@@ -148,8 +148,8 @@ class BulkCreateUserFromCsvViewSet(ModelViewSet):
             orgunits_hierarchy = OrgUnit.objects.hierarchy(user_access_ou)
 
             for i, row in enumerate(reader):
-                if i > 0 and not set(COLUMNS_LIST).issubset(csv_indexes):
-                    missing_elements = set(COLUMNS_LIST) - set(csv_indexes)
+                if i > 0 and not set(BULK_CREATE_USER_COLUMNS_LIST).issubset(csv_indexes):
+                    missing_elements = set(BULK_CREATE_USER_COLUMNS_LIST) - set(csv_indexes)
                     raise serializers.ValidationError(
                         {
                             "error": f"Something is wrong with your CSV File. Possibly missing {missing_elements} column(s)."

--- a/iaso/api/bulk_create_users.py
+++ b/iaso/api/bulk_create_users.py
@@ -19,6 +19,21 @@ from iaso.models import BulkCreateUserCsvFile, Profile, OrgUnit, UserRole, Proje
 from hat.menupermissions import models as permission
 
 
+COLUMNS_LIST = [
+    "username",
+    "password",
+    "email",
+    "first_name",
+    "last_name",
+    "orgunit",
+    "profile_language",
+    "dhis2_id",
+    "permissions",
+    "user_roles",
+    "projects",
+]
+
+
 class BulkCreateUserSerializer(serializers.ModelSerializer):
     class Meta:
         model = BulkCreateUserCsvFile
@@ -90,19 +105,6 @@ class BulkCreateUserFromCsvViewSet(ModelViewSet):
     @transaction.atomic
     def create(self, request, *args, **kwargs):
         user_created_count = 0
-        columns_list = [
-            "username",
-            "password",
-            "email",
-            "first_name",
-            "last_name",
-            "orgunit",
-            "profile_language",
-            "dhis2_id",
-            "permissions",
-            "user_roles",
-            "projects",
-        ]
         if request.FILES:
             user_access_ou = OrgUnit.objects.filter_for_user_and_app_id(request.user, None)
 
@@ -146,8 +148,8 @@ class BulkCreateUserFromCsvViewSet(ModelViewSet):
             orgunits_hierarchy = OrgUnit.objects.hierarchy(user_access_ou)
 
             for i, row in enumerate(reader):
-                if i > 0 and not set(columns_list).issubset(csv_indexes):
-                    missing_elements = set(columns_list) - set(csv_indexes)
+                if i > 0 and not set(COLUMNS_LIST).issubset(csv_indexes):
+                    missing_elements = set(COLUMNS_LIST) - set(csv_indexes)
                     raise serializers.ValidationError(
                         {
                             "error": f"Something is wrong with your CSV File. Possibly missing {missing_elements} column(s)."

--- a/iaso/api/profiles.py
+++ b/iaso/api/profiles.py
@@ -22,7 +22,7 @@ from typing import Any, List, Optional, Union
 from hat.api.export_utils import Echo, iter_items, generate_xlsx
 from hat.menupermissions import models as permission
 from hat.menupermissions.models import CustomPermissionSupport
-from iaso.api.bulk_create_users import COLUMNS_LIST
+from iaso.api.bulk_create_users import BULK_CREATE_USER_COLUMNS_LIST
 from iaso.api.common import FileFormatEnum, CONTENT_TYPE_CSV, CONTENT_TYPE_XLSX
 from iaso.models import Profile, OrgUnit, UserRole, Project
 
@@ -270,7 +270,7 @@ class ProfilesViewSet(viewsets.ViewSet):
     def list_export(
         queryset: "QuerySet[Profile]", file_format: FileFormatEnum
     ) -> Union[HttpResponse, StreamingHttpResponse]:
-        columns = [{"title": column} for column in COLUMNS_LIST]
+        columns = [{"title": column} for column in BULK_CREATE_USER_COLUMNS_LIST]
 
         def get_row(profile: Profile, **_) -> List[Any]:
             return [
@@ -279,12 +279,12 @@ class ProfilesViewSet(viewsets.ViewSet):
                 profile.user.email,
                 profile.user.first_name,
                 profile.user.last_name,
-                ",".join(str(item.pk) for item in profile.org_units.all()),
+                ",".join(str(item.pk) for item in profile.org_units.all().order_by("id")),
                 profile.language,
                 profile.dhis2_id,
                 ",".join(item.codename for item in profile.user.user_permissions.all()),
-                ",".join(str(item.pk) for item in profile.user_roles.all()),
-                ",".join(str(item.pk) for item in profile.projects.all()),
+                ",".join(str(item.pk) for item in profile.user_roles.all().order_by("id")),
+                ",".join(str(item.pk) for item in profile.projects.all().order_by("id")),
             ]
 
         filename = "users"

--- a/iaso/api/profiles.py
+++ b/iaso/api/profiles.py
@@ -8,7 +8,7 @@ from django.contrib.sites.shortcuts import get_current_site
 from django.core.mail import send_mail
 from django.core.paginator import Paginator
 from django.db.models import Q, QuerySet
-from django.http import JsonResponse
+from django.http import HttpResponse, JsonResponse, StreamingHttpResponse
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
 from django.utils.encoding import force_bytes
@@ -17,11 +17,13 @@ from django.utils.translation import gettext as _
 from rest_framework import viewsets, permissions, status
 from rest_framework.exceptions import PermissionDenied, ValidationError
 from rest_framework.response import Response
-from typing import Optional, List
+from typing import Any, List, Optional, Union
 
-from iaso.models import Profile, OrgUnit, UserRole, Project
+from hat.api.export_utils import Echo, iter_items, generate_xlsx
 from hat.menupermissions import models as permission
 from hat.menupermissions.models import CustomPermissionSupport
+from iaso.api.common import FileFormatEnum, CONTENT_TYPE_CSV, CONTENT_TYPE_XLSX
+from iaso.models import Profile, OrgUnit, UserRole, Project
 
 PK_ME = "me"
 
@@ -238,6 +240,11 @@ class ProfilesViewSet(viewsets.ViewSet):
             ids=ids,
         )
 
+        if request.GET.get("csv"):
+            return self.list_export(queryset=queryset, file_format=FileFormatEnum.CSV)
+        if request.GET.get("xlsx"):
+            return self.list_export(queryset=queryset, file_format=FileFormatEnum.XLSX)
+
         if limit:
             queryset = queryset.order_by(*orders)
             limit = int(limit)
@@ -257,6 +264,59 @@ class ProfilesViewSet(viewsets.ViewSet):
             return Response(res)
         else:
             return Response({"profiles": [profile.as_short_dict() for profile in queryset]})
+
+    @staticmethod
+    def list_export(
+        queryset: "QuerySet[Profile]", file_format: FileFormatEnum
+    ) -> Union[HttpResponse, StreamingHttpResponse]:
+        columns = [
+            {"title": "username"},
+            {"title": "password"},
+            {"title": "email"},
+            {"title": "first_name"},
+            {"title": "last_name"},
+            {"title": "orgunit"},
+            {"title": "profile_language"},
+            {"title": "dhis2_id"},
+            {"title": "permissions"},
+            {"title": "user_roles"},
+            {"title": "projects"},
+        ]
+
+        def get_row(profile: Profile, **_) -> List[Any]:
+            return [
+                profile.user.username,
+                "",  # Password is left empty on purpose.
+                profile.user.email,
+                profile.user.first_name,
+                profile.user.last_name,
+                ",".join(str(item.pk) for item in profile.org_units.all()),
+                profile.language,
+                profile.dhis2_id,
+                ",".join(item.codename for item in profile.user.user_permissions.all()),
+                ",".join(str(item.pk) for item in profile.user_roles.all()),
+                ",".join(str(item.pk) for item in profile.projects.all()),
+            ]
+
+        filename = "users"
+        response: Union[HttpResponse, StreamingHttpResponse]
+
+        if file_format == FileFormatEnum.XLSX:
+            filename = filename + ".xlsx"
+            response = HttpResponse(
+                generate_xlsx("Users", columns, queryset, get_row),
+                content_type=CONTENT_TYPE_XLSX,
+            )
+        elif file_format == FileFormatEnum.CSV:
+            filename = f"{filename}.csv"
+            response = StreamingHttpResponse(
+                streaming_content=(iter_items(queryset, Echo(), columns, get_row)), content_type=CONTENT_TYPE_CSV
+            )
+        else:
+            raise ValueError(f"Unknown file format requested: {file_format}")
+
+        response["Content-Disposition"] = "attachment; filename=%s" % filename
+        return response
 
     def retrieve(self, request, *args, **kwargs):
         pk = kwargs.get("pk")

--- a/iaso/api/profiles.py
+++ b/iaso/api/profiles.py
@@ -22,6 +22,7 @@ from typing import Any, List, Optional, Union
 from hat.api.export_utils import Echo, iter_items, generate_xlsx
 from hat.menupermissions import models as permission
 from hat.menupermissions.models import CustomPermissionSupport
+from iaso.api.bulk_create_users import COLUMNS_LIST
 from iaso.api.common import FileFormatEnum, CONTENT_TYPE_CSV, CONTENT_TYPE_XLSX
 from iaso.models import Profile, OrgUnit, UserRole, Project
 
@@ -269,19 +270,7 @@ class ProfilesViewSet(viewsets.ViewSet):
     def list_export(
         queryset: "QuerySet[Profile]", file_format: FileFormatEnum
     ) -> Union[HttpResponse, StreamingHttpResponse]:
-        columns = [
-            {"title": "username"},
-            {"title": "password"},
-            {"title": "email"},
-            {"title": "first_name"},
-            {"title": "last_name"},
-            {"title": "orgunit"},
-            {"title": "profile_language"},
-            {"title": "dhis2_id"},
-            {"title": "permissions"},
-            {"title": "user_roles"},
-            {"title": "projects"},
-        ]
+        columns = [{"title": column} for column in COLUMNS_LIST]
 
         def get_row(profile: Profile, **_) -> List[Any]:
             return [

--- a/iaso/test.py
+++ b/iaso/test.py
@@ -41,6 +41,7 @@ class IasoTestCaseMixin:
 
         if language is not None:
             user.iaso_profile.language = language
+            user.iaso_profile.save()
 
         if projects is not None:
             user.iaso_profile.projects.set(projects)

--- a/iaso/tests/api/test_profiles.py
+++ b/iaso/tests/api/test_profiles.py
@@ -20,18 +20,6 @@ class ProfileAPITestCase(APITestCase):
     def setUpTestData(cls):
         cls.ghi = m.Account.objects.create(name="Global Health Initiative")
         cls.another_account = m.Account.objects.create(name="Another account")
-        cls.jane = cls.create_user_with_profile(username="janedoe", account=cls.ghi, permissions=[permission._FORMS])
-        cls.john = cls.create_user_with_profile(username="johndoe", account=cls.ghi, is_superuser=True)
-        cls.jim = cls.create_user_with_profile(
-            username="jim", account=cls.ghi, permissions=[permission._FORMS, permission._USERS_ADMIN]
-        )
-        cls.jam = cls.create_user_with_profile(
-            username="jam",
-            account=cls.ghi,
-            permissions=[permission._USERS_MANAGED],
-        )
-        cls.jom = cls.create_user_with_profile(username="jom", account=cls.ghi, permissions=[])
-        cls.jum = cls.create_user_with_profile(username="jum", account=cls.ghi, permissions=[])
 
         # TODO : make the org unit creations shorter and reusable
         cls.project = m.Project.objects.create(
@@ -104,6 +92,21 @@ class ProfileAPITestCase(APITestCase):
         cls.user_role_another_account = m.UserRole.objects.create(
             group=cls.group_another_account, account=cls.another_account
         )
+
+        # Users.
+        cls.jane = cls.create_user_with_profile(username="janedoe", account=cls.ghi, permissions=[permission._FORMS])
+        cls.john = cls.create_user_with_profile(username="johndoe", account=cls.ghi, is_superuser=True)
+        cls.jim = cls.create_user_with_profile(
+            username="jim", account=cls.ghi, permissions=[permission._FORMS, permission._USERS_ADMIN]
+        )
+        cls.jam = cls.create_user_with_profile(
+            username="jam",
+            account=cls.ghi,
+            permissions=[permission._USERS_MANAGED],
+            language="en",
+        )
+        cls.jom = cls.create_user_with_profile(username="jom", account=cls.ghi, permissions=[], language="fr")
+        cls.jum = cls.create_user_with_profile(username="jum", account=cls.ghi, permissions=[], projects=[cls.project])
 
     def test_can_delete_dhis2_id(self):
         self.client.force_authenticate(self.john)
@@ -188,6 +191,8 @@ class ProfileAPITestCase(APITestCase):
         self.assertValidProfileListData(response.json(), 6)
 
     def test_profile_list_export_as_csv(self):
+        self.john.iaso_profile.org_units.set([self.jedi_squad_1, self.jedi_council_corruscant])
+
         self.client.force_authenticate(self.jane)
         response = self.client.get("/api/profiles/?csv=true")
         self.assertEqual(response.status_code, 200)
@@ -209,15 +214,17 @@ class ProfileAPITestCase(APITestCase):
             "projects\r\n"
         )
         expected_csv += "janedoe,,,,,,,,iaso_forms,,\r\n"
-        expected_csv += "johndoe,,,,,,,,,,\r\n"
+        expected_csv += f'johndoe,,,,,"{self.jedi_squad_1.pk},{self.jedi_council_corruscant.pk}",,,,,\r\n'
         expected_csv += 'jim,,,,,,,,"iaso_forms,iaso_users",,\r\n'
-        expected_csv += "jam,,,,,,,,iaso_users_managed,,\r\n"
-        expected_csv += "jom,,,,,,,,,,\r\n"
-        expected_csv += "jum,,,,,,,,,,\r\n"
+        expected_csv += "jam,,,,,,en,,iaso_users_managed,,\r\n"
+        expected_csv += "jom,,,,,,fr,,,,\r\n"
+        expected_csv += f"jum,,,,,,,,,,{self.project.id}\r\n"
 
         self.assertEqual(response_csv, expected_csv)
 
     def test_profile_list_export_as_xlsx(self):
+        self.john.iaso_profile.org_units.set([self.jedi_squad_1, self.jedi_council_corruscant])
+
         self.client.force_authenticate(self.jane)
         response = self.client.get("/api/profiles/?xlsx=true")
         self.assertEqual(response.status_code, 200)
@@ -252,8 +259,15 @@ class ProfileAPITestCase(APITestCase):
                 "email": {0: None, 1: None, 2: None, 3: None, 4: None, 5: None},
                 "first_name": {0: None, 1: None, 2: None, 3: None, 4: None, 5: None},
                 "last_name": {0: None, 1: None, 2: None, 3: None, 4: None, 5: None},
-                "orgunit": {0: None, 1: None, 2: None, 3: None, 4: None, 5: None},
-                "profile_language": {0: None, 1: None, 2: None, 3: None, 4: None, 5: None},
+                "orgunit": {
+                    0: None,
+                    1: f"{self.jedi_squad_1.pk},{self.jedi_council_corruscant.pk}",
+                    2: None,
+                    3: None,
+                    4: None,
+                    5: None,
+                },
+                "profile_language": {0: None, 1: None, 2: None, 3: "en", 4: "fr", 5: None},
                 "dhis2_id": {0: None, 1: None, 2: None, 3: None, 4: None, 5: None},
                 "permissions": {
                     0: "iaso_forms",
@@ -264,7 +278,7 @@ class ProfileAPITestCase(APITestCase):
                     5: None,
                 },
                 "user_roles": {0: None, 1: None, 2: None, 3: None, 4: None, 5: None},
-                "projects": {0: None, 1: None, 2: None, 3: None, 4: None, 5: None},
+                "projects": {0: None, 1: None, 2: None, 3: None, 4: None, 5: self.project.id},
             },
         )
 


### PR DESCRIPTION
Make list of users downloadable.

Related JIRA tickets : [IA-2364](https://bluesquare.atlassian.net/browse/IA-2364)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented (***hopefully yes***)
- [x] Are there enough tests
- [x] Documentation has been included (for new feature)

## Changes

The main addition here is to make the list of users downloadable in CSV or XSLX.

I made minor changes to speed up the unit tests locally:

- a custom setting file for tests located at `hat/settings_test.py`
- a new Makefile with a few shortcuts to launch tests

Please let me know if you're OK with that.

## How to test

Explain how to test your PR.
If a specific config is required explain it here (dataset, account, profile, ...)

## Print screen / video

![screenshot](https://github.com/BLSQ/iaso/assets/281139/e2e35a5b-e712-4d23-9e81-7d82b1e78646)



[IA-2364]: https://bluesquare.atlassian.net/browse/IA-2364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ