### PR TITLE
IA-2403: Completeness stats export CSV

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/completenessStats/hooks/api/useGetCompletnessStats.ts
+++ b/hat/assets/js/apps/Iaso/domains/completenessStats/hooks/api/useGetCompletnessStats.ts
@@ -14,9 +14,16 @@ const queryParamsMap = new Map([
 ]);
 
 const apiParamsKeys = ['order', 'page', 'limit', 'search', 'period'];
-const getParams = (params: CompletenessRouterParams) => {
+const getParams = (params: CompletenessRouterParams, forExport?: boolean) => {
     const { pageSize, ...urlParams } = params;
-    const apiParams = { ...urlParams, limit: pageSize ?? 10 };
+    const apiParams: Record<string, any> = {
+        ...urlParams,
+        limit: pageSize ?? 10,
+    };
+    if (forExport) {
+        apiParams.limit = undefined;
+        apiParams.page = undefined;
+    }
     const queryParams: Record<string, string> = {};
     apiParamsKeys.forEach(apiParamKey => {
         const apiParam = apiParams[apiParamKey];
@@ -36,8 +43,9 @@ const getParams = (params: CompletenessRouterParams) => {
 
 export const buildQueryString = (
     params: CompletenessRouterParams,
+    forExport?: boolean,
 ): URLSearchParams => {
-    const queryString = new URLSearchParams(getParams(params));
+    const queryString = new URLSearchParams(getParams(params, forExport));
     return queryString;
 };
 

--- a/hat/assets/js/apps/Iaso/domains/completenessStats/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/completenessStats/index.tsx
@@ -68,7 +68,8 @@ export const CompletenessStats: FunctionComponent<Props> = ({
         completenessStats,
     );
     const csvUrl = useMemo(
-        () => `/api/v2/completeness_stats.csv?${buildQueryString(params)}`,
+        () =>
+            `/api/v2/completeness_stats.csv?${buildQueryString(params, true)}`,
         [params],
     );
     const theme = useTheme();


### PR DESCRIPTION
Completeness stats export to csv is only exporting first page of pagination

Related JIRA tickets : IA-2403
## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

modify `csvUrl` to delete limit and page

## How to test
Go to Completeness stats page, drill down into the main org unit to have multiple results (more than the pagination) and click export. The CSV should contain all he org units


