### PR TITLE
IA-2379: Completeness stats: page crashes when trying to show parent of top org unit

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/completenessStats/utils.tsx
+++ b/hat/assets/js/apps/Iaso/domains/completenessStats/utils.tsx
@@ -4,7 +4,7 @@ import { genUrl } from '../../routing/routing';
 export const usetGetParentPageUrl = (router: Router) => {
     return (parentOrgUnitId?: number | string): string =>
         genUrl(router, {
-            parentId: `${parentOrgUnitId}`,
+            parentId: parentOrgUnitId ? `${parentOrgUnitId}` : undefined,
             page: null,
         });
 };


### PR DESCRIPTION
When “Digging down” the table then back up, the button to show parent is still shown when the top org unit is reached. This results in undefined being passed as org unit id to the API, which crashes  the page.

Probably related: on the map, there seems to be an edge case where the map wrongly remove the button to show parent

Related JIRA tickets : IA-2379

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

`undefined` was added as a string

## How to test

Open completeness stats, select a form. Drill down and up in the health pyramid

## Print screen / video


https://github.com/BLSQ/iaso/assets/12494624/fa10e817-c7d4-4d4c-804c-0f62da75bc41


