### PR TITLE
Polio 1164 add endpoint for lqas round data

### DIFF
--- a/plugins/polio/api.py
+++ b/plugins/polio/api.py
@@ -516,10 +516,14 @@ Timeline tracker Automated message
         log_campaign_modification(campaign, old_campaign_dump, request_user)
 
         return Response({"message": "email sent"})
+
     # We need to authorize PATCH request to enable restore_deleted_campaign endpoint
     # But Patching the campign directly is very much error prone, so we disable it indirectly
     def partial_update(self):
-        """Don't PATCH this way, it won't do anything"""
+        """Don't PATCH this way, it won't do anything
+        We need to authorize PATCH request to enable restore_deleted_campaign endpoint
+        But Patching the campign directly is very much error prone, so we disable it indirectly
+        """
         pass
 
     @action(methods=["PATCH"], detail=False)
@@ -2099,9 +2103,10 @@ class RoundViewset(ModelViewSet):
     serializer_class = RoundSerializer
     model = Round
 
-    # Overriding to prevent patching the whole round which is error prone, due to nested fields among others.
     def partial_update(self):
-        """Don't PATCH this way, it will not do anything"""
+        """Don't PATCH this way, it will not do anything
+        Overriding to prevent patching the whole round which is error prone, due to nested fields among others.
+        """
         pass
 
     # Endpoint used to update lqas passed and failed fields by OpenHexa pipeline

--- a/plugins/polio/api.py
+++ b/plugins/polio/api.py
@@ -2099,7 +2099,7 @@ class CountriesWithLqasIMConfigViewSet(ModelViewSet):
 class RoundViewset(ModelViewSet):
     # Patch should be in the list to allow updatelqasfields to work
     http_method_names = ["patch"]
-    permission_classes = [HasPermission(permission.POLIO), HasPermission(permission.POLIO_CONFIG)]
+    permission_classes = [HasPermission(permission.POLIO, permission.POLIO_CONFIG)]  # type: ignore
     serializer_class = RoundSerializer
     model = Round
 

--- a/plugins/polio/api.py
+++ b/plugins/polio/api.py
@@ -516,6 +516,11 @@ Timeline tracker Automated message
         log_campaign_modification(campaign, old_campaign_dump, request_user)
 
         return Response({"message": "email sent"})
+    # We need to authorize PATCH request to enable restore_deleted_campaign endpoint
+    # But Patching the campign directly is very much error prone, so we disable it indirectly
+    def partial_update(self):
+        """Don't PATCH this way, it won't do anything"""
+        pass
 
     @action(methods=["PATCH"], detail=False)
     def restore_deleted_campaigns(self, request):

--- a/plugins/polio/serializers.py
+++ b/plugins/polio/serializers.py
@@ -1238,3 +1238,16 @@ class ConfigSerializer(serializers.ModelSerializer):
 
     data = serializers.JSONField(source="content")  # type: ignore
     key = serializers.CharField(source="slug")
+
+
+class LqasDistrictsUpdateSerializer(serializers.Serializer):
+    number = serializers.IntegerField(required=True)
+    lqas_district_failing = serializers.IntegerField(required=True)
+    lqas_district_passing = serializers.IntegerField(required=True)
+    obr_name = serializers.CharField(required=True)
+
+    def update(self, instance, validated_data):
+        instance.lqas_district_passing = validated_data["lqas_district_passing"]
+        instance.lqas_district_failing = validated_data["lqas_district_failing"]
+        instance.save()
+        return instance

--- a/plugins/polio/tests/test_api.py
+++ b/plugins/polio/tests/test_api.py
@@ -1,4 +1,5 @@
 from datetime import date
+from unittest import skip
 
 from django.contrib.auth.models import User, Permission
 from django.utils.timezone import now
@@ -302,6 +303,7 @@ class PolioAPITestCase(APITestCase):
         self.assertNotEqual(r["round_two"], None, r)
         self.assertEqual(r["round_two"]["started_at"], "2021-04-01", r)
 
+    @skip("Skipping as long as PATCH is disabled for campaigns")
     def test_patch_campaign(self):
         self.client.force_authenticate(self.yoda)
         self.assertEqual(Campaign.objects.count(), 0)
@@ -340,6 +342,7 @@ class PolioAPITestCase(APITestCase):
         self.assertEqual(campaign.rounds.get(number=1).lqas_district_failing, 100)
         self.assertEqual(campaign.rounds.get(number=1).lqas_district_passing, None)
 
+    @skip("Skipping as long as PATCH is disabled for campaigns")
     def test_patch_campaign_remove_round(self):
         self.client.force_authenticate(self.yoda)
         self.assertEqual(Campaign.objects.count(), 0)
@@ -375,6 +378,7 @@ class PolioAPITestCase(APITestCase):
         self.assertEqual(2, rounds.count())
         self.assertQuerysetEqual(rounds, [1, 2], lambda r: r.number)
 
+    @skip("Skipping as long as PATCH is disabled for campaigns")
     def test_patch_campaign_remove_all_rounds(self):
         self.client.force_authenticate(self.yoda)
         self.assertEqual(Campaign.objects.count(), 0)
@@ -545,6 +549,7 @@ class PolioAPITestCase(APITestCase):
             ],
         )
 
+    @skip("Skipping as long as PATCH is disabled for campaigns")
     def test_update_campaign_with_vaccine_data(self):
         self.client.force_authenticate(self.yoda)
         self.assertEqual(Campaign.objects.count(), 0)
@@ -768,9 +773,8 @@ class TeamAPITestCase(APITestCase):
         self.client.force_authenticate(self.user)
         self.assertEqual(self.user.is_superuser, False)
         self.user.user_permissions.add(Permission.objects.get(codename="iaso_polio"))
-
         payload = {"obr_name": "test2"}
-        response = self.client.patch(f"/api/polio/campaigns/{self.c.id}/", payload, format="json")
+        response = self.client.put(f"/api/polio/campaigns/{self.c.id}/", payload, format="json")
         self.assertJSONResponse(response, 200)
 
         self.assertEqual(Modification.objects.count(), 1)

--- a/plugins/polio/tests/test_api.py
+++ b/plugins/polio/tests/test_api.py
@@ -318,8 +318,8 @@ class PolioAPITestCase(APITestCase):
                 {
                     "number": 1,
                     "started_at": "2021-02-01",
-                    "lqas_district_failing":100
-                    # Removed that line to test that empty field in payload 
+                    "lqas_district_failing": 100
+                    # Removed that line to test that empty field in payload
                     # will not overwrite existing field in DB
                     # "ended_at": "2021-02-20",
                 },
@@ -335,10 +335,10 @@ class PolioAPITestCase(APITestCase):
         campaign.refresh_from_db()
         self.assertEqual(campaign.obr_name, "obr_name2")
         self.assertEqual(campaign.rounds.count(), 2, campaign.rounds)
-        self.assertEqual(campaign.rounds.get(number=1).number,1)
-        self.assertEqual(campaign.rounds.get(number=1).ended_at,date(2021, 1, 20))
-        self.assertEqual(campaign.rounds.get(number=1).lqas_district_failing,100)
-        self.assertEqual(campaign.rounds.get(number=1).lqas_district_passing,None)
+        self.assertEqual(campaign.rounds.get(number=1).number, 1)
+        self.assertEqual(campaign.rounds.get(number=1).ended_at, date(2021, 1, 20))
+        self.assertEqual(campaign.rounds.get(number=1).lqas_district_failing, 100)
+        self.assertEqual(campaign.rounds.get(number=1).lqas_district_passing, None)
 
     def test_patch_campaign_remove_round(self):
         self.client.force_authenticate(self.yoda)

--- a/plugins/polio/tests/test_api.py
+++ b/plugins/polio/tests/test_api.py
@@ -318,7 +318,10 @@ class PolioAPITestCase(APITestCase):
                 {
                     "number": 1,
                     "started_at": "2021-02-01",
-                    "ended_at": "2021-02-20",
+                    "lqas_district_failing":100
+                    # Removed that line to test that empty field in payload 
+                    # will not overwrite existing field in DB
+                    # "ended_at": "2021-02-20",
                 },
                 {
                     "number": 2,
@@ -332,6 +335,10 @@ class PolioAPITestCase(APITestCase):
         campaign.refresh_from_db()
         self.assertEqual(campaign.obr_name, "obr_name2")
         self.assertEqual(campaign.rounds.count(), 2, campaign.rounds)
+        self.assertEqual(campaign.rounds.get(number=1).number,1)
+        self.assertEqual(campaign.rounds.get(number=1).ended_at,date(2021, 1, 20))
+        self.assertEqual(campaign.rounds.get(number=1).lqas_district_failing,100)
+        self.assertEqual(campaign.rounds.get(number=1).lqas_district_passing,None)
 
     def test_patch_campaign_remove_round(self):
         self.client.force_authenticate(self.yoda)

--- a/plugins/polio/tests/test_base.py
+++ b/plugins/polio/tests/test_base.py
@@ -1,7 +1,7 @@
 import datetime
 import json
 from typing import List
-from unittest import mock
+from unittest import mock, skip
 from unittest.mock import patch
 
 import jwt  # type: ignore
@@ -139,6 +139,7 @@ class PolioAPITestCase(APITestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.json()), 1)
 
+    @skip("Skipping as long as PATCH is disabled for campaigns")
     def test_add_group_to_existing_campaign_without_group(self):
         """
         Ensure a group will be created when updating an existing campaign without a group


### PR DESCRIPTION
OpenHexa pipeline needed an endpoint to safely PATCH lqas districts passed and failed to round in DB.

Related JIRA tickets : POLIO-1164

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- Add `RoundViewSet` and  `api/polio/rounds` endpoint. It's only used for the custom PATCH request for now.
- Add `updatelqasfields` method to `RoundViewset`. It takes the round number, campaign obr_name and the values of the lqas fields to update.
- Override `partial_update` method in `CampaignViewSet` to prevent unsafe updates.

## How to test

Go to polio> Campaigns
Choose and obr_name
Go to `/swagger` and find `/api/polio/rounds/updatelqasfields`
Click try it out
Fill in all fields and send the request

## Print screen / video

https://github.com/BLSQ/iaso/assets/38907762/ea75d61b-58e0-4927-b52d-3772d0f1fe44


## Notes

Requires https://github.com/BLSQ/iaso-pipelines/pull/10 to be merged and run as pipeline in OpenHexa
