### PR TITLE
IA-2410 Add a `Project` filter on forms page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,3 +16,14 @@ drop-test-db:
 
 dbshell:
 	docker-compose exec iaso ./manage.py dbshell
+
+# Django.
+# =============================================================================
+
+.PHONY: django_admin
+
+# make django_admin
+# make django_admin COMMAND=shell_plus
+# make django_admin COMMAND=createsuperuser
+django_admin:
+	docker-compose exec -ti iaso ./manage.py $(COMMAND)

--- a/hat/assets/js/apps/Iaso/constants/routes.js
+++ b/hat/assets/js/apps/Iaso/constants/routes.js
@@ -103,6 +103,10 @@ export const formsPath = {
             isRequired: false,
             key: 'planning',
         },
+        {
+            isRequired: false,
+            key: 'projectsIds',
+        },
     ],
     component: props => <Forms {...props} />,
     isRootUrl: true,

--- a/hat/assets/js/apps/Iaso/domains/forms/components/Filters.tsx
+++ b/hat/assets/js/apps/Iaso/domains/forms/components/Filters.tsx
@@ -69,7 +69,18 @@ const Filters: FunctionComponent<Props> = ({ params }) => {
                         onEnterPressed={handleSearch}
                         onErrorChange={setTextSearchError}
                     />
+                    <InputComponent
+                        keyValue="showDeleted"
+                        onChange={(_key, value) => {
+                            handleChange('showDeleted', !showDeleted);
+                            setShowDeleted(value);
+                        }}
+                        value={showDeleted}
+                        type="checkbox"
+                        label={MESSAGES.showDeleted}
+                    />
                 </Grid>
+
                 <Grid item xs={12} md={3}>
                     <InputComponent
                         type="select"
@@ -95,8 +106,8 @@ const Filters: FunctionComponent<Props> = ({ params }) => {
                         multi
                     />
                 </Grid>
-                <Grid container item xs={12} md={12} justifyContent="flex-end">
-                    <Box mt={isLargeLayout ? 2 : 0}>
+                <Grid container item xs={12} md={3} justifyContent="flex-end">
+                    <Box mt={isLargeLayout ? 3 : 0}>
                         <Button
                             data-test="search-button"
                             disabled={
@@ -112,18 +123,6 @@ const Filters: FunctionComponent<Props> = ({ params }) => {
                             {formatMessage(MESSAGES.search)}
                         </Button>
                     </Box>
-                </Grid>
-                <Grid item xs={12} md={3}>
-                    <InputComponent
-                        keyValue="showDeleted"
-                        onChange={(_key, value) => {
-                            handleChange('showDeleted', !showDeleted);
-                            setShowDeleted(value);
-                        }}
-                        value={showDeleted}
-                        type="checkbox"
-                        label={MESSAGES.showDeleted}
-                    />
                 </Grid>
             </Grid>
         </>

--- a/hat/assets/js/apps/Iaso/domains/forms/components/Filters.tsx
+++ b/hat/assets/js/apps/Iaso/domains/forms/components/Filters.tsx
@@ -1,4 +1,4 @@
-import React, { useState, FunctionComponent, useEffect } from 'react';
+import React, { useState, FunctionComponent } from 'react';
 
 import {
     Grid,
@@ -19,6 +19,7 @@ import MESSAGES from '../messages';
 
 import { baseUrl } from '../config';
 import { useGetPlanningsOptions } from '../../plannings/hooks/requests/useGetPlannings';
+import { useGetProjectsDropdownOptions } from '../../projects/hooks/requests';
 
 const useStyles = makeStyles(theme => ({
     ...commonStyles(theme),
@@ -31,6 +32,7 @@ type Params = {
     search?: string;
     showDeleted?: string;
     planning?: string;
+    projectsIds?: string;
 };
 
 type Props = {
@@ -47,6 +49,8 @@ const Filters: FunctionComponent<Props> = ({ params }) => {
         filters.showDeleted === 'true',
     );
     const { data: planningsDropdownOptions } = useGetPlanningsOptions();
+    const { data: allProjects, isFetching: isFetchingProjects } =
+        useGetProjectsDropdownOptions();
 
     const theme = useTheme();
     const isLargeLayout = useMediaQuery(theme.breakpoints.up('md'));
@@ -66,7 +70,6 @@ const Filters: FunctionComponent<Props> = ({ params }) => {
                         onErrorChange={setTextSearchError}
                     />
                 </Grid>
-
                 <Grid item xs={12} md={3}>
                     <InputComponent
                         type="select"
@@ -78,15 +81,33 @@ const Filters: FunctionComponent<Props> = ({ params }) => {
                         options={planningsDropdownOptions}
                     />
                 </Grid>
-
-                <Grid
-                    item
-                    xs={12}
-                    md={6}
-                    container
-                    justifyContent="flex-end"
-                    alignItems="center"
-                >
+                <Grid item xs={12} md={3}>
+                    <InputComponent
+                        keyValue="projectsIds"
+                        onChange={handleChange}
+                        value={filters.projectsIds}
+                        type="select"
+                        options={allProjects}
+                        label={MESSAGES.projects}
+                        loading={isFetchingProjects}
+                        onEnterPressed={handleSearch}
+                        clearable
+                        multi
+                    />
+                </Grid>
+                <Grid item xs={12} md={3}>
+                    <InputComponent
+                        keyValue="showDeleted"
+                        onChange={(_key, value) => {
+                            handleChange('showDeleted', !showDeleted);
+                            setShowDeleted(value);
+                        }}
+                        value={showDeleted}
+                        type="checkbox"
+                        label={MESSAGES.showDeleted}
+                    />
+                </Grid>
+                <Grid container item xs={12} md={12} justifyContent="flex-end">
                     <Box mt={isLargeLayout ? 2 : 0}>
                         <Button
                             data-test="search-button"
@@ -103,20 +124,6 @@ const Filters: FunctionComponent<Props> = ({ params }) => {
                             {formatMessage(MESSAGES.search)}
                         </Button>
                     </Box>
-                </Grid>
-            </Grid>
-            <Grid container>
-                <Grid item xs={12}>
-                    <InputComponent
-                        keyValue="showDeleted"
-                        onChange={(key, value) => {
-                            handleChange('showDeleted', !showDeleted);
-                            setShowDeleted(value);
-                        }}
-                        value={showDeleted}
-                        type="checkbox"
-                        label={MESSAGES.showDeleted}
-                    />
                 </Grid>
             </Grid>
         </>

--- a/hat/assets/js/apps/Iaso/domains/forms/components/Filters.tsx
+++ b/hat/assets/js/apps/Iaso/domains/forms/components/Filters.tsx
@@ -95,18 +95,6 @@ const Filters: FunctionComponent<Props> = ({ params }) => {
                         multi
                     />
                 </Grid>
-                <Grid item xs={12} md={3}>
-                    <InputComponent
-                        keyValue="showDeleted"
-                        onChange={(_key, value) => {
-                            handleChange('showDeleted', !showDeleted);
-                            setShowDeleted(value);
-                        }}
-                        value={showDeleted}
-                        type="checkbox"
-                        label={MESSAGES.showDeleted}
-                    />
-                </Grid>
                 <Grid container item xs={12} md={12} justifyContent="flex-end">
                     <Box mt={isLargeLayout ? 2 : 0}>
                         <Button
@@ -124,6 +112,18 @@ const Filters: FunctionComponent<Props> = ({ params }) => {
                             {formatMessage(MESSAGES.search)}
                         </Button>
                     </Box>
+                </Grid>
+                <Grid item xs={12} md={3}>
+                    <InputComponent
+                        keyValue="showDeleted"
+                        onChange={(_key, value) => {
+                            handleChange('showDeleted', !showDeleted);
+                            setShowDeleted(value);
+                        }}
+                        value={showDeleted}
+                        type="checkbox"
+                        label={MESSAGES.showDeleted}
+                    />
                 </Grid>
             </Grid>
         </>

--- a/hat/assets/js/cypress/integration/02 - forms/list.spec.js
+++ b/hat/assets/js/cypress/integration/02 - forms/list.spec.js
@@ -225,7 +225,6 @@ describe('Forms', () => {
                 }).as('getFormSearch');
 
                 cy.get('#search-search').type(search);
-                // cy.fillSingleSelect('#planning', 1);
                 cy.fillMultiSelect('#projectsIds', [0, 1], false);
                 cy.get('#check-box-showDeleted').check();
 

--- a/iaso/api/forms.py
+++ b/iaso/api/forms.py
@@ -230,6 +230,10 @@ class FormsViewSet(ModelViewSet):
         if planning_ids:
             queryset = queryset.filter(plannings__id__in=planning_ids.split(","))
 
+        projects_ids = self.request.query_params.get("projectsIds")
+        if projects_ids:
+            queryset = queryset.filter(projects__id__in=projects_ids.split(","))
+
         queryset = queryset.annotate(instance_updated_at=Max("instances__updated_at"))
 
         if not self.request.user.is_anonymous:

--- a/iaso/tests/api/test_forms.py
+++ b/iaso/tests/api/test_forms.py
@@ -27,7 +27,6 @@ class FormsAPITestCase(APITestCase):
         cls.project_1 = m.Project.objects.create(
             name="Hydroponic gardens", app_id="stars.empire.agriculture.hydroponics", account=star_wars
         )
-
         cls.project_2 = m.Project.objects.create(
             name="New Land Speeder concept", app_id="stars.empire.agriculture.land_speeder", account=star_wars
         )
@@ -83,6 +82,23 @@ class FormsAPITestCase(APITestCase):
         response = self.client.get("/api/forms/", headers={"Content-Type": "application/json"})
         self.assertJSONResponse(response, 200)
         self.assertValidFormListData(response.json(), 2)
+
+    def test_forms_list_filtered_by_project(self):
+        """GET /forms/ filtered by project"""
+        self.client.force_authenticate(self.yoda)
+        # Filter by project 1 and 2.
+        response = self.client.get(
+            f"/api/forms/?projectsIds={self.project_1.pk}&{self.project_2.pk}",
+            headers={"Content-Type": "application/json"},
+        )
+        self.assertJSONResponse(response, 200)
+        self.assertValidFormListData(response.json(), 2)
+        # Filter by project 2 only.
+        response = self.client.get(
+            f"/api/forms/?projectsIds={self.project_2.pk}", headers={"Content-Type": "application/json"}
+        )
+        self.assertJSONResponse(response, 200)
+        self.assertValidFormListData(response.json(), 0)
 
     def test_form_return_only_deleted(self):
         """GET /forms/ return only deleted forms"""


### PR DESCRIPTION
Add a `Project` filter on forms page.

Related JIRA tickets : [IA-2410](https://bluesquare.atlassian.net/browse/IA-2410)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are my typescript files well typed
- [x] Are there enough tests

## Changes

- front-end
    - add a new multi select input to filter by `projects`
    - ~~small UI revamp to realign buttons~~
- back-end
    - filter queryset by `projects` in `FormsViewSet` when required

## How to test

N/A

## Print screen / video

![ui](https://github.com/BLSQ/iaso/assets/281139/01b8545b-dd0f-4244-8fe0-a801d2d72336)

## Notes

N/A

[IA-2410]: https://bluesquare.atlassian.net/browse/IA-2410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ