### PR TITLE
Add a `OrgUnitType` filter on forms page

### DIFF
--- a/hat/assets/js/apps/Iaso/constants/routes.js
+++ b/hat/assets/js/apps/Iaso/constants/routes.js
@@ -105,6 +105,10 @@ export const formsPath = {
         },
         {
             isRequired: false,
+            key: 'orgUnitTypeIds',
+        },
+        {
+            isRequired: false,
             key: 'projectsIds',
         },
     ],

--- a/hat/assets/js/apps/Iaso/domains/forms/components/Filters.tsx
+++ b/hat/assets/js/apps/Iaso/domains/forms/components/Filters.tsx
@@ -20,6 +20,7 @@ import MESSAGES from '../messages';
 import { baseUrl } from '../config';
 import { useGetPlanningsOptions } from '../../plannings/hooks/requests/useGetPlannings';
 import { useGetProjectsDropdownOptions } from '../../projects/hooks/requests';
+import { useGetOrgUnitTypes } from '../../orgUnits/hooks/requests/useGetOrgUnitTypes';
 
 const useStyles = makeStyles(theme => ({
     ...commonStyles(theme),
@@ -49,6 +50,8 @@ const Filters: FunctionComponent<Props> = ({ params }) => {
         filters.showDeleted === 'true',
     );
     const { data: planningsDropdownOptions } = useGetPlanningsOptions();
+    const { data: orgUnitTypes, isFetching: isFetchingOuTypes } =
+        useGetOrgUnitTypes();
     const { data: allProjects, isFetching: isFetchingProjects } =
         useGetProjectsDropdownOptions();
 
@@ -90,6 +93,18 @@ const Filters: FunctionComponent<Props> = ({ params }) => {
                         value={filters.planning}
                         label={MESSAGES.planning}
                         options={planningsDropdownOptions}
+                    />
+                </Grid>
+                <Grid item xs={12} md={3}>
+                    <InputComponent
+                        type="select"
+                        onChange={handleChange}
+                        keyValue="orgUnitTypeIds"
+                        multi
+                        label={MESSAGES.orgUnitsTypes}
+                        value={filters.orgUnitTypeIds}
+                        loading={isFetchingOuTypes}
+                        options={orgUnitTypes ?? []}
                     />
                 </Grid>
                 <Grid item xs={12} md={3}>

--- a/hat/assets/js/apps/Iaso/domains/forms/components/Filters.tsx
+++ b/hat/assets/js/apps/Iaso/domains/forms/components/Filters.tsx
@@ -121,7 +121,7 @@ const Filters: FunctionComponent<Props> = ({ params }) => {
                         multi
                     />
                 </Grid>
-                <Grid container item xs={12} md={3} justifyContent="flex-end">
+                <Grid container item xs={12} md={12} justifyContent="flex-end">
                     <Box mt={isLargeLayout ? 3 : 0}>
                         <Button
                             data-test="search-button"

--- a/hat/assets/js/cypress/integration/02 - forms/list.spec.js
+++ b/hat/assets/js/cypress/integration/02 - forms/list.spec.js
@@ -225,6 +225,7 @@ describe('Forms', () => {
                 }).as('getFormSearch');
 
                 cy.get('#search-search').type(search);
+                cy.fillMultiSelect('#orgUnitTypeIds', [0, 1], false);
                 cy.fillMultiSelect('#projectsIds', [0, 1], false);
                 cy.get('#check-box-showDeleted').check();
 
@@ -236,6 +237,7 @@ describe('Forms', () => {
                         all: 'true',
                         limit: '50',
                         order: 'instance_updated_at',
+                        orgUnitTypeIds: '47,11',
                         page: '1',
                         projectsIds: '1,2',
                         search: 'ZELDA',

--- a/iaso/api/forms.py
+++ b/iaso/api/forms.py
@@ -8,19 +8,17 @@ from django.http import StreamingHttpResponse, HttpResponse
 from django.utils.dateparse import parse_date
 from rest_framework import serializers, permissions, status
 from rest_framework.decorators import action
-from rest_framework.exceptions import ParseError, NotFound
 from rest_framework.generics import get_object_or_404
 from rest_framework.request import Request
 
 from hat.api.export_utils import Echo, generate_xlsx, iter_items
 from hat.audit.models import log_modification, FORM_API
+from hat.menupermissions import models as permission
 from iaso.models import Form, Project, OrgUnitType, OrgUnit, FormPredefinedFilter
 from iaso.utils import timestamp_to_datetime
 from .common import ModelViewSet, TimestampField, DynamicFieldsModelSerializer, CONTENT_TYPE_XLSX, CONTENT_TYPE_CSV
 from .enketo import public_url_for_enketo
 from .projects import ProjectSerializer
-from .query_params import APP_ID
-from hat.menupermissions import models as permission
 
 
 class HasFormPermission(permissions.BasePermission):
@@ -229,6 +227,10 @@ class FormsViewSet(ModelViewSet):
         planning_ids = self.request.query_params.get("planning", None)
         if planning_ids:
             queryset = queryset.filter(plannings__id__in=planning_ids.split(","))
+
+        org_unit_type_ids = self.request.query_params.get("orgUnitTypeIds")
+        if org_unit_type_ids:
+            queryset = queryset.filter(org_unit_types__id__in=org_unit_type_ids.split(","))
 
         projects_ids = self.request.query_params.get("projectsIds")
         if projects_ids:

--- a/iaso/tests/api/test_forms.py
+++ b/iaso/tests/api/test_forms.py
@@ -83,6 +83,23 @@ class FormsAPITestCase(APITestCase):
         self.assertJSONResponse(response, 200)
         self.assertValidFormListData(response.json(), 2)
 
+    def test_forms_list_filtered_by_org_unit_type(self):
+        self.client.force_authenticate(self.yoda)
+        # Filter by org_unit type `jedi_council` and `jedi_academy`.
+        response = self.client.get(
+            f"/api/forms/?orgUnitTypeIds={self.jedi_council.pk}&{self.jedi_academy.pk}",
+            headers={"Content-Type": "application/json"},
+        )
+        self.assertJSONResponse(response, 200)
+        self.assertValidFormListData(response.json(), 1)
+        # Filter by org_unit type `sith_guild`.
+        response = self.client.get(
+            f"/api/forms/?orgUnitTypeIds={self.sith_guild.pk}",
+            headers={"Content-Type": "application/json"},
+        )
+        self.assertJSONResponse(response, 200)
+        self.assertValidFormListData(response.json(), 0)
+
     def test_forms_list_filtered_by_project(self):
         """GET /forms/ filtered by project"""
         self.client.force_authenticate(self.yoda)


### PR DESCRIPTION
Add a `OrgUnitType` filter on forms page.

Related JIRA tickets : [IA-2409](https://bluesquare.atlassian.net/browse/IA-2409)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are my typescript files well typed
- [x] Are there enough tests

## Changes

- front-end
    - add a new multi select input to filter by `OrgUnitType`
- back-end
    - filter queryset by `projects` in `OrgUnitType` when required

## How to test

N/A

## Print screen / video

![screen](https://github.com/BLSQ/iaso/assets/281139/5b19126f-6a1f-4d6b-b5c2-2335b51c274e)

## Notes

N/A

[IA-2409]: https://bluesquare.atlassian.net/browse/IA-2409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ