### PR TITLE
Security: upgrade to Django 3.2.21

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 # (Please update this notice if the required Python version changes.)
 
 # django
-django==3.2.15
+django==3.2.21
 django-cors-headers==3.2.1
 djangorestframework==3.11.2
 django-filter==2.4.0


### PR DESCRIPTION
Security: upgrade to Django 3.2.21

- [Django security releases issued: 4.2.5, 4.1.11, and 3.2.21](https://www.djangoproject.com/weblog/2023/sep/04/security-releases/)
- [Django 3.2.21 release notes](https://docs.djangoproject.com/en/dev/releases/3.2.21/)

Includes:

- [Django 3.2.20 release notes](https://docs.djangoproject.com/en/dev/releases/3.2.20/)
- [Django 3.2.19 release notes](https://docs.djangoproject.com/en/dev/releases/3.2.19/)
- [Django 3.2.18 release notes](https://docs.djangoproject.com/en/dev/releases/3.2.18/)
- [Django 3.2.17 release notes](https://docs.djangoproject.com/en/dev/releases/3.2.17/)
- [Django 3.2.16 release notes](https://docs.djangoproject.com/en/dev/releases/3.2.16/)