### PR TITLE
POLIO-1190 link to dashboard were missing from mail alert in nOPV2 vaccine authorization

### DIFF
--- a/plugins/polio/tasks/vaccine_authorizations_mail_alerts.py
+++ b/plugins/polio/tasks/vaccine_authorizations_mail_alerts.py
@@ -3,12 +3,15 @@ import datetime as dt
 from datetime import timedelta
 
 from django.contrib.auth.models import User
+from django.contrib.sites.models import Site
 from django.core.mail import send_mail
 from django.shortcuts import get_object_or_404
 
 from hat import settings
 from iaso.models import Team
 from plugins.polio.models import VaccineAuthorization
+
+vaccine_dashboard_link = f"{Site.objects.get_current()}/dashboard/polio/vaccinemodule/nopv2authorisation/accountId/1/order/-current_expiration_date/pageSize/20/page/1"
 
 
 def vaccine_authorizations_60_days_expiration_email_alert():
@@ -39,7 +42,7 @@ def vaccine_authorizations_60_days_expiration_email_alert():
                 {obj.country} nOPV2 vaccines authorization date will expire on {obj.expiration_date}.
                 A new authorization is {next_vaccine_auth}, with an expiry date on {next_vaccine_auth.expiration_date}.
                 Please take appropriate action as needed. 
-                Link to the platform vaccine authorization page
+                Link to the platform vaccine authorization page : {vaccine_dashboard_link}
                 RRT team
                 """,
                 settings.DEFAULT_FROM_EMAIL,
@@ -56,7 +59,7 @@ def vaccine_authorizations_60_days_expiration_email_alert():
                             {obj.country} nOPV2 vaccines authorization date will expire on {obj.expiration_date}.
                             No new authorization pending.
                             Please take appropriate action as needed. 
-                            Link to the platform vaccine authorization page
+                            Link to the platform vaccine authorization page : {vaccine_dashboard_link}
                             RRT team
                             """,
                 settings.DEFAULT_FROM_EMAIL,
@@ -96,7 +99,7 @@ def expired_vaccine_authorizations_email_alert():
                 {obj.country} nOPV2 vaccines authorization has expired expired on {obj.expiration_date}.
                 A new authorization is ongoing {next_vaccine_auth}, with an expiry date on {next_vaccine_auth.expiration_date}.
                 Please take appropriate action as needed. 
-                Link to the platform vaccine authorization page
+                Link to the platform vaccine authorization page : {vaccine_dashboard_link}
                 RRT team
                 """,
                 settings.DEFAULT_FROM_EMAIL,
@@ -112,7 +115,7 @@ def expired_vaccine_authorizations_email_alert():
                             {obj.country} nOPV2 vaccines authorization has expired on {obj.expiration_date}.
                             No new authorization pending.
                             Please take appropriate action as needed. 
-                            Link to the platform vaccine authorization page
+                            Link to the platform vaccine authorization page : {vaccine_dashboard_link}
                             RRT team
                             """,
                 settings.DEFAULT_FROM_EMAIL,

--- a/plugins/polio/tasks/vaccine_authorizations_mail_alerts.py
+++ b/plugins/polio/tasks/vaccine_authorizations_mail_alerts.py
@@ -11,14 +11,18 @@ from hat import settings
 from iaso.models import Team
 from plugins.polio.models import VaccineAuthorization
 
-vaccine_dashboard_link = f"{Site.objects.get_current()}/dashboard/polio/vaccinemodule/nopv2authorisation/accountId/1/order/-current_expiration_date/pageSize/20/page/1"
-
 
 def vaccine_authorizations_60_days_expiration_email_alert():
     future_date = dt.date.today() + timedelta(days=60)
     vaccine_auths = VaccineAuthorization.objects.filter(expiration_date=future_date)
 
     team = get_object_or_404(Team, name="nOPV2 vaccine authorization alerts")
+    vaccine_dashboard_link = (
+        f"{Site.objects.get_current()}/"
+        + "/dashboard/polio/vaccinemodule/nopv2authorisation/accountId/{0}/order/-current_expiration_date/pageSize/20/page/1".format(
+            team.project.account.id
+        )
+    )
 
     mailing_list = [user.email for user in User.objects.filter(pk__in=team.users.all())]
 
@@ -42,7 +46,7 @@ def vaccine_authorizations_60_days_expiration_email_alert():
                 {obj.country} nOPV2 vaccines authorization date will expire on {obj.expiration_date}.
                 A new authorization is {next_vaccine_auth}, with an expiry date on {next_vaccine_auth.expiration_date}.
                 Please take appropriate action as needed. 
-                Link to the platform vaccine authorization page : {vaccine_dashboard_link}
+                Link to the platform vaccine authorization page : {vaccine_dashboard_link} 
                 RRT team
                 """,
                 settings.DEFAULT_FROM_EMAIL,
@@ -59,7 +63,7 @@ def vaccine_authorizations_60_days_expiration_email_alert():
                             {obj.country} nOPV2 vaccines authorization date will expire on {obj.expiration_date}.
                             No new authorization pending.
                             Please take appropriate action as needed. 
-                            Link to the platform vaccine authorization page : {vaccine_dashboard_link}
+                            Link to the platform vaccine authorization page : {vaccine_dashboard_link} 
                             RRT team
                             """,
                 settings.DEFAULT_FROM_EMAIL,
@@ -76,6 +80,12 @@ def expired_vaccine_authorizations_email_alert():
     vaccine_auths = VaccineAuthorization.objects.filter(expiration_date=past_date)
 
     team = get_object_or_404(Team, name="nOPV2 vaccine authorization alerts")
+    vaccine_dashboard_link = (
+        f"{Site.objects.get_current()}/"
+        + "/dashboard/polio/vaccinemodule/nopv2authorisation/accountId/{0}/order/-current_expiration_date/pageSize/20/page/1".format(
+            team.project.account.id
+        )
+    )
 
     mailing_list = [user.email for user in User.objects.filter(pk__in=team.users.all())]
 
@@ -115,7 +125,7 @@ def expired_vaccine_authorizations_email_alert():
                             {obj.country} nOPV2 vaccines authorization has expired on {obj.expiration_date}.
                             No new authorization pending.
                             Please take appropriate action as needed. 
-                            Link to the platform vaccine authorization page : {vaccine_dashboard_link}
+                            Link to the platform vaccine authorization page : {vaccine_dashboard_link} 
                             RRT team
                             """,
                 settings.DEFAULT_FROM_EMAIL,

--- a/plugins/polio/tests/test_vaccine_authorizations.py
+++ b/plugins/polio/tests/test_vaccine_authorizations.py
@@ -510,12 +510,18 @@ class VaccineAuthorizationAPITestCase(APITestCase):
 
         response = expired_vaccine_authorizations_email_alert()
 
-        self.assertEqual(response, {"vacc_auth_mail_sent_to": ["XlfeeekfdpppZ@somemailzz.io"]})
+        page_url = f"example.com//dashboard/polio/vaccinemodule/nopv2authorisation/accountId/{team.project.account.id}/order/-current_expiration_date/pageSize/20/page/1"
+        url_is_correct = False
 
+        if page_url in mail.outbox[0].body:
+            url_is_correct = True
+
+        self.assertEqual(response, {"vacc_auth_mail_sent_to": ["XlfeeekfdpppZ@somemailzz.io"]})
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].subject, f"ALERT: Vaccine Authorization {past_vacc_auth} has expired.")
         self.assertEqual(mail.outbox[0].from_email, from_email)
         self.assertEqual(mail.outbox[0].to, ["XlfeeekfdpppZ@somemailzz.io"])
+        self.assertEqual(url_is_correct, True)
 
     def test_vaccine_authorization_update_expired_entries(self):
         expired_entry = VaccineAuthorization.objects.create(


### PR DESCRIPTION
The dashboard link to the platform was missing.

Related JIRA tickets : POLIO-1190

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

## How to test

Expired : 

Create a vacc auth expired since 1 day exactly. As it's a cron job the easiest way to try the function is to run a python shell in iaso and run expired_vaccine_authorizations_email_alert(). 

You should see in the console that the mail have been sent and the content
you need a team of users named nOPV2 vaccine authorization alerts in order to make it work.

To Expire : 

Create a vacc auth with an expiration day equal to today's date + 60 days.  As it's a cron job the easiest way to try the function is to run a python shell in iaso and run vaccine_authorizations_60_days_expiration_email_alert(). 

You should see in the console that the mail have been sent and the content
you need a team of users named nOPV2 vaccine authorization alerts in order to make it work.

