### PR TITLE
POLIO-1195: fix typo in API call

### DIFF
--- a/plugins/polio/js/src/hooks/useGetRegions.js
+++ b/plugins/polio/js/src/hooks/useGetRegions.js
@@ -9,7 +9,7 @@ export const useGetRegions = country => {
         orgUnitParentId: country,
         // FIXME this is not super safe as the ids can change from one account to the other
         // orgUnitTypeId: 6,
-        orgunitTypeCategory: 'REGION',
+        orgUnitTypeCategory: 'REGION',
     };
 
     const queryString = new URLSearchParams(params);


### PR DESCRIPTION
Loading time of API call to orgunits was very long

Related JIRA tickets :  POLIO-1195

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- Fixed a typo in the API call

## How to test

- Go to POLIO > LQAS > Per country > choose any campaign for any country. The loading time should be reasonable
- Open the browser inspector and inspect the response to `/api/orgunits/?validation_status=all&limit=3000&order=id&orgUnitParentId=<ID>&orgUnitTypeCategory=REGION`. The size should be in the KB range, not MB.

## Print screen / video

BEFORE

https://github.com/BLSQ/iaso/assets/38907762/e7b3597c-70dc-43ee-a990-d626e45d5920

AFTER

https://github.com/BLSQ/iaso/assets/38907762/f4b3b229-fa58-46bc-b9fc-c15c77ee89a9


