### PR TITLE
IA-2296 completeness v5

### DIFF
--- a/hat/assets/js/apps/Iaso/components/snackBars/messages.js
+++ b/hat/assets/js/apps/Iaso/components/snackBars/messages.js
@@ -319,6 +319,10 @@ const MESSAGES = defineMessages({
         id: 'iaso.snackBar.goToEntity',
         defaultMessage: 'Go to entity',
     },
+    completenessMapWarning: {
+        defaultMessage: 'Org unit(s) without geolocation found',
+        id: 'iaso.completenessStats.completenessMapWarning',
+    },
 });
 
 export default MESSAGES;

--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -53,6 +53,7 @@
     "iaso.completenessStats.childrenCompleteness": "Children completeness",
     "iaso.completenessStats.completed": "Completed",
     "iaso.completenessStats.completeness": "Completeness",
+    "iaso.completenessStats.completenessMapWarning": "Org unit(s) without geolocation found",
     "iaso.completenessStats.count": "Instance(s) count",
     "iaso.completenessStats.descendants": "Descendants",
     "iaso.completenessStats.descendantsNoSubmissionExpected": "No descendant OrgUnit is expected to fill that form. Check the Form config if this is unexpected",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -24,6 +24,7 @@
     "iaso.assignment.baseOrgUnitsType": "Types d'unités d'org. de base",
     "iaso.assignment.clickRowToUnAssign": "Sélectionnez la ligne pour désassigner l'unité d'org.",
     "iaso.assignment.count": "Nombre d'assignations",
+    "iaso.completenessStats.completenessMapWarning": "Unité d'org. trouvée(s) sans donnée géographique",
     "iaso.assignment.inAnotherTeam": "dans une autre équipe",
     "iaso.assignment.label": "Affectation",
     "iaso.assignment.map.disabled": "Déjà assigné",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -24,7 +24,7 @@
     "iaso.assignment.baseOrgUnitsType": "Types d'unités d'org. de base",
     "iaso.assignment.clickRowToUnAssign": "Sélectionnez la ligne pour désassigner l'unité d'org.",
     "iaso.assignment.count": "Nombre d'assignations",
-    "iaso.completenessStats.completenessMapWarning": "Unité d'org. trouvée(s) sans donnée géographique",
+    "iaso.completenessStats.completenessMapWarning": "Unité(s) d'org. trouvée(s) sans données géographiques",
     "iaso.assignment.inAnotherTeam": "dans une autre équipe",
     "iaso.assignment.label": "Affectation",
     "iaso.assignment.map.disabled": "Déjà assigné",

--- a/hat/assets/js/apps/Iaso/domains/assignments/hooks/requests/useGetAssignments.ts
+++ b/hat/assets/js/apps/Iaso/domains/assignments/hooks/requests/useGetAssignments.ts
@@ -6,7 +6,7 @@ import { AssignmentApi } from '../../types/assigment';
 import { Team } from '../../types/team';
 
 type Option = {
-    planning: string;
+    planning: string | undefined;
 };
 
 export type AssignmentsResult = {
@@ -21,11 +21,12 @@ const getAssignments = async (options: Option): Promise<AssignmentApi[]> => {
 
 export const useGetAssignments = (
     options: Option,
-    currentTeam: Team | undefined,
+    currentTeam?: Team,
 ): UseQueryResult<AssignmentsResult, Error> => {
     const queryKey: any[] = ['assignmentsList'];
     // @ts-ignore
     return useSnackQuery(queryKey, () => getAssignments(options), undefined, {
+        enabled: Boolean(options.planning),
         select: data => {
             const filteredAssignments = data.filter(assignment => {
                 if (currentTeam?.type) {

--- a/hat/assets/js/apps/Iaso/domains/completenessStats/CompletenessStatsFilters.tsx
+++ b/hat/assets/js/apps/Iaso/domains/completenessStats/CompletenessStatsFilters.tsx
@@ -74,7 +74,7 @@ export const CompletenessStatsFilters: FunctionComponent<Props> = ({
     const { data: orgUnitTypes, isFetching: fetchingTypes } =
         useGetOrgUnitTypesOptions(filters.parentId);
     const { data: availablePlannings, isFetching: fetchingPlannings } =
-        useGetPlanningsOptions();
+        useGetPlanningsOptions(filters.formId);
     useSkipEffectOnMount(() => {
         setInitialParentId(params?.parentId);
     }, [params]);
@@ -135,11 +135,20 @@ export const CompletenessStatsFilters: FunctionComponent<Props> = ({
         [handleChange],
     );
 
+    const handleChangeForm = useCallback(
+        (keyValue, value) => {
+            if (keyValue === 'formId') {
+                handleChange('planningId', undefined);
+            }
+            handleChange(keyValue, value);
+        },
+        [handleChange],
+    );
+
     const {
         data: validationStatusOptions,
         isLoading: isLoadingValidationStatusOptions,
     } = useGetValidationStatus();
-
     return (
         <>
             <Grid container spacing={2}>
@@ -147,7 +156,7 @@ export const CompletenessStatsFilters: FunctionComponent<Props> = ({
                     <InputWithInfos infos={formatMessage(MESSAGES.formsInfos)}>
                         <InputComponent
                             type="select"
-                            onChange={handleChange}
+                            onChange={handleChangeForm}
                             keyValue="formId"
                             label={MESSAGES.form}
                             value={filters.formId}

--- a/hat/assets/js/apps/Iaso/domains/completenessStats/CompletenessStatsFilters.tsx
+++ b/hat/assets/js/apps/Iaso/domains/completenessStats/CompletenessStatsFilters.tsx
@@ -137,9 +137,7 @@ export const CompletenessStatsFilters: FunctionComponent<Props> = ({
 
     const handleChangeForm = useCallback(
         (keyValue, value) => {
-            if (keyValue === 'formId') {
-                handleChange('planningId', undefined);
-            }
+            handleChange('planningId', undefined);
             handleChange(keyValue, value);
         },
         [handleChange],

--- a/hat/assets/js/apps/Iaso/domains/completenessStats/hooks/api/useGetCompletnessMapStats.ts
+++ b/hat/assets/js/apps/Iaso/domains/completenessStats/hooks/api/useGetCompletnessMapStats.ts
@@ -37,7 +37,10 @@ export const buildQueryString = (
             queryParams[value] = params[key];
         }
     });
-    const queryString = new URLSearchParams(getParams(params));
+    const queryString = new URLSearchParams({
+        ...getParams(params),
+        as_location: 'true',
+    });
     return queryString;
 };
 

--- a/hat/assets/js/apps/Iaso/domains/completenessStats/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/completenessStats/index.tsx
@@ -14,6 +14,11 @@ import { Router } from 'react-router';
 import { TableWithDeepLink } from '../../components/tables/TableWithDeepLink';
 import { baseUrls } from '../../constants/urls';
 import { redirectTo } from '../../routing/actions';
+import { warningSnackBar } from '../../constants/snackBars';
+import {
+    closeFixedSnackbar,
+    enqueueSnackbar,
+} from '../../redux/snackBarsReducer';
 import {
     buildQueryString,
     useGetCompletenessStats,
@@ -49,6 +54,7 @@ type Props = {
     router: Router;
 };
 
+const snackbarKey = 'completenessMapWarning';
 export const CompletenessStats: FunctionComponent<Props> = ({
     params,
     router,
@@ -67,6 +73,23 @@ export const CompletenessStats: FunctionComponent<Props> = ({
         params,
         completenessStats,
     );
+    const mapResults =
+        completenessMapStats?.filter(location => !location.is_root) || [];
+    const displayWarning =
+        mapResults?.length < (completenessStats?.count || 0) && tab === 'map';
+
+    useEffect(() => {
+        if (displayWarning) {
+            dispatch(enqueueSnackbar(warningSnackBar(snackbarKey)));
+        } else {
+            dispatch(closeFixedSnackbar(snackbarKey));
+        }
+        return () => {
+            if (displayWarning) {
+                dispatch(closeFixedSnackbar(snackbarKey));
+            }
+        };
+    }, [dispatch, displayWarning]);
     const csvUrl = useMemo(
         () =>
             `/api/v2/completeness_stats.csv?${buildQueryString(params, true)}`,

--- a/hat/assets/js/apps/Iaso/domains/completenessStats/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/completenessStats/index.tsx
@@ -76,7 +76,9 @@ export const CompletenessStats: FunctionComponent<Props> = ({
     const mapResults =
         completenessMapStats?.filter(location => !location.is_root) || [];
     const displayWarning =
-        mapResults?.length < (completenessStats?.count || 0) && tab === 'map';
+        mapResults?.length < (completenessStats?.count || 0) &&
+        tab === 'map' &&
+        !isFetchingMapStats;
 
     useEffect(() => {
         if (displayWarning) {

--- a/hat/assets/js/apps/Iaso/domains/completenessStats/types.ts
+++ b/hat/assets/js/apps/Iaso/domains/completenessStats/types.ts
@@ -67,6 +67,7 @@ export type CompletenessRouterParams = UrlParams & {
     groupId?: string;
     parentId?: string;
     accountId?: string;
+    planningId?: string;
     tab?: 'list' | 'map';
     showDirectCompleteness: 'true' | 'false';
 };

--- a/hat/assets/js/apps/Iaso/domains/plannings/hooks/requests/useGetPlannings.ts
+++ b/hat/assets/js/apps/Iaso/domains/plannings/hooks/requests/useGetPlannings.ts
@@ -10,6 +10,7 @@ import {
 } from '../../../../utils/dates';
 import { endpoint } from '../../constants';
 import { PlanningParams } from '../../types';
+import { DropdownOptions } from '../../../../types/utils';
 
 export type OrgUnitDetails = {
     id: number;
@@ -27,6 +28,7 @@ export type PlanningApi = {
     started_at?: string;
     ended_at?: string;
     org_unit_details: OrgUnitDetails;
+    form?: [number];
 };
 
 type Planning = PlanningApi & {
@@ -95,7 +97,7 @@ const getPlanningsOptions = async (
 };
 export const useGetPlanningsOptions = (
     formIds?: string,
-): UseQueryResult<Planning[], Error> => {
+): UseQueryResult<DropdownOptions<number>[], Error> => {
     const queryKey: any[] = ['planningsList', formIds];
     // @ts-ignore
     return useSnackQuery({
@@ -107,6 +109,7 @@ export const useGetPlanningsOptions = (
                     return {
                         value: planning.id,
                         label: planning.name,
+                        original: planning,
                     };
                 });
             },

--- a/hat/assets/js/apps/Iaso/domains/plannings/hooks/requests/useGetPlannings.ts
+++ b/hat/assets/js/apps/Iaso/domains/plannings/hooks/requests/useGetPlannings.ts
@@ -83,16 +83,24 @@ export const useGetPlannings = (
     });
 };
 
-const getPlanningsOptions = async (): Promise<PlanningApi[]> => {
-    const url = makeUrlWithParams(endpoint, {});
+const getPlanningsOptions = async (
+    formIds?: string,
+): Promise<PlanningApi[]> => {
+    const apiParams: Record<string, any> = {};
+    if (formIds) {
+        apiParams.form_ids = formIds;
+    }
+    const url = makeUrlWithParams(endpoint, apiParams);
     return getRequest(url) as Promise<PlanningApi[]>;
 };
-export const useGetPlanningsOptions = (): UseQueryResult<Planning[], Error> => {
-    const queryKey: any[] = ['planningsList'];
+export const useGetPlanningsOptions = (
+    formIds?: string,
+): UseQueryResult<Planning[], Error> => {
+    const queryKey: any[] = ['planningsList', formIds];
     // @ts-ignore
     return useSnackQuery({
         queryKey,
-        queryFn: () => getPlanningsOptions(),
+        queryFn: () => getPlanningsOptions(formIds),
         options: {
             select: (data: Planning[]) => {
                 return data?.map(planning => {

--- a/iaso/api/completeness_stats.py
+++ b/iaso/api/completeness_stats.py
@@ -436,8 +436,6 @@ class CompletenessStatsV2ViewSet(viewsets.ViewSet):
 
             return Response(paginated_res)
         if as_location:
-            print("ICI")
-            print(as_location)
             ou_with_stats = ou_with_stats.filter(Q(location__isnull=False) | Q(simplified_geom__isnull=False))
             object_list = with_parent([to_map(ou) for ou in ou_with_stats], True)
         else:

--- a/iaso/api/completeness_stats.py
+++ b/iaso/api/completeness_stats.py
@@ -227,7 +227,7 @@ class CompletenessStatsV2ViewSet(viewsets.ViewSet):
         orders = params["order"]
         form_qs = params["forms"]
         period = params.get("period", None)
-        planning = params.get("planning", None)
+        planning = params.get("planning_id", None)
         org_unit_validation_status = params["org_unit_validation_status"]
         as_location = params.get("as_location", None)
 
@@ -437,11 +437,14 @@ class CompletenessStatsV2ViewSet(viewsets.ViewSet):
             }
 
             return Response(paginated_res)
+        object_list = []
         if as_location:
             ou_with_stats = ou_with_stats.filter(Q(location__isnull=False) | Q(simplified_geom__isnull=False))
-            object_list = with_parent([to_map(ou) for ou in ou_with_stats], True)
+            if ou_with_stats.count() > 0:
+                object_list = with_parent([to_map(ou) for ou in ou_with_stats], True)
         else:
-            object_list = with_parent([to_dict(ou) for ou in ou_with_stats], True)
+            if ou_with_stats.count() > 0:
+                object_list = with_parent([to_dict(ou) for ou in ou_with_stats], True)
         return Response({"results": object_list})
 
     @action(methods=["GET"], detail=False)

--- a/iaso/api/completeness_stats.py
+++ b/iaso/api/completeness_stats.py
@@ -392,9 +392,11 @@ class CompletenessStatsV2ViewSet(viewsets.ViewSet):
                 ou_qs = OrgUnit.objects.filter(id=parent_ou.id)
                 ou_qs = get_annotated_queryset(ou_qs, orgunit_qs, instance_qs, form_qs)
 
-                top_row_ou = to_dict(ou_qs[0]) if not is_map else to_map(ou_qs[0])
-                top_row_ou["is_root"] = True
-                temp_list.insert(0, top_row_ou)
+                if ou_qs.count() > 0:
+                    top_row_ou = to_dict(ou_qs[0]) if not is_map else to_map(ou_qs[0])
+                    top_row_ou["is_root"] = True
+                    temp_list.insert(0, top_row_ou)
+
             return temp_list
 
         limit = request.GET.get("limit", None)

--- a/iaso/api/completeness_stats.py
+++ b/iaso/api/completeness_stats.py
@@ -227,17 +227,21 @@ class CompletenessStatsV2ViewSet(viewsets.ViewSet):
         orders = params["order"]
         form_qs = params["forms"]
         period = params.get("period", None)
-        planning = params.get("planning_id", None)
+        planning_id = params.get("planning_id", None)
         org_unit_validation_status = params["org_unit_validation_status"]
         as_location = params.get("as_location", None)
 
         instance_qs = Instance.objects.all()
+
+        planning = None
+        if planning_id:
+            planning = get_object_or_404(Planning, id=planning_id)
         if period:
             # In the future we would like to support multiple periods, but then we will have to count properly
             # the requirements
             instance_qs = instance_qs.filter(period=period)
         if planning:
-            instance_qs = instance_qs.filter(planning_id=planning.id)
+            instance_qs = instance_qs.filter(planning_id=planning)
             form_qs = form_qs.filter(plannings=planning)
 
         profile = request.user.iaso_profile  # type: ignore

--- a/iaso/api/microplanning.py
+++ b/iaso/api/microplanning.py
@@ -354,11 +354,14 @@ class PlanningSearchFilterBackend(filters.BaseFilterBackend):
 class PublishingStatusFilterBackend(filters.BaseFilterBackend):
     def filter_queryset(self, request, queryset, view):
         status = request.query_params.get("publishing_status", "all")
+        form_ids = request.query_params.get("form_ids", None)
 
         if status == "draft":
             queryset = queryset.filter(published_at__isnull=True)
         if status == "published":
             queryset = queryset.exclude(published_at__isnull=True)
+        if form_ids:
+            queryset = queryset.filter(forms__id__in=form_ids.split(","))
         return queryset
 
 

--- a/iaso/tests/api/test_completeness_stats.py
+++ b/iaso/tests/api/test_completeness_stats.py
@@ -163,7 +163,9 @@ class CompletenessStatsAPITestCase(APITestCase):
     def test_base_map_results(self):
         self.client.force_authenticate(self.user)
 
-        response = self.client.get("/api/v2/completeness_stats/", {"org_unit_validation_status": "VALID,NEW"})
+        response = self.client.get(
+            "/api/v2/completeness_stats/", {"org_unit_validation_status": "VALID,NEW", "as_location": True}
+        )
         j = self.assertJSONResponse(response, 200)
         expected_result = {
             "results": [
@@ -308,6 +310,17 @@ class CompletenessStatsAPITestCase(APITestCase):
                 },
             ],
         }
+        print("")
+        print("")
+        print(expected_result)
+        print("")
+        print("")
+        print("")
+        print("")
+        print("")
+        print(j)
+        print("")
+        print("")
         self.assertAlmostEqualRecursive(
             expected_result,
             j,

--- a/iaso/tests/api/test_completeness_stats.py
+++ b/iaso/tests/api/test_completeness_stats.py
@@ -310,17 +310,6 @@ class CompletenessStatsAPITestCase(APITestCase):
                 },
             ],
         }
-        print("")
-        print("")
-        print(expected_result)
-        print("")
-        print("")
-        print("")
-        print("")
-        print("")
-        print(j)
-        print("")
-        print("")
         self.assertAlmostEqualRecursive(
             expected_result,
             j,


### PR DESCRIPTION
- when there is no submission expected, the shape should appear grey, not red
- filter planning with selected forms
- have an error message when there is no shape to explain why nothing shows

Related JIRA tickets : IA-2388, IA-2354, IA-2389

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are my typescript files well typed
- [x] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- filter plannings with planning using selected forms
- compare map an list results to display a warning that one or more org unit doesn't have a geolocation
- get assignments for selected planning and check that the org units are used in the planning to change the color 

## How to test

Make sure you have a planning with org unit assigned to a user or a team
Go to completeness stats page, select the form used in the planning.
You should have only planning using this form in plannings dropdown .
Select the initial planning and drill down to the assignment level.
Org unit without assignment should be grey.
Unselect the planning, all org units should be red, green or orange.

Add a children org unit without geolocation to an existing org unit with a shape or a marker.
Visit completeness on the parent org unit. 
You should see a snackbar saying that an org unit is missing geolocation.



## Print screen / video


https://github.com/BLSQ/iaso/assets/12494624/a97755c9-9fb9-4044-a88e-50c23627d1e5
https://github.com/BLSQ/iaso/assets/12494624/e9e87cac-7e02-40c9-b4c3-eea5e97f82ce


