### PR TITLE
POLIO-1201 Quantity is not showing on nopv2 auth page

### DIFF
--- a/plugins/polio/js/src/pages/VaccineModule/Nopv2Authorisations/Details/Modals/CreateEdit/CreateEditAuthorisationModal.tsx
+++ b/plugins/polio/js/src/pages/VaccineModule/Nopv2Authorisations/Details/Modals/CreateEdit/CreateEditAuthorisationModal.tsx
@@ -14,7 +14,7 @@ import { useCreateEditNopv2Authorisation } from '../../../hooks/api';
 import { EditIconButton } from '../../../../../../../../../../hat/assets/js/apps/Iaso/components/Buttons/EditIconButton';
 import { useNopv2AuthorisationsSchema } from '../../../hooks/validation';
 import MESSAGES from './MESSAGES';
-import { NumberInput } from '../../../../../../components/Inputs';
+import { NumberInput } from '../../../../../../components/Inputs/NumberInput';
 import { MultilineText } from '../../../../../../components/Inputs/MultilineText';
 import { SingleSelect } from '../../../../../../components/Inputs/SingleSelect';
 import { useStatusOptions } from '../../../hooks/statuses';

--- a/plugins/polio/js/src/pages/VaccineModule/Nopv2Authorisations/Details/useNopv2AuthDetailsTableColumns.tsx
+++ b/plugins/polio/js/src/pages/VaccineModule/Nopv2Authorisations/Details/useNopv2AuthDetailsTableColumns.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { Column, formatThousand, useSafeIntl } from 'bluesquare-components';
+import { Column, useSafeIntl } from 'bluesquare-components';
 import MESSAGES from '../../../../constants/messages';
 import { DateCell } from '../../../../../../../../hat/assets/js/apps/Iaso/components/Cells/DateTimeCell';
 import { DeleteAuthorisationModal } from './Modals/Delete/DeleteAuthorisationModal';
@@ -32,8 +32,8 @@ export const useNopv2AuthDetailsTableColumns = (): Column[] => {
                 accessor: 'quantity',
                 Cell: settings => (
                     <span>
-                        {formatThousand(settings.row.original.quantity) > 0
-                            ? formatThousand(settings.row.original.quantity)
+                        {settings.row.original.quantity > 0
+                            ? settings.row.original.quantity
                             : '--'}
                     </span>
                 ),

--- a/plugins/polio/js/src/pages/VaccineModule/Nopv2Authorisations/Table/useNopv2AuthTableColumns.tsx
+++ b/plugins/polio/js/src/pages/VaccineModule/Nopv2Authorisations/Table/useNopv2AuthTableColumns.tsx
@@ -2,7 +2,6 @@ import React, { useMemo } from 'react';
 import {
     Column,
     IconButton,
-    formatThousand,
     useSafeIntl,
 } from 'bluesquare-components';
 import { NOPV2_AUTH_DETAILS } from '../../../../constants/routes';
@@ -34,8 +33,8 @@ export const useNopv2AuthTableColumns = (): Column[] => {
                 accessor: 'quantity',
                 Cell: settings => (
                     <span>
-                        {formatThousand(settings.row.original.quantity) > 0
-                            ? formatThousand(settings.row.original.quantity)
+                        {settings.row.original.quantity > 0
+                            ? settings.row.original.quantity
                             : '--'}
                     </span>
                 ),


### PR DESCRIPTION
As the table was using thousFormat to format the number in the table, the quantity exceeding 999999 were not showing. 
The format has been removed to show the data until we have a formater for big numbers. 

Related JIRA tickets : POLIO-1201

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

Remove formatThousand from nopv2 tables

## How to test

Create a nopv2 vac auth with millions of quantity and check if its displayed correctly

