### PR TITLE
POLIO-1113: LQAS/IM: country view doesn't detect round 0

### DIFF
--- a/plugins/polio/js/src/components/LQAS-IM/LqasImMapHeader.tsx
+++ b/plugins/polio/js/src/components/LQAS-IM/LqasImMapHeader.tsx
@@ -59,10 +59,13 @@ export const LqasImMapHeader: FunctionComponent<Props> = ({
                                     <InputComponent
                                         type="select"
                                         keyValue="lqasImHeader"
-                                        options={options}
-                                        value={round}
+                                        options={options.map(o => ({
+                                            ...o,
+                                            value: `${o.value}`,
+                                        }))}
+                                        value={`${round}`}
                                         onChange={(_keyValue, value) =>
-                                            onRoundSelect(value)
+                                            onRoundSelect(parseInt(value, 10))
                                         }
                                         labelString={formatMessage(
                                             MESSAGES.round,

--- a/plugins/polio/js/src/pages/LQAS/index.js
+++ b/plugins/polio/js/src/pages/LQAS/index.js
@@ -56,8 +56,8 @@ export const Lqas = ({ router }) => {
     } = useLqasData({ campaign, country, selectedRounds, LQASData });
 
     const dropDownOptions = useMemo(() => {
-        return makeDropdownOptions(LQASData?.stats, campaign, selectedRounds);
-    }, [LQASData, campaign, selectedRounds]);
+        return makeDropdownOptions(LQASData?.stats, campaign);
+    }, [LQASData, campaign]);
 
     const onRoundChange = useCallback(
         index => value => {


### PR DESCRIPTION
Whereas the campaign has a round 0 and the API finds data for round 0

Related JIRA tickets : POLIO-1113

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

Cast locally value to a string to avoid zero comparaison

## How to test

select a campaign using round 0 in LQAS country map, try to select round 0in dropdown

## Print screen / video

https://github.com/BLSQ/iaso/assets/12494624/f7e66c0b-ec3c-4562-9ced-51fed4c9755f



