### PR TITLE
TRIA-17 use trypelim reducers in app

### DIFF
--- a/hat/assets/js/apps/Iaso/redux/createStore.js
+++ b/hat/assets/js/apps/Iaso/redux/createStore.js
@@ -6,12 +6,17 @@ import {
 } from 'redux';
 import { routerReducer } from 'react-router-redux';
 
-export default (initialState = {}, reducers = {}, middleWare = []) =>
-    _createStore(
-        combineReducers({
-            routing: routerReducer,
-            ...reducers,
-        }),
+const createReducer = (appReducers, pluginReducers) => {
+    return combineReducers({
+        routing: routerReducer,
+        ...appReducers,
+        ...pluginReducers,
+    });
+};
+
+export default (initialState = {}, reducers = {}, middleWare = []) => {
+    const store = _createStore(
+        createReducer(reducers),
         initialState,
         compose(
             applyMiddleware(...middleWare),
@@ -20,3 +25,10 @@ export default (initialState = {}, reducers = {}, middleWare = []) =>
                 : f => f,
         ),
     );
+    store.pluginReducers = {};
+    store.injectReducer = (key, pluginReducer) => {
+        store.pluginReducers[key] = pluginReducer;
+        store.replaceReducer(createReducer(reducers, store.pluginReducers));
+    };
+    return store;
+};

--- a/hat/assets/js/apps/Iaso/redux/useInjectedStore.ts
+++ b/hat/assets/js/apps/Iaso/redux/useInjectedStore.ts
@@ -1,0 +1,63 @@
+import { useContext, useEffect, useMemo, useState } from 'react';
+import { ReactReduxContext } from 'react-redux';
+/**
+ *
+ * @deprecated Redux
+ * This is adding a list of reducers to the existing one's.
+ * As using redux is a practice we are trying to avoid, try not to use this hook
+ * Also do not use same reducer key as the existing one's (see hat/assets/js/apps/Iaso/redux/store.js)
+ *
+ * Example how to use in a component:
+ *  const store = useInjectedStore([
+        {
+            reducerKey: 'reducerKey',
+            reducer: IMPORTED_REDUCER,
+        },
+    ]);
+    if (!store) return null;
+    return (
+        <Provider store={store}>
+            <CUSTOM_COMPONENT />
+        </Provider>
+    );
+ *
+ */
+
+type Reducer = {
+    reducerKey: string;
+    reducer: (
+        // eslint-disable-next-line no-unused-vars
+        state: any,
+        // eslint-disable-next-line no-unused-vars
+        action: Record<any, any>,
+    ) => Record<any, any>;
+};
+
+type Reducers = Reducer[];
+
+export const useInjectedStore = (reducers: Reducers): any => {
+    const { store }: { store: any } = useContext(ReactReduxContext);
+    const existingKeys = useMemo(() => {
+        return Object.keys(store.getState());
+    }, [store]);
+    const [injectedStore, setInjectedStore] = useState<boolean>(false);
+    useEffect(() => {
+        if (store && !injectedStore) {
+            for (let i = 0; i < reducers.length; i += 1) {
+                const { reducerKey, reducer } = reducers[i];
+
+                if (existingKeys.includes(reducerKey)) {
+                    console.warn(
+                        `A reducer with this key ("${reducerKey}") already exists in the store`,
+                    );
+                } else {
+                    store.injectReducer(reducerKey, reducer);
+                }
+            }
+            setInjectedStore(true);
+        }
+    }, [store, injectedStore, reducers, existingKeys]);
+    if (!injectedStore) return undefined;
+
+    return store;
+};


### PR DESCRIPTION
Trypelim is using a bunch of reducers in order to work, we should be able to add manually reducers to the existing one's so we d'ont have to rewrite all the logic of trypelim pages

Related JIRA tickets :[TRIA-17](https://bluesquare.atlassian.net/browse/TRIA-17)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- extend store to allow plugin reducers to be added
- `useInjectedStore` hook to inject a reducer

## How to test

Wrap a component qith the code in useInjectedStore and try to inject a existing reducer with a different key, it should work



[TRIA-17]: https://bluesquare.atlassian.net/browse/TRIA-17?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ