### PR TITLE
IA-2433: Remove form versions multi select

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/forms/components/FormVersionsComponent.js
+++ b/hat/assets/js/apps/Iaso/domains/forms/components/FormVersionsComponent.js
@@ -1,11 +1,9 @@
-import React, { useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { Box } from '@material-ui/core';
 import {
     useSafeIntl,
     AddButton as AddButtonComponent,
-    selectionInitialState,
-    setTableSelection,
 } from 'bluesquare-components';
 import { fetchList } from '../../../utils/requests';
 
@@ -27,8 +25,6 @@ const FormVersionsComponent = ({
     formId,
 }) => {
     const intl = useSafeIntl();
-    const [selection, setSelection] = useState(selectionInitialState);
-
     if (!formId) return null;
 
     return (
@@ -75,18 +71,6 @@ const FormVersionsComponent = ({
                     formId,
                     periodType,
                 )}
-                multiSelect
-                selection={selection}
-                setTableSelection={(selectionType, items, totalCount) => {
-                    setSelection(
-                        setTableSelection(
-                            selection,
-                            selectionType,
-                            items,
-                            totalCount,
-                        ),
-                    );
-                }}
                 forceRefresh={forceRefresh}
                 onForceRefreshDone={() => setForceRefresh(false)}
             />


### PR DESCRIPTION
Multiselect on form detail page is not used

Related JIRA tickets : IA-2433

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

remove props

## How to test

Open a form detail and check that you cannot select multiple version of a form

## Print screen / video

<img width="838" alt="Screenshot 2023-09-18 at 09 56 32" src="https://github.com/BLSQ/iaso/assets/12494624/1f774ac0-3e3b-49dd-b9b4-383fe0c753c0">

