### PR TITLE
IA-2434: display creator name correctly if no last name and no first name

### DIFF
--- a/iaso/models/org_unit.py
+++ b/iaso/models/org_unit.py
@@ -240,6 +240,14 @@ class OrgUnitQuerySet(django_cte.CTEQuerySet):
 OrgUnitManager = models.Manager.from_queryset(OrgUnitQuerySet)
 
 
+def get_creator_name(creator):
+    if creator is None:
+        return None
+    if creator.first_name or creator.last_name:
+        return f"{creator.username} ({creator.first_name} {creator.last_name})"
+    return f"{creator.username}"
+
+
 class OrgUnit(TreeModel):
     VALIDATION_NEW = "NEW"
     VALIDATION_VALID = "VALID"
@@ -438,9 +446,7 @@ class OrgUnit(TreeModel):
             "altitude": self.location.z if self.location else None,
             "has_geo_json": True if self.simplified_geom else False,
             "reference_instance_id": self.reference_instance_id,
-            "creator": None
-            if self.creator is None
-            else f"{self.creator.username} ({self.creator.first_name} {self.creator.last_name})",
+            "creator": get_creator_name(self.creator),
         }
         if not light:  # avoiding joins here
             res["groups"] = [group.as_dict(with_counts=False) for group in self.groups.all()]

--- a/iaso/models/org_unit.py
+++ b/iaso/models/org_unit.py
@@ -244,7 +244,7 @@ def get_creator_name(creator):
     if creator is None:
         return None
     if creator.first_name or creator.last_name:
-        return f"{creator.username} ({creator.first_name} {creator.last_name})"
+        return f"{creator.username} ({creator.get_full_name()})"
     return f"{creator.username}"
 
 


### PR DESCRIPTION
Org unit api was returning creator name with "()"  if no last name and first name
Related JIRA tickets : IA-2434

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

Create custom method to display creator

## How to test

- Remove first name and last name form your user
- Find an existing org unit and set the creator to yourself
- open the dashboard on the org unit detail page and check that the creator is correctly dispalyed

## Print screen / video
![Screenshot 2023-09-19 at 15 37 58](https://github.com/BLSQ/iaso/assets/12494624/938465ae-e1ea-42cb-893f-810d49fabbeb)
<img width="499" alt="Screenshot 2023-09-19 at 15 36 56" src="https://github.com/BLSQ/iaso/assets/12494624/19c89fec-1510-4aec-99a1-342a271237e6">

