### PR TITLE
IA-2337: load profiles on org unit details

### DIFF
--- a/hat/assets/js/apps/Iaso/constants/filters.js
+++ b/hat/assets/js/apps/Iaso/constants/filters.js
@@ -492,6 +492,7 @@ export const linksFiltersWithPrefix = (
     profiles = [],
     algorithms = [],
     sources = [],
+    isFetchingProfiles = false,
 ) =>
     filtersWithPrefix(
         [
@@ -509,6 +510,7 @@ export const linksFiltersWithPrefix = (
             },
             {
                 ...validator(profiles),
+                loading: isFetchingProfiles,
                 column: 2,
             },
             {

--- a/hat/assets/js/apps/Iaso/domains/forms/hooks/useGetValidationStatus.ts
+++ b/hat/assets/js/apps/Iaso/domains/forms/hooks/useGetValidationStatus.ts
@@ -28,6 +28,7 @@ const MESSAGES = defineMessages({
 
 export const useGetValidationStatus = (
     includeAll = false,
+    enabled = true,
 ): UseQueryResult<DropdownOptions<string>[], Error> => {
     const queryKey: any[] = ['validationStatus'];
     const { formatMessage } = useSafeIntl();
@@ -36,6 +37,7 @@ export const useGetValidationStatus = (
         queryFn: () => getRequest('/api/validationstatus/'),
         options: {
             retry: false,
+            enabled,
             keepPreviousData: true,
             select: (data: OrgUnitStatus[]) => {
                 const options: DropdownOptions<string>[] = data.map(

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/details.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/details.js
@@ -251,6 +251,7 @@ const OrgUnitDetail = ({ params, router }) => {
         isFetchingDetail,
         isFetchingOrgUnitTypes,
         isFetchingGroups,
+        isFetchingProfiles,
         parentOrgUnit,
     } = useOrgUnitDetailData(
         isNewOrgunit,
@@ -427,7 +428,6 @@ const OrgUnitDetail = ({ params, router }) => {
                 )}
             </TopBar>
 
-            {/* there is already a loader on SingleTable for the other tabs */}
             {(isFetchingDetail || isFetchingDatas || savingOu) &&
                 (tab === 'infos' || tab === 'map' || tab === 'comments') && (
                     <LoadingSpinner />
@@ -590,6 +590,7 @@ const OrgUnitDetail = ({ params, router }) => {
                                         profiles,
                                         algorithms,
                                         sources,
+                                        isFetchingProfiles,
                                     )}
                                     params={params}
                                     paramsPrefix="linksParams"

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/details.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/details.js
@@ -137,7 +137,7 @@ const OrgUnitDetail = ({ params, router }) => {
     const {
         data: validationStatusOptions,
         isLoading: isLoadingValidationStatusOptions,
-    } = useGetValidationStatus(true);
+    } = useGetValidationStatus(true, tab === 'children');
 
     const title = useMemo(() => {
         if (isNewOrgunit) {
@@ -258,6 +258,7 @@ const OrgUnitDetail = ({ params, router }) => {
         params.orgUnitId,
         setCurrentOrgUnit,
         params.levels,
+        tab,
     );
 
     const goToRevision = useCallback(

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/hooks.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/hooks.js
@@ -151,7 +151,6 @@ export const useOrgUnitDetailData = (
         links,
         isFetchingDatas:
             isFetchingAlgorithm ||
-            isFetchingProfiles ||
             isFetchingAlgorithmRuns ||
             isFetchingGroups ||
             isFetchingSources ||
@@ -162,6 +161,7 @@ export const useOrgUnitDetailData = (
         isFetchingDetail,
         isFetchingOrgUnitTypes,
         isFetchingGroups,
+        isFetchingProfiles,
         parentOrgUnit,
     };
 };

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/hooks.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/hooks.js
@@ -14,6 +14,7 @@ export const useOrgUnitDetailData = (
     orgUnitId,
     setCurrentOrgUnit,
     levels,
+    tab,
 ) => {
     const { data: originalOrgUnit, isFetching: isFetchingDetail } =
         useSnackQuery(
@@ -35,6 +36,10 @@ export const useOrgUnitDetailData = (
         }
         return basUrl;
     }, [isNewOrgunit, originalOrgUnit?.source_id]);
+    const cacheOptions = {
+        staleTime: 1000 * 60 * 15, // in MS
+        cacheTime: 1000 * 60 * 5,
+    };
     const [
         { data: algorithms = [], isFetching: isFetchingAlgorithm },
         { data: algorithmRuns = [], isFetching: isFetchingAlgorithmRuns },
@@ -52,12 +57,19 @@ export const useOrgUnitDetailData = (
         {
             queryKey: ['algorithms'],
             queryFn: () => getRequest('/api/algorithms/'),
+            options: {
+                enabled: tab === 'links',
+                ...cacheOptions,
+            },
         },
         {
             queryKey: ['algorithmRuns'],
             queryFn: () => getRequest('/api/algorithmsruns/'),
             snackErrorMsg: MESSAGES.fetchAlgorithmsError,
-            options: {},
+            options: {
+                enabled: tab === 'links',
+                ...cacheOptions,
+            },
         },
         {
             queryKey: ['groups'],
@@ -65,6 +77,8 @@ export const useOrgUnitDetailData = (
             snackErrorMsg: MESSAGES.fetchGroupsError,
             options: {
                 select: data => data.groups,
+                enabled: tab === 'children' || tab === 'infos',
+                ...cacheOptions,
             },
         },
         {
@@ -73,6 +87,8 @@ export const useOrgUnitDetailData = (
             snackErrorMsg: MESSAGES.fetchProfilesError,
             options: {
                 select: data => data.profiles,
+                enabled: tab === 'links',
+                ...cacheOptions,
             },
         },
         {
@@ -85,6 +101,8 @@ export const useOrgUnitDetailData = (
                         ...ot,
                         color: getOtChipColors(i),
                     })),
+                enabled: tab === 'map' || tab === 'children' || tab === 'infos',
+                ...cacheOptions,
             },
         },
         {
@@ -107,7 +125,8 @@ export const useOrgUnitDetailData = (
                         ...s,
                         color: getChipColors(i),
                     })),
-                enabled: !isNewOrgunit,
+                enabled: !isNewOrgunit && (tab === 'map' || tab === 'links'),
+                ...cacheOptions,
             },
         },
         // FIXME this can probably be refactored into a single query
@@ -122,7 +141,8 @@ export const useOrgUnitDetailData = (
                         color: getChipColors(i),
                     })),
                 // here seems to be an error here as the condition for enabling is the same as the query above
-                enabled: !isNewOrgunit,
+                enabled: isNewOrgunit && (tab === 'map' || tab === 'links'),
+                ...cacheOptions,
             },
         },
         {
@@ -134,6 +154,8 @@ export const useOrgUnitDetailData = (
                     Boolean(levels) &&
                     isNewOrgunit &&
                     levels.split(',').length === 1,
+
+                ...cacheOptions,
             },
         },
     ]);


### PR DESCRIPTION
Org unit detail loads the full list of profile of the account, and that's slow
See here for an account with a lot of profiles. 

https://iaso.bluesquare.org/dashboard/orgunits/detail/accountId/17/orgUnitId/765262/levels/765261,765262/tab/infos

To be investigated:

why do we load profiles for this page

why is the profile api slow (it should not)
Related JIRA tickets : IA-2337

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

Avoid fetching profiles from blocking the whole page and pass it to the dropdown to show local load

## How to test

Open the detail of a org unit on the links tab, the dropdown for creator should display a loader

## Print screen / video

<img width="1311" alt="Screenshot 2023-09-20 at 13 02 06" src="https://github.com/BLSQ/iaso/assets/12494624/e5aed997-bc78-4ece-90a8-9029efdb9590">

## Notes

The api call in prod is slow but have more than 5000 profiles to load
@mathvdh or @kemar you can maybe have a look on the profiles api and see if we can improve this