### PR TITLE
POLIO-1205- Correct filters on vaccine authorisations

### DIFF
--- a/plugins/polio/api/vaccines/vaccine_authorization.py
+++ b/plugins/polio/api/vaccines/vaccine_authorization.py
@@ -164,6 +164,7 @@ class VaccineAuthorizationViewSet(ModelViewSet):
         """
         Returns the most recent validated or expired authorization or the most recent ongoing or signature if the first case does not exists.
         """
+        # Filters are done after calculation as all the status are required in order to compute the correct response
         user = self.request.user
         user_access_ou = OrgUnit.objects.filter_for_user_and_app_id(user, None)
         user_access_ou = user_access_ou.filter(org_unit_type__name="COUNTRY")

--- a/plugins/polio/api/vaccines/vaccine_authorization.py
+++ b/plugins/polio/api/vaccines/vaccine_authorization.py
@@ -269,7 +269,6 @@ class VaccineAuthorizationViewSet(ModelViewSet):
             for ou_q in org_units:
                 for ou in ou_q:
                     ou_pk_list.append(ou.pk)
-            print(ou_pk_list)
             response = [entry for entry in response if entry["country"]["id"] in ou_pk_list]
 
         if ordering:

--- a/plugins/polio/api/vaccines/vaccine_authorization.py
+++ b/plugins/polio/api/vaccines/vaccine_authorization.py
@@ -162,11 +162,9 @@ class VaccineAuthorizationViewSet(ModelViewSet):
         return super().create(request)
 
     def list(self, request: Request, *args, **kwargs):
-
         auth_status = self.request.query_params.get("auth_status", None)
 
         if auth_status == "EXPIRED":
-
             queryset = self.get_queryset().filter(status="EXPIRED")
 
             serializer = VaccineAuthorizationSerializer(queryset, many=True)

--- a/plugins/polio/api/vaccines/vaccine_authorization.py
+++ b/plugins/polio/api/vaccines/vaccine_authorization.py
@@ -259,16 +259,10 @@ class VaccineAuthorizationViewSet(ModelViewSet):
         if block_country:
             block_country = block_country.split(",")
             block_country = Group.objects.filter(pk__in=block_country)
-            org_units = [
-                ou_queryset
-                for ou_queryset in [
-                    ou_group_queryset for ou_group_queryset in [country.org_units.all() for country in block_country]
-                ]
-            ]
+            org_units = [country.org_units.all() for country in block_country]
             ou_pk_list = []
             for ou_q in org_units:
-                for ou in ou_q:
-                    ou_pk_list.append(ou.pk)
+                ou_pk_list = [ou.pk for ou in ou_q]
             response = [entry for entry in response if entry["country"]["id"] in ou_pk_list]
 
         if ordering:

--- a/plugins/polio/api/vaccines/vaccine_authorization.py
+++ b/plugins/polio/api/vaccines/vaccine_authorization.py
@@ -162,7 +162,7 @@ class VaccineAuthorizationViewSet(ModelViewSet):
     @action(detail=False, methods=["GET"])
     def get_most_recent_authorizations(self, request):
         """
-        Returns the most recent validated or expired authorization or the most recent ongoing or signature if the first case does not exists.
+        Compute the most recent vaccine authorization per country.
         """
         # Filters are done after calculation as all the status are required in order to compute the correct response
         user = self.request.user

--- a/plugins/polio/settings.py
+++ b/plugins/polio/settings.py
@@ -1,0 +1,7 @@
+# use this file to store constants
+
+
+COUNTRY = "COUNTRY"
+DISTRICT = "DISTRICT"
+REGION = "REGION"
+HEALTH_FACILITY = "HEALTH FACILITY"

--- a/plugins/polio/tests/test_vaccine_authorizations.py
+++ b/plugins/polio/tests/test_vaccine_authorizations.py
@@ -69,6 +69,38 @@ class VaccineAuthorizationAPITestCase(APITestCase):
             source_ref="PvtAI4RUMkr",
         )
 
+        cls.org_unit_CHAD = m.OrgUnit.objects.create(
+            org_unit_type=cls.org_unit_type_country,
+            version=cls.source_version_1,
+            name="CHAD",
+            validation_status=m.OrgUnit.VALIDATION_VALID,
+            source_ref="PvtAI4RUMkr",
+        )
+
+        cls.org_unit_BURKINA_FASO = m.OrgUnit.objects.create(
+            org_unit_type=cls.org_unit_type_country,
+            version=cls.source_version_1,
+            name="Burkina Faso",
+            validation_status=m.OrgUnit.VALIDATION_VALID,
+            source_ref="PvtAI4RUMkr",
+        )
+
+        cls.org_unit_ZIMBABWE = m.OrgUnit.objects.create(
+            org_unit_type=cls.org_unit_type_country,
+            version=cls.source_version_1,
+            name="Zimbabwe",
+            validation_status=m.OrgUnit.VALIDATION_VALID,
+            source_ref="PvtAI4RUMkr",
+        )
+
+        cls.org_unit_SIERRA_LEONE = m.OrgUnit.objects.create(
+            org_unit_type=cls.org_unit_type_country,
+            version=cls.source_version_1,
+            name="Sierra Leone",
+            validation_status=m.OrgUnit.VALIDATION_VALID,
+            source_ref="PvtAI4RUMkr",
+        )
+
         cls.org_unit_ALGERIA = m.OrgUnit.objects.create(
             org_unit_type=cls.org_unit_type_country,
             version=cls.source_version_1,
@@ -728,3 +760,166 @@ class VaccineAuthorizationAPITestCase(APITestCase):
         self.assertEqual(response.data[0]["next_expiration_date"], seventh.expiration_date)
         self.assertEqual(response.data[1]["next_expiration_date"], sixth.expiration_date)
         self.assertEqual(response.data[2]["next_expiration_date"], fifth.expiration_date)
+
+    def test_get_most_recent_filters_status(self):
+        self.client.force_authenticate(self.user_1)
+        self.user_1.iaso_profile.org_units.set(
+            [
+                self.org_unit_DRC.pk,
+                self.org_unit_SOMALIA,
+                self.org_unit_ALGERIA,
+                self.org_unit_ZIMBABWE,
+                self.org_unit_CHAD,
+                self.org_unit_SIERRA_LEONE,
+                self.org_unit_BURKINA_FASO,
+            ]
+        )
+
+        VaccineAuthorization.objects.create(
+            account=self.user_1.iaso_profile.account,
+            country=self.org_unit_SOMALIA,
+            status="EXPIRED",
+            quantity=400,
+            expiration_date=date.today() - datetime.timedelta(days=30),
+        )
+
+        VaccineAuthorization.objects.create(
+            account=self.user_1.iaso_profile.account,
+            country=self.org_unit_SOMALIA,
+            status="VALIDATED",
+            quantity=400,
+            expiration_date=date.today() + datetime.timedelta(days=220),
+        )
+
+        VaccineAuthorization.objects.create(
+            account=self.user_1.iaso_profile.account,
+            country=self.org_unit_DRC,
+            status="EXPIRED",
+            quantity=40000,
+            expiration_date=date.today() - datetime.timedelta(days=220),
+        )
+
+        VaccineAuthorization.objects.create(
+            account=self.user_1.iaso_profile.account,
+            country=self.org_unit_ALGERIA,
+            status="SIGNATURE",
+            quantity=40000,
+            expiration_date=date.today() + datetime.timedelta(days=120),
+        )
+
+        VaccineAuthorization.objects.create(
+            account=self.user_1.iaso_profile.account,
+            country=self.org_unit_CHAD,
+            status="EXPIRED",
+            quantity=40000,
+            expiration_date=date.today() - datetime.timedelta(days=1),
+        )
+
+        VaccineAuthorization.objects.create(
+            account=self.user_1.iaso_profile.account,
+            country=self.org_unit_SIERRA_LEONE,
+            status="SIGNATURE",
+            quantity=40000,
+            expiration_date=date.today() + datetime.timedelta(days=250),
+        )
+
+        VaccineAuthorization.objects.create(
+            account=self.user_1.iaso_profile.account,
+            country=self.org_unit_ZIMBABWE,
+            status="ONGOING",
+            quantity=40000,
+            expiration_date=date.today() + datetime.timedelta(days=250),
+        )
+
+        VaccineAuthorization.objects.create(
+            account=self.user_1.iaso_profile.account,
+            country=self.org_unit_ZIMBABWE,
+            status="EXPIRED",
+            quantity=40000,
+            expiration_date=date.today() - datetime.timedelta(days=250),
+        )
+
+        VaccineAuthorization.objects.create(
+            account=self.user_1.iaso_profile.account,
+            country=self.org_unit_ZIMBABWE,
+            status="SIGNATURE",
+            quantity=40000,
+            expiration_date=date.today() + datetime.timedelta(days=250),
+        )
+
+        VaccineAuthorization.objects.create(
+            account=self.user_1.iaso_profile.account,
+            country=self.org_unit_BURKINA_FASO,
+            status="EXPIRED",
+            quantity=40000,
+            expiration_date=date.today() - datetime.timedelta(days=250),
+        )
+
+        VaccineAuthorization.objects.create(
+            account=self.user_1.iaso_profile.account,
+            country=self.org_unit_BURKINA_FASO,
+            status="VALIDATED",
+            quantity=40000,
+            expiration_date=date.today() + datetime.timedelta(days=100),
+        )
+
+        # response length
+        response = self.client.get("/api/polio/vaccineauthorizations/get_most_recent_authorizations/?order=status")
+
+        self.assertEqual((len(response.data)), 7)
+
+        # VALIDATED status
+        response = self.client.get(
+            "/api/polio/vaccineauthorizations/get_most_recent_authorizations/?auth_status=VALIDATED"
+        )
+
+        self.assertEqual(len(response.data), 2)
+
+        # ONGOING status
+        response = self.client.get(
+            "/api/polio/vaccineauthorizations/get_most_recent_authorizations/?auth_status=ONGOING"
+        )
+
+        self.assertEqual(len(response.data), 0)
+
+        # EXPIRED status
+        response = self.client.get(
+            "/api/polio/vaccineauthorizations/get_most_recent_authorizations/?auth_status=EXPIRED"
+        )
+
+        self.assertEqual(len(response.data), 2)
+
+        # SIGNATURE status
+        response = self.client.get(
+            "/api/polio/vaccineauthorizations/get_most_recent_authorizations/?auth_status=SIGNATURE"
+        )
+
+        self.assertEqual(len(response.data), 3)
+
+        # SIGNATURE and EXPIRED status
+        response = self.client.get(
+            "/api/polio/vaccineauthorizations/get_most_recent_authorizations/?auth_status=SIGNATURE,EXPIRED"
+        )
+
+        self.assertEqual(len(response.data), 5)
+
+        # SIGNATURE and ONGOING status
+        response = self.client.get(
+            "/api/polio/vaccineauthorizations/get_most_recent_authorizations/?auth_status=SIGNATURE,ONGOING"
+        )
+
+        self.assertEqual(len(response.data), 3)
+
+        # SIGNATURE and VALIDATED status
+        response = self.client.get(
+            "/api/polio/vaccineauthorizations/get_most_recent_authorizations/?auth_status=SIGNATURE,VALIDATED"
+        )
+
+        self.assertEqual(len(response.data), 5)
+
+        # SIGNATURE, VALIDATED, EXPIRED status
+        response = self.client.get(
+            "/api/polio/vaccineauthorizations/get_most_recent_authorizations/?auth_status=SIGNATURE,EXPIRED,VALIDATED"
+        )
+
+        self.assertEqual(len(response.data), 7)


### PR DESCRIPTION
It was not only EXPIRED but also Signature filters that were broken.
As the status are required to compute the correct response, filtering in the get_queryset method was not possible for this action. So I moved the filtering after calculation of the response. 

Related JIRA tickets : POLIO-1205

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests
- [ ] Documentation has been included (for new feature)

## How to test

Go to vaccine authorisation tab in Polio and user the status filter. The result should be correct.  A team named " nOPV2 vaccine authorization alerts " is required with your user in it to see the results. 

## Print screen / video


https://github.com/BLSQ/iaso/assets/45785235/3ca43d6a-ae11-4d7f-b736-ae956711b28d


