### PR TITLE
IA-2449 update dependencies pandas numpy cython

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -99,7 +99,7 @@ steps:
     RDS_USERNAME: postgres
     CACHE: false
     DEV_SERVER: true
-    PLUGINS: polio
+    PLUGINS: polio,wfp
     DJANGO_SUPERUSER_USERNAME: adm
     DJANGO_SUPERUSER_EMAIL: adm@example.com
     DJANGO_SUPERUSER_PASSWORD: $(DJANGO_SUPERUSER_PASSWORD)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,12 +7,12 @@ django==3.2.21
 django-cors-headers==3.2.1
 djangorestframework==3.11.2
 django-filter==2.4.0
-pandas==1.0.1
-cython==0.29.23
+pandas==1.1.5
+#cython==0.29.36
 pyproj==3.0.1
 geopandas==0.8.0
 Fiona~=1.8.19
-numpy==1.18.1
+numpy==1.19.4
 Pillow==8.3.2
 django-storages==1.9.1
 boto3==1.12.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ Fiona~=1.8.19
 numpy==1.19.4
 Pillow==8.3.2
 django-storages==1.9.1
-boto3==1.12.1
+boto3==1.16.63
 geopy==1.21.0
 Shapely==1.7.0
 unidecode==1.2.0
@@ -24,7 +24,7 @@ django-cte==1.2.1
 
 # web server and auth
 oauth2client==4.1.3
-requests==2.22.0
+requests==2.26.0
 
 # postgresql and sql
 psycopg2-binary==2.8.5
@@ -81,3 +81,5 @@ django-json-widget==1.1.1
 
 # Seems to be required to run the project
 django-stubs==1.9.0
+
+gql[requests]==3.4.0


### PR DESCRIPTION
Smallest possible update on requirements.txt in order to tackle the problem of main not building in Docker (on mac).
Removed Cython which is a transient dependency.

Related JIRA tickets : IA-2449

## Changes

See requirements.txt file.

## How to test

Pull this branch and rebuild your docker iaso env. See if it works.

## Notes

Mainly doing this PR to see if this doesn't break CI (Gonna clear the caches)
