### PR TITLE
IA-2440: Single per period field should show that it's mandatory

### DIFF
--- a/hat/assets/js/apps/Iaso/components/forms/InputComponent.js
+++ b/hat/assets/js/apps/Iaso/components/forms/InputComponent.js
@@ -176,6 +176,7 @@ class InputComponent extends Component {
                             onChange={newValue => onChange(keyValue, newValue)}
                             value={value}
                             label={labelText}
+                            required={required}
                         />
                     );
                 case 'radio':
@@ -188,6 +189,7 @@ class InputComponent extends Component {
                             onChange={newValue => onChange(keyValue, newValue)}
                             options={options}
                             value={value}
+                            required={required}
                         />
                     );
                 default:

--- a/package-lock.json
+++ b/package-lock.json
@@ -6217,7 +6217,7 @@
         },
         "node_modules/bluesquare-components": {
             "version": "0.2.0",
-            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#929a7485e4efc83aa626cbf19ee7d64f3c9a65c3",
+            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#11544c7b1e578db5fde5bb4f1e5dd9f00a84e11d",
             "license": "Apache-2.0",
             "dependencies": {
                 "@babel/plugin-transform-runtime": "^7.17.0",
@@ -34559,7 +34559,7 @@
             "dev": true
         },
         "bluesquare-components": {
-            "version": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#929a7485e4efc83aa626cbf19ee7d64f3c9a65c3",
+            "version": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#11544c7b1e578db5fde5bb4f1e5dd9f00a84e11d",
             "from": "bluesquare-components@github:BLSQ/bluesquare-components",
             "requires": {
                 "@babel/plugin-transform-runtime": "^7.17.0",


### PR DESCRIPTION
You can’t create a form without clicking here, but nothing clearly shows that. We should at least have a little start ( * ) next to the text 

Related JIRA tickets : IA-2440

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- upgrade bluesquare-components to display * in label
- changes to inputComponent to allow required prop on radio and checkbox

## How to test

Create a new form, 'Single period field should display *

## Print screen / video
![Screenshot 2023-09-25 at 11 01 49](https://github.com/BLSQ/iaso/assets/12494624/1ca4d59e-46be-417c-a6ba-d03b07ac7ebc)

