### PR TITLE
IA-2392:Org unit logs add link to parentorg unit and translate status

### DIFF
--- a/hat/assets/js/apps/Iaso/components/logs/LogValue.tsx
+++ b/hat/assets/js/apps/Iaso/components/logs/LogValue.tsx
@@ -1,21 +1,23 @@
-import React,  {FunctionComponent} from 'react';
+import React, { FunctionComponent, useState } from 'react';
 import { wktToGeoJSON as terraformer } from '@terraformer/wkt';
-// @ts-ignore
-import { textPlaceholder } from 'bluesquare-components';
+import { textPlaceholder, useSafeIntl } from 'bluesquare-components';
 import moment from 'moment';
 import { makeStyles } from '@material-ui/core';
 
 import { GeoJsonMap } from '../maps/GeoJsonMapComponent';
 import { MarkerMap } from '../maps/MarkerMapComponent';
 import { GeoJson } from '../maps/types';
+import { LinkToOrgUnit } from '../../domains/orgUnits/components/LinkToOrgUnit';
+import { useGetOrgUnitDetail } from '../../domains/orgUnits/hooks/requests/useGetOrgUnitDetail';
 
+import MESSAGES from './messages';
 
 type Props = {
     fieldKey: string;
     value?: string | number;
 };
 
-const wktToGeoJSON = (value: string | number):GeoJson | undefined  => {
+const wktToGeoJSON = (value: string | number): GeoJson | undefined => {
     return terraformer(value.toString().replace('SRID=4326;', ''));
 };
 
@@ -27,15 +29,21 @@ const styles = theme => ({
 
 const useStyles = makeStyles(styles);
 
-export const LogValue: FunctionComponent<Props> = ({fieldKey, value}) => {
+export const LogValue: FunctionComponent<Props> = ({ fieldKey, value }) => {
     const classes = useStyles();
+    const { formatMessage } = useSafeIntl();
+    const [parentOrgUnitId, setParentOrgUnitId] = useState<
+        undefined | number
+    >();
+    const { data: parentOrgUnit, isFetching: isFetchingOrgUnit } =
+        useGetOrgUnitDetail(parentOrgUnitId);
     if (!value || value === '') return textPlaceholder;
     try {
         switch (fieldKey) {
             case 'geom':
             case 'catchment':
             case 'simplified_geom': {
-                const geoJson:GeoJson | undefined= wktToGeoJSON(value);
+                const geoJson: GeoJson | undefined = wktToGeoJSON(value);
                 if (!geoJson) return textPlaceholder;
                 return (
                     <div className={classes.cellMap}>
@@ -44,12 +52,24 @@ export const LogValue: FunctionComponent<Props> = ({fieldKey, value}) => {
                 );
             }
 
+            case 'validation_status': {
+                return MESSAGES[value] ? formatMessage(MESSAGES[value]) : value;
+            }
             case 'updated_at': {
                 return moment(value).format('LTS');
             }
 
+            case 'parent': {
+                if (value !== parentOrgUnitId) {
+                    setParentOrgUnitId(value as number);
+                }
+                if (parentOrgUnit && !isFetchingOrgUnit) {
+                    return <LinkToOrgUnit orgUnit={parentOrgUnit} />;
+                }
+                return '';
+            }
             case 'location': {
-                const geoJson:GeoJson | undefined = wktToGeoJSON(value);
+                const geoJson: GeoJson | undefined = wktToGeoJSON(value);
                 if (!geoJson || !geoJson?.coordinates) return textPlaceholder;
                 const { coordinates } = geoJson;
                 return (
@@ -67,8 +87,6 @@ export const LogValue: FunctionComponent<Props> = ({fieldKey, value}) => {
     } catch (e) {
         // eslint-disable-next-line no-console
         console.error('Could not parse', e);
-        throw new Error(
-            value.toString(),
-        );
+        throw new Error(value.toString());
     }
 };

--- a/hat/assets/js/apps/Iaso/components/logs/messages.js
+++ b/hat/assets/js/apps/Iaso/components/logs/messages.js
@@ -57,6 +57,18 @@ export const MESSAGES = defineMessages({
         id: 'iaso.label.renderError',
         defaultMessage: 'Error rendering value',
     },
+    REJECTED: {
+        defaultMessage: 'Rejected',
+        id: 'iaso.forms.rejectedCap',
+    },
+    NEW: {
+        defaultMessage: 'New',
+        id: 'iaso.forms.newCap',
+    },
+    VALID: {
+        defaultMessage: 'Validated',
+        id: 'iaso.forms.validated',
+    },
 });
 
 export default MESSAGES;

--- a/hat/assets/js/apps/Iaso/utils/requests.js
+++ b/hat/assets/js/apps/Iaso/utils/requests.js
@@ -141,7 +141,7 @@ export const fetchOrgUnitDetail = (dispatch, orgUnitId) =>
         });
 
 export const fetchLogDetail = (dispatch, logId) =>
-    getRequest(`/api/logs/${logId}`)
+    getRequest(`/api/logs/${logId}/`)
         .then(logDetail => logDetail)
         .catch(error => {
             dispatch(


### PR DESCRIPTION
In the history of an organisation unit, the information is not always clear and sometimes not translated.


For example :

the modification of a parent is noted according to the id of the parent and not its name. The name of the parent should appear clearly.

ditto for the path

the modification of the status of an OU is noted in English and should be translated into French when the language of the IASO instance is French (NEW → Nouveau, VALID → Validé)

Related JIRA tickets : IA-2392

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- use LinkToOrgUnit to display parent log (+ fetch parent org unit detail)
- translate status

## How to test

- Create a new org unit, without parent and save
- add the parent and save
- change status and save
- go to to history tab and check that parent org unit log and status are correctly displayed

## Print screen / video

<img width="1597" alt="Screenshot 2023-09-25 at 12 29 41" src="https://github.com/BLSQ/iaso/assets/12494624/9c193778-ec36-42fa-b72d-b704ccdaa88e">
<img width="1654" alt="Screenshot 2023-09-25 at 12 29 28" src="https://github.com/BLSQ/iaso/assets/12494624/931ab9a4-b604-4529-aeee-9350e9caa6b6">
