### PR TITLE
IA-1787 Form list: Form in multiple projects are counted multiple times in the submissions count

### DIFF
--- a/iaso/api/forms.py
+++ b/iaso/api/forms.py
@@ -254,6 +254,7 @@ class FormsViewSet(ModelViewSet):
                         & ~Q(instances__deleted=True)
                         & Q(instances__org_unit__in=orgunits)
                     ),
+                    distinct=True,
                 )
             )
         else:
@@ -263,6 +264,7 @@ class FormsViewSet(ModelViewSet):
                     filter=(
                         ~Q(instances__file="") & ~Q(instances__device__test_device=True) & ~Q(instances__deleted=True)
                     ),
+                    distinct=True,
                 )
             )
 


### PR DESCRIPTION
Instances count were multiplied by the number of projects if a same form is shared between projects.  It results in 
instance_count was instance X projects which was wrong. Simply adding distinct to the querysets solve this bug. 

Related JIRA tickets : IA-1787

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes


## How to test

Have a form with multiple submissions from multiple projects.
For example if you have 2 instances, in different projects you should have 2 submissions for the form. But the list will show 4.

## Print screen / video


https://github.com/BLSQ/iaso/assets/45785235/5d25262b-dbaf-472b-8dc7-8dc47374ffdb

