### PR TITLE
fix the duplication of planning

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -796,7 +796,7 @@
     "iaso.periods.end": "Période de fin",
     "iaso.periods.start": "Période de début",
     "iaso.permission.reports": "Appareils",
-    "iaso.permissions.assignments": "Planning",
+    "iaso.permissions.assignments": "Attributions",
     "iaso.permissions.completeness": "Complétude des exports",
     "iaso.permissions.completeness_stats": "Statistiques de complétude",
     "iaso.permissions.dataTasks": "Batch monitoring",

--- a/hat/assets/js/apps/Iaso/domains/users/permissionsMessages.ts
+++ b/hat/assets/js/apps/Iaso/domains/users/permissionsMessages.ts
@@ -81,7 +81,7 @@ const PERMISSIONS_MESSAGES = defineMessages({
     },
     iaso_assignments: {
         id: 'iaso.permissions.assignments',
-        defaultMessage: 'Planning',
+        defaultMessage: 'Attributions',
     },
     iaso_completeness_stats: {
         id: 'iaso.permissions.completeness_stats',


### PR DESCRIPTION
Explain what problem this PR is resolving
- Remove planning duplication in permissions
Related JIRA tickets : No ticket related(it's a hot fix)

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes
- Change assignment permission into Attributions instead of Planning in fr.json and permissionMessages
