### PR TITLE
IA-2457: Automatically generated App ID should have a "." instead of a "-"

### DIFF
--- a/iaso/api/setup_account.py
+++ b/iaso/api/setup_account.py
@@ -53,7 +53,7 @@ class SetupAccountSerializer(serializers.Serializer):
         )
 
         # Create a setup_account project with an app_id represented by the account name
-        app_id = validated_data["account_name"].replace(" ", "-")
+        app_id = validated_data["account_name"].replace(" ", ".").replace("-", ".")
 
         initial_project = Project.objects.create(
             name=validated_data["account_name"] + " project", account=account, app_id=app_id

--- a/iaso/tests/api/test_setup_account.py
+++ b/iaso/tests/api/test_setup_account.py
@@ -127,7 +127,7 @@ class SetupAccountApiTestCase(APITestCase):
         self.client.force_authenticate(self.admin)
 
         data = {
-            "account_name": "initial_project_account test",
+            "account_name": "initial_project_account test-appid",
             "user_username": "username",
             "password": "password",
         }
@@ -142,7 +142,7 @@ class SetupAccountApiTestCase(APITestCase):
 
         project = created_project.first()
         # Check if the project has the correct app_id
-        self.assertEqual(project.app_id, "initial_project_account-test")
+        self.assertEqual(project.app_id, "initial_project_account.test.appid")
         # Check if the project is linked to the correct account
         self.assertEqual(project.account, created_account.first())
         # Check if the project is linked to the correct data source

--- a/iaso/tests/api/test_setup_account.py
+++ b/iaso/tests/api/test_setup_account.py
@@ -135,9 +135,9 @@ class SetupAccountApiTestCase(APITestCase):
         response = self.client.post("/api/setupaccount/", data=data, format="json")
         self.assertEqual(response.status_code, 201)
 
-        created_account = m.Account.objects.filter(name="initial_project_account test")
-        created_project = m.Project.objects.filter(name="initial_project_account test project")
-        created_data_source = m.DataSource.objects.filter(name="initial_project_account test")
+        created_account = m.Account.objects.filter(name="initial_project_account test-appid")
+        created_project = m.Project.objects.filter(name="initial_project_account test-appid project")
+        created_data_source = m.DataSource.objects.filter(name="initial_project_account test-appid")
         self.assertEqual(len(created_project), 1)
 
         project = created_project.first()


### PR DESCRIPTION
Explain what problem this PR is resolving
- The dash in the app_id triggered error
- Replace the space and the dash by a dot
Related JIRA tickets : [IA-2457](https://bluesquare.atlassian.net/browse/IA-2457)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes
- Replace a space by a dot instead of a dash
- Replace a dash by a dot

## How to test
- Setup an new account in api/setup_account
- Check the app_id in the project automatically created by the setup_account


[IA-2457]: https://bluesquare.atlassian.net/browse/IA-2457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ