### PR TITLE
IA-2461 Fix cypress run when triggered by comments

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -37,6 +37,7 @@ jobs:
           ref: ${{ github.event.inputs.ref }}
 
       - id: 'get-branch'
+        name: Get branch name from PR when triggered by comment
         if: github.event_name != 'workflow_dispatch'
         run: echo ::set-output name=branch::$(gh pr view $PR_NO --repo $REPO --json headRefName --jq '.headRefName')
         env:
@@ -138,6 +139,7 @@ jobs:
           ref: ${{ github.event.inputs.ref }}
       
       - id: 'get-branch'
+        name: Get branch name from PR when triggered by comment
         if: github.event_name != 'workflow_dispatch'
         run: echo ::set-output name=branch::$(gh pr view $PR_NO --repo $REPO --json headRefName --jq '.headRefName')
         env:


### PR DESCRIPTION
When cypress tests where launched using the @cypress comment trigger. The cypress tests were actually run on the main branch, not the branch linked to the PR where the comment was made which was not useful.

This is no fixed. 

Related JIRA tickets : IA-2461


## Changes

Added a step to extract the branch name in this case.
Use the output of this step for the checkout

## How to test

Use the @cypress comment on a one of your PR and check during the execution that at the checkout step the related branch is checked out (not main)