### PR TITLE
POLIO-1223 Expiry date is past but the status is APPROVED and not EXPIRED

### DIFF
--- a/plugins/polio/tasks/vaccine_authorizations_mail_alerts.py
+++ b/plugins/polio/tasks/vaccine_authorizations_mail_alerts.py
@@ -177,7 +177,7 @@ def send_email_expired_vaccine_authorizations_alert(task=None):
 
 @task_decorator(task_name="vaccine_authorization_update_expired_entries")
 def vaccine_authorization_update_expired_entries(task=None):
-    expired_vacc_auth = VaccineAuthorization.objects.filter(expiration_date=datetime.date.today() - timedelta(days=1))
+    expired_vacc_auth = VaccineAuthorization.objects.filter(expiration_date__lt=datetime.date.today())
     total = expired_vacc_auth.count()
 
     expired_auth = 0

--- a/plugins/polio/tests/test_vaccine_authorizations.py
+++ b/plugins/polio/tests/test_vaccine_authorizations.py
@@ -661,9 +661,6 @@ class VaccineAuthorizationAPITestCase(APITestCase):
         expired_entry.refresh_from_db()
         expired_entry_third.refresh_from_db()
         valid_entry.refresh_from_db()
-        print(task.status)
-        print(task.progress_message)
-        print(task.result)
         self.assertEqual(task.status, "SUCCESS")
 
         self.assertEqual(expired_entry_second.status, "EXPIRED")

--- a/plugins/polio/tests/test_vaccine_authorizations.py
+++ b/plugins/polio/tests/test_vaccine_authorizations.py
@@ -622,6 +622,7 @@ class VaccineAuthorizationAPITestCase(APITestCase):
             status="VALIDATED",
             quantity=5000000,
             expiration_date=date.today() - datetime.timedelta(days=1),
+            start_date=date.today() - datetime.timedelta(days=20),
         )
 
         valid_entry = VaccineAuthorization.objects.create(
@@ -632,18 +633,44 @@ class VaccineAuthorizationAPITestCase(APITestCase):
             expiration_date=date.today(),
         )
 
+        expired_entry_second = VaccineAuthorization.objects.create(
+            account=self.user_1.iaso_profile.account,
+            country=self.org_unit_DRC,
+            status="VALIDATED",
+            quantity=5000000,
+            expiration_date=date.today() - datetime.timedelta(days=200),
+            start_date=date.today() - datetime.timedelta(days=250),
+        )
+
+        expired_entry_third = VaccineAuthorization.objects.create(
+            account=self.user_1.iaso_profile.account,
+            country=self.org_unit_DRC,
+            status="VALIDATED",
+            quantity=5000000,
+            expiration_date=date.today() - datetime.timedelta(days=300),
+            start_date=date.today() - datetime.timedelta(days=350),
+        )
+
         task = vaccine_authorization_update_expired_entries(user=self.user_1)
 
         self.assertEqual(task.status, "QUEUED")
         task_service = TestTaskService()
         task_service.run_all()
         task.refresh_from_db()
+        expired_entry_second.refresh_from_db()
         expired_entry.refresh_from_db()
+        expired_entry_third.refresh_from_db()
         valid_entry.refresh_from_db()
+        print(task.status)
+        print(task.progress_message)
+        print(task.result)
         self.assertEqual(task.status, "SUCCESS")
 
+        self.assertEqual(expired_entry_second.status, "EXPIRED")
         self.assertEqual(expired_entry.status, "EXPIRED")
+        self.assertEqual(expired_entry_third.status, "EXPIRED")
         self.assertEqual(valid_entry.status, "VALIDATED")
+        self.assertEqual(task.progress_message, "3 expired nOPV2 vaccine authorization.")
 
     def test_order_get_recent_vacc(self):
         self.client.force_authenticate(self.user_1)


### PR DESCRIPTION
The vaccine Authorisation status job was looking exactly for a date expired since 1 day. Normally it’s impossible to create an authorisation with a past expiration_date so this case should not happen in production. However I did  change the script to look for all the past dates instead of strictly today - 1.   

Related JIRA tickets : POLIO-1223

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests
- [ ] Documentation has been included (for new feature)

## How to test

You can run the function from a python shell in iaso environment. As it'as a tasks triggered by EB I don't see how you can try it on a local env.