### PR TITLE
IA-2453 [FIX] Handle the fact that `OrgUnit.source_ref` is nullable

### DIFF
--- a/iaso/api/profiles.py
+++ b/iaso/api/profiles.py
@@ -293,7 +293,7 @@ class ProfilesViewSet(viewsets.ViewSet):
                 profile.user.first_name,
                 profile.user.last_name,
                 ",".join(str(item.pk) for item in org_units),
-                ",".join(item.source_ref for item in org_units),
+                ",".join(item.source_ref for item in org_units if item.source_ref),
                 profile.language,
                 profile.dhis2_id,
                 ",".join(item.codename for item in profile.user.user_permissions.all()),

--- a/iaso/tests/api/test_profiles.py
+++ b/iaso/tests/api/test_profiles.py
@@ -53,7 +53,7 @@ class ProfileAPITestCase(APITestCase):
             catchment=cls.mock_multipolygon,
             location=cls.mock_point,
             validation_status=m.OrgUnit.VALIDATION_VALID,
-            source_ref="PvtAI4RUMkr",
+            source_ref=None,
         )
         cls.jedi_council_corruscant = m.OrgUnit.objects.create(
             org_unit_type=cls.jedi_council,
@@ -217,9 +217,7 @@ class ProfileAPITestCase(APITestCase):
         )
 
         expected_csv += "janedoe,,,,,,,,,iaso_forms,,\r\n"
-        expected_csv += (
-            f'johndoe,,,,,"{self.jedi_squad_1.pk},{self.jedi_council_corruscant.pk}","PvtAI4RUMkr,FooBarB4z00",,,,,\r\n'
-        )
+        expected_csv += f'johndoe,,,,,"{self.jedi_squad_1.pk},{self.jedi_council_corruscant.pk}",FooBarB4z00,,,,,\r\n'
         expected_csv += 'jim,,,,,,,,,"iaso_forms,iaso_users",,\r\n'
         expected_csv += "jam,,,,,,,en,,iaso_users_managed,,\r\n"
         expected_csv += "jom,,,,,,,fr,,,,\r\n"
@@ -275,7 +273,7 @@ class ProfileAPITestCase(APITestCase):
                 },
                 "orgunit__source_ref": {
                     0: None,
-                    1: "PvtAI4RUMkr,FooBarB4z00",
+                    1: "FooBarB4z00",
                     2: None,
                     3: None,
                     4: None,


### PR DESCRIPTION
Fix: Handle the fact that `OrgUnit.source_ref` [is nullable](https://github.com/BLSQ/iaso/blob/5d93a0aee1864fc48fdb69e2f61fa80a3466f822/iaso/models/org_unit.py#L266).

Related JIRA tickets : [IA-2453](https://bluesquare.atlassian.net/browse/IA-2453)


[IA-2453]: https://bluesquare.atlassian.net/browse/IA-2453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ