### PR TITLE
WC2-279 Bump django storages version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ geopandas==0.8.0
 Fiona~=1.8.19
 numpy==1.19.4
 Pillow==8.3.2
-django-storages==1.9.1
+django-storages==1.14.2
 boto3==1.16.63
 geopy==1.21.0
 Shapely==1.7.0


### PR DESCRIPTION
We recently update the version of boto.
This silently seemed to have introduce a bug/conflict with django-storages (See [here](https://github.com/jschneier/django-storages/issues/843) for details)
Which introduced a bug in the merging of duplicates.
This bumps django storages to last version which fixes the bug with merging duplicates.


Related JIRA tickets : WC2-279

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented

## Changes

Just upgrade django-storages version in requirements.txt

## How to test

Try to merge a duplicate and see if it bugs with a unicode error.
