### PR TITLE
Polio-1233 polio features behind admin perm (front-end)

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/TreeView/OrgUnitTreeviewPicker.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/TreeView/OrgUnitTreeviewPicker.js
@@ -125,6 +125,7 @@ const OrgUnitTreeviewPicker = ({
                     selectedItems={value}
                     key={`TruncatedTree${key.toString()}`}
                     label={label}
+                    disabled={disabled}
                     redirect={id =>
                         disabled
                             ? null

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/TreeView/OrgUnitTreeviewPicker.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/TreeView/OrgUnitTreeviewPicker.js
@@ -105,7 +105,6 @@ const OrgUnitTreeviewPicker = ({
         (multiselect
             ? intl.formatMessage(MESSAGES.selectMultiple)
             : intl.formatMessage(MESSAGES.selectSingle));
-
     const makeTruncatedTrees = treesData => {
         if (treesData.size === 0)
             return (
@@ -127,10 +126,12 @@ const OrgUnitTreeviewPicker = ({
                     key={`TruncatedTree${key.toString()}`}
                     label={label}
                     redirect={id =>
-                        window.open(
-                            `/dashboard/${baseUrls.orgUnitDetails}/orgUnitId/${id}`,
-                            '_blank',
-                        )
+                        disabled
+                            ? null
+                            : window.open(
+                                  `/dashboard/${baseUrls.orgUnitDetails}/orgUnitId/${id}`,
+                                  '_blank',
+                              )
                     }
                 />
             );
@@ -169,9 +170,13 @@ const OrgUnitTreeviewPicker = ({
                                 icon="clear"
                                 size="small"
                                 tooltipMessage={MESSAGES.clear}
-                                onClick={() => {
-                                    resetSelection();
-                                }}
+                                onClick={
+                                    disabled
+                                        ? noOp
+                                        : () => {
+                                              resetSelection();
+                                          }
+                                }
                             />
                         </Box>
                     )}
@@ -183,7 +188,8 @@ const OrgUnitTreeviewPicker = ({
                                 : MESSAGES.selectSingle
                         }
                         icon="orgUnit"
-                        onClick={onClick}
+                        onClick={disabled ? noOp : onClick}
+                        disabled={disabled}
                     />
                 </Paper>
             </FormControl>

--- a/package-lock.json
+++ b/package-lock.json
@@ -6169,7 +6169,7 @@
         },
         "node_modules/bluesquare-components": {
             "version": "0.2.0",
-            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#4d8c7676ebdb7f0d2f1d8b5d72f8d7d633880825",
+            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#4fda0190bc1137603d0eec303e2e25eb9f1bd57b",
             "license": "Apache-2.0",
             "dependencies": {
                 "@babel/plugin-transform-runtime": "^7.17.0",
@@ -34521,7 +34521,7 @@
             "dev": true
         },
         "bluesquare-components": {
-            "version": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#4d8c7676ebdb7f0d2f1d8b5d72f8d7d633880825",
+            "version": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#4fda0190bc1137603d0eec303e2e25eb9f1bd57b",
             "from": "bluesquare-components@github:BLSQ/bluesquare-components",
             "requires": {
                 "@babel/plugin-transform-runtime": "^7.17.0",

--- a/plugins/polio/api/lqas_im/lqas_stats.py
+++ b/plugins/polio/api/lqas_im/lqas_stats.py
@@ -58,7 +58,7 @@ def add_nfm_stats_for_rounds(campaign_stats, nfm_stats, kind: str):
                         round_stats[kind][reason] += count
     return campaign_stats
 
-
+#Deprecated
 class LQASStatsViewSet(viewsets.ViewSet):
     """
     Endpoint used to transform IM (independent monitoring) data from existing ODK forms stored in ONA.

--- a/plugins/polio/api/lqas_im/lqas_stats.py
+++ b/plugins/polio/api/lqas_im/lqas_stats.py
@@ -58,7 +58,8 @@ def add_nfm_stats_for_rounds(campaign_stats, nfm_stats, kind: str):
                         round_stats[kind][reason] += count
     return campaign_stats
 
-#Deprecated
+
+# Deprecated
 class LQASStatsViewSet(viewsets.ViewSet):
     """
     Endpoint used to transform IM (independent monitoring) data from existing ODK forms stored in ONA.

--- a/plugins/polio/js/src/components/Inputs/OrgUnitsSelect.tsx
+++ b/plugins/polio/js/src/components/Inputs/OrgUnitsSelect.tsx
@@ -39,7 +39,6 @@ export const OrgUnitsLevels: FunctionComponent<Props> = ({
     const initialOrgUnitId = values[name];
     const errors = backendErrors ?? getErrors(touched, formErrors, name);
     const { data: initialOrgUnit, isLoading } = useGetOrgUnit(initialOrgUnitId);
-    console.log('DISABLED?', disabled);
     return (
         <Box position="relative">
             <OrgUnitTreeviewModal

--- a/plugins/polio/js/src/components/Inputs/OrgUnitsSelect.tsx
+++ b/plugins/polio/js/src/components/Inputs/OrgUnitsSelect.tsx
@@ -11,6 +11,7 @@ type Props = {
     label: string;
     required?: boolean;
     clearable?: boolean;
+    disabled?: boolean;
     errors?: string[];
 };
 
@@ -24,6 +25,7 @@ export const OrgUnitsLevels: FunctionComponent<Props> = ({
     label,
     required = false,
     clearable = true,
+    disabled = false,
     errors: backendErrors = undefined,
 }) => {
     const { name } = field;
@@ -37,7 +39,7 @@ export const OrgUnitsLevels: FunctionComponent<Props> = ({
     const initialOrgUnitId = values[name];
     const errors = backendErrors ?? getErrors(touched, formErrors, name);
     const { data: initialOrgUnit, isLoading } = useGetOrgUnit(initialOrgUnitId);
-
+    console.log('DISABLED?', disabled);
     return (
         <Box position="relative">
             <OrgUnitTreeviewModal
@@ -53,6 +55,7 @@ export const OrgUnitsLevels: FunctionComponent<Props> = ({
                 errors={errors}
                 required={required}
                 clearable={clearable}
+                disabled={disabled}
             />
             {isLoading && (
                 <Box

--- a/plugins/polio/js/src/domains/Campaigns/BaseInfo/BaseInfoForm.js
+++ b/plugins/polio/js/src/domains/Campaigns/BaseInfo/BaseInfoForm.js
@@ -42,6 +42,7 @@ export const BaseInfoForm = () => {
 
     const { formatMessage } = useSafeIntl();
     const currentUser = useCurrentUser();
+    const isUserAdmin = userHasPermission('iaso_polio_config', currentUser);
     const { data: groupedCampaigns } = useGetGroupedCampaigns();
     const groupedCampaignsOptions = useMemo(
         () =>
@@ -79,6 +80,7 @@ export const BaseInfoForm = () => {
                             component={TextInput}
                             className={classes.input}
                             required
+                            disabled={!isUserAdmin}
                         />
                         <Field
                             label={formatMessage(MESSAGES.groupedCampaigns)}
@@ -126,17 +128,20 @@ export const BaseInfoForm = () => {
                             component={OrgUnitsLevels}
                             clearable={false}
                             required
+                            disabled={!isUserAdmin}
                         />
                     </Box>
                 </Grid>
                 <Grid item xs={6} md={6}>
-                    <Field
-                        className={classes.input}
-                        label={formatMessage(MESSAGES.preventive)}
-                        name="is_preventive"
-                        component={BooleanInput}
-                    />
-                    {userHasPermission('iaso_polio_config', currentUser) && (
+                    {isUserAdmin && (
+                        <Field
+                            className={classes.input}
+                            label={formatMessage(MESSAGES.preventive)}
+                            name="is_preventive"
+                            component={BooleanInput}
+                        />
+                    )}
+                    {isUserAdmin && (
                         <Field
                             className={classes.input}
                             label={formatMessage(MESSAGES.testCampaign)}
@@ -144,14 +149,22 @@ export const BaseInfoForm = () => {
                             component={BooleanInput}
                         />
                     )}
-                    <SendEmailButton />
-                    <Field
-                        className={classes.input}
-                        label={formatMessage(MESSAGES.enable_send_weekly_email)}
-                        name="enable_send_weekly_email"
-                        component={BooleanInput}
-                    />
-                    <EmailListForCountry countryId={top_level_org_unit_id} />
+                    {isUserAdmin && (
+                        <>
+                            <SendEmailButton />
+                            <Field
+                                className={classes.input}
+                                label={formatMessage(
+                                    MESSAGES.enable_send_weekly_email,
+                                )}
+                                name="enable_send_weekly_email"
+                                component={BooleanInput}
+                            />
+                            <EmailListForCountry
+                                countryId={top_level_org_unit_id}
+                            />
+                        </>
+                    )}
                 </Grid>
                 <Grid container item spacing={2}>
                     <Grid item xs={12} md={6}>

--- a/plugins/polio/js/src/domains/Campaigns/Dashboard.js
+++ b/plugins/polio/js/src/domains/Campaigns/Dashboard.js
@@ -14,6 +14,8 @@ import { Box, Tooltip } from '@material-ui/core';
 import AddIcon from '@material-ui/icons/Add';
 import DownloadIcon from '@material-ui/icons/GetApp';
 import TopBar from 'Iaso/components/nav/TopBarComponent';
+import { userHasPermission } from '../../../../../../hat/assets/js/apps/Iaso/domains/users/utils';
+import { useCurrentUser } from '../../../../../../hat/assets/js/apps/Iaso/utils/usersUtils.ts';
 import { TableWithDeepLink } from '../../../../../../hat/assets/js/apps/Iaso/components/tables/TableWithDeepLink.tsx';
 import { PolioCreateEditDialog as CreateEditDialog } from './MainDialog/CreateEditDialog';
 import { PageAction } from '../../components/Buttons/PageAction';
@@ -46,7 +48,7 @@ const Dashboard = ({ router }) => {
     const [isRestoreDialogOpen, setIsRestoreDialogOpen] = useState(false);
     const [selectedCampaignId, setSelectedCampaignId] = useState();
     const classes = useStyles();
-
+    const currentUser = useCurrentUser();
     const paramsToUse = useSingleTableParams(params);
     const apiParams = useCampaignParams(paramsToUse);
 
@@ -149,6 +151,8 @@ const Dashboard = ({ router }) => {
         setSelectedCampaignId(undefined);
         openCreateEditDialog();
     };
+
+    const isUserAdmin = userHasPermission('iaso_polio_config', currentUser);
 
     useEffect(() => {
         if (params.campaignId) {
@@ -295,16 +299,18 @@ const Dashboard = ({ router }) => {
             />
             <Box className={classes.containerFullHeightNoTabPadded}>
                 <PageActions params={params}>
-                    <PageAction
-                        icon={AddIcon}
-                        onClick={handleClickCreateButton}
-                    >
-                        {formatMessage(MESSAGES.create)}
-                    </PageAction>
+                    {isUserAdmin && (
+                        <PageAction
+                            icon={AddIcon}
+                            onClick={handleClickCreateButton}
+                        >
+                            {formatMessage(MESSAGES.create)}
+                        </PageAction>
+                    )}
                     <PageActionWithLink icon={DownloadIcon} url={exportToCSV}>
                         {formatMessage(MESSAGES.csv)}
                     </PageActionWithLink>
-                    <ImportLine />
+                    {isUserAdmin && <ImportLine />}
                 </PageActions>
                 <TableWithDeepLink
                     data={campaigns?.campaigns ?? []}

--- a/plugins/polio/js/src/domains/Campaigns/Preparedness/PreparednessConfig.js
+++ b/plugins/polio/js/src/domains/Campaigns/Preparedness/PreparednessConfig.js
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 import {
     Button,
     CircularProgress,
@@ -15,6 +16,8 @@ import OpenInNewIcon from '@material-ui/icons/OpenInNew';
 import PropTypes from 'prop-types';
 
 import { TextInput } from '../../../components/Inputs';
+import { useCurrentUser } from '../../../../../../../hat/assets/js/apps/Iaso/utils/usersUtils.ts';
+import { userHasPermission } from '../../../../../../../hat/assets/js/apps/Iaso/domains/users/utils';
 import { useStyles } from '../../../styles/theme';
 import {
     useGeneratePreparednessSheet,
@@ -29,6 +32,8 @@ export const PreparednessConfig = ({ roundNumber, campaignName }) => {
     const { formatMessage } = useSafeIntl();
     const { values, setFieldValue, dirty } = useFormikContext();
     const { rounds = [], id: campaignId } = values;
+    const currentUser = useCurrentUser();
+    const isUserAdmin = userHasPermission('iaso_polio_config', currentUser);
     const currentRound = rounds.find(r => r.number === roundNumber);
     const roundIndex = rounds.findIndex(r => r.number === roundNumber);
     const roundStartDate = currentRound?.started_at;
@@ -97,7 +102,8 @@ export const PreparednessConfig = ({ roundNumber, campaignName }) => {
                             disabled={
                                 previewMutation.isLoading ||
                                 isGeneratingSpreadsheet ||
-                                isLockedForEdition
+                                isLockedForEdition ||
+                                !isUserAdmin
                             }
                             className={classes.input}
                         />


### PR DESCRIPTION
Block some features of the main polio form to non-admin users (front-end

Related JIRA tickets : POLIO-1233, POLIO-1210

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- Add checks on `iaso_polio_config` permission and hide/disable features accordingly
- Add and pass a `disabled` prop to `OrgUnitTreeviewPicker`. !! depends on PR in bluesuare-components!!

## How to test

If PR on bluesquare-components has not been merged, use replace dependency to bluesauare-components with this one:
` "bluesquare-components": "github:BLSQ/bluesquare-components#POLIO-1233_add_disable_to_TruncatedTreeview",`


- Create a user with `iaso_polio` permission but not `iaso_polio_config`
- Log in as this user
- Go to campaigns
- Pick a campaign.
- Check POLIO-1210 for the restricted fields

## Print screen / video

https://github.com/BLSQ/iaso/assets/38907762/75ff08bf-2650-4c7c-abe0-8d63126309b1


## Notes

Depends on https://github.com/BLSQ/bluesquare-components/pull/128
