### PR TITLE
POLIO-1251:convert reason to SerializermethodField

### DIFF
--- a/plugins/polio/api/shared_serializers.py
+++ b/plugins/polio/api/shared_serializers.py
@@ -119,6 +119,11 @@ class RoundDateHistoryEntryForRoundSerializer(serializers.ModelSerializer):
     modified_by = UserSerializer(required=False, read_only=True)
     round: Field = serializers.PrimaryKeyRelatedField(read_only=True, many=False)
     reason_for_delay = ReasonForDelayFieldSerializer()
+    reason = serializers.SerializerMethodField()
+
+    @staticmethod
+    def get_reason(obj: RoundDateHistoryEntry):
+        return obj.reason_for_delay.key_name
 
     def validate(self, data):
         if data.get("reason_for_delay", None) is None:

--- a/plugins/polio/api/shared_serializers.py
+++ b/plugins/polio/api/shared_serializers.py
@@ -123,7 +123,7 @@ class RoundDateHistoryEntryForRoundSerializer(serializers.ModelSerializer):
 
     @staticmethod
     def get_reason(obj: RoundDateHistoryEntry):
-        return obj.reason_for_delay.key_name
+        return obj.reason_for_delay.key_name if obj.reason_for_delay else None
 
     def validate(self, data):
         if data.get("reason_for_delay", None) is None:


### PR DESCRIPTION
Sync `reason` with `reason_for-delay` in  campaigns API

Related JIRA tickets : POLIO-1251

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- convert `reason` to  method field and return `key_name` from `ReasonForDelay` instance

## How to test

- Go to polio > configuration > Reasons for delay
- Create a reason for delay that doesn't exist in the `DelayReasons` text choice
- Go to campaigns
- Edit dates for a round and choose the new reason in the dropdown
- Save campaign
- Open campaign: inspect the API payload: the `datelogs`from the edited round should have an entry with the new reason's `key_name` as value for the reason `field`

## Print screen / video

https://github.com/BLSQ/iaso/assets/38907762/feb4e76a-13f6-4d2d-a659-090a623e3764




