### PR TITLE
POLIO-1112:  date filter deep linking doesn't show right date selection

### DIFF
--- a/plugins/polio/js/src/domains/LQAS-IM/LQAS/LqasAfroOverview/Filters/LqasAfroMapFilters.tsx
+++ b/plugins/polio/js/src/domains/LQAS-IM/LQAS/LqasAfroOverview/Filters/LqasAfroMapFilters.tsx
@@ -32,7 +32,9 @@ export const LqasAfroMapFilters: FunctionComponent<Props> = ({ params }) => {
         setFilters,
     } = useFilterState({ baseUrl, params, withPagination: false });
     const periodOptions = usePeriodOptions();
-    const [chooseDates, setChooseDates] = useState<boolean>(false);
+    const [chooseDates, setChooseDates] = useState<boolean>(
+        Boolean(params.startDate) || Boolean(params.endDate),
+    );
 
     const onSwitchChange = useCallback(() => {
         setFilters({


### PR DESCRIPTION
If you follow https://staging.poliooutbreaks.com/dashboard/polio/lqas/lqas-map/accountId/1/startDate/01-07-2021



you will see this:

![Screenshot 2023-07-20 at 16 46 11](https://github.com/BLSQ/iaso/assets/12494624/62d8d505-2027-42a4-876f-5987e284a8a0)

instead of this:
![Screenshot 2023-07-20 at 16 46 32](https://github.com/BLSQ/iaso/assets/12494624/e1bca8aa-c3fd-4416-a12d-0501327b7f31)


POLIO-1112

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

Change local state if a date is in the url 

## How to test

visit dashboard/polio/lqas/lqas-map/accountId/1/endDate/19-10-2023, choose date and latest campaign should be

## Print screen / video

https://github.com/BLSQ/iaso/assets/12494624/27086e1f-e0a1-4495-8dc0-0362928d58f9



