### PR TITLE
IA-2478: support barcode with text field in query builder search

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/forms/fields/constants.ts
+++ b/hat/assets/js/apps/Iaso/domains/forms/fields/constants.ts
@@ -183,7 +183,18 @@ export const iasoFields: Field[] = [
     },
     {
         type: 'barcode',
-        disabled: true,
+        queryBuilder: {
+            type: 'text',
+            excludeOperators: [
+                'proximity',
+                'ends_with',
+                'starts_with',
+                'like',
+                'not_like',
+                'is_empty',
+                'is_not_empty',
+            ],
+        },
     },
     {
         type: 'calculate',


### PR DESCRIPTION
Barcode type was not supported by query builder

Related JIRA tickets : IA-2478

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

Map barcode to text field

## How to test

Create a form with this XLS
[barcode_2023101601.xlsx](https://github.com/BLSQ/iaso/files/13021877/barcode_2023101601.xlsx)
Try to search an instance with the query builder, you should see bar code field

## Print screen / video

<img width="1202" alt="Screenshot 2023-10-18 at 13 42 23" src="https://github.com/BLSQ/iaso/assets/12494624/248c162d-8cae-40b5-9cef-34b34cbb404b">

