### PR TITLE
Polio-1261, polio-1262: improve lqas maps

### DIFF
--- a/plugins/polio/api/lqas_im/countries_with_lqas_im.py
+++ b/plugins/polio/api/lqas_im/countries_with_lqas_im.py
@@ -22,27 +22,8 @@ class CountriesWithLqasIMConfigViewSet(ModelViewSet):
     ]
 
     def get_queryset(self):
-        category = self.request.query_params.get("category")
-        # For lqas, we filter out the countries with no datastore
-        if category == "lqas":
-            configs = Config.objects.filter(slug=f"{category}-config").first().content
-            country_ids = []
-            for config in configs:
-                if JsonDataStore.objects.filter(slug=f"{category}_{config['country_id']}").exists():
-                    country_ids.append(config["country_id"])
-                else:
-                    continue
-
-            return (
-                OrgUnit.objects.filter_for_user_and_app_id(self.request.user, self.request.query_params.get("app_id"))
-                .filter(validation_status="VALID")
-                .filter(org_unit_type__category="COUNTRY")
-                .filter(id__in=country_ids)
-            )
-        # For IM we send all countries. We'll align with LQAS when the datastores are configured for IM as well
-        else:
-            return (
-                OrgUnit.objects.filter_for_user_and_app_id(self.request.user, self.request.query_params.get("app_id"))
-                .filter(validation_status="VALID")
-                .filter(org_unit_type__category="COUNTRY")
-            )
+        return (
+            OrgUnit.objects.filter_for_user_and_app_id(self.request.user, self.request.query_params.get("app_id"))
+            .filter(validation_status="VALID")
+            .filter(org_unit_type__category="COUNTRY")
+        )

--- a/plugins/polio/js/src/constants/messages.js
+++ b/plugins/polio/js/src/constants/messages.js
@@ -2472,6 +2472,10 @@ const MESSAGES = defineMessages({
         id: 'iaso.polio.label.result',
         defaultMessage: 'Result',
     },
+    noRoundFound: {
+        id: 'iaso.polio.label.noRoundFound',
+        defaultMessage: 'No round found',
+    },
 });
 
 export default MESSAGES;

--- a/plugins/polio/js/src/constants/translations/en.json
+++ b/plugins/polio/js/src/constants/translations/en.json
@@ -354,6 +354,7 @@
     "iaso.polio.label.noDataFound": "No data found",
     "iaso.polio.label.noFile": "No file found",
     "iaso.polio.label.non_compliance": "Non compliance",
+    "iaso.polio.label.noRoundFound": "No round found",
     "iaso.polio.label.noScope": "No scope",
     "iaso.polio.label.noScopeFound": "No scope was encoded for this campaign",
     "iaso.polio.label.note": "Note",

--- a/plugins/polio/js/src/constants/translations/fr.json
+++ b/plugins/polio/js/src/constants/translations/fr.json
@@ -354,6 +354,7 @@
     "iaso.polio.label.noDataFound": "Aucunes données trouvées",
     "iaso.polio.label.noFile": "Aucun fichier trouvé",
     "iaso.polio.label.non_compliance": "Non-conformité",
+    "iaso.polio.label.noRoundFound": "Aucun round trouvé",
     "iaso.polio.label.noScope": "Pas de périmètre",
     "iaso.polio.label.noScopeFound": "Aucun périmètre encodé pour cette campagne",
     "iaso.polio.label.note": "Note",

--- a/plugins/polio/js/src/domains/LQAS-IM/IM/index.js
+++ b/plugins/polio/js/src/domains/LQAS-IM/IM/index.js
@@ -100,7 +100,7 @@ export const ImStats = ({ imType, router }) => {
                                 campaigns={campaigns}
                                 country={country}
                                 data={convertedData}
-                                isFetching={isFetching}
+                                isFetching={isFetching || campaignsFetching}
                                 debugData={debugData}
                                 paperElevation={paperElevation}
                                 type={imType}

--- a/plugins/polio/js/src/domains/LQAS-IM/LQAS/CountryOverview/LqasOverviewContainer.tsx
+++ b/plugins/polio/js/src/domains/LQAS-IM/LQAS/CountryOverview/LqasOverviewContainer.tsx
@@ -5,7 +5,7 @@ import React, {
     useState,
 } from 'react';
 
-import { Paper, Divider, Box, Tab, Tabs, makeStyles } from '@material-ui/core';
+import { Paper, Divider, Tab, Tabs, makeStyles } from '@material-ui/core';
 
 import { useDispatch } from 'react-redux';
 import { commonStyles, useSafeIntl } from 'bluesquare-components';
@@ -82,16 +82,6 @@ export const LqasOverviewContainer: FunctionComponent<Props> = ({
     const campaignObject = campaigns.filter(
         (c: Record<string, unknown>) => c.obr_name === campaign,
     )[0] as Campaign;
-    const optionsFromCampaign = useMemo(() => {
-        return campaignObject?.rounds
-            .sort((a, b) => a.number - b.number)
-            .map(r => {
-                return {
-                    label: `Round ${r.number}`,
-                    value: r.number,
-                };
-            });
-    }, [campaignObject]);
     const countryId = parseInt(country, 10);
     const { data: shapes = defaultShapes, isFetching: isFetchingGeoJson } =
         useGetGeoJson(countryId, 'DISTRICT');
@@ -140,15 +130,15 @@ export const LqasOverviewContainer: FunctionComponent<Props> = ({
     const scopeCount = computeScopeCounts(campaignObject, round);
     return (
         <Paper elevation={paperElevation}>
-            {/* <Box pb={2}> */}
             <LqasImMapHeader
                 round={round}
                 startDate={startDate}
                 endDate={endDate}
-                options={optionsFromCampaign ?? []}
+                options={options ?? []}
                 onRoundSelect={onRoundChange}
+                campaignObrName={campaign}
+                isFetching={isFetching}
             />
-            {/* </Box> */}
             <Divider />
             <LqasSummary
                 round={round}

--- a/plugins/polio/js/src/domains/LQAS-IM/LQAS/CountryOverview/LqasOverviewContainer.tsx
+++ b/plugins/polio/js/src/domains/LQAS-IM/LQAS/CountryOverview/LqasOverviewContainer.tsx
@@ -82,6 +82,16 @@ export const LqasOverviewContainer: FunctionComponent<Props> = ({
     const campaignObject = campaigns.filter(
         (c: Record<string, unknown>) => c.obr_name === campaign,
     )[0] as Campaign;
+    const optionsFromCampaign = useMemo(() => {
+        return campaignObject?.rounds
+            .sort((a, b) => a.number - b.number)
+            .map(r => {
+                return {
+                    label: `Round ${r.number}`,
+                    value: r.number,
+                };
+            });
+    }, [campaignObject]);
     const countryId = parseInt(country, 10);
     const { data: shapes = defaultShapes, isFetching: isFetchingGeoJson } =
         useGetGeoJson(countryId, 'DISTRICT');
@@ -130,15 +140,15 @@ export const LqasOverviewContainer: FunctionComponent<Props> = ({
     const scopeCount = computeScopeCounts(campaignObject, round);
     return (
         <Paper elevation={paperElevation}>
-            <Box mb={2}>
-                <LqasImMapHeader
-                    round={round}
-                    startDate={startDate}
-                    endDate={endDate}
-                    options={options}
-                    onRoundSelect={onRoundChange}
-                />
-            </Box>
+            {/* <Box pb={2}> */}
+            <LqasImMapHeader
+                round={round}
+                startDate={startDate}
+                endDate={endDate}
+                options={optionsFromCampaign ?? []}
+                onRoundSelect={onRoundChange}
+            />
+            {/* </Box> */}
             <Divider />
             <LqasSummary
                 round={round}

--- a/plugins/polio/js/src/domains/LQAS-IM/LQAS/LqasAfroOverview/Map/LqasAfroMap.tsx
+++ b/plugins/polio/js/src/domains/LQAS-IM/LQAS/LqasAfroOverview/Map/LqasAfroMap.tsx
@@ -1,7 +1,6 @@
 import React, { FunctionComponent, useState, useMemo, useContext } from 'react';
 import { MapContainer } from 'react-leaflet';
 
-// import { Bounds } from '../../../../../../../../../hat/assets/js/apps/Iaso/utils/map/mapUtils';
 import { CustomZoomControl } from '../../../../../../../../../hat/assets/js/apps/Iaso/components/maps/tools/CustomZoomControl';
 import TILES from '../../../../../../../../../hat/assets/js/apps/Iaso/constants/mapTiles';
 

--- a/plugins/polio/js/src/domains/LQAS-IM/LQAS/LqasAfroOverview/Map/LqasAfroPopUp.tsx
+++ b/plugins/polio/js/src/domains/LQAS-IM/LQAS/LqasAfroOverview/Map/LqasAfroPopUp.tsx
@@ -40,7 +40,6 @@ export const LqasAfroPopup: FunctionComponent<Props> = ({
     const classes: Record<string, string> = useStyle();
     const { formatMessage } = useSafeIntl();
     const ref = useRef();
-    if (shape.status === 'inScope') return null;
     const title =
         view === COUNTRY ? shape.data?.country_name : shape.data?.district_name;
 
@@ -90,13 +89,15 @@ export const LqasAfroPopup: FunctionComponent<Props> = ({
                             valueSize={valueSize}
                         />
                     )}
-                    <PopupItemComponent
-                        label={formatMessage(MESSAGES.round)}
-                        value={shape.data.round_number}
-                        labelSize={labelSize}
-                        valueSize={valueSize}
-                    />
-                    {view === COUNTRY && (
+                    {shape.status !== 'inScope' && (
+                        <PopupItemComponent
+                            label={formatMessage(MESSAGES.round)}
+                            value={shape.data.round_number}
+                            labelSize={labelSize}
+                            valueSize={valueSize}
+                        />
+                    )}
+                    {view === COUNTRY && shape.status !== 'inScope' && (
                         <PopupItemComponent
                             label={formatMessage(MESSAGES.passing)}
                             value={`${shape.lqas_passed}/${shape.scope_count}`}
@@ -104,7 +105,7 @@ export const LqasAfroPopup: FunctionComponent<Props> = ({
                             valueSize={valueSize}
                         />
                     )}
-                    {view === DISTRICT && (
+                    {view === DISTRICT && shape.status !== 'inScope' && (
                         <>
                             <PopupItemComponent
                                 label={formatMessage(MESSAGES.childrenChecked)}

--- a/plugins/polio/js/src/domains/LQAS-IM/LQAS/hooks/useLqasData.ts
+++ b/plugins/polio/js/src/domains/LQAS-IM/LQAS/hooks/useLqasData.ts
@@ -25,6 +25,7 @@ export const useLqasData = ({
 }: UseLQASDataParams): Record<string, unknown> => {
     const convertedData = useConvertedLqasImData(LQASData);
 
+    // TODO move out of this hook
     const { data: campaigns = [], isFetching: campaignsFetching } =
         useGetCampaigns({
             countries: [country],

--- a/plugins/polio/js/src/domains/LQAS-IM/LQAS/index.js
+++ b/plugins/polio/js/src/domains/LQAS-IM/LQAS/index.js
@@ -25,7 +25,7 @@ import MESSAGES from '../../../constants/messages';
 import { BadRoundNumbers } from '../shared/BadRoundNumber.tsx';
 import { genUrl } from '../../../../../../../hat/assets/js/apps/Iaso/routing/routing.ts';
 import { commaSeparatedIdsToArray } from '../../../../../../../hat/assets/js/apps/Iaso/utils/forms';
-import { paperElevation } from '../shared/constants.ts';
+import { LIST, paperElevation } from '../shared/constants.ts';
 import { useLqasIm } from '../shared/requests.ts';
 import { Sides } from '../../../constants/types.ts';
 
@@ -96,6 +96,14 @@ export const Lqas = ({ router }) => {
                     dropDownOptions[0].value,
                     dropDownOptions[0].value,
                 ]);
+                const url = genUrl(router, {
+                    rounds: [
+                        dropDownOptions[0].value,
+                        dropDownOptions[0].value,
+                    ],
+                    rightTab: LIST,
+                });
+                dispatch(push(url));
             }
             if (dropDownOptions.length > 1) {
                 setSelectedRounds([
@@ -104,7 +112,7 @@ export const Lqas = ({ router }) => {
                 ]);
             }
         }
-    }, [dropDownOptions, campaign, rounds]);
+    }, [dropDownOptions, campaign, rounds, router, dispatch]);
 
     return (
         <>

--- a/plugins/polio/js/src/domains/LQAS-IM/LQAS/index.js
+++ b/plugins/polio/js/src/domains/LQAS-IM/LQAS/index.js
@@ -1,5 +1,5 @@
 /* eslint-disable react/no-array-index-key */
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import {
     useSafeIntl,
@@ -23,10 +23,9 @@ import { useLqasData } from './hooks/useLqasData.ts';
 import { LqasOverviewContainer } from './CountryOverview/LqasOverviewContainer.tsx';
 import MESSAGES from '../../../constants/messages';
 import { BadRoundNumbers } from '../shared/BadRoundNumber.tsx';
-import { makeDropdownOptions } from '../shared/LqasIm.tsx';
 import { genUrl } from '../../../../../../../hat/assets/js/apps/Iaso/routing/routing.ts';
 import { commaSeparatedIdsToArray } from '../../../../../../../hat/assets/js/apps/Iaso/utils/forms';
-import { defaultRounds, paperElevation } from '../shared/constants.ts';
+import { paperElevation } from '../shared/constants.ts';
 import { useLqasIm } from '../shared/requests.ts';
 import { Sides } from '../../../constants/types.ts';
 
@@ -42,8 +41,9 @@ export const Lqas = ({ router }) => {
     const classes = useStyles();
     const dispatch = useDispatch();
     const { campaign, country, rounds } = router.params;
+    // TODO initialize undefined to be able to make boolean check on it
     const [selectedRounds, setSelectedRounds] = useState(
-        rounds ? commaSeparatedIdsToArray(rounds) : defaultRounds,
+        rounds ? commaSeparatedIdsToArray(rounds) : [undefined, undefined],
     );
     const { data: LQASData, isFetching } = useLqasIm('lqas', country);
 
@@ -57,8 +57,16 @@ export const Lqas = ({ router }) => {
     } = useLqasData({ campaign, country, selectedRounds, LQASData });
 
     const dropDownOptions = useMemo(() => {
-        return makeDropdownOptions(LQASData?.stats, campaign);
-    }, [LQASData, campaign]);
+        return campaigns
+            ?.filter(c => c.obr_name === campaign)[0]
+            ?.rounds.sort((a, b) => a.number - b.number)
+            .map(r => {
+                return {
+                    label: `Round ${r.number}`,
+                    value: r.number,
+                };
+            });
+    }, [campaign, campaigns]);
 
     const onRoundChange = useCallback(
         index => value => {
@@ -76,9 +84,27 @@ export const Lqas = ({ router }) => {
     const divider = (
         <HorizontalDivider mt={6} mb={4} ml={-4} mr={-4} displayTrigger />
     );
+
     useSkipEffectOnMount(() => {
-        setSelectedRounds(defaultRounds);
-    }, [campaign, country]);
+        setSelectedRounds([undefined, undefined]);
+    }, [country]);
+
+    useEffect(() => {
+        if (dropDownOptions && !rounds) {
+            if (dropDownOptions.length === 1) {
+                setSelectedRounds([
+                    dropDownOptions[0].value,
+                    dropDownOptions[0].value,
+                ]);
+            }
+            if (dropDownOptions.length > 1) {
+                setSelectedRounds([
+                    dropDownOptions[0].value,
+                    dropDownOptions[1].value,
+                ]);
+            }
+        }
+    }, [dropDownOptions, campaign, rounds]);
 
     return (
         <>
@@ -94,24 +120,40 @@ export const Lqas = ({ router }) => {
                     category="lqas"
                 />
                 <Grid container spacing={2} direction="row">
-                    {selectedRounds.map((rnd, index) => (
-                        <Grid item xs={6} key={`round_${rnd}_${index}`}>
-                            <LqasOverviewContainer
-                                round={parseInt(rnd, 10)} // parsing the rnd because it will be a string when coming from params
-                                campaign={campaign}
-                                campaigns={campaigns}
-                                country={country}
-                                data={convertedData}
-                                isFetching={isFetching}
-                                debugData={debugData}
-                                paperElevation={paperElevation}
-                                onRoundChange={onRoundChange(index)}
-                                options={dropDownOptions}
-                                side={index === 0 ? Sides.left : Sides.right}
-                                router={router}
-                            />
-                        </Grid>
-                    ))}
+                    {/* {selectedRounds.map((rnd, index) => ( */}
+                    <Grid item xs={6} key={`round_${selectedRounds[0]}_${0}`}>
+                        <LqasOverviewContainer
+                            round={parseInt(selectedRounds[0], 10)} // parsing the rnd because it will be a string when coming from params
+                            campaign={campaign}
+                            campaigns={campaigns}
+                            country={country}
+                            data={convertedData}
+                            isFetching={isFetching || campaignsFetching}
+                            debugData={debugData}
+                            paperElevation={paperElevation}
+                            onRoundChange={onRoundChange(0)}
+                            options={dropDownOptions}
+                            side={Sides.left}
+                            router={router}
+                        />
+                    </Grid>
+                    <Grid item xs={6} key={`round_${selectedRounds[1]}_${1}`}>
+                        <LqasOverviewContainer
+                            round={parseInt(selectedRounds[1], 10)} // parsing the rnd because it will be a string when coming from params
+                            campaign={campaign}
+                            campaigns={campaigns}
+                            country={country}
+                            data={convertedData}
+                            isFetching={isFetching || campaignsFetching}
+                            debugData={debugData}
+                            paperElevation={paperElevation}
+                            onRoundChange={onRoundChange(1)}
+                            options={dropDownOptions}
+                            side={Sides.right}
+                            router={router}
+                        />
+                    </Grid>
+                    {/* ))} */}
                 </Grid>
 
                 {campaign && !isFetching && (

--- a/plugins/polio/js/src/domains/LQAS-IM/shared/Filters.tsx
+++ b/plugins/polio/js/src/domains/LQAS-IM/shared/Filters.tsx
@@ -63,7 +63,8 @@ const Filters: FunctionComponent<Props> = ({
     const onChange = (key, value) => {
         const newFilters = {
             ...filters,
-            rounds: '1,2',
+            rounds: undefined, // This
+            // rounds: '1,2', // This
             [key]: value,
         };
         if (key === 'country') {

--- a/plugins/polio/js/src/domains/LQAS-IM/shared/Filters.tsx
+++ b/plugins/polio/js/src/domains/LQAS-IM/shared/Filters.tsx
@@ -8,6 +8,8 @@ import { replace } from 'react-router-redux';
 import { Box, Grid, IconButton } from '@material-ui/core';
 
 import OpenInNewIcon from '@material-ui/icons/OpenInNew';
+import { useCurrentUser } from '../../../../../../../hat/assets/js/apps/Iaso/utils/usersUtils';
+import { userHasPermission } from '../../../../../../../hat/assets/js/apps/Iaso/domains/users/utils';
 import MESSAGES from '../../../constants/messages';
 import { makeCampaignsDropDown } from '../../../utils/index';
 import { genUrl } from '../../../../../../../hat/assets/js/apps/Iaso/routing/routing';
@@ -50,6 +52,7 @@ const Filters: FunctionComponent<Props> = ({
         country: params.country ? parseInt(params.country, 10) : undefined,
     });
     const { campaign, country } = filters;
+    const currentUser = useCurrentUser();
 
     const { data: countriesOptions, isFetching: countriesLoading } =
         useGetLqasImCountriesOptions(category);
@@ -120,14 +123,15 @@ const Filters: FunctionComponent<Props> = ({
                     </Grid>
                 )}
                 {/* remove condition when IM pipeline is ready */}
-                {category === 'lqas' && (
-                    <Grid item md={campaignLink ? 3 : 4}>
-                        <RefreshLqasData
-                            category={category}
-                            countryId={country}
-                        />
-                    </Grid>
-                )}
+                {category === 'lqas' &&
+                    userHasPermission('iaso_polio_config', currentUser) && (
+                        <Grid item md={campaignLink ? 3 : 4}>
+                            <RefreshLqasData
+                                category={category}
+                                countryId={country}
+                            />
+                        </Grid>
+                    )}
             </Grid>
         </Box>
     );

--- a/plugins/polio/js/src/domains/LQAS-IM/shared/LqasImDates.tsx
+++ b/plugins/polio/js/src/domains/LQAS-IM/shared/LqasImDates.tsx
@@ -16,11 +16,13 @@ const styles = theme => ({
         fontWeight: 'bold',
         marginLeft: theme.spacing(2),
         fontSize: '1rem',
+        paddingBottom: theme.spacing(2),
     },
     labelEnd: {
         fontWeight: 'bold',
         marginLeft: theme.spacing(2),
         fontSize: '1rem',
+        paddingBottom: theme.spacing(2),
     },
     infoIcon: {
         fontSize: 14,
@@ -45,6 +47,7 @@ export const LqasImDates: FunctionComponent<Props> = ({ type, date }) => {
     const { formatMessage } = useSafeIntl();
     const label = type === 'start' ? MESSAGES.startDate : MESSAGES.endDate;
     const displayedDate = date?.date ?? formatMessage(MESSAGES.noDateFound);
+    const isDateOk = date && !date?.isDefault;
     return (
         <>
             <Grid
@@ -59,9 +62,7 @@ export const LqasImDates: FunctionComponent<Props> = ({ type, date }) => {
             <Grid
                 item
                 className={
-                    date?.isDefault
-                        ? classes.dateTextDefault
-                        : classes.dateTextOK
+                    isDateOk ? classes.dateTextOK : classes.dateTextDefault
                 }
             >
                 {`${displayedDate}`}

--- a/plugins/polio/js/src/domains/LQAS-IM/shared/LqasImMapHeader.tsx
+++ b/plugins/polio/js/src/domains/LQAS-IM/shared/LqasImMapHeader.tsx
@@ -19,6 +19,8 @@ type Props = {
     options: DropdownOptions<number>[];
     // eslint-disable-next-line no-unused-vars
     onRoundSelect: (round: number) => void;
+    campaignObrName?: string;
+    isFetching: boolean;
 };
 
 const styles = theme => ({
@@ -50,9 +52,12 @@ export const LqasImMapHeader: FunctionComponent<Props> = ({
     endDate,
     options,
     onRoundSelect,
+    campaignObrName,
+    isFetching,
 }) => {
     const classes = useStyles();
     const { formatMessage } = useSafeIntl();
+    if (!campaignObrName || isFetching) return null;
     return (
         <Box>
             <Grid container direction="row">

--- a/plugins/polio/js/src/domains/LQAS-IM/shared/LqasImMapHeader.tsx
+++ b/plugins/polio/js/src/domains/LQAS-IM/shared/LqasImMapHeader.tsx
@@ -1,6 +1,7 @@
 import React, { FunctionComponent } from 'react';
-import { Box, makeStyles, Divider, Grid } from '@material-ui/core';
+import { Box, makeStyles, Divider, Grid, Typography } from '@material-ui/core';
 import { useSafeIntl } from 'bluesquare-components';
+import classNames from 'classnames';
 import MESSAGES from '../../../constants/messages';
 import { LqasImDates } from './LqasImDates';
 import { DropdownOptions } from '../../../../../../../hat/assets/js/apps/Iaso/types/utils';
@@ -20,9 +21,26 @@ type Props = {
     onRoundSelect: (round: number) => void;
 };
 
-const styles = () => ({
+const styles = theme => ({
+    placeHolderContainer: {
+        marginTop: theme.spacing(2),
+        textAlign: 'center',
+    },
+    lqasImMapHeaderPlaceholder: {
+        // padding: theme.spacing(2),
+        fontWeight: 'bold',
+    },
     // setting marginRight to prevent Divider from breaking the grid, marginLeft to prevent misalignment
     verticalDivider: { marginRight: -1, marginLeft: -1 },
+    // This is to align the divider.There's a 2px misalignment for some reason
+    dividerOffset: {
+        marginRight: '2px',
+    },
+    // The padding is compensate when there's no round and keep the general height of the component
+    paddingY: {
+        paddingTop: theme.spacing(2),
+        paddingBottom: theme.spacing(2),
+    },
 });
 // @ts-ignore
 const useStyles = makeStyles(styles);
@@ -37,11 +55,11 @@ export const LqasImMapHeader: FunctionComponent<Props> = ({
     const { formatMessage } = useSafeIntl();
     return (
         <Box>
-            {options.length > 0 && (
-                <Grid container direction="row">
-                    <Grid container item xs={6} direction="row">
-                        <Grid item xs={12}>
-                            <Box ml={2} mr={2}>
+            <Grid container direction="row">
+                <Grid container item xs={6} direction="row">
+                    <Grid item xs={12}>
+                        <Box ml={2} mr={2} mb={2}>
+                            {options.length > 0 && (
                                 <InputComponent
                                     type="select"
                                     keyValue="lqasImHeader"
@@ -56,48 +74,56 @@ export const LqasImMapHeader: FunctionComponent<Props> = ({
                                     labelString={formatMessage(MESSAGES.round)}
                                     clearable={false}
                                 />
-                            </Box>
-                        </Grid>
+                            )}
+                            {options.length <= 0 && (
+                                <Box className={classes.placeHolderContainer}>
+                                    <Typography
+                                        className={
+                                            classes.lqasImMapHeaderPlaceholder
+                                        }
+                                    >
+                                        {formatMessage(MESSAGES.noRoundFound)}
+                                    </Typography>
+                                </Box>
+                            )}
+                        </Box>
                     </Grid>
-                    {startDate && endDate && (
-                        <>
-                            <Divider
-                                orientation="vertical"
-                                className={classes.verticalDivider}
-                                flexItem
-                            />
-                            <Grid container item xs={6}>
-                                <Grid
-                                    container
-                                    item
-                                    direction="row"
-                                    xs={6}
-                                    alignItems="center"
-                                >
-                                    <LqasImDates
-                                        type="start"
-                                        date={startDate}
-                                    />
-                                </Grid>
-                                <Divider
-                                    orientation="vertical"
-                                    className={classes.verticalDivider}
-                                    flexItem
-                                />
-                                <Grid
-                                    container
-                                    item
-                                    direction="row"
-                                    xs={6}
-                                    alignItems="center"
-                                >
-                                    <LqasImDates type="end" date={endDate} />
-                                </Grid>
-                            </Grid>
-                        </>
-                    )}
                 </Grid>
-            )}
+                <Divider
+                    orientation="vertical"
+                    className={classes.verticalDivider}
+                    flexItem
+                />
+
+                <Grid
+                    container
+                    item
+                    direction="row"
+                    xs={3}
+                    alignItems="center"
+                    className={classNames(
+                        classes.dividerOffset,
+                        classes.paddingY,
+                    )}
+                >
+                    <LqasImDates type="start" date={startDate} />
+                </Grid>
+                <Divider
+                    orientation="vertical"
+                    className={classes.verticalDivider}
+                    flexItem
+                />
+                <Grid
+                    container
+                    item
+                    direction="row"
+                    xs={3}
+                    alignItems="center"
+                    className={classes.paddingY}
+                >
+                    <LqasImDates type="end" date={endDate} />
+                </Grid>
+            </Grid>
         </Box>
     );
 };

--- a/plugins/polio/js/src/domains/LQAS-IM/shared/MapContainer.tsx
+++ b/plugins/polio/js/src/domains/LQAS-IM/shared/MapContainer.tsx
@@ -61,6 +61,8 @@ export const MapContainer: FunctionComponent<Props> = ({
                     endDate={endDate}
                     options={options}
                     onRoundSelect={onRoundChange}
+                    campaignObrName={campaign}
+                    isFetching={isFetching}
                 />
             </Box>
             <Divider />


### PR DESCRIPTION
- Needed to link to lqas country page from afro map even if no data for country
- LQAS country view needed refactoring to be able to handle single round campaigns and rounds with no data

Related JIRA tickets : POLIO-1261, POLIO-1262

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

POLIO-1262:
- Remove condition that round should have data to display link button to lqas country page. 
- Adapted the tooltip to skip some fields if no data

POLIO-1261:
- Refactored `LqasImHeader` to handle `undefined` round options
- Bonus: fix alignment bug with vertical `Divider`
- Refactored `Lqas` to get round options from campaign i.o Lqas data to be able to always display the dropdown list
- Refactored `/api/polio/lqasim/countries` to return all countries in order to avoid a bug in the interface when displaying a country without data


## How to test

POLIO-1262
- Go to LQAS > Map
- click on a country or a district with no data (gray background)
- It should land you on the lqas country page

POLIO-1261
- Duplicate locally the campaign DRC-2023-09-KIN_nOPV, which has only one round
- Get lqas data for it
- Go to LQAS > country
- Select DRC as country
- Select the campaign
- You should see the map on the right and the list on the left

## Print screen / video

Uploading Screen Recording 2023-10-18 at 15.44.27.mov…


