### PR TITLE
POLIO-1255: hide refresh button for non admin user

### DIFF
--- a/plugins/polio/js/src/domains/LQAS-IM/shared/Filters.tsx
+++ b/plugins/polio/js/src/domains/LQAS-IM/shared/Filters.tsx
@@ -8,6 +8,8 @@ import { replace } from 'react-router-redux';
 import { Box, Grid, IconButton } from '@material-ui/core';
 
 import OpenInNewIcon from '@material-ui/icons/OpenInNew';
+import { useCurrentUser } from '../../../../../../../hat/assets/js/apps/Iaso/utils/usersUtils';
+import { userHasPermission } from '../../../../../../../hat/assets/js/apps/Iaso/domains/users/utils';
 import MESSAGES from '../../../constants/messages';
 import { makeCampaignsDropDown } from '../../../utils/index';
 import { genUrl } from '../../../../../../../hat/assets/js/apps/Iaso/routing/routing';
@@ -50,6 +52,7 @@ const Filters: FunctionComponent<Props> = ({
         country: params.country ? parseInt(params.country, 10) : undefined,
     });
     const { campaign, country } = filters;
+    const currentUser = useCurrentUser();
 
     const { data: countriesOptions, isFetching: countriesLoading } =
         useGetLqasImCountriesOptions(category);
@@ -120,14 +123,15 @@ const Filters: FunctionComponent<Props> = ({
                     </Grid>
                 )}
                 {/* remove condition when IM pipeline is ready */}
-                {category === 'lqas' && (
-                    <Grid item md={campaignLink ? 3 : 4}>
-                        <RefreshLqasData
-                            category={category}
-                            countryId={country}
-                        />
-                    </Grid>
-                )}
+                {category === 'lqas' &&
+                    userHasPermission('iaso_polio_config', currentUser) && (
+                        <Grid item md={campaignLink ? 3 : 4}>
+                            <RefreshLqasData
+                                category={category}
+                                countryId={country}
+                            />
+                        </Grid>
+                    )}
             </Grid>
         </Box>
     );


### PR DESCRIPTION
Explain what problem this PR is resolving

Related JIRA tickets :POLIO-1255

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- blocked render of lqas refresh button if user does not have the iaso_polio_config  permission

## How to test

- create a user without iaso_polio_config permission
- Go to lqas country view
- select a country and campaign
- you should not see the refresh button

Note: you may not see any results on the map if you user does not have the permission to read datastores. It can be given through the django admin. There's already a ticket about that https://bluesquare.atlassian.net/browse/POLIO-1273

## Print screen / video

![Screenshot 2023-10-18 at 17 13 22](https://github.com/BLSQ/iaso/assets/38907762/f41955a1-3006-4d68-820a-0100e67923b2)


