### PR TITLE
Polio-1263 updatelqas endpoint 404

### DIFF
--- a/plugins/polio/api/rounds/round.py
+++ b/plugins/polio/api/rounds/round.py
@@ -4,7 +4,6 @@ from drf_yasg.utils import swagger_auto_schema
 from rest_framework import serializers, status
 from rest_framework.decorators import action
 from rest_framework.response import Response
-from hat.audit.audit_mixin import AuditMixin
 
 from hat.menupermissions import models as permission
 from iaso.api.common import HasPermission, ModelViewSet, UserSerializer
@@ -239,7 +238,7 @@ class LqasDistrictsUpdateSerializer(serializers.Serializer):
 
 
 @swagger_auto_schema(tags=["rounds"], request_body=LqasDistrictsUpdateSerializer)
-class RoundViewSet(AuditMixin, ModelViewSet):
+class RoundViewSet(ModelViewSet):
     # Patch should be in the list to allow updatelqasfields to work
     http_method_names = ["patch"]
     permission_classes = [HasPermission(permission.POLIO, permission.POLIO_CONFIG)]  # type: ignore

--- a/plugins/polio/api/rounds/round.py
+++ b/plugins/polio/api/rounds/round.py
@@ -225,8 +225,14 @@ class LqasDistrictsUpdateSerializer(serializers.Serializer):
     obr_name = serializers.CharField(required=True)
 
     def update(self, instance, validated_data):
-        instance.lqas_district_passing = validated_data["lqas_district_passing"]
-        instance.lqas_district_failing = validated_data["lqas_district_failing"]
+        # We save None i.o 0 to avoid breaking powerBi dashboards
+        instance.lqas_district_passing = (
+            validated_data["lqas_district_passing"] if validated_data["lqas_district_passing"] > 0 else None
+        )
+        # We save None i.o 0 to avoid breaking powerBi dashboards
+        instance.lqas_district_failing = (
+            validated_data["lqas_district_failing"] if validated_data["lqas_district_failing"] > 0 else None
+        )
         instance.save()
         return instance
 

--- a/plugins/polio/api/rounds/round.py
+++ b/plugins/polio/api/rounds/round.py
@@ -4,6 +4,7 @@ from drf_yasg.utils import swagger_auto_schema
 from rest_framework import serializers, status
 from rest_framework.decorators import action
 from rest_framework.response import Response
+from hat.audit.audit_mixin import AuditMixin
 
 from hat.menupermissions import models as permission
 from iaso.api.common import HasPermission, ModelViewSet, UserSerializer
@@ -238,7 +239,7 @@ class LqasDistrictsUpdateSerializer(serializers.Serializer):
 
 
 @swagger_auto_schema(tags=["rounds"], request_body=LqasDistrictsUpdateSerializer)
-class RoundViewSet(ModelViewSet):
+class RoundViewSet(AuditMixin, ModelViewSet):
     # Patch should be in the list to allow updatelqasfields to work
     http_method_names = ["patch"]
     permission_classes = [HasPermission(permission.POLIO, permission.POLIO_CONFIG)]  # type: ignore


### PR DESCRIPTION
OpenHExa pipeline got 404 when patching campaign

Related JIRA tickets : POLIO-1263

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- When request data for fields is 0, save `None` instead to avoid breaking dashboards

## How to test

Run openHexa pipeline 😇
Alternately try Django API. it will update but give an error message when proceeding this way


## Notes


Goes together with a pipeline PR: https://github.com/BLSQ/iaso-pipelines/pull/23
Lack of logging of chnages is part of another ticket (POLIO-1274)
