### PR TITLE
PoC to parse accuracy in the same object as location

### DIFF
--- a/iaso/api/org_unit_change_requests/serializers.py
+++ b/iaso/api/org_unit_change_requests/serializers.py
@@ -1,11 +1,66 @@
 from rest_framework import serializers
 
 from iaso.models import OrgUnitChangeRequest
+from collections import OrderedDict
+
+from django.contrib.gis.geos import GEOSGeometry
+from django.contrib.gis.geos.error import GEOSException
+from django.utils.translation import gettext_lazy as _
+
+
+class PointFieldWithAccuracy(serializers.Serializer):
+    """
+    Expected input:
+    {
+        "latitude": 49.8782482189424,
+        "longitude": 24.452545489,
+        "altitude": 5.1,
+        "accuracy": 1.2
+    }
+    """
+
+    default_error_messages = {
+        "invalid": _("Enter a valid location."),
+    }
+
+    point_field: str = "new_location"
+    accuracy_field: str = "new_accuracy"
+
+    def __init(self, point_field="new_location", accuracy_field="new_accuracy"):
+        self.point_field = point_field
+        self.accuracy_field = accuracy_field
+
+    def to_internal_value(self, value):
+        if not value and not self.required:
+            return
+        try:
+            latitude = value.get("latitude")
+            longitude = value.get("longitude")
+            altitude = value.get("altitude")
+            accuracy = value.get("accuracy")
+            ret = OrderedDict()
+            ret[self.point_field] = GEOSGeometry(f"POINT({longitude} {latitude} {altitude})", srid=4326)
+            ret[self.accuracy_field] = accuracy
+            return ret
+        except (GEOSException, ValueError):
+            self.fail("invalid")
+
+    def to_representation(self, instance):
+        if hasattr(instance, self.point_field) & hasattr(instance, self.accuracy_field):
+            value = getattr(instance, self.point_field)
+            return {
+                "latitude": value.y,
+                "longitude": value.x,
+                "altitude": value.z,
+                "accuracy": getattr(instance, self.accuracy_field),
+            }
+        return None
 
 
 class MobileOrgUnitChangeRequestListSerializer(serializers.ModelSerializer):
-    org_unit_id = serializers.IntegerField(source="org_unit.id")
-    org_unit_uuid = serializers.UUIDField(source="org_unit.uuid")
+    org_unit_id = serializers.IntegerField(source="org_unit.id", allow_null=True)
+    org_unit_uuid = serializers.UUIDField(source="org_unit.uuid", allow_null=True)
+    new_location = PointFieldWithAccuracy(source="*")
 
     class Meta:
         model = OrgUnitChangeRequest
@@ -23,7 +78,6 @@ class MobileOrgUnitChangeRequestListSerializer(serializers.ModelSerializer):
             "new_org_unit_type_id",
             "new_groups",
             "new_location",
-            "new_accuracy",
             "new_reference_instances",
         ]
 

--- a/iaso/api/org_unit_change_requests/serializers.py
+++ b/iaso/api/org_unit_change_requests/serializers.py
@@ -48,6 +48,8 @@ class PointFieldWithAccuracy(serializers.Serializer):
     def to_representation(self, instance):
         if hasattr(instance, self.point_field) & hasattr(instance, self.accuracy_field):
             value = getattr(instance, self.point_field)
+            if value is None:
+                return None
             return {
                 "latitude": value.y,
                 "longitude": value.x,

--- a/iaso/tests/api/org_unit_change_requests/test_org_unit_change_requests_mobile.py
+++ b/iaso/tests/api/org_unit_change_requests/test_org_unit_change_requests_mobile.py
@@ -59,11 +59,47 @@ class MobileOrgUnitChangeRequestListSerializerTestCase(TestCase):
                 "new_name": "",
                 "new_org_unit_type_id": self.org_unit_type.pk,
                 "new_groups": [new_group.pk],
-                "new_location": "SRID=4326;POINT Z (-2.4747713 47.3358576 1.3358576)",
-                "new_accuracy": None,
+                "new_location": {
+                    "latitude": 47.3358576,
+                    "longitude": -2.4747713,
+                    "altitude": 1.3358576,
+                    "accuracy": None,
+                },
                 "new_reference_instances": [new_instance.pk],
             },
         )
+
+    def test_list_deserializer(self):
+        new_group = m.Group.objects.create(name="new group")
+        new_instance = m.Instance.objects.create(form=self.form, org_unit=self.org_unit)
+
+        serializer = MobileOrgUnitChangeRequestListSerializer(
+            data={
+                "org_unit_id": self.org_unit.pk,
+                "org_unit_uuid": self.org_unit.uuid,
+                "status": "new",
+                "approved_fields": ["new_org_unit_type"],
+                "rejection_comment": "",
+                "created_at": "2023-10-13T13:00:00Z",
+                "updated_at": None,
+                "new_parent_id": None,
+                "new_name": "",
+                "new_org_unit_type_id": self.org_unit_type.pk,
+                "new_groups": [new_group.pk],
+                "new_location": {
+                    "latitude": 47.3358576,
+                    "longitude": -2.4747713,
+                    "altitude": 1.3358576,
+                    "accuracy": 1.23,
+                },
+                "new_reference_instances": [new_instance.pk],
+            }
+        )
+        serializer.is_valid(raise_exception=True)
+        data = serializer.validated_data
+
+        self.assertEqual(data["new_location"].__str__(), Point(-2.4747713, 47.3358576, 1.3358576, srid=4326).__str__())
+        self.assertEqual(data["new_accuracy"], 1.23)
 
 
 class MobileOrgUnitChangeRequestAPITestCase(APITestCase):


### PR DESCRIPTION
This PR offers a simple and generic way to parse `new_accuracy` within the `new_location` object while still store them in different attributes of the model class.

Related JIRA tickets : IA-2425

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [X] Are there enough tests
