### PR TITLE
HOTFIX: preparedness creation type error

### DIFF
--- a/plugins/polio/models.py
+++ b/plugins/polio/models.py
@@ -578,7 +578,7 @@ class Campaign(SoftDeletableModel):
                 .filter(groups__roundScope__round__campaign=self)
                 .distinct()
             )
-        return self.get_campaign_scope_districts()
+        return self.get_campaign_scope_districts_qs()
 
     def get_districts_for_round(self, round):
         districts = []


### PR DESCRIPTION
- make sure get_districts_for_round_number always return a QS

Explain what problem this PR is resolving

Related JIRA tickets : IA-XXX, WC2-XXX, POLIO-XXX

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes
- make sure get_districts_for_round_number always return a QS

## How to test

Try creating a preparedness spreadsheet for a campaign with a global scope (no scope per round)

## Print screen / video

Upload here print screens or videos showing the changes

## Notes

Branched from v1.216d, so it can be deployed as hotfix
