### PR TITLE
IA-2487: Provide groups in `/api/mobile/orgUnits`

### DIFF
--- a/iaso/api/mobile/groups.py
+++ b/iaso/api/mobile/groups.py
@@ -55,11 +55,7 @@ class MobileGroupsViewSet(ListModelMixin, GenericViewSet):
         return super().list(request, *args, **kwargs)
 
     def get_queryset(self) -> QuerySet:
-        app_id_serializer = AppIdSerializer(data=self.request.query_params)
-        app_id_serializer.is_valid(raise_exception=True)
-        self.app_id_param = app_id_serializer.data[APP_ID]
-
+        app_id = AppIdSerializer(data=self.request.query_params).get_app_id(raise_exception=True)
         project_qs = Project.objects.select_related("account__default_version")
-        project = get_object_or_404(project_qs, app_id=self.app_id_param)
-
+        project = get_object_or_404(project_qs, app_id=app_id)
         return Group.objects.filter(source_version=project.account.default_version)

--- a/iaso/api/serializers.py
+++ b/iaso/api/serializers.py
@@ -3,6 +3,7 @@ from django.db.models import Q
 from rest_framework import serializers
 
 from iaso.api.common import TimestampField
+from iaso.api.query_params import APP_ID
 from iaso.models import OrgUnit, OrgUnitType, Group
 
 
@@ -28,6 +29,11 @@ class AppIdSerializer(serializers.Serializer):
     """
 
     app_id = serializers.CharField(allow_blank=False)
+
+    def get_app_id(self, raise_exception: bool):
+        if not self.is_valid(raise_exception=raise_exception):
+            return None
+        return self.data[APP_ID]
 
 
 class GroupSerializer(TimestampSerializerMixin, serializers.ModelSerializer):


### PR DESCRIPTION
The mobile application needs to know to which groups the OrgUnits are linked.
This adds the information to the `/api/mobile/orgUnits` endpoint.

Related JIRA tickets: IA-2487

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well-documented
- [X] Are there enough tests


## Changes



## How to test

- Go to `/api/mobile/orgUnits/?app_id=...` with a proper app_id and sufficient permissions. *Advice: use `&page=1&limit=10` to load the page faster*
- See that groups are empty for all the OrgUnit
- Add a group and attach it to some OrgUnit
- Go back to the endpoint and see that the array is populated with the right id

## Notes

At first, I had reused the query from [groups.py#L65](/BLSQ/iaso/tree/main/iaso/api/mobile/groups.py#L65) but I noticed it wasn't necessary as there is a constraint forcing the OrgUnit to be attached to a group with the same `source_version`.
