### PR TITLE
IA-2498 Reduce the default page size for dhis2 export to 100

### DIFF
--- a/iaso/dhis2/export_request_builder.py
+++ b/iaso/dhis2/export_request_builder.py
@@ -70,7 +70,7 @@ class ExportRequestBuilder:
         export_request.save()
         # make paginator deterministic
         instances = instances.order_by("id")
-        paginator = Paginator(instances, 200)
+        paginator = Paginator(instances, 100)
 
         for page in range(1, paginator.num_pages + 1):
             export_statuses = []


### PR DESCRIPTION
Reduce the default page size for dhis2 export to 100.

Related JIRA tickets : [IA-2498](https://bluesquare.atlassian.net/browse/IA-2498)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

Reduce the default page size for dhis2 export to 100.

[IA-2498]: https://bluesquare.atlassian.net/browse/IA-2498?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ