### PR TITLE
POLIO-1277 Add GPEI to the mailing list for the vaccine authorization emails

### DIFF
--- a/plugins/polio/tests/test_vaccine_authorizations.py
+++ b/plugins/polio/tests/test_vaccine_authorizations.py
@@ -613,9 +613,7 @@ class VaccineAuthorizationAPITestCase(APITestCase):
         for i, vacc_auth in enumerate(vaccine_auths):
             try:
                 gpei_coordinator = Profile.objects.get(user__username__istartswith="gpei", org_units=vacc_auth.country)
-                print("GPEI: ", gpei_coordinator)
                 mailing_list.append(gpei_coordinator.user.email)
-                print("MAILING LIST: ", mailing_list)
             except ObjectDoesNotExist:
                 pass
 

--- a/plugins/polio/tests/test_vaccine_authorizations.py
+++ b/plugins/polio/tests/test_vaccine_authorizations.py
@@ -1,17 +1,23 @@
-import datetime
 from datetime import date
+
+import datetime
+import datetime as dt
+from datetime import timedelta
 
 from django.contrib.auth.models import User
 from django.core import mail
+from django.core.exceptions import ObjectDoesNotExist
+from django.shortcuts import get_object_or_404
 from django.utils.timezone import now
 from rest_framework.test import APIClient
 
 from beanstalk_worker.services import TestTaskService
 from hat import settings
 from iaso import models as m
-from iaso.models import Account, Group, OrgUnitType, Team
+from iaso.models import Account, Group, OrgUnitType, Team, Profile
 from iaso.test import APITestCase
 from plugins.polio.models import VaccineAuthorization
+from plugins.polio.settings import NOPV2_VACCINE_TEAM_NAME
 from plugins.polio.tasks.vaccine_authorizations_mail_alerts import (
     expired_vaccine_authorizations_email_alert,
     vaccine_authorization_update_expired_entries,
@@ -42,6 +48,18 @@ class VaccineAuthorizationAPITestCase(APITestCase):
             account=cls.account,
             permissions=["iaso_polio_vaccine_authorizations_admin", "iaso_polio_vaccine_authorizations_read_only"],
             email="XlfeeekfdpppZ@somemailzz.io",
+        )
+        cls.gpei_coordinator_A = cls.create_user_with_profile(
+            username="gpeicoordinator_A",
+            account=cls.account,
+            permissions=["iaso_polio_vaccine_authorizations_admin", "iaso_polio_vaccine_authorizations_read_only"],
+            email="gpeicoordinator@somemailzz.iox",
+        )
+        cls.gpei_coordinator_B = cls.create_user_with_profile(
+            username="gpeicoordinator_B",
+            account=cls.account,
+            permissions=["iaso_polio_vaccine_authorizations_admin", "iaso_polio_vaccine_authorizations_read_only"],
+            email="gpeicoordinator@somemailzz.iox",
         )
         cls.user_2 = cls.create_user_with_profile(
             username="user_2", account=cls.account, permissions=["iaso_polio_vaccine_authorizations_read_only"]
@@ -537,7 +555,7 @@ class VaccineAuthorizationAPITestCase(APITestCase):
 
         response = vaccine_authorizations_60_days_expiration_email_alert(vaccine_auths, mailing_list)
 
-        self.assertEqual(response, {"vacc_auth_mail_sent_to": ["XlfeeekfdpppZ@somemailzz.io"]})
+        self.assertEqual(response["vacc_auth_mail_sent_to"], [self.user_1.email])
 
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(
@@ -556,6 +574,52 @@ class VaccineAuthorizationAPITestCase(APITestCase):
         task_service.run_all()
         task.refresh_from_db()
         self.assertEqual(task.status, "SUCCESS")
+
+    def test_send_email_vaccine_authorizations_mailing_list_builder(self):
+        """This test only purpose is to check that the code building the mailing list do it correctly"""
+        self.client.force_authenticate(self.user_1)
+        self.user_1.iaso_profile.org_units.set([self.org_unit_DRC.pk])
+        self.gpei_coordinator_A.iaso_profile.org_units.set([self.org_unit_DRC.pk])
+
+        self.team.users.set([self.user_1])
+
+        sixty_days_date = datetime.date.today() + datetime.timedelta(days=60)
+
+        VaccineAuthorization.objects.create(
+            account=self.user_1.iaso_profile.account,
+            country=self.org_unit_DRC,
+            status="VALIDATED",
+            quantity=1000000,
+            comment="Validated for 1M",
+            expiration_date=sixty_days_date,
+        )
+
+        VaccineAuthorization.objects.create(
+            account=self.user_1.iaso_profile.account,
+            country=self.org_unit_DRC,
+            status="ONGOING",
+            quantity=1000000,
+            comment="Validated for 1M",
+            expiration_date=datetime.date.today() + datetime.timedelta(days=100),
+        )
+
+        future_date = dt.date.today() + timedelta(days=60)
+        vaccine_auths = VaccineAuthorization.objects.filter(expiration_date=future_date)
+
+        team = get_object_or_404(Team, name=NOPV2_VACCINE_TEAM_NAME)
+
+        mailing_list = [user.email for user in User.objects.filter(pk__in=team.users.all())]
+
+        for i, vacc_auth in enumerate(vaccine_auths):
+            try:
+                gpei_coordinator = Profile.objects.get(user__username__istartswith="gpei", org_units=vacc_auth.country)
+                print("GPEI: ", gpei_coordinator)
+                mailing_list.append(gpei_coordinator.user.email)
+                print("MAILING LIST: ", mailing_list)
+            except ObjectDoesNotExist:
+                pass
+
+        self.assertEqual(mailing_list, [self.user_1.email, self.gpei_coordinator_A.email])
 
     def test_expired_vaccine_authorizations_email_alert(self):
         self.client.force_authenticate(self.user_1)


### PR DESCRIPTION
Add the GPEI coordinator per country to the vaccine authorization mails. Before it was only sent to the NOPV2 team. 

Related JIRA tickets : POLIO-1277

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

The GPEI coordinator is added to the mailing list for the vaccine mail alert. We retrieve the country of the vaccine_auth then search the coordinator ( username starts with GPEI ) then check if the org_unit of the profile match with the country. 

## How to test

Kinda tricky to test as the mailing list is build when the task is called. So I copied the code that build the mailing list and test it in unit test. I don't really see another way to test it. 

