### PR TITLE
IA-2507: HOTFIX prevent multiple clicks on button

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/forms/components/FormVersionsDialogComponent.js
+++ b/hat/assets/js/apps/Iaso/domains/forms/components/FormVersionsDialogComponent.js
@@ -6,7 +6,7 @@ import { Grid, Typography, Box } from '@material-ui/core';
 import { LoadingSpinner, useSafeIntl } from 'bluesquare-components';
 import ConfirmCancelDialogComponent from '../../../components/dialogs/ConfirmCancelDialogComponent';
 import FileInputComponent from '../../../components/forms/FileInputComponent';
-import PeriodPicker from '../../periods/components/PeriodPicker';
+import PeriodPicker from '../../periods/components/PeriodPicker.tsx';
 
 import MESSAGES from '../messages';
 import { createFormVersion, updateFormVersion } from '../../../utils/requests';
@@ -62,39 +62,41 @@ const FormVersionsDialogComponent = ({
 
     const onConfirm = useCallback(
         async closeDialog => {
-            setIsLoading(true);
-            let savePromise;
-            const data = {
-                form_id: formId,
-            };
-            if (formState.start_period.value) {
-                data.start_period = formState.start_period.value;
-            }
-            if (formState.end_period.value) {
-                data.end_period = formState.end_period.value;
-            }
-            if (!formVersion.id) {
-                savePromise = createFormVersion({
-                    xls_file: formState.xls_file.value,
-                    data,
-                });
-            } else {
-                data.id = formVersion.id;
-                savePromise = updateFormVersion(data);
-            }
-            try {
-                await savePromise;
-                setIsLoading(false);
-                closeDialog();
-                setFormState(emptyVersion(formVersion.id));
-                onConfirmed();
-                dispatch(enqueueSnackbar(succesfullSnackBar()));
-            } catch (error) {
-                setIsLoading(false);
-                if (error.status === 400) {
-                    Object.entries(error.details).forEach(entry =>
-                        setFieldErrors(entry[0], entry[1]),
-                    );
+            if (!isLoading) {
+                setIsLoading(true);
+                let savePromise;
+                const data = {
+                    form_id: formId,
+                };
+                if (formState.start_period.value) {
+                    data.start_period = formState.start_period.value;
+                }
+                if (formState.end_period.value) {
+                    data.end_period = formState.end_period.value;
+                }
+                if (!formVersion.id) {
+                    savePromise = createFormVersion({
+                        xls_file: formState.xls_file.value,
+                        data,
+                    });
+                } else {
+                    data.id = formVersion.id;
+                    savePromise = updateFormVersion(data);
+                }
+                try {
+                    await savePromise;
+                    closeDialog();
+                    setIsLoading(false);
+                    setFormState(emptyVersion(formVersion.id));
+                    onConfirmed();
+                    dispatch(enqueueSnackbar(succesfullSnackBar()));
+                } catch (error) {
+                    setIsLoading(false);
+                    if (error.status === 400) {
+                        Object.entries(error.details).forEach(entry =>
+                            setFieldErrors(entry[0], entry[1]),
+                        );
+                    }
                 }
             }
         },
@@ -106,6 +108,7 @@ const FormVersionsDialogComponent = ({
             formVersion.id,
             onConfirmed,
             setFormState,
+            isLoading,
         ],
     );
 

--- a/hat/assets/js/apps/Iaso/domains/forms/components/FormVersionsDialogComponent.js
+++ b/hat/assets/js/apps/Iaso/domains/forms/components/FormVersionsDialogComponent.js
@@ -123,7 +123,8 @@ const FormVersionsDialogComponent = ({
     };
     const allowConfirm = () => {
         return Boolean(
-            !periodsErrors.start &&
+            !isLoading &&
+                !periodsErrors.start &&
                 !periodsErrors.end &&
                 ((!formState.id.value && formState.xls_file.value) ||
                     formState.id.value),


### PR DESCRIPTION
Save button is not disabled properly for form version creation. This can lead to multiple versions with the same id in DB

Related JIRA tickets : IA-2507

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- Disable save button if `isLoading`  is true
- Disable API call if `isLoading` is true

## How to test

- Go to Forms
- Pick a form
- Download the xlsx file (can't be done without some friction from inside docker)
- Create a new version
- click save: The save button should be disabled until the modal closes

## Print screen / video

https://github.com/BLSQ/iaso/assets/38907762/9d3e60ef-23f7-4c97-8ffe-b44c74026979




## Notes

This branch can has been forked from v1.217 so it can be deployed as hotfix (if there was no other hotfix in the meantime)
