### PR TITLE
POLIO-1277 Add GPEI Coordinator to mailing list of vacc auth emails.

### DIFF
--- a/plugins/polio/tasks/vaccine_authorizations_mail_alerts.py
+++ b/plugins/polio/tasks/vaccine_authorizations_mail_alerts.py
@@ -4,12 +4,13 @@ from datetime import timedelta
 
 from django.contrib.auth.models import User
 from django.contrib.sites.models import Site
+from django.core.exceptions import ObjectDoesNotExist
 from django.core.mail import send_mail
 from django.shortcuts import get_object_or_404
 
 from beanstalk_worker import task_decorator
 from hat import settings
-from iaso.models import Team
+from iaso.models import Team, Profile
 from plugins.polio.models import VaccineAuthorization
 from logging import getLogger
 
@@ -73,6 +74,8 @@ def vaccine_authorizations_60_days_expiration_email_alert(vaccine_auths, mailing
 
 @task_decorator(task_name="vaccine_authorizations_60_days_expiration_email_alert")
 def send_email_vaccine_authorizations_60_days_expiration_alert(task=None):
+    # NOTE: If any change is made to the mailing list building it should be replicated in the corresponding test too.
+    # Test Name:  test_send_email_vaccine_authorizations_mailing_list_builder
     future_date = dt.date.today() + timedelta(days=60)
     vaccine_auths = VaccineAuthorization.objects.filter(expiration_date=future_date)
     total = vaccine_auths.count()
@@ -83,6 +86,11 @@ def send_email_vaccine_authorizations_60_days_expiration_alert(task=None):
     email_sent = 0
 
     for i, vacc_auth in enumerate(vaccine_auths):
+        try:
+            gpei_coordinator = Profile.objects.get(user__username__istartswith="gpei", org_units=vacc_auth.country)
+            mailing_list.append(gpei_coordinator.user.email)
+        except ObjectDoesNotExist:
+            pass
         task.report_progress_and_stop_if_killed(
             progress_value=i,
             end_value=total,
@@ -159,6 +167,11 @@ def send_email_expired_vaccine_authorizations_alert(task=None):
     email_sent = 0
 
     for i, vacc_auth in enumerate(vaccine_auths):
+        try:
+            gpei_coordinator = Profile.objects.get(user__username__istartswith="gpei", org_units=vacc_auth.country)
+            mailing_list.append(gpei_coordinator.user.email)
+        except ObjectDoesNotExist:
+            pass
         task.report_progress_and_stop_if_killed(
             progress_value=i,
             end_value=total,
@@ -177,6 +190,8 @@ def send_email_expired_vaccine_authorizations_alert(task=None):
 
 @task_decorator(task_name="vaccine_authorization_update_expired_entries")
 def vaccine_authorization_update_expired_entries(task=None):
+    # NOTE: If any change is made to the mailing list building it should be replicated in the corresponding test too.
+    # Test Name:  test_send_email_vaccine_authorizations_mailing_list_builder
     expired_vacc_auth = VaccineAuthorization.objects.filter(expiration_date__lt=datetime.date.today())
     total = expired_vacc_auth.count()
 

--- a/plugins/polio/tests/test_vaccine_authorizations.py
+++ b/plugins/polio/tests/test_vaccine_authorizations.py
@@ -3,15 +3,18 @@ from datetime import date
 
 from django.contrib.auth.models import User
 from django.core import mail
+from django.core.exceptions import ObjectDoesNotExist
+from django.shortcuts import get_object_or_404
 from django.utils.timezone import now
 from rest_framework.test import APIClient
 
 from beanstalk_worker.services import TestTaskService
 from hat import settings
 from iaso import models as m
-from iaso.models import Account, Group, OrgUnitType, Team
+from iaso.models import Account, Group, OrgUnitType, Team, Profile
 from iaso.test import APITestCase
 from plugins.polio.models import VaccineAuthorization
+from plugins.polio.settings import NOPV2_VACCINE_TEAM_NAME
 from plugins.polio.tasks.vaccine_authorizations_mail_alerts import (
     expired_vaccine_authorizations_email_alert,
     vaccine_authorization_update_expired_entries,
@@ -43,6 +46,20 @@ class VaccineAuthorizationAPITestCase(APITestCase):
             permissions=["iaso_polio_vaccine_authorizations_admin", "iaso_polio_vaccine_authorizations_read_only"],
             email="XlfeeekfdpppZ@somemailzz.io",
         )
+
+        cls.gpei_coordinator_A = cls.create_user_with_profile(
+            username="gpeicoordinator_A",
+            account=cls.account,
+            permissions=["iaso_polio_vaccine_authorizations_admin", "iaso_polio_vaccine_authorizations_read_only"],
+            email="gpeicoordinator@somemailzz.iox",
+        )
+        cls.gpei_coordinator_B = cls.create_user_with_profile(
+            username="gpeicoordinator_B",
+            account=cls.account,
+            permissions=["iaso_polio_vaccine_authorizations_admin", "iaso_polio_vaccine_authorizations_read_only"],
+            email="gpeicoordinator@somemailzz.iox",
+        )
+
         cls.user_2 = cls.create_user_with_profile(
             username="user_2", account=cls.account, permissions=["iaso_polio_vaccine_authorizations_read_only"]
         )
@@ -545,7 +562,7 @@ class VaccineAuthorizationAPITestCase(APITestCase):
             f"ALERT: Vaccine Authorization {sixty_days_expiration_auth} arrives to expiration date in 2 months",
         )
         self.assertEqual(mail.outbox[0].from_email, from_email)
-        self.assertEqual(mail.outbox[0].to, ["XlfeeekfdpppZ@somemailzz.io"])
+        self.assertEqual(response["vacc_auth_mail_sent_to"], [self.user_1.email])
 
         # test the task
 
@@ -556,6 +573,50 @@ class VaccineAuthorizationAPITestCase(APITestCase):
         task_service.run_all()
         task.refresh_from_db()
         self.assertEqual(task.status, "SUCCESS")
+
+    def test_send_email_vaccine_authorizations_mailing_list_builder(self):
+        """This test only purpose is to check that the code building the mailing list do it correctly"""
+        self.client.force_authenticate(self.user_1)
+        self.user_1.iaso_profile.org_units.set([self.org_unit_DRC.pk])
+        self.gpei_coordinator_A.iaso_profile.org_units.set([self.org_unit_DRC.pk])
+
+        self.team.users.set([self.user_1])
+
+        sixty_days_date = datetime.date.today() + datetime.timedelta(days=60)
+
+        VaccineAuthorization.objects.create(
+            account=self.user_1.iaso_profile.account,
+            country=self.org_unit_DRC,
+            status="VALIDATED",
+            quantity=1000000,
+            comment="Validated for 1M",
+            expiration_date=sixty_days_date,
+        )
+
+        VaccineAuthorization.objects.create(
+            account=self.user_1.iaso_profile.account,
+            country=self.org_unit_DRC,
+            status="ONGOING",
+            quantity=1000000,
+            comment="Validated for 1M",
+            expiration_date=datetime.date.today() + datetime.timedelta(days=100),
+        )
+
+        future_date = datetime.date.today() + datetime.timedelta(days=60)
+        vaccine_auths = VaccineAuthorization.objects.filter(expiration_date=future_date)
+
+        team = get_object_or_404(Team, name=NOPV2_VACCINE_TEAM_NAME)
+
+        mailing_list = [user.email for user in User.objects.filter(pk__in=team.users.all())]
+
+        for i, vacc_auth in enumerate(vaccine_auths):
+            try:
+                gpei_coordinator = Profile.objects.get(user__username__istartswith="gpei", org_units=vacc_auth.country)
+                mailing_list.append(gpei_coordinator.user.email)
+            except ObjectDoesNotExist:
+                pass
+
+        self.assertEqual(mailing_list, [self.user_1.email, self.gpei_coordinator_A.email])
 
     def test_expired_vaccine_authorizations_email_alert(self):
         self.client.force_authenticate(self.user_1)


### PR DESCRIPTION

**CAN BE HOTFIXED**
Add the GPEI coordinator per country to the vaccine authorization mails. Before it was only sent to the NOPV2 team. 

Related JIRA tickets : POLIO-1277

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

The GPEI coordinator is added to the mailing list for the vaccine mail alert. We retrieve the country of the vaccine_auth then search the coordinator ( username starts with GPEI ) then check if the org_unit of the profile match with the country. 

## How to test

Kinda tricky to test as the mailing list is build when the task is called. So I copied the code that build the mailing list and test it in unit test. I don't really see another way to test it. 

