### PR TITLE
IA-2506 fix delete account performance and reimplement s3 export

### DIFF
--- a/iaso/management/commands/delete_accounts.py
+++ b/iaso/management/commands/delete_accounts.py
@@ -1,4 +1,5 @@
 import traceback
+import datetime
 from collections import defaultdict
 
 import django
@@ -269,10 +270,31 @@ class Command(BaseCommand):
 
         Instance.objects.raw("delete from vector_control_apiimport")
 
-    def delete_modification_logs_and_comments(self):
+    def delete_modification_logs_and_comments(self, cursor):
         dump_modification_stats()
-
         # this part is a bit brittle, may should become a loop on ContentType.objects.all() ?
+
+        # apparently this query does the same thing as the one below
+        # but in batches so we can delete as much as we can with this one
+        # and keep the last as "last measure" to be sure
+        instance_content_type = ContentType.objects.get_by_natural_key(app_label="iaso", model="instance")
+        pages = 2000
+        sql = "".join(
+            [
+                "WITH cte AS ( ",
+                'SELECT "id" FROM "audit_modification" WHERE "content_type_id" =' + str(instance_content_type.id) + "",
+                ' AND NOT ("object_id" IN (SELECT CAST(U0."id" AS text) AS "id_as_str" FROM "iaso_instance" U0)) ORDER BY "id" LIMIT 20000 ) ',
+                ' DELETE FROM "audit_modification" WHERE "id" IN (SELECT "id" FROM cte)',
+            ]
+        )
+        # speedup the delete by setting the work_mem to a much higher value
+        # the 20000 limit looks a good thread of between speed and seing progress
+        cursor.execute("SET work_mem = '1GB'")
+        for i in range(pages):
+            cursor.execute(sql)
+            print(i, cursor.rowcount, datetime.datetime.now())
+            if cursor.rowcount == 0:
+                break
 
         print(
             "instance related",
@@ -430,12 +452,12 @@ class Command(BaseCommand):
         print("sql dashboard", Dashboard.objects.all().delete())
 
         cursor.execute(
-            "delete from iaso_exportrequest where id not in ( select export_request_id from iaso_exportstatus )"
+            "delete from iaso_exportrequest where id not in ( select distinct export_request_id from iaso_exportstatus )"
         )
 
         print("******* Deleting Modification (might take a while too)")
 
-        self.delete_modification_logs_and_comments()
+        self.delete_modification_logs_and_comments(cursor)
 
         print("******* Starting delete of orphaned export log")
 

--- a/iaso/management/commands/list_account_files.py
+++ b/iaso/management/commands/list_account_files.py
@@ -1,0 +1,107 @@
+import os
+import csv
+from pathlib import Path
+from django.core.paginator import Paginator
+
+from django.contrib.contenttypes.models import ContentType
+from django.core.management.base import BaseCommand
+
+
+def fullname(o):
+    klass = o.__class__
+    module = klass.__module__
+    if module == "builtins":
+        return klass.__qualname__  # avoid outputs like 'builtins.str'
+    return module + "." + klass.__qualname__
+
+
+def model_and_fields_with_files(account_id_to_keep):
+    file_path = "./media/account/" + account_id_to_keep + "/inventory.csv"
+    print("producing ", file_path)
+
+    fieldnames = ["source", "destination", "model", "field_name", "id"]
+
+    with open(file_path, "w", newline="") as csvfile:
+        csv_writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+        csv_writer.writeheader()
+
+        for ct in ContentType.objects.all():
+            m = ct.model_class()
+            if m:
+                file_fields = []
+                for field in m._meta.get_fields():
+                    if fullname(field) == "django.db.models.fields.files.FileField":
+                        file_fields.append(field)
+
+                if len(file_fields) > 0:
+                    print(m.__module__, m.__name__)
+                    for field in file_fields:
+                        print(
+                            "\t",
+                            field.name,
+                            "\t",
+                            fullname(field),
+                        )
+
+                    print("\t", "count", m.objects.count())
+                    LIMIT = 10000
+                    all_objects = m.objects.order_by("id").all()
+
+                    paginator = Paginator(all_objects, LIMIT)
+
+                    for page_num in paginator.page_range:
+                        page = paginator.get_page(page_num)
+                        for object in page:
+                            values = object.__dict__
+                            for field in file_fields:
+                                if values.get(field.name):
+                                    target_file_name = (
+                                        "./media/account/" + account_id_to_keep + "/" + values.get(field.name)
+                                    )
+
+                                    record = {
+                                        "source": values.get(field.name),
+                                        "destination": target_file_name,
+                                        "model": object.__class__.__qualname__,
+                                        "field_name": field.name,
+                                        "id": object.id,
+                                    }
+                                    csv_writer.writerows([record])
+
+
+#
+# this "replace" the process to extract an "account of the saas" and more specifically the copy_account_files task
+#
+# since downloading from s3 is slow, doing it on a machine "nearer" (like our bastion machine helps a lot)
+# so this task generate an csv with all the files to download (that we will upload to s3 afterwards)
+# and the the bastion will run a ruby script to download these files in parallel at max speed
+# for the moment I kept the "copy_account_files" command since I'm not sharing the download script here
+# if the the next extract is working well, we should probably delete the copy_account_files_command
+#
+# exemple usage : docker-compose run --rm iaso manage list_account_files --account 17
+
+
+class Command(BaseCommand):
+    help = "Generate a list of files to copy to a local directory"
+
+    def add_arguments(self, parser):
+        parser.add_argument("--account", type=str)
+
+    def handle(self, *args, **options):
+        account_id_to_keep = options.get("account")
+
+        print("Listing files from S3 to extract for a given account")
+
+        print("all models that have a FileField")
+        for ct in ContentType.objects.all():
+            m = ct.model_class()
+            if m:
+                file_fields = []
+                for field in m._meta.get_fields():
+                    if fullname(field) == "django.db.models.fields.files.FileField":
+                        file_fields.append(field)
+
+                if len(file_fields) > 0:
+                    print(m.__module__, m.__name__, file_fields)
+
+        model_and_fields_with_files(account_id_to_keep)


### PR DESCRIPTION
The extract of an account was much slower (here we exported a large project with 350000+ submissions)
Here are some fixes to speed up the queries (see the jira comment for the details/motivation)

Related JIRA tickets : [IA-2506](https://bluesquare.atlassian.net/browse/IA-2506)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- some performance improvement  for the delete task
- some pagination for the "copy_account_files"
- an alternate process to extract the s3 content based on a csv (list_account_files) 

## How to test

see : https://github.com/BLSQ/ops-runbooks/blob/main/local-hosting/iaso-produce-tenant-dump.md

I need to document the new list_account_files procedure in this runbook.

## Notes

the process to test is quiet long, and this is the code that was used to extract the account 17 yesterday.


[IA-2506]: https://bluesquare.atlassian.net/browse/IA-2506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ