### PR TITLE
IA-2495: Org Units History: missing translation for `instance_defining`

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -239,6 +239,7 @@
     "iaso.forms.geom_ref": "Reference coordinates",
     "iaso.forms.gps_source": "GPS source",
     "iaso.forms.hasInstances": "Form submissions",
+    "iaso.forms.instance_defining": "Instance definition",
     "iaso.forms.instance_updated_at": "Latest submission",
     "iaso.forms.latest_version_files": "Latest version",
     "iaso.forms.level": "Level",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -239,6 +239,7 @@
     "iaso.forms.geom_ref": "Coordonnées de référence",
     "iaso.forms.gps_source": "Source GPS",
     "iaso.forms.hasInstances": "Soumissions de formulaire",
+    "iaso.forms.instance_defining": "Définition d'instance",
     "iaso.forms.instance_updated_at": "Dernière soumission",
     "iaso.forms.latest_version_files": "Dernière version",
     "iaso.forms.level": "Niveau",

--- a/hat/assets/js/apps/Iaso/domains/forms/messages.js
+++ b/hat/assets/js/apps/Iaso/domains/forms/messages.js
@@ -626,6 +626,10 @@ const MESSAGES = defineMessages({
         id: 'iaso.forms.validation_status',
         defaultMessage: 'Status',
     },
+    instance_defining: {
+        id: 'iaso.forms.instance_defining',
+        defaultMessage: 'Instance definition',
+    },
 });
 
 export default MESSAGES;


### PR DESCRIPTION
Explain what problem this PR is resolving
- There is  a missing key translation on org unit history
Related JIRA tickets : [IA-2495](https://bluesquare.atlassian.net/browse/IA-2495)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [x] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes
- Add translation of the "instance_defining"

## How to test
- Go in the org unit history and check if the instance_defining is translated

## Print screen / video
![Screenshot from 2023-11-16 10-56-43](https://github.com/BLSQ/iaso/assets/19631540/f4e08f8d-41ee-4dc6-9800-8b55d66cf73b)



[IA-2495]: https://bluesquare.atlassian.net/browse/IA-2495?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ