### PR TITLE
WC2-304: Converting the field created_at datetime for entity in order to compa…

### DIFF
--- a/iaso/api/entity.py
+++ b/iaso/api/entity.py
@@ -250,7 +250,7 @@ class EntityViewSet(ModelViewSet):
             # TODO: see if we use created_at as reference date (or latest instance creation, update, ...)
             queryset = queryset.filter(created_at__gte=date_from)
         if date_to:
-            queryset = queryset.filter(created_at__lte=date_to)
+            queryset = queryset.filter(created_at__date__lte=date_to)
         if show_deleted:
             queryset = queryset.filter(deleted_at__isnull=True)
         if created_by_id:
@@ -259,7 +259,6 @@ class EntityViewSet(ModelViewSet):
             queryset = queryset.filter(attributes__created_by__teams__id=created_by_team_id)
 
         # location
-
         return queryset
 
     def create(self, request, *args, **kwargs):


### PR DESCRIPTION
From the beneficiaries list page, when filtering data from start date to end date, it was excluding the data linked to the last selected date of range. 

Related JIRA tickets : [WC2-304](https://bluesquare.atlassian.net/browse/WC2-304?atlOrigin=eyJpIjoiZGY2OGRiMTk2ODkxNGZhNTlmYjJjYTE0N2Y5M2VmNzgiLCJwIjoiaiJ9)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

Converted the created_at field in the date format without time.

## How to test

- Go on beneficiaries menu and click on the beneficiaries list
- Click on any beneficiary type(e.g: Child Under 5)
- Filter on the start and end date
- Click the **Search** button

You should get the beneficiaries created in the selected period(start and end date).

## Print screen / video

![Coda-2-Beneficiaries-Child-Under-5](https://github.com/BLSQ/iaso/assets/6383219/404fe854-7a60-4fe9-b6da-1b09a8be19aa)


[WC2-304]: https://bluesquare.atlassian.net/browse/WC2-304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ