### PR TITLE
TRIA-7 Add Trypelim plugin to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,3 +182,5 @@ pyvenv.cfg
 originals
 
 *.code-workspace
+
+plugins/trypelim


### PR DESCRIPTION
Add Trypelim plugin to .gitignore. Trypelim is in it's own repo, this makes it a bit more manageable for local development.

Related JIRA tickets : https://bluesquare.atlassian.net/browse/TRIA-7