### PR TITLE
IA-2551: completeness stats crash

### DIFF
--- a/hat/assets/js/apps/Iaso/components/LegendBuilder/utils.ts
+++ b/hat/assets/js/apps/Iaso/components/LegendBuilder/utils.ts
@@ -33,7 +33,7 @@ export const getRangeValues = (
 export const getThresHoldLabels = (
     scaleThreshold?: ScaleThreshold,
 ): string[] => {
-    const { domain } = scaleThreshold || { domain: [] };
+    const domain = scaleThreshold?.domain ?? [];
     const labels = domain.map((percent, index, array) => {
         if (index === 0) {
             return `< ${percent}%`;

--- a/hat/assets/js/apps/Iaso/domains/completenessStats/components/Map.tsx
+++ b/hat/assets/js/apps/Iaso/domains/completenessStats/components/Map.tsx
@@ -88,12 +88,15 @@ export const Map: FunctionComponent<Props> = ({
     params,
     selectedFormId,
     router,
-    threshold = defaultScaleThreshold,
+    threshold,
 }) => {
-    console.log('threshold', threshold);
+    const effectiveThreshold: ScaleThreshold =
+        !threshold || Object.keys(threshold).length === 0
+            ? defaultScaleThreshold
+            : threshold;
     const { planningId } = params;
     const classes: Record<string, string> = useStyles();
-    const getLegend = useGetLegend(threshold);
+    const getLegend = useGetLegend(effectiveThreshold);
     const bounds: Bounds | undefined = useMemo(
         () => locations && getOrgUnitsBounds(locations),
         [locations],
@@ -194,7 +197,7 @@ export const Map: FunctionComponent<Props> = ({
                 <CompletenessSelect params={params} />
                 <MapLegend
                     showDirectCompleteness={showDirectCompleteness}
-                    threshold={threshold}
+                    threshold={effectiveThreshold}
                 />
                 {parentLocation?.parent_org_unit?.id && (
                     <Box className={classes.parentIcon}>

--- a/hat/assets/js/apps/Iaso/domains/completenessStats/components/Map.tsx
+++ b/hat/assets/js/apps/Iaso/domains/completenessStats/components/Map.tsx
@@ -91,7 +91,7 @@ export const Map: FunctionComponent<Props> = ({
     threshold,
 }) => {
     const effectiveThreshold: ScaleThreshold =
-        !threshold || Object.keys(threshold).length === 0
+        !threshold || isEqual(threshold,{})
             ? defaultScaleThreshold
             : threshold;
     const { planningId } = params;

--- a/hat/assets/js/apps/Iaso/domains/completenessStats/components/Map.tsx
+++ b/hat/assets/js/apps/Iaso/domains/completenessStats/components/Map.tsx
@@ -12,6 +12,7 @@ import {
     LoadingSpinner,
     IconButton,
 } from 'bluesquare-components';
+import { isEqual } from 'lodash';
 import { Tile } from '../../../components/maps/tools/TilesSwitchControl';
 import { PopupComponent as Popup } from './Popup';
 
@@ -91,7 +92,7 @@ export const Map: FunctionComponent<Props> = ({
     threshold,
 }) => {
     const effectiveThreshold: ScaleThreshold =
-        !threshold || isEqual(threshold,{})
+        !threshold || isEqual(threshold, {})
             ? defaultScaleThreshold
             : threshold;
     const { planningId } = params;

--- a/hat/assets/js/apps/Iaso/domains/forms/components/FormFormComponent.tsx
+++ b/hat/assets/js/apps/Iaso/domains/forms/components/FormFormComponent.tsx
@@ -189,8 +189,8 @@ const FormForm: FunctionComponent<FormFormProps> = ({
                                 withMarginTop={false}
                             />
                         </Grid>
-                        <Grid item xs={3} />
-                        <Grid item xs={3}>
+                        <Grid item xs={2} />
+                        <Grid item xs={4}>
                             <FormLegendInput
                                 currentForm={currentForm}
                                 setFieldValue={setFieldValue}


### PR DESCRIPTION
If you visit completeness stas page for a specific form without a legend attached to it , the page crash

Related JIRA tickets : IA-2551

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- threshold is an empty object by default, provide default legend in this case
- enlarge create legend button for fr version

## How to test

go to completeness stats page and select a form without legend and visit the map. it should use the default legend

## Print screen / video

<img width="1645" alt="Screenshot 2023-12-06 at 10 26 25" src="https://github.com/BLSQ/iaso/assets/12494624/7712497d-792f-4b06-ad48-64294159eb49">

