### PR TITLE
The fix-docker-build-on-ubuntu

### DIFF
--- a/docker/db/Dockerfile
+++ b/docker/db/Dockerfile
@@ -1,5 +1,7 @@
 FROM postgres:12
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update \
  && apt-get install postgis postgresql-12-postgis-3 -y \
  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
On my machine at least

```
docker-compose build
```
get stuck on an interactive message saying createcluster.conf will modified and a "are you sure" message is shown

```
 => CANCELED [db 2/5] RUN apt-get update  && apt-get install postgis postgresql-12-postgis-3 -y  && rm -rf /var/lib/apt/lists/*
```
but since the build is not interactive we can't answer
the new arg make sure apt won't trigger interactive messages 



Related JIRA tickets : IA-XXX, WC2-XXX, POLIO-XXX

https://bluesquare.slack.com/archives/C032F8GFAUD/p1697800999509589

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

Explain the changes that were made. The idea is not to list exhaustively all the changes made (GitHub already provides a full diff), but to help the reviewers better understand:
- which specific file changes go together, e.g: when creating a table in the front-end, there usually is a config file that goes with it
- the reasoning behind some changes, e.g: deleted files because they are now redundant
- the behaviour to expect, e.g: tooltip has purple background color because the client likes it so, changed a key in the API response to be consistent with other endpoints

## How to test

Explain how to test your PR.
If a specific config is required explain it here (dataset, account, profile, ...)

