### PR TITLE
IA-2552 Allow to tune sentry error sample rate

### DIFF
--- a/docs/pages/dev/reference/env_variables/env_variables.md
+++ b/docs/pages/dev/reference/env_variables/env_variables.md
@@ -1,0 +1,58 @@
+# Environnement variables
+
+## DB connection related
+
+the url is build based on the following env variables
+```
+RDS_USERNAME
+RDS_PASSWORD
+RDS_HOSTNAME
+RDS_DB_NAME
+RDS_PORT
+```
+
+the SQL dashboard use a dedicated user/password with readonly access to the data
+
+```
+DB_READONLY_USERNAME 
+DB_READONLY_PASSWORD
+```
+
+## AWS related
+
+Storing the various files like
+ - js/css/... static assets
+ - raw forms (xlsform), submissions (xml and media),... is done in s3 (or an s3 compatible api like minio)
+
+```
+AWS_ACCESS_KEY_ID:
+AWS_SECRET_ACCESS_KEY:
+AWS_S3_REGION_NAME
+AWS_STORAGE_BUCKET_NAME:
+AWS_S3_ENDPOINT_URL: (used to for ex to point to minio)
+```
+
+for async task
+
+```
+BACKGROUND_TASK_SERVICE    : default to SQS :  possible values are  SQS POSTGRES
+BEANSTALK_SQS_REGION
+BEANSTALK_SQS_URL
+
+```
+
+
+## Sentry related
+
+If you don't provide a SENTRY_URL, sentry won't be configured
+
+
+| name                                   | optional  | default value   | description                             |---|
+|----------------------------------------|-----------|-----------------|-----------------------------------------|---|
+| SENTRY_URL                             |  true     | -               |  url specific to your sentry account    |   |
+| SENTRY_ENVIRONMENT                     |  true     | development     |  environnement (dev, staging, prod,...) |   |
+| SENTRY_TRACES_SAMPLE_RATE              |  true     |   0.1           |  float between 0 and 1 : send 10%       |   |
+| SENTRY_ERRORS_SAMPLE_RATE              |  true     |   1.0           |  float between 0 and 1 : send everything|   |
+| SENTRY_ERRORS_HTTPERROR_SAMPLE_RATE    |  true     |   0.8           |  float between 0 and 1 : send 80% of the errors | |  
+
+     

--- a/hat/settings.py
+++ b/hat/settings.py
@@ -468,7 +468,7 @@ if SENTRY_URL:
 
     ignore_logger("django.security.DisallowedHost")
 
-    errors_sample_rate = get_env_as_float("SENTRY_ERRORS_SAMPLE_RATE", "0.1")
+    errors_sample_rate = get_env_as_float("SENTRY_ERRORS_SAMPLE_RATE", "1.0")
 
     httperror_errors_sample_rate = get_env_as_float("SENTRY_ERRORS_HTTPERROR_SAMPLE_RATE", "0.8")
 

--- a/hat/settings.py
+++ b/hat/settings.py
@@ -20,11 +20,13 @@ import urllib.parse
 from datetime import timedelta
 from typing import Any, Dict
 from urllib.parse import urlparse
+from requests.exceptions import HTTPError
 
 import sentry_sdk
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.translation import gettext_lazy as _
 from sentry_sdk.integrations.django import DjangoIntegration
+from sentry_sdk.integrations.logging import ignore_logger
 
 from plugins.wfp.wfp_pkce_generator import generate_pkce
 
@@ -437,12 +439,17 @@ except Exception as e:
     print("error importing hat.__version", e)
     VERSION = "undetected_version"
 
-if SENTRY_URL:
-    traces_sample_rate_str: str = os.environ.get("SENTRY_TRACES_SAMPLE_RATE", "0.1")
+
+def get_env_as_float(variable_name: str, default_str: str) -> float:
+    var_str: str = os.environ.get(variable_name, default_str)
     try:
-        traces_sample_rate = float(traces_sample_rate_str)
+        return float(var_str)
     except ValueError:
-        raise Exception(f"Error wrong SENTRY_TRACES_SAMPLE_RATE value {traces_sample_rate_str}, should be float")
+        raise Exception(f"Error wrong {variable_name} value {var_str}, should be float")
+
+
+if SENTRY_URL:
+    traces_sample_rate = get_env_as_float("SENTRY_TRACES_SAMPLE_RATE", "0.1")
 
     # from OpenHexa
     # Exclude /_health/ from sentry  as it fill the quota
@@ -459,10 +466,28 @@ if SENTRY_URL:
             if path.startswith("/_health"):
                 return 0
 
+    ignore_logger("django.security.DisallowedHost")
+
+    errors_sample_rate = get_env_as_float("SENTRY_ERRORS_SAMPLE_RATE", "0.1")
+
+    httperror_errors_sample_rate = get_env_as_float("SENTRY_ERRORS_HTTPERROR_SAMPLE_RATE", "0.8")
+
+    # Helps reducing sentry quota usage when bad request/connectivity issue with external api
+    def sentry_error_sampler(_, hint):
+        exception_sampler_values = {
+            HTTPError: httperror_errors_sample_rate,
+        }
+
+        try:
+            return exception_sampler_values[hint["exc_info"][0]]
+        except (IndexError, KeyError, TypeError):
+            return errors_sample_rate
+
     sentry_sdk.init(
         SENTRY_URL,
         traces_sample_rate=traces_sample_rate,
         traces_sampler=sentry_tracer_sampler,
+        error_sampler=sentry_error_sampler,
         integrations=[DjangoIntegration()],
         send_default_pii=True,
         release=VERSION,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,6 +41,7 @@ nav:
       - ./pages/dev/reference/sql_dashboard/SQL_Dashboard_feature.md
       - ./pages/dev/reference/docker/docker.md
       - ./pages/dev/reference/background_tasks/background_tasks.md
+      - ./pages/dev/reference/env_variables/env_variables.md
       # - Entities:
       #   - ./pages/dev/reference/entities_in_iaso/entities_in_iaso.md
       # - Front-end:

--- a/requirements.txt
+++ b/requirements.txt
@@ -62,7 +62,7 @@ xlrd==1.2.0
 pyjwt==1.7.1
 djangorestframework_simplejwt==4.4.0
 
-sentry-sdk==1.5.11
+sentry-sdk[django]==1.38.0
 django-lazy-services==0.0.3
 dateparser==1.0.0
 


### PR DESCRIPTION
Sentry quota is regularly reached  and this PR try to help reducing sentry usage (temporarily or more definitively)

Related JIRA tickets : IA-2552

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

Sentry quota is regularly reached to help reducing sentry usage : 

- don't send `django.security.DisallowedHost` (happening often during security scanning, this has been partially fixed by setting a Web Application Firewall, but not all environments have that)
- adds sample rate limit to not send every errors to sentry (by default send everything)
- since we rely on some external api not under our control make a special case of HTTPError with a lower rate (by default send 80% of them)
- but still allow to override that via env variables
  - SENTRY_TRACES_SAMPLE_RATE (was already existing )
  - SENTRY_ERRORS_SAMPLE_RATE (new, equivalent but for the errors see the doc, currently send everything)
  - SENTRY_ERRORS_HTTPERROR_SAMPLE_RATE (new equivalent for the http error, allow to overide the default without code modification in case we decide to send every error again or even lower the sampling rate)

I've upgraded the sentry sdk and companion extra django integration, the error_sampler is "new" wasn't supported by our current version.

## How to test

this is a bit complicated but doable
 - modify your docker compose to add a valid  SENTRY_URL` (you can the same url as your staging/production env)
 -  in my case I've seeded an account via
```
 docker-compose run --rm iaso manage seed_test_data --mode=seed --dhis2version=2.37.10
```
 - then modified on the django api I know (here iaso/api/instances.py#retrieve function) and put a snippet like this
```
    import requests
    resp = requests.get("https://httpbin.org/status/401")
    resp.raise_for_status()
```
or 
```
   raise Exception("Oups local error triggering a 500")
```
- finally access the feature through the ui to trigger the HTTPError
- check the results in sentry UI

## Print screen / video



## Notes

we will work on the root causes in separate PR.
