### PR TITLE
POLIO-1326 httperror due to ? and & mismatch

### DIFF
--- a/plugins/polio/api/common.py
+++ b/plugins/polio/api/common.py
@@ -132,8 +132,13 @@ def get_url_content(url, login, password, minutes, prefer_cache: bool = False):
         empty = False
         j = []
         while not empty:
-            paginated_url = url + ("&page=%d&page_size=10000" % page)
+            if "?" in url:
+                paginated_url = url + f"&page={page}&page_size=10000"
+            else:
+                paginated_url = url + f"?page={page}&page_size=10000"
+
             logger.info("paginated_url: " + paginated_url)
+
             response = requests.get(paginated_url, auth=(login, password))
 
             empty = response.status_code == 404

--- a/plugins/polio/tests/api/test_ona_api_common.py
+++ b/plugins/polio/tests/api/test_ona_api_common.py
@@ -1,0 +1,49 @@
+from plugins.polio.api.common import find_orgunit_in_cache, get_url_content, make_orgunits_cache
+
+from django.test import TestCase  # type: ignore
+import responses  # type: ignore
+
+
+class ApiCommonTestCase(TestCase):
+    def mock_2_pages(self, suffix):
+        responses.add(
+            responses.GET,
+            f"https://demo.com/api/form/4564/data.json{suffix}page=1&page_size=10000",
+            json=[{"id": 1}],
+            status=200,
+        )
+
+        responses.add(
+            responses.GET,
+            f"https://demo.com/api/form/4564/data.json{suffix}page=2&page_size=10000",
+            json=[{"id": 2}],
+            status=200,
+        )
+
+        responses.add(
+            responses.GET,
+            f"https://demo.com/api/form/4564/data.json{suffix}page=3&page_size=10000",
+            status=404,
+        )
+
+    @responses.activate
+    def test_get_url_content_without_params(self):
+        self.mock_2_pages("?")
+
+        content = get_url_content(
+            "https://demo.com/api/form/4564/data.json", "myuser", "mypassword", 50000, prefer_cache=False
+        )
+        self.assertEqual(content, [{"id": 1}, {"id": 2}])
+
+    @responses.activate
+    def test_get_url_content_with_params(self):
+        self.mock_2_pages("?created__lt=20231212&")
+
+        content = get_url_content(
+            "https://demo.com/api/form/4564/data.json?created__lt=20231212",
+            "myuser",
+            "mypassword",
+            50000,
+            prefer_cache=False,
+        )
+        self.assertEqual(content, [{"id": 1}, {"id": 2}])


### PR DESCRIPTION
The constructed url to contact ona servers contains &page=x&pageSize=y instead of ?page=x&pageSize=y when the url doesn't contains already query params


Related JIRA tickets : POLIO-1326

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

Since I don't know if the config might contains filters or not
I tried to keep it compatible for both usecase 

## How to test

Except launching the test
```
make test TARGET=plugins.polio.tests.api.test_ona_api_common
 
```


## Print screen / video

the produced output of the pagination for the 2 tests
```
System check identified no issues (0 silenced).
INFO     2023-12-08 15:32:09,024 plugins.polio.api.common -- fetching from https://demo.com/api/form/4564/data.json?created__lt=20231212
INFO     2023-12-08 15:32:09,024 plugins.polio.api.common -- paginated_url: https://demo.com/api/form/4564/data.json?created__lt=20231212&page=1&page_size=10000
INFO     2023-12-08 15:32:09,027 plugins.polio.api.common -- paginated_url: https://demo.com/api/form/4564/data.json?created__lt=20231212&page=2&page_size=10000
INFO     2023-12-08 15:32:09,028 plugins.polio.api.common -- paginated_url: https://demo.com/api/form/4564/data.json?created__lt=20231212&page=3&page_size=10000
INFO     2023-12-08 15:32:09,030 plugins.polio.api.common -- fetched 22 bytes
.INFO     2023-12-08 15:32:09,036 plugins.polio.api.common -- fetching from https://demo.com/api/form/4564/data.json
INFO     2023-12-08 15:32:09,036 plugins.polio.api.common -- paginated_url: https://demo.com/api/form/4564/data.json?page=1&page_size=10000
INFO     2023-12-08 15:32:09,038 plugins.polio.api.common -- paginated_url: https://demo.com/api/form/4564/data.json?page=2&page_size=10000
INFO     2023-12-08 15:32:09,041 plugins.polio.api.common -- paginated_url: https://demo.com/api/form/4564/data.json?page=3&page_size=10000
INFO     2023-12-08 15:32:09,043 plugins.polio.api.common -- fetched 22 bytes

```

## Notes


