### PR TITLE
IA-2490: entity type dialog

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/entities/entityTypes/components/EntityTypesDialog.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/entityTypes/components/EntityTypesDialog.tsx
@@ -21,6 +21,7 @@ import { useGetForms } from '../hooks/requests/forms';
 import { useTranslatedErrors } from '../../../../libs/validation';
 import { useGetPossibleFieldsForEntityTypes } from '../../../forms/hooks/useGetPossibleFields';
 import MESSAGES from '../messages';
+import { formatLabel } from '../../../instances/utils';
 
 type RenderTriggerProps = {
     openDialog: () => void;
@@ -224,7 +225,7 @@ export const EntityTypesDialog: FunctionComponent<Props> = ({
                         label={MESSAGES.fieldsListView}
                         options={possibleFields.map(field => ({
                             value: field.name,
-                            label: field.label,
+                            label: formatLabel(field),
                         }))}
                         helperText={
                             isNew && !values.reference_form
@@ -250,7 +251,7 @@ export const EntityTypesDialog: FunctionComponent<Props> = ({
                         label={MESSAGES.fieldsDetailInfoView}
                         options={possibleFields.map(field => ({
                             value: field.name,
-                            label: field.label,
+                            label: formatLabel(field),
                         }))}
                         helperText={
                             isNew && !values.reference_form
@@ -274,7 +275,7 @@ export const EntityTypesDialog: FunctionComponent<Props> = ({
                         label={MESSAGES.fieldsDuplicateSearch}
                         options={possibleFields.map(field => ({
                             value: field.name,
-                            label: field.label,
+                            label: formatLabel(field),
                         }))}
                         helperText={
                             isNew && !values.reference_form

--- a/hat/assets/js/apps/Iaso/domains/entities/entityTypes/components/EntityTypesDialog.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/entityTypes/components/EntityTypesDialog.tsx
@@ -4,24 +4,22 @@ import { useFormik, FormikProvider, FormikProps } from 'formik';
 import * as yup from 'yup';
 import {
     useSafeIntl,
-    IconButton as IconButtonComponent,
     IntlFormatMessage,
     IntlMessage,
+    IconButton,
 } from 'bluesquare-components';
-import { makeStyles, Box } from '@material-ui/core';
+import { Box } from '@material-ui/core';
 import isEqual from 'lodash/isEqual';
 
 import InputComponent from '../../../../components/forms/InputComponent';
 import ConfirmCancelDialogComponent from '../../../../components/dialogs/ConfirmCancelDialogComponent';
 import { EntityType } from '../types/entityType';
 
-import { baseUrls } from '../../../../constants/urls';
-
-import { useGetForms } from '../hooks/requests/forms';
+import { useGetFormForEntityType, useGetForms } from '../hooks/requests/forms';
 import { useTranslatedErrors } from '../../../../libs/validation';
-import { useGetPossibleFieldsForEntityTypes } from '../../../forms/hooks/useGetPossibleFields';
 import MESSAGES from '../messages';
 import { formatLabel } from '../../../instances/utils';
+import { baseUrls } from '../../../../constants/urls';
 
 type RenderTriggerProps = {
     openDialog: () => void;
@@ -42,17 +40,6 @@ type Props = {
     ) => void;
 };
 
-const useStyles = makeStyles(theme => ({
-    root: {
-        position: 'relative',
-    },
-    view: {
-        position: 'absolute',
-        top: theme.spacing(1),
-        right: theme.spacing(1),
-    },
-}));
-
 export const EntityTypesDialog: FunctionComponent<Props> = ({
     titleMessage,
     renderTrigger,
@@ -66,7 +53,6 @@ export const EntityTypesDialog: FunctionComponent<Props> = ({
     },
     saveEntityType,
 }) => {
-    const classes: Record<string, string> = useStyles();
     const [isOpen, setIsOpen] = useState<boolean>(false);
     const [closeModal, setCloseModal] = useState<any>();
     const { formatMessage }: { formatMessage: IntlFormatMessage } =
@@ -139,11 +125,14 @@ export const EntityTypesDialog: FunctionComponent<Props> = ({
     });
     const isNew = !initialData?.id;
     const { data: formsList, isFetching: isFetchingForms } = useGetForms(isNew);
-    const { possibleFields, isFetchingForm } =
-        useGetPossibleFieldsForEntityTypes({
-            formId: values?.reference_form,
-            enabled: isOpen,
-        });
+    const {
+        possibleFields,
+        isFetchingForm,
+        name: formName,
+    } = useGetFormForEntityType({
+        formId: values?.reference_form,
+        enabled: isOpen,
+    });
     return (
         <FormikProvider value={formik}>
             {/* @ts-ignore */}
@@ -162,9 +151,6 @@ export const EntityTypesDialog: FunctionComponent<Props> = ({
                 confirmMessage={MESSAGES.save}
                 renderTrigger={renderTrigger}
                 maxWidth="xs"
-                dialogProps={{
-                    classNames: classes.dialog,
-                }}
                 onOpen={() => {
                     resetForm();
                     setIsOpen(true);
@@ -173,26 +159,23 @@ export const EntityTypesDialog: FunctionComponent<Props> = ({
                     setIsOpen(false);
                 }}
             >
-                {!isNew && (
-                    <Box className={classes.view}>
-                        <IconButtonComponent
-                            url={`/${baseUrls.formDetail}/formId/${values.reference_form}`}
-                            icon="remove-red-eye"
-                            tooltipMessage={MESSAGES.viewForm}
-                            dataTestId="see-form-button"
-                        />
-                    </Box>
-                )}
-                <div className={classes.root} id="entity-types-dialog">
-                    <InputComponent
-                        keyValue="name"
-                        onChange={onChange}
-                        value={values.name}
-                        errors={getErrors('name')}
-                        type="text"
-                        label={MESSAGES.name}
-                        required
-                    />
+                <div id="entity-types-dialog">
+                    {!isNew && formName && (
+                        <Box mb={2}>
+                            {`${formatMessage(MESSAGES.referenceForm)}: `}
+                            {formName}
+                            <Box ml={1} display="inline-block">
+                                <IconButton
+                                    url={`/${baseUrls.formDetail}/formId/${values.reference_form}`}
+                                    icon="remove-red-eye"
+                                    tooltipMessage={MESSAGES.viewForm}
+                                    iconSize="small"
+                                    fontSize="small"
+                                    dataTestId="see-form-button"
+                                />
+                            </Box>
+                        </Box>
+                    )}
                     {isNew && (
                         <InputComponent
                             required
@@ -212,6 +195,15 @@ export const EntityTypesDialog: FunctionComponent<Props> = ({
                             label={MESSAGES.referenceForm}
                         />
                     )}
+                    <InputComponent
+                        keyValue="name"
+                        onChange={onChange}
+                        value={values.name}
+                        errors={getErrors('name')}
+                        type="text"
+                        label={MESSAGES.name}
+                        required
+                    />
                     <InputComponent
                         type="select"
                         multi

--- a/hat/assets/js/apps/Iaso/domains/entities/entityTypes/hooks/requests/forms.ts
+++ b/hat/assets/js/apps/Iaso/domains/entities/entityTypes/hooks/requests/forms.ts
@@ -3,7 +3,8 @@ import { UseQueryResult } from 'react-query';
 import { useSnackQuery } from '../../../../../libs/apiHooks';
 import { getRequest } from '../../../../../libs/Api';
 
-import { Form } from '../../../../forms/types/forms';
+import { Form, PossibleField } from '../../../../forms/types/forms';
+import { usePossibleFields } from '../../../../forms/hooks/useGetPossibleFields';
 
 export const useGetForm = (
     formId: number | undefined,
@@ -41,4 +42,26 @@ export const useGetForms = (
                 ),
         },
     });
+};
+type Result = {
+    possibleFields: PossibleField[];
+    isFetchingForm: boolean;
+    name?: string;
+};
+export const useGetFormForEntityType = ({
+    formId,
+    enabled = true,
+}: {
+    formId?: number;
+    enabled?: boolean;
+}): Result => {
+    const { data: currentForm, isFetching: isFetchingForm } = useGetForm(
+        formId,
+        enabled && Boolean(formId),
+        'possible_fields,name',
+    );
+    return {
+        ...usePossibleFields(isFetchingForm, currentForm),
+        name: currentForm?.name,
+    };
 };

--- a/hat/assets/js/apps/Iaso/domains/forms/hooks/useGetPossibleFields.ts
+++ b/hat/assets/js/apps/Iaso/domains/forms/hooks/useGetPossibleFields.ts
@@ -15,7 +15,10 @@ type Result = {
     isFetchingForm: boolean;
 };
 
-const usePossibleFields = (isFetchingForm: boolean, form?: Form): Result => {
+export const usePossibleFields = (
+    isFetchingForm: boolean,
+    form?: Form,
+): Result => {
     return useMemo(() => {
         const possibleFields =
             form?.possible_fields?.map(field => ({
@@ -33,21 +36,6 @@ export const useGetPossibleFields = (formId?: number): Result => {
     const { data: currentForm, isFetching: isFetchingForm } = useGetForm(
         formId,
         Boolean(formId),
-        'possible_fields',
-    );
-    return usePossibleFields(isFetchingForm, currentForm);
-};
-
-export const useGetPossibleFieldsForEntityTypes = ({
-    formId,
-    enabled = true,
-}: {
-    formId?: number;
-    enabled?: boolean;
-}): Result => {
-    const { data: currentForm, isFetching: isFetchingForm } = useGetForm(
-        formId,
-        enabled && Boolean(formId),
         'possible_fields',
     );
     return usePossibleFields(isFetchingForm, currentForm);


### PR DESCRIPTION
When editing, we should display the name of the reference form at least

Also dialog was not supporting translated fields in translated forms
![Screenshot 2023-12-12 at 12 16 10](https://github.com/BLSQ/iaso/assets/12494624/5a9961d3-41ac-4c56-a8fa-ff7551e35663)


Related JIRA tickets : IA-2490
## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- use formatLabel to display translated label
- fetch and display form name while editing

## How to test

Make sure you have a beneficiary type using a translated form like this one:
[simple_form_2023072401.xlsx](https://github.com/BLSQ/iaso/files/13647448/simple_form_2023072401.xlsx)

Open the beneficiary type dialog and check that the link is correct to the form and that the fields are correctly displayed

## Print screen / video

![Screenshot 2023-12-12 at 12 15 28](https://github.com/BLSQ/iaso/assets/12494624/d8a4550a-d03c-4b1b-afaa-a666c5706b61)

