### PR TITLE
IA-2553 datasource cleanup url leading slash login page

### DIFF
--- a/iaso/dhis2/url_helper.py
+++ b/iaso/dhis2/url_helper.py
@@ -6,5 +6,4 @@ def clean_url(dhis2_url: Union[str, None]) -> Union[str, None]:
         return None
     cleaned_url = dhis2_url.replace("dhis-web-commons/security/login.action", "")
     cleaned_url = cleaned_url.strip("/")
-    print(cleaned_url, " was ", dhis2_url)
     return cleaned_url

--- a/iaso/dhis2/url_helper.py
+++ b/iaso/dhis2/url_helper.py
@@ -1,0 +1,10 @@
+from typing import Union
+
+
+def clean_url(dhis2_url: Union[str, None]) -> Union[str, None]:
+    if not dhis2_url:
+        return None
+    cleaned_url = dhis2_url.replace("dhis-web-commons/security/login.action", "")
+    cleaned_url = cleaned_url.strip("/")
+    print(cleaned_url, " was ", dhis2_url)
+    return cleaned_url

--- a/iaso/tests/test_url_helper.py
+++ b/iaso/tests/test_url_helper.py
@@ -1,0 +1,19 @@
+from ..dhis2.url_helper import clean_url
+from django.test import TestCase
+
+
+class Dhis2UrlHelperTests(TestCase):
+    def test_none(self):
+        self.assertEquals(clean_url(None), None)
+
+    def test_no_trailing_slash(self):
+        self.assertEquals(clean_url("https://play.dhis2.org/2.37.10"), "https://play.dhis2.org/2.37.10")
+
+    def test_trailing_slash(self):
+        self.assertEquals(clean_url("https://play.dhis2.org/2.37.10/"), "https://play.dhis2.org/2.37.10")
+
+    def test_login_url(self):
+        self.assertEquals(
+            clean_url("https://play.dhis2.org/2.37.10/dhis-web-commons/security/login.action"),
+            "https://play.dhis2.org/2.37.10",
+        )


### PR DESCRIPTION
Make auto cleanup of the dhis2 url to support person typing url with or without trailing slash or giving the full url to the login page.

Related JIRA tickets : IA-2553

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

On create or update, cleanup the dhis2_url of the datasource's ExternalCredential

also modified the self check of the dhis2 connection to
 - support some dhis2 where the `instanceBaseUrl` is not in the system/info endpoint
 - not use the ping endpoint but the system/info (ping will be removed in future versions and all our other products check the connection using that endpoint )


## How to test


1. seed an fresh env with `docker-compose run --rm iaso manage seed_test_data --mode=seed --dhis2version=2.38`
2. login with user/password in the output
3. go to the screen http://localhost:8081/dashboard/orgunits/sources/list/
4. create/update and click test connections
  - for testing you can use
    - https://play.dhis2.org/2.37.10/dhis-web-commons/security/login.action
    - https://play.dhis2.org/2.37.10/
    - https://play.dhis2.org/2.37.10
  - and user/password : admin / district

## Print screen / video

![image](https://github.com/BLSQ/iaso/assets/371692/b81a5082-37f5-4439-a1bb-d7ffc390a8f7)
![image](https://github.com/BLSQ/iaso/assets/371692/d153fcc5-998a-4bc0-8faf-bf4109df478c)
![image](https://github.com/BLSQ/iaso/assets/371692/357c0c1f-d679-4017-94d9-7b5886e09f97)
