### PR TITLE
POLIO-1340 Display details of notification import tasks

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -1098,6 +1098,8 @@
     "iaso.tasks.launcher": "User",
     "iaso.tasks.message": "Message",
     "iaso.tasks.name": "Name",
+    "iaso.tasks.polioNotificationImport.details": "Polio Notifications Import Details",
+    "iaso.tasks.polioNotificationImport.errors": "{count} error(s). The following data couldn't be imported.",
     "iaso.tasks.progress": "Progress",
     "iaso.tasks.queued": "Queued",
     "iaso.tasks.running": "Running",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -1098,6 +1098,8 @@
     "iaso.tasks.launcher": "Utilisateur",
     "iaso.tasks.message": "Message",
     "iaso.tasks.name": "Nom",
+    "iaso.tasks.polioNotificationImport.details": "Détails de l'importation des notifications Polio",
+    "iaso.tasks.polioNotificationImport.errors": "{count} erreur(s). L'import des données suivantes a échoué.",
     "iaso.tasks.progress": "Avancement",
     "iaso.tasks.queued": "En attente",
     "iaso.tasks.running": "En cours d'exécution",

--- a/hat/assets/js/apps/Iaso/domains/tasks/components/NotificationImportDetailButton.tsx
+++ b/hat/assets/js/apps/Iaso/domains/tasks/components/NotificationImportDetailButton.tsx
@@ -1,0 +1,23 @@
+import React, { FunctionComponent } from 'react';
+import { IconButton } from 'bluesquare-components';
+
+import VisibilityIcon from '@mui/icons-material/Visibility';
+
+import MESSAGES from '../messages';
+
+type IconButtonProps = {
+    onClick: () => void;
+    dataTestId?: string;
+};
+
+export const NotificationImportDetailButton: FunctionComponent<IconButtonProps> =
+    ({ onClick, dataTestId = 'roundHistoryButton' }) => {
+        return (
+            <IconButton
+                dataTestId={dataTestId}
+                onClick={onClick}
+                overrideIcon={VisibilityIcon}
+                tooltipMessage={MESSAGES.polioNotificationImportDetails}
+            />
+        );
+    };

--- a/hat/assets/js/apps/Iaso/domains/tasks/components/NotificationImportDetailButton.tsx
+++ b/hat/assets/js/apps/Iaso/domains/tasks/components/NotificationImportDetailButton.tsx
@@ -11,7 +11,10 @@ type IconButtonProps = {
 };
 
 export const NotificationImportDetailButton: FunctionComponent<IconButtonProps> =
-    ({ onClick, dataTestId = 'roundHistoryButton' }) => {
+    ({
+        onClick,
+        dataTestId = 'open-polio-notifications-import-details-button',
+    }) => {
         return (
             <IconButton
                 dataTestId={dataTestId}

--- a/hat/assets/js/apps/Iaso/domains/tasks/components/NotificationImportDetailModal.tsx
+++ b/hat/assets/js/apps/Iaso/domains/tasks/components/NotificationImportDetailModal.tsx
@@ -1,0 +1,78 @@
+import React, { FunctionComponent } from 'react';
+
+import {
+    LoadingSpinner,
+    makeFullModal,
+    useSafeIntl,
+} from 'bluesquare-components';
+import { AlertModal } from '../../../components/AlertModal/AlertModal';
+
+import MESSAGES from '../messages';
+import { NotificationImportDetailButton } from './NotificationImportDetailButton';
+import { Task } from '../types';
+import { useGetPolioNotificationImport } from '../hooks/api';
+
+type Props = {
+    task: Task<any>;
+    isOpen: boolean;
+    closeDialog: () => void;
+};
+
+const NotificationImportDetailModal: FunctionComponent<Props> = ({
+    task,
+    isOpen,
+    closeDialog,
+}) => {
+    const { formatMessage } = useSafeIntl();
+
+    const {
+        data: notificationImport,
+        isFetching: isFetchingNotificationImport,
+    } = useGetPolioNotificationImport(task.polio_notification_id);
+
+    return (
+        <AlertModal
+            isOpen={isOpen}
+            closeDialog={closeDialog}
+            titleMessage={formatMessage(
+                MESSAGES.polioNotificationImportDetails,
+            )}
+            maxWidth="md"
+        >
+            {isFetchingNotificationImport && <LoadingSpinner />}
+            {!isFetchingNotificationImport && (
+                <>
+                    <p>{task.result.message}</p>
+                    {notificationImport &&
+                        notificationImport.errors.length > 0 && (
+                            <>
+                                <p>
+                                    {formatMessage(
+                                        MESSAGES.polioNotificationImportErrors,
+                                        {
+                                            count: notificationImport.errors
+                                                .length,
+                                        },
+                                    )}
+                                </p>
+                                <pre style={{ maxHeight: '550px' }}>
+                                    {JSON.stringify(
+                                        notificationImport.errors,
+                                        null,
+                                        ' ',
+                                    )}
+                                </pre>
+                            </>
+                        )}
+                </>
+            )}
+        </AlertModal>
+    );
+};
+
+const modalWithIconButton = makeFullModal(
+    NotificationImportDetailModal,
+    NotificationImportDetailButton,
+);
+
+export { modalWithIconButton as NotificationImportDetailModal };

--- a/hat/assets/js/apps/Iaso/domains/tasks/components/NotificationImportDetailModal.tsx
+++ b/hat/assets/js/apps/Iaso/domains/tasks/components/NotificationImportDetailModal.tsx
@@ -28,7 +28,7 @@ const NotificationImportDetailModal: FunctionComponent<Props> = ({
     const {
         data: notificationImport,
         isFetching: isFetchingNotificationImport,
-    } = useGetPolioNotificationImport(task.polio_notification_id);
+    } = useGetPolioNotificationImport(task.polio_notification_import_id);
 
     return (
         <AlertModal
@@ -37,6 +37,7 @@ const NotificationImportDetailModal: FunctionComponent<Props> = ({
             titleMessage={formatMessage(
                 MESSAGES.polioNotificationImportDetails,
             )}
+            id="polio-notifications-import-details-modal"
             maxWidth="md"
         >
             {isFetchingNotificationImport && <LoadingSpinner />}

--- a/hat/assets/js/apps/Iaso/domains/tasks/config.js
+++ b/hat/assets/js/apps/Iaso/domains/tasks/config.js
@@ -5,6 +5,7 @@ import {
 } from 'bluesquare-components';
 import MESSAGES from './messages';
 import { DateTimeCell } from '../../components/Cells/DateTimeCell';
+import { NotificationImportDetailModal } from './components/NotificationImportDetailModal.tsx';
 
 const getTranslatedStatusMessage = (formatMessage, status) => {
     // Return untranslated status if not translation available
@@ -21,7 +22,11 @@ const safePercent = (a, b) => {
     return `${percent.toFixed(2)}%`;
 };
 
-const tasksTableColumns = (formatMessage, killTaskAction) => [
+const tasksTableColumns = (
+    formatMessage,
+    killTaskAction,
+    hasPolioNotificationsPerm,
+) => [
     {
         Header: formatMessage(MESSAGES.name),
         sortable: true,
@@ -138,6 +143,16 @@ const tasksTableColumns = (formatMessage, killTaskAction) => [
                 {settings.row.original.should_be_killed === true &&
                     settings.row.original.status === 'RUNNING' &&
                     formatMessage(MESSAGES.killSignalSent)}
+                {hasPolioNotificationsPerm &&
+                    ['SUCCESS', 'ERRORED'].includes(
+                        settings.row.original.status,
+                    ) &&
+                    settings.row.original.name ===
+                        'create_polio_notifications_async' && (
+                        <NotificationImportDetailModal
+                            task={settings.row.original}
+                        />
+                    )}
             </section>
         ),
     },

--- a/hat/assets/js/apps/Iaso/domains/tasks/hooks/api.ts
+++ b/hat/assets/js/apps/Iaso/domains/tasks/hooks/api.ts
@@ -1,0 +1,22 @@
+import { UseQueryResult } from 'react-query';
+import { getRequest } from '../../../libs/Api';
+import { useSnackQuery } from '../../../libs/apiHooks';
+
+import { PolioNotificationImport } from '../types';
+
+export const useGetPolioNotificationImport = (
+    polioNotificationImportId: number | string | undefined,
+): UseQueryResult<PolioNotificationImport, Error> => {
+    return useSnackQuery({
+        queryKey: ['instance', polioNotificationImportId],
+        queryFn: () =>
+            getRequest(
+                `/api/polio/notifications/${polioNotificationImportId}/get_import_details/`,
+            ),
+        options: {
+            enabled: Boolean(polioNotificationImportId),
+            retry: false,
+            keepPreviousData: true,
+        },
+    });
+};

--- a/hat/assets/js/apps/Iaso/domains/tasks/index.js
+++ b/hat/assets/js/apps/Iaso/domains/tasks/index.js
@@ -14,6 +14,9 @@ import { baseUrls } from 'Iaso/constants/urls';
 import { TableWithDeepLink } from 'Iaso/components/tables/TableWithDeepLink';
 import tasksTableColumns from './config';
 import MESSAGES from './messages';
+import { POLIO_NOTIFICATIONS } from '../../utils/permissions.ts';
+import { userHasPermission } from '../users/utils';
+import { useCurrentUser } from '../../utils/usersUtils.ts';
 
 const baseUrl = baseUrls.tasks;
 
@@ -69,6 +72,11 @@ const Tasks = ({ params }) => {
         MESSAGES.fetchTasksError,
     );
 
+    const hasPolioNotificationsPerm = userHasPermission(
+        POLIO_NOTIFICATIONS,
+        useCurrentUser(),
+    );
+
     return (
         <>
             <TopBar
@@ -95,6 +103,7 @@ const Tasks = ({ params }) => {
                     columns={tasksTableColumns(
                         intl.formatMessage,
                         killTaskAction,
+                        hasPolioNotificationsPerm,
                     )}
                     baseUrl={baseUrl}
                     extraProps={{

--- a/hat/assets/js/apps/Iaso/domains/tasks/messages.js
+++ b/hat/assets/js/apps/Iaso/domains/tasks/messages.js
@@ -97,6 +97,15 @@ const MESSAGES = defineMessages({
         defaultMessage: 'An error occurred while fetching tasks list',
         id: 'iaso.snackBar.fetchTasksError',
     },
+    polioNotificationImportDetails: {
+        defaultMessage: 'Polio Notifications Import Details',
+        id: 'iaso.tasks.polioNotificationImport.details',
+    },
+    polioNotificationImportErrors: {
+        defaultMessage:
+            "{count} error(s). The following data couldn't be imported.",
+        id: 'iaso.tasks.polioNotificationImport.errors',
+    },
 });
 
 export default MESSAGES;

--- a/hat/assets/js/apps/Iaso/domains/tasks/types.ts
+++ b/hat/assets/js/apps/Iaso/domains/tasks/types.ts
@@ -28,7 +28,7 @@ export type Task<T> = {
     status: TaskStatus;
     should_be_killed: boolean;
     progress_message: Nullable<string>;
-    polio_notification_id?: number;
+    polio_notification_import_id?: number;
 };
 
 export type TaskApiResponse<T> = {

--- a/hat/assets/js/apps/Iaso/domains/tasks/types.ts
+++ b/hat/assets/js/apps/Iaso/domains/tasks/types.ts
@@ -28,8 +28,20 @@ export type Task<T> = {
     status: TaskStatus;
     should_be_killed: boolean;
     progress_message: Nullable<string>;
+    polio_notification_id?: number;
 };
 
 export type TaskApiResponse<T> = {
     task: Task<T>;
+};
+
+export type PolioNotificationImport = {
+    id: number;
+    account: number;
+    file: string;
+    status: string;
+    errors: [];
+    created_by: number;
+    created_at: string; // DateTime
+    updated_at?: string; // DateTime
 };

--- a/hat/assets/js/cypress/fixtures/tasks/list.json
+++ b/hat/assets/js/cypress/fixtures/tasks/list.json
@@ -17,7 +17,8 @@
             "status": "QUEUED",
             "name": "import_gpkg_task",
             "should_be_killed": true,
-            "progress_message": null
+            "progress_message": null,
+            "polio_notification_import_id": null
         },
         {
             "id": 140,
@@ -35,7 +36,8 @@
             "status": "QUEUED",
             "name": "import_gpkg_task",
             "should_be_killed": false,
-            "progress_message": null
+            "progress_message": null,
+            "polio_notification_import_id": null
         },
         {
             "id": 139,
@@ -53,7 +55,8 @@
             "status": "QUEUED",
             "name": "import_gpkg_task",
             "should_be_killed": false,
-            "progress_message": null
+            "progress_message": null,
+            "polio_notification_import_id": null
         },
         {
             "id": 138,
@@ -71,7 +74,8 @@
             "status": "QUEUED",
             "name": "import_gpkg_task",
             "should_be_killed": false,
-            "progress_message": null
+            "progress_message": null,
+            "polio_notification_import_id": null
         },
         {
             "id": 137,
@@ -89,7 +93,8 @@
             "status": "QUEUED",
             "name": "import_gpkg_task",
             "should_be_killed": false,
-            "progress_message": null
+            "progress_message": null,
+            "polio_notification_import_id": null
         },
         {
             "id": 136,
@@ -116,7 +121,8 @@
             "status": "ERRORED",
             "name": "dhis2_ou_exporter",
             "should_be_killed": false,
-            "progress_message": "Error when updating Org Units Efmr3Xo36DR,O6uvpzGd5pu,UGVLYrO63mR\nURL : http://dhis2:8080/api/metadata\nReceived status code: 200\nErrors:\r\n * Invalid reference [O6uvparent] (OrganisationUnit) on object Bo [O6uvpzGd5pu] (OrganisationUnit) for association `parent`.\n"
+            "progress_message": "Error when updating Org Units Efmr3Xo36DR,O6uvpzGd5pu,UGVLYrO63mR\nURL : http://dhis2:8080/api/metadata\nReceived status code: 200\nErrors:\r\n * Invalid reference [O6uvparent] (OrganisationUnit) on object Bo [O6uvpzGd5pu] (OrganisationUnit) for association `parent`.\n",
+            "polio_notification_import_id": null
         },
         {
             "id": 135,
@@ -137,7 +143,8 @@
             "status": "SUCCESS",
             "name": "dhis2_ou_exporter",
             "should_be_killed": false,
-            "progress_message": "Export Done"
+            "progress_message": "Export Done",
+            "polio_notification_import_id": null
         },
         {
             "id": 134,
@@ -158,7 +165,8 @@
             "status": "SUCCESS",
             "name": "dhis2_ou_exporter",
             "should_be_killed": false,
-            "progress_message": "Export Done"
+            "progress_message": "Export Done",
+            "polio_notification_import_id": null
         },
         {
             "id": 133,
@@ -179,7 +187,8 @@
             "status": "SUCCESS",
             "name": "dhis2_ou_exporter",
             "should_be_killed": false,
-            "progress_message": "Export Done"
+            "progress_message": "Export Done",
+            "polio_notification_import_id": null
         },
         {
             "id": 132,
@@ -200,7 +209,52 @@
             "status": "SUCCESS",
             "name": "dhis2_ou_exporter",
             "should_be_killed": false,
-            "progress_message": "Export Done"
+            "progress_message": "Export Done",
+            "polio_notification_import_id": null
+        },
+        {
+            "id": 131,
+            "created_at": 1702374482.051425,
+            "started_at": 1702374668.504679,
+            "ended_at": 1702374677.768638,
+            "progress_value": 0,
+            "end_value": 0,
+            "launcher": {
+                "first_name": "Oli",
+                "last_name": "Vier",
+                "username": "olethanh"
+            },
+            "result": {
+                "result": "SUCCESS",
+                "message": "1 polio notifications created."
+            },
+            "status": "SUCCESS",
+            "name": "create_polio_notifications_async",
+            "should_be_killed": false,
+            "progress_message": "1 polio notifications created.",
+            "polio_notification_import_id": 1
+        },
+        {
+            "id": 130,
+            "created_at": 1702312214.045271,
+            "started_at": 1702312214.058046,
+            "ended_at": 1702312231.506536,
+            "progress_value": 0,
+            "end_value": 0,
+            "launcher": {
+                "first_name": "Oli",
+                "last_name": "Vier",
+                "username": "olethanh"
+            },
+            "result": {
+                "result": "SUCCESS",
+                "message": "3768 polio notifications created."
+            },
+            "status": "SUCCESS",
+            "name": "create_polio_notifications_async",
+            "should_be_killed": false,
+            "progress_message": "3768 polio notifications created.",
+            "polio_notification_import_id": 2
         }
     ],
     "has_next": true,

--- a/hat/assets/js/cypress/fixtures/tasks/polio_notification_import.json
+++ b/hat/assets/js/cypress/fixtures/tasks/polio_notification_import.json
@@ -1,0 +1,10 @@
+{
+    "id": 1,
+    "account": 8,
+    "file": "/media/uploads/polio_notifications/2023-12-12-09-48/POLIO_line_list_for_AFRO_Compiled_10OCT2023.xlsx",
+    "status": "done",
+    "errors": [],
+    "created_by": 63,
+    "created_at": "2023-12-12T09:48:02.024481Z",
+    "updated_at": "2023-12-12T09:51:17.755389Z"
+}

--- a/hat/assets/js/cypress/fixtures/tasks/polio_notification_import_with_errors.json
+++ b/hat/assets/js/cypress/fixtures/tasks/polio_notification_import_with_errors.json
@@ -1,0 +1,25 @@
+{
+    "id": 2,
+    "account": 8,
+    "file": "/media/uploads/polio_notifications/2023-12-11-16-30/POLIO_line_list_for_AFRO_Compiled_10OCT2023.xlsx",
+    "status": "done",
+    "errors": [
+        {
+            "COUNTRY": "CHAD",
+            "LINEAGE": "NIE-ZAS-1",
+            "DISTRICT": "LIWA",
+            "PROVINCE": "LAC",
+            "EPID_NUMBER": "CHA-LAC-LIW-23-013-C3 ",
+            "VDPV_CATEGORY": "cVDPV2",
+            "SITE_NAME/GEOCODE": "",
+            "CLOSEST_MATCH_VDPV2": "ENV-NIE-KNS-FGE-KMS-21-007 ",
+            "DATE_RESULTS_RECEIVED": "2023-03-08T00:00:00",
+            "SOURCE(AFP/ENV/CONTACT/HC)": "CONTACT",
+            "VDPV_NUCLEOTIDE_DIFF_SABIN2": 34,
+            "DATE_COLLECTION/DATE_OF_ONSET_(M/D/YYYY)": ""
+        }
+    ],
+    "created_by": 63,
+    "created_at": "2023-12-11T16:30:14.024390Z",
+    "updated_at": "2023-12-11T16:30:31.490902Z"
+}

--- a/hat/assets/js/cypress/integration/04 - tasks/list.spec.js
+++ b/hat/assets/js/cypress/integration/04 - tasks/list.spec.js
@@ -1,6 +1,7 @@
 /// <reference types="cypress" />
 
 import superUser from '../../fixtures/profiles/me/superuser.json';
+import * as Permission from '../../../apps/Iaso/utils/permissions.ts';
 
 const siteBaseUrl = Cypress.env('siteBaseUrl');
 
@@ -52,7 +53,7 @@ describe('Tasks', () => {
             cy.visit(baseUrl);
 
             cy.get('table').should('have.length', 1);
-            cy.get('table').find('tbody').find('tr').should('have.length', 10);
+            cy.get('table').find('tbody').find('tr').should('have.length', 12);
             cy.get('table')
                 .find('tbody')
                 .find('tr')
@@ -97,6 +98,74 @@ describe('Tasks', () => {
                 id: 140,
                 should_be_killed: true,
             });
+        });
+    });
+    describe('Polio notifications import tasks', () => {
+        let modal;
+        let openModalBtn;
+
+        beforeEach(() => {
+            cy.intercept('/api/tasks/**', { fixture: 'tasks/list.json' });
+            openModalBtn =
+                '[data-test="open-polio-notifications-import-details-button"]';
+            modal = '#polio-notifications-import-details-modal';
+        });
+
+        it('modals buttons should not be rendered if user does not have the right Polio permission', () => {
+            const fakeUser = {
+                ...superUser,
+                permissions: [Permission.DATA_TASKS],
+                is_superuser: false,
+            };
+            cy.intercept('GET', '/api/profiles/me/**', fakeUser);
+            cy.visit(baseUrl);
+            cy.get('table').should('have.length', 1);
+            cy.get('table').find('tbody').find('tr').should('have.length', 12);
+            cy.get(openModalBtn).should('have.length', 0);
+        });
+
+        it('opens a modal containing a Polio Notifications Import', () => {
+            cy.intercept('/api/polio/notifications/**', {
+                fixture: 'tasks/polio_notification_import.json',
+            });
+            cy.visit(baseUrl);
+            cy.get(openModalBtn)
+                .should('have.length', 2)
+                .eq(0)
+                .click()
+                .then(() => {
+                    cy.getAndAssert(modal, 'modal');
+                    cy.getAndAssert(`${modal} h2`).should(
+                        'have.text',
+                        'Polio Notifications Import Details',
+                    );
+                    cy.getAndAssert(`${modal} p`).should(
+                        'have.text',
+                        '1 polio notifications created.',
+                    );
+                });
+        });
+
+        it('opens a modal containing a Polio Notifications Import with errors', () => {
+            cy.intercept('/api/polio/notifications/**', {
+                fixture: 'tasks/polio_notification_import_with_errors.json',
+            });
+            cy.visit(baseUrl);
+            cy.get(openModalBtn)
+                .should('have.length', 2)
+                .eq(1)
+                .click()
+                .then(() => {
+                    cy.getAndAssert(modal, 'modal');
+                    cy.getAndAssert(`${modal} h2`).should(
+                        'have.text',
+                        'Polio Notifications Import Details',
+                    );
+                    cy.getAndAssert(`${modal} pre`).should(
+                        'contain.text',
+                        '"COUNTRY": "CHAD"',
+                    );
+                });
         });
     });
 });

--- a/iaso/api/tasks/__init__.py
+++ b/iaso/api/tasks/__init__.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 from rest_framework import permissions, serializers
 
 from iaso.models import Task
@@ -7,6 +9,8 @@ from hat.menupermissions import models as permission
 
 
 class TaskSerializer(serializers.ModelSerializer):
+    polio_notification_id = serializers.SerializerMethodField()
+
     class Meta:
         model = Task
 
@@ -24,6 +28,7 @@ class TaskSerializer(serializers.ModelSerializer):
             "name",
             "should_be_killed",
             "progress_message",
+            "polio_notification_id",
         ]
 
         read_only_fields = ["launcher_name"]
@@ -32,6 +37,11 @@ class TaskSerializer(serializers.ModelSerializer):
     ended_at = TimestampField(read_only=True)
     created_at = TimestampField(read_only=True)
     started_at = TimestampField(read_only=True)
+
+    def get_polio_notification_id(self, obj: Task) -> Union[int, None]:
+        if obj.name == "create_polio_notifications_async":
+            return obj.params.get("kwargs", {}).get("pk")
+        return None
 
     def update(self, task, validated_data):
         if validated_data["should_be_killed"] is not None:

--- a/iaso/api/tasks/__init__.py
+++ b/iaso/api/tasks/__init__.py
@@ -9,7 +9,7 @@ from hat.menupermissions import models as permission
 
 
 class TaskSerializer(serializers.ModelSerializer):
-    polio_notification_id = serializers.SerializerMethodField()
+    polio_notification_import_id = serializers.SerializerMethodField()
 
     class Meta:
         model = Task
@@ -28,7 +28,7 @@ class TaskSerializer(serializers.ModelSerializer):
             "name",
             "should_be_killed",
             "progress_message",
-            "polio_notification_id",
+            "polio_notification_import_id",
         ]
 
         read_only_fields = ["launcher_name"]
@@ -38,7 +38,7 @@ class TaskSerializer(serializers.ModelSerializer):
     created_at = TimestampField(read_only=True)
     started_at = TimestampField(read_only=True)
 
-    def get_polio_notification_id(self, obj: Task) -> Union[int, None]:
+    def get_polio_notification_import_id(self, obj: Task) -> Union[int, None]:
         if obj.name == "create_polio_notifications_async":
             return obj.params.get("kwargs", {}).get("pk")
         return None

--- a/iaso/tests/api/test_tasks.py
+++ b/iaso/tests/api/test_tasks.py
@@ -1,26 +1,127 @@
-from beanstalk_worker.services import TestTaskService
-from iaso.test import APITestCase
-from ...models import OrgUnit, OrgUnitType, Account, Project, SourceVersion, DataSource, Task
+import datetime
+import time_machine
+
+from django.utils import timezone
+
+from iaso import models as m
+from iaso.api.tasks import TaskSerializer
+from iaso.test import APITestCase, TestCase
+
+
+DT = datetime.datetime(2023, 12, 20, 15, 0, 0, 0, tzinfo=timezone.utc)
+
+
+@time_machine.travel(DT, tick=False)
+class TaskSerializerSerializerTestCase(TestCase):
+    """
+    Test Task serializer.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        data_source = m.DataSource.objects.create(name="Data source")
+        version = m.SourceVersion.objects.create(number=1, data_source=data_source)
+        account = m.Account.objects.create(name="Account", default_version=version)
+        user = cls.create_user_with_profile(
+            username="user", account=account, permissions=["iaso_sources", "iaso_data_tasks"]
+        )
+
+        cls.task = m.Task.objects.create(
+            progress_value=1,
+            end_value=1,
+            account=user.iaso_profile.account,
+            launcher=user,
+            status="Success",
+            name="org_unit_bulk_update",
+            result="324.49 sec, processed 5262 org units",
+            params={},
+        )
+
+        cls.task_polio = m.Task.objects.create(
+            progress_value=1,
+            end_value=1,
+            account=user.iaso_profile.account,
+            launcher=user,
+            status="Success",
+            name="create_polio_notifications_async",
+            result="3768 polio notifications created.",
+            params={
+                "args": [],
+                "kwargs": {"pk": 10},
+                "method": "create_polio_notifications_async",
+                "module": "plugins.polio.models",
+            },
+        )
+
+    def test_serialize_instance_of_task(self):
+        serializer = TaskSerializer(self.task)
+        self.assertEqual(
+            serializer.data,
+            {
+                "id": self.task.pk,
+                "created_at": DT.timestamp(),
+                "started_at": None,
+                "ended_at": None,
+                "progress_value": 1,
+                "end_value": 1,
+                "launcher": {
+                    "first_name": "",
+                    "last_name": "",
+                    "username": "user",
+                },
+                "result": "324.49 sec, processed 5262 org units",
+                "status": "Success",
+                "name": "org_unit_bulk_update",
+                "should_be_killed": False,
+                "progress_message": None,
+                "polio_notification_id": None,
+            },
+        )
+
+    def test_serialize_instance_of_polio_notification_task(self):
+        serializer = TaskSerializer(self.task_polio)
+        self.assertEqual(
+            serializer.data,
+            {
+                "id": self.task_polio.pk,
+                "created_at": DT.timestamp(),
+                "started_at": None,
+                "ended_at": None,
+                "progress_value": 1,
+                "end_value": 1,
+                "launcher": {
+                    "first_name": "",
+                    "last_name": "",
+                    "username": "user",
+                },
+                "result": "3768 polio notifications created.",
+                "status": "Success",
+                "name": "create_polio_notifications_async",
+                "should_be_killed": False,
+                "progress_message": None,
+                "polio_notification_id": 10,
+            },
+        )
 
 
 class IasoTasksTestCase(APITestCase):
     @classmethod
     def setUp(cls):
-        source = DataSource.objects.create(name="Valley Championship")
-        old_version = SourceVersion.objects.create(number=1, data_source=source)
-        cls.new_version = SourceVersion.objects.create(number=2, data_source=source)
+        source = m.DataSource.objects.create(name="Valley Championship")
+        old_version = m.SourceVersion.objects.create(number=1, data_source=source)
+        cls.new_version = m.SourceVersion.objects.create(number=2, data_source=source)
 
-        account = Account(name="Cobra Kai", default_version=cls.new_version)
+        account = m.Account(name="Cobra Kai", default_version=cls.new_version)
         account.save()
 
-        cls.project = Project(name="The Show", app_id="com.cobrakai.show", account=account)
+        cls.project = m.Project(name="The Show", app_id="com.cobrakai.show", account=account)
         cls.project.save()
 
-        org_unit_type = OrgUnitType(name="Dojo", short_name="dojo")
+        org_unit_type = m.OrgUnitType(name="Dojo", short_name="dojo")
         org_unit_type.save()
         cls.project.unit_types.add(org_unit_type)
         source.projects.add(cls.project)
-        OrgUnit.objects.create(version=old_version, name="Myagi", org_unit_type=org_unit_type, source_ref="nomercy")
+        m.OrgUnit.objects.create(version=old_version, name="Myagi", org_unit_type=org_unit_type, source_ref="nomercy")
         cls.source = source
         cls.johnny = cls.create_user_with_profile(
             username="johnny", account=account, permissions=["iaso_sources", "iaso_data_tasks"]
@@ -38,7 +139,7 @@ class IasoTasksTestCase(APITestCase):
         """
         self.client.force_authenticate(self.johnny)
 
-        task = Task.objects.create(
+        task = m.Task.objects.create(
             progress_value=1,
             end_value=1,
             account=self.johnny.iaso_profile.account,

--- a/iaso/tests/api/test_tasks.py
+++ b/iaso/tests/api/test_tasks.py
@@ -74,7 +74,7 @@ class TaskSerializerSerializerTestCase(TestCase):
                 "name": "org_unit_bulk_update",
                 "should_be_killed": False,
                 "progress_message": None,
-                "polio_notification_id": None,
+                "polio_notification_import_id": None,
             },
         )
 
@@ -99,7 +99,7 @@ class TaskSerializerSerializerTestCase(TestCase):
                 "name": "create_polio_notifications_async",
                 "should_be_killed": False,
                 "progress_message": None,
-                "polio_notification_id": 10,
+                "polio_notification_import_id": 10,
             },
         )
 

--- a/plugins/polio/api/notifications/serializers.py
+++ b/plugins/polio/api/notifications/serializers.py
@@ -6,10 +6,15 @@ from plugins.polio.models import Notification, NotificationImport
 class NotificationImportSerializer(serializers.ModelSerializer):
     class Meta:
         model = NotificationImport
-        fields = ["id", "account", "file", "created_by"]
+        fields = ["id", "account", "file", "status", "errors", "created_by", "created_at", "updated_at"]
         extra_kwargs = {
             "id": {"read_only": True},
             "account": {"read_only": True},
+            "status": {"read_only": True},
+            "errors": {"read_only": True},
+            "created_by": {"read_only": True},
+            "created_at": {"read_only": True},
+            "updated_at": {"read_only": True},
         }
 
     def validate_file(self, file):

--- a/plugins/polio/api/notifications/views.py
+++ b/plugins/polio/api/notifications/views.py
@@ -8,6 +8,7 @@ from rest_framework.response import Response
 
 from django.db.models import F
 from django.http import FileResponse
+from django.shortcuts import get_object_or_404
 from django.utils import timezone
 
 from iaso.api.common import Paginator
@@ -83,3 +84,13 @@ class NotificationViewSet(viewsets.ModelViewSet):
         notification_import = serializer.save(account=account, created_by=user)
         create_polio_notifications_async(pk=notification_import.pk, user=user)
         return Response(serializer.data, status=status.HTTP_201_CREATED)
+
+    @action(detail=True, methods=["get"])
+    def get_import_details(self, request, pk=None):
+        """
+        Get the details of an import task.
+        """
+        account = request.user.iaso_profile.account
+        notification_import = get_object_or_404(NotificationImport, account=account, pk=pk)
+        serializer = NotificationImportSerializer(notification_import)
+        return Response(serializer.data, status=status.HTTP_200_OK)


### PR DESCRIPTION
Display details of notification import tasks.

Related JIRA tickets : [POLIO-1340](https://bluesquare.atlassian.net/browse/POLIO-1340)

## Changes

- add Polio Import Notification details in the Tasks UI
- include a `polio_notification_id` in the output of `TaskSerializer`
- include new fields (like `errors`) in the output of `NotificationImportSerializer`
- add Cypress tests

## How to test

1. ensure to:
    - be admin
    - **or** to have the perm `menupermissions | custom permission support | Polio notifications`
1. navigate to `Polio > Virus notification`
2. click on `CREATE FROM FILE`
1. import an .xlsx file ([sample available here](https://bluesquare.atlassian.net/browse/POLIO-1275?focusedCommentId=59457))
        - the backend's import is async, so a worker must be running
        - `docker-compose run iaso manage tasks_worker`
1. navigate to `Admin > Tasks`
1. you must have 2 perms:
        1. `menupermissions | custom permission support | Tâches`
        1. `menupermissions | custom permission support | Polio notifications`
1. you should be able to view the details of the import

## Print screen / video

https://github.com/BLSQ/iaso/assets/281139/9aa7e374-c66e-405a-89d9-9c5b4eea97b3


[POLIO-1340]: https://bluesquare.atlassian.net/browse/POLIO-1340?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ