### PR TITLE
IA-2579: remove duplicate key

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/dataSources/components/ExportToDHIS2Dialog.js
+++ b/hat/assets/js/apps/Iaso/domains/dataSources/components/ExportToDHIS2Dialog.js
@@ -53,7 +53,6 @@ const initialExportData = defaultVersionId => ({
         FIELDS_TO_EXPORT.geometry,
         FIELDS_TO_EXPORT.name,
         FIELDS_TO_EXPORT.parent,
-        FIELDS_TO_EXPORT.geometry,
         FIELDS_TO_EXPORT.openingDate,
         FIELDS_TO_EXPORT.closedDate,
     ],


### PR DESCRIPTION
Remove duplicate key preselection in dropdown of datasource export

Related JIRA tickets : IA-2579

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

Remove duplicate key preselection in dropdown of datasource export

## How to test

Go to datasources, try to export check the preselected fields

## Print screen / video


![Screenshot 2023-12-19 at 15 09 45](https://github.com/BLSQ/iaso/assets/38907762/47521829-85a2-453f-ac80-69e8a0c811bf)
