### PR TITLE
POLIO-1364: HotFix - Empty analytics script trigger error in a raw html page

### DIFF
--- a/iaso/views.py
+++ b/iaso/views.py
@@ -82,7 +82,10 @@ def addTag(html, tagToAppend):
     soup = Soup(html, "html.parser")
     if not soup.head:
         head = soup.new_tag("head")
-        soup.html.insert(1, head)
+        if soup.html:
+            soup.html.insert(1, head)
+        else:
+            soup.insert(1, head)
     soup.head.append(Soup(tagToAppend, "html.parser"))
     return soup
 

--- a/iaso/views.py
+++ b/iaso/views.py
@@ -33,27 +33,45 @@ def page(request, page_slug):
     if page.needs_authentication and ((not request.user.is_authenticated) or (request.user not in page.users.all())):
         return redirect_to_login(path, resolved_login_url, "next")
     if page.type == IFRAME:
+        content = {"src": page.content, "title": page.name, "page": page}
+        if page.analytics_script:
+            content["analytics_script"] = page.analytics_script
         response = render(
             request,
             "iaso/pages/iframe.html",
-            {"src": page.content, "title": page.name, "page": page, "analytics_script": page.analytics_script},
+            content,
         )
     elif page.type == TEXT:
+        content = {
+            "text": page.content,
+            "title": page.name,
+        }
+        if page.analytics_script:
+            content["analytics_script"] = page.analytics_script
+
         response = render(
             request,
             "iaso/pages/text.html",
-            {"text": page.content, "title": page.name, "analytics_script": page.analytics_script},
+            content,
         )
     elif page.type == POWERBI:
         config = load_powerbi_config_for_page(page)
+        content = {
+            "config": config,
+            "title": page.name,
+            "page": page,
+        }
+        if page.analytics_script:
+            content["analytics_script"] = page.analytics_script
         response = render(
             request,
             "iaso/pages/powerbi.html",
-            {"config": config, "title": page.name, "page": page, "analytics_script": page.analytics_script},
+            content,
         )
     else:
         raw_html = page.content
-        raw_html = addTag(raw_html, page.analytics_script)
+        if page.analytics_script:
+            raw_html = addTag(raw_html, page.analytics_script)
         response = HttpResponse(raw_html)
     response["X-Frame-Options"] = "ALLOW"
     return response


### PR DESCRIPTION
Explain what problem this PR is resolving
- An empty analytics script trigger an error
- This PR is about to fix it
Related JIRA tickets : [POLIO-1364](https://bluesquare.atlassian.net/browse/POLIO-1364)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes
- Added checks on the page.analytics_script
## How to test
- Add an analytics script and check if the script is in the head of the html source code

[POLIO-1364]: https://bluesquare.atlassian.net/browse/POLIO-1364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ