### PR TITLE
IA-2584: Closing date input

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitForm.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitForm.tsx
@@ -30,8 +30,8 @@ const initialFormState = (orgUnit: OrgUnit): OrgunitInititialState => ({
     parent: orgUnit.parent,
     source_ref: orgUnit.source_ref,
     reference_instance_id: orgUnit.reference_instance_id,
-    opening_date: orgUnit.opening_date,
-    closed_date: orgUnit.closed_date,
+    opening_date: orgUnit.opening_date ? orgUnit.opening_date : undefined,
+    closed_date: orgUnit.closed_date ? orgUnit.closed_date : undefined,
 });
 
 const useStyles = makeStyles(theme => ({


### PR DESCRIPTION
Explain what problem this PR is resolving
- While editing close date on org unit detail you need to input twice before see changes
- This PR is about to fix it
Related JIRA tickets : [IA-2584](https://bluesquare.atlassian.net/browse/IA-2584)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes
- When it's a new OrgUnit the opening and closed date are undefined, but when it's existing OrgUnit the two are null
- Check the opening and closed date, if it's false to make it undefined

## How to test
- Edit an OrgUnit and enter the opening or closed date and check if it's done once

## Print screen / video
[Screencast from 2023-12-27 16-07-31.webm](https://github.com/BLSQ/iaso/assets/19631540/aae9caa5-4236-4fe7-8ac4-008d7e01660a)



[IA-2584]: https://bluesquare.atlassian.net/browse/IA-2584?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ