### PR TITLE
Polio-1366: mui5 polio bugs

### DIFF
--- a/hat/assets/js/apps/Iaso/components/nav/TabWithInfoIcon.tsx
+++ b/hat/assets/js/apps/Iaso/components/nav/TabWithInfoIcon.tsx
@@ -19,10 +19,6 @@ export const useStyles = makeStyles(theme => ({
         cursor: 'default',
     },
     tabIcon: {
-        position: 'relative',
-        top: 1,
-        left: theme.spacing(0.5),
-        // color: theme.palette.primary.main,
         cursor: 'pointer',
     },
 }));
@@ -72,6 +68,7 @@ export const TabWithInfoIcon: FunctionComponent<Props> = ({
             )}
             disableFocusRipple={disabled}
             disableRipple={disabled}
+            iconPosition="end"
             icon={
                 (showIcon && (
                     <Tooltip title={tooltipMessage}>

--- a/hat/assets/js/apps/Iaso/components/nav/TabWithInfoIcon.tsx
+++ b/hat/assets/js/apps/Iaso/components/nav/TabWithInfoIcon.tsx
@@ -12,10 +12,10 @@ export const useStyles = makeStyles(theme => ({
         },
     },
     tabError: {
-        color: `${theme.palette.error.main} !important`,
+        // color: `${theme.palette.error.main} !important`,
     },
     tabDisabled: {
-        // color: `${theme.palette.text.disabled} !important`,
+        color: `${theme.palette.mediumGray.main} !important`,
         cursor: 'default',
     },
     tabIcon: {

--- a/hat/assets/js/apps/Iaso/index.tsx
+++ b/hat/assets/js/apps/Iaso/index.tsx
@@ -46,6 +46,8 @@ declare global {
 
 const iasoApp = (element, enabledPluginsName, themeConfig, userHomePage) => {
     const plugins: Plugin[] = getPlugins(enabledPluginsName);
+    // Arbitrarily take the home page of the first plugin in the list
+    const pluginHomePage = plugins.map(plugin => plugin.homeUrl)[0];
     ReactDOM.render(
         <QueryClientProvider client={queryClient}>
             <PluginsContext.Provider value={{ plugins }}>
@@ -67,7 +69,9 @@ const iasoApp = (element, enabledPluginsName, themeConfig, userHomePage) => {
                                 >
                                     <App
                                         history={history}
-                                        userHomePage={userHomePage}
+                                        userHomePage={
+                                            pluginHomePage || userHomePage
+                                        }
                                     />
                                 </SnackbarProvider>
                             </LocalizedAppComponent>

--- a/plugins/polio/js/config.js
+++ b/plugins/polio/js/config.js
@@ -784,7 +784,7 @@ export default {
     routes,
     menu,
     translations,
-    homeUrl: `/${DASHBOARD_BASE_URL}`,
+    homeUrl: `${DASHBOARD_BASE_URL}`,
     // homeOffline: () => <div>OFFLINE</div>,
     // homeOnline: () => <div>CONNECTED HOME POLIO</div>,
 };

--- a/plugins/polio/js/src/domains/Calendar/campaignCalendar/map/VaccinesLegend.js
+++ b/plugins/polio/js/src/domains/Calendar/campaignCalendar/map/VaccinesLegend.js
@@ -18,23 +18,30 @@ const VaccinesLegend = () => {
                     <FormattedMessage {...MESSAGES.vaccines} />
                 </Typography>
                 {polioVaccines.map(vaccine => (
-                    <Grid container spacing={1} key={vaccine.value}>
-                        <Grid item sm={6} container justifyContent="flex-start">
-                            <span
-                                className={classes.roundColor}
-                                style={{ backgroundColor: vaccine.color }}
-                            />
+                    <Box mt={1}>
+                        <Grid container spacing={1} key={vaccine.value}>
+                            <Grid
+                                item
+                                sm={6}
+                                container
+                                justifyContent="flex-start"
+                            >
+                                <span
+                                    className={classes.roundColor}
+                                    style={{ backgroundColor: vaccine.color }}
+                                />
+                            </Grid>
+                            <Grid
+                                item
+                                sm={6}
+                                container
+                                justifyContent="flex-end"
+                                alignItems="center"
+                            >
+                                {vaccine.label}
+                            </Grid>
                         </Grid>
-                        <Grid
-                            item
-                            sm={6}
-                            container
-                            justifyContent="flex-end"
-                            alignItems="center"
-                        >
-                            {vaccine.label}
-                        </Grid>
-                    </Grid>
+                    </Box>
                 ))}
             </Box>
         </Paper>

--- a/plugins/polio/js/src/domains/Campaigns/MainDialog/PolioDialogTab.tsx
+++ b/plugins/polio/js/src/domains/Campaigns/MainDialog/PolioDialogTab.tsx
@@ -49,6 +49,7 @@ export const PolioDialogTab: FunctionComponent<Props> = ({
             )}
             disableFocusRipple={disabled}
             disableRipple={disabled}
+            iconPosition="end"
             icon={
                 (disabled && title === formatMessage(MESSAGES.scope) && (
                     <Tooltip

--- a/plugins/polio/js/src/domains/Campaigns/Rounds/RoundsForm.js
+++ b/plugins/polio/js/src/domains/Campaigns/Rounds/RoundsForm.js
@@ -106,7 +106,7 @@ export const RoundsForm = () => {
         <>
             <Box mt={rounds.length > 0 ? -4 : 0} display="flex">
                 {displayAddZeroRound && (
-                    <Box mr={rounds.length === 0 ? 2 : 0}>
+                    <Box mr={rounds.length === 0 ? 2 : 0} mt={2}>
                         <Button
                             className={
                                 rounds.length > 0 ? classes.addRoundButton : ''
@@ -186,18 +186,20 @@ export const RoundsForm = () => {
                     )}
                 </Box>
                 {(!lastRound || lastRound?.number < maxRoundsCount) && (
-                    <Button
-                        className={
-                            rounds.length > 0 ? classes.addRoundButton : ''
-                        }
-                        size="small"
-                        color="secondary"
-                        onClick={() => handleAddRound(newRoundNumber)}
-                        startIcon={<AddIcon fontSize="small" />}
-                        variant="outlined"
-                    >
-                        {formatMessage(MESSAGES.round)} {newRoundNumber}
-                    </Button>
+                    <Box mt={2}>
+                        <Button
+                            className={
+                                rounds.length > 0 ? classes.addRoundButton : ''
+                            }
+                            size="small"
+                            color="secondary"
+                            onClick={() => handleAddRound(newRoundNumber)}
+                            startIcon={<AddIcon fontSize="small" />}
+                            variant="outlined"
+                        >
+                            {formatMessage(MESSAGES.round)} {newRoundNumber}
+                        </Button>
+                    </Box>
                 )}
             </Box>
             {currentRoundNumber !== undefined && (

--- a/plugins/polio/js/src/domains/Campaigns/Scope/Scopes/MapScope.tsx
+++ b/plugins/polio/js/src/domains/Campaigns/Scope/Scopes/MapScope.tsx
@@ -153,9 +153,14 @@ export const MapScope: FunctionComponent<Props> = ({
                                         <span className={classes.vaccineName}>
                                             {vaccine.value}
                                         </span>
-                                        {': '}
-                                        {vaccineCount[vaccine.value] ?? 0}{' '}
-                                        {formatMessage(MESSAGES.districts)}
+
+                                        <span>
+                                            {`: ${
+                                                vaccineCount[vaccine.value] ?? 0
+                                            } ${formatMessage(
+                                                MESSAGES.districts,
+                                            )}`}
+                                        </span>
                                     </Box>
                                 </ListItem>
                             ))}

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/SupplyChainTabs.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/SupplyChainTabs.tsx
@@ -32,11 +32,22 @@ export const SupplyChainTabs: FunctionComponent<Props> = ({
             value={tab}
             classes={{
                 root: classes.tabs,
-                indicator: classes.indicator,
+                // indicator: classes.indicator,
             }}
             onChange={onChangeTab}
+            // textColor="secondary"
+            indicatorColor="secondary"
         >
-            <Tab key={VRF} value={VRF} label={formatMessage(MESSAGES[VRF])} />
+            <TabWithInfoIcon
+                key={VRF}
+                value={VRF}
+                title={formatMessage(MESSAGES[VRF])}
+                disabled={false}
+                hasTabError={false}
+                handleChange={onChangeTab}
+                showIcon={false}
+                tooltipMessage=""
+            />
             {/* TODO extract Tabs component */}
             <TabWithInfoIcon
                 key={PREALERT}

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/SupplyChainTabs.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/SupplyChainTabs.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent } from 'react';
 import { commonStyles, useSafeIntl } from 'bluesquare-components';
-import { Tab, Tabs } from '@mui/material';
+import { Tabs } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import { TabWithInfoIcon } from '../../../../../../../../hat/assets/js/apps/Iaso/components/nav/TabWithInfoIcon';
 import MESSAGES from '../messages';
@@ -32,10 +32,8 @@ export const SupplyChainTabs: FunctionComponent<Props> = ({
             value={tab}
             classes={{
                 root: classes.tabs,
-                // indicator: classes.indicator,
             }}
             onChange={onChangeTab}
-            // textColor="secondary"
             indicatorColor="secondary"
         >
             <TabWithInfoIcon
@@ -48,7 +46,6 @@ export const SupplyChainTabs: FunctionComponent<Props> = ({
                 showIcon={false}
                 tooltipMessage=""
             />
-            {/* TODO extract Tabs component */}
             <TabWithInfoIcon
                 key={PREALERT}
                 value={PREALERT}

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/VaccineSupplyChain.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/VaccineSupplyChain.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent } from 'react';
-import { useSafeIntl } from 'bluesquare-components';
+import { useSafeIntl, AddButton } from 'bluesquare-components';
 import { Box, Grid } from '@mui/material';
 import { useDispatch } from 'react-redux';
 import { userHasPermission } from '../../../../../../../hat/assets/js/apps/Iaso/domains/users/utils';

--- a/plugins/polio/js/src/styles/theme.js
+++ b/plugins/polio/js/src/styles/theme.js
@@ -199,8 +199,6 @@ export const useStyles = makeStyles(() => ({
     vaccinesList: {
         paddingBottom: 0,
         paddingTop: 0,
-        // width: '200px',
-        width: `200 px !important`,
         position: 'relative',
         left: -16,
     },

--- a/plugins/polio/js/src/styles/theme.js
+++ b/plugins/polio/js/src/styles/theme.js
@@ -216,9 +216,6 @@ export const useStyles = makeStyles(() => ({
         cursor: 'default',
     },
     tabIcon: {
-        position: 'relative',
-        top: 1,
-        left: theme.spacing(0.5),
         color: theme.palette.primary.main,
         cursor: 'pointer',
     },

--- a/plugins/polio/js/src/styles/theme.js
+++ b/plugins/polio/js/src/styles/theme.js
@@ -165,12 +165,13 @@ export const useStyles = makeStyles(() => ({
     fullHeight: { height: '100%' },
     vaccinesSelect: {
         fontSize: 12,
-        positio: 'relative',
+        position: 'relative',
+        width: '175px',
         height: theme.spacing(5),
         paddingTop: theme.spacing(1),
         paddingBottom: theme.spacing(1),
-        display: 'flex',
-        justifyContent: 'center',
+        display: 'inline-flex',
+        justifyContent: 'flex-start',
         alignItems: 'center',
     },
     vaccineName: {
@@ -198,7 +199,8 @@ export const useStyles = makeStyles(() => ({
     vaccinesList: {
         paddingBottom: 0,
         paddingTop: 0,
-        width: 175,
+        // width: '200px',
+        width: `200 px !important`,
         position: 'relative',
         left: -16,
     },


### PR DESCRIPTION
Bugs in the polio plugin from MUI 5 migration

Related JIRA tickets :POLIO-1366

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- Campaign scope map's vaccine legend: fix width to 175 and switch alignment to flex start to fix funny "radio" button shapes
- Add round buttons: wrap in `Box` and add margin top to restore alignment
- Scope tooltip (disabled tab): use `iconPosition`prop to set position, remove old css
-  Same change in `TabWithInfoIcon` component
- Calendar's vaccine legend: add `Box` with margin top to restore spacing
- Vaccine supplychain: replace `Tab` with `TabWithInfoIcon` for VRF in order to have consistent text colors, use `indicatorColor` prop to make tab indicator visible again, update CSS to distinguish between active and inactive tabs
- Fixed bug with custom plugin home page
- Add missing import in supplychain

## How to test

- Open and play with:
    - Campaign rounds: add rounds
    - Campaign scope: check and use vaccine legend on scope map
    - Campaigns calendar: check vaccine legend 
    - Vaccine Supplychain: open existing VRF, try to create VRF, see what happens with the tabs
    - home page: check that user lands on campaigns page on login
 

## Print screen / video (of the bugs)

Scopes
![Screenshot 2024-01-02 at 14 07 16](https://github.com/BLSQ/iaso/assets/38907762/28d5d467-7462-48dc-b520-948991d90e3d)

Rounds
![Screenshot 2024-01-02 at 14 07 52](https://github.com/BLSQ/iaso/assets/38907762/d12ccba7-6d98-4cd6-90bf-78c6d8f71020)

Scopes tooltip
![Screenshot 2024-01-02 at 14 08 06](https://github.com/BLSQ/iaso/assets/38907762/1dae3411-4713-465a-830f-1a56a6eae25d)

Calendar
![Screenshot 2024-01-02 at 14 08 23](https://github.com/BLSQ/iaso/assets/38907762/605d868b-96ef-4bee-b5bc-6325af701322)

Supplychain was broken so there's no screenshot



## Notes

Has to be merged BEFORE deploying https://github.com/BLSQ/iaso/pull/1008
