### PR TITLE
IA-2595 Org Unit Change Request API - Fix error on `POST`

### DIFF
--- a/docs/pages/dev/reference/API/org_unit_registry.md
+++ b/docs/pages/dev/reference/API/org_unit_registry.md
@@ -37,7 +37,7 @@ The Django model that stores "Change Requests" is `OrgUnitChangeRequest`.
   "new_location_accuracy": "Double - New accuracy of the OrgUnit",
   "new_opening_date": "Timestamp",
   "new_closed_date": "Timestamp",
-  "new_reference_instances": "Array of instance ids? - may be null or omitted, cannot be empty"
+  "new_reference_instances": "Array of instance ids or UUIDs? - may be null or omitted, cannot be empty"
 }
 ```
 

--- a/iaso/api/org_unit_change_requests/serializers.py
+++ b/iaso/api/org_unit_change_requests/serializers.py
@@ -201,6 +201,11 @@ class OrgUnitChangeRequestWriteSerializer(serializers.ModelSerializer):
     )
     new_location = ThreeDimPointField(required=False)
     updated_at = TimestampField(required=False)
+    new_reference_instances = IdOrUuidRelatedField(
+        many=True,
+        queryset=Instance.objects.all(),
+        required=False,
+    )
 
     class Meta:
         model = OrgUnitChangeRequest

--- a/iaso/api/org_unit_change_requests/views.py
+++ b/iaso/api/org_unit_change_requests/views.py
@@ -3,7 +3,6 @@ import django_filters
 from rest_framework import filters
 from rest_framework import viewsets
 from rest_framework.exceptions import PermissionDenied, ValidationError
-from rest_framework.mixins import CreateModelMixin, ListModelMixin, RetrieveModelMixin, UpdateModelMixin
 
 from django.utils import timezone
 from rest_framework.response import Response
@@ -24,9 +23,7 @@ from iaso.api.serializers import AppIdSerializer
 from iaso.models import OrgUnitChangeRequest, OrgUnit
 
 
-class OrgUnitChangeRequestViewSet(
-    CreateModelMixin, ListModelMixin, RetrieveModelMixin, UpdateModelMixin, viewsets.GenericViewSet
-):
+class OrgUnitChangeRequestViewSet(viewsets.ModelViewSet):
     filter_backends = [filters.OrderingFilter, django_filters.rest_framework.DjangoFilterBackend]
     filterset_class = OrgUnitChangeRequestListFilter
     pagination_class = OrgUnitChangeRequestPagination
@@ -41,7 +38,7 @@ class OrgUnitChangeRequestViewSet(
     def get_serializer_class(self):
         if self.action in ["create", "update"]:
             return OrgUnitChangeRequestWriteSerializer
-        if self.action == "list":
+        if self.action in ["list", "metadata"]:
             return OrgUnitChangeRequestListSerializer
         if self.action == "retrieve":
             return OrgUnitChangeRequestRetrieveSerializer

--- a/iaso/tests/api/org_unit_change_requests/test_serializers.py
+++ b/iaso/tests/api/org_unit_change_requests/test_serializers.py
@@ -445,9 +445,9 @@ class OrgUnitChangeRequestWriteSerializerTestCase(TestCase):
         group2 = m.Group.objects.create(name="Group 2")
 
         form1 = m.Form.objects.create(name="Vaccine form 1")
-        instance1 = m.Instance.objects.create(form=form1, org_unit=self.org_unit)
+        instance1 = m.Instance.objects.create(form=form1, org_unit=self.org_unit, uuid=uuid.uuid4())
         form2 = m.Form.objects.create(name="Vaccine form 2")
-        instance2 = m.Instance.objects.create(form=form2, org_unit=self.org_unit)
+        instance2 = m.Instance.objects.create(form=form2, org_unit=self.org_unit, uuid=uuid.uuid4())
 
         parent_org_unit = m.OrgUnit.objects.create(org_unit_type=self.org_unit_type)
 
@@ -466,7 +466,7 @@ class OrgUnitChangeRequestWriteSerializerTestCase(TestCase):
             "new_location_accuracy": 4.0,
             "new_opening_date": "2022-10-27",
             "new_closed_date": "2024-10-27",
-            "new_reference_instances": [instance1.id, instance2.id],
+            "new_reference_instances": [instance1.id, instance2.uuid],
         }
         serializer = OrgUnitChangeRequestWriteSerializer(data=data)
 


### PR DESCRIPTION
Fix an error when POSTing with a list of UUIDs instead of IDs for `new_reference_instances`.

Related JIRA tickets : [IA-2595](https://bluesquare.atlassian.net/browse/IA-2595)

## Changes

- allow the submission of IDs or UUIDs (or both) for the `new_reference_instances` field
- fix the `OPTIONS` view in DRF UI to not generate a 500
- update the documentation


[IA-2595]: https://bluesquare.atlassian.net/browse/IA-2595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ