### PR TITLE
POLIO-1344: make virus field mandatory

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/forms/detail.tsx
+++ b/hat/assets/js/apps/Iaso/domains/forms/detail.tsx
@@ -47,7 +47,7 @@ interface FormDetailProps {
 }
 
 const useStyles = makeStyles(theme => ({
-    ...(commonStyles(theme) as CommonStyles),
+    ...(commonStyles(theme) as unknown as CommonStyles),
     tabs: {
         ...commonStyles(theme).tabs,
         padding: 0,
@@ -113,7 +113,7 @@ const FormDetail: FunctionComponent<FormDetailProps> = ({ router, params }) => {
     const [forceRefreshVersions, setForceRefreshVersions] = useState(false);
     const dispatch = useDispatch();
     const { formatMessage } = useSafeIntl();
-    const classes = useStyles();
+    const classes: Record<string, string> = useStyles();
     const [currentForm, setFieldValue, setFieldErrors, setFormState] =
         useFormState(formatFormData(form));
     const isFormModified = useMemo(() => {

--- a/plugins/polio/js/src/domains/Campaigns/BaseInfo/BaseInfoForm.js
+++ b/plugins/polio/js/src/domains/Campaigns/BaseInfo/BaseInfoForm.js
@@ -96,6 +96,7 @@ export const BaseInfoForm = () => {
                             name="virus"
                             className={classes.input}
                             options={polioViruses}
+                            required
                             component={Select}
                         />
                         <Field

--- a/plugins/polio/js/src/hooks/useFormValidator.js
+++ b/plugins/polio/js/src/hooks/useFormValidator.js
@@ -318,9 +318,20 @@ export const useFormValidator = () => {
 
     return yup.object().shape({
         epid: yup.string().nullable(),
-        obr_name: yup.string().trim().required(),
-        initial_org_unit: yup.number().positive().integer().required(),
+        obr_name: yup
+            .string()
+            .trim()
+            .required(formatMessage(MESSAGES.requiredField)),
+        initial_org_unit: yup
+            .number()
+            .positive()
+            .integer()
+            .required(formatMessage(MESSAGES.requiredField)),
         grouped_campaigns: yup.array(yup.number()).nullable(),
+        virus: yup
+            .string()
+            .nullable()
+            .required(formatMessage(MESSAGES.requiredField)),
         description: yup.string().nullable(),
         onset_at: yup
             .date()


### PR DESCRIPTION
virus field is not optional anymore

Related JIRA tickets : POLIO-1344

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- add `required` prop to input component
- Update yup validation
- Fix some TS error

Note: the field will only move to error state if it is touched. This is due to our current policy of not erroring untouched fields. If it should change, another ticket should be open, as it would have implications for form validation across iaso. The tab title text will turn to red, so the UI does give at least some form of feedback 


## How to test

Go to campaign, try to create a new campaign without virus
Then try to update a campaign without virus

## Print screen / video
![Screenshot 2024-01-03 at 15 19 39](https://github.com/BLSQ/iaso/assets/38907762/74092de7-c104-4494-9c48-ebecf2f32639)



## Notes

- This fix is front-end only. If this needs to be enforced on the backend side, please open another ticket as the migration will need to be specified.

