### PR TITLE
IA-2601 Return UUIDs instead of IDs for `new_reference_instances`

### DIFF
--- a/docs/pages/dev/reference/API/org_unit_registry.md
+++ b/docs/pages/dev/reference/API/org_unit_registry.md
@@ -204,7 +204,7 @@ The Django model that stores "Change Requests" is `OrgUnitChangeRequest`.
       "new_location_accuracy": "Double - New accuracy of the OrgUnit",
       "new_opening_date": "Timestamp in double",
       "new_closed_date": "Timestamp in double",
-      "new_reference_instances": "Array of instance ids? - may be null or omitted, cannot be empty"
+      "new_reference_instances": "Array of instance UUIDs? - may be null or omitted, cannot be empty"
     }
   ]
 }

--- a/iaso/api/org_unit_change_requests/serializers.py
+++ b/iaso/api/org_unit_change_requests/serializers.py
@@ -66,6 +66,7 @@ class MobileOrgUnitChangeRequestListSerializer(serializers.ModelSerializer):
     new_location = ThreeDimPointField()
     created_at = TimestampField()
     updated_at = TimestampField()
+    new_reference_instances = serializers.SlugRelatedField(slug_field="uuid", many=True, read_only=True)
 
     class Meta:
         model = OrgUnitChangeRequest

--- a/iaso/tests/api/org_unit_change_requests/test_serializers.py
+++ b/iaso/tests/api/org_unit_change_requests/test_serializers.py
@@ -210,7 +210,7 @@ class MobileOrgUnitChangeRequestListSerializerTestCase(TestCase):
         change_request = m.OrgUnitChangeRequest.objects.create(**kwargs)
         new_group = m.Group.objects.create(name="new group")
         change_request.new_groups.set([new_group])
-        new_instance = m.Instance.objects.create(form=self.form, org_unit=self.org_unit)
+        new_instance = m.Instance.objects.create(form=self.form, org_unit=self.org_unit, uuid=uuid.uuid4())
         change_request.new_reference_instances.set([new_instance])
 
         serializer = MobileOrgUnitChangeRequestListSerializer(change_request)
@@ -239,7 +239,7 @@ class MobileOrgUnitChangeRequestListSerializerTestCase(TestCase):
                 "new_location_accuracy": None,
                 "new_opening_date": "2022-10-27",
                 "new_closed_date": "2024-10-27",
-                "new_reference_instances": [new_instance.pk],
+                "new_reference_instances": [str(new_instance.uuid)],
             },
         )
 


### PR DESCRIPTION
Return UUIDs instead of IDs in `MobileOrgUnitChangeRequestListSerializer.new_reference_instances`

Related JIRA tickets : [IA-2601](https://bluesquare.atlassian.net/browse/IA-2601)



[IA-2601]: https://bluesquare.atlassian.net/browse/IA-2601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ