### PR TITLE
POLIO-1338: restore supplychain tabs layout

### DIFF
--- a/hat/assets/js/apps/Iaso/components/nav/TabWithInfoIcon.tsx
+++ b/hat/assets/js/apps/Iaso/components/nav/TabWithInfoIcon.tsx
@@ -1,21 +1,19 @@
-import React, { FunctionComponent, ReactNode, useCallback } from 'react';
+import React, {
+    FunctionComponent,
+    ReactNode,
+    useCallback,
+    useMemo,
+} from 'react';
 import { Tab, Tooltip } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import InfoIcon from '@mui/icons-material/Info';
 import classnames from 'classnames';
 
 export const useStyles = makeStyles(theme => ({
-    tab: {
-        '& .MuiTab-wrapper': {
-            display: 'flex',
-            flexDirection: 'row-reverse',
-        },
-    },
     tabError: {
-        // color: `${theme.palette.error.main} !important`,
+        color: `${theme.palette.error.main} !important`,
     },
     tabDisabled: {
-        color: `${theme.palette.mediumGray.main} !important`,
         cursor: 'default',
     },
     tabIcon: {
@@ -50,21 +48,29 @@ export const TabWithInfoIcon: FunctionComponent<Props> = ({
     handleChange,
     tooltipMessage,
     showIcon = false,
+    // passed from Mui Tabs component
+    ...props
 }) => {
     const classes: Record<string, string> = useStyles();
+    // Remove onChange to avoid bugs when tab is disabled
+    const filteredProps = useMemo(() => {
+        // @ts-ignore
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { onChange, ...rest } = props;
+        return rest;
+    }, [props]);
     const onChange = useCallback(() => {
         if (!disabled) {
             handleChange(undefined, value);
         }
     }, [disabled, handleChange, value]);
     return (
+        // @ts-ignore
         <Tab
             label={title}
-            onClick={onChange}
             className={classnames(
-                classes.tab,
-                hasTabError && classes.tabError,
                 disabled && classes.tabDisabled,
+                hasTabError && classes.tabError,
             )}
             disableFocusRipple={disabled}
             disableRipple={disabled}
@@ -79,6 +85,9 @@ export const TabWithInfoIcon: FunctionComponent<Props> = ({
                     </Tooltip>
                 )) || <></>
             }
+            // eslint-disable-next-line react/jsx-props-no-spreading
+            {...filteredProps}
+            onClick={onChange}
         />
     );
 };

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/SupplyChainTabs.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/SupplyChainTabs.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent } from 'react';
 import { commonStyles, useSafeIntl } from 'bluesquare-components';
-import { Tabs } from '@mui/material';
+import { Tab, Tabs } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import { TabWithInfoIcon } from '../../../../../../../../hat/assets/js/apps/Iaso/components/nav/TabWithInfoIcon';
 import MESSAGES from '../messages';
@@ -30,22 +30,14 @@ export const SupplyChainTabs: FunctionComponent<Props> = ({
     return (
         <Tabs
             value={tab}
+            textColor="inherit"
+            indicatorColor="secondary"
             classes={{
                 root: classes.tabs,
             }}
             onChange={onChangeTab}
-            indicatorColor="secondary"
         >
-            <TabWithInfoIcon
-                key={VRF}
-                value={VRF}
-                title={formatMessage(MESSAGES[VRF])}
-                disabled={false}
-                hasTabError={false}
-                handleChange={onChangeTab}
-                showIcon={false}
-                tooltipMessage=""
-            />
+            <Tab key={VRF} value={VRF} label={formatMessage(MESSAGES[VRF])} />
             <TabWithInfoIcon
                 key={PREALERT}
                 value={PREALERT}


### PR DESCRIPTION
Improvement over previous fix

Related JIRA tickets :  POLIO-1338

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes
- Use `Tab` fro VRF i.o `TabWithInfoIcon`
- Refactor `TabWithInfoIcon` to enable showing tooltip text when disabled
- Reafctor `SupplychainTabs` so tabs inherit text color 

## How to test

Go to supplychain, open create modal (create button) and edit modal (details on table). Play with tabs

## Print screen / video


https://github.com/BLSQ/iaso/assets/38907762/72e77695-9fc3-45e8-8694-866c7179a7c2


