### PR TITLE
IA-2602: Fix GET /api/mobile/orgunits/changes/

### DIFF
--- a/docs/pages/dev/reference/API/org_unit_registry.md
+++ b/docs/pages/dev/reference/API/org_unit_registry.md
@@ -219,7 +219,17 @@ The Django model that stores "Change Requests" is `OrgUnitChangeRequest`.
       "new_location_accuracy": "Double - New accuracy of the OrgUnit",
       "new_opening_date": "Timestamp in double",
       "new_closed_date": "Timestamp in double",
-      "new_reference_instances": "Array of instance UUIDs? - may be null or omitted, cannot be empty"
+      "new_reference_instances": [
+        {
+          "id": "Int",
+          "uuid": "UUID - provided by the client",
+          "form_id": "Int",
+          "form_version_id": "Int",
+          "created_at": "Timestamp in double",
+          "updated_at": "Timestamp in double",
+          "json": "JSONObject - contains the key/value of the instance"
+        }
+      ]
     }
   ]
 }

--- a/iaso/api/org_unit_change_requests/serializers.py
+++ b/iaso/api/org_unit_change_requests/serializers.py
@@ -2,6 +2,8 @@ import uuid
 
 from rest_framework import serializers
 from django.contrib.auth.models import User
+
+from iaso.api.mobile.org_units import ReferenceInstancesSerializer
 from iaso.models import Instance, OrgUnit, OrgUnitChangeRequest, OrgUnitType
 from iaso.utils.serializer.id_or_uuid_field import IdOrUuidRelatedField
 from iaso.utils.serializer.three_dim_point_field import ThreeDimPointField
@@ -86,7 +88,7 @@ class MobileOrgUnitChangeRequestListSerializer(serializers.ModelSerializer):
     new_location = ThreeDimPointField()
     created_at = TimestampField()
     updated_at = TimestampField()
-    new_reference_instances = serializers.SlugRelatedField(slug_field="uuid", many=True, read_only=True)
+    new_reference_instances = ReferenceInstancesSerializer(many=True)
 
     class Meta:
         model = OrgUnitChangeRequest

--- a/iaso/api/org_unit_change_requests/views_mobile.py
+++ b/iaso/api/org_unit_change_requests/views_mobile.py
@@ -20,14 +20,13 @@ class MobileOrgUnitChangeRequestViewSet(ListModelMixin, viewsets.GenericViewSet)
     pagination_class = OrgUnitChangeRequestPagination
 
     def get_queryset(self):
-        app_id_serializer = AppIdSerializer(data=self.request.query_params)
-        app_id_serializer.is_valid(raise_exception=True)
-        app_id = app_id_serializer.validated_data["app_id"]
+        app_id = AppIdSerializer(data=self.request.query_params).get_app_id(raise_exception=True)
 
         org_units = OrgUnit.objects.filter_for_user_and_app_id(self.request.user, app_id)
 
         return (
             OrgUnitChangeRequest.objects.filter(org_unit__in=org_units)
+            .filter(created_by=self.request.user)
             .select_related("org_unit")
             .prefetch_related(
                 "new_groups",

--- a/iaso/tests/api/org_unit_change_requests/test_org_unit_change_requests_mobile.py
+++ b/iaso/tests/api/org_unit_change_requests/test_org_unit_change_requests_mobile.py
@@ -20,6 +20,9 @@ class MobileOrgUnitChangeRequestAPITestCase(APITestCase):
         user = cls.create_user_with_profile(
             username="user", account=account, permissions=["iaso_org_unit_change_request"]
         )
+        user2 = cls.create_user_with_profile(
+            username="user2", account=account, permissions=["iaso_org_unit_change_request"]
+        )
 
         data_source.projects.set([project])
         org_unit_type.projects.set([project])
@@ -28,10 +31,12 @@ class MobileOrgUnitChangeRequestAPITestCase(APITestCase):
         cls.org_unit = org_unit
         cls.project = project
         cls.user = user
+        cls.user2 = user2
 
     def test_list_ok(self):
-        m.OrgUnitChangeRequest.objects.create(org_unit=self.org_unit, new_name="Foo")
-        m.OrgUnitChangeRequest.objects.create(org_unit=self.org_unit, new_name="Bar")
+        m.OrgUnitChangeRequest.objects.create(org_unit=self.org_unit, new_name="Foo", created_by=self.user)
+        m.OrgUnitChangeRequest.objects.create(org_unit=self.org_unit, new_name="Bar", created_by=self.user2)
+        m.OrgUnitChangeRequest.objects.create(org_unit=self.org_unit, new_name="Ding", created_by=self.user)
 
         self.client.force_authenticate(self.user)
 


### PR DESCRIPTION
The endpoint ‘GET /api/mobile/orgunits/changes/?app_id=…’ is used by the mobile application to keep track of the changes made to the user’s change requests. It therefore doesn’t have to return the whole list of change request but only the ones of the authorized user.

Also, the endpoint should return the reference instances' data to recreate them when they are not present on the mobile device.

Related JIRA tickets : IA-2602

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [X] Are there enough tests
- [X] Documentation has been included (for new feature)

## Changes

- Return only the changes of the authenticated user
- Return instances as objects and not as UUIDs

## How to test

Send a change request linked to an instance, then request your change request list.
