### PR TITLE
POLIO-1360: VRF overflow

### DIFF
--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/shared.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/shared.tsx
@@ -11,7 +11,7 @@ import {
 export const useSharedStyles = makeStyles({
     scrollableForm: {
         height: `calc(100vh - ${MENU_HEIGHT_WITH_TABS + 200}px)`,
-        overflow: 'scroll',
+        overflowY: 'auto',
     },
 });
 


### PR DESCRIPTION
While creating or editing a VRF scrolls are always present:
![image](https://github.com/BLSQ/iaso/assets/12494624/de27d6b3-8f28-4144-a903-80b6d0ac8a31)


Related JIRA tickets : POLIO-1360

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

Set overflow to auto

## How to test

Edit or create a VRF in supply chain

## Print screen / video

<img width="1821" alt="Screenshot 2024-01-10 at 14 56 34" src="https://github.com/BLSQ/iaso/assets/12494624/118f8f6a-35dd-48eb-9a19-c191639fabf6">

