### PR TITLE
WC2-313: Form id is breaking form table

### DIFF
--- a/hat/assets/js/apps/Iaso/components/Cells/BreakWordCell.tsx
+++ b/hat/assets/js/apps/Iaso/components/Cells/BreakWordCell.tsx
@@ -1,0 +1,20 @@
+/* eslint-disable camelcase */
+import { Box } from '@mui/material';
+import React, { ReactElement } from 'react';
+import { makeStyles } from '@mui/styles';
+
+const useStyles = makeStyles(() => ({
+    root: {
+        overflowWrap: 'anywhere',
+    },
+}));
+
+export const BreakWordCell = (cellInfo: { value?: string }): ReactElement => {
+    const value = cellInfo?.value;
+    const classes = useStyles();
+    return (
+        <Box className={classes.root} style={{}}>
+            {value || '--'}
+        </Box>
+    );
+};

--- a/hat/assets/js/apps/Iaso/components/Cells/BreakWordCell.tsx
+++ b/hat/assets/js/apps/Iaso/components/Cells/BreakWordCell.tsx
@@ -12,9 +12,5 @@ const useStyles = makeStyles(() => ({
 export const BreakWordCell = (cellInfo: { value?: string }): ReactElement => {
     const value = cellInfo?.value;
     const classes = useStyles();
-    return (
-        <Box className={classes.root} style={{}}>
-            {value || '--'}
-        </Box>
-    );
+    return <Box className={classes.root}>{value || '--'}</Box>;
 };

--- a/hat/assets/js/apps/Iaso/domains/forms/config/index.js
+++ b/hat/assets/js/apps/Iaso/domains/forms/config/index.js
@@ -14,7 +14,7 @@ import { YesNoCell } from '../../../components/Cells/YesNoCell';
 import { CreateSubmissionModal } from '../components/CreateSubmissionModal/CreateSubmissionModal.tsx';
 import { createInstance } from '../../instances/actions';
 import * as Permission from '../../../utils/permissions.ts';
-import { BreakWordCell } from '../../../components/Cells/BreakWordCell';
+import { BreakWordCell } from '../../../components/Cells/BreakWordCell.tsx';
 
 export const baseUrl = baseUrls.forms;
 

--- a/hat/assets/js/apps/Iaso/domains/forms/config/index.js
+++ b/hat/assets/js/apps/Iaso/domains/forms/config/index.js
@@ -9,11 +9,12 @@ import { baseUrls } from '../../../constants/urls';
 import { userHasPermission } from '../../users/utils';
 import MESSAGES from '../messages';
 import DeleteDialog from '../../../components/dialogs/DeleteDialogComponent';
-import { DateTimeCell } from '../../../components/Cells/DateTimeCell';
+import { DateTimeCell } from '../../../components/Cells/DateTimeCell.tsx';
 import { YesNoCell } from '../../../components/Cells/YesNoCell';
 import { CreateSubmissionModal } from '../components/CreateSubmissionModal/CreateSubmissionModal.tsx';
 import { createInstance } from '../../instances/actions';
 import * as Permission from '../../../utils/permissions.ts';
+import { BreakWordCell } from '../../../components/Cells/BreakWordCell';
 
 export const baseUrl = baseUrls.forms;
 
@@ -141,6 +142,7 @@ const formsTableColumns = ({
             Header: formatMessage(MESSAGES.form_id),
             accessor: 'form_id',
             sortable: false,
+            Cell: BreakWordCell,
         },
         {
             Header: formatMessage(MESSAGES.latest_version_files),

--- a/hat/assets/js/apps/Iaso/domains/forms/config/index.spec.js
+++ b/hat/assets/js/apps/Iaso/domains/forms/config/index.spec.js
@@ -1,21 +1,17 @@
 import { IconButton } from 'bluesquare-components';
 import { expect } from 'chai';
 import formsTableColumns, { formVersionsTableColumns } from '.';
-import FormVersionsDialog from '../components/FormVersionsDialogComponent';
 
-import formsFixture from '../fixtures/forms.json';
 import formVersionsfixture from '../fixtures/formVersions.json';
 
 import { colOriginal } from '../../../../../test/utils';
 
 let columns;
 let formVersionscolumns;
-const fakeForm = formsFixture.forms[0];
 const fakeFormVersion = formVersionsfixture.form_versions[0];
 let wrapper;
 let xlsButton;
 let actionColumn;
-let formVersionsDialog;
 const setForceRefreshSpy = sinon.spy();
 
 describe('Forms config', () => {
@@ -63,37 +59,6 @@ describe('Forms config', () => {
                 formatMessage: () => null,
             });
             expect(columns).to.have.lengthOf(10);
-        });
-        it('should render a component if Cell is defined', () => {
-            columns.forEach(c => {
-                if (c.Cell) {
-                    const cell = c.Cell(colOriginal(fakeForm));
-                    expect(cell).to.exist;
-                }
-            });
-        });
-        it('should render a component if Cell is defined and no from id', () => {
-            columns.forEach(c => {
-                if (c.Cell) {
-                    const cell = c.Cell(
-                        colOriginal({
-                            ...fakeForm,
-                            form_id: 0,
-                        }),
-                    );
-                    expect(cell).to.exist;
-                }
-            });
-        });
-        it('should render a component if value not present and Cell is defined', () => {
-            const tempForm = { ...fakeForm };
-            delete tempForm.instance_updated_at;
-            columns.forEach(c => {
-                if (c.Cell) {
-                    const cell = c.Cell(colOriginal(tempForm));
-                    expect(cell).to.exist;
-                }
-            });
         });
     });
 });


### PR DESCRIPTION
If a cell is conaining a long string without whitespace, the column is too large and breaking the table

Related JIRA tickets : WC2-313

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

New BreakWord cell to apply custom CSS

## How to test

Open forms page, edit the html directly in the browser and duplicate multiple times the ID, the table should not move

## Print screen / video

<img width="271" alt="Screenshot 2024-01-10 at 15 28 08" src="https://github.com/BLSQ/iaso/assets/12494624/ae1a1bce-840c-4af3-a795-7a90585c20f8">

