### PR TITLE
IA-2628 Use `IdOrUuidRelatedField` for `new_parent_id`

### DIFF
--- a/docs/pages/dev/reference/API/org_unit_registry.md
+++ b/docs/pages/dev/reference/API/org_unit_registry.md
@@ -6,10 +6,9 @@ This API allows the DHIS2 Health pyramid to be updated using Iaso.
 
 The Django model that stores "Change Requests" is `OrgUnitChangeRequest`.
 
-# Create or update an `OrgUnitChangeRequest` object - Web + Mobile (IA-2421)
+# Create an `OrgUnitChangeRequest` object - Web + Mobile (IA-2421)
 
 - `POST /api/orgunits/changes/?app_id=…`
-- `PUT /api/orgunits/changes/?app_id=…`
 
 ## Permissions
 

--- a/iaso/api/org_unit_change_requests/serializers.py
+++ b/iaso/api/org_unit_change_requests/serializers.py
@@ -227,7 +227,7 @@ class OrgUnitChangeRequestWriteSerializer(serializers.ModelSerializer):
         queryset=OrgUnit.objects.all(),
         required=False,
     )
-    new_parent_id = serializers.PrimaryKeyRelatedField(
+    new_parent_id = IdOrUuidRelatedField(
         source="new_parent",
         queryset=OrgUnit.objects.all(),
         required=False,

--- a/iaso/tests/api/org_unit_change_requests/test_serializers.py
+++ b/iaso/tests/api/org_unit_change_requests/test_serializers.py
@@ -427,12 +427,14 @@ class OrgUnitChangeRequestWriteSerializerTestCase(TestCase):
         data_source = m.DataSource.objects.create(name="Data source")
         version1 = m.SourceVersion.objects.create(number=1, data_source=data_source)
         version2 = m.SourceVersion.objects.create(number=2, data_source=data_source)
-        parent_org_unit = m.OrgUnit.objects.create(org_unit_type=self.org_unit_type, version=version2)
+        parent_org_unit = m.OrgUnit.objects.create(
+            org_unit_type=self.org_unit_type, version=version2, uuid=uuid.uuid4()
+        )
         self.org_unit.version = version1
         self.org_unit.save()
         data = {
             "org_unit_id": self.org_unit.id,
-            "new_parent_id": parent_org_unit.id,
+            "new_parent_id": str(parent_org_unit.uuid),
         }
         serializer = OrgUnitChangeRequestWriteSerializer(data=data)
         self.assertFalse(serializer.is_valid())


### PR DESCRIPTION
Allow `new_parent_id` to be an ID or a UUID to fix a bug in the mobile app.

Related JIRA tickets : [IA-2628](https://bluesquare.atlassian.net/browse/IA-2628)


[IA-2628]: https://bluesquare.atlassian.net/browse/IA-2628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ