### PR TITLE
IA-2608: invalidate query keys to force data refresh

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/workflows/hooks/requests/useBulkUpdateWorkflowFollowUp.tsx
+++ b/hat/assets/js/apps/Iaso/domains/workflows/hooks/requests/useBulkUpdateWorkflowFollowUp.tsx
@@ -12,6 +12,6 @@ export const useBulkUpdateWorkflowFollowUp = (
 ): UseMutationResult =>
     useSnackMutation({
         mutationFn: (data: FollowUps[]) => bulkUpdateWorkflowFollowUp(data),
-        invalidateQueryKey: ['workflowVersion'],
+        invalidateQueryKey: ['workflowVersions'],
         options: { onSuccess: onSuccess || (() => null) },
     });

--- a/hat/assets/js/apps/Iaso/domains/workflows/hooks/requests/useDeleteWorkflowChange.tsx
+++ b/hat/assets/js/apps/Iaso/domains/workflows/hooks/requests/useDeleteWorkflowChange.tsx
@@ -8,6 +8,6 @@ const deleteWorkflowChange = async (changeId: number): Promise<any> => {
 export const useDeleteWorkflowChange = (): UseMutationResult =>
     useSnackMutation({
         mutationFn: deleteWorkflowChange,
-        invalidateQueryKey: 'workflowVersion',
+        invalidateQueryKey: ['workflowVersions','workflowVersionsChanges'],
         snackSuccessMessage: MESSAGES.changeDeleted,
     });

--- a/hat/assets/js/apps/Iaso/domains/workflows/hooks/requests/useSaveWorkflowChange.tsx
+++ b/hat/assets/js/apps/Iaso/domains/workflows/hooks/requests/useSaveWorkflowChange.tsx
@@ -23,6 +23,6 @@ export const useSaveWorkflowChange = (
             data.id
                 ? updateWorkflowChange(data)
                 : createWorkflowChange(data, versionId),
-        invalidateQueryKey: 'workflowVersion',
+        invalidateQueryKey: ['workflowVersions','workflowVersionsChanges'],
         options: { onSuccess: () => closeDialog() },
     });


### PR DESCRIPTION
Workflow chnages table wouldn't refresh after change edition

Related JIRA tickets : IA-2608

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- Add `workflowVersionsChanges` to the list of query keys to invalidate when saving/deleting a workflow change
- Fix typo in other query key

## How to test

Go to Beneficairy types > workflows
Edit a change in a workflow then save
The table should update

Same with delete

## Print screen / video


https://github.com/BLSQ/iaso/assets/38907762/bc1f3207-2500-4839-b9bd-c81bcd565980


