### PR TITLE
POLIO-1359, POLIO-1361 reformat ETA, wastage ratio

### DIFF
--- a/hat/assets/js/apps/Iaso/components/forms/InputComponent.tsx
+++ b/hat/assets/js/apps/Iaso/components/forms/InputComponent.tsx
@@ -83,6 +83,8 @@ export type InputComponentProps = {
     blockForbiddenChars?: boolean;
     onErrorChange?: () => void;
     numberInputOptions?: {
+        prefix?: string;
+        suffix?: string;
         min?: number;
         max?: number;
         decimalScale?: number;
@@ -146,7 +148,6 @@ const InputComponent: React.FC<InputComponentProps> = ({
 
     const localizedNumberOptions =
         useLocalizedNumberInputOptions(numberInputOptions);
-
     const toggleDisplayPassword = () => {
         setDisplayPassword(!displayPassword);
     };

--- a/plugins/polio/js/src/components/Inputs/NumberInput.tsx
+++ b/plugins/polio/js/src/components/Inputs/NumberInput.tsx
@@ -10,6 +10,15 @@ type Props = {
     max?: number;
     disabled?: boolean;
     withMarginTop?: boolean;
+    numberInputOptions?: {
+        prefix?: string;
+        suffix?: string;
+        min?: number;
+        max?: number;
+        decimalScale?: number;
+        decimalSeparator?: '.' | ',';
+        thousandSeparator?: '.' | ',';
+    };
 };
 
 export const NumberInput: FunctionComponent<Props> = ({
@@ -18,6 +27,7 @@ export const NumberInput: FunctionComponent<Props> = ({
     form,
     min,
     max,
+    numberInputOptions = {},
     withMarginTop = false,
     disabled = false,
 }) => {
@@ -39,6 +49,7 @@ export const NumberInput: FunctionComponent<Props> = ({
             max={max}
             errors={hasError ? [get(form.errors, field.name)] : []}
             disabled={disabled}
+            numberInputOptions={numberInputOptions}
         />
     );
 };

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/VaccineRequestForm/VaccineRequestForm.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/VaccineRequestForm/VaccineRequestForm.tsx
@@ -253,13 +253,18 @@ export const VaccineRequestForm: FunctionComponent<Props> = ({
                     </Grid>
                     <Grid container item xs={12} md={9} lg={6} spacing={2}>
                         <Grid item xs={12}>
-                            <TextArea
-                                value={values?.vrf?.comment ?? ''}
-                                // errors={errors.comment ? errors.comment : []}
-                                label={formatMessage(MESSAGES.comments)}
-                                onChange={onCommentChange}
-                                debounceTime={0}
-                            />
+                            {/* With MUI 5, the spacing isn't taken into account if there's only one <Grid> item
+                              so the <Box> is used to compensate and align the TextArea with the other fields
+                            */}
+                            <Box mr={1}>
+                                <TextArea
+                                    value={values?.vrf?.comment ?? ''}
+                                    // errors={errors.comment ? errors.comment : []}
+                                    label={formatMessage(MESSAGES.comments)}
+                                    onChange={onCommentChange}
+                                    debounceTime={0}
+                                />
+                            </Box>
                         </Grid>
                     </Grid>
                 </Grid>

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/VaccineRequestForm/VaccineRequestForm.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/VaccineRequestForm/VaccineRequestForm.tsx
@@ -172,6 +172,7 @@ export const VaccineRequestForm: FunctionComponent<Props> = ({
                                     name="vrf.wastage_rate_used_on_vrf"
                                     component={NumberInput}
                                     disabled={false}
+                                    numberInputOptions={{ suffix: '%' }}
                                 />
                             </Box>
                         </Grid>

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Table/useVaccineSupplyChainTableColumns.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Table/useVaccineSupplyChainTableColumns.tsx
@@ -10,7 +10,6 @@ import { useCurrentUser } from '../../../../../../../../hat/assets/js/apps/Iaso/
 import {
     DateCell,
     MultiDateCell,
-    MultiDateTimeCellRfc,
 } from '../../../../../../../../hat/assets/js/apps/Iaso/components/Cells/DateTimeCell';
 import MESSAGES from '../messages';
 import DeleteDialog from '../../../../../../../../hat/assets/js/apps/Iaso/components/dialogs/DeleteDialogComponent';
@@ -90,7 +89,7 @@ export const useVaccineSupplyChainTableColumns = (): Column[] => {
             {
                 Header: formatMessage(MESSAGES.estimatedDateOfArrival),
                 accessor: 'eta',
-                Cell: MultiDateTimeCellRfc,
+                Cell: MultiDateCell,
             },
             {
                 Header: 'VAR',

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/hooks/validation.ts
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/hooks/validation.ts
@@ -67,7 +67,7 @@ const useVrfShape = () => {
             .date()
             .typeError(formatMessage(MESSAGES.invalidDate))
             .nullable(),
-        date_vrf_submission_to_orpg: yup
+        date_vrf_submission_orpg: yup
             .date()
             .typeError(formatMessage(MESSAGES.invalidDate))
             .nullable(),
@@ -81,7 +81,7 @@ const useVrfShape = () => {
             .date()
             .typeError(formatMessage(MESSAGES.invalidDate))
             .nullable(),
-        date_vrf_submitted_to_dg: yup
+        date_vrf_submission_dg: yup
             .date()
             .typeError(formatMessage(MESSAGES.invalidDate))
             .nullable(),
@@ -143,12 +143,6 @@ const useArrivalReportShape = () => {
             // TS can't detect the added method
             // @ts-ignore
             .isNumbersArrayString(formatMessage),
-        doses_per_vial: yup
-            .number()
-            .nullable()
-            .min(0, formatMessage(MESSAGES.positiveInteger))
-            .integer()
-            .typeError(formatMessage(MESSAGES.positiveInteger)),
         expiration_date: yup
             .date()
             .typeError(formatMessage(MESSAGES.invalidDate))

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/hooks/validation.ts
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/hooks/validation.ts
@@ -67,7 +67,7 @@ const useVrfShape = () => {
             .date()
             .typeError(formatMessage(MESSAGES.invalidDate))
             .nullable(),
-        date_vrf_submission_orpg: yup
+        date_vrf_submission_to_orpg: yup
             .date()
             .typeError(formatMessage(MESSAGES.invalidDate))
             .nullable(),
@@ -81,7 +81,7 @@ const useVrfShape = () => {
             .date()
             .typeError(formatMessage(MESSAGES.invalidDate))
             .nullable(),
-        date_vrf_submission_dg: yup
+        date_vrf_submitted_to_dg: yup
             .date()
             .typeError(formatMessage(MESSAGES.invalidDate))
             .nullable(),
@@ -143,6 +143,12 @@ const useArrivalReportShape = () => {
             // TS can't detect the added method
             // @ts-ignore
             .isNumbersArrayString(formatMessage),
+        doses_per_vial: yup
+            .number()
+            .nullable()
+            .min(0, formatMessage(MESSAGES.positiveInteger))
+            .integer()
+            .typeError(formatMessage(MESSAGES.positiveInteger)),
         expiration_date: yup
             .date()
             .typeError(formatMessage(MESSAGES.invalidDate))


### PR DESCRIPTION
some light formatting on the front-end

Related JIRA tickets :  POLIO-1359, POLIO-1361

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- List table: replace DateTimeCell with DateCell
- wastage ratio: pass a suffix to NumberInput

## How to test

Change package.json to depend on https://github.com/BLSQ/bluesquare-components/pull/139
Go to VaccineSupplychain:
- List view: estimated date of arrival should show only date, no time
- Open a detailed view, in VRF, the wastage ratio number should be suffixed with `'%'`

## Print screen / video

![Screenshot 2024-01-17 at 11 35 15](https://github.com/BLSQ/iaso/assets/38907762/17c0c21b-47d5-40da-ad2b-f45e62210e3b)


https://github.com/BLSQ/iaso/assets/38907762/58ecaf3b-f45b-4586-8cdc-d33f5aa4072e


## Notes

Depends on https://github.com/BLSQ/bluesquare-components/pull/139
