### PR TITLE
POLIO-1337: fix supplychain validation

### DIFF
--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/hooks/validation.ts
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/hooks/validation.ts
@@ -67,7 +67,7 @@ const useVrfShape = () => {
             .date()
             .typeError(formatMessage(MESSAGES.invalidDate))
             .nullable(),
-        date_vrf_submission_orpg: yup
+        date_vrf_submission_to_orpg: yup
             .date()
             .typeError(formatMessage(MESSAGES.invalidDate))
             .nullable(),
@@ -81,7 +81,7 @@ const useVrfShape = () => {
             .date()
             .typeError(formatMessage(MESSAGES.invalidDate))
             .nullable(),
-        date_vrf_submission_dg: yup
+        date_vrf_submitted_to_dg: yup
             .date()
             .typeError(formatMessage(MESSAGES.invalidDate))
             .nullable(),
@@ -143,6 +143,12 @@ const useArrivalReportShape = () => {
             // TS can't detect the added method
             // @ts-ignore
             .isNumbersArrayString(formatMessage),
+        doses_per_vial: yup
+            .number()
+            .nullable()
+            .min(0, formatMessage(MESSAGES.positiveInteger))
+            .integer()
+            .typeError(formatMessage(MESSAGES.positiveInteger)),
         expiration_date: yup
             .date()
             .typeError(formatMessage(MESSAGES.invalidDate))


### PR DESCRIPTION
Supply chain: yup validation wasn't working for some fields

Related JIRA tickets :  POLIO-1337

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- Removed typos in some yup keys
- Add 1 missing yup field

## How to test
Change dependency to blsq-components to #POLIO-1337_error_text_too_big

Go to Vaccine supplychain, click edit on any entry.
Input badly formatted data (wrong dates, negative numbers). Error messages should be displayed correctly

## Print screen / video

![Screenshot 2024-01-17 at 12 51 05](https://github.com/BLSQ/iaso/assets/38907762/f55becf2-1e3f-402f-b9fc-8e75ba2d72fa)


## Notes

⚠️Depends on https://github.com/BLSQ/bluesquare-components/pull/140. 
