### PR TITLE
Polio-1352, POLIO-1395 add form validation to vaccine stock

### DIFF
--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/CreateEditDestruction.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/CreateEditDestruction.tsx
@@ -17,6 +17,7 @@ import {
 } from '../../../../../components/Inputs';
 import { useSaveDestruction } from '../../hooks/api';
 import { EditIconButton } from '../../../../../../../../../hat/assets/js/apps/Iaso/components/Buttons/EditIconButton';
+import { useDestructionValidation } from './validation';
 
 type Props = {
     destruction?: any;
@@ -36,6 +37,7 @@ export const CreateEditDestruction: FunctionComponent<Props> = ({
 }) => {
     const { formatMessage } = useSafeIntl();
     const { mutateAsync: save } = useSaveDestruction();
+    const validationSchema = useDestructionValidation();
     const formik = useFormik<any>({
         initialValues: {
             id: destruction?.id,
@@ -46,8 +48,7 @@ export const CreateEditDestruction: FunctionComponent<Props> = ({
             lot_numbers: destruction?.lot_numbers,
         },
         onSubmit: values => save(values),
-        // TODO add validation
-        // validationSchema,
+        validationSchema,
     });
 
     const titleMessage = destruction?.id ? MESSAGES.edit : MESSAGES.create;
@@ -78,6 +79,7 @@ export const CreateEditDestruction: FunctionComponent<Props> = ({
                         label={formatMessage(MESSAGES.action)}
                         name="action"
                         component={TextInput}
+                        required
                         shrinkLabel={false}
                     />
                 </Box>

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/CreateEditDestruction.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/CreateEditDestruction.tsx
@@ -74,7 +74,7 @@ export const CreateEditDestruction: FunctionComponent<Props> = ({
                 confirmMessage={MESSAGES.save}
                 cancelMessage={MESSAGES.cancel}
             >
-                <Box mb={2}>
+                <Box mb={2} mt={2}>
                     <Field
                         label={formatMessage(MESSAGES.action)}
                         name="action"
@@ -100,7 +100,7 @@ export const CreateEditDestruction: FunctionComponent<Props> = ({
                         component={NumberInput}
                     />
                 </Box>
-                <Box mb={2}>
+                <Box>
                     <Field
                         label={formatMessage(MESSAGES.lot_numbers)}
                         name="lot_numbers"

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/CreateEditFormA.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/CreateEditFormA.tsx
@@ -18,6 +18,7 @@ import {
 } from '../../../../../components/Inputs';
 import { useCampaignOptions, useSaveFormA } from '../../hooks/api';
 import { EditIconButton } from '../../../../../../../../../hat/assets/js/apps/Iaso/components/Buttons/EditIconButton';
+import { useFormAValidation } from './validation';
 
 type Props = {
     formA?: any;
@@ -37,6 +38,7 @@ export const CreateEditFormA: FunctionComponent<Props> = ({
 }) => {
     const { formatMessage } = useSafeIntl();
     const { mutateAsync: save } = useSaveFormA();
+    const validationSchema = useFormAValidation();
     const formik = useFormik<any>({
         initialValues: {
             id: formA?.id,
@@ -50,8 +52,7 @@ export const CreateEditFormA: FunctionComponent<Props> = ({
             vials_missing: formA?.vials_missing,
         },
         onSubmit: values => save(values),
-        // TODO add validation
-        // validationSchema,
+        validationSchema,
     });
     const { data: campaignOptions, isFetching: isFetchingCampaigns } =
         useCampaignOptions(countryName, vaccine);

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/CreateEditIncident.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/CreateEditIncident.tsx
@@ -15,6 +15,7 @@ import { DateInput, NumberInput } from '../../../../../components/Inputs';
 import { useSaveIncident } from '../../hooks/api';
 import { EditIconButton } from '../../../../../../../../../hat/assets/js/apps/Iaso/components/Buttons/EditIconButton';
 import { useIncidentOptions } from './useIncidentOptions';
+import { useIncidentValidation } from './validation';
 
 type Props = {
     incident?: any;
@@ -34,6 +35,7 @@ export const CreateEditIncident: FunctionComponent<Props> = ({
 }) => {
     const { formatMessage } = useSafeIntl();
     const { mutateAsync: save } = useSaveIncident();
+    const validationSchema = useIncidentValidation();
     const formik = useFormik<any>({
         initialValues: {
             id: incident?.id,
@@ -44,8 +46,7 @@ export const CreateEditIncident: FunctionComponent<Props> = ({
             unusable_vials: incident?.unusable_vials,
         },
         onSubmit: values => save(values),
-        // TODO add validation
-        // validationSchema,
+        validationSchema,
     });
     const incidentTypeOptions = useIncidentOptions();
     const titleMessage = incident?.id ? MESSAGES.edit : MESSAGES.create;

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/validation.ts
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/validation.ts
@@ -78,6 +78,12 @@ export const useIncidentValidation = () => {
             .date()
             .typeError(formatMessage(MESSAGES.invalidDate))
             .nullable(),
+        usable_vials: yup
+            .number()
+            .nullable()
+            .min(0, formatMessage(MESSAGES.positiveInteger))
+            .integer()
+            .typeError(formatMessage(MESSAGES.positiveInteger)),
         unusable_vials: yup
             .number()
             .nullable()

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/validation.ts
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/validation.ts
@@ -1,0 +1,88 @@
+import { useSafeIntl } from 'bluesquare-components';
+import * as yup from 'yup';
+import MESSAGES from '../../messages';
+
+export const useFormAValidation = () => {
+    const { formatMessage } = useSafeIntl();
+    return yup.object().shape({
+        obr_name: yup
+            .string()
+            .nullable()
+            .required(formatMessage(MESSAGES.requiredField)),
+        lot_numbers_for_usable_vials: yup.string().nullable(), // actually an array of numbers in string form. custom test should be added
+        date_of_report: yup
+            .date()
+            .typeError(formatMessage(MESSAGES.invalidDate))
+            .nullable(),
+        forma_reception_rrt: yup
+            .date()
+            .typeError(formatMessage(MESSAGES.invalidDate))
+            .nullable(),
+        vials_used: yup
+            .number()
+            .nullable()
+            .min(0, formatMessage(MESSAGES.positiveInteger))
+            .integer()
+            .typeError(formatMessage(MESSAGES.positiveInteger)),
+        vials_missing: yup
+            .number()
+            .nullable()
+            .min(0, formatMessage(MESSAGES.positiveInteger))
+            .integer()
+            .typeError(formatMessage(MESSAGES.positiveInteger)),
+        unusable_vials: yup
+            .number()
+            .nullable()
+            .min(0, formatMessage(MESSAGES.positiveInteger))
+            .integer()
+            .typeError(formatMessage(MESSAGES.positiveInteger)),
+    });
+};
+
+export const useDestructionValidation = () => {
+    const { formatMessage } = useSafeIntl();
+    return yup.object().shape({
+        action: yup
+            .string()
+            .nullable()
+            .required(formatMessage(MESSAGES.requiredField)),
+        destruction_reception_rrt: yup
+            .date()
+            .typeError(formatMessage(MESSAGES.invalidDate))
+            .nullable(),
+        date_of_report: yup
+            .date()
+            .typeError(formatMessage(MESSAGES.invalidDate))
+            .nullable(),
+        vials_destroyed: yup
+            .number()
+            .nullable()
+            .min(0, formatMessage(MESSAGES.positiveInteger))
+            .integer()
+            .typeError(formatMessage(MESSAGES.positiveInteger)),
+        lot_numbers: yup.string().nullable(), // actually an array of numbers in string form. custom test should be added
+    });
+};
+export const useIncidentValidation = () => {
+    const { formatMessage } = useSafeIntl();
+    return yup.object().shape({
+        stock_correction: yup
+            .string()
+            .nullable()
+            .required(formatMessage(MESSAGES.requiredField)), // can be made more strict witha ccepted values from dropdown
+        incident_reception_rrt: yup
+            .date()
+            .typeError(formatMessage(MESSAGES.invalidDate))
+            .nullable(),
+        date_of_report: yup
+            .date()
+            .typeError(formatMessage(MESSAGES.invalidDate))
+            .nullable(),
+        unusable_vials: yup
+            .number()
+            .nullable()
+            .min(0, formatMessage(MESSAGES.positiveInteger))
+            .integer()
+            .typeError(formatMessage(MESSAGES.positiveInteger)),
+    });
+};

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/VaccineStockVariation.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/VaccineStockVariation.tsx
@@ -99,6 +99,8 @@ export const VaccineStockVariation: FunctionComponent<Props> = ({ router }) => {
                         root: classes.tabs,
                         indicator: classes.indicator,
                     }}
+                    textColor="inherit"
+                    indicatorColor="secondary"
                     onChange={handleChangeTab}
                 >
                     <Tab

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/messages.ts
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/messages.ts
@@ -246,6 +246,10 @@ const MESSAGES = defineMessages({
         id: 'iaso.forms.error.fieldRequired',
         defaultMessage: 'This field is required',
     },
+    lotNumberError: {
+        id: 'iaso.polio.form.error.lotNumberError',
+        defaultMessage: 'Please input numbers separated by a comma',
+    },
 });
 
 export default MESSAGES;

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/messages.ts
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/messages.ts
@@ -230,6 +230,22 @@ const MESSAGES = defineMessages({
         defaultMessage: 'Create',
         id: 'iaso.label.create',
     },
+    positiveInteger: {
+        id: 'iaso.polio.form.validator.error.positiveInteger',
+        defaultMessage: 'Please use a positive integer',
+    },
+    positiveNumber: {
+        id: 'iaso.polio.form.validator.error.positiveNumber',
+        defaultMessage: 'Please use a positive number',
+    },
+    invalidDate: {
+        id: 'iaso.polio.form.invalidDate',
+        defaultMessage: 'Date is invalid',
+    },
+    requiredField: {
+        id: 'iaso.forms.error.fieldRequired',
+        defaultMessage: 'This field is required',
+    },
 });
 
 export default MESSAGES;


### PR DESCRIPTION
There wa sno input validation for vaccine stock modals

Related JIRA tickets : POLIO-1352, POLIO-1395

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [X] Are my typescript files well typed. I skipped typing the validation as it's just passed as is 
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- I skipped typing the validation as it's just passed as is to formik
- Add validation for all 3 modals
- fix tab color (POLIO-1395)
- fix positioning in destruction modal

## How to test

Go to polio >vaccine module > stock managment > stock variation

try inputting wrong data in all fields

## Print screen / video
![Screenshot 2024-01-17 at 14 59 21](https://github.com/BLSQ/iaso/assets/38907762/1f4de2b1-d758-4651-8e48-2790b95f28b7)

![Screenshot 2024-01-17 at 15 00 48](https://github.com/BLSQ/iaso/assets/38907762/6c0bb790-7716-4286-a724-8c00c2100dfb)

![Screenshot 2024-01-17 at 14 59 47](https://github.com/BLSQ/iaso/assets/38907762/13d5b31c-288f-4b76-9a7d-4dcc7f26cea1)

