### PR TITLE
Polio-1320 move pipeline version to config

### DIFF
--- a/hat/assets/js/apps/Iaso/hooks/taskMonitor.ts
+++ b/hat/assets/js/apps/Iaso/hooks/taskMonitor.ts
@@ -78,6 +78,6 @@ export const useCreateTask = ({
     return useSnackMutation({
         mutationFn: request => createTask(request, endpoint, key),
         showSucessSnackBar: false,
-        invalidateQueryKey: ['task-monitor'],
+        invalidateQueryKey: ['get-latest-task-run'],
     });
 };

--- a/hat/settings.py
+++ b/hat/settings.py
@@ -556,16 +556,6 @@ THEME_PRIMARY_COLOR = os.environ.get("THEME_PRIMARY_COLOR", "#006699")
 THEME_SECONDARY_COLOR = os.environ.get("THEME_SECONDARY_COLOR", "#0066CC")
 THEME_PRIMARY_BACKGROUND_COLOR = os.environ.get("THEME_PRIMARY_BACKGROUND_COLOR", "#F5F5F5")
 SHOW_NAME_WITH_LOGO = os.environ.get("SHOW_NAME_WITH_LOGO", "yes")
-# OpenHexa API url
-OPENHEXA_URL = os.environ.get("OPENHEXA_URL", None)
-# OpenHexa api token
-OPENHEXA_TOKEN = os.environ.get("OPENHEXA_TOKEN", "token")
-# "prod", "staging" or "custom". Use "custom" for local testing
-OH_PIPELINE_TARGET = os.environ.get("OH_PIPELINE_TARGET", "staging")
-# uuid of the OH pipeline
-LQAS_PIPELINE = os.environ.get("LQAS_PIPELINE", "pipeline")
-# Optional: the version of the pipeline to run (number)
-LQAS_PIPELINE_VERSION = os.environ.get("LQAS_PIPELINE_VERSION", None)
 
 AUTHENTICATION_BACKENDS = [
     "django.contrib.auth.backends.ModelBackend",

--- a/plugins/polio/js/src/domains/LQAS-IM/shared/RefreshLqasData.tsx
+++ b/plugins/polio/js/src/domains/LQAS-IM/shared/RefreshLqasData.tsx
@@ -9,15 +9,9 @@ import moment from 'moment';
 import { Box, Button } from '@mui/material';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import { useQueryClient } from 'react-query';
-import {
-    Task,
-    TaskApiResponse,
-} from '../../../../../../../hat/assets/js/apps/Iaso/domains/tasks/types';
+import { Task } from '../../../../../../../hat/assets/js/apps/Iaso/domains/tasks/types';
 import { useGetLatestLQASIMUpdate } from '../../../hooks/useGetLatestLQASIMUpdate';
-import {
-    useCreateTask,
-    useTaskMonitor,
-} from '../../../../../../../hat/assets/js/apps/Iaso/hooks/taskMonitor';
+import { useCreateTask } from '../../../../../../../hat/assets/js/apps/Iaso/hooks/taskMonitor';
 import MESSAGES from '../../../constants/messages';
 
 type Props = {
@@ -57,15 +51,8 @@ export const RefreshLqasData: FunctionComponent<Props> = ({
 }) => {
     const taskUrl = category === 'lqas' ? LQAS_TASK_ENDPOINT : undefined;
     const { formatMessage } = useSafeIntl();
-    const [taskId, setTaskId] = useState<number>();
     const [lastTaskStatus, setlastTaskStatus] = useState<string | undefined>();
     const queryClient = useQueryClient();
-    const { data: isDataUpdating, isFetching: isFetchingTaskStatus } =
-        useTaskMonitor({
-            taskId,
-            endpoint: taskUrl,
-            invalidateQueries: [category, 'get-latest-task-run'],
-        });
     const { mutateAsync: createRefreshTask } = useCreateTask({
         endpoint: taskUrl,
     });
@@ -78,11 +65,7 @@ export const RefreshLqasData: FunctionComponent<Props> = ({
         useLastUpdate(latestManualRefresh);
     const launchRefresh = useCallback(() => {
         if (countryId) {
-            createRefreshTask({ country_id: countryId }).then(
-                (task: TaskApiResponse<any>) => {
-                    setTaskId(task.task.id);
-                },
-            );
+            createRefreshTask({ country_id: countryId });
         }
     }, [countryId, createRefreshTask]);
 
@@ -95,10 +78,7 @@ export const RefreshLqasData: FunctionComponent<Props> = ({
         }
     }, [lastTaskStatus, latestManualRefresh?.status, queryClient]);
 
-    const disableButton =
-        isDataUpdating ||
-        isFetchingTaskStatus ||
-        Boolean(latestManualRefresh?.status === 'RUNNING'); // TODO make enum with statuses
+    const disableButton = Boolean(latestManualRefresh?.status === 'RUNNING'); // TODO make enum with statuses
     return (
         <>
             {countryId && (

--- a/plugins/polio/tasks/api/refresh_lqas_data.py
+++ b/plugins/polio/tasks/api/refresh_lqas_data.py
@@ -140,12 +140,12 @@ class RefreshLQASDataViewset(ModelViewSet):
 
     def refresh_lqas_data(self, country_id=None, task_id=None):
         config = get_object_or_404(Config, slug="lqas-pipeline-config")
-        lqas_pipeline_version=config.content["lqas_pipeline_version"]
-        oh_pipeline_target=config.content["oh_pipeline_target"]
-        lqas_pipeline=config.content["lqas_pipeline"]
-        openhexa_url=config.content["openhexa_url"]
-        openhexa_token=config.content["openhexa_token"]
-        
+        lqas_pipeline_version = config.content["lqas_pipeline_version"]
+        oh_pipeline_target = config.content["oh_pipeline_target"]
+        lqas_pipeline = config.content["lqas_pipeline"]
+        openhexa_url = config.content["openhexa_url"]
+        openhexa_token = config.content["openhexa_token"]
+
         transport = RequestsHTTPTransport(
             url=openhexa_url,
             verify=True,

--- a/plugins/polio/tasks/api/refresh_lqas_data.py
+++ b/plugins/polio/tasks/api/refresh_lqas_data.py
@@ -140,15 +140,15 @@ class RefreshLQASDataViewset(ModelViewSet):
 
     def refresh_lqas_data(self, country_id=None, task_id=None):
         try:
-            config = get_object_or_404(Config, slug="lqas-pipeline-config")
+            pipeline_config = get_object_or_404(Config, slug="lqas-pipeline-config")
         except:
             logger.exception("Could not fetch openhexa config")
             return ERRORED
-        lqas_pipeline_version = config.content["lqas_pipeline_version"]
-        oh_pipeline_target = config.content["oh_pipeline_target"]
-        lqas_pipeline = config.content["lqas_pipeline"]
-        openhexa_url = config.content["openhexa_url"]
-        openhexa_token = config.content["openhexa_token"]
+        lqas_pipeline_version = pipeline_config.content["lqas_pipeline_version"]
+        oh_pipeline_target = pipeline_config.content["oh_pipeline_target"]
+        lqas_pipeline = pipeline_config.content["lqas_pipeline"]
+        openhexa_url = pipeline_config.content["openhexa_url"]
+        openhexa_token = pipeline_config.content["openhexa_token"]
 
         transport = RequestsHTTPTransport(
             url=openhexa_url,

--- a/plugins/polio/tasks/api/refresh_lqas_data.py
+++ b/plugins/polio/tasks/api/refresh_lqas_data.py
@@ -139,7 +139,11 @@ class RefreshLQASDataViewset(ModelViewSet):
         return Response({"task": TaskSerializer(instance=task).data})
 
     def refresh_lqas_data(self, country_id=None, task_id=None):
-        config = get_object_or_404(Config, slug="lqas-pipeline-config")
+        try:
+            config = get_object_or_404(Config, slug="lqas-pipeline-config")
+        except:
+            logger.exception("Could not fetch openhexa config")
+            return ERRORED
         lqas_pipeline_version = config.content["lqas_pipeline_version"]
         oh_pipeline_target = config.content["oh_pipeline_target"]
         lqas_pipeline = config.content["lqas_pipeline"]


### PR DESCRIPTION
storing this data in an env variable was not practical as it needs frequent updates

Related JIRA tickets : POLIO-1320

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [NA] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- Get all Openhexa settings from a `Config` object i.o from `settings.py` (env var)
- Remove obsolete variables from settings.py

## How to test

- Go to django admin, and add a `Config` called "lqas-pipeline-config"
- Fill it with the OpenHexa settings and save
- Log in to OpenHexa and open lqas pipeline
- In the interface, go to polio>lqas>country view
- Choose a campaign and click Refresh
- Go to OpenHexa: the pipeline should have been launched with the proper params

## Print screen / video

No visible changes

