### PR TITLE
IA-2613: Use Org unit change requests old values while approved

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/Dialogs/ReviewOrgUnitChangesButtons.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/Dialogs/ReviewOrgUnitChangesButtons.tsx
@@ -33,7 +33,7 @@ export const ApproveOrgUnitChangesButtons: FunctionComponent<Props> = ({
     const handleConfirm = useCallback(() => {
         submitChangeRequest({
             status: 'approved',
-            approved_fields: selectedFields.map(field => field.key),
+            approved_fields: selectedFields.map(field => `new_${field.key}`),
         });
     }, [selectedFields, submitChangeRequest]);
     return (

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/Dialogs/ReviewOrgUnitChangesButtons.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/Dialogs/ReviewOrgUnitChangesButtons.tsx
@@ -51,7 +51,9 @@ export const ApproveOrgUnitChangesButtons: FunctionComponent<Props> = ({
                     color="primary"
                     data-test="cancel-button"
                 >
-                    {formatMessage(MESSAGES.cancel)}
+                    {isNew
+                        ? formatMessage(MESSAGES.cancel)
+                        : formatMessage(MESSAGES.close)}
                 </Button>
                 {isNew && (
                     <>

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/Dialogs/ReviewOrgUnitChangesDeleteButtons.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/Dialogs/ReviewOrgUnitChangesDeleteButtons.tsx
@@ -40,7 +40,6 @@ export const ReviewOrgUnitChangesDeleteButtons: FunctionComponent<Props> = ({
                 <Button
                     data-test="cancel-reject-button"
                     onClick={() => setIsRejectDialogOpen(false)}
-                    variant="contained"
                     autoFocus
                 >
                     {formatMessage(MESSAGES.cancel)}
@@ -51,7 +50,7 @@ export const ReviewOrgUnitChangesDeleteButtons: FunctionComponent<Props> = ({
                     data-test="confirm-reject-button"
                     onClick={handleReject}
                     variant="contained"
-                    color="error"
+                    color="primary"
                     autoFocus
                     disabled={!rejectedReason || rejectedReason.length === 0}
                 >

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/Dialogs/ReviewOrgUnitChangesDialog.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/Dialogs/ReviewOrgUnitChangesDialog.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 import React, {
     FunctionComponent,
     useCallback,
@@ -11,7 +10,6 @@ import {
     SimpleModal,
     IconButton as IconButtonBlsq,
 } from 'bluesquare-components';
-import { Grid } from '@mui/material';
 import MESSAGES from '../messages';
 import { useGetApprovalProposal } from '../hooks/api/useGetApprovalProposal';
 import { SelectedChangeRequest } from '../Tables/ReviewOrgUnitChangesTable';
@@ -20,7 +18,29 @@ import { ApproveOrgUnitChangesButtons } from './ReviewOrgUnitChangesButtons';
 import { ChangeRequestValidationStatus } from '../types';
 import { useSaveChangeRequest } from '../hooks/api/useSaveChangeRequest';
 import { ReviewOrgUnitChangesDetailsTable } from '../Tables/details/ReviewOrgUnitChangesDetailsTable';
-import { ReviewOrgUnitChangesInfos } from './ReviewOrgUnitChangesInfos';
+import { ReviewOrgUnitChangesDialogTitle } from './ReviewOrgUnitChangesDialogTitle';
+
+/*
+Org Unit Change Request
+
+3 statuses:
+- New → orange
+- Approved-→ green
+- Rejected → red
+
+If new:
+Left side: current org unit values (fetched from org unit API)
+Right side: proposed changes. Red if not selected, green if selected
+
+
+If approved:
+Left side: old org unit values: org unit values at request creation time  Comes from change request API (old_value field)
+Right side: proposed change → approved = green, rejected = red
+
+If rejected:
+Left side: old org unit values: org unit values at request creation time  Comes from change request API (old_value field)
+Right side: proposed changes in red 
+*/
 
 type Props = {
     isOpen: boolean;
@@ -59,7 +79,13 @@ export const ReviewOrgUnitChangesDialog: FunctionComponent<Props> = ({
             onClose={() => null}
             id="approve-orgunit-changes-dialog"
             dataTestId="approve-orgunit-changes-dialog"
-            titleMessage={titleMessage}
+            titleMessage={
+                <ReviewOrgUnitChangesDialogTitle
+                    titleMessage={titleMessage}
+                    changeRequest={changeRequest}
+                    isFetchingChangeRequest={isFetchingChangeRequest}
+                />
+            }
             closeDialog={closeDialog}
             buttons={() =>
                 isFetchingChangeRequest ? (
@@ -74,23 +100,13 @@ export const ReviewOrgUnitChangesDialog: FunctionComponent<Props> = ({
                 )
             }
         >
-            <Grid container spacing={2}>
-                <Grid item xs={3}>
-                    <ReviewOrgUnitChangesInfos
-                        changeRequest={changeRequest}
-                        isFetchingChangeRequest={isFetchingChangeRequest}
-                    />
-                </Grid>
-                <Grid item xs={9}>
-                    <ReviewOrgUnitChangesDetailsTable
-                        isSaving={isSaving}
-                        changeRequest={changeRequest}
-                        isFetchingChangeRequest={isFetchingChangeRequest}
-                        newFields={newFields}
-                        setSelected={setSelected}
-                    />
-                </Grid>
-            </Grid>
+            <ReviewOrgUnitChangesDetailsTable
+                isSaving={isSaving}
+                changeRequest={changeRequest}
+                isFetchingChangeRequest={isFetchingChangeRequest}
+                newFields={newFields}
+                setSelected={setSelected}
+            />
         </SimpleModal>
     );
 };

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/Dialogs/ReviewOrgUnitChangesDialogTitle.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/Dialogs/ReviewOrgUnitChangesDialogTitle.tsx
@@ -1,0 +1,75 @@
+import React, { FunctionComponent, useState } from 'react';
+import { Box, Typography, IconButton, Popover } from '@mui/material';
+import InfoIcon from '@mui/icons-material/Info';
+import { OrgUnitChangeRequestDetails } from '../types';
+import {
+    ReviewOrgUnitChangesInfos,
+    colorCodes,
+} from './ReviewOrgUnitChangesInfos';
+
+type Props = {
+    titleMessage: string;
+    changeRequest?: OrgUnitChangeRequestDetails;
+    isFetchingChangeRequest: boolean;
+};
+
+export const ReviewOrgUnitChangesDialogTitle: FunctionComponent<Props> = ({
+    titleMessage,
+    changeRequest,
+    isFetchingChangeRequest,
+}) => {
+    const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
+
+    const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+        setAnchorEl(event.currentTarget);
+    };
+
+    const handleClose = () => {
+        setAnchorEl(null);
+    };
+
+    const open = Boolean(anchorEl);
+    const id = open ? 'org-unit-change-request-popover' : undefined;
+    const statusColor =
+        changeRequest && colorCodes[changeRequest.status]
+            ? `${colorCodes[changeRequest.status]}.main`
+            : 'inherit';
+
+    return (
+        <Typography
+            variant="h5"
+            color="primary"
+            sx={{
+                color: statusColor,
+            }}
+        >
+            {titleMessage}
+            <Box sx={{ display: 'inline-block', ml: 2 }}>
+                <IconButton
+                    onClick={handleClick}
+                    aria-describedby={id}
+                    sx={{
+                        color: statusColor,
+                    }}
+                >
+                    <InfoIcon />
+                </IconButton>
+                <Popover
+                    id={id}
+                    open={open}
+                    anchorEl={anchorEl}
+                    onClose={handleClose}
+                    anchorOrigin={{
+                        vertical: 'bottom',
+                        horizontal: 'left',
+                    }}
+                >
+                    <ReviewOrgUnitChangesInfos
+                        changeRequest={changeRequest}
+                        isFetchingChangeRequest={isFetchingChangeRequest}
+                    />
+                </Popover>
+            </Box>
+        </Typography>
+    );
+};

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/Dialogs/ReviewOrgUnitChangesDialogTitle.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/Dialogs/ReviewOrgUnitChangesDialogTitle.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent, useState } from 'react';
-import { Box, Typography, IconButton, Popover } from '@mui/material';
+import { Box, IconButton, Popover } from '@mui/material';
 import InfoIcon from '@mui/icons-material/Info';
 import { OrgUnitChangeRequestDetails } from '../types';
 import {
@@ -36,9 +36,7 @@ export const ReviewOrgUnitChangesDialogTitle: FunctionComponent<Props> = ({
             : 'inherit';
 
     return (
-        <Typography
-            variant="h5"
-            color="primary"
+        <Box
             sx={{
                 color: statusColor,
             }}
@@ -70,6 +68,6 @@ export const ReviewOrgUnitChangesDialogTitle: FunctionComponent<Props> = ({
                     />
                 </Popover>
             </Box>
-        </Typography>
+        </Box>
     );
 };

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/Dialogs/ReviewOrgUnitChangesInfos.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/Dialogs/ReviewOrgUnitChangesInfos.tsx
@@ -1,6 +1,13 @@
 import React, { FunctionComponent, useMemo } from 'react';
 import { useSafeIntl } from 'bluesquare-components';
-import { Card, CardContent, Grid } from '@mui/material';
+import {
+    Card,
+    CardContent,
+    Table,
+    TableBody,
+    TableCell,
+    TableRow,
+} from '@mui/material';
 
 import MESSAGES from '../messages';
 import {
@@ -25,9 +32,19 @@ const useStatusStyles = (status?: ChangeRequestValidationStatus) => {
     return useMemo(
         () => ({
             infoCard: {
+                fontSize: 14,
                 backgroundColor: status
                     ? `${colorCodes[status]}.background`
                     : 'inherit',
+            },
+            cardContent: {
+                px: 2,
+                pt: theme => `${theme.spacing(1)} !important}`,
+                pb: theme => `${theme.spacing(1)} !important}`,
+            },
+            cell: {
+                borderBottom: 'none',
+                p: 0.25,
             },
             label: {
                 fontWeight: 'bold',
@@ -53,56 +70,72 @@ export const ReviewOrgUnitChangesInfos: FunctionComponent<Props> = ({
     const styles = useStatusStyles(changeRequest?.status);
     if (isFetchingChangeRequest || !changeRequest) return null;
     const { status } = changeRequest;
+    const labelStyle = { ...styles.label, ...styles.cell };
+    const valueStyle = { ...styles.value, ...styles.cell };
     return (
         <Card sx={styles.infoCard}>
-            <CardContent>
-                <Grid container spacing={1}>
-                    <Grid item xs={4} sx={styles.label}>
-                        {formatMessage(MESSAGES.status)}:
-                    </Grid>
-                    <Grid item xs={8} sx={styles.status}>
-                        {formatMessage(MESSAGES[status])}
-                    </Grid>
+            <CardContent sx={styles.cardContent}>
+                <Table size="small">
+                    <TableBody>
+                        <TableRow>
+                            <TableCell sx={labelStyle}>
+                                {formatMessage(MESSAGES.status)}:
+                            </TableCell>
+                            <TableCell
+                                sx={{ ...styles.status, ...styles.cell }}
+                            >
+                                {formatMessage(MESSAGES[status])}
+                            </TableCell>
+                        </TableRow>
+                        <TableRow>
+                            <TableCell sx={labelStyle}>
+                                {formatMessage(MESSAGES.updated_at)}:
+                            </TableCell>
+                            <TableCell sx={valueStyle}>
+                                {DateTimeCell({
+                                    value: changeRequest.updated_at,
+                                })}
+                            </TableCell>
+                        </TableRow>
+                        <TableRow>
+                            <TableCell sx={labelStyle}>
+                                {formatMessage(MESSAGES.created_at)}:
+                            </TableCell>
+                            <TableCell sx={valueStyle}>
+                                {DateTimeCell({
+                                    value: changeRequest.created_at,
+                                })}
+                            </TableCell>
+                        </TableRow>
+                        <TableRow>
+                            <TableCell sx={labelStyle}>
+                                {formatMessage(MESSAGES.updated_by)}:
+                            </TableCell>
+                            <TableCell sx={valueStyle}>
+                                <UserCell value={changeRequest.updated_by} />
+                            </TableCell>
+                        </TableRow>
+                        <TableRow>
+                            <TableCell sx={labelStyle}>
+                                {formatMessage(MESSAGES.created_by)}:
+                            </TableCell>
+                            <TableCell sx={valueStyle}>
+                                <UserCell value={changeRequest.created_by} />
+                            </TableCell>
+                        </TableRow>
 
-                    <Grid item xs={4} sx={styles.label}>
-                        {formatMessage(MESSAGES.created_at)}:
-                    </Grid>
-                    <Grid item xs={8} sx={styles.value}>
-                        {DateTimeCell({ value: changeRequest.created_at })}
-                    </Grid>
-
-                    <Grid item xs={4} sx={styles.label}>
-                        {formatMessage(MESSAGES.created_by)}:
-                    </Grid>
-                    <Grid item xs={8} sx={styles.value}>
-                        <UserCell value={changeRequest.created_by} />
-                    </Grid>
-
-                    <Grid item xs={4} sx={styles.label}>
-                        {formatMessage(MESSAGES.updated_at)}:
-                    </Grid>
-                    <Grid item xs={8} sx={styles.value}>
-                        {DateTimeCell({ value: changeRequest.updated_at })}
-                    </Grid>
-
-                    <Grid item xs={4} sx={styles.label}>
-                        {formatMessage(MESSAGES.updated_by)}:
-                    </Grid>
-                    <Grid item xs={8} sx={styles.value}>
-                        <UserCell value={changeRequest.updated_by} />
-                    </Grid>
-
-                    {changeRequest.status === 'rejected' && (
-                        <>
-                            <Grid item xs={4} sx={styles.label}>
-                                {formatMessage(MESSAGES.comment)}:
-                            </Grid>
-                            <Grid item xs={8} sx={styles.value}>
-                                {changeRequest.rejection_comment}
-                            </Grid>
-                        </>
-                    )}
-                </Grid>
+                        {changeRequest.status === 'rejected' && (
+                            <TableRow>
+                                <TableCell sx={labelStyle}>
+                                    {formatMessage(MESSAGES.comment)}:
+                                </TableCell>
+                                <TableCell sx={valueStyle}>
+                                    {changeRequest.rejection_comment}
+                                </TableCell>
+                            </TableRow>
+                        )}
+                    </TableBody>
+                </Table>
             </CardContent>
         </Card>
     );

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/Dialogs/ReviewOrgUnitChangesInfos.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/Dialogs/ReviewOrgUnitChangesInfos.tsx
@@ -29,37 +29,60 @@ export const colorCodes: Record<ChangeRequestValidationStatus, string> = {
 };
 
 const useStatusStyles = (status?: ChangeRequestValidationStatus) => {
-    return useMemo(
+    const baseStyle = useMemo(
         () => ({
-            infoCard: {
-                fontSize: 14,
-                backgroundColor: status
-                    ? `${colorCodes[status]}.background`
-                    : 'inherit',
-            },
-            cardContent: {
-                px: 2,
-                pt: theme => `${theme.spacing(1)} !important}`,
-                pb: theme => `${theme.spacing(1)} !important}`,
-            },
-            cell: {
-                borderBottom: 'none',
-                p: 0.25,
-            },
-            label: {
-                fontWeight: 'bold',
-                textAlign: 'right',
-            },
-            value: {
-                textAlign: 'left',
-            },
-            status: {
-                textAlign: 'left',
-                color: status ? `${colorCodes[status]}.main` : 'inherit',
-            },
+            borderBottom: 'none',
+            p: 0.25,
+        }),
+        [],
+    );
+
+    const infoCard = useMemo(
+        () => ({
+            fontSize: 14,
+            backgroundColor: status
+                ? `${colorCodes[status]}.background`
+                : 'inherit',
         }),
         [status],
     );
+
+    const cardContent = useMemo(
+        () => ({
+            px: 2,
+            pt: theme => `${theme.spacing(1)} !important}`,
+            pb: theme => `${theme.spacing(1)} !important}`,
+        }),
+        [],
+    );
+
+    const label = useMemo(
+        () => ({
+            ...baseStyle,
+            fontWeight: 'bold',
+            textAlign: 'right',
+        }),
+        [baseStyle],
+    );
+
+    const value = useMemo(
+        () => ({
+            ...baseStyle,
+            textAlign: 'left',
+        }),
+        [baseStyle],
+    );
+
+    const statusStyle = useMemo(
+        () => ({
+            ...baseStyle,
+            textAlign: 'left',
+            color: status ? `${colorCodes[status]}.main` : 'inherit',
+        }),
+        [status, baseStyle],
+    );
+
+    return { infoCard, cardContent, label, value, status: statusStyle };
 };
 
 export const ReviewOrgUnitChangesInfos: FunctionComponent<Props> = ({
@@ -70,66 +93,62 @@ export const ReviewOrgUnitChangesInfos: FunctionComponent<Props> = ({
     const styles = useStatusStyles(changeRequest?.status);
     if (isFetchingChangeRequest || !changeRequest) return null;
     const { status } = changeRequest;
-    const labelStyle = { ...styles.label, ...styles.cell };
-    const valueStyle = { ...styles.value, ...styles.cell };
     return (
         <Card sx={styles.infoCard}>
             <CardContent sx={styles.cardContent}>
                 <Table size="small">
                     <TableBody>
                         <TableRow>
-                            <TableCell sx={labelStyle}>
+                            <TableCell sx={styles.label}>
                                 {formatMessage(MESSAGES.status)}:
                             </TableCell>
-                            <TableCell
-                                sx={{ ...styles.status, ...styles.cell }}
-                            >
+                            <TableCell sx={styles.status}>
                                 {formatMessage(MESSAGES[status])}
                             </TableCell>
                         </TableRow>
                         <TableRow>
-                            <TableCell sx={labelStyle}>
+                            <TableCell sx={styles.label}>
                                 {formatMessage(MESSAGES.updated_at)}:
                             </TableCell>
-                            <TableCell sx={valueStyle}>
+                            <TableCell sx={styles.value}>
                                 {DateTimeCell({
                                     value: changeRequest.updated_at,
                                 })}
                             </TableCell>
                         </TableRow>
                         <TableRow>
-                            <TableCell sx={labelStyle}>
+                            <TableCell sx={styles.label}>
                                 {formatMessage(MESSAGES.created_at)}:
                             </TableCell>
-                            <TableCell sx={valueStyle}>
+                            <TableCell sx={styles.value}>
                                 {DateTimeCell({
                                     value: changeRequest.created_at,
                                 })}
                             </TableCell>
                         </TableRow>
                         <TableRow>
-                            <TableCell sx={labelStyle}>
+                            <TableCell sx={styles.label}>
                                 {formatMessage(MESSAGES.updated_by)}:
                             </TableCell>
-                            <TableCell sx={valueStyle}>
+                            <TableCell sx={styles.value}>
                                 <UserCell value={changeRequest.updated_by} />
                             </TableCell>
                         </TableRow>
                         <TableRow>
-                            <TableCell sx={labelStyle}>
+                            <TableCell sx={styles.label}>
                                 {formatMessage(MESSAGES.created_by)}:
                             </TableCell>
-                            <TableCell sx={valueStyle}>
+                            <TableCell sx={styles.value}>
                                 <UserCell value={changeRequest.created_by} />
                             </TableCell>
                         </TableRow>
 
                         {changeRequest.status === 'rejected' && (
                             <TableRow>
-                                <TableCell sx={labelStyle}>
+                                <TableCell sx={styles.label}>
                                     {formatMessage(MESSAGES.comment)}:
                                 </TableCell>
-                                <TableCell sx={valueStyle}>
+                                <TableCell sx={styles.value}>
                                     {changeRequest.rejection_comment}
                                 </TableCell>
                             </TableRow>

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/Tables/details/ReviewOrgUnitChangesDetailsTable.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/Tables/details/ReviewOrgUnitChangesDetailsTable.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable camelcase */
 import React, { FunctionComponent } from 'react';
 import { LoadingSpinner } from 'bluesquare-components';
-import { TableContainer, Table, Paper } from '@mui/material';
+import { TableContainer, Table } from '@mui/material';
 import { NewOrgUnitField } from '../../hooks/useNewFields';
 import { ReviewOrgUnitChangesDetailsTableHead } from './ReviewOrgUnitChangesDetailsTableHead';
 import { ReviewOrgUnitChangesDetailsTableBody } from './ReviewOrgUnitChangesDetailsTableBody';
@@ -27,22 +27,20 @@ export const ReviewOrgUnitChangesDetailsTable: FunctionComponent<Props> = ({
         !isFetchingChangeRequest && changeRequest?.status === 'new';
 
     return (
-        <Paper sx={{ mb: -2 }}>
-            <TableContainer sx={{ maxHeight: '75vh', minHeight: 300 }}>
-                {(isFetchingChangeRequest || isSaving) && (
-                    <LoadingSpinner absolute />
-                )}
-                <Table size="small" stickyHeader>
-                    <ReviewOrgUnitChangesDetailsTableHead isNew={isNew} />
-                    <ReviewOrgUnitChangesDetailsTableBody
-                        isFetchingChangeRequest={isFetchingChangeRequest}
-                        changeRequest={changeRequest}
-                        newFields={newFields}
-                        setSelected={setSelected}
-                        isNew={isNew}
-                    />
-                </Table>
-            </TableContainer>
-        </Paper>
+        <TableContainer sx={{ maxHeight: '75vh', minHeight: 300, mb: -2 }}>
+            {(isFetchingChangeRequest || isSaving) && (
+                <LoadingSpinner absolute />
+            )}
+            <Table size="small" stickyHeader>
+                <ReviewOrgUnitChangesDetailsTableHead isNew={isNew} />
+                <ReviewOrgUnitChangesDetailsTableBody
+                    isFetchingChangeRequest={isFetchingChangeRequest}
+                    changeRequest={changeRequest}
+                    newFields={newFields}
+                    setSelected={setSelected}
+                    isNew={isNew}
+                />
+            </Table>
+        </TableContainer>
     );
 };

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/Tables/details/ReviewOrgUnitChangesDetailsTableRow.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/Tables/details/ReviewOrgUnitChangesDetailsTableRow.tsx
@@ -59,6 +59,14 @@ const useStyles = makeStyles(theme => ({
             fontSize: 20,
         },
     },
+    verticalTop: {
+        verticalAlign: 'top',
+    },
+    checkBoxCell: {
+        padding: 0,
+        width: 30,
+    },
+    labelCell: { verticalAlign: 'top', width: '5vw' },
 }));
 
 export const ReviewOrgUnitChangesDetailsTableRow: FunctionComponent<Props> = ({
@@ -82,20 +90,11 @@ export const ReviewOrgUnitChangesDetailsTableRow: FunctionComponent<Props> = ({
             changeRequest.approved_fields.includes(`new_${field.key}`));
     return (
         <TableRow key={field.key}>
-            <TableCell sx={{ verticalAlign: 'top', width: '5vw' }}>
-                {field.label}
-            </TableCell>
-            <TableCell
-                sx={{
-                    verticalAlign: 'top',
-                }}
-            >
+            <TableCell className={classes.labelCell}>{field.label}</TableCell>
+            <TableCell className={classes.verticalTop}>
                 {field.oldValue}
             </TableCell>
             <TableCell
-                sx={{
-                    verticalAlign: 'top',
-                }}
                 className={classNames(
                     !isFetchingChangeRequest &&
                         isCellRejected &&
@@ -103,19 +102,14 @@ export const ReviewOrgUnitChangesDetailsTableRow: FunctionComponent<Props> = ({
                     !isFetchingChangeRequest &&
                         isCellApproved &&
                         classes.cellApproved,
-
                     !isCellApproved && !isCellRejected && classes.cell,
+                    classes.verticalTop,
                 )}
             >
                 {field.newValue}
             </TableCell>
             {isNew && (
-                <TableCell
-                    sx={{
-                        padding: 0,
-                        width: 30,
-                    }}
-                >
+                <TableCell className={classes.checkBoxCell}>
                     {field.isChanged && (
                         <Box
                             display="flex"

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/Tables/details/ReviewOrgUnitChangesDetailsTableRow.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/Tables/details/ReviewOrgUnitChangesDetailsTableRow.tsx
@@ -71,7 +71,10 @@ export const ReviewOrgUnitChangesDetailsTableRow: FunctionComponent<Props> = ({
     const classes = useStyles();
     const isCellRejected =
         (field.isChanged && !field.isSelected && isNew) ||
-        (field.isChanged && changeRequest?.status === 'rejected');
+        (field.isChanged && changeRequest?.status === 'rejected') ||
+        (field.isChanged &&
+            changeRequest?.status === 'approved' &&
+            !changeRequest.approved_fields.includes(`new_${field.key}`));
     const isCellApproved =
         (field.isChanged && field.isSelected) ||
         (!isNew &&

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/Tables/details/ReviewOrgUnitChangesDetailsTableRow.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/Tables/details/ReviewOrgUnitChangesDetailsTableRow.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-import React, { FunctionComponent, useMemo } from 'react';
+import React, { FunctionComponent } from 'react';
 import { Box, TableCell, TableRow } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import classNames from 'classnames';
@@ -71,31 +71,28 @@ export const ReviewOrgUnitChangesDetailsTableRow: FunctionComponent<Props> = ({
     const classes = useStyles();
     const isCellRejected =
         (field.isChanged && !field.isSelected && isNew) ||
-        changeRequest?.status === 'rejected';
+        (field.isChanged && changeRequest?.status === 'rejected');
     const isCellApproved =
         (field.isChanged && field.isSelected) ||
         (!isNew &&
             changeRequest?.status === 'approved' &&
-            changeRequest.approved_fields.includes(field.key));
-
-    const cellStyles = useMemo(
-        () => ({
-            verticalAlign: 'top',
-            padding: theme =>
-                !field.removePadding
-                    ? `6px ${theme.spacing(1)}`
-                    : `0 ${theme.spacing(1)} 0 0`,
-        }),
-        [field.removePadding],
-    );
+            changeRequest.approved_fields.includes(`new_${field.key}`));
     return (
         <TableRow key={field.key}>
             <TableCell sx={{ verticalAlign: 'top', width: '5vw' }}>
                 {field.label}
             </TableCell>
-            <TableCell sx={cellStyles}>{field.oldValue}</TableCell>
             <TableCell
-                sx={cellStyles}
+                sx={{
+                    verticalAlign: 'top',
+                }}
+            >
+                {field.oldValue}
+            </TableCell>
+            <TableCell
+                sx={{
+                    verticalAlign: 'top',
+                }}
                 className={classNames(
                     !isFetchingChangeRequest &&
                         isCellRejected &&

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/hooks/useNewFields.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/hooks/useNewFields.tsx
@@ -6,6 +6,7 @@ import React, {
 } from 'react';
 import { textPlaceholder, useSafeIntl } from 'bluesquare-components';
 import moment from 'moment';
+import orderBy from 'lodash/orderBy';
 import { Box } from '@mui/material';
 import {
     InstanceForChangeRequest,
@@ -89,183 +90,100 @@ export const useNewFields = (
             return;
         }
         const orgUnit = changeRequest.org_unit;
-        const newFields: NewOrgUnitField[] = [];
-        Object.entries(changeRequest).forEach(([key, value]) => {
-            let field: NewOrgUnitField | null = null;
-            const originalKey = key.replace('new_', '');
-            switch (key) {
-                // case 'new_location_accuracy': Org unit does not have accuracy in his payload
-                case 'new_name': {
-                    const val = value as string | number | undefined;
-                    const oldValue = orgUnit[originalKey]
-                        ? orgUnit[originalKey]
-                        : textPlaceholder;
-                    field = {
-                        key: originalKey,
-                        label: formatMessage(MESSAGES.name),
-                        isChanged: Boolean(value),
-                        isSelected: false,
-                        newValue: val ? (
-                            <span>{val.toString()}</span>
-                        ) : (
-                            oldValue
-                        ),
-                        oldValue,
-                        order: 1,
-                    };
-                    break;
-                }
-                case 'new_parent': {
-                    const oldValue = orgUnit?.parent ? (
-                        <LinkToOrgUnit orgUnit={orgUnit.parent} />
-                    ) : (
-                        textPlaceholder
-                    );
-                    field = {
-                        key: originalKey,
-                        label: formatMessage(MESSAGES.parent),
-                        isChanged: Boolean(value),
-                        isSelected: false,
-                        newValue: value ? (
-                            <LinkToOrgUnit orgUnit={value as ShortOrgUnit} />
-                        ) : (
-                            oldValue
-                        ),
-                        oldValue,
-                        order: 3,
-                    };
-                    break;
-                }
-                case 'new_org_unit_type': {
-                    const type = value as NestedOrgUnitType;
-                    const oldValue = orgUnit.org_unit_type ? (
-                        <span>{orgUnit.org_unit_type.short_name}</span>
-                    ) : (
-                        textPlaceholder
-                    );
-                    field = {
-                        key: originalKey,
-                        label: formatMessage(MESSAGES.orgUnitsType),
-                        isChanged: Boolean(value),
-                        isSelected: false,
-                        newValue: type ? (
-                            <span>{type.short_name}</span>
-                        ) : (
-                            textPlaceholder
-                        ),
-                        oldValue,
-                        order: 2,
-                    };
-                    break;
-                }
-                case 'new_groups': {
-                    const groups = value as NestedGroup[];
-                    field = {
-                        key: originalKey,
-                        label: formatMessage(MESSAGES.groups),
-                        isChanged: groups.length > 0,
-                        isSelected: false,
-                        newValue: (
-                            <span>
-                                {getGroupsValue(
-                                    groups.length > 0 ? groups : orgUnit.groups,
-                                )}
-                            </span>
-                        ),
-                        oldValue: getGroupsValue(orgUnit.groups),
+        const fieldDefinitions = {
+            new_name: {
+                label: formatMessage(MESSAGES.name),
+                order: 1,
+                formatValue: val => <span>{val.toString()}</span>,
+            },
+            new_parent: {
+                label: formatMessage(MESSAGES.parent),
+                order: 3,
+                formatValue: val => (
+                    <LinkToOrgUnit orgUnit={val as ShortOrgUnit} />
+                ),
+            },
+            new_org_unit_type: {
+                label: formatMessage(MESSAGES.orgUnitsType),
+                order: 2,
+                formatValue: val => (
+                    <span>{(val as NestedOrgUnitType).short_name}</span>
+                ),
+            },
+            new_groups: {
+                label: formatMessage(MESSAGES.groups),
+                order: 4,
+                formatValue: val => (
+                    <span>{getGroupsValue(val as NestedGroup[])}</span>
+                ),
+            },
+            new_location: {
+                label: formatMessage(MESSAGES.location),
+                order: 5,
+                formatValue: val => getLocationValue(val as NestedLocation),
+                removePadding: true,
+            },
+            new_opening_date: {
+                label: formatMessage(MESSAGES.openingDate),
+                order: 6,
+                formatValue: val => <span>{moment(val).format('LTS')}</span>,
+            },
+            new_closed_date: {
+                label: formatMessage(MESSAGES.closingDate),
+                order: 7,
+                formatValue: val => <span>{moment(val).format('LTS')}</span>,
+            },
+            new_reference_instances: {
+                label: formatMessage(MESSAGES.multiReferenceInstancesLabel),
+                order: 8,
+                formatValue: val => (
+                    <ReferenceInstances
+                        instances={val as InstanceForChangeRequest[]}
+                    />
+                ),
+                removePadding: true,
+            },
+        };
 
-                        order: 4,
-                    };
+        const newFields = orderBy(
+            Object.entries(changeRequest).reduce<NewOrgUnitField[]>(
+                (acc, [key, value]) => {
+                    const originalKey = key.replace('new_', '');
+                    const fieldDef = fieldDefinitions[key];
+                    if (fieldDef) {
+                        const oldValue = orgUnit[originalKey]
+                            ? fieldDef.formatValue(orgUnit[originalKey])
+                            : textPlaceholder;
+                        const newValue = value
+                            ? fieldDef.formatValue(value)
+                            : oldValue;
+                        const isChanged = Boolean(value);
+                        const { label, order } = fieldDef;
+                        acc.push({
+                            key: originalKey,
+                            label,
+                            isChanged,
+                            isSelected: false,
+                            newValue,
+                            oldValue,
+                            order,
+                            ...(fieldDef.removePadding && {
+                                removePadding: true,
+                            }),
+                        });
+                    }
+                    return acc;
+                },
+                [],
+            ),
+            ['order'],
+            ['asc'],
+        );
 
-                    break;
-                }
-                case 'new_location': {
-                    const location = value as NestedLocation | undefined;
-                    const oldValue = orgUnit.location ? (
-                        getLocationValue(orgUnit.location)
-                    ) : (
-                        <Box px="6px" py={2}>
-                            {textPlaceholder}
-                        </Box>
-                    );
-                    field = {
-                        key: originalKey,
-                        label: formatMessage(MESSAGES.location),
-                        isChanged: Boolean(value),
-                        isSelected: false,
-                        newValue: location
-                            ? getLocationValue(location)
-                            : oldValue,
-                        oldValue,
-                        removePadding: true,
-                        order: 5,
-                    };
-                    break;
-                }
-                case 'new_opening_date':
-                case 'new_closed_date': {
-                    const date = value as string | undefined;
-                    const oldValue = orgUnit[originalKey]
-                        ? moment(orgUnit[originalKey]).format('LTS')
-                        : textPlaceholder;
-                    field = {
-                        key: originalKey,
-                        label:
-                            key === 'new_opening_date'
-                                ? formatMessage(MESSAGES.openingDate)
-                                : formatMessage(MESSAGES.closingDate),
-                        isChanged: Boolean(value),
-                        isSelected: false,
-                        newValue: date ? (
-                            <span>{moment(date).format('LTS')}</span>
-                        ) : (
-                            oldValue
-                        ),
-                        oldValue,
-                        order: key === 'new_opening_date' ? 6 : 7,
-                    };
-
-                    break;
-                }
-                case 'new_reference_instances': {
-                    const instances = value as InstanceForChangeRequest[];
-                    field = {
-                        key: originalKey,
-                        label: formatMessage(
-                            MESSAGES.multiReferenceInstancesLabel,
-                        ),
-                        isChanged: instances.length > 0,
-                        isSelected: false,
-                        newValue: (
-                            <ReferenceInstances
-                                instances={
-                                    instances.length > 0
-                                        ? instances
-                                        : orgUnit.reference_instances
-                                }
-                            />
-                        ),
-                        oldValue: (
-                            <ReferenceInstances
-                                instances={orgUnit.reference_instances}
-                            />
-                        ),
-                        removePadding: true,
-                        order: 8,
-                    };
-                    break;
-                }
-                default:
-                    break;
-            }
-            if (field !== null) {
-                newFields.push(field);
-            }
-        });
         setFields(newFields);
     }, [changeRequest, formatMessage]);
 
-    const setSelected: UseNewFields['setSelected'] = key => {
+    const setSelected = key => {
         setFields(currentFields =>
             currentFields.map(field =>
                 field.key === key
@@ -274,6 +192,5 @@ export const useNewFields = (
             ),
         );
     };
-
     return { newFields: fields, setSelected };
 };

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/hooks/useNewFields.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/hooks/useNewFields.tsx
@@ -122,12 +122,12 @@ export const useNewFields = (
             new_opening_date: {
                 label: formatMessage(MESSAGES.openingDate),
                 order: 6,
-                formatValue: val => <span>{moment(val).format('LTS')}</span>,
+                formatValue: val => <span>{moment(val).format('L')}</span>,
             },
             new_closed_date: {
                 label: formatMessage(MESSAGES.closingDate),
                 order: 7,
-                formatValue: val => <span>{moment(val).format('LTS')}</span>,
+                formatValue: val => <span>{moment(val).format('L')}</span>,
             },
             new_reference_instances: {
                 label: formatMessage(MESSAGES.multiReferenceInstancesLabel),
@@ -148,7 +148,7 @@ export const useNewFields = (
                     if (fieldDef) {
                         let oldValue = textPlaceholder;
                         if (
-                            changeRequest.status === 'approved' &&
+                            changeRequest.status !== 'new' &&
                             changeRequest[`old_${originalKey}`]
                         ) {
                             oldValue = fieldDef.formatValue(

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/hooks/useNewFields.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/hooks/useNewFields.tsx
@@ -54,7 +54,7 @@ const ReferenceInstances: FunctionComponent<ReferenceInstancesProps> = ({
                         key={instance.id}
                         instanceId={`${instance.id}`}
                         minHeight="150px"
-                        titleVariant="subtitle1"
+                        titleVariant="subtitle2"
                     />
                 </Box>
             ))}
@@ -151,9 +151,19 @@ export const useNewFields = (
                     const originalKey = key.replace('new_', '');
                     const fieldDef = fieldDefinitions[key];
                     if (fieldDef) {
-                        const oldValue = orgUnit[originalKey]
-                            ? fieldDef.formatValue(orgUnit[originalKey])
-                            : textPlaceholder;
+                        let oldValue = textPlaceholder;
+                        if (
+                            changeRequest.status === 'approved' &&
+                            changeRequest[`old_${originalKey}`]
+                        ) {
+                            oldValue = fieldDef.formatValue(
+                                changeRequest[`old_${originalKey}`],
+                            );
+                        } else if (orgUnit[originalKey]) {
+                            oldValue = fieldDef.formatValue(
+                                orgUnit[originalKey],
+                            );
+                        }
                         const newValue = value
                             ? fieldDef.formatValue(value)
                             : oldValue;

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/hooks/useNewFields.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/hooks/useNewFields.tsx
@@ -139,47 +139,40 @@ export const useNewFields = (
                 ),
             },
         };
-
         const newFields = orderBy(
-            Object.entries(changeRequest).reduce<NewOrgUnitField[]>(
-                (acc, [key, value]) => {
+            Object.entries(changeRequest)
+                .filter(([key]) => fieldDefinitions[key]) // Filter entries that are defined in fieldDefinitions
+                .map(([key, value]) => {
                     const originalKey = key.replace('new_', '');
                     const fieldDef = fieldDefinitions[key];
-                    if (fieldDef) {
-                        let oldValue = textPlaceholder;
-                        if (
-                            changeRequest.status !== 'new' &&
-                            changeRequest[`old_${originalKey}`]
-                        ) {
-                            oldValue = fieldDef.formatValue(
-                                changeRequest[`old_${originalKey}`],
-                            );
-                        } else if (orgUnit[originalKey]) {
-                            oldValue = fieldDef.formatValue(
-                                orgUnit[originalKey],
-                            );
-                        }
-                        const isChanged = Array.isArray(value)
-                            ? value.length > 0
-                            : Boolean(value);
-                        const newValue = isChanged
-                            ? fieldDef.formatValue(value)
-                            : oldValue;
-                        const { label, order } = fieldDef;
-                        acc.push({
-                            key: originalKey,
-                            label,
-                            isChanged,
-                            isSelected: false,
-                            newValue,
-                            oldValue,
-                            order,
-                        });
+                    let oldValue = textPlaceholder;
+                    if (
+                        changeRequest.status !== 'new' &&
+                        changeRequest[`old_${originalKey}`]
+                    ) {
+                        oldValue = fieldDef.formatValue(
+                            changeRequest[`old_${originalKey}`],
+                        );
+                    } else if (orgUnit[originalKey]) {
+                        oldValue = fieldDef.formatValue(orgUnit[originalKey]);
                     }
-                    return acc;
-                },
-                [],
-            ),
+                    const isChanged = Array.isArray(value)
+                        ? value.length > 0
+                        : Boolean(value);
+                    const newValue = isChanged
+                        ? fieldDef.formatValue(value)
+                        : oldValue;
+                    const { label, order } = fieldDef;
+                    return {
+                        key: originalKey,
+                        label,
+                        isChanged,
+                        isSelected: false,
+                        newValue,
+                        oldValue,
+                        order,
+                    };
+                }),
             ['order'],
             ['asc'],
         );

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/hooks/useNewFields.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/hooks/useNewFields.tsx
@@ -28,7 +28,6 @@ export type NewOrgUnitField = {
     newValue: ReactElement | string;
     oldValue: ReactElement | string;
     label: string;
-    removePadding?: boolean;
     order: number;
 };
 
@@ -49,9 +48,8 @@ const ReferenceInstances: FunctionComponent<ReferenceInstancesProps> = ({
         <>
             {!instances || (instances.length === 0 && textPlaceholder)}
             {instances.map(instance => (
-                <Box mb={1}>
+                <Box mb={1} key={instance.id}>
                     <InstanceDetail
-                        key={instance.id}
                         instanceId={`${instance.id}`}
                         minHeight="150px"
                         titleVariant="subtitle2"
@@ -83,7 +81,6 @@ export const useNewFields = (
 ): UseNewFields => {
     const { formatMessage } = useSafeIntl();
     const [fields, setFields] = useState<NewOrgUnitField[]>([]);
-
     useMemo(() => {
         if (!changeRequest) {
             setFields([]);
@@ -121,7 +118,6 @@ export const useNewFields = (
                 label: formatMessage(MESSAGES.location),
                 order: 5,
                 formatValue: val => getLocationValue(val as NestedLocation),
-                removePadding: true,
             },
             new_opening_date: {
                 label: formatMessage(MESSAGES.openingDate),
@@ -141,7 +137,6 @@ export const useNewFields = (
                         instances={val as InstanceForChangeRequest[]}
                     />
                 ),
-                removePadding: true,
             },
         };
 
@@ -164,10 +159,12 @@ export const useNewFields = (
                                 orgUnit[originalKey],
                             );
                         }
-                        const newValue = value
+                        const isChanged = Array.isArray(value)
+                            ? value.length > 0
+                            : Boolean(value);
+                        const newValue = isChanged
                             ? fieldDef.formatValue(value)
                             : oldValue;
-                        const isChanged = Boolean(value);
                         const { label, order } = fieldDef;
                         acc.push({
                             key: originalKey,
@@ -177,9 +174,6 @@ export const useNewFields = (
                             newValue,
                             oldValue,
                             order,
-                            ...(fieldDef.removePadding && {
-                                removePadding: true,
-                            }),
                         });
                     }
                     return acc;

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/messages.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/messages.ts
@@ -141,6 +141,10 @@ const MESSAGES = defineMessages({
         id: 'iaso.changeRequest.comment',
         defaultMessage: 'Comment',
     },
+    close: {
+        id: 'iaso.label.close',
+        defaultMessage: 'Close',
+    },
 });
 
 export default MESSAGES;

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/types.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/types.ts
@@ -65,15 +65,24 @@ export type OrgUnitChangeRequestDetails = {
     approved_fields: string[];
     rejection_comment?: string;
     org_unit: OrgUnitForChangeRequest;
-    new_parent?: ShortOrgUnit;
-    new_name?: string;
-    new_org_unit_type: NestedOrgUnitType;
+    new_closed_date?: string;
     new_groups: NestedGroup[];
     new_location?: NestedLocation;
     new_location_accuracy?: number;
+    new_name?: string;
     new_opening_date?: string;
-    new_closed_date?: string;
+    new_org_unit_type: NestedOrgUnitType;
+    new_parent?: ShortOrgUnit;
     new_reference_instances: InstanceForChangeRequest[];
+    old_closed_date?: string;
+    old_groups: NestedGroup[];
+    old_location?: NestedLocation;
+    old_location_accuracy?: number;
+    old_name?: string;
+    old_opening_date?: string;
+    old_org_unit_type: NestedOrgUnitType;
+    old_parent?: ShortOrgUnit;
+    old_reference_instances: InstanceForChangeRequest[];
 };
 
 type OrgUnitForChangeRequest = {

--- a/iaso/models/org_unit.py
+++ b/iaso/models/org_unit.py
@@ -689,7 +689,17 @@ class OrgUnitChangeRequest(models.Model):
 
     def save(self, *args, **kwargs):
         self.clean()
+        # Save old values.
+        self.old_parent = self.org_unit.parent
+        self.old_name = self.org_unit.name
+        self.old_org_unit_type = self.org_unit.org_unit_type
+        self.old_location = self.org_unit.location
+        self.old_opening_date = self.org_unit.opening_date
+        self.old_closed_date = self.org_unit.closed_date
         super().save(*args, **kwargs)
+        # Wait for the instance to have an ID to save m2m relations.
+        self.old_groups.set(self.org_unit.groups.all())
+        self.old_reference_instances.set(self.org_unit.reference_instances.all())
 
     def clean(self, *args, **kwargs):
         super().clean()
@@ -736,16 +746,6 @@ class OrgUnitChangeRequest(models.Model):
 
     def __apply_changes(self, user: User, approved_fields: typing.List[str]) -> None:
         initial_org_unit = deepcopy(self.org_unit)
-
-        # Save old values.
-        self.old_parent = initial_org_unit.parent
-        self.old_name = initial_org_unit.name
-        self.old_org_unit_type = initial_org_unit.org_unit_type
-        self.old_groups.set(initial_org_unit.groups.all())
-        self.old_location = initial_org_unit.location
-        self.old_opening_date = initial_org_unit.opening_date
-        self.old_closed_date = initial_org_unit.closed_date
-        self.old_reference_instances.set(initial_org_unit.reference_instances.all())
 
         for field_name in approved_fields:
             if field_name == "new_location_accuracy":

--- a/iaso/models/org_unit.py
+++ b/iaso/models/org_unit.py
@@ -689,17 +689,20 @@ class OrgUnitChangeRequest(models.Model):
 
     def save(self, *args, **kwargs):
         self.clean()
-        # Save old values.
-        self.old_parent = self.org_unit.parent
-        self.old_name = self.org_unit.name
-        self.old_org_unit_type = self.org_unit.org_unit_type
-        self.old_location = self.org_unit.location
-        self.old_opening_date = self.org_unit.opening_date
-        self.old_closed_date = self.org_unit.closed_date
+        is_new = self.pk is None
+        if is_new:
+            # Save old values.
+            self.old_parent = self.org_unit.parent
+            self.old_name = self.org_unit.name
+            self.old_org_unit_type = self.org_unit.org_unit_type
+            self.old_location = self.org_unit.location
+            self.old_opening_date = self.org_unit.opening_date
+            self.old_closed_date = self.org_unit.closed_date
         super().save(*args, **kwargs)
-        # Wait for the instance to have an ID to save m2m relations.
-        self.old_groups.set(self.org_unit.groups.all())
-        self.old_reference_instances.set(self.org_unit.reference_instances.all())
+        if is_new:
+            # Wait for the instance to have an ID to save old m2m relations.
+            self.old_groups.set(self.org_unit.groups.all())
+            self.old_reference_instances.set(self.org_unit.reference_instances.all())
 
     def clean(self, *args, **kwargs):
         super().clean()

--- a/iaso/tests/api/org_unit_change_requests/test_serializers.py
+++ b/iaso/tests/api/org_unit_change_requests/test_serializers.py
@@ -375,7 +375,13 @@ class OrgUnitChangeRequestRetrieveSerializerTestCase(TestCase):
                 "new_reference_instances": [],
                 "old_parent": None,
                 "old_name": "",
-                "old_org_unit_type": None,
+                "old_org_unit_type": OrderedDict(
+                    [
+                        ("id", self.org_unit_type.pk),
+                        ("name", self.org_unit_type.name),
+                        ("short_name", self.org_unit_type.short_name),
+                    ]
+                ),
                 "old_groups": [],
                 "old_location": None,
                 "old_opening_date": None,

--- a/iaso/tests/models/test_org_unit_change_request.py
+++ b/iaso/tests/models/test_org_unit_change_request.py
@@ -110,6 +110,15 @@ class OrgUnitChangeRequestModelTestCase(TestCase):
         self.assertEqual(change_request.new_reference_instances.count(), 1)
         self.assertEqual(change_request.new_reference_instances.first(), self.new_instance1)
         self.assertCountEqual(change_request.approved_fields, kwargs["approved_fields"])
+        # Change request old values.
+        self.assertEqual(change_request.old_parent, self.org_unit.parent)
+        self.assertEqual(change_request.old_name, "Hôpital Général")
+        self.assertEqual(change_request.old_org_unit_type, self.org_unit.org_unit_type)
+        self.assertCountEqual(change_request.old_groups.all(), [self.new_group1])
+        self.assertEqual(change_request.old_location, "SRID=4326;POINT Z (-1.1111111 1.1111111 1.1111111)")
+        self.assertEqual(change_request.old_opening_date, datetime.date(2020, 1, 1))
+        self.assertEqual(change_request.old_closed_date, datetime.date(2055, 1, 1))
+        self.assertCountEqual(change_request.old_reference_instances.all(), [self.new_instance1])
 
     def test_clean_approved_fields(self):
         approved_fields = ["new_name", "foo"]
@@ -197,15 +206,6 @@ class OrgUnitChangeRequestModelTestCase(TestCase):
         self.assertEqual(change_request.updated_at, self.DT)
         self.assertEqual(change_request.updated_by, self.user)
         self.assertCountEqual(change_request.approved_fields, approved_fields)
-        # Change request old values.
-        self.assertEqual(change_request.old_parent, self.parent)
-        self.assertEqual(change_request.old_name, "Hôpital Général")
-        self.assertEqual(change_request.old_org_unit_type, self.org_unit_type)
-        self.assertCountEqual(change_request.old_groups.all(), [self.new_group1])
-        self.assertEqual(change_request.old_location, "SRID=4326;POINT Z (-1.1111111 1.1111111 1.1111111)")
-        self.assertEqual(change_request.old_opening_date, datetime.date(2020, 1, 1))
-        self.assertEqual(change_request.old_closed_date, datetime.date(2055, 1, 1))
-        self.assertCountEqual(change_request.old_reference_instances.all(), [self.new_instance1])
 
         # Org Unit.
         self.assertEqual(self.org_unit.validation_status, self.org_unit.VALIDATION_VALID)

--- a/iaso/tests/models/test_org_unit_change_request.py
+++ b/iaso/tests/models/test_org_unit_change_request.py
@@ -120,6 +120,12 @@ class OrgUnitChangeRequestModelTestCase(TestCase):
         self.assertEqual(change_request.old_closed_date, datetime.date(2055, 1, 1))
         self.assertCountEqual(change_request.old_reference_instances.all(), [self.new_instance1])
 
+        # Ensure updating a change_request won't override old values.
+        change_request.org_unit.name = "Another name"
+        change_request.org_unit.save()
+        change_request.save()
+        self.assertEqual(change_request.old_name, "Hôpital Général")
+
     def test_clean_approved_fields(self):
         approved_fields = ["new_name", "foo"]
         change_request = m.OrgUnitChangeRequest(org_unit=self.org_unit, approved_fields=approved_fields)


### PR DESCRIPTION
Using old field values while change request is approved, following [those](https://github.com/BLSQ/iaso/pull/1047) changes

Related JIRA tickets : IA-2613
## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- refactor `useNewFields` for readability
- review status colors 
- using old values if status is approved

## How to test

Remove old change requests you did before Marc previous PR.
Create 3 change requests
Reject, approved and let the last one to new (use the dashboard, not the admin)
Make sure the dialog renders properly the fields with correct colors, also if this is the approved one, values on the left should be different than the modified version.


## Print screen / video

<img width="1620" alt="Screenshot 2024-01-24 at 10 35 30" src="https://github.com/BLSQ/iaso/assets/12494624/fcb0fed2-083f-4bde-9297-0f5a38b8dc2b">
<img width="1624" alt="Screenshot 2024-01-24 at 10 35 20" src="https://github.com/BLSQ/iaso/assets/12494624/694a5727-5735-4a2e-9be1-04aaf492f6d3">
<img width="1592" alt="Screenshot 2024-01-24 at 10 35 11" src="https://github.com/BLSQ/iaso/assets/12494624/eb64acbe-b264-471a-9443-869b0710f479">

