### PR TITLE
WC2-317: Entities dates filter

### DIFF
--- a/iaso/api/entity.py
+++ b/iaso/api/entity.py
@@ -232,6 +232,8 @@ class EntityViewSet(ModelViewSet):
         created_by_team_id = self.request.query_params.get("created_by_team_id", None)
 
         queryset = Entity.objects.filter(account=self.request.user.iaso_profile.account)
+
+        queryset = queryset.annotate(last_saved_instance=Max("instances__created_at"))
         if form_name:
             queryset = queryset.filter(attributes__form__name__icontains=form_name)
         if search:
@@ -247,10 +249,9 @@ class EntityViewSet(ModelViewSet):
         if org_unit_id:
             queryset = queryset.filter(attributes__org_unit__id=org_unit_id)
         if date_from:
-            # TODO: see if we use created_at as reference date (or latest instance creation, update, ...)
-            queryset = queryset.filter(created_at__gte=date_from)
+            queryset = queryset.filter(last_saved_instance__gte=date_from)
         if date_to:
-            queryset = queryset.filter(created_at__date__lte=date_to)
+            queryset = queryset.filter(last_saved_instance__date__lte=date_to)
         if show_deleted:
             queryset = queryset.filter(deleted_at__isnull=True)
         if created_by_id:


### PR DESCRIPTION
Table is displaying last visit date and filters are filtering on created_at date on entities, so the result of the search in incoherent. 

![Screenshot 2024-01-24 at 14 39 49](https://github.com/BLSQ/iaso/assets/12494624/79a66f7f-dd98-442b-835e-26cbae96c036)
![Screenshot 2024-01-24 at 14 39 37](https://github.com/BLSQ/iaso/assets/12494624/869b7d0d-f425-4fa2-ac49-17e34efa0dd3)


Related JIRA tickets : WC2-317

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

Change filters to compare last visit dates

## How to test

Filter entities on last visit date of one of your entity, you should have a result

## Print screen / video

![Screenshot 2024-01-24 at 14 34 16](https://github.com/BLSQ/iaso/assets/12494624/3e51c614-542c-4a3d-8711-59f0008bdc13)
