### PR TITLE
IA-2637: completeness stats map tab

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -76,6 +76,7 @@
     "iaso.completenessStats.itselfNoSubmissionExcepted": "No submission is expected on this level for this form",
     "iaso.completenessStats.itselfSubmissionCount": "Total submissions: {value}",
     "iaso.completenessStats.notCompleted": "Not completed",
+    "iaso.completenessStats.selectAForm": "Please select a Form to watch completeness with the map view",
     "iaso.completenessStats.title": "Completeness stats",
     "iaso.datasource.gpkg.title.update": "Update {sourceName} - {versionNumber}",
     "iaso.datasources.addAskTitle": "{title} - Source: {source} - Version: {version}",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -76,6 +76,7 @@
     "iaso.completenessStats.itselfNoSubmissionExcepted": "Aucune soumission n'est attendue à ce niveau",
     "iaso.completenessStats.itselfSubmissionCount": "Total soumissions: {value}",
     "iaso.completenessStats.notCompleted": "Non terminé",
+    "iaso.completenessStats.selectAForm": "Sélectionnez un formulaire pour voir la carte",
     "iaso.completenessStats.title": "Statistiques de complétude",
     "iaso.datasource.gpkg.title.update": "Mise à jour {sourceName} - {versionNumber}",
     "iaso.datasources.addAskTitle": "{title} - Source: {source} - Version: {version}",

--- a/hat/assets/js/apps/Iaso/domains/completenessStats/CompletenessStatsFilters.tsx
+++ b/hat/assets/js/apps/Iaso/domains/completenessStats/CompletenessStatsFilters.tsx
@@ -60,10 +60,6 @@ export const CompletenessStatsFilters: FunctionComponent<Props> = ({
             const tempParams = {
                 ...params,
                 ...filters,
-                tab:
-                    filters.formId?.split(',').length !== 1
-                        ? 'list'
-                        : params.tab,
             };
             tempParams.page = '1';
             dispatch(redirectToReplace(baseUrl, tempParams));

--- a/hat/assets/js/apps/Iaso/domains/completenessStats/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/completenessStats/index.tsx
@@ -7,7 +7,7 @@ import React, {
 } from 'react';
 import { useDispatch } from 'react-redux';
 import { useSafeIntl, commonStyles } from 'bluesquare-components';
-import { Box, Grid, useTheme, Tabs, Tab } from '@mui/material';
+import { Box, Grid, useTheme, Tabs, Tab, Paper } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import Color from 'color';
 
@@ -174,29 +174,36 @@ export const CompletenessStats: FunctionComponent<Props> = ({
                         <CsvButton csvUrl={csvUrl} />
                     </Grid>
                 </Grid>
-                {selectedFormsIds.length === 1 && (
-                    <Box mt={2}>
-                        <Tabs
-                            value={tab}
-                            onChange={(_, newtab) => handleChangeTab(newtab)}
-                        >
-                            <Tab
-                                value="list"
-                                label={formatMessage(MESSAGES.list)}
-                            />
-                            <Tab
-                                value="map"
-                                label={formatMessage(MESSAGES.map)}
-                            />
-                        </Tabs>
-                    </Box>
-                )}
-
-                {selectedFormsIds.length === 1 && (
-                    <Box
-                        width="100%"
-                        className={tab === 'map' ? '' : classes.hiddenOpacity}
+                <Box mt={2}>
+                    <Tabs
+                        value={tab}
+                        onChange={(_, newtab) => handleChangeTab(newtab)}
                     >
+                        <Tab
+                            value="list"
+                            label={formatMessage(MESSAGES.list)}
+                        />
+                        <Tab value="map" label={formatMessage(MESSAGES.map)} />
+                    </Tabs>
+                </Box>
+
+                <Box
+                    width="100%"
+                    className={tab === 'map' ? '' : classes.hiddenOpacity}
+                >
+                    {selectedFormsIds.length !== 1 && (
+                        <Paper
+                            sx={{
+                                mt: 2,
+                                p: 2,
+                                display: 'flex',
+                                justifyContent: 'center',
+                            }}
+                        >
+                            {formatMessage(MESSAGES.selectAForm)}
+                        </Paper>
+                    )}
+                    {selectedFormsIds.length === 1 && (
                         <Map
                             locations={completenessMapStats || []}
                             isLoading={isFetchingMapStats}
@@ -205,8 +212,8 @@ export const CompletenessStats: FunctionComponent<Props> = ({
                             router={router}
                             threshold={selectedForm?.original.legend_threshold}
                         />
-                    </Box>
-                )}
+                    )}
+                </Box>
                 {tab === 'list' && (
                     <Box mt={selectedFormsIds.length === 1 ? 0 : 2}>
                         <TableWithDeepLink

--- a/hat/assets/js/apps/Iaso/domains/completenessStats/messages.ts
+++ b/hat/assets/js/apps/Iaso/domains/completenessStats/messages.ts
@@ -143,6 +143,11 @@ const MESSAGES = defineMessages({
             'Please select one form to enable completeness map view',
         id: 'iaso.completenessStats.formsInfos',
     },
+    selectAForm: {
+        defaultMessage:
+            'Please select a Form to watch completeness with the map view',
+        id: 'iaso.completenessStats.selectAForm',
+    },
 });
 
 export default MESSAGES;


### PR DESCRIPTION
Have the "Map" tab appearing even if no form is selected, and then have the message "Please select a Form to watch on a map"
It’s not very intuitive today to first select a Form to be able to see the completeness map

The tab “Map” could appear next to “List” and then we would have the message “Please select a Form to watch completeness with the map view” 

Related JIRA tickets : IA-2637

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

-  always display map tab
- adding placeholder text
- remove redirect while changing form filter

## How to test

Open Completeness stats list page, click on map tab, placeholder text should be displayed.
Select a form, the map should present

## Print screen / video
<img width="841" alt="Screenshot 2024-01-24 at 16 47 28" src="https://github.com/BLSQ/iaso/assets/12494624/cfe74cea-2017-4e03-b49c-825e0d738906">

