### PR TITLE
POLIO-1404:small ui fixes

### DIFF
--- a/plugins/polio/js/src/domains/Campaigns/Rounds/ReasonForDelayModal/ReasonForDelayModal.tsx
+++ b/plugins/polio/js/src/domains/Campaigns/Rounds/ReasonForDelayModal/ReasonForDelayModal.tsx
@@ -4,7 +4,7 @@ import {
     ConfirmCancelModal,
     makeFullModal,
 } from 'bluesquare-components';
-import { Divider } from '@mui/material';
+import { Box, Divider } from '@mui/material';
 import { Field, useFormikContext } from 'formik';
 import { useSelector } from 'react-redux';
 import MESSAGES from '../../../../constants/messages';
@@ -46,13 +46,15 @@ const ReasonForDelayModal: FunctionComponent<Props> = ({
             allowConfirm={allowConfirm}
         >
             <Divider />
-            <Field
-                label={formatMessage(MESSAGES.startDate)}
-                name="startDate"
-                component={DateInput}
-                fullWidth
-                clearable={false}
-            />
+            <Box mt={2}>
+                <Field
+                    label={formatMessage(MESSAGES.startDate)}
+                    name="startDate"
+                    component={DateInput}
+                    fullWidth
+                    clearable={false}
+                />
+            </Box>
             <Field
                 label={formatMessage(MESSAGES.endDate)}
                 name="endDate"

--- a/plugins/polio/js/src/domains/Campaigns/Rounds/RoundsForm.js
+++ b/plugins/polio/js/src/domains/Campaigns/Rounds/RoundsForm.js
@@ -203,7 +203,7 @@ export const RoundsForm = () => {
                 )}
             </Box>
             {currentRoundNumber !== undefined && (
-                <Box mt={2} width="100%" >
+                <Box mt={2} width="100%">
                     <RoundForm roundNumber={currentRoundNumber} />
                 </Box>
             )}

--- a/plugins/polio/js/src/styles/theme.js
+++ b/plugins/polio/js/src/styles/theme.js
@@ -107,7 +107,6 @@ export const useStyles = makeStyles(() => ({
     subTab: {
         fontSize: 12,
         minWidth: 100,
-        width: 100,
     },
     addRoundButton: {
         fontSize: 10,


### PR DESCRIPTION
Explain what problem this PR is resolving

Related JIRA tickets : POLIO-1404

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- add margin to reasons for delay modal divider, to avoir cutting text
- remove round tab fixed width


## How to test

Go to polio, open round tab (campaign needs multiple rounds): the "close" icon button (X) should not be crammed against the text

Try to edit round dates: the label of the first input (start date) should be fully visible

## Print screen / video

Before:

![Screenshot 2024-01-29 at 14 53 52](https://github.com/BLSQ/iaso/assets/38907762/796774d8-bd53-461f-ab6d-fbab43986e33)

![Screenshot 2024-01-29 at 14 54 01](https://github.com/BLSQ/iaso/assets/38907762/aa1e7268-99a3-4ba4-bfb9-bccc4aa11a9e)


After:
![Uploading Screenshot 2024-01-29 at 14.59.32.png…]()

![Screenshot 2024-01-29 at 14 59 40](https://github.com/BLSQ/iaso/assets/38907762/eb48c314-1e0c-4f63-93a3-21299ac3aab0)



