### PR TITLE
Wc2 325 incorrect exit status in etl for child

### DIFF
--- a/plugins/wfp/common.py
+++ b/plugins/wfp/common.py
@@ -13,9 +13,6 @@ class ETL:
         updated_at = datetime.date(2023, 7, 10)
         beneficiaries = (
             Instance.objects.filter(entity__entity_type__name=self.type)
-            # .filter(entity__id__in=[19,277, 284, 20])
-            # .filter(entity__id__in=[19, 20, 277])
-            # .filter(entity__id__in=[195, 20, 19, 308, 277, 189])
             .filter(json__isnull=False)
             .filter(form__isnull=False)
             .filter(updated_at__gte=updated_at)

--- a/plugins/wfp/management/commands/wfp_etl_Under5.py
+++ b/plugins/wfp/management/commands/wfp_etl_Under5.py
@@ -4,7 +4,7 @@ from itertools import groupby
 from operator import itemgetter
 from ...common import ETL
 import logging
-from datetime import datetime, timedelta, date
+from datetime import datetime, timedelta
 
 logger = logging.getLogger(__name__)
 

--- a/plugins/wfp/management/commands/wfp_etl_Under5.py
+++ b/plugins/wfp/management/commands/wfp_etl_Under5.py
@@ -4,7 +4,7 @@ from itertools import groupby
 from operator import itemgetter
 from ...common import ETL
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, date
 
 logger = logging.getLogger(__name__)
 
@@ -84,7 +84,10 @@ class Under5:
 
                 if visit["form_id"] == "Anthropometric visit child":
                     current_journey["nutrition_programme"] = ETL().program_mapper(visit)
-                anthropometric_visit_forms = ["child_antropometric_followUp_tsfp", "child_antropometric_followUp_otp"]
+                anthropometric_visit_forms = [
+                    "child_antropometric_followUp_tsfp",
+                    "child_antropometric_followUp_otp",
+                ]
 
                 current_journey = ETL().journey_Formatter(
                     visit,
@@ -111,19 +114,33 @@ class Under5:
 
                     if visit.get("next_visit_days", None) is not None and visit.get("next_visit_days", None) != "":
                         next_visit_days = visit.get("next_visit_days", None)
-                        if next_visit_date is not None and next_visit_date != "":
-                            nextSecondVisitDate = datetime.strptime(
-                                next_visit_date[:10], "%Y-%m-%d"
-                            ).date() + timedelta(days=int(next_visit_days))
+                    elif (
+                        visit.get("number_of_days__int__", None) is not None
+                        and visit.get("number_of_days__int__", None) != ""
+                    ):
+                        next_visit_days = visit.get("number_of_days__int__", None)
+                    elif (
+                        visit.get("OTP_next_visit", None) is not None
+                        and visit.get("OTP_next_visit", None) != ""
+                        and visit.get("OTP_next_visit") != "--"
+                    ):
+                        next_visit_days = visit.get("OTP_next_visit", None)
+                    elif (
+                        visit.get("TSFP_next_visit", None) is not None
+                        and visit.get("TSFP_next_visit", None) != ""
+                        and visit.get("TSFP_next_visit") != "--"
+                    ):
+                        next_visit_days = visit.get("TSFP_next_visit", None)
 
-                    followUpVisitsAtNextVisit = ETL().followup_visits_at_next_visit_date(
-                        visits,
-                        anthropometric_visit_forms,
-                        next_visit_date[:10],
-                        nextSecondVisitDate,
+                    if next_visit_date is not None and next_visit_date != "":
+                        nextSecondVisitDate = datetime.strptime(next_visit_date[:10], "%Y-%m-%d").date() + timedelta(
+                            days=int(next_visit_days)
+                        )
+
+                    missed_followup_visit = ETL().missed_followup_visit(
+                        visits, anthropometric_visit_forms, next_visit_date[:10], nextSecondVisitDate, next_visit_days
                     )
-                    # Missed 2 consecutives visits(exit type is set to defaulter)
-                    if current_journey.get("exit_type", None) is None and len(followUpVisitsAtNextVisit) < 2:
+                    if current_journey.get("exit_type", None) is None and missed_followup_visit > 1:
                         current_journey["exit_type"] = "defaulter"
 
                 current_journey["steps"].append(visit)

--- a/plugins/wfp/management/commands/wfp_etl_pbwg.py
+++ b/plugins/wfp/management/commands/wfp_etl_pbwg.py
@@ -4,7 +4,7 @@ from itertools import groupby
 from operator import itemgetter
 from ...common import ETL
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, date
 
 logger = logging.getLogger(__name__)
 
@@ -110,14 +110,11 @@ class PBWG:
                                 next_visit_date[:10], "%Y-%m-%d"
                             ).date() + timedelta(days=int(next_visit_days))
 
-                    followUpVisitsAtNextVisit = ETL().followup_visits_at_next_visit_date(
-                        visits,
-                        anthropometric_visit_forms,
-                        next_visit_date[:10],
-                        nextSecondVisitDate,
+                    missed_followup_visit = ETL().missed_followup_visit(
+                        visits, anthropometric_visit_forms, next_visit_date[:10], nextSecondVisitDate, next_visit_days
                     )
-                    # Missed 2 consecutives visits
-                    if current_journey.get("exit_type", None) != "cured" and len(followUpVisitsAtNextVisit) < 2:
+
+                    if current_journey.get("exit_type", None) is None and missed_followup_visit > 1:
                         current_journey["exit_type"] = "defaulter"
 
                 current_journey["steps"].append(visit)

--- a/plugins/wfp/management/commands/wfp_etl_pbwg.py
+++ b/plugins/wfp/management/commands/wfp_etl_pbwg.py
@@ -4,7 +4,7 @@ from itertools import groupby
 from operator import itemgetter
 from ...common import ETL
 import logging
-from datetime import datetime, timedelta, date
+from datetime import datetime, timedelta
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Explain what problem this PR is resolving

Related JIRA tickets : [WC2-325](https://bluesquare.atlassian.net/browse/WC2-325)

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

Explain the changes that were made. The idea is not to list exhaustively all the changes made (GitHub already provides a full diff), but to help the reviewers better understand:
- which specific file changes go together, e.g: when creating a table in the front-end, there usually is a config file that goes with it
- the reasoning behind some changes, e.g: deleted files because they are now redundant
- the behaviour to expect, e.g: tooltip has purple background color because the client likes it so, changed a key in the API response to be consistent with other endpoints

## How to test

From the local instance with wfp coda database, Lunch with `docker-compose run iaso manage wfp_etl` the ETL script in order to generate data for tableau dashboard and go to the debug page for the beneficiary: e.g: http://localhost:8081/wfp/debug/277/
For this beneficiary, its exit type will be set to None as the **Expected defaulting date** is 14 Feb 2024.

## Print screen / video

Upload here print screens or videos showing the changes

## Notes

Things that the reviewers should know: known bugs that are out of the scope of the PR, other trade-offs that were made.
If the PR depends on a PR in bluesquare-components, or merges into another PR (i.o. main), it should also be mentioned here


[WC2-325]: https://bluesquare.atlassian.net/browse/WC2-325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ