### PR TITLE
POLIO-1450: add max value to wastage ratio

### DIFF
--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/VaccineRequestForm/VaccineRequestForm.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/VaccineRequestForm/VaccineRequestForm.tsx
@@ -172,7 +172,10 @@ export const VaccineRequestForm: FunctionComponent<Props> = ({
                                     name="vrf.wastage_rate_used_on_vrf"
                                     component={NumberInput}
                                     disabled={false}
-                                    numberInputOptions={{ suffix: '%' }}
+                                    numberInputOptions={{
+                                        suffix: '%',
+                                        max: 100,
+                                    }}
                                 />
                             </Box>
                         </Grid>


### PR DESCRIPTION
Users could input and save a ratio > 100%

Related JIRA tickets :POLIO-1450

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

Explain the changes that were made. The idea is not to list exhaustively all the changes made (GitHub already provides a full - Set `max` prop of `NumberInput` to `100`: this adds an info icon about the limit. Users can still input values > 100 but it will be "rounded down" to 100 when saving

## How to test

Go to Polio > Vaccine module > Supplychain, open a VRF and try to save a wastage ratio > 100


## Print screen / video


https://github.com/BLSQ/iaso/assets/38907762/51bf0f16-ca59-48c7-b992-0bdfc1724862


