### PR TITLE
Polio 1452 save button bug

### DIFF
--- a/plugins/polio/js/src/components/Inputs/NumberInput.tsx
+++ b/plugins/polio/js/src/components/Inputs/NumberInput.tsx
@@ -49,7 +49,7 @@ export const NumberInput: FunctionComponent<Props> = ({
             max={max}
             errors={hasError ? [get(form.errors, field.name)] : []}
             disabled={disabled}
-            numberInputOptions={numberInputOptions}
+            numberInputOptions={{ min, max, ...numberInputOptions }}
         />
     );
 };

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/PreAlerts/PreAlert.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/PreAlerts/PreAlert.tsx
@@ -26,7 +26,9 @@ export const PreAlert: FunctionComponent<Props> = ({ index }) => {
     const markedForDeletion = pre_alerts?.[index].to_delete ?? false;
 
     const doses_per_vial = pre_alerts?.[index].doses_per_vial ?? 20;
-    const current_vials_shipped = Math.ceil((pre_alerts?.[index].doses_shipped ?? 0) / doses_per_vial);
+    const current_vials_shipped = Math.ceil(
+        (pre_alerts?.[index].doses_shipped ?? 0) / doses_per_vial,
+    );
 
     const onDelete = useCallback(() => {
         if (values?.pre_alerts?.[index].id) {
@@ -112,21 +114,20 @@ export const PreAlert: FunctionComponent<Props> = ({ index }) => {
                     </Grid>
 
                     <Grid container item xs={12} spacing={2}>
-
                         <Grid item xs={6} md={4} />
 
                         <Grid item xs={6} md={4}>
                             <Typography variant="button">
-                                {`${formatMessage(MESSAGES.doses_per_vial)}:`} <NumberCell value={doses_per_vial} />
+                                {`${formatMessage(MESSAGES.doses_per_vial)}:`}{' '}
+                                <NumberCell value={doses_per_vial} />
                             </Typography>
-
                         </Grid>
 
                         <Grid item xs={6} md={4}>
                             <Typography variant="button">
-                                {`${formatMessage(MESSAGES.vials_shipped)}:`} <NumberCell value={current_vials_shipped} />
+                                {`${formatMessage(MESSAGES.vials_shipped)}:`}{' '}
+                                <NumberCell value={current_vials_shipped} />
                             </Typography>
-
                         </Grid>
                     </Grid>
                 </Grid>

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/PreAlerts/PreAlerts.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/PreAlerts/PreAlerts.tsx
@@ -4,19 +4,9 @@ import { PreAlert } from './PreAlert';
 import MESSAGES from '../../messages';
 import { MultiFormTab } from '../shared';
 import { PREALERT } from '../../constants';
+import { emptyPreAlert } from '../../hooks/utils';
 
 type Props = { className?: string; items?: any[] };
-
-const emptyPreAlert = {
-    date_pre_alert_reception: undefined,
-    po_number: undefined,
-    estimated_arrival_time: undefined,
-    expiration_date: undefined,
-    doses_shipped: undefined,
-    doses_per_vial: 20,
-    lot_numbers: undefined,
-    id: undefined,
-};
 
 export const PreAlerts: FunctionComponent<Props> = ({
     className,
@@ -27,6 +17,7 @@ export const PreAlerts: FunctionComponent<Props> = ({
     const onClick = useCallback(() => {
         setFieldValue(PREALERT, [...values[PREALERT], emptyPreAlert]);
     }, [setFieldValue, values]);
+
     return (
         <MultiFormTab
             className={className}

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/VAR/VaccineArrivalReports.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/VAR/VaccineArrivalReports.tsx
@@ -4,18 +4,10 @@ import { VaccineArrivalReport } from './VaccineArrivalReport';
 import MESSAGES from '../../messages';
 import { MultiFormTab } from '../shared';
 import { VAR } from '../../constants';
+import { emptyArrivalReport } from '../../hooks/utils';
 
 type Props = { className?: string; items?: any[] };
 
-const emptyArrivalReport = {
-    report_date: undefined,
-    po_number: undefined,
-    lot_numbers: undefined,
-    expiration_date: undefined,
-    doses_shipped: undefined,
-    doses_received: undefined,
-    doses_per_vial: 20, //this is hardcoded in backend too, we need to think about it.
-};
 export const VaccineArrivalReports: FunctionComponent<Props> = ({
     className,
     items = [],

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/VaccineRequestForm/VaccineRequestForm.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/VaccineRequestForm/VaccineRequestForm.tsx
@@ -172,7 +172,10 @@ export const VaccineRequestForm: FunctionComponent<Props> = ({
                                     name="vrf.wastage_rate_used_on_vrf"
                                     component={NumberInput}
                                     disabled={false}
-                                    numberInputOptions={{ suffix: '%' }}
+                                    numberInputOptions={{
+                                        suffix: '%',
+                                        max: 100,
+                                    }}
                                 />
                             </Box>
                         </Grid>

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/hooks/utils.ts
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/hooks/utils.ts
@@ -40,11 +40,13 @@ const areArrayElementsChanged = (
 ): boolean => {
     return Boolean(
         newElements.find(el => {
+            // We need to loop on object keys because when setting a field to undefined
+            // formik may remove it from the form state, so we can't use isEqual or structuredClone
             const keys = Object.keys(el);
             const result = keys.find(
                 key =>
-                    key !== 'doses_per_vial' &&
-                    key !== 'vials_shipped' &&
+                    key !== 'doses_per_vial' && // this key is not sent to the backend so it's not relevant
+                    key !== 'vials_shipped' && // idem
                     el[key] !== undefined,
             );
 
@@ -62,9 +64,11 @@ const canSaveArrayTab = (
         ? // @ts-ignore we check that values[tab] is not undefined, so the ts error is wrong
           values[tab].slice(values[tab].length - 1)
         : [];
+    // If there's no new preAlert/arrivalReport, we just check that values have changed
     if (newElements.length === 0) {
         return !isEqual(initialValues[tab], values[tab]);
     }
+    // If an element has been added, we check that it's not empty
     return areArrayElementsChanged(newElements);
 };
 

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/hooks/utils.ts
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/hooks/utils.ts
@@ -84,7 +84,7 @@ const canSaveTab = (
         return canSaveArrayTab(PREALERT, initialValues, values);
     }
     if (tab === VAR) {
-        return canSaveArrayTab(PREALERT, initialValues, values);
+        return canSaveArrayTab(VAR, initialValues, values);
     }
     return false;
 };

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/types.ts
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/types.ts
@@ -38,7 +38,7 @@ export type VRFFormData = Omit<VRF, 'rounds'> & {
 
 export type PreAlert = {
     id?: number;
-    date_reception: string; // date in string form
+    date_pre_alert_reception: string; // date in string form
     po_number: string;
     eta: string;
     lot_number: number;


### PR DESCRIPTION
Save button in supplychain was sometimes wrongly enabled

Related JIRA tickets : POLIO-1452

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- For  pre alerts and arrival reports:
    - if no new element is added, we check that the values have been changed by comparing `values` with `initialValues`
    - else, we check that no new element added is empty 

## How to test

Go to supplychain, edit an existing item
Try to add a new prealert: add and delete values before saving, check  save button behaviour

Do the same with VAR/Arrival reports

## Print screen / video

https://github.com/BLSQ/iaso/assets/38907762/2451e39e-d33a-4911-8f1e-c5cf74a8af32




## Notes
Depends on https://github.com/BLSQ/bluesquare-components/pull/141
