### PR TITLE
Polio-1454: vaccine stocks: add create modal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6176,7 +6176,7 @@
         },
         "node_modules/bluesquare-components": {
             "version": "1.0.0",
-            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#4451b8e606800c8e8d4f1bccf1c04316abfd9a67",
+            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#1a6a08577974d40a4ea7043ed5869a5fa34446a8",
             "license": "Apache-2.0",
             "dependencies": {
                 "@babel/plugin-proposal-class-properties": "^7.18.6",
@@ -33227,7 +33227,7 @@
             "dev": true
         },
         "bluesquare-components": {
-            "version": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#4451b8e606800c8e8d4f1bccf1c04316abfd9a67",
+            "version": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#1a6a08577974d40a4ea7043ed5869a5fa34446a8",
             "from": "bluesquare-components@github:BLSQ/bluesquare-components",
             "requires": {
                 "@babel/plugin-proposal-class-properties": "^7.18.6",

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/CreateVaccineStock/CreateVaccineStock.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/CreateVaccineStock/CreateVaccineStock.tsx
@@ -1,0 +1,87 @@
+import React, { FunctionComponent } from 'react';
+import {
+    AddButton,
+    ConfirmCancelModal,
+    makeFullModal,
+    useSafeIntl,
+} from 'bluesquare-components';
+import { Field, FormikProvider, useFormik } from 'formik';
+import { isEqual } from 'lodash';
+import { Box } from '@mui/material';
+import { SingleSelect } from '../../../../components/Inputs/SingleSelect';
+import MESSAGES from '../messages';
+import { useSaveVaccineStock } from '../hooks/api';
+import { useGetCountriesOptions } from '../../SupplyChain/hooks/api/vrf';
+import { defaultVaccineOptions } from '../../SupplyChain/constants';
+
+type Props = {
+    isOpen: boolean;
+    closeDialog: () => void;
+};
+
+const CreateVaccineStock: FunctionComponent<Props> = ({
+    isOpen,
+    closeDialog,
+}) => {
+    const { formatMessage } = useSafeIntl();
+    const { mutateAsync: save } = useSaveVaccineStock();
+    // const validationSchema = useVaccineStockValidation();
+    const { data: countriesOptions, isFetching: isFetchingCountries } =
+        useGetCountriesOptions();
+
+    const formik = useFormik<any>({
+        initialValues: {
+            country: undefined,
+            vaccine: undefined,
+        },
+        onSubmit: values => save(values),
+        // validationSchema,
+    });
+    const title = formatMessage(MESSAGES.create);
+    const allowConfirm = formik.isValid && !isEqual(formik.touched, {});
+
+    return (
+        <FormikProvider value={formik}>
+            <ConfirmCancelModal
+                titleMessage={title}
+                onConfirm={() => formik.handleSubmit()}
+                allowConfirm={allowConfirm}
+                open={isOpen}
+                closeDialog={closeDialog}
+                id="vaccine-stock-modal"
+                dataTestId="vaccine-stock-modal"
+                onCancel={() => null}
+                onClose={() => {
+                    closeDialog();
+                }}
+                confirmMessage={MESSAGES.save}
+                cancelMessage={MESSAGES.cancel}
+            >
+                <Box mb={2} mt={2}>
+                    <Field
+                        label={formatMessage(MESSAGES.country)}
+                        name="country"
+                        component={SingleSelect}
+                        required
+                        options={countriesOptions}
+                        withMarginTop
+                        isLoading={isFetchingCountries}
+                    />
+                </Box>
+                <Field
+                    label={formatMessage(MESSAGES.vaccine)}
+                    name="vaccine"
+                    component={SingleSelect}
+                    required
+                    options={defaultVaccineOptions}
+                    withMarginTop
+                    // isLoading={isFetchingCountries}
+                />
+            </ConfirmCancelModal>
+        </FormikProvider>
+    );
+};
+
+const modalWithButton = makeFullModal(CreateVaccineStock, AddButton);
+
+export { modalWithButton as CreateVaccineStock };

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/VaccineStockManagement.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/VaccineStockManagement.tsx
@@ -8,6 +8,7 @@ import MESSAGES from './messages';
 import { VaccineStockManagementFilters } from './Filters/VaccineStockManagementFilters';
 import { VaccineStockManagementTable } from './Table/VaccineStockManagementTable';
 import { StockManagementListParams } from './types';
+import { CreateVaccineStock } from './CreateVaccineStock/CreateVaccineStock';
 
 type Props = { router: Router };
 
@@ -26,6 +27,9 @@ export const VaccineStockManagement: FunctionComponent<Props> = ({
                 <VaccineStockManagementFilters
                     params={router.params as StockManagementListParams}
                 />
+                <Box mt={2} justifyContent="flex-end" display="flex">
+                    <CreateVaccineStock iconProps={{}} />
+                </Box>
                 <VaccineStockManagementTable
                     params={router.params as StockManagementListParams}
                 />

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/hooks/api.ts
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/hooks/api.ts
@@ -1,6 +1,9 @@
 import { UseQueryResult } from 'react-query';
 import { UrlParams } from 'bluesquare-components';
-import { getRequest } from '../../../../../../../../hat/assets/js/apps/Iaso/libs/Api';
+import {
+    getRequest,
+    postRequest,
+} from '../../../../../../../../hat/assets/js/apps/Iaso/libs/Api';
 import { useUrlParams } from '../../../../../../../../hat/assets/js/apps/Iaso/hooks/useUrlParams';
 import {
     FormattedApiParams,
@@ -302,5 +305,16 @@ const createEditIncident = async (body: any) => {
 export const useSaveIncident = () => {
     return useSnackMutation({
         mutationFn: body => createEditIncident(body),
+    });
+};
+
+const saveVaccineStock = body => {
+    return postRequest(apiUrl, body);
+};
+
+export const useSaveVaccineStock = () => {
+    return useSnackMutation({
+        mutationFn: body => saveVaccineStock(body),
+        invalidateQueryKey: 'vaccine-stock-list',
     });
 };

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/constants.ts
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/constants.ts
@@ -3,3 +3,18 @@ export const VAR = 'arrival_reports';
 export const PREALERT = 'pre_alerts';
 
 export const apiUrl = '/api/polio/vaccine/request_forms/';
+
+export const defaultVaccineOptions = [
+    {
+        label: 'nOPV2',
+        value: 'nOPV2',
+    },
+    {
+        label: 'mOPV2',
+        value: 'mOPV2',
+    },
+    {
+        label: 'bOPV',
+        value: 'bOPV',
+    },
+];

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/hooks/api/vrf.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/hooks/api/vrf.tsx
@@ -30,7 +30,7 @@ import {
 } from '../../../../Campaigns/hooks/api/useGetCampaigns';
 import { Campaign } from '../../../../../constants/types';
 import { enqueueSnackbar } from '../../../../../../../../../hat/assets/js/apps/Iaso/redux/snackBarsReducer';
-import { apiUrl } from '../../constants';
+import { apiUrl, defaultVaccineOptions } from '../../constants';
 import {
     CampaignDropdowns,
     ParsedSettledPromise,
@@ -105,22 +105,6 @@ export const useGetCountriesOptions = (
         return { data: options, isFetching };
     }, [countries, isFetching]);
 };
-
-// This is just to avoid a warning polluting the console
-const defaultVaccineOptions = [
-    {
-        label: 'nOPV2',
-        value: 'nOPV2',
-    },
-    {
-        label: 'mOPV2',
-        value: 'mOPV2',
-    },
-    {
-        label: 'bOPV',
-        value: 'bOPV',
-    },
-];
 
 export const useCampaignDropDowns = (
     countryId?: number,


### PR DESCRIPTION
Add a create modal for vaccine stocks

Related JIRA tickets : POLIO-1454

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
NA

## Changes

- Add Create modal (no edit necessary) to the vaccine stocks list page. It enables creating a stock for a combination of country + vaccine.
- There's no validation since all inputs are through dropdowns
- It's possible to send the same country+vaccine to the backend twice, but the backend will refuse it with a 400. Preventing this at the front-end level would require additional endpoints

## How to test
Go to vaccine stocks try the button

## Print screen / video

Upload here print screens or videos showing the changes

## Notes

Merges into POLIO-1449-vaccine-stock-management-backend-form-a-destruction-incident-api
