### PR TITLE
IA-2621:  Org unit change request parent shape

### DIFF
--- a/hat/assets/js/apps/Iaso/components/maps/GeoJsonMapComponent.tsx
+++ b/hat/assets/js/apps/Iaso/components/maps/GeoJsonMapComponent.tsx
@@ -66,7 +66,6 @@ export const GeoJsonMap: FunctionComponent<Props> = ({ geoJson }) => {
                 />
 
                 <GeoJSON
-                    // @ts-ignore TODO: fix this type problem
                     style={{
                         color: theme.palette.secondary.main,
                     }}

--- a/hat/assets/js/apps/Iaso/components/maps/MarkerMapComponent.tsx
+++ b/hat/assets/js/apps/Iaso/components/maps/MarkerMapComponent.tsx
@@ -1,37 +1,58 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import React, { FunctionComponent, useState, useMemo } from 'react';
-import { GeoJSON, MapContainer, ScaleControl } from 'react-leaflet';
+import { useTheme } from '@mui/material/styles';
+import {
+    GeoJSON,
+    MapContainer,
+    ScaleControl,
+    Tooltip,
+    Pane,
+} from 'react-leaflet';
 import L from 'leaflet';
-
-import { makeStyles } from '@mui/styles';
 import { pink } from '@mui/material/colors';
-import { commonStyles } from 'bluesquare-components';
+import { commonStyles, useSafeIntl } from 'bluesquare-components';
 
-import { Box } from '@mui/material';
+import { Box, Alert, SxProps, Theme } from '@mui/material';
 import { CustomTileLayer } from './tools/CustomTileLayer';
 
 import tiles from '../../constants/mapTiles';
 import MarkerComponent from './markers/MarkerComponent';
 import { Tile } from './tools/TilesSwitchControl';
 import { CustomZoomControl } from './tools/CustomZoomControl';
-import { GeoJson } from './types';
+import { ShortOrgUnit } from '../../domains/orgUnits/types/orgUnit';
+import MESSAGES from './messages';
+import { useMarkerWithinBounds } from './hooks/useMarkerWithinBounds';
 
-const useStyles = makeStyles(theme => ({
-    mapContainer: {
-        ...commonStyles(theme).mapContainer,
-        height: 400,
-        minWidth: 200,
-        marginBottom: 0,
-        position: 'relative',
-    },
-}));
+const useStyles = () => {
+    const theme = useTheme();
+    return {
+        mapContainer: {
+            ...(commonStyles(theme).mapContainer as Record<
+                string,
+                SxProps<Theme>
+            >),
+            height: 400,
+            minWidth: 200,
+            marginBottom: 0,
+            position: 'relative',
+        },
+        alertContainer: {
+            zIndex: 402,
+            position: 'absolute',
+            top: 10,
+            left: 50,
+            maxWidth: 'calc(100% - 90px)',
+        },
+        alert: { padding: '0 6px', fontSize: 12, '& svg': { fontSize: 17 } },
+    };
+};
 
 type Props = {
     latitude: number | undefined;
     longitude: number | undefined;
     maxZoom?: number;
     mapHeight?: number;
-    parentGeoJson?: GeoJson;
+    parent?: ShortOrgUnit;
 };
 
 export const MarkerMap: FunctionComponent<Props> = ({
@@ -39,11 +60,12 @@ export const MarkerMap: FunctionComponent<Props> = ({
     longitude,
     maxZoom,
     mapHeight = 400,
-    parentGeoJson,
+    parent,
 }) => {
     const [currentTile, setCurrentTile] = useState<Tile>(tiles.osm);
+    const { formatMessage } = useSafeIntl();
 
-    const classes: Record<string, string> = useStyles();
+    const styles: Record<string, SxProps<Theme>> = useStyles();
 
     const boundsOptions: Record<string, [number, number] | number> = {
         padding: [50, 50],
@@ -52,18 +74,30 @@ export const MarkerMap: FunctionComponent<Props> = ({
 
     const bounds = useMemo(() => {
         let newBounds = L.latLngBounds([L.latLng(latitude, longitude)]);
-        if (parentGeoJson) {
-            const parentBounds = L.geoJSON(parentGeoJson).getBounds();
+        if (parent?.geo_json) {
+            const parentBounds = L.geoJSON(parent.geo_json).getBounds();
             newBounds = newBounds.isValid()
                 ? newBounds.extend(parentBounds)
                 : parentBounds;
         }
         return newBounds;
-    }, [latitude, longitude, parentGeoJson]);
+    }, [latitude, longitude, parent?.geo_json]);
 
+    const isMarkerInside = useMarkerWithinBounds(
+        latitude,
+        longitude,
+        parent?.geo_json,
+    );
     if (latitude === undefined || longitude === undefined) return null;
     return (
-        <Box className={classes.mapContainer} height={mapHeight}>
+        <Box sx={styles.mapContainer} height={mapHeight}>
+            {!isMarkerInside && (
+                <Box sx={styles.alertContainer}>
+                    <Alert severity="warning" sx={styles.alert}>
+                        {formatMessage(MESSAGES.locationNotInShape)}
+                    </Alert>
+                </Box>
+            )}
             <MapContainer
                 doubleClickZoom={false}
                 scrollWheelZoom={false}
@@ -84,23 +118,31 @@ export const MarkerMap: FunctionComponent<Props> = ({
                     currentTile={currentTile}
                     setCurrentTile={setCurrentTile}
                 />
-                <MarkerComponent
-                    item={{
-                        latitude,
-                        longitude,
-                    }}
-                    markerProps={() => ({
-                        fillColor: 'red',
-                    })}
-                />
-                {parentGeoJson && (
-                    <GeoJSON
-                        data={parentGeoJson}
-                        pathOptions={{
-                            color: pink['300'],
-                        }}
-                    />
+                {parent?.geo_json && (
+                    <Pane name="parent">
+                        <GeoJSON
+                            data={parent.geo_json}
+                            pathOptions={{
+                                color: pink['300'],
+                            }}
+                        >
+                            <Tooltip sticky pane="popupPane">
+                                {formatMessage(MESSAGES.parent)}: {parent.name}
+                            </Tooltip>
+                        </GeoJSON>
+                    </Pane>
                 )}
+                <Pane name="location">
+                    <MarkerComponent
+                        item={{
+                            latitude,
+                            longitude,
+                        }}
+                        markerProps={() => ({
+                            fillColor: 'red',
+                        })}
+                    />
+                </Pane>
             </MapContainer>
         </Box>
     );

--- a/hat/assets/js/apps/Iaso/components/maps/hooks/useMarkerWithinBounds.ts
+++ b/hat/assets/js/apps/Iaso/components/maps/hooks/useMarkerWithinBounds.ts
@@ -1,0 +1,20 @@
+import { useState, useEffect } from 'react';
+import L from 'leaflet';
+import { ShortOrgUnit } from '../../../domains/orgUnits/types/orgUnit';
+
+export const useMarkerWithinBounds = (
+    latitude: number | undefined,
+    longitude: number | undefined,
+    geoJson: ShortOrgUnit['geo_json'],
+): boolean => {
+    const [isMarkerInside, setIsMarkerInside] = useState(true);
+
+    useEffect(() => {
+        if (geoJson && latitude !== undefined && longitude !== undefined) {
+            const bounds = L.geoJSON(geoJson).getBounds();
+            setIsMarkerInside(bounds.contains(L.latLng(latitude, longitude)));
+        }
+    }, [latitude, longitude, geoJson]);
+
+    return isMarkerInside;
+};

--- a/hat/assets/js/apps/Iaso/components/maps/messages.js
+++ b/hat/assets/js/apps/Iaso/components/maps/messages.js
@@ -39,7 +39,8 @@ const MESSAGES = defineMessages({
     },
     locationNotInShape: {
         id: 'iaso.map.locationNotInShape',
-        defaultMessage: 'The location is not within the bounds of the shape.',
+        defaultMessage:
+            "The location is not within the bounds of the parent's shape.",
     },
 });
 

--- a/hat/assets/js/apps/Iaso/components/maps/messages.js
+++ b/hat/assets/js/apps/Iaso/components/maps/messages.js
@@ -33,6 +33,14 @@ const MESSAGES = defineMessages({
         id: 'iaso.map.title.markerClustering',
         defaultMessage: 'Clustering',
     },
+    parent: {
+        id: 'iaso.label.parent',
+        defaultMessage: 'Parent',
+    },
+    locationNotInShape: {
+        id: 'iaso.map.locationNotInShape',
+        defaultMessage: 'The location is not within the bounds of the shape.',
+    },
 });
 
 export default MESSAGES;

--- a/hat/assets/js/apps/Iaso/components/maps/tools/CustomTileLayer.tsx
+++ b/hat/assets/js/apps/Iaso/components/maps/tools/CustomTileLayer.tsx
@@ -28,7 +28,6 @@ export const CustomTileLayer: FunctionComponent<Props> = ({
             <TileLayer
                 ref={ref}
                 url={currentTile.url}
-                // @ts-ignore TODO: fix this type problem
                 attribution={currentTile.attribution || ''}
             />
             <TilesSwitchControl

--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -717,6 +717,7 @@
     "iaso.map.location": "Location",
     "iaso.map.locationLimit": "Map results limit",
     "iaso.map.locationLimit.error": "Please enter a correct value",
+    "iaso.map.locationNotInShape": "The location is not within the bounds of the shape.",
     "iaso.map.marker.delete": "Delete marker",
     "iaso.map.shape.addLocation": "Add a location",
     "iaso.map.shape.editCatchmentDisabled": "Catchment edition is disabled on this account",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -717,7 +717,7 @@
     "iaso.map.location": "Location",
     "iaso.map.locationLimit": "Map results limit",
     "iaso.map.locationLimit.error": "Please enter a correct value",
-    "iaso.map.locationNotInShape": "The location is not within the bounds of the shape.",
+    "iaso.map.locationNotInShape": "The location is not within the bounds of the parent's shape.",
     "iaso.map.marker.delete": "Delete marker",
     "iaso.map.shape.addLocation": "Add a location",
     "iaso.map.shape.editCatchmentDisabled": "Catchment edition is disabled on this account",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -717,6 +717,7 @@
     "iaso.map.location": "Localisation",
     "iaso.map.locationLimit": "Nombre max de résultats",
     "iaso.map.locationLimit.error": "Veuillez entrer une valeur correcte",
+    "iaso.map.locationNotInShape": "La localisation ne se trouve pas dans la limite de son parent",
     "iaso.map.marker.delete": "Effacer le marqueur",
     "iaso.map.shape.addLocation": "Ajouter un marqueur",
     "iaso.map.shape.editCatchmentDisabled": "L'édition du rayon est désactivée sur ce compte",

--- a/hat/assets/js/apps/Iaso/domains/assignments/components/AssignmentsMap.tsx
+++ b/hat/assets/js/apps/Iaso/domains/assignments/components/AssignmentsMap.tsx
@@ -227,7 +227,6 @@ export const AssignmentsMap: FunctionComponent<Props> = ({
                                     .map(shape => {
                                         return (
                                             <GeoJSON
-                                                // @ts-ignore TODO: fix this type problem
                                                 onEachFeature={(_, layer) =>
                                                     onEachFeature(
                                                         layer,
@@ -253,7 +252,6 @@ export const AssignmentsMap: FunctionComponent<Props> = ({
                                     )
                                     .map(shape => (
                                         <GeoJSON
-                                            // @ts-ignore TODO: fix this type problem
                                             onEachFeature={(_, layer) =>
                                                 onEachFeature(layer, shape)
                                             }
@@ -271,7 +269,6 @@ export const AssignmentsMap: FunctionComponent<Props> = ({
                             <Pane name="shapes-selected">
                                 {locations.shapes.selected.map(shape => (
                                     <GeoJSON
-                                        // @ts-ignore TODO: fix this type problem
                                         onEachFeature={(_, layer) =>
                                             onEachFeature(layer, shape)
                                         }
@@ -355,7 +352,6 @@ export const AssignmentsMap: FunctionComponent<Props> = ({
                                                     onParentClick(shape),
                                             }}
                                             data={shape.geoJson}
-                                            // @ts-ignore TODO: fix this type problem
                                             style={{
                                                 color: parentColor,
                                                 fillOpacity: '0',

--- a/hat/assets/js/apps/Iaso/domains/instances/compare/hooks/useGetInstance.ts
+++ b/hat/assets/js/apps/Iaso/domains/instances/compare/hooks/useGetInstance.ts
@@ -14,6 +14,8 @@ export const useGetInstance = (
         {
             enabled: Boolean(instanceId),
             retry: false,
+            staleTime: 1000 * 60 * 15,
+            cacheTime: 1000 * 60 * 5,
         },
     );
 };

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitsMap.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitsMap.tsx
@@ -260,7 +260,6 @@ export const OrgUnitsMap: FunctionComponent<Props> = ({
                                 <Pane name="no-org-unit-type" key={o.id}>
                                     <GeoJSON
                                         key={`${o.id}-${o.search_index}`}
-                                        // @ts-ignore TODO: fix this type problem
                                         style={{
                                             color: getSearchColor(
                                                 o.search_index || 0,
@@ -275,7 +274,6 @@ export const OrgUnitsMap: FunctionComponent<Props> = ({
                                         <OrgUnitPopupComponent
                                             currentOrgUnit={currentOrgUnit}
                                         />
-                                        {/* @ts-ignore TODO: fix this type problem */}
                                         <Tooltip pane="popupPane">
                                             {o.name}
                                         </Tooltip>
@@ -301,7 +299,6 @@ export const OrgUnitsMap: FunctionComponent<Props> = ({
                                     .map(o => (
                                         <GeoJSON
                                             key={`${o.id}-${o.search_index}`}
-                                            // @ts-ignore TODO: fix this type problem
                                             style={{
                                                 color: getSearchColor(
                                                     o.search_index || 0,

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/orgUnitMap/OrgUnitMap/OrgUnitMap.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/orgUnitMap/OrgUnitMap/OrgUnitMap.tsx
@@ -488,7 +488,6 @@ export const OrgUnitMap: FunctionComponent<Props> = ({
                 />
                 <MapContainer
                     key={currentOrgUnit.id}
-                    // @ts-ignore TODO: fix this type problem
                     maxZoom={currentTile.maxZoom}
                     style={{ height: '100%' }}
                     center={[0, 0]}
@@ -523,7 +522,6 @@ export const OrgUnitMap: FunctionComponent<Props> = ({
                                     data={
                                         state.ancestorWithGeoJson.value.geo_json
                                     }
-                                    // @ts-ignore TODO: fix this type problem
                                     style={() => ({
                                         color: pink['300'],
                                     })}

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/orgUnitMap/OrgUnitMap/OrgUnitTypesSelectedShapes.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/orgUnitMap/OrgUnitMap/OrgUnitTypesSelectedShapes.tsx
@@ -55,7 +55,6 @@ export const OrgUnitTypesSelectedShapes: FunctionComponent<Props> = ({
                                             click: () =>
                                                 fetchSubOrgUnitDetail(o),
                                         }}
-                                        // @ts-ignore TODO: fix this type problem
                                         style={() => ({
                                             color: ot.color,
                                         })}

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/orgUnitMap/OrgUnitMap/SourceShape.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/orgUnitMap/OrgUnitMap/SourceShape.tsx
@@ -21,7 +21,6 @@ export const SourceShape: FunctionComponent<Props> = ({
     const { formatMessage } = useSafeIntl();
     return (
         <GeoJSON
-            // @ts-ignore TODO: fix this type problem
             style={{
                 color: source.color,
             }}

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/Dialogs/ReviewOrgUnitChangesDialog.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/Dialogs/ReviewOrgUnitChangesDialog.tsx
@@ -29,7 +29,7 @@ Org Unit Change Request
 - Rejected → red
 
 If new:
-Left side: current org unit values (fetched from org unit API)
+Left side: old org unit values: org unit values at request creation time  Comes from change request API (old_value field)
 Right side: proposed changes. Red if not selected, green if selected
 
 

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/Dialogs/ReviewOrgUnitChangesDialog.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/Dialogs/ReviewOrgUnitChangesDialog.tsx
@@ -11,7 +11,6 @@ import {
     IconButton as IconButtonBlsq,
 } from 'bluesquare-components';
 import MESSAGES from '../messages';
-import { useGetApprovalProposal } from '../hooks/api/useGetApprovalProposal';
 import { SelectedChangeRequest } from '../Tables/ReviewOrgUnitChangesTable';
 import { useNewFields } from '../hooks/useNewFields';
 import { ApproveOrgUnitChangesButtons } from './ReviewOrgUnitChangesButtons';
@@ -19,6 +18,7 @@ import { ChangeRequestValidationStatus } from '../types';
 import { useSaveChangeRequest } from '../hooks/api/useSaveChangeRequest';
 import { ReviewOrgUnitChangesDetailsTable } from '../Tables/details/ReviewOrgUnitChangesDetailsTable';
 import { ReviewOrgUnitChangesDialogTitle } from './ReviewOrgUnitChangesDialogTitle';
+import { useGetApprovalProposal } from '../hooks/api/useGetApprovalProposal';
 
 /*
 Org Unit Change Request
@@ -45,7 +45,7 @@ Right side: proposed changes in red
 type Props = {
     isOpen: boolean;
     closeDialog: () => void;
-    selectedChangeRequest?: SelectedChangeRequest;
+    selectedChangeRequest: SelectedChangeRequest;
 };
 
 export const ReviewOrgUnitChangesDialog: FunctionComponent<Props> = ({
@@ -54,8 +54,9 @@ export const ReviewOrgUnitChangesDialog: FunctionComponent<Props> = ({
     selectedChangeRequest,
 }) => {
     const { formatMessage } = useSafeIntl();
+
     const { data: changeRequest, isFetching: isFetchingChangeRequest } =
-        useGetApprovalProposal(selectedChangeRequest?.id);
+        useGetApprovalProposal(selectedChangeRequest.id);
     const isNew: boolean =
         !isFetchingChangeRequest && changeRequest?.status === 'new';
     const { newFields, setSelected } = useNewFields(changeRequest);
@@ -69,8 +70,7 @@ export const ReviewOrgUnitChangesDialog: FunctionComponent<Props> = ({
         return formatMessage(MESSAGES.validateOrRejectChanges);
     }, [changeRequest?.status, formatMessage]);
     const { mutate: submitChangeRequest, isLoading: isSaving } =
-        useSaveChangeRequest(closeDialog, selectedChangeRequest?.id);
-    if (!selectedChangeRequest) return null;
+        useSaveChangeRequest(closeDialog, selectedChangeRequest.id);
 
     return (
         <SimpleModal

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/Tables/ReviewOrgUnitChangesTable.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/Tables/ReviewOrgUnitChangesTable.tsx
@@ -175,11 +175,13 @@ export const ReviewOrgUnitChangesTable: FunctionComponent<Props> = ({
     return (
         <>
             {/* This dialog is at this level to keep selected request in state and allow further multiaction/pagination feature */}
-            <ReviewOrgUnitChangesDialog
-                isOpen={Boolean(selectedChangeRequest)}
-                selectedChangeRequest={selectedChangeRequest}
-                closeDialog={handleCloseDialog}
-            />
+            {selectedChangeRequest && (
+                <ReviewOrgUnitChangesDialog
+                    isOpen
+                    selectedChangeRequest={selectedChangeRequest}
+                    closeDialog={handleCloseDialog}
+                />
+            )}
             {/* @ts-ignore */}
             <TableWithDeepLink
                 marginTop={false}

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/hooks/api/useGetApprovalProposal.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/hooks/api/useGetApprovalProposal.ts
@@ -5,21 +5,15 @@ import { OrgUnitChangeRequestDetails } from '../../types';
 
 const apiUrl = '/api/orgunits/changes/';
 
-const getOrgUnitChangeProposal = (id?: number) => {
-    const url = `${apiUrl}${id}/`;
-
-    return getRequest(url) as Promise<OrgUnitChangeRequestDetails>;
-};
-
 export const useGetApprovalProposal = (
     id?: number,
 ): UseQueryResult<OrgUnitChangeRequestDetails, Error> => {
     return useSnackQuery({
         queryKey: ['getApprovalProposal', id],
-        queryFn: () => getOrgUnitChangeProposal(id),
+        queryFn: () => getRequest(`${apiUrl}${id}/`),
         options: {
             enabled: Boolean(id),
-            staleTime: 1000 * 60 * 15, // in MS
+            staleTime: 1000 * 60 * 15,
             cacheTime: 1000 * 60 * 5,
         },
     });

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/hooks/api/useSaveChangeRequest.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/hooks/api/useSaveChangeRequest.ts
@@ -11,7 +11,7 @@ export type UseSaveChangeRequestQueryData = {
 
 export const useSaveChangeRequest = (
     closeDialog: () => void,
-    id?: number,
+    id: number,
 ): UseMutationResult =>
     useSnackMutation({
         mutationFn: (data: UseSaveChangeRequestQueryData) =>

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/hooks/useNewFields.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/hooks/useNewFields.tsx
@@ -213,10 +213,6 @@ export const useNewFields = (
                         fieldKey,
                         value,
                     );
-
-                    if (fieldKey === 'groups') {
-                        console.log(isChanged);
-                    }
                     const { label, order } = fieldDef;
                     return {
                         key: fieldKey,

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/hooks/useNewFields.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/hooks/useNewFields.tsx
@@ -14,12 +14,12 @@ import {
     NestedOrgUnitType,
     NestedLocation,
     OrgUnitChangeRequestDetails,
-    ShortOrgUnit,
 } from '../types';
 import { MarkerMap } from '../../../../components/maps/MarkerMapComponent';
 import { LinkToOrgUnit } from '../../components/LinkToOrgUnit';
 import MESSAGES from '../messages';
 import InstanceDetail from '../../../instances/compare/components/InstanceDetail';
+import { ShortOrgUnit } from '../../types/orgUnit';
 
 export type NewOrgUnitField = {
     key: string;
@@ -94,7 +94,7 @@ const getLocationValue = (
             latitude={location.latitude}
             maxZoom={8}
             mapHeight={300}
-            parentGeoJson={parent?.geo_json}
+            parent={parent}
         />
     );
 };

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/types.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/types.ts
@@ -2,7 +2,7 @@
 import { Pagination, UrlParams } from 'bluesquare-components';
 import { User } from '../../../utils/usersUtils';
 import { OrgunitType } from '../types/orgunitTypes';
-import { GeoJson } from '../../../components/maps/types';
+import { ShortOrgUnit } from '../types/orgUnit';
 
 export type ChangeRequestValidationStatus = 'new' | 'rejected' | 'approved';
 export type ApproveOrgUnitParams = UrlParams & {
@@ -52,11 +52,7 @@ export type OrgUnitChangeRequests = Array<OrgUnitChangeRequest>;
 export interface OrgUnitChangeRequestsPaginated extends Pagination {
     results: OrgUnitChangeRequest[];
 }
-export type ShortOrgUnit = {
-    name: string;
-    id: number;
-    geo_json?: GeoJson;
-};
+
 export type OrgUnitChangeRequestDetails = {
     id: number;
     uuid: string;

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/types.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/types.ts
@@ -1,8 +1,8 @@
 /* eslint-disable camelcase */
 import { Pagination, UrlParams } from 'bluesquare-components';
 import { User } from '../../../utils/usersUtils';
-import { ShortOrgUnit } from '../types/orgUnit';
 import { OrgunitType } from '../types/orgunitTypes';
+import { GeoJson } from '../../../components/maps/types';
 
 export type ChangeRequestValidationStatus = 'new' | 'rejected' | 'approved';
 export type ApproveOrgUnitParams = UrlParams & {
@@ -52,7 +52,11 @@ export type OrgUnitChangeRequests = Array<OrgUnitChangeRequest>;
 export interface OrgUnitChangeRequestsPaginated extends Pagination {
     results: OrgUnitChangeRequest[];
 }
-
+export type ShortOrgUnit = {
+    name: string;
+    id: number;
+    geo_json?: GeoJson;
+};
 export type OrgUnitChangeRequestDetails = {
     id: number;
     uuid: string;

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/types/orgUnit.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/types/orgUnit.ts
@@ -4,13 +4,14 @@ import { Shape } from './shapes';
 import { Nullable } from '../../../types/utils';
 import { Instance } from '../../instances/types/instance';
 import { OrgunitType } from './orgunitTypes';
+import { GeoJson } from '../../../components/maps/types';
 
 /* eslint-disable camelcase */
 export type ShortOrgUnit = {
     name: string;
     id: number;
+    geo_json?: GeoJson;
 };
-
 export type Group = {
     created_at: number;
     updated_at: number;

--- a/hat/assets/js/apps/Iaso/domains/registry/components/MapTooltip.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/MapTooltip.tsx
@@ -13,11 +13,7 @@ export const MapToolTip: FunctionComponent<Props> = ({
     pane,
 }) => {
     return (
-        <Tooltip
-            // @ts-ignore TODO: fix this type problem
-            permanent={permanent}
-            pane={pane}
-        >
+        <Tooltip permanent={permanent} pane={pane}>
             {label}
         </Tooltip>
     );

--- a/hat/assets/js/apps/Iaso/domains/registry/components/OrgUnitChildrenMap.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/OrgUnitChildrenMap.tsx
@@ -201,7 +201,6 @@ export const OrgUnitChildrenMap: FunctionComponent<Props> = ({
                         {orgUnit.geo_json && (
                             <Pane name="orgunit-shapes">
                                 <GeoJSON
-                                    // @ts-ignore TODO: fix this type problem
                                     className="secondary"
                                     data={orgUnit.geo_json}
                                     style={() => ({
@@ -246,7 +245,6 @@ export const OrgUnitChildrenMap: FunctionComponent<Props> = ({
                                 {orgUnitsShapes.map(childrenOrgUnit => (
                                     <GeoJSON
                                         key={childrenOrgUnit.id}
-                                        // @ts-ignore TODO: fix this type problem
                                         style={() => ({
                                             color: subType.color || '',
                                         })}

--- a/hat/assets/js/apps/Iaso/types/react-leaflet.d.ts
+++ b/hat/assets/js/apps/Iaso/types/react-leaflet.d.ts
@@ -1,0 +1,25 @@
+import { CSSProperties } from React;
+import 'react-leaflet';
+import { GeoJSON as LeafletGeoJSON } from 'leaflet';
+
+declare module 'react-leaflet' {
+    export interface TooltipProps {
+        permanent?: boolean;
+        sticky?: boolean;
+        pane?: string;
+    }
+    export interface GeoJSONProps {
+        style?: CSSProperties | ((feature: any) => CSSProperties);
+        onEachFeature?: (feature: any, layer: LeafletGeoJSON) => void;
+        className?: string;
+    }
+    export interface TileLayerProps {
+        attribution?: string;
+        position?:
+            | 'topleft'
+            | 'topright'
+            | 'bottomleft'
+            | 'bottomright'
+            | 'center';
+    }
+}

--- a/iaso/api/org_unit_change_requests/serializers.py
+++ b/iaso/api/org_unit_change_requests/serializers.py
@@ -8,6 +8,7 @@ from iaso.models import Instance, OrgUnit, OrgUnitChangeRequest, OrgUnitType
 from iaso.utils.serializer.id_or_uuid_field import IdOrUuidRelatedField
 from iaso.utils.serializer.three_dim_point_field import ThreeDimPointField
 from iaso.api.common import TimestampField
+from iaso.utils import geojson_queryset
 
 
 class UserNestedSerializer(serializers.ModelSerializer):
@@ -18,10 +19,18 @@ class UserNestedSerializer(serializers.ModelSerializer):
 
 
 class OrgUnitNestedSerializer(serializers.ModelSerializer):
+    geo_json = serializers.SerializerMethodField()
+
     class Meta:
         model = OrgUnit
-        fields = ["id", "name"]
+        fields = ["id", "name", "geo_json"]
         ref_name = "OrgUnitNestedSerializerForChangeRequest"
+
+    def get_geo_json(self, obj):
+        if obj.simplified_geom:
+            shape_queryset = OrgUnit.objects.filter(id=obj.id)
+            return geojson_queryset(shape_queryset, geometry_field="simplified_geom")
+        return None
 
 
 class OrgUnitTypeNestedSerializer(serializers.ModelSerializer):

--- a/plugins/polio/js/src/domains/Calendar/campaignCalendar/map/CalendarMap.tsx
+++ b/plugins/polio/js/src/domains/Calendar/campaignCalendar/map/CalendarMap.tsx
@@ -46,7 +46,6 @@ export const CalendarMap: FunctionComponent<Props> = ({
                 scrollWheelZoom={false}
             >
                 <TileLayer
-                    // @ts-ignore TODO: fix this type problem
                     attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
                     url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
                     position="bottomleft"

--- a/plugins/polio/js/src/domains/Calendar/campaignCalendar/map/CalendarMapPanesRegular.tsx
+++ b/plugins/polio/js/src/domains/Calendar/campaignCalendar/map/CalendarMapPanesRegular.tsx
@@ -27,7 +27,6 @@ export const CalendarMapPanesRegular: FunctionComponent<Props> = ({
                             <GeoJSON
                                 key={shape.id}
                                 data={shape.geo_json}
-                                // @ts-ignore TODO: fix this type problem
                                 style={() =>
                                     getGeoJsonStyle(
                                         campaignShape.color || color,


### PR DESCRIPTION
Add alert on whether the change request location falls within the parent's shape or not

Related JIRA tickets : IA-2621
## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are my typescript files well typed
- [x] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)


## Changes

- fixed typescript issues for react-leaflet and removed ts-ignore
- added geo_json on parent org unit in api
- hook to see if a location is within a shape
- customise markermap component to get a parent org unit and display it on map
- add popup if marker is not inside his parent shape
- covering edge case when you change parent too

## How to test

- make sure you have an org unit with a parent
- create a change request with this org unit and change the location  with something like this SRID=4326;POINT Z (23.0449 -2.9820 0)
- open change request dialog and check that everything is fine
- if you location is within the parent shape, edit the change request new location value and change lat or long to 0

## Print screen / video

![Screenshot 2024-02-01 at 12 51 05](https://github.com/BLSQ/iaso/assets/12494624/6c470b86-582a-4463-9696-f9c6cec73502)

