### PR TITLE
POLIO-1469: make doses related fields mandatory

### DIFF
--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/PreAlerts/PreAlert.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/PreAlerts/PreAlert.tsx
@@ -71,6 +71,7 @@ export const PreAlert: FunctionComponent<Props> = ({ index }) => {
                                 component={TextInput}
                                 disabled={markedForDeletion}
                                 shrinkLabel={false}
+                                required
                             />
                         </Grid>
                         {/* TODO make list */}
@@ -109,6 +110,7 @@ export const PreAlert: FunctionComponent<Props> = ({ index }) => {
                                 name={`pre_alerts[${index}].doses_shipped`}
                                 component={NumberInput}
                                 disabled={markedForDeletion}
+                                required
                             />
                         </Grid>
                     </Grid>

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/VAR/VaccineArrivalReport.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/VAR/VaccineArrivalReport.tsx
@@ -25,8 +25,12 @@ export const VaccineArrivalReport: FunctionComponent<Props> = ({ index }) => {
     const markedForDeletion = arrival_reports?.[index].to_delete ?? false;
 
     const doses_per_vial = arrival_reports?.[index].doses_per_vial ?? 20;
-    const current_vials_shipped = Math.ceil((arrival_reports?.[index].doses_shipped ?? 0) / doses_per_vial);
-    const current_vials_received = Math.ceil((arrival_reports?.[index].doses_received ?? 0) / doses_per_vial);
+    const current_vials_shipped = Math.ceil(
+        (arrival_reports?.[index].doses_shipped ?? 0) / doses_per_vial,
+    );
+    const current_vials_received = Math.ceil(
+        (arrival_reports?.[index].doses_received ?? 0) / doses_per_vial,
+    );
 
     return (
         <div className={classes.container}>
@@ -55,6 +59,7 @@ export const VaccineArrivalReport: FunctionComponent<Props> = ({ index }) => {
                                 component={TextInput}
                                 shrinkLabel={false}
                                 disabled={markedForDeletion}
+                                required
                             />
                         </Grid>
                         <Grid item xs={6} md={4}>
@@ -83,6 +88,7 @@ export const VaccineArrivalReport: FunctionComponent<Props> = ({ index }) => {
                                 name={`${VAR}[${index}].doses_shipped`}
                                 component={NumberInput}
                                 disabled={markedForDeletion}
+                                required
                             />
                         </Grid>
 
@@ -92,6 +98,7 @@ export const VaccineArrivalReport: FunctionComponent<Props> = ({ index }) => {
                                 name={`${VAR}[${index}].doses_received`}
                                 component={NumberInput}
                                 disabled={markedForDeletion}
+                                required
                             />
                         </Grid>
                     </Grid>
@@ -99,18 +106,20 @@ export const VaccineArrivalReport: FunctionComponent<Props> = ({ index }) => {
                     <Grid container item xs={12} spacing={2}>
                         <Grid item xs={6} md={4}>
                             <Typography variant="button">
-                                {`${formatMessage(MESSAGES.doses_per_vial)}:`} <NumberCell value={doses_per_vial} />
-                            </Typography>
-
-                        </Grid>
-                        <Grid item xs={6} md={4}>
-                            <Typography variant="button">
-                                {`${formatMessage(MESSAGES.vials_shipped)}:`} <NumberCell value={current_vials_shipped} />
+                                {`${formatMessage(MESSAGES.doses_per_vial)}:`}{' '}
+                                <NumberCell value={doses_per_vial} />
                             </Typography>
                         </Grid>
                         <Grid item xs={6} md={4}>
                             <Typography variant="button">
-                                {`${formatMessage(MESSAGES.vials_received)}:`} <NumberCell value={current_vials_received} />
+                                {`${formatMessage(MESSAGES.vials_shipped)}:`}{' '}
+                                <NumberCell value={current_vials_shipped} />
+                            </Typography>
+                        </Grid>
+                        <Grid item xs={6} md={4}>
+                            <Typography variant="button">
+                                {`${formatMessage(MESSAGES.vials_received)}:`}{' '}
+                                <NumberCell value={current_vials_received} />
                             </Typography>
                         </Grid>
                     </Grid>

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/VaccineRequestForm/VaccineRequestForm.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/VaccineRequestForm/VaccineRequestForm.tsx
@@ -161,6 +161,7 @@ export const VaccineRequestForm: FunctionComponent<Props> = ({
                                     name="vrf.quantities_ordered_in_doses"
                                     component={NumberInput}
                                     disabled={false}
+                                    required
                                 />
                             </Box>
                         </Grid>
@@ -211,6 +212,7 @@ export const VaccineRequestForm: FunctionComponent<Props> = ({
                                 name="vrf.quantities_approved_by_orpg_in_doses"
                                 component={NumberInput}
                                 disabled={false}
+                                required
                             />
                         </Grid>
                         <Grid item xs={6} md={3}>
@@ -243,6 +245,7 @@ export const VaccineRequestForm: FunctionComponent<Props> = ({
                                 name="vrf.quantities_approved_by_dg_in_doses"
                                 component={NumberInput}
                                 disabled={false}
+                                required
                             />
                         </Grid>
                         <Grid item xs={6} md={3}>

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/hooks/validation.ts
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/hooks/validation.ts
@@ -41,14 +41,23 @@ const useVrfShape = () => {
         id: yup.string().nullable(),
         country: yup
             .number()
-            .required()
+            .required(formatMessage(MESSAGES.requiredField))
             .nullable()
             .min(0, formatMessage(MESSAGES.positiveInteger))
             .integer()
             .typeError(formatMessage(MESSAGES.positiveInteger)),
-        campaign: yup.string().required().nullable(),
-        vaccine_type: yup.string().required().nullable(),
-        rounds: yup.mixed().nullable().required(),
+        campaign: yup
+            .string()
+            .required(formatMessage(MESSAGES.requiredField))
+            .nullable(),
+        vaccine_type: yup
+            .string()
+            .required(formatMessage(MESSAGES.requiredField))
+            .nullable(),
+        rounds: yup
+            .mixed()
+            .nullable()
+            .required(formatMessage(MESSAGES.requiredField)),
         date_vrf_signature: yup
             .date()
             .typeError(formatMessage(MESSAGES.invalidDate))
@@ -56,6 +65,7 @@ const useVrfShape = () => {
         quantities_ordered_in_doses: yup
             .number()
             .nullable()
+            .required(formatMessage(MESSAGES.requiredField))
             .min(0, formatMessage(MESSAGES.positiveInteger))
             .integer()
             .typeError(formatMessage(MESSAGES.positiveInteger)),
@@ -74,6 +84,7 @@ const useVrfShape = () => {
         quantities_approved_by_orpg_in_doses: yup
             .number()
             .nullable()
+            .required(formatMessage(MESSAGES.requiredField))
             .min(0, formatMessage(MESSAGES.positiveInteger))
             .integer()
             .typeError(formatMessage(MESSAGES.positiveInteger)),
@@ -88,6 +99,7 @@ const useVrfShape = () => {
         quantities_approved_by_dg_in_doses: yup
             .number()
             .nullable()
+            .required(formatMessage(MESSAGES.requiredField))
             .min(0, formatMessage(MESSAGES.positiveInteger))
             .integer()
             .typeError(formatMessage(MESSAGES.positiveInteger)),
@@ -106,7 +118,10 @@ const usePreAlertShape = () => {
             .date()
             .typeError(formatMessage(MESSAGES.invalidDate))
             .nullable(),
-        po_number: yup.string().nullable(),
+        po_number: yup
+            .string()
+            .nullable()
+            .required(formatMessage(MESSAGES.requiredField)),
         lot_numbers: yup
             .mixed()
             .nullable()
@@ -124,6 +139,7 @@ const usePreAlertShape = () => {
         doses_shipped: yup
             .number()
             .nullable()
+            .required(formatMessage(MESSAGES.requiredField))
             .min(0, formatMessage(MESSAGES.positiveInteger))
             .integer()
             .typeError(formatMessage(MESSAGES.positiveInteger)),
@@ -136,7 +152,10 @@ const useArrivalReportShape = () => {
             .date()
             .typeError(formatMessage(MESSAGES.invalidDate))
             .nullable(),
-        po_number: yup.string().nullable(),
+        po_number: yup
+            .string()
+            .nullable()
+            .required(formatMessage(MESSAGES.requiredField)),
         lot_numbers: yup
             .mixed()
             .nullable()
@@ -156,12 +175,14 @@ const useArrivalReportShape = () => {
         doses_shipped: yup
             .number()
             .nullable()
+            .required(formatMessage(MESSAGES.requiredField))
             .min(0, formatMessage(MESSAGES.positiveInteger))
             .integer()
             .typeError(formatMessage(MESSAGES.positiveInteger)),
         doses_received: yup
             .number()
             .nullable()
+            .required(formatMessage(MESSAGES.requiredField))
             .min(0, formatMessage(MESSAGES.positiveInteger))
             .integer()
             .typeError(formatMessage(MESSAGES.positiveInteger)),

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/messages.ts
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/messages.ts
@@ -298,6 +298,10 @@ const MESSAGES = defineMessages({
         id: 'iaso.polio.form.error.lotNumberError',
         defaultMessage: 'Please input numbers separated by a comma',
     },
+    requiredField: {
+        id: 'iaso.forms.error.fieldRequired',
+        defaultMessage: 'This field is required',
+    },
 });
 
 export default MESSAGES;


### PR DESCRIPTION


Related JIRA tickets : POLIO-1469

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
NA

## Changes

Make all fields related to doses mandatory in supply chain to avoid crashes in stock management

## How to test

 go to supply chain, test VRF, Pre altert and arrival reports: all doses related fields should bemarked with an `*`

## Print screen / video

![Screenshot 2024-02-02 at 16 05 53](https://github.com/BLSQ/iaso/assets/38907762/09019541-9740-482f-963d-213e9415481a
![Screenshot 2024-02-02 at 16 05 50](https://github.com/BLSQ/iaso/assets/38907762/cd9494ca-a26d-48d7-8252-851b82f9e66e)
)

![Screenshot 2024-02-02 at 16 05 47](https://github.com/BLSQ/iaso/assets/38907762/f60b015e-3186-4176-b76a-91fb4cf43849)



