### PR TITLE
IA-2684 Fix `default_platform` (bis)

### DIFF
--- a/.elasticbeanstalk/config.github.yml
+++ b/.elasticbeanstalk/config.github.yml
@@ -4,7 +4,7 @@ branch-defaults:
 global:
   application_name: Iaso
   default_ec2_keyname: iaso-eb
-  default_platform: arn:aws:elasticbeanstalk:eu-central-1::platform/Python 3.9 running on 64bit Amazon Linux 2023/4.0.7
+  default_platform: Python 3.9 running on 64bit Amazon Linux 2023
   default_region: eu-central-1
   include_git_submodules: true
   instance_profile: null


### PR DESCRIPTION
Fix Github Action Deploy Alert:

> The platform version that your environment is using isn’t recommended

Related JIRA tickets : [IA-2684](https://bluesquare.atlassian.net/browse/IA-2684)


[IA-2684]: https://bluesquare.atlassian.net/browse/IA-2684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ