### PR TITLE
IA-2643: Org Unit change requests filters

### DIFF
--- a/docs/pages/dev/reference/API/org_unit_registry.md
+++ b/docs/pages/dev/reference/API/org_unit_registry.md
@@ -85,13 +85,21 @@ The Django model that stores "Change Requests" is `OrgUnitChangeRequest`.
 - `page`: Int (optional) - Current page (default: 1)
 - `limit`: Int (optional) - Number of entities returned by page (default: 20)
 - `org_unit_id`: Int (optional) - Id of the OrgUnit to which the changes apply (default: null)
-- `org_unit_type_id`: Int (optional) - Id of the OrgUnitType to filter on, either the current OrgUnitType or in the change (default: null)
+- `org_unit_type_id`: Int (optional) - Id of the OrgUnitType to filter on, either the old OrgUnitType before the change or the new one after the change (default: null)
 - `status`: Array<Enum<Status>> (optional) - One of `new`, `validated`, `rejected` to filter the requests (default: null)
     - can be combined, e.g. `&status=rejected&status=new`
-- `parent_id`: Int (optional) - Id of the parent OrgUnit to filter on, either the current parent or in the change (default: null)
+- `parent_id`: Int (optional) - Id of the old parent OrgUnit to filter on, before the change (default: null)
 - `project`: Int (optional) - Id of the project to filter on.
-- `groups`: List of int, comma separated (optional) - Ids of the group to filter on, either the currents groups or in the change (default: null)
+- `groups`: List of int, comma separated (optional) - Ids of the old groups to filter on, before the change (default: null)
     - e.g. `&groups=1847,1846`
+- `forms`: List of int, comma separated (optional) - Ids of the old forms to filter on, before the change (default: null)
+    - e.g. `&forms=12,34`
+- `users`: List of int, comma separated (optional) - Ids of the users who either created or last updated the change request (default: null)
+    - e.g. `&users=56,78`
+- `user_roles`: List of int, comma separated (optional) - Ids of the old user roles to filter on, specifically the roles associated with the user who created the change request (default: null)
+    - e.g. `&user_roles=90,123`
+- `with_location`: String (optional) - Filters the change requests based on the presence (`"true"`) or absence (`"false"`) of an old location, before the change (default: null)
+    - e.g. `&with_location=true`
 
 ## Possible responses
 

--- a/hat/assets/js/apps/Iaso/constants/routes.js
+++ b/hat/assets/js/apps/Iaso/constants/routes.js
@@ -508,6 +508,22 @@ export const orgUnitChangeRequestPath = {
             key: 'created_at_before',
             isRequired: false,
         },
+        {
+            key: 'forms',
+            isRequired: false,
+        },
+        {
+            key: 'userIds',
+            isRequired: false,
+        },
+        {
+            key: 'userRoles',
+            isRequired: false,
+        },
+        {
+            key: 'withLocation',
+            isRequired: false,
+        },
     ],
 };
 export const registryPath = {

--- a/hat/assets/js/apps/Iaso/domains/instances/hooks/useGetProfilesDropdown.ts
+++ b/hat/assets/js/apps/Iaso/domains/instances/hooks/useGetProfilesDropdown.ts
@@ -7,7 +7,7 @@ import { getRequest } from '../../../libs/Api';
 import { makeUrlWithParams } from '../../../libs/utils';
 
 export const useGetProfilesDropdown = (
-    ids: string,
+    ids?: string,
 ): UseQueryResult<DropdownOptions<number>, Error> => {
     return useSnackQuery({
         queryKey: ['profiles', ids],

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/Filter/ReviewOrgUnitChangesFilter.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/Filter/ReviewOrgUnitChangesFilter.tsx
@@ -71,7 +71,7 @@ export const ReviewOrgUnitChangesFilter: FunctionComponent<Props> = ({
     );
 
     return (
-        <Box mb={4}>
+        <>
             <Grid container spacing={2}>
                 <Grid item xs={12} md={4} lg={3}>
                     <InputComponent
@@ -193,6 +193,6 @@ export const ReviewOrgUnitChangesFilter: FunctionComponent<Props> = ({
                     </Box>
                 </Grid>
             </Grid>
-        </Box>
+        </>
     );
 };

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/Filter/ReviewOrgUnitChangesFilter.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/Filter/ReviewOrgUnitChangesFilter.tsx
@@ -71,35 +71,9 @@ export const ReviewOrgUnitChangesFilter: FunctionComponent<Props> = ({
     );
 
     return (
-        <>
+        <Box mb={4}>
             <Grid container spacing={2}>
                 <Grid item xs={12} md={4} lg={3}>
-                    <DatesRange
-                        xs={12}
-                        sm={12}
-                        md={12}
-                        lg={12}
-                        keyDateFrom="created_at_after"
-                        keyDateTo="created_at_before"
-                        onChangeDate={handleChange}
-                        dateFrom={filters.created_at_after}
-                        dateTo={filters.created_at_before}
-                        labelFrom={MESSAGES.createdDateFrom}
-                        labelTo={MESSAGES.createdDateTo}
-                    />
-                </Grid>
-                <Grid item xs={12} md={4} lg={3}>
-                    <InputComponent
-                        type="select"
-                        multi
-                        clearable
-                        keyValue="org_unit_type_id"
-                        value={filters.org_unit_type_id}
-                        onChange={handleChange}
-                        loading={isLoadingTypes}
-                        options={orgUnitTypeOptions}
-                        labelString={formatMessage(MESSAGES.orgUnitType)}
-                    />
                     <InputComponent
                         type="select"
                         multi
@@ -110,8 +84,6 @@ export const ReviewOrgUnitChangesFilter: FunctionComponent<Props> = ({
                         options={statusOptions}
                         labelString={formatMessage(MESSAGES.status)}
                     />
-                </Grid>
-                <Grid item xs={12} md={4} lg={3}>
                     <InputComponent
                         type="select"
                         multi
@@ -134,19 +106,7 @@ export const ReviewOrgUnitChangesFilter: FunctionComponent<Props> = ({
                         loading={isLoadingForms}
                         labelString={formatMessage(MESSAGES.forms)}
                     />
-                    <InputComponent
-                        type="select"
-                        multi
-                        clearable
-                        keyValue="userRoles"
-                        value={filters.userRoles}
-                        onChange={handleChange}
-                        loading={isFetchingUserRoles}
-                        options={userRoles}
-                        labelString={formatMessage(MESSAGES.userRoles)}
-                    />
                 </Grid>
-
                 <Grid item xs={12} md={4} lg={3}>
                     <OrgUnitTreeviewModal
                         toggleOnLabelClick={false}
@@ -155,6 +115,17 @@ export const ReviewOrgUnitChangesFilter: FunctionComponent<Props> = ({
                             handleChange('parent_id', orgUnit?.id);
                         }}
                         initialSelection={initialOrgUnit}
+                    />
+                    <InputComponent
+                        type="select"
+                        multi
+                        clearable
+                        keyValue="org_unit_type_id"
+                        value={filters.org_unit_type_id}
+                        onChange={handleChange}
+                        loading={isLoadingTypes}
+                        options={orgUnitTypeOptions}
+                        labelString={formatMessage(MESSAGES.orgUnitType)}
                     />
                     <InputComponent
                         keyValue="withLocation"
@@ -174,6 +145,8 @@ export const ReviewOrgUnitChangesFilter: FunctionComponent<Props> = ({
                         ]}
                         label={MESSAGES.location}
                     />
+                </Grid>
+                <Grid item xs={12} md={4} lg={3}>
                     <Box mt={2}>
                         <AsyncSelect
                             keyValue="userIds"
@@ -185,25 +158,41 @@ export const ReviewOrgUnitChangesFilter: FunctionComponent<Props> = ({
                             fetchOptions={input => getUsersDropDown(input)}
                         />
                     </Box>
+                    <InputComponent
+                        type="select"
+                        multi
+                        clearable
+                        keyValue="userRoles"
+                        value={filters.userRoles}
+                        onChange={handleChange}
+                        loading={isFetchingUserRoles}
+                        options={userRoles}
+                        labelString={formatMessage(MESSAGES.userRoles)}
+                    />
+                </Grid>
+
+                <Grid item xs={12} md={4} lg={3}>
+                    <DatesRange
+                        xs={12}
+                        sm={12}
+                        md={12}
+                        lg={12}
+                        keyDateFrom="created_at_after"
+                        keyDateTo="created_at_before"
+                        onChangeDate={handleChange}
+                        dateFrom={filters.created_at_after}
+                        dateTo={filters.created_at_before}
+                        labelFrom={MESSAGES.createdDateFrom}
+                        labelTo={MESSAGES.createdDateTo}
+                    />
+                    <Box mt={2} display="flex" justifyContent="flex-end">
+                        <FilterButton
+                            disabled={!filtersUpdated}
+                            onFilter={handleSearch}
+                        />
+                    </Box>
                 </Grid>
             </Grid>
-
-            <Box
-                display="flex"
-                justifyContent="flex-start"
-                alignItems="end"
-                flexDirection="column"
-                width="100%"
-                mb={3}
-                mt={-1}
-            >
-                <Box mt={2}>
-                    <FilterButton
-                        disabled={!filtersUpdated}
-                        onFilter={handleSearch}
-                    />
-                </Box>
-            </Box>
-        </>
+        </Box>
     );
 };

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/Filter/ReviewOrgUnitChangesFilter.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/Filter/ReviewOrgUnitChangesFilter.tsx
@@ -62,7 +62,7 @@ export const ReviewOrgUnitChangesFilter: FunctionComponent<Props> = ({
         ],
         [formatMessage],
     );
-    const joinValuesBeforeHandleFormChange = useCallback(
+    const handleChangeUsers = useCallback(
         (keyValue, newValue) => {
             const joined = newValue?.map(r => r.value)?.join(',');
             handleChange(keyValue, joined);
@@ -152,7 +152,7 @@ export const ReviewOrgUnitChangesFilter: FunctionComponent<Props> = ({
                             keyValue="userIds"
                             label={MESSAGES.user}
                             value={selectedUsers ?? ''}
-                            onChange={joinValuesBeforeHandleFormChange}
+                            onChange={handleChangeUsers}
                             debounceTime={500}
                             multi
                             fetchOptions={input => getUsersDropDown(input)}

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/ReviewOrgUnitChanges.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/ReviewOrgUnitChanges.tsx
@@ -5,21 +5,17 @@ import { commonStyles, useSafeIntl } from 'bluesquare-components';
 import { ReviewOrgUnitChangesFilter } from './Filter/ReviewOrgUnitChangesFilter';
 import { ReviewOrgUnitChangesTable } from './Tables/ReviewOrgUnitChangesTable';
 import { useGetApprovalProposals } from './hooks/api/useGetApprovalProposals';
-import { Router } from '../../../types/general';
 import TopBar from '../../../components/nav/TopBarComponent';
 import { ApproveOrgUnitParams } from './types';
 import MESSAGES from './messages';
 
-type Props = { router: Router; params: ApproveOrgUnitParams };
+type Props = { params: ApproveOrgUnitParams };
 
 const useStyles = makeStyles(theme => ({
     ...commonStyles(theme),
 }));
 
-export const ReviewOrgUnitChanges: FunctionComponent<Props> = ({
-    router,
-    params,
-}) => {
+export const ReviewOrgUnitChanges: FunctionComponent<Props> = ({ params }) => {
     const { data, isFetching } = useGetApprovalProposals(params);
     const classes: Record<string, string> = useStyles();
     const { formatMessage } = useSafeIntl();
@@ -27,7 +23,7 @@ export const ReviewOrgUnitChanges: FunctionComponent<Props> = ({
         <div>
             <TopBar title={formatMessage(MESSAGES.reviewChangeProposals)} />
             <Box className={classes.containerFullHeightNoTabPadded}>
-                <ReviewOrgUnitChangesFilter params={router.params} />
+                <ReviewOrgUnitChangesFilter params={params} />
                 <ReviewOrgUnitChangesTable
                     data={data}
                     isFetching={isFetching}

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/Tables/ReviewOrgUnitChangesTable.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/Tables/ReviewOrgUnitChangesTable.tsx
@@ -191,7 +191,7 @@ export const ReviewOrgUnitChangesTable: FunctionComponent<Props> = ({
                 columns={columns}
                 count={data?.count ?? 0}
                 baseUrl={baseUrl}
-                countOnTop={false}
+                countOnTop
                 params={params}
                 extraProps={{ loading: isFetching, selectedChangeRequest }}
                 onTableParamsChange={p => {

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/hooks/api/useGetApprovalProposals.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/hooks/api/useGetApprovalProposals.ts
@@ -20,6 +20,10 @@ const getOrgUnitChangeProposals = (options: ApproveOrgUnitParams) => {
         page: options.page,
         created_at_after: options.created_at_after,
         created_at_before: options.created_at_before,
+        forms: options.forms,
+        users: options.userIds,
+        user_roles: options.userRoles,
+        with_location: options.withLocation,
     };
 
     const url = makeUrlWithParams(apiUrl, apiParams);

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/messages.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/messages.ts
@@ -153,6 +153,26 @@ const MESSAGES = defineMessages({
         id: 'iaso.label.close',
         defaultMessage: 'Close',
     },
+    forms: {
+        defaultMessage: 'Forms',
+        id: 'iaso.forms.title',
+    },
+    user: {
+        id: 'iaso.label.user',
+        defaultMessage: 'User',
+    },
+    userRoles: {
+        defaultMessage: 'User roles',
+        id: 'iaso.label.userRoles',
+    },
+    with: {
+        id: 'iaso.label.with',
+        defaultMessage: 'With',
+    },
+    without: {
+        id: 'iaso.label.without',
+        defaultMessage: 'Without',
+    },
 });
 
 export default MESSAGES;

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/types.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/types.ts
@@ -12,6 +12,10 @@ export type ApproveOrgUnitParams = UrlParams & {
     status?: ChangeRequestValidationStatus;
     created_at_after?: string;
     created_at_before?: string;
+    forms?: string;
+    userIds?: string;
+    userRoles?: string;
+    withLocation?: string;
 };
 export type Group = {
     id: number;

--- a/iaso/api/org_unit_change_requests/filters.py
+++ b/iaso/api/org_unit_change_requests/filters.py
@@ -5,6 +5,9 @@ from django.conf import settings
 from django.db.models import Q
 from django.db.models.query import QuerySet
 from django.utils.translation import gettext_lazy as _
+from django.contrib.gis.geos import GEOSGeometry
+from django.db.models.functions import Cast
+from django.contrib.gis.db.models import PointField
 
 from iaso.models import OrgUnitChangeRequest, OrgUnit
 
@@ -25,6 +28,11 @@ class OrgUnitChangeRequestListFilter(django_filters.rest_framework.FilterSet):
     project = django_filters.NumberFilter(field_name="org_unit__org_unit_type__projects", label=_("Project ID"))
     created_at = django_filters.DateFromToRangeFilter()
 
+    forms = django_filters.CharFilter(method="filter_forms", label=_("Forms IDs (comma-separated)"))
+    users = django_filters.CharFilter(method="filter_users", label=_("Users IDs (comma-separated)"))
+    user_roles = django_filters.CharFilter(method="filter_user_roles", label=_("User roles IDs (comma-separated)"))
+    with_location = django_filters.CharFilter(method="filter_with_location", label=_("With or without location"))
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.form.fields["created_at"].fields[0].input_formats = settings.API_DATE_INPUT_FORMATS
@@ -39,12 +47,12 @@ class OrgUnitChangeRequestListFilter(django_filters.rest_framework.FilterSet):
             parent = OrgUnit.objects.get(id=value)
             parent_qs = OrgUnit.objects.filter(id=parent.id)
             descendants_qs = OrgUnit.objects.hierarchy(parent_qs).values_list("id", flat=True)
-            return queryset.filter(Q(org_unit_id__in=descendants_qs) | Q(new_parent_id__in=descendants_qs))
+            return queryset.filter(Q(old_parent_id__in=descendants_qs) | Q(new_parent_id__in=descendants_qs))
         except OrgUnit.DoesNotExist:
             raise ValidationError({"parent_id": [f"OrgUnit with id {value} does not exist."]})
 
     def filter_org_unit_type_id(self, queryset: QuerySet, _, value: str) -> QuerySet:
-        return queryset.filter(Q(org_unit__org_unit_type_id=value) | Q(new_org_unit_type_id=value))
+        return queryset.filter(Q(old__org_unit_type_id=value) | Q(new_org_unit_type_id=value))
 
     def filter_groups(self, queryset: QuerySet, name: str, value: str) -> QuerySet:
         """
@@ -53,4 +61,54 @@ class OrgUnitChangeRequestListFilter(django_filters.rest_framework.FilterSet):
         groups_ids = [val for val in value.split(",") if val.isnumeric()]
         if not groups_ids:
             raise ValidationError({name: ["Invalid value."]})
-        return queryset.filter(Q(org_unit__groups__in=groups_ids) | Q(new_groups__in=groups_ids))
+        return queryset.filter(Q(old_groups__in=groups_ids) | Q(new_groups__in=groups_ids))
+
+    def filter_forms(self, queryset: QuerySet, name: str, value: str) -> QuerySet:
+        """
+        `value` is intended to be a comma-separated list of numeric chars.
+        """
+        forms_ids = [val for val in value.split(",") if val.isnumeric()]
+        if not forms_ids:
+            raise ValidationError({name: ["Invalid value."]})
+        forms_ids = [int(form_id) for form_id in forms_ids]
+        return queryset.filter(
+            Q(old_reference_instances__form_id__in=forms_ids) | Q(new_reference_instances__form_id__in=forms_ids)
+        )
+
+    def filter_users(self, queryset: QuerySet, name: str, value: str) -> QuerySet:
+        """
+        `value` is intended to be a comma-separated list of numeric chars.
+        """
+        users_ids = [val for val in value.split(",") if val.isnumeric()]
+        if not users_ids:
+            raise ValidationError({name: ["Invalid value."]})
+        users_ids = [int(user_id) for user_id in users_ids]
+        return queryset.filter(Q(created_by_id__in=users_ids) | Q(updated_by__in=users_ids))
+
+    def filter_user_roles(self, queryset: QuerySet, name: str, value: str) -> QuerySet:
+        """
+        `value` is intended to be a comma-separated list of numeric chars.
+        """
+        users_roles_ids = [val for val in value.split(",") if val.isnumeric()]
+        if not users_roles_ids:
+            raise ValidationError({name: ["Invalid value."]})
+        users_roles_ids = [int(users_roles_id) for users_roles_id in users_roles_ids]
+        return queryset.filter(
+            Q(created_by__iaso_profile__user_roles__id__in=users_roles_ids)
+            | Q(updated_by__iaso_profile__user_roles__id__in=users_roles_ids)
+        )
+
+    def filter_with_location(self, queryset: QuerySet, name: str, value: str) -> QuerySet:
+        """
+        `value` is intended to be boolean string "true" or "false".
+        """
+
+        has_location = Q(new_location__isnull=False) | Q(old_location__isnull=False)
+
+        if value == "true":
+            queryset = queryset.filter(has_location)
+
+        if value == "false":
+            queryset = queryset.exclude(has_location)
+
+        return queryset

--- a/iaso/tests/api/org_unit_change_requests/test_org_unit_change_requests.py
+++ b/iaso/tests/api/org_unit_change_requests/test_org_unit_change_requests.py
@@ -3,8 +3,10 @@ import datetime
 import time_machine
 
 from django.utils import timezone
+from django.contrib.auth.models import Group
 
 from iaso.test import APITestCase
+from django.contrib.gis.geos import Point
 from iaso import models as m
 
 
@@ -19,17 +21,16 @@ class OrgUnitChangeRequestAPITestCase(APITestCase):
     def setUpTestData(cls):
         data_source = m.DataSource.objects.create(name="Data source")
         version = m.SourceVersion.objects.create(number=1, data_source=data_source)
-        account = m.Account.objects.create(name="Account", default_version=version)
-        project = m.Project.objects.create(name="Project", account=account, app_id="foo.bar.baz")
-
         org_unit_type = m.OrgUnitType.objects.create(name="Org unit type")
         org_unit = m.OrgUnit.objects.create(
             org_unit_type=org_unit_type, version=version, uuid="1539f174-4c53-499c-85de-7a58458c49ef"
         )
 
-        user = cls.create_user_with_profile(username="user", account=account)
+        cls.account = m.Account.objects.create(name="Account", default_version=version)
+        project = m.Project.objects.create(name="Project", account=cls.account, app_id="foo.bar.baz")
+        user = cls.create_user_with_profile(username="user", account=cls.account)
         user_with_review_perm = cls.create_user_with_profile(
-            username="user_with_review_perm", account=account, permissions=["iaso_org_unit_change_request_review"]
+            username="user_with_review_perm", account=cls.account, permissions=["iaso_org_unit_change_request_review"]
         )
 
         data_source.projects.set([project])
@@ -268,3 +269,166 @@ class OrgUnitChangeRequestAPITestCase(APITestCase):
         response = self.client.get("/api/orgunits/changes/?created_at_before=17-10-2022")
         self.assertJSONResponse(response, 200)
         self.assertEqual(1, len(response.data["results"]))
+
+    def test_filter_on_forms(self):
+        form = m.Form.objects.create(name="Test Form")
+        instance = m.Instance.objects.create(
+            org_unit=self.org_unit,
+            form=form,
+            period="202001",
+            project=self.project,
+        )
+
+        change_request1 = m.OrgUnitChangeRequest.objects.create(org_unit=self.org_unit, new_name="Foo")
+        change_request1.new_reference_instances.add(instance)
+        change_request2 = m.OrgUnitChangeRequest.objects.create(org_unit=self.org_unit, new_name="Bar")
+        change_request2.old_reference_instances.add(instance)
+
+        self.client.force_authenticate(self.user)
+        response = self.client.get(f"/api/orgunits/changes/?forms={form.id}")
+        self.assertJSONResponse(response, 200)
+        self.assertEqual(len(response.data["results"]), 2)
+        self.assertIn(change_request1.id, [change["id"] for change in response.data["results"]])
+        self.assertIn(change_request2.id, [change["id"] for change in response.data["results"]])
+
+    def test_filter_on_groups(self):
+        group1 = m.Group.objects.create(name="Group 1")
+        group2 = m.Group.objects.create(name="Group 2")
+
+        # Create change requests with new groups
+        change_request1 = m.OrgUnitChangeRequest.objects.create(org_unit=self.org_unit, new_name="Foo")
+        change_request1.new_groups.add(group1)
+
+        # Create change requests with old groups
+        change_request2 = m.OrgUnitChangeRequest.objects.create(org_unit=self.org_unit, new_name="Bar")
+        change_request2.old_groups.add(group2)
+
+        self.client.force_authenticate(self.user)
+
+        # Test filtering by both new and old groups
+        response = self.client.get(f"/api/orgunits/changes/?groups={group1.id},{group2.id}")
+        self.assertJSONResponse(response, 200)
+        self.assertEqual(len(response.data["results"]), 2)
+        self.assertIn(change_request1.id, [change["id"] for change in response.data["results"]])
+        self.assertIn(change_request2.id, [change["id"] for change in response.data["results"]])
+
+        # Test filtering by new groups only
+        response = self.client.get(f"/api/orgunits/changes/?groups={group1.id}")
+        self.assertJSONResponse(response, 200)
+        self.assertEqual(len(response.data["results"]), 1)
+        self.assertIn(change_request1.id, [change["id"] for change in response.data["results"]])
+        self.assertNotIn(change_request2.id, [change["id"] for change in response.data["results"]])
+
+        # Test filtering by old groups only
+        response = self.client.get(f"/api/orgunits/changes/?groups={group2.id}")
+        self.assertJSONResponse(response, 200)
+        self.assertEqual(len(response.data["results"]), 1)
+        self.assertNotIn(change_request1.id, [change["id"] for change in response.data["results"]])
+        self.assertIn(change_request2.id, [change["id"] for change in response.data["results"]])
+
+    def test_filter_on_parent_id(self):
+        parent_org_unit = m.OrgUnit.objects.create(name="Parent Org Unit")
+        another_parent_org_unit = m.OrgUnit.objects.create(name="Another Parent Org Unit")
+
+        # Create a change request with a new parent
+        change_request1 = m.OrgUnitChangeRequest.objects.create(
+            org_unit=self.org_unit, new_name="Foo", new_parent=parent_org_unit
+        )
+
+        # Create a change request with an old parent
+        change_request2 = m.OrgUnitChangeRequest.objects.create(
+            org_unit=self.org_unit, new_name="Bar", old_parent=another_parent_org_unit
+        )
+
+        change_request2.old_parent = another_parent_org_unit
+        change_request2.save()
+        self.client.force_authenticate(self.user)
+
+        # Test filtering by new parent
+        response = self.client.get(f"/api/orgunits/changes/?parent_id={parent_org_unit.id}")
+        self.assertJSONResponse(response, 200)
+        self.assertEqual(len(response.data["results"]), 1)
+        self.assertIn(change_request1.id, [change["id"] for change in response.data["results"]])
+        self.assertNotIn(change_request2.id, [change["id"] for change in response.data["results"]])
+
+        # Test filtering by old parent
+        response = self.client.get(f"/api/orgunits/changes/?parent_id={another_parent_org_unit.id}")
+        self.assertJSONResponse(response, 200)
+        self.assertEqual(len(response.data["results"]), 1)
+        self.assertNotIn(change_request1.id, [change["id"] for change in response.data["results"]])
+        self.assertIn(change_request2.id, [change["id"] for change in response.data["results"]])
+
+    def test_filter_on_org_unit_type_id(self):
+        org_unit_type = m.OrgUnitType.objects.create(name="New Org Unit Type")
+        change_request1 = m.OrgUnitChangeRequest.objects.create(
+            org_unit=self.org_unit, new_name="Foo", new_org_unit_type=org_unit_type
+        )
+        change_request2 = m.OrgUnitChangeRequest.objects.create(org_unit=self.org_unit, new_name="Bar")
+
+        self.client.force_authenticate(self.user)
+        response = self.client.get(f"/api/orgunits/changes/?org_unit_type_id={org_unit_type.id}")
+        self.assertJSONResponse(response, 200)
+        self.assertEqual(len(response.data["results"]), 1)
+        self.assertIn(change_request1.id, [change["id"] for change in response.data["results"]])
+        self.assertNotIn(change_request2.id, [change["id"] for change in response.data["results"]])
+
+    def test_filter_on_users(self):
+        another_user = self.create_user_with_profile(username="another_user", account=self.account)
+        change_request1 = m.OrgUnitChangeRequest.objects.create(
+            org_unit=self.org_unit, new_name="Foo", created_by=another_user
+        )
+        change_request2 = m.OrgUnitChangeRequest.objects.create(
+            org_unit=self.org_unit, new_name="Foo", created_by=self.user
+        )
+
+        self.client.force_authenticate(self.user)
+        response = self.client.get(f"/api/orgunits/changes/?users={another_user.id}")
+        self.assertJSONResponse(response, 200)
+        self.assertEqual(len(response.data["results"]), 1)
+        self.assertIn(change_request1.id, [change["id"] for change in response.data["results"]])
+        self.assertNotIn(change_request2.id, [change["id"] for change in response.data["results"]])
+
+    def test_filter_on_user_roles(self):
+        group = Group.objects.create(name="Group")
+        user_role = m.UserRole.objects.create(account=self.account, group=group)
+        another_user = self.create_user_with_profile(username="another_user", account=self.account)
+        self.user.iaso_profile.user_roles.add(user_role)
+        change_request1 = m.OrgUnitChangeRequest.objects.create(
+            org_unit=self.org_unit, new_name="Foo", created_by=self.user
+        )
+        change_request2 = m.OrgUnitChangeRequest.objects.create(
+            org_unit=self.org_unit, new_name="Foo", created_by=another_user
+        )
+
+        self.client.force_authenticate(self.user)
+        response = self.client.get(f"/api/orgunits/changes/?user_roles={user_role.id}")
+        self.assertJSONResponse(response, 200)
+        self.assertEqual(len(response.data["results"]), 1)
+        self.assertIn(change_request1.id, [change["id"] for change in response.data["results"]])
+        self.assertNotIn(change_request2.id, [change["id"] for change in response.data["results"]])
+
+    def test_filter_on_with_location(self):
+        change_request_with_new_location = m.OrgUnitChangeRequest.objects.create(
+            org_unit=self.org_unit,
+            new_name="Foo",
+            new_location=Point(0, 0, 0, srid=4326),
+        )
+        change_request_with_old_location = m.OrgUnitChangeRequest.objects.create(
+            org_unit=self.org_unit,
+            new_name="Foo",
+        )
+        change_request_with_old_location.old_location = Point(0, 0, 0, srid=4326)
+        change_request_with_old_location.save()
+        change_request_without_location = m.OrgUnitChangeRequest.objects.create(org_unit=self.org_unit, new_name="Bar")
+
+        self.client.force_authenticate(self.user)
+        response = self.client.get("/api/orgunits/changes/?with_location=true")
+        self.assertJSONResponse(response, 200)
+        self.assertEqual(len(response.data["results"]), 2)
+        self.assertIn(change_request_with_new_location.id, [change["id"] for change in response.data["results"]])
+        self.assertIn(change_request_with_old_location.id, [change["id"] for change in response.data["results"]])
+
+        response = self.client.get("/api/orgunits/changes/?with_location=false")
+        self.assertJSONResponse(response, 200)
+        self.assertEqual(len(response.data["results"]), 1)
+        self.assertIn(change_request_without_location.id, [change["id"] for change in response.data["results"]])


### PR DESCRIPTION
Adding `forms`, `user,` `user role` and `with location` filters  on org unit change requests list page

Related JIRA tickets : IA-2643

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests
- [x] Documentation has been included (for new feature)

## Doc
[Here](https://github.com/BLSQ/iaso/blob/e7c4df9d0b6a63492219c2d838bfd14104f06f3d/docs/pages/dev/reference/API/org_unit_registry.md#query-parameters-1)
## Changes

-  adding front-end filters to component
- adding routes and correct types
- adding filters to api
- filters are now searching in old values and new values of a change request ( not anymore on current value of org unit and new value)
- adding python tests on filters

## How to test

Open Change request list page and try to use new filters

## Print screen / video

https://github.com/BLSQ/iaso/assets/12494624/540d060a-504d-4853-8b4c-c25ceb5e2b51

## Notes

See [this](https://bluesquare.atlassian.net/browse/IA-2690) ticket 
