### PR TITLE
IA-2543: Users: save button not disabled while saving

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/users/components/UsersDialog.tsx
+++ b/hat/assets/js/apps/Iaso/domains/users/components/UsersDialog.tsx
@@ -53,6 +53,7 @@ type Props = {
     allowSendEmailInvitation?: boolean;
     isOpen: boolean;
     closeDialog: () => void;
+    savingProfile: boolean;
 };
 // Declaring defaultData here because using initialData={} in the props below will cause and infinite loop
 const defaultData: InitialUserData = {};
@@ -63,6 +64,7 @@ const UserDialogComponent: FunctionComponent<Props> = ({
     saveProfile,
     allowSendEmailInvitation = false,
     closeDialog,
+    savingProfile,
 }) => {
     const connectedUser = useCurrentUser();
     const { formatMessage } = useSafeIntl();
@@ -137,6 +139,7 @@ const UserDialogComponent: FunctionComponent<Props> = ({
                 open={isOpen}
                 closeDialog={() => null}
                 allowConfirm={
+                    !savingProfile &&
                     !(
                         user.user_name.value === '' ||
                         (!user.id?.value && user.password.value === '')

--- a/hat/assets/js/apps/Iaso/domains/users/config.js
+++ b/hat/assets/js/apps/Iaso/domains/users/config.js
@@ -20,6 +20,7 @@ export const usersTableColumns = ({
     params,
     currentUser,
     saveProfile,
+    savingProfile,
 }) => [
     {
         Header: formatMessage(MESSAGES.userName),
@@ -59,6 +60,7 @@ export const usersTableColumns = ({
                     titleMessage={MESSAGES.updateUser}
                     params={params}
                     saveProfile={saveProfile}
+                    savingProfile={savingProfile}
                 />
                 {currentUser.id !== settings.row.original.id &&
                     userHasPermission(Permission.USERS_ADMIN, currentUser) && (

--- a/hat/assets/js/apps/Iaso/domains/users/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/users/index.tsx
@@ -138,6 +138,7 @@ export const Users: FunctionComponent<Props> = ({ params }) => {
                         className={classes.marginTop}
                     >
                         <AddUsersDialog
+                            savingProfile={savingProfile}
                             titleMessage={MESSAGES.create}
                             saveProfile={saveProfile}
                             allowSendEmailInvitation
@@ -166,6 +167,7 @@ export const Users: FunctionComponent<Props> = ({ params }) => {
                         params,
                         currentUser,
                         saveProfile,
+                        savingProfile,
                     })}
                     count={data?.count ?? 0}
                     baseUrl={baseUrl}


### PR DESCRIPTION
This enables chaining API calls

Repro: go to users and create a new user

Related JIRA tickets : IA-2543

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)


## Changes

Using savingProfile to disable save button

## How to test

Create a new user and save

## Print screen / video



https://github.com/BLSQ/iaso/assets/12494624/a45972b1-8293-4918-8903-0eb8cd39b176

