### PR TITLE
POLIO-1460: add target population to supply chain front end

### DIFF
--- a/plugins/polio/api/vaccines/supply_chain.py
+++ b/plugins/polio/api/vaccines/supply_chain.py
@@ -372,6 +372,7 @@ class VaccineRequestFormDetailSerializer(serializers.ModelSerializer):
             "country_name",
             "country_id",
             "obr_name",
+            "target_population",
         ]
 
 

--- a/plugins/polio/js/src/constants/translations/en.json
+++ b/plugins/polio/js/src/constants/translations/en.json
@@ -539,6 +539,7 @@
     "iaso.polio.label.submission": "Submission",
     "iaso.polio.label.submitted": "Submitted",
     "iaso.polio.label.supplyChainStatus": "Supply chain status",
+    "iaso.polio.label.targetPopulation": "Target population",
     "iaso.polio.label.Teachers_Student": "Teachers",
     "iaso.polio.label.testCampaign": "Test campaign",
     "iaso.polio.label.testCampaigns": "Test campaigns",

--- a/plugins/polio/js/src/constants/translations/fr.json
+++ b/plugins/polio/js/src/constants/translations/fr.json
@@ -538,6 +538,7 @@
     "iaso.polio.label.submission": "Soumission",
     "iaso.polio.label.submitted": "Soumis",
     "iaso.polio.label.supplyChainStatus": "Statut de la chaîne d'approvisionnement",
+    "iaso.polio.label.targetPopulation": "Population cible",
     "iaso.polio.label.Teachers_Student": "Professeurs",
     "iaso.polio.label.testCampaign": "Campagne de test",
     "iaso.polio.label.testCampaigns": "Campagnes de test",

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/VaccineRequestForm/VaccineRequestForm.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/VaccineRequestForm/VaccineRequestForm.tsx
@@ -225,6 +225,14 @@ export const VaccineRequestForm: FunctionComponent<Props> = ({
                                 disabled={false}
                             />
                         </Grid>
+                        <Grid item xs={6} md={3}>
+                            <Field
+                                label={formatMessage(MESSAGES.targetPopulation)}
+                                name="vrf.target_population"
+                                component={NumberInput}
+                                disabled={false}
+                            />
+                        </Grid>
                     </Grid>
                     <Grid container item xs={12} spacing={2}>
                         <Grid item xs={6} md={3}>

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/hooks/utils.ts
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/hooks/utils.ts
@@ -214,13 +214,16 @@ export const useInitializeValueOnFetch = ({
             setFieldValue(key, value[key]);
             // set InitialValues so we can compare with form values and enables/disabel dave button accordingly
             if (key === VRF) {
+                const wastageRate =
+                    value.wastage_rate_used_on_vrf === null ||
+                    value.wastage_rate_used_on_vrf === undefined
+                        ? value.wastage_rate_used_on_vrf
+                        : parseFloat(value.wastage_rate_used_on_vrf);
                 setInitialValues({
                     [key]: {
                         ...value,
                         // parsing the value, as NumberInput will automatically do it in the form, which will make theinterface believe the value has been changed
-                        wastage_rate_used_on_vrf: parseFloat(
-                            value.wastage_rate_used_on_vrf,
-                        ),
+                        wastage_rate_used_on_vrf: wastageRate,
                     },
                 });
             } else {

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/hooks/validation.ts
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/hooks/validation.ts
@@ -108,6 +108,12 @@ const useVrfShape = () => {
             .required(formatMessage(MESSAGES.requiredField))
             .typeError(formatMessage(MESSAGES.invalidDate))
             .nullable(),
+        target_population: yup
+            .number()
+            .nullable()
+            .min(0, formatMessage(MESSAGES.positiveInteger))
+            .integer()
+            .typeError(formatMessage(MESSAGES.positiveInteger)),
         comments: yup.string().nullable(),
     });
 };

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/messages.ts
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/messages.ts
@@ -310,6 +310,10 @@ const MESSAGES = defineMessages({
         id: 'iaso.polio.label.cancelChanges',
         defaultMessage: 'Cancel changes',
     },
+    targetPopulation: {
+        id: 'iaso.polio.label.targetPopulation',
+        defaultMessage: 'Target population',
+    },
 });
 
 export default MESSAGES;

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/types.ts
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/types.ts
@@ -29,6 +29,7 @@ export type VRF = {
     date_vrf_submitted_to_dg?: string; // date in string form
     quantities_approved_by_dg_in_doses?: number;
     date_dg_approval?: string; // date in string form
+    target_population?: number;
     comments?: string;
 };
 


### PR DESCRIPTION
Add target population field in VRF form

Related JIRA tickets :  POLIO-1460, POLIO-1458

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [X] Are my typescript files well typed
- [X] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
In the code

## Changes

- Add field to serializer
- Add field to form
- Add field to validation
- Update TS type
- Fix validation bug with wastage rate

## How to test

Go to supplychain: Create and update a VRF, then refresh to test GET endpoint.

## Print screen / video

https://github.com/BLSQ/iaso/assets/38907762/3f376ad2-37f6-47d5-a3bc-15bcbdd254c5


## Notes
merges  in https://github.com/BLSQ/iaso/pull/1122
