### PR TITLE
HOTFIX: POLIO-1451: remove lot numbers and exp date from serializers

### DIFF
--- a/plugins/polio/api/vaccines/supply_chain.py
+++ b/plugins/polio/api/vaccines/supply_chain.py
@@ -103,8 +103,6 @@ class NestedVaccinePreAlertSerializerForPost(BasePostPatchSerializer):
             "date_pre_alert_reception",
             "po_number",
             "estimated_arrival_time",
-            "lot_numbers",
-            "expiration_date",
             "doses_shipped",
             "doses_per_vial",
             "vials_shipped",
@@ -115,9 +113,7 @@ class NestedVaccinePreAlertSerializerForPatch(NestedVaccinePreAlertSerializerFor
     id = serializers.IntegerField(required=True, read_only=False)
     date_pre_alert_reception = serializers.DateField(required=False)
     po_number = serializers.CharField(required=False)
-    lot_numbers = serializers.ListField(child=serializers.CharField(), required=False)
     estimated_arrival_time = serializers.DateField(required=False)
-    expiration_date = serializers.DateField(required=False)
     doses_shipped = serializers.IntegerField(required=False)
     doses_per_vial = serializers.IntegerField(required=False, read_only=True)
     vials_shipped = serializers.IntegerField(required=False, read_only=True)
@@ -142,8 +138,6 @@ class NestedVaccineArrivalReportSerializerForPost(BasePostPatchSerializer):
             "doses_per_vial",
             "vials_received",
             "vials_shipped",
-            "lot_numbers",
-            "expiration_date",
             "doses_shipped",
             "po_number",
         ]
@@ -152,9 +146,7 @@ class NestedVaccineArrivalReportSerializerForPost(BasePostPatchSerializer):
 class NestedVaccineArrivalReportSerializerForPatch(NestedVaccineArrivalReportSerializerForPost):
     id = serializers.IntegerField(required=True, read_only=False)
     arrival_report_date = serializers.DateField(required=False)
-    expiration_date = serializers.DateField(required=False)
     po_number = serializers.CharField(required=False)
-    lot_numbers = serializers.ListField(child=serializers.CharField(), required=False)
     doses_received = serializers.IntegerField(required=False)
     doses_shipped = serializers.IntegerField(required=False)
     doses_per_vial = serializers.IntegerField(required=False, read_only=True)

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/hooks/api/preAlerts.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/hooks/api/preAlerts.tsx
@@ -1,25 +1,15 @@
 /* eslint-disable camelcase */
+import { UseQueryResult } from 'react-query';
 import { getRequest } from '../../../../../../../../../hat/assets/js/apps/Iaso/libs/Api';
 import { useSnackQuery } from '../../../../../../../../../hat/assets/js/apps/Iaso/libs/apiHooks';
 import { apiUrl } from '../../constants';
 
-export const useGetPreAlertDetails = (vrfId?: string) => {
+export const useGetPreAlertDetails = (vrfId?: string): UseQueryResult => {
     return useSnackQuery({
         queryFn: () => getRequest(`${apiUrl}${vrfId}/get_pre_alerts/`),
         queryKey: ['preAlertDetails', vrfId],
         options: {
             enabled: Boolean(vrfId),
-            select: data => {
-                if (!data) return data;
-                return {
-                    pre_alerts: data.pre_alerts.map(pre_alert => {
-                        return {
-                            ...pre_alert,
-                            lot_number: pre_alert.lot_numbers.join(', '),
-                        };
-                    }),
-                };
-            },
         },
     });
 };


### PR DESCRIPTION
 lot numbers and expiry date fields have been removed from interface, but the backend still expects them when saving

Explain what problem this PR is resolving

Related JIRA tickets :POLIO-1451

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [X] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
- Tell us where the doc can be found (docs folder, wiki, in the code...)

## Changes

- Remove `lot_numbers` and `expiry_date` from Pre- alerts and Arrival reports POST and PATCH serializers
- Remove `select`option on `useGetPreAlertDetails` hook

## How to test

Go to supplychain > Open existing VRF: edit and save PreAlerts and ArrivalReports --> should not get a 400

## Print screen / video

https://github.com/BLSQ/iaso/assets/38907762/9d878899-daca-48e7-afd2-c49727c70a6f



