### PR TITLE
POLIO-1476 supplychain to delete layout

### DIFF
--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/PreAlerts/PreAlert.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/PreAlerts/PreAlert.tsx
@@ -10,8 +10,9 @@ import { DateInput } from '../../../../../components/Inputs/DateInput';
 import { NumberInput, TextInput } from '../../../../../components/Inputs';
 import MESSAGES from '../../messages';
 import { SupplyChainFormData } from '../../types';
-import { usePaperStyles } from '../shared';
+import { grayText, usePaperStyles } from '../shared';
 import { NumberCell } from '../../../../../../../../../hat/assets/js/apps/Iaso/components/Cells/NumberCell';
+import { Optional } from '../../../../../../../../../hat/assets/js/apps/Iaso/types/utils';
 
 type Props = {
     index: number;
@@ -24,10 +25,11 @@ export const PreAlert: FunctionComponent<Props> = ({ index }) => {
         useFormikContext<SupplyChainFormData>();
     const { pre_alerts } = values as SupplyChainFormData;
     const markedForDeletion = pre_alerts?.[index].to_delete ?? false;
-
+    const uneditableTextStyling = markedForDeletion ? grayText : undefined;
     const doses_per_vial = pre_alerts?.[index].doses_per_vial ?? 20;
     const current_vials_shipped = Math.ceil(
-        (pre_alerts?.[index].doses_shipped ?? 0) / doses_per_vial,
+        ((pre_alerts?.[index].doses_shipped as Optional<number>) ?? 0) /
+            doses_per_vial,
     );
 
     const onDelete = useCallback(() => {
@@ -43,7 +45,6 @@ export const PreAlert: FunctionComponent<Props> = ({ index }) => {
             }
         }
     }, [index, setFieldTouched, setFieldValue, values?.pre_alerts]);
-
     return (
         <div className={classes.container}>
             <Paper
@@ -104,7 +105,10 @@ export const PreAlert: FunctionComponent<Props> = ({ index }) => {
                             alignContent="center"
                         >
                             <Box>
-                                <Typography variant="button">
+                                <Typography
+                                    variant="button"
+                                    sx={uneditableTextStyling}
+                                >
                                     {`${formatMessage(
                                         MESSAGES.doses_per_vial,
                                     )}:`}{' '}
@@ -120,7 +124,10 @@ export const PreAlert: FunctionComponent<Props> = ({ index }) => {
                             alignContent="center"
                         >
                             <Box>
-                                <Typography variant="button">
+                                <Typography
+                                    variant="button"
+                                    sx={uneditableTextStyling}
+                                >
                                     {`${formatMessage(
                                         MESSAGES.vials_shipped,
                                     )}:`}{' '}

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/VAR/VaccineArrivalReport.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/VAR/VaccineArrivalReport.tsx
@@ -11,8 +11,9 @@ import { NumberInput, TextInput } from '../../../../../components/Inputs';
 import MESSAGES from '../../messages';
 import { SupplyChainFormData } from '../../types';
 import { VAR } from '../../constants';
-import { usePaperStyles } from '../shared';
+import { grayText, usePaperStyles } from '../shared';
 import { NumberCell } from '../../../../../../../../../hat/assets/js/apps/Iaso/components/Cells/NumberCell';
+import { Optional } from '../../../../../../../../../hat/assets/js/apps/Iaso/types/utils';
 
 type Props = { index: number };
 
@@ -23,13 +24,16 @@ export const VaccineArrivalReport: FunctionComponent<Props> = ({ index }) => {
         useFormikContext<SupplyChainFormData>();
     const { arrival_reports } = values as SupplyChainFormData;
     const markedForDeletion = arrival_reports?.[index].to_delete ?? false;
+    const uneditableTextStyling = markedForDeletion ? grayText : undefined;
 
     const doses_per_vial = arrival_reports?.[index].doses_per_vial ?? 20;
     const current_vials_shipped = Math.ceil(
-        (arrival_reports?.[index].doses_shipped ?? 0) / doses_per_vial,
+        ((arrival_reports?.[index].doses_shipped as Optional<number>) ?? 0) /
+            doses_per_vial,
     );
     const current_vials_received = Math.ceil(
-        (arrival_reports?.[index].doses_received ?? 0) / doses_per_vial,
+        ((arrival_reports?.[index].doses_received as Optional<number>) ?? 0) /
+            doses_per_vial,
     );
 
     return (
@@ -85,19 +89,28 @@ export const VaccineArrivalReport: FunctionComponent<Props> = ({ index }) => {
                     </Grid>
                     <Grid container item xs={12} spacing={2}>
                         <Grid item xs={6} md={3}>
-                            <Typography variant="button">
+                            <Typography
+                                variant="button"
+                                sx={uneditableTextStyling}
+                            >
                                 {`${formatMessage(MESSAGES.doses_per_vial)}:`}{' '}
                                 <NumberCell value={doses_per_vial} />
                             </Typography>
                         </Grid>
                         <Grid item xs={6} md={3}>
-                            <Typography variant="button">
+                            <Typography
+                                variant="button"
+                                sx={uneditableTextStyling}
+                            >
                                 {`${formatMessage(MESSAGES.vials_shipped)}:`}{' '}
                                 <NumberCell value={current_vials_shipped} />
                             </Typography>
                         </Grid>
                         <Grid item xs={6} md={3}>
-                            <Typography variant="button">
+                            <Typography
+                                variant="button"
+                                sx={uneditableTextStyling}
+                            >
                                 {`${formatMessage(MESSAGES.vials_received)}:`}{' '}
                                 <NumberCell value={current_vials_received} />
                             </Typography>

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/shared.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/shared.tsx
@@ -7,6 +7,7 @@ import {
     MENU_HEIGHT_WITH_TABS,
     useSafeIntl,
 } from 'bluesquare-components';
+import { grey } from '@mui/material/colors';
 
 export const useSharedStyles = makeStyles({
     scrollableForm: {
@@ -62,7 +63,9 @@ export const usePaperStyles = makeStyles((theme: Theme) => ({
         '&  label.MuiInputLabel-root': {
             backgroundColor: `${theme.palette.grey['200']} !important`,
         },
-        backgroundColor: theme.palette.grey['200'],
+        // Couldn't apply the color with bgColor and sx. Also theme.palette.grey['200'] woudln't work either
+        backgroundColor: `${theme.palette.grey['200']} !important`,
     },
     container: { display: 'inline-flex', width: '100%' },
 }));
+export const grayText = { color: grey[500] };


### PR DESCRIPTION
Since mui 5 migration, layout of items maked for deletion was broken

Related JIRA tickets : POLIO-1476

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [X] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
Comments in the code

## Changes

- Update styling of Paper
- Add sx prop to style `Typography` text when marked fro deletion

## How to test

Go to supplychain details and mark pre-alerts and arrival reports for deletion

## Print screen / video

https://github.com/BLSQ/iaso/assets/38907762/b991835d-2748-4c11-a552-6f15bf226a09


## Notes

Merges into https://github.com/BLSQ/iaso/pull/1130
