### PR TITLE
POLIO-1477 add delete button in stocks

### DIFF
--- a/plugins/polio/api/vaccines/stock_management.py
+++ b/plugins/polio/api/vaccines/stock_management.py
@@ -304,6 +304,9 @@ class VaccineStockManagementViewSet(ModelViewSet):
     GET /api/polio/vaccine/vaccine_stock/{id}/
     Return a specific item from the previous list.
 
+    DELETE /api/polio/vaccine/vaccine_stock/{id}/
+    Delete a vaccine stock. All related OutgoingMovements, IncidentReports and Destructions will also be deleted.
+
     GET /api/polio/vaccine/vaccine_stock/{id}/summary/
     Return a summary of vaccine stock for a given VaccineStock ID (Used on detail page)
 
@@ -319,7 +322,7 @@ class VaccineStockManagementViewSet(ModelViewSet):
 
     permission_classes = [VaccineStockManagementReadWritePerm]
     serializer_class = VaccineStockSerializer
-    http_method_names = ["get", "head", "options", "post"]
+    http_method_names = ["get", "head", "options", "post", "delete"]
 
     model = VaccineStock
 

--- a/plugins/polio/js/src/constants/translations/en.json
+++ b/plugins/polio/js/src/constants/translations/en.json
@@ -285,6 +285,7 @@
     "iaso.polio.label.days": "Days",
     "iaso.polio.label.deleteBudgetEvent": "Delete budget event",
     "iaso.polio.label.deleteNopv2Auth": "Delete authorisation",
+    "iaso.polio.label.deleteStockWarning": "Are you sure you want to delete this vaccine stock",
     "iaso.polio.label.deleteVRF": "Delete VRF?",
     "iaso.polio.label.deleteVRFWarning": "This will also delete all attached pre-alerts and VARs",
     "iaso.polio.label.deleteWarning": "Are you sure you want to delete this campaign?",

--- a/plugins/polio/js/src/constants/translations/fr.json
+++ b/plugins/polio/js/src/constants/translations/fr.json
@@ -284,6 +284,7 @@
     "iaso.polio.label.days": "Jours",
     "iaso.polio.label.deleteBudgetEvent": "Effacer l'étape du budget",
     "iaso.polio.label.deleteNopv2Auth": "Effacer autorisation",
+    "iaso.polio.label.deleteStockWarning": "Voulez-vous effacer ce stock de vaccins",
     "iaso.polio.label.deleteVRF": "Effacter VRF?",
     "iaso.polio.label.deleteVRFWarning": "Les pré-alertes et VArs liés seront aussi effacés",
     "iaso.polio.label.deleteWarning": "Etes-vous sûr(e) de vouloir effacer cette campagne?",

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/Table/useVaccineStockManagementTableColumns.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/Table/useVaccineStockManagementTableColumns.tsx
@@ -1,12 +1,18 @@
 import React, { useMemo } from 'react';
 import { Column, IconButton, useSafeIntl } from 'bluesquare-components';
+import { POLIO_VACCINE_STOCK_WRITE } from '../../../../../../../../hat/assets/js/apps/Iaso/utils/permissions';
+import { userHasPermission } from '../../../../../../../../hat/assets/js/apps/Iaso/domains/users/utils';
 import { STOCK_MANAGEMENT_DETAILS } from '../../../../constants/routes';
 import MESSAGES from '../messages';
 import { NumberCell } from '../../../../../../../../hat/assets/js/apps/Iaso/components/Cells/NumberCell';
+import { useDeleteVaccineStock } from '../hooks/api';
+import { DeleteModal } from '../../../../../../../../hat/assets/js/apps/Iaso/components/DeleteRestoreModals/DeleteModal';
+import { useCurrentUser } from '../../../../../../../../hat/assets/js/apps/Iaso/utils/usersUtils';
 
 export const useVaccineStockManagementTableColumns = (): Column[] => {
     const { formatMessage } = useSafeIntl();
-    // const { mutateAsync: deleteVrf } = useDeleteVrf();
+    const { mutateAsync: deleteStock } = useDeleteVaccineStock();
+    const currentUser = useCurrentUser();
     return useMemo(() => {
         return [
             {
@@ -75,13 +81,29 @@ export const useVaccineStockManagementTableColumns = (): Column[] => {
                             <IconButton
                                 icon="remove-red-eye"
                                 tooltipMessage={MESSAGES.view}
-                                // disabled
                                 url={`${STOCK_MANAGEMENT_DETAILS}/id/${settings.row.original.id}`}
                             />
+                            {userHasPermission(
+                                POLIO_VACCINE_STOCK_WRITE,
+                                currentUser,
+                            ) && (
+                                <DeleteModal
+                                    // Without the key prop, the modal won't close if we're not deleting the last item of the table
+                                    key={settings.row.original.id}
+                                    type="icon"
+                                    onConfirm={() =>
+                                        deleteStock(settings.row.original.id)
+                                    }
+                                    titleMessage={MESSAGES.deleteStockWarning}
+                                    iconProps={{}}
+                                >
+                                    {formatMessage(MESSAGES.deleteTextBody)}
+                                </DeleteModal>
+                            )}
                         </>
                     );
                 },
             },
         ];
-    }, [formatMessage]);
+    }, [deleteStock, formatMessage, currentUser]);
 };

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/hooks/api.ts
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/hooks/api.ts
@@ -1,7 +1,8 @@
 /* eslint-disable camelcase */
-import { UseQueryResult } from 'react-query';
+import { UseMutationResult, UseQueryResult } from 'react-query';
 import { UrlParams } from 'bluesquare-components';
 import {
+    deleteRequest,
     getRequest,
     patchRequest,
     postRequest,
@@ -339,6 +340,17 @@ const saveVaccineStock = body => {
 export const useSaveVaccineStock = () => {
     return useSnackMutation({
         mutationFn: body => saveVaccineStock(body),
+        invalidateQueryKey: 'vaccine-stock-list',
+    });
+};
+
+const deleteVaccineStock = (id: string) => {
+    return deleteRequest(`${apiUrl}${id}`);
+};
+
+export const useDeleteVaccineStock = (): UseMutationResult => {
+    return useSnackMutation({
+        mutationFn: deleteVaccineStock,
         invalidateQueryKey: 'vaccine-stock-list',
     });
 };

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/messages.ts
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/messages.ts
@@ -261,6 +261,14 @@ const MESSAGES = defineMessages({
         id: 'iaso.polio.label.seeSupplyChainForCountry',
         defaultMessage: 'See supply chain for country',
     },
+    deleteStockWarning: {
+        id: 'iaso.polio.label.deleteStockWarning',
+        defaultMessage: 'Are you sure you want to delete this vaccine stock?',
+    },
+    deleteTextBody: {
+        id: 'iaso.label.deleteText',
+        defaultMessage: 'This operation cannot be undone.',
+    },
 });
 
 export default MESSAGES;

--- a/plugins/polio/tests/test_vaccine_stock_management.py
+++ b/plugins/polio/tests/test_vaccine_stock_management.py
@@ -285,3 +285,9 @@ class VaccineStockManagementAPITestCase(APITestCase):
         self.assertEqual(data["total_unusable_vials"], 6)
         self.assertEqual(data["total_usable_doses"], 200)
         self.assertEqual(data["total_unusable_doses"], 120)
+
+    def test_delete(self):
+        self.client.force_authenticate(self.user_rw_perms)
+        response = self.client.delete(f"{BASE_URL}{self.vaccine_stock.pk}/")
+        self.assertEqual(response.status_code, 204)
+        self.assertIsNone(pm.VaccineStock.objects.filter(pk=self.vaccine_stock.pk).first())


### PR DESCRIPTION
Delete button was missing from stock management table

Related JIRA tickets : POLIO-1477

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [X] Are my typescript files well typed
- [X] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [X] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
In the code(comments)

## Changes

- Add delete Icon button
- Enable delete only ofr users with write permission
- Add useDeleteVaccineStock hook (react-query)
- Add translations
- Add DELETE in backend
- Add backend test on DELETE endpoint

This is a hard delete, like in supplychain. It was provided as a way to enable correction of bad input during manual input of historical data. If a soft delete is required, it should be done in a separate PR (and include supplychain)

## How to test

Go to polio> vaccine module > vaccine stock:
- create a couple of new stocks
- Try deleting one
- log in as user with read_only perm on stocks: delete button should not appear

## Print screen / video

https://github.com/BLSQ/iaso/assets/38907762/61f70308-a2fd-475b-9462-9787b5850b55



