### PR TITLE
POLIO-1480: fix campaign options in formA

### DIFF
--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/CreateEditFormA.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/CreateEditFormA.tsx
@@ -57,7 +57,7 @@ export const CreateEditFormA: FunctionComponent<Props> = ({
         validationSchema,
     });
     const { data: campaignOptions, isFetching: isFetchingCampaigns } =
-        useCampaignOptions(countryName);
+        useCampaignOptions(countryName, formik.values.campaign);
     const titleMessage = formA?.id ? MESSAGES.edit : MESSAGES.create;
     const title = `${countryName} - ${vaccine}: ${formatMessage(
         titleMessage,
@@ -87,17 +87,7 @@ export const CreateEditFormA: FunctionComponent<Props> = ({
                         name="campaign"
                         component={SingleSelect}
                         required
-                        options={
-                            // @ts-ignore
-                            (campaignOptions ?? []).length > 0
-                                ? campaignOptions
-                                : [
-                                      {
-                                          label: formik.values.campaign,
-                                          value: formik.values.campaign,
-                                      },
-                                  ]
-                        }
+                        options={campaignOptions}
                         withMarginTop
                         isLoading={isFetchingCampaigns}
                         disabled={!countryName}


### PR DESCRIPTION

[object Object] appears as otion in campaigns dropdown (formA)

Related JIRA tickets : POLIO-1480

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [X] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
NA

## Changes

- Refactor useCampaignOptions to return empty list when campaignName is undefined

## How to test

Try to create a new FormA in stock management.
To make test the fallback value, comment the `select` option in `useCampaignOptions` so it returns undefined. Then try to create a new FormA and try to edit an existing one.

## Print screen / video
Normal behaviour
https://github.com/BLSQ/iaso/assets/38907762/1459ecf5-0229-4f6a-8dbb-d8e148b51184

If the API returns no calmpaigns

https://github.com/BLSQ/iaso/assets/38907762/6dbcdd03-e357-4f22-b166-fe725bb9d25b


