### PR TITLE
IA-2671 [OrgUnitChangeRequest] Add checks on opening and closed dates

### DIFF
--- a/iaso/api/org_unit_change_requests/serializers.py
+++ b/iaso/api/org_unit_change_requests/serializers.py
@@ -294,14 +294,15 @@ class OrgUnitChangeRequestWriteSerializer(serializers.ModelSerializer):
                 f"You must provide at least one of the following fields: {', '.join(new_fields_api)}."
             )
 
-        new_opening_date = validated_data.get("new_opening_date")
         new_closed_date = validated_data.get("new_closed_date")
+        new_opening_date = validated_data.get("new_opening_date")
+        new_parent = validated_data.get("new_parent")
+        org_unit = validated_data.get("org_unit")
 
         if (new_opening_date and new_closed_date) and (new_closed_date <= new_opening_date):
             raise serializers.ValidationError("`new_closed_date` must be later than `new_opening_date`.")
-
-        org_unit = validated_data.get("org_unit")
-        new_parent = validated_data.get("new_parent")
+        elif (org_unit.closed_date and new_opening_date) and (new_opening_date >= org_unit.closed_date):
+            raise serializers.ValidationError("`new_opening_date` must be before the current org_unit closed date.")
 
         if org_unit and new_parent:
             if new_parent.version_id != org_unit.version_id:

--- a/iaso/tests/api/org_unit_change_requests/test_org_unit_change_requests.py
+++ b/iaso/tests/api/org_unit_change_requests/test_org_unit_change_requests.py
@@ -214,29 +214,6 @@ class OrgUnitChangeRequestAPITestCase(APITestCase):
         change_request.refresh_from_db()
         self.assertEqual(change_request.status, change_request.Statuses.APPROVED)
 
-    def test_partial_update_approve_should_reset_closed_date(self):
-        self.org_unit.closed_date = datetime.date(2025, 10, 27)
-        self.org_unit.save()
-        self.client.force_authenticate(self.user_with_review_perm)
-
-        kwargs = {
-            "org_unit": self.org_unit,
-            "created_by": self.user,
-            "new_closed_date": None,
-        }
-        change_request = m.OrgUnitChangeRequest.objects.create(**kwargs)
-
-        data = {
-            "status": change_request.Statuses.APPROVED,
-            "approved_fields": ["new_closed_date"],
-        }
-        response = self.client.patch(f"/api/orgunits/changes/{change_request.pk}/", data=data, format="json")
-        self.assertEqual(response.status_code, 200)
-
-        change_request.refresh_from_db()
-        self.assertEqual(change_request.status, change_request.Statuses.APPROVED)
-        self.assertIsNone(change_request.org_unit.closed_date)
-
     def test_partial_update_approve_fail_wrong_status(self):
         self.client.force_authenticate(self.user_with_review_perm)
 

--- a/iaso/tests/api/org_unit_change_requests/test_serializers.py
+++ b/iaso/tests/api/org_unit_change_requests/test_serializers.py
@@ -496,6 +496,21 @@ class OrgUnitChangeRequestWriteSerializerTestCase(TestCase):
             "`new_closed_date` must be later than `new_opening_date`.", serializer.errors["non_field_errors"][0]
         )
 
+    def test_validate_opening_date(self):
+        self.org_unit.closed_date = datetime.date(2024, 2, 14)
+        self.org_unit.save()
+        one_day_after_org_unit_closed_date = self.org_unit.closed_date + datetime.timedelta(days=1)
+        data = {
+            "org_unit_id": self.org_unit.id,
+            "new_opening_date": one_day_after_org_unit_closed_date,
+        }
+        serializer = OrgUnitChangeRequestWriteSerializer(data=data)
+        self.assertFalse(serializer.is_valid())
+        self.assertIn(
+            "`new_opening_date` must be before the current org_unit closed date.",
+            serializer.errors["non_field_errors"][0],
+        )
+
     def test_validate_new_reference_instances(self):
         form = m.Form.objects.create(name="Vaccine form 1")
         instance1 = m.Instance.objects.create(form=form, org_unit=self.org_unit)

--- a/iaso/tests/models/test_org_unit_change_request.py
+++ b/iaso/tests/models/test_org_unit_change_request.py
@@ -235,18 +235,3 @@ class OrgUnitChangeRequestModelTestCase(TestCase):
 
         self.assertEqual(diff["modified"]["name"]["before"], "Hôpital Général")
         self.assertEqual(diff["modified"]["name"]["after"], "New name given in a change request")
-
-    def test_approve_should_reset_closed_date(self):
-        self.org_unit.closed_date = datetime.date(2025, 10, 27)
-        self.org_unit.save()
-
-        change_request = m.OrgUnitChangeRequest.objects.create(
-            org_unit=self.org_unit,
-            new_closed_date=None,
-        )
-
-        change_request.approve(user=self.user, approved_fields=["new_closed_date"])
-        change_request.refresh_from_db()
-
-        self.assertEqual(change_request.status, change_request.Statuses.APPROVED)
-        self.assertEqual(self.org_unit.closed_date, None)

--- a/iaso/tests/models/test_org_unit_change_request.py
+++ b/iaso/tests/models/test_org_unit_change_request.py
@@ -235,3 +235,18 @@ class OrgUnitChangeRequestModelTestCase(TestCase):
 
         self.assertEqual(diff["modified"]["name"]["before"], "Hôpital Général")
         self.assertEqual(diff["modified"]["name"]["after"], "New name given in a change request")
+
+    def test_approve_should_reset_closed_date(self):
+        self.org_unit.closed_date = datetime.date(2025, 10, 27)
+        self.org_unit.save()
+
+        change_request = m.OrgUnitChangeRequest.objects.create(
+            org_unit=self.org_unit,
+            new_closed_date=None,
+        )
+
+        change_request.approve(user=self.user, approved_fields=["new_closed_date"])
+        change_request.refresh_from_db()
+
+        self.assertEqual(change_request.status, change_request.Statuses.APPROVED)
+        self.assertEqual(self.org_unit.closed_date, None)


### PR DESCRIPTION
[OrgUnitChangeRequest] Add checks on opening and closed dates.

Related JIRA tickets : [IA-2671](https://bluesquare.atlassian.net/browse/IA-2671)

## Changes

- ensure `new_opening_date` is before `org_unit.closed_date`
- ~~ensure we can re-open an `OrgUnit` (this was already the case)~~
    - **important**: the current implementation does not detect that a value needs to be deleted
    - this requires a change in how `requested_fields` works

Bonus:

I spitted some `TestCases` in two as a purely organisational matter.

[IA-2671]: https://bluesquare.atlassian.net/browse/IA-2671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ