### PR TITLE
POLIO-1478: Add memory monitoring on beanstalk instances

### DIFF
--- a/.ebextensions/cloudwatch_agent_metrics.config
+++ b/.ebextensions/cloudwatch_agent_metrics.config
@@ -1,0 +1,45 @@
+files:  
+  "/opt/aws/amazon-cloudwatch-agent/bin/config.json": 
+    mode: "000600"
+    owner: root
+    group: root
+    content: |
+      {
+        "agent": {
+          "metrics_collection_interval": 60,
+          "run_as_user": "root"
+        },
+        "metrics": {
+          "aggregation_dimensions": [
+            [
+                "InstanceId"
+            ]
+          ],        
+          "append_dimensions": {
+            "AutoScalingGroupName": "${aws:AutoScalingGroupName}",
+            "ImageId": "${aws:ImageId}",
+            "InstanceId": "${aws:InstanceId}",
+            "InstanceType": "${aws:InstanceType}"
+          },
+          "metrics_collected": {
+            "disk": {
+              "measurement": [
+                "used_percent"
+              ],
+              "metrics_collection_interval": 60,
+              "resources": [
+                "*"
+              ]
+            },
+            "mem": {
+              "measurement": [
+                "mem_used_percent"
+              ],
+              "metrics_collection_interval": 60
+            }
+          }
+        }
+      }  
+container_commands:
+  start_cloudwatch_agent: 
+    command: /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:/opt/aws/amazon-cloudwatch-agent/bin/config.json


### PR DESCRIPTION
Use an .ebextensions configuration file to configure and run the Amazon CloudWatch agent in EC2 instance.

Related JIRA tickets : [POLIO-1478](https://bluesquare.atlassian.net/browse/POLIO-1478)


## Changes

After configuring the CloudWatch agent on EC2 instance, the agent will send metrics to CloudWatch.

## How to test

Create a CloudWatch alarm to monitor the memory and disk metrics.



[POLIO-1478]: https://bluesquare.atlassian.net/browse/POLIO-1478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ