### PR TITLE
WC2-333 Add admin search fields for Entity

### DIFF
--- a/iaso/admin.py
+++ b/iaso/admin.py
@@ -414,7 +414,14 @@ class SourceVersionAdmin(admin.ModelAdmin):
 @admin.register(Entity)
 @admin_attr_decorator
 class EntityAdmin(admin.ModelAdmin):
-    search_fields = ["account__name", "entity_type__name", "attributes__json"]
+    search_fields = [
+        "uuid",
+        "account__name",
+        "entity_type__name",
+        "attributes__json",
+        "attributes__id",
+        "attributes__uuid",
+    ]
 
     def get_form(self, request, obj=None, **kwargs):
         # In the <select> for the entity type, we also want to indicate the account name

--- a/iaso/models/entity.py
+++ b/iaso/models/entity.py
@@ -150,7 +150,7 @@ class Entity(SoftDeletableModel):
     submission
     """
 
-    name = models.CharField(max_length=255, blank=True)
+    name = models.CharField(max_length=255, blank=True)  # this field is not used, name value is taken from attributes
     uuid = models.UUIDField(default=uuid.uuid4, editable=False)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)


### PR DESCRIPTION
Explain what problem this PR is resolving

Related JIRA tickets : WC2-333

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] My migrations file are included

## Changes

Remove unused and confusing "name" field on Entity.
Add more search possibilities to Entities admin.

## How to test

Go to django admin and you can now search by attributes id and uuid.

