### PR TITLE
IA-2712: Move the groups creation button to the top so it can be visible

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/groups/index.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/groups/index.js
@@ -18,7 +18,7 @@ import GroupsDialog from './components/GroupsDialog';
 import tableColumns, { baseUrl } from './config';
 import MESSAGES from './messages';
 
-import { redirectTo } from '../../../routing/actions';
+import { redirectTo } from '../../../routing/actions.ts';
 
 import { useGetGroups, useSaveGroups, useDeleteGroups } from './hooks/requests';
 
@@ -45,6 +45,26 @@ const Groups = ({ params }) => {
             />
             <Box className={classes.containerFullHeightNoTabPadded}>
                 <Filters params={params} />
+                <Box
+                    mt={1}
+                    mp={2}
+                    display="flex"
+                    justifyContent="flex-end"
+                    alignItems="end"
+                >
+                    <GroupsDialog
+                        saveGroup={saveGroup}
+                        titleMessage={MESSAGES.create}
+                        renderTrigger={({ openDialog }) => (
+                            <AddButtonComponent
+                                dataTestId="add-group-button"
+                                onClick={openDialog}
+                            />
+                        )}
+                        params={params}
+                    />
+                </Box>
+
                 <Table
                     data={data?.groups ?? []}
                     pages={data?.pages ?? 1}
@@ -61,26 +81,8 @@ const Groups = ({ params }) => {
                     redirectTo={(_, newParams) =>
                         dispatch(redirectTo(baseUrl, newParams))
                     }
+                    marginTop={false}
                 />
-                <Grid
-                    container
-                    spacing={0}
-                    justifyContent="flex-end"
-                    alignItems="center"
-                    className={classes.marginTop}
-                >
-                    <GroupsDialog
-                        saveGroup={saveGroup}
-                        titleMessage={MESSAGES.create}
-                        renderTrigger={({ openDialog }) => (
-                            <AddButtonComponent
-                                dataTestId="add-group-button"
-                                onClick={openDialog}
-                            />
-                        )}
-                        params={params}
-                    />
-                </Grid>
             </Box>
         </>
     );


### PR DESCRIPTION
Explain what problem this PR is resolving
- The creation button of groups is not visible because is at the bottom
Related JIRA tickets : [IA-2712](https://bluesquare.atlassian.net/browse/IA-2712)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes
- Moved the button to the top

## How to test
- Go in groups page and check if the button is at top
## Print screen / video
![Screenshot from 2024-02-20 17-19-54](https://github.com/BLSQ/iaso/assets/19631540/55a88e08-4bba-41eb-82d5-3a80bc8f6404)


[IA-2712]: https://bluesquare.atlassian.net/browse/IA-2712?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ