### PR TITLE
POLIO-1488 hide lot numbers info in vaccine stock management

### DIFF
--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/CreateEditDestruction.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/CreateEditDestruction.tsx
@@ -48,7 +48,7 @@ export const CreateEditDestruction: FunctionComponent<Props> = ({
                 destruction?.rrt_destruction_report_reception_date,
             destruction_report_date: destruction?.destruction_report_date,
             unusable_vials_destroyed: destruction?.unusable_vials_destroyed,
-            lot_numbers: destruction?.lot_numbers,
+            // lot_numbers: destruction?.lot_numbers,
             vaccine_stock: vaccineStockId,
         },
         onSubmit: values => save(values),
@@ -109,14 +109,14 @@ export const CreateEditDestruction: FunctionComponent<Props> = ({
                         required
                     />
                 </Box>
-                <Box>
+                {/* <Box>
                     <Field
                         label={formatMessage(MESSAGES.lot_numbers)}
                         name="lot_numbers"
                         component={TextInput}
                         shrinkLabel={false}
                     />
-                </Box>
+                </Box> */}
             </ConfirmCancelModal>
         </FormikProvider>
     );

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/CreateEditFormA.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/CreateEditFormA.tsx
@@ -45,7 +45,7 @@ export const CreateEditFormA: FunctionComponent<Props> = ({
         initialValues: {
             id: formA?.id,
             campaign: formA?.campaign,
-            lot_numbers: formA?.lot_numbers ?? '',
+            // lot_numbers: formA?.lot_numbers ?? '',
             report_date: formA?.report_date,
             form_a_reception_date: formA?.form_a_reception_date,
             usable_vials_used: formA?.usable_vials_used,
@@ -93,7 +93,7 @@ export const CreateEditFormA: FunctionComponent<Props> = ({
                         disabled={!countryName}
                     />
                 </Box>
-                <Box mb={2}>
+                {/* <Box mb={2}>
                     <Field
                         label={formatMessage(
                             MESSAGES.lot_numbers_for_usable_vials,
@@ -102,7 +102,7 @@ export const CreateEditFormA: FunctionComponent<Props> = ({
                         component={TextInput}
                         shrinkLabel={false}
                     />
-                </Box>
+                </Box> */}
                 <Field
                     label={formatMessage(MESSAGES.report_date)}
                     name="report_date"

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/validation.ts
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/validation.ts
@@ -15,8 +15,8 @@ yup.addMethod(
                 const valuesArray = Array.isArray(value)
                     ? value
                     : value
-                          .split(',')
-                          .map((v: string | number) => `${v}`.trim());
+                        .split(',')
+                        .map((v: string | number) => `${v}`.trim());
                 const hasOtherChar = valuesArray.some(v => !regexp.test(v));
                 if (hasOtherChar) {
                     errorMessage = formatMessage(MESSAGES.lotNumberError);
@@ -44,7 +44,7 @@ export const useFormAValidation = () => {
         lot_numbers: yup
             .mixed()
             .nullable()
-            .required(formatMessage(MESSAGES.requiredField))
+            // .required(formatMessage(MESSAGES.requiredField))
             // TS can't detect the added method
             // @ts-ignore
             .isNumbersArrayString(formatMessage),

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Table/columns.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Table/columns.tsx
@@ -42,28 +42,28 @@ export const useFormATableColumns = (
                 sortable: true,
                 Cell: DateCell,
             },
-            {
-                // Not formatting lot numbers as it's not clear how they will be formatted
-                Header: formatMessage(MESSAGES.lot_numbers_for_usable_vials),
-                accessor: 'lot_numbers',
-                id: 'lot_numbers',
-                sortable: true,
-                Cell: settings => {
-                    const { lot_numbers } = settings.row.original;
-                    if ((lot_numbers ?? []).length === 0) {
-                        return <span>{textPlaceholder}</span>;
-                    }
-                    return (
-                        <>
-                            {lot_numbers.map((lotNumber, index) => (
-                                <div key={`${lotNumber}-${index}`}>
-                                    {lotNumber ?? textPlaceholder}
-                                </div>
-                            ))}
-                        </>
-                    );
-                },
-            },
+            // {
+            //     // Not formatting lot numbers as it's not clear how they will be formatted
+            //     Header: formatMessage(MESSAGES.lot_numbers_for_usable_vials),
+            //     accessor: 'lot_numbers',
+            //     id: 'lot_numbers',
+            //     sortable: true,
+            //     Cell: settings => {
+            //         const { lot_numbers } = settings.row.original;
+            //         if ((lot_numbers ?? []).length === 0) {
+            //             return <span>{textPlaceholder}</span>;
+            //         }
+            //         return (
+            //             <>
+            //                 {lot_numbers.map((lotNumber, index) => (
+            //                     <div key={`${lotNumber}-${index}`}>
+            //                         {lotNumber ?? textPlaceholder}
+            //                     </div>
+            //                 ))}
+            //             </>
+            //         );
+            //     },
+            // },
             {
                 Header: formatMessage(MESSAGES.forma_unusable_vials),
                 accessor: 'unusable_vials',
@@ -233,8 +233,8 @@ export const useIncidentTableColumns = (
                 Cell: settings =>
                     settings.row.original.stock_correction
                         ? formatMessage(
-                              MESSAGES[settings.row.original.stock_correction],
-                          )
+                            MESSAGES[settings.row.original.stock_correction],
+                        )
                         : textPlaceholder,
             },
             {


### PR DESCRIPTION
In the current status it has been asked to hide all references to lot numbers from Vaccine Stock Management.

Related JIRA tickets : POLIO-1488

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are my typescript files well typed


## Changes

Commented out the occurences in the frontend as it might be asked to put those back soon.
Didn't change the backend as this fields were already optional.

## How to test

Go to to Frontend > Vaccine Stock Management, Choose a Country/Vaccine line and click on the eye. Then on the next window, check the list, it shouldn't mention any lot number anywhere. Then click "Stock Variation" and again check everywhere and there should not be any mentions of lot numbers.

