### PR TITLE
IA-2709: Multilingual forms on WEB

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/instances/utils/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/utils/index.tsx
@@ -76,19 +76,68 @@ type Field = {
 type Locales = {
     fr: string[];
     en: string[];
+    es: string[];
+    pt: string[];
 };
 
 /*
 The array of strings 'labelLocales' is used to handle different formats for multilingual labels.
 Some forms use the format 'label::French' or 'label::English', while others use lowercase locales like 'label::french' or 'label::english'.
 Additionally, to align with ODK standards (https://docs.getodk.org/guide-form-language/#guide-form-language-building),
-the format 'label::French (fr)' and 'label::English (en)' is also supported.
-We also include the locale codes 'fr' and 'en' to cover cases where labels might be defined using just the locale code.
+the format 'label::French (fr)', 'label::English (en)', 'label::Español (es)', and 'label::Português (pt)' is also supported.
+We also include the locale codes 'fr', 'en', 'es', and 'pt' to cover cases where labels might be defined using just the locale code.
 This array-based approach ensures compatibility with all these formats without disrupting the display for older multilingual forms.
 */
 const labelLocales: Locales = {
-    fr: ['French', 'french', 'French (fr)', 'fr'],
-    en: ['English', 'english', 'English (en)', 'en'],
+    fr: [
+        'French',
+        'french',
+        'Français (fr)',
+        'fr',
+        'français (fr)',
+        'fre',
+        'fra',
+        'français',
+        'francés',
+        'francês',
+        'frances',
+    ],
+    en: [
+        'English',
+        'english',
+        'English (en)',
+        'en',
+        'english (en)',
+        'eng',
+        'anglais',
+        'inglés',
+        'inglês',
+        'ingles',
+    ],
+    es: [
+        'Spanish',
+        'spanish',
+        'Español (es)',
+        'es',
+        'español (es)',
+        'spa',
+        'español',
+        'espagnol',
+        'espanhol',
+        'espanol',
+    ],
+    pt: [
+        'Portuguese',
+        'portuguese',
+        'Português (pt)',
+        'pt',
+        'português (pt)',
+        'por',
+        'português',
+        'portugais',
+        'portugués',
+        'portugues',
+    ],
 };
 
 const localizeLabel = (field: Field): string => {


### PR DESCRIPTION
In some forms version, the translated columns are labeled as label::French and label::English, which aligns with the current implementation. However, in other cases, such as with cahier_de_denombrement, the translated columns are labeled as label::french and label::english, with the locale keys in lowercase.

Furthermore, according to ODK standards, the recommended format for these labels is label::French (fr) and label::English (en)

Related JIRA tickets : IA-2709

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
- I wrote some explanation nearby the function

## Changes

the frontend can now support those configs:
```
const labelLocales: Locales = {
    fr: ['French', 'french', 'French (fr)', 'fr'],
    en: ['English', 'english', 'English (en)', 'en'],
};
```
## How to test

Create 3 differents forms with those XLS, make sure you can différenciante them only by the name of the form.
[French (fr), English (en).xlsx](https://github.com/BLSQ/iaso/files/14372585/French.fr.English.en.xlsx)
[French, English.xlsx](https://github.com/BLSQ/iaso/files/14372586/French.English.xlsx)
[french-english.xlsx](https://github.com/BLSQ/iaso/files/14372587/french-english.xlsx)

Try to create beneficiary types using those forms has reference form, list fields should display translated labels.

## Print screen / video


https://github.com/BLSQ/iaso/assets/12494624/5bf53b00-2a01-4a64-94da-d8f65918855a

