### PR TITLE
Cypress webpack preprocessor

### DIFF
--- a/hat/assets/js/cypress/plugins/index.js
+++ b/hat/assets/js/cypress/plugins/index.js
@@ -1,6 +1,8 @@
 /* eslint-disable no-param-reassign */
 /// <reference types="cypress" />
 import * as dotenv from 'dotenv';
+
+const webpackPreprocessor = require('@cypress/webpack-preprocessor');
 // ***********************************************************
 // This example plugins/index.js can be used to load plugins
 //
@@ -18,7 +20,23 @@ import * as dotenv from 'dotenv';
  * @type {Cypress.PluginConfig}
  */
 dotenv.config();
+
+const webpackOptions = {
+    resolve: {
+        extensions: ['.ts', '.tsx', '.js'],
+    },
+    module: {
+        rules: [
+            {
+                test: /\.css$/,
+                use: ['style-loader', 'css-loader'],
+            },
+        ],
+    },
+};
+
 module.exports = (on, config) => {
+    on('file:preprocessor', webpackPreprocessor({ webpackOptions }));
     // `on` is used to hook into various events Cypress emits
     // `config` is the resolved Cypress config
     config.env.siteBaseUrl = process.env.CYPRESS_BASE_URL;

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,6 +73,7 @@
                 "@babel/preset-react": "^7.0.0",
                 "@babel/preset-typescript": "^7.16.0",
                 "@babel/register": "^7.12.1",
+                "@cypress/webpack-preprocessor": "^6.0.1",
                 "@formatjs/cli": "^4.8.2",
                 "@typescript-eslint/eslint-plugin": "^4.29.2",
                 "@typescript-eslint/parser": "^4.29.2",
@@ -1955,6 +1956,29 @@
             "bin": {
                 "uuid": "dist/bin/uuid"
             }
+        },
+        "node_modules/@cypress/webpack-preprocessor": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/@cypress/webpack-preprocessor/-/webpack-preprocessor-6.0.1.tgz",
+            "integrity": "sha512-WVNeFVSnFKxE3WZNRIriduTgqJRpevaiJIPlfqYTTzfXRD7X1Pv4woDE+G4caPV9bJqVKmVFiwzrXMRNeJxpxA==",
+            "dev": true,
+            "dependencies": {
+                "bluebird": "3.7.1",
+                "debug": "^4.3.4",
+                "lodash": "^4.17.20"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.1",
+                "@babel/preset-env": "^7.0.0",
+                "babel-loader": "^8.3 || ^9",
+                "webpack": "^4 || ^5"
+            }
+        },
+        "node_modules/@cypress/webpack-preprocessor/node_modules/bluebird": {
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.1.tgz",
+            "integrity": "sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg==",
+            "dev": true
         },
         "node_modules/@cypress/xvfb": {
             "version": "1.2.4",
@@ -30068,6 +30092,25 @@
                     "version": "8.3.2",
                     "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
                     "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+                    "dev": true
+                }
+            }
+        },
+        "@cypress/webpack-preprocessor": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/@cypress/webpack-preprocessor/-/webpack-preprocessor-6.0.1.tgz",
+            "integrity": "sha512-WVNeFVSnFKxE3WZNRIriduTgqJRpevaiJIPlfqYTTzfXRD7X1Pv4woDE+G4caPV9bJqVKmVFiwzrXMRNeJxpxA==",
+            "dev": true,
+            "requires": {
+                "bluebird": "3.7.1",
+                "debug": "^4.3.4",
+                "lodash": "^4.17.20"
+            },
+            "dependencies": {
+                "bluebird": {
+                    "version": "3.7.1",
+                    "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.1.tgz",
+                    "integrity": "sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg==",
                     "dev": true
                 }
             }

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
         "@babel/preset-react": "^7.0.0",
         "@babel/preset-typescript": "^7.16.0",
         "@babel/register": "^7.12.1",
+        "@cypress/webpack-preprocessor": "^6.0.1",
         "@formatjs/cli": "^4.8.2",
         "@typescript-eslint/eslint-plugin": "^4.29.2",
         "@typescript-eslint/parser": "^4.29.2",


### PR DESCRIPTION
Cypress test are crashing [here](https://github.com/BLSQ/iaso/actions/runs/8064975732/job/22030059169) because new PhoneInput is using custom css and not specific loader is set to process it.


## Changes

- added a preprocessor to resolve css with style-loader and css-loader

## How to test

https://github.com/BLSQ/iaso/actions/runs/8067667341
