### PR TITLE
Export `creator` example

### DIFF
--- a/iaso/api/org_units.py
+++ b/iaso/api/org_units.py
@@ -228,6 +228,9 @@ class OrgUnitViewSet(viewsets.ViewSet):
                 {"title": "Ref Ext parent 2", "width": 20},
                 {"title": "Ref Ext parent 3", "width": 20},
                 {"title": "Ref Ext parent 4", "width": 20},
+                {"title": "Creator", "width": 20},
+                {"title": "Creator first name", "width": 20},
+                {"title": "Creator last name", "width": 20},
             ]
             counts_by_forms = []
             for frm in forms:
@@ -257,6 +260,9 @@ class OrgUnitViewSet(viewsets.ViewSet):
                 "instances_count",
                 "opening_date",
                 "closed_date",
+                "creator__username",
+                "creator__first_name",
+                "creator__last_name",
             )
 
             user_account_name = profile.account.name if profile else ""
@@ -287,6 +293,9 @@ class OrgUnitViewSet(viewsets.ViewSet):
                     *[org_unit.get(count_field_name) for count_field_name in counts_by_forms],
                     org_unit.get("instances_count"),
                     *[int(org_unit.get("id") in group.org_units__ids) for group in groups],
+                    org_unit.get("creator__username"),
+                    org_unit.get("creator__first_name"),
+                    org_unit.get("creator__last_name"),
                 ]
                 return org_unit_values
 

--- a/iaso/tests/api/test_orgunits.py
+++ b/iaso/tests/api/test_orgunits.py
@@ -519,6 +519,25 @@ class OrgUnitAPITestCase(APITestCase):
         )
         self.assertFileResponse(response, 200, "text/csv; charset=utf-8")
 
+    def test_can_retrieve_org_units_list_in_csv_format(self):
+        # TODO: handle this properly in `setUpTestData()`.
+        self.yoda.first_name = "Yo"
+        self.yoda.last_name = "Da"
+        self.yoda.save()
+        self.jedi_council_brussels.creator = self.yoda
+        self.jedi_council_brussels.save()
+
+        self.client.force_authenticate(self.yoda)
+
+        response = self.client.get(f"/api/orgunits/?csv=true")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "text/csv")
+
+        response_csv = response.getvalue().decode("utf-8")
+        # TODO: test this properly, see `ProfileAPITestCase.test_profile_list_export_as_csv`.
+        print("-" * 80)
+        print(response_csv)
+
     def assertValidOrgUnitListData(self, *, list_data: typing.Mapping, expected_length: int):
         self.assertValidListData(list_data=list_data, results_key="orgUnits", expected_length=expected_length)
         for org_unit_data in list_data["orgUnits"]:


### PR DESCRIPTION
@butofleury here's one possible way to export the creator with `username`, `first_name` and `last_name` as 3 separated columns.

Calling a method would be too much of a hassle in the current state of affairs because we are relying [on the result of `.values`](https://github.com/BLSQ/iaso/blob/1d92a38c33d16840ed6972a492e1cb71080a2d6c/iaso/api/org_units.py#L245) (which returns a list of `dict`s and NOT a list of instances) to populate the CSV content.
