### PR TITLE
POLIO-1409: Make campaing round date required again

### DIFF
--- a/plugins/polio/js/src/domains/Campaigns/Rounds/RoundDates/RoundDates.tsx
+++ b/plugins/polio/js/src/domains/Campaigns/Rounds/RoundDates/RoundDates.tsx
@@ -101,6 +101,7 @@ export const RoundDates: FunctionComponent<Props> = ({
                         label={formatMessage(MESSAGES.startDate)}
                         name={`rounds[${roundIndex}].started_at`}
                         component={DateInput}
+                        required
                         fullWidth
                     />
 
@@ -108,6 +109,7 @@ export const RoundDates: FunctionComponent<Props> = ({
                         label={formatMessage(MESSAGES.endDate)}
                         name={`rounds[${roundIndex}].ended_at`}
                         component={DateInput}
+                        required
                         fullWidth
                     />
                 </>

--- a/plugins/polio/js/src/hooks/useFormValidator.js
+++ b/plugins/polio/js/src/hooks/useFormValidator.js
@@ -218,13 +218,13 @@ const useRoundShape = () => {
             .date()
             .typeError(formatMessage(MESSAGES.invalidDate))
             .nullable()
-            // .required(formatMessage(MESSAGES.fieldRequired))
+            .required(formatMessage(MESSAGES.fieldRequired))
             .isValidRoundStartDate(formatMessage),
         ended_at: yup
             .date()
             .typeError(formatMessage(MESSAGES.invalidDate))
             .nullable()
-            // .required(formatMessage(MESSAGES.fieldRequired))
+            .required(formatMessage(MESSAGES.fieldRequired))
             .isValidRoundEndDate(formatMessage),
         mop_up_started_at: yup
             .date()


### PR DESCRIPTION
Round date needs to be required

Related JIRA tickets POLIO-1409

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)


## Changes

just put back fields to required

## How to test

try to crreate a round without start or end date

## Print screen / video
![Screenshot 2024-03-07 at 12 16 46](https://github.com/BLSQ/iaso/assets/12494624/f35c1fc2-0b43-48a4-b7c9-24d31d725513)


