### PR TITLE
IA-2699 Allow to limit authentication to third party authentication

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -131,7 +131,7 @@ jobs:
         run: |
           . ./venv/bin/activate &&  python manage.py migrate
           . ./venv/bin/activate &&  python manage.py createcachetable
-          . ./venv/bin/activate &&  python manage.py test
+          . ./venv/bin/activate &&  python -W "ignore" manage.py test
           # check we don't have missing migration
           . ./venv/bin/activate &&  python manage.py makemigrations --check
         env:

--- a/beanstalk_worker/services.py
+++ b/beanstalk_worker/services.py
@@ -92,7 +92,7 @@ class PostgresTaskService(_TaskServiceBase):
 
     def run_task(self, task):
         params = task.params
-        print(params)
+
         if not (params and "module" in params and "method" in params):
             # This is for old task that may be in the DB but are not in the new system
             logger.warning(f"Skipping {task} missing method in params: {params}")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,6 +75,7 @@ services:
       WFP_AUTH_CLIENT_ID:
       WFP_AUTH_ACCOUNT:
       WFP_EMAIL_RECIPIENTS_NEW_ACCOUNT:
+      DISABLE_PASSWORD_LOGINS:
       SERVER_URL:
     # Limit logging in dev to not overflow terminal
     logging: &iaso_logging

--- a/docs/pages/dev/reference/env_variables/env_variables.md
+++ b/docs/pages/dev/reference/env_variables/env_variables.md
@@ -40,7 +40,15 @@ BEANSTALK_SQS_REGION
 BEANSTALK_SQS_URL
 
 ```
+## Disabling login through passwords
 
+In case you wish to deactivate passwords using login:
+
+- in the basic login page
+- to connect to the admin
+- through /api/token , which is used by default by the mobile application 
+
+you can set the environment variable `DISABLE_PASSWORD_LOGINS`to the value`"true"`
 
 ## Sentry related
 

--- a/hat/api/token_authentication.py
+++ b/hat/api/token_authentication.py
@@ -33,6 +33,5 @@ def generate_auto_authentication_link(link, user):
     protocol = "https" if settings.SSL_ON else "http"
 
     final_link = "%s://%s/api/token_auth/?token=%s&next=%s" % (protocol, domain, access_token, encoded_link)
-    print(final_link)
 
     return final_link

--- a/hat/settings.py
+++ b/hat/settings.py
@@ -69,6 +69,9 @@ SENTRY_URL = os.environ.get("SENTRY_URL", "")
 # If you have such plugin, you can activate the use of celery by setting this env variable to "true"
 USE_CELERY = os.environ.get("USE_CELERY", "")
 
+# It is possible to deactivate password login for the API, the website and the admin using this environment variable
+DISABLE_PASSWORD_LOGINS = os.environ.get("DISABLE_PASSWORD_LOGINS", "").lower() == "true"
+
 # env variables allowing to configure the cache used by Iaso. By default, it's using a table in Postgres
 # to setup Redis, use django_redis.cache.RedisCache as CACHE_BACKEND and something like "redis://127.0.0.1:6379" as CACHE_LOCATION
 CACHE_BACKEND = os.environ.get("CACHE_BACKEND", "django.core.cache.backends.db.DatabaseCache")

--- a/hat/templates/iaso/disabled_password_login.html
+++ b/hat/templates/iaso/disabled_password_login.html
@@ -1,0 +1,23 @@
+{% extends 'iaso/base_auth.html' %}
+{% load i18n %}
+{% load static %}
+{% load socialaccount %}
+{% block body %}
+<div class="auth__container iasologin">
+  <div class="auth__content">
+    <header class="auth__header">
+      <h1 class="auth__heading"> <img alt="logo" src="{% static logo_path %}" /></h1>
+    </header>
+    <div>
+      {% get_providers as socialaccount_providers %}
+      {% for provider in socialaccount_providers %}
+        {% if  provider.id == 'wfp' %}
+          {% include "wfp_auth/login_subtemplate.html" %}
+        {% endif %}
+      {% endfor %}
+      {% include "./language_picker.html" %}
+    </div>
+  </div>
+</div>
+
+{% endblock %}

--- a/hat/urls.py
+++ b/hat/urls.py
@@ -74,7 +74,6 @@ for plugin_name in settings.PLUGINS:
     urls_module_name = "plugins." + plugin_name + ".urls"
     urls_module = importlib.util.find_spec(urls_module_name)  # checking if the urls module exists for this plugin
     if urls_module:
-        print("importing urls for plugin", plugin_name)
         urlpatterns = urlpatterns + [
             path(plugin_name + "/", include(urls_module_name)),
         ]

--- a/hat/urls.py
+++ b/hat/urls.py
@@ -10,24 +10,37 @@ from drf_yasg.views import get_schema_view
 from rest_framework import permissions
 import importlib
 from iaso.views import health, page
+from django.views.generic import TemplateView
 
 
 admin.site.site_header = "Administration de Iaso"
 admin.site.site_title = "Iaso"
 admin.site.index_title = "Administration de Iaso"
 
-urlpatterns = [
+if settings.DISABLE_PASSWORD_LOGINS:
+    urlpatterns = [
+        path("login/", TemplateView.as_view(template_name="iaso/disabled_password_login.html"), name="login"),
+        path("admin/login/", TemplateView.as_view(template_name="iaso/disabled_password_login.html"), name="login"),
+    ]
+else:
+    urlpatterns = [
+        path("login/", auth.views.LoginView.as_view(template_name="iaso/login.html"), name="login"),
+        path("admin/login/", auth.views.LoginView.as_view(template_name="iaso/login.html"), name="login"),
+    ]
+
+urlpatterns = urlpatterns + [
     path("", RedirectView.as_view(pattern_name="dashboard:home_iaso", permanent=False), name="index"),
     path("_health/", health),
     path("_health", health),  # same without slash otherwise AWS complain about redirect
     path("health/", health),  # alias since current apache config hide _health/
     path("accounts/", include("django.contrib.auth.urls")),
     path("accounts/", include("allauth.urls")),
+    path("login/", auth.views.LoginView.as_view(template_name="iaso/login.html"), name="login"),
+    path("admin/login/", auth.views.LoginView.as_view(template_name="iaso/login.html"), name="login"),
     path("admin/", admin.site.urls),
     path("api/", include("iaso.urls")),
     path("pages/<page_slug>/", page, name="pages"),
     path("i18n/", include("django.conf.urls.i18n")),
-    path("login/", auth.views.LoginView.as_view(template_name="iaso/login.html"), name="login"),
     path("logout-iaso", auth.views.LogoutView.as_view(next_page="login"), name="logout-iaso"),
     path(
         "forgot-password/",

--- a/hat/urls.py
+++ b/hat/urls.py
@@ -35,8 +35,6 @@ urlpatterns = urlpatterns + [
     path("health/", health),  # alias since current apache config hide _health/
     path("accounts/", include("django.contrib.auth.urls")),
     path("accounts/", include("allauth.urls")),
-    path("login/", auth.views.LoginView.as_view(template_name="iaso/login.html"), name="login"),
-    path("admin/login/", auth.views.LoginView.as_view(template_name="iaso/login.html"), name="login"),
     path("admin/", admin.site.urls),
     path("api/", include("iaso.urls")),
     path("pages/<page_slug>/", page, name="pages"),

--- a/iaso/api/deduplication/algos/__init__.py
+++ b/iaso/api/deduplication/algos/__init__.py
@@ -35,9 +35,7 @@ def run_algo(algo_name, algo_params, task=None) -> List[PotentialDuplicate]:
     """
     if algo_name in DeduplicationAlgorithm.ALGORITHMS:
         algo = DeduplicationAlgorithm.ALGORITHMS[algo_name]()
-        print(f"Running algo {algo_name} with params {algo_params}")
         enriched_params = enrich_params(algo_params)
-        print(f"Enriched params: {enriched_params}")
         return algo.run(algo_params, task)
     else:
         raise ValueError(f"Unknown algorithm {algo_name}")

--- a/iaso/api/deduplication/algos/levenshtein.py
+++ b/iaso/api/deduplication/algos/levenshtein.py
@@ -100,7 +100,6 @@ class InverseAlgorithm(DeduplicationAlgorithm):
                     break
 
                 for record in records:
-                    print(record[0], record[1], record[2])
                     potential_duplicates.append(PotentialDuplicate(record[0], record[1], record[2]))
         finally:
             cursor.close()
@@ -112,7 +111,5 @@ class InverseAlgorithm(DeduplicationAlgorithm):
         )
 
         finalize_from_task(task, potential_duplicates)
-
-        print(f"found duplicates :{len(potential_duplicates)}")
 
         return potential_duplicates

--- a/iaso/api/deduplication/entity_duplicate.py
+++ b/iaso/api/deduplication/entity_duplicate.py
@@ -169,8 +169,6 @@ def merge_attributes(e1: Entity, e2: Entity, new_entity_uuid: UUID, merge_def: D
 
     root = tree.getroot()
 
-    ET.dump(root)
-
     for field_name, e_id in merge_def.items():
         the_val = lookup[e_id].json[field_name]
         try:
@@ -188,8 +186,6 @@ def merge_attributes(e1: Entity, e2: Entity, new_entity_uuid: UUID, merge_def: D
     meta_instance_id = root.find("meta/instanceID")
     if meta_instance_id is not None:
         meta_instance_id.text = "uuid:" + str(new_uuid)
-
-    # ET.dump(root)
 
     new_xml_string = ET.tostring(root, encoding="utf-8", xml_declaration=False)
     new_xml_content = ContentFile(new_xml_string)  # .decode("utf-8")
@@ -221,8 +217,6 @@ def copy_instance(inst: Instance, new_entity: Entity):
         return None
 
     root = tree.getroot()
-
-    # ET.dump(root)
 
     entity_uuid = root.find("entityUuid")
     if entity_uuid is not None:

--- a/iaso/api/enketo.py
+++ b/iaso/api/enketo.py
@@ -80,7 +80,6 @@ def enketo_create_url(request):
 
         return JsonResponse({"edit_url": edit_url}, status=201)
     except EnketoError as error:
-        print(error)
         return JsonResponse({"error": str(error)}, status=409)
 
 
@@ -183,7 +182,6 @@ def enketo_public_create_url(request):
 
             return JsonResponse({"url": edit_url}, status=201)
         except EnketoError as error:
-            print(error)
             return JsonResponse({"error": str(error)}, status=409)
 
 
@@ -246,7 +244,6 @@ def enketo_edit_url(request, instance_uuid):
         instance.to_export = False  # could be controlled but, by default, for a normal edit, no auto export
         edit_url = _build_url_for_edition(request, instance, request.user.id)
     except EnketoError as error:
-        print(error)
         return JsonResponse({"error": str(error)}, status=409)
 
     return JsonResponse({"edit_url": edit_url}, status=201)

--- a/iaso/api/org_unit_change_requests/views.py
+++ b/iaso/api/org_unit_change_requests/views.py
@@ -99,9 +99,8 @@ class OrgUnitChangeRequestViewSet(viewsets.ModelViewSet):
         PATCH to approve or reject an `OrgUnitChangeRequest`.
         """
         change_request = self.get_object()
-        print("1. change_request", change_request)
+
         self.has_org_unit_permission(change_request.org_unit)
-        print("2. has_org_unit_permission")
         if change_request.status != change_request.Statuses.NEW:
             raise ValidationError(
                 f"Status must be `{change_request.Statuses.NEW}` but current status is `{change_request.status}`."
@@ -123,6 +122,6 @@ class OrgUnitChangeRequestViewSet(viewsets.ModelViewSet):
                 user=self.request.user,
                 rejection_comment=serializer.validated_data["rejection_comment"],
             )
-        print("saved the patch!, serializing now")
+
         response_serializer = OrgUnitChangeRequestRetrieveSerializer(change_request)
         return Response(response_serializer.data)

--- a/iaso/api/org_unit_change_requests/views.py
+++ b/iaso/api/org_unit_change_requests/views.py
@@ -99,7 +99,9 @@ class OrgUnitChangeRequestViewSet(viewsets.ModelViewSet):
         PATCH to approve or reject an `OrgUnitChangeRequest`.
         """
         change_request = self.get_object()
+        print("1. change_request", change_request)
         self.has_org_unit_permission(change_request.org_unit)
+        print("2. has_org_unit_permission")
         if change_request.status != change_request.Statuses.NEW:
             raise ValidationError(
                 f"Status must be `{change_request.Statuses.NEW}` but current status is `{change_request.status}`."
@@ -121,6 +123,6 @@ class OrgUnitChangeRequestViewSet(viewsets.ModelViewSet):
                 user=self.request.user,
                 rejection_comment=serializer.validated_data["rejection_comment"],
             )
-
+        print("saved the patch!, serializing now")
         response_serializer = OrgUnitChangeRequestRetrieveSerializer(change_request)
         return Response(response_serializer.data)

--- a/iaso/dhis2/datavalue_exporter.py
+++ b/iaso/dhis2/datavalue_exporter.py
@@ -793,7 +793,6 @@ class DataValueExporter:
         stats = {"exported_count": 0, "errored_count": 0}
         export_statuses = []
         for page in range(1, paginator.num_pages + 1):
-            print(page)
             page_start = timer()
             prefix = "page %d/%d" % (page, paginator.num_pages)
 

--- a/iaso/diffing/exporter.py
+++ b/iaso/diffing/exporter.py
@@ -200,7 +200,6 @@ class Exporter:
 
             self.iaso_logger.info(resp)
             report = resp.json()
-            pprint(report)
 
             if resp.status_code == 200 and report["status"] == "ERROR":
                 my_exc = dhis2.exceptions.RequestException(code=resp.status_code, url=resp.url, description=resp.text)

--- a/iaso/enketo/enketo_url.py
+++ b/iaso/enketo/enketo_url.py
@@ -84,7 +84,7 @@ def get_url_from_enketo(url, data):
         handle_enketo_error(response)
 
     except requests.exceptions.ConnectionError as connectionError:
-        logger.error(str(connectionError))
+        logger.warning(str(connectionError))
         raise EnketoError("Enketo is not available")
 
 

--- a/iaso/gpkg/import_gpkg.py
+++ b/iaso/gpkg/import_gpkg.py
@@ -245,7 +245,6 @@ def import_gpkg_file2(
 
             total_org_unit += 1
 
-    print(f"OrgUnit updated or created : {total_org_unit}")
     for ref, parent_ref in to_update_with_parent:
         ou = ref_ou[ref]
         if parent_ref and parent_ref not in ref_ou:

--- a/iaso/test.py
+++ b/iaso/test.py
@@ -71,13 +71,20 @@ class IasoTestCaseMixin:
         return file_mock
 
     @staticmethod
-    def reload_urlconf(urlconfs: list) -> None:
+    def reload_urls(urlconfs: list) -> None:
         """
-        Clear the URL cache because Django caches URLs as soon as they are first loaded.
-        This is useful whe testing dynamic URLs, e.g. depending on a setting flag.
+        Clear the URL cache, because Django caches URLs as soon as they are first loaded.
+        This is useful when testing dynamic URLs (e.g. URLs depending on a setting flag).
 
         Usage:
-            self.reload_urlconf(["hat.urls", "iaso.urls"])
+
+            with self.settings(settings.FOO=True):
+                self.reload_urls(urlconfs)
+                // tests
+
+            // Reload URLs without `settings.FOO=True`.
+            self.reload_urls(urlconfs)
+
         """
         for urlconf in urlconfs:
             importlib.reload(importlib.import_module(urlconf))

--- a/iaso/test.py
+++ b/iaso/test.py
@@ -1,5 +1,8 @@
+import importlib
 import typing
 from unittest import mock
+
+from rest_framework.test import APITestCase as BaseAPITestCase, APIClient
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission
@@ -7,7 +10,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.files import File
 from django.http import StreamingHttpResponse, HttpResponse
 from django.test import TestCase as BaseTestCase
-from rest_framework.test import APITestCase as BaseAPITestCase, APIClient
+from django.urls import clear_url_caches
 
 from hat.menupermissions.models import CustomPermissionSupport
 from hat.api_import.models import APIImport
@@ -66,6 +69,19 @@ class IasoTestCaseMixin:
             setattr(file_mock, key, value)
 
         return file_mock
+
+    @staticmethod
+    def reload_urlconf(urlconfs: list) -> None:
+        """
+        Clear the URL cache because Django caches URLs as soon as they are first loaded.
+        This is useful whe testing dynamic URLs, e.g. depending on a setting flag.
+
+        Usage:
+            self.reload_urlconf(["hat.urls", "iaso.urls"])
+        """
+        for urlconf in urlconfs:
+            importlib.reload(importlib.import_module(urlconf))
+        clear_url_caches()
 
 
 class TestCase(BaseTestCase, IasoTestCaseMixin):

--- a/iaso/tests/api/deduplication/test_entities_deduplication.py
+++ b/iaso/tests/api/deduplication/test_entities_deduplication.py
@@ -513,11 +513,13 @@ class EntitiesDuplicationAPITestCase(APITestCase):
         self.assertEqual(duplicate.validation_status, ValidationStatus.PENDING)
 
         merged_data = {i: duplicate.entity1.id for i in duplicate.analyze.metadata["fields"]}
+
         response = self.client.post(
             f"/api/entityduplicates/",
             data={"merge": merged_data, "entity1_id": duplicate.entity1.id, "entity2_id": duplicate.entity2.id},
             format="json",
         )
+
         self.assertEqual(response.status_code, 200)
         response_data = response.json()
 

--- a/iaso/tests/api/test_completeness_stats.py
+++ b/iaso/tests/api/test_completeness_stats.py
@@ -3,7 +3,6 @@
 
 # Please refer to the diagram in ../docs/test_completeness_stats.png to understand the expected results
 
-import pprint
 from typing import Any
 
 from django.contrib.auth.models import User, Permission

--- a/iaso/tests/api/test_completeness_stats.py
+++ b/iaso/tests/api/test_completeness_stats.py
@@ -324,11 +324,6 @@ class CompletenessStatsAPITestCase(APITestCase):
             ],
         }
 
-        pp = pprint.PrettyPrinter(indent=4)
-        print("expected_result:")
-        pp.pprint(expected_result)
-        print("\nj:")
-        pp.pprint(j)
         self.assertAlmostEqualRecursive(
             expected_result,
             j,

--- a/iaso/tests/api/test_entities.py
+++ b/iaso/tests/api/test_entities.py
@@ -691,8 +691,6 @@ class EntityAPITestCase(APITestCase):
 
         response_json = response.json()
 
-        var_dump(response_json)
-
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response_json.get("count"), 2)
         self.assertEqual(response_json.get("results")[0].get("entity_type_id"), str(entity_type.id))
@@ -756,8 +754,6 @@ class EntityAPITestCase(APITestCase):
         response = self.client.get(f"/api/mobile/entities/?app_id={app_id}")
 
         response_json = response.json()
-
-        var_dump(response_json)
 
         self.assertEqual(response_json["count"], 1)
         self.assertEqual(response_json["results"][0]["entity_type_id"], str(entity_type.id))

--- a/iaso/tests/api/test_entity_types.py
+++ b/iaso/tests/api/test_entity_types.py
@@ -214,8 +214,6 @@ class EntityTypeAPITestCase(APITestCase):
 
         response = self.client.post("/api/entitytypes/", data=payload, format="json")
 
-        print(response.json())
-
         self.assertEqual(response.status_code, 400)
 
     def test_entity_types_are_multitenancy(self):

--- a/iaso/tests/api/test_profiles.py
+++ b/iaso/tests/api/test_profiles.py
@@ -601,7 +601,6 @@ class ProfileAPITestCase(APITestCase):
         self.assertJSONResponse(response, 200)
         response_data = response.json()
         self.assertIn("account", response_data)
-        print(response_data["account"])
         self.assertEqual(response_data["account"]["feature_flags"], [])
 
         # add a feature flags
@@ -611,7 +610,7 @@ class ProfileAPITestCase(APITestCase):
         self.assertJSONResponse(response, 200)
         response_data = response.json()
         self.assertIn("account", response_data)
-        print(response_data["account"])
+
         self.assertEqual(response_data["account"]["feature_flags"], ["shape"])
 
         # remove feature flags
@@ -620,7 +619,7 @@ class ProfileAPITestCase(APITestCase):
         self.assertJSONResponse(response, 200)
         response_data = response.json()
         self.assertIn("account", response_data)
-        print(response_data["account"])
+
         self.assertEqual(response_data["account"]["feature_flags"], [])
 
     def test_search_user_by_permissions(self):

--- a/iaso/tests/api/test_profiles_bulk_update.py
+++ b/iaso/tests/api/test_profiles_bulk_update.py
@@ -628,7 +628,7 @@ class OrgUnitsBulkUpdateAPITestCase(APITestCase):
         self.assertEqual(Task.objects.filter(status=QUEUED).count(), 0)
 
         response = self.client.get("/api/tasks/%d/" % task.id)
-        #print(response.json())
+
         self.assertEqual(response.status_code, 200)
         # Task completion status
         return self.assertValidTaskAndInDB(response.json(), new_status)

--- a/iaso/tests/api/test_profiles_bulk_update.py
+++ b/iaso/tests/api/test_profiles_bulk_update.py
@@ -628,7 +628,7 @@ class OrgUnitsBulkUpdateAPITestCase(APITestCase):
         self.assertEqual(Task.objects.filter(status=QUEUED).count(), 0)
 
         response = self.client.get("/api/tasks/%d/" % task.id)
-        print(response.json())
+        #print(response.json())
         self.assertEqual(response.status_code, 200)
         # Task completion status
         return self.assertValidTaskAndInDB(response.json(), new_status)

--- a/iaso/tests/api/test_token.py
+++ b/iaso/tests/api/test_token.py
@@ -1,9 +1,6 @@
-import importlib
 from unittest import mock
 
 from django.core.files import File
-from django.test import override_settings
-from django.urls import clear_url_caches
 
 from iaso import models as m
 from iaso.test import APITestCase
@@ -25,12 +22,16 @@ class DisableLoginTokenAPITestCase(APITestCase):
         response = self.client.post(f"/api/token/", data={"username": "yoda", "password": "IMomLove"}, format="json")
         self.assertEqual(response.status_code, 200)
 
-    @override_settings(DISABLE_PASSWORD_LOGINS=True)
     def test_acquire_token_and_authenticate_when_passwords_disabled(self):
         """Test that token authentication is not possible when passwords are disabled"""
-        self.reload_urlconf(["hat.urls", "iaso.urls"])
-        response = self.client.post(f"/api/token/", data={"username": "yoda", "password": "IMomLove"}, format="json")
-        self.assertEqual(response.status_code, 404)
+        urlconfs = ["hat.urls", "iaso.urls"]
+        with self.settings(DISABLE_PASSWORD_LOGINS=True):
+            self.reload_urls(urlconfs)
+            response = self.client.post(
+                f"/api/token/", data={"username": "yoda", "password": "IMomLove"}, format="json"
+            )
+            self.assertEqual(response.status_code, 404)
+        self.reload_urls(urlconfs)
 
 
 class TokenAPITestCase(APITestCase):

--- a/iaso/tests/api/test_token.py
+++ b/iaso/tests/api/test_token.py
@@ -9,17 +9,19 @@ from iaso.test import APITestCase
 class DisableLoginTokenAPITestCase(APITestCase):
     @classmethod
     def setUpTestData(cls):
-        data_source = m.DataSource.objects.create(name="counsil")
+        data_source = m.DataSource.objects.create(name="ds")
         version = m.SourceVersion.objects.create(data_source=data_source, number=1)
-        star_wars = m.Account.objects.create(name="Star Wars", default_version=version)
-        cls.yoda = cls.create_user_with_profile(username="yoda", account=star_wars)
+        test_account = m.Account.objects.create(name="test_account", default_version=version)
+        cls.test_user = cls.create_user_with_profile(username="test_user", account=test_account)
 
-        cls.yoda.set_password("IMomLove")
-        cls.yoda.save()
+        cls.test_user.set_password("IMomLove")
+        cls.test_user.save()
 
     def test_acquire_token_and_authenticate(self):
         """Test that token authentication is possible."""
-        response = self.client.post(f"/api/token/", data={"username": "yoda", "password": "IMomLove"}, format="json")
+        response = self.client.post(
+            f"/api/token/", data={"username": "test_user", "password": "IMomLove"}, format="json"
+        )
         self.assertEqual(response.status_code, 200)
 
     def test_acquire_token_and_authenticate_when_passwords_disabled(self):
@@ -28,7 +30,7 @@ class DisableLoginTokenAPITestCase(APITestCase):
         with self.settings(DISABLE_PASSWORD_LOGINS=True):
             self.reload_urls(urlconfs)
             response = self.client.post(
-                f"/api/token/", data={"username": "yoda", "password": "IMomLove"}, format="json"
+                f"/api/token/", data={"username": "test_user", "password": "IMomLove"}, format="json"
             )
             self.assertEqual(response.status_code, 404)
         self.reload_urls(urlconfs)

--- a/iaso/tests/api/test_token.py
+++ b/iaso/tests/api/test_token.py
@@ -35,6 +35,8 @@ class DisableLoginTokenAPITestCase(APITestCase):
             )
             self.assertEqual(response.status_code, 404)
 
+        reload_urlconf()
+
 
 class TokenAPITestCase(APITestCase):
     @classmethod

--- a/iaso/tests/api/test_token.py
+++ b/iaso/tests/api/test_token.py
@@ -1,6 +1,9 @@
+import importlib
 from unittest import mock
 
 from django.core.files import File
+from django.test import override_settings
+from django.urls import clear_url_caches
 
 from iaso import models as m
 from iaso.test import APITestCase
@@ -17,25 +20,17 @@ class DisableLoginTokenAPITestCase(APITestCase):
         cls.yoda.set_password("IMomLove")
         cls.yoda.save()
 
+    def test_acquire_token_and_authenticate(self):
+        """Test that token authentication is possible."""
+        response = self.client.post(f"/api/token/", data={"username": "yoda", "password": "IMomLove"}, format="json")
+        self.assertEqual(response.status_code, 200)
+
+    @override_settings(DISABLE_PASSWORD_LOGINS=True)
     def test_acquire_token_and_authenticate_when_passwords_disabled(self):
         """Test that token authentication is not possible when passwords are disabled"""
-
-        def reload_urlconf():
-            import importlib
-            from django.urls import clear_url_caches
-
-            clear_url_caches()
-            importlib.reload(importlib.import_module("hat.urls"))
-            importlib.reload(importlib.import_module("iaso.urls"))
-
-        with self.settings(DISABLE_PASSWORD_LOGINS=True):
-            reload_urlconf()
-            response = self.client.post(
-                f"/api/token/", data={"username": "yoda", "password": "IMomLove"}, format="json"
-            )
-            self.assertEqual(response.status_code, 404)
-
-        reload_urlconf()
+        self.reload_urlconf(["hat.urls", "iaso.urls"])
+        response = self.client.post(f"/api/token/", data={"username": "yoda", "password": "IMomLove"}, format="json")
+        self.assertEqual(response.status_code, 404)
 
 
 class TokenAPITestCase(APITestCase):

--- a/iaso/tests/api/workflows/test_import_export.py
+++ b/iaso/tests/api/workflows/test_import_export.py
@@ -180,8 +180,6 @@ class WorkflowsImportExportAPITestCase(BaseWorkflowsAPITestCase):
         orig_wf = self.workflow_et_adults_blue_with_followups_and_changes
         orig_versions_count = orig_wf.workflow_versions.count()
         orig_version = orig_wf.workflow_versions.filter(status="DRAFT").first()
-        orig_version_change = orig_version.changes.first()
-        orig_version_first_followup = orig_version.follow_ups.order_by("created_at").first()
 
         self.assertJSONResponse(r, 200)
         self.assertEqual(len(r.data["versions"]), orig_versions_count)
@@ -223,8 +221,6 @@ class WorkflowsImportExportAPITestCase(BaseWorkflowsAPITestCase):
 
         orig_wf = self.workflow_et_adults_blue_with_followups_and_changes
         orig_versions_count = orig_wf.workflow_versions.count()
-
-        print("orig_versions_count", orig_versions_count)
 
         self.assertJSONResponse(r, 200)
 
@@ -293,5 +289,5 @@ class WorkflowsImportExportAPITestCase(BaseWorkflowsAPITestCase):
 
         # Step 4: Verify if the previously soft deleted workflow version is was undeleted
         last_version_from_db = WorkflowVersion.objects.get(pk=version_to_delete.pk)
-        print("last_version_from_db", last_version_from_db)
+
         self.assertEqual(last_version_from_db.deleted_at, None)

--- a/iaso/tests/gpkg/test_export2.py
+++ b/iaso/tests/gpkg/test_export2.py
@@ -57,7 +57,6 @@ class GPKGExport(TestCase):
             validation_status="new",
             description="",
         )
-        print(m.SourceVersion.objects.all())
 
         v2 = m.SourceVersion.objects.get(data_source__name=self.source_name, number=2)
         self.assertEqual(v2.orgunit_set.all().count(), 3)

--- a/iaso/tests/test_microplanning.py
+++ b/iaso/tests/test_microplanning.py
@@ -1,6 +1,5 @@
 import mock
 from django.contrib.auth.models import User
-from django.test import TransactionTestCase
 from django.utils.timezone import now
 from django_ltree.fields import PathValue  # type: ignore
 
@@ -11,7 +10,7 @@ from iaso.models.microplanning import TeamType, Team, Planning, Assignment
 from iaso.test import IasoTestCaseMixin, APITestCase
 
 
-class TeamTestCase(TransactionTestCase, IasoTestCaseMixin):
+class TeamTestCase(APITestCase, IasoTestCaseMixin):
     fixtures = ["user.yaml"]
 
     def test_simple_team_model(self):

--- a/iaso/tests/test_pyramid_exporter.py
+++ b/iaso/tests/test_pyramid_exporter.py
@@ -144,7 +144,6 @@ class CommandTests(TestCase):
         )
 
         def request_callback_update(request):
-            # print(json.loads(request.body))
             return (200, {}, json.dumps({"status": "OK"}))
 
         responses.add_callback(

--- a/iaso/tests/test_task_launcher.py
+++ b/iaso/tests/test_task_launcher.py
@@ -20,16 +20,12 @@ class TaskLauncher(APITestCase):
         res = self.client.get("/tasks/launch_task/iaso.tests.test_task_launcher.fake_empty_task/test_wrong_user/")
         res_json = self.assertJSONResponse(res, 200)
 
-        print(res_json)
-
         assert res_json["status"] == "fail"
         assert "User not found" in res_json["error"]
 
     def test_with_ok_username_wrong_taskname_should_fail(self):
         res = self.client.get("/tasks/launch_task/iaso.tests.test_XXX_launcher.fake_empty_task/test_task_user/")
         res_json = self.assertJSONResponse(res, 400)
-
-        print(res_json)
 
         assert res_json["status"] == "fail"
         assert "Error while loading task" in res_json["error"]
@@ -38,8 +34,6 @@ class TaskLauncher(APITestCase):
     def test_with_ok_username_ok_taskname_should_succeed(self):
         res = self.client.get("/tasks/launch_task/iaso.tests.test_task_launcher.fake_empty_task/test_task_user/")
         res_json = self.assertJSONResponse(res, 200)
-
-        print(res_json)
 
         assert res_json["status"] == "success"
         assert res_json["task"]["id"] > 0
@@ -52,8 +46,6 @@ class TaskLauncher(APITestCase):
             "/tasks/launch_task/iaso.tests.test_task_launcher.fake_empty_task/test_task_user/?a=1&b=2"
         )
         res_json = self.assertJSONResponse(res, 200)
-
-        print(res_json)
 
         assert res_json["status"] == "success"
         assert res_json["task"]["id"] > 0

--- a/iaso/tests/tests_event_tracker_exporter.py
+++ b/iaso/tests/tests_event_tracker_exporter.py
@@ -777,7 +777,6 @@ class DataValueExporterTests(TestCase):
 
         self.assertEqual(len(sent_create), 3)
 
-
         self.assertEqual(
             {
                 "orgUnit": "OU_DHIS2_ID",

--- a/iaso/tests/tests_event_tracker_exporter.py
+++ b/iaso/tests/tests_event_tracker_exporter.py
@@ -777,7 +777,7 @@ class DataValueExporterTests(TestCase):
 
         self.assertEqual(len(sent_create), 3)
 
-        print(sent_create[1])
+
         self.assertEqual(
             {
                 "orgUnit": "OU_DHIS2_ID",

--- a/iaso/tests/tests_value_formatter.py
+++ b/iaso/tests/tests_value_formatter.py
@@ -108,8 +108,6 @@ class ValueFormatterTests(TestCase):
 
             with self.assertRaises(Exception) as context:
                 value_formatter.format_value(de, "a bad string", orgunit_resolver)
-            print(str(context.exception))
-            print(testcase[1])
             self.assertTrue(str(context.exception).startswith(testcase[1]))
 
     def test_dont_fail_fast_on_int_or_float(self):

--- a/iaso/urls.py
+++ b/iaso/urls.py
@@ -2,6 +2,7 @@ import pkgutil
 from typing import Union, List
 
 from django.contrib import auth
+from django.conf import settings
 from django.urls import path, include, URLPattern, URLResolver
 from rest_framework import routers
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView  # type: ignore
@@ -206,9 +207,13 @@ def append_datasources_subresource(viewset, resource_name, urlpatterns):
     )
 
 
+if not settings.DISABLE_PASSWORD_LOGINS:
+    urlpatterns = urlpatterns + [
+        path("token/", TokenObtainPairView.as_view(), name="token_obtain_pair"),
+        path("token/refresh/", TokenRefreshView.as_view(), name="token_refresh"),
+    ]
+
 urlpatterns = urlpatterns + [
-    path("token/", TokenObtainPairView.as_view(), name="token_obtain_pair"),
-    path("token/refresh/", TokenRefreshView.as_view(), name="token_refresh"),
     path("storages/<str:storage_type>/<str:storage_customer_chosen_id>/logs", logs_per_device),
     path("workflows/export/<workflow_id>/", export_workflow, name="export_workflow"),
     path("workflows/import/", import_workflow, name="import_workflow"),

--- a/plugins/polio/preparedness/parser.py
+++ b/plugins/polio/preparedness/parser.py
@@ -7,6 +7,9 @@ from plugins.polio.preparedness.calculator import get_preparedness_score
 from plugins.polio.preparedness.client import get_client
 from plugins.polio.preparedness.exceptions import InvalidFormatError
 from plugins.polio.preparedness.spread_cache import CachedSpread, CachedSheet
+from logging import getLogger
+
+logger = getLogger(__name__)
 
 
 def parse_value(value: str):
@@ -137,10 +140,10 @@ def get_national_level_preparedness(spread: CachedSpread):
             "Resumo da preparação em Nível Central",
         )
         if not cell:
-            print(f"No national data found on worksheet: {worksheet.title}")
+            logger.warning(f"No national data found on worksheet: {worksheet.title}")
             continue
 
-        print(f"Data found on worksheet: {worksheet.title}")
+        logger.info(f"Data found on worksheet: {worksheet.title}")
         kv = worksheet.get_dict_position(NATIONAL_INDICATORS)
         if kv.get("communication_sm_activities"):
             kv["communication_sm_activities"] = from_percent(kv["communication_sm_activities"])
@@ -187,15 +190,15 @@ def get_regional_level_preparedness(spread: CachedSpread):
             "Summary of district Level Preparedness",
         )
         if not cell:
-            print(f"No regional data found on worksheet: {sheet.title}")
+            logger.warning(f"No regional data found on worksheet: {sheet.title}")
             continue
-        print(f"Regional Data found on worksheet: {sheet.title}")
+        logger.info(f"Regional Data found on worksheet: {sheet.title}")
 
         start_region = sheet.find_formula("=C4")
         if not start_region:
             start_region = sheet.find_formula("=C5")
         if not start_region:
-            print(f"start of data for region not found in {sheet.title}")
+            logger.info(f"start of data for region not found in {sheet.title}")
             start_region = (7, 5)
         regional_name = sheet.get_rc(*start_region)
 

--- a/plugins/polio/tasks/weekly_email.py
+++ b/plugins/polio/tasks/weekly_email.py
@@ -22,7 +22,7 @@ def send_notification_email(campaign):
     from_email = settings.DEFAULT_FROM_EMAIL
 
     if not (campaign.obr_name and country and campaign.deleted_at is None):
-        print(f"Campaign {campaign} skipped because of missing fields")
+        logger.warning(f"Campaign {campaign} skipped because of missing fields")
         return False
     try:
         cug = CountryUsersGroup.objects.get(country=country)

--- a/plugins/polio/tests/test_preparedness_parser.py
+++ b/plugins/polio/tests/test_preparedness_parser.py
@@ -24,5 +24,4 @@ class PreparednessParserTests(TestCase):
         PREPAREDNESS_EXPECTED_STATS = "plugins/polio/tests/fixtures/preparedness_expected_stats.json"
 
         stats = get_preparedness(CachedSpread(self.load_fixture(PREPAREDNESS_SHEET)))
-        print(json.dumps(stats, indent=4))
         self.assertEqual(stats, self.load_fixture(PREPAREDNESS_EXPECTED_STATS))

--- a/plugins/polio/tests/test_reasons_for_delay.py
+++ b/plugins/polio/tests/test_reasons_for_delay.py
@@ -143,7 +143,7 @@ class PolioReasonSForDelayTestCase(APITestCase):
             },
         )
         jr = self.assertJSONResponse(response, 200)
-        print(jr)
+
         self.assertEqual(jr["key_name"], self.cat_ate_my_homework.key_name)
         self.assertEqual(jr["name_en"], new_name_en)
         self.assertEqual(jr["name_fr"], self.cat_ate_my_homework.name_fr)

--- a/plugins/polio/tests/test_vaccine_authorizations.py
+++ b/plugins/polio/tests/test_vaccine_authorizations.py
@@ -1089,7 +1089,6 @@ class VaccineAuthorizationAPITestCase(APITestCase):
 
         response = self.client.post("/api/polio/vaccineauthorizations/", data=data)
 
-        print("RESPONSE: ", response.data)
         self.assertEqual(response.status_code, 403)
         self.assertEqual(response.data["error"], "A vaccine authorization is already validated for this country")
 

--- a/plugins/wfp/tests/test_etl.py
+++ b/plugins/wfp/tests/test_etl.py
@@ -8,8 +8,7 @@ class ETLTestCase(TestCase):
     def test_create_beneficiary(self):
         beneficiary = Beneficiary(birth_date="2022-08-08", gender="Male", entity_id=18)
         beneficiary.save()
-        print(f"CREATED BENEFICIARY WITH ENTITY ID {beneficiary.entity_id}")
-        print("\n")
+
         self.assertEqual(beneficiary.entity_id, 18)
 
     def test_create_journey(self):
@@ -29,7 +28,7 @@ class ETLTestCase(TestCase):
             instance_id=1,
         )
         journey.save()
-        print("CREATED JOURNEY ", journey.id)
+
         self.assertEqual(journey.instance_id, 1)
 
     def test_create_visit(self):
@@ -43,7 +42,7 @@ class ETLTestCase(TestCase):
             orgUnit.save()
             visit = Visit(number=visit_number, org_unit=orgUnit, instance_id=421, journey=journey)
             visit.save()
-            print("CREATED VISIT ", visit.id)
+
             self.assertEqual(visit.instance_id, 421)
 
             for ration in ["RUSF", "RUTF", "CSB++", ""]:
@@ -54,6 +53,5 @@ class ETLTestCase(TestCase):
                     instance_id=visit.instance_id,
                 )
                 step.save()
-                print("CREATED STEP ", step.id)
+
                 self.assertEqual(step.instance_id, visit.instance_id)
-            print("\n")


### PR DESCRIPTION
Adding an environment variable DISABLE_PASSWORD_LOGINS that allows to disable logins using password (to only allow SSO )

Related JIRA tickets : IA-2699 (and sub stories)

I also removed a LOT of print() in the codebase so that the test outputs are clean. 

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are my typescript files well typed
- [x] New translations have been added or updated if new strings have been introduced in the frontend
- [x] My migrations file are included
- [x] Are there enough tests
- [x] Documentation has been included (for new feature)

## Doc
- under /docs

## How to test
Activate the environment variable. 

Go to /login  or /admin and check that no password field is available to fill
 /api/token/ should give you a 404 too

## Print screen / video

![CleanShot 2024-03-15 at 18 11 52@2x](https://github.com/BLSQ/iaso/assets/185797/826628f5-784f-42a5-b3f6-8a78103e96a8)




