### PR TITLE
IA-2791: remove duplicate EditIconButtons

### DIFF
--- a/hat/assets/js/apps/Iaso/components/LegendBuilder/LegendBuilderDialog.tsx
+++ b/hat/assets/js/apps/Iaso/components/LegendBuilder/LegendBuilderDialog.tsx
@@ -7,8 +7,7 @@ import {
     useSafeIntl,
 } from 'bluesquare-components';
 import * as Yup from 'yup';
-import SettingsIcon from '@mui/icons-material/Settings';
-import { IconButton, Box, Button } from '@mui/material';
+import { Box, Button } from '@mui/material';
 
 import { useFormik } from 'formik';
 import Add from '@mui/icons-material/Add';
@@ -16,6 +15,7 @@ import { MESSAGES } from './messages';
 import { ScaleThreshold } from './types';
 import { LegendBuilder } from './index';
 import { getRangeValues, getScaleThreshold } from './utils';
+import { EditIconButton } from '../Buttons/EditIconButton';
 
 type Props = {
     titleMessage: IntlMessage;
@@ -105,18 +105,6 @@ type PropsIcon = {
     onClick: () => void;
 };
 
-export const EditIconButton: FunctionComponent<PropsIcon> = ({ onClick }) => {
-    const { formatMessage } = useSafeIntl();
-    return (
-        <IconButton
-            onClick={onClick}
-            aria-label={formatMessage(MESSAGES.edit)}
-            size="small"
-        >
-            <SettingsIcon />
-        </IconButton>
-    );
-};
 const AddButton: FunctionComponent<PropsIcon> = ({ onClick }) => {
     const { formatMessage } = useSafeIntl();
     return (

--- a/hat/assets/js/apps/Iaso/domains/payments/components/PaymentLotDialog.tsx
+++ b/hat/assets/js/apps/Iaso/domains/payments/components/PaymentLotDialog.tsx
@@ -8,8 +8,7 @@ import {
     selectionInitialState,
 } from 'bluesquare-components';
 import * as Yup from 'yup';
-import SettingsIcon from '@mui/icons-material/Settings';
-import { IconButton, Button, Box, Divider, Grid } from '@mui/material';
+import { Button, Box, Divider, Grid } from '@mui/material';
 import Add from '@mui/icons-material/Add';
 
 import { useFormik } from 'formik';
@@ -27,6 +26,7 @@ import {
     useSavePaymentLot,
 } from '../hooks/requests/useSavePaymentLot';
 import getDisplayName, { useCurrentUser } from '../../../utils/usersUtils';
+import { EditIconButton } from '../../../components/Buttons/EditIconButton';
 
 const styles: SxStyles = {
     table: {
@@ -195,23 +195,6 @@ const PaymentLotDialog: FunctionComponent<Props> = ({
                 />
             </Box>
         </ConfirmCancelModal>
-    );
-};
-
-type PropsIcon = {
-    onClick: () => void;
-};
-
-export const EditIconButton: FunctionComponent<PropsIcon> = ({ onClick }) => {
-    const { formatMessage } = useSafeIntl();
-    return (
-        <IconButton
-            onClick={onClick}
-            aria-label={formatMessage(MESSAGES.edit)}
-            size="small"
-        >
-            <SettingsIcon />
-        </IconButton>
     );
 };
 

--- a/hat/assets/js/apps/Iaso/domains/userRoles/components/CreateEditUserRole.tsx
+++ b/hat/assets/js/apps/Iaso/domains/userRoles/components/CreateEditUserRole.tsx
@@ -20,7 +20,7 @@ import {
 import InputComponent from '../../../components/forms/InputComponent';
 import { PermissionsSwitches } from './PermissionsSwitches';
 import { Permission } from '../types/userRoles';
-import { EditIconButton } from '../../users/components/UsersDialog';
+import { EditIconButton } from '../../../components/Buttons/EditIconButton';
 
 type ModalMode = 'create' | 'edit';
 type Props = Partial<SaveUserRoleQuery> & {

--- a/hat/assets/js/apps/Iaso/domains/users/components/UsersDialog.tsx
+++ b/hat/assets/js/apps/Iaso/domains/users/components/UsersDialog.tsx
@@ -9,7 +9,6 @@ import {
     makeFullModal,
     ConfirmCancelModal,
     AddButton,
-    IconButton,
 } from 'bluesquare-components';
 
 import { MutateFunction } from 'react-query';
@@ -23,6 +22,7 @@ import { Profile, useCurrentUser } from '../../../utils/usersUtils';
 import { useInitialUser } from './useInitialUser';
 import { InitialUserData } from '../types';
 import { WarningModal } from './WarningModal/WarningModal';
+import { EditIconButton } from '../../../components/Buttons/EditIconButton';
 
 const useStyles = makeStyles(theme => ({
     tabs: {
@@ -219,20 +219,6 @@ const UserDialogComponent: FunctionComponent<Props> = ({
                 </div>
             </ConfirmCancelModal>
         </>
-    );
-};
-
-type PropsIcon = {
-    onClick: () => void;
-};
-
-export const EditIconButton: FunctionComponent<PropsIcon> = ({ onClick }) => {
-    return (
-        <IconButton
-            onClick={onClick}
-            icon="edit"
-            tooltipMessage={MESSAGES.edit}
-        />
     );
 };
 

--- a/hat/assets/js/apps/Iaso/domains/workflows/components/ModalButtons.tsx
+++ b/hat/assets/js/apps/Iaso/domains/workflows/components/ModalButtons.tsx
@@ -11,16 +11,6 @@ type Props = {
     dataTestId?: string;
 };
 
-export const EditIconButton: FunctionComponent<Props> = ({ onClick }) => {
-    return (
-        <IconButton
-            onClick={onClick}
-            icon="edit"
-            tooltipMessage={MESSAGES.edit}
-        />
-    );
-};
-
 export const PublishButton: FunctionComponent<Props> = ({
     onClick,
     dataTestId,

--- a/hat/assets/js/apps/Iaso/domains/workflows/components/changes/Modal.tsx
+++ b/hat/assets/js/apps/Iaso/domains/workflows/components/changes/Modal.tsx
@@ -18,7 +18,6 @@ import isEqual from 'lodash/isEqual';
 
 import { Box } from '@mui/material';
 import { makeStyles } from '@mui/styles';
-import { EditIconButton } from '../ModalButtons';
 import { MappingTable } from './MappingTable';
 import { Popper } from './InfoPopper';
 
@@ -33,6 +32,7 @@ import {
     useGetPossibleFieldsByFormVersion,
 } from '../../../forms/hooks/useGetPossibleFields';
 import { DropdownOptions } from '../../../../types/utils';
+import { EditIconButton } from '../../../../components/Buttons/EditIconButton';
 
 type Props = {
     isOpen: boolean;

--- a/hat/assets/js/apps/Iaso/domains/workflows/components/followUps/Modal.tsx
+++ b/hat/assets/js/apps/Iaso/domains/workflows/components/followUps/Modal.tsx
@@ -15,11 +15,10 @@ import {
 } from 'bluesquare-components';
 
 import { Grid, Box, useTheme } from '@mui/material';
+import { EditIconButton } from '../../../../components/Buttons/EditIconButton';
 import InputComponent from '../../../../components/forms/InputComponent';
-import { EditIconButton } from '../ModalButtons';
 import { commaSeparatedIdsToArray } from '../../../../utils/forms';
 import { Popper } from '../../../forms/fields/components/Popper';
-
 import { useGetForms } from '../../hooks/requests/useGetForms';
 import { useBulkUpdateWorkflowFollowUp } from '../../hooks/requests/useBulkUpdateWorkflowFollowUp';
 import { useCreateWorkflowFollowUp } from '../../hooks/requests/useCreateWorkflowFollowUp';


### PR DESCRIPTION
 We duplicated the EditIconButton a lot

Explain what problem this PR is resolving

Related JIRA tickets : IA-2791

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
N/A

## Changes

- Delete all duplicate `EditIconButton` and replace them with `/apps/Iaso/components/Buttons/EditIconButton.tsx`

## How to test

Check impacted pages, there should be no visible change:
- LegendBuilder 
- UserRole modal 
- User modal 
- Beneficiary type workflow changes 
- Beneficiary type workflow follow up

## Print screen / video

No visible change

