### PR TITLE
IA-2334: Org unit registry Tooltip

### DIFF
--- a/hat/assets/js/apps/Iaso/components/maps/popups/PopupItemComponent.js
+++ b/hat/assets/js/apps/Iaso/components/maps/popups/PopupItemComponent.js
@@ -1,11 +1,11 @@
 import React from 'react';
 
-import { Grid } from '@mui/material';
+import { Box, Grid } from '@mui/material';
 import { withStyles } from '@mui/styles';
 
 import PropTypes, { number } from 'prop-types';
 
-import { textPlaceholder, mapPopupStyles } from 'bluesquare-components';
+import { mapPopupStyles, textPlaceholder } from 'bluesquare-components';
 
 const styles = theme => ({
     ...mapPopupStyles(theme),
@@ -16,7 +16,7 @@ const PopupItemComponent = props => {
     return (
         <Grid container spacing={0}>
             <Grid item xs={labelSize} className={classes.popupListItemLabel}>
-                {label}:
+                <Box mr={1}>{label}:</Box>
             </Grid>
             <Grid item xs={valueSize} className={classes.popuplistItem}>
                 {value || textPlaceholder}

--- a/hat/assets/js/apps/Iaso/domains/registry/components/MapPopUp.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/MapPopUp.tsx
@@ -2,20 +2,20 @@ import React, { FunctionComponent, useRef } from 'react';
 import { Popup, useMap } from 'react-leaflet';
 
 import ClearIcon from '@mui/icons-material/Clear';
-import { Card, CardContent, Box, Divider, IconButton } from '@mui/material';
+import { Box, Card, CardContent, Divider, IconButton } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 
 import {
-    useSafeIntl,
     commonStyles,
     mapPopupStyles,
+    useSafeIntl,
 } from 'bluesquare-components';
 
-import MESSAGES from '../messages';
-import { OrgUnit } from '../../orgUnits/types/orgUnit';
-import { LinkToRegistry } from './LinkToRegistry';
 import PopupItemComponent from '../../../components/maps/popups/PopupItemComponent';
 import { LinkToOrgUnit } from '../../orgUnits/components/LinkToOrgUnit';
+import { OrgUnit } from '../../orgUnits/types/orgUnit';
+import MESSAGES from '../messages';
+import { LinkToRegistry } from './LinkToRegistry';
 
 type Props = {
     orgUnit: OrgUnit;

--- a/hat/assets/js/apps/Iaso/domains/registry/components/OrgUnitChildrenMap.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/OrgUnitChildrenMap.tsx
@@ -146,7 +146,6 @@ export const OrgUnitChildrenMap: FunctionComponent<Props> = ({
         },
         [dispatch, params],
     );
-    console.log('showTooltip', showTooltip);
     if (isFetchingChildren)
         return (
             <Box position="relative" height={500}>

--- a/hat/assets/js/apps/Iaso/domains/registry/components/OrgUnitChildrenMap.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/OrgUnitChildrenMap.tsx
@@ -1,45 +1,45 @@
-import React, {
-    FunctionComponent,
-    useState,
-    useMemo,
-    useCallback,
-} from 'react';
-import { useDispatch } from 'react-redux';
-import { MapContainer, GeoJSON, Pane, ScaleControl } from 'react-leaflet';
-import { LoadingSpinner, commonStyles } from 'bluesquare-components';
 import { Box, useTheme } from '@mui/material';
 import { makeStyles } from '@mui/styles';
+import { LoadingSpinner, commonStyles } from 'bluesquare-components';
 import classNames from 'classnames';
 import { keyBy } from 'lodash';
+import React, {
+    FunctionComponent,
+    useCallback,
+    useMemo,
+    useState,
+} from 'react';
+import { GeoJSON, MapContainer, Pane, ScaleControl } from 'react-leaflet';
 import MarkerClusterGroup from 'react-leaflet-markercluster';
+import { useDispatch } from 'react-redux';
 import {
     circleColorMarkerOptions,
+    colorClusterCustomMarker,
     getOrgUnitBounds,
     getOrgUnitsBounds,
     mergeBounds,
-    colorClusterCustomMarker,
 } from '../../../utils/map/mapUtils';
 
+import CircleMarkerComponent from '../../../components/maps/markers/CircleMarkerComponent';
 import { Tile } from '../../../components/maps/tools/TilesSwitchControl';
 import { MapLegend } from './MapLegend';
-import CircleMarkerComponent from '../../../components/maps/markers/CircleMarkerComponent';
 
 import { OrgUnit } from '../../orgUnits/types/orgUnit';
 import { OrgunitTypes } from '../../orgUnits/types/orgunitTypes';
 
 import { Legend, useGetlegendOptions } from '../hooks/useGetLegendOptions';
 
-import { MapToggleTooltips } from './MapToggleTooltips';
 import { MapToggleFullscreen } from './MapToggleFullscreen';
+import { MapToggleTooltips } from './MapToggleTooltips';
 
-import TILES from '../../../constants/mapTiles';
-import { MapPopUp } from './MapPopUp';
-import { RegistryDetailParams } from '../types';
-import { redirectToReplace } from '../../../routing/actions';
-import { baseUrls } from '../../../constants/urls';
+import MarkersListComponent from '../../../components/maps/markers/MarkersListComponent';
 import { CustomTileLayer } from '../../../components/maps/tools/CustomTileLayer';
 import { CustomZoomControl } from '../../../components/maps/tools/CustomZoomControl';
-import MarkersListComponent from '../../../components/maps/markers/MarkersListComponent';
+import TILES from '../../../constants/mapTiles';
+import { baseUrls } from '../../../constants/urls';
+import { redirectToReplace } from '../../../routing/actions';
+import { RegistryDetailParams } from '../types';
+import { MapPopUp } from './MapPopUp';
 import { MapToolTip } from './MapTooltip';
 
 type Props = {
@@ -146,7 +146,7 @@ export const OrgUnitChildrenMap: FunctionComponent<Props> = ({
         },
         [dispatch, params],
     );
-
+    console.log('showTooltip', showTooltip);
     if (isFetchingChildren)
         return (
             <Box position="relative" height={500}>
@@ -206,7 +206,22 @@ export const OrgUnitChildrenMap: FunctionComponent<Props> = ({
                                     style={() => ({
                                         color: theme.palette.secondary.main,
                                     })}
-                                />
+                                >
+                                    <MapPopUp orgUnit={orgUnit} />
+                                    {showTooltip && (
+                                        <MapToolTip
+                                            permanent
+                                            pane="popupPane"
+                                            label={orgUnit.name}
+                                        />
+                                    )}
+                                    {!showTooltip && (
+                                        <MapToolTip
+                                            pane="popupPane"
+                                            label={orgUnit.name}
+                                        />
+                                    )}
+                                </GeoJSON>
                             </Pane>
                         )}
                         {orgUnit.latitude && orgUnit.longitude && (
@@ -219,7 +234,18 @@ export const OrgUnitChildrenMap: FunctionComponent<Props> = ({
                                     ...circleColorMarkerOptions(
                                         theme.palette.secondary.main,
                                     ),
+                                    key: `markers-${orgUnit.id}-${showTooltip}`,
                                 })}
+                                popupProps={() => ({
+                                    orgUnit,
+                                })}
+                                tooltipProps={() => ({
+                                    permanent: showTooltip,
+                                    pane: 'popupPane',
+                                    label: orgUnit.name,
+                                })}
+                                PopupComponent={MapPopUp}
+                                TooltipComponent={MapToolTip}
                             />
                         )}
                     </>


### PR DESCRIPTION
Tooltip with org unit infos wad only present for children org unit.

Also initial issue was that those tooltip are not present in full screen mode.

Related JIRA tickets : IA-2334
## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)


## Changes

Display popup and tooltip on current org unit too.


## How to test

Open registry page for an org unit with a shape and some children with location.

Make sure tootltip and popup are displayed while hovering, switching to view tooltip mode, ... test in full screen mode too.


## Print screen / video


https://github.com/BLSQ/iaso/assets/12494624/cfc520e6-6fb9-463b-adfd-2ef7abe3d936

