### PR TITLE
IA-2482 Missing-IASO-ref-in-CSV_XLS-export-orgUnit

### DIFF
--- a/iaso/tests/utils/test_common.py
+++ b/iaso/tests/utils/test_common.py
@@ -1,5 +1,5 @@
 from iaso.test import TestCase
-from iaso.utils.models.common import get_creator_name
+from iaso.utils.models.common import get_creator_name, get_org_unit_parents_ref
 
 
 class CommonTestCase(TestCase):
@@ -12,3 +12,38 @@ class CommonTestCase(TestCase):
             user.get("last_name", ""),
         )
         self.assertEqual(creator, "yoda (Yo Da)")
+
+    def test_get_org_unit_parents_ref(self):
+        org_unit = {
+            "id": 9354,
+            "name": "Test 2",
+            "org_unit_type__name": "FosaPlay",
+            "version__data_source__name": "reference_play_test2.40.3",
+            "validation_status": "NEW",
+            "parent__name": "Parent",
+            "parent__parent__name": "Parent 1",
+            "parent__parent__parent__name": "Parent 2",
+            "parent__parent__source_ref": "fdc6uOvgoji",
+            "parent__parent__parent__source_ref": "ImspTQPwCqd",
+            "parent__id": 7513,
+            "parent__parent__id": 7417,
+            "parent__parent__parent__id": 6688,
+        }
+        parent_source_ref_field_names = [
+            "parent__source_ref",
+            "parent__parent__source_ref",
+            "parent__parent__parent__source_ref",
+            "parent__parent__parent__parent__source_ref",
+        ]
+
+        parent_field_ids = [
+            "parent__id",
+            "parent__parent__id",
+            "parent__parent__parent__id",
+            "parent__parent__parent__parent__id",
+        ]
+        parents_source_ref = [
+            get_org_unit_parents_ref(field_name, org_unit, parent_source_ref_field_names, parent_field_ids)
+            for field_name in parent_source_ref_field_names
+        ]
+        self.assertEqual(parents_source_ref, ["iaso#7513", "fdc6uOvgoji", "ImspTQPwCqd", None])

--- a/iaso/utils/models/common.py
+++ b/iaso/utils/models/common.py
@@ -11,3 +11,14 @@ def get_creator_name(creator: User = None, username: str = "", first_name: str =
     elif username:
         return username
     return ""
+
+
+def get_org_unit_parents_ref(field_name, org_unit, parent_source_ref_field_names, parent_field_ids):
+    if org_unit.get(field_name):
+        return org_unit.get(field_name)
+    else:
+        parent_index = parent_source_ref_field_names.index(field_name)
+        parent_ref = org_unit.get(parent_field_ids[parent_index])
+        if parent_ref:
+            return f"iaso#{parent_ref}"
+        return None

--- a/iaso/utils/models/common.py
+++ b/iaso/utils/models/common.py
@@ -19,6 +19,7 @@ def get_org_unit_parents_ref(field_name, org_unit, parent_source_ref_field_names
     else:
         parent_index = parent_source_ref_field_names.index(field_name)
         parent_ref = org_unit.get(parent_field_ids[parent_index])
+        """if the external reference id is missing, prefix with iaso the internal id. e.g: 'iaso#1475'"""
         if parent_ref:
             return f"iaso#{parent_ref}"
         return None


### PR DESCRIPTION

Related JIRA tickets : [IA-2482](https://bluesquare.atlassian.net/browse/IA-2482)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

For:
 - Ref externe: when the external id is missing, get the iaso id like **"iaso#9357"**
 - Parent ref ext: same as Ref externe

## How to test
From the org units list, after searching the org units, launch csv or xlsx export. You should see the iaso id as Ref externe and Parent ref ext values event if the external ref are missing.

## Print screen / video

![iaso-ref-id](https://github.com/BLSQ/iaso/assets/6383219/ac1c33f8-4283-4faa-ba61-e60f584080d1)

[IA-2482]: https://bluesquare.atlassian.net/browse/IA-2482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ