### PR TITLE
IA-2785 prevent user to pay themselves

### DIFF
--- a/iaso/api/payments/serializers.py
+++ b/iaso/api/payments/serializers.py
@@ -142,6 +142,12 @@ class PaymentSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError("Invalid status")
         return status
 
+    def validate_user(self, user):
+        request = self.context["request"]
+        request_user = request.user
+        if user == request_user:
+            raise serializers.ValidationError("Users cannot modify their own payments")
+
     def get_change_requests(self, obj):
         change_requests = OrgUnitChangeRequest.objects.filter(payment=obj)
         return OrgChangeRequestNestedSerializer(change_requests, many=True).data

--- a/iaso/api/payments/views.py
+++ b/iaso/api/payments/views.py
@@ -215,19 +215,17 @@ class PaymentLotsViewSet(ModelViewSet):
 
             audit_logger = PaymentLotAuditLogger()
 
-            # Link the potential Payments to the payment lot to enable front-end to filter them out while the task is creating the Payments
-
             # Create the PaymentLot instance but don't save it yet
             payment_lot = PaymentLot(name=name, comment=comment, created_by=request.user, updated_by=request.user)
 
             # Save the PaymentLot instance to ensure it has a primary key
             payment_lot.save()
             potential_payments = PotentialPayment.objects.filter(id__in=potential_payment_ids)
+            # Link the potential Payments to the payment lot to enable front-end to filter them out while the task is creating the Payments
             payment_lot.potential_payments.add(*potential_payments)
             payment_lot.save()
             audit_logger.log_modification(old_data_dump=None, instance=payment_lot, request_user=user)
-
-            # Launch a atask in the worker to update payments, delete potehtial payments, update change requests, update payment_lot status
+            # Launch a a task in the worker to update payments, delete potehtial payments, update change requests, update payment_lot status
             # and log everything
             task = create_payments_from_payment_lot(
                 payment_lot_id=payment_lot.pk,

--- a/iaso/tasks/create_payments_from_payment_lot.py
+++ b/iaso/tasks/create_payments_from_payment_lot.py
@@ -67,7 +67,9 @@ def create_payments_from_payment_lot(
         the_task.result = {"result": ERRORED, "message": "Payment Lot not found"}
         the_task.save()
 
-    potential_payments = PotentialPayment.objects.filter(id__in=potential_payment_ids)
+    user = the_task.launcher
+    # users shouldn't be able to generate payments for themselves
+    potential_payments = PotentialPayment.objects.filter(id__in=potential_payment_ids).exclude(user=user)
     total = len(potential_payment_ids)
     if potential_payments.count() != total:
         the_task.status = ERRORED
@@ -77,7 +79,6 @@ def create_payments_from_payment_lot(
         raise ObjectDoesNotExist
 
     # audit stuff
-    user = the_task.launcher
     audit_logger = PaymentLotAuditLogger()
     old_payment_lot_dump = audit_logger.serialize_instance(payment_lot)
 

--- a/iaso/tests/api/payments/test_payments.py
+++ b/iaso/tests/api/payments/test_payments.py
@@ -26,7 +26,9 @@ class PaymentViewSetAPITestCase(APITestCase):
             validation_status=m.OrgUnit.VALIDATION_VALID,
         )
         cls.user = cls.create_user_with_profile(username="user", permissions=["iaso_payments"], account=account)
-        cls.payment_beneficiary = cls.create_user_with_profile(username="payment_beneficiary", account=account)
+        cls.payment_beneficiary = cls.create_user_with_profile(
+            username="payment_beneficiary", permissions=["iaso_payments"], account=account
+        )
         cls.payment_lot = m.PaymentLot.objects.create(name="Test Payment Lot", created_by=cls.user, updated_by=cls.user)
         cls.payment = m.Payment.objects.create(
             created_by=cls.user,
@@ -40,6 +42,18 @@ class PaymentViewSetAPITestCase(APITestCase):
             status=m.OrgUnitChangeRequest.Statuses.APPROVED,
             payment=cls.payment,
         )
+        cls.payment_to_self = m.Payment.objects.create(
+            created_by=cls.payment_beneficiary,
+            payment_lot=cls.payment_lot,
+            status=m.Payment.Statuses.PENDING,
+            user=cls.user,
+        )
+        cls.second_change_request = m.OrgUnitChangeRequest.objects.create(
+            org_unit=org_unit,
+            new_name="Serenne",
+            status=m.OrgUnitChangeRequest.Statuses.APPROVED,
+            payment=cls.payment_to_self,
+        )
 
     def test_list(self):
         self.client.force_authenticate(user=self.user)
@@ -47,7 +61,7 @@ class PaymentViewSetAPITestCase(APITestCase):
         r = self.assertJSONResponse(response, 200)
         results = r["results"]
         result = results[0]
-        self.assertEquals(len(results), 1)
+        self.assertEquals(len(results), 2)  # users can see payment for themeselves, just not update them
         change_requests = result["change_requests"]
         change_request = result["change_requests"][0]
         self.assertEquals(len(change_requests), 1)
@@ -76,6 +90,22 @@ class PaymentViewSetAPITestCase(APITestCase):
         r = self.assertJSONResponse(response, 200)
         self.assertEqual(r["status"], m.Payment.Statuses.SENT)
         self.assertEqual(r["updated_by"], self.user.id)
+
+        # update second payment so all payments are sent
+        self.client.force_authenticate(user=self.payment_beneficiary)
+        response = self.client.patch(
+            f"/api/payments/{self.payment_to_self.id}/", format="json", data={"status": "sent"}
+        )
+        r = self.assertJSONResponse(response, 200)
+        self.assertEqual(r["status"], m.Payment.Statuses.SENT)
+        self.assertEqual(r["updated_by"], self.payment_beneficiary.id)
         self.payment_lot.refresh_from_db()
         self.assertEqual(self.payment_lot.status, m.PaymentLot.Statuses.SENT)
-        self.assertEqual(am.Modification.objects.count(), 2)
+        self.assertEqual(am.Modification.objects.count(), 3)
+
+    def test_update_own_payment(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.patch(
+            f"/api/payments/{self.payment_to_self.id}/", format="json", data={"status": "sent"}
+        )
+        self.assertJSONResponse(response, 400)

--- a/iaso/tests/api/payments/test_payments_bulk_update.py
+++ b/iaso/tests/api/payments/test_payments_bulk_update.py
@@ -64,6 +64,19 @@ class TestPaymentsBulkUpdate(TaskAPITestCase):
             status=m.OrgUnitChangeRequest.Statuses.APPROVED,
             payment=cls.second_payment,
         )
+        # User handling their own payments. This payment should not appear in any test result
+        cls.payment_to_self = m.Payment.objects.create(
+            created_by=cls.user,
+            payment_lot=cls.payment_lot,
+            status=m.Payment.Statuses.PENDING,
+            user=cls.user,
+        )
+        cls.third_change_request = m.OrgUnitChangeRequest.objects.create(
+            org_unit=org_unit,
+            new_name="Wetlands",
+            status=m.OrgUnitChangeRequest.Statuses.APPROVED,
+            payment=cls.payment_to_self,
+        )
 
     def test_user_not_authenticated(self):
         """POST /api/tasks/create/paymentsbulkupdate/, no auth -> 403"""


### PR DESCRIPTION
Explain what problem this PR is resolving

Related JIRA tickets : IA-2785

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [X] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
In the code

## Changes

- filter out change requests from the request user when generating `PotentialPayments`
- raise Validation error when a user updates their own `Payment`
- exclude `PotentialPayments `by task launcher (user) when running the payment lot creation task
- exclude `Payments` by the task launcher (user) when launching the payment bulk update task
- idem with the`mark_payments_as_read` task

## How to test

- Create change requests with 2 different users, and have a 3rd user with the payment permission
- Go to potential payments page with each user: only potential payments for the other user should be created when using the change request creators, but the 3rd user should see all
- Create payment lot for both users with change requests
- Go to Payment Lot page as one of the users with change requests:
    - Try updating  a payment for the same user you're logged as: you should get a 400
    - Try bulk updating payments for both users: only payments for the other user should be updated
    - Try using the "mark as read" button: only payments for the other user should be updated 

## Print screen / video
Sorry, maybe later

## Notes

Forked from IA-2779
