### PR TITLE
IA-2718: Add tooltip explaining how to search by org unit IDs

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -825,7 +825,7 @@
     "iaso.orgUnits.referenceForms": "Reference forms",
     "iaso.orgUnits.removeFromGroups": "Remove from group(s)",
     "iaso.orgUnits.search": "Search org unit",
-    "iaso.orgUnits.searchParams": "Use prefix “refs:” for external org unit ID search. Use prefix “ids:” for internal org unit ID search. Separate with a comma for multiple IDs. E.g: “refs: 123456, 654321”",
+    "iaso.orgUnits.searchParams": "Use prefix “refs:” for external org unit ID search. Use prefix “ids:” for internal org unit ID search. You can also search multiple IDs at once, separated by a comma or a space. E.g. “ids: 123456, 654321” or “refs: O6uvpzGd5pu, ImspTQPwCqd”",
     "iaso.orgUnits.selectionAction": "With selected org unit",
     "iaso.orgUnits.selectOrgUnit": "Please select an org Unit",
     "iaso.orgUnits.selectProjects": "Select a project",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -825,7 +825,7 @@
     "iaso.orgUnits.referenceForms": "Formulaires de référence",
     "iaso.orgUnits.removeFromGroups": "Retirer du(des) groupe(s)",
     "iaso.orgUnits.search": "Rechercher une unité d'org.",
-    "iaso.orgUnits.searchParams": "Utilisez le préfixe “refs:” pour la recherche d'ID externe d'unité d’organisation. Utilisez le préfixe “ids:” pour la recherche d'ID interne d'unité d’organisation. Séparez par une virgule pour plusieurs identifiants. Par exemple: “refs: 123456, 654321”",
+    "iaso.orgUnits.searchParams": "Utilisez le préfixe “refs:” pour la recherche d'ID externe d'unité d’organisation. Utilisez le préfixe “ids:” pour la recherche d'ID interne d'unité d’organisation. Vous pouvez également rechercher plusieurs ID à la fois, séparés par une virgule ou un espace. Par exemple: “ids: 123456, 654321” ou “refs: O6uvpzGd5pu, ImspTQPwCqd”",
     "iaso.orgUnits.selectionAction": "Avec la sélection d'unités d'organisation",
     "iaso.orgUnits.selectOrgUnit": "Merci de sélectionner une unité d'organisation",
     "iaso.orgUnits.selectProjects": "Selectionner un projet",

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/messages.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/messages.js
@@ -545,8 +545,10 @@ const MESSAGES = defineMessages({
     },
     searchParams: {
         id: 'iaso.orgUnits.searchParams',
-        defaultMessage: 'Use prefix “refs:” for external org unit ID search. Use prefix “ids:” for internal org unit ID search. Separate with a comma for multiple IDs. E.g. “refs: 123456, 654321”',
-    }
+        defaultMessage:
+            // eslint-disable-next-line max-len
+            'Use prefix “refs:” for external org unit ID search. Use prefix “ids:” for internal org unit ID search. You can also search multiple IDs at once, separated by a comma or a space. E.g. “ids: 123456, 654321” or “refs: O6uvpzGd5pu, ImspTQPwCqd”',
+    },
 });
 
 export default MESSAGES;


### PR DESCRIPTION
Elie has asked to make the org unit search by IDs/Refs tootlip content more clear. For more details see his last comment in the related JIRA ticket.

Related JIRA tickets : [IA-2718](https://bluesquare.atlassian.net/browse/IA-2718)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)


## Changes

Made org unit search by IDs/Refs tootlip content more clear

## How to test

Mouse over on the tooltip next the search field and see the appearing text.

## Print screen / video

https://github.com/BLSQ/iaso/assets/6383219/35899470-7adf-49b2-8d21-5e4fd4d43047





[IA-2718]: https://bluesquare.atlassian.net/browse/IA-2718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ