### PR TITLE
POLIO-1528-upgrade-postgis-extensions

### DIFF
--- a/iaso/migrations/0271_upgrade_postgis_extensions_20240325_1139.py
+++ b/iaso/migrations/0271_upgrade_postgis_extensions_20240325_1139.py
@@ -1,0 +1,9 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("iaso", "0270_auto_20240314_1515"),
+    ]
+
+    operations = [migrations.RunSQL("SELECT postgis_extensions_upgrade();")]


### PR DESCRIPTION
Upgrading postgis extensions to fix sentry issue 

Error message was: "A stored procedure tried to use deprecated C function 'pgis_geometry_union_finalfn'
DETAIL:  Library function 'pgis_geometry_union_finalfn' was deprecated in PostGIS 3.3.0
HINT:  Consider running: SELECT postgis_extensions_upgrade()"

See POLIO-1528 https://bluesquare.atlassian.net/browse/POLIO-1528

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] My migrations file are included
