### PR TITLE
IA-2811 Instance API should give a 404 if form_id is unknown, not a 500

### DIFF
--- a/iaso/api/instance_filters.py
+++ b/iaso/api/instance_filters.py
@@ -2,6 +2,7 @@ import datetime
 import json
 from typing import Dict, Any, Optional
 
+from django.shortcuts import get_object_or_404
 from django.http import QueryDict
 from rest_framework.exceptions import ValidationError
 
@@ -84,10 +85,10 @@ def get_form_from_instance_filters(instance_filters: Dict[str, Any]) -> Optional
 
     form = None
     if form_id:
-        form = Form.objects.get(pk=form_id)
+        form = get_object_or_404(Form, pk=form_id)
     elif form_ids:
         form_ids = form_ids.split(",")
         if len(form_ids) == 1:  # if there is only one form_ids specified
-            form = Form.objects.get(pk=form_ids[0])
+            form = get_object_or_404(Form, pk=form_ids[0])
 
     return form

--- a/iaso/tests/api/test_instances.py
+++ b/iaso/tests/api/test_instances.py
@@ -505,6 +505,16 @@ class InstancesAPITestCase(APITestCase):
 
         self.assertValidInstanceListData(response.json(), 0)
 
+    def test_instance_unknown_form_id(self):
+        """GET /instances/?form_id=form_id"""
+        self.client.force_authenticate(self.yoda)
+        response = self.client.get("/api/instances/?csv=true&form_ids=99999")
+
+        self.assertJSONResponse(response, 404)
+        response = self.client.get("/api/instances/?csv=true&form_id=99999")
+
+        self.assertJSONResponse(response, 404)
+
     def test_instance_list_by_form_id_ok_soft_deleted(self):
         """GET /instances/?form_id=form_id"""
 


### PR DESCRIPTION
Explain what problem this PR is resolving
Instance API should give a 404 if parameter form_id is unknown, not a 500
Related JIRA tickets : IA-2811
## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are there enough tests