### PR TITLE
POLIO-1498 Rename outgoing movement into form a unusable vials

### DIFF
--- a/plugins/polio/api/vaccines/stock_management.py
+++ b/plugins/polio/api/vaccines/stock_management.py
@@ -537,7 +537,7 @@ class VaccineStockManagementViewSet(ModelViewSet):
                 results.append(
                     {
                         "date": movement.report_date,
-                        "action": "Outgoing Movement",
+                        "action": "Form A - Unusable vials",
                         "vials_in": movement.unusable_vials or 0,
                         "doses_in": (movement.unusable_vials or 0) * calc.get_doses_per_vial(),
                         "vials_out": None,
@@ -550,9 +550,11 @@ class VaccineStockManagementViewSet(ModelViewSet):
             results.append(
                 {
                     "date": report.destruction_report_date,
-                    "action": f"{report.action} ({report.lot_numbers})"
-                    if len(report.action) > 0
-                    else f"Stock Destruction ({report.lot_numbers})",
+                    "action": (
+                        f"{report.action} ({report.lot_numbers})"
+                        if len(report.action) > 0
+                        else f"Stock Destruction ({report.lot_numbers})"
+                    ),
                     "vials_in": None,
                     "doses_in": None,
                     "vials_out": report.unusable_vials_destroyed or 0,


### PR DESCRIPTION
Rename "Outgoing movement" into "Form A - unusable vials" in Vaccine Stock Management > Unusable Vials.

Related JIRA tickets : POLIO-1498

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented

## Changes

Rename one label

## How to test

Go to Vaccine Stock Management and find if there is no more "Outgoing Movement" in the list of unusable vials.

## Print screen / video

<img width="1151" alt="Screenshot 2024-03-26 at 16 17 53" src="https://github.com/BLSQ/iaso/assets/383344/261759a9-37dc-43f1-bb8b-67a209a9516e">

