### PR TITLE
IA-2808 remove ghost duplicates from other aacount

### DIFF
--- a/iaso/api/deduplication/entity_duplicate.py
+++ b/iaso/api/deduplication/entity_duplicate.py
@@ -415,7 +415,8 @@ class EntityDuplicateViewSet(viewsets.GenericViewSet):
             return Response(data=serializer.data, content_type="application/json")
 
     def get_queryset(self):
-        initial_queryset = EntityDuplicate.objects.all()
+        user_account = self.request.user.iaso_profile.account
+        initial_queryset = EntityDuplicate.objects.filter(entity1__account=user_account, entity2__account=user_account)
         return initial_queryset
 
     @swagger_auto_schema(manual_parameters=[duplicate_detail_entities_param])

--- a/iaso/api/deduplication/entity_duplicate_analyzis.py
+++ b/iaso/api/deduplication/entity_duplicate_analyzis.py
@@ -117,8 +117,8 @@ class EntityDuplicateAnalyzisViewSet(viewsets.GenericViewSet):
         return self.results_key
 
     def get_queryset(self):
-        initial_queryset = EntityDuplicateAnalyzis.objects.all()
-        return initial_queryset
+        user_account = self.request.user.iaso_profile.account
+        return EntityDuplicateAnalyzis.objects.filter(task__account=user_account)
 
     def list(self, request, *args, **kwargs):
         """

--- a/iaso/tests/api/deduplication/test_entities_deduplication.py
+++ b/iaso/tests/api/deduplication/test_entities_deduplication.py
@@ -595,3 +595,50 @@ class EntitiesDuplicationAPITestCase(APITestCase):
         orig_json["_version"] = orig_version_id
         duplicate.entity1.attributes.json = orig_json
         duplicate.entity1.attributes.save()
+
+    def test_duplicate_visibility_across_accounts(self):
+        # You shouldn't see duplicates from another account
+
+        self.client.force_authenticate(self.user_with_default_ou_rw)
+
+        response = self.client.post(
+            "/api/entityduplicates_analyzes/",
+            {
+                "entity_type_id": self.default_entity_type.id,
+                "fields": ["Prenom", "Nom", "Age"],
+                "algorithm": "levenshtein",
+                "parameters": {},
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 201)
+        assert "analyze_id" in response.data
+
+        analyze_id = response.data["analyze_id"]
+
+        task_service = TestTaskService()
+        task_service.run_all()
+
+        response_analyze = self.client.get(f"/api/entityduplicates_analyzes/{analyze_id}/")
+
+        self.assertEqual(response_analyze.status_code, 200)
+
+        response = self.client.get(f"/api/entityduplicates/")
+
+        self.assertNotEqual(response.data["results"], [])
+
+        account_2 = m.Account.objects.create(name="Account 2")
+
+        user2 = self.create_user_with_profile(
+            username="user__2",
+            account=account_2,
+            permissions=["iaso_entity_duplicates_read", "iaso_entity_duplicates_write"],
+        )
+
+        # Authenticate as user2 and check if we see the duplicate
+        self.client.force_authenticate(user2)
+
+        response = self.client.get(f"/api/entityduplicates/")
+
+        self.assertEqual(response.data["results"], [])

--- a/iaso/tests/api/deduplication/test_entities_deduplication.py
+++ b/iaso/tests/api/deduplication/test_entities_deduplication.py
@@ -295,18 +295,19 @@ class EntitiesDuplicationAPITestCase(APITestCase):
 
         datas = [
             {"entity1": self.same_entity_2.id, "entity2": self.same_entity_1.id, "similarity_score": 100},
+            {"entity1": self.close_entity.id, "entity2": self.same_entity_1.id, "similarity_score": 78},
             {"entity1": self.same_entity_in_other_ou.id, "entity2": self.same_entity_1.id, "similarity_score": 100},
             {"entity1": self.same_entity_in_other_ou.id, "entity2": self.same_entity_2.id, "similarity_score": 100},
-            {"entity1": self.close_entity.id, "entity2": self.same_entity_1.id, "similarity_score": 78},
             {"entity1": self.close_entity.id, "entity2": self.same_entity_2.id, "similarity_score": 78},
             {"entity1": self.same_entity_in_other_ou.id, "entity2": self.close_entity.id, "similarity_score": 78},
         ]
-        for idx, datas in enumerate(datas):
-            self.assertEqual(response_duplicate.data["results"][idx]["ignored"], False)
-            self.assertEqual(response_duplicate.data["results"][idx]["similarity"], datas["similarity_score"])
-            self.assertEqual(response_duplicate.data["results"][idx]["entity1"]["id"], datas["entity1"])
-            self.assertEqual(response_duplicate.data["results"][idx]["entity2"]["id"], datas["entity2"])
-            self.assertEqual(response_duplicate.data["results"][idx]["analyzis"][0]["analyze_id"], analyze_id)
+        for data in datas:
+            for result in response_duplicate.data["results"]:
+                if result["entity1"]["id"] == data["entity1"] and result["entity2"]["id"] == data["entity2"]:
+                    self.assertEqual(result["ignored"], False)
+                    self.assertEqual(result["similarity"], data["similarity_score"])
+                    self.assertEqual(result["analyzis"][0]["analyze_id"], analyze_id)
+                    break
 
     def test_detail_of_duplicate(self):
         self.client.force_authenticate(self.user_with_default_ou_rw)


### PR DESCRIPTION
When creating a new Account, duplicates from other account show up while they shouldn't

Related JIRA tickets : IA-2808 

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are there enough tests

## Changes

Duplicates and Duplicates analyzes where NOT filtered by Account by default. This has gone unnoticed because the only client using it was WFP and they only have 1 account on their server ...

## How to test

In a new account or an account where duplicate should exist. The list of duplicates should be empty.

