### PR TITLE
WC2-352 Adding endpoint to get an API token

### DIFF
--- a/iaso/api/api_tokens.py
+++ b/iaso/api/api_tokens.py
@@ -1,0 +1,21 @@
+from rest_framework import serializers, viewsets
+from rest_framework.response import Response
+from rest_framework_simplejwt.tokens import RefreshToken  # type: ignore
+
+
+class APITokenSerializer(serializers.Serializer):
+    token = serializers.CharField()
+
+
+class APITokenViewSet(viewsets.ViewSet):
+    f"""
+    Used to obtain a token usable for the API.
+    This is only really useful when the login/password authentication is disabled and only SSO is active.
+    """
+
+    def list(self, request):
+        refresh = RefreshToken.for_user(request.user)
+        token = str(refresh.access_token)
+
+        serializer = APITokenSerializer({"token": token})
+        return Response(serializer.data)

--- a/iaso/api/api_tokens.py
+++ b/iaso/api/api_tokens.py
@@ -8,7 +8,7 @@ class APITokenSerializer(serializers.Serializer):
 
 
 class APITokenViewSet(viewsets.ViewSet):
-    f"""
+    """
     Used to obtain a token usable for the API.
     This is only really useful when the login/password authentication is disabled and only SSO is active.
     """

--- a/iaso/tests/api/test_api_token.py
+++ b/iaso/tests/api/test_api_token.py
@@ -1,0 +1,23 @@
+from iaso import models as m
+from iaso.test import APITestCase
+
+
+class APITokenTestCase(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.ghi = ghi = m.Account.objects.create(name="Test Account")
+        cls.jane = cls.create_user_with_profile(username="janedoe", account=ghi)
+
+    def test_api_token_without_auth(self):
+        """GET /api/apitoken/ without auth should result in a 401"""
+
+        response = self.client.get("/api/apitoken/")
+        self.assertJSONResponse(response, 401)
+
+    def test_api_token_with_auth(self):
+        """GET  /api/apitoken/ with auth should result in a 200 and a token"""
+        self.client.force_authenticate(self.jane)
+
+        response = self.client.get("/api/apitoken/")
+        self.assertJSONResponse(response, 200)
+        self.assertIsNotNone(response.json().get("token"))

--- a/iaso/urls.py
+++ b/iaso/urls.py
@@ -22,6 +22,7 @@ from .api.accounts import AccountViewSet
 from .api.algorithms import AlgorithmsViewSet
 from .api.algorithms_runs import AlgorithmsRunsViewSet
 from .api.apps import AppsViewSet
+from .api.api_tokens import APITokenViewSet
 from .api.bulk_create_users import BulkCreateUserFromCsvViewSet
 from .api.check_version import CheckVersionViewSet
 from .api.comment import CommentViewSet
@@ -120,6 +121,7 @@ router.register(r"devicesownerships", DevicesOwnershipViewSet, basename="devices
 router.register(r"devicespositions?", DevicesPositionViewSet, basename="devicesposition")
 router.register(r"datasources", DataSourceViewSet, basename="datasources")
 router.register(r"accounts", AccountViewSet, basename="accounts")
+router.register(r"apitoken", APITokenViewSet, basename="apitoken")
 router.register(r"sourceversions", SourceVersionViewSet, basename="sourceversion")
 router.register(r"links", LinkViewSet, basename="links")
 router.register(r"logs", LogsViewSet, basename="logs")


### PR DESCRIPTION
Adds an endpoint to get an API token

Related JIRA tickets : WC2-352

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] New translations have been added or updated if new strings have been introduced in the frontend
- [x] Are there enough tests


## Doc
-  in Swagger

## Changes

Explain the changes that were made. The idea is not to list exhaustively all the changes made (GitHub already provides a full diff), but to help the reviewers better understand:
- which specific file changes go together, e.g: when creating a table in the front-end, there usually is a config file that goes with it
- the reasoning behind some changes, e.g: deleted files because they are now redundant
- the behaviour to expect, e.g: tooltip has purple background color because the client likes it so, changed a key in the API response to be consistent with other endpoints

## How to test

Login with a password, access  /api/apitoken/ and if you feel like it, test the token with the sample code found here: https://iaso.readthedocs.io/en/latest/pages/dev/how_to/use_iaso_apis/use_iaso_apis.html

