### PR TITLE
IA-2837 update change request front

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/hooks/useNewFields.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/hooks/useNewFields.tsx
@@ -23,6 +23,7 @@ import MESSAGES from '../messages';
 import InstanceDetail from '../../../instances/compare/components/InstanceDetail';
 import { ShortOrgUnit } from '../../types/orgUnit';
 import { Nullable, Optional } from '../../../../types/utils';
+import { BooleanValue } from '../../../../libs/utils';
 
 export type NewOrgUnitField = {
     key: string;
@@ -103,6 +104,11 @@ const getLocationValue = (
         />
     );
 };
+
+const PlaceholderValue: ReactElement | Optional<Nullable<string>> = (
+    <>{textPlaceholder}</>
+);
+
 export const useNewFields = (
     changeRequest?: OrgUnitChangeRequestDetails,
 ): UseNewFields => {
@@ -184,35 +190,27 @@ export const useNewFields = (
             isChanged: boolean;
         } => {
             const fieldDef = fieldDefinitions[`new_${key}`];
-            let oldValue: ReactElement | Optional<Nullable<string>> = (
-                <>{textPlaceholder}</>
-            );
-            let newValue: ReactElement | Optional<Nullable<string>> = (
-                <>{textPlaceholder}</>
-            );
-            const isChanged = Array.isArray(value)
-                ? value.length > 0
-                : Boolean(value);
-            if (changeRequest) {
-                if (isChanged && changeRequest[`new_${key}`]) {
-                    newValue = fieldDef.formatValue(
-                        changeRequest[`new_${key}`],
-                        false,
-                    );
-                }
-                if (changeRequest[`old_${key}`]) {
-                    oldValue = fieldDef.formatValue(
-                        changeRequest[`old_${key}`],
-                        true,
-                    );
-                    if (!isChanged) {
-                        newValue = fieldDef.formatValue(
-                            changeRequest[`old_${key}`],
-                            false,
-                        );
-                    }
-                }
+
+            if (!changeRequest) {
+                return {
+                    oldValue: PlaceholderValue,
+                    newValue: PlaceholderValue,
+                    isChanged: BooleanValue(value),
+                };
             }
+
+            const requestedFields = changeRequest.requested_fields;
+
+            const isChanged = requestedFields.includes(key);
+
+            // This will not work if we have to show fields with boolean values
+            const newValue = changeRequest[`new_${key}`]
+                ? fieldDef.formatValue(changeRequest[`new_${key}`], false)
+                : PlaceholderValue;
+
+            const oldValue = changeRequest[`old_${key}`]
+                ? fieldDef.formatValue(changeRequest[`old_${key}`], true)
+                : PlaceholderValue;
 
             return {
                 oldValue,

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/hooks/useNewFields.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/hooks/useNewFields.tsx
@@ -23,7 +23,7 @@ import MESSAGES from '../messages';
 import InstanceDetail from '../../../instances/compare/components/InstanceDetail';
 import { ShortOrgUnit } from '../../types/orgUnit';
 import { Nullable, Optional } from '../../../../types/utils';
-import { BooleanValue } from '../../../../libs/utils';
+import { BooleanValue, PlaceholderValue } from '../../../../libs/utils';
 
 export type NewOrgUnitField = {
     key: string;
@@ -105,9 +105,12 @@ const getLocationValue = (
     );
 };
 
-const PlaceholderValue: ReactElement | Optional<Nullable<string>> = (
-    <>{textPlaceholder}</>
-);
+const getPlaceholderValue = (key: string) => {
+    if (key === 'location') {
+        return <></>;
+    }
+    return PlaceholderValue;
+};
 
 export const useNewFields = (
     changeRequest?: OrgUnitChangeRequestDetails,
@@ -206,11 +209,11 @@ export const useNewFields = (
             // This will not work if we have to show fields with boolean values
             const newValue = changeRequest[`new_${key}`]
                 ? fieldDef.formatValue(changeRequest[`new_${key}`], false)
-                : PlaceholderValue;
+                : getPlaceholderValue(key);
 
             const oldValue = changeRequest[`old_${key}`]
                 ? fieldDef.formatValue(changeRequest[`old_${key}`], true)
-                : PlaceholderValue;
+                : getPlaceholderValue(key);
 
             return {
                 oldValue,

--- a/hat/assets/js/apps/Iaso/libs/utils.tsx
+++ b/hat/assets/js/apps/Iaso/libs/utils.tsx
@@ -60,3 +60,8 @@ export const makeRegexValidator =
             return true;
         },
     });
+
+// Same as built-in Boolean method, but works with arrays as well
+export const BooleanValue = (value: Array<unknown> | unknown): boolean => {
+    return Array.isArray(value) ? value.length > 0 : Boolean(value);
+};

--- a/hat/assets/js/apps/Iaso/libs/utils.tsx
+++ b/hat/assets/js/apps/Iaso/libs/utils.tsx
@@ -4,6 +4,11 @@
  * @param {string} url
  * @param {{[p: string]: T}} urlParams
  */
+
+import React, { ReactElement } from 'react';
+import { textPlaceholder } from 'bluesquare-components';
+import { Nullable, Optional } from '../types/utils';
+
 // url should include closing slash
 export const makeUrlWithParams = (
     url: string,
@@ -65,3 +70,7 @@ export const makeRegexValidator =
 export const BooleanValue = (value: Array<unknown> | unknown): boolean => {
     return Array.isArray(value) ? value.length > 0 : Boolean(value);
 };
+
+export const PlaceholderValue: ReactElement | Optional<Nullable<string>> = (
+    <>{textPlaceholder}</>
+);


### PR DESCRIPTION
Update change request front-end to handle field erasing

Related JIRA tickets : IA-2837

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
N/A

## Changes

- If `changeRequest` is `undefined` return default values
- else: show new value if it exists, otherwise show placeholder
- compute `isChanged` value from `chageRequest.requested_fields` to enable columns with `null`values to be selectable

## How to test

With data from `setuper`
- Add opening and closing date to an org unit
- Create a change request setting these dates to null (in django admin)
- Find an org unit with a location and create a change request setting this location to null (in django admin)
- For both change requests, the updated fields should be selectable in the interface
- When approving those changes, the values should be updated accordingly

## Print screen / video


https://github.com/BLSQ/iaso/assets/38907762/916c6cce-ce03-4e76-830a-986738a5aa1b



## Notes

Depends on https://github.com/BLSQ/iaso/pull/1225
