### PR TITLE
IA-2817 no dash in app

### DIFF
--- a/hat/assets/js/apps/Iaso/constants/filters.js
+++ b/hat/assets/js/apps/Iaso/constants/filters.js
@@ -5,16 +5,7 @@ import FullStarsSvg from '../components/stars/FullStarsSvgComponent';
 import getDisplayName from '../utils/usersUtils.ts';
 import { usePrettyPeriod } from '../domains/periods/utils';
 import { orgUnitLabelString } from '../domains/orgUnits/utils';
-import { capitalize } from '../utils/index';
-
-export const forbiddenCharacters = ['"', '?', '/', '%', '&'];
-
-export const containsForbiddenCharacter = value => {
-    for (let i = 0; i < value.length; i += 1) {
-        if (forbiddenCharacters.includes(value[i])) return true;
-    }
-    return false;
-};
+import { capitalize } from '../utils/index.ts';
 
 export const search = (urlKey = 'search') => ({
     urlKey,

--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -983,7 +983,7 @@
     "iaso.projects.needsAuthentication": "Requires authentication",
     "iaso.projects.true": "User needs authentication",
     "iaso.projects.update": "Update project",
-    "iaso.projets.label.appIdError": "\"-\" and whitespace are not allowed in app id",
+    "iaso.projets.label.appIdError": "\", ?, /, %, &, - and whitespace are not allowed in app id",
     "iaso.province": "Province",
     "iaso.queryBuilder.supportedTypeFields": "Supported type of fields",
     "iaso.queryBuilder.title": "Query builder",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -983,6 +983,7 @@
     "iaso.projects.needsAuthentication": "Requires authentication",
     "iaso.projects.true": "User needs authentication",
     "iaso.projects.update": "Update project",
+    "iaso.projets.label.appIdError": "\"-\" character is not allowed in app id",
     "iaso.province": "Province",
     "iaso.queryBuilder.supportedTypeFields": "Supported type of fields",
     "iaso.queryBuilder.title": "Query builder",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -983,7 +983,7 @@
     "iaso.projects.needsAuthentication": "Requires authentication",
     "iaso.projects.true": "User needs authentication",
     "iaso.projects.update": "Update project",
-    "iaso.projets.label.appIdError": "\"-\" character is not allowed in app id",
+    "iaso.projets.label.appIdError": "\"-\" and whitespace are not allowed in app id",
     "iaso.province": "Province",
     "iaso.queryBuilder.supportedTypeFields": "Supported type of fields",
     "iaso.queryBuilder.title": "Query builder",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -983,7 +983,7 @@
     "iaso.projects.needsAuthentication": "Nécessite une authentification",
     "iaso.projects.true": "L'utilisateur a besoin d'une authentification",
     "iaso.projects.update": "Modifier un projet",
-    "iaso.projets.label.appIdError": "Le symbole \"-\" n'est pas autorisé dans l'app id",
+    "iaso.projets.label.appIdError": "Le symbole \"-\" et les espaces ne sont pas autorisés dans l'app id",
     "iaso.province": "Province",
     "iaso.queryBuilder.supportedTypeFields": "Type de champ supportés",
     "iaso.queryBuilder.title": "Query builder",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -983,6 +983,7 @@
     "iaso.projects.needsAuthentication": "Nécessite une authentification",
     "iaso.projects.true": "L'utilisateur a besoin d'une authentification",
     "iaso.projects.update": "Modifier un projet",
+    "iaso.projets.label.appIdError": "Le symbole \"-\" n'est pas autorisé dans l'app id",
     "iaso.province": "Province",
     "iaso.queryBuilder.supportedTypeFields": "Type de champ supportés",
     "iaso.queryBuilder.title": "Query builder",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -983,7 +983,7 @@
     "iaso.projects.needsAuthentication": "Nécessite une authentification",
     "iaso.projects.true": "L'utilisateur a besoin d'une authentification",
     "iaso.projects.update": "Modifier un projet",
-    "iaso.projets.label.appIdError": "Le symbole \"-\" et les espaces ne sont pas autorisés dans l'app id",
+    "iaso.projets.label.appIdError": "Les symboles \", ?, /, %, &, - et les espaces ne sont pas autorisés dans l'app id",
     "iaso.province": "Province",
     "iaso.queryBuilder.supportedTypeFields": "Type de champ supportés",
     "iaso.queryBuilder.title": "Query builder",

--- a/hat/assets/js/apps/Iaso/domains/projects/components/ProjectFeatureFlags.tsx
+++ b/hat/assets/js/apps/Iaso/domains/projects/components/ProjectFeatureFlags.tsx
@@ -6,7 +6,7 @@ import MESSAGES from '../messages';
 
 import { FeatureFlag } from '../types/featureFlag';
 
-type Form = {
+export type Form = {
     value: Array<string>;
     errors: Array<string>;
 };

--- a/hat/assets/js/apps/Iaso/domains/projects/components/ProjectsDialog.tsx
+++ b/hat/assets/js/apps/Iaso/domains/projects/components/ProjectsDialog.tsx
@@ -64,6 +64,15 @@ const emptyProject = {
     feature_flags: { value: [], errors: [] } as Form,
 };
 
+export const forbiddenCharacters = ['"', '?', '/', '%', '&', ' ', '-'];
+
+export const containsForbiddenCharacter = (value: string): boolean => {
+    for (let i = 0; i < value.length; i += 1) {
+        if (forbiddenCharacters.includes(value[i])) return true;
+    }
+    return false;
+};
+
 const ProjectsDialog: FunctionComponent<Props> = ({
     titleMessage,
     renderTrigger,
@@ -124,8 +133,7 @@ const ProjectsDialog: FunctionComponent<Props> = ({
     const setInfoFieldValue = useCallback(
         (fieldName, fieldValue) => {
             const errors: unknown[] = [];
-            const hasForbiddenChar =
-                fieldValue.includes('-') || fieldValue.includes(' ');
+            const hasForbiddenChar = containsForbiddenCharacter(fieldValue);
             if (fieldName === 'app_id' && hasForbiddenChar) {
                 errors.push(appIdError);
             }

--- a/hat/assets/js/apps/Iaso/domains/projects/components/ProjectsDialog.tsx
+++ b/hat/assets/js/apps/Iaso/domains/projects/components/ProjectsDialog.tsx
@@ -104,7 +104,7 @@ const ProjectsDialog: FunctionComponent<Props> = ({
     const appIdError = formatMessage(MESSAGES.appIdError);
 
     const onClosed = () => {
-        setProject(emptyProject);
+        setProject(initialProject(null));
         setTab('infos');
     };
 
@@ -165,7 +165,7 @@ const ProjectsDialog: FunctionComponent<Props> = ({
             .then(() => {
                 closeDialog();
                 setTab('infos');
-                setProject(emptyProject);
+                setProject(initialProject(initialData));
             })
             .catch(error => {
                 if (error.status === 400) {

--- a/hat/assets/js/apps/Iaso/domains/projects/components/ProjectsDialog.tsx
+++ b/hat/assets/js/apps/Iaso/domains/projects/components/ProjectsDialog.tsx
@@ -124,7 +124,9 @@ const ProjectsDialog: FunctionComponent<Props> = ({
     const setInfoFieldValue = useCallback(
         (fieldName, fieldValue) => {
             const errors: unknown[] = [];
-            if (fieldName === 'app_id' && fieldValue.includes('-')) {
+            const hasForbiddenChar =
+                fieldValue.includes('-') || fieldValue.includes(' ');
+            if (fieldName === 'app_id' && hasForbiddenChar) {
                 errors.push(appIdError);
             }
             setProject({
@@ -165,7 +167,7 @@ const ProjectsDialog: FunctionComponent<Props> = ({
             .then(() => {
                 closeDialog();
                 setTab('infos');
-                setProject(initialProject(initialData));
+                setProject(initialProject(null));
             })
             .catch(error => {
                 if (error.status === 400) {

--- a/hat/assets/js/apps/Iaso/domains/projects/components/ProjectsDialog.tsx
+++ b/hat/assets/js/apps/Iaso/domains/projects/components/ProjectsDialog.tsx
@@ -13,12 +13,13 @@ import { useSafeIntl, IntlMessage } from 'bluesquare-components';
 import ConfirmCancelDialogComponent from '../../../components/dialogs/ConfirmCancelDialogComponent';
 
 import { ProjectInfos } from './ProjectInfos';
-import { ProjectFeatureFlags } from './ProjectFeatureFlags';
+import { Form, ProjectFeatureFlags } from './ProjectFeatureFlags';
 
 import { Project } from '../types/project';
 
 import MESSAGES from '../messages';
 import { useGetFeatureFlags } from '../hooks/requests';
+import { FeatureFlag } from '../types/featureFlag';
 
 type RenderTriggerProps = {
     openDialog: () => void;
@@ -56,6 +57,13 @@ const useStyles = makeStyles(theme => ({
     },
 }));
 
+const emptyProject = {
+    id: { value: '', errors: [] },
+    app_id: { value: '', errors: [] },
+    name: { value: '', errors: [] },
+    feature_flags: { value: [], errors: [] } as Form,
+};
+
 const ProjectsDialog: FunctionComponent<Props> = ({
     titleMessage,
     renderTrigger,
@@ -73,10 +81,7 @@ const ProjectsDialog: FunctionComponent<Props> = ({
     const classes: Record<string, string> = useStyles();
     const initialProject = useCallback(
         app => {
-            let pr = initialData || {};
-            if (app) {
-                pr = app;
-            }
+            const pr = app || initialData || {};
             return {
                 id: { value: get(pr, 'id', null), errors: [] },
                 app_id: { value: get(pr, 'app_id', ''), errors: [] },
@@ -85,40 +90,66 @@ const ProjectsDialog: FunctionComponent<Props> = ({
                     errors: [],
                 },
                 feature_flags: {
-                    value: get(pr, 'feature_flags', []).map(v => v.id),
+                    value: get(pr, 'feature_flags', [] as FeatureFlag[]).map(
+                        (v: FeatureFlag): number => v.id,
+                    ),
                     errors: [],
                 },
             };
         },
         [initialData],
     );
-    const [project, setProject] = useState(initialProject(null));
+    const [project, setProject] = useState(emptyProject);
     const [tab, setTab] = useState<Tab>('infos');
+    const appIdError = formatMessage(MESSAGES.appIdError);
 
     const onClosed = () => {
-        setProject(initialProject(null));
+        setProject(emptyProject);
         setTab('infos');
     };
 
-    const setFieldValue = (fieldName, fieldValue) => {
-        setProject({
-            ...project,
-            [fieldName]: {
-                value: fieldValue,
-                errors: [],
-            },
-        });
-    };
+    const setFieldValue = useCallback(
+        (fieldName, fieldValue) => {
+            setProject({
+                ...project,
+                [fieldName]: {
+                    value: fieldValue,
+                    errors: [],
+                },
+            });
+        },
+        [project],
+    );
 
-    const setFieldErrors = (fieldName, fieldError) => {
-        setProject({
-            ...project,
-            [fieldName]: {
-                value: project[fieldName].value,
-                errors: [fieldError],
-            },
-        });
-    };
+    const setInfoFieldValue = useCallback(
+        (fieldName, fieldValue) => {
+            const errors: unknown[] = [];
+            if (fieldName === 'app_id' && fieldValue.includes('-')) {
+                errors.push(appIdError);
+            }
+            setProject({
+                ...project,
+                [fieldName]: {
+                    value: fieldValue,
+                    errors,
+                },
+            });
+        },
+        [appIdError, project],
+    );
+
+    const setFieldErrors = useCallback(
+        (fieldName, fieldError) => {
+            setProject({
+                ...project,
+                [fieldName]: {
+                    value: project[fieldName].value,
+                    errors: [fieldError],
+                },
+            });
+        },
+        [project],
+    );
 
     const onConfirm = closeDialog => {
         const currentProject: Project = {
@@ -134,7 +165,7 @@ const ProjectsDialog: FunctionComponent<Props> = ({
             .then(() => {
                 closeDialog();
                 setTab('infos');
-                setProject(initialProject(null));
+                setProject(emptyProject);
             })
             .catch(error => {
                 if (error.status === 400) {
@@ -155,6 +186,7 @@ const ProjectsDialog: FunctionComponent<Props> = ({
             project.name.value !== '' &&
             project.app_id &&
             project.app_id.value !== '' &&
+            project.app_id.errors.length === 0 &&
             !isFetchingFeatureFlags,
         [project, isFetchingFeatureFlags],
     );
@@ -199,9 +231,7 @@ const ProjectsDialog: FunctionComponent<Props> = ({
                 </Tabs>
                 {tab === 'infos' && (
                     <ProjectInfos
-                        setFieldValue={(key, value) =>
-                            setFieldValue(key, value)
-                        }
+                        setFieldValue={setInfoFieldValue}
                         currentProject={project}
                     />
                 )}

--- a/hat/assets/js/apps/Iaso/domains/projects/messages.ts
+++ b/hat/assets/js/apps/Iaso/domains/projects/messages.ts
@@ -59,7 +59,7 @@ const MESSAGES = defineMessages({
     },
     appIdError: {
         id: 'iaso.projets.label.appIdError',
-        defaultMessage: '"-" character is not allowed in app id',
+        defaultMessage: '"-" and whitespace are not allowed in app id',
     },
 });
 

--- a/hat/assets/js/apps/Iaso/domains/projects/messages.ts
+++ b/hat/assets/js/apps/Iaso/domains/projects/messages.ts
@@ -57,6 +57,10 @@ const MESSAGES = defineMessages({
         id: 'iaso.label.save',
         defaultMessage: 'Save',
     },
+    appIdError: {
+        id: 'iaso.projets.label.appIdError',
+        defaultMessage: '"-" character is not allowed in app id',
+    },
 });
 
 export default MESSAGES;

--- a/hat/assets/js/apps/Iaso/domains/projects/messages.ts
+++ b/hat/assets/js/apps/Iaso/domains/projects/messages.ts
@@ -59,7 +59,8 @@ const MESSAGES = defineMessages({
     },
     appIdError: {
         id: 'iaso.projets.label.appIdError',
-        defaultMessage: '"-" and whitespace are not allowed in app id',
+        defaultMessage:
+            '", ?, /, %, &, - and whitespace are not allowed in app id',
     },
 });
 


### PR DESCRIPTION
Explain what problem this PR is resolving

Related JIRA tickets : IA-2817

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [X] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
NA

## Changes
- Add a check on dash and whitespace when creating/updating appId in web front-end

## How to test

- Go to Profiles
- Try to edit and create projects. If app id has a dash or whitespace, the field will error and save will be disabled

## Print screen / video

https://github.com/BLSQ/iaso/assets/38907762/a7312ed7-4a03-4c62-880c-39cab2a59468



## Notes

The `ProjectDialog` component should be refactored to use the new modal (more performant) and formik, but that's for another ticket
