### PR TITLE
IA-2710 (bis) Prevent Change Request's payload validation to fail for fields without value

### DIFF
--- a/iaso/api/org_unit_change_requests/serializers.py
+++ b/iaso/api/org_unit_change_requests/serializers.py
@@ -305,12 +305,6 @@ class OrgUnitChangeRequestWriteSerializer(serializers.ModelSerializer):
     def validate(self, validated_data):
         # Fields names are different between API and model, e.g. `new_parent_id` VS `new_parent`.
         new_fields_api = [name for name in self.Meta.fields if name.startswith("new_")]
-        new_fields_model = OrgUnitChangeRequest.get_new_fields()
-
-        if not any([validated_data.get(field) for field in new_fields_model]):
-            raise serializers.ValidationError(
-                f"You must provide at least one of the following fields: {', '.join(new_fields_api)}."
-            )
 
         new_closed_date = validated_data.get("new_closed_date")
         new_opening_date = validated_data.get("new_opening_date")
@@ -335,6 +329,11 @@ class OrgUnitChangeRequestWriteSerializer(serializers.ModelSerializer):
         validated_data["requested_fields"] = [
             field for field in validated_data if field in OrgUnitChangeRequest.get_new_fields()
         ]
+
+        if not validated_data["requested_fields"]:
+            raise serializers.ValidationError(
+                f"You must provide at least one of the following fields: {', '.join(new_fields_api)}."
+            )
 
         return validated_data
 

--- a/iaso/tests/api/org_unit_change_requests/test_serializers.py
+++ b/iaso/tests/api/org_unit_change_requests/test_serializers.py
@@ -440,6 +440,13 @@ class OrgUnitChangeRequestWriteSerializerTestCase(TestCase):
         self.assertFalse(serializer.is_valid())
         self.assertIn("You must provide at least one of the following fields", serializer.errors["non_field_errors"][0])
 
+        data = {
+            "org_unit_id": self.org_unit.id,
+            "new_closed_date": None,
+        }
+        serializer = OrgUnitChangeRequestWriteSerializer(data=data)
+        self.assertTrue(serializer.is_valid())
+
     def test_validate_new_parent_version(self):
         data_source = m.DataSource.objects.create(name="Data source")
         version1 = m.SourceVersion.objects.create(number=1, data_source=data_source)


### PR DESCRIPTION
Prevent Change Request's payload validation to fail for fields with no value.

Fix for [IA-2710](https://bluesquare.atlassian.net/browse/IA-2710)

## Changes

This was triggering a validation error because `new_closed_date` was `null`:

```
{
  "uuid":"f02ad3ff-6bc3-43c2-aa44-ba258356505e",
  "org_unit_id":"1972317",
  "created_at":1.712741023886E9,
  "updated_at":1.712741023886E9,
  "new_closed_date":null
}
```

The validation logic is fixed to consider `null` as valid (as this can be used to erase a field).

An error is raised only when none of the new fields is present.

[IA-2710]: https://bluesquare.atlassian.net/browse/IA-2710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ