### PR TITLE
IA-2862: HOTFIX fix date reset UI

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/hooks/useNewFields.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/hooks/useNewFields.tsx
@@ -142,17 +142,17 @@ export const useNewFields = (
                 label: formatMessage(MESSAGES.name),
                 order: 1,
                 fieldType: '',
-                formatValue: val => val,
-                // formatValue: val => <span>{val.toString()}</span>,
+                // span is necessary to enable text styling
+                formatValue: val => <span>{val.toString()}</span>,
             },
             new_org_unit_type: {
                 label: formatMessage(MESSAGES.orgUnitsType),
                 order: 2,
                 fieldType: 'string',
-                formatValue: val => (val as NestedOrgUnitType)?.short_name,
-                // formatValue: val => (
-                //     <span>{(val as NestedOrgUnitType).short_name}</span>
-                // ),
+                // span is necessary to enable text styling
+                formatValue: val => (
+                    <span>{(val as NestedOrgUnitType)?.short_name}</span>
+                ),
             },
             new_parent: {
                 label: formatMessage(MESSAGES.parent),

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/hooks/useNewFields.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/hooks/useNewFields.tsx
@@ -231,7 +231,7 @@ export const useNewFields = (
 
             const requestedFields = changeRequest.requested_fields;
 
-            const isChanged = requestedFields.includes(key);
+            const isChanged = requestedFields.includes(`new_${key}`);
 
             // This will not work if we have to show fields with boolean values
             const newValue = computeNewValue(

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/hooks/useNewFields.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/hooks/useNewFields.tsx
@@ -114,6 +114,23 @@ const getPlaceholderValue = (key: string) => {
     return PlaceholderValue;
 };
 
+const computeNewValue = (
+    key: string,
+    changeRequest: OrgUnitChangeRequestDetails,
+    fieldDef: FieldDefinition,
+    isChanged: boolean,
+): Optional<Nullable<string>> | ReactElement => {
+    if (!isChanged) {
+        return changeRequest[`old_${key}`]
+            ? fieldDef.formatValue(changeRequest[`old_${key}`], false)
+            : getPlaceholderValue(key);
+    }
+    // This will not work if we have to show fields with boolean values
+    return changeRequest[`new_${key}`]
+        ? fieldDef.formatValue(changeRequest[`new_${key}`], false)
+        : getPlaceholderValue(key);
+};
+
 export const useNewFields = (
     changeRequest?: OrgUnitChangeRequestDetails,
 ): UseNewFields => {
@@ -217,9 +234,12 @@ export const useNewFields = (
             const isChanged = requestedFields.includes(key);
 
             // This will not work if we have to show fields with boolean values
-            const newValue = changeRequest[`new_${key}`]
-                ? fieldDef.formatValue(changeRequest[`new_${key}`], false)
-                : getPlaceholderValue(key);
+            const newValue = computeNewValue(
+                key,
+                changeRequest,
+                fieldDef,
+                isChanged,
+            );
 
             const oldValue = changeRequest[`old_${key}`]
                 ? fieldDef.formatValue(changeRequest[`old_${key}`], true)

--- a/hat/assets/js/apps/Iaso/libs/utils.tsx
+++ b/hat/assets/js/apps/Iaso/libs/utils.tsx
@@ -71,6 +71,7 @@ export const BooleanValue = (value: Array<unknown> | unknown): boolean => {
     return Array.isArray(value) ? value.length > 0 : Boolean(value);
 };
 
+// using a span is necessary to allow text styling
 export const PlaceholderValue: ReactElement | Optional<Nullable<string>> = (
-    <>{textPlaceholder}</>
+    <span>{textPlaceholder}</span>
 );


### PR DESCRIPTION
Explain what problem this PR is resolving

Related JIRA tickets : IA-2862

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [X] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
NA

## Changes

- Fix key used to check `isChanged` status to correctly display select boxes for "null dates"
- Display old values for fields that are not changed (regression fix)
- Put text values in a `<span>` tag to enable styling (text color)

## How to test

- Create a change request resetting opening/closed date and/or location
- Open it in the UI: the reset fields should be selectable and the unchanged values should also be displayed


## Print screen / video

![Screenshot 2024-04-10 at 16 16 29](https://github.com/BLSQ/iaso/assets/38907762/e18f4342-f2b5-4bb1-8e96-9e59c261e2c6)


## Notes

This branch is a fork of v1.229, so it can be deployed as hotfix
