### PR TITLE
WC2-359: Beneficiaries date filtering

### DIFF
--- a/iaso/api/entity.py
+++ b/iaso/api/entity.py
@@ -18,9 +18,15 @@ from rest_framework.response import Response
 
 from hat.api.export_utils import Echo, generate_xlsx, iter_items
 from hat.menupermissions import models as permission
-from iaso.api.common import (CONTENT_TYPE_CSV, CONTENT_TYPE_XLSX,
-                             EXPORTS_DATETIME_FORMAT, DeletionFilterBackend,
-                             HasPermission, ModelViewSet, TimestampField)
+from iaso.api.common import (
+    CONTENT_TYPE_CSV,
+    CONTENT_TYPE_XLSX,
+    EXPORTS_DATETIME_FORMAT,
+    DeletionFilterBackend,
+    HasPermission,
+    ModelViewSet,
+    TimestampField,
+)
 from iaso.models import Entity, EntityType, Instance
 from iaso.models.deduplication import ValidationStatus
 


### PR DESCRIPTION
In the web app, when filtering the beneficiaries' by specific dates in the beneficiaries' list pages (example from children in this [link](https://qa.coda.go.wfp.org/dashboard/entities/list/accountId/1/entityTypeIds/1/order/-last_saved_instance/pageSize/20/page/1)), the list given by the app is only for beneficiaries by last visit date.

It would be more useful for the health workers to be able to see, when filtering by specific timeframes, all the beneficiaries being in programme at that moment in time. 

This means beneficiaries should be listed not only by the last visit date, but at any date when they are in a programme.

Related JIRA tickets : WC2-359

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

Check if entity has an instance within date range

## How to test

Take a beneficiary with multiple submissions at different time in the year.
Select one of those first submission and filter entities on a short date range including the date of this submission.
You should see your entity in the result 

## Print screen / video

![Screenshot 2024-04-11 at 11 59 01](https://github.com/BLSQ/iaso/assets/12494624/fc004c93-3b36-44b1-917c-1eea025fb5e2)
![Screenshot 2024-04-11 at 11 58 52](https://github.com/BLSQ/iaso/assets/12494624/1d641179-cd88-41cf-a0b8-256e60730600)

