### PR TITLE
IA-2810: Snackbar with long error message

### DIFF
--- a/hat/assets/js/apps/Iaso/components/snackBars/SnackBarErrorMessage.js
+++ b/hat/assets/js/apps/Iaso/components/snackBars/SnackBarErrorMessage.js
@@ -1,13 +1,13 @@
-import React from 'react';
 import { Button, Tooltip } from '@mui/material';
 import { makeStyles } from '@mui/styles';
+import React from 'react';
 
 import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
 
 import { commonStyles, useSafeIntl } from 'bluesquare-components';
-import MESSAGES from './messages';
 import { closeFixedSnackbar } from '../../redux/snackBarsReducer';
+import MESSAGES from './messages';
 
 const useStyles = makeStyles(theme => ({
     ...commonStyles(theme),
@@ -21,10 +21,9 @@ const useStyles = makeStyles(theme => ({
         zIndex: -100,
     },
     errorMessage: {
-        display: '-webkit-box',
-        '-webkit-line-clamp': 30,
-        '-webkit-box-orient': 'vertical',
+        display: 'flex',
         overflow: 'hidden',
+        whiteSpace: 'pre-wrap',
     },
 }));
 
@@ -42,7 +41,7 @@ const SnackBarErrorMessage = ({ errorLog, id }) => {
         errorMessage = JSON.stringify(
             { ...errorLog, message: errorLog.message },
             null,
-            1,
+            2,
         );
     } else {
         errorMessage = JSON.stringify(errorLog, null, 1);


### PR DESCRIPTION
Long error message are not fully displayed on snackbars

Related JIRA tickets : IA-2810
## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)


## Changes

Adapt css to handle long error messages

## How to test

add this code to forms.py line 224:

```
        raise serializers.ValidationError(
            {
                "Lorem": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
                "ipsum": ["lorem", "ipsum"],
            }
        )
```
 visit form page and check snackbar

## Print screen / video
![Screenshot 2024-04-11 at 15 38 44](https://github.com/BLSQ/iaso/assets/12494624/bc3144d7-fde5-40a6-82c9-f6c1446dd94c)

