### PR TITLE
Ia 2845 500 login

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/hooks/useNewFields.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/hooks/useNewFields.tsx
@@ -142,17 +142,17 @@ export const useNewFields = (
                 label: formatMessage(MESSAGES.name),
                 order: 1,
                 fieldType: '',
-                formatValue: val => val,
-                // formatValue: val => <span>{val.toString()}</span>,
+                // span is necessary to enable text styling
+                formatValue: val => <span>{val.toString()}</span>,
             },
             new_org_unit_type: {
                 label: formatMessage(MESSAGES.orgUnitsType),
                 order: 2,
                 fieldType: 'string',
-                formatValue: val => (val as NestedOrgUnitType)?.short_name,
-                // formatValue: val => (
-                //     <span>{(val as NestedOrgUnitType).short_name}</span>
-                // ),
+                // span is necessary to enable text styling
+                formatValue: val => (
+                    <span>{(val as NestedOrgUnitType)?.short_name}</span>
+                ),
             },
             new_parent: {
                 label: formatMessage(MESSAGES.parent),

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/hooks/useNewFields.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/hooks/useNewFields.tsx
@@ -231,7 +231,7 @@ export const useNewFields = (
 
             const requestedFields = changeRequest.requested_fields;
 
-            const isChanged = requestedFields.includes(key);
+            const isChanged = requestedFields.includes(`new_${key}`);
 
             // This will not work if we have to show fields with boolean values
             const newValue = computeNewValue(

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/hooks/useNewFields.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/hooks/useNewFields.tsx
@@ -114,6 +114,23 @@ const getPlaceholderValue = (key: string) => {
     return PlaceholderValue;
 };
 
+const computeNewValue = (
+    key: string,
+    changeRequest: OrgUnitChangeRequestDetails,
+    fieldDef: FieldDefinition,
+    isChanged: boolean,
+): Optional<Nullable<string>> | ReactElement => {
+    if (!isChanged) {
+        return changeRequest[`old_${key}`]
+            ? fieldDef.formatValue(changeRequest[`old_${key}`], false)
+            : getPlaceholderValue(key);
+    }
+    // This will not work if we have to show fields with boolean values
+    return changeRequest[`new_${key}`]
+        ? fieldDef.formatValue(changeRequest[`new_${key}`], false)
+        : getPlaceholderValue(key);
+};
+
 export const useNewFields = (
     changeRequest?: OrgUnitChangeRequestDetails,
 ): UseNewFields => {
@@ -217,9 +234,12 @@ export const useNewFields = (
             const isChanged = requestedFields.includes(key);
 
             // This will not work if we have to show fields with boolean values
-            const newValue = changeRequest[`new_${key}`]
-                ? fieldDef.formatValue(changeRequest[`new_${key}`], false)
-                : getPlaceholderValue(key);
+            const newValue = computeNewValue(
+                key,
+                changeRequest,
+                fieldDef,
+                isChanged,
+            );
 
             const oldValue = changeRequest[`old_${key}`]
                 ? fieldDef.formatValue(changeRequest[`old_${key}`], true)

--- a/hat/assets/js/apps/Iaso/libs/utils.tsx
+++ b/hat/assets/js/apps/Iaso/libs/utils.tsx
@@ -71,6 +71,7 @@ export const BooleanValue = (value: Array<unknown> | unknown): boolean => {
     return Array.isArray(value) ? value.length > 0 : Boolean(value);
 };
 
+// using a span is necessary to allow text styling
 export const PlaceholderValue: ReactElement | Optional<Nullable<string>> = (
-    <>{textPlaceholder}</>
+    <span>{textPlaceholder}</span>
 );

--- a/hat/settings.py
+++ b/hat/settings.py
@@ -596,7 +596,10 @@ ACCOUNT_EMAIL_VERIFICATION = "none"
 CODE_CHALLENGE = generate_pkce()
 
 SOCIALACCOUNT_PROVIDERS = {}
-if os.environ.get("WFP_AUTH_CLIENT_ID"):
+
+WFP_AUTH_CLIENT_ID = os.environ.get("WFP_AUTH_CLIENT_ID", False)
+ACTIVATE_SOCIAL_ACCOUNT = WFP_AUTH_CLIENT_ID is not False  # for now, only WFP uses social_accounts
+if WFP_AUTH_CLIENT_ID:
     # Activate WFP login
     # activate the wfp_auth plugin only if needed
     index = INSTALLED_APPS.index("allauth.socialaccount")

--- a/hat/urls.py
+++ b/hat/urls.py
@@ -17,24 +17,30 @@ admin.site.site_header = "Administration de Iaso"
 admin.site.site_title = "Iaso"
 admin.site.index_title = "Administration de Iaso"
 
+
 if settings.DISABLE_PASSWORD_LOGINS:
+    login_template = "iaso/disabled_password_login.html"
     urlpatterns = [
-        path("login/", TemplateView.as_view(template_name="iaso/disabled_password_login.html"), name="login"),
-        path("admin/login/", TemplateView.as_view(template_name="iaso/disabled_password_login.html"), name="login"),
+        path("admin/login/", TemplateView.as_view(template_name=login_template), name="admin-login"),
+        path("login/", TemplateView.as_view(template_name=login_template), name="login"),
     ]
 else:
+    login_template = "iaso/login.html"
     urlpatterns = [
-        path("login/", auth.views.LoginView.as_view(template_name="iaso/login.html"), name="login"),
-        path("admin/login/", auth.views.LoginView.as_view(template_name="iaso/login.html"), name="login"),
+        path("admin/login/", auth.views.LoginView.as_view(template_name=login_template), name="admin-login"),
+        path("login/", auth.views.LoginView.as_view(template_name=login_template), name="login"),
     ]
 
-urlpatterns = urlpatterns + [
+urlpatterns += [
+    # these 3 next lines ensure that no signup or password login is provided by allauth
+    path("accounts/login/", RedirectView.as_view(pattern_name="login", permanent=False)),
+    path("accounts/signup/", RedirectView.as_view(pattern_name="login", permanent=False)),
+    path("accounts/social/signup/", RedirectView.as_view(pattern_name="login", permanent=False)),
+    path("accounts/", include("allauth.urls")),  # allauth is providing the social login flow
     path("", RedirectView.as_view(pattern_name="dashboard:home_iaso", permanent=False), name="index"),
     path("_health/", health),
     path("_health", health),  # same without slash otherwise AWS complain about redirect
     path("health/", health),  # alias since current apache config hide _health/
-    path("accounts/", include("django.contrib.auth.urls")),
-    path("accounts/", include("allauth.urls")),
     path("admin/", admin.site.urls),
     path("api/", include("iaso.urls")),
     path("pages/<page_slug>/", page, name="pages"),
@@ -69,6 +75,7 @@ urlpatterns = urlpatterns + [
     ),
     path("sync/", include("hat.sync.urls")),
 ]
+
 
 for plugin_name in settings.PLUGINS:
     urls_module_name = "plugins." + plugin_name + ".urls"

--- a/hat/urls.py
+++ b/hat/urls.py
@@ -31,12 +31,16 @@ else:
         path("login/", auth.views.LoginView.as_view(template_name=login_template), name="login"),
     ]
 
+if settings.ACTIVATE_SOCIAL_ACCOUNT:
+    # ------------------ adding urls of allauth for social account ------------------
+    urlpatterns += [
+        # these 3 next lines ensure that no signup or password login is provided by allauth
+        path("accounts/login/", RedirectView.as_view(pattern_name="login", permanent=False)),
+        path("accounts/signup/", RedirectView.as_view(pattern_name="login", permanent=False)),
+        path("accounts/social/signup/", RedirectView.as_view(pattern_name="login", permanent=False)),
+        path("accounts/", include("allauth.urls")),  # allauth is providing the social login flow
+    ]
 urlpatterns += [
-    # these 3 next lines ensure that no signup or password login is provided by allauth
-    path("accounts/login/", RedirectView.as_view(pattern_name="login", permanent=False)),
-    path("accounts/signup/", RedirectView.as_view(pattern_name="login", permanent=False)),
-    path("accounts/social/signup/", RedirectView.as_view(pattern_name="login", permanent=False)),
-    path("accounts/", include("allauth.urls")),  # allauth is providing the social login flow
     path("", RedirectView.as_view(pattern_name="dashboard:home_iaso", permanent=False), name="index"),
     path("_health/", health),
     path("_health", health),  # same without slash otherwise AWS complain about redirect


### PR DESCRIPTION
Ensuring there is a single url with name "login" preventing resolution errors. 
Ensuring also that the URLS of allauth are not loaded when we don't use single sign on, and further than that, ensuring that only the URLs used for SSO are made available. 

Adding also a variable in settings.py ACTIVATE_SOCIAL_ACCOUNT that is used to deactivate these allauth.urls

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented

## How to test
Activate the various feature flags. Run manage show_urls to verify that nothing too much is here. 

