### PR TITLE
POLIO-1465: Supply chain prefill VAR

### DIFF
--- a/hat/assets/js/apps/Iaso/components/forms/InputComponent.tsx
+++ b/hat/assets/js/apps/Iaso/components/forms/InputComponent.tsx
@@ -113,7 +113,7 @@ export type InputComponentProps = {
     autoComplete?: string;
     // eslint-disable-next-line no-unused-vars
     renderTags?: (tagValue: Array<any>, getTagProps: any) => Array<any>;
-    freeSolo?: boolean;
+    freeSolo?: boolean; // this props i only use on single select and allow user to give an option not present in the list. Errors will be ignored
 };
 
 const useLocalizedNumberInputOptions = (
@@ -256,12 +256,10 @@ const InputComponent: React.FC<InputComponentProps> = ({
                         getOptionLabel={getOptionLabel}
                         getOptionSelected={getOptionSelected}
                         options={translateOptions(options, formatMessage)}
-                        onChange={newValue => {
-                            onChange(keyValue, newValue);
-                        }}
+                        onChange={newValue => onChange(keyValue, newValue)}
                         renderTags={renderTags}
                         helperText={helperText}
-                        freeSolo={freeSolo}
+                        freeSolo={!multi && freeSolo}
                     />
                 );
             case 'arrayInput':

--- a/hat/assets/js/apps/Iaso/components/forms/InputComponent.tsx
+++ b/hat/assets/js/apps/Iaso/components/forms/InputComponent.tsx
@@ -1,29 +1,29 @@
-import React, { ReactNode, useMemo, useState } from 'react';
 import { Box } from '@mui/material';
 import {
-    TextInput,
-    PasswordInput,
-    NumberInput,
-    Radio,
-    Checkbox,
     ArrayFieldInput,
-    SearchInput,
-    // @ts-ignore
-    translateOptions,
-    Select,
-    useSafeIntl,
+    BaseCountryData,
+    Checkbox,
     IntlMessage,
     LangOptions,
+    NumberInput,
+    PasswordInput,
     PhoneInput,
-    BaseCountryData,
+    Radio,
+    SearchInput,
+    Select,
+    TextInput,
+    // @ts-ignore
+    translateOptions,
+    useSafeIntl,
 } from 'bluesquare-components';
+import React, { ReactNode, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 import MESSAGES from '../../domains/forms/messages';
-import { DropdownOptions } from '../../types/utils';
 import {
     useNumberSeparatorsFromLocale,
     useThousandGroupStyle,
 } from '../../hooks/useNumberSeparatorsFromLocale';
+import { DropdownOptions } from '../../types/utils';
 
 type Option = DropdownOptions<string | number>;
 
@@ -113,6 +113,7 @@ export type InputComponentProps = {
     autoComplete?: string;
     // eslint-disable-next-line no-unused-vars
     renderTags?: (tagValue: Array<any>, getTagProps: any) => Array<any>;
+    freeSolo?: boolean;
 };
 
 const useLocalizedNumberInputOptions = (
@@ -165,6 +166,7 @@ const InputComponent: React.FC<InputComponentProps> = ({
     setFieldError = () => null,
     autoComplete = 'off',
     phoneInputOptions = {},
+    freeSolo = false,
 }) => {
     const [displayPassword, setDisplayPassword] = useState(false);
     const { formatMessage } = useSafeIntl();
@@ -259,6 +261,7 @@ const InputComponent: React.FC<InputComponentProps> = ({
                         }}
                         renderTags={renderTags}
                         helperText={helperText}
+                        freeSolo={freeSolo}
                     />
                 );
             case 'arrayInput':

--- a/package-lock.json
+++ b/package-lock.json
@@ -6200,7 +6200,7 @@
         },
         "node_modules/bluesquare-components": {
             "version": "1.0.0",
-            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#eae1d8601f18f30de62c184602c4e1f446a010e7",
+            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#4ff041549d0649c36a774145969aa9cc8ce65d11",
             "license": "Apache-2.0",
             "dependencies": {
                 "@babel/plugin-proposal-class-properties": "^7.18.6",
@@ -33315,7 +33315,7 @@
             "dev": true
         },
         "bluesquare-components": {
-            "version": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#eae1d8601f18f30de62c184602c4e1f446a010e7",
+            "version": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#4ff041549d0649c36a774145969aa9cc8ce65d11",
             "from": "bluesquare-components@github:BLSQ/bluesquare-components",
             "requires": {
                 "@babel/plugin-proposal-class-properties": "^7.18.6",

--- a/plugins/polio/js/src/components/Inputs/Select.tsx
+++ b/plugins/polio/js/src/components/Inputs/Select.tsx
@@ -16,6 +16,7 @@ type Props = {
     onChange?: (_keyValue: string, value: any) => void;
     // eslint-disable-next-line no-unused-vars
     renderTags?: (tagValue: Array<any>, getTagProps: any) => Array<any>;
+    freeSolo?: boolean;
 };
 
 export const Select: FunctionComponent<Props> = ({
@@ -29,6 +30,7 @@ export const Select: FunctionComponent<Props> = ({
     clearable = true,
     withMarginTop = false,
     required = false,
+    freeSolo = false,
 }) => {
     const hasError =
         form.errors &&
@@ -55,6 +57,7 @@ export const Select: FunctionComponent<Props> = ({
                 }
             }}
             errors={hasError ? [get(form.errors, field.name)] : []}
+            freeSolo={freeSolo}
         />
     );
 };

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/PreAlerts/PreAlert.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/PreAlerts/PreAlert.tsx
@@ -1,19 +1,19 @@
 /* eslint-disable camelcase */
-import React, { FunctionComponent, useCallback } from 'react';
-import { Box, Grid, Paper, Typography } from '@mui/material';
-import { Field, useFormikContext } from 'formik';
 import RestoreFromTrashIcon from '@mui/icons-material/RestoreFromTrash';
+import { Box, Grid, Paper, Typography } from '@mui/material';
 import { IconButton, useSafeIntl } from 'bluesquare-components';
 import classNames from 'classnames';
+import { Field, useFormikContext } from 'formik';
+import React, { FunctionComponent, useCallback } from 'react';
 import { DeleteIconButton } from '../../../../../../../../../hat/assets/js/apps/Iaso/components/Buttons/DeleteIconButton';
-import { DateInput } from '../../../../../components/Inputs/DateInput';
+import { NumberCell } from '../../../../../../../../../hat/assets/js/apps/Iaso/components/Cells/NumberCell';
+import { Optional } from '../../../../../../../../../hat/assets/js/apps/Iaso/types/utils';
 import { NumberInput, TextInput } from '../../../../../components/Inputs';
+import { DateInput } from '../../../../../components/Inputs/DateInput';
+import { dosesPerVial } from '../../hooks/utils';
 import MESSAGES from '../../messages';
 import { SupplyChainFormData } from '../../types';
 import { grayText, usePaperStyles } from '../shared';
-import { NumberCell } from '../../../../../../../../../hat/assets/js/apps/Iaso/components/Cells/NumberCell';
-import { Optional } from '../../../../../../../../../hat/assets/js/apps/Iaso/types/utils';
-import { dosesPerVial } from '../../hooks/utils';
 
 type Props = {
     index: number;
@@ -29,11 +29,14 @@ export const PreAlert: FunctionComponent<Props> = ({ index, vaccine }) => {
     const markedForDeletion = pre_alerts?.[index].to_delete ?? false;
     const uneditableTextStyling = markedForDeletion ? grayText : undefined;
     const doses_per_vial_default = vaccine ? dosesPerVial[vaccine] : undefined;
-    const doses_per_vial = pre_alerts?.[index].doses_per_vial ?? doses_per_vial_default;
-    const current_vials_shipped = doses_per_vial ? Math.ceil(
-        ((pre_alerts?.[index].doses_shipped as Optional<number>) ?? 0) /
-        doses_per_vial,
-    ) : 0;
+    const doses_per_vial =
+        pre_alerts?.[index].doses_per_vial ?? doses_per_vial_default;
+    const current_vials_shipped = doses_per_vial
+        ? Math.ceil(
+              ((pre_alerts?.[index].doses_shipped as Optional<number>) ?? 0) /
+                  doses_per_vial,
+          )
+        : 0;
 
     const onDelete = useCallback(() => {
         if (values?.pre_alerts?.[index].id) {
@@ -87,6 +90,7 @@ export const PreAlert: FunctionComponent<Props> = ({ index, vaccine }) => {
                                 name={`pre_alerts[${index}].estimated_arrival_time`}
                                 component={DateInput}
                                 disabled={markedForDeletion}
+                                required
                             />
                         </Grid>
                     </Grid>

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/VAR/VaccineArrivalReport.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/VAR/VaccineArrivalReport.tsx
@@ -47,12 +47,15 @@ export const VaccineArrivalReport: FunctionComponent<Props> = ({
         : 0;
 
     const poNumberOptions = useMemo(() => {
-        return values.pre_alerts?.map(
-            preAlert =>
-                ({
+        return (
+            values.pre_alerts
+                ?.filter(
+                    preAlert => preAlert.po_number && preAlert.doses_shipped,
+                )
+                .map(preAlert => ({
                     label: preAlert.po_number,
                     value: preAlert.po_number,
-                } || []),
+                })) || []
         );
     }, [values.pre_alerts]);
     const handleChangePoNumber = useCallback(


### PR DESCRIPTION
1 entry in Pre-alert = 1 entry in VAR

Fields in pre-alert should pre fill the VAR fields: 

PO number

Doses shipped

Related JIRA tickets : POLIO-1465

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)


## Changes

- added [`freeSolo`](https://mui.com/material-ui/api/autocomplete/) support on single select component to allow user to input a custom value
- compute doses shipped with selected pre-alert

## How to test

go to `/dashboard/polio/vaccinemodule/supplychain/`
Edit a row, make sure you have a few pre -alert saved and create new VAR.
You should be able to select existing po number and change dose shipped, type a custom po number, change doses shipped and try to save

## Print screen / video

https://github.com/BLSQ/iaso/assets/12494624/f681527c-bc21-41d0-bc22-a3446edc5741


