### PR TITLE
IA-2884 improve dhis2 error message parsing when conflicts don't have…

### DIFF
--- a/iaso/dhis2/datavalue_exporter.py
+++ b/iaso/dhis2/datavalue_exporter.py
@@ -21,7 +21,8 @@ class InstanceExportError(BaseException):
     def __init__(self, *args):
         self.counts = args[1]
         self.descriptions = args[2]
-        self.message = str(args[0]) + " : " + self.descriptions[0]
+        description = self.descriptions[0] if len(self.descriptions) > 0 else ""
+        self.message = str(args[0]) + " : " + description
 
     def __str__(self):
         return "InstanceExportError, {0} ".format(self.message)
@@ -75,6 +76,7 @@ class AggregateHandler(BaseHandler):
         response = resp["response"]
         counts = {}
         descriptions = []
+
         if "importCount" in response:
             for count_type in ("imported", "updated", "deleted", "ignored"):
                 counts[count_type] = response["importCount"][count_type]
@@ -337,11 +339,11 @@ class EventHandler(BaseHandler):
             message = "ERROR while processing " + prefix
             resp = json.loads(dhis2_exception.description)
             exception = self.handle_exception(resp, message)
+
             raise exception
 
     def handle_exception(self, resp, message):
         response = resp["response"]
-
         if response["status"] == "ERROR":
             counts = {}
 
@@ -354,6 +356,8 @@ class EventHandler(BaseHandler):
             self.logger.error("---------------------------------------------------------")
             self.logger.error("----------------------- EXPORT ERROR --------------------")
             self.logger.error("Failed to create events got" + str(descriptions) + str(conflicts) + str(resp))
+            if len(descriptions) == 0:
+                descriptions = [json.dumps(conflicts)]
             return InstanceExportError(message, counts, descriptions)
 
 

--- a/iaso/tests/fixtures/dhis2/event-create-error-235-type.json
+++ b/iaso/tests/fixtures/dhis2/event-create-error-235-type.json
@@ -1,0 +1,88 @@
+{
+    "httpStatus": "Conflict",
+    "httpStatusCode": 409,
+    "status": "ERROR",
+    "message": "An error occurred, please check import summary.",
+    "response": {
+        "responseType": "ImportSummaries",
+        "status": "ERROR",
+        "imported": 0,
+        "updated": 0,
+        "deleted": 0,
+        "ignored": 1,
+        "importOptions": {
+            "idSchemes": {},
+            "dryRun": false,
+            "async": false,
+            "importStrategy": "CREATE_AND_UPDATE",
+            "mergeMode": "REPLACE",
+            "reportMode": "FULL",
+            "skipExistingCheck": false,
+            "sharing": false,
+            "skipNotifications": false,
+            "skipAudit": false,
+            "datasetAllowsPeriods": false,
+            "strictPeriods": false,
+            "strictDataElements": false,
+            "strictCategoryOptionCombos": false,
+            "strictAttributeOptionCombos": false,
+            "strictOrganisationUnits": false,
+            "requireCategoryOptionCombo": false,
+            "requireAttributeOptionCombo": false,
+            "skipPatternValidation": false,
+            "ignoreEmptyCollection": false,
+            "force": false,
+            "firstRowIsHeader": true,
+            "skipLastUpdated": false,
+            "mergeDataValues": false,
+            "skipCache": false
+        },
+        "importSummaries": [
+            {
+                "responseType": "ImportSummary",
+                "status": "ERROR",
+                "importOptions": {
+                    "idSchemes": {},
+                    "dryRun": false,
+                    "async": false,
+                    "importStrategy": "CREATE_AND_UPDATE",
+                    "mergeMode": "REPLACE",
+                    "reportMode": "FULL",
+                    "skipExistingCheck": false,
+                    "sharing": false,
+                    "skipNotifications": false,
+                    "skipAudit": false,
+                    "datasetAllowsPeriods": false,
+                    "strictPeriods": false,
+                    "strictDataElements": false,
+                    "strictCategoryOptionCombos": false,
+                    "strictAttributeOptionCombos": false,
+                    "strictOrganisationUnits": false,
+                    "requireCategoryOptionCombo": false,
+                    "requireAttributeOptionCombo": false,
+                    "skipPatternValidation": false,
+                    "ignoreEmptyCollection": false,
+                    "force": false,
+                    "firstRowIsHeader": true,
+                    "skipLastUpdated": false,
+                    "mergeDataValues": false,
+                    "skipCache": false
+                },
+                "importCount": {
+                    "imported": 0,
+                    "updated": 0,
+                    "ignored": 1,
+                    "deleted": 0
+                },
+                "conflicts": [
+                    {
+                        "object": "DkhbIf6Xm9X",
+                        "value": "value_not_positive_integer"
+                    }
+                ],
+                "reference": "sTe5QHwLPd3"
+            }
+        ],
+        "total": 1
+    }
+}


### PR DESCRIPTION
Sometime the dhis2 api doesn't return conflicts "with a description"
Ex in this jira the valueType of the data element don't match the value sent by iaso.

Related JIRA tickets : IA-2884 

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc

## Changes


## How to test

Don't think it's easy to test, but perhaps using the seed command and changing the valueType of the program used by the seed command
