### PR TITLE
POLIO-1541 add stocks fields to api for dashboarding

### DIFF
--- a/plugins/polio/api/dashboards/supply_chain.py
+++ b/plugins/polio/api/dashboards/supply_chain.py
@@ -1,12 +1,24 @@
 from rest_framework import serializers
+
 from iaso.api.common import ModelViewSet
+from plugins.polio.admin import DestructionReport
+from plugins.polio.api.vaccines.stock_management import VaccineStockCalculator
 from plugins.polio.api.vaccines.supply_chain import VaccineSupplyChainReadWritePerm
-from plugins.polio.models import VaccineArrivalReport, VaccinePreAlert, VaccineRequestForm
+from plugins.polio.models import (
+    OutgoingStockMovement,
+    VaccineArrivalReport,
+    VaccinePreAlert,
+    VaccineRequestForm,
+    VaccineStock,
+)
 
 
 class VaccineRequestFormDashboardSerializer(serializers.ModelSerializer):
     obr_name = serializers.CharField(source="campaign.obr_name")
     country = serializers.SerializerMethodField()
+    stock_in_hand = serializers.SerializerMethodField()
+    form_a_reception_date = serializers.SerializerMethodField()
+    destruction_report_reception_date = serializers.SerializerMethodField()
 
     class Meta:
         model = VaccineRequestForm
@@ -15,15 +27,52 @@ class VaccineRequestFormDashboardSerializer(serializers.ModelSerializer):
     def get_country(self, obj):
         return obj.campaign.country.pk
 
+    def get_stock_in_hand(self, obj):
+        # Create a cache dictionary in the context if it doesn't exist
+        if "stock_in_hand_cache" not in self.context:
+            self.context["stock_in_hand_cache"] = {}
+
+        # Create a unique key for this country and vaccine type
+        cache_key = f"{obj.campaign.country.pk}_{obj.vaccine_type}"
+
+        # If the value is not in the cache, calculate it
+        if cache_key not in self.context["stock_in_hand_cache"]:
+            vaccine_stock, _ = VaccineStock.objects.get_or_create(
+                country=obj.campaign.country, vaccine=obj.vaccine_type
+            )
+            vaccine_stock_calculator = VaccineStockCalculator(vaccine_stock)
+            self.context["stock_in_hand_cache"][cache_key] = vaccine_stock_calculator.get_stock_of_usable_vials()
+
+        return self.context["stock_in_hand_cache"][cache_key]
+
+    def get_form_a_reception_date(self, obj):
+        vaccine_stock, _ = VaccineStock.objects.get_or_create(country=obj.campaign.country, vaccine=obj.vaccine_type)
+        latest_outgoing_stock_movement = (
+            OutgoingStockMovement.objects.filter(vaccine_stock=vaccine_stock).order_by("-form_a_reception_date").first()
+        )
+        return latest_outgoing_stock_movement.form_a_reception_date if latest_outgoing_stock_movement else None
+
+    def get_destruction_report_reception_date(self, obj):
+        vaccine_stock, _ = VaccineStock.objects.get_or_create(country=obj.campaign.country, vaccine=obj.vaccine_type)
+        latest_destruction_report = (
+            DestructionReport.objects.filter(vaccine_stock=vaccine_stock)
+            .order_by("-rrt_destruction_report_reception_date")
+            .first()
+        )
+        return latest_destruction_report.rrt_destruction_report_reception_date if latest_destruction_report else None
+
 
 class VaccineRequestFormDashboardViewSet(ModelViewSet):
     """
     GET /api/polio/dashboards/vaccine_request_forms/
     Returns all vaccine request forms for the user's account.
     Simple endpoint that returns all model fields to facilitate data manipulation by OpenHexa or PowerBI
-    2 additional fields have been added:
+    3 additional fields have been added:
     - obr_name: the campaign's OBR name, that may need to be displayed
     - country: the id of the vaccine request form's country
+    - stock_in_hand: the stock in hand calculated from VaccineStockCalculator
+    - get_form_a_reception_date: Form A reception (RRT) date
+    - get_destruction_report_reception_date: Destruction Report Received by RRT date
     """
 
     http_method_names = ["get"]

--- a/plugins/polio/tests/test_supply_chain_dashboards.py
+++ b/plugins/polio/tests/test_supply_chain_dashboards.py
@@ -136,8 +136,9 @@ class SupplyChainDashboardsAPITestCase(APITestCase):
             action="destroyed",
         )
 
-        with self.assertNumQueries(MAKE_ME_DREAM_NUMBER):
+        with self.assertNumQueries(12):
             response = self.client.get(self.vrf_url)
+
         jr = self.assertJSONResponse(response, 200)
         results = jr["results"]
         self.assertEqual(len(results), 1)

--- a/plugins/polio/tests/test_supply_chain_dashboards.py
+++ b/plugins/polio/tests/test_supply_chain_dashboards.py
@@ -136,7 +136,8 @@ class SupplyChainDashboardsAPITestCase(APITestCase):
             action="destroyed",
         )
 
-        response = self.client.get(self.vrf_url)
+        with self.assertNumQueries(MAKE_ME_DREAM_NUMBER):
+            response = self.client.get(self.vrf_url)
         jr = self.assertJSONResponse(response, 200)
         results = jr["results"]
         self.assertEqual(len(results), 1)

--- a/plugins/polio/tests/test_supply_chain_dashboards.py
+++ b/plugins/polio/tests/test_supply_chain_dashboards.py
@@ -1,9 +1,18 @@
 from datetime import date
+
+from hat.menupermissions import models as permission
 from iaso.models.base import Account
 from iaso.models.org_unit import OrgUnit, OrgUnitType
 from iaso.test import APITestCase
-from plugins.polio.models import Campaign, VaccineArrivalReport, VaccinePreAlert, VaccineRequestForm
-from hat.menupermissions import models as permission
+from plugins.polio.models import (
+    Campaign,
+    DestructionReport,
+    OutgoingStockMovement,
+    VaccineArrivalReport,
+    VaccinePreAlert,
+    VaccineRequestForm,
+    VaccineStock,
+)
 
 
 class SupplyChainDashboardsAPITestCase(APITestCase):
@@ -30,6 +39,7 @@ class SupplyChainDashboardsAPITestCase(APITestCase):
         cls.campaign = Campaign.objects.create(
             obr_name="Outsiplou-2024", account=cls.account, initial_org_unit=cls.country
         )
+        cls.vaccine_type = "mOPV2"
         cls.other_campaign = Campaign.objects.create(obr_name="Not the expected result", account=cls.other_account)
         cls.vrf = VaccineRequestForm.objects.create(
             campaign=cls.campaign,
@@ -37,7 +47,7 @@ class SupplyChainDashboardsAPITestCase(APITestCase):
             date_vrf_reception=date.today(),
             date_dg_approval=date.today(),
             quantities_ordered_in_doses=1000,
-            vaccine_type="mOPV2",
+            vaccine_type=cls.vaccine_type,
         )
         cls.vrf.rounds.set([])
         cls.other_vrf = VaccineRequestForm.objects.create(
@@ -46,7 +56,7 @@ class SupplyChainDashboardsAPITestCase(APITestCase):
             date_vrf_reception=date.today(),
             date_dg_approval=date.today(),
             quantities_ordered_in_doses=1000,
-            vaccine_type="mOPV2",
+            vaccine_type=cls.vaccine_type,
         )
         cls.other_vrf.rounds.set([])
         cls.pre_alert = VaccinePreAlert.objects.create(request_form=cls.vrf, date_pre_alert_reception=date.today())
@@ -58,6 +68,10 @@ class SupplyChainDashboardsAPITestCase(APITestCase):
         )
         cls.other_arrival_report = VaccineArrivalReport.objects.create(
             request_form=cls.other_vrf, arrival_report_date=date.today(), doses_received=1000
+        )
+
+        cls.vaccine_stock = VaccineStock.objects.create(
+            country=cls.country, vaccine=cls.vaccine_type, account=cls.account
         )
 
     def test_user_has_permission_vrf(self):
@@ -99,6 +113,44 @@ class SupplyChainDashboardsAPITestCase(APITestCase):
         self.assertEqual(len(results), 1)
         vrf = results[0]
         self.assertEqual(vrf["obr_name"], self.campaign.obr_name)
+
+    def test_vrf_new_fields(self):
+        self.client.force_authenticate(self.authorized_user_read)
+
+        # Create ArrivalReport and DestructionReport
+        form_a = OutgoingStockMovement.objects.create(
+            campaign=self.campaign,
+            vaccine_stock=self.vaccine_stock,
+            report_date=date.today(),
+            form_a_reception_date=date.today(),
+            usable_vials_used=100,
+            unusable_vials=100,
+            missing_vials=10,
+        )
+
+        destruction_report = DestructionReport.objects.create(
+            vaccine_stock=self.vaccine_stock,
+            rrt_destruction_report_reception_date=date.today(),
+            destruction_report_date=date.today(),
+            unusable_vials_destroyed=10,
+            action="destroyed",
+        )
+
+        response = self.client.get(self.vrf_url)
+        jr = self.assertJSONResponse(response, 200)
+        results = jr["results"]
+        self.assertEqual(len(results), 1)
+        vrf = results[0]
+        self.assertEqual(vrf["obr_name"], self.campaign.obr_name)
+        self.assertIn("stock_in_hand", vrf)
+        self.assertIn("form_a_reception_date", vrf)
+        self.assertIn("destruction_report_reception_date", vrf)
+
+        # Check if the dates match with the created ArrivalReport and DestructionReport
+        self.assertEqual(vrf["form_a_reception_date"], str(form_a.form_a_reception_date))
+        self.assertEqual(
+            vrf["destruction_report_reception_date"], str(destruction_report.rrt_destruction_report_reception_date)
+        )
 
     def test_pre_alerts_filters_by_account(self):
         self.client.force_authenticate(self.authorized_user_read)


### PR DESCRIPTION
Add stocks fields to API for vaccine stock dashboarding

Fields added : 

- Stock in hand - computed field “Usable vials” for the country
- Form A reception (RRT) date
- Destruction Report Received by RRT date

Related JIRA tickets : POLIO-1541

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are there enough tests


## Changes

Add some fields on the serializer and cache some calculations

## How to test

Call the APIs and see if the fields are present.
Check the test code.
