### PR TITLE
POLIO-1543: (LQAS) adapt graphQL mutation code

### DIFF
--- a/iaso/api/tasks/__init__.py
+++ b/iaso/api/tasks/__init__.py
@@ -282,7 +282,7 @@ class ExternalTaskModelViewSet(ModelViewSet):
             oh_config["task_id"] = task_id
         # We can specify a version in case the latest version gets bugged
         mutation_input = (
-            {"id": pipeline, "version": int(pipeline_version), "config": oh_config}
+            {"id": pipeline, "versionId": pipeline_version, "config": oh_config}
             if pipeline_version
             else {"id": pipeline, "config": config}
         )
@@ -306,6 +306,7 @@ class ExternalTaskModelViewSet(ModelViewSet):
             # The SUCCESS state will be set by the OpenHexa pipeline
             if run_result["success"]:
                 return RUNNING
+            logger.info(f"Launched OpenHexa run: {run_result['id']}")
         except:
             logger.exception("Could not launch pipeline")
             return ERRORED


### PR DESCRIPTION
There was a breaking change in the latest openhexa release

Related JIRA tickets : POLIO-1543

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
- Added wiki entry about keeping pipeline version up to date in polio config: https://wiki.bluesquare.org/en/Dev-team/product-management/iaso/Polio/update_pipeline_version

## Changes

- Changed a param name

## How to test

Setup your local environement: https://github.com/BLSQ/iaso-pipelines/wiki/Setup-Iaso-to-test-OpenHexa-Polio-integration#1-start-ngrok-tunnel-to-localhost8081

NB: get the config from polio prod, and change the target to "custom"

go to LQAS country page, click Refresh LQAS data:
- The task should launch in iaso
- The pipeline should launch in openhexa

