### PR TITLE
POLIO-1542 Filter Non Polio Campaigns From Dropdown

### DIFF
--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/hooks/api/vrf.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/hooks/api/vrf.tsx
@@ -121,6 +121,7 @@ export const useCampaignDropDowns = (
         enabled: Boolean(countryId),
         countries: countryId ? [`${countryId}`] : undefined,
         campaignCategory: 'regular' as CampaignCategory,
+        campaignType: 'polio',
     };
 
     const { data, isFetching } = useGetCampaigns(options, CAMPAIGNS_ENDPOINT);


### PR DESCRIPTION
in Vaccine Supply Chain, a dropdown is displaying non polio campaigns, it should filter it out.

Related JIRA tickets : POLIO-1542

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented

## Changes

Oneliner


## How to test

When creating a Vaccine Request Form in Vaccine Supply Chain it shouldnt display any non polio campaigns in dropdown.
