### PR TITLE
POLIO-1545: add missing import

### DIFF
--- a/plugins/polio/js/src/domains/Calendar/Calendar.tsx
+++ b/plugins/polio/js/src/domains/Calendar/Calendar.tsx
@@ -4,6 +4,7 @@ import { Box, Button, Grid, Theme, Typography } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import {
     ExcellSvg,
+    LoadingSpinner,
     commonStyles,
     getTableUrl,
     useSafeIntl,


### PR DESCRIPTION
calendar pdf export crashes page

Related JIRA tickets : POLIO-1545

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
- Tell us where the doc can be found (docs folder, wiki, in the code...)

## Changes

- Add missing import

## How to test

Go to polio calendar and export pdf

## Print screen / video


![Screenshot 2024-04-23 at 13 41 34](https://github.com/BLSQ/iaso/assets/38907762/56384725-d697-4c35-af49-d6b1e77b30c5)

