### PR TITLE
IA-2830: add write permission to compareInstances route config

### DIFF
--- a/hat/assets/js/apps/Iaso/constants/routes.js
+++ b/hat/assets/js/apps/Iaso/constants/routes.js
@@ -339,7 +339,7 @@ export const compareInstanceLogsPath = {
 
 export const compareInstancesPath = {
     baseUrl: baseUrls.compareInstances,
-    permissions: [Permission.SUBMISSIONS],
+    permissions: [Permission.SUBMISSIONS, Permission.SUBMISSIONS_UPDATE],
     component: props => <CompareSubmissions {...props} />,
     params: [
         {


### PR DESCRIPTION
Compare instances page was only accessible with read permission

Related JIRA tickets : IA-2830

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)



## Changes

- add `SUBMISSIONS_UPDATE` permission to route config


## How to test

- create user with the read+write perm for submissions (not both permissions)
- Go to Submissions and use "Compare feature"
- You should be able to use the page

