### PR TITLE
Adding check on transfer_from_otp__bool__ field to identify transfer to TSFP

### DIFF
--- a/plugins/wfp/common.py
+++ b/plugins/wfp/common.py
@@ -141,9 +141,8 @@ class ETL:
             visit.get("transfer__int__") is not None and visit.get("transfer__int__") == "1"
         ):
             exit_type = "transfer_to_otp"
-
-        elif (visit.get("_transfer") is not None and visit.get("_transfer") == "1") and (
-            visit.get("_transfer_to_tsfp") is not None and visit.get("_transfer_to_tsfp") == "1"
+        elif (visit.get("_transfer_to_tsfp") is not None and visit.get("_transfer_to_tsfp") == "1") or (
+            visit.get("transfer_from_otp__bool__") is not None and visit.get("transfer_from_otp__bool__") == "1"
         ):
             exit_type = "transfer_to_tsfp"
 


### PR DESCRIPTION
I got a case when a transfer from OTP to TSFP is flagged with the field **transfer_from_otp__bool__**. 

More details in the tickets: https://dev.azure.com/worldfoodprogramme/CODA2/_workitems/edit/239470

Related JIRA tickets : [WC2-362](https://bluesquare.atlassian.net/browse/WC2-362)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)


## Changes

Added an additionnal check on transfer_from_otp__bool__. e.g: [http://localhost:8081/wfp/debug/367/](http://localhost:8081/wfp/debug/367/)


## How to test

From the local instance with wfp coda database, Lunch with docker-compose run iaso manage wfp_etl the ETL script in order to generate data for tableau dashboard and go to the debug page for the beneficiary: e.g: [http://localhost:8081/wfp/debug/371/](http://localhost:8081/wfp/debug/371/)

[WC2-362]: https://bluesquare.atlassian.net/browse/WC2-362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ