### PR TITLE
IA-2945: link components

### DIFF
--- a/hat/assets/js/apps/Iaso/components/nav/LinkTo.tsx
+++ b/hat/assets/js/apps/Iaso/components/nav/LinkTo.tsx
@@ -22,6 +22,7 @@ type Props = {
     size?: 'small' | 'medium' | 'large' | 'default' | 'inherit';
     tooltipMessage?: IntlMessage;
     color?: string;
+    target?: '_blank' | '_self' | '_parent' | '_top';
 };
 
 const useStyles = makeStyles(() => ({
@@ -39,11 +40,13 @@ export const LinkTo: FunctionComponent<Props> = ({
     replace = false,
     iconSize = 'medium',
     size = 'medium',
+    target = '_self',
     color,
     tooltipMessage = MESSAGES.see,
 }) => {
     const { pathname: location } = useLocation();
     const targetBlankEnabled = useKeyPressListener('Meta');
+    const actualTarget = targetBlankEnabled ? '_blank' : target;
     const classes: Record<string, string> = useStyles();
     if (condition) {
         if (useIcon) {
@@ -58,16 +61,18 @@ export const LinkTo: FunctionComponent<Props> = ({
                     url={url}
                     replace={replace}
                     color={color}
+                    target={actualTarget}
                 />
             );
         }
         return (
             <Link
                 className={classNames(className, classes.link)}
-                state={{ location }}
                 reloadDocument={targetBlankEnabled}
                 to={url}
+                state={{ location }}
                 replace={replace}
+                target={actualTarget}
             >
                 {text || textPlaceholder}
             </Link>

--- a/hat/assets/js/apps/Iaso/components/nav/LinkTo.tsx
+++ b/hat/assets/js/apps/Iaso/components/nav/LinkTo.tsx
@@ -1,0 +1,78 @@
+import React, { FunctionComponent } from 'react';
+import { makeStyles } from '@mui/styles';
+import classNames from 'classnames';
+import {
+    IconButton as IconButtonComponent,
+    IntlMessage,
+    textPlaceholder,
+    useKeyPressListener,
+} from 'bluesquare-components';
+
+import { Link, useLocation } from 'react-router-dom';
+import MESSAGES from './messages';
+
+type Props = {
+    condition: boolean;
+    url: string;
+    text?: string;
+    useIcon?: boolean;
+    className?: string;
+    replace?: boolean;
+    iconSize?: 'small' | 'medium' | 'large' | 'default' | 'inherit';
+    size?: 'small' | 'medium' | 'large' | 'default' | 'inherit';
+    tooltipMessage?: IntlMessage;
+    color?: string;
+};
+
+const useStyles = makeStyles(() => ({
+    link: {
+        cursor: 'pointer',
+    },
+}));
+
+export const LinkTo: FunctionComponent<Props> = ({
+    condition,
+    url,
+    text,
+    useIcon = false,
+    className = '',
+    replace = false,
+    iconSize = 'medium',
+    size = 'medium',
+    color,
+    tooltipMessage = MESSAGES.see,
+}) => {
+    const { pathname: location } = useLocation();
+    const targetBlankEnabled = useKeyPressListener('Meta');
+    const classes: Record<string, string> = useStyles();
+    if (condition) {
+        if (useIcon) {
+            return (
+                <IconButtonComponent
+                    icon="remove-red-eye"
+                    tooltipMessage={tooltipMessage}
+                    iconSize={iconSize}
+                    size={size}
+                    location={location}
+                    reloadDocument={targetBlankEnabled}
+                    url={url}
+                    replace={replace}
+                    color={color}
+                />
+            );
+        }
+        return (
+            <Link
+                className={classNames(className, classes.link)}
+                state={{ location }}
+                reloadDocument={targetBlankEnabled}
+                to={url}
+                replace={replace}
+            >
+                {text || textPlaceholder}
+            </Link>
+        );
+    }
+    if (useIcon) return null;
+    return <>{text || textPlaceholder}</>;
+};

--- a/hat/assets/js/apps/Iaso/components/nav/messages.ts
+++ b/hat/assets/js/apps/Iaso/components/nav/messages.ts
@@ -1,0 +1,10 @@
+import { defineMessages } from 'react-intl';
+
+const MESSAGES = defineMessages({
+    see: {
+        defaultMessage: 'See',
+        id: 'iaso.label.see',
+    },
+});
+
+export default MESSAGES;

--- a/hat/assets/js/apps/Iaso/domains/entities/duplicates/details/DuplicateDetails.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/duplicates/details/DuplicateDetails.tsx
@@ -121,7 +121,6 @@ export const DuplicateDetails: FunctionComponent<Props> = () => {
     const disableMerge = Boolean(
         tableState.find(row => row.final.status === 'dropped'),
     );
-    console.log('params', params);
     const { data: dupDetailData, isFetching } = useGetDuplicateDetails({
         params,
     });

--- a/hat/assets/js/apps/Iaso/domains/forms/components/LinkToForm.tsx
+++ b/hat/assets/js/apps/Iaso/domains/forms/components/LinkToForm.tsx
@@ -1,26 +1,18 @@
 import React, { FunctionComponent } from 'react';
-
-import { Link, useLocation } from 'react-router-dom';
 import { userHasPermission } from '../../users/utils';
 import { baseUrls } from '../../../constants/urls';
 import { useCurrentUser } from '../../../utils/usersUtils';
 import * as Permission from '../../../utils/permissions';
+import { LinkTo } from '../../../components/nav/LinkTo';
 
 type Props = {
     formId: string | number;
-    formName: unknown;
+    formName?: string;
 };
 
 export const LinkToForm: FunctionComponent<Props> = ({ formId, formName }) => {
     const user = useCurrentUser();
-    const { pathname } = useLocation();
-    if (userHasPermission(Permission.FORMS, user)) {
-        const formUrl = `/${baseUrls.formDetail}/formId/${formId}`;
-        return (
-            <Link to={formUrl} state={{ location: pathname }}>
-                {formName}
-            </Link>
-        );
-    }
-    return <>{formName}</>;
+    const condition = userHasPermission(Permission.FORMS, user);
+    const url = `/${baseUrls.formDetail}/formId/${formId}`;
+    return <LinkTo condition={condition} url={url} text={formName} />;
 };

--- a/hat/assets/js/apps/Iaso/domains/instances/components/LinkToInstance.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/LinkToInstance.tsx
@@ -1,39 +1,38 @@
 import React, { FunctionComponent } from 'react';
-
-import { IconButton as IconButtonComponent } from 'bluesquare-components';
-import { Link, useLocation } from 'react-router-dom';
-import { userHasPermission } from '../../users/utils';
+import { userHasOneOfPermissions } from '../../users/utils';
 import { baseUrls } from '../../../constants/urls';
 import { useCurrentUser } from '../../../utils/usersUtils';
 import MESSAGES from '../../assignments/messages';
-import * as Permission from '../../../utils/permissions';
+import { SUBMISSIONS, SUBMISSIONS_UPDATE } from '../../../utils/permissions';
+import { LinkTo } from '../../../components/nav/LinkTo';
 
 type Props = {
     instanceId: string;
     useIcon?: boolean;
     color?: string;
+    replace?: boolean;
 };
 export const LinkToInstance: FunctionComponent<Props> = ({
     instanceId,
     useIcon = false,
     color = 'inherit',
+    replace = false,
 }) => {
     const user = useCurrentUser();
-    const { pathname: location } = useLocation();
-    if (userHasPermission(Permission.SUBMISSIONS, user)) {
-        const formUrl = `/${baseUrls.instanceDetail}/instanceId/${instanceId}`;
-        if (useIcon) {
-            return (
-                <IconButtonComponent
-                    icon="remove-red-eye"
-                    url={formUrl}
-                    tooltipMessage={MESSAGES.details}
-                    color={color}
-                    location={location}
-                />
-            );
-        }
-        return <Link to={formUrl}>{instanceId}</Link>;
-    }
-    return <>{instanceId}</>;
+    const condition = userHasOneOfPermissions(
+        [SUBMISSIONS, SUBMISSIONS_UPDATE],
+        user,
+    );
+    const url = `/${baseUrls.instanceDetail}/instanceId/${instanceId}`;
+    return (
+        <LinkTo
+            condition={condition}
+            url={url}
+            useIcon={useIcon}
+            replace={replace}
+            tooltipMessage={MESSAGES.details}
+            text={instanceId}
+            color={color}
+        />
+    );
 };

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/LinkToOrgUnit.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/LinkToOrgUnit.tsx
@@ -1,22 +1,11 @@
 import React, { FunctionComponent } from 'react';
-import { useDispatch } from 'react-redux';
-import { makeStyles } from '@mui/styles';
-import classNames from 'classnames';
-import {
-    IconButton as IconButtonComponent,
-    useKeyPressListener,
-} from 'bluesquare-components';
-
-import { Link } from 'react-router-dom';
 import { userHasPermission } from '../../users/utils';
 import { baseUrls } from '../../../constants/urls';
 import { useCurrentUser } from '../../../utils/usersUtils';
 import { OrgUnit, ShortOrgUnit } from '../types/orgUnit';
-
-import { redirectTo, redirectToReplace } from '../../../routing/actions';
-
+import { ORG_UNITS } from '../../../utils/permissions';
+import { LinkTo } from '../../../components/nav/LinkTo';
 import MESSAGES from '../../assignments/messages';
-import * as Permission from '../../../utils/permissions';
 
 type Props = {
     orgUnit?: OrgUnit | ShortOrgUnit;
@@ -27,55 +16,30 @@ type Props = {
     size?: 'small' | 'medium' | 'large' | 'default' | 'inherit';
 };
 
-const useStyles = makeStyles(() => ({
-    link: {
-        cursor: 'pointer',
-    },
-}));
-
 export const LinkToOrgUnit: FunctionComponent<Props> = ({
     orgUnit,
-    useIcon = false,
-    className = '',
-    replace = false,
-    iconSize = 'medium',
-    size = 'medium',
+    useIcon,
+    className,
+    replace,
+    iconSize,
+    size,
 }) => {
     const user = useCurrentUser();
-    const targetBlankEnabled = useKeyPressListener('Meta');
-    const classes: Record<string, string> = useStyles();
-    const dispatch = useDispatch();
-    if (userHasPermission(Permission.ORG_UNITS, user) && orgUnit) {
-        const url = `/${baseUrls.orgUnitDetails}/orgUnitId/${orgUnit.id}`;
-        const handleClick = () => {
-            if (targetBlankEnabled) {
-                window.open(`/dashboard${url}`, '_blank');
-            } else if (replace) {
-                dispatch(redirectToReplace(url));
-            } else {
-                dispatch(redirectTo(url));
-            }
-        };
-        if (useIcon) {
-            return (
-                <IconButtonComponent
-                    onClick={handleClick}
-                    icon="remove-red-eye"
-                    tooltipMessage={MESSAGES.details}
-                    iconSize={iconSize}
-                    size={size}
-                />
-            );
-        }
-        return (
-            <Link
-                className={classNames(className, classes.link)}
-                onClick={handleClick}
-            >
-                {orgUnit.name}
-            </Link>
-        );
-    }
-    if (useIcon) return null;
-    return <>{orgUnit ? orgUnit.name : '-'}</>;
+    const condition = userHasPermission(ORG_UNITS, user) && Boolean(orgUnit);
+    const url = `/${baseUrls.orgUnitDetails}/orgUnitId/${orgUnit?.id}`;
+    const text = orgUnit?.name;
+
+    return (
+        <LinkTo
+            condition={condition}
+            url={url}
+            useIcon={useIcon}
+            className={className}
+            replace={replace}
+            size={size}
+            iconSize={iconSize}
+            text={text}
+            tooltipMessage={MESSAGES.details}
+        />
+    );
 };

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/hooks/api/useGetApprovalProposals.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/hooks/api/useGetApprovalProposals.ts
@@ -10,24 +10,6 @@ import {
 const apiUrl = '/api/orgunits/changes/';
 
 const getOrgUnitChangeProposals = (url: string) => {
-    // const apiParams = {
-    //     parent_id: options.parent_id,
-    //     groups: options.groups,
-    //     org_unit_type_id: options.org_unit_type_id,
-    //     status: options.status,
-    //     order: options.order || '-updated_at',
-    //     limit: options.pageSize || 10,
-    //     page: options.page,
-    //     created_at_after: options.created_at_after,
-    //     created_at_before: options.created_at_before,
-    //     forms: options.forms,
-    //     users: options.userIds,
-    //     user_roles: options.userRoles,
-    //     with_location: options.withLocation,
-    // };
-
-    // const url = makeUrlWithParams(apiUrl, apiParams);
-
     return getRequest(url) as Promise<OrgUnitChangeRequestsPaginated>;
 };
 

--- a/hat/assets/js/apps/Iaso/domains/plannings/components/LinkToPlanning.tsx
+++ b/hat/assets/js/apps/Iaso/domains/plannings/components/LinkToPlanning.tsx
@@ -1,11 +1,10 @@
 import React, { FunctionComponent } from 'react';
-
-import { Link } from 'react-router-dom';
 import { userHasPermission } from '../../users/utils';
 import { baseUrls } from '../../../constants/urls';
 import { useCurrentUser } from '../../../utils/usersUtils';
 import { Planning } from '../../assignments/types/planning';
-import * as Permission from '../../../utils/permissions';
+import { PLANNINGS } from '../../../utils/permissions';
+import { LinkTo } from '../../../components/nav/LinkTo';
 
 type Props = {
     planning: Planning;
@@ -13,10 +12,9 @@ type Props = {
 
 export const LinkToPlanning: FunctionComponent<Props> = ({ planning }) => {
     const user = useCurrentUser();
+    const condition = userHasPermission(PLANNINGS, user);
+    const url = `/${baseUrls.assignments}/planningId/${planning.id}/team/${planning.team}`;
+    const { name: text } = planning;
 
-    if (userHasPermission(Permission.PLANNINGS, user)) {
-        const planningUrl = `/${baseUrls.assignments}/planningId/${planning.id}/team/${planning.team}`;
-        return <Link to={planningUrl}>{planning.name}</Link>;
-    }
-    return <>{planning.name}</>;
+    return <LinkTo condition={condition} url={url} text={text} />;
 };

--- a/hat/assets/js/apps/Iaso/domains/registry/components/LinkToRegistry.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/LinkToRegistry.tsx
@@ -1,23 +1,13 @@
 import React, { FunctionComponent } from 'react';
-import { useDispatch } from 'react-redux';
-import { makeStyles } from '@mui/styles';
-import {
-    IconButton as IconButtonComponent,
-    useKeyPressListener,
-} from 'bluesquare-components';
-import MenuBookIcon from '@mui/icons-material/MenuBook';
-import { Link } from 'react-router-dom';
-import classNames from 'classnames';
-
 import { userHasPermission } from '../../users/utils';
 import { baseUrls } from '../../../constants/urls';
 import { useCurrentUser } from '../../../utils/usersUtils';
 import { OrgUnit, ShortOrgUnit } from '../../orgUnits/types/orgUnit';
-import { redirectTo, redirectToReplace } from '../../../routing/actions';
+import { LinkTo } from '../../../components/nav/LinkTo';
 
 import MESSAGES from '../messages';
 
-import * as Permission from '../../../utils/permissions';
+import { REGISTRY } from '../../../utils/permissions';
 
 type Props = {
     orgUnit?: OrgUnit | ShortOrgUnit;
@@ -28,56 +18,30 @@ type Props = {
     size?: 'small' | 'medium' | 'large' | 'default' | 'inherit';
 };
 
-const useStyles = makeStyles(() => ({
-    link: {
-        cursor: 'pointer',
-    },
-}));
-
 export const LinkToRegistry: FunctionComponent<Props> = ({
     orgUnit,
-    useIcon = false,
-    className = '',
-    replace = false,
-    iconSize = 'medium',
-    size = 'medium',
+    useIcon,
+    className,
+    replace,
+    iconSize,
+    size,
 }) => {
     const user = useCurrentUser();
+    const condition = userHasPermission(REGISTRY, user) && Boolean(orgUnit);
+    const url = `/${baseUrls.registryDetail}/orgUnitId/${orgUnit?.id}`;
+    const text = orgUnit?.name;
 
-    const targetBlankEnabled = useKeyPressListener('Meta');
-    const classes: Record<string, string> = useStyles();
-    const dispatch = useDispatch();
-    if (userHasPermission(Permission.REGISTRY, user) && orgUnit) {
-        const url = `/${baseUrls.registryDetail}/orgUnitId/${orgUnit?.id}`;
-        const handleClick = () => {
-            if (targetBlankEnabled) {
-                window.open(`/dashboard${url}`, '_blank');
-            } else if (replace) {
-                dispatch(redirectToReplace(url));
-            } else {
-                dispatch(redirectTo(url));
-            }
-        };
-        if (useIcon) {
-            return (
-                <IconButtonComponent
-                    onClick={handleClick}
-                    overrideIcon={MenuBookIcon}
-                    tooltipMessage={MESSAGES.seeRegistry}
-                    iconSize={iconSize}
-                    size={size}
-                />
-            );
-        }
-        return (
-            <Link
-                className={classNames(className, classes.link)}
-                onClick={handleClick}
-            >
-                {orgUnit.name}
-            </Link>
-        );
-    }
-    if (useIcon) return null;
-    return <>{orgUnit ? orgUnit.name : '-'}</>;
+    return (
+        <LinkTo
+            condition={condition}
+            url={url}
+            useIcon={useIcon}
+            className={className}
+            replace={replace}
+            size={size}
+            iconSize={iconSize}
+            text={text}
+            tooltipMessage={MESSAGES.seeRegistry}
+        />
+    );
 };

--- a/hat/assets/js/apps/Iaso/domains/storages/components/LinkToEntity.tsx
+++ b/hat/assets/js/apps/Iaso/domains/storages/components/LinkToEntity.tsx
@@ -1,11 +1,10 @@
 import React, { FunctionComponent } from 'react';
-
-import { Link } from 'react-router-dom';
 import { userHasPermission } from '../../users/utils';
 import { baseUrls } from '../../../constants/urls';
 import { useCurrentUser } from '../../../utils/usersUtils';
 import { Beneficiary } from '../../entities/types/beneficiary';
-import * as Permission from '../../../utils/permissions';
+import { ENTITIES } from '../../../utils/permissions';
+import { LinkTo } from '../../../components/nav/LinkTo';
 
 type Props = {
     entity?: Beneficiary;
@@ -13,14 +12,9 @@ type Props = {
 
 export const LinkToEntity: FunctionComponent<Props> = ({ entity }) => {
     const user = useCurrentUser();
-    if (userHasPermission(Permission.ENTITIES, user) && entity?.name) {
-        const url = `/${baseUrls.entityDetails}/entityId/${entity.id}`;
-        return (
-            <Link to={url}>
-                {/*  // TODO this will not work as this field is not in use anymore */}
-                {entity.name}
-            </Link>
-        );
-    }
-    return <>{entity ? entity.name : '-'}</>;
+    const condition =
+        userHasPermission(ENTITIES, user) && Boolean(entity?.name);
+    const url = `/${baseUrls.entityDetails}/entityId/${entity?.id}`;
+
+    return <LinkTo condition={condition} url={url} text={entity?.name} />;
 };

--- a/hat/assets/js/apps/Iaso/routing/hooks/useGoBack.tsx
+++ b/hat/assets/js/apps/Iaso/routing/hooks/useGoBack.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 
 export const useGoBack = (
@@ -7,9 +8,12 @@ export const useGoBack = (
     const navigate = useNavigate();
     const { state, pathname } = useLocation();
     // We need different behaviour for "nested" back arrows, otherwise deep-linking will lead to circular rerouting
-    const options = !nested ? { from: pathname } : null;
-    if (!state) {
-        return () => navigate(`/${fallBackUrl}`, { state: options });
-    }
-    return () => navigate(-1);
+    return useCallback(() => {
+        const options = !nested ? { location: pathname } : null;
+        if (!state) {
+            navigate(`/${fallBackUrl}`, { state: options });
+        } else {
+            navigate(-1);
+        }
+    }, [fallBackUrl, navigate, nested, pathname, state]);
 };

--- a/hat/assets/js/apps/Iaso/routing/routing.ts
+++ b/hat/assets/js/apps/Iaso/routing/routing.ts
@@ -69,15 +69,16 @@ export const useRedirectTo = (): RedirectFn => {
 };
 export const useRedirectToReplace = (): RedirectFn => {
     const navigate = useNavigate();
-    const { pathname } = useLocation();
+    // When replacing, we pass the old state to avoid losing the point of origin
+    const { state } = useLocation();
     return useCallback(
         (url: string, params?: Record<string, string>) => {
             const destination = makeRedirectionUrl(url, params);
             navigate(destination, {
                 replace: true,
-                state: { location: pathname },
+                state,
             });
         },
-        [navigate, pathname],
+        [navigate, state],
     );
 };


### PR DESCRIPTION
Refator all "LinkTo<domain>"  components

Related JIRA tickets : IA-2945

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
- Should update front-end guidelines

## Changes

- Add generic `LinkTo` component:
    - Abstract repeated logic
    - Automatically update location state 
- Use it in `LinkToOrgUnit`, etc to remove repeated code

## How to test
setup: cf IA-2939
- Look for all components called `LinkTo<something>`
- Check that the link works and the location state is updated

## Notes

Merges into https://github.com/BLSQ/iaso/pull/1284, same dependency to bluesauare-components