### PR TITLE
IA-2956:  Org Unit tree fixes

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -6,7 +6,7 @@
     "blsq.label.clicktoOpenFileSelect": "Cliquer pour sélectionner des fichiers",
     "blsq.label.dropHere": "Déposez les fichiers ici",
     "blsq.label.Files": "Fichiers",
-    "blsq.treeview.displayNew": "Afficher les unités d'org.",
+    "blsq.treeview.displayNew": "Afficher les nouvelles unités d'org.",
     "blsq.treeview.displayRejected": "Afficher les unités d'org. rejétées",
     "blsq.treeview.displayTypes": "Afficher les types d'unités d'org.",
     "blsq.treeview.error": "Veuillez sélectionner une unité d'org.",

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/TreeView/OrgUnitTreeviewModal.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/TreeView/OrgUnitTreeviewModal.js
@@ -47,6 +47,7 @@ const OrgUnitTreeviewModal = ({
     allowedTypes,
     errors,
 }) => {
+    const modalRef = useRef(null);
     const theme = useTheme();
     const classes = useStyles();
     const [settings, setSettings] = useState({
@@ -203,17 +204,24 @@ const OrgUnitTreeviewModal = ({
             allowConfirm={selectedOrgUnitsIds?.length > 0}
         >
             <Box
+                ref={modalRef}
                 sx={{
                     position: 'absolute',
                     top: theme.spacing(1),
                     right: theme.spacing(2),
                 }}
             >
-                <SettingsPopper setSettings={setSettings} settings={settings} />
+                <SettingsPopper
+                    anchorEl={modalRef}
+                    setSettings={setSettings}
+                    settings={settings}
+                />
             </Box>
             <Box mt={1}>
                 <TreeViewWithSearch
-                    getChildrenData={getChildrenData}
+                    getChildrenData={id =>
+                        getChildrenData(id, validationStatus)
+                    }
                     getRootData={getRootDataWithSource}
                     label={makeTreeviewLabel(
                         classes,

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/TreeView/OrgUnitTreeviewModal.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/TreeView/OrgUnitTreeviewModal.js
@@ -232,6 +232,7 @@ const OrgUnitTreeviewModal = ({
                     parseNodeIds={getOrgUnitAncestors}
                     multiselect={multiselect}
                     queryOptions={{ keepPreviousData: true }}
+                    childrenQueryOptions={{ keepPreviousData: true }}
                     preselected={selectedOrgUnitsIds}
                     preexpanded={selectedOrgUnitParents}
                     selectedData={selectedOrgUnits}

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/TreeView/OrgUnitTreeviewModal.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/TreeView/OrgUnitTreeviewModal.js
@@ -47,7 +47,6 @@ const OrgUnitTreeviewModal = ({
     allowedTypes,
     errors,
 }) => {
-    const modalRef = useRef(null);
     const theme = useTheme();
     const classes = useStyles();
     const [settings, setSettings] = useState({
@@ -204,18 +203,13 @@ const OrgUnitTreeviewModal = ({
             allowConfirm={selectedOrgUnitsIds?.length > 0}
         >
             <Box
-                ref={modalRef}
                 sx={{
                     position: 'absolute',
                     top: theme.spacing(1),
                     right: theme.spacing(2),
                 }}
             >
-                <SettingsPopper
-                    anchorEl={modalRef}
-                    setSettings={setSettings}
-                    settings={settings}
-                />
+                <SettingsPopper setSettings={setSettings} settings={settings} />
             </Box>
             <Box mt={1}>
                 <TreeViewWithSearch

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/TreeView/SettingsPopper.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/TreeView/SettingsPopper.tsx
@@ -75,9 +75,6 @@ export const SettingsPopper: FunctionComponent<Props> = ({
         [setSettings],
     );
 
-    const handleClickAway = useCallback(() => {
-        setAnchorEl(null);
-    }, []);
     const open = Boolean(anchorEl);
     return (
         <Box>
@@ -98,7 +95,11 @@ export const SettingsPopper: FunctionComponent<Props> = ({
                     <CancelOutlinedIcon color="primary" fontSize="small" />
                 </IconButton>
 
-                <ClickAwayListener onClickAway={handleClickAway}>
+                <ClickAwayListener
+                    onClickAway={() => {
+                        setAnchorEl(null);
+                    }}
+                >
                     <Paper sx={styles.paper} elevation={1}>
                         {settingKeys.map(settingKey => (
                             <Box key={settingKey} py={0.5}>

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/TreeView/SettingsPopper.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/TreeView/SettingsPopper.tsx
@@ -12,8 +12,8 @@ import { useSafeIntl } from 'bluesquare-components';
 import React, {
     Dispatch,
     FunctionComponent,
-    MouseEvent,
     SetStateAction,
+    useEffect,
     useState,
 } from 'react';
 import { SxStyles } from '../../../../types/general';
@@ -46,17 +46,23 @@ const settingKeys: string[] = ['displayTypes', 'displayRejected', 'displayNew'];
 type Props = {
     settings: Settings;
     setSettings: Dispatch<SetStateAction<Settings>>;
+    anchorEl: React.RefObject<HTMLElement>;
 };
 
 export const SettingsPopper: FunctionComponent<Props> = ({
     settings,
     setSettings,
+    anchorEl,
 }) => {
-    const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+    const [open, setOpen] = useState(false);
+    const [anchorElement, setAnchorElement] = useState(null);
 
+    useEffect(() => {
+        setAnchorElement(anchorEl.current);
+    }, [anchorEl.current]);
     const { formatMessage } = useSafeIntl();
-    const handleClick = (event: MouseEvent<HTMLElement>) => {
-        setAnchorEl(anchorEl ? null : event.currentTarget);
+    const handleClick = () => {
+        setOpen(!open);
     };
     const handleChangeSettings = (setting: string) => {
         setSettings({
@@ -64,7 +70,6 @@ export const SettingsPopper: FunctionComponent<Props> = ({
             [setting]: !settings[setting],
         });
     };
-    const open = Boolean(anchorEl);
     return (
         <Box>
             <IconButton onClick={handleClick}>
@@ -73,7 +78,7 @@ export const SettingsPopper: FunctionComponent<Props> = ({
             <Popper
                 sx={styles.popper}
                 open={open}
-                anchorEl={anchorEl}
+                anchorEl={anchorElement}
                 placement="right"
             >
                 <IconButton

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/TreeView/SettingsPopper.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/TreeView/SettingsPopper.tsx
@@ -2,18 +2,21 @@ import CancelOutlinedIcon from '@mui/icons-material/CancelOutlined';
 import SettingsIcon from '@mui/icons-material/Settings';
 import {
     Box,
+    ClickAwayListener,
     FormControlLabel,
     IconButton,
     Paper,
     Popper,
     Switch,
 } from '@mui/material';
+
 import { useSafeIntl } from 'bluesquare-components';
 import React, {
     Dispatch,
     FunctionComponent,
+    MouseEvent,
     SetStateAction,
-    useEffect,
+    useCallback,
     useState,
 } from 'react';
 import { SxStyles } from '../../../../types/general';
@@ -46,30 +49,36 @@ const settingKeys: string[] = ['displayTypes', 'displayRejected', 'displayNew'];
 type Props = {
     settings: Settings;
     setSettings: Dispatch<SetStateAction<Settings>>;
-    anchorEl: React.RefObject<HTMLElement>;
 };
 
 export const SettingsPopper: FunctionComponent<Props> = ({
     settings,
     setSettings,
-    anchorEl,
 }) => {
-    const [open, setOpen] = useState(false);
-    const [anchorElement, setAnchorElement] = useState(null);
+    const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
 
-    useEffect(() => {
-        setAnchorElement(anchorEl.current);
-    }, [anchorEl.current]);
     const { formatMessage } = useSafeIntl();
-    const handleClick = () => {
-        setOpen(!open);
-    };
-    const handleChangeSettings = (setting: string) => {
-        setSettings({
-            ...settings,
-            [setting]: !settings[setting],
-        });
-    };
+    const handleClick = useCallback(
+        (event: MouseEvent<HTMLElement>) => {
+            setAnchorEl(anchorEl ? null : event.currentTarget);
+        },
+        [anchorEl],
+    );
+
+    const handleChangeSettings = useCallback(
+        (setting: string) => {
+            setSettings(prevSettings => ({
+                ...prevSettings,
+                [setting]: !prevSettings[setting],
+            }));
+        },
+        [setSettings],
+    );
+
+    const handleClickAway = useCallback(() => {
+        setAnchorEl(null);
+    }, []);
+    const open = Boolean(anchorEl);
     return (
         <Box>
             <IconButton onClick={handleClick}>
@@ -78,7 +87,7 @@ export const SettingsPopper: FunctionComponent<Props> = ({
             <Popper
                 sx={styles.popper}
                 open={open}
-                anchorEl={anchorElement}
+                anchorEl={anchorEl}
                 placement="right"
             >
                 <IconButton
@@ -88,25 +97,28 @@ export const SettingsPopper: FunctionComponent<Props> = ({
                 >
                     <CancelOutlinedIcon color="primary" fontSize="small" />
                 </IconButton>
-                <Paper sx={styles.paper} elevation={1}>
-                    {settingKeys.map(settingKey => (
-                        <Box key={settingKey} py={0.5}>
-                            <FormControlLabel
-                                control={
-                                    <Switch
-                                        size="small"
-                                        checked={settings[settingKey]}
-                                        onChange={() =>
-                                            handleChangeSettings(settingKey)
-                                        }
-                                        color="primary"
-                                    />
-                                }
-                                label={formatMessage(MESSAGES[settingKey])}
-                            />
-                        </Box>
-                    ))}
-                </Paper>
+
+                <ClickAwayListener onClickAway={handleClickAway}>
+                    <Paper sx={styles.paper} elevation={1}>
+                        {settingKeys.map(settingKey => (
+                            <Box key={settingKey} py={0.5}>
+                                <FormControlLabel
+                                    control={
+                                        <Switch
+                                            size="small"
+                                            checked={settings[settingKey]}
+                                            onChange={() =>
+                                                handleChangeSettings(settingKey)
+                                            }
+                                            color="primary"
+                                        />
+                                    }
+                                    label={formatMessage(MESSAGES[settingKey])}
+                                />
+                            </Box>
+                        ))}
+                    </Paper>
+                </ClickAwayListener>
             </Popper>
         </Box>
     );

--- a/package-lock.json
+++ b/package-lock.json
@@ -6200,7 +6200,7 @@
         },
         "node_modules/bluesquare-components": {
             "version": "1.0.0",
-            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#9e8bafc8c86990e979ba235321cbc4c253cff9e8",
+            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#0d6e67ca75d92b61c421c227954f6df415624853",
             "license": "Apache-2.0",
             "dependencies": {
                 "@babel/plugin-proposal-class-properties": "^7.18.6",
@@ -33315,7 +33315,7 @@
             "dev": true
         },
         "bluesquare-components": {
-            "version": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#9e8bafc8c86990e979ba235321cbc4c253cff9e8",
+            "version": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#0d6e67ca75d92b61c421c227954f6df415624853",
             "from": "bluesquare-components@github:BLSQ/bluesquare-components",
             "requires": {
                 "@babel/plugin-proposal-class-properties": "^7.18.6",


### PR DESCRIPTION
- Popper should follow dialog size or close on click away

- result on children is not filtering rejected or new

- french translation is wrong

Related JIRA tickets : IA-2956

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are my typescript files well typed
- [x] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- invalid children queries too 
- fix french translation
- close Popper on click away

## How to test

Open a org uni tree picker on a sub level rejected org unit .

Play with settings

## Print screen / video


https://github.com/BLSQ/iaso/assets/12494624/cb05dd43-05f5-4462-b631-6df1be9fd0ee



## Notes

⚠️ This has too merged after[ bluesquare-components PR](https://github.com/BLSQ/bluesquare-components/pull/151)
