### PR TITLE
HotFix: remove renderOption to avoid the Uncaught TypeError: option is undefined

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/projects/components/ProjectFeatureFlags.tsx
+++ b/hat/assets/js/apps/Iaso/domains/projects/components/ProjectFeatureFlags.tsx
@@ -25,12 +25,6 @@ type Props = {
     isFetchingFeatureFlag: boolean;
 };
 
-const renderOption = (props, option) => (
-    <Tooltip key={option.value} title={option.tooltip} disableInteractive>
-        <span {...props}>{option.label}</span>
-    </Tooltip>
-);
-
 const renderTags = (value, getTagProps) =>
     value.map((option, index) => (
         <Tooltip
@@ -83,7 +77,6 @@ const ProjectFeatureFlags: FunctionComponent<Props> = ({
             type="select"
             options={options}
             label={MESSAGES.featureFlags}
-            renderOption={renderOption}
             renderTags={renderTags}
         />
     );


### PR DESCRIPTION
Explain what problem this PR is resolving
- Avoid Uncaught TypeError: option is undefined on autocomplete featureflags option
Related JIRA tickets : IA-XXX, WC2-XXX, POLIO-XXX

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
- Tell us where the doc can be found (docs folder, wiki, in the code...)

## Changes
- Remove the renderOption from the select multiple for featureflags

## How to test
- Go in admin -> project
- Edit or create a project
- search in autocomplete and check if it works fine