### PR TITLE
WC2-361 Calculate the weight gain only for cured and Transfer from OTP to TSFP cases!

### DIFF
--- a/plugins/wfp/management/commands/wfp_etl_Under5.py
+++ b/plugins/wfp/management/commands/wfp_etl_Under5.py
@@ -197,7 +197,12 @@ class Under5:
         journey.initial_weight = record.get("initial_weight", None)
         journey.start_date = record.get("start_date", None)
 
-        if record.get("exit_type", None) is not None and record.get("exit_type", None) != "":
+        # Calculate the weight gain only for cured and Transfer from OTP to TSFP cases!
+        if (
+            record.get("exit_type", None) is not None
+            and record.get("exit_type", None) != ""
+            and record.get("exit_type", None) in ["cured", "transfer_to_tsfp"]
+        ):
             journey.discharge_weight = record.get("discharge_weight", None)
             journey.weight_gain = record.get("weight_gain", 0)
             journey.weight_loss = record.get("weight_loss", 0)


### PR DESCRIPTION
Abi from WFP has requested to limit the calculation to cured and Transfer from OTP to TSFP as shared by the country office.

More details in the ticket: https://dev.azure.com/worldfoodprogramme/CODA2/_workitems/edit/241569

Related JIRA tickets : [WFPPM-16](https://bluesquare.atlassian.net/browse/WFPPM-16)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)


## Changes

Limiting the calculation for weight gain for exit type cured and Transfer from OTP to TSFP cases!

## How to test

From the local instance with wfp coda database, Lunch with `docker-compose run iaso manage wfp_etl` the ETL script in order to generate data for tableau dashboard and open the admin to see the content Journey table. [http://localhost:8081/admin/wfp/journey/](http://localhost:8081/admin/wfp/journey/?exit_type__exact=cured)

[WC2-362]: https://bluesquare.atlassian.net/browse/WC2-362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ