### PR TITLE
WC2-367: Form detail label key name

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/forms/components/FormFormComponent.tsx
+++ b/hat/assets/js/apps/Iaso/domains/forms/components/FormFormComponent.tsx
@@ -1,30 +1,30 @@
 /* eslint-disable camelcase */
-import React, { useState, FunctionComponent, useEffect } from 'react';
-import { Box, Grid, Typography, Theme } from '@mui/material';
+import { Box, Grid, Theme, Typography } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import { useSafeIntl } from 'bluesquare-components';
+import React, { FunctionComponent, useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router';
 
-import { History, FormatListBulleted } from '@mui/icons-material';
-import { baseUrls } from '../../../constants/urls';
+import { FormatListBulleted, History } from '@mui/icons-material';
+import { DisplayIfUserHasPerm } from '../../../components/DisplayIfUserHasPerm';
 import InputComponent from '../../../components/forms/InputComponent';
+import { baseUrls } from '../../../constants/urls';
 import {
     commaSeparatedIdsToArray,
     commaSeparatedIdsToStringArray,
 } from '../../../utils/forms';
-import { useGetOrgUnitTypesDropdownOptions } from '../../orgUnits/orgUnitTypes/hooks/useGetOrgUnitTypesDropdownOptions';
-import { useGetProjectsDropdownOptions } from '../../projects/hooks/requests';
+import { SUBMISSIONS, SUBMISSIONS_UPDATE } from '../../../utils/permissions';
 import { formatLabel } from '../../instances/utils';
+import { useGetOrgUnitTypesDropdownOptions } from '../../orgUnits/orgUnitTypes/hooks/useGetOrgUnitTypesDropdownOptions';
 import {
     NO_PERIOD,
     periodTypeOptionsWithNoPeriod,
 } from '../../periods/constants';
+import { useGetProjectsDropdownOptions } from '../../projects/hooks/requests';
+import { CR_MODE_NONE, changeRequestModeOptions } from '../constants';
 import MESSAGES from '../messages';
-import { DisplayIfUserHasPerm } from '../../../components/DisplayIfUserHasPerm';
 import { FormDataType } from '../types/forms';
 import { FormLegendInput } from './FormLegendInput';
-import { SUBMISSIONS, SUBMISSIONS_UPDATE } from '../../../utils/permissions';
-import { CR_MODE_NONE, changeRequestModeOptions } from '../constants';
 
 const useStyles = makeStyles((theme: Theme) => ({
     radio: {
@@ -87,6 +87,16 @@ const FormForm: FunctionComponent<FormFormProps> = ({
         setFieldValue('period_type', periodTypeValue);
     };
 
+    const labelKeysOptions = useMemo(() => {
+        return currentForm.possible_fields.value
+            .map(field => ({
+                label: `${formatLabel(field)} [${field.name}]`,
+                value: field.name,
+            }))
+            .sort((option1, option2) =>
+                option1.label.localeCompare(option2.label),
+            );
+    }, [currentForm.possible_fields.value]);
     let orgUnitTypes;
     if (currentForm.org_unit_type_ids.value.length > 0) {
         orgUnitTypes = currentForm.org_unit_type_ids.value.join(',');
@@ -306,16 +316,7 @@ const FormForm: FunctionComponent<FormFormProps> = ({
                                 value={currentForm.label_keys.value}
                                 errors={currentForm.possible_fields.errors}
                                 type="select"
-                                options={currentForm.possible_fields.value
-                                    .map(field => ({
-                                        label: formatLabel(field),
-                                        value: field.name,
-                                    }))
-                                    .sort((option1, option2) =>
-                                        option1.label.localeCompare(
-                                            option2.label,
-                                        ),
-                                    )}
+                                options={labelKeysOptions}
                                 label={MESSAGES.fields}
                             />
                             <InputComponent


### PR DESCRIPTION
When using the “Default fields to display” parameter in the advanced settings of a form, the list offers all question names that ever existed but only displays their label.

@Michael Matiashe configured it to one, but the value didn’t appear in the application because it was wrong.

It would be better to display the question name along the label to remove the confusion.

Related JIRA tickets : WC2-367

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)



## Changes

just adding field name in label

## How to test

Open detail of a forms, click on advanced settings and open default field dropdown

## Print screen / video

![Screenshot 2024-05-07 at 14 52 26](https://github.com/BLSQ/iaso/assets/12494624/02dfd43c-23c5-4b16-b451-735f15d90765)

