### PR TITLE
IA-2747: Have the landing page activated by default on the setuper test account

### DIFF
--- a/hat/constants.py
+++ b/hat/constants.py
@@ -1,1 +1,7 @@
 DATE_FORMAT = "%Y-%m-%d"
+
+ACCOUNT_FEATURE_FLAGS = [
+    {"code": "SHOW_HOME_ONLINE", "name": "Display plugin online home page"},
+    {"code": "SHOW_BENEFICIARY_TYPES_IN_LIST_MENU", "name": "Display beneficiaries by types in side menu"},
+    {"code": "SHOW_PAGES", "name": "Show page menu"},
+]

--- a/hat/constants.py
+++ b/hat/constants.py
@@ -1,7 +1,1 @@
 DATE_FORMAT = "%Y-%m-%d"
-
-ACCOUNT_FEATURE_FLAGS = [
-    {"code": "SHOW_HOME_ONLINE", "name": "Display plugin online home page"},
-    {"code": "SHOW_BENEFICIARY_TYPES_IN_LIST_MENU", "name": "Display beneficiaries by types in side menu"},
-    {"code": "SHOW_PAGES", "name": "Show page menu"},
-]

--- a/iaso/api/setup_account.py
+++ b/iaso/api/setup_account.py
@@ -7,7 +7,6 @@ from rest_framework import permissions, serializers
 from rest_framework.mixins import CreateModelMixin
 from rest_framework.viewsets import GenericViewSet
 
-from hat.constants import ACCOUNT_FEATURE_FLAGS
 from hat.menupermissions.constants import MODULES
 from hat.menupermissions.models import CustomPermissionSupport
 from iaso.api.common import IsAdminOrSuperUser
@@ -76,9 +75,8 @@ class SetupAccountSerializer(serializers.Serializer):
             modules=account_modules,
             analytics_script=validated_data.get("analytics_script", ""),
         )
-        account_feature_flags = [feature_flag["code"] for feature_flag in ACCOUNT_FEATURE_FLAGS]
+        account_feature_flags = ["SHOW_HOME_ONLINE", "SHOW_BENEFICIARY_TYPES_IN_LIST_MENU", "SHOW_PAGES"]
         account.feature_flags.set(account_feature_flags)
-        account.save()
 
         # Create a setup_account project with an app_id represented by the account name
         app_id = validated_data["account_name"].replace(" ", ".").replace("-", ".")
@@ -98,6 +96,7 @@ class SetupAccountSerializer(serializers.Serializer):
         data_source.save()
 
         Profile.objects.create(account=account, user=user)
+
         # Get all permissions linked to the modules
         modules_permissions = account_module_permissions(account_modules)
 

--- a/iaso/api/setup_account.py
+++ b/iaso/api/setup_account.py
@@ -7,6 +7,7 @@ from rest_framework import permissions, serializers
 from rest_framework.mixins import CreateModelMixin
 from rest_framework.viewsets import GenericViewSet
 
+from hat.constants import ACCOUNT_FEATURE_FLAGS
 from hat.menupermissions.constants import MODULES
 from hat.menupermissions.models import CustomPermissionSupport
 from iaso.api.common import IsAdminOrSuperUser
@@ -75,6 +76,9 @@ class SetupAccountSerializer(serializers.Serializer):
             modules=account_modules,
             analytics_script=validated_data.get("analytics_script", ""),
         )
+        account_feature_flags = [feature_flag["code"] for feature_flag in ACCOUNT_FEATURE_FLAGS]
+        account.feature_flags.set(account_feature_flags)
+        account.save()
 
         # Create a setup_account project with an app_id represented by the account name
         app_id = validated_data["account_name"].replace(" ", ".").replace("-", ".")


### PR DESCRIPTION
Explain what problem this PR is resolving

Related JIRA tickets : [IA-2747](https://bluesquare.atlassian.net/browse/IA-2747)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)


## Changes

Linked account feature flags to the created test account!

## How to test

From django admin, check the created account, you should see some activated feature flags!

## Print screen / video



https://github.com/BLSQ/iaso/assets/6383219/0e17b610-d9a2-4ec5-ba69-3c8871a964c6



[IA-2747]: https://bluesquare.atlassian.net/browse/IA-2747?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ