### PR TITLE
POLIO-1536, POLIO-1539, POLIO-1547, POLIO-1549: budget process layout improvements

### DIFF
--- a/hat/assets/js/apps/Iaso/components/forms/TextArea.tsx
+++ b/hat/assets/js/apps/Iaso/components/forms/TextArea.tsx
@@ -1,11 +1,8 @@
 import React, { FunctionComponent, useEffect, useRef, useState } from 'react';
 
 import {
-    // @ts-ignore
     FormControl,
-    // @ts-ignore
     commonStyles,
-    // @ts-ignores
     useSkipEffectOnMount,
 } from 'bluesquare-components';
 import classnames from 'classnames';
@@ -116,7 +113,7 @@ export const TextArea: FunctionComponent<Props> = ({
     return (
         <FormControl errors={errors}>
             <InputLabel
-                shrink={Boolean(textValue)}
+                shrink={Boolean(textValue) || focus}
                 className={classnames(
                     classes.inputLabel,
                     focus && classes.inputLabelFocus,
@@ -130,6 +127,7 @@ export const TextArea: FunctionComponent<Props> = ({
             </InputLabel>
             <textarea
                 onFocus={() => setFocus(true)}
+                onBlur={() => setFocus(false)}
                 className={classnames(
                     classes.textArea,
                     hasErrors && classes.errorArea,

--- a/plugins/polio/js/src/domains/Budget/BudgetButtons.tsx
+++ b/plugins/polio/js/src/domains/Budget/BudgetButtons.tsx
@@ -6,16 +6,21 @@ import MESSAGES from './messages';
 import { CreateBudgetProcessModal } from './BudgetProcess/CreateBudgetProcessModal';
 import { CsvButton } from '../../../../../../hat/assets/js/apps/Iaso/components/Buttons/CsvButton';
 
-type Props = { csvUrl: string; isUserPolioBudgetAdmin: boolean };
+type Props = {
+    csvUrl: string;
+    isUserPolioBudgetAdmin: boolean;
+    isMobileLayout?: boolean;
+};
 
 export const BudgetButtons: FunctionComponent<Props> = ({
     csvUrl,
     isUserPolioBudgetAdmin,
+    isMobileLayout = false,
 }) => {
     return (
         <Grid container justifyContent="flex-end">
             {isUserPolioBudgetAdmin && (
-                <Box mr={2}>
+                <Box mb={isMobileLayout ? 2 : 0}>
                     <CreateBudgetProcessModal
                         iconProps={{
                             message: MESSAGES.createBudgetProcessTitle,

--- a/plugins/polio/js/src/domains/Budget/BudgetButtons.tsx
+++ b/plugins/polio/js/src/domains/Budget/BudgetButtons.tsx
@@ -20,7 +20,7 @@ export const BudgetButtons: FunctionComponent<Props> = ({
     return (
         <Grid container justifyContent="flex-end">
             {isUserPolioBudgetAdmin && (
-                <Box mb={isMobileLayout ? 2 : 0}>
+                <Box mb={isMobileLayout ? 2 : 0} mr={isMobileLayout ? 0 : 2}>
                     <CreateBudgetProcessModal
                         iconProps={{
                             message: MESSAGES.createBudgetProcessTitle,

--- a/plugins/polio/js/src/domains/Budget/BudgetDetails/BudgetDetails.tsx
+++ b/plugins/polio/js/src/domains/Budget/BudgetDetails/BudgetDetails.tsx
@@ -37,7 +37,7 @@ export const BudgetProcessDetails: FunctionComponent<Props> = ({ router }) => {
     const { campaignName, budgetProcessId, transition_key, ...rest } = params;
     const classes = useStyles();
     const [showHidden, setShowHidden] = useState<boolean>(
-        rest.show_hidden ?? false,
+        rest.show_hidden === 'true',
     );
 
     const apiParams = useMemo(() => {

--- a/plugins/polio/js/src/domains/Budget/BudgetDetails/BudgetDetails.tsx
+++ b/plugins/polio/js/src/domains/Budget/BudgetDetails/BudgetDetails.tsx
@@ -43,11 +43,11 @@ export const BudgetProcessDetails: FunctionComponent<Props> = ({ router }) => {
     const apiParams = useMemo(() => {
         return {
             ...rest,
-            deletion_status: showHidden ? 'all' : undefined,
+            deletion_status: rest.show_hidden === 'true' ? 'all' : undefined,
             budget_process_id: budgetProcessId,
             transition_key__in: transition_key,
         };
-    }, [budgetProcessId, rest, showHidden, transition_key]);
+    }, [budgetProcessId, rest, transition_key]);
 
     // @ts-ignore
     const prevPathname = useSelector(state => state.routerCustom.prevPathname);

--- a/plugins/polio/js/src/domains/Budget/BudgetDetails/BudgetDetailsFilters.tsx
+++ b/plugins/polio/js/src/domains/Budget/BudgetDetails/BudgetDetailsFilters.tsx
@@ -63,10 +63,11 @@ export const BudgetDetailsFilters: FunctionComponent<Props> = ({
                     />
                     <InputComponent
                         type="checkbox"
-                        keyValue="showHidden"
+                        keyValue="show_hidden"
                         labelString={formatMessage(MESSAGES.showHidden)}
-                        onChange={(_keyValue, newValue) => {
+                        onChange={(keyValue, newValue) => {
                             setShowHidden(newValue);
+                            handleChange(keyValue, newValue);
                         }}
                         value={showHidden}
                         withMarginTop={false}

--- a/plugins/polio/js/src/domains/Budget/BudgetFilters.tsx
+++ b/plugins/polio/js/src/domains/Budget/BudgetFilters.tsx
@@ -43,7 +43,7 @@ export const BudgetFilters: FunctionComponent<Props> = ({
         useGetGroupDropdown({ blockOfCountries: 'True' });
     const countriesList = (data && data.orgUnits) || [];
     return (
-        <Box mb={4}>
+        <Box mb={isXSLayout ? 4 : 2}>
             <Grid container spacing={isXSLayout ? 0 : 2}>
                 <Grid item xs={12} sm={6} md={3}>
                     <InputComponent

--- a/plugins/polio/js/src/domains/Budget/BudgetProcess/CreateBudgetProcessModal.tsx
+++ b/plugins/polio/js/src/domains/Budget/BudgetProcess/CreateBudgetProcessModal.tsx
@@ -94,16 +94,16 @@ const CreateBudgetProcessModal: FunctionComponent<Props> = ({
                     <Box mb={2}>
                         <Divider />
                     </Box>
-                    <Grid container direction="row" item spacing={2}>
-                        <Grid item xs={6}>
-                            <Box mb={2}>
-                                <Field
-                                    label={formatMessage(MESSAGES.labelCountry)}
-                                    name="country"
-                                    component={SingleSelect}
-                                    options={dropdownsData?.countries || []}
-                                />
-                            </Box>
+                    <Grid container direction="row" spacing={2}>
+                        <Grid item xs={12} sm={6}>
+                            <Field
+                                label={formatMessage(MESSAGES.labelCountry)}
+                                name="country"
+                                component={SingleSelect}
+                                options={dropdownsData?.countries || []}
+                            />
+                        </Grid>
+                        <Grid item xs={12} sm={6}>
                             <Field
                                 label={formatMessage(MESSAGES.labelCampaign)}
                                 name="campaign"
@@ -111,7 +111,7 @@ const CreateBudgetProcessModal: FunctionComponent<Props> = ({
                                 options={currentCampaignOptions}
                             />
                         </Grid>
-                        <Grid item xs={6}>
+                        <Grid item xs={12} sm={6}>
                             <Field
                                 label={formatMessage(MESSAGES.labelRound)}
                                 name="rounds"

--- a/plugins/polio/js/src/domains/Budget/BudgetProcess/EditBudgetProcessModal.tsx
+++ b/plugins/polio/js/src/domains/Budget/BudgetProcess/EditBudgetProcessModal.tsx
@@ -93,7 +93,7 @@ const EditBudgetProcessModal: FunctionComponent<Props> = ({
                     </Box>
 
                     <Grid container direction="row" item spacing={2}>
-                        <Grid item xs={6}>
+                        <Grid item xs={12} sm={6}>
                             <Field
                                 label={formatMessage(MESSAGES.labelRound)}
                                 name="rounds"

--- a/plugins/polio/js/src/domains/Budget/CreateBudgetStep/CreateBudgetStep.tsx
+++ b/plugins/polio/js/src/domains/Budget/CreateBudgetStep/CreateBudgetStep.tsx
@@ -234,14 +234,16 @@ const CreateBudgetStep: FunctionComponent<Props> = ({
                 onClose={() => null}
             >
                 <>
-                    <TextArea
-                        value={values.comment}
-                        errors={getErrors('comment')}
-                        label={formatMessage(MESSAGES.notes)}
-                        onChange={onCommentChange}
-                        required={requiredFields.includes('comment')}
-                        debounceTime={0}
-                    />
+                    <Box mt={1}>
+                        <TextArea
+                            value={values.comment}
+                            errors={getErrors('comment')}
+                            label={formatMessage(MESSAGES.notes)}
+                            onChange={onCommentChange}
+                            required={requiredFields.includes('comment')}
+                            debounceTime={0}
+                        />
+                    </Box>
                     <InputComponent
                         type="number"
                         keyValue="amount"

--- a/plugins/polio/js/src/domains/Budget/cards/BudgetCard.tsx
+++ b/plugins/polio/js/src/domains/Budget/cards/BudgetCard.tsx
@@ -16,10 +16,12 @@ import {
 } from 'bluesquare-components';
 import classnames from 'classnames';
 
+import { DisplayIfUserHasPerm } from '../../../../../../../hat/assets/js/apps/Iaso/components/DisplayIfUserHasPerm';
 import { BUDGET_DETAILS } from '../../../constants/routes';
 import MESSAGES from '../../../constants/messages';
 import { WARNING_COLOR } from '../../../styles/constants';
 import { Budget } from '../types';
+import { EditBudgetProcessModal } from '../BudgetProcess/EditBudgetProcessModal';
 
 type Props = {
     budget: Budget;
@@ -89,15 +91,24 @@ export const BudgetCard: FunctionComponent<Props> = ({ budget }) => {
                     xs={2}
                     direction="column"
                     justifyContent="center"
-                    alignItems="flex-start"
+                    alignItems="center"
                 >
                     <Divider orientation="vertical" />
 
                     <IconButtonComponent
                         icon="remove-red-eye"
                         tooltipMessage={MESSAGES.details}
-                        url={`${baseUrl}/campaignName/${budget.obr_name}/campaignId/${budget.id}`}
+                        url={`${baseUrl}/campaignName/${budget.obr_name}/budgetProcessId/${budget.id}`}
                     />
+
+                    <DisplayIfUserHasPerm
+                        permissions={['iaso_polio_budget_admin']}
+                    >
+                        <EditBudgetProcessModal
+                            budgetProcess={budget}
+                            iconProps={{}}
+                        />
+                    </DisplayIfUserHasPerm>
                 </Grid>
             </Grid>
         </Card>

--- a/plugins/polio/js/src/domains/Budget/index.tsx
+++ b/plugins/polio/js/src/domains/Budget/index.tsx
@@ -126,10 +126,13 @@ export const BudgetProcessList: FunctionComponent<Props> = ({ router }) => {
                             buttonSize="small"
                             statesList={possibleStates}
                         />
-                        <BudgetButtons
-                            csvUrl={`/api/polio/budget/export_csv/?${csvParams}`}
-                            isUserPolioBudgetAdmin={isUserPolioBudgetAdmin}
-                        />
+                        <Box mb={2}>
+                            <BudgetButtons
+                                csvUrl={`/api/polio/budget/export_csv/?${csvParams}`}
+                                isUserPolioBudgetAdmin={isUserPolioBudgetAdmin}
+                                isMobileLayout
+                            />
+                        </Box>
                     </Collapse>
                 )}
 


### PR DESCRIPTION
small layout improvements

Related JIRA tickets : POLIO-1536, POLIO-1547, POLIO-1549, POLIO-1539

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
None

## Changes

- `BudgetCard`: 
    - Adapt redirection url
    - Add edit button
    - Adapt modal layout for xs screens
    - Improve buttons layout
- Improve `TextArea`'s handling of focus so cursor is visible on first click
- Add margin top so Comments label is visible in `CreateBudgetStep` modal
- Improve buttons layout on mobile layout
- Re-order dropdown input in `CreateBudgetProcess` modal
- Fix deep-linking in `BudgetDetailsFilters`
- Toggle "show hidden" when user click "filter" button, to align behaviour with other filters in iaso, eg: forms

## How to test

- Go to Budgets
- Switch to mobile view in the browser
- Budget cards should have both see and edit buttons
- "Plan a new Budget process" button should be better aligned
- click "plan new budget process" button: campaign input should come before round input
- Go to the details of a process
- Try adding a step (regular, not override)
- Click in the "comments". text area: the input label should shrink and the cursor be visible within the text area
- Try hiding a line in the process table: the url should be updated and the deep link should work

## Print screen / video
![image](https://github.com/BLSQ/iaso/assets/38907762/2e6fe18f-9998-4d48-b446-a7630cb1c754)
![image](https://github.com/BLSQ/iaso/assets/38907762/96bf76f1-d02f-4cf6-9754-18a81e357df2)
![Screenshot 2024-05-13 at 13 00 38](https://github.com/BLSQ/iaso/assets/38907762/9674f8eb-eb0f-4ed4-be32-c9340f7a1587)
![Screenshot 2024-05-13 at 13 00 54](https://github.com/BLSQ/iaso/assets/38907762/35633e10-a3b7-4cc1-8b84-ceba6df26fbf)

https://github.com/BLSQ/iaso/assets/38907762/15766bed-cbca-4e14-a016-0d34f3c4b240


