### PR TITLE
POLIO-1548 Hide non-polio campaigns

### DIFF
--- a/plugins/polio/budget/api.py
+++ b/plugins/polio/budget/api.py
@@ -78,7 +78,7 @@ class BudgetProcessViewSet(ModelViewSet, CSVExportMixin):
 
     def get_queryset(self) -> QuerySet:
         user = self.request.user
-        campaigns = Campaign.objects.filter_for_user(user)
+        campaigns = Campaign.polio_objects.filter_for_user(user)
         budget_processes = (
             BudgetProcess.objects.filter(rounds__campaign__in=campaigns)
             .distinct()
@@ -146,7 +146,7 @@ class BudgetProcessViewSet(ModelViewSet, CSVExportMixin):
         campaign_uuid = query_params.validated_data["campaign_id"]
         budget_process_id = query_params.validated_data["budget_process_id"]
 
-        campaign = Campaign.objects.filter(id=campaign_uuid).filter_for_user(self.request.user).first()
+        campaign = Campaign.polio_objects.filter(id=campaign_uuid).filter_for_user(self.request.user).first()
         available_rounds = (
             Round.objects.filter(campaign=campaign)
             .select_related("campaign__country")

--- a/plugins/polio/budget/api.py
+++ b/plugins/polio/budget/api.py
@@ -125,13 +125,19 @@ class BudgetProcessViewSet(ModelViewSet, CSVExportMixin):
         """
         Returns all available rounds that can be used to create a new `BudgetProcess`.
         """
-        user_campaigns = Campaign.objects.filter_for_user(self.request.user).filter(country__isnull=False)
+        user_campaigns = Campaign.polio_objects.filter_for_user(self.request.user).filter(country__isnull=False)
         available_rounds = (
             Round.objects.filter(budget_process__isnull=True, campaign__in=user_campaigns)
             .select_related("campaign__country")
             .order_by("campaign__country__name", "campaign__obr_name", "number")
             .only(
-                "id", "number", "campaign_id", "campaign__obr_name", "campaign__country_id", "campaign__country__name"
+                "id",
+                "number",
+                "campaign_id",
+                "campaign__obr_name",
+                "campaign__country_id",
+                "campaign__country__name",
+                "target_population",
             )
         )
         return Response(available_rounds.as_ui_dropdown_data(), status=status.HTTP_200_OK)
@@ -153,7 +159,13 @@ class BudgetProcessViewSet(ModelViewSet, CSVExportMixin):
             .filter(Q(budget_process_id=budget_process_id) | Q(budget_process__isnull=True))
             .order_by("number")
             .only(
-                "id", "number", "campaign_id", "campaign__obr_name", "campaign__country_id", "campaign__country__name"
+                "id",
+                "number",
+                "campaign_id",
+                "campaign__obr_name",
+                "campaign__country_id",
+                "campaign__country__name",
+                "target_population",
             )
         )
         return Response(available_rounds.as_ui_dropdown_data()["rounds"], status=status.HTTP_200_OK)

--- a/plugins/polio/models.py
+++ b/plugins/polio/models.py
@@ -321,26 +321,6 @@ class Round(models.Model):
         return len(self.campaign.get_districts_for_round(self))
 
 
-class CampaignQuerySet(models.QuerySet):
-    def filter_for_user(self, user: Union[User, AnonymousUser]):
-        qs = self
-        if user.is_authenticated:
-            # Authenticated users only get campaigns linked to their account
-            qs = qs.filter(account=user.iaso_profile.account)
-
-            # Restrict Campaign to the OrgUnit on the country he can access
-            if user.iaso_profile.org_units.count():
-                org_units = OrgUnit.objects.hierarchy(user.iaso_profile.org_units.all()).defer(
-                    "geom", "simplified_geom"
-                )
-                qs = qs.filter(Q(country__in=org_units) | Q(initial_org_unit__in=org_units))
-        return qs
-
-
-# workaround for MyPy detection
-CampaignManager = models.Manager.from_queryset(CampaignQuerySet)
-
-
 class CampaignType(models.Model):
     POLIO = "Polio"
     MEASLES = "Measles"
@@ -364,11 +344,35 @@ class CampaignType(models.Model):
         super(CampaignType, self).save(*args, **kwargs)
 
 
+class CampaignQuerySet(models.QuerySet):
+    def filter_for_user(self, user: Union[User, AnonymousUser]):
+        qs = self
+        if user.is_authenticated:
+            # Authenticated users only get campaigns linked to their account
+            qs = qs.filter(account=user.iaso_profile.account)
+
+            # Restrict Campaign to the OrgUnit on the country he can access
+            if user.iaso_profile.org_units.count():
+                org_units = OrgUnit.objects.hierarchy(user.iaso_profile.org_units.all()).defer(
+                    "geom", "simplified_geom"
+                )
+                qs = qs.filter(Q(country__in=org_units) | Q(initial_org_unit__in=org_units))
+        return qs
+
+
+class PolioCampaignManager(models.Manager):
+    def get_queryset(self):
+        return super().get_queryset().prefetch_related("campaign_types").filter(campaign_types__name=CampaignType.POLIO)
+
+
 class Campaign(SoftDeletableModel):
     class Meta:
         ordering = ["obr_name"]
 
-    objects = CampaignManager()
+    # Managers.
+    objects = models.Manager.from_queryset(CampaignQuerySet)()
+    polio_objects = PolioCampaignManager.from_queryset(CampaignQuerySet)()
+
     scopes: "django.db.models.manager.RelatedManager[CampaignScope]"
     rounds: "django.db.models.manager.RelatedManager[Round]"
     id = models.UUIDField(default=uuid4, primary_key=True, editable=False)

--- a/plugins/polio/tests/api/test_budget.py
+++ b/plugins/polio/tests/api/test_budget.py
@@ -13,7 +13,7 @@ from rest_framework import status
 from iaso import models as m
 from iaso.test import APITestCase
 from plugins.polio.budget.models import BudgetProcess, BudgetStep, MailTemplate
-from plugins.polio.models import Campaign, Round
+from plugins.polio.models import Campaign, CampaignType, Round
 from plugins.polio.tests.utils.budget import get_mocked_workflow
 
 
@@ -48,12 +48,16 @@ class BudgetProcessViewSetTestCase(APITestCase):
             username="test", first_name="test", last_name="test", account=cls.account, permissions=["iaso_polio_budget"]
         )
 
+        # Campaign type.
+        cls.polio_type = CampaignType.objects.get(name=CampaignType.POLIO)
+
         # Campaign.
         cls.campaign = Campaign.objects.create(
             obr_name="test campaign",
             account=cls.user.iaso_profile.account,
             country=m.OrgUnit.objects.create(name="ANGOLA"),
         )
+        cls.campaign.campaign_types.set([cls.polio_type])
 
         # Budget Processes.
         cls.budget_process_1 = BudgetProcess.objects.create(created_by=cls.user)
@@ -789,6 +793,9 @@ class FilterBudgetProcessViewSetTestCase(APITestCase):
         cls.account = m.Account.objects.create(name="Account", default_version=cls.source_version)
         cls.user = cls.create_user_with_profile(username="user", account=cls.account, permissions=["iaso_polio_budget"])
 
+        # Campaign type.
+        cls.polio_type = CampaignType.objects.get(name=CampaignType.POLIO)
+
         # Campaign.
         cls.country = m.OrgUnit.objects.create(name="ANGOLA")
         cls.campaign = Campaign.objects.create(
@@ -796,6 +803,7 @@ class FilterBudgetProcessViewSetTestCase(APITestCase):
             account=cls.user.iaso_profile.account,
             country=cls.country,
         )
+        cls.campaign.campaign_types.set([cls.polio_type])
 
         # Budget Processes.
         cls.budget_process_1 = BudgetProcess.objects.create(created_by=cls.user)

--- a/plugins/polio/tests/models/test_campaign_models.py
+++ b/plugins/polio/tests/models/test_campaign_models.py
@@ -1,0 +1,42 @@
+from iaso import models as m
+from iaso.test import TestCase
+
+from plugins.polio.models import Campaign, CampaignType
+
+
+class CampaignTestCase(TestCase):
+    """
+    Test Campaign model.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        # User.
+        cls.data_source = m.DataSource.objects.create(name="Data Source")
+        cls.source_version = m.SourceVersion.objects.create(data_source=cls.data_source, number=1)
+        cls.account = m.Account.objects.create(name="Account", default_version=cls.source_version)
+        cls.user = cls.create_user_with_profile(
+            email="john@polio.org",
+            username="test",
+            first_name="John",
+            last_name="Doe",
+            account=cls.account,
+            permissions=["iaso_polio_budget"],
+        )
+
+        # Campaigns types.
+        cls.polio_type = CampaignType.objects.get(name=CampaignType.POLIO)
+        cls.measles_type = CampaignType.objects.get(name=CampaignType.MEASLES)
+
+        # Campaigns.
+        cls.polio_campaign = Campaign.objects.create(obr_name="Polio", account=cls.account)
+        cls.polio_campaign.campaign_types.set([cls.polio_type])
+        cls.measles_campaign = Campaign.objects.create(obr_name="Measles", account=cls.account)
+        cls.measles_campaign.campaign_types.set([cls.measles_type])
+
+    def test_polio_campaign_manager(self):
+        self.assertEqual(Campaign.objects.count(), 2)
+        self.assertEqual(Campaign.polio_objects.count(), 1)
+
+        polio_campaign = Campaign.polio_objects.first()
+        self.assertEqual(polio_campaign.campaign_types.first().name, CampaignType.POLIO)


### PR DESCRIPTION
Hide non-polio campaigns

Related JIRA tickets : [POLIO-1548](https://bluesquare.atlassian.net/browse/POLIO-1548)

## Changes

- Hide non-polio campaigns via a custom `PolioCampaignManager`
- fix a N+1 problem in `available_rounds_for_create` thanx to [django-querycount](https://github.com/BLSQ/iaso/commit/dbd07b198a18e86c194417e81cf1f155ebe0a36d#diff-2b4945591edfeaa4cf4d3f155e66d4b43d1bda7a55d881d5cf3107f1b05abbbcR23) (kudos @bramj)

## How to test

The best way is to read the unit tests.


[POLIO-1548]: https://bluesquare.atlassian.net/browse/POLIO-1548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ