### PR TITLE
IA-2804: Filter on planning in Completeness stats doesn't work

### DIFF
--- a/iaso/api/completeness_stats.py
+++ b/iaso/api/completeness_stats.py
@@ -261,7 +261,7 @@ class CompletenessStatsV2ViewSet(viewsets.ViewSet):
             # the requirements
             instance_qs = instance_qs.filter(period=period)
         if planning:
-            instance_qs = instance_qs.filter(planning_id=planning.id)
+            instance_qs = instance_qs.filter(planning=planning)
             form_qs = form_qs.filter(plannings=planning)
 
         # filter instance_qs on users related to selected teams

--- a/iaso/api/completeness_stats.py
+++ b/iaso/api/completeness_stats.py
@@ -248,7 +248,7 @@ class CompletenessStatsV2ViewSet(viewsets.ViewSet):
         orders = params["order"]
         form_qs = params["forms"]
         period = params.get("period", None)
-        planning_id = params.get("planning_id", None)
+        planning = params.get("planning", None)
         org_unit_validation_status = params["org_unit_validation_status"]
         as_location = params.get("as_location", None)
         teams = params.get("teams")
@@ -256,15 +256,12 @@ class CompletenessStatsV2ViewSet(viewsets.ViewSet):
 
         instance_qs = Instance.objects.all()
 
-        planning = None
-        if planning_id:
-            planning = get_object_or_404(Planning, id=planning_id)
         if period:
             # In the future we would like to support multiple periods, but then we will have to count properly
             # the requirements
             instance_qs = instance_qs.filter(period=period)
         if planning:
-            instance_qs = instance_qs.filter(planning_id=planning)
+            instance_qs = instance_qs.filter(planning_id=planning.id)
             form_qs = form_qs.filter(plannings=planning)
 
         # filter instance_qs on users related to selected teams
@@ -279,6 +276,7 @@ class CompletenessStatsV2ViewSet(viewsets.ViewSet):
 
         org_units: OrgUnitQuerySet
         org_units = OrgUnit.objects.filter(validation_status__in=org_unit_validation_status)  # type: ignore
+
         # Calculate the ou for which we want reporting `top_ous`
         #  We only want ou to which user has access
         #   if no params we return the top ou for the default source


### PR DESCRIPTION
Explain what problem this PR is resolving
- Filter on planning in Completeness stats doesn't work
- This PR is about to fix it
Related JIRA tickets : [IA-2804](https://bluesquare.atlassian.net/browse/IA-2804)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes
- Changed the way to get planning param

## How to test

- Go on completeness stats
- Filter on planning 
- And check if it give the right form and the right orgUnit

## Print screen / video
[Screencast from 2024-05-20 11-00-28.webm](https://github.com/BLSQ/iaso/assets/19631540/907f1107-ff53-4d0d-84c9-b75839904008)



[IA-2804]: https://bluesquare.atlassian.net/browse/IA-2804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ