### PR TITLE
Hotfix: Improve performance on mobile entities endpoint

### DIFF
--- a/iaso/models/entity.py
+++ b/iaso/models/entity.py
@@ -112,8 +112,6 @@ class EntityQuerySet(models.QuerySet):
             ).exclude(file=""),
         )
 
-        self = self.filter(attributes__isnull=False).filter(instances__isnull=False)
-
         self = self.prefetch_related(p).prefetch_related("instances__form")
 
         return self
@@ -133,9 +131,7 @@ class EntityQuerySet(models.QuerySet):
                 if project.account is None:
                     raise ProjectNotFoundError(f"Project Account is None for app_id {app_id}")  # Should be a 401
 
-                self = self.filter(
-                    account=project.account, instances__project=project, attributes__project=project
-                ).distinct("id")
+                self = self.filter(account=project.account).distinct("id")
             except Project.DoesNotExist:
                 raise ProjectNotFoundError(f"Project Not Found for app_id {app_id}")
 

--- a/iaso/models/entity.py
+++ b/iaso/models/entity.py
@@ -112,6 +112,8 @@ class EntityQuerySet(models.QuerySet):
             ).exclude(file=""),
         )
 
+        self = self.filter(attributes_id__isnull=False)
+
         self = self.prefetch_related(p).prefetch_related("instances__form")
 
         return self


### PR DESCRIPTION
Remove duplicated INNER JOIN statements.

Changes the suspected heavy query from:

```sql
SELECT DISTINCT ON ("iaso_entity"."id")
	"iaso_entity"."id",
	"iaso_entity"."deleted_at",
	"iaso_entity"."name",
	"iaso_entity"."uuid",
	"iaso_entity"."created_at",
	"iaso_entity"."updated_at",
	"iaso_entity"."entity_type_id",
	"iaso_entity"."attributes_id",
	"iaso_entity"."account_id",
	"iaso_entitytype"."id",
	"iaso_entitytype"."name",
	"iaso_entitytype"."created_at",
	"iaso_entitytype"."updated_at",
	"iaso_entitytype"."reference_form_id",
	"iaso_entitytype"."account_id",
	"iaso_entitytype"."is_active",
	"iaso_entitytype"."fields_list_view",
	"iaso_entitytype"."fields_detail_info_view",
	"iaso_entitytype"."fields_duplicate_search"
FROM
	"iaso_entity"
	INNER JOIN "iaso_instance" ON ("iaso_entity"."attributes_id" = "iaso_instance"."id")
	INNER JOIN "iaso_instance" T5 ON ("iaso_entity"."id" = T5."entity_id")
	INNER JOIN "iaso_instance" T7 ON ("iaso_entity"."id" = T7."entity_id")
	INNER JOIN "iaso_instance" T8 ON ("iaso_entity"."id" = T8."entity_id")
	INNER JOIN "iaso_entitytype" ON ("iaso_entity"."entity_type_id" = "iaso_entitytype"."id")
WHERE ("iaso_entity"."deleted_at" IS NULL
	AND "iaso_entity"."account_id" = 2
	AND "iaso_entity"."account_id" = 2
	AND "iaso_instance"."project_id" = 2
	AND T5."project_id" = 2
	AND "iaso_entity"."deleted_at" IS NULL
	AND T7."updated_at" >= '2022-12-29T00:00:00+00:00'::timestamptz
	AND "iaso_entity"."attributes_id" IS NOT NULL
	AND T8."id" IS NOT NULL
	AND "iaso_entity"."deleted_at" IS NULL)
ORDER BY
	"iaso_entity"."id" ASC
LIMIT 1000;
```

to:

```sql
SELECT DISTINCT ON ("iaso_entity"."id")
	"iaso_entity"."id",
	"iaso_entity"."deleted_at",
	"iaso_entity"."name",
	"iaso_entity"."uuid",
	"iaso_entity"."created_at",
	"iaso_entity"."updated_at",
	"iaso_entity"."entity_type_id",
	"iaso_entity"."attributes_id",
	"iaso_entity"."account_id",
	"iaso_entitytype"."id",
	"iaso_entitytype"."name",
	"iaso_entitytype"."created_at",
	"iaso_entitytype"."updated_at",
	"iaso_entitytype"."reference_form_id",
	"iaso_entitytype"."account_id",
	"iaso_entitytype"."is_active",
	"iaso_entitytype"."fields_list_view",
	"iaso_entitytype"."fields_detail_info_view",
	"iaso_entitytype"."fields_duplicate_search"
FROM
	"iaso_entity"
	INNER JOIN "iaso_instance" ON ("iaso_entity"."id" = "iaso_instance"."entity_id")
	INNER JOIN "iaso_entitytype" ON ("iaso_entity"."entity_type_id" = "iaso_entitytype"."id")
WHERE ("iaso_entity"."deleted_at" IS NULL
	AND "iaso_entity"."account_id" = 2
	AND "iaso_entity"."account_id" = 2
	AND "iaso_entity"."deleted_at" IS NULL
	AND "iaso_instance"."updated_at" >= '2022-12-29T00:00:00+00:00'::timestamptz
	AND "iaso_entity"."attributes_id" IS NOT NULL
	AND "iaso_entity"."deleted_at" IS NULL)
ORDER BY
	"iaso_entity"."id" ASC
LIMIT 1000
```

Note the duplicated `INNER JOIN "iaso_instance ...`