### PR TITLE
IA-2991 Fix for bug only when no limit parameter was given

### DIFF
--- a/iaso/models/base.py
+++ b/iaso/models/base.py
@@ -1350,8 +1350,8 @@ class Profile(models.Model):
             "email": self.user.email,
             "language": self.language,
             "user_id": self.user.id,
-            "phone_number": self.phone_number if len(self.phone_number) > 0 else None,
-            "country_code": self.phone_number.country_code if self.phone_number else None,
+            "phone_number": self.phone_number.as_e164 if self.phone_number else None,
+            "country_code": region_code_for_number(self.phone_number).lower() if self.phone_number else None,
             "projects": [p.as_dict() for p in self.projects.all().order_by("name")],
         }
 


### PR DESCRIPTION
When calling the `/api/profiles` without any parameters (no `?limit=xxx` or else) it was creating a bug when serializing the phone numbers of users. 

Related JIRA tickets : IA-2991
## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented

## Changes

Very small changes copied from the code that was run with a `?limit=` parameter was added.

## How to test

Just call `/api/profiles` with at least one user having a phone number in the DB it should NOT return an error
