### PR TITLE
Performance improvements (mainly on entities dashboard)

### DIFF
--- a/hat/assets/js/apps/Iaso/constants/menu.tsx
+++ b/hat/assets/js/apps/Iaso/constants/menu.tsx
@@ -55,8 +55,6 @@ import { MenuItem, MenuItems, Plugins } from '../domains/app/types';
 import { useGetOrgunitsExtraPath } from '../domains/home/hooks/useGetOrgunitsExtraPath';
 import { CHANGE_REQUEST } from './urls';
 
-
-
 // !! remove permission property if the menu has a subMenu !!
 const menuItems = (
     entityTypes: Array<DropdownOptions<number>>,
@@ -78,7 +76,7 @@ const menuItems = (
             isActive: pathname =>
                 pathname?.includes(`/entityTypeIds/${entityType.value}/`) &&
                 pathname?.includes(`entities/list/`),
-            extraPath: `/entityTypeIds/${entityType.value}/order/-last_saved_instance/pageSize/20/page/1`,
+            extraPath: `/entityTypeIds/${entityType.value}/locationLimit/1000/order/-last_saved_instance/pageSize/20/page/1`,
         }));
     }
     return [

--- a/hat/assets/js/apps/Iaso/constants/urls.ts
+++ b/hat/assets/js/apps/Iaso/constants/urls.ts
@@ -289,6 +289,7 @@ export const baseRouteConfigs: Record<string, RouteConfig> = {
             'submitterId',
             'submitterTeamId',
             'entityTypeIds',
+            'locationLimit',
             ...paginationPathParams,
         ],
     },

--- a/hat/assets/js/apps/Iaso/domains/entities/components/Filters.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/components/Filters.tsx
@@ -18,6 +18,7 @@ import {
 
 // @ts-ignore
 import DatesRange from 'Iaso/components/filters/DatesRange';
+import { LocationLimit } from 'Iaso/utils/map/LocationLimit';
 import InputComponent from '../../../components/forms/InputComponent';
 import { OrgUnitTreeviewModal } from '../../orgUnits/components/TreeView/OrgUnitTreeviewModal';
 
@@ -65,6 +66,7 @@ const Filters: FunctionComponent<Props> = ({ params, isFetching }) => {
         submitterId: params.submitterId,
         submitterTeamId: params.submitterTeamId,
         entityTypeIds: params.entityTypeIds,
+        locationLimit: params.locationLimit,
     });
 
     useEffect(() => {
@@ -76,6 +78,7 @@ const Filters: FunctionComponent<Props> = ({ params, isFetching }) => {
             submitterId: params.submitterId,
             submitterTeamId: params.submitterTeamId,
             entityTypeIds: params.entityTypeIds,
+            locationLimit: params.locationLimit,
         });
     }, [params]);
     const [filtersUpdated, setFiltersUpdated] = useState(false);
@@ -172,6 +175,15 @@ const Filters: FunctionComponent<Props> = ({ params, isFetching }) => {
                             initialSelection={initialOrgUnit}
                         />
                     </Box>
+                    {params.tab === 'map' && (
+                        <Box mt={2}>
+                            <LocationLimit
+                                keyValue="locationLimit"
+                                onChange={handleChange}
+                                value={filters.locationLimit}
+                            />
+                        </Box>
+                    )}
                 </Grid>
                 <Grid item xs={12} sm={6} md={3}>
                     <DatesRange

--- a/hat/assets/js/apps/Iaso/domains/entities/entityTypes/config.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/entityTypes/config.tsx
@@ -88,7 +88,7 @@ export const useColumns = ({
                             )}
                             <IconButtonComponent
                                 id={`entities-link-${type.id}`}
-                                url={`/${baseUrls.entities}/entityTypeIds/${type.id}/order/-last_saved_instance/pageSize/20/page/1`}
+                                url={`/${baseUrls.entities}/entityTypeIds/${type.id}/locationLimit/1000/order/-last_saved_instance/pageSize/20/page/1`}
                                 icon="remove-red-eye"
                                 tooltipMessage={MESSAGES.beneficiaries}
                                 disabled={type.entities_count === 0}

--- a/hat/assets/js/apps/Iaso/domains/entities/hooks/requests.ts
+++ b/hat/assets/js/apps/Iaso/domains/entities/hooks/requests.ts
@@ -41,6 +41,7 @@ type Params = {
     submitterId?: string;
     submitterTeamId?: string;
     entityTypeIds?: string;
+    locationLimit?: string;
 };
 
 type ApiParams = {
@@ -54,6 +55,8 @@ type ApiParams = {
     created_by_team_id?: string;
     created_by_id?: string;
     entity_type_ids?: string;
+    asLocation?: boolean;
+    locationLimit?: string;
 };
 
 type GetAPiParams = {
@@ -62,7 +65,7 @@ type GetAPiParams = {
 };
 export const useGetBeneficiariesApiParams = (
     params: Params,
-    withPagination = true,
+    asLocation = false,
 ): GetAPiParams => {
     const apiParams: ApiParams = {
         order_columns: params.order || 'id',
@@ -77,10 +80,12 @@ export const useGetBeneficiariesApiParams = (
         created_by_id: params.submitterId,
         created_by_team_id: params.submitterTeamId,
         entity_type_ids: params.entityTypeIds,
+        limit: params.pageSize || '20',
+        page: params.page || '1',
     };
-    if (withPagination) {
-        apiParams.limit = params.pageSize || '20';
-        apiParams.page = params.page || '1';
+    if (asLocation) {
+        apiParams.asLocation = true;
+        apiParams.limit = params.locationLimit || '1000';
     }
     const url = makeUrlWithParams('/api/entities/', apiParams);
     return {
@@ -108,7 +113,7 @@ export const useGetBeneficiariesLocations = (
     params: Params,
     displayedLocation: DisplayedLocation,
 ): UseQueryResult<Array<Location>, Error> => {
-    const { url, apiParams } = useGetBeneficiariesApiParams(params, false);
+    const { url, apiParams } = useGetBeneficiariesApiParams(params, true);
     // @ts-ignore
     return useSnackQuery({
         queryKey: ['beneficiariesLocations', apiParams],

--- a/hat/assets/js/apps/Iaso/domains/entities/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/index.tsx
@@ -46,6 +46,7 @@ type Params = {
     search?: string;
     entityTypes?: string;
     entityTypeIds?: string;
+    locationLimit?: string;
 };
 
 export const Beneficiaries: FunctionComponent = () => {

--- a/hat/assets/js/apps/Iaso/domains/entities/types/filters.ts
+++ b/hat/assets/js/apps/Iaso/domains/entities/types/filters.ts
@@ -6,12 +6,14 @@ export type Filters = {
     submitterId?: string;
     submitterTeamId?: string;
     entityTypeIds?: string;
+    locationLimit?: string;
 };
 
 export type Params = {
     pageSize: string;
     order: string;
     page: string;
+    tab: string;
     search?: string;
     location?: string;
     dateFrom?: string;
@@ -19,4 +21,5 @@ export type Params = {
     submitterId?: string;
     submitterTeamId?: string;
     entityTypeIds?: string;
+    locationLimit?: string;
 };

--- a/iaso/api/entity.py
+++ b/iaso/api/entity.py
@@ -234,14 +234,10 @@ class EntityViewSet(ModelViewSet):
         queryset = Entity.objects.filter(account=self.request.user.iaso_profile.account)
 
         queryset = queryset.prefetch_related(
-            "attributes",
-            "attributes__created_by",
             "attributes__created_by__teams",
             "attributes__form",
-            "attributes__org_unit",
             "attributes__org_unit__org_unit_type",
             "attributes__org_unit__parent",
-            "attributes__org_unit__version",
             "attributes__org_unit__version__data_source",
             "entity_type",
         )

--- a/iaso/api/entity.py
+++ b/iaso/api/entity.py
@@ -87,7 +87,7 @@ class EntitySerializer(serializers.ModelSerializer):
 
     def get_org_unit(self, entity: Entity):
         if entity.attributes and entity.attributes.org_unit:
-            return entity.attributes.org_unit.as_location(with_parents=True)
+            return entity.attributes.org_unit.as_location(with_parents=False)
         return None
 
     def get_submitter(self, entity: Entity):
@@ -233,6 +233,19 @@ class EntityViewSet(ModelViewSet):
 
         queryset = Entity.objects.filter(account=self.request.user.iaso_profile.account)
 
+        queryset = queryset.prefetch_related(
+            "attributes",
+            "attributes__created_by",
+            "attributes__created_by__teams",
+            "attributes__form",
+            "attributes__org_unit",
+            "attributes__org_unit__org_unit_type",
+            "attributes__org_unit__parent",
+            "attributes__org_unit__version",
+            "attributes__org_unit__version__data_source",
+            "entity_type",
+        )
+
         if form_name:
             queryset = queryset.filter(attributes__form__name__icontains=form_name)
         if search:
@@ -315,6 +328,7 @@ class EntityViewSet(ModelViewSet):
         page_offset = request.GET.get("page", 1)
         orders = request.GET.get("order", "-created_at").split(",")
         order_columns = request.GET.get("order_columns", None)
+        as_location = request.GET.get("asLocation", None)
 
         queryset = queryset.order_by(*orders)
 
@@ -345,7 +359,11 @@ class EntityViewSet(ModelViewSet):
 
         entities = entities.order_by(*new_order_columns)
 
-        if limit:
+        if as_location:
+            limit_int = int(limit)
+            paginator = Paginator(entities, limit_int)
+            entities = paginator.page(1).object_list
+        elif limit:
             limit_int = int(limit)
             page_offset = int(page_offset)
             start_int = (page_offset - 1) * limit_int
@@ -364,7 +382,7 @@ class EntityViewSet(ModelViewSet):
             if attributes is not None and entity.attributes is not None:
                 file_content = entity.attributes.get_and_save_json_of_xml().get("file_content", None)
                 attributes_pk = attributes.pk
-                attributes_ou = entity.attributes.org_unit.as_location(with_parents=True) if entity.attributes.org_unit else None  # type: ignore
+                attributes_ou = entity.attributes.org_unit.as_location(with_parents=False) if entity.attributes.org_unit else None  # type: ignore
                 attributes_latitude = attributes.location.y if attributes.location else None  # type: ignore
                 attributes_longitude = attributes.location.x if attributes.location else None  # type: ignore
             name = None
@@ -372,6 +390,10 @@ class EntityViewSet(ModelViewSet):
             if file_content is not None:
                 name = file_content.get("name")
                 program = file_content.get("program")
+            duplicates = []
+            # invokes many SQL queries and not needed for map display
+            if not as_location:
+                duplicates = get_duplicates(entity)
             result = {
                 "id": entity.id,
                 "uuid": entity.uuid,
@@ -383,7 +405,7 @@ class EntityViewSet(ModelViewSet):
                 "last_saved_instance": entity.last_saved_instance,
                 "org_unit": attributes_ou,
                 "program": program,
-                "duplicates": get_duplicates(entity),
+                "duplicates": duplicates,
                 "latitude": attributes_latitude,
                 "longitude": attributes_longitude,
             }
@@ -454,7 +476,14 @@ class EntityViewSet(ModelViewSet):
             response["Content-Disposition"] = "attachment; filename=%s" % filename
             return response
 
-        if limit:
+        if as_location:
+            return Response(
+                {
+                    "limit": limit_int,
+                    "result": result_list,
+                }
+            )
+        elif limit:
             return Response(
                 {
                     "count": total_count,

--- a/iaso/api/profiles.py
+++ b/iaso/api/profiles.py
@@ -255,6 +255,8 @@ class ProfilesViewSet(viewsets.ViewSet):
             ids=ids,
         )
 
+        queryset = queryset.prefetch_related("user")
+
         if request.GET.get("csv"):
             return self.list_export(queryset=queryset, file_format=FileFormatEnum.CSV)
         if request.GET.get("xlsx"):

--- a/iaso/api/serializers.py
+++ b/iaso/api/serializers.py
@@ -106,7 +106,7 @@ class OrgUnitSerializer(TimestampSerializerMixin, serializers.ModelSerializer):
         creator = None
         if org_unit.creator is not None:
             if org_unit.creator.first_name is not None and org_unit.creator.last_name is not None:
-                creator = f"{org_unit.creator.username} ( {org_unit.creator.first_name} {org_unit.creator.last_name} )"
+                creator = f"{org_unit.creator.username} ({org_unit.creator.first_name} {org_unit.creator.last_name})"
             else:
                 creator = org_unit.creator.username
         return creator

--- a/iaso/models/base.py
+++ b/iaso/models/base.py
@@ -1364,7 +1364,6 @@ class Profile(models.Model):
             "user_id": self.user.id,
             "phone_number": self.phone_number.as_e164 if self.phone_number else None,
             "country_code": region_code_for_number(self.phone_number).lower() if self.phone_number else None,
-            "projects": [p.as_dict() for p in self.projects.all().order_by("name")],
         }
 
     def has_a_team(self):

--- a/iaso/models/org_unit.py
+++ b/iaso/models/org_unit.py
@@ -206,7 +206,7 @@ class OrgUnitQuerySet(django_cte.CTEQuerySet):
         if user and user.is_anonymous and app_id is None:
             return self.none()
 
-        queryset: OrgUnitQuerySet = self.defer("geom", "simplified_geom")
+        queryset: OrgUnitQuerySet = self.defer("geom")
 
         if user and user.is_authenticated:
             account = user.iaso_profile.account

--- a/iaso/tests/api/test_orgunits.py
+++ b/iaso/tests/api/test_orgunits.py
@@ -1196,7 +1196,7 @@ class OrgUnitAPITestCase(APITestCase):
 
         jedi_squad_endor_2_children.save()
 
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(6):
             response = self.client.get(
                 f"/api/orgunits/?&parent_id={self.jedi_council_endor.pk}&limit=10&page=1&order=name&validation_status=all&onlyDirectChildren=true"
             )


### PR DESCRIPTION
- [Improve performance of dashboard entities page](https://github.com/BLSQ/iaso/commit/603ed793ee8f37c2403b85f478071873cf27276c). There were a few issues with the /entities/list page:

  - Missing prefetch_relateds resulting in n+1 calls
  - No pagination on the api call for the map display
  - Unnecessary data (org unit parents) being fetched on the list and map page

- [Small improvement on /profiles API endpoint](https://github.com/BLSQ/iaso/commit/651cb9326a15d80240c127741075c03220147434)
  - Added missing prefetch for `user` model.
  - No need to load projects in the small dict (used to load profiles/users in select filters for example) **let me know if you disagree**
- Took out `simplified_geom` from the `defer` clause since it's used in the base OrgUnitSerializer for the field `has_geo_json`. Because it was in deferred, it would launch a new query for every record. **let me know if you disagree**