### PR TITLE
POLIO-1552: SIA calendar: withdraw upper case mode for OBR name

### DIFF
--- a/plugins/polio/js/src/domains/Calendar/campaignCalendar/Styles.ts
+++ b/plugins/polio/js/src/domains/Calendar/campaignCalendar/Styles.ts
@@ -130,7 +130,6 @@ export const useStyles = makeStyles(theme => {
             justifyContent: 'center',
             alignItems: 'center',
             overflow: 'hidden',
-            textTransform: 'uppercase',
         },
         tableCellSpanTitle: {
             alignItems: 'center',
@@ -148,6 +147,7 @@ export const useStyles = makeStyles(theme => {
             alignItems: 'center',
             justifyContent: 'flex-start',
             fontSize: 9,
+            wordBreak: 'break-word',
         },
         popper: {
             zIndex: 500,


### PR DESCRIPTION
The OBR names usually have a lower case for “nOPV” and here they are written “NOPV”. The issue it creates is that they copy the OBR names from this calendar to the ODK forms, hence creating problems for vaccine stocks dashboards

Related JIRA tickets :POLIO-1552

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)


## Changes

remove text transform css properties, adding word-break property

## How to test

Visit calendar page and check column name

## Print screen / video


![Screenshot 2024-05-24 at 15 21 00](https://github.com/BLSQ/iaso/assets/12494624/fb0c33ab-7fff-4477-9c97-eb19a5e73afe)

