### PR TITLE
IA-2905: missing org unit tooltip

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/utils.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/utils.js
@@ -1,11 +1,11 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 
 import { textPlaceholder, useSafeIntl } from 'bluesquare-components';
 
 import { orderOrgUnitsByDepth } from '../../utils/map/mapUtils.ts';
 
+import { useGetOrgUnitValidationStatus } from './hooks/utils/useGetOrgUnitValidationStatus.ts';
 import MESSAGES from './messages';
-import { useGetValidationStatus } from '../forms/hooks/useGetValidationStatus.ts';
 
 export const fetchLatestOrgUnitLevelId = levels => {
     if (levels) {
@@ -191,13 +191,18 @@ export const getOrgUnitAncestors = orgUnit => {
 };
 
 export const useGetStatusMessage = () => {
-    const { data: validationStatusOptions } = useGetValidationStatus();
-    if (!validationStatusOptions) return () => '';
-    const getStatusMessage = status =>
-        validationStatusOptions.find(option => option.value === status)?.label;
+    const { data: validationStatusOptions } = useGetOrgUnitValidationStatus();
+    const getStatusMessage = useCallback(
+        status => {
+            if (!validationStatusOptions) return '';
+            return validationStatusOptions.find(
+                option => option.value === status,
+            )?.label;
+        },
+        [validationStatusOptions],
+    );
     return getStatusMessage;
 };
-
 export const getOrgUnitGroups = orgUnit => (
     <span>
         {orgUnit.groups &&


### PR DESCRIPTION
When you hover your mouse cursor on the Org Unit name in the list, it turns into a “hand” which makes you think the name is “clickable” while it actually isn’t.

In fact a tooltip should be displayed while hovering org unit name

Related JIRA tickets : IA-2905

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- replace `useGetValidationStatus` by `useGetOrgUnitValidationStatus`
- use `useCallback` to memoified function 

## How to test

Open org unit list, search for some result, hover an org unit name, you should see a tooltip.

## Print screen / video
<img width="422" alt="Screenshot 2024-05-24 at 16 21 38" src="https://github.com/BLSQ/iaso/assets/12494624/aef6eef8-a92f-4902-b4be-613908b2a6da">


