### PR TITLE
IA-3016 + IA-3019 + IA-3020 Bugfixes on entities dashboard

### DIFF
--- a/iaso/api/entity.py
+++ b/iaso/api/entity.py
@@ -319,6 +319,8 @@ class EntityViewSet(ModelViewSet):
         queryset = self.filter_queryset(self.get_queryset())
         csv_format = request.GET.get("csv", None)
         xlsx_format = request.GET.get("xlsx", None)
+        is_export = any([csv_format, xlsx_format])
+
         # TODO: investigate if request.user can be anonymous here
         entity_type_ids = request.query_params.get("entity_type_ids", None)
         limit = request.GET.get("limit", None)
@@ -360,7 +362,7 @@ class EntityViewSet(ModelViewSet):
             limit_int = int(limit)
             paginator = Paginator(entities, limit_int)
             entities = paginator.page(1).object_list
-        elif limit:
+        elif limit and not is_export:
             limit_int = int(limit)
             page_offset = int(page_offset)
             start_int = (page_offset - 1) * limit_int
@@ -389,7 +391,7 @@ class EntityViewSet(ModelViewSet):
                 program = file_content.get("program")
             duplicates = []
             # invokes many SQL queries and not needed for map display
-            if not as_location:
+            if not as_location and not is_export:
                 duplicates = get_duplicates(entity)
             result = {
                 "id": entity.id,
@@ -420,7 +422,7 @@ class EntityViewSet(ModelViewSet):
                 columns_list = [i for n, i in enumerate(columns_list) if i not in columns_list[n + 1 :]]
                 columns_list = [c for c in columns_list if len(c) > 2]
             result_list.append(result)
-        if xlsx_format or csv_format:
+        if is_export:
             columns = [
                 {"title": "ID", "width": 20},
                 {"title": "UUID", "width": 20},

--- a/iaso/api/entity.py
+++ b/iaso/api/entity.py
@@ -385,10 +385,8 @@ class EntityViewSet(ModelViewSet):
                 attributes_latitude = attributes.location.y if attributes.location else None  # type: ignore
                 attributes_longitude = attributes.location.x if attributes.location else None  # type: ignore
             name = None
-            program = None
             if file_content is not None:
                 name = file_content.get("name")
-                program = file_content.get("program")
             duplicates = []
             # invokes many SQL queries and not needed for map display
             if not as_location and not is_export:
@@ -403,7 +401,6 @@ class EntityViewSet(ModelViewSet):
                 "entity_type": entity.entity_type.name,
                 "last_saved_instance": entity.last_saved_instance,
                 "org_unit": attributes_ou,
-                "program": program,
                 "duplicates": duplicates,
                 "latitude": attributes_latitude,
                 "longitude": attributes_longitude,
@@ -430,7 +427,6 @@ class EntityViewSet(ModelViewSet):
                 {"title": "Creation Date", "width": 20},
                 {"title": "HC", "width": 20},
                 {"title": "Last update", "width": 20},
-                {"title": "Program", "width": 20},
             ]
             for col in columns_list:
                 columns.append({"title": col["label"]})
@@ -454,7 +450,6 @@ class EntityViewSet(ModelViewSet):
                     created_at,
                     entity["org_unit"]["name"] if entity["org_unit"] else "",
                     last_saved_instance,
-                    entity["program"],
                 ]
                 for col in columns_list:
                     values.append(entity.get(col["name"]))

--- a/iaso/api/entity.py
+++ b/iaso/api/entity.py
@@ -27,7 +27,7 @@ from iaso.api.common import (
     ModelViewSet,
     TimestampField,
 )
-from iaso.models import Entity, EntityType, Instance
+from iaso.models import Entity, EntityType, Instance, OrgUnit
 from iaso.models.deduplication import ValidationStatus
 
 
@@ -255,7 +255,8 @@ class EntityViewSet(ModelViewSet):
         if entity_type_ids:
             queryset = queryset.filter(entity_type_id__in=entity_type_ids.split(","))
         if org_unit_id:
-            queryset = queryset.filter(attributes__org_unit__id=org_unit_id)
+            parent = OrgUnit.objects.get(id=org_unit_id)
+            queryset = queryset.filter(attributes__org_unit__path__descendants=parent.path)
 
         if date_from or date_to:
             date_from_dt = datetime.datetime.strptime(date_from, "%Y-%m-%d") if date_from else datetime.datetime.min


### PR DESCRIPTION
A few bugfixes on the entities:

- [IA-3016](https://bluesquare.atlassian.net/browse/IA-3016) Entities org unit filter needs to return results for all entities linked to descendants. The search was on the exact id, instead of all descendants. So searching on a province could return 0 results, even though there are plenty of entities for said province.
- [IA-3019](https://bluesquare.atlassian.net/browse/IA-3019) Entities: Remove pagination for CSV/XLSX export
- [IA-3020](https://bluesquare.atlassian.net/browse/IA-3020) Entities page: remove column 'Programme' (specific for WFP, shouldn't be in Iaso in general)

[IA-3016]: https://bluesquare.atlassian.net/browse/IA-3016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IA-3019]: https://bluesquare.atlassian.net/browse/IA-3019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IA-3020]: https://bluesquare.atlassian.net/browse/IA-3020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ