### PR TITLE
Missing registry 

### DIFF
--- a/hat/menupermissions/constants.py
+++ b/hat/menupermissions/constants.py
@@ -89,7 +89,8 @@ PERMISSIONS_PRESENTATION = {
         "iaso_sources",
         "iaso_write_sources",
         "iaso_links",
-        "iaso_registry",
+        "iaso_registry_read",
+        "iaso_registry_write",
         "iaso_org_unit_change_request_review",
     ],
     "entities": [


### PR DESCRIPTION
Registry entry in the menu and permission are missing

## Changes

remove old `iaso_registry` permission to `iaso_registry_read` and `iaso_registry_write` 

## How to test

Connect to the dashboard as superuser, you should see the registry entry in the menu  and in user permissiosn
