### PR TITLE
IA-3042: fix submissions perm in form table

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/forms/config/index.js
+++ b/hat/assets/js/apps/Iaso/domains/forms/config/index.js
@@ -17,6 +17,7 @@ import { createInstance } from '../../instances/actions';
 import * as Permission from '../../../utils/permissions.ts';
 import { BreakWordCell } from '../../../components/Cells/BreakWordCell.tsx';
 import { useCurrentUser } from '../../../utils/usersUtils.ts';
+import { DisplayIfUserHasPerm } from '../../../components/DisplayIfUserHasPerm.tsx';
 
 export const baseUrl = baseUrls.forms;
 
@@ -223,10 +224,9 @@ export const useFormsTableColumns = ({
                             )}
                             {!showDeleted && (
                                 <>
-                                    {userHasPermission(
-                                        Permission.SUBMISSIONS,
-                                        user,
-                                    ) && (
+                                    <DisplayIfUserHasPerm
+                                        permissions={[Permission.SUBMISSIONS]}
+                                    >
                                         <IconButton
                                             url={`${urlToInstances}`}
                                             tooltipMessage={
@@ -234,11 +234,12 @@ export const useFormsTableColumns = ({
                                             }
                                             overrideIcon={FormatListBulleted}
                                         />
-                                    )}
-                                    {userHasPermission(
-                                        Permission.SUBMISSIONS,
-                                        user,
-                                    ) && (
+                                    </DisplayIfUserHasPerm>
+                                    <DisplayIfUserHasPerm
+                                        permissions={[
+                                            Permission.SUBMISSIONS_UPDATE,
+                                        ]}
+                                    >
                                         <CreateSubmissionModal
                                             titleMessage={
                                                 MESSAGES.instanceCreationDialogTitle
@@ -267,21 +268,15 @@ export const useFormsTableColumns = ({
                                                     .org_unit_type_ids
                                             }
                                         />
-                                    )}
-                                    {userHasPermission(
-                                        Permission.FORMS,
-                                        user,
-                                    ) && (
+                                    </DisplayIfUserHasPerm>
+                                    <DisplayIfUserHasPerm
+                                        permissions={[Permission.FORMS]}
+                                    >
                                         <IconButton
                                             url={`/${baseUrls.formDetail}/formId/${settings.row.original.id}`}
                                             icon="edit"
                                             tooltipMessage={MESSAGES.edit}
                                         />
-                                    )}
-                                    {userHasPermission(
-                                        Permission.FORMS,
-                                        user,
-                                    ) && (
                                         <IconButton
                                             // eslint-disable-next-line max-len
                                             url={`/${baseUrls.mappings}/formId/${settings.row.original.id}/order/form_version__form__name,form_version__version_id,mapping__mapping_type/pageSize/20/page/1`}
@@ -290,11 +285,6 @@ export const useFormsTableColumns = ({
                                                 MESSAGES.dhis2Mappings
                                             }
                                         />
-                                    )}
-                                    {userHasPermission(
-                                        Permission.FORMS,
-                                        user,
-                                    ) && (
                                         <DeleteDialog
                                             titleMessage={
                                                 MESSAGES.deleteFormTitle
@@ -305,7 +295,7 @@ export const useFormsTableColumns = ({
                                                 ).then(closeDialog)
                                             }
                                         />
-                                    )}
+                                    </DisplayIfUserHasPerm>
                                 </>
                             )}
                         </section>


### PR DESCRIPTION
Users with read-only permission for submissions could create submissions via the forms table

Related JIRA tickets : IA-3042

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
NA

## Changes

- check update permission before displaying the create submission button
- use DisplayIfUserHasPerm i.o manual permission check for conditional rendering

## How to test
- Create a profile with permissions for forms and read-only submissions
- Go to forms table: the button to create a new submission should not be present

## Print screen / video
<img width="1429" alt="Screenshot 2024-05-29 at 13 24 00" src="https://github.com/BLSQ/iaso/assets/38907762/de1e31c7-a2e3-4c55-a7f8-bfb0c9a285be">



