### PR TITLE
IA-2985 Org Unit Tree API bug fixes

### DIFF
--- a/iaso/api/org_unit_tree/serializers.py
+++ b/iaso/api/org_unit_tree/serializers.py
@@ -7,10 +7,27 @@ from iaso.api.common import DynamicFieldsModelSerializer
 from iaso.models import OrgUnit
 
 
+class OrgUnitSearchParentSerializer(serializers.ModelSerializer):
+    org_unit_type_name = serializers.SerializerMethodField()
+
+    class Meta:
+        model = OrgUnit
+        fields = [
+            "id",
+            "name",
+            "parent",
+            "org_unit_type_id",
+            "org_unit_type_name",
+        ]
+
+    def get_org_unit_type_name(self, org_unit: OrgUnit) -> Union[str, None]:
+        return org_unit.org_unit_type.short_name if org_unit.org_unit_type else None
+
+
 class OrgUnitTreeSerializer(DynamicFieldsModelSerializer, serializers.ModelSerializer):
     has_children = serializers.SerializerMethodField()
     org_unit_type_short_name = serializers.SerializerMethodField()
-    parent = serializers.SerializerMethodField()
+    parent = OrgUnitSearchParentSerializer()
 
     @classmethod
     def get_has_children(cls, org_unit: OrgUnit) -> bool:
@@ -18,14 +35,6 @@ class OrgUnitTreeSerializer(DynamicFieldsModelSerializer, serializers.ModelSeria
 
     def get_org_unit_type_short_name(self, org_unit: OrgUnit) -> Union[str, None]:
         return org_unit.org_unit_type.short_name if org_unit.org_unit_type else None
-
-    def get_parent(self, org_unit: OrgUnit):
-        if org_unit.parent:
-            parent_with_annotation = (
-                OrgUnit.objects.filter(pk=org_unit.parent.pk).annotate(children_count=Count("orgunit")).first()
-            )
-            return OrgUnitTreeSerializer(parent_with_annotation, context=self.context).data
-        return None
 
     class Meta:
         model = OrgUnit
@@ -36,7 +45,7 @@ class OrgUnitTreeSerializer(DynamicFieldsModelSerializer, serializers.ModelSeria
             "has_children",
             "org_unit_type_id",
             "org_unit_type_short_name",
-            "parent",
+            "parent",  # Only required when searching (use `&fields=:all`).
         ]
         default_fields = [
             "id",
@@ -45,5 +54,4 @@ class OrgUnitTreeSerializer(DynamicFieldsModelSerializer, serializers.ModelSeria
             "has_children",
             "org_unit_type_id",
             "org_unit_type_short_name",
-            "parent",
         ]

--- a/iaso/api/org_unit_tree/views.py
+++ b/iaso/api/org_unit_tree/views.py
@@ -51,7 +51,9 @@ class OrgUnitTreeViewSet(viewsets.ModelViewSet):
                 raise ValidationError({"data_source_id": ["A `data_source_id` must be provided for anonymous users."]})
             qs = OrgUnit.objects.all()  # `qs` will be filtered by `data_source_id` in `OrgUnitTreeFilter`.
         elif user.is_superuser or force_full_tree:
-            qs = OrgUnit.objects.filter(version=user.iaso_profile.account.default_version)
+            qs = OrgUnit.objects.filter(version__data_source__projects__account=user.iaso_profile.account)
+            qs = qs.select_related("version__data_source")
+            qs = qs.prefetch_related("version__data_source__projects__account")
         else:
             qs = OrgUnit.objects.filter_for_user(user)
 

--- a/iaso/api/org_unit_tree/views.py
+++ b/iaso/api/org_unit_tree/views.py
@@ -22,7 +22,10 @@ class OrgUnitTreeQuerystringSerializer(serializers.Serializer):
 
 class OrgUnitTreeViewSet(viewsets.ModelViewSet):
     """
-    Explore the OrgUnit tree level by level.
+    This viewset is a bit unusual because it serves two purposes:
+
+    1. explore the OrgUnit tree level by level (list view)
+    2. search the OrgUnit tree with the same parameters (search view)
     """
 
     filter_backends = [filters.OrderingFilter, django_filters.rest_framework.DjangoFilterBackend]
@@ -65,7 +68,7 @@ class OrgUnitTreeViewSet(viewsets.ModelViewSet):
 
         qs = qs.only("id", "name", "validation_status", "version", "org_unit_type", "parent")
         qs = qs.order_by("name")
-        qs = qs.select_related("org_unit_type")
+        qs = qs.select_related("org_unit_type", "parent__org_unit_type")
 
         if validation_status == {OrgUnit.VALIDATION_VALID}:
             exclude_filter = ~Q(orgunit__validation_status__in=[OrgUnit.VALIDATION_REJECTED, OrgUnit.VALIDATION_NEW])

--- a/iaso/api/org_unit_tree/views.py
+++ b/iaso/api/org_unit_tree/views.py
@@ -47,15 +47,19 @@ class OrgUnitTreeViewSet(viewsets.ModelViewSet):
         validation_status = querystring.validated_data.get("validation_status", set())
 
         if user.is_anonymous:
-            if not data_source_id:
-                raise ValidationError({"data_source_id": ["A `data_source_id` must be provided for anonymous users."]})
-            qs = OrgUnit.objects.all()  # `qs` will be filtered by `data_source_id` in `OrgUnitTreeFilter`.
+            qs = OrgUnit.objects.all()
         elif user.is_superuser or force_full_tree:
             qs = OrgUnit.objects.filter(version__data_source__projects__account=user.iaso_profile.account)
             qs = qs.select_related("version__data_source")
             qs = qs.prefetch_related("version__data_source__projects__account")
         else:
             qs = OrgUnit.objects.filter_for_user(user)
+
+        if not data_source_id:
+            if user.is_anonymous:
+                raise ValidationError({"data_source_id": ["A `data_source_id` must be provided for anonymous users."]})
+            else:
+                qs = qs.filter(version_id=self.request.user.iaso_profile.account.default_version_id)
 
         can_view_full_tree = any([user.is_anonymous, user.is_superuser, force_full_tree])
         display_root_level = not parent_id

--- a/iaso/tests/api/org_unit_tree/test_views.py
+++ b/iaso/tests/api/org_unit_tree/test_views.py
@@ -169,15 +169,16 @@ class OrgUnitTreeViewsAPITestCase(APITestCase):
     def test_search(self):
         self.client.force_authenticate(self.user)
 
-        response = self.client.get("/api/orgunits/tree/search/?search=b")
-        self.assertJSONResponse(response, 200)
+        with self.assertNumQueries(3):
+            response = self.client.get("/api/orgunits/tree/search/?search=b&fields=:all")
+            self.assertJSONResponse(response, 200)
+            self.assertEqual(3, len(response.data["results"]))
+            self.assertEqual(response.data["results"][0]["name"], "Banwa")
+            self.assertEqual(response.data["results"][1]["name"], "Boucle du Mouhon")
+            self.assertEqual(response.data["results"][2]["name"], "Burkina Faso")
 
-        self.assertEqual(3, len(response.data["results"]))
-        self.assertEqual(response.data["results"][0]["name"], "Banwa")
-        self.assertEqual(response.data["results"][1]["name"], "Boucle du Mouhon")
-        self.assertEqual(response.data["results"][2]["name"], "Burkina Faso")
-
-        response = self.client.get("/api/orgunits/tree/search/?search=BURKINA")
-        self.assertJSONResponse(response, 200)
-        self.assertEqual(1, len(response.data["results"]))
-        self.assertEqual(response.data["results"][0]["name"], "Burkina Faso")
+        with self.assertNumQueries(3):
+            response = self.client.get("/api/orgunits/tree/search/?search=BURKINA")
+            self.assertJSONResponse(response, 200)
+            self.assertEqual(1, len(response.data["results"]))
+            self.assertEqual(response.data["results"][0]["name"], "Burkina Faso")

--- a/iaso/tests/api/org_unit_tree/test_views.py
+++ b/iaso/tests/api/org_unit_tree/test_views.py
@@ -112,7 +112,7 @@ class OrgUnitTreeViewsAPITestCase(APITestCase):
 
     def test_root_with_force_full_tree(self):
         self.client.force_authenticate(self.user)
-        with self.assertNumQueries(1):
+        with self.assertNumQueries(3):
             response = self.client.get("/api/orgunits/tree/?force_full_tree=true")
             self.assertJSONResponse(response, 200)
             self.assertEqual(2, len(response.data))
@@ -122,13 +122,13 @@ class OrgUnitTreeViewsAPITestCase(APITestCase):
     def test_specific_level_with_force_full_tree(self):
         self.client.force_authenticate(self.user)
 
-        with self.assertNumQueries(1):
+        with self.assertNumQueries(3):
             response = self.client.get(f"/api/orgunits/tree/?parent_id={self.angola.pk}&force_full_tree=true")
             self.assertJSONResponse(response, 200)
             self.assertEqual(1, len(response.data))
             self.assertEqual(response.data[0]["name"], "Huila")
 
-        with self.assertNumQueries(1):
+        with self.assertNumQueries(3):
             response = self.client.get(f"/api/orgunits/tree/?parent_id={self.burkina.pk}&force_full_tree=true")
             self.assertJSONResponse(response, 200)
             self.assertEqual(1, len(response.data))


### PR DESCRIPTION
Org Unit Tree API bug fixes.

Related JIRA tickets : [IA-2985](https://bluesquare.atlassian.net/browse/IA-2985)

## Changes

- Fix N+1 when fetching parents
- Fix filtering of Org Units by account
- Filter by default version when no `data_source_id` is given

## Notes

`parent` is not returned by default.

You have to call the API with `&fields=:all`, eg:

`http://localhost:8081/api/orgunits/tree/search/?search=congo&page=2&fields=:all`



[IA-2985]: https://bluesquare.atlassian.net/browse/IA-2985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ