### PR TITLE
IA-3004: Display a QRCode in the project configuration popup

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/projects/components/ProjectInfos.tsx
+++ b/hat/assets/js/apps/Iaso/domains/projects/components/ProjectInfos.tsx
@@ -10,6 +10,7 @@ type Form = {
 };
 
 type ProjectForm = {
+    id?: Form;
     app_id: Form;
     name: Form;
 };
@@ -43,6 +44,16 @@ const ProjectInfos: FunctionComponent<Props> = ({
             label={MESSAGES.appId}
             required
         />
+        {currentProject.id?.value && (
+            <div style={{ textAlign: 'center' }}>
+                <img
+                    width={200}
+                    height={200}
+                    alt="QRCode"
+                    src={`/api/projects/${currentProject.id?.value}/qr_code/`}
+                />
+            </div>
+        )}
     </>
 );
 

--- a/iaso/tests/api/test_projects.py
+++ b/iaso/tests/api/test_projects.py
@@ -155,6 +155,24 @@ class ProjectsAPITestCase(APITestCase):
         response = self.client.delete(f"/api/projects/{self.project_1.id}/", format="json")
         self.assertJSONResponse(response, 405)
 
+    def test_qr_code_unauthenticated(self):
+        """GET /projects/<project_id>/qr_code/: return the proper QR code"""
+        response = self.client.get(f"/api/projects/{self.project_1.id}/qr_code/")
+        self.assertEqual(401, response.status_code)
+
+    def test_qr_code(self):
+        """GET /projects/<project_id>/qr_code/: return the proper QR code"""
+        self.client.force_authenticate(self.jane)
+        response = self.client.get(f"/api/projects/{self.project_1.id}/qr_code/")
+        self.assertEqual(200, response.status_code)
+        self.assertEqual("image/png", response["Content-Type"])
+
+    def test_qr_code_not_found(self):
+        """GET /projects/<project_id>/qr_code/: return 404"""
+        self.client.force_authenticate(self.jane)
+        response = self.client.get(f"/api/projects/WRONG/qr_code/")
+        self.assertEqual(404, response.status_code)
+
     def assertValidProjectListData(self, list_data: typing.Mapping, expected_length: int, paginated: bool = False):
         self.assertValidListData(
             list_data=list_data, expected_length=expected_length, results_key="projects", paginated=paginated

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ django-sql-dashboard==1.2  # https://github.com/simonw/django-sql-dashboard/tags
 django-storages==1.14.2  # https://github.com/jschneier/django-storages/tags
 django-translated-fields==0.12.0  # https://github.com/matthiask/django-translated-fields/tags
 django-phonenumber-field[phonenumberslite]==7.3.0 # https://django-phonenumber-field.readthedocs.io/en/latest/
+django-qr-code==4.0.1 # https://django-qr-code.readthedocs.io/en/latest/
 
 # Django REST Framework.
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Display a QRCode in the project configuration popup

Related JIRA tickets : IA-3004

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [X] Are my typescript files well typed
- [X] Are there enough tests

## Doc
- Documentation can be found in the code

## Changes

This adds a small endpoint on `/api/projects/<project_id>/` called `qr_code` which generates a QRCode with the following JSON inside:
```json
{
  "url": "URL of the server",
  "app_id": "app_id of the project referred by id"
}
```

## How to test

As a user with sufficient rights, go in the project configuration. When a project already exists, a QRCode should be showing on the first tab.

## Print screen / video

![image](https://github.com/BLSQ/iaso/assets/564099/e8b0fcfb-0ab1-4442-b413-c36a36c7a8bb)


