### PR TITLE
IA-2967 Add calculated fields to submissions filter

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/forms/fields/constants.ts
+++ b/hat/assets/js/apps/Iaso/domains/forms/fields/constants.ts
@@ -198,7 +198,18 @@ export const iasoFields: Field[] = [
     },
     {
         type: 'calculate',
-        disabled: true,
+        queryBuilder: {
+            type: 'text',
+            excludeOperators: [
+                'proximity',
+                'ends_with',
+                'starts_with',
+                'like',
+                'not_like',
+                'is_empty',
+                'is_not_empty',
+            ],
+        },
     },
     {
         type: 'acknowledge',

--- a/hat/assets/js/apps/Iaso/domains/instances/utils/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/utils/index.tsx
@@ -73,6 +73,7 @@ const KeyValueFields: FunctionComponent<KeyValueFieldsProps> = ({ entry }) => (
 type Field = {
     label?: string | Record<string, string>;
     name: string;
+    type: string;
 };
 type Locales = {
     fr: string[];
@@ -204,6 +205,7 @@ export const formatLabel = (field: Field): string => {
     if (!field.label.trim()) return field.name;
     if (field.label.includes(':')) return field.label.split(':')[0];
     if (field.label.includes('$')) return field.label.split('$')[0];
+    if (field.type === 'calculate') return 'Σ ' + field.label;
     return field.label;
 };
 


### PR DESCRIPTION
In the dashboard, on the form submissions page, when you filter results on a specific form, you can choose to filter on attributes in the forms (modal with title "Search in submitted fields").

Here, I've now made the calculated fields also available since it makes a lot of sense to search on these in the light of searching in reference forms for entities.

![image](https://github.com/BLSQ/iaso/assets/2719739/a6ea660a-29e4-4559-89b3-be20fbea884f)

