### PR TITLE
IA-3065: fix mappings details crash

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/mappings/details.js
+++ b/hat/assets/js/apps/Iaso/domains/mappings/details.js
@@ -19,16 +19,17 @@ import {
     applyUpdate as applyUpdateAction,
 } from './actions';
 
-import { redirectToReplace as redirectToReplaceAction } from '../../routing/actions';
+import { redirectToReplace as redirectToReplaceAction } from '../../routing/actions.ts';
 
 import TopBar from '../../components/nav/TopBarComponent';
 import RecursiveTreeView from './components/RecursiveTreeView';
 import QuestionInfos from './components/QuestionInfos';
 import QuestionMappingForm from './components/QuestionMappingForm';
 import DerivedQuestionMappingForm from './components/DerivedQuestionMappingForm';
-import { baseUrls } from '../../constants/urls';
+import { baseUrls } from '../../constants/urls.ts';
 import GeneraMappingInfo from './components/GeneraMappingInfo';
 import Descriptor from './descriptor';
+import { withMappingDetailsParams } from '../../routing/legacy.tsx';
 import MESSAGES from './messages';
 
 const styles = theme => ({
@@ -281,5 +282,9 @@ const MapDispatchToProps = dispatch => ({
 });
 
 export default withStyles(styles)(
-    injectIntl(connect(MapStateToProps, MapDispatchToProps)(MappingDetails)),
+    injectIntl(
+        withMappingDetailsParams(
+            connect(MapStateToProps, MapDispatchToProps)(MappingDetails),
+        ),
+    ),
 );

--- a/hat/assets/js/apps/Iaso/domains/mappings/index.js
+++ b/hat/assets/js/apps/Iaso/domains/mappings/index.js
@@ -17,7 +17,7 @@ import { redirectTo as redirectToAction } from '../../routing/actions.ts';
 import { fetchMappingVersions as fetchMappingVersionsAction } from './actions';
 import TopBar from '../../components/nav/TopBarComponent';
 import mappingsTableColumns from './config';
-import withParams from '../../routing/legacy.tsx';
+import { withParams } from '../../routing/legacy.tsx';
 import CreateMappingVersionDialogComponent from './components/CreateMappingVersionDialogComponent';
 import { baseUrls } from '../../constants/urls.ts';
 

--- a/hat/assets/js/apps/Iaso/routing/legacy.tsx
+++ b/hat/assets/js/apps/Iaso/routing/legacy.tsx
@@ -6,11 +6,20 @@ import { baseUrls } from '../constants/urls';
 
 // Temporary fix to enable use of react-router 6 with DHIS2 Mapping component.
 /** @deprecated */
-const withParams = Component => {
+export const withParams = Component => {
     return function WrappedComponent(props) {
         const params = useParamsObject(baseUrls.mappings);
         return <Component params={params} {...props} />;
     };
 };
 // wrapped ParamsHOC to avoid rule of hooks error
-export default withParams;
+
+// Temporary fix to enable use of react-router 6 with DHIS2 Mapping component.
+/** @deprecated */
+export const withMappingDetailsParams = Component => {
+    return function WrappedComponent(props) {
+        const params = useParamsObject(baseUrls.mappingDetail);
+        return <Component params={params} {...props} />;
+    };
+};
+// wrapped ParamsHOC to avoid rule of hooks error


### PR DESCRIPTION


Mapping details page was crashing

Related JIRA tickets : IA-3065

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
- Tell us where the doc can be found (docs folder, wiki, in the code...)

## Changes
- Add HoC for mapping details page (router)

## How to test

Explain how to test your PR.
- With a "seed" account, go to forms, click on the DHIS2 mapping icon button for a form, then click on the icon button in the mappings table.

## Print screen / video


https://github.com/BLSQ/iaso/assets/38907762/3378ff14-dd78-4a07-9a4d-24812bcd9f1c



## Notes

Back button on mapping details page is broken, but it already was
