### PR TITLE
HOTFIX IA-3073: replace relative url with absolute in ProtectedRoutes

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/instances/utils/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/utils/index.tsx
@@ -287,7 +287,7 @@ export const useInstancesColumns = (
             });
         tableColumns = tableColumns.concat(childrenArray);
         if (
-            userHasPermission(Permission.REGISTRY_WRITE, currentUser) &&
+            userHasPermission(Permission.REGISTRY_WRITE, currentUser) ||
             userHasOneOfPermissions(
                 [Permission.SUBMISSIONS_UPDATE, Permission.SUBMISSIONS],
                 currentUser,

--- a/hat/assets/js/apps/Iaso/domains/users/components/ProtectedRoute.js
+++ b/hat/assets/js/apps/Iaso/domains/users/components/ProtectedRoute.js
@@ -45,7 +45,7 @@ const ProtectedRoute = ({ routeConfig, allRoutes, component }) => {
                 allRoutes,
             );
             if (newBaseUrl) {
-                navigate(`./${newBaseUrl}`);
+                navigate(`/${newBaseUrl}`);
             }
         }
     }, [


### PR DESCRIPTION
Redirection on login makes UI crash

Related JIRA tickets : IA-3073

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
NA

## Changes

- The url to which users were redirected in `ProtectedRoutes` was relative, which launched the router in an infinite loop. It was replaced with an absolute url

## How to test

- Create a user without permission for forms (default home page)

- Log in as this user

## Print screen / video

Before:
https://github.com/BLSQ/iaso/assets/38907762/6d099751-ba81-4dd9-8273-6529e085be8c


After:
https://github.com/BLSQ/iaso/assets/38907762/93fc34ae-1335-47d3-856e-b3c03b070c35



## Notes

forked from the v1.236, so this PR is hotfixable
