### PR TITLE
IA-3021 Remove user profile's location restrictions when searching entities via the mobile app

### DIFF
--- a/iaso/api/mobile/entity.py
+++ b/iaso/api/mobile/entity.py
@@ -32,15 +32,22 @@ def filter_for_mobile_entity(queryset, request):
     return queryset
 
 
-def get_queryset_for_user_and_app_id(user, app_id):
+def get_queryset_for_app_id(user, app_id):
     try:
-        queryset = Entity.objects.filter_for_user_and_app_id(user, app_id)
+        return Entity.objects.filter_for_app_id(user, app_id)
     except ProjectNotFoundError as e:
         raise NotFound(e.message)
     except UserNotAuthError as e:
         raise AuthenticationFailed(e.message)
 
-    return queryset
+
+def get_queryset_for_user_and_app_id(user, app_id):
+    try:
+        return Entity.objects.filter_for_user_and_app_id(user, app_id)
+    except ProjectNotFoundError as e:
+        raise NotFound(e.message)
+    except UserNotAuthError as e:
+        raise AuthenticationFailed(e.message)
 
 
 class LargeResultsSetPagination(PageNumberPagination):

--- a/iaso/api/mobile/entity_type.py
+++ b/iaso/api/mobile/entity_type.py
@@ -141,6 +141,13 @@ class MobileEntityTypesViewSet(ModelViewSet):
 
         queryset = filter_for_mobile_entity(queryset, self.request)
 
+        queryset = queryset.select_related("entity_type").prefetch_related(
+            "instances__org_unit",
+            "attributes__org_unit",
+            "instances__form__form_versions",
+            "attributes__form__form_versions",
+        )
+
         page = self.paginate_queryset(queryset)
         serializer = MobileEntitySerializer(
             page, many=True, context={"possible_form_versions": self.get_possible_form_versions_dict()}

--- a/iaso/api/mobile/entity_type.py
+++ b/iaso/api/mobile/entity_type.py
@@ -8,6 +8,7 @@ from iaso.api.mobile.entity import (
     LargeResultsSetPagination,
     MobileEntitySerializer,
     filter_for_mobile_entity,
+    get_queryset_for_app_id,
     get_queryset_for_user_and_app_id,
 )
 from iaso.models import Entity, EntityType, FormVersion, Project
@@ -125,7 +126,15 @@ class MobileEntityTypesViewSet(ModelViewSet):
         if not type_pk:
             raise ParseError("type_pk is required")
 
-        queryset = get_queryset_for_user_and_app_id(user, app_id)
+        queryset = None
+        # If there's an "Online search" from the mobile app, we want to be
+        # able to search without location restrictions.
+        # The entities for the user's location should already be on the mobile
+        # device.
+        if self.request.query_params.get("json_content"):
+            queryset = get_queryset_for_app_id(user, app_id)
+        else:
+            queryset = get_queryset_for_user_and_app_id(user, app_id)
 
         if queryset:
             queryset = queryset.filter(entity_type__pk=type_pk)

--- a/iaso/models/entity.py
+++ b/iaso/models/entity.py
@@ -132,11 +132,7 @@ class EntityQuerySet(models.QuerySet):
 
         return self
 
-    def filter_for_user_and_app_id(
-        self, user: typing.Optional[typing.Union[User, AnonymousUser]], app_id: typing.Optional[str]
-    ):
-        self = self.filter_for_user(user)
-
+    def filter_for_app_id(self, user: typing.Optional[typing.Union[User, AnonymousUser]], app_id: typing.Optional[str]):
         if app_id is not None:
             try:
                 project = Project.objects.get_for_user_and_app_id(user, app_id)
@@ -149,6 +145,11 @@ class EntityQuerySet(models.QuerySet):
                 raise ProjectNotFoundError(f"Project Not Found for app_id {app_id}")
 
         return self
+
+    def filter_for_user_and_app_id(
+        self, user: typing.Optional[typing.Union[User, AnonymousUser]], app_id: typing.Optional[str]
+    ):
+        return self.filter_for_user(user).filter_for_app_id(user, app_id)
 
 
 class Entity(SoftDeletableModel):

--- a/iaso/models/entity.py
+++ b/iaso/models/entity.py
@@ -120,7 +120,7 @@ class EntityQuerySet(models.QuerySet):
 
     def filter_for_user(self, user: typing.Optional[typing.Union[User, AnonymousUser]]):
         if not user or not user.is_authenticated:
-            raise UserNotAuthError(f"User not Authentified")
+            raise UserNotAuthError(f"User not Authenticated")
 
         profile = user.iaso_profile
         self = self.filter(account=profile.account)
@@ -133,18 +133,18 @@ class EntityQuerySet(models.QuerySet):
         return self
 
     def filter_for_app_id(self, user: typing.Optional[typing.Union[User, AnonymousUser]], app_id: typing.Optional[str]):
-        if app_id is not None:
-            try:
-                project = Project.objects.get_for_user_and_app_id(user, app_id)
+        if not user or not user.is_authenticated:
+            raise UserNotAuthError(f"User not Authenticated")
 
-                if project.account is None:
-                    raise ProjectNotFoundError(f"Project Account is None for app_id {app_id}")  # Should be a 401
+        try:
+            project = Project.objects.get_for_user_and_app_id(user, app_id)
 
-                self = self.filter(account=project.account).distinct("id")
-            except Project.DoesNotExist:
-                raise ProjectNotFoundError(f"Project Not Found for app_id {app_id}")
+            if project.account is None:
+                raise ProjectNotFoundError(f"Project Account is None for app_id {app_id}")  # Should be a 401
 
-        return self
+            return self.filter(account=project.account).distinct("id")
+        except Project.DoesNotExist:
+            raise ProjectNotFoundError(f"Project Not Found for app_id {app_id}")
 
     def filter_for_user_and_app_id(
         self, user: typing.Optional[typing.Union[User, AnonymousUser]], app_id: typing.Optional[str]


### PR DESCRIPTION
The whole point is to be able to find someone when the data is not on the mobile device.

E.g. for the QR codes for the MILDA distribution: when someone is not found on the device, it means they must be from another org unit, if not the entity would be found instantly on the device.