### PR TITLE
Fix FormVersion API ignores app_id when authenticated

### DIFF
--- a/iaso/api/form_versions.py
+++ b/iaso/api/form_versions.py
@@ -171,13 +171,11 @@ class FormVersionsViewSet(ModelViewSet):
         orders = self.request.query_params.get("order", "full_name").split(",")
         mapped_filter = self.request.query_params.get("mapped", "")
 
-        if self.request.user.is_anonymous:
-            app_id = self.request.query_params.get(APP_ID)
-            if app_id is not None:
-                queryset = FormVersion.objects.filter(form__projects__app_id=app_id)
-            else:
-                queryset = FormVersion.objects.none()
-
+        app_id = self.request.query_params.get(APP_ID)
+        if app_id is not None:
+            queryset = FormVersion.objects.filter(form__projects__app_id=app_id)
+        elif self.request.user.is_anonymous:
+            queryset = FormVersion.objects.none()
         else:
             profile = self.request.user.iaso_profile
             queryset = FormVersion.objects.filter(form__projects__account=profile.account)

--- a/iaso/tests/api/test_form_versions_readonly.py
+++ b/iaso/tests/api/test_form_versions_readonly.py
@@ -84,15 +84,13 @@ class ReadOnlyFormsVersionAPITestCase(APITestCase):
         cls.form_no_need_auth = create_add_form("Form no_need_auth", cls.blue_council, cls.blue_project_no_need_auth)
 
     def test_form_versions_list_without_auth(self):
-        """GET /mobile/formversions/: without auth should return no versions"""
+        """GET /mobile/formversions/: without auth should return 401"""
 
         response = self.client.get(BASE_URL)
-        self.assertJSONResponse(response, 200)
-        response_data = response.json()
-        assert response_data["form_versions"] == []
+        self.assertJSONResponse(response, 401)
 
     def test_form_versions_list_without_auth_with_appid(self):
-        """GET /mobile/formversions/: without auth but with app_id should return the version of the form which allow access without auth"""
+        """GET /mobile/formversions/: without auth"""
 
         response = self.client.get(f"{BASE_URL}?app_id={self.blue_project_no_need_auth.app_id}")
         self.assertJSONResponse(response, 200)
@@ -152,8 +150,8 @@ class ReadOnlyFormsVersionAPITestCase(APITestCase):
         )
 
         # Should fail in both cases as the project needs authentication and the user is not authenticated
-        self.assertJSONResponse(response_3, 404)
-        self.assertJSONResponse(response_4, 403)
+        self.assertJSONResponse(response_3, 401)
+        self.assertJSONResponse(response_4, 401)
 
     def test_form_no_need_auth(self):
         self.client.force_authenticate(self.blue_with_perms)
@@ -169,7 +167,7 @@ class ReadOnlyFormsVersionAPITestCase(APITestCase):
         response_1 = self.client.get(
             f"{BASE_URL}{self.form_no_need_auth.latest_version.id}/"
         )  # should fail without app id
-        self.assertJSONResponse(response_1, 404)
+        self.assertJSONResponse(response_1, 401)
 
         response_2 = self.client.get(
             f"{BASE_URL}{self.form_no_need_auth.latest_version.id}/?app_id={self.blue_project_no_need_auth.app_id}"

--- a/iaso/tests/api/test_mappingversions.py
+++ b/iaso/tests/api/test_mappingversions.py
@@ -51,7 +51,7 @@ class FormsVersionAPITestCase(APITestCase):
             name="Death Start survey", form_id="sample2", period_type="MONTH", single_per_period=False
         )
         cls.form_2.org_unit_types.add(cls.sith_council)
-        cls.form_1.save()
+        cls.form_2.save()
         form_2_file_mock = mock.MagicMock(spec=File)
         form_2_file_mock.name = "test.xml"
         cls.form_2.form_versions.create(file=form_2_file_mock, version_id="2020022401")


### PR DESCRIPTION
When retrieving form versions on Staging, I noticed that the endpoint returned versions for forms that were not returned. 
After some investigation, it seems that the problem is that when the user is authenticated, the endpoint ignores the `app_id` parameter.

## Self proofreading checklist

- [X] Did I use eslint and black formatters

## Changes

I change the code of the form versions endpoint to check for the `app_id` parameter first. It falls back to the previous way of working afterward.

## How to test

Configure an environment with forms linked to multiple projects, then call the `/api/formversions` authenticated. You should retrieve them all. Then call with an `app_id` parameter and you should get only the proper ones.

## Notes

I'm not sure why the code was the way that it was previously. Therefore, I ask in your review to take that into account to see if this is not breaking an expected behavior somewhere.
