### PR TITLE
IA-3074: HOTFIX org unit map crash

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/instances/components/InstancePopUp/InstancePopUp.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/InstancePopUp/InstancePopUp.tsx
@@ -19,6 +19,8 @@ import InstanceDetailsField from '../InstanceDetailsField';
 
 import MESSAGES from '../../messages';
 import { Instance } from '../../types/instance';
+import { baseUrls } from '../../../../constants/urls';
+import { getOrgUnitsTree } from '../../../orgUnits/utils';
 
 const useStyles = makeStyles(theme => ({
     ...commonStyles(theme),
@@ -56,7 +58,7 @@ export const InstancePopup: FunctionComponent<Props> = ({
     const confirmDialog = useCallback(() => {
         replaceLocation(currentInstance);
         map.closePopup(popup.current);
-    }, [currentInstance, replaceLocation]);
+    }, [currentInstance, map, replaceLocation]);
 
     const hasHero = (currentInstance?.files?.length ?? 0) > 0;
 

--- a/hat/assets/js/apps/Iaso/domains/instances/utils/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/utils/index.tsx
@@ -287,7 +287,7 @@ export const useInstancesColumns = (
             });
         tableColumns = tableColumns.concat(childrenArray);
         if (
-            userHasPermission(Permission.REGISTRY_WRITE, currentUser) &&
+            userHasPermission(Permission.REGISTRY_WRITE, currentUser) ||
             userHasOneOfPermissions(
                 [Permission.SUBMISSIONS_UPDATE, Permission.SUBMISSIONS],
                 currentUser,

--- a/hat/assets/js/apps/Iaso/domains/users/components/ProtectedRoute.js
+++ b/hat/assets/js/apps/Iaso/domains/users/components/ProtectedRoute.js
@@ -45,7 +45,7 @@ const ProtectedRoute = ({ routeConfig, allRoutes, component }) => {
                 allRoutes,
             );
             if (newBaseUrl) {
-                navigate(`./${newBaseUrl}`);
+                navigate(`/${newBaseUrl}`);
             }
         }
     }, [


### PR DESCRIPTION
missing imports crash map on marker click

Related JIRA tickets : IA-3074
## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
NA

## Changes

- Add missing imports

## How to test
Go to org units, select an org unit with children that have markers ("with point")
Go to map
Click on marker
The page should not crash

## Print screen / video
![Screenshot 2024-06-07 at 10 01 03](https://github.com/BLSQ/iaso/assets/38907762/58530d1b-82bd-4383-abae-325f0ecfeb5a)



## Notes
forked from v1.236b
