### PR TITLE
IA-3081: Wrong help message leading to bad user experience

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -1190,7 +1190,7 @@
     "iaso.storages.usb": "USB",
     "iaso.storages.writeProfile": "Write profile",
     "iaso.storages.writeRecord": "Write record",
-    "iaso.submissions.filterParam": "Apply at least one filter in order to be able to download data",
+    "iaso.submissions.filterParam": "Apply a filter on the “form” tab to be able to download the data",
     "iaso.submissions.searchSubmissionFormsParamsInfo": "Select one form to enable search using form submitted fields",
     "iaso.table.label.close": "Close",
     "iaso.table.label.resetSearch": "Empty search",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -1190,7 +1190,7 @@
     "iaso.storages.usb": "USB",
     "iaso.storages.writeProfile": "Write profile",
     "iaso.storages.writeRecord": "Write record",
-    "iaso.submissions.filterParam": "Apply a filter on the “form” tab to be able to download the data",
+    "iaso.submissions.filterParam": "Select a form to enable data download",
     "iaso.submissions.searchSubmissionFormsParamsInfo": "Select one form to enable search using form submitted fields",
     "iaso.table.label.close": "Close",
     "iaso.table.label.resetSearch": "Empty search",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -1190,7 +1190,7 @@
     "iaso.storages.usb": "USB",
     "iaso.storages.writeProfile": "Sauvegarde du profile",
     "iaso.storages.writeRecord": "Sauvegarde enregistrement",
-    "iaso.submissions.filterParam": "Appliquer au moins un filtre pour pouvoir télécharger les données",
+    "iaso.submissions.filterParam": "Appliquer un filtre sur l’onglet “formulaire” pour pouvoir télécharger les données",
     "iaso.submissions.searchSubmissionFormsParamsInfo": "Sélectionner un formulaire pour activer la recherche à l'aide des champs soumis du formulaire",
     "iaso.table.label.close": "Fermer",
     "iaso.table.label.resetSearch": "Vider la recherche",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -1190,7 +1190,7 @@
     "iaso.storages.usb": "USB",
     "iaso.storages.writeProfile": "Sauvegarde du profile",
     "iaso.storages.writeRecord": "Sauvegarde enregistrement",
-    "iaso.submissions.filterParam": "Appliquer un filtre sur l’onglet “formulaire” pour pouvoir télécharger les données",
+    "iaso.submissions.filterParam": "Sélectionner un formulaire pour activer le téléchargement",
     "iaso.submissions.searchSubmissionFormsParamsInfo": "Sélectionner un formulaire pour activer la recherche à l'aide des champs soumis du formulaire",
     "iaso.table.label.close": "Fermer",
     "iaso.table.label.resetSearch": "Vider la recherche",

--- a/hat/assets/js/apps/Iaso/domains/instances/messages.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/messages.js
@@ -601,7 +601,7 @@ const MESSAGES = defineMessages({
     filterParam: {
         id: 'iaso.submissions.filterParam',
         defaultMessage:
-            'Apply a filter on the “form” tab to be able to download the data',
+           'Select a form to enable data download',
     },
     searchSubmissionFormsParamsInfo: {
         id: 'iaso.submissions.searchSubmissionFormsParamsInfo',

--- a/hat/assets/js/apps/Iaso/domains/instances/messages.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/messages.js
@@ -601,7 +601,7 @@ const MESSAGES = defineMessages({
     filterParam: {
         id: 'iaso.submissions.filterParam',
         defaultMessage:
-            'Apply at least one filter in order to be able to download data',
+            'Apply a filter on the “form” tab to be able to download the data',
     },
     searchSubmissionFormsParamsInfo: {
         id: 'iaso.submissions.searchSubmissionFormsParamsInfo',


### PR DESCRIPTION
Explain what problem this PR is resolving
- Wrong help message leading to bad user experience
- This PR is about to fix that
Related JIRA tickets : [IA-3081](https://bluesquare.atlassian.net/browse/IA-3081)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [x] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes
- Change the message from **Appliquer au moins un filtre pour pouvoir télécharger les données** to **Appliquer un filtre sur l’onglet “formulaire” pour pouvoir télécharger les données**

## How to test
- Hover on CSV and EXCEL download button on submissions page

## Print screen / video
![Screenshot from 2024-06-08 13-32-03](https://github.com/BLSQ/iaso/assets/19631540/1b30e0e9-6262-4c3d-a614-f2e94d491e27)


[IA-3081]: https://bluesquare.atlassian.net/browse/IA-3081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ