### PR TITLE
IA-3071 Registry clean state, params on org unit change

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -147,6 +147,7 @@
   ],
 
     "rules": {
+      "react/function-component-definition": "off",
       "no-tabs": "off",
       "no-console":["error",{"allow":["warn","error"]}],
       "prettier/prettier": "warn",

--- a/hat/assets/js/apps/Iaso/domains/registry/components/Instances.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/Instances.tsx
@@ -52,8 +52,7 @@ export const Instances: FunctionComponent<Props> = ({
         }
         return undefined;
     }, [subOrgUnitTypes, tab]);
-    const { data: orgunitTypeDetail, isFetching: isFetchingOrgunitTypeDetail } =
-        useGetOrgUnitType(currentType?.id);
+    const { data: orgunitTypeDetail } = useGetOrgUnitType(currentType?.id);
     const { data: formsList, isFetching: isFetchingForms } = useGetForms({
         orgUnitTypeIds: currentType?.id,
     });

--- a/hat/assets/js/apps/Iaso/domains/registry/components/Instances.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/Instances.tsx
@@ -100,7 +100,8 @@ export const Instances: FunctionComponent<Props> = ({
             (formsList?.length ?? 0) >= 0 &&
             !isFetchingForms &&
             !formIds &&
-            orgunitTypeDetail
+            orgunitTypeDetail &&
+            !isLoading
         ) {
             const selectedForm =
                 orgunitTypeDetail.reference_forms.length > 0

--- a/hat/assets/js/apps/Iaso/domains/registry/components/OrgUnitChildrenList.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/OrgUnitChildrenList.tsx
@@ -4,7 +4,7 @@ import { Table, useRedirectToReplace } from 'bluesquare-components';
 import React, { Dispatch, FunctionComponent, SetStateAction } from 'react';
 import { baseUrls } from '../../../constants/urls';
 import { OrgUnit } from '../../orgUnits/types/orgUnit';
-import { useGetOrgUnitsListColumns } from '../config';
+import { HEIGHT, useGetOrgUnitsListColumns } from '../config';
 import { OrgUnitListChildren } from '../hooks/useGetOrgUnit';
 import { RegistryParams } from '../types';
 
@@ -19,7 +19,7 @@ const useStyles = makeStyles(theme => ({
     root: {
         position: 'relative',
         '& .MuiTableContainer-root': {
-            maxHeight: 444, // to fit with map height
+            maxHeight: `calc(${HEIGHT} - 120px)`, // to fit with map height
             overflow: 'auto',
             // @ts-ignore
             borderTop: `1px solid ${theme.palette.ligthGray.border}`,

--- a/hat/assets/js/apps/Iaso/domains/registry/components/OrgUnitChildrenList.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/OrgUnitChildrenList.tsx
@@ -1,8 +1,9 @@
 import { Box } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import { Table, useRedirectToReplace } from 'bluesquare-components';
-import React, { FunctionComponent } from 'react';
+import React, { Dispatch, FunctionComponent, SetStateAction } from 'react';
 import { baseUrls } from '../../../constants/urls';
+import { OrgUnit } from '../../orgUnits/types/orgUnit';
 import { useGetOrgUnitsListColumns } from '../config';
 import { OrgUnitListChildren } from '../hooks/useGetOrgUnit';
 import { RegistryParams } from '../types';
@@ -11,6 +12,7 @@ type Props = {
     params: RegistryParams;
     orgUnitChildren?: OrgUnitListChildren;
     isFetchingChildren: boolean;
+    setSelectedChildren: Dispatch<SetStateAction<OrgUnit | undefined>>;
 };
 export const defaultSorted = [{ id: 'name', desc: true }];
 const useStyles = makeStyles(theme => ({
@@ -45,9 +47,10 @@ export const OrgUnitChildrenList: FunctionComponent<Props> = ({
     params,
     orgUnitChildren,
     isFetchingChildren,
+    setSelectedChildren,
 }) => {
     const classes: Record<string, string> = useStyles();
-    const columns = useGetOrgUnitsListColumns();
+    const columns = useGetOrgUnitsListColumns(setSelectedChildren);
     const redirectToReplace = useRedirectToReplace();
     return (
         <Box className={classes.root}>

--- a/hat/assets/js/apps/Iaso/domains/registry/components/OrgUnitPaper.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/OrgUnitPaper.tsx
@@ -141,6 +141,7 @@ export const OrgUnitPaper: FunctionComponent<Props> = ({
                         params={params}
                         orgUnitChildren={orgUnitListChildren}
                         isFetchingChildren={isFetchingListChildren}
+                        setSelectedChildren={setSelectedChildren}
                     />
                 </Box>
             </Box>

--- a/hat/assets/js/apps/Iaso/domains/registry/config.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/config.tsx
@@ -1,7 +1,7 @@
 import MapIcon from '@mui/icons-material/Map';
 import { Box } from '@mui/material';
 import { Column, IntlFormatMessage, useSafeIntl } from 'bluesquare-components';
-import React, { ReactElement } from 'react';
+import React, { Dispatch, ReactElement, SetStateAction } from 'react';
 
 import { InstanceMetasField } from '../instances/components/ColumnSelect';
 import { Instance } from '../instances/types/instance';
@@ -10,6 +10,7 @@ import { LinkToRegistry } from './components/LinkToRegistry';
 
 import { LinkToOrgUnit } from '../orgUnits/components/LinkToOrgUnit';
 import { OrgUnitLocationIcon } from '../orgUnits/components/OrgUnitLocationIcon';
+import { OrgUnit } from '../orgUnits/types/orgUnit';
 import MESSAGES from './messages';
 
 export const defaultSorted = [{ id: 'org_unit__name', desc: false }];
@@ -79,7 +80,9 @@ export const INSTANCE_METAS_FIELDS: InstanceMetasField[] = [
     },
 ];
 
-export const useGetOrgUnitsListColumns = (): Column[] => {
+export const useGetOrgUnitsListColumns = (
+    setSelectedChildren: Dispatch<SetStateAction<OrgUnit | undefined>>,
+): Column[] => {
     const { formatMessage }: { formatMessage: IntlFormatMessage } =
         useSafeIntl();
     const columns: Column[] = [
@@ -88,6 +91,23 @@ export const useGetOrgUnitsListColumns = (): Column[] => {
             id: 'name',
             accessor: 'name',
             align: 'left',
+
+            Cell: settings => (
+                <Box
+                    sx={{
+                        cursor: 'pointer',
+                        color: 'primary.main',
+                        '&:hover': {
+                            textDecoration: 'underline',
+                        },
+                    }}
+                    onClick={() =>
+                        setSelectedChildren(settings.row.original as OrgUnit)
+                    }
+                >
+                    {settings.value}
+                </Box>
+            ),
         },
         {
             Header: formatMessage(MESSAGES.type),

--- a/hat/assets/js/apps/Iaso/domains/registry/hooks/useGetOrgUnit.ts
+++ b/hat/assets/js/apps/Iaso/domains/registry/hooks/useGetOrgUnit.ts
@@ -19,7 +19,7 @@ export const useGetOrgUnit = (
         options: {
             retry: false,
             enabled: Boolean(orgUnitId),
-            keepPreviousData: true,
+            keepPreviousData: Boolean(orgUnitId),
             staleTime: 1000 * 60 * 15, // in MS
             cacheTime: 1000 * 60 * 5,
         },

--- a/hat/assets/js/apps/Iaso/domains/registry/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/index.tsx
@@ -8,6 +8,7 @@ import { orderBy } from 'lodash';
 import React, {
     FunctionComponent,
     useCallback,
+    useEffect,
     useMemo,
     useState,
 } from 'react';
@@ -110,10 +111,6 @@ export const Registry: FunctionComponent = () => {
                     ...params,
                     orgUnitId: `${newOrgUnit.id}`,
                 };
-                delete newParams.orgUnitChildrenId;
-                delete newParams.submissionId;
-
-                setSelectedChildrenId(undefined);
                 redirectTo(`/${baseUrls.registry}`, newParams);
             }
         },
@@ -138,6 +135,22 @@ export const Registry: FunctionComponent = () => {
         [params, redirectToReplace],
     );
     const isFullScreen = params.fullScreen === 'true';
+
+    useEffect(() => {
+        if (orgUnitId && (params.orgUnitChildrenId || params.submissionId)) {
+            const newParams = {
+                ...params,
+            };
+            delete newParams.orgUnitChildrenId;
+            delete newParams.submissionId;
+            delete newParams.formIds;
+
+            setSelectedChildrenId(undefined);
+            redirectTo(`/${baseUrls.registry}`, newParams);
+        }
+        // Only remove selected children or submission if org unit change
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [orgUnitId]);
     return (
         <>
             <TopBar

--- a/hat/assets/js/apps/Iaso/domains/registry/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/index.tsx
@@ -68,9 +68,18 @@ const styles: SxStyles = {
             'inset 0px 2px 4px -1px rgba(0,0,0,0.2),inset 0px 4px 5px 0px rgba(0,0,0,0.14),inset 0px 1px 10px 0px rgba(0,0,0,0.12)',
     },
 };
+
+const baseUrl = baseUrls.registry;
 export const Registry: FunctionComponent = () => {
-    const params = useParamsObject(baseUrls.registry) as RegistryParams;
-    const { orgUnitId, orgUnitChildrenId, formIds, tab, fullScreen } = params;
+    const params = useParamsObject(baseUrl) as RegistryParams;
+    const {
+        orgUnitId,
+        orgUnitChildrenId,
+        formIds,
+        tab,
+        fullScreen,
+        submissionId,
+    } = params;
     const isFullScreen = fullScreen === 'true';
     const [selectedChildrenId, setSelectedChildrenId] = useState<
         string | undefined
@@ -127,42 +136,8 @@ export const Registry: FunctionComponent = () => {
         orgUnitTypeIds: currentType?.id,
     });
 
-    const handleOrgUnitChange = useCallback(
-        (newOrgUnit: OrgUnit) => {
-            if (newOrgUnit) {
-                const newParams = {
-                    ...params,
-                    orgUnitId: `${newOrgUnit.id}`,
-                };
-                redirectTo(`/${baseUrls.registry}`, newParams);
-            }
-        },
-        [params, redirectTo],
-    );
-
-    const handleChildrenChange = useCallback(
-        (newChildren: OrgUnit) => {
-            const newParams = {
-                ...params,
-            };
-            if (newChildren) {
-                setSelectedChildrenId(`${newChildren.id}`);
-                newParams.orgUnitChildrenId = `${newChildren.id}`;
-            } else {
-                setSelectedChildrenId(undefined);
-                newParams.orgUnitChildrenId = undefined;
-            }
-            newParams.submissionId = undefined;
-            redirectToReplace(`/${baseUrls.registry}`, newParams);
-        },
-        [params, redirectToReplace],
-    );
-
     useEffect(() => {
-        if (
-            orgUnitId &&
-            (params.orgUnitChildrenId || params.submissionId || params.formIds)
-        ) {
+        if (orgUnitId && (orgUnitChildrenId || submissionId || formIds)) {
             const newParams = {
                 ...params,
             };
@@ -170,7 +145,7 @@ export const Registry: FunctionComponent = () => {
             newParams.submissionId = undefined;
             newParams.formIds = undefined;
             setSelectedChildrenId(undefined);
-            redirectTo(`/${baseUrls.registry}`, newParams);
+            redirectToReplace(`/${baseUrl}`, newParams);
         }
         // Only remove selected children or submission if org unit change
         // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -192,12 +167,42 @@ export const Registry: FunctionComponent = () => {
                 ...params,
                 formIds: selectedForm,
             };
-            redirectToReplace(baseUrls.registry, newParams);
+            redirectToReplace(`/${baseUrl}`, newParams);
         }
-        // only preselect a form if forms list contain an element and params is empty
+        // Only preselect a form if forms list contain an element and params is empty
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [formsList, isFetchingForms, orgunitTypeDetail]);
 
+    const handleOrgUnitChange = useCallback(
+        (newOrgUnit: OrgUnit) => {
+            if (newOrgUnit) {
+                const newParams = {
+                    ...params,
+                    orgUnitId: `${newOrgUnit.id}`,
+                };
+                redirectTo(`/${baseUrl}`, newParams);
+            }
+        },
+        [params, redirectTo],
+    );
+
+    const handleChildrenChange = useCallback(
+        (newChildren: OrgUnit) => {
+            const newParams = {
+                ...params,
+            };
+            if (newChildren) {
+                setSelectedChildrenId(`${newChildren.id}`);
+                newParams.orgUnitChildrenId = `${newChildren.id}`;
+            } else {
+                setSelectedChildrenId(undefined);
+                newParams.orgUnitChildrenId = undefined;
+            }
+            newParams.submissionId = undefined;
+            redirectToReplace(`/${baseUrl}`, newParams);
+        },
+        [params, redirectToReplace],
+    );
     return (
         <>
             <TopBar

--- a/hat/assets/js/apps/Iaso/domains/registry/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/index.tsx
@@ -137,21 +137,6 @@ export const Registry: FunctionComponent = () => {
     });
 
     useEffect(() => {
-        if (orgUnitId && (orgUnitChildrenId || submissionId || formIds)) {
-            const newParams = {
-                ...params,
-            };
-            newParams.orgUnitChildrenId = undefined;
-            newParams.submissionId = undefined;
-            newParams.formIds = undefined;
-            setSelectedChildrenId(undefined);
-            redirectToReplace(`/${baseUrl}`, newParams);
-        }
-        // Only remove selected children or submission if org unit change
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [orgUnitId]);
-
-    useEffect(() => {
         if (
             formsList &&
             (formsList?.length ?? 0) >= 0 &&
@@ -172,6 +157,10 @@ export const Registry: FunctionComponent = () => {
         // Only preselect a form if forms list contain an element and params is empty
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [formsList, isFetchingForms, orgunitTypeDetail]);
+
+    useEffect(() => {
+        setSelectedChildrenId(undefined);
+    }, [orgUnitId]);
 
     const handleOrgUnitChange = useCallback(
         (newOrgUnit: OrgUnit) => {
@@ -242,7 +231,7 @@ export const Registry: FunctionComponent = () => {
                                     orgUnit={orgUnit}
                                     showRegistry
                                     showOnlyParents={false}
-                                    params={params}
+                                    params={{ orgUnitId }}
                                 />
                             )}
                         </Box>


### PR DESCRIPTION
When going "up" in the registry, the screen should reset to the parent org unit

Related JIRA tickets : IA-3071

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes
Clean state and params when org uni id changes.

## How to test
Go to registry page, drill down to a lower level org unit still displaying children.
Click on a children, name should appear on the right.

Click on one parent in the breadcrumb.

Selected org unit should change.
Explain how to test your PR.
If a specific config is required explain it here (dataset, account, profile, ...)

## Print screen / video


https://github.com/BLSQ/iaso/assets/12494624/500418c8-1ac4-472d-a17a-7e8296a44db4

