### PR TITLE
IA-3086 Remove `OrgUnitSearchParentSerializer`

### DIFF
--- a/iaso/api/org_unit_tree/serializers.py
+++ b/iaso/api/org_unit_tree/serializers.py
@@ -1,33 +1,14 @@
 from typing import Union
 
-from django.db.models import Count
 from rest_framework import serializers
 
 from iaso.api.common import DynamicFieldsModelSerializer
 from iaso.models import OrgUnit
 
 
-class OrgUnitSearchParentSerializer(serializers.ModelSerializer):
-    org_unit_type_name = serializers.SerializerMethodField()
-
-    class Meta:
-        model = OrgUnit
-        fields = [
-            "id",
-            "name",
-            "parent",
-            "org_unit_type_id",
-            "org_unit_type_name",
-        ]
-
-    def get_org_unit_type_name(self, org_unit: OrgUnit) -> Union[str, None]:
-        return org_unit.org_unit_type.short_name if org_unit.org_unit_type else None
-
-
-class OrgUnitTreeSerializer(DynamicFieldsModelSerializer, serializers.ModelSerializer):
+class OrgUnitTreeSerializer(serializers.ModelSerializer):
     has_children = serializers.SerializerMethodField()
     org_unit_type_short_name = serializers.SerializerMethodField()
-    parent = OrgUnitSearchParentSerializer()
 
     @classmethod
     def get_has_children(cls, org_unit: OrgUnit) -> bool:
@@ -39,15 +20,6 @@ class OrgUnitTreeSerializer(DynamicFieldsModelSerializer, serializers.ModelSeria
     class Meta:
         model = OrgUnit
         fields = [
-            "id",
-            "name",
-            "validation_status",
-            "has_children",
-            "org_unit_type_id",
-            "org_unit_type_short_name",
-            "parent",  # Only required when searching (use `&fields=:all`).
-        ]
-        default_fields = [
             "id",
             "name",
             "validation_status",

--- a/iaso/tests/api/org_unit_tree/test_views.py
+++ b/iaso/tests/api/org_unit_tree/test_views.py
@@ -170,7 +170,7 @@ class OrgUnitTreeViewsAPITestCase(APITestCase):
         self.client.force_authenticate(self.user)
 
         with self.assertNumQueries(3):
-            response = self.client.get("/api/orgunits/tree/search/?search=b&fields=:all")
+            response = self.client.get("/api/orgunits/tree/search/?search=b")
             self.assertJSONResponse(response, 200)
             self.assertEqual(3, len(response.data["results"]))
             self.assertEqual(response.data["results"][0]["name"], "Banwa")


### PR DESCRIPTION
Remove `OrgUnitSearchParentSerializer`.

Related JIRA tickets : [IA-3086](https://bluesquare.atlassian.net/browse/IA-3086)

## Changes

We can now remove `OrgUnitSearchParentSerializer` introduced in #1337 because the front-end managed to use the Org Unit Tree API without it in #1339

This is a great news because the API used to return the full tree for each result.

It will be faster!



[IA-3086]: https://bluesquare.atlassian.net/browse/IA-3086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ