### PR TITLE
IA-3070: registry list select

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/registry/components/OrgUnitChildrenList.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/OrgUnitChildrenList.tsx
@@ -4,7 +4,7 @@ import { Table, useRedirectToReplace } from 'bluesquare-components';
 import React, { Dispatch, FunctionComponent, SetStateAction } from 'react';
 import { baseUrls } from '../../../constants/urls';
 import { OrgUnit } from '../../orgUnits/types/orgUnit';
-import { useGetOrgUnitsListColumns } from '../config';
+import { HEIGHT, useGetOrgUnitsListColumns } from '../config';
 import { OrgUnitListChildren } from '../hooks/useGetOrgUnit';
 import { RegistryParams } from '../types';
 
@@ -19,7 +19,7 @@ const useStyles = makeStyles(theme => ({
     root: {
         position: 'relative',
         '& .MuiTableContainer-root': {
-            maxHeight: 444, // to fit with map height
+            maxHeight: `calc(${HEIGHT} - 120px)`, // to fit with map height
             overflow: 'auto',
             // @ts-ignore
             borderTop: `1px solid ${theme.palette.ligthGray.border}`,

--- a/hat/assets/js/apps/Iaso/domains/registry/components/OrgUnitChildrenList.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/OrgUnitChildrenList.tsx
@@ -1,8 +1,9 @@
 import { Box } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import { Table, useRedirectToReplace } from 'bluesquare-components';
-import React, { FunctionComponent } from 'react';
+import React, { Dispatch, FunctionComponent, SetStateAction } from 'react';
 import { baseUrls } from '../../../constants/urls';
+import { OrgUnit } from '../../orgUnits/types/orgUnit';
 import { useGetOrgUnitsListColumns } from '../config';
 import { OrgUnitListChildren } from '../hooks/useGetOrgUnit';
 import { RegistryParams } from '../types';
@@ -11,6 +12,7 @@ type Props = {
     params: RegistryParams;
     orgUnitChildren?: OrgUnitListChildren;
     isFetchingChildren: boolean;
+    setSelectedChildren: Dispatch<SetStateAction<OrgUnit | undefined>>;
 };
 export const defaultSorted = [{ id: 'name', desc: true }];
 const useStyles = makeStyles(theme => ({
@@ -45,9 +47,10 @@ export const OrgUnitChildrenList: FunctionComponent<Props> = ({
     params,
     orgUnitChildren,
     isFetchingChildren,
+    setSelectedChildren,
 }) => {
     const classes: Record<string, string> = useStyles();
-    const columns = useGetOrgUnitsListColumns();
+    const columns = useGetOrgUnitsListColumns(setSelectedChildren);
     const redirectToReplace = useRedirectToReplace();
     return (
         <Box className={classes.root}>

--- a/hat/assets/js/apps/Iaso/domains/registry/components/OrgUnitPaper.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/OrgUnitPaper.tsx
@@ -141,6 +141,7 @@ export const OrgUnitPaper: FunctionComponent<Props> = ({
                         params={params}
                         orgUnitChildren={orgUnitListChildren}
                         isFetchingChildren={isFetchingListChildren}
+                        setSelectedChildren={setSelectedChildren}
                     />
                 </Box>
             </Box>

--- a/hat/assets/js/apps/Iaso/domains/registry/config.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/config.tsx
@@ -1,7 +1,7 @@
 import MapIcon from '@mui/icons-material/Map';
 import { Box } from '@mui/material';
 import { Column, IntlFormatMessage, useSafeIntl } from 'bluesquare-components';
-import React, { ReactElement } from 'react';
+import React, { Dispatch, ReactElement, SetStateAction } from 'react';
 
 import { InstanceMetasField } from '../instances/components/ColumnSelect';
 import { Instance } from '../instances/types/instance';
@@ -10,6 +10,7 @@ import { LinkToRegistry } from './components/LinkToRegistry';
 
 import { LinkToOrgUnit } from '../orgUnits/components/LinkToOrgUnit';
 import { OrgUnitLocationIcon } from '../orgUnits/components/OrgUnitLocationIcon';
+import { OrgUnit } from '../orgUnits/types/orgUnit';
 import MESSAGES from './messages';
 
 export const defaultSorted = [{ id: 'org_unit__name', desc: false }];
@@ -79,7 +80,9 @@ export const INSTANCE_METAS_FIELDS: InstanceMetasField[] = [
     },
 ];
 
-export const useGetOrgUnitsListColumns = (): Column[] => {
+export const useGetOrgUnitsListColumns = (
+    setSelectedChildren: Dispatch<SetStateAction<OrgUnit | undefined>>,
+): Column[] => {
     const { formatMessage }: { formatMessage: IntlFormatMessage } =
         useSafeIntl();
     const columns: Column[] = [
@@ -88,6 +91,23 @@ export const useGetOrgUnitsListColumns = (): Column[] => {
             id: 'name',
             accessor: 'name',
             align: 'left',
+
+            Cell: settings => (
+                <Box
+                    sx={{
+                        cursor: 'pointer',
+                        color: 'primary.main',
+                        '&:hover': {
+                            textDecoration: 'underline',
+                        },
+                    }}
+                    onClick={() =>
+                        setSelectedChildren(settings.row.original as OrgUnit)
+                    }
+                >
+                    {settings.value}
+                </Box>
+            ),
         },
         {
             Header: formatMessage(MESSAGES.type),


### PR DESCRIPTION
We should be able to select from the list of org units to fill the detail.
![CleanShot 2024-06-04 at 21 44 20@2x-20240604-194523](https://github.com/BLSQ/iaso/assets/12494624/3d7e3ade-cc0b-49f7-90e7-699ed29c4b4e)


Related JIRA tickets : IA-3070
## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)


## Changes

Allow to select an org unit in the list view

## How to test

Open registry on a org unit having children. select list view and clic on one children name. It should be displayed on the right.

## Print screen / video


https://github.com/BLSQ/iaso/assets/12494624/feb445c5-3748-4c39-9fb4-cb57462a7529


