### PR TITLE
IA-3089: remove create submission button in org unit details page

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/forms/config/index.js
+++ b/hat/assets/js/apps/Iaso/domains/forms/config/index.js
@@ -238,69 +238,78 @@ export const useFormsTableColumns = ({
                                     {/* If orgUnitId is not undefined, it means the btable is used in the org units details page,
                                     which, in turn, means we shouldn't show the button to create a submission */}
                                     {!orgUnitId && (
-                                        <DisplayIfUserHasPerm
-                                            permissions={[
-                                                Permission.SUBMISSIONS_UPDATE,
-                                            ]}
-                                        >
-                                            <CreateSubmissionModal
-                                                titleMessage={
-                                                    MESSAGES.instanceCreationDialogTitle
-                                                }
-                                                confirmMessage={MESSAGES.ok}
-                                                cancelMessage={MESSAGES.cancel}
-                                                formType={{
-                                                    id: settings.row.original
-                                                        .id,
-                                                    periodType:
+                                        <>
+                                            <DisplayIfUserHasPerm
+                                                permissions={[
+                                                    Permission.SUBMISSIONS_UPDATE,
+                                                ]}
+                                            >
+                                                <CreateSubmissionModal
+                                                    titleMessage={
+                                                        MESSAGES.instanceCreationDialogTitle
+                                                    }
+                                                    confirmMessage={MESSAGES.ok}
+                                                    cancelMessage={
+                                                        MESSAGES.cancel
+                                                    }
+                                                    formType={{
+                                                        id: settings.row
+                                                            .original.id,
+                                                        periodType:
+                                                            settings.row
+                                                                .original
+                                                                .period_type,
+                                                    }}
+                                                    onCreateOrReAssign={(
+                                                        currentForm,
+                                                        payload,
+                                                    ) =>
+                                                        dispatch(
+                                                            createInstance(
+                                                                currentForm,
+                                                                payload,
+                                                            ),
+                                                        )
+                                                    }
+                                                    orgUnitTypes={
                                                         settings.row.original
-                                                            .period_type,
-                                                }}
-                                                onCreateOrReAssign={(
-                                                    currentForm,
-                                                    payload,
-                                                ) =>
-                                                    dispatch(
-                                                        createInstance(
-                                                            currentForm,
-                                                            payload,
-                                                        ),
-                                                    )
-                                                }
-                                                orgUnitTypes={
-                                                    settings.row.original
-                                                        .org_unit_type_ids
-                                                }
-                                            />
-                                        </DisplayIfUserHasPerm>
+                                                            .org_unit_type_ids
+                                                    }
+                                                />
+                                            </DisplayIfUserHasPerm>
+
+                                            <DisplayIfUserHasPerm
+                                                permissions={[Permission.FORMS]}
+                                            >
+                                                <IconButton
+                                                    url={`/${baseUrls.formDetail}/formId/${settings.row.original.id}`}
+                                                    icon="edit"
+                                                    tooltipMessage={
+                                                        MESSAGES.edit
+                                                    }
+                                                />
+                                                <IconButton
+                                                    // eslint-disable-next-line max-len
+                                                    url={`/${baseUrls.mappings}/formId/${settings.row.original.id}/order/form_version__form__name,form_version__version_id,mapping__mapping_type/pageSize/20/page/1`}
+                                                    icon="dhis"
+                                                    tooltipMessage={
+                                                        MESSAGES.dhis2Mappings
+                                                    }
+                                                />
+                                                <DeleteDialog
+                                                    titleMessage={
+                                                        MESSAGES.deleteFormTitle
+                                                    }
+                                                    onConfirm={closeDialog =>
+                                                        deleteForm(
+                                                            settings.row
+                                                                .original.id,
+                                                        ).then(closeDialog)
+                                                    }
+                                                />
+                                            </DisplayIfUserHasPerm>
+                                        </>
                                     )}
-                                    <DisplayIfUserHasPerm
-                                        permissions={[Permission.FORMS]}
-                                    >
-                                        <IconButton
-                                            url={`/${baseUrls.formDetail}/formId/${settings.row.original.id}`}
-                                            icon="edit"
-                                            tooltipMessage={MESSAGES.edit}
-                                        />
-                                        <IconButton
-                                            // eslint-disable-next-line max-len
-                                            url={`/${baseUrls.mappings}/formId/${settings.row.original.id}/order/form_version__form__name,form_version__version_id,mapping__mapping_type/pageSize/20/page/1`}
-                                            icon="dhis"
-                                            tooltipMessage={
-                                                MESSAGES.dhis2Mappings
-                                            }
-                                        />
-                                        <DeleteDialog
-                                            titleMessage={
-                                                MESSAGES.deleteFormTitle
-                                            }
-                                            onConfirm={closeDialog =>
-                                                deleteForm(
-                                                    settings.row.original.id,
-                                                ).then(closeDialog)
-                                            }
-                                        />
-                                    </DisplayIfUserHasPerm>
                                 </>
                             )}
                         </section>

--- a/hat/assets/js/apps/Iaso/domains/forms/config/index.js
+++ b/hat/assets/js/apps/Iaso/domains/forms/config/index.js
@@ -235,40 +235,45 @@ export const useFormsTableColumns = ({
                                             overrideIcon={FormatListBulleted}
                                         />
                                     </DisplayIfUserHasPerm>
-                                    <DisplayIfUserHasPerm
-                                        permissions={[
-                                            Permission.SUBMISSIONS_UPDATE,
-                                        ]}
-                                    >
-                                        <CreateSubmissionModal
-                                            titleMessage={
-                                                MESSAGES.instanceCreationDialogTitle
-                                            }
-                                            confirmMessage={MESSAGES.ok}
-                                            cancelMessage={MESSAGES.cancel}
-                                            formType={{
-                                                id: settings.row.original.id,
-                                                periodType:
+                                    {/* If orgUnitId is not undefined, it means the btable is used in the org units details page,
+                                    which, in turn, means we shouldn't show the button to create a submission */}
+                                    {!orgUnitId && (
+                                        <DisplayIfUserHasPerm
+                                            permissions={[
+                                                Permission.SUBMISSIONS_UPDATE,
+                                            ]}
+                                        >
+                                            <CreateSubmissionModal
+                                                titleMessage={
+                                                    MESSAGES.instanceCreationDialogTitle
+                                                }
+                                                confirmMessage={MESSAGES.ok}
+                                                cancelMessage={MESSAGES.cancel}
+                                                formType={{
+                                                    id: settings.row.original
+                                                        .id,
+                                                    periodType:
+                                                        settings.row.original
+                                                            .period_type,
+                                                }}
+                                                onCreateOrReAssign={(
+                                                    currentForm,
+                                                    payload,
+                                                ) =>
+                                                    dispatch(
+                                                        createInstance(
+                                                            currentForm,
+                                                            payload,
+                                                        ),
+                                                    )
+                                                }
+                                                orgUnitTypes={
                                                     settings.row.original
-                                                        .period_type,
-                                            }}
-                                            onCreateOrReAssign={(
-                                                currentForm,
-                                                payload,
-                                            ) =>
-                                                dispatch(
-                                                    createInstance(
-                                                        currentForm,
-                                                        payload,
-                                                    ),
-                                                )
-                                            }
-                                            orgUnitTypes={
-                                                settings.row.original
-                                                    .org_unit_type_ids
-                                            }
-                                        />
-                                    </DisplayIfUserHasPerm>
+                                                        .org_unit_type_ids
+                                                }
+                                            />
+                                        </DisplayIfUserHasPerm>
+                                    )}
                                     <DisplayIfUserHasPerm
                                         permissions={[Permission.FORMS]}
                                     >

--- a/hat/assets/js/cypress/integration/06 - orgUnits tabs/detailFormsTab.spec.js
+++ b/hat/assets/js/cypress/integration/06 - orgUnits tabs/detailFormsTab.spec.js
@@ -51,7 +51,7 @@ const testRowContent = (index, form = formsList.forms[index]) => {
         .find('td')
         .eq(8)
         .should('contain', form.latest_form_version.version_id);
-    cy.get('@row').find('td').last().find('button').should('have.length', 5);
+    cy.get('@row').find('td').last().find('button').should('have.length', 4);
 };
 
 const goToPage = () => {
@@ -222,7 +222,7 @@ describe('forms tab', () => {
                     .find('td')
                     .last()
                     .find('button')
-                    .eq(2)
+                    .eq(1)
                     .find('a')
                     .should('have.attr', 'href', formEditionHref);
 
@@ -230,7 +230,7 @@ describe('forms tab', () => {
                     .find('td')
                     .last()
                     .find('button')
-                    .eq(3)
+                    .eq(2)
                     .find('a')
                     .should('have.attr', 'href', dhisMappingsHref);
             });

--- a/hat/assets/js/cypress/integration/06 - orgUnits tabs/detailFormsTab.spec.js
+++ b/hat/assets/js/cypress/integration/06 - orgUnits tabs/detailFormsTab.spec.js
@@ -51,7 +51,7 @@ const testRowContent = (index, form = formsList.forms[index]) => {
         .find('td')
         .eq(8)
         .should('contain', form.latest_form_version.version_id);
-    cy.get('@row').find('td').last().find('button').should('have.length', 4);
+    cy.get('@row').find('td').last().find('button').should('have.length', 1);
 };
 
 const goToPage = () => {
@@ -201,11 +201,6 @@ describe('forms tab', () => {
         it('should contain a link with the right href', () => {
             const submissionsHref = `/dashboard/forms/submissions/formIds/1/levels/${orgUnit.id}/tab/list`;
 
-            const formEditionHref = '/dashboard/forms/detail/formId/1';
-
-            const dhisMappingsHref =
-                '/dashboard/forms/mappings/formId/1/order/form_version__form__name,form_version__version_id,mapping__mapping_type/pageSize/20/page/1';
-
             cy.wait('@getOuDetail').then(() => {
                 cy.get('table').as('table');
                 cy.get('@table').find('tbody').find('tr').eq(0).as('row');
@@ -217,22 +212,6 @@ describe('forms tab', () => {
                     .eq(0)
                     .find('a')
                     .should('have.attr', 'href', submissionsHref);
-
-                cy.get('@row')
-                    .find('td')
-                    .last()
-                    .find('button')
-                    .eq(1)
-                    .find('a')
-                    .should('have.attr', 'href', formEditionHref);
-
-                cy.get('@row')
-                    .find('td')
-                    .last()
-                    .find('button')
-                    .eq(2)
-                    .find('a')
-                    .should('have.attr', 'href', dhisMappingsHref);
             });
         });
     });


### PR DESCRIPTION
Explain what problem this PR is resolving

Related JIRA tickets : IA-3089

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
left a comment in the code

## Changes

- only show button if no rgUnitId is passed to the columns hook

## How to test

- Go to the details page of an org unit that has submissions
- Go to forms tab
- There should be no action button to add a submission in the forms table

## Print screen / video

![Screenshot 2024-06-12 at 09 35 11](https://github.com/BLSQ/iaso/assets/38907762/58431402-ad13-4b6d-aa69-6c61e47e5dff)


