### PR TITLE
IA-3056 Change Requests performance improvements

### DIFF
--- a/iaso/api/org_unit_change_requests/serializers.py
+++ b/iaso/api/org_unit_change_requests/serializers.py
@@ -284,6 +284,10 @@ class OrgUnitChangeRequestWriteSerializer(serializers.ModelSerializer):
             "new_closed_date",
             "new_reference_instances",
         ]
+        extra_kwargs = {
+            "new_groups": {"write_only": True},
+            "new_reference_instances": {"write_only": True},
+        }
 
     def validate_new_reference_instances(self, new_reference_instances):
         seen = []

--- a/iaso/api/org_unit_change_requests/views.py
+++ b/iaso/api/org_unit_change_requests/views.py
@@ -88,8 +88,8 @@ class OrgUnitChangeRequestViewSet(viewsets.ModelViewSet):
         app_id_serializer = AppIdSerializer(data=self.request.query_params)
         app_id_serializer.is_valid()
         app_id = app_id_serializer.validated_data.get("app_id")
-        org_units = OrgUnit.objects.filter_for_user_and_app_id(self.request.user, app_id)
-        if org_unit_to_change not in org_units:
+        org_units_for_user = OrgUnit.objects.filter_for_user_and_app_id(self.request.user, app_id)
+        if not org_units_for_user.filter(id=org_unit_to_change.pk).exists():
             raise PermissionDenied("The user is trying to create a change request for an unauthorized OrgUnit.")
 
     def perform_create(self, serializer):

--- a/iaso/api/org_unit_change_requests/views.py
+++ b/iaso/api/org_unit_change_requests/views.py
@@ -75,10 +75,11 @@ class OrgUnitChangeRequestViewSet(viewsets.ModelViewSet):
             "old_org_unit_type",
         ).prefetch_related(
             "org_unit__groups",
+            "org_unit__reference_instances__form",
             "new_groups",
             "old_groups",
-            "new_reference_instances",
-            "old_reference_instances",
+            "new_reference_instances__form",
+            "old_reference_instances__form",
         )
         return org_units_change_requests.filter(org_unit__in=org_units)
 

--- a/iaso/models/org_unit.py
+++ b/iaso/models/org_unit.py
@@ -737,16 +737,15 @@ class OrgUnitChangeRequest(models.Model):
             if field_name == "new_location_accuracy":
                 continue
             elif field_name == "new_groups":
-                self.org_unit.groups.set(self.new_groups.all())
+                self.org_unit.groups.clear()
+                self.org_unit.groups.add(*self.new_groups.all())
             elif field_name == "new_reference_instances":
-                # Delete old ones.
                 self.org_unit.reference_instances.clear()
-                for instance in self.new_reference_instances.all():
-                    OrgUnitReferenceInstance.objects.create(
-                        org_unit=self.org_unit,
-                        form=instance.form,
-                        instance=instance,
-                    )
+                new_reference_instances = [
+                    OrgUnitReferenceInstance(org_unit_id=self.org_unit.pk, form_id=instance.form_id, instance=instance)
+                    for instance in self.new_reference_instances.all()
+                ]
+                OrgUnitReferenceInstance.objects.bulk_create(new_reference_instances)
             # Handle non m2m fields.
             else:
                 new_value = getattr(self, field_name)

--- a/iaso/models/org_unit.py
+++ b/iaso/models/org_unit.py
@@ -689,17 +689,17 @@ class OrgUnitChangeRequest(models.Model):
         is_new = self.pk is None
         if is_new:
             # Save old values.
-            self.old_parent = self.org_unit.parent
+            self.old_parent_id = self.org_unit.parent_id
             self.old_name = self.org_unit.name
-            self.old_org_unit_type = self.org_unit.org_unit_type
+            self.old_org_unit_type_id = self.org_unit.org_unit_type_id
             self.old_location = self.org_unit.location
             self.old_opening_date = self.org_unit.opening_date
             self.old_closed_date = self.org_unit.closed_date
         super().save(*args, **kwargs)
         if is_new:
             # Wait for the instance to have an ID to save old m2m relations
-            self.old_groups.set(self.org_unit.groups.all())
-            self.old_reference_instances.set(self.org_unit.reference_instances.all())
+            self.old_groups.add(*self.org_unit.groups.all())
+            self.old_reference_instances.add(*self.org_unit.reference_instances.all())
 
     def clean(self, *args, **kwargs):
         super().clean()

--- a/iaso/tests/api/org_unit_change_requests/test_org_unit_change_requests.py
+++ b/iaso/tests/api/org_unit_change_requests/test_org_unit_change_requests.py
@@ -32,6 +32,18 @@ class OrgUnitChangeRequestAPITestCase(APITestCase):
             closed_date=cls.DT.date(),
         )
 
+        group_1 = m.Group.objects.create(name="Group 1", source_version=version)
+        group_2 = m.Group.objects.create(name="Group 2", source_version=version)
+        group_3 = m.Group.objects.create(name="Group 3", source_version=version)
+        org_unit.groups.add(group_1, group_2, group_3)
+
+        form_1 = m.Form.objects.create(name="Form 1")
+        form_2 = m.Form.objects.create(name="Form 2")
+        instance_1 = m.Instance.objects.create(form=form_1, org_unit=org_unit)
+        instance_2 = m.Instance.objects.create(form=form_2, org_unit=org_unit)
+        m.OrgUnitReferenceInstance.objects.create(org_unit=org_unit, form=form_1, instance=instance_1)
+        m.OrgUnitReferenceInstance.objects.create(org_unit=org_unit, form=form_2, instance=instance_2)
+
         account = m.Account.objects.create(name="Account", default_version=version)
         project = m.Project.objects.create(name="Project", account=account, app_id="foo.bar.baz")
         user = cls.create_user_with_profile(username="user", account=account)
@@ -180,7 +192,7 @@ class OrgUnitChangeRequestAPITestCase(APITestCase):
             "org_unit_id": self.org_unit.id,
             "new_name": "Bar",
         }
-        with self.assertNumQueries(10):
+        with self.assertNumQueries(12):
             response = self.client.post("/api/orgunits/changes/?app_id=foo.bar.baz", data=data, format="json")
         self.assertEqual(response.status_code, 201)
         change_request = m.OrgUnitChangeRequest.objects.get(uuid=data["uuid"])

--- a/iaso/tests/api/org_unit_change_requests/test_org_unit_change_requests.py
+++ b/iaso/tests/api/org_unit_change_requests/test_org_unit_change_requests.py
@@ -180,7 +180,7 @@ class OrgUnitChangeRequestAPITestCase(APITestCase):
             "org_unit_id": self.org_unit.id,
             "new_name": "Bar",
         }
-        with self.assertNumQueries(14):
+        with self.assertNumQueries(11):
             response = self.client.post("/api/orgunits/changes/?app_id=foo.bar.baz", data=data, format="json")
         self.assertEqual(response.status_code, 201)
         change_request = m.OrgUnitChangeRequest.objects.get(uuid=data["uuid"])

--- a/iaso/tests/api/org_unit_change_requests/test_org_unit_change_requests.py
+++ b/iaso/tests/api/org_unit_change_requests/test_org_unit_change_requests.py
@@ -180,7 +180,8 @@ class OrgUnitChangeRequestAPITestCase(APITestCase):
             "org_unit_id": self.org_unit.id,
             "new_name": "Bar",
         }
-        response = self.client.post("/api/orgunits/changes/?app_id=foo.bar.baz", data=data, format="json")
+        with self.assertNumQueries(14):
+            response = self.client.post("/api/orgunits/changes/?app_id=foo.bar.baz", data=data, format="json")
         self.assertEqual(response.status_code, 201)
         change_request = m.OrgUnitChangeRequest.objects.get(uuid=data["uuid"])
         self.assertEqual(change_request.new_name, data["new_name"])

--- a/iaso/tests/api/org_unit_change_requests/test_org_unit_change_requests.py
+++ b/iaso/tests/api/org_unit_change_requests/test_org_unit_change_requests.py
@@ -180,7 +180,7 @@ class OrgUnitChangeRequestAPITestCase(APITestCase):
             "org_unit_id": self.org_unit.id,
             "new_name": "Bar",
         }
-        with self.assertNumQueries(11):
+        with self.assertNumQueries(10):
             response = self.client.post("/api/orgunits/changes/?app_id=foo.bar.baz", data=data, format="json")
         self.assertEqual(response.status_code, 201)
         change_request = m.OrgUnitChangeRequest.objects.get(uuid=data["uuid"])

--- a/iaso/tests/api/org_unit_change_requests/test_org_unit_change_requests.py
+++ b/iaso/tests/api/org_unit_change_requests/test_org_unit_change_requests.py
@@ -175,7 +175,8 @@ class OrgUnitChangeRequestAPITestCase(APITestCase):
             "new_name": "I want this new name",
             "new_org_unit_type_id": self.org_unit_type.pk,
         }
-        response = self.client.post("/api/orgunits/changes/", data=data, format="json")
+        with self.assertNumQueries(11):
+            response = self.client.post("/api/orgunits/changes/", data=data, format="json")
         self.assertEqual(response.status_code, 201)
         change_request = m.OrgUnitChangeRequest.objects.get(new_name=data["new_name"])
         self.assertEqual(change_request.new_name, data["new_name"])

--- a/iaso/tests/models/test_org_unit_change_request.py
+++ b/iaso/tests/models/test_org_unit_change_request.py
@@ -206,8 +206,7 @@ class OrgUnitChangeRequestModelTestCase(TestCase):
             "new_groups",
             "new_reference_instances",
         ]
-        with self.assertNumQueries(14):
-            change_request.approve(user=self.user, approved_fields=approved_fields)
+        change_request.approve(user=self.user, approved_fields=approved_fields)
         change_request.refresh_from_db()
 
         # Change request.

--- a/iaso/tests/models/test_org_unit_change_request.py
+++ b/iaso/tests/models/test_org_unit_change_request.py
@@ -206,7 +206,8 @@ class OrgUnitChangeRequestModelTestCase(TestCase):
             "new_groups",
             "new_reference_instances",
         ]
-        change_request.approve(user=self.user, approved_fields=approved_fields)
+        with self.assertNumQueries(14):
+            change_request.approve(user=self.user, approved_fields=approved_fields)
         change_request.refresh_from_db()
 
         # Change request.


### PR DESCRIPTION
Change Requests performance improvements.

Related JIRA tickets : [IA-3056](https://bluesquare.atlassian.net/browse/IA-3056)

## Changes

- added missing `prefetch_related`
- used `m2m.add()` (which uses `bulk_create()`) instead of `m2m.set()`
- used `bulk_create(new_reference_instances)`
- used `id`s instead of `instance`s when possible
- added `write_only` to some serializers fields

## How to test

- create a change request on the mobile application then upload it to the server
- approve a change request on the website


[IA-3056]: https://bluesquare.atlassian.net/browse/IA-3056?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ