### PR TITLE
IA-3026: prevent loading map tiles if map is not displayed

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/details.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/details.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/function-component-definition */
 /* eslint-disable camelcase */
 import { Box, Grid, Tab, Tabs } from '@mui/material';
 import { makeStyles } from '@mui/styles';
@@ -7,6 +8,7 @@ import {
     LoadingSpinner,
     useSafeIntl,
     useGoBack,
+    useRedirectToReplace,
 } from 'bluesquare-components';
 import omit from 'lodash/omit';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
@@ -50,7 +52,6 @@ import {
     getOrgUnitsTree,
 } from './utils';
 import { useParamsObject } from '../../routing/hooks/useParamsObject.tsx';
-import { useRedirectToReplace } from 'bluesquare-components';
 
 const baseUrl = baseUrls.orgUnitDetails;
 const useStyles = makeStyles(theme => ({
@@ -438,11 +439,7 @@ const OrgUnitDetail = () => {
                     )}
                     {!isNewOrgunit && (
                         <>
-                            <div
-                                className={
-                                    tab === 'map' ? '' : classes.hiddenOpacity
-                                }
-                            >
+                            {tab === 'map' && (
                                 <Box className={classes.containerFullHeight}>
                                     {!isFetchingDetail && (
                                         <OrgUnitMap
@@ -481,7 +478,7 @@ const OrgUnitDetail = () => {
                                         />
                                     )}
                                 </Box>
-                            </div>
+                            )}
 
                             {tab === 'history' && (
                                 <div data-test="logs-tab">

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/index.tsx
@@ -12,6 +12,7 @@ import {
     useSafeIntl,
     LoadingSpinner,
     useSkipEffectOnMount,
+    makeRedirectionUrl,
 } from 'bluesquare-components';
 import { useQueryClient } from 'react-query';
 
@@ -49,7 +50,6 @@ import {
 import { useBulkSaveOrgUnits } from './hooks/requests/useBulkSaveOrgUnits';
 import { useGetApiParams } from './hooks/useGetApiParams';
 import { useParamsObject } from '../../routing/hooks/useParamsObject';
-import { makeRedirectionUrl } from 'bluesquare-components';
 // HOOKS
 
 const useStyles = makeStyles(theme => ({
@@ -70,14 +70,6 @@ const useStyles = makeStyles(theme => ({
     tabs: {
         ...commonStyles(theme).tabs,
         padding: 0,
-    },
-    hiddenOpacity: {
-        position: 'absolute',
-        top: '0px',
-        left: '0px',
-        zIndex: '-100',
-        opacity: '0',
-        width: '100%',
     },
 }));
 
@@ -299,11 +291,7 @@ export const OrgUnits: FunctionComponent = () => {
                                 />
                             )}
 
-                            <div
-                                className={
-                                    tab === 'map' ? '' : classes.hiddenOpacity
-                                }
-                            >
+                            {tab === 'map' && (
                                 <div className={classes.containerMarginNeg}>
                                     <OrgUnitsMap
                                         getSearchColor={getSearchColor}
@@ -315,7 +303,7 @@ export const OrgUnits: FunctionComponent = () => {
                                         }
                                     />
                                 </div>
-                            </div>
+                            )}
                         </>
                     )}
                 </Box>

--- a/hat/assets/js/cypress/fixtures/datasources/details-ou.json
+++ b/hat/assets/js/cypress/fixtures/datasources/details-ou.json
@@ -1,14 +1,12 @@
 {
-    "sources": [
-        {
+    "sources": [{
             "id": 33,
             "name": "Play",
             "read_only": false,
             "description": "",
             "created_at": "2021-10-11T12:06:38.774158Z",
             "updated_at": "2022-02-03T12:10:13.705774Z",
-            "versions": [
-                {
+            "versions": [{
                     "number": 0,
                     "description": null,
                     "id": 42,
@@ -27,13 +25,11 @@
             ],
             "url": "https://play.dhis2.org/2.36.3/",
             "projects": [
-                [
-                    {
-                        "id": 19,
-                        "name": "test",
-                        "app_id": "demoexport"
-                    }
-                ]
+                [{
+                    "id": 19,
+                    "name": "test",
+                    "app_id": "demoexport"
+                }]
             ],
             "default_version": {
                 "number": 0,
@@ -58,8 +54,7 @@
             "description": "",
             "created_at": "2021-10-11T12:06:38.774158Z",
             "updated_at": "2022-02-03T12:10:13.705774Z",
-            "versions": [
-                {
+            "versions": [{
                     "number": 0,
                     "description": null,
                     "id": 42,
@@ -78,13 +73,59 @@
             ],
             "url": "https://play.dhis2.org/2.36.3/",
             "projects": [
-                [
-                    {
-                        "id": 19,
-                        "name": "test",
-                        "app_id": "demoexport"
-                    }
-                ]
+                [{
+                    "id": 19,
+                    "name": "test",
+                    "app_id": "demoexport"
+                }]
+            ],
+            "default_version": {
+                "number": 0,
+                "description": null,
+                "id": 42,
+                "created_at": 1633954015.900216,
+                "updated_at": 1633954015.900236,
+                "org_units_count": 1333
+            },
+            "credentials": {
+                "id": 12,
+                "name": "https://play.dhis2.org/2.36.3/",
+                "login": "admin",
+                "url": "https://play.dhis2.org/2.36.3/",
+                "is_valid": true
+            }
+        },
+        {
+            "id": 1,
+            "name": "World Company",
+            "read_only": false,
+            "description": "",
+            "created_at": "2021-11-11T12:06:38.774158Z",
+            "updated_at": "2022-03-03T12:10:13.705774Z",
+            "versions": [{
+                    "number": 0,
+                    "description": null,
+                    "id": 142,
+                    "created_at": 1633954017.900216,
+                    "updated_at": 1633954025.900236,
+                    "org_units_count": 1344
+                },
+                {
+                    "number": 1,
+                    "description": null,
+                    "id": 143,
+                    "created_at": 1633954388.550682,
+                    "updated_at": 1633954388.550701,
+                    "org_units_count": 1345
+                }
+            ],
+            "url": "https://play.dhis2.org/2.36.3/",
+            "projects": [
+                [{
+                    "id": 1,
+                    "name": "Test2.35.3",
+                    "app_id": "pp_id_2"
+                }]
             ],
             "default_version": {
                 "number": 0,

--- a/hat/assets/js/cypress/integration/05 - orgUnits/list.spec.js
+++ b/hat/assets/js/cypress/integration/05 - orgUnits/list.spec.js
@@ -16,6 +16,9 @@ const goToPage = () => {
     cy.intercept('GET', '/api/groups/**', {
         fixture: 'groups/list.json',
     });
+    cy.intercept('GET', '/api/datasources/**', {
+        fixture: `datasources/details-ou.json`,
+    });
     cy.intercept('GET', '/sockjs-node/**');
     cy.visit(baseUrl);
 };


### PR DESCRIPTION
Explain what problem this PR is resolving

Related JIRA tickets : IA-3026

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
NA

## Changes

- Replaced "hiddenOpacity" class with conditional rendering for map in org unit list and org unit details pages
- Fixed cypress tests

## How to test

- Open browser inspector -> network tab. Make sure to display all, not only XHR
- Go to org units list and search
- Go to map tab: the tiles should only be loaded when switching tabs
- Same operation with org unit detail

## Print screen / video

https://github.com/BLSQ/iaso/assets/38907762/fa61efd1-fdc0-4294-94fa-c61de960f767


