### PR TITLE
IA-3091 Fix domain name in invitation email

### DIFF
--- a/iaso/api/profiles.py
+++ b/iaso/api/profiles.py
@@ -4,7 +4,6 @@ from django.conf import settings
 from django.contrib.auth import models, update_session_auth_hash
 from django.contrib.auth.models import Permission, User
 from django.contrib.auth.tokens import PasswordResetTokenGenerator
-from django.contrib.sites.shortcuts import get_current_site
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.mail import send_mail
 from django.core.paginator import Paginator
@@ -14,7 +13,6 @@ from django.shortcuts import get_object_or_404
 from django.template import Context, Template
 from django.urls import reverse
 from django.utils.encoding import force_bytes
-from django.utils.html import strip_tags
 from django.utils.http import urlsafe_base64_encode
 from django.utils.translation import gettext as _
 from phonenumber_field.phonenumber import PhoneNumber
@@ -524,8 +522,6 @@ class ProfilesViewSet(viewsets.ViewSet):
             profile.projects.add(item)
 
     def send_email_invitation(self, profile, email_subject, email_message, email_html_message):
-        current_site = get_current_site(self.request)
-        site_name = current_site.name
         domain = settings.DNS_DOMAIN
         token_generator = PasswordResetTokenGenerator()
         token = token_generator.make_token(profile.user)
@@ -539,11 +535,10 @@ class ProfilesViewSet(viewsets.ViewSet):
             url=f"{protocol}://{domain}{create_password_path}",
             protocol=protocol,
             domain=domain,
-            site_name=site_name,
             account_name=profile.account.name,
         )
 
-        email_subject_text = email_subject.format(site_name=f"{site_name}")
+        email_subject_text = email_subject.format(domain=f"{domain}")
         html_email_template = Template(email_html_message)
         html_email_context = Context(
             {
@@ -552,7 +547,6 @@ class ProfilesViewSet(viewsets.ViewSet):
                 "account_name": profile.account.name,
                 "userName": profile.user.username,
                 "url": f"{protocol}://{domain}{create_password_path}",
-                "site_name": site_name,
             }
         )
 
@@ -685,7 +679,7 @@ window instead.
 If you did not request an account on {account_name}, you can ignore this e-mail - no password will be created.
 
 Sincerely,
-The {site_name} Team.
+The {domain} Team.
     """
 
     CREATE_PASSWORD_HTML_MESSAGE_EN = """<p>Hello,<br><br>
@@ -704,7 +698,7 @@ window instead.<br><br>
 If you did not request an account on {{account_name}}, you can ignore this e-mail - no password will be created.<br><br>
 
 Sincerely,<br>
-The {{site_name}} Team.</p>
+The {{domain}} Team.</p>
     """
 
     CREATE_PASSWORD_MESSAGE_FR = """Bonjour, 
@@ -722,7 +716,7 @@ Si le lien ne fonctionne pas, merci de copier et coller l'URL dans une nouvelle 
 Si vous n'avez pas demandé de compte sur {account_name}, vous pouvez ignorer cet e-mail - aucun mot de passe ne sera créé.
 
 Cordialement,
-L'équipe {site_name}.
+L'équipe {domain}.
     """
 
     CREATE_PASSWORD_HTML_MESSAGE_FR = """<p>Bonjour,<br><br>
@@ -740,8 +734,8 @@ Si le lien ne fonctionne pas, merci de copier et coller l'URL dans une nouvelle 
 Si vous n'avez pas demandé de compte sur {{account_name}}, vous pouvez ignorer cet e-mail - aucun mot de passe ne sera créé.<br><br>
 
 Cordialement,<br>
-L'équipe {{site_name}}.</p>
+L'équipe {{domain}}.</p>
     """
 
-    EMAIL_SUBJECT_FR = "Configurer un mot de passe pour votre nouveau compte sur {site_name}"
-    EMAIL_SUBJECT_EN = "Set up a password for your new account on {site_name}"
+    EMAIL_SUBJECT_FR = "Configurer un mot de passe pour votre nouveau compte sur {domain}"
+    EMAIL_SUBJECT_EN = "Set up a password for your new account on {domain}"

--- a/iaso/api/profiles.py
+++ b/iaso/api/profiles.py
@@ -526,8 +526,7 @@ class ProfilesViewSet(viewsets.ViewSet):
     def send_email_invitation(self, profile, email_subject, email_message, email_html_message):
         current_site = get_current_site(self.request)
         site_name = current_site.name
-        domain = current_site.domain
-        from_email = settings.DEFAULT_FROM_EMAIL
+        domain = settings.DNS_DOMAIN
         token_generator = PasswordResetTokenGenerator()
         token = token_generator.make_token(profile.user)
 
@@ -544,7 +543,7 @@ class ProfilesViewSet(viewsets.ViewSet):
             account_name=profile.account.name,
         )
 
-        email_subject_text = email_subject.format(dns_domain=f"{site_name}")
+        email_subject_text = email_subject.format(site_name=f"{site_name}")
         html_email_template = Template(email_html_message)
         html_email_context = Context(
             {
@@ -562,7 +561,7 @@ class ProfilesViewSet(viewsets.ViewSet):
         send_mail(
             email_subject_text,
             email_message_text,
-            from_email,
+            settings.DEFAULT_FROM_EMAIL,
             [profile.user.email],
             html_message=rendered_html_email,
         )
@@ -744,5 +743,5 @@ Cordialement,<br>
 L'équipe {{site_name}}.</p>
     """
 
-    EMAIL_SUBJECT_FR = "Configurer un mot de passe pour votre nouveau compte sur {dns_domain}"
-    EMAIL_SUBJECT_EN = "Set up a password for your new account on {dns_domain}"
+    EMAIL_SUBJECT_FR = "Configurer un mot de passe pour votre nouveau compte sur {site_name}"
+    EMAIL_SUBJECT_EN = "Set up a password for your new account on {site_name}"

--- a/iaso/tests/api/test_profiles.py
+++ b/iaso/tests/api/test_profiles.py
@@ -4,9 +4,9 @@ import numpy as np
 import pandas as pd
 from django.conf import settings
 from django.contrib.auth.models import Group, Permission
-from django.contrib.gis.geos import MultiPolygon, Point, Polygon
 from django.contrib.sites.models import Site
 from django.core import mail
+from django.test import override_settings
 from django.utils.translation import gettext as _
 
 from hat.menupermissions import models as permission
@@ -512,6 +512,7 @@ class ProfileAPITestCase(APITestCase):
         self.assertEqual(org_units.count(), 1)
         self.assertEqual(org_units[0].name, "Corruscant Jedi Council")
 
+    @override_settings(DEFAULT_FROM_EMAIL="sender@test.com", DNS_DOMAIN="iaso-test.bluesquare.org")
     def test_create_profile_with_send_email(self):
         site = Site.objects.first()
         site.name = "Iaso Dev"
@@ -529,12 +530,12 @@ class ProfileAPITestCase(APITestCase):
         response = self.client.post("/api/profiles/", data=data, format="json")
         self.assertEqual(response.status_code, 200)
 
-        domain = site.name
-        from_email = settings.DEFAULT_FROM_EMAIL
         self.assertEqual(len(mail.outbox), 1)
-        self.assertEqual(mail.outbox[0].subject, f"Set up a password for your new account on {domain}")
-        self.assertEqual(mail.outbox[0].from_email, from_email)
-        self.assertEqual(mail.outbox[0].to, ["test@test.com"])
+        email = mail.outbox[0]
+        self.assertEqual(email.subject, f"Set up a password for your new account on {site.name}")
+        self.assertEqual(email.from_email, "sender@test.com")
+        self.assertEqual(email.to, ["test@test.com"])
+        self.assertIn(f"http://iaso-test.bluesquare.org", email.body)
 
     def test_create_profile_with_no_password_and_not_send_email(self):
         self.client.force_authenticate(self.jim)

--- a/iaso/tests/api/test_profiles.py
+++ b/iaso/tests/api/test_profiles.py
@@ -4,7 +4,6 @@ import numpy as np
 import pandas as pd
 from django.conf import settings
 from django.contrib.auth.models import Group, Permission
-from django.contrib.sites.models import Site
 from django.core import mail
 from django.test import override_settings
 from django.utils.translation import gettext as _
@@ -514,9 +513,6 @@ class ProfileAPITestCase(APITestCase):
 
     @override_settings(DEFAULT_FROM_EMAIL="sender@test.com", DNS_DOMAIN="iaso-test.bluesquare.org")
     def test_create_profile_with_send_email(self):
-        site = Site.objects.first()
-        site.name = "Iaso Dev"
-        site.save()
         self.client.force_authenticate(self.jim)
         data = {
             "user_name": "userTest",
@@ -532,10 +528,11 @@ class ProfileAPITestCase(APITestCase):
 
         self.assertEqual(len(mail.outbox), 1)
         email = mail.outbox[0]
-        self.assertEqual(email.subject, f"Set up a password for your new account on {site.name}")
+        self.assertEqual(email.subject, "Set up a password for your new account on iaso-test.bluesquare.org")
         self.assertEqual(email.from_email, "sender@test.com")
         self.assertEqual(email.to, ["test@test.com"])
         self.assertIn(f"http://iaso-test.bluesquare.org", email.body)
+        self.assertIn(f"The iaso-test.bluesquare.org Team.", email.body)
 
     def test_create_profile_with_no_password_and_not_send_email(self):
         self.client.force_authenticate(self.jim)


### PR DESCRIPTION
Fix domain name in invitation email.

Related JIRA tickets : [IA-3091](https://bluesquare.atlassian.net/browse/IA-3091)

## Changes

Use `DNS_DOMAIN` instead of both:

- `current_site.domain`
- `current_site.name`

## How to test

The unit test should be enough.


[IA-3091]: https://bluesquare.atlassian.net/browse/IA-3091?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ