### PR TITLE
IA-3075: show all instance locations on org unit map

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/forms/components/FormsFilterComponent.js
+++ b/hat/assets/js/apps/Iaso/domains/forms/components/FormsFilterComponent.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/function-component-definition */
 import React, { useMemo } from 'react';
 
 import PropTypes from 'prop-types';
@@ -42,7 +43,6 @@ export const FormsFilterComponent = ({
                     } else {
                         newForms[exisitingFormIndex].instances.push(i);
                     }
-                    uniqueFormIds.delete(i.form_id);
                 }
             });
         }

--- a/hat/assets/js/apps/Iaso/domains/instances/components/InstanceDetailsLocation.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/InstanceDetailsLocation.tsx
@@ -39,7 +39,7 @@ const InstanceDetailsLocation: React.FunctionComponent<Props> = ({
         orgUnit.altitude !== null && orgUnit.altitude !== 0;
     const hasAltitudeFromForm =
         !altitude || (altitude !== null && altitude !== 0);
-    const hasAccuracy = accuracy;
+    const hasAccuracy = Boolean(accuracy);
 
     return (
         <>
@@ -82,22 +82,24 @@ const InstanceDetailsLocation: React.FunctionComponent<Props> = ({
                     }
                 />
             )}
-            {orgUnit && hasCoordinatesFromOrgUnit && !hasCoordinatesFromForm && (
-                <>
-                    <InstanceDetailsField
-                        label={formatMessage(MESSAGES.latitude)}
-                        value={`${
-                            currentInstance.org_unit.latitude
-                        } ${formatMessage(MESSAGES.fromOrgUnit)}`}
-                    />
-                    <InstanceDetailsField
-                        label={formatMessage(MESSAGES.longitude)}
-                        value={`${
-                            currentInstance.org_unit.longitude
-                        } ${formatMessage(MESSAGES.fromOrgUnit)}`}
-                    />
-                </>
-            )}
+            {orgUnit &&
+                hasCoordinatesFromOrgUnit &&
+                !hasCoordinatesFromForm && (
+                    <>
+                        <InstanceDetailsField
+                            label={formatMessage(MESSAGES.latitude)}
+                            value={`${
+                                currentInstance.org_unit.latitude
+                            } ${formatMessage(MESSAGES.fromOrgUnit)}`}
+                        />
+                        <InstanceDetailsField
+                            label={formatMessage(MESSAGES.longitude)}
+                            value={`${
+                                currentInstance.org_unit.longitude
+                            } ${formatMessage(MESSAGES.fromOrgUnit)}`}
+                        />
+                    </>
+                )}
             {hasCoordinatesFromForm && (
                 <>
                     <InstanceDetailsField


### PR DESCRIPTION
- remove unnecessary condition
- fix small visual bug in InstanceDetailsLocation

Explain what problem this PR is resolving

Related JIRA tickets : IA-3075

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
NA

## Changes

- Fix an error in the logic of the map

## How to test

- Launch enketo
- On a setuper DB look for submissions for `test_form` (the one with locations)
- Pick a submission, find it's org unit name (there's a link in the table)  
- Add a submission of `test_form` for the chosen org unit. Don't forget to add coordinates.
- Go to the "map" tab of the details page of your org unit   
- Select "test_form" in the forms dropdown
- you should see both markers  

## Print screen / video

![Screenshot 2024-06-12 at 17 20 02](https://github.com/BLSQ/iaso/assets/38907762/93e25bef-0294-4b01-951d-c6bc652a725d)


