### PR TITLE
Hotfix: IA-3087 gps push bug

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/instances/components/CreateReAssignDialogComponent.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/CreateReAssignDialogComponent.tsx
@@ -1,11 +1,11 @@
 import React, { FunctionComponent, useState } from 'react';
-// @ts-ignore
 import {
     ConfirmCancelModal,
     useSafeIntl,
     AddButton,
     makeFullModal,
 } from 'bluesquare-components';
+import UpdateIcon from '@mui/icons-material/Update';
 import { Period } from '../../periods/models';
 import { isValidPeriod } from '../../periods/utils';
 import MESSAGES from '../messages';
@@ -129,26 +129,24 @@ export const CreateReAssignDialogComponent: FunctionComponent<Props> = ({
                     errors={fieldValue.period.errors}
                 />
             )}
-            <>
-                <OrgUnitTreeviewModal
-                    required
-                    clearable={false}
-                    titleMessage={MESSAGES.selectedOrgUnit}
-                    toggleOnLabelClick={false}
-                    onConfirm={orgUnit => {
-                        setFieldValue({
-                            ...fieldValue,
-                            orgUnit: {
-                                ...fieldValue.orgUnit,
-                                value: orgUnit,
-                            },
-                        });
-                    }}
-                    multiselect={false}
-                    initialSelection={fieldValue.orgUnit.value}
-                    allowedTypes={orgUnitTypes}
-                />
-            </>
+            <OrgUnitTreeviewModal
+                required
+                clearable={false}
+                titleMessage={MESSAGES.selectedOrgUnit}
+                toggleOnLabelClick={false}
+                onConfirm={orgUnit => {
+                    setFieldValue({
+                        ...fieldValue,
+                        orgUnit: {
+                            ...fieldValue.orgUnit,
+                            value: orgUnit,
+                        },
+                    });
+                }}
+                multiselect={false}
+                initialSelection={fieldValue.orgUnit.value}
+                allowedTypes={orgUnitTypes}
+            />
         </ConfirmCancelModal>
     );
 };
@@ -156,6 +154,11 @@ export const CreateReAssignDialogComponent: FunctionComponent<Props> = ({
 const CreateReAssignDialog = makeFullModal(
     CreateReAssignDialogComponent,
     AddButton,
+);
+
+export const ReAssignDialog = makeFullModal(
+    CreateReAssignDialogComponent,
+    UpdateIcon,
 );
 
 export { CreateReAssignDialog };

--- a/hat/assets/js/apps/Iaso/domains/instances/hooks/speedDialActions.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/hooks/speedDialActions.tsx
@@ -1,25 +1,15 @@
 /* eslint-disable camelcase */
 import React, { ReactElement, useCallback, useMemo } from 'react';
 import DeleteIcon from '@mui/icons-material/Delete';
-import UpdateIcon from '@mui/icons-material/Update';
 import EditLocationIcon from '@mui/icons-material/EditLocation';
 import RestoreFromTrashIcon from '@mui/icons-material/RestoreFromTrash';
 import LinkIcon from '@mui/icons-material/Link';
 import LinkOffIcon from '@mui/icons-material/LinkOff';
 import LockIcon from '@mui/icons-material/Lock';
-
-import {
-    // @ts-ignore
-    ExportButton,
-    // @ts-ignore
-    makeFullModal,
-    // @ts-ignore
-    useSafeIntl,
-} from 'bluesquare-components';
+import { ExportButton, useSafeIntl } from 'bluesquare-components';
 import { DialogContentText } from '@mui/material';
 import { useDispatch } from 'react-redux';
 import EnketoIcon from '../components/EnketoIcon';
-import { CreateReAssignDialogComponent } from '../components/CreateReAssignDialogComponent';
 import ExportInstancesDialogComponent from '../components/ExportInstancesDialogComponent';
 import MESSAGES from '../messages';
 import { Instance } from '../types/instance';
@@ -29,6 +19,7 @@ import { usePostLockInstance } from '../hooks';
 import { FormDef, useLinkOrgUnitToReferenceSubmission } from './speeddials';
 import { Nullable } from '../../../types/utils';
 import { reAssignInstance } from '../actions';
+import { ReAssignDialog } from '../components/CreateReAssignDialogComponent';
 
 export type SpeedDialAction = {
     id: string;
@@ -40,10 +31,6 @@ export const useBaseActions = (
     currentInstance: Instance,
     formDef?: FormDef,
 ): SpeedDialAction[] => {
-    const CreateReAssignDialog = useMemo(
-        () => makeFullModal(CreateReAssignDialogComponent, UpdateIcon),
-        [],
-    );
     const dispatch = useDispatch();
     const onReAssignInstance = useCallback(
         (...props) => {
@@ -79,7 +66,7 @@ export const useBaseActions = (
             {
                 id: 'instanceReAssignAction',
                 icon: (
-                    <CreateReAssignDialog
+                    <ReAssignDialog
                         titleMessage={MESSAGES.reAssignInstance}
                         confirmMessage={MESSAGES.reAssignInstanceAction}
                         currentInstance={currentInstance}
@@ -91,7 +78,7 @@ export const useBaseActions = (
                 disabled: currentInstance && currentInstance.deleted,
             },
         ];
-    }, [currentInstance, formDef, reAssignInstance]);
+    }, [currentInstance, formDef, onReAssignInstance]);
 };
 
 export const useEditLocationWithGpsAction = (
@@ -112,10 +99,11 @@ export const useEditLocationWithGpsAction = (
             currentInstance.org_unit,
         ],
     );
-    const { mutateAsync: saveOrgUnit } = useSaveOrgUnit(() => {
-        // @ts-ignore
-        window.location.reload(false);
-    }, ['orgUnits']);
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    const { mutateAsync: saveOrgUnit } = useSaveOrgUnit(() => {}, [
+        'orgUnits',
+        'instance',
+    ]);
     return useMemo(
         () => ({
             id: 'editLocationWithInstanceGps',

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitDisplay.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitDisplay.tsx
@@ -26,7 +26,6 @@ const OrgUnitDisplay = ({
     }
     return (
         <LinkWithLocation
-            target="_blank"
             className={classes.link}
             to={`/${baseUrls.orgUnitDetails}/orgUnitId/${orgUnit.id}`}
         >


### PR DESCRIPTION
Users get API error when saving location from submission page
Submission detail page redirection to org unit opens a new tab, which can lead users to overwrite changes (if the open the org unit tab before pushing coordinates for example)

Related JIRA tickets : IA-3087

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
- Tell us where the doc can be found (docs folder, wiki, in the code...)

## Changes

- Remove forced window refresh, which was causing the GET request to fail
- Replace with query key invalidation
- Remove `target="_blank"  from link to org unit in instance details

## How to test

Go to the details of an instance
Click on the org unit link in the "Location" paper: it should not open a new tab
Try pushing coordinates (via speeddial): the window shouldn't relaod and there should be no error snack bar

## Print screen / video


https://github.com/BLSQ/iaso/assets/38907762/5a033c78-912e-4204-9c0e-64f7061b7194



## Notes

HOTFIX v1.236e
