### PR TITLE
IA-3104 Fix endless load of when filtering on Org Units "without form" or "with duplicate"

### DIFF
--- a/iaso/api/org_unit_search.py
+++ b/iaso/api/org_unit_search.py
@@ -102,7 +102,7 @@ def build_org_units_queryset(queryset, params, profile):
         queryset = queryset.filter(instance__created_at__lte=date_to)
 
     if date_from is not None and date_to is not None:
-        queryset = queryset.filter(instance__created_at__range=[date_from, date_to])
+        queryset = queryset.filter(instance__created_at__range=[date_from, date_to]).distinct("id")
 
     if has_instances is not None:
         if has_instances == "true":

--- a/iaso/api/org_unit_search.py
+++ b/iaso/api/org_unit_search.py
@@ -231,7 +231,7 @@ def build_org_units_queryset(queryset, params, profile):
     queryset = queryset.prefetch_related("parent__parent__parent")
     queryset = queryset.prefetch_related("parent__parent__parent__parent")
 
-    return queryset.distinct()
+    return queryset.distinct("id")
 
 
 def annotate_query(queryset, count_instances, count_per_form, forms):

--- a/iaso/api/org_unit_search.py
+++ b/iaso/api/org_unit_search.py
@@ -226,12 +226,9 @@ def build_org_units_queryset(queryset, params, profile):
     queryset = queryset.select_related("org_unit_type")
 
     queryset = queryset.prefetch_related("groups")
-    queryset = queryset.prefetch_related("parent")
-    queryset = queryset.prefetch_related("parent__parent")
-    queryset = queryset.prefetch_related("parent__parent__parent")
     queryset = queryset.prefetch_related("parent__parent__parent__parent")
 
-    return queryset.distinct("id")
+    return queryset
 
 
 def annotate_query(queryset, count_instances, count_per_form, forms):

--- a/iaso/api/org_units.py
+++ b/iaso/api/org_units.py
@@ -175,7 +175,7 @@ class OrgUnitViewSet(viewsets.ViewSet):
                     temp_org_unit = unit.as_dict()
                     temp_org_unit["geo_json"] = None
                     if temp_org_unit["has_geo_json"] == True:
-                        shape_queryset = self.get_queryset().filter(id=temp_org_unit["id"])
+                        shape_queryset = queryset.filter(id=temp_org_unit["id"])
                         temp_org_unit["geo_json"] = geojson_queryset(shape_queryset, geometry_field="simplified_geom")
                     org_units.append(temp_org_unit)
                 return Response({"orgUnits": org_units})
@@ -189,7 +189,7 @@ class OrgUnitViewSet(viewsets.ViewSet):
                     temp_org_unit = unit.as_location(with_parents=request.GET.get("withParents", None))
                     temp_org_unit["geo_json"] = None
                     if temp_org_unit["has_geo_json"] == True:
-                        shape_queryset = self.get_queryset().filter(id=temp_org_unit["id"])
+                        shape_queryset = queryset.filter(id=temp_org_unit["id"])
                         temp_org_unit["geo_json"] = geojson_queryset(shape_queryset, geometry_field="simplified_geom")
                     org_units.append(temp_org_unit)
                 return Response(org_units)

--- a/iaso/api/org_units.py
+++ b/iaso/api/org_units.py
@@ -141,7 +141,7 @@ class OrgUnitViewSet(viewsets.ViewSet):
         else:
             queryset = build_org_units_queryset(queryset, request.GET, profile)
 
-        queryset = queryset.order_by(*order).distinct(*order)
+        queryset = queryset.order_by(*order)
 
         if not is_export:
             if limit and not as_location:

--- a/iaso/api/org_units.py
+++ b/iaso/api/org_units.py
@@ -94,7 +94,7 @@ class OrgUnitViewSet(viewsets.ViewSet):
 
          These parameter can totally conflict and the result is undocumented
         """
-        queryset = self.get_queryset().select_related("parent__org_unit_type")
+        queryset = self.get_queryset().defer("geom").select_related("parent__org_unit_type")
         forms = Form.objects.filter_for_user_and_app_id(self.request.user, self.request.query_params.get("app_id"))
         limit = request.GET.get("limit", None)
         page_offset = request.GET.get("page", 1)

--- a/iaso/api/org_units.py
+++ b/iaso/api/org_units.py
@@ -141,7 +141,7 @@ class OrgUnitViewSet(viewsets.ViewSet):
         else:
             queryset = build_org_units_queryset(queryset, request.GET, profile)
 
-        queryset = queryset.order_by(*order)
+        queryset = queryset.order_by(*order).distinct(*order)
 
         if not is_export:
             if limit and not as_location:


### PR DESCRIPTION
Fix endless load of when filtering on Org Units "without form" or "with duplicate".

Related JIRA tickets : [IA-3104](https://bluesquare.atlassian.net/browse/IA-3104)

## Changes

- Fix `distinct()` without argument
- Don't use `self.get_queryset()` in for loops
- Use `.defer("geom")`
- Fix N+1 with `geojson_queryset()`

## `distinct()` fix

![distinct](https://github.com/BLSQ/iaso/assets/281139/c71acd5c-6811-4874-ba66-059237c1d9a2)

## `geojson_queryset()`N+1  fix

Eg for `/api/orgunits/?limit=3000&order=id&searches=%5B%7B%22validation_status%22%3A%22all%22%2C%22color%22%3A%22f4511e%22%2C%22source%22%3A5%2C%22hasInstances%22%3A%22false%22%7D%5D&locationLimit=3000&asLocation=true`

![geo_json](https://github.com/BLSQ/iaso/assets/281139/66ec5a15-3333-41f7-b153-ae5adba4cda8)


[IA-3104]: https://bluesquare.atlassian.net/browse/IA-3104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ