### PR TITLE
IA-3112: LIVE_COMPONENTS warnings remove

### DIFF
--- a/hat/webpack.dev.js
+++ b/hat/webpack.dev.js
@@ -206,8 +206,8 @@ module.exports = {
         }),
         // XLSX
         new webpack.IgnorePlugin({ resourceRegExp: /cptable/ }),
-        new webpack.WatchIgnorePlugin({
-            paths: [/\.d\.ts$/],
+        new webpack.IgnorePlugin({
+            resourceRegExp: /^perf_hooks$/,
         }),
     ],
 
@@ -319,4 +319,13 @@ module.exports = {
 
         extensions: ['.js', '.tsx', '.ts'],
     },
+    stats: {
+        errorDetails: true,
+    },
+    ignoreWarnings: [
+        {
+            module: /typescript/,
+            message: /the request of a dependency is an expression/,
+        },
+    ],
 };


### PR DESCRIPTION
While running bluesquare-components locally with LIVE_COMPONENTS=true we had multiple annoying warnings.

I made a PR on bluesquare-components [here](https://github.com/BLSQ/bluesquare-components/pull/158/files)

Related JIRA tickets : IA-3112

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes
- fix `IconButtonBuiltInIcon` type not exported correctly
- upgrade html-entities package
- ignor typescript and per_hooks warnings for now

## How to test
Run Iaso with a local config of bluesqaure-components with LIVE_COMPONENTS=true 
Build should not return an error or a warning.
## Print screen / video


