### PR TITLE
POLIO-1568 HOTFIX: remove success snackbar from spreadsheet API query

### DIFF
--- a/plugins/polio/js/src/domains/Campaigns/Preparedness/PreparednessConfig.js
+++ b/plugins/polio/js/src/domains/Campaigns/Preparedness/PreparednessConfig.js
@@ -77,9 +77,6 @@ export const PreparednessConfig = ({ roundNumber, campaignName }) => {
             },
         );
     };
-    console.log('isLoading', isLoading);
-    console.log('isGeneratingSpreadsheet', isGeneratingSpreadsheet);
-    console.log('previewing', previewMutation.isLoading);
 
     const generateSpreadsheet = () => {
         generateSpreadsheetMutation(roundNumber);

--- a/plugins/polio/js/src/domains/Campaigns/Preparedness/PreparednessConfig.js
+++ b/plugins/polio/js/src/domains/Campaigns/Preparedness/PreparednessConfig.js
@@ -9,7 +9,7 @@ import {
     Typography,
 } from '@mui/material';
 import { Field, useFormikContext } from 'formik';
-import React from 'react';
+import React, { useCallback } from 'react';
 import { useSafeIntl } from 'bluesquare-components';
 import moment from 'moment';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
@@ -40,11 +40,20 @@ export const PreparednessConfig = ({ roundNumber, campaignName }) => {
     const isLockedForEdition = roundStartDate
         ? moment().isAfter(moment(roundStartDate, 'YYYY-MM-DD', 'day'))
         : false;
+    const key = `rounds[${roundIndex}].preparedness_spreadsheet_url`;
+    const lastKey = `rounds[${roundIndex}].last_preparedness`;
+
+    const onGenerateSheetSuccess = useCallback(
+        data => {
+            setFieldValue(key, data.url);
+        },
+        [key, setFieldValue],
+    );
     const {
-        mutate: generateSpreadsheetMutation,
+        mutateAsync: generateSpreadsheetMutation,
         isLoading: isGeneratingSpreadsheet,
         error: generationError,
-    } = useGeneratePreparednessSheet(values.id, roundNumber);
+    } = useGeneratePreparednessSheet(values.id, onGenerateSheetSuccess);
     const {
         preparedness_spreadsheet_url,
         last_preparedness: preparednessForm,
@@ -55,9 +64,6 @@ export const PreparednessConfig = ({ roundNumber, campaignName }) => {
     );
 
     const preparednessData = preparednessForm ?? lastPreparedness;
-
-    const key = `rounds[${roundIndex}].preparedness_spreadsheet_url`;
-    const lastKey = `rounds[${roundIndex}].last_preparedness`;
 
     const previewMutation = useFetchPreparedness();
 
@@ -71,13 +77,12 @@ export const PreparednessConfig = ({ roundNumber, campaignName }) => {
             },
         );
     };
+    console.log('isLoading', isLoading);
+    console.log('isGeneratingSpreadsheet', isGeneratingSpreadsheet);
+    console.log('previewing', previewMutation.isLoading);
 
     const generateSpreadsheet = () => {
-        generateSpreadsheetMutation(roundNumber, {
-            onSuccess: data => {
-                setFieldValue(key, data.url);
-            },
-        });
+        generateSpreadsheetMutation(roundNumber);
     };
 
     const message = isLockedForEdition

--- a/plugins/polio/js/src/domains/Campaigns/Preparedness/hooks/useGetPreparednessData.js
+++ b/plugins/polio/js/src/domains/Campaigns/Preparedness/hooks/useGetPreparednessData.js
@@ -31,13 +31,16 @@ export const useFetchPreparedness = () => {
     return useSnackMutation(refreshPreparedness, null);
 };
 
-export const useGeneratePreparednessSheet = campaign_id => {
-    return useSnackMutation(roundNumber =>
-        postRequest(
-            `/api/polio/campaigns/${campaign_id}/create_preparedness_sheet/`,
-            {
-                round_number: roundNumber,
-            },
-        ),
-    );
+export const useGeneratePreparednessSheet = (campaign_id, onSuccess) => {
+    return useSnackMutation({
+        mutationFn: roundNumber =>
+            postRequest(
+                `/api/polio/campaigns/${campaign_id}/create_preparedness_sheet/`,
+                {
+                    round_number: roundNumber,
+                },
+            ),
+        showSucessSnackBar: false,
+        options: { onSuccess },
+    });
 };


### PR DESCRIPTION
Generating a spreadsheet would cause an early re-render and lose the data

Related JIRA tickets :POLIO-1568

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
NA

## Changes

- disabled the success snack bar for the spreadsheet generation

## How to test

- Go to polio campaigns. Opena campaign with at least 1 round starting in the future
- Go to preparedness tab, generate a spreadsheet
- The url should appear in the input field once the query is done

## Print screen / video


https://github.com/BLSQ/iaso/assets/38907762/2a6443f4-77a9-4fd3-9a9f-f8d2856dac8f




