### PR TITLE
IA-3105: Reduce loading spinner zIndex

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6437,8 +6437,7 @@
         },
         "node_modules/bluesquare-components": {
             "version": "1.0.0",
-            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#fc5332ca64367b8f51aee2d8056fb6abd4416f10",
-            "license": "Apache-2.0",
+            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#9507fe4b2c7b3051f67d9ab3ea62fb1f206d9979",
             "dependencies": {
                 "@babel/plugin-transform-class-properties": "^7.24.6",
                 "@babel/plugin-transform-object-rest-spread": "^7.24.6",


### PR DESCRIPTION
Explain what problem this PR is resolving

Related JIRA tickets : IA-3105

Loading spinner zIndex is too high and over certain element:

![image](https://github.com/BLSQ/iaso/assets/12494624/a9dc9e8c-6277-4997-9930-e0ee0d0e8171)

![Screenshot 2024-06-18 at 15 59 46](https://github.com/BLSQ/iaso/assets/12494624/ebd6abc7-a43b-4df8-bb1b-75b0fc302c93)


## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)


## Changes

Reduce spinner zIndex in bluesquare-components

## How to test

Open forms page, while loading, reopen menu, you should not see the loading spinner getting over the menu:


## Print screen / video

https://github.com/BLSQ/iaso/assets/12494624/a2240664-f5b1-4c1d-8f8e-c9c65e4811d2


