### PR TITLE
IA-3046: Registry read only and reference submission

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/registry/components/selectedOrgUnit/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/selectedOrgUnit/index.tsx
@@ -10,10 +10,7 @@ import {
     useGetOrgUnitInstances,
 } from '../../hooks/useGetInstances';
 
-import * as Permissions from '../../../../utils/permissions';
-import { useCurrentUser } from '../../../../utils/usersUtils';
 import { OrgUnit } from '../../../orgUnits/types/orgUnit';
-import { userHasPermission } from '../../../users/utils';
 import { HEIGHT } from '../../config';
 import { RegistryParams } from '../../types';
 import { EmptyInstances } from './EmptyInstances';
@@ -45,12 +42,8 @@ export const SelectedOrgUnit: FunctionComponent<Props> = ({
     isFetching: isFetchingOrgUnit,
 }) => {
     const classes: Record<string, string> = useStyles();
-    const currentUser = useCurrentUser();
 
-    const { data: instances, isFetching } = useGetOrgUnitInstances(
-        orgUnit?.id,
-        !userHasPermission(Permissions.REGISTRY_WRITE, currentUser),
-    );
+    const { data: instances, isFetching } = useGetOrgUnitInstances(orgUnit?.id);
     const currentInstanceId = useMemo(() => {
         return (
             params.submissionId ||


### PR DESCRIPTION
On instance staging (account = kqrxutg)

If I have all permission, I see this ==> 

![image](https://github.com/BLSQ/iaso/assets/12494624/ec6fd672-d4df-4d6c-885d-586854edd61e)
 

If I have read only I have this

![image](https://github.com/BLSQ/iaso/assets/12494624/965c203e-00e7-47cc-950e-c5a0ec48c318)

![image](https://github.com/BLSQ/iaso/assets/12494624/f5034d64-39ab-4b93-b2ec-37d8f0f9fa7a)
 

If Read only, user should still be able to visualise the form

Also on the bottom part

Related JIRA tickets : IA-3046

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [x] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)


## Changes

Remove isReference from api call

## How to test

You need a user with only read permission on registry and an org unit with a reference submission and a regular submission attached to it. While visiting registry on this org unit you should have the same result as somebody with write permission.


