### PR TITLE
HOTFIX: Do not download full tree for users without org units in their profile

### DIFF
--- a/iaso/api/org_unit_tree/views.py
+++ b/iaso/api/org_unit_tree/views.py
@@ -57,16 +57,14 @@ class OrgUnitTreeViewSet(viewsets.ModelViewSet):
         else:
             qs = OrgUnit.objects.filter_for_user(user)
 
-        can_view_full_tree = any([user.is_anonymous, user.is_superuser, force_full_tree])
         display_root_level = not parent_id
 
         if display_root_level and self.action == "list":
-            if can_view_full_tree:
+            if user.is_authenticated and user.iaso_profile.org_units.exists():
+                # Root level of the tree for this user (the user may be restricted to a subpart of the tree).
+                qs = qs.filter(id__in=user.iaso_profile.org_units.all())
+            else:
                 qs = qs.filter(parent__isnull=True)
-            elif user.is_authenticated:
-                if user.iaso_profile.org_units.exists():
-                    # Root level of the tree for this user (the user may be restricted to a subpart of the tree).
-                    qs = qs.filter(id__in=user.iaso_profile.org_units.all())
 
         qs = qs.only("id", "name", "validation_status", "version", "org_unit_type", "parent")
         qs = qs.order_by("name")

--- a/iaso/tests/api/org_unit_tree/test_views.py
+++ b/iaso/tests/api/org_unit_tree/test_views.py
@@ -110,15 +110,6 @@ class OrgUnitTreeViewsAPITestCase(APITestCase):
             self.assertEqual(1, len(response.data))
             self.assertEqual(response.data[0]["name"], "Boucle du Mouhon")
 
-    def test_root_with_force_full_tree(self):
-        self.client.force_authenticate(self.user)
-        with self.assertNumQueries(3):
-            response = self.client.get("/api/orgunits/tree/?force_full_tree=true")
-            self.assertJSONResponse(response, 200)
-            self.assertEqual(2, len(response.data))
-            self.assertEqual(response.data[0]["name"], "Angola")
-            self.assertEqual(response.data[1]["name"], "Burkina Faso")
-
     def test_specific_level_with_force_full_tree(self):
         self.client.force_authenticate(self.user)
 


### PR DESCRIPTION
Do not download full tree for users without org units in their profile.