### PR TITLE
IA-3134 Allow a super user to view the default tree root

### DIFF
--- a/iaso/api/org_unit_tree/views.py
+++ b/iaso/api/org_unit_tree/views.py
@@ -60,7 +60,8 @@ class OrgUnitTreeViewSet(viewsets.ModelViewSet):
         display_root_level = not parent_id
 
         if display_root_level and self.action == "list":
-            if user.is_authenticated and user.iaso_profile.org_units.exists():
+            force_full_tree = force_full_tree or user.is_superuser
+            if not force_full_tree and user.is_authenticated and user.iaso_profile.org_units.exists():
                 # Root level of the tree for this user (the user may be restricted to a subpart of the tree).
                 qs = qs.filter(id__in=user.iaso_profile.org_units.all())
             else:

--- a/iaso/tests/api/org_unit_tree/test_views.py
+++ b/iaso/tests/api/org_unit_tree/test_views.py
@@ -67,11 +67,64 @@ class OrgUnitTreeViewsAPITestCase(APITestCase):
         cls.data_source.projects.set([cls.project])
         cls.user.iaso_profile.org_units.set([cls.burkina])  # Restrict access to a subset of org units for user.
 
-    def test_root_for_anonymous(self):
+        cls.user_without_org_unit_for_profile = cls.create_user_with_profile(username="user2", account=cls.account)
+
+    def test_root_level_for_anonymous_user(self):
+        """
+        Anonymous users view the default tree root (`data_source_id` is mandatory for anonymous users).
+        """
         with self.assertNumQueries(2):
-            # Select `DataSource`.
-            # Select `OrgUnit`s.
             response = self.client.get(f"/api/orgunits/tree/?data_source_id={self.data_source.pk}")
+            self.assertJSONResponse(response, 200)
+            self.assertEqual(2, len(response.data))
+            self.assertEqual(response.data[0]["name"], "Angola")
+            self.assertEqual(response.data[1]["name"], "Burkina Faso")
+
+    def test_root_level_for_authenticated_user_with_org_unit_for_profile(self):
+        """
+        Authenticated users with org units linked to their profile view a custom tree root.
+        """
+        self.client.force_authenticate(self.user)
+        with self.assertNumQueries(3):
+            response = self.client.get("/api/orgunits/tree/")
+            self.assertJSONResponse(response, 200)
+            self.assertEqual(1, len(response.data))
+            self.assertEqual(response.data[0]["name"], "Burkina Faso")
+
+    def test_root_level_force_full_tree_for_authenticated_user_with_org_unit_for_profile(self):
+        """
+        `force_full_tree` gives access to the default tree root, even to authenticated users
+        with org units linked to their profile.
+        """
+        self.client.force_authenticate(self.user)
+        with self.assertNumQueries(3):
+            response = self.client.get("/api/orgunits/tree/?force_full_tree=true")
+            self.assertJSONResponse(response, 200)
+            self.assertEqual(2, len(response.data))
+            self.assertEqual(response.data[0]["name"], "Angola")
+            self.assertEqual(response.data[1]["name"], "Burkina Faso")
+
+    def test_root_level_for_authenticated_user_without_org_unit_for_profile(self):
+        """
+        Authenticated users without org units linked to their profile view the default tree root.
+        """
+        self.client.force_authenticate(self.user_without_org_unit_for_profile)
+        with self.assertNumQueries(3):
+            response = self.client.get("/api/orgunits/tree/")
+            self.assertJSONResponse(response, 200)
+            self.assertEqual(2, len(response.data))
+            self.assertEqual(response.data[0]["name"], "Angola")
+            self.assertEqual(response.data[1]["name"], "Burkina Faso")
+
+    def test_root_level_for_superuser(self):
+        """
+        Superusers view the default tree root.
+        """
+        self.user_without_org_unit_for_profile.is_superuser = True
+        self.user_without_org_unit_for_profile.save()
+        self.client.force_authenticate(self.user_without_org_unit_for_profile)
+        with self.assertNumQueries(3):
+            response = self.client.get("/api/orgunits/tree/")
             self.assertJSONResponse(response, 200)
             self.assertEqual(2, len(response.data))
             self.assertEqual(response.data[0]["name"], "Angola")
@@ -87,14 +140,6 @@ class OrgUnitTreeViewsAPITestCase(APITestCase):
             self.assertJSONResponse(response, 200)
             self.assertEqual(1, len(response.data))
             self.assertEqual(response.data[0]["name"], "Huila")
-
-    def test_root_for_authenticated_user(self):
-        self.client.force_authenticate(self.user)
-        with self.assertNumQueries(3):
-            response = self.client.get("/api/orgunits/tree/")
-            self.assertJSONResponse(response, 200)
-            self.assertEqual(1, len(response.data))
-            self.assertEqual(response.data[0]["name"], "Burkina Faso")
 
     def test_specific_level_for_authenticated_user(self):
         self.client.force_authenticate(self.user)


### PR DESCRIPTION
Allow a super user to view the default tree root even for those having org units linked to their profile.

Related JIRA tickets : [IA-3134](https://bluesquare.atlassian.net/browse/IA-3134)



[IA-3134]: https://bluesquare.atlassian.net/browse/IA-3134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ