### PR TITLE
IA-3140 registry bugs

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/registry/components/map/OrgUnitChildrenLocations.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/map/OrgUnitChildrenLocations.tsx
@@ -14,7 +14,7 @@ import MarkersListComponent from '../../../../components/maps/markers/MarkersLis
 import { MapToolTip } from './MapTooltip';
 import { selectedOrgUnitColor } from './OrgUnitChildrenMap';
 
-const MARKER_RADIUS = 12;
+const MARKER_RADIUS = 8;
 
 type Props = {
     selectedChildrenId: string | undefined;

--- a/hat/assets/js/apps/Iaso/domains/registry/components/map/OrgUnitChildrenMap.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/map/OrgUnitChildrenMap.tsx
@@ -63,6 +63,7 @@ const boundsOptions = {
 };
 const tabsHeight = '50px';
 const mapHeight = `calc(${HEIGHT} - ${tabsHeight})`;
+const mapHeightFullScreen = `calc(92vh - ${tabsHeight})`;
 const useStyles = makeStyles(theme => ({
     mapContainer: {
         ...commonStyles(theme).mapContainer,
@@ -74,10 +75,6 @@ const useStyles = makeStyles(theme => ({
             borderBottomLeftRadius: 0,
             borderBottomRightRadius: 0,
         },
-        // Temporary fix to avoid loading spinner to have a zindex of 10 000 and passing over the org unit tree
-        '& > div:not(.map)': {
-            zIndex: 1000,
-        },
     },
     fullScreen: {
         position: 'fixed',
@@ -85,7 +82,7 @@ const useStyles = makeStyles(theme => ({
         left: '0',
         width: '100vw',
         height: 'calc(100vh - 127px)',
-        zIndex: 40,
+        zIndex: 1300,
     },
 }));
 
@@ -197,7 +194,9 @@ export const OrgUnitChildrenMap: FunctionComponent<Props> = ({
                     doubleClickZoom={false}
                     maxZoom={currentTile.maxZoom}
                     style={{
-                        minHeight: mapHeight,
+                        minHeight: isMapFullScreen
+                            ? mapHeightFullScreen
+                            : mapHeight,
                         height: '100%',
                     }}
                     center={[1, 20]}


### PR DESCRIPTION
circle marker is too big ans fullscreen is broken on registry

Related JIRA tickets : IA-3140
## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)


## Changes

- reduce radius of marker component
- fix css for fullscreen map

## How to test

Open registry on an org unit having sub org unit with markers.
Check the size of the markers
Try to put the map on fullscreen mode

## Print screen / video

<img width="1680" alt="Screenshot 2024-06-21 at 10 30 28" src="https://github.com/BLSQ/iaso/assets/12494624/cd53215f-deec-4d1c-b239-95deae1899f7">
<img width="906" alt="Screenshot 2024-06-21 at 10 30 21" src="https://github.com/BLSQ/iaso/assets/12494624/1b4458b2-1162-418b-bca4-4f6b78864e0d">
