### PR TITLE
IA-3047 Submission photo

### DIFF
--- a/hat/assets/js/apps/Iaso/components/dialogs/ImageGalleryComponent.tsx
+++ b/hat/assets/js/apps/Iaso/components/dialogs/ImageGalleryComponent.tsx
@@ -1,8 +1,8 @@
 import React, { FunctionComponent } from 'react';
 
+import Close from '@mui/icons-material/Close';
 import ArrowLeft from '@mui/icons-material/KeyboardArrowLeft';
 import ArrowRight from '@mui/icons-material/KeyboardArrowRight';
-import Close from '@mui/icons-material/Close';
 
 import {
     Box,
@@ -104,54 +104,52 @@ const ImageGallery: FunctionComponent<Props> = ({
     const currentImgSrc = currentImg.path;
 
     return (
-        <>
-            <Dialog
-                classes={{
-                    paper: styles.paper as any,
-                }}
-                open
-                onClose={(event, reason) => {
-                    if (reason === 'backdropClick') {
-                        closeLightbox();
-                    }
-                }}
-                maxWidth="xl"
-            >
-                <DialogContent sx={styles.content}>
-                    {currentIndex > 0 && (
-                        <IconButton
-                            color="primary"
-                            sx={styles.prevButton}
-                            onClick={() => setCurrentIndex(currentIndex - 1)}
-                        >
-                            <ArrowLeft sx={styles.navIcon} />
-                        </IconButton>
-                    )}
-                    {currentIndex + 1 < imageList.length && (
-                        <IconButton
-                            color="primary"
-                            sx={styles.nextButton}
-                            onClick={() => setCurrentIndex(currentIndex + 1)}
-                        >
-                            <ArrowRight sx={styles.navIcon} />
-                        </IconButton>
-                    )}
+        <Dialog
+            classes={{
+                paper: styles.paper as any,
+            }}
+            open
+            onClose={(event, reason) => {
+                if (reason === 'backdropClick') {
+                    closeLightbox();
+                }
+            }}
+            maxWidth="xl"
+        >
+            <DialogContent sx={styles.content}>
+                {currentIndex > 0 && (
                     <IconButton
                         color="primary"
-                        sx={styles.closeButton}
-                        onClick={() => closeLightbox()}
+                        sx={styles.prevButton}
+                        onClick={() => setCurrentIndex(currentIndex - 1)}
                     >
-                        <Close sx={styles.closeIcon} />
+                        <ArrowLeft sx={styles.navIcon} />
                     </IconButton>
-                    <ImageGalleryLink url={url} urlLabel={urlLabel} />
-                    <Box sx={styles.infos}>{getExtraInfos(currentImg)}</Box>
-                    <Typography color="primary" variant="h6" sx={styles.count}>
-                        {`${currentIndex + 1} / ${imageList.length}`}
-                    </Typography>
-                    <img style={styles.image} alt="" src={currentImgSrc} />
-                </DialogContent>
-            </Dialog>
-        </>
+                )}
+                {currentIndex + 1 < imageList.length && (
+                    <IconButton
+                        color="primary"
+                        sx={styles.nextButton}
+                        onClick={() => setCurrentIndex(currentIndex + 1)}
+                    >
+                        <ArrowRight sx={styles.navIcon} />
+                    </IconButton>
+                )}
+                <IconButton
+                    color="primary"
+                    sx={styles.closeButton}
+                    onClick={() => closeLightbox()}
+                >
+                    <Close sx={styles.closeIcon} />
+                </IconButton>
+                <ImageGalleryLink url={url} urlLabel={urlLabel} />
+                <Box sx={styles.infos}>{getExtraInfos(currentImg)}</Box>
+                <Typography color="primary" variant="h6" sx={styles.count}>
+                    {`${currentIndex + 1} / ${imageList.length}`}
+                </Typography>
+                <img style={styles.image} alt="" src={currentImgSrc} />
+            </DialogContent>
+        </Dialog>
     );
 };
 

--- a/hat/assets/js/apps/Iaso/components/dialogs/ImageGalleryComponent.tsx
+++ b/hat/assets/js/apps/Iaso/components/dialogs/ImageGalleryComponent.tsx
@@ -55,6 +55,10 @@ const styles = {
         top: theme => theme.spacing(2),
         right: theme => theme.spacing(2),
         cursor: 'pointer',
+        backgroundColor: theme => theme.palette.secondary.main,
+        '&:hover': {
+            backgroundColor: theme => theme.palette.secondary.dark,
+        },
     },
     navIcon: {
         fontSize: '50px',
@@ -83,7 +87,7 @@ type Props = {
     imageList: ShortFile[];
     currentIndex: number;
     // eslint-disable-next-line no-unused-vars
-    setCurrentIndex: (index: number) => void;
+    setCurrentIndex?: (index: number) => void;
     url: string | null;
     urlLabel: { id: string; defaultMessage: string } | undefined;
     // eslint-disable-next-line no-unused-vars
@@ -94,7 +98,7 @@ const ImageGallery: FunctionComponent<Props> = ({
     closeLightbox,
     imageList,
     currentIndex,
-    setCurrentIndex,
+    setCurrentIndex = () => null,
     url,
     urlLabel,
     getExtraInfos = () => null,
@@ -144,9 +148,11 @@ const ImageGallery: FunctionComponent<Props> = ({
                 </IconButton>
                 <ImageGalleryLink url={url} urlLabel={urlLabel} />
                 <Box sx={styles.infos}>{getExtraInfos(currentImg)}</Box>
-                <Typography color="primary" variant="h6" sx={styles.count}>
-                    {`${currentIndex + 1} / ${imageList.length}`}
-                </Typography>
+                {currentIndex + 1 > 1 && (
+                    <Typography color="primary" variant="h6" sx={styles.count}>
+                        {`${currentIndex + 1} / ${imageList.length}`}
+                    </Typography>
+                )}
                 <img style={styles.image} alt="" src={currentImgSrc} />
             </DialogContent>
         </Dialog>

--- a/hat/assets/js/apps/Iaso/domains/forms/components/FormVersionsDialogComponent.js
+++ b/hat/assets/js/apps/Iaso/domains/forms/components/FormVersionsDialogComponent.js
@@ -1,18 +1,16 @@
 import { Box, Grid, Typography } from '@mui/material';
 import PropTypes from 'prop-types';
 import React, { useCallback, useMemo, useState } from 'react';
-
 import { LoadingSpinner, useSafeIntl } from 'bluesquare-components';
+import { useQueryClient } from 'react-query';
 import ConfirmCancelDialogComponent from '../../../components/dialogs/ConfirmCancelDialogComponent';
 import FileInputComponent from '../../../components/forms/FileInputComponent';
 import PeriodPicker from '../../periods/components/PeriodPicker.tsx';
-
 import { useFormState } from '../../../hooks/form';
 import { createFormVersion, updateFormVersion } from '../../../utils/requests';
 import { errorTypes, getPeriodsErrors } from '../../periods/utils';
 import MESSAGES from '../messages';
-
-import { openSnackBar } from '../../../components/snackBars/EventDispatcher';
+import { openSnackBar } from '../../../components/snackBars/EventDispatcher.ts';
 import { succesfullSnackBar } from '../../../constants/snackBars';
 
 const emptyVersion = (id = null) => ({
@@ -31,6 +29,7 @@ const FormVersionsDialogComponent = ({
     ...dialogProps
 }) => {
     const intl = useSafeIntl();
+    const queryClient = useQueryClient();
     const [isLoading, setIsLoading] = useState(false);
     const [formState, setFieldValue, setFieldErrors, setFormState] =
         useFormState({
@@ -80,6 +79,7 @@ const FormVersionsDialogComponent = ({
                     setFormState(emptyVersion(formVersion.id));
                     onConfirmed();
                     openSnackBar(succesfullSnackBar());
+                    queryClient.invalidateQueries(['formVersions', formId]);
                 } catch (error) {
                     setIsLoading(false);
                     if (error.status === 400) {
@@ -91,13 +91,16 @@ const FormVersionsDialogComponent = ({
             }
         },
         [
-            setFieldErrors,
-            formState,
-            formId,
-            formVersion.id,
-            onConfirmed,
-            setFormState,
             isLoading,
+            formId,
+            formState.start_period.value,
+            formState.end_period.value,
+            formState.xls_file.value,
+            formVersion.id,
+            setFormState,
+            onConfirmed,
+            queryClient,
+            setFieldErrors,
         ],
     );
 

--- a/hat/assets/js/apps/Iaso/domains/forms/components/FormVersionsDialogComponent.spec.js
+++ b/hat/assets/js/apps/Iaso/domains/forms/components/FormVersionsDialogComponent.spec.js
@@ -9,6 +9,7 @@ import FormVersionsDialog from './FormVersionsDialogComponent';
 import PeriodPicker from '../../periods/components/PeriodPicker.tsx';
 import ConfirmCancelDialogComponent from '../../../components/dialogs/ConfirmCancelDialogComponent';
 import { renderWithStore } from '../../../../../test/utils/redux';
+import { withQueryClientProvider } from '../../../../../test/utils';
 import formVersionFixture from '../fixtures/formVersions.json';
 import { PERIOD_TYPE_DAY } from '../../periods/constants';
 import MESSAGES from '../messages';
@@ -36,26 +37,28 @@ const awaitUseEffect = async wrapper => {
 const getConnectedWrapper = () =>
     mount(
         renderWithStore(
-            <LocalizationProvider
-                dateAdapter={AdapterMoment}
-                adapterLocale="en"
-            >
-                <FormVersionsDialog
-                    formId={formId}
-                    formVersion={fakeFormVersion}
-                    titleMessage={MESSAGES.createFormVersion}
-                    renderTrigger={({ openDialog }) => (
-                        <IconButtonComponent
-                            id="open-dialog"
-                            onClick={openDialog}
-                            icon="edit"
-                            tooltipMessage={MESSAGES.createFormVersion}
-                        />
-                    )}
-                    onConfirmed={() => null}
-                    periodType={PERIOD_TYPE_DAY}
-                />
-            </LocalizationProvider>,
+            withQueryClientProvider(
+                <LocalizationProvider
+                    dateAdapter={AdapterMoment}
+                    adapterLocale="en"
+                >
+                    <FormVersionsDialog
+                        formId={formId}
+                        formVersion={fakeFormVersion}
+                        titleMessage={MESSAGES.createFormVersion}
+                        renderTrigger={({ openDialog }) => (
+                            <IconButtonComponent
+                                id="open-dialog"
+                                onClick={openDialog}
+                                icon="edit"
+                                tooltipMessage={MESSAGES.createFormVersion}
+                            />
+                        )}
+                        onConfirmed={() => null}
+                        periodType={PERIOD_TYPE_DAY}
+                    />
+                </LocalizationProvider>,
+            ),
             {
                 forms: {
                     current: undefined,
@@ -69,20 +72,22 @@ describe('FormVersionsDialog connected component', () => {
         before(() => {
             connectedWrapper = mount(
                 renderWithStore(
-                    <FormVersionsDialog
-                        formId={formId}
-                        titleMessage={MESSAGES.createFormVersion}
-                        onConfirmed={() => null}
-                        periodType={PERIOD_TYPE_DAY}
-                        renderTrigger={({ openDialog }) => (
-                            <IconButtonComponent
-                                id="open-dialog"
-                                onClick={openDialog}
-                                icon="edit"
-                                tooltipMessage={MESSAGES.createFormVersion}
-                            />
-                        )}
-                    />,
+                    withQueryClientProvider(
+                        <FormVersionsDialog
+                            formId={formId}
+                            titleMessage={MESSAGES.createFormVersion}
+                            onConfirmed={() => null}
+                            periodType={PERIOD_TYPE_DAY}
+                            renderTrigger={({ openDialog }) => (
+                                <IconButtonComponent
+                                    id="open-dialog"
+                                    onClick={openDialog}
+                                    icon="edit"
+                                    tooltipMessage={MESSAGES.createFormVersion}
+                                />
+                            )}
+                        />,
+                    ),
                     {
                         forms: {
                             current: undefined,

--- a/hat/assets/js/apps/Iaso/domains/instances/components/InstanceFileContent.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/InstanceFileContent.js
@@ -1,7 +1,7 @@
-import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import InstanceFileContentRich from './InstanceFileContentRich';
+import React, { Component } from 'react';
 import InstanceFileContentBasic from './InstanceFileContentBasic';
+import InstanceFileContentRich from './InstanceFileContentRich';
 
 /**
  * Wrapper component for instance file content
@@ -25,7 +25,6 @@ export default class InstanceFileContent extends Component {
     render() {
         const { instance, showQuestionKey, showNote, logId } = this.props;
         const hasDescriptor = instance?.form_descriptor;
-
         return !this.state.hasError && hasDescriptor ? (
             <InstanceFileContentRich
                 logId={logId}
@@ -33,6 +32,7 @@ export default class InstanceFileContent extends Component {
                 formDescriptor={instance?.form_descriptor}
                 showQuestionKey={showQuestionKey}
                 showNote={showNote}
+                files={instance?.files}
             />
         ) : (
             <InstanceFileContentBasic fileContent={instance?.file_content} />

--- a/hat/assets/js/apps/Iaso/domains/instances/components/InstanceFileContentRich.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/InstanceFileContentRich.js
@@ -4,10 +4,11 @@ import { Table, TableBody, TableCell, TableRow, Tooltip } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import isPlainObject from 'lodash/isPlainObject';
 import PropTypes from 'prop-types';
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 
 import { textPlaceholder } from 'bluesquare-components';
+import ImageGallery from '../../../components/dialogs/ImageGalleryComponent';
 
 const useStyle = makeStyles(theme => ({
     tableCellHead: {
@@ -162,6 +163,7 @@ InstanceFileContentRich.propTypes = {
 
 const PhotoField = ({ descriptor, data, showQuestionKey, files }) => {
     const classes = useStyle();
+    const [open, setOpen] = useState(false);
 
     const value = data[descriptor.name];
     const fileUrl = useMemo(() => {
@@ -185,15 +187,26 @@ const PhotoField = ({ descriptor, data, showQuestionKey, files }) => {
                 title={getRawValue(descriptor, data)}
             >
                 {value && fileUrl && (
-                    <img
-                        src={fileUrl}
-                        alt={descriptor.name}
-                        style={{
-                            objectFit: 'contain',
-                            maxWidth: '35vw',
-                            maxHeight: '35vh',
-                        }}
-                    />
+                    <>
+                        <img
+                            src={fileUrl}
+                            alt={descriptor.name}
+                            style={{
+                                objectFit: 'contain',
+                                maxWidth: '35vw',
+                                maxHeight: '35vh',
+                                cursor: 'pointer',
+                            }}
+                            onClick={() => setOpen(true)}
+                        />
+                        {open && (
+                            <ImageGallery
+                                closeLightbox={() => setOpen(false)}
+                                imageList={[{ path: fileUrl }]}
+                                currentIndex={0}
+                            />
+                        )}
+                    </>
                 )}
                 {(!value || !fileUrl) && textPlaceholder}
             </TableCell>


### PR DESCRIPTION
We should be able to see photo fields while consulting submission 

Related JIRA tickets : IA-3047
## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- New PhotoField for photo field type
- use imagegallery to open image

## How to test

Use this form to create a new form and create a submission with enketo.
[data_for_health_facilitydonnees_formation_sanitaire_2024051701.xlsx](https://github.com/user-attachments/files/15952112/data_for_health_facilitydonnees_formation_sanitaire_2024051701.xlsx)


When done, you should see your picture in the form content

## Print screen / video

![Screenshot 2024-06-21 at 16 08 37](https://github.com/BLSQ/iaso/assets/12494624/5c731e91-9f50-40ed-928b-f2715cc46116)
![Screenshot 2024-06-21 at 16 04 03](https://github.com/BLSQ/iaso/assets/12494624/f063c49f-4ec2-48c5-b828-0528b15e6df6)

