### PR TITLE
IA-3023: Org unit details tree view 

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitInfos.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitInfos.tsx
@@ -7,8 +7,8 @@ import { Box, Button, Grid } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 
 import {
-    useSafeIntl,
     FormControl as FormControlComponent,
+    useSafeIntl,
 } from 'bluesquare-components';
 import InputComponent from '../../../components/forms/InputComponent';
 import { commaSeparatedIdsToArray } from '../../../utils/forms';
@@ -17,12 +17,13 @@ import { OrgUnitTreeviewModal } from './TreeView/OrgUnitTreeviewModal';
 
 import { OrgUnitCreationDetails } from './OrgUnitCreationDetails';
 
-import { OrgUnitState, Group, OrgUnit } from '../types/orgUnit';
-import { OrgunitType } from '../types/orgunitTypes';
-import { Instance } from '../../instances/types/instance';
-import { useGetValidationStatus } from '../../forms/hooks/useGetValidationStatus';
-import { OrgUnitMultiReferenceInstances } from './OrgUnitMultiReferenceInstances';
 import DatesRange from '../../../components/filters/DatesRange';
+import { useGetValidationStatus } from '../../forms/hooks/useGetValidationStatus';
+import { Instance } from '../../instances/types/instance';
+import { Group, OrgUnit, OrgUnitState } from '../types/orgUnit';
+import { OrgunitType } from '../types/orgunitTypes';
+import { OrgUnitMultiReferenceInstances } from './OrgUnitMultiReferenceInstances';
+import { useGetOrgUnit } from './TreeView/requests';
 
 const useStyles = makeStyles(theme => ({
     speedDialTop: {
@@ -32,17 +33,6 @@ const useStyles = makeStyles(theme => ({
         marginLeft: `${theme.spacing(2)} !important`,
     },
 }));
-
-const getParentOrgUnit = (orgUnit: OrgUnit): Partial<OrgUnit> =>
-    orgUnit?.parent && {
-        id: orgUnit.parent.id,
-        name: orgUnit.parent.name,
-        source: orgUnit.parent.source,
-        source_id: orgUnit.parent.source_id,
-        parent: orgUnit.parent.parent,
-        parent_name: orgUnit.parent.parent_name,
-        validation_status: orgUnit.parent.validation_status,
-    };
 
 type Props = {
     orgUnitState: OrgUnitState;
@@ -93,7 +83,11 @@ export const OrgUnitInfos: FunctionComponent<Props> = ({
         data: validationStatusOptions,
         isLoading: isLoadingValidationStatusOptions,
     } = useGetValidationStatus();
-
+    const { data: parentOrgunit } = useGetOrgUnit(
+        orgUnitState.parent.value
+            ? `${orgUnitState.parent.value.id}`
+            : undefined,
+    );
     return (
         <Grid container spacing={2}>
             <Grid item xs={12} md={4}>
@@ -189,7 +183,7 @@ export const OrgUnitInfos: FunctionComponent<Props> = ({
                             }
                         }}
                         source={orgUnit.source_id}
-                        initialSelection={getParentOrgUnit(orgUnit)}
+                        initialSelection={parentOrgunit}
                         resetTrigger={resetTrigger}
                     />
                 </FormControlComponent>

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/types/orgUnit.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/types/orgUnit.ts
@@ -3,8 +3,8 @@ import { ReactNode } from 'react';
 import { GeoJson } from '../../../components/maps/types';
 import { Nullable } from '../../../types/utils';
 import { Instance } from '../../instances/types/instance';
-import { OrgunitType } from './orgunitTypes';
 import { DataSource } from './dataSources';
+import { OrgunitType } from './orgunitTypes';
 import { Shape } from './shapes';
 
 /* eslint-disable camelcase */
@@ -47,7 +47,7 @@ export type OrgunitInititialState = {
     validation_status?: string;
     aliases: string[];
     source_id?: number;
-    parent?: OrgUnit;
+    parent?: ParentOrgUnit;
     source_ref?: string;
     reference_instance_id?: Nullable<number>;
     opening_date?: Date;


### PR DESCRIPTION
Org Units, Info tab: when changing the parent, the preview doesn't show the whole hierachy

Related JIRA tickets : IA-3023

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
- Tell us where the doc can be found (docs folder, wiki, in the code...)

## Changes

Fetch parent org unit details to get full hierarchy

## How to test

Edit an org unitand change the parent to a lower level org unit, you should see the hierarchy in the input 

## Print screen / video


https://github.com/BLSQ/iaso/assets/12494624/2d1b0b9f-4e4e-476a-843d-1b0bd04026aa


https://github.com/BLSQ/iaso/assets/12494624/2d1b0b9f-4e4e-476a-843d-1b0bd04026aa


https://github.com/BLSQ/iaso/assets/12494624/2d1b0b9f-4e4e-476a-843d-1b0bd04026aa


