### PR TITLE
IA-3155: HOTFIX registry crash

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/registry/components/Instances.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/Instances.tsx
@@ -80,8 +80,8 @@ export const Instances: FunctionComponent<Props> = ({
             const newParams = {
                 ...params,
                 tab: `${newType.id}`,
+                formIds: undefined,
             };
-            delete newParams.formIds;
             redirectToReplace(baseUrls.registry, newParams);
         },
         [params, redirectToReplace],
@@ -96,8 +96,7 @@ export const Instances: FunctionComponent<Props> = ({
     }, [formIds, formsList]);
     useEffect(() => {
         if (
-            formsList &&
-            (formsList?.length ?? 0) >= 0 &&
+            (formsList?.length ?? 0) > 0 &&
             !isFetchingForms &&
             !formIds &&
             orgunitTypeDetail &&
@@ -106,7 +105,8 @@ export const Instances: FunctionComponent<Props> = ({
             const selectedForm =
                 orgunitTypeDetail.reference_forms.length > 0
                     ? `${orgunitTypeDetail.reference_forms[0].id}`
-                    : formsList[0]?.value;
+                    : // @ts-ignore formsList cannot be undefined since we check it in the condition
+                      formsList[0]?.value;
             const newParams = {
                 ...params,
                 formIds: selectedForm,

--- a/hat/assets/js/apps/Iaso/domains/registry/components/map/OrgUnitChildrenMap.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/map/OrgUnitChildrenMap.tsx
@@ -190,7 +190,9 @@ export const OrgUnitChildrenMap: FunctionComponent<Props> = ({
                 isMapFullScreen && classes.fullScreen,
             )}
         >
-            {isFetchingChildren && <LoadingSpinner absolute />}
+            {(isFetchingChildren || isFetchingOrgUnit) && (
+                <LoadingSpinner absolute />
+            )}
             <MapLegend options={legendOptions} setOptions={setLegendOptions} />
             <Box className="map">
                 <MapContainer

--- a/hat/assets/js/apps/Iaso/domains/registry/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/index.tsx
@@ -115,7 +115,7 @@ export const Registry: FunctionComponent = () => {
 
     const handleOrgUnitChange = useCallback(
         (newOrgUnit: OrgUnit) => {
-            if (newOrgUnit) {
+            if (newOrgUnit?.id) {
                 redirectTo(`/${baseUrl}`, {
                     orgUnitId: `${newOrgUnit.id}`,
                 });
@@ -129,12 +129,15 @@ export const Registry: FunctionComponent = () => {
             const newParams = {
                 ...params,
             };
-            if (newChildren) {
+            // Need to check the id because clicking on the marker will somehow still pass
+            // an object with the coordinates
+            if (newChildren?.id) {
                 setSelectedChildrenId(`${newChildren.id}`);
                 newParams.orgUnitChildrenId = `${newChildren.id}`;
             } else {
                 setSelectedChildrenId(undefined);
-                newParams.orgUnitChildrenId = undefined;
+                // newParams.orgUnitChildrenId = undefined;
+                delete newParams.orgUnitChildrenId;
             }
             newParams.submissionId = undefined;
             redirectToReplace(`/${baseUrl}`, newParams);


### PR DESCRIPTION


registry crash when clicking on shapes

Related JIRA tickets : IA-3155

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
- Tell us where the doc can be found (docs folder, wiki, in the code...)

## Changes

- remove infinite loop in useEffect

## How to test


## Print screen / video

before
![Screenshot 2024-06-27 at 16 02 29](https://github.com/BLSQ/iaso/assets/38907762/5df79ef9-94fa-4022-8e45-95b71c0dcd7c)

after

https://github.com/BLSQ/iaso/assets/38907762/18e9df91-398f-40c3-bd70-1f518b4b58e8



## Notes

hotfixable on v1.237g
