### PR TITLE
IA-2891: Registry glitches + IA-3047 support image types + IA-3161 + IA-3048

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/instances/components/InstanceFileContentRich.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/InstanceFileContentRich.js
@@ -269,6 +269,7 @@ function FormChild({ descriptor, data, showQuestionKey, showNote, files }) {
                 />
             ) : null;
         case 'photo':
+        case 'image':
             return (
                 <PhotoField
                     descriptor={descriptor}

--- a/hat/assets/js/apps/Iaso/domains/registry/components/selectedOrgUnit/OrgUnitTitle.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/selectedOrgUnit/OrgUnitTitle.tsx
@@ -1,13 +1,13 @@
 import AddIcon from '@mui/icons-material/Add';
 import { Box, Grid, Typography } from '@mui/material';
-import { makeStyles } from '@mui/styles';
-import { IconButton, commonStyles } from 'bluesquare-components';
+import { IconButton } from 'bluesquare-components';
 import React, { FunctionComponent } from 'react';
 
 import { baseUrls } from '../../../../constants/urls';
 import MESSAGES from '../../messages';
 
 import { DisplayIfUserHasPerm } from '../../../../components/DisplayIfUserHasPerm';
+import { SxStyles } from '../../../../types/general';
 import * as Permissions from '../../../../utils/permissions';
 import { OrgUnit } from '../../../orgUnits/types/orgUnit';
 import { RegistryParams } from '../../types';
@@ -18,45 +18,45 @@ type Props = {
     params: RegistryParams;
 };
 
-const useStyles = makeStyles(theme => ({
-    ...commonStyles(theme),
-    paperTitle: {
-        padding: theme.spacing(2),
+const styles: SxStyles = {
+    titleContainer: {
+        height: '55px',
+        overflow: 'hidden',
         display: 'flex',
+        alignItems: 'center',
+    },
+    title: {
+        fontSize: '20px',
+        lineHeight: '24px',
+        marginLeft: theme => theme.spacing(2),
     },
     paperTitleButtonContainer: {
         position: 'relative',
     },
     paperTitleButton: {
         position: 'absolute',
-        right: -theme.spacing(1),
-        top: -theme.spacing(1),
+        right: theme => theme.spacing(1),
+        top: theme => theme.spacing(1),
     },
-}));
+};
 
 export const OrgUnitTitle: FunctionComponent<Props> = ({ orgUnit, params }) => {
-    const classes: Record<string, string> = useStyles();
-
     const isRootOrgUnit = params.orgUnitId === `${orgUnit?.id}`;
     return (
-        <Grid container className={classes.paperTitle}>
-            <Grid xs={8} item>
-                <Typography
-                    color="primary"
-                    variant="h6"
-                    className={classes.title}
-                >
+        <Grid container spacing={0}>
+            <Grid xs={9} item sx={styles.titleContainer}>
+                <Typography color="primary" variant="h6" sx={styles.title}>
                     {orgUnit.name} ({orgUnit.org_unit_type_name})
                 </Typography>
             </Grid>
             <Grid
-                xs={4}
+                xs={3}
                 item
                 container
                 justifyContent="flex-end"
-                className={classes.paperTitleButtonContainer}
+                sx={styles.paperTitleButtonContainer}
             >
-                <Box className={classes.paperTitleButton}>
+                <Box sx={styles.paperTitleButton}>
                     <DisplayIfUserHasPerm
                         permissions={[Permissions.REGISTRY_WRITE]}
                     >

--- a/hat/assets/js/apps/Iaso/domains/registry/config.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/config.tsx
@@ -111,7 +111,6 @@ export const useGetOrgUnitsListColumns = (
                         setSelectedChildren(settings.row.original as OrgUnit)
                     }
                 >
-                    {selectedChildrenId}-{settings.row.original.id}-
                     {settings.value}
                 </Box>
             ),


### PR DESCRIPTION
- support image types to display
- remove log text on org unit children list in registry
- Cannot scroll to end of submission in regsitry

https://github.com/BLSQ/iaso/assets/12494624/79b69b92-6d9e-441e-9532-0addb498500f

Related JIRA tickets : IA-3047 IA-2891  IA-3161, IA-3148
## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
- Tell us where the doc can be found (docs folder, wiki, in the code...)

## Changes

- adding image type
- remove log text
- fix org unit name height

## How to test

- use this from to test image type field 
[test_form_2024012501.xlsx](https://github.com/user-attachments/files/16015345/test_form_2024012501.xlsx)

- go to registry and open an org unit whit children, open list tab
- give a very long name to an org unit having submission, visit it in the registry


## Print screen / video

![Screenshot 2024-06-27 at 16 05 13](https://github.com/BLSQ/iaso/assets/12494624/cb660ec0-3b97-4511-a9ca-7a10dc325ca5)


https://github.com/BLSQ/iaso/assets/12494624/af078e18-3a23-4046-ac93-fda2d3c0bd52

