### PR TITLE
IA-3173: remove dev flag from payment feature

### DIFF
--- a/hat/assets/js/apps/Iaso/constants/menu.tsx
+++ b/hat/assets/js/apps/Iaso/constants/menu.tsx
@@ -227,21 +227,18 @@ const menuItems = (
         {
             label: formatMessage(MESSAGES.payments),
             key: 'payments',
-            dev: true,
             icon: props => <PaymentsIcon {...props} />,
             subMenu: [
                 {
                     label: formatMessage(MESSAGES.potentialPayments),
                     permissions: paths.potentialPaymentsPath.permissions,
                     key: 'potential',
-                    dev: true,
                     icon: props => <PriceCheckIcon {...props} />,
                 },
                 {
                     label: formatMessage(MESSAGES.lots),
                     permissions: paths.potentialPaymentsPath.permissions,
                     key: 'lots',
-                    dev: true,
                     icon: props => <AccountBalanceIcon {...props} />,
                 },
             ],


### PR DESCRIPTION
Related JIRA tickets : IA-3173, IA-2903

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
NA

## Changes

- remove dev flag from payment feature

## How to test

- In django admin: remove `SHOW_DEV_FEATURES` feature flag from account
- Log in as user with permissions to see payments
- Payments interface should be visible

## Print screen / video

https://github.com/BLSQ/iaso/assets/38907762/d8a5d800-70a7-4e6d-9d1c-8f6a76246850



