### PR TITLE
IA-3150: fix payment download

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/payments/components/PaymentLotActionCell.tsx
+++ b/hat/assets/js/apps/Iaso/domains/payments/components/PaymentLotActionCell.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable camelcase */
 import FileDownloadIcon from '@mui/icons-material/FileDownload';
 import SendIcon from '@mui/icons-material/Send';
-import { IconButton } from 'bluesquare-components';
+import { ExternalLinkIconButton, IconButton } from 'bluesquare-components';
 import React, { ReactElement, useCallback } from 'react';
 import { PaymentLot } from '../types';
 
@@ -44,14 +44,10 @@ export const PaymentLotActionCell = ({
                 iconProps={{ disabled: disableButtons }}
                 paymentLot={paymentLot}
             />
-            <IconButton
+            <ExternalLinkIconButton
                 tooltipMessage={MESSAGES.download_payments}
                 overrideIcon={FileDownloadIcon}
                 url={`/api/payments/lots/${paymentLot.id}/?xlsx=true`}
-                download
-                reloadDocument // Pass this prop to prevent the router to prepend '/dashboar' to the url
-                iconSize="small"
-                disabled={disableButtons}
             />
         </>
     );


### PR DESCRIPTION

download iconbutton was broken

Related JIRA tickets : IA-3150

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
N/A

## Changes

- Use ExternalLinkIconButton i.o IconButton

## How to test

Go to payments mots page
click download icon button

## Print screen / video

https://github.com/BLSQ/iaso/assets/38907762/dd62510b-e758-4313-a3b0-98aed7f58fee


## Notes 

This should go in the release if we merge the PR removing the dev feature flag on payment feature:https://github.com/BLSQ/iaso/pull/1439
