### PR TITLE
fix cypress test

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/links/components/LinksTableWithDownloads.tsx
+++ b/hat/assets/js/apps/Iaso/domains/links/components/LinksTableWithDownloads.tsx
@@ -54,7 +54,7 @@ export const LinksTableWithDownloads: FunctionComponent<Props> = ({
         ? Boolean(data?.links?.length)
         : Boolean(params.searchActive);
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { searchActive, ...dnldParams } = apiParams;
+    const { searchActive, tab, ...dnldParams } = apiParams;
     const csvUrl = `${dwnldBaseUrl}/?${makeQueryString(
         dnldParams,
         tableDefaults,


### PR DESCRIPTION
org unit links tab test kaput



## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc

## Changes

- remove `tab` property from download url params

## How to test

 Go to org unit links with non-enmpty table and hover on download links: there should be no `tab` query param

## Print screen / video

![Screenshot 2024-07-02 at 15 05 01](https://github.com/BLSQ/iaso/assets/38907762/bc8652ba-a863-4efb-a46f-d0f304b6d8c1)



