### PR TITLE
IA-3193, IA-3195: Fix filters in Links and Algos

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/algorithmRuns/hooks/api/useGetAlgorithmRuns.tsx
+++ b/hat/assets/js/apps/Iaso/domains/algorithmRuns/hooks/api/useGetAlgorithmRuns.tsx
@@ -27,7 +27,7 @@ export const useGetAlgorithmRuns = ({
     const apiParams = useApiParams(tableParams, tableDefaults);
     const queryString = new URLSearchParams(apiParams).toString();
     return useSnackQuery({
-        queryKey: ['algos'],
+        queryKey: ['algos', queryString],
         queryFn: () => getAlgos(queryString),
         options: {
             keepPreviousData: true,

--- a/hat/assets/js/apps/Iaso/domains/links/hooks/filters.ts
+++ b/hat/assets/js/apps/Iaso/domains/links/hooks/filters.ts
@@ -76,7 +76,7 @@ export const useGetProfilesOptions = (): UseQueryResult<
             select: data =>
                 (data?.profiles ?? []).map(user => ({
                     label: user.user_name,
-                    value: user.id,
+                    value: user.user_id,
                 })),
         },
     });

--- a/iaso/api/links.py
+++ b/iaso/api/links.py
@@ -103,9 +103,7 @@ class LinkViewSet(viewsets.ViewSet):
             queryset = queryset.filter(source__version__number=origin_version)
 
         if validator_id:
-            print("validatorId A", validator_id)
-            validator_id=int(validator_id)
-            print("validatorId B", validator_id)
+            validator_id = int(validator_id)
             queryset = queryset.filter(validator=validator_id)
 
         if algorithm_id:

--- a/iaso/api/links.py
+++ b/iaso/api/links.py
@@ -65,7 +65,7 @@ class LinkViewSet(viewsets.ViewSet):
         destination = request.GET.get("destination", None)
         origin_version = request.GET.get("originVersion", None)
         destination_version = request.GET.get("destinationVersion", None)
-        validator = request.GET.get("validator", None)
+        validator_id = request.GET.get("validatorId", None)
         algorithm_id = request.GET.get("algorithmId", None)
         algorithm_run_id = request.GET.get("algorithmRunId", None)
         run_id = request.GET.get("run", None)
@@ -102,8 +102,10 @@ class LinkViewSet(viewsets.ViewSet):
         if origin_version:
             queryset = queryset.filter(source__version__number=origin_version)
 
-        if validator:
-            validator_id = validator.get("id")
+        if validator_id:
+            print("validatorId A", validator_id)
+            validator_id=int(validator_id)
+            print("validatorId B", validator_id)
             queryset = queryset.filter(validator=validator_id)
 
         if algorithm_id:


### PR DESCRIPTION
Links: validator id filter did nothing
Algos: table never refreshed

Related JIRA tickets : IA-3193, IA-3195

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc


## Changes

- Links: 
    - updated `LinkViewSet` to handle the `vaidatorId`param: changed param name and convert value to int.
    - updated `useGetProfilesOptions` to use user id i.o profile id

## How to test

- Go to Org unit > details > links and test the filters
- Go to links and test the filters
- Go to Algorithm runs: test the filters
- Go to algorithm runs: crreate anew algorithm -> the table data should update after POST request is successful

## Print screen / video

https://github.com/BLSQ/iaso/assets/38907762/c1bb2a4b-7a47-4f1e-a1a5-cc99c9bd63f3


https://github.com/BLSQ/iaso/assets/38907762/8f6e45c2-cc53-4129-bb1b-caceaabb8b06



## Notes

Can be hotfixed on v1.238
