### PR TITLE
IA-3208: Day and time columns show only time

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/app/components/SidebarMenuComponent.js
+++ b/hat/assets/js/apps/Iaso/domains/app/components/SidebarMenuComponent.js
@@ -209,7 +209,6 @@ const SidebarMenu = ({ classes, location }) => {
 SidebarMenu.propTypes = {
     classes: PropTypes.object.isRequired,
     location: PropTypes.object.isRequired,
-    activeLocale: PropTypes.object.isRequired,
 };
 
 export default withStyles(styles)(SidebarMenu);

--- a/hat/assets/js/apps/Iaso/domains/app/contexts/LocaleContext.tsx
+++ b/hat/assets/js/apps/Iaso/domains/app/contexts/LocaleContext.tsx
@@ -2,7 +2,6 @@ import { LangOptions } from 'bluesquare-components';
 import moment from 'moment';
 import React, {
     createContext,
-    useCallback,
     useContext,
     useEffect,
     useMemo,
@@ -18,25 +17,23 @@ const LocaleContext = createContext({
     },
 });
 
+const updateMomentLocale = (newLocale: LangOptions) => {
+    moment.locale(newLocale);
+    moment.updateLocale(newLocale, {
+        longDateFormat: longDateFormats[newLocale],
+        week: {
+            dow: 1,
+        },
+    });
+};
 export const useLocale = () => useContext(LocaleContext);
 const defaultLanguage = 'en';
 export const LocaleProvider = ({ children }) => {
     const [locale, setLocale] = useState<LangOptions>(defaultLanguage);
 
-    const updateLocale = useCallback((newLocale: LangOptions) => {
-        moment.locale(newLocale);
-        moment.updateLocale(newLocale, {
-            longDateFormat: longDateFormats[newLocale],
-            week: {
-                dow: 1,
-            },
-        });
-        setLocale(newLocale);
-    }, []);
-
     useEffect(() => {
-        updateLocale(defaultLanguage);
-    }, [locale, updateLocale]);
+        updateMomentLocale(defaultLanguage);
+    }, []);
 
     const value: {
         locale: LangOptions;
@@ -45,9 +42,12 @@ export const LocaleProvider = ({ children }) => {
     } = useMemo(
         () => ({
             locale,
-            setLocale: updateLocale,
+            setLocale: (newLocale: LangOptions) => {
+                updateMomentLocale(newLocale);
+                setLocale(newLocale);
+            },
         }),
-        [locale, updateLocale],
+        [locale],
     );
 
     return (

--- a/hat/assets/js/apps/Iaso/domains/app/contexts/LocaleContext.tsx
+++ b/hat/assets/js/apps/Iaso/domains/app/contexts/LocaleContext.tsx
@@ -1,6 +1,13 @@
 import { LangOptions } from 'bluesquare-components';
 import moment from 'moment';
-import React, { createContext, useContext, useMemo, useState } from 'react';
+import React, {
+    createContext,
+    useCallback,
+    useContext,
+    useEffect,
+    useMemo,
+    useState,
+} from 'react';
 import { longDateFormats } from '../../../utils/dates';
 
 const LocaleContext = createContext({
@@ -12,11 +19,24 @@ const LocaleContext = createContext({
 });
 
 export const useLocale = () => useContext(LocaleContext);
-
+const defaultLanguage = 'en';
 export const LocaleProvider = ({ children }) => {
-    const [locale, setLocale] = useState<LangOptions>(
-        moment.locale() as LangOptions,
-    );
+    const [locale, setLocale] = useState<LangOptions>(defaultLanguage);
+
+    const updateLocale = useCallback((newLocale: LangOptions) => {
+        moment.locale(newLocale);
+        moment.updateLocale(newLocale, {
+            longDateFormat: longDateFormats[newLocale],
+            week: {
+                dow: 1,
+            },
+        });
+        setLocale(newLocale);
+    }, []);
+
+    useEffect(() => {
+        updateLocale(defaultLanguage);
+    }, [locale, updateLocale]);
 
     const value: {
         locale: LangOptions;
@@ -25,18 +45,9 @@ export const LocaleProvider = ({ children }) => {
     } = useMemo(
         () => ({
             locale,
-            setLocale: (newLocale: LangOptions) => {
-                moment.locale(newLocale);
-                moment.updateLocale(newLocale, {
-                    longDateFormat: longDateFormats[newLocale],
-                    week: {
-                        dow: 1,
-                    },
-                });
-                setLocale(newLocale as LangOptions);
-            },
+            setLocale: updateLocale,
         }),
-        [locale],
+        [locale, updateLocale],
     );
 
     return (

--- a/hat/assets/js/apps/Iaso/domains/users/hooks/useGetCurrentUser.ts
+++ b/hat/assets/js/apps/Iaso/domains/users/hooks/useGetCurrentUser.ts
@@ -10,7 +10,7 @@ export const useGetCurrentUser = (
     showError = true,
 ): UseQueryResult<Profile, Error> => {
     const queryKey: any[] = ['currentUser'];
-    const { setLocale } = useLocale();
+    const { setLocale, locale } = useLocale();
     return useSnackQuery({
         queryKey,
         queryFn: () => getRequest('/api/profiles/me/'),
@@ -20,9 +20,9 @@ export const useGetCurrentUser = (
                 console.warn('User not connected');
             },
             onSuccess: result => {
-                setLocale(
-                    result.language ? (result.language as LangOptions) : 'en',
-                );
+                if (result.language && result.language !== locale) {
+                    setLocale(result.language as LangOptions);
+                }
             },
             retry: false,
             enabled,

--- a/hat/assets/js/apps/Iaso/domains/users/hooks/useGetCurrentUser.ts
+++ b/hat/assets/js/apps/Iaso/domains/users/hooks/useGetCurrentUser.ts
@@ -10,7 +10,7 @@ export const useGetCurrentUser = (
     showError = true,
 ): UseQueryResult<Profile, Error> => {
     const queryKey: any[] = ['currentUser'];
-    const { setLocale, locale } = useLocale();
+    const { setLocale } = useLocale();
     return useSnackQuery({
         queryKey,
         queryFn: () => getRequest('/api/profiles/me/'),
@@ -20,9 +20,7 @@ export const useGetCurrentUser = (
                 console.warn('User not connected');
             },
             onSuccess: result => {
-                if (result.language && result.language !== locale) {
-                    setLocale(result.language as LangOptions);
-                }
+                setLocale(result.language as LangOptions);
             },
             retry: false,
             enabled,

--- a/hat/assets/js/apps/Iaso/domains/users/hooks/useGetCurrentUser.ts
+++ b/hat/assets/js/apps/Iaso/domains/users/hooks/useGetCurrentUser.ts
@@ -20,7 +20,9 @@ export const useGetCurrentUser = (
                 console.warn('User not connected');
             },
             onSuccess: result => {
-                setLocale(result.language as LangOptions);
+                setLocale(
+                    result.language ? (result.language as LangOptions) : 'en',
+                );
             },
             retry: false,
             enabled,


### PR DESCRIPTION
![image](https://github.com/BLSQ/iaso/assets/12494624/779d4f7c-1683-41c2-b8aa-41da9c64291c)

Related JIRA tickets : IA-3208
## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
-

## Changes

- Long date format should be set anyway, we were not changing the locale and then long date format if user has same lang ad default one
- removing proptype warning

## How to test

- make sure you user is using 'en'
- load forms page, dates should be correct
- open the console and check that the warning disappears 


