### PR TITLE
IA-3199: Registry: inconsistent permission behaviour in form details

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/registry/components/selectedOrgUnit/InstanceTitle.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/selectedOrgUnit/InstanceTitle.tsx
@@ -108,7 +108,10 @@ export const InstanceTitle: FunctionComponent<Props> = ({
             </Grid>
             {currentInstance && (
                 <DisplayIfUserHasPerm
-                    permissions={[Permissions.REGISTRY_WRITE]}
+                    permissions={[
+                        Permissions.SUBMISSIONS_UPDATE,
+                        Permissions.SUBMISSIONS,
+                    ]}
                 >
                     <Grid
                         xs={4}
@@ -131,13 +134,20 @@ export const InstanceTitle: FunctionComponent<Props> = ({
                                     tooltipMessage={MESSAGES.editOnEnketo}
                                 />
                             </DisplayIfUserHasPerm>
-                            <LinkToInstance
-                                instanceId={`${currentInstance.id}`}
-                                useIcon
-                                color="secondary"
-                                iconSize="small"
-                                size="small"
-                            />
+                            <DisplayIfUserHasPerm
+                                permissions={[
+                                    Permissions.SUBMISSIONS_UPDATE,
+                                    Permissions.SUBMISSIONS,
+                                ]}
+                            >
+                                <LinkToInstance
+                                    instanceId={`${currentInstance.id}`}
+                                    useIcon
+                                    color="secondary"
+                                    iconSize="small"
+                                    size="small"
+                                />
+                            </DisplayIfUserHasPerm>
                         </Box>
                     </Grid>
                 </DisplayIfUserHasPerm>


### PR DESCRIPTION
**Repro**

create a user with read permission for registry and write permission for submissions

log in as this user and go to registry 

Select an org unit with at least one submission

**Expected**

In the form details (right half of the screen): there is an enketo iconbutton to edit the submission

**Actual:**

There isn’t

Note: this is only for the form details. The button appears correctly in the table (lower part of the screen)

Related JIRA tickets : IA-3199

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
-
## Changes

display edit button if submission write permission
display link to instance if write or read permission

## How to test

If user has submission read or submission write , you should see instance icon
if user has only write permission, you should see enketo icon 

## Print screen / video

**ONLY READ:**
![Screenshot 2024-07-04 at 12 05 35](https://github.com/BLSQ/iaso/assets/12494624/1f6c77a3-3273-4dcf-af5c-9d35e6685ad9)
**WRITE:**

![Screenshot 2024-07-04 at 12 06 01](https://github.com/BLSQ/iaso/assets/12494624/fafee6bf-e682-4254-97d6-e009f14c270b)
