### PR TITLE
IA-2864: Add IASO logo to password reset screen

### DIFF
--- a/hat/templates/iaso/forgot_password.html
+++ b/hat/templates/iaso/forgot_password.html
@@ -1,7 +1,11 @@
 {% extends 'iaso/base_auth.html' %}
 {% load i18n %}
+{% load static %}
 {% block body %}
   <div class="auth__container">
+    <header class="auth__header">
+      <h1 class="auth__heading"> <img alt="logo" src="{% static logo_path %}" /></h1>
+    </header>
     <div class="auth__content">
       <form method="post" class="auth__form">
         {% csrf_token %}

--- a/hat/templates/iaso/forgot_password_confirmation.html
+++ b/hat/templates/iaso/forgot_password_confirmation.html
@@ -3,6 +3,9 @@
 {% load static %}
 {% block body %}
   <div class="auth__container">
+    <header class="auth__header">
+      <h1 class="auth__heading"> <img alt="logo" src="{% static logo_path %}" /></h1>
+    </header>
     <div class="auth__content">
       <div class="auth__message">
         <p>{% trans "We've emailed you instructions for setting your password, if an account exists with the email you entered. You should receive them shortly." %}</p>

--- a/hat/templates/iaso/reset_password_complete.html
+++ b/hat/templates/iaso/reset_password_complete.html
@@ -1,7 +1,11 @@
 {% extends 'iaso/base_auth.html' %}
 {% load i18n %}
+{% load static %}
 {% block body %}
 <div class="auth__container">
+  <header class="auth__header">
+    <h1 class="auth__heading"> <img alt="logo" src="{% static logo_path %}" /></h1>
+  </header>
   <div class="auth__content">
     <div class="auth__message">
       <p>

--- a/hat/templates/iaso/reset_password_confirmation.html
+++ b/hat/templates/iaso/reset_password_confirmation.html
@@ -1,9 +1,14 @@
 {% extends 'iaso/base_auth.html' %}
 {% load i18n %}
+{% load static %}
 {% block body %}
   <div class="auth__container">
+      <header class="auth__header">
+        <h1 class="auth__heading"> <img alt="logo" src="{% static logo_path %}" /></h1>
+      </header>
       {% if form %}
         <div class="auth__content">
+          
           <form method="post" class="auth__form">
             {% csrf_token %}
             {{ form }}


### PR DESCRIPTION
Explain what problem this PR is resolving

Related JIRA tickets : [IA-2864](https://bluesquare.atlassian.net/browse/IA-2864)

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes
- Added IASO logo on : forgot_password, forgot_password_confirmation, reset_password_complete and reset_password_confirmation pages

## How to test
- Create a new user a send an email to him for resenting its password
- Check if the IASO logo is there 

## Print screen / video
![Screenshot from 2024-07-08 16-46-22](https://github.com/BLSQ/iaso/assets/19631540/e46542fd-ed18-4abf-808e-d14a3260af84)


[IA-2864]: https://bluesquare.atlassian.net/browse/IA-2864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ