### PR TITLE
HOTFIX: LQAS adapt status key to new API

### DIFF
--- a/iaso/gpkg/import_gpkg.py
+++ b/iaso/gpkg/import_gpkg.py
@@ -116,7 +116,7 @@ def create_or_update_orgunit(
         geom = convert_to_geography(geometry["type"], geometry["coordinates"])
         if isinstance(geom, Point):
             orgunit.location = geom
-        else:
+        elif geom is not None:
             orgunit.geom = geom
             orgunit.simplified_geom = simplify_geom(geom)
 

--- a/plugins/polio/js/src/constants/messages.ts
+++ b/plugins/polio/js/src/constants/messages.ts
@@ -818,6 +818,10 @@ const MESSAGES = defineMessages({
         id: 'iaso.polio.label.verypoor',
         defaultMessage: 'Very poor',
     },
+    '3lqasverypoor': {
+        id: 'iaso.polio.label.verypoor',
+        defaultMessage: 'Very poor',
+    },
     '3lqasmoderate': {
         id: 'iaso.polio.label.moderate',
         defaultMessage: 'Moderate',

--- a/plugins/polio/js/src/domains/LQAS-IM/LQAS/CountryOverview/LqasCountryListOverview.tsx
+++ b/plugins/polio/js/src/domains/LQAS-IM/LQAS/CountryOverview/LqasCountryListOverview.tsx
@@ -19,8 +19,19 @@ import {
 } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import MapIcon from '@mui/icons-material/Map';
-import {OK_COLOR, FAIL_COLOR, MODERATE_COLOR, POOR_COLOR} from '../../../../styles/constants';
-import {LQAS_PASS, LQAS_FAIL, LQAS_MODERATE, LQAS_POOR} from '../constants';
+import {
+    OK_COLOR,
+    FAIL_COLOR,
+    MODERATE_COLOR,
+    POOR_COLOR,
+} from '../../../../styles/constants';
+import {
+    LQAS_PASS,
+    LQAS_FAIL,
+    LQAS_MODERATE,
+    LQAS_POOR,
+    LQAS_VERY_POOR,
+} from '../constants';
 import { useStyles } from '../../../../styles/theme';
 import MESSAGES from '../../../../constants/messages';
 import { TablePlaceHolder } from '../../../Campaigns/Scope/Scopes/TablePlaceHolder';
@@ -60,6 +71,7 @@ const useTableStyle = makeStyles(theme => {
         },
         [LQAS_PASS]: { color: OK_COLOR },
         [LQAS_FAIL]: { color: FAIL_COLOR },
+        [LQAS_VERY_POOR]: { color: FAIL_COLOR },
         [LQAS_MODERATE]: { color: MODERATE_COLOR },
         [LQAS_POOR]: { color: POOR_COLOR },
     };
@@ -253,9 +265,8 @@ export const LqasCountryListOverview: FunctionComponent<Props> = ({
                                             <TableCell>
                                                 <Typography
                                                     className={
-                                                        shape.status &&
-                                                        shape.status !==
-                                                            IN_SCOPE
+                                                        shape?.status !==
+                                                        IN_SCOPE
                                                             ? tableClasses[
                                                                   shape.status
                                                               ]
@@ -263,11 +274,10 @@ export const LqasCountryListOverview: FunctionComponent<Props> = ({
                                                     }
                                                     variant="body2"
                                                 >
-                                                    {(shape?.data?.status &&
+                                                    {(shape?.status &&
                                                         formatMessage(
                                                             MESSAGES[
-                                                                shape?.data
-                                                                    ?.status
+                                                                shape?.status
                                                             ],
                                                         )) ||
                                                         formatMessage(


### PR DESCRIPTION
- UI can now handle status 3lqasverypoor

Explain what problem this PR is resolving

Related JIRA tickets : POLIOPM-178, POLIO-1586

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc


## Changes

- Add missing translation key
- Add corresponding CSS class
- Simplify the way status is accessed

## How to test

- Get datastore data for lqas DRC and copy it in local DB
- Check campaign DRC-NID-03-2024-B_nOPV
- Go to list view for round 1
- Districts with "very poor" should appear with the right color scheme and translation (eg: BOMONGO)

## Print screen / video
![Screenshot 2024-07-09 at 11 24 28](https://github.com/BLSQ/iaso/assets/38907762/f27c587d-0f96-4720-9d99-3f0eb543296f)


## Notes

HOTFIX on v1.238
