### PR TITLE
IA-3210: Org unit tree children version / source

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/TreeView/OrgUnitTreeviewModal.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/TreeView/OrgUnitTreeviewModal.tsx
@@ -159,6 +159,12 @@ const OrgUnitTreeviewModal: FunctionComponent<Props> = ({
         return getRootData(value, key, statusSettings);
     }, [source, version, statusSettings]);
 
+    const getChildrenWithSource = useCallback(
+        async id => {
+            return getChildrenData(id, statusSettings, version, source);
+        },
+        [source, version, statusSettings],
+    );
     const searchOrgUnitsWithSource = useCallback(
         async (value, count) => {
             return searchOrgUnits({
@@ -281,9 +287,7 @@ const OrgUnitTreeviewModal: FunctionComponent<Props> = ({
                 {isFetchingOrgUnit && <LoadingSpinner absolute />}
                 <Box mt={1}>
                     <TreeViewWithSearch
-                        getChildrenData={id =>
-                            getChildrenData(id, statusSettings)
-                        }
+                        getChildrenData={getChildrenWithSource}
                         getRootData={getRootDataWithSource}
                         // eslint-disable-next-line react/no-unstable-nested-components
                         label={(orgUnit: OrgUnit) => (

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/TreeView/requests.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/TreeView/requests.ts
@@ -16,13 +16,19 @@ const baseApiUrl = '/api/orgunits/tree/';
 export const getChildrenData = async (
     id: string,
     statusSettings: OrgUnitStatus[],
+    version?: string | number,
+    source?: string | number,
 ): Promise<OrgUnit[]> => {
     try {
-        const response = await getRequest(
-            `${baseApiUrl}?parent_id=${id}&ignoreEmptyNames=true${getValidationStatus(
-                statusSettings,
-            )}`,
-        );
+        let url = `${baseApiUrl}?parent_id=${id}&ignoreEmptyNames=true${getValidationStatus(
+            statusSettings,
+        )}`;
+        if (version) {
+            url = `${url}&version=${version}`;
+        } else if (source) {
+            url = `${url}&data_source_id=${source}`;
+        }
+        const response = await getRequest(url);
         return response.map((orgUnit: any) => ({
             ...orgUnit,
             id: orgUnit.id.toString(),


### PR DESCRIPTION
Call to have children of selected org unit is not using selected version or source leading to inconsistent  data

Related JIRA tickets : IA-3210

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
--

## Changes

Adapt same behaviour as getRootData and add version or source to api call to get cchildren

## How to test

Open org units search, open network panel, open the tree view, drill down in the tree, all the calls should conaint a version or a source

## Print screen / video

![Screenshot 2024-07-10 at 12 29 11](https://github.com/BLSQ/iaso/assets/12494624/1f97496e-5739-47f3-bece-56ff5400a6be)

