### PR TITLE
IA-3221: Make check on instance_locks length more robust

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/instances/components/InstanceDetailsLocksHistory.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/InstanceDetailsLocksHistory.tsx
@@ -37,6 +37,7 @@ const InstanceDetailsLocksHistory: FunctionComponent<{
         },
         MESSAGES.lockSuccess,
     );
+    const hasLocks = (currentInstance?.instance_locks?.length ?? 0) > 0;
     // @ts-ignore
     return (
         <WidgetPaper
@@ -45,7 +46,7 @@ const InstanceDetailsLocksHistory: FunctionComponent<{
             title={formatMessage(MESSAGES.instanceLocks)}
         >
             {isLoading && <LoadingSpinner fixed={false} />}
-            {currentInstance.instance_locks.length === 0 && (
+            {!hasLocks && (
                 <Grid xs={5} container item>
                     <Typography
                         variant="body2"
@@ -56,7 +57,7 @@ const InstanceDetailsLocksHistory: FunctionComponent<{
                     </Typography>
                 </Grid>
             )}
-            {currentInstance.instance_locks.length > 0 && (
+            {hasLocks && (
                 <Table>
                     <TableHead>
                         <TableRow>
@@ -85,18 +86,16 @@ const InstanceDetailsLocksHistory: FunctionComponent<{
                                 </TableCell>
                                 <TableCell>
                                     {instanceLock.unlocked_by ? (
-                                        <>
-                                            <span
-                                                title={formatMessage(
-                                                    MESSAGES.lockOpened,
-                                                )}
-                                            >
-                                                <LockOpenIcon />
-                                                {getDisplayName(
-                                                    instanceLock.unlocked_by,
-                                                )}
-                                            </span>
-                                        </>
+                                        <span
+                                            title={formatMessage(
+                                                MESSAGES.lockOpened,
+                                            )}
+                                        >
+                                            <LockOpenIcon />
+                                            {getDisplayName(
+                                                instanceLock.unlocked_by,
+                                            )}
+                                        </span>
                                     ) : (
                                         <ConfirmCancelDialogComponent
                                             titleMessage={

--- a/hat/assets/js/cypress/integration/11 - submissions/details.spec.js
+++ b/hat/assets/js/cypress/integration/11 - submissions/details.spec.js
@@ -24,9 +24,14 @@ describe('Instance details', () => {
         cy.intercept('GET', '/api/profiles/me/**', superUser);
         cy.intercept(
             'GET',
-            '/api/logs/?objectId=1007&order=-created_at&contentType=iaso.form',
+            '/api/logs/?objectId=1007&order=-created_at&contentType=iaso.instance',
             submissionLogs,
         ).as('getLogs');
+        cy.intercept(
+            'GET',
+            '/api/forms/?fields=org_unit_type_ids,period_type',
+            { org_unit_type_ids: [], period_type: 'YEAR' },
+        );
     });
     testPermission(baseUrl);
     describe.skip('Top Bar', () => {
@@ -44,6 +49,8 @@ describe('Instance details', () => {
     describe('Component layout', () => {
         it('positions grid components correctly', async () => {
             cy.visit(baseUrl);
+            cy.wait('@getSubmission');
+            cy.wait('@getLogs');
             cy.getAndAssert('#infos', 'infos');
             cy.getAndAssert('#location', 'location');
             cy.getAndAssert('#export-requests', 'export-requests');


### PR DESCRIPTION
test for submission detaisl was passing but had in fact runtime errors
Related JIRA tickets : IA-3221

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc


## Changes
 - Add `hasLocks` variable in `InstanceDetailsLocksHistory` and add null checks when setting it

## How to test
Run cypress test for submission details. It should pass with no error

## Print screen / video

Before
![Screenshot 2024-07-12 at 11 41 57](https://github.com/user-attachments/assets/0f4ff17b-69f0-4486-905d-4c88527f5e9b)

After
![Screenshot 2024-07-12 at 11 55 37](https://github.com/user-attachments/assets/cfbcd710-587b-430b-a60a-8f79a6e03249)

## Notes

Things that the reviewers should know: known bugs that are out of the scope of the PR, other trade-offs that were made.
If the PR depends on a PR in bluesquare-components, or merges into another PR (i.o. main), it should also be mentioned here
