### PR TITLE
IA-3222: Org unit pop up bug

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitPopupComponent.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitPopupComponent.js
@@ -24,7 +24,7 @@ import {
 import PopupItemComponent from '../../../components/maps/popups/PopupItemComponent';
 import ConfirmDialog from '../../../components/dialogs/ConfirmDialogComponent';
 import { baseUrls } from '../../../constants/urls.ts';
-import MESSAGES from '../messages';
+import MESSAGES from '../messages.ts';
 
 const useStyles = makeStyles(theme => ({
     ...commonStyles(theme),
@@ -71,9 +71,7 @@ const OrgUnitPopupComponent = ({
     );
     const activeOrgUnit = currentOrgUnit || reduxCurrentOrgUnit;
     const confirmDialog = () => {
-        // eslint-disable-next-line react-hooks/rules-of-hooks
         replaceLocation(activeOrgUnit);
-        popup.current.leafletElement.options.leaflet.map.closePopup();
     };
     let groups = null;
     if (activeOrgUnit && activeOrgUnit.groups.length > 0) {


### PR DESCRIPTION

![Screenshot from 2024-07-12 11-24-31](https://github.com/user-attachments/assets/42c7ce85-ddca-4d9f-9ec6-4a20a7ee2cd6)

Related JIRA tickets : IA-3222

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc


## Changes

 - Remove `closepopup` code that was causing the error

## How to test

  Go to org unit details > map
  click on shape
  click on "Use this location"
  page should not crash


## Notes

The error would prevent the pop up to close, so removing the faulty call, just removes the error.
