### PR TITLE
IA-2357 - Added status field to API Instance retrieve

### DIFF
--- a/iaso/api/instances.py
+++ b/iaso/api/instances.py
@@ -444,14 +444,19 @@ class InstancesViewSet(viewsets.ViewSet):
         return Response({"res": "ok"})
 
     def retrieve(self, request, pk=None):
-        self.get_queryset().prefetch_related(
-            "instance_locks",
-            "instance_locks__top_org_unit",
-            "instance_locks__user",
-            "org_unit__reference_instances",
-            "org_unit__org_unit_type__reference_forms",
+        queryset = (
+            self.get_queryset()
+            .prefetch_related(
+                "instancelock_set",
+                "instancelock_set__top_org_unit",
+                "instancelock_set__locked_by",
+                "instancelock_set__unlocked_by",
+                "org_unit__reference_instances",
+                "org_unit__org_unit_type__reference_forms",
+            )
+            .with_status()
         )
-        instance: Instance = get_object_or_404(self.get_queryset(), pk=pk)
+        instance: Instance = get_object_or_404(queryset, pk=pk)
         self.check_object_permissions(request, instance)
         all_instance_locks = instance.instancelock_set.all()
 

--- a/iaso/test.py
+++ b/iaso/test.py
@@ -56,7 +56,9 @@ class IasoTestCaseMixin:
         return user
 
     @staticmethod
-    def create_form_instance(*, form: m.Form = None, period: str = None, org_unit: m.OrgUnit = None, **kwargs):
+    def create_form_instance(
+        *, project: m.Project, form: m.Form = None, period: str = None, org_unit: m.OrgUnit = None, **kwargs
+    ):
         instance_file_mock = mock.MagicMock(spec=File)
         instance_file_mock.name = "test.xml"
 
@@ -72,6 +74,7 @@ class IasoTestCaseMixin:
             period=period,
             org_unit=org_unit,
             file=instance_file_mock,
+            project=project,
             **kwargs,
         )
 

--- a/iaso/tests/api/test_completeness_stats.py
+++ b/iaso/tests/api/test_completeness_stats.py
@@ -137,11 +137,11 @@ class CompletenessStatsAPITestCase(APITestCase):
         cls.form_hs_4.org_unit_types.add(cls.org_unit_type_aire_sante)
         cls.form_hs_4.org_unit_types.add(cls.org_unit_type_country)
         cls.hopital_aaa_ou = OrgUnit.objects.filter(org_unit_type=cls.org_unit_type_hopital).first()
-        cls.instance_1 = cls.create_form_instance(form=cls.form_hs_1, org_unit=cls.hopital_aaa_ou)
+        cls.instance_1 = cls.create_form_instance(form=cls.form_hs_1, org_unit=cls.hopital_aaa_ou, project=None)
 
         cls.as_abb_ou = OrgUnit.objects.get(pk=10)
-        cls.instance_2 = cls.create_form_instance(form=cls.form_hs_4, org_unit=cls.as_abb_ou)
-        cls.instance_3 = cls.create_form_instance(form=cls.form_hs_4, org_unit=cls.as_abb_ou)
+        cls.instance_2 = cls.create_form_instance(form=cls.form_hs_4, org_unit=cls.as_abb_ou, project=None)
+        cls.instance_3 = cls.create_form_instance(form=cls.form_hs_4, org_unit=cls.as_abb_ou, project=None)
 
         cls.user_1 = User.objects.create(username="test 1")
         Profile.objects.create(user=cls.user_1, account=cls.account)
@@ -776,7 +776,7 @@ class CompletenessStatsAPITestCase(APITestCase):
         """Make sure that non-valid ous are not counted in the counters for OU+children. See IA-1788"""
         self.client.force_authenticate(self.user)
         # first check it's counted when it's valid
-        self.create_form_instance(form=self.form_hs_4, org_unit=self.as_abb_ou)
+        self.create_form_instance(form=self.form_hs_4, org_unit=self.as_abb_ou, project=None)
         self.as_abb_ou.validation_status = OrgUnit.VALIDATION_NEW
         self.as_abb_ou.save()
         response = self.client.get(

--- a/iaso/tests/api/test_enketo.py
+++ b/iaso/tests/api/test_enketo.py
@@ -372,8 +372,12 @@ class EnketoAPITestCase(APITestCase):
         self.setUpMockEnketo()
         self.form_1.single_per_period = True
         self.form_1.save()
-        self.create_form_instance(form=self.form_1, period="202001", org_unit=self.jedi_council_corruscant)
-        self.create_form_instance(form=self.form_1, period="202001", org_unit=self.jedi_council_corruscant)
+        self.create_form_instance(
+            form=self.form_1, period="202001", org_unit=self.jedi_council_corruscant, project=None
+        )
+        self.create_form_instance(
+            form=self.form_1, period="202001", org_unit=self.jedi_council_corruscant, project=None
+        )
 
         data = {
             "period": "202001",
@@ -405,7 +409,9 @@ class EnketoAPITestCase(APITestCase):
         self.setUpMockEnketo()
         self.form_1.single_per_period = True
         self.form_1.save()
-        instance = self.create_form_instance(form=self.form_1, period="20220201", org_unit=self.jedi_council_corruscant)
+        instance = self.create_form_instance(
+            form=self.form_1, period="20220201", org_unit=self.jedi_council_corruscant, project=None
+        )
         instance.file = UploadedFile(open("iaso/tests/fixtures/hydroponics_test_upload.xml"))
         instance.save()
 
@@ -434,7 +440,9 @@ class EnketoAPITestCase(APITestCase):
         self.setUpMockEnketo()
         self.form_1.single_per_period = False
         self.form_1.save()
-        instance = self.create_form_instance(form=self.form_1, period="20220201", org_unit=self.jedi_council_corruscant)
+        instance = self.create_form_instance(
+            form=self.form_1, period="20220201", org_unit=self.jedi_council_corruscant, project=None
+        )
         instance.file = UploadedFile(open("iaso/tests/fixtures/hydroponics_test_upload.xml"))
         instance.save()
         old_count = Instance.objects.count()
@@ -464,10 +472,14 @@ class EnketoAPITestCase(APITestCase):
         self.setUpMockEnketo()
         self.form_1.single_per_period = False
         self.form_1.save()
-        instance = self.create_form_instance(form=self.form_1, period="20220201", org_unit=self.jedi_council_corruscant)
+        instance = self.create_form_instance(
+            form=self.form_1, period="20220201", org_unit=self.jedi_council_corruscant, project=None
+        )
         instance.file = UploadedFile(open("iaso/tests/fixtures/hydroponics_test_upload.xml"))
         instance.save()
-        instance = self.create_form_instance(form=self.form_1, period="20220201", org_unit=self.jedi_council_corruscant)
+        instance = self.create_form_instance(
+            form=self.form_1, period="20220201", org_unit=self.jedi_council_corruscant, project=None
+        )
         instance.file = UploadedFile(open("iaso/tests/fixtures/hydroponics_test_upload.xml"))
         instance.save()
         old_count = Instance.objects.count()

--- a/iaso/tests/api/test_entity_types.py
+++ b/iaso/tests/api/test_entity_types.py
@@ -91,19 +91,21 @@ class EntityTypeAPITestCase(APITestCase):
         form_2_file_mock.name = "test.xml"
         cls.form_2.form_versions.create(file=form_2_file_mock, version_id="2020022401")
         cls.form_2.org_unit_types.add(cls.jedi_council)
-        cls.create_form_instance(form=cls.form_2, period="202001", org_unit=cls.jedi_council_corruscant)
+        cls.create_form_instance(form=cls.form_2, period="202001", org_unit=cls.jedi_council_corruscant, project=None)
         cls.form_2.save()
 
         # Instance saved without period
         cls.form_3.form_versions.create(file=form_2_file_mock, version_id="2020022401")
         cls.form_3.org_unit_types.add(cls.jedi_council)
-        cls.create_form_instance(form=cls.form_3, org_unit=cls.jedi_council_corruscant)
+        cls.create_form_instance(form=cls.form_3, org_unit=cls.jedi_council_corruscant, project=None)
         cls.form_3.save()
 
         # A deleted Instance
         cls.form_4.form_versions.create(file=form_2_file_mock, version_id="2020022402")
         cls.form_4.org_unit_types.add(cls.jedi_council)
-        cls.create_form_instance(form=cls.form_4, period="2020Q1", org_unit=cls.jedi_council_corruscant, deleted=True)
+        cls.create_form_instance(
+            form=cls.form_4, period="2020Q1", org_unit=cls.jedi_council_corruscant, deleted=True, project=None
+        )
         cls.form_4.save()
 
         cls.project.unit_types.add(cls.jedi_council)

--- a/iaso/tests/api/test_instances.py
+++ b/iaso/tests/api/test_instances.py
@@ -362,6 +362,7 @@ class InstancesAPITestCase(APITestCase):
             org_unit=self.jedi_council_corruscant,
             uuid=instance_uuid,
             deleted=True,
+            project=None,
         )
         pre_existing_instance_count = m.Instance.objects.count()
         body = [
@@ -401,6 +402,7 @@ class InstancesAPITestCase(APITestCase):
             period="202002",
             org_unit=self.jedi_council_corruscant,
             uuid=instance_uuid,
+            project=None,
         )
         pre_existing_instance_count = m.Instance.objects.count()
         body = [
@@ -446,7 +448,7 @@ class InstancesAPITestCase(APITestCase):
         """POST /api/instances/ with one pre-existing instance (created by the /sync view, with a filename only)"""
 
         instance_filename = "RDC Collecte Data DPS_2_2019-08-08_11-54-46.xml"
-        pre_existing_instance = self.create_form_instance(file_name=instance_filename)
+        pre_existing_instance = self.create_form_instance(file_name=instance_filename, project=None)
         pre_existing_instance_count = m.Instance.objects.count()
         body = [
             {

--- a/iaso/tests/api/test_token.py
+++ b/iaso/tests/api/test_token.py
@@ -72,7 +72,7 @@ class TokenAPITestCase(APITestCase):
         form_2_file_mock.name = "test.xml"
         cls.form_2.form_versions.create(file=form_2_file_mock, version_id="2020022401")
         cls.form_2.org_unit_types.add(cls.jedi_council)
-        cls.create_form_instance(form=cls.form_2, period="202001", org_unit=cls.jedi_council_corruscant)
+        cls.create_form_instance(form=cls.form_2, period="202001", org_unit=cls.jedi_council_corruscant, project=None)
         cls.form_2.save()
 
         cls.project.unit_types.add(cls.jedi_council)

--- a/iaso/tests/models/test_instance.py
+++ b/iaso/tests/models/test_instance.py
@@ -6,16 +6,16 @@ from django.core.exceptions import ValidationError
 from hat.audit.models import Modification, INSTANCE_API
 from iaso import models as m
 from iaso.odk import parsing
-from iaso.test import TestCase
+from iaso.test import TestCase, APITestCase, IasoTestCaseMixin
 
 
-class InstanceModelTestCase(TestCase):
+class InstanceBase(IasoTestCaseMixin):
     @classmethod
-    def setUpTestData(cls):
+    def prepare_setup_data(cls):
         cls.maxDiff = None
-        star_wars = m.Account.objects.create(name="Star Wars")
 
-        cls.yoda = cls.create_user_with_profile(username="yoda", account=star_wars)
+        cls.star_wars = m.Account.objects.create(name="Star Wars")
+        cls.yoda = cls.create_user_with_profile(username="yoda", account=cls.star_wars, permissions=["iaso_forms"])
 
         cls.sector = m.OrgUnitType.objects.create(name="Sector", short_name="Sec")
         cls.system = m.OrgUnitType.objects.create(name="System", short_name="Sys")
@@ -30,12 +30,14 @@ class InstanceModelTestCase(TestCase):
         )
 
         cls.project = m.Project.objects.create(
-            name="Hydroponic gardens", app_id="stars.empire.agriculture.hydroponics", account=star_wars
+            name="Hydroponic gardens", app_id="stars.empire.agriculture.hydroponics", account=cls.star_wars
         )
 
         cls.form_1 = m.Form.objects.create(name="Hydroponics study", period_type="MONTH", single_per_period=True)
         cls.form_1.org_unit_types.add(cls.jedi_council)
         cls.form_1.org_unit_types.add(cls.jedi_academy)
+        cls.form_1.save()
+
         cls.form_2 = m.Form.objects.create(
             name="Hydroponic public survey",
             form_id="sample2",
@@ -54,45 +56,81 @@ class InstanceModelTestCase(TestCase):
         cls.project.forms.add(cls.form_2)
         cls.project.save()
 
-    def test_instance_status(self):
-        instance_1 = self.create_form_instance(form=self.form_1, period="202001", org_unit=self.jedi_council_coruscant)
-        instance_2 = self.create_form_instance(form=self.form_1, period="202002", org_unit=self.jedi_council_coruscant)
-        instance_3 = self.create_form_instance(form=self.form_1, period="202002", org_unit=self.jedi_council_coruscant)
-        instance_4 = self.create_form_instance(
-            form=self.form_1, period="202003", org_unit=self.jedi_council_coruscant, last_export_success_at=now()
+    @classmethod
+    def set_up_instances_for_status_testing(cls):
+        cls.instance_1 = cls.create_form_instance(
+            form=cls.form_1, period="202001", org_unit=cls.jedi_council_coruscant, project=cls.project
         )
-        instance_5 = self.create_form_instance(form=self.form_2, period="2020Q1", org_unit=self.jedi_council_coruscant)
-        instance_6 = self.create_form_instance(form=self.form_2, period="2020Q1", org_unit=self.jedi_academy_coruscant)
+        cls.instance_2 = cls.create_form_instance(
+            form=cls.form_1, period="202002", org_unit=cls.jedi_council_coruscant, project=cls.project
+        )
+        cls.instance_3 = cls.create_form_instance(
+            form=cls.form_1, period="202002", org_unit=cls.jedi_council_coruscant, project=cls.project
+        )
+        cls.instance_4 = cls.create_form_instance(
+            form=cls.form_1,
+            period="202003",
+            org_unit=cls.jedi_council_coruscant,
+            last_export_success_at=now(),
+            project=cls.project,
+        )
+        cls.instance_5 = cls.create_form_instance(
+            form=cls.form_2, period="2020Q1", org_unit=cls.jedi_council_coruscant, project=cls.project
+        )
+        cls.instance_6 = cls.create_form_instance(
+            form=cls.form_2, period="2020Q1", org_unit=cls.jedi_academy_coruscant, project=cls.project
+        )
+
+
+class InstanceModelTestCase(TestCase, InstanceBase):
+    @classmethod
+    def setUpTestData(cls):
+        InstanceBase.prepare_setup_data()
+
+    def test_instance_status(self):
+        self.set_up_instances_for_status_testing()
 
         self.assertNumQueries(1, lambda: list(m.Instance.objects.with_status()))
-        self.assertStatusIs(instance_1, m.Instance.STATUS_READY)
-        self.assertStatusIs(instance_2, m.Instance.STATUS_DUPLICATED)
-        self.assertStatusIs(instance_3, m.Instance.STATUS_DUPLICATED)
-        self.assertStatusIs(instance_4, m.Instance.STATUS_EXPORTED)
-        self.assertStatusIs(instance_5, m.Instance.STATUS_READY)
-        self.assertStatusIs(instance_6, m.Instance.STATUS_READY)
+        self.assertStatusIs(self.instance_1, m.Instance.STATUS_READY)
+        self.assertStatusIs(self.instance_2, m.Instance.STATUS_DUPLICATED)
+        self.assertStatusIs(self.instance_3, m.Instance.STATUS_DUPLICATED)
+        self.assertStatusIs(self.instance_4, m.Instance.STATUS_EXPORTED)
+        self.assertStatusIs(self.instance_5, m.Instance.STATUS_READY)
+        self.assertStatusIs(self.instance_6, m.Instance.STATUS_READY)
 
     def test_instance_status_duplicated_over_exported(self):
         instance_1 = self.create_form_instance(
-            form=self.form_1, period="202002", org_unit=self.jedi_council_coruscant, last_export_success_at=now()
+            form=self.form_1,
+            period="202002",
+            org_unit=self.jedi_council_coruscant,
+            last_export_success_at=now(),
+            project=None,
         )
         instance_2 = self.create_form_instance(
-            form=self.form_1, period="202002", org_unit=self.jedi_council_coruscant, last_export_success_at=now()
+            form=self.form_1,
+            period="202002",
+            org_unit=self.jedi_council_coruscant,
+            last_export_success_at=now(),
+            project=None,
         )
 
         self.assertStatusIs(instance_1, m.Instance.STATUS_DUPLICATED)
         self.assertStatusIs(instance_2, m.Instance.STATUS_DUPLICATED)
 
     def test_instance_status_counts(self):
-        self.create_form_instance(form=self.form_1, period="201901", org_unit=self.jedi_council_coruscant)
-        self.create_form_instance(form=self.form_1, period="201901", org_unit=self.jedi_council_coruscant)
-        self.create_form_instance(form=self.form_1, period="201902", org_unit=self.jedi_council_coruscant)
-        self.create_form_instance(form=self.form_1, period="201903", org_unit=self.jedi_council_coruscant)
+        self.create_form_instance(form=self.form_1, period="201901", org_unit=self.jedi_council_coruscant, project=None)
+        self.create_form_instance(form=self.form_1, period="201901", org_unit=self.jedi_council_coruscant, project=None)
+        self.create_form_instance(form=self.form_1, period="201902", org_unit=self.jedi_council_coruscant, project=None)
+        self.create_form_instance(form=self.form_1, period="201903", org_unit=self.jedi_council_coruscant, project=None)
 
-        self.create_form_instance(form=self.form_1, period="201901", org_unit=self.jedi_academy_coruscant)
-        self.create_form_instance(form=self.form_1, period="201902", org_unit=self.jedi_academy_coruscant)
+        self.create_form_instance(form=self.form_1, period="201901", org_unit=self.jedi_academy_coruscant, project=None)
+        self.create_form_instance(form=self.form_1, period="201902", org_unit=self.jedi_academy_coruscant, project=None)
         self.create_form_instance(
-            form=self.form_1, period="201903", org_unit=self.jedi_academy_coruscant, last_export_success_at=now()
+            form=self.form_1,
+            period="201903",
+            org_unit=self.jedi_academy_coruscant,
+            last_export_success_at=now(),
+            project=None,
         )
 
         counts = sorted(m.Instance.objects.with_status().counts_by_status(), key=lambda x: x["period"])
@@ -401,20 +439,20 @@ class InstanceModelTestCase(TestCase):
         ) = self.create_simple_hierarchy()
 
         for _ in range(7):
-            self.create_form_instance(org_unit=alderaan)
+            self.create_form_instance(org_unit=alderaan, project=None)
 
         for _ in range(2):
-            self.create_form_instance(org_unit=sluis)
+            self.create_form_instance(org_unit=sluis, project=None)
 
         for _ in range(3):
-            self.create_form_instance(org_unit=dagobah)
+            self.create_form_instance(org_unit=dagobah, project=None)
 
         for _ in range(4):
-            self.create_form_instance(org_unit=first_council)
-            self.create_form_instance(org_unit=second_council)
+            self.create_form_instance(org_unit=first_council, project=None)
+            self.create_form_instance(org_unit=second_council, project=None)
 
         for _ in range(5):
-            self.create_form_instance(org_unit=first_academy)
+            self.create_form_instance(org_unit=first_academy, project=None)
 
         self.assertEqual(7, m.Instance.objects.for_org_unit_hierarchy(alderaan).count())
         self.assertEqual(18, m.Instance.objects.for_org_unit_hierarchy(sluis).count())
@@ -433,7 +471,7 @@ class InstanceModelTestCase(TestCase):
         )
 
         # membership sanity checks with a single instance
-        instance = self.create_form_instance(org_unit=dagobah)
+        instance = self.create_form_instance(org_unit=dagobah, project=None)
         self.assertIn(instance, m.Instance.objects.for_org_unit_hierarchy(sluis))
         self.assertIn(instance, m.Instance.objects.for_org_unit_hierarchy(dagobah))
         self.assertNotIn(instance, m.Instance.objects.for_org_unit_hierarchy(first_council))
@@ -468,7 +506,9 @@ class InstanceModelTestCase(TestCase):
         return (alderaan, sluis, dagobah, first_council, second_council, first_academy, second_academy)
 
     def test_org_unit_soft_delete_no_one(self):
-        instance = self.create_form_instance(form=self.form_1, period="202001", org_unit=self.jedi_council_coruscant)
+        instance = self.create_form_instance(
+            form=self.form_1, period="202001", org_unit=self.jedi_council_coruscant, project=None
+        )
 
         self.assertFalse(instance.deleted)
         self.assertEqual(0, Modification.objects.count())
@@ -486,7 +526,9 @@ class InstanceModelTestCase(TestCase):
         self.assertTrue(modification.new_value[0]["fields"]["deleted"])
 
     def test_org_unit_soft_delete_someone(self):
-        instance = self.create_form_instance(form=self.form_1, period="202002", org_unit=self.jedi_council_coruscant)
+        instance = self.create_form_instance(
+            form=self.form_1, period="202002", org_unit=self.jedi_council_coruscant, project=None
+        )
 
         self.assertFalse(instance.deleted)
         self.assertEqual(0, Modification.objects.count())
@@ -497,6 +539,45 @@ class InstanceModelTestCase(TestCase):
         self.assertEqual(1, Modification.objects.count())
         modification = Modification.objects.first()
         self.assertEqual(self.yoda, modification.user)
+
+
+class InstanceAPITestCase(APITestCase, InstanceBase):
+    @classmethod
+    def setUpTestData(cls):
+        InstanceBase.prepare_setup_data()
+
+    def test_retrieve_status(self):
+        # Prepare data like in other test
+        self.set_up_instances_for_status_testing()
+
+        # Authenticate & query API endpoint
+        self.client.force_authenticate(self.yoda)
+        response_1 = self.client.get(f"/api/instances/{self.instance_1.id}/", format="json")
+        json_1 = self.assertJSONResponse(response_1, 200)
+        response_2 = self.client.get(f"/api/instances/{self.instance_2.id}/", format="json")
+        json_2 = self.assertJSONResponse(response_2, 200)
+        response_3 = self.client.get(f"/api/instances/{self.instance_3.id}/", format="json")
+        json_3 = self.assertJSONResponse(response_3, 200)
+        response_4 = self.client.get(f"/api/instances/{self.instance_4.id}/", format="json")
+        json_4 = self.assertJSONResponse(response_4, 200)
+        response_5 = self.client.get(f"/api/instances/{self.instance_5.id}/", format="json")
+        json_5 = self.assertJSONResponse(response_5, 200)
+        response_6 = self.client.get(f"/api/instances/{self.instance_6.id}/", format="json")
+        json_6 = self.assertJSONResponse(response_6, 200)
+
+        # Check results
+        self.assertStatusesAreEqual(self.instance_1, json_1["status"], m.Instance.STATUS_READY)
+        self.assertStatusesAreEqual(self.instance_2, json_2["status"], m.Instance.STATUS_DUPLICATED)
+        self.assertStatusesAreEqual(self.instance_3, json_3["status"], m.Instance.STATUS_DUPLICATED)
+        self.assertStatusesAreEqual(self.instance_4, json_4["status"], m.Instance.STATUS_EXPORTED)
+        self.assertStatusesAreEqual(self.instance_5, json_5["status"], m.Instance.STATUS_READY)
+        self.assertStatusesAreEqual(self.instance_6, json_6["status"], m.Instance.STATUS_READY)
+
+    def assertStatusesAreEqual(self, instance: m.Instance, api_status: str, expected_status: str):
+        instance_with_status = m.Instance.objects.with_status().get(pk=instance.pk)
+        self.assertEqual(instance_with_status.status, api_status)
+        self.assertEqual(instance_with_status.status, expected_status)
+        self.assertEqual(api_status, expected_status)
 
 
 class ReferenceInstanceTestCase(TestCase):


### PR DESCRIPTION
Added the calculated "status" field to the API Instance retrieve endpoint.

Related JIRA tickets : IA-2357

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
/

## Changes
- Added the `status` field that was missing when a single `Instance` is fetched.
- Updated the test helper `IasoTestCaseMixin.create_form_instance()` to force users to specify a project (even if `None`), otherwise test instances will not appear through the API since they are not linked to a `Project`.


## How to test
- Go the list of instances
- Select an instance and remember its `status` in the list
- Go the instance details and check if its `status` is the same

## Print screen / video

![image](https://github.com/user-attachments/assets/5a883325-1001-48cc-81d4-481e46163d48)


## Notes
/
