### PR TITLE
IA-2533: Add a link to home page next to the logout icon on top right corner

### DIFF
--- a/hat/assets/js/apps/Iaso/components/nav/HomePageButton.tsx
+++ b/hat/assets/js/apps/Iaso/components/nav/HomePageButton.tsx
@@ -1,0 +1,37 @@
+import React, { FunctionComponent } from 'react';
+import { IconButton as MuiIconButton, Tooltip } from '@mui/material';
+import { makeStyles } from '@mui/styles';
+import HomeIcon from '@mui/icons-material/Home';
+import { useSafeIntl } from 'bluesquare-components';
+
+import MESSAGES from './messages';
+import { baseUrls } from '../../constants/urls';
+
+const useStyles = makeStyles(theme => ({
+    homePageButton: {
+        padding: theme.spacing(0),
+    },
+}));
+
+type Props = {
+    color?: 'inherit' | 'primary' | 'secondary';
+};
+
+export const HomePageButton: FunctionComponent<Props> = ({
+    color = 'inherit',
+}) => {
+    const classes = useStyles();
+    const { formatMessage } = useSafeIntl();
+    return (
+        <Tooltip arrow title={formatMessage(MESSAGES.homePage)}>
+            <MuiIconButton
+                className={classes.homePageButton}
+                color={color}
+                href={`/dashboard/${baseUrls.home}`}
+                id="top-bar-home-page-button"
+            >
+                <HomeIcon />
+            </MuiIconButton>
+        </Tooltip>
+    );
+};

--- a/hat/assets/js/apps/Iaso/components/nav/TopBarComponent.js
+++ b/hat/assets/js/apps/Iaso/components/nav/TopBarComponent.js
@@ -16,6 +16,7 @@ import { useCurrentUser } from '../../utils/usersUtils.ts';
 import { useSidebar } from '../../domains/app/contexts/SideBarContext.tsx';
 import { CurrentUserInfos } from './CurrentUser/index.tsx';
 import { LogoutButton } from './LogoutButton.tsx';
+import { HomePageButton } from './HomePageButton.tsx';
 
 const styles = theme => ({
     menuButton: {
@@ -121,8 +122,10 @@ function TopBar(props) {
                                     version={window.IASO_VERSION}
                                 />
                             </Box>
-
                             <Box display="flex" justifyContent="center" pl={2}>
+                                <HomePageButton />
+                            </Box>
+                            <Box display="flex" justifyContent="center" pl={1}>
                                 <LogoutButton />
                             </Box>
                         </Grid>

--- a/hat/assets/js/apps/Iaso/components/nav/messages.ts
+++ b/hat/assets/js/apps/Iaso/components/nav/messages.ts
@@ -29,6 +29,10 @@ const MESSAGES = defineMessages({
         defaultMessage: 'Logout',
         id: 'iaso.logout',
     },
+    homePage: {
+        defaultMessage: 'Home page',
+        id: 'iaso.users.label.homePage',
+    },
     see: {
         defaultMessage: 'See',
         id: 'iaso.label.see',


### PR DESCRIPTION
Explain what problem this PR is resolving
- Add a link to home page next to the logout icon on top right corner
Related JIRA tickets : [IA-2533](https://bluesquare.atlassian.net/browse/IA-2533)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
- Tell us where the doc can be found (docs folder, wiki, in the code...)

## Changes
- A home icon has been added and a link to home page added

## How to test
- Check on the top right if the home icon is there and redirect to home page

## Print screen / video
[Screencast from 2024-07-17 16-02-09.webm](https://github.com/user-attachments/assets/707a7531-b5b7-479d-98d6-3fcd316313a7)


[IA-2533]: https://bluesquare.atlassian.net/browse/IA-2533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ