### PR TITLE
POLIO-1626 Chronogram tasks: sort by default with the order "Before/During/After"

### DIFF
--- a/plugins/polio/api/chronogram/views.py
+++ b/plugins/polio/api/chronogram/views.py
@@ -71,7 +71,10 @@ class ChronogramViewSet(viewsets.ModelViewSet):
         """
         Returns all available rounds that can be used to create a new `Chronogram`.
         """
-        user_campaigns = Campaign.polio_objects.filter_for_user(self.request.user).filter(country__isnull=False)
+        user_campaigns = Campaign.polio_objects.filter_for_user(self.request.user).filter(
+            country__isnull=False,
+            is_test=False,
+        )
         already_linked_rounds = (
             Chronogram.objects.valid().filter(round__campaign__in=user_campaigns).values_list("round_id", flat=True)
         )

--- a/plugins/polio/js/src/domains/Chronogram/ChronogramDetails/Table/ChronogramDetailsTable.tsx
+++ b/plugins/polio/js/src/domains/Chronogram/ChronogramDetails/Table/ChronogramDetailsTable.tsx
@@ -21,13 +21,14 @@ export const ChronogramDetailsTable: FunctionComponent<Props> = ({
     const apiParams: ChronogramTasksParams = {
         ...params,
         limit: params.pageSize || '20',
-        order: params.order || 'id',
+        order: params.order || 'start_offset_in_days',
         page: params.page || '1',
     };
     const { data, isFetching } = useGetChronogramTasks(apiParams);
     const columns = useChronogramDetailsTableColumn(chronogramTaskMetaData);
     return (
         <TableWithDeepLink
+            defaultSorted={[{ id: 'start_offset_in_days', desc: false }]}
             baseUrl={baseUrls.chronogramDetails}
             data={data?.results ?? []}
             pages={data?.pages ?? 1}

--- a/plugins/polio/js/src/domains/Chronogram/ChronogramDetails/Table/useChronogramDetailsTableColumn.tsx
+++ b/plugins/polio/js/src/domains/Chronogram/ChronogramDetails/Table/useChronogramDetailsTableColumn.tsx
@@ -17,6 +17,7 @@ export const useChronogramDetailsTableColumn = (
     chronogramTaskMetaData: ChronogramTaskMetaData,
 ): Column[] => {
     const { formatMessage } = useSafeIntl();
+    // @ts-ignore
     return useMemo(() => {
         return [
             {
@@ -59,7 +60,8 @@ export const useChronogramDetailsTableColumn = (
             {
                 Header: formatMessage(MESSAGES.labelUserInCharge),
                 id: 'user_in_charge',
-                accessor: 'user_in_charge.full_name',
+                accessor: row =>
+                    row.user_in_charge.full_name || row.user_in_charge.username,
                 sortable: false,
             },
             {

--- a/plugins/polio/js/src/domains/Chronogram/ChronogramDetails/hooks/validation.ts
+++ b/plugins/polio/js/src/domains/Chronogram/ChronogramDetails/hooks/validation.ts
@@ -23,7 +23,7 @@ export const useChronogramTaskSchema = () => {
             .string()
             .trim()
             .required(formatMessage(MESSAGES.validationFieldRequired)),
-        user_in_charge: yup.number(),
+        user_in_charge: yup.number().nullable(),
         comment: yup.string().trim(),
     });
 };

--- a/plugins/polio/tests/api/test_chronogram_views.py
+++ b/plugins/polio/tests/api/test_chronogram_views.py
@@ -361,3 +361,15 @@ class ChronogramViewSetTestCase(APITestCase):
             ],
         }
         self.assertEqual(response_data, expected_data)
+
+        # Ensure test campaigns doesn't appear in the list.
+        self.campaign.is_test = True
+        self.campaign.save()
+        response = self.client.get("/api/polio/chronograms/available_rounds_for_create/")
+        response_data = self.assertJSONResponse(response, 200)
+        expected_data = {
+            "countries": [],
+            "campaigns": [],
+            "rounds": [],
+        }
+        self.assertEqual(response_data, expected_data)


### PR DESCRIPTION
Chronogram task page: sort by default with the order "Before/During/After".

Related JIRA tickets : [POLIO-1626](https://bluesquare.atlassian.net/browse/POLIO-1626)

## Print screen / video

![order](https://github.com/user-attachments/assets/af37dbea-55e3-4c87-8856-0775d24fc473)


[POLIO-1626]: https://bluesquare.atlassian.net/browse/POLIO-1626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ