### PR TITLE
POLIO-1632 Chronogram: test campaigns should not appear in the list of campaigns

### DIFF
--- a/plugins/polio/api/chronogram/views.py
+++ b/plugins/polio/api/chronogram/views.py
@@ -71,7 +71,10 @@ class ChronogramViewSet(viewsets.ModelViewSet):
         """
         Returns all available rounds that can be used to create a new `Chronogram`.
         """
-        user_campaigns = Campaign.polio_objects.filter_for_user(self.request.user).filter(country__isnull=False)
+        user_campaigns = Campaign.polio_objects.filter_for_user(self.request.user).filter(
+            country__isnull=False,
+            is_test=False,
+        )
         already_linked_rounds = (
             Chronogram.objects.valid().filter(round__campaign__in=user_campaigns).values_list("round_id", flat=True)
         )

--- a/plugins/polio/js/src/domains/Chronogram/ChronogramDetails/Table/useChronogramDetailsTableColumn.tsx
+++ b/plugins/polio/js/src/domains/Chronogram/ChronogramDetails/Table/useChronogramDetailsTableColumn.tsx
@@ -17,6 +17,7 @@ export const useChronogramDetailsTableColumn = (
     chronogramTaskMetaData: ChronogramTaskMetaData,
 ): Column[] => {
     const { formatMessage } = useSafeIntl();
+    // @ts-ignore
     return useMemo(() => {
         return [
             {
@@ -59,7 +60,8 @@ export const useChronogramDetailsTableColumn = (
             {
                 Header: formatMessage(MESSAGES.labelUserInCharge),
                 id: 'user_in_charge',
-                accessor: 'user_in_charge.full_name',
+                accessor: row =>
+                    row.user_in_charge.full_name || row.user_in_charge.username,
                 sortable: false,
             },
             {

--- a/plugins/polio/js/src/domains/Chronogram/ChronogramDetails/hooks/validation.ts
+++ b/plugins/polio/js/src/domains/Chronogram/ChronogramDetails/hooks/validation.ts
@@ -23,7 +23,7 @@ export const useChronogramTaskSchema = () => {
             .string()
             .trim()
             .required(formatMessage(MESSAGES.validationFieldRequired)),
-        user_in_charge: yup.number(),
+        user_in_charge: yup.number().nullable(),
         comment: yup.string().trim(),
     });
 };

--- a/plugins/polio/tests/api/test_chronogram_views.py
+++ b/plugins/polio/tests/api/test_chronogram_views.py
@@ -361,3 +361,15 @@ class ChronogramViewSetTestCase(APITestCase):
             ],
         }
         self.assertEqual(response_data, expected_data)
+
+        # Ensure test campaigns doesn't appear in the list.
+        self.campaign.is_test = True
+        self.campaign.save()
+        response = self.client.get("/api/polio/chronograms/available_rounds_for_create/")
+        response_data = self.assertJSONResponse(response, 200)
+        expected_data = {
+            "countries": [],
+            "campaigns": [],
+            "rounds": [],
+        }
+        self.assertEqual(response_data, expected_data)


### PR DESCRIPTION
POLIO-1632 Chronogram: test campaigns should not appear in the list of campaigns.

Related JIRA tickets : [POLIO-1632](https://bluesquare.atlassian.net/browse/POLIO-1632)

## Print screen

![test](https://github.com/user-attachments/assets/4e482112-5683-4615-825c-dc75972d5710)


[POLIO-1632]: https://bluesquare.atlassian.net/browse/POLIO-1632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ