### PR TITLE
POLIO-1617 Chronogram: fix blank responsible

### DIFF
--- a/plugins/polio/js/src/domains/Chronogram/ChronogramDetails/Table/useChronogramDetailsTableColumn.tsx
+++ b/plugins/polio/js/src/domains/Chronogram/ChronogramDetails/Table/useChronogramDetailsTableColumn.tsx
@@ -17,6 +17,7 @@ export const useChronogramDetailsTableColumn = (
     chronogramTaskMetaData: ChronogramTaskMetaData,
 ): Column[] => {
     const { formatMessage } = useSafeIntl();
+    // @ts-ignore
     return useMemo(() => {
         return [
             {
@@ -59,7 +60,8 @@ export const useChronogramDetailsTableColumn = (
             {
                 Header: formatMessage(MESSAGES.labelUserInCharge),
                 id: 'user_in_charge',
-                accessor: 'user_in_charge.full_name',
+                accessor: row =>
+                    row.user_in_charge.full_name || row.user_in_charge.username,
                 sortable: false,
             },
             {

--- a/plugins/polio/js/src/domains/Chronogram/ChronogramDetails/hooks/validation.ts
+++ b/plugins/polio/js/src/domains/Chronogram/ChronogramDetails/hooks/validation.ts
@@ -23,7 +23,7 @@ export const useChronogramTaskSchema = () => {
             .string()
             .trim()
             .required(formatMessage(MESSAGES.validationFieldRequired)),
-        user_in_charge: yup.number(),
+        user_in_charge: yup.number().nullable(),
         comment: yup.string().trim(),
     });
 };


### PR DESCRIPTION
Chronogram: fix blank responsible.

Related JIRA tickets : [POLIO-1617](https://bluesquare.atlassian.net/browse/POLIO-1617)

## Changes

- fallback to `username` when `full_name` is empty
- make `user_in_charge` nullable (this allows to remove a user from a task)

## Print screen

![responsible](https://github.com/user-attachments/assets/952e6ff4-07a4-4db5-bf74-4894d68d5080)


[POLIO-1617]: https://bluesquare.atlassian.net/browse/POLIO-1617?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ