### PR TITLE
POLIO-1633 POLIO-1634 Vaccine Stock Corrections

### DIFF
--- a/plugins/polio/api/dashboards/supply_chain.py
+++ b/plugins/polio/api/dashboards/supply_chain.py
@@ -50,7 +50,7 @@ class VaccineRequestFormDashboardSerializer(serializers.ModelSerializer):
         # If the value is not in the cache, calculate it
         if cache_key not in self.context["stock_in_hand_cache"]:
             vaccine_stock_calculator = VaccineStockCalculator(vaccine_stock)
-            self.context["stock_in_hand_cache"][cache_key] = vaccine_stock_calculator.get_stock_of_usable_vials()
+            self.context["stock_in_hand_cache"][cache_key] = vaccine_stock_calculator.get_total_of_usable_vials()
 
         return self.context["stock_in_hand_cache"][cache_key]
 

--- a/plugins/polio/api/vaccines/stock_management.py
+++ b/plugins/polio/api/vaccines/stock_management.py
@@ -327,10 +327,10 @@ class VaccineStockSerializer(serializers.ModelSerializer):
         return obj.calculator.get_vials_used()
 
     def get_stock_of_usable_vials(self, obj):
-        return obj.calculator.get_stock_of_usable_vials()
+        return obj.calculator.get_total_of_usable_vials()
 
     def get_stock_of_unusable_vials(self, obj):
-        return obj.calculator.get_stock_of_unusable_vials()
+        return obj.calculator.get_total_of_unusable_vials()
 
     def get_vials_destroyed(self, obj):
         return obj.calculator.get_vials_destroyed()

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/Details/Table/VaccineStockManagementDetailsTable.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/Details/Table/VaccineStockManagementDetailsTable.tsx
@@ -3,7 +3,10 @@ import { UrlParams } from 'bluesquare-components';
 import { baseUrls } from '../../../../../constants/urls';
 import { TableWithDeepLink } from '../../../../../../../../../hat/assets/js/apps/Iaso/components/tables/TableWithDeepLink';
 import { TabValue } from '../../types';
-import { useVaccineStockManagementDetailsColumns } from './useVaccineStockManagementDetailsColumns';
+import {
+    useVaccineStockManagementDetailsColumnsUnusable,
+    useVaccineStockManagementDetailsColumnsUsable,
+} from './useVaccineStockManagementDetailsColumns';
 
 type Props = {
     params: Partial<UrlParams>;
@@ -12,13 +15,35 @@ type Props = {
     isFetching: boolean;
 };
 
-export const VaccineStockManagementDetailsTable: FunctionComponent<Props> = ({
-    params,
-    paramsPrefix,
-    data,
-    isFetching,
-}) => {
-    const columns = useVaccineStockManagementDetailsColumns();
+export const VaccineStockManagementDetailsTableUsable: FunctionComponent<
+    Props
+> = ({ params, paramsPrefix, data, isFetching }) => {
+    const columns = useVaccineStockManagementDetailsColumnsUsable();
+
+    return (
+        <TableWithDeepLink
+            data={data?.results ?? []}
+            count={data?.count}
+            pages={data?.pages}
+            params={params}
+            paramsPrefix={paramsPrefix}
+            columns={columns}
+            baseUrl={baseUrls.stockManagementDetails}
+            marginTop={false}
+            elevation={0}
+            extraProps={{
+                loading: isFetching,
+                params,
+                defaultPageSize: 20,
+            }}
+        />
+    );
+};
+
+export const VaccineStockManagementDetailsTableUnusable: FunctionComponent<
+    Props
+> = ({ params, paramsPrefix, data, isFetching }) => {
+    const columns = useVaccineStockManagementDetailsColumnsUnusable();
 
     return (
         <TableWithDeepLink

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/Details/Table/useVaccineStockManagementDetailsColumns.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/Details/Table/useVaccineStockManagementDetailsColumns.tsx
@@ -5,7 +5,7 @@ import { DateCell } from '../../../../../../../../../hat/assets/js/apps/Iaso/com
 import MESSAGES from '../../messages';
 import { NumberCell } from '../../../../../../../../../hat/assets/js/apps/Iaso/components/Cells/NumberCell';
 
-export const useVaccineStockManagementDetailsColumns = (): Column[] => {
+export const useVaccineStockManagementDetailsColumnsUsable = (): Column[] => {
     const { formatMessage } = useSafeIntl();
     return useMemo(() => {
         const columns = [
@@ -65,6 +65,49 @@ export const useVaccineStockManagementDetailsColumns = (): Column[] => {
                     }
 
                     return <NumberCell value={doses_out} />;
+                },
+            },
+        ];
+        return columns;
+    }, [formatMessage]);
+};
+
+export const useVaccineStockManagementDetailsColumnsUnusable = (): Column[] => {
+    const { formatMessage } = useSafeIntl();
+    return useMemo(() => {
+        const columns = [
+            {
+                Header: formatMessage(MESSAGES.date),
+                accessor: 'date',
+                id: 'date',
+                Cell: DateCell,
+            },
+            {
+                Header: formatMessage(MESSAGES.action),
+                accessor: 'action',
+                id: 'action',
+            },
+            {
+                Header: formatMessage(MESSAGES.vials_in),
+                accessor: 'vials_in',
+                Cell: settings => {
+                    const { vials_in } = settings.row.original;
+                    if (!vials_in) {
+                        return <span>{textPlaceholder}</span>;
+                    }
+                    return <NumberCell value={vials_in} />;
+                },
+            },
+            {
+                Header: formatMessage(MESSAGES.vials_out),
+                accessor: 'vials_out',
+                Cell: settings => {
+                    const { vials_out } = settings.row.original;
+                    if (!vials_out) {
+                        return <span>{textPlaceholder}</span>;
+                    }
+
+                    return <NumberCell value={vials_out} />;
                 },
             },
         ];

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/Details/VaccineStockManagementDetails.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/Details/VaccineStockManagementDetails.tsx
@@ -15,7 +15,10 @@ import { UNUSABLE_VIALS, USABLE_VIALS } from '../constants';
 import { StockManagementDetailsParams, TabValue } from '../types';
 import TopBar from '../../../../../../../../hat/assets/js/apps/Iaso/components/nav/TopBarComponent';
 import MESSAGES from '../messages';
-import { VaccineStockManagementDetailsTable } from './Table/VaccineStockManagementDetailsTable';
+import {
+    VaccineStockManagementDetailsTableUnusable,
+    VaccineStockManagementDetailsTableUsable,
+} from './Table/VaccineStockManagementDetailsTable';
 import {
     useGetStockManagementSummary,
     useGetUnusableVials,
@@ -127,7 +130,7 @@ export const VaccineStockManagementDetails: FunctionComponent = () => {
 
                         {/* Using 2 tables to avoid messing up the Tables internal state, which will create bugs */}
                         {tab === USABLE_VIALS && (
-                            <VaccineStockManagementDetailsTable
+                            <VaccineStockManagementDetailsTableUsable
                                 params={params}
                                 paramsPrefix={tab}
                                 data={usableVials}
@@ -135,7 +138,7 @@ export const VaccineStockManagementDetails: FunctionComponent = () => {
                             />
                         )}
                         {tab === UNUSABLE_VIALS && (
-                            <VaccineStockManagementDetailsTable
+                            <VaccineStockManagementDetailsTableUnusable
                                 params={params}
                                 paramsPrefix={tab}
                                 data={unusableVials}

--- a/plugins/polio/tests/test_supply_chain_dashboards.py
+++ b/plugins/polio/tests/test_supply_chain_dashboards.py
@@ -135,7 +135,7 @@ class SupplyChainDashboardsAPITestCase(APITestCase):
             action="destroyed",
         )
 
-        with self.assertNumQueries(12):
+        with self.assertNumQueries(13):
             response = self.client.get(self.vrf_url)
 
         jr = self.assertJSONResponse(response, 200)

--- a/plugins/polio/tests/test_vaccine_stock_management.py
+++ b/plugins/polio/tests/test_vaccine_stock_management.py
@@ -138,9 +138,9 @@ class VaccineStockManagementAPITestCase(APITestCase):
         self.assertEqual(stock["country_name"], "Testland")
         self.assertEqual(stock["vaccine_type"], pm.VACCINES[0][0])
         self.assertEqual(stock["vials_received"], 20)  # 400 doses / 20 doses per vial
-        self.assertEqual(stock["vials_used"], 10)
-        self.assertEqual(stock["stock_of_usable_vials"], 10)  # 20 received - 10 used
-        self.assertEqual(stock["stock_of_unusable_vials"], 1)  # 1 incident
+        self.assertEqual(stock["vials_used"], 13)
+        self.assertEqual(stock["stock_of_usable_vials"], 7)  # 20 received - 13 used
+        self.assertEqual(stock["stock_of_unusable_vials"], 8)
         self.assertEqual(stock["vials_destroyed"], 3)  # 3 destroyed
 
     def test_usable_vials_endpoint(self):


### PR DESCRIPTION
POLIO-1633 : Stocks: Remove 'dose' columns from unusable tab 
POLIO-1634 : Correct numbers on the Stock management page

Related JIRA tickets : POLIO-1633 POLIO-1634

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are there enough tests

## Changes

Small corrections to remove a column from frontend and Usage of the calculator after last refactoring for the list page ( it was already used in the summary of the detail page)

## How to test

Visit the Vaccine Stock Management page and check that "Doses" columns are removed from unusable tab on details page.
Also in the list view make sure the numbers are correct

## Print screen / video

<img width="1138" alt="Screenshot 2024-07-19 at 13 50 55" src="https://github.com/user-attachments/assets/9b1fdd81-094f-47f6-a63f-0e20ccaf50de">
<img width="1136" alt="Screenshot 2024-07-19 at 13 50 47" src="https://github.com/user-attachments/assets/560febfd-674d-4dbd-8aff-efcd4cea512f">
