### PR TITLE
IA-3253 Fix: Entity.MultipleObjectsReturned on /api/entities/{pk}/

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/entities/entityTypes/config.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/entityTypes/config.tsx
@@ -63,6 +63,7 @@ export const useColumns = ({
                 accessor: 'actions',
                 resizable: false,
                 sortable: false,
+                width: 200,
                 Cell: (settings): ReactElement => {
                     const type = settings.row.original as EntityType;
                     return (

--- a/iaso/api/entity.py
+++ b/iaso/api/entity.py
@@ -56,7 +56,7 @@ class EntitySerializer(serializers.ModelSerializer):
 
     def get_attributes(self, entity: Entity):
         if entity.attributes:
-            return entity.attributes.as_full_model()
+            return entity.attributes.as_dict()
         return None
 
     def get_org_unit(self, entity: Entity):
@@ -213,6 +213,11 @@ class EntityViewSet(ModelViewSet):
         entities = Entity.objects.filter(account=request.user.iaso_profile.account)
         serializer = EntitySerializer(entities, many=True)
         return Response(serializer.data)
+
+    def retrieve(self, request, pk=None):
+        queryset = Entity.objects.filter_for_user(self.request.user).distinct()
+        entity = get_object_or_404(queryset, pk=pk)
+        return Response(EntitySerializer(entity, many=False).data)
 
     def list(self, request: Request, *args, **kwargs):
         queryset = self.filter_queryset(self.get_queryset())


### PR DESCRIPTION
[IA-3253](https://bluesquare.atlassian.net/browse/IA-3253)

Fix: Entity.MultipleObjectsReturned on /api/entities/{pk}/

When a user has geo-restrictions, the `filter_for_user()` will add an
`INNER JOIN ` to the query, resulting in duplicates returned.

Adding the retrieve action explicitly and adding a `distinct` to the query fixes the issue.

Also: no need to add the full instance model in the serializer, it adds a lot of queries and weight to the call and it's not used in the
dashboard. By simply changing to `as_dict()`, the payload is only 1/5th of what it was before.

[IA-3253]: https://bluesquare.atlassian.net/browse/IA-3253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ