### PR TITLE
IA-3251 Fix: Remove DataSource version description...

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/hooks/useGetVersionLabel.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/hooks/useGetVersionLabel.tsx
@@ -6,9 +6,7 @@ import MESSAGES from '../messages';
 import { DataSource } from '../types/dataSources';
 
 export const getVersionLabel = (version: Version, defaultMessage: string) => {
-    return `${version.number}${
-        version.description ? ` - ${version.description}` : ''
-    }${version.is_default ? ` (${defaultMessage})` : ''}`;
+    return `${version.number}${version.is_default ? ` (${defaultMessage})` : ''}`;
 };
 
 export const useGetVersionLabel = (


### PR DESCRIPTION
from label on org unit treeview.

The description is for internal use, only display the version.

See screenshots https://bluesquare.atlassian.net/browse/IA-3251