### PR TITLE
WC2-456:Discrepancies between Tableau dashboard data and ETL data

### DIFF
--- a/plugins/wfp/admin.py
+++ b/plugins/wfp/admin.py
@@ -32,17 +32,25 @@ class JourneyAdmin(admin.ModelAdmin):
         "exit_type",
         "instance_id",
     )
-    list_filter = ("admission_criteria", "admission_type", "nutrition_programme", "programme_type", "exit_type")
+    list_filter = (
+        "admission_criteria",
+        "admission_type",
+        "nutrition_programme",
+        "programme_type",
+        "start_date",
+        "end_date",
+        "exit_type",
+    )
 
 
 @admin.register(Visit)
 class VisitAdmin(admin.ModelAdmin):
     list_display = ("id", "date", "number", "org_unit", "journey")
     raw_id_fields = ("org_unit", "journey")
-    list_filter = ("date",)
+    list_filter = ("date", "number", "journey__programme_type")
 
 
 @admin.register(Step)
 class StepAdmin(admin.ModelAdmin):
     list_display = ("id", "assistance_type", "visit")
-    list_filter = ("assistance_type",)
+    list_filter = ("assistance_type", "visit__journey__programme_type")

--- a/plugins/wfp/common.py
+++ b/plugins/wfp/common.py
@@ -21,7 +21,7 @@ class ETL:
         updated_at = datetime.date(2023, 7, 10)
         beneficiaries = (
             Instance.objects.filter(entity__entity_type__name=self.type)
-            # .filter(entity__id__in=[1, 42, 46, 49, 58, 77, 90, 111, 322, 323, 330])
+            # .filter(entity__id__in=[1, 42, 46, 49, 58, 77, 90, 111, 322, 323, 330, 196, 226])
             .filter(json__isnull=False)
             .filter(form__isnull=False)
             .filter(updated_at__gte=updated_at)
@@ -194,6 +194,8 @@ class ETL:
         elif admission_type == "referred_from_tsfp":
             return "referred_from_tsfp_mam"
         elif admission_type == "referred_from_sc_itp":
+            return "referred_from_sc"
+        elif admission_type == "returned_from_sc":
             return "referred_from_sc"
         else:
             return admission_type

--- a/plugins/wfp/management/commands/wfp_etl_Under5.py
+++ b/plugins/wfp/management/commands/wfp_etl_Under5.py
@@ -78,10 +78,9 @@ class Under5:
 
                     if form_id == "Anthropometric visit child":
                         initial_weight = current_weight
-
                         instances[i]["initial_weight"] = initial_weight
-                        visit_date = visit.get("visit_date", current_date)
-                        initial_date = visit.get("_visit_date", visit_date)
+                        visit_date = visit.get("_visit_date", visit.get("visit_date", current_date))
+                        initial_date = visit_date
 
                     if initial_date is not None:
                         duration = (current_date - initial_date).days
@@ -95,13 +94,13 @@ class Under5:
                     current_record["weight_difference"] = weight["weight_difference"]
                     current_record["duration"] = duration
 
-                    if visit.get("created_at"):
-                        current_record["date"] = visit.get("created_at").strftime("%Y-%m-%d")
+                    visit_date = visit.get("_visit_date", visit.get("visit_date", current_date))
+                    if visit_date:
+                        current_record["date"] = visit_date.strftime("%Y-%m-%d")
 
                     current_record["instance_id"] = visit["id"]
                     current_record["form_id"] = form_id
                     instances[i]["visits"].append(current_record)
-
             i = i + 1
         return list(
             filter(

--- a/plugins/wfp/management/commands/wfp_etl_pbwg.py
+++ b/plugins/wfp/management/commands/wfp_etl_pbwg.py
@@ -79,7 +79,6 @@ class PBWG:
 
         for visit in visits:
             if visit:
-
                 if visit.get("duration", None) is not None and visit.get("duration", None) != "":
                     current_journey["duration"] = visit.get("duration")
 


### PR DESCRIPTION
Explain what problem this PR is resolving

Related JIRA tickets :[WC2-456](https://bluesquare.atlassian.net/browse/WC2-456)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- Added start/end date to Pregnant and Breastfeeding woman data and also fixed the start date to visit date of visit 0
- Added filters on journey(start/end date fields), visits(program type) and steps(program type) from django admin. 

## How to test

From the local instance with wfp coda QA database, launch with `docker-compose run iaso manage wfp_etl` the ETL script in order to generate data for tableau dashboard. Then open : http://localhost:8081/admin/wfp/

From:
-  [Journeys](http://localhost:8081/admin/wfp/journey/) : apply filter on program type and/or start date
- [Visits](http://localhost:8081/admin/wfp/visit/): apply filter on program type and/or start date
  As the start date should be the same as visit date for visit 0,  you should get same result in the 2 cases.

For more details, see the video bellow.

## Print screen / video

[Sélectionnez-l’objet-visit-à-changer-Iaso.webm](https://github.com/user-attachments/assets/34fe4bf5-fb5d-4401-9916-2ee7c6a2a678)


[WC2-456]: https://bluesquare.atlassian.net/browse/WC2-456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ