### PR TITLE
[IA-3172] Added "manager" filter on Teams

### DIFF
--- a/hat/assets/js/apps/Iaso/constants/urls.ts
+++ b/hat/assets/js/apps/Iaso/constants/urls.ts
@@ -374,7 +374,7 @@ export const baseRouteConfigs: Record<string, RouteConfig> = {
     },
     teams: {
         url: 'settings/teams',
-        params: ['accountId', 'search', ...paginationPathParams],
+        params: ['accountId', 'search', 'managers', ...paginationPathParams],
     },
     storages: {
         url: 'storages',

--- a/hat/assets/js/apps/Iaso/constants/urls.ts
+++ b/hat/assets/js/apps/Iaso/constants/urls.ts
@@ -374,7 +374,7 @@ export const baseRouteConfigs: Record<string, RouteConfig> = {
     },
     teams: {
         url: 'settings/teams',
-        params: ['accountId', 'search', 'managers', ...paginationPathParams],
+        params: ['accountId', 'search', 'managers', 'types', ...paginationPathParams],
     },
     storages: {
         url: 'storages',

--- a/hat/assets/js/apps/Iaso/domains/teams/components/TeamFilters.tsx
+++ b/hat/assets/js/apps/Iaso/domains/teams/components/TeamFilters.tsx
@@ -1,11 +1,14 @@
 import { Box, Grid } from '@mui/material';
-import React, { FunctionComponent, useState } from 'react';
+import React, { FunctionComponent, useCallback, useState } from "react";
 import { FilterButton } from '../../../components/FilterButton';
 import InputComponent from '../../../components/forms/InputComponent';
 import { useFilterState } from '../../../hooks/useFilterState';
 import { TeamParams } from '../types/team';
 import MESSAGES from '../messages';
 import { baseUrls } from '../../../constants/urls';
+import { AsyncSelect } from "../../../components/forms/AsyncSelect";
+import { getUsersDropDown } from "../../instances/hooks/requests/getUsersDropDown";
+import { useGetProfilesDropdown } from "../../instances/hooks/useGetProfilesDropdown";
 
 type Props = {
     params: TeamParams;
@@ -16,39 +19,51 @@ export const TeamFilters: FunctionComponent<Props> = ({ params }) => {
     const { filters, handleSearch, handleChange, filtersUpdated } =
         useFilterState({ baseUrl, params });
     const [textSearchError, setTextSearchError] = useState<boolean>(false);
-    return (
-        <>
-            <Grid container spacing={0}>
-                <Grid item xs={12} sm={6} md={3}>
-                    <InputComponent
-                        keyValue="search"
-                        onChange={handleChange}
-                        value={filters.search}
-                        type="search"
-                        label={MESSAGES.search}
-                        onEnterPressed={handleSearch}
-                        onErrorChange={setTextSearchError}
-                        blockForbiddenChars
-                    />
-                </Grid>
+    const { data: selectedManagers } = useGetProfilesDropdown(filters.managers);
+    const handleChangeManagers = useCallback(
+        (keyValue, newValue) => {
+            const joined = newValue?.map(r => r.value)?.join(',');
+            handleChange(keyValue, joined);
+        },
+        [handleChange],
+    );
 
-                <Grid
-                    container
-                    item
-                    xs={12}
-                    sm={6}
-                    md={9}
-                    justifyContent="flex-end"
-                    spacing={0}
-                >
-                    <Box mt={2} mb={2}>
-                        <FilterButton
-                            disabled={textSearchError || !filtersUpdated}
-                            onFilter={handleSearch}
-                        />
-                    </Box>
-                </Grid>
+    return (
+        <Grid container spacing={2}>
+            <Grid item xs={12} md={4} lg={3}>
+                <InputComponent
+                    keyValue="search"
+                    onChange={handleChange}
+                    value={filters.search}
+                    type="search"
+                    label={MESSAGES.search}
+                    onEnterPressed={handleSearch}
+                    onErrorChange={setTextSearchError}
+                    blockForbiddenChars
+                />
             </Grid>
-        </>
+            <Grid item xs={12} md={4} lg={3}>
+                <Box mt={2}>
+                    <AsyncSelect
+                        keyValue="managers"
+                        label={MESSAGES.manager}
+                        value={selectedManagers ?? ''}
+                        onChange={handleChangeManagers}
+                        debounceTime={500}
+                        multi
+                        fetchOptions={input => getUsersDropDown(input)}
+                    />
+                </Box>
+            </Grid>
+
+            <Grid item xs={12} md={4} lg={6}>
+                <Box mt={2} display="flex" justifyContent="flex-end">
+                    <FilterButton
+                        disabled={textSearchError || !filtersUpdated}
+                        onFilter={handleSearch}
+                    />
+                </Box>
+            </Grid>
+        </Grid>
     );
 };

--- a/hat/assets/js/apps/Iaso/domains/teams/components/TeamFilters.tsx
+++ b/hat/assets/js/apps/Iaso/domains/teams/components/TeamFilters.tsx
@@ -1,5 +1,6 @@
 import { Box, Grid } from '@mui/material';
 import React, { FunctionComponent, useCallback, useState } from "react";
+import { useSafeIntl } from "bluesquare-components";
 import { FilterButton } from '../../../components/FilterButton';
 import InputComponent from '../../../components/forms/InputComponent';
 import { useFilterState } from '../../../hooks/useFilterState';
@@ -9,6 +10,7 @@ import { baseUrls } from '../../../constants/urls';
 import { AsyncSelect } from "../../../components/forms/AsyncSelect";
 import { getUsersDropDown } from "../../instances/hooks/requests/getUsersDropDown";
 import { useGetProfilesDropdown } from "../../instances/hooks/useGetProfilesDropdown";
+import { TEAM_OF_TEAMS, TEAM_OF_USERS } from "../constants";
 
 type Props = {
     params: TeamParams;
@@ -16,6 +18,7 @@ type Props = {
 
 const baseUrl = baseUrls.teams;
 export const TeamFilters: FunctionComponent<Props> = ({ params }) => {
+    const { formatMessage } = useSafeIntl();
     const { filters, handleSearch, handleChange, filtersUpdated } =
         useFilterState({ baseUrl, params });
     const [textSearchError, setTextSearchError] = useState<boolean>(false);
@@ -30,7 +33,7 @@ export const TeamFilters: FunctionComponent<Props> = ({ params }) => {
 
     return (
         <Grid container spacing={2}>
-            <Grid item xs={12} md={4} lg={3}>
+            <Grid item xs={12} md={3} lg={3}>
                 <InputComponent
                     keyValue="search"
                     onChange={handleChange}
@@ -42,7 +45,7 @@ export const TeamFilters: FunctionComponent<Props> = ({ params }) => {
                     blockForbiddenChars
                 />
             </Grid>
-            <Grid item xs={12} md={4} lg={3}>
+            <Grid item xs={12} md={3} lg={3}>
                 <Box mt={2}>
                     <AsyncSelect
                         keyValue="managers"
@@ -55,8 +58,28 @@ export const TeamFilters: FunctionComponent<Props> = ({ params }) => {
                     />
                 </Box>
             </Grid>
+            <Grid item xs={12} md={3} lg={3}>
+                <InputComponent
+                    type="select"
+                    keyValue="types"
+                    onChange={handleChange}
+                    value={filters.types}
+                    label={MESSAGES.type}
+                    multi
+                    options={[
+                        {
+                            label: formatMessage(MESSAGES.teamsOfTeams),
+                            value: TEAM_OF_TEAMS,
+                        },
+                        {
+                            label: formatMessage(MESSAGES.teamsOfUsers),
+                            value: TEAM_OF_USERS,
+                        },
+                    ]}
+                />
+            </Grid>
 
-            <Grid item xs={12} md={4} lg={6}>
+            <Grid item xs={12} md={3} lg={3}>
                 <Box mt={2} display="flex" justifyContent="flex-end">
                     <FilterButton
                         disabled={textSearchError || !filtersUpdated}

--- a/hat/assets/js/apps/Iaso/domains/teams/types/team.ts
+++ b/hat/assets/js/apps/Iaso/domains/teams/types/team.ts
@@ -33,6 +33,7 @@ export type TeamFilterParams = {
     dateFrom?: string;
     project?: number;
     type?: TeamType;
+    managers?: User;
 };
 
 export type TeamParams = UrlParams &

--- a/iaso/api/microplanning.py
+++ b/iaso/api/microplanning.py
@@ -173,6 +173,15 @@ class TeamManagersFilterBackend(filters.BaseFilterBackend):
         return queryset
 
 
+class TeamTypesFilterBackend(filters.BaseFilterBackend):
+    def filter_queryset(self, request, queryset, view):
+        types = request.GET.get("types", None)
+        if types:
+            team_types = [val for val in types.split(",") if TeamType.is_valid_team_type(val)]
+            return queryset.filter(type__in=team_types)
+        return queryset
+
+
 class TeamSearchFilterBackend(filters.BaseFilterBackend):
     def filter_queryset(self, request, queryset, view):
         search = request.query_params.get("search")
@@ -215,6 +224,7 @@ class TeamViewSet(AuditMixin, ModelViewSet):
         TeamSearchFilterBackend,
         DeletionFilterBackend,
         TeamManagersFilterBackend,
+        TeamTypesFilterBackend,
     ]
     permission_classes = [ReadOnlyOrHasPermission(permission.TEAMS)]  # type: ignore
     serializer_class = TeamSerializer
@@ -224,7 +234,6 @@ class TeamViewSet(AuditMixin, ModelViewSet):
         "id": ["in"],
         "name": ["icontains"],
         "project": ["exact"],
-        "type": ["exact"],
     }
 
     audit_serializer = AuditTeamSerializer  # type: ignore

--- a/iaso/api/microplanning.py
+++ b/iaso/api/microplanning.py
@@ -164,6 +164,15 @@ class TeamSerializer(serializers.ModelSerializer):
         return validated_data
 
 
+class TeamManagersFilterBackend(filters.BaseFilterBackend):
+    def filter_queryset(self, request, queryset, view):
+        managers = request.GET.get("managers", None)
+        if managers:
+            manager_ids = [int(val) for val in managers.split(",") if val.isnumeric()]
+            return queryset.filter(manager_id__in=manager_ids)
+        return queryset
+
+
 class TeamSearchFilterBackend(filters.BaseFilterBackend):
     def filter_queryset(self, request, queryset, view):
         search = request.query_params.get("search")
@@ -205,6 +214,7 @@ class TeamViewSet(AuditMixin, ModelViewSet):
         DjangoFilterBackend,
         TeamSearchFilterBackend,
         DeletionFilterBackend,
+        TeamManagersFilterBackend,
     ]
     permission_classes = [ReadOnlyOrHasPermission(permission.TEAMS)]  # type: ignore
     serializer_class = TeamSerializer

--- a/iaso/models/microplanning.py
+++ b/iaso/models/microplanning.py
@@ -34,6 +34,10 @@ class TeamType(models.TextChoices):
     TEAM_OF_TEAMS = "TEAM_OF_TEAMS", "Team of teams"
     TEAM_OF_USERS = "TEAM_OF_USERS", "Team of users"
 
+    @classmethod
+    def is_valid_team_type(cls, value):
+        return value in cls.values
+
 
 TeamManager = models.Manager.from_queryset(TeamQuerySet)
 

--- a/iaso/tests/test_microplanning.py
+++ b/iaso/tests/test_microplanning.py
@@ -455,6 +455,35 @@ class TeamAPITestCase(APITestCase):
         # one for delete, one for undelete
         self.assertEqual(Modification.objects.count(), 2)
 
+    def test_list_filter_by_manager(self):
+        # Set up new team and new user who'll be the new manager
+        ash_ketchum = self.create_user_with_profile(
+            username="ash_ketchum", account=self.account, permissions=["iaso_teams"], projects=[self.project1]
+        )
+        team_fire_pokemons = Team.objects.create(project=self.project1, name="team_fire_pokemons", manager=ash_ketchum)
+        team_electric_pokemons = Team.objects.create(
+            project=self.project1, name="team_electric_pokemons", manager=ash_ketchum
+        )
+
+        misty = self.create_user_with_profile(
+            username="misty", account=self.account, permissions=["iaso_teams"], projects=[self.project1]
+        )
+        team_water_pokemons = Team.objects.create(project=self.project1, name="team_water_pokemons", manager=misty)
+
+        self.client.force_authenticate(ash_ketchum)
+
+        # Fetch the list of teams with a filter on a single manager
+        response = self.client.get(f"/api/microplanning/teams/?order=id&managers={ash_ketchum.id}", format="json")
+        r = self.assertJSONResponse(response, 200)
+        self.assertEqual(len(r), 2)
+        self.assertEqual(r[0]["name"], team_fire_pokemons.name)
+        self.assertEqual(r[1]["name"], team_electric_pokemons.name)
+
+        # Fetch the list of teams with a filter on multiple managers
+        response = self.client.get(f"/api/microplanning/teams/?managers={ash_ketchum.id},{misty.id}", format="json")
+        r = self.assertJSONResponse(response, 200)
+        self.assertEqual(len(r), 3)
+
 
 class PlanningTestCase(APITestCase):
     fixtures = ["user.yaml"]


### PR DESCRIPTION
Added a multi select "manager" filter for Teams page.

Related JIRA tickets : IA-3172

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
/

## Changes

- Added a backend filter for managers on `Team` 
- Added a frontend multi-select picker for managers on Teams page

## How to test

- Go on the Teams page
- Filter the list of Teams based on your selection in the picker

## Print screen / video

![image](https://github.com/user-attachments/assets/71a37ce8-da30-40af-a6e8-5fd87206b580)


## Notes
/
