### PR TITLE
[IA-3170] Add Team type filter

### DIFF
--- a/hat/assets/js/apps/Iaso/constants/urls.ts
+++ b/hat/assets/js/apps/Iaso/constants/urls.ts
@@ -374,7 +374,7 @@ export const baseRouteConfigs: Record<string, RouteConfig> = {
     },
     teams: {
         url: 'settings/teams',
-        params: ['accountId', 'search', 'managers', ...paginationPathParams],
+        params: ['accountId', 'search', 'managers', 'types', ...paginationPathParams],
     },
     storages: {
         url: 'storages',

--- a/hat/assets/js/apps/Iaso/domains/teams/components/TeamFilters.tsx
+++ b/hat/assets/js/apps/Iaso/domains/teams/components/TeamFilters.tsx
@@ -1,5 +1,6 @@
 import { Box, Grid } from '@mui/material';
 import React, { FunctionComponent, useCallback, useState } from "react";
+import { useSafeIntl } from "bluesquare-components";
 import { FilterButton } from '../../../components/FilterButton';
 import InputComponent from '../../../components/forms/InputComponent';
 import { useFilterState } from '../../../hooks/useFilterState';
@@ -9,6 +10,7 @@ import { baseUrls } from '../../../constants/urls';
 import { AsyncSelect } from "../../../components/forms/AsyncSelect";
 import { getUsersDropDown } from "../../instances/hooks/requests/getUsersDropDown";
 import { useGetProfilesDropdown } from "../../instances/hooks/useGetProfilesDropdown";
+import { TEAM_OF_TEAMS, TEAM_OF_USERS } from "../constants";
 
 type Props = {
     params: TeamParams;
@@ -16,6 +18,7 @@ type Props = {
 
 const baseUrl = baseUrls.teams;
 export const TeamFilters: FunctionComponent<Props> = ({ params }) => {
+    const { formatMessage } = useSafeIntl();
     const { filters, handleSearch, handleChange, filtersUpdated } =
         useFilterState({ baseUrl, params });
     const [textSearchError, setTextSearchError] = useState<boolean>(false);
@@ -30,7 +33,7 @@ export const TeamFilters: FunctionComponent<Props> = ({ params }) => {
 
     return (
         <Grid container spacing={2}>
-            <Grid item xs={12} md={4} lg={3}>
+            <Grid item xs={12} md={3} lg={3}>
                 <InputComponent
                     keyValue="search"
                     onChange={handleChange}
@@ -42,7 +45,7 @@ export const TeamFilters: FunctionComponent<Props> = ({ params }) => {
                     blockForbiddenChars
                 />
             </Grid>
-            <Grid item xs={12} md={4} lg={3}>
+            <Grid item xs={12} md={3} lg={3}>
                 <Box mt={2}>
                     <AsyncSelect
                         keyValue="managers"
@@ -55,8 +58,28 @@ export const TeamFilters: FunctionComponent<Props> = ({ params }) => {
                     />
                 </Box>
             </Grid>
+            <Grid item xs={12} md={3} lg={3}>
+                <InputComponent
+                    type="select"
+                    keyValue="types"
+                    onChange={handleChange}
+                    value={filters.types}
+                    label={MESSAGES.type}
+                    multi
+                    options={[
+                        {
+                            label: formatMessage(MESSAGES.teamsOfTeams),
+                            value: TEAM_OF_TEAMS,
+                        },
+                        {
+                            label: formatMessage(MESSAGES.teamsOfUsers),
+                            value: TEAM_OF_USERS,
+                        },
+                    ]}
+                />
+            </Grid>
 
-            <Grid item xs={12} md={4} lg={6}>
+            <Grid item xs={12} md={3} lg={3}>
                 <Box mt={2} display="flex" justifyContent="flex-end">
                     <FilterButton
                         disabled={textSearchError || !filtersUpdated}

--- a/iaso/api/microplanning.py
+++ b/iaso/api/microplanning.py
@@ -173,6 +173,15 @@ class TeamManagersFilterBackend(filters.BaseFilterBackend):
         return queryset
 
 
+class TeamTypesFilterBackend(filters.BaseFilterBackend):
+    def filter_queryset(self, request, queryset, view):
+        types = request.GET.get("types", None)
+        if types:
+            team_types = [val for val in types.split(",") if TeamType.is_valid_team_type(val)]
+            return queryset.filter(type__in=team_types)
+        return queryset
+
+
 class TeamSearchFilterBackend(filters.BaseFilterBackend):
     def filter_queryset(self, request, queryset, view):
         search = request.query_params.get("search")
@@ -215,6 +224,7 @@ class TeamViewSet(AuditMixin, ModelViewSet):
         TeamSearchFilterBackend,
         DeletionFilterBackend,
         TeamManagersFilterBackend,
+        TeamTypesFilterBackend,
     ]
     permission_classes = [ReadOnlyOrHasPermission(permission.TEAMS)]  # type: ignore
     serializer_class = TeamSerializer
@@ -224,7 +234,6 @@ class TeamViewSet(AuditMixin, ModelViewSet):
         "id": ["in"],
         "name": ["icontains"],
         "project": ["exact"],
-        "type": ["exact"],
     }
 
     audit_serializer = AuditTeamSerializer  # type: ignore

--- a/iaso/models/microplanning.py
+++ b/iaso/models/microplanning.py
@@ -34,6 +34,10 @@ class TeamType(models.TextChoices):
     TEAM_OF_TEAMS = "TEAM_OF_TEAMS", "Team of teams"
     TEAM_OF_USERS = "TEAM_OF_USERS", "Team of users"
 
+    @classmethod
+    def is_valid_team_type(cls, value):
+        return value in cls.values
+
 
 TeamManager = models.Manager.from_queryset(TeamQuerySet)
 


### PR DESCRIPTION
Added a multi-select filter for Team type.

Related JIRA tickets : IA-3170

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
/

## Changes

- Added a backend filter for types on `Team`
- Added a frontend multi-select picker for types on Teams page

## How to test

- Go on the Teams page
- Filter the list of Teams based on your selection in the picker

## Print screen / video
![image](https://github.com/user-attachments/assets/f252655e-2f0b-442a-bff7-629058a26bfc)


## Notes
/