### PR TITLE
Hotfix csv exports [IA-3267]

### DIFF
--- a/iaso/api/instances.py
+++ b/iaso/api/instances.py
@@ -42,6 +42,7 @@ from . import common
 from .comment import UserSerializerForComment
 from .common import CONTENT_TYPE_CSV, CONTENT_TYPE_XLSX, FileFormatEnum, TimestampField, safe_api_import
 from .instance_filters import get_form_from_instance_filters, parse_instance_filters
+from ..utils.models.common import get_creator_name
 
 
 class InstanceSerializer(serializers.ModelSerializer):
@@ -235,8 +236,12 @@ class InstancesViewSet(viewsets.ViewSet):
         filename = "%s-%s" % (filename, strftime("%Y-%m-%d-%H-%M", gmtime()))
 
         def get_row(instance, **kwargs):
-            created_at = timestamp_to_datetime(instance.source_created_at.timestamp())
-            updated_at = timestamp_to_datetime(instance.source_updated_at.timestamp())
+            created_at = (
+                timestamp_to_datetime(instance.source_created_at.timestamp()) if instance.source_created_at else ""
+            )
+            updated_at = (
+                timestamp_to_datetime(instance.source_updated_at.timestamp()) if instance.source_updated_at else ""
+            )
             org_unit = instance.org_unit
             file_content = instance.get_and_save_json_of_xml()
 
@@ -251,7 +256,7 @@ class InstancesViewSet(viewsets.ViewSet):
                 instance.period,
                 created_at,
                 updated_at,
-                instance.created_by,
+                get_creator_name(instance.created_by) if instance.created_by else None,
                 instance.status,
                 instance.org_unit.name,
                 instance.org_unit.id,

--- a/iaso/api/instances.py
+++ b/iaso/api/instances.py
@@ -290,6 +290,14 @@ class InstancesViewSet(viewsets.ViewSet):
             )
         elif file_format == FileFormatEnum.CSV:
             filename = filename + ".csv"
+            queryset = queryset.prefetch_related( "created_by", "form_version__form")
+            queryset = queryset.prefetch_related(Prefetch("org_unit", queryset=OrgUnit.objects.only("name", "parent_id", "source_ref")))
+            queryset = queryset.prefetch_related(Prefetch("org_unit__parent", queryset=OrgUnit.objects.only("name", "parent_id", "source_ref")))
+            queryset = queryset.prefetch_related(Prefetch("org_unit__parent__parent", queryset=OrgUnit.objects.only("name", "parent_id", "source_ref")))
+            queryset = queryset.prefetch_related(Prefetch("org_unit__parent__parent__parent", queryset=OrgUnit.objects.only("name", "parent_id", "source_ref")))
+            queryset = queryset.prefetch_related(Prefetch("org_unit__parent__parent__parent__parent", queryset=OrgUnit.objects.only("name", "parent_id", "source_ref")))
+            queryset = queryset.prefetch_related(Prefetch("org_unit__parent__parent__parent__parent__parent", queryset=OrgUnit.objects.only("name", "parent_id", "source_ref")))
+
             response = StreamingHttpResponse(
                 streaming_content=(iter_items(queryset, Echo(), columns, get_row)), content_type=CONTENT_TYPE_CSV
             )
@@ -320,9 +328,9 @@ class InstancesViewSet(viewsets.ViewSet):
 
         # 2. Prepare queryset (common part between searches and exports)
         queryset = self.get_queryset()
-        queryset = queryset.exclude(file="").exclude(device__test_device=True)
-        queryset = queryset.prefetch_related("org_unit__org_unit_type")
-        queryset = queryset.prefetch_related("org_unit__version__data_source")
+        queryset = queryset.exclude(file="")#.exclude(device__test_device=True)
+        #queryset = queryset.prefetch_related("org_unit__org_unit_type")
+        #queryset = queryset.prefetch_related("org_unit__version__data_source")
         queryset = queryset.prefetch_related("form")
         queryset = queryset.prefetch_related("created_by")
         queryset = queryset.for_filters(**filters)

--- a/iaso/api/instances.py
+++ b/iaso/api/instances.py
@@ -8,7 +8,7 @@ from django.contrib.auth.models import User
 from django.contrib.gis.geos import Point
 from django.core.paginator import Paginator
 from django.db import connection, transaction
-from django.db.models import Count, Q, QuerySet
+from django.db.models import Count, Q, QuerySet, Prefetch
 from django.http import HttpResponse, StreamingHttpResponse
 from django.utils.timezone import now
 from rest_framework import permissions, serializers, status, viewsets

--- a/iaso/api/instances.py
+++ b/iaso/api/instances.py
@@ -290,13 +290,33 @@ class InstancesViewSet(viewsets.ViewSet):
             )
         elif file_format == FileFormatEnum.CSV:
             filename = filename + ".csv"
-            queryset = queryset.prefetch_related( "created_by", "form_version__form")
-            queryset = queryset.prefetch_related(Prefetch("org_unit", queryset=OrgUnit.objects.only("name", "parent_id", "source_ref")))
-            queryset = queryset.prefetch_related(Prefetch("org_unit__parent", queryset=OrgUnit.objects.only("name", "parent_id", "source_ref")))
-            queryset = queryset.prefetch_related(Prefetch("org_unit__parent__parent", queryset=OrgUnit.objects.only("name", "parent_id", "source_ref")))
-            queryset = queryset.prefetch_related(Prefetch("org_unit__parent__parent__parent", queryset=OrgUnit.objects.only("name", "parent_id", "source_ref")))
-            queryset = queryset.prefetch_related(Prefetch("org_unit__parent__parent__parent__parent", queryset=OrgUnit.objects.only("name", "parent_id", "source_ref")))
-            queryset = queryset.prefetch_related(Prefetch("org_unit__parent__parent__parent__parent__parent", queryset=OrgUnit.objects.only("name", "parent_id", "source_ref")))
+            queryset = queryset.prefetch_related("created_by", "form_version__form")
+            queryset = queryset.prefetch_related(
+                Prefetch("org_unit", queryset=OrgUnit.objects.only("name", "parent_id", "source_ref"))
+            )
+            queryset = queryset.prefetch_related(
+                Prefetch("org_unit__parent", queryset=OrgUnit.objects.only("name", "parent_id", "source_ref"))
+            )
+            queryset = queryset.prefetch_related(
+                Prefetch("org_unit__parent__parent", queryset=OrgUnit.objects.only("name", "parent_id", "source_ref"))
+            )
+            queryset = queryset.prefetch_related(
+                Prefetch(
+                    "org_unit__parent__parent__parent", queryset=OrgUnit.objects.only("name", "parent_id", "source_ref")
+                )
+            )
+            queryset = queryset.prefetch_related(
+                Prefetch(
+                    "org_unit__parent__parent__parent__parent",
+                    queryset=OrgUnit.objects.only("name", "parent_id", "source_ref"),
+                )
+            )
+            queryset = queryset.prefetch_related(
+                Prefetch(
+                    "org_unit__parent__parent__parent__parent__parent",
+                    queryset=OrgUnit.objects.only("name", "parent_id", "source_ref"),
+                )
+            )
 
             response = StreamingHttpResponse(
                 streaming_content=(iter_items(queryset, Echo(), columns, get_row)), content_type=CONTENT_TYPE_CSV
@@ -328,9 +348,9 @@ class InstancesViewSet(viewsets.ViewSet):
 
         # 2. Prepare queryset (common part between searches and exports)
         queryset = self.get_queryset()
-        queryset = queryset.exclude(file="")#.exclude(device__test_device=True)
-        #queryset = queryset.prefetch_related("org_unit__org_unit_type")
-        #queryset = queryset.prefetch_related("org_unit__version__data_source")
+        queryset = queryset.exclude(file="")  # .exclude(device__test_device=True)
+        # queryset = queryset.prefetch_related("org_unit__org_unit_type")
+        # queryset = queryset.prefetch_related("org_unit__version__data_source")
         queryset = queryset.prefetch_related("form")
         queryset = queryset.prefetch_related("created_by")
         queryset = queryset.for_filters(**filters)

--- a/iaso/api/instances.py
+++ b/iaso/api/instances.py
@@ -236,11 +236,15 @@ class InstancesViewSet(viewsets.ViewSet):
         filename = "%s-%s" % (filename, strftime("%Y-%m-%d-%H-%M", gmtime()))
 
         def get_row(instance, **kwargs):
-            created_at = (
-                timestamp_to_datetime(instance.source_created_at.timestamp()) if instance.source_created_at else ""
+            created_at_timestamp = (
+                instance.source_created_at.timestamp()
+                if instance.source_created_at
+                else instance.created_at.timestamp()
             )
-            updated_at = (
-                timestamp_to_datetime(instance.source_updated_at.timestamp()) if instance.source_updated_at else ""
+            updated_at_timestamp = (
+                instance.source_updated_at.timestamp()
+                if instance.source_updated_at
+                else instance.updated_at.timestamp()
             )
             org_unit = instance.org_unit
             file_content = instance.get_and_save_json_of_xml()
@@ -254,8 +258,8 @@ class InstancesViewSet(viewsets.ViewSet):
                 instance.location.z if instance.location else None,
                 instance.accuracy,
                 instance.period,
-                created_at,
-                updated_at,
+                timestamp_to_datetime(created_at_timestamp),
+                timestamp_to_datetime(updated_at_timestamp),
                 get_creator_name(instance.created_by) if instance.created_by else None,
                 instance.status,
                 instance.org_unit.name,

--- a/iaso/tests/api/test_instances.py
+++ b/iaso/tests/api/test_instances.py
@@ -989,7 +989,7 @@ class InstancesAPITestCase(APITestCase):
 
         self.client.force_authenticate(self.yoda)
         response = self.client.get(
-            f"/api/instances/?form_ids={sourceless_instance.form.id}&order_by=id&csv=true",
+            f"/api/instances/?form_ids={sourceless_instance.form.id}&order=id&csv=true",
             headers={"Content-Type": "text/csv"},
         )
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
Speeding up CSV exports by removing a ton of SQL requests

Related JIRA tickets : IA-3267

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are there enough tests

## Doc
- Tell us where the doc can be found (docs folder, wiki, in the code...)

## Changes

Ensuring that only something like 20 requests are made per 5000 lines of csv exports (but the csv exports are batched by 5k to allow streaming and not overload the database)

## How to test

![CleanShot 2024-07-28 at 06 51 48@2x](https://github.com/user-attachments/assets/3f0e0947-1903-4407-8146-69bdf3e02113)


## Notes

Sorry, a test is not passing, but it's only on github actions for now