### PR TITLE
POLIO-1619 + POLIO-1620 Fix "Statuses" and "Period" not translated into English

### DIFF
--- a/hat/assets/js/apps/Iaso/libs/Api.ts
+++ b/hat/assets/js/apps/Iaso/libs/Api.ts
@@ -1,4 +1,6 @@
 /* eslint-disable camelcase */
+import moment from 'moment';
+
 import { PostArg } from '../types/general';
 import { Nullable, Optional } from '../types/utils';
 import { FETCHING_ABORTED } from './constants';
@@ -88,7 +90,10 @@ export const getRequest = async (
     url: string,
     signal?: Nullable<AbortSignal>,
 ): Promise<any> => {
-    return iasoFetch(url, { signal }).then(response => {
+    return iasoFetch(url, {
+        headers: { 'Accept-Language': moment.locale() },
+        signal,
+    }).then(response => {
         return response.json();
     });
 };
@@ -128,7 +133,10 @@ export const basePostRequest = (
         init = {
             method: 'POST',
             body: JSON.stringify(data),
-            headers: { 'Content-Type': 'application/json' },
+            headers: {
+                'Content-Type': 'application/json',
+                'Accept-Language': moment.locale(),
+            },
             signal,
         };
     }
@@ -161,7 +169,10 @@ export const patchRequest = (
     iasoFetch(url, {
         method: 'PATCH',
         body: JSON.stringify(data),
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+            'Content-Type': 'application/json',
+            'Accept-Language': moment.locale(),
+        },
         signal,
     }).then(response => response.json());
 
@@ -174,6 +185,7 @@ export const deleteRequest = (
         headers: {
             'Content-Type': 'application/json',
             Accept: 'application/json',
+            'Accept-Language': moment.locale(),
         },
         signal,
     }).then(() => true);
@@ -187,7 +199,10 @@ export const restoreRequest = (
         body: JSON.stringify({
             deleted_at: null,
         }),
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+            'Content-Type': 'application/json',
+            'Accept-Language': moment.locale(),
+        },
         signal,
     }).then(() => true);
 
@@ -199,7 +214,10 @@ export const putRequest = (
     iasoFetch(url, {
         method: 'PUT',
         body: JSON.stringify(data),
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+            'Content-Type': 'application/json',
+            'Accept-Language': moment.locale(),
+        },
         signal,
     }).then(response => response.json());
 
@@ -212,6 +230,7 @@ export const optionsRequest = async (
         headers: {
             'Content-Type': 'application/json',
             Accept: 'application/json',
+            'Accept-Language': moment.locale(),
         },
         signal,
     }).then(response => {


### PR DESCRIPTION
Fix "Statuses" and "Period" not translated into English.

Related JIRA tickets:

- [POLIO-1619](https://bluesquare.atlassian.net/browse/POLIO-1619)
- [POLIO-1620](https://bluesquare.atlassian.net/browse/POLIO-1620)

## Changes

Add the `Accept-Language` header to front-end HTTP requests.

## How does this work?

1. some model fields are translated in the backend ([example](https://github.com/BLSQ/iaso/blob/dec6ddfe6fda808adb03fe34d85a3767e8a2865a/plugins/polio/models/chronogram.py#L136) and its [translations](https://github.com/BLSQ/iaso/blob/dec6ddfe6fda808adb03fe34d85a3767e8a2865a/plugins/polio/locale/fr/LC_MESSAGES/django.po#L476-L478))
2. and then their translations are exposed through the API ([example](https://github.com/BLSQ/iaso/blob/c562f2d66ebce78668e6dfe4417229cc624b0670/plugins/polio/api/chronogram/serializers.py#L33))
3. Django needs to know [in which language to translate these fields](https://docs.djangoproject.com/en/4.2/topics/i18n/translation/#how-django-discovers-language-preference)
4. and does so by inspecting the `Accept-Language` HTTP header

## How to test

Ensure you've run [`django-admin compilemessages`](https://docs.djangoproject.com/en/5.0/ref/django-admin/#compilemessages) locally.

Then use a super user or a user with the "Polio Chronogram" permission and play with the UI in English and then in French.

You should see the translations in the right language.

## Video

https://github.com/user-attachments/assets/e18217db-68f5-4eb9-a3ec-917bfdb8c416




[POLIO-1619]: https://bluesquare.atlassian.net/browse/POLIO-1619?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[POLIO-1620]: https://bluesquare.atlassian.net/browse/POLIO-1620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ