### PR TITLE
WC2-460: No PBWG data showing

### DIFF
--- a/plugins/wfp/management/commands/wfp_etl_pbwg.py
+++ b/plugins/wfp/management/commands/wfp_etl_pbwg.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 class PBWG:
     def run(self):
-        beneficiaries = ETL("Test PBWG").retrieve_entities()
+        beneficiaries = ETL("PBWG").retrieve_entities()
         logger.info(f"Instances linked to PBWG program: {beneficiaries.count()}")
         entities = sorted(list(beneficiaries), key=itemgetter("entity_id"))
         existing_beneficiaries = ETL().existing_beneficiaries()


### PR DESCRIPTION
Explain what problem this PR is resolving

Related JIRA tickets : [WC2-460](https://bluesquare.atlassian.net/browse/WC2-460)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)


## Changes

Recently the beneficiary type names has changed to align QA and Prod by removing **the word Test** but we forgot to adapt it in the ETL script. The data was anymore generated when running the script for PBWG. 

Removed the word Test in the script to retrieve the beneficiary for PBWG program.

## How to test

From the local instance with wfp coda database, launch with `docker-compose run iaso manage wfp_etl` the ETL script in order to generate data for tableau dashboard. Then open django admin  : http://localhost:8081/admin/wfp/

From:
 -  [Journeys](http://localhost:8081/admin/wfp/journey/) : apply filter on program type PLW
 - [Visits](http://localhost:8081/admin/wfp/visit/): apply filter on program type PLW

For the 2 cases, you should get the data. For more details, see the video bellow.

## Print screen / video

[PLW data from django admin.webm](https://github.com/user-attachments/assets/dc49e263-2c49-4d8e-a33c-1cadc9bb100c)


[WC2-460]: https://bluesquare.atlassian.net/browse/WC2-460?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ