### PR TITLE
[IA-3171] Added projects filter on Teams

### DIFF
--- a/hat/assets/js/apps/Iaso/constants/urls.ts
+++ b/hat/assets/js/apps/Iaso/constants/urls.ts
@@ -374,7 +374,14 @@ export const baseRouteConfigs: Record<string, RouteConfig> = {
     },
     teams: {
         url: 'settings/teams',
-        params: ['accountId', 'search', 'managers', 'types', ...paginationPathParams],
+        params: [
+            'accountId',
+            'search',
+            'managers',
+            'types',
+            'projects',
+            ...paginationPathParams,
+        ],
     },
     storages: {
         url: 'storages',

--- a/hat/assets/js/apps/Iaso/domains/teams/components/TeamFilters.tsx
+++ b/hat/assets/js/apps/Iaso/domains/teams/components/TeamFilters.tsx
@@ -11,6 +11,7 @@ import { AsyncSelect } from "../../../components/forms/AsyncSelect";
 import { getUsersDropDown } from "../../instances/hooks/requests/getUsersDropDown";
 import { useGetProfilesDropdown } from "../../instances/hooks/useGetProfilesDropdown";
 import { TEAM_OF_TEAMS, TEAM_OF_USERS } from "../constants";
+import { useGetProjectsDropdownOptions } from "../../projects/hooks/requests";
 
 type Props = {
     params: TeamParams;
@@ -23,6 +24,8 @@ export const TeamFilters: FunctionComponent<Props> = ({ params }) => {
         useFilterState({ baseUrl, params });
     const [textSearchError, setTextSearchError] = useState<boolean>(false);
     const { data: selectedManagers } = useGetProfilesDropdown(filters.managers);
+    const { data: allProjects, isFetching: isFetchingProjects } =
+        useGetProjectsDropdownOptions();
     const handleChangeManagers = useCallback(
         (keyValue, newValue) => {
             const joined = newValue?.map(r => r.value)?.join(',');
@@ -44,8 +47,6 @@ export const TeamFilters: FunctionComponent<Props> = ({ params }) => {
                     onErrorChange={setTextSearchError}
                     blockForbiddenChars
                 />
-            </Grid>
-            <Grid item xs={12} md={3} lg={3}>
                 <Box mt={2}>
                     <AsyncSelect
                         keyValue="managers"
@@ -77,9 +78,20 @@ export const TeamFilters: FunctionComponent<Props> = ({ params }) => {
                         },
                     ]}
                 />
+                <InputComponent
+                    keyValue="projects"
+                    onChange={handleChange}
+                    value={filters.projects}
+                    type="select"
+                    options={allProjects}
+                    label={MESSAGES.project}
+                    loading={isFetchingProjects}
+                    onEnterPressed={handleSearch}
+                    clearable
+                    multi
+                />
             </Grid>
-
-            <Grid item xs={12} md={3} lg={3}>
+            <Grid item xs={12} md={6} lg={6}>
                 <Box mt={2} display="flex" justifyContent="flex-end">
                     <FilterButton
                         disabled={textSearchError || !filtersUpdated}

--- a/iaso/api/microplanning.py
+++ b/iaso/api/microplanning.py
@@ -173,6 +173,15 @@ class TeamManagersFilterBackend(filters.BaseFilterBackend):
         return queryset
 
 
+class TeamProjectsFilterBackend(filters.BaseFilterBackend):
+    def filter_queryset(self, request, queryset, view):
+        projects = request.GET.get("projects", None)
+        if projects:
+            project_ids = [int(val) for val in projects.split(",") if val.isnumeric()]
+            return queryset.filter(project_id__in=project_ids)
+        return queryset
+
+
 class TeamTypesFilterBackend(filters.BaseFilterBackend):
     def filter_queryset(self, request, queryset, view):
         types = request.GET.get("types", None)
@@ -225,6 +234,7 @@ class TeamViewSet(AuditMixin, ModelViewSet):
         DeletionFilterBackend,
         TeamManagersFilterBackend,
         TeamTypesFilterBackend,
+        TeamProjectsFilterBackend,
     ]
     permission_classes = [ReadOnlyOrHasPermission(permission.TEAMS)]  # type: ignore
     serializer_class = TeamSerializer


### PR DESCRIPTION
Added a new multi select projects filter on Teams page

Explain what problem this PR is resolving

Related JIRA tickets : IA-3171

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
/

## Changes
- Added a new backend filter for projects
- Added a new frontend multi select filter for projects
- Added a new backend API test

## How to test
- Go on the Teams page
- Use the `Project` picker
- (optional) If you have a single project, add a new project - for instance with the setuper - and give it the same accountID as the initial one


## Print screen / video
![image](https://github.com/user-attachments/assets/05b0fefe-4a4a-4ab5-994e-96f4d6974371)


## Notes
/
