### PR TITLE
[IA-3275] Fix csv instance export when no data

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/registry/components/Instances.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/Instances.tsx
@@ -191,7 +191,9 @@ export const Instances: FunctionComponent<Props> = ({
                                             xlsxUrl={`${apiUrl}&xlsx=true`}
                                             disabled={
                                                 isFetchingList ||
-                                                data?.count === 0
+                                                data?.count === 0 ||
+                                                formIds === undefined ||
+                                                formIds === null
                                             }
                                         />
                                     </Box>

--- a/hat/assets/js/apps/Iaso/domains/registry/components/Instances.tsx
+++ b/hat/assets/js/apps/Iaso/domains/registry/components/Instances.tsx
@@ -192,8 +192,7 @@ export const Instances: FunctionComponent<Props> = ({
                                             disabled={
                                                 isFetchingList ||
                                                 data?.count === 0 ||
-                                                formIds === undefined ||
-                                                formIds === null
+                                                !formIds
                                             }
                                         />
                                     </Box>

--- a/iaso/api/instances.py
+++ b/iaso/api/instances.py
@@ -209,12 +209,11 @@ class InstancesViewSet(viewsets.ViewSet):
             filename = "%s-%s" % (filename, form.id)
             if form.correlatable:
                 columns.append({"title": "correlation id", "width": 20})
+        else:
+            return Response({"error": "There is no form"}, status=400)
 
         sub_columns = ["" for __ in columns]
-        # TODO: Check the logic here, it's going to fail in any case if there is no form
-        # Don't know what we are trying to achieve exactly
-        # The type ignore is obviously wrong since the type can be null, but the frontend always send forms.
-        latest_form_version = form.latest_version  # type: ignore
+        latest_form_version = form.latest_version
         questions_by_name = latest_form_version.questions_by_name() if latest_form_version else {}
         if form and latest_form_version:
             file_content_template = questions_by_name

--- a/iaso/api/instances.py
+++ b/iaso/api/instances.py
@@ -210,7 +210,7 @@ class InstancesViewSet(viewsets.ViewSet):
             if form.correlatable:
                 columns.append({"title": "correlation id", "width": 20})
         else:
-            return Response({"error": "There is no form"}, status=400)
+            return Response({"error": "There is no form"}, status=status.HTTP_400_BAD_REQUEST)
 
         sub_columns = ["" for __ in columns]
         latest_form_version = form.latest_version

--- a/iaso/tests/api/test_instances.py
+++ b/iaso/tests/api/test_instances.py
@@ -1024,6 +1024,15 @@ class InstancesAPITestCase(APITestCase):
         # Make sure the export is using the default created/updated_at if there is no source
         self.assertEqual(row_to_test, expected_row)
 
+    def test_submissions_list_in_csv_format_error_no_form(self):
+        # Make sure IA-3275 is fixed by sending a 400 instead of letting the backend crash
+        self.client.force_authenticate(self.yoda)
+        response = self.client.get(
+            f"/api/instances/?limit=20&order=org_unit__name&page=1&showDeleted=false&org_unit_status=VALID&csv=true",
+            headers={"Content-Type": "text/csv"},
+        )
+        self.assertJSONResponse(response, 400)
+
     def test_user_restriction(self):
         full = self.create_user_with_profile(username="full", account=self.star_wars, permissions=["iaso_submissions"])
         self.client.force_authenticate(full)

--- a/iaso/tests/api/test_instances.py
+++ b/iaso/tests/api/test_instances.py
@@ -10,6 +10,8 @@ from django.contrib.gis.geos import Point
 from django.core.files import File
 from django.utils import timezone
 from django.utils.timezone import now
+from rest_framework import status
+
 from hat.api.export_utils import timestamp_to_utc_datetime
 from hat.audit.models import Modification
 from iaso import models as m
@@ -1031,7 +1033,7 @@ class InstancesAPITestCase(APITestCase):
             f"/api/instances/?limit=20&order=org_unit__name&page=1&showDeleted=false&org_unit_status=VALID&csv=true",
             headers={"Content-Type": "text/csv"},
         )
-        self.assertJSONResponse(response, 400)
+        self.assertJSONResponse(response, status.HTTP_400_BAD_REQUEST)
 
     def test_user_restriction(self):
         full = self.create_user_with_profile(username="full", account=self.star_wars, permissions=["iaso_submissions"])


### PR DESCRIPTION
Fixed an error 500 when there is no form data during an instance csv export.

Related JIRA tickets : IA-3275

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
/

## Changes
- Update frontend to block the csv/xlsx buttons to be active if there is no form in the current tab
- Update backend to return a `400` error if there is no `form` nor `form_ids` parameters in the query

## How to test
- Go on the "registry" page
- Select a level which doesn't have any form, and make sure you can't click on the csv/xlsx buttons
- Select a level which has at least one form but no submissions, and make sure you can't click on the csv/xlsx buttons
- (optional) Query the instances API directly and make sure you get a `400` error. For instance: [http://localhost:8081/api/instances/?orgUnitTypeId=404&limit=20&order=org_unit__name&page=1&showDeleted=false&orgUnitParentId=2187066&org_unit_status=VALID&csv=true](http://localhost:8081/api/instances/?orgUnitTypeId=404&limit=20&order=org_unit__name&page=1&showDeleted=false&orgUnitParentId=2187066&org_unit_status=VALID&csv=true)

## Print screen / video

![image](https://github.com/user-attachments/assets/1730b8a6-eee5-44ce-905d-c13914310d58)


## Notes

There were a few comments in the backend code, mentioning some weird logic and the fact that the frontend will always send a `form` or `form_ids` parameter. There were also some mypy annotations to ignore cases where `Form` is `None`. 

Since we somehow ended up in a situation where the frontend didn't this parameter and now there's a check to make sure that there is actually a `form` value, I got rid of these comments. But we might still need to check the logic behind all of this again, because there might still be a few edge cases that will cause issues. 
