### PR TITLE
[IA-3266] Added entity UUID to instance exports

### DIFF
--- a/iaso/api/instances.py
+++ b/iaso/api/instances.py
@@ -192,6 +192,7 @@ class InstancesViewSet(viewsets.ViewSet):
             {"title": "Date de modification", "width": 20},
             {"title": "Créé par", "width": 20},
             {"title": "Status", "width": 20},
+            {"title": "Entité", "width": 20},
             {"title": "Org unit", "width": 20},
             {"title": "Org unit id", "width": 20},
             {"title": "Référence externe", "width": 20},
@@ -261,6 +262,8 @@ class InstancesViewSet(viewsets.ViewSet):
                 timestamp_to_datetime(updated_at_timestamp),
                 get_creator_name(instance.created_by) if instance.created_by else None,
                 instance.status,
+                # Special format for UUID to stay consistent with other UUIDs coming from file_content_template
+                f"uuid:{instance.entity.uuid}" if instance.entity else None,
                 instance.org_unit.name,
                 instance.org_unit.id,
                 instance.org_unit.source_ref,
@@ -286,7 +289,7 @@ class InstancesViewSet(viewsets.ViewSet):
 
         response: Union[HttpResponse, StreamingHttpResponse]
 
-        queryset = queryset.prefetch_related("created_by", "form_version__form")
+        queryset = queryset.prefetch_related("created_by", "entity", "form_version__form")
         queryset = queryset.prefetch_related(
             Prefetch("org_unit", queryset=OrgUnit.objects.only("name", "parent_id", "source_ref"))
         )

--- a/iaso/tests/api/test_instances.py
+++ b/iaso/tests/api/test_instances.py
@@ -958,6 +958,7 @@ class InstancesAPITestCase(APITestCase):
             self.instance_1.source_updated_at.strftime("%Y-%m-%d %H:%M:%S"),
             "yoda (Yo Da)",
             "READY",
+            "",  # entity UUID
             "Coruscant Jedi Council",
             f"{self.jedi_council_corruscant.id}",
             "jedi_council_corruscant_ref",
@@ -1013,6 +1014,7 @@ class InstancesAPITestCase(APITestCase):
             sourceless_instance.updated_at.strftime("%Y-%m-%d %H:%M:%S"),
             "yoda (Yo Da)",
             "READY",
+            "",  # entity UUID
             "Coruscant Jedi Council",
             f"{self.jedi_council_corruscant.id}",
             "jedi_council_corruscant_ref",


### PR DESCRIPTION
Added entity UUID to instance exports

Related JIRA tickets : IA-3266

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
/

## Changes
- Added entity UUID in `Instance` exports, in column `M`

## How to test
- Go to the instances page
- Choose a form
- Download the instances in CSV or XLSX

## Print screen / video
![image](https://github.com/user-attachments/assets/51a974d1-3552-489a-8976-ddd7ab285e7d)


## Notes
If the order of the columns is important and cannot be changed, this new field should be placed in another column (maybe after the form question columns?)
