### PR TITLE
HOTFIX IA-3277: fix redirection to org unit details page

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/details.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/details.js
@@ -290,6 +290,12 @@ const OrgUnitDetail = () => {
     );
 
     useEffect(() => {
+        if (!params.tab) {
+            redirectToReplace(baseUrl, { ...params, tab: 'infos' });
+        }
+    }, [params, redirectToReplace]);
+
+    useEffect(() => {
         if (isNewOrgunit && !currentOrgUnit) {
             if (params.levels && parentOrgUnit) {
                 setCurrentOrgUnit({


### PR DESCRIPTION
Link from submissions to org unit was broken, because no tab was set

Explain what problem this PR is resolving

Related JIRA tickets : IA-3277

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
NA

## Changes
- set tab to 'infos' if corresponding param is undefined in org unit details

## How to test

Go to instances, click the link to org unit
Go to org unit change requests, test a link (org unit name in the table)

## Print screen / video

https://github.com/user-attachments/assets/dc7828e2-16c7-4b98-922d-54978f8e9dc3



## Notes

Can be hotfixed on v1.240
