### PR TITLE
IA-3279: add minHeight to Treeview modal

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/TreeView/OrgUnitTreeviewModal.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/TreeView/OrgUnitTreeviewModal.tsx
@@ -75,7 +75,6 @@ const OrgUnitTreeviewModal: FunctionComponent<Props> = ({
     useIcon = false,
 }) => {
     const theme = useTheme();
-
     const { formatMessage } = useSafeIntl();
     const { fetchOrgUnit, isFetching: isFetchingOrgUnit } = useFetchOrgUnits();
     const [settings, setSettings] = useState<Settings>({
@@ -285,7 +284,7 @@ const OrgUnitTreeviewModal: FunctionComponent<Props> = ({
             </Box>
             <Box position="relative">
                 {isFetchingOrgUnit && <LoadingSpinner absolute />}
-                <Box mt={1}>
+                <Box mt={1} minHeight="350px">
                     <TreeViewWithSearch
                         getChildrenData={getChildrenWithSource}
                         getRootData={getRootDataWithSource}

--- a/package-lock.json
+++ b/package-lock.json
@@ -6437,7 +6437,8 @@
         },
         "node_modules/bluesquare-components": {
             "version": "1.0.0",
-            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#9507fe4b2c7b3051f67d9ab3ea62fb1f206d9979",
+            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#372ad0883cd0a14e3912476fae4a31e39204e803",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@babel/plugin-transform-class-properties": "^7.24.6",
                 "@babel/plugin-transform-object-rest-spread": "^7.24.6",


### PR DESCRIPTION
In treeview modal, results of org unit text search are not all visible

Related JIRA tickets : IA-3279

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
NA

## Changes

- Add a minHeight to the `Box` containing the treeview 
- Combined with the `maxHeight` on the list added in [bluesquare-components](https://github.com/BLSQ/bluesquare-components/pull/163), this makes the list always visible (big results can be scrolled)

## How to test

Open the treeview modal anywhere (e.g: org units)

## Print screen / video

https://github.com/user-attachments/assets/5805c838-b5af-43bf-8e86-0effeb0629df


## Notes

Depends on https://github.com/BLSQ/bluesquare-components/pull/163
