### PR TITLE
WC2-462 Beneficiary list: Add column for org unit groups

### DIFF
--- a/hat/assets/js/apps/Iaso/constants/urls.ts
+++ b/hat/assets/js/apps/Iaso/constants/urls.ts
@@ -311,6 +311,7 @@ export const baseRouteConfigs: Record<string, RouteConfig> = {
             'submitterTeamId',
             'entityTypeIds',
             'locationLimit',
+            'groups',
             ...paginationPathParams,
         ],
     },

--- a/hat/assets/js/apps/Iaso/domains/entities/components/Filters.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/components/Filters.tsx
@@ -56,6 +56,23 @@ type Props = {
     isFetching: boolean;
 };
 
+const createGroupsInputComponent = props => {
+    const { isFetchingGroups, handleChange, filters, groups } = props;
+    return (
+        <InputComponent
+            type="select"
+            multi
+            disabled={isFetchingGroups}
+            keyValue="groups"
+            onChange={handleChange}
+            value={!isFetchingGroups && filters?.groups}
+            label={MESSAGES.groups}
+            options={groups}
+            loading={isFetchingGroups}
+        />
+    );
+};
+
 const Filters: FunctionComponent<Props> = ({ params, isFetching }) => {
     const getParams = useFiltersParams();
     const currentUser = useCurrentUser();
@@ -143,6 +160,15 @@ const Filters: FunctionComponent<Props> = ({ params, isFetching }) => {
         [filters],
     );
 
+    const groupsInputComponent = useMemo(() => {
+        return createGroupsInputComponent({
+            isFetchingGroups,
+            handleChange,
+            filters,
+            groups,
+        });
+    }, [filters, groups, handleChange, isFetchingGroups]);
+
     const { url: apiUrl } = useGetBeneficiariesApiParams(params);
     return (
         <Box mb={1}>
@@ -176,6 +202,10 @@ const Filters: FunctionComponent<Props> = ({ params, isFetching }) => {
                         />
                     )}
 
+                    {hasFeatureFlag(
+                        currentUser,
+                        SHOW_BENEFICIARY_TYPES_IN_LIST_MENU,
+                    ) && groupsInputComponent}
                     <Box id="ou-tree-input">
                         <OrgUnitTreeviewModal
                             toggleOnLabelClick={false}
@@ -189,17 +219,7 @@ const Filters: FunctionComponent<Props> = ({ params, isFetching }) => {
                             initialSelection={initialOrgUnit}
                         />
                     </Box>
-                    <InputComponent
-                        type="select"
-                        multi
-                        disabled={isFetchingGroups}
-                        keyValue="groups"
-                        onChange={handleChange}
-                        value={!isFetchingGroups && filters?.groups}
-                        label={MESSAGES.groups}
-                        options={groups}
-                        loading={isFetchingGroups}
-                    />
+
                     {params.tab === 'map' && (
                         <Box mt={2}>
                             <LocationLimit
@@ -222,6 +242,10 @@ const Filters: FunctionComponent<Props> = ({ params, isFetching }) => {
                         dateFrom={filters.dateFrom}
                         dateTo={filters.dateTo}
                     />
+                    {!hasFeatureFlag(
+                        currentUser,
+                        SHOW_BENEFICIARY_TYPES_IN_LIST_MENU,
+                    ) && groupsInputComponent}
                 </Grid>
                 <Grid item xs={12} sm={6} md={3}>
                     <InputComponent

--- a/hat/assets/js/apps/Iaso/domains/entities/components/Filters.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/components/Filters.tsx
@@ -30,6 +30,7 @@ import MESSAGES from '../messages';
 import { baseUrl } from '../config';
 
 import { useGetOrgUnit } from '../../orgUnits/components/TreeView/requests';
+import { useGetGroups } from '../../orgUnits/hooks/requests/useGetGroups';
 import { useGetTeamsDropdown } from '../../teams/hooks/requests/useGetTeams';
 import {
     useGetBeneficiariesApiParams,
@@ -70,6 +71,7 @@ const Filters: FunctionComponent<Props> = ({ params, isFetching }) => {
         submitterTeamId: params.submitterTeamId,
         entityTypeIds: params.entityTypeIds,
         locationLimit: params.locationLimit,
+        groups: params.groups,
     });
 
     useEffect(() => {
@@ -82,6 +84,7 @@ const Filters: FunctionComponent<Props> = ({ params, isFetching }) => {
             submitterTeamId: params.submitterTeamId,
             entityTypeIds: params.entityTypeIds,
             locationLimit: params.locationLimit,
+            groups: params.groups,
         });
     }, [params]);
     const [filtersUpdated, setFiltersUpdated] = useState(false);
@@ -100,6 +103,12 @@ const Filters: FunctionComponent<Props> = ({ params, isFetching }) => {
     }, [filters.submitterTeamId, teamOptions]);
 
     const { data: usersOptions } = useGetUsersDropDown(selectedTeam);
+    const dataSourceId = currentUser?.account?.default_version?.data_source?.id;
+    const sourceVersionId = currentUser?.account?.default_version?.id;
+    const { data: groups, isFetching: isFetchingGroups } = useGetGroups({
+        dataSourceId,
+        sourceVersionId,
+    });
 
     const handleSearch = useCallback(() => {
         if (filtersUpdated) {
@@ -180,6 +189,17 @@ const Filters: FunctionComponent<Props> = ({ params, isFetching }) => {
                             initialSelection={initialOrgUnit}
                         />
                     </Box>
+                    <InputComponent
+                        type="select"
+                        multi
+                        disabled={isFetchingGroups}
+                        keyValue="groups"
+                        onChange={handleChange}
+                        value={!isFetchingGroups && filters?.groups}
+                        label={MESSAGES.groups}
+                        options={groups}
+                        loading={isFetchingGroups}
+                    />
                     {params.tab === 'map' && (
                         <Box mt={2}>
                             <LocationLimit

--- a/hat/assets/js/apps/Iaso/domains/entities/config.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/config.tsx
@@ -70,15 +70,15 @@ export const useStaticColumns = (): Array<Column> => {
                     return <>--</>;
                 }
 
-                return groups.map(group => (
-                    <div>
+                return groups.map((group, index) => (
+                    <span key={group.id}>
                         <LinkWithLocation
-                            key={group.id}
                             to={filterOrgUnitsByGroupUrl(group.id)}
                         >
                             {group.name}
                         </LinkWithLocation>
-                    </div>
+                        {index !== groups.length - 1 && ', '}
+                    </span>
                 ));
             },
         },

--- a/hat/assets/js/apps/Iaso/domains/entities/config.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/config.tsx
@@ -6,6 +6,7 @@ import {
     useSafeIntl,
     Column,
     IntlFormatMessage,
+    LinkWithLocation,
 } from 'bluesquare-components';
 
 import moment from 'moment';
@@ -27,6 +28,7 @@ import getDisplayName from '../../utils/usersUtils';
 import { useGetFieldValue } from './hooks/useGetFieldValue';
 import { formatLabel } from '../instances/utils';
 import { LinkToInstance } from '../instances/components/LinkToInstance';
+import { filterOrgUnitsByGroupUrl } from '../orgUnits/utils';
 
 export const baseUrl = baseUrls.entities;
 
@@ -56,6 +58,26 @@ export const useStaticColumns = (): Array<Column> => {
                         )}
                     </>
                 );
+            },
+        },
+        {
+            Header: 'Groups',
+            id: 'attributes__org_unit__groups',
+            sortable: false,
+            Cell: settings => {
+                const groups = settings.row.original?.org_unit?.groups;
+                if (!groups || groups.length === 0) {
+                    return <>--</>;
+                }
+
+                return groups.map(group => (
+                    <LinkWithLocation
+                        key={group.id}
+                        to={filterOrgUnitsByGroupUrl(group.id)}
+                    >
+                        {group.name}
+                    </LinkWithLocation>
+                ));
             },
         },
         {

--- a/hat/assets/js/apps/Iaso/domains/entities/config.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/config.tsx
@@ -71,12 +71,14 @@ export const useStaticColumns = (): Array<Column> => {
                 }
 
                 return groups.map(group => (
-                    <LinkWithLocation
-                        key={group.id}
-                        to={filterOrgUnitsByGroupUrl(group.id)}
-                    >
-                        {group.name}
-                    </LinkWithLocation>
+                    <div>
+                        <LinkWithLocation
+                            key={group.id}
+                            to={filterOrgUnitsByGroupUrl(group.id)}
+                        >
+                            {group.name}
+                        </LinkWithLocation>
+                    </div>
                 ));
             },
         },

--- a/hat/assets/js/apps/Iaso/domains/entities/config.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/config.tsx
@@ -7,6 +7,7 @@ import {
     Column,
     IntlFormatMessage,
     LinkWithLocation,
+    textPlaceholder,
 } from 'bluesquare-components';
 
 import moment from 'moment';
@@ -67,7 +68,7 @@ export const useStaticColumns = (): Array<Column> => {
             Cell: settings => {
                 const groups = settings.row.original?.org_unit?.groups;
                 if (!groups || groups.length === 0) {
-                    return <>--</>;
+                    return <>{textPlaceholder}</>;
                 }
 
                 return groups.map((group, index) => (
@@ -90,7 +91,7 @@ export const useStaticColumns = (): Array<Column> => {
                 return settings.row.original?.org_unit ? (
                     <LinkToOrgUnit orgUnit={settings.row.original?.org_unit} />
                 ) : (
-                    <>--</>
+                    <>{textPlaceholder}</>
                 );
             },
         },

--- a/hat/assets/js/apps/Iaso/domains/entities/hooks/requests.ts
+++ b/hat/assets/js/apps/Iaso/domains/entities/hooks/requests.ts
@@ -42,6 +42,7 @@ type Params = {
     submitterTeamId?: string;
     entityTypeIds?: string;
     locationLimit?: string;
+    groups?: string;
 };
 
 type ApiParams = {
@@ -57,6 +58,7 @@ type ApiParams = {
     entity_type_ids?: string;
     asLocation?: boolean;
     locationLimit?: string;
+    groups?: string;
 };
 
 type GetAPiParams = {
@@ -82,6 +84,7 @@ export const useGetBeneficiariesApiParams = (
         entity_type_ids: params.entityTypeIds,
         limit: params.pageSize || '20',
         page: params.page || '1',
+        groups: params.groups,
     };
     if (asLocation) {
         apiParams.asLocation = true;

--- a/hat/assets/js/apps/Iaso/domains/entities/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/index.tsx
@@ -47,6 +47,7 @@ type Params = {
     entityTypes?: string;
     entityTypeIds?: string;
     locationLimit?: string;
+    groups?: string;
 };
 
 export const Beneficiaries: FunctionComponent = () => {

--- a/hat/assets/js/apps/Iaso/domains/entities/messages.ts
+++ b/hat/assets/js/apps/Iaso/domains/entities/messages.ts
@@ -249,6 +249,10 @@ const MESSAGES = defineMessages({
         id: 'iaso.label.submissionsLocations',
         defaultMessage: 'Submissions locations',
     },
+    groups: {
+        defaultMessage: 'Group',
+        id: 'iaso.label.group',
+    },
 });
 
 export default MESSAGES;

--- a/hat/assets/js/apps/Iaso/domains/entities/types/filters.ts
+++ b/hat/assets/js/apps/Iaso/domains/entities/types/filters.ts
@@ -7,6 +7,7 @@ export type Filters = {
     submitterTeamId?: string;
     entityTypeIds?: string;
     locationLimit?: string;
+    groups?: string;
 };
 
 export type Params = {
@@ -22,4 +23,5 @@ export type Params = {
     submitterTeamId?: string;
     entityTypeIds?: string;
     locationLimit?: string;
+    groups?: string;
 };

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/groups/config.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/groups/config.js
@@ -3,25 +3,17 @@ import {
     formatThousand,
     IconButton,
     textPlaceholder,
-    LinkWithLocation
+    LinkWithLocation,
 } from 'bluesquare-components';
 import GroupsDialog from './components/GroupsDialog';
 import DeleteDialog from '../../../components/dialogs/DeleteDialogComponent';
 import MESSAGES from './messages';
 import { DateTimeCell } from '../../../components/Cells/DateTimeCell.tsx';
 import { baseUrls } from '../../../constants/urls';
-import { getChipColors } from '../../../constants/chipColors';
+import { filterOrgUnitsByGroupUrl } from '../utils';
 
 export const baseUrl = baseUrls.groups;
 
-const getUrl = groupId => {
-    const defaultChipColor = getChipColors(0).replace('#', '');
-    return (
-        `/${baseUrls.orgUnits}/locationLimit/3000/order/id` +
-        `/pageSize/50/page/1/searchTabIndex/0/searchActive/true` +
-        `/searches/[{"validation_status":"all", "color":"${defaultChipColor}", "group":"${groupId}", "source": null}]`
-    );
-};
 const TableColumns = (formatMessage, params, deleteGroup, saveGroup) => [
     {
         Header: 'Id',
@@ -53,7 +45,9 @@ const TableColumns = (formatMessage, params, deleteGroup, saveGroup) => [
         Header: formatMessage(MESSAGES.orgUnit),
         accessor: 'org_unit_count',
         Cell: settings => (
-            <LinkWithLocation to={getUrl(settings.row.original.id)}>
+            <LinkWithLocation
+                to={filterOrgUnitsByGroupUrl(settings.row.original.id)}
+            >
                 {formatThousand(settings.value)}
             </LinkWithLocation>
         ),

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/utils.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/utils.js
@@ -1,5 +1,8 @@
 import React, { useCallback } from 'react';
 import { textPlaceholder } from 'bluesquare-components';
+
+import { getChipColors } from '../../constants/chipColors';
+import { baseUrls } from '../../constants/urls';
 import { orderOrgUnitsByDepth } from '../../utils/map/mapUtils.ts';
 import { useGetOrgUnitValidationStatus } from './hooks/utils/useGetOrgUnitValidationStatus.ts';
 import MESSAGES from './messages.ts';
@@ -185,4 +188,13 @@ export const compareGroupVersions = (a, b) => {
         return 0;
     }
     return comparison;
+};
+
+export const filterOrgUnitsByGroupUrl = groupId => {
+    const defaultChipColor = getChipColors(0).replace('#', '');
+    return (
+        `/${baseUrls.orgUnits}/locationLimit/3000/order/id` +
+        `/pageSize/50/page/1/searchTabIndex/0/searchActive/true` +
+        `/searches/[{"validation_status":"all", "color":"${defaultChipColor}", "group":"${groupId}", "source": null}]`
+    );
 };

--- a/hat/assets/js/cypress/integration/07 - entities/list.spec.js
+++ b/hat/assets/js/cypress/integration/07 - entities/list.spec.js
@@ -250,7 +250,7 @@ describe('Entities', () => {
         testTablerender({
             baseUrl,
             rows: 20,
-            columns: 5,
+            columns: 6,
             apiKey: 'entities',
             withVisit: false,
         });

--- a/iaso/api/entity.py
+++ b/iaso/api/entity.py
@@ -176,13 +176,7 @@ class EntityViewSet(ModelViewSet):
         if created_by_team_id:
             queryset = queryset.filter(attributes__created_by__teams__id=created_by_team_id)
         if groups:
-            if isinstance(groups, str):
-                group_ids = groups.split(",")
-            elif isinstance(groups, int):
-                group_ids = [groups]
-            else:
-                group_ids = groups
-            queryset = queryset.filter(attributes__org_unit__groups__in=group_ids)
+            queryset = queryset.filter(attributes__org_unit__groups__in=groups.split(","))
 
         # location
         return queryset

--- a/iaso/api/entity.py
+++ b/iaso/api/entity.py
@@ -129,6 +129,7 @@ class EntityViewSet(ModelViewSet):
         show_deleted = self.request.query_params.get("show_deleted", None)
         created_by_id = self.request.query_params.get("created_by_id", None)
         created_by_team_id = self.request.query_params.get("created_by_team_id", None)
+        groups = self.request.query_params.get("groups", None)
 
         queryset = Entity.objects.filter_for_user(self.request.user)
 
@@ -174,6 +175,14 @@ class EntityViewSet(ModelViewSet):
             queryset = queryset.filter(attributes__created_by_id=created_by_id)
         if created_by_team_id:
             queryset = queryset.filter(attributes__created_by__teams__id=created_by_team_id)
+        if groups:
+            if isinstance(groups, str):
+                group_ids = groups.split(",")
+            elif isinstance(groups, int):
+                group_ids = [groups]
+            else:
+                group_ids = groups
+            queryset = queryset.filter(attributes__org_unit__groups__in=group_ids)
 
         # location
         return queryset

--- a/iaso/api/entity.py
+++ b/iaso/api/entity.py
@@ -61,7 +61,7 @@ class EntitySerializer(serializers.ModelSerializer):
 
     def get_org_unit(self, entity: Entity):
         if entity.attributes and entity.attributes.org_unit:
-            return entity.attributes.org_unit.as_location(with_parents=False)
+            return entity.attributes.org_unit.as_dict_for_entity()
         return None
 
     def get_submitter(self, entity: Entity):
@@ -135,6 +135,7 @@ class EntityViewSet(ModelViewSet):
         queryset = queryset.prefetch_related(
             "attributes__created_by__teams",
             "attributes__form",
+            "attributes__org_unit__groups",
             "attributes__org_unit__org_unit_type",
             "attributes__org_unit__parent",
             "attributes__org_unit__version__data_source",
@@ -285,7 +286,7 @@ class EntityViewSet(ModelViewSet):
             if attributes is not None and entity.attributes is not None:
                 file_content = entity.attributes.get_and_save_json_of_xml().get("file_content", None)
                 attributes_pk = attributes.pk
-                attributes_ou = entity.attributes.org_unit.as_location(with_parents=False) if entity.attributes.org_unit else None  # type: ignore
+                attributes_ou = entity.attributes.org_unit.as_dict_for_entity() if entity.attributes.org_unit else None  # type: ignore
                 attributes_latitude = attributes.location.y if attributes.location else None  # type: ignore
                 attributes_longitude = attributes.location.x if attributes.location else None  # type: ignore
             name = None

--- a/iaso/models/base.py
+++ b/iaso/models/base.py
@@ -448,6 +448,12 @@ class Group(models.Model):
     def __str__(self):
         return "%s | %s " % (self.name, self.source_version)
 
+    def as_small_dict(self):
+        return {
+            "id": self.id,
+            "name": self.name,
+        }
+
     def as_dict(self, with_counts=True):
         res = {
             "id": self.id,
@@ -1128,7 +1134,7 @@ class Instance(models.Model):
             "form_name": self.form.name if self.form else None,
             "created_at": self.source_created_at.timestamp() if self.source_created_at else self.created_at.timestamp(),
             "updated_at": self.source_updated_at.timestamp() if self.source_updated_at else self.updated_at.timestamp(),
-            "org_unit": self.org_unit.as_dict(with_groups=False) if self.org_unit else None,
+            "org_unit": self.org_unit.as_dict() if self.org_unit else None,
             "latitude": self.location.y if self.location else None,
             "longitude": self.location.x if self.location else None,
             "altitude": self.location.z if self.location else None,

--- a/iaso/models/org_unit.py
+++ b/iaso/models/org_unit.py
@@ -410,7 +410,7 @@ class OrgUnit(TreeModel):
             "aliases": self.aliases,
         }
 
-    def as_dict(self, with_groups=True):
+    def as_dict(self):
         res = {
             "name": self.name,
             "short_name": self.name,
@@ -548,6 +548,11 @@ class OrgUnit(TreeModel):
             res["search_index"] = self.search_index
         if with_parents:
             res["parent"] = self.parent.as_dict_with_parents(light=True, light_parents=True) if self.parent else None
+        return res
+
+    def as_dict_for_entity(self):
+        res = self.as_location(with_parents=False)
+        res["groups"] = [group.as_small_dict() for group in self.groups.all()]
         return res
 
     def source_path(self):


### PR DESCRIPTION
- Display the org units' group(s) in a new column. The groups are displayed as a comma-separated list with a link to the org units page filtered on the group.
- Also added a filter for the groups.

Related JIRA tickets : https://bluesquare.atlassian.net/browse/WC2-462

## Print screen / video

https://github.com/user-attachments/assets/a9b702ed-7383-4f07-bfd4-17484c93088f
