### PR TITLE
POLIO-1621 Chronogram template task: make column "Activity" wider by default

### DIFF
--- a/plugins/polio/js/src/domains/Chronogram/ChronogramTemplateTask/Table/useChronogramTemplateTaskTableColumns.tsx
+++ b/plugins/polio/js/src/domains/Chronogram/ChronogramTemplateTask/Table/useChronogramTemplateTaskTableColumns.tsx
@@ -29,6 +29,7 @@ export const useChronogramTemplateTaskTableColumns = (
                 id: 'description',
                 accessor: 'description',
                 sortable: false,
+                width: 800,
             },
             {
                 Header: formatMessage(MESSAGES.labelStartOffsetInDays),


### PR DESCRIPTION
Chronogram template task: make column "Activity" wider by default

Related JIRA tickets : [POLIO-1621](https://bluesquare.atlassian.net/browse/POLIO-1621)

## How to test

- you must be super admin or have the `iaso_polio_chronogram` permission
- go to `localhost:8081/dashboard/polio/chronogram/templateTask`
- the "Activity" column should be wider by default

## Print screen

![wider](https://github.com/user-attachments/assets/78cd57c5-3a5b-41c5-ac0e-553d85da9b96)



[POLIO-1621]: https://bluesquare.atlassian.net/browse/POLIO-1621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ