### PR TITLE
POLIO-1628 Chronogram default page: make column wider and rename "task delayed"

### DIFF
--- a/plugins/polio/js/src/constants/translations/en.json
+++ b/plugins/polio/js/src/constants/translations/en.json
@@ -94,7 +94,7 @@
     "iaso.polio.chronogram.label.delay_in_days": "Delay",
     "iaso.polio.chronogram.label.description": "Activity",
     "iaso.polio.chronogram.label.is_on_time": "On time",
-    "iaso.polio.chronogram.label.num_task_delayed": "Task delayed",
+    "iaso.polio.chronogram.label.num_task_delayed": "Number of task(s) delayed",
     "iaso.polio.chronogram.label.percentage_of_completion": "Percentage of Completion Before/During/After",
     "iaso.polio.chronogram.label.period": "Period",
     "iaso.polio.chronogram.label.round": "Round",

--- a/plugins/polio/js/src/constants/translations/fr.json
+++ b/plugins/polio/js/src/constants/translations/fr.json
@@ -93,7 +93,7 @@
     "iaso.polio.chronogram.label.delay_in_days": "Délai",
     "iaso.polio.chronogram.label.description": "Activité",
     "iaso.polio.chronogram.label.is_on_time": "Dans les délais",
-    "iaso.polio.chronogram.label.num_task_delayed": "Tâche retardée",
+    "iaso.polio.chronogram.label.num_task_delayed": "Nombre de tâches retardées",
     "iaso.polio.chronogram.label.percentage_of_completion": "Pourcentage de réalisation avant/pendant/après",
     "iaso.polio.chronogram.label.period": "Période",
     "iaso.polio.chronogram.label.round": "Round",

--- a/plugins/polio/js/src/domains/Chronogram/Chronogram/Table/useChronogramTableColumns.tsx
+++ b/plugins/polio/js/src/domains/Chronogram/Chronogram/Table/useChronogramTableColumns.tsx
@@ -28,6 +28,7 @@ export const useChronogramTableColumns = (
                 Header: formatMessage(MESSAGES.labelCampaignObrName),
                 id: 'round__campaign__obr_name',
                 accessor: 'campaign_obr_name',
+                width: 700,
             },
             {
                 Header: formatMessage(MESSAGES.labelRoundNumber),

--- a/plugins/polio/js/src/domains/Chronogram/Chronogram/messages.ts
+++ b/plugins/polio/js/src/domains/Chronogram/Chronogram/messages.ts
@@ -63,7 +63,7 @@ const MESSAGES = defineMessages({
     },
     labelNumTaskDelayed: {
         id: 'iaso.polio.chronogram.label.num_task_delayed',
-        defaultMessage: 'Task delayed',
+        defaultMessage: 'Number of task(s) delayed',
     },
     labelPercentageOfCompletion: {
         id: 'iaso.polio.chronogram.label.percentage_of_completion',


### PR DESCRIPTION
Chronogram default page: make column wider and rename "task delayed".

Related JIRA tickets : [POLIO-1628](https://bluesquare.atlassian.net/browse/POLIO-1628)

## How to test

- you must be super admin or have the `iaso_polio_chronogram` permission
- go to `localhost:8081/dashboard/polio/chronogram`
- the "Campaign" column should be wider by default
- "Task delayed" should be renamed into "Number of task(s) delayed"

## Print screen

![wider](https://github.com/user-attachments/assets/a21260d0-2f35-4bf9-b9ab-355983e4f967)


[POLIO-1628]: https://bluesquare.atlassian.net/browse/POLIO-1628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ