### PR TITLE
SLEEP-1459 Add retries with exponential backoff to XML file downloads

### DIFF
--- a/iaso/tasks/process_mobile_bulk_upload.py
+++ b/iaso/tasks/process_mobile_bulk_upload.py
@@ -142,7 +142,7 @@ def update_instance_file_if_needed(instance, incoming_updated_at, file, user):
         instance.last_modified_by = user
         instance.source_updated_at = incoming_updated_at
         instance.save()
-        instance.get_and_save_json_of_xml(force=True)
+        instance.get_and_save_json_of_xml(force=True, tries=8)
     else:
         logger.info(
             "\tSkipping form %s (current timestamp %s, incoming %s)",


### PR DESCRIPTION
Implemented because of issues with the bulk upload.

The bulk upload downloads a lot of files rapidly from S3 (the XML files) This can result in error:
`HTTP Error 503: Slow Down`

To handle this we add a 3 retries by default. With a 1 sec, 2 sec and 4 sec delay.
For the bulk uploads we can up this to 8 retries (the last one will have a 128 sec delay).

**Note: Already deployed and successfully executed on Trypelim production**