### PR TITLE
SLEEP-1458 Add instance-like filters on entities

### DIFF
--- a/hat/assets/js/apps/Iaso/constants/urls.ts
+++ b/hat/assets/js/apps/Iaso/constants/urls.ts
@@ -120,13 +120,13 @@ export const baseRouteConfigs: Record<string, RouteConfig> = {
     mappings: {
         url: 'forms/mappings',
         params: [
-            'accountId', 
-            'formId', 
+            'accountId',
+            'formId',
             'mappingTypes',
             'orgUnitTypeIds',
             'projectsIds',
-            'search', 
-            ...paginationPathParams
+            'search',
+            ...paginationPathParams,
         ],
     },
     mappingDetail: {
@@ -326,6 +326,7 @@ export const baseRouteConfigs: Record<string, RouteConfig> = {
             'entityTypeIds',
             'locationLimit',
             'groups',
+            'fieldsSearch',
             ...paginationPathParams,
         ],
     },

--- a/hat/assets/js/apps/Iaso/domains/entities/components/Filters.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/components/Filters.tsx
@@ -255,19 +255,6 @@ const Filters: FunctionComponent<Props> = ({ params, isFetching }) => {
                             initialSelection={initialOrgUnit}
                         />
                     </Box>
-                    <QueryBuilderInput
-                        label={MESSAGES.queryBuilder}
-                        onChange={handleChangeQueryBuilder}
-                        initialLogic={fieldsSearchJson}
-                        fields={fields}
-                        iconProps={{
-                            label: MESSAGES.queryBuilder,
-                            value: getHumanReadableJsonLogic(fieldsSearchJson),
-                            onClear: () =>
-                                handleChange('fieldsSearch', undefined),
-                        }}
-                        InfoPopper={<Popper />}
-                    />
                     {params.tab === 'map' && (
                         <Box mt={2}>
                             <LocationLimit
@@ -313,35 +300,60 @@ const Filters: FunctionComponent<Props> = ({ params, isFetching }) => {
                         options={usersOptions}
                     />
                 </Grid>
-
-                <Grid item xs={12} sm={6} md={3}>
-                    <Box
-                        mt={2}
-                        display="flex"
-                        justifyContent="flex-end"
-                        alignItems="end"
-                        flexDirection="column"
-                    >
-                        <Box mb={2}>
-                            <Button
-                                data-test="search-button"
-                                disabled={textSearchError || !filtersUpdated}
-                                variant="contained"
-                                color="primary"
-                                onClick={() => handleSearch()}
-                            >
-                                <SearchIcon className={classes.buttonIcon} />
-                                {formatMessage(MESSAGES.search)}
-                            </Button>
-                        </Box>
-                        <DownloadButtonsComponent
-                            csvUrl={`${apiUrl}&csv=true`}
-                            xlsxUrl={`${apiUrl}&xlsx=true`}
-                            disabled={isFetching}
-                        />
-                    </Box>
-                </Grid>
             </Grid>
+
+            <Box mt={-2}>
+                <Grid container columnSpacing={2}>
+                    <Grid item xs={12} sm={6}>
+                        <QueryBuilderInput
+                            label={MESSAGES.queryBuilder}
+                            onChange={handleChangeQueryBuilder}
+                            initialLogic={fieldsSearchJson}
+                            fields={fields}
+                            iconProps={{
+                                label: MESSAGES.queryBuilder,
+                                value: getHumanReadableJsonLogic(
+                                    fieldsSearchJson,
+                                ),
+                                onClear: () =>
+                                    handleChange('fieldsSearch', undefined),
+                            }}
+                            InfoPopper={<Popper />}
+                        />
+                    </Grid>
+                    <Grid item xs={12} sm={6}>
+                        <Box
+                            mt={2}
+                            display="flex"
+                            justifyContent="flex-end"
+                            alignItems="end"
+                            flexDirection="column"
+                        >
+                            <Box mb={2}>
+                                <Button
+                                    data-test="search-button"
+                                    disabled={
+                                        textSearchError || !filtersUpdated
+                                    }
+                                    variant="contained"
+                                    color="primary"
+                                    onClick={() => handleSearch()}
+                                >
+                                    <SearchIcon
+                                        className={classes.buttonIcon}
+                                    />
+                                    {formatMessage(MESSAGES.search)}
+                                </Button>
+                            </Box>
+                            <DownloadButtonsComponent
+                                csvUrl={`${apiUrl}&csv=true`}
+                                xlsxUrl={`${apiUrl}&xlsx=true`}
+                                disabled={isFetching}
+                            />
+                        </Box>
+                    </Grid>
+                </Grid>
+            </Box>
         </Box>
     );
 };

--- a/hat/assets/js/apps/Iaso/domains/entities/components/Filters.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/components/Filters.tsx
@@ -52,7 +52,7 @@ import {
 import { Popper } from '../../forms/fields/components/Popper';
 import { parseJson } from '../../instances/utils/jsonLogicParse';
 import { useGetAllPossibleFields } from '../../forms/hooks/useGetPossibleFields';
-import { useGetFormDescriptor } from '../../forms/fields/hooks/useGetFormDescriptor';
+import { useGetAllFormDescriptors } from '../../forms/fields/hooks/useGetFormDescriptor';
 import { useGetQueryBuilderFieldsForAllForms } from '../../forms/fields/hooks/useGetQueryBuildersFields';
 import { useGetQueryBuilderListToReplace } from '../../forms/fields/hooks/useGetQueryBuilderListToReplace';
 
@@ -140,7 +140,7 @@ const Filters: FunctionComponent<Props> = ({ params, isFetching }) => {
 
     // Load QueryBuilder resources
     const { allPossibleFields } = useGetAllPossibleFields();
-    const { data: formDescriptors } = useGetFormDescriptor();
+    const { data: formDescriptors } = useGetAllFormDescriptors();
     const fields = useGetQueryBuilderFieldsForAllForms(
         formDescriptors,
         allPossibleFields,

--- a/hat/assets/js/apps/Iaso/domains/entities/entityTypes/hooks/requests/forms.ts
+++ b/hat/assets/js/apps/Iaso/domains/entities/entityTypes/hooks/requests/forms.ts
@@ -35,11 +35,15 @@ export const useGetForm = (
 
 export const useGetForms = (
     enabled: boolean,
+    fields?: string[] | undefined,
 ): UseQueryResult<Form[], Error> => {
+    let url = '/api/forms/?fields=id,name,latest_form_version';
+    if (fields) {
+        url += `,${fields.join(',')}`;
+    }
     return useSnackQuery({
         queryKey: ['forms'],
-        queryFn: () =>
-            getRequest('/api/forms/?fields=id,name,latest_form_version'),
+        queryFn: () => getRequest(url),
         options: {
             staleTime: 60000,
             enabled,

--- a/hat/assets/js/apps/Iaso/domains/entities/entityTypes/hooks/requests/forms.ts
+++ b/hat/assets/js/apps/Iaso/domains/entities/entityTypes/hooks/requests/forms.ts
@@ -6,7 +6,6 @@ import { getRequest } from '../../../../../libs/Api';
 import { Form, PossibleField } from '../../../../forms/types/forms';
 import { usePossibleFields } from '../../../../forms/hooks/useGetPossibleFields';
 
-
 export const useGetForm = (
     formId: number | undefined,
     enabled: boolean,
@@ -37,10 +36,9 @@ export const useGetForms = (
     enabled: boolean,
     fields?: string[] | undefined,
 ): UseQueryResult<Form[], Error> => {
-    let url = '/api/forms/?fields=id,name,latest_form_version';
-    if (fields) {
-        url += `,${fields.join(',')}`;
-    }
+    const apiUrl = '/api/forms/?fields=id,name,latest_form_version';
+    const url = fields ? `${apiUrl},${fields.join(',')}` : apiUrl;
+
     return useSnackQuery({
         queryKey: ['forms'],
         queryFn: () => getRequest(url),

--- a/hat/assets/js/apps/Iaso/domains/entities/hooks/requests.ts
+++ b/hat/assets/js/apps/Iaso/domains/entities/hooks/requests.ts
@@ -14,37 +14,22 @@ import {
 } from '../../../libs/Api';
 import MESSAGES from '../messages';
 
+import { Location } from '../components/ListMap';
+import getDisplayName, { Profile } from '../../../utils/usersUtils';
 import { makeUrlWithParams } from '../../../libs/utils';
 
 import { Beneficiary } from '../types/beneficiary';
-import { PaginatedInstances } from '../../instances/types/instance';
+import { DisplayedLocation } from '../types/locations';
 import { DropdownOptions } from '../../../types/utils';
-import getDisplayName, { Profile } from '../../../utils/usersUtils';
 import { DropdownTeamsOptions, Team } from '../../teams/types/team';
 import { ExtraColumn } from '../types/fields';
-import { DisplayedLocation } from '../types/locations';
-import { Location } from '../components/ListMap';
+import { PaginatedInstances } from '../../instances/types/instance';
+import { Params } from '../types/filters';
 
 export interface PaginatedBeneficiaries extends Pagination {
     result: Array<Beneficiary>;
     columns: Array<ExtraColumn>;
 }
-
-type Params = {
-    pageSize: string;
-    order: string;
-    page: string;
-    search?: string;
-    location?: string;
-    dateFrom?: string;
-    dateTo?: string;
-    submitterId?: string;
-    submitterTeamId?: string;
-    entityTypeIds?: string;
-    locationLimit?: string;
-    groups?: string;
-    tab?: string;
-};
 
 type ApiParams = {
     limit?: string;
@@ -61,6 +46,7 @@ type ApiParams = {
     locationLimit?: string;
     groups?: string;
     tab: string;
+    fields_search?: string;
 };
 
 type GetAPiParams = {
@@ -88,6 +74,7 @@ export const useGetBeneficiariesApiParams = (
         page: params.page || '1',
         groups: params.groups,
         tab: params.tab || 'list',
+        fields_search: params.fieldsSearch,
     };
     if (asLocation) {
         apiParams.asLocation = true;

--- a/hat/assets/js/apps/Iaso/domains/entities/hooks/requests.ts
+++ b/hat/assets/js/apps/Iaso/domains/entities/hooks/requests.ts
@@ -43,6 +43,7 @@ type Params = {
     entityTypeIds?: string;
     locationLimit?: string;
     groups?: string;
+    tab?: string;
 };
 
 type ApiParams = {
@@ -59,6 +60,7 @@ type ApiParams = {
     asLocation?: boolean;
     locationLimit?: string;
     groups?: string;
+    tab: string;
 };
 
 type GetAPiParams = {
@@ -85,6 +87,7 @@ export const useGetBeneficiariesApiParams = (
         limit: params.pageSize || '20',
         page: params.page || '1',
         groups: params.groups,
+        tab: params.tab || 'list',
     };
     if (asLocation) {
         apiParams.asLocation = true;
@@ -105,6 +108,7 @@ export const useGetBeneficiariesPaginated = (
         queryKey: ['beneficiaries', apiParams],
         queryFn: () => getRequest(url),
         options: {
+            enabled: apiParams.tab === 'list',
             staleTime: 60000,
             cacheTime: 1000 * 60 * 5,
             keepPreviousData: true,
@@ -120,6 +124,7 @@ export const useGetBeneficiariesLocations = (
         queryKey: ['beneficiariesLocations', apiParams],
         queryFn: () => getRequest(url),
         options: {
+            enabled: apiParams.tab === 'map',
             staleTime: 60000,
             select: data =>
                 data?.result?.map(beneficiary => ({

--- a/hat/assets/js/apps/Iaso/domains/entities/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/index.tsx
@@ -48,6 +48,7 @@ type Params = {
     entityTypeIds?: string;
     locationLimit?: string;
     groups?: string;
+    fieldsSearch?: string;
 };
 
 export const Beneficiaries: FunctionComponent = () => {

--- a/hat/assets/js/apps/Iaso/domains/entities/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/index.tsx
@@ -106,6 +106,7 @@ export const Beneficiaries: FunctionComponent = () => {
     }
     const { data: locations, isFetching: isFetchingLocations } =
         useGetBeneficiariesLocations(params, displayedLocation);
+
     return (
         <>
             {isLoading && tab === 'map' && <LoadingSpinner />}

--- a/hat/assets/js/apps/Iaso/domains/entities/messages.ts
+++ b/hat/assets/js/apps/Iaso/domains/entities/messages.ts
@@ -253,6 +253,10 @@ const MESSAGES = defineMessages({
         defaultMessage: 'Group',
         id: 'iaso.label.group',
     },
+    queryBuilder: {
+        id: 'iaso.instance.queryBuilder',
+        defaultMessage: 'Search in submitted fields',
+    },
 });
 
 export default MESSAGES;

--- a/hat/assets/js/apps/Iaso/domains/entities/types/filters.ts
+++ b/hat/assets/js/apps/Iaso/domains/entities/types/filters.ts
@@ -1,27 +1,19 @@
 export type Filters = {
-    search?: string;
-    location?: string;
     dateFrom?: string;
     dateTo?: string;
-    submitterId?: string;
-    submitterTeamId?: string;
     entityTypeIds?: string;
+    fieldsSearch?: string;
+    location?: string;
     locationLimit?: string;
     groups?: string;
+    search?: string;
+    submitterId?: string;
+    submitterTeamId?: string;
 };
 
-export type Params = {
-    pageSize: string;
+export type Params = Filters & {
     order: string;
     page: string;
+    pageSize: string;
     tab: string;
-    search?: string;
-    location?: string;
-    dateFrom?: string;
-    dateTo?: string;
-    submitterId?: string;
-    submitterTeamId?: string;
-    entityTypeIds?: string;
-    locationLimit?: string;
-    groups?: string;
 };

--- a/hat/assets/js/apps/Iaso/domains/forms/fields/hooks/useGetFormDescriptor.ts
+++ b/hat/assets/js/apps/Iaso/domains/forms/fields/hooks/useGetFormDescriptor.ts
@@ -12,7 +12,7 @@ type FormVersionsList = {
 };
 
 const getVersion = (formId: number | undefined): Promise<FormVersionsList> => {
-    return getRequest(`/api/formversions/?form_id=${formId}&fields=descriptor`);
+    return getRequest(`/api/formversions/?form_id=&fields=descriptor`);
 };
 export const useGetFormDescriptor = (
     formId?: number,
@@ -25,7 +25,7 @@ export const useGetFormDescriptor = (
         queryKey,
         queryFn: () => getVersion(formId),
         options: {
-            enabled: Boolean(formId),
+            // enabled: Boolean(formId), TODO
             select: (
                 data: FormVersionsList | undefined,
             ): FormDescriptor[] | undefined => {

--- a/hat/assets/js/apps/Iaso/domains/forms/fields/hooks/useGetFormDescriptor.ts
+++ b/hat/assets/js/apps/Iaso/domains/forms/fields/hooks/useGetFormDescriptor.ts
@@ -12,8 +12,16 @@ type FormVersionsList = {
 };
 
 const getVersion = (formId: number | undefined): Promise<FormVersionsList> => {
-    return getRequest(`/api/formversions/?form_id=&fields=descriptor`);
+    return getRequest(`/api/formversions/?form_id=${formId}&fields=descriptor`);
 };
+
+const processResult = (
+    data: FormVersionsList | undefined,
+): FormDescriptor[] | undefined => {
+    if (!data) return data;
+    return data.form_versions?.map(version => version.descriptor);
+};
+
 export const useGetFormDescriptor = (
     formId?: number,
 ): UseQueryResult<FormDescriptor[] | undefined, Error> => {
@@ -25,13 +33,21 @@ export const useGetFormDescriptor = (
         queryKey,
         queryFn: () => getVersion(formId),
         options: {
-            // enabled: Boolean(formId), TODO
-            select: (
-                data: FormVersionsList | undefined,
-            ): FormDescriptor[] | undefined => {
-                if (!data) return data;
-                return data.form_versions?.map(version => version.descriptor);
-            },
+            enabled: Boolean(formId),
+            select: data => processResult(data),
+        },
+    });
+};
+
+export const useGetAllFormDescriptors = (): UseQueryResult<
+    FormDescriptor[] | undefined,
+    Error
+> => {
+    return useSnackQuery({
+        queryKey: ['instanceDescriptors'],
+        queryFn: () => getRequest('/api/formversions/?fields=descriptor'),
+        options: {
+            select: data => processResult(data),
         },
     });
 };

--- a/hat/assets/js/apps/Iaso/domains/forms/fields/hooks/useGetQueryBuilderListToReplace.ts
+++ b/hat/assets/js/apps/Iaso/domains/forms/fields/hooks/useGetQueryBuilderListToReplace.ts
@@ -1,5 +1,5 @@
 import { QueryBuilderListToReplace } from 'bluesquare-components';
-import { purple, blue } from '@mui/material/colors';
+import { blue, purple, green, red } from '@mui/material/colors';
 
 export const useGetQueryBuilderListToReplace =
     (): QueryBuilderListToReplace[] => {
@@ -7,6 +7,14 @@ export const useGetQueryBuilderListToReplace =
             {
                 color: purple[700],
                 items: ['AND', 'OR'],
+            },
+            {
+                color: green[700],
+                items: ['SOME OF', 'ALL OF', 'HAVE'],
+            },
+            {
+                color: red[700],
+                items: ['NONE OF'],
             },
             {
                 color: blue[700],

--- a/hat/assets/js/apps/Iaso/domains/forms/fields/hooks/useGetQueryBuildersFields.ts
+++ b/hat/assets/js/apps/Iaso/domains/forms/fields/hooks/useGetQueryBuildersFields.ts
@@ -3,6 +3,7 @@ import { QueryBuilderFields } from 'bluesquare-components';
 import { formatLabel } from '../../../instances/utils';
 
 import { FormDescriptor, PossibleField } from '../../types/forms';
+import { PossibleFieldsForForm } from '../../hooks/useGetPossibleFields';
 
 import { iasoFields, Field } from '../constants';
 import { findDescriptorInChildren } from '../../../../utils';
@@ -57,19 +58,19 @@ export const useGetQueryBuildersFields = (
 
 export const useGetQueryBuilderFieldsForAllForms = (
     formDescriptors?: FormDescriptor[],
-    allPossibleFields?: PossibleField[],
+    allPossibleFields?: PossibleFieldsForForm[],
 ): QueryBuilderFields => {
     if (!allPossibleFields || !formDescriptors) return {};
     const fields: QueryBuilderFields = {};
 
-    for (const [form_id, possibleFields] of Object.entries(allPossibleFields)) {
+    for (const { form_id, name, possibleFields } of allPossibleFields) {
         const subfields = useGetQueryBuildersFields(
             formDescriptors,
             possibleFields,
         );
 
         fields[form_id] = {
-            label: form_id,
+            label: name,
             type: '!group',
             mode: 'array',
             conjunctions: ['AND', 'OR'],

--- a/hat/assets/js/apps/Iaso/domains/forms/fields/hooks/useGetQueryBuildersFields.ts
+++ b/hat/assets/js/apps/Iaso/domains/forms/fields/hooks/useGetQueryBuildersFields.ts
@@ -54,3 +54,30 @@ export const useGetQueryBuildersFields = (
     });
     return fields;
 };
+
+export const useGetQueryBuilderFieldsForAllForms = (
+    formDescriptors?: FormDescriptor[],
+    allPossibleFields?: PossibleField[],
+): QueryBuilderFields => {
+    if (!allPossibleFields || !formDescriptors) return {};
+    const fields: QueryBuilderFields = {};
+
+    for (const [form_id, possibleFields] of Object.entries(allPossibleFields)) {
+        const subfields = useGetQueryBuildersFields(
+            formDescriptors,
+            possibleFields,
+        );
+
+        fields[form_id] = {
+            label: form_id,
+            type: '!group',
+            mode: 'array',
+            conjunctions: ['AND', 'OR'],
+            operators: ['some', 'all', 'none'],
+            defaultOperator: 'some',
+            subfields: subfields,
+        };
+    }
+
+    return fields;
+};

--- a/hat/assets/js/apps/Iaso/domains/forms/hooks/useGetPossibleFields.ts
+++ b/hat/assets/js/apps/Iaso/domains/forms/hooks/useGetPossibleFields.ts
@@ -3,7 +3,10 @@ import { useMemo } from 'react';
 import { UseQueryResult } from 'react-query';
 import { cloneDeep } from 'lodash';
 import { DropdownOptions } from '../../../types/utils';
-import { useGetForm } from '../../entities/entityTypes/hooks/requests/forms';
+import {
+    useGetForm,
+    useGetForms,
+} from '../../entities/entityTypes/hooks/requests/forms';
 
 import { useSnackQuery } from '../../../libs/apiHooks';
 import { getRequest } from '../../../libs/Api';
@@ -13,6 +16,10 @@ import { Form, PossibleField } from '../types/forms';
 type Result = {
     possibleFields: PossibleField[];
     isFetchingForm: boolean;
+};
+type AllResults = {
+    allPossibleFields: any; // TODO
+    isFetchingForms: boolean;
 };
 
 export const usePossibleFields = (
@@ -40,6 +47,36 @@ export const useGetPossibleFields = (formId?: number, appId?: string): Result =>
         appId,
     );
     return usePossibleFields(isFetchingForm, currentForm);
+};
+
+export const useAllPossibleFields = (
+    isFetchingForms: boolean,
+    allForms: Form[] = [],
+): AllResults => {
+    return useMemo(() => {
+        let allPossibleFields = {};
+        allForms.forEach(form => {
+            const possibleFields =
+                form?.possible_fields?.map(field => ({
+                    ...field,
+                    fieldKey: field.name.replace('.', ''),
+                })) || [];
+            allPossibleFields[form.form_id] = possibleFields;
+        });
+
+        return {
+            allPossibleFields,
+            isFetchingForms,
+        };
+    }, [isFetchingForms]);
+};
+
+export const useGetAllPossibleFields = (): AllResults => {
+    const { data: allForms, isFetching: isFetchingForms } = useGetForms(true, [
+        'form_id',
+        'possible_fields',
+    ]);
+    return useAllPossibleFields(isFetchingForms, allForms);
 };
 
 type PossibleFieldsDropdown = {

--- a/hat/assets/js/apps/Iaso/domains/forms/hooks/useGetPossibleFields.ts
+++ b/hat/assets/js/apps/Iaso/domains/forms/hooks/useGetPossibleFields.ts
@@ -17,8 +17,13 @@ type Result = {
     possibleFields: PossibleField[];
     isFetchingForm: boolean;
 };
+export type PossibleFieldsForForm = {
+    form_id: string;
+    name: string;
+    possibleFields: PossibleField[];
+};
 type AllResults = {
-    allPossibleFields: any; // TODO
+    allPossibleFields: PossibleFieldsForForm[];
     isFetchingForms: boolean;
 };
 
@@ -54,14 +59,18 @@ export const useAllPossibleFields = (
     allForms: Form[] = [],
 ): AllResults => {
     return useMemo(() => {
-        let allPossibleFields = {};
+        let allPossibleFields: PossibleFieldsForForm[] = [];
         allForms.forEach(form => {
             const possibleFields =
                 form?.possible_fields?.map(field => ({
                     ...field,
                     fieldKey: field.name.replace('.', ''),
                 })) || [];
-            allPossibleFields[form.form_id] = possibleFields;
+            allPossibleFields.push({
+                form_id: form.form_id,
+                name: form.name,
+                possibleFields,
+            });
         });
 
         return {

--- a/hat/assets/js/apps/Iaso/domains/forms/hooks/useGetPossibleFields.ts
+++ b/hat/assets/js/apps/Iaso/domains/forms/hooks/useGetPossibleFields.ts
@@ -44,7 +44,10 @@ export const usePossibleFields = (
     }, [form?.possible_fields, isFetchingForm]);
 };
 
-export const useGetPossibleFields = (formId?: number, appId?: string): Result => {
+export const useGetPossibleFields = (
+    formId?: number,
+    appId?: string,
+): Result => {
     const { data: currentForm, isFetching: isFetchingForm } = useGetForm(
         formId,
         Boolean(formId),
@@ -59,7 +62,7 @@ export const useAllPossibleFields = (
     allForms: Form[] = [],
 ): AllResults => {
     return useMemo(() => {
-        let allPossibleFields: PossibleFieldsForForm[] = [];
+        const allPossibleFields: PossibleFieldsForForm[] = [];
         allForms.forEach(form => {
             const possibleFields =
                 form?.possible_fields?.map(field => ({
@@ -77,7 +80,7 @@ export const useAllPossibleFields = (
             allPossibleFields,
             isFetchingForms,
         };
-    }, [isFetchingForms]);
+    }, [isFetchingForms, allForms]);
 };
 
 export const useGetAllPossibleFields = (): AllResults => {

--- a/hat/assets/js/apps/Iaso/domains/instances/components/InstancesFiltersComponent.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/InstancesFiltersComponent.js
@@ -268,7 +268,7 @@ const InstancesFiltersComponent = ({
             <UserOrgUnitRestriction />
 
             <Grid container spacing={2}>
-                <Grid item xs={12} md={3}>
+                <Grid item xs={12} sm={6} md={3}>
                     <InputComponent
                         keyValue="search"
                         onChange={handleFormChange}
@@ -336,7 +336,7 @@ const InstancesFiltersComponent = ({
                         />
                     </Box>
                 </Grid>
-                <Grid item xs={12} md={3}>
+                <Grid item xs={12} sm={6} md={3}>
                     <InputComponent
                         keyValue="status"
                         clearable
@@ -372,7 +372,7 @@ const InstancesFiltersComponent = ({
                         />
                     </Box>
                 </Grid>
-                <Grid item xs={12} md={3}>
+                <Grid item xs={12} sm={6} md={3}>
                     <Box id="ou-tree-input">
                         <OrgUnitTreeviewModal
                             toggleOnLabelClick={false}
@@ -411,7 +411,7 @@ const InstancesFiltersComponent = ({
                         loading={fetchingPlannings}
                     />
                 </Grid>
-                <Grid item xs={12} md={3}>
+                <Grid item xs={12} sm={6} md={3}>
                     <DatesRange
                         xs={12}
                         sm={12}

--- a/iaso/api/entity.py
+++ b/iaso/api/entity.py
@@ -133,6 +133,7 @@ class EntityViewSet(ModelViewSet):
         created_by_id = self.request.query_params.get("created_by_id", None)
         created_by_team_id = self.request.query_params.get("created_by_team_id", None)
         groups = self.request.query_params.get("groups", None)
+        fields_search = self.request.GET.get("fields_search", None)
 
         queryset = Entity.objects.filter_for_user(self.request.user)
 
@@ -183,6 +184,10 @@ class EntityViewSet(ModelViewSet):
         if groups:
             queryset = queryset.filter(attributes__org_unit__groups__in=groups.split(","))
 
+        if fields_search:
+            q = jsonlogic_to_q(json.loads(fields_search), field_prefix="json__")
+            queryset = queryset.filter(q)
+
         # location
         return queryset
 
@@ -230,13 +235,6 @@ class EntityViewSet(ModelViewSet):
 
     def list(self, request: Request, *args, **kwargs):
         queryset = self.filter_queryset(self.get_queryset())
-
-        json_content = request.GET.get("jsonContent", None)
-        # json_content = '{"and": [{"==": [{"var": "trypelim_CATT.result"}, "positive"]}]}'
-        if json_content:
-            q = jsonlogic_to_q(json.loads(json_content), field_prefix="json__")
-            queryset = queryset.filter(q)
-            print(queryset.query)
 
         csv_format = request.GET.get("csv", None)
         xlsx_format = request.GET.get("xlsx", None)

--- a/iaso/api/entity.py
+++ b/iaso/api/entity.py
@@ -30,7 +30,7 @@ from iaso.api.common import (
 )
 from iaso.models import Entity, EntityType, Instance, OrgUnit
 from iaso.models.deduplication import ValidationStatus
-from iaso.utils.jsonlogic import jsonlogic_to_q
+from iaso.utils.jsonlogic import entities_jsonlogic_to_q
 
 
 class EntitySerializer(serializers.ModelSerializer):
@@ -185,7 +185,7 @@ class EntityViewSet(ModelViewSet):
             queryset = queryset.filter(attributes__org_unit__groups__in=groups.split(","))
 
         if fields_search:
-            q = jsonlogic_to_q(json.loads(fields_search), field_prefix="json__")
+            q = entities_jsonlogic_to_q(json.loads(fields_search))
             queryset = queryset.filter(q)
 
         # location

--- a/iaso/api/entity.py
+++ b/iaso/api/entity.py
@@ -1,6 +1,7 @@
 import csv
 import datetime
 import io
+import json
 import math
 from time import gmtime, strftime
 from typing import Any, List, Union
@@ -29,6 +30,7 @@ from iaso.api.common import (
 )
 from iaso.models import Entity, EntityType, Instance, OrgUnit
 from iaso.models.deduplication import ValidationStatus
+from iaso.utils.jsonlogic import jsonlogic_to_q
 
 
 class EntitySerializer(serializers.ModelSerializer):
@@ -228,6 +230,14 @@ class EntityViewSet(ModelViewSet):
 
     def list(self, request: Request, *args, **kwargs):
         queryset = self.filter_queryset(self.get_queryset())
+
+        json_content = request.GET.get("jsonContent", None)
+        # json_content = '{"and": [{"==": [{"var": "trypelim_CATT.result"}, "positive"]}]}'
+        if json_content:
+            q = jsonlogic_to_q(json.loads(json_content), field_prefix="json__")
+            queryset = queryset.filter(q)
+            print(queryset.query)
+
         csv_format = request.GET.get("csv", None)
         xlsx_format = request.GET.get("xlsx", None)
         is_export = any([csv_format, xlsx_format])

--- a/iaso/tests/api/test_entities.py
+++ b/iaso/tests/api/test_entities.py
@@ -268,7 +268,7 @@ class EntityAPITestCase(APITestCase):
 
     def test_get_entity_search_in_instances(self):
         """
-        Test the 'searchInInstances' filter of /api/entities
+        Test the 'fields_search' filter of /api/entities
 
         This parameter allows to filter entities based on the presence of a
         form instance with certain attributes.
@@ -320,7 +320,7 @@ class EntityAPITestCase(APITestCase):
 
         response = self.client.get(
             "/api/entities/",
-            {"jsonContent": self._generate_json_filter("and", "F", "Bujumbura")},
+            {"fields_search": self._generate_json_filter("and", "F", "Bujumbura")},
         )
         self.assertEqual(len(response.json()["result"]), 1)
         the_result = response.json()["result"][0]
@@ -328,13 +328,13 @@ class EntityAPITestCase(APITestCase):
 
         response = self.client.get(
             "/api/entities/",
-            {"jsonContent": self._generate_json_filter("and", "M", "Bujumbura")},
+            {"fields_search": self._generate_json_filter("and", "M", "Bujumbura")},
         )
         self.assertEqual(len(response.json()["result"]), 0)
 
         response = self.client.get(
             "/api/entities/",
-            {"jsonContent": self._generate_json_filter("or", "F", "Kinshasa")},
+            {"fields_search": self._generate_json_filter("or", "F", "Kinshasa")},
         )
         self.assertEqual(len(response.json()["result"]), 2)
         result_ids = [r["id"] for r in response.json()["result"]]
@@ -345,15 +345,15 @@ class EntityAPITestCase(APITestCase):
             {
                 operator: [
                     {
-                        "==": [
-                            {"var": f"{self.form_1.form_id}.gender"},
-                            gender,
+                        "some": [
+                            {"var": self.form_1.form_id},
+                            {"==": [{"var": "gender"}, gender]},
                         ]
                     },
                     {
-                        "==": [
-                            {"var": f"{self.form_2.form_id}.residence"},
-                            residence,
+                        "some": [
+                            {"var": self.form_2.form_id},
+                            {"==": [{"var": "residence"}, residence]},
                         ]
                     },
                 ]

--- a/iaso/tests/api/test_entities.py
+++ b/iaso/tests/api/test_entities.py
@@ -317,41 +317,66 @@ class EntityAPITestCase(APITestCase):
             json={"residence": "Kinshasa"},
             entity=ent2,
         )
+        Instance.objects.create(
+            org_unit=self.jedi_council_corruscant,
+            form=self.form_2,
+            json={"residence": "Accra"},
+            entity=ent2,
+        )
 
+        # gender f AND SOME residence Bujumbura
         response = self.client.get(
             "/api/entities/",
-            {"fields_search": self._generate_json_filter("and", "F", "Bujumbura")},
+            {"fields_search": self._generate_json_filter("and", "some", "F", "Bujumbura")},
         )
         self.assertEqual(len(response.json()["result"]), 1)
         the_result = response.json()["result"][0]
         self.assertEqual(the_result["id"], ent1.id)
 
+        # gender m AND SOME residence Bujumbura
         response = self.client.get(
             "/api/entities/",
-            {"fields_search": self._generate_json_filter("and", "M", "Bujumbura")},
+            {"fields_search": self._generate_json_filter("and", "some", "M", "Bujumbura")},
         )
         self.assertEqual(len(response.json()["result"]), 0)
 
+        # gender f OR SOME residence Kinshasa
         response = self.client.get(
             "/api/entities/",
-            {"fields_search": self._generate_json_filter("or", "F", "Kinshasa")},
+            {"fields_search": self._generate_json_filter("or", "some", "F", "Kinshasa")},
         )
         self.assertEqual(len(response.json()["result"]), 2)
         result_ids = [r["id"] for r in response.json()["result"]]
         self.assertEqual(sorted(result_ids), sorted([ent1.id, ent2.id]))
 
-    def _generate_json_filter(self, operator, gender, residence):
+        # gender m AND SOME residence Kinshasa
+        response = self.client.get(
+            "/api/entities/",
+            {"fields_search": self._generate_json_filter("and", "some", "M", "Kinshasa")},
+        )
+        self.assertEqual(len(response.json()["result"]), 1)
+        the_result = response.json()["result"][0]
+        self.assertEqual(the_result["id"], ent2.id)
+
+        # gender M AND ALL residence Kinshasa
+        response = self.client.get(
+            "/api/entities/",
+            {"fields_search": self._generate_json_filter("and", "all", "M", "Kinshasa")},
+        )
+        self.assertEqual(len(response.json()["result"]), 0)
+
+    def _generate_json_filter(self, operator, some_or_all, gender, residence):
         return json.dumps(
             {
                 operator: [
                     {
-                        "some": [
+                        some_or_all: [
                             {"var": self.form_1.form_id},
                             {"==": [{"var": "gender"}, gender]},
                         ]
                     },
                     {
-                        "some": [
+                        some_or_all: [
                             {"var": self.form_2.form_id},
                             {"==": [{"var": "residence"}, residence]},
                         ]

--- a/iaso/tests/api/test_entities.py
+++ b/iaso/tests/api/test_entities.py
@@ -1,3 +1,4 @@
+import json
 import time
 import uuid
 from unittest import mock
@@ -48,7 +49,9 @@ class EntityAPITestCase(APITestCase):
             username="user_without_ou", account=star_wars, permissions=["iaso_entities"]
         )
 
-        cls.form_1 = m.Form.objects.create(name="Hydroponics study", period_type=m.MONTH, single_per_period=True)
+        cls.form_1 = m.Form.objects.create(
+            name="Hydroponics study", period_type=m.MONTH, single_per_period=True, form_id="form_1"
+        )
 
         cls.create_form_instance(
             form=cls.form_1, period="202001", org_unit=cls.jedi_council_corruscant, project=cls.project, uuid=uuid.uuid4
@@ -63,10 +66,14 @@ class EntityAPITestCase(APITestCase):
             form=cls.form_1, period="202003", org_unit=cls.jedi_council_corruscant, project=cls.project, uuid=uuid.uuid4
         )
 
+        cls.entity_type = EntityType.objects.create(
+            name="Type 1",
+            reference_form=cls.form_1,
+            account=cls.star_wars,
+        )
+
     def test_create_single_entity(self):
         self.client.force_authenticate(self.yoda)
-
-        entity_type = EntityType.objects.create(name="Type 1", reference_form=self.form_1)
 
         instance = Instance.objects.create(
             org_unit=self.jedi_council_corruscant,
@@ -76,7 +83,7 @@ class EntityAPITestCase(APITestCase):
 
         payload = {
             "name": "New Client",
-            "entity_type": entity_type.pk,
+            "entity_type": self.entity_type.pk,
             "attributes": instance.uuid,
             "account": self.yoda.iaso_profile.account.pk,
         }
@@ -88,8 +95,6 @@ class EntityAPITestCase(APITestCase):
     def test_create_multiples_entity(self):
         self.client.force_authenticate(self.yoda)
 
-        entity_type = EntityType.objects.create(name="Type 1", reference_form=self.form_1)
-
         instance = Instance.objects.create(
             org_unit=self.jedi_council_corruscant, form=self.form_1, period="202002", uuid=uuid.uuid4()
         )
@@ -100,12 +105,12 @@ class EntityAPITestCase(APITestCase):
 
         payload = {
             "name": "New Client",
-            "entity_type": entity_type.pk,
+            "entity_type": self.entity_type.pk,
             "attributes": instance.uuid,
             "account": self.yoda.iaso_profile.account.pk,
         }, {
             "name": "New Client 2",
-            "entity_type": entity_type.pk,
+            "entity_type": self.entity_type.pk,
             "attributes": second_instance.uuid,
             "account": self.yoda.iaso_profile.account.pk,
         }
@@ -118,20 +123,18 @@ class EntityAPITestCase(APITestCase):
     def test_create_entity_same_attributes(self):
         self.client.force_authenticate(self.yoda)
 
-        entity_type = EntityType.objects.create(name="Type 1", reference_form=self.form_1)
-
         instance = Instance.objects.create(
             org_unit=self.jedi_council_corruscant, form=self.form_1, period="202002", uuid=uuid.uuid4()
         )
 
         payload = {
             "name": "New Client",
-            "entity_type": entity_type.pk,
+            "entity_type": self.entity_type.pk,
             "attributes": instance.uuid,
             "account": self.yoda.iaso_profile.account.pk,
         }, {
             "name": "New Client 2",
-            "entity_type": entity_type.pk,
+            "entity_type": self.entity_type.pk,
             "attributes": instance.uuid,
             "account": self.yoda.iaso_profile.account.pk,
         }
@@ -143,8 +146,6 @@ class EntityAPITestCase(APITestCase):
     def test_retrieve_entity(self):
         self.client.force_authenticate(self.yoda)
 
-        entity_type = EntityType.objects.create(name="Type 1", reference_form=self.form_1, account=self.star_wars)
-
         instance = Instance.objects.create(
             org_unit=self.jedi_council_corruscant, form=self.form_1, period="202002", uuid=uuid.uuid4()
         )
@@ -155,12 +156,12 @@ class EntityAPITestCase(APITestCase):
 
         payload = {
             "name": "New Client",
-            "entity_type": entity_type.pk,
+            "entity_type": self.entity_type.pk,
             "attributes": instance.uuid,
             "account": self.yoda.iaso_profile.account.pk,
         }, {
             "name": "New Client 2",
-            "entity_type": entity_type.pk,
+            "entity_type": self.entity_type.pk,
             "attributes": second_instance.uuid,
             "account": self.yoda.iaso_profile.account.pk,
         }
@@ -175,8 +176,6 @@ class EntityAPITestCase(APITestCase):
     def test_retrieve_entity_without_attributes(self):
         self.client.force_authenticate(self.yoda)
 
-        entity_type = EntityType.objects.create(name="Type 1", reference_form=self.form_1, account=self.star_wars)
-
         instance = Instance.objects.create(
             org_unit=self.jedi_council_corruscant, form=self.form_1, period="202002", uuid=uuid.uuid4()
         )
@@ -187,12 +186,12 @@ class EntityAPITestCase(APITestCase):
 
         payload = {
             "name": "New Client",
-            "entity_type": entity_type.pk,
+            "entity_type": self.entity_type.pk,
             "attributes": instance.uuid,
             "account": self.yoda.iaso_profile.account.pk,
         }, {
             "name": "New Client 2",
-            "entity_type": entity_type.pk,
+            "entity_type": self.entity_type.pk,
             "attributes": second_instance.uuid,
             "account": self.yoda.iaso_profile.account.pk,
         }
@@ -200,7 +199,7 @@ class EntityAPITestCase(APITestCase):
         self.client.post("/api/entities/bulk_create/", data=payload, format="json")
 
         entity = Entity.objects.create(
-            name="New Client 3", entity_type=entity_type, account=self.yoda.iaso_profile.account
+            name="New Client 3", entity_type=self.entity_type, account=self.yoda.iaso_profile.account
         )
 
         entity.refresh_from_db()
@@ -210,7 +209,7 @@ class EntityAPITestCase(APITestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.json()["result"]), 3)
 
-        response = self.client.get(f"/api/entities/?entity_type_id={entity_type.pk}", format="json")
+        response = self.client.get(f"/api/entities/?entity_type_id={self.entity_type.pk}", format="json")
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.json()["result"]), 3)
@@ -227,9 +226,6 @@ class EntityAPITestCase(APITestCase):
         """
         self.client.force_authenticate(self.yoda)
 
-        # Let's first create the test data
-        entity_type = EntityType.objects.create(name="Type 1", reference_form=self.form_1)
-
         instance = Instance.objects.create(
             org_unit=self.jedi_council_corruscant,
             form=self.form_1,
@@ -239,7 +235,7 @@ class EntityAPITestCase(APITestCase):
 
         payload = {
             "name": "New Client",
-            "entity_type": entity_type.pk,
+            "entity_type": self.entity_type.pk,
             "attributes": instance.uuid,
             "account": self.yoda.iaso_profile.account.pk,
         }
@@ -270,10 +266,102 @@ class EntityAPITestCase(APITestCase):
         self.assertEqual(len(response.json()["result"]), 1)
         self.assertEqual(the_result["id"], newly_added_entity.id)
 
+    def test_get_entity_search_in_instances(self):
+        """
+        Test the 'searchInInstances' filter of /api/entities
+
+        This parameter allows to filter entities based on the presence of a
+        form instance with certain attributes.
+        """
+        self.client.force_authenticate(self.yoda)
+        self.form_2 = m.Form.objects.create(name="Form 2", form_id="form_2")
+
+        # Entity 1 - Female from Bujumbura
+        ent1_instance1 = Instance.objects.create(
+            org_unit=self.jedi_council_corruscant,
+            form=self.form_1,
+            json={"gender": "F"},
+        )
+        ent1 = Entity.objects.create(
+            name="Ent 1",
+            entity_type=self.entity_type,
+            attributes=ent1_instance1,
+            account=self.star_wars,
+        )
+        ent1_instance1.entity = ent1
+        ent1_instance1.save()
+        Instance.objects.create(
+            org_unit=self.jedi_council_corruscant,
+            form=self.form_2,
+            json={"residence": "Bujumbura"},
+            entity=ent1,
+        )
+
+        # Entity 2 - Male from Kinshasa
+        ent2_instance1 = Instance.objects.create(
+            org_unit=self.jedi_council_corruscant,
+            form=self.form_1,
+            json={"gender": "M"},
+        )
+        ent2 = Entity.objects.create(
+            name="Ent 1",
+            entity_type=self.entity_type,
+            attributes=ent2_instance1,
+            account=self.star_wars,
+        )
+        ent2_instance1.entity = ent2
+        ent2_instance1.save()
+        Instance.objects.create(
+            org_unit=self.jedi_council_corruscant,
+            form=self.form_2,
+            json={"residence": "Kinshasa"},
+            entity=ent2,
+        )
+
+        response = self.client.get(
+            "/api/entities/",
+            {"jsonContent": self._generate_json_filter("and", "F", "Bujumbura")},
+        )
+        self.assertEqual(len(response.json()["result"]), 1)
+        the_result = response.json()["result"][0]
+        self.assertEqual(the_result["id"], ent1.id)
+
+        response = self.client.get(
+            "/api/entities/",
+            {"jsonContent": self._generate_json_filter("and", "M", "Bujumbura")},
+        )
+        self.assertEqual(len(response.json()["result"]), 0)
+
+        response = self.client.get(
+            "/api/entities/",
+            {"jsonContent": self._generate_json_filter("or", "F", "Kinshasa")},
+        )
+        self.assertEqual(len(response.json()["result"]), 2)
+        result_ids = [r["id"] for r in response.json()["result"]]
+        self.assertEqual(sorted(result_ids), sorted([ent1.id, ent2.id]))
+
+    def _generate_json_filter(self, operator, gender, residence):
+        return json.dumps(
+            {
+                operator: [
+                    {
+                        "==": [
+                            {"var": f"{self.form_1.form_id}.gender"},
+                            gender,
+                        ]
+                    },
+                    {
+                        "==": [
+                            {"var": f"{self.form_2.form_id}.residence"},
+                            residence,
+                        ]
+                    },
+                ]
+            }
+        )
+
     def test_get_entity_by_id(self):
         self.client.force_authenticate(self.yoda)
-
-        entity_type = EntityType.objects.create(name="Type 1", reference_form=self.form_1)
 
         instance = Instance.objects.create(
             org_unit=self.jedi_council_corruscant,
@@ -283,7 +371,7 @@ class EntityAPITestCase(APITestCase):
 
         payload = {
             "name": "New Client",
-            "entity_type": entity_type.pk,
+            "entity_type": self.entity_type.pk,
             "attributes": instance.uuid,
             "account": self.yoda.iaso_profile.account.pk,
         }
@@ -297,11 +385,10 @@ class EntityAPITestCase(APITestCase):
 
     def test_handle_wrong_attributes(self):
         self.client.force_authenticate(self.yoda)
-        entity_type = EntityType.objects.create(name="Type 1", reference_form=self.form_1)
 
         payload = {
             "name": "New Client",
-            "entity_type": entity_type.pk,
+            "entity_type": self.entity_type.pk,
             "attributes": 2324,
             "account": self.yoda.iaso_profile.account.pk,
         }
@@ -313,22 +400,20 @@ class EntityAPITestCase(APITestCase):
     def test_update_entity(self):
         self.client.force_authenticate(self.yoda)
 
-        entity_type = EntityType.objects.create(name="Type 1", reference_form=self.form_1)
-
         instance = Instance.objects.create(
             org_unit=self.jedi_council_corruscant, form=self.form_1, period="202002", uuid=uuid.uuid4()
         )
 
         payload_post = {
             "name": "New Client",
-            "entity_type": entity_type.pk,
+            "entity_type": self.entity_type.pk,
             "attributes": instance.uuid,
             "account": self.yoda.iaso_profile.account.pk,
         }
 
         self.client.post("/api/entities/", data=payload_post, format="json")
 
-        payload = {"name": "New Client-2", "entity_type": entity_type.pk, "attributes": instance.pk}
+        payload = {"name": "New Client-2", "entity_type": self.entity_type.pk, "attributes": instance.pk}
 
         response = self.client.patch("/api/entities/{0}/".format(Entity.objects.last().pk), data=payload, format="json")
 
@@ -336,8 +421,6 @@ class EntityAPITestCase(APITestCase):
 
     def test_retrieve_only_non_deleted_entity(self):
         self.client.force_authenticate(self.yoda)
-
-        entity_type = EntityType.objects.create(name="Type 1", reference_form=self.form_1, account=self.star_wars)
 
         instance = Instance.objects.create(
             org_unit=self.jedi_council_corruscant, form=self.form_1, period="202002", uuid=uuid.uuid4()
@@ -349,12 +432,12 @@ class EntityAPITestCase(APITestCase):
 
         payload = {
             "name": "New Client",
-            "entity_type": entity_type.pk,
+            "entity_type": self.entity_type.pk,
             "attributes": instance.uuid,
             "account": self.yoda.iaso_profile.account.pk,
         }, {
             "name": "New Client 2",
-            "entity_type": entity_type.pk,
+            "entity_type": self.entity_type.pk,
             "attributes": second_instance.uuid,
             "account": self.yoda.iaso_profile.account.pk,
         }
@@ -369,11 +452,9 @@ class EntityAPITestCase(APITestCase):
     def test_cant_create_entity_without_attributes(self):
         self.client.force_authenticate(self.yoda)
 
-        entity_type = EntityType.objects.create(name="Type 1", reference_form=self.form_1)
-
         payload = {
             "name": "New Client",
-            "entity_type": entity_type.pk,
+            "entity_type": self.entity_type.pk,
             "attributes": None,
             "account": self.yoda.iaso_profile.account.pk,
         }
@@ -384,8 +465,6 @@ class EntityAPITestCase(APITestCase):
 
     def test_retrieve_entity_only_same_account(self):
         self.client.force_authenticate(self.yoda)
-
-        entity_type = EntityType.objects.create(name="Type 1", reference_form=self.form_1, account=self.star_wars)
 
         instance = Instance.objects.create(
             org_unit=self.jedi_council_corruscant,
@@ -401,14 +480,14 @@ class EntityAPITestCase(APITestCase):
 
         Entity.objects.create(
             name="New Client",
-            entity_type=entity_type,
+            entity_type=self.entity_type,
             attributes=instance,
             account=self.yop_solo.iaso_profile.account,
         )
 
         Entity.objects.create(
             name="New Client",
-            entity_type=entity_type,
+            entity_type=self.entity_type,
             attributes=second_instance,
             account=self.yoda.iaso_profile.account,
         )
@@ -421,12 +500,12 @@ class EntityAPITestCase(APITestCase):
     @mock.patch("iaso.api.entity.gmtime", lambda: time.struct_time((2021, 7, 18, 14, 57, 0, 1, 291, 0)))
     def test_export_entity(self):
         self.client.force_authenticate(self.yoda)
-        entity_type = EntityType.objects.create(
-            name="Type 1",
-            reference_form=self.form_1,
-            fields_detail_info_view=["something", "else"],
-            fields_list_view=["something", "else"],
-        )
+        # entity_type = EntityType.objects.create(
+        #     name="Type 1",
+        #     reference_form=self.form_1,
+        #     fields_detail_info_view=["something", "else"],
+        #     fields_list_view=["something", "else"],
+        # )
 
         instance = Instance.objects.create(
             org_unit=self.jedi_council_corruscant,
@@ -442,14 +521,14 @@ class EntityAPITestCase(APITestCase):
 
         Entity.objects.create(
             name="New Client",
-            entity_type=entity_type,
+            entity_type=self.entity_type,
             attributes=instance,
             account=self.yop_solo.iaso_profile.account,
         )
 
         Entity.objects.create(
             name="New Client",
-            entity_type=entity_type,
+            entity_type=self.entity_type,
             attributes=second_instance,
             account=self.yoda.iaso_profile.account,
         )
@@ -465,12 +544,12 @@ class EntityAPITestCase(APITestCase):
         self.assertEqual(response.get("Content-Disposition"), "attachment; filename=entities-2021-07-18-14-57.xlsx")
 
         # export specific entity type as xlsx
-        response = self.client.get(f"/api/entities/?entity_type_ids={entity_type.pk}&xlsx=true/")
+        response = self.client.get(f"/api/entities/?entity_type_ids={self.entity_type.pk}&xlsx=true/")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.get("Content-Disposition"), "attachment; filename=entities-2021-07-18-14-57.xlsx")
 
         # export specific entity type as csv
-        response = self.client.get(f"/api/entities/?entity_type_ids={entity_type.pk}&csv=true/")
+        response = self.client.get(f"/api/entities/?entity_type_ids={self.entity_type.pk}&csv=true/")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.get("Content-Disposition"), "attachment; filename=entities-2021-07-18-14-57.csv")
 
@@ -478,11 +557,6 @@ class EntityAPITestCase(APITestCase):
 
     def test_handle_export_entity_type_empty_field_list(self):
         self.client.force_authenticate(self.yoda)
-
-        entity_type = EntityType.objects.create(
-            name="Type 1",
-            reference_form=self.form_1,
-        )
 
         instance = Instance.objects.create(
             org_unit=self.jedi_council_corruscant,
@@ -492,7 +566,7 @@ class EntityAPITestCase(APITestCase):
 
         entity = Entity.objects.create(
             name="New Client",
-            entity_type=entity_type,
+            entity_type=self.entity_type,
             account=self.yop_solo.iaso_profile.account,
         )
 
@@ -516,11 +590,6 @@ class EntityAPITestCase(APITestCase):
 
         FormVersion.objects.create(form=self.form_1, version_id="A_FORM_ID")
 
-        entity_type = EntityType.objects.create(
-            name="Type 1",
-            reference_form=self.form_1,
-        )
-
         instance = Instance.objects.create(
             org_unit=self.jedi_council_corruscant,
             form=self.form_1,
@@ -534,7 +603,7 @@ class EntityAPITestCase(APITestCase):
 
         entity = Entity.objects.create(
             name="New Client",
-            entity_type=entity_type,
+            entity_type=self.entity_type,
             attributes=instance,
             account=self.yoda.iaso_profile.account,
         )
@@ -566,11 +635,6 @@ class EntityAPITestCase(APITestCase):
         self.form_1.save()
 
         FormVersion.objects.create(form=self.form_1, version_id="A_FORM_ID")
-
-        entity_type = EntityType.objects.create(
-            name="Type 1",
-            reference_form=self.form_1,
-        )
 
         instance = Instance.objects.create(
             org_unit=self.jedi_council_corruscant,
@@ -657,21 +721,21 @@ class EntityAPITestCase(APITestCase):
 
         entity = Entity.objects.create(
             name="New Client",
-            entity_type=entity_type,
+            entity_type=self.entity_type,
             attributes=instance,
             account=self.yoda.iaso_profile.account,
         )
 
         entity_unvalidated = Entity.objects.create(
             name="New Client",
-            entity_type=entity_type,
+            entity_type=self.entity_type,
             attributes=instance_unvalidated_ou,
             account=self.yoda.iaso_profile.account,
         )
 
         entity_no_attributes = Entity.objects.create(
             name="New Client_2",
-            entity_type=entity_type,
+            entity_type=self.entity_type,
             account=self.yop_solo.iaso_profile.account,
         )
 
@@ -692,9 +756,9 @@ class EntityAPITestCase(APITestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response_json.get("count"), 2)
-        self.assertEqual(response_json.get("results")[0].get("entity_type_id"), str(entity_type.id))
+        self.assertEqual(response_json.get("results")[0].get("entity_type_id"), str(self.entity_type.id))
         self.assertEqual(len(response_json.get("results")[0].get("instances")), 1)
-        self.assertEqual(response_json.get("results")[1].get("entity_type_id"), str(entity_type.id))
+        self.assertEqual(response_json.get("results")[1].get("entity_type_id"), str(self.entity_type.id))
         self.assertEqual(len(response_json.get("results")[1].get("instances")), 0)
 
     def test_access_respect_appid_mobile(self):
@@ -730,14 +794,9 @@ class EntityAPITestCase(APITestCase):
         }
         instance_app_id.save()
 
-        entity_type, created = EntityType.objects.get_or_create(
-            name="Type 1",
-            reference_form=self.form_1,
-        )
-
         entity_app_id = Entity.objects.create(
             name="New Client",
-            entity_type=entity_type,
+            entity_type=self.entity_type,
             attributes=instance_app_id,
             account=self.yoda.iaso_profile.account,
         )
@@ -755,7 +814,7 @@ class EntityAPITestCase(APITestCase):
         response_json = response.json()
 
         self.assertEqual(response_json["count"], 1)
-        self.assertEqual(response_json["results"][0]["entity_type_id"], str(entity_type.id))
+        self.assertEqual(response_json["results"][0]["entity_type_id"], str(self.entity_type.id))
 
         response_entity_instance = response_json["results"][0]["instances"]
 
@@ -789,17 +848,15 @@ class EntityAPITestCase(APITestCase):
         user_manager.refresh_from_db()
         self.client.force_authenticate(user_manager)
 
-        entity_type = EntityType.objects.create(name="Type 1", reference_form=self.form_1, account=self.star_wars)
-
         # Village 1 (district 1): instance + entity
         instance_1 = Instance.objects.create(org_unit=village_1, form=self.form_1, period="202002")
-        entity = Entity.objects.create(entity_type=entity_type, attributes=instance_1, account=self.star_wars)
+        entity = Entity.objects.create(entity_type=self.entity_type, attributes=instance_1, account=self.star_wars)
         instance_1.entity = entity
         instance_1.save()
 
         # Village 2 (district 2): instance + entity
         instance_2 = Instance.objects.create(org_unit=village_2, form=self.form_1, period="202002")
-        entity_2 = Entity.objects.create(entity_type=entity_type, attributes=instance_2, account=self.star_wars)
+        entity_2 = Entity.objects.create(entity_type=self.entity_type, attributes=instance_2, account=self.star_wars)
         instance_2.entity = entity_2
         instance_2.save()
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
                 "abortcontroller-polyfill": "^1.7.5",
                 "array-flat-polyfill": "^1.0.1",
                 "babel-plugin-formatjs": "^10.3.4",
-                "bluesquare-components": "github:BLSQ/bluesquare-components#IA-2850_react-router_update_dev",
+                "bluesquare-components": "github:BLSQ/bluesquare-components#SLEEP-1458-entities-filtering",
                 "classnames": "^2.2.6",
                 "color": "^3.1.2",
                 "dom-to-pdf": "^0.3.1",
@@ -3909,9 +3909,9 @@
             }
         },
         "node_modules/@react-awesome-query-builder/core": {
-            "version": "6.5.2",
-            "resolved": "https://registry.npmjs.org/@react-awesome-query-builder/core/-/core-6.5.2.tgz",
-            "integrity": "sha512-Ijpo/uO6upsclgIRLI8YLf+coFWkfjAS/WRB7+qeXmMX9MsaqKlYa8tk9dzYtGKK3msr6bdwCiMPlsd9CNDhrg==",
+            "version": "6.6.3",
+            "resolved": "https://registry.npmjs.org/@react-awesome-query-builder/core/-/core-6.6.3.tgz",
+            "integrity": "sha512-+631G0kojyUfJYNiMU/Su/bJPiwFA9o5XEQXr5VGxIJDnfs+zU+iqg2CeUlqknRKOdRgqylJbi5ZXKVqRLDsxA==",
             "dependencies": {
                 "@babel/runtime": "^7.24.5",
                 "clone": "^2.1.2",
@@ -3925,11 +3925,11 @@
             }
         },
         "node_modules/@react-awesome-query-builder/mui": {
-            "version": "6.5.2",
-            "resolved": "https://registry.npmjs.org/@react-awesome-query-builder/mui/-/mui-6.5.2.tgz",
-            "integrity": "sha512-5iYxZnBRAbUwbV6DJiI2+0FYdAJybRZmWd/qZqrXCxq/0DN4mVqp7/AF2x4Wk2ggDy0bo5JLHPIgpUONVKBg9A==",
+            "version": "6.6.3",
+            "resolved": "https://registry.npmjs.org/@react-awesome-query-builder/mui/-/mui-6.6.3.tgz",
+            "integrity": "sha512-WI1sRwdooseztVCyvO+vWLx3KFI9LPiM2041qpVfWWP3Ot2lrTAxRuyxVOGOVZOuMClFhps3kqVGF/72QdD/Dg==",
             "dependencies": {
-                "@react-awesome-query-builder/ui": "^6.5.2",
+                "@react-awesome-query-builder/ui": "^6.6.3",
                 "lodash": "^4.17.21",
                 "material-ui-confirm": "^3.0.5"
             },
@@ -3939,17 +3939,17 @@
                 "@mui/base": "^5.0.0-alpha.87",
                 "@mui/icons-material": "^5.2.4",
                 "@mui/material": "^5.2.4",
-                "@mui/x-date-pickers": "^5.0.0-beta.2 || ^6.0.0",
+                "@mui/x-date-pickers": "^5.0.0-beta.2 || ^6.0.0 || ^7.0.0",
                 "react": "^16.8.4 || ^17.0.1 || ^18.0.0",
                 "react-dom": "^16.8.4 || ^17.0.1 || ^18.0.0"
             }
         },
         "node_modules/@react-awesome-query-builder/ui": {
-            "version": "6.5.2",
-            "resolved": "https://registry.npmjs.org/@react-awesome-query-builder/ui/-/ui-6.5.2.tgz",
-            "integrity": "sha512-onex0K8Ji/nZC+LrR2z7WwuUvo/selzb9aphFBRgGbzrdjkavag68h6sf1tMdaNv1Fki2fuvQcl8q4glCkVOeg==",
+            "version": "6.6.3",
+            "resolved": "https://registry.npmjs.org/@react-awesome-query-builder/ui/-/ui-6.6.3.tgz",
+            "integrity": "sha512-cuCKn8Mto5vTjfmvJrFiM/ETopLXcPnyQ2PKc8gt+dpfLs7UzYLWBF+V72aYMiPfAMA27Jf2+aPNEGD2x0LemA==",
             "dependencies": {
-                "@react-awesome-query-builder/core": "^6.5.2",
+                "@react-awesome-query-builder/core": "^6.6.3",
                 "classnames": "^2.5.1",
                 "lodash": "^4.17.21",
                 "prop-types": "^15.8.1",
@@ -6437,7 +6437,7 @@
         },
         "node_modules/bluesquare-components": {
             "version": "1.0.0",
-            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#c11a6f8d00363868960e77393cc3b896c934ac74",
+            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#7d971cd44fd0f8203587570fd3ee37f326708558",
             "dependencies": {
                 "@babel/plugin-transform-class-properties": "^7.24.6",
                 "@babel/plugin-transform-object-rest-spread": "^7.24.6",
@@ -6447,7 +6447,7 @@
                 "@dnd-kit/core": "^6.0.8",
                 "@dnd-kit/modifiers": "^6.0.0",
                 "@dnd-kit/sortable": "^7.0.1",
-                "@react-awesome-query-builder/mui": "^6.4.2",
+                "@react-awesome-query-builder/mui": "^6.6.2",
                 "babel-plugin-formatjs": "^10.3.18",
                 "dayjs": "^1.11.10",
                 "install": "^0.13.0",
@@ -11275,9 +11275,9 @@
             "integrity": "sha512-fedL7PRwmeVkgyhu9hLeTBaI6wcGk7JGJswdaRsa5aUbkXI1kr1xZwTPBtaYPpwf56878iDek6VbVnuWMebJmw=="
         },
         "node_modules/i18next": {
-            "version": "23.11.5",
-            "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.11.5.tgz",
-            "integrity": "sha512-41pvpVbW9rhZPk5xjCX2TPJi2861LEig/YRhUkY+1FQ2IQPS0bKUDYnEqY8XPPbB48h1uIwLnP9iiEfuSl20CA==",
+            "version": "23.14.0",
+            "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.14.0.tgz",
+            "integrity": "sha512-Y5GL4OdA8IU2geRrt2+Uc1iIhsjICdHZzT9tNwQ3TVqdNzgxHToGCKf/TPRP80vTCAP6svg2WbbJL+Gx5MFQVA==",
             "funding": [
                 {
                     "type": "individual",
@@ -11350,9 +11350,9 @@
             }
         },
         "node_modules/immutable": {
-            "version": "4.3.6",
-            "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.6.tgz",
-            "integrity": "sha512-Ju0+lEMyzMVZarkTn/gqRpdqd5dOPaz1mCZ0SH3JV6iFw81PldE/PEB1hWVEA288HPt4WXW8O7AWxB10M+03QQ=="
+            "version": "4.3.7",
+            "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.7.tgz",
+            "integrity": "sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw=="
         },
         "node_modules/import-fresh": {
             "version": "3.3.0",
@@ -12518,9 +12518,9 @@
             "dev": true
         },
         "node_modules/json-logic-js": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/json-logic-js/-/json-logic-js-2.0.2.tgz",
-            "integrity": "sha512-ZBtBdMJieqQcH7IX/LaBsr5pX+Y5JIW+EhejtM3Ffg2jdN9Iwf+Ht6TbHnvAZ/YtwyuhPaCBlnvzrwVeWdvGDQ=="
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/json-logic-js/-/json-logic-js-2.0.5.tgz",
+            "integrity": "sha512-rTT2+lqcuUmj4DgWfmzupZqQDA64AdmYqizzMPWj3DxGdfFNsxPpcNVSaTj4l8W2tG/+hg7/mQhxjU3aPacO6g=="
         },
         "node_modules/json-parse-even-better-errors": {
             "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
         "abortcontroller-polyfill": "^1.7.5",
         "array-flat-polyfill": "^1.0.1",
         "babel-plugin-formatjs": "^10.3.4",
-        "bluesquare-components": "github:BLSQ/bluesquare-components#IA-2850_react-router_update_dev",
+        "bluesquare-components": "github:BLSQ/bluesquare-components#SLEEP-1458-entities-filtering",
         "classnames": "^2.2.6",
         "color": "^3.1.2",
         "dom-to-pdf": "^0.3.1",


### PR DESCRIPTION
I'm really excited about this one!

This PR adds JSON logic filters to the entities page to allow searches such as 'give me all entities that have a form instance with "A" == "100"'.

It uses the `react-awesome-query-builder` in the frontend, formatting the data as "subfields", and adds support in the backend to turn this into SQL `EXISTS` subqueries.

PR on `bluesquare-components`: https://github.com/BLSQ/bluesquare-components/pull/164

Related JIRA tickets : https://bluesquare.atlassian.net/browse/SLEEP-1458

**Note: I'm fairly confident that the generated queries are correct. My main concern is performance when the instances/entities tables grow. I plan to use Trypelim as the guinea pig for this. With about 100K entities and 200K instances it should give us an idea of how this will scale.**

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are my typescript files well typed
- [x] New translations have been added or updated if new strings have been introduced in the frontend
- ~My migrations file are include~
- [x] Are there enough tests
- ~Documentation has been included (for new feature)~

## Print screen / video


https://github.com/user-attachments/assets/311c8ad4-db7c-4767-a15d-6666ad4d332f

## Notes

Things that the reviewers should know: known bugs that are out of the scope of the PR, other trade-offs that were made.
If the PR depends on a PR in bluesquare-components, or merges into another PR (i.o. main), it should also be mentioned here
