### PR TITLE
WC2-471: Child exit by death not showing in dashboard

### DIFF
--- a/plugins/wfp/common.py
+++ b/plugins/wfp/common.py
@@ -313,7 +313,7 @@ class ETL:
             current_journey["admission_type"] = self.admission_type(visit)
             current_journey["programme_type"] = self.program_mapper(visit)
             current_journey["org_unit_id"] = visit.get("org_unit_id")
-
+            current_journey["visits"].append(visit)
         exit = None
         followup_forms.append(anthropometric_visit_form)
         if visit["form_id"] in followup_forms:
@@ -324,7 +324,6 @@ class ETL:
             current_journey["discharge_weight"] = visit.get("discharge_weight", None)
             current_journey["weight_difference"] = visit.get("weight_difference", None)
             current_journey["exit_type"] = self.exit_type(visit)
-            current_journey["visits"].append(visit)
 
         if index > 0:
             index = index - 1
@@ -456,7 +455,7 @@ class ETL:
         visit_number = 0
         for current_visit in visits:
             visit = Visit()
-            visit.date = current_visit["date"]
+            visit.date = current_visit.get("date", None)
             visit.number = visit_number
             visit.journey = journey
             orgUnit = OrgUnit.objects.get(id=current_visit["org_unit_id"])

--- a/plugins/wfp/common.py
+++ b/plugins/wfp/common.py
@@ -239,7 +239,6 @@ class ETL:
             "wfp_coda_pbwg_assistance",
             "wfp_coda_pbwg_assistance_followup",
         ]:
-
             if visit.get("next_visit__date__", None) is not None and visit.get("next_visit__date__", None) != "":
                 next_visit_date = visit.get("next_visit__date__", None)
             elif (

--- a/plugins/wfp/common.py
+++ b/plugins/wfp/common.py
@@ -280,7 +280,6 @@ class ETL:
                 and visit.get("tsfp_next_visit", None) != ""
                 and visit.get("tsfp_next_visit") != "--"
             ):
-
                 next_visit_days = visit.get("tsfp_next_visit", None)
             elif (
                 visit.get("otp_next_visit", None) is not None

--- a/plugins/wfp/common.py
+++ b/plugins/wfp/common.py
@@ -20,10 +20,7 @@ class ETL:
         updated_at = date(2023, 7, 10)
         beneficiaries = (
             Instance.objects.filter(entity__entity_type__name=self.type)
-            # .filter(entity__id__in=[1, 42, 46, 49, 58, 77, 90, 111, 322, 323, 330, 196, 226, 254, 424, 430, 431])
-            # .filter(entity__id__in=[254, 424, 430, 431])
-            # .filter(entity__id__in=[254, 431, 315])
-            # .filter(entity__id__in=[254])
+            # .filter(entity__id__in=[1, 42, 46, 49, 58, 77, 90, 111, 322, 323, 330, 196, 226, 254,315, 424, 430, 431])
             .filter(json__isnull=False)
             .filter(form__isnull=False)
             .filter(updated_at__gte=updated_at)

--- a/plugins/wfp/common.py
+++ b/plugins/wfp/common.py
@@ -1,7 +1,6 @@
 from .models import *
 from iaso.models import *
-import datetime
-from datetime import date
+from datetime import datetime, timedelta, date
 
 
 class ETL:
@@ -18,10 +17,12 @@ class ETL:
 
     def retrieve_entities(self):
         steps_id = ETL().steps_to_exclude()
-        updated_at = datetime.date(2023, 7, 10)
+        updated_at = date(2023, 7, 10)
         beneficiaries = (
             Instance.objects.filter(entity__entity_type__name=self.type)
-            # .filter(entity__id__in=[1, 42, 46, 49, 58, 77, 90, 111, 322, 323, 330, 196, 226])
+            # .filter(entity__id__in=[1, 42, 46, 49, 58, 77, 90, 111, 322, 323, 330, 196, 226, 254, 424, 430, 431])
+            # .filter(entity__id__in=[254, 424, 430, 431])
+            .filter(entity__id__in=[254, 431, 315])
             .filter(json__isnull=False)
             .filter(form__isnull=False)
             .filter(updated_at__gte=updated_at)
@@ -39,8 +40,14 @@ class ETL:
                 "updated_at",
                 "form",
                 "entity__deleted_at",
+                "json__visit_date",
+                "json___visit_date",
+                "source_created_at",
             )
-            .order_by("created_at", "entity_id")
+            .order_by(
+                "entity_id",
+                "source_created_at",
+            )
         )
         return beneficiaries
 
@@ -73,7 +80,7 @@ class ETL:
                 program = visit.get("programme")
             elif visit.get("program") is not None:
                 if visit.get("program") == "NONE":
-                    program = "TSFP"
+                    program = visit.get("previous_discharge_program", None)
                 elif visit.get("program") != "NONE":
                     program = visit.get("program")
             elif visit.get("program_two") is not None and visit.get("program_two") != "NONE":
@@ -133,7 +140,9 @@ class ETL:
 
     def exit_type(self, visit):
         exit_type = None
-        if (visit.get("new_programme") is not None and visit.get("new_programme") == "TSFP") and (
+        if visit.get("new_programme", None) is not None and visit.get("new_programme", None) == "NONE":
+            exit_type = visit.get("reason_for_not_continuing", None)
+        elif (visit.get("new_programme") is not None and visit.get("new_programme") == "TSFP") and (
             visit.get("transfer__int__") is not None and visit.get("transfer__int__") == "1"
         ):
             exit_type = "transfer_to_tsfp"
@@ -181,6 +190,8 @@ class ETL:
     def exit_type_converter(self, exit_type):
         if exit_type == "dismissedduetocheating":
             return "dismissed_due_to_cheating"
+        if exit_type == "dismissal":
+            return "dismissed_due_to_cheating"
         elif exit_type == "transferredout":
             return "transferred_out"
         elif exit_type == "voluntarywithdrawal":
@@ -218,7 +229,65 @@ class ETL:
         followUp_steps.insert(0, admission)
         return followUp_steps
 
-    def journey_Formatter(self, visit, anthropometric_visit_form, followup_forms, current_journey):
+    def exit_by_defaulter(self, visits, visit, anthropometric_visit_forms):
+        exit = None
+        next_visit_date = ""
+        next_visit_days = 0
+        nextSecondVisitDate = ""
+        missed_followup_visit = 0
+        if visit["form_id"] in [
+            "child_assistance_follow_up",
+            "child_assistance_admission",
+            "wfp_coda_pbwg_assistance",
+            "wfp_coda_pbwg_assistance_followup",
+        ]:
+
+            if visit.get("next_visit__date__", None) is not None and visit.get("next_visit__date__", None) != "":
+                next_visit_date = visit.get("next_visit__date__", None)
+            elif (
+                visit.get("new_next_visit__date__", None) is not None
+                and visit.get("new_next_visit__date__", None) != ""
+            ):
+                next_visit_date = visit.get("new_next_visit__date__", None)
+
+            if visit.get("next_visit_days", None) is not None and visit.get("next_visit_days", None) != "":
+                next_visit_days = visit.get("next_visit_days", None)
+            elif (
+                visit.get("number_of_days__int__", None) is not None and visit.get("number_of_days__int__", None) != ""
+            ):
+                next_visit_days = visit.get("number_of_days__int__", None)
+            elif (
+                visit.get("OTP_next_visit", None) is not None
+                and visit.get("OTP_next_visit", None) != ""
+                and visit.get("OTP_next_visit") != "--"
+            ):
+                next_visit_days = visit.get("OTP_next_visit", None)
+            elif (
+                visit.get("TSFP_next_visit", None) is not None
+                and visit.get("TSFP_next_visit", None) != ""
+                and visit.get("TSFP_next_visit") != "--"
+            ):
+                next_visit_days = visit.get("TSFP_next_visit", None)
+            elif (
+                visit.get("otp_next_visit", None) is not None
+                and visit.get("otp_next_visit", None) != ""
+                and visit.get("otp_next_visit") != "--"
+            ):
+                next_visit_days = visit.get("otp_next_visit", None)
+
+            if next_visit_date is not None and next_visit_date != "":
+                nextSecondVisitDate = datetime.strptime(next_visit_date[:10], "%Y-%m-%d").date() + timedelta(
+                    days=int(next_visit_days)
+                )
+            missed_followup_visit = self.missed_followup_visit(
+                visits, anthropometric_visit_forms, next_visit_date[:10], nextSecondVisitDate, next_visit_days
+            )
+            # print("MISSED FOLLOWUP ", missed_followup_visit, next_visit_date, nextSecondVisitDate, next_visit_days)
+        if missed_followup_visit > 1 and next_visit_date != "" and nextSecondVisitDate != "":
+            exit = {"exit_type": "defaulter", "end_date": nextSecondVisitDate}
+        return exit
+
+    def journey_Formatter(self, visit, anthropometric_visit_form, followup_forms, current_journey, visits):
         if visit["form_id"] == anthropometric_visit_form:
             current_journey["instance_id"] = visit.get("instance_id", None)
             current_journey["start_date"] = visit.get("start_date", None)
@@ -233,19 +302,30 @@ class ETL:
             current_journey["programme_type"] = self.program_mapper(visit)
             current_journey["org_unit_id"] = visit.get("org_unit_id")
 
+        followup_forms.append(anthropometric_visit_form)
         if visit["form_id"] in followup_forms:
-            end_date = visit.get("end_date", visit.get("created_at", ""))
+            end_date = visit.get("end_date", visit.get("source_created_at", ""))
             current_journey["end_date"] = (
-                end_date if end_date is not None else visit.get("created_at", None).strftime("%Y-%m-%d")
+                end_date if end_date is not None else visit.get("source_created_at", None).strftime("%Y-%m-%d")
             )
             current_journey["discharge_weight"] = visit.get("discharge_weight", None)
             current_journey["weight_difference"] = visit.get("weight_difference", None)
             current_journey["exit_type"] = self.exit_type(visit)
-
-        followup_forms.append(anthropometric_visit_form)
-        if visit["form_id"] in followup_forms:
             current_journey["visits"].append(visit)
 
+        exit = self.exit_by_defaulter(visits, visit, followup_forms)
+        # print("exit ...:", exit)
+        if exit is not None and current_journey.get("exit_type", None) is None:
+            current_journey["exit_type"] = exit["exit_type"]
+            current_journey["end_date"] = exit["end_date"]
+            duration = (
+                datetime.strptime(datetime.strftime(exit["end_date"], "%Y-%m-%d"), "%Y-%m-%d")
+                - datetime.strptime(current_journey["start_date"], "%Y-%m-%d")
+            ).days
+            # print("DURATION IN DAYS ...:", duration)
+            # print("for exit ...:", duration, exit, exit["exit_type"], exit["end_date"], current_journey)
+            current_journey["duration"] = duration
+            return current_journey
         return current_journey
 
     def assistance_to_step(self, assistance, visit, instance_id):
@@ -397,10 +477,10 @@ class ETL:
             if visit["form_id"] in formIds:
                 if visit.get("visit_date") is not None:
                     currentVisitDate = visit.get("visit_date", None)[:10]
-                elif visit.get("date", None) is not None:
-                    currentVisitDate = visit.get("date", None)[:10]
                 elif visit.get("_visit_date", None) is not None:
                     currentVisitDate = visit.get("_visit_date", None)[:10]
+                elif visit.get("date", None) is not None:
+                    currentVisitDate = visit.get("date", None)[:10]
 
                 today = date.today().strftime("%Y-%m-%d")
                 if next_visit__date__ == "" and secondNextVisitDate == "":

--- a/plugins/wfp/management/commands/wfp_etl_Under5.py
+++ b/plugins/wfp/management/commands/wfp_etl_Under5.py
@@ -89,13 +89,10 @@ class Under5:
                             "source_created_at", visit.get("_visit_date", visit.get("visit_date", current_date))
                         )
                         initial_date = visit_date
-                    # print("ALL CURRENT ...:", current_date, visit)
+
                     if initial_date is not None:
                         duration = (current_date - initial_date).days
                         current_record["start_date"] = initial_date.strftime("%Y-%m-%d")
-                    # print("INITIAL DATE ", initial_date)
-                    # print("CURRENT DATE ", current_date)
-                    # print("DURATION DATE ", duration)
 
                     weight = self.compute_gained_weight(initial_weight, current_weight, duration)
                     current_record["end_date"] = current_date.strftime("%Y-%m-%d")
@@ -106,11 +103,9 @@ class Under5:
                     current_record["weight_difference"] = weight["weight_difference"]
                     current_record["duration"] = duration
 
-                    # visit_date = visit.get("_visit_date", visit.get("visit_date", current_date))
                     visit_date = visit.get(
                         "source_created_at", visit.get("_visit_date", visit.get("visit_date", current_date))
                     )
-
                     if visit_date:
                         current_record["date"] = visit_date.strftime("%Y-%m-%d")
 
@@ -136,7 +131,7 @@ class Under5:
             "child_antropometric_followUp_tsfp",
             "child_antropometric_followUp_otp",
         ]
-        for visit in visits:
+        for index, visit in enumerate(visits):
             if visit:
                 current_journey["weight_gain"] = visit.get("weight_gain", None)
                 current_journey["weight_loss"] = visit.get("weight_loss", None)
@@ -147,15 +142,13 @@ class Under5:
                     current_journey["nutrition_programme"] = ETL().program_mapper(visit)
 
                 current_journey = ETL().journey_Formatter(
-                    visit, "Anthropometric visit child", anthropometric_visit_forms, current_journey, visits
+                    visit, "Anthropometric visit child", anthropometric_visit_forms, current_journey, visits, index
                 )
             current_journey["steps"].append(visit)
-        # print("GOT CURRENTLY THE JOURNEY ", current_journey)
         journey.append(current_journey)
         return journey
 
     def save_journey(self, beneficiary, record):
-        # print("GOT RECORD ", record)
         journey = Journey()
         journey.beneficiary = beneficiary
         journey.programme_type = "U5"
@@ -168,19 +161,16 @@ class Under5:
         journey.start_date = record.get("start_date", None)
         journey.duration = record.get("duration", None)
         journey.end_date = record.get("end_date", None)
-        # journey.duration = record["duration"]
-        # journey.end_date = record["end_date"]
 
         # Calculate the weight gain only for cured and Transfer from OTP to TSFP cases!
         if (
             record.get("exit_type", None) is not None
             and record.get("exit_type", None) != ""
-            # and record.get("exit_type", None) in ["cured", "transfer_to_tsfp", "defaulter", "death", "transferred_out"]
+            and record.get("exit_type", None) in ["cured", "transfer_to_tsfp"]
         ):
             journey.discharge_weight = record.get("discharge_weight", None)
             journey.weight_gain = record.get("weight_gain", 0)
             journey.weight_loss = record.get("weight_loss", 0)
-        # print("JOURNEY ...:", journey)
         journey.save()
         return journey
 

--- a/plugins/wfp/management/commands/wfp_etl_pbwg.py
+++ b/plugins/wfp/management/commands/wfp_etl_pbwg.py
@@ -57,9 +57,9 @@ class PBWG:
         journey = Journey()
         journey.beneficiary = beneficiary
         journey.programme_type = "PLW"
-        journey.admission_criteria = record["admission_criteria"]
+        journey.admission_criteria = record.get("admission_criteria", None)
         journey.admission_type = record.get("admission_type", None)
-        journey.nutrition_programme = record["nutrition_programme"]
+        journey.nutrition_programme = record.get("nutrition_programme", None)
         journey.exit_type = record.get("exit_type", None)
         journey.instance_id = record.get("instance_id", None)
         journey.start_date = record.get("start_date", None)

--- a/plugins/wfp/management/commands/wfp_etl_pbwg.py
+++ b/plugins/wfp/management/commands/wfp_etl_pbwg.py
@@ -77,7 +77,7 @@ class PBWG:
         journey = []
         current_journey = {"visits": [], "steps": []}
 
-        for visit in visits:
+        for index, visit in enumerate(visits):
             if visit:
                 if visit.get("duration", None) is not None and visit.get("duration", None) != "":
                     current_journey["duration"] = visit.get("duration")
@@ -90,7 +90,7 @@ class PBWG:
                     "wfp_coda_pbwg_followup_anthro",
                 ]
                 current_journey = ETL().journey_Formatter(
-                    visit, "wfp_coda_pbwg_anthropometric", anthropometric_visit_forms, current_journey, visits
+                    visit, "wfp_coda_pbwg_anthropometric", anthropometric_visit_forms, current_journey, visits, index
                 )
                 current_journey["steps"].append(visit)
         journey.append(current_journey)
@@ -128,7 +128,6 @@ class PBWG:
                     form_id = visit.get("form__form_id")
                     current_record["org_unit_id"] = visit.get("org_unit_id", None)
 
-                    # visit_date = visit.get("_visit_date", visit.get("visit_date", visit.get("created_at")))
                     visit_date = visit.get("source_created_at", visit.get("_visit_date", visit.get("visit_date", None)))
                     if form_id == "wfp_coda_pbwg_anthropometric":
                         initial_date = visit_date

--- a/plugins/wfp/management/commands/wfp_etl_pbwg.py
+++ b/plugins/wfp/management/commands/wfp_etl_pbwg.py
@@ -90,41 +90,8 @@ class PBWG:
                     "wfp_coda_pbwg_followup_anthro",
                 ]
                 current_journey = ETL().journey_Formatter(
-                    visit,
-                    "wfp_coda_pbwg_anthropometric",
-                    anthropometric_visit_forms,
-                    current_journey,
+                    visit, "wfp_coda_pbwg_anthropometric", anthropometric_visit_forms, current_journey, visits
                 )
-
-                if visit["form_id"] in ["wfp_coda_pbwg_assistance", "wfp_coda_pbwg_assistance_followup"]:
-                    next_visit_date = ""
-                    next_visit_days = 0
-                    nextSecondVisitDate = ""
-                    if (
-                        visit.get("next_visit__date__", None) is not None
-                        and visit.get("next_visit__date__", None) != ""
-                    ):
-                        next_visit_date = visit.get("next_visit__date__", None)
-                    elif (
-                        visit.get("new_next_visit__date__", None) is not None
-                        and visit.get("new_next_visit__date__", None) != ""
-                    ):
-                        next_visit_date = visit.get("new_next_visit__date__", None)
-
-                    if visit.get("next_visit_days", None) is not None and visit.get("next_visit_days", None) != "":
-                        next_visit_days = visit.get("next_visit_days", None)
-                        if next_visit_date is not None and next_visit_date != "":
-                            nextSecondVisitDate = datetime.strptime(
-                                next_visit_date[:10], "%Y-%m-%d"
-                            ).date() + timedelta(days=int(next_visit_days))
-
-                    missed_followup_visit = ETL().missed_followup_visit(
-                        visits, anthropometric_visit_forms, next_visit_date[:10], nextSecondVisitDate, next_visit_days
-                    )
-
-                    if current_journey.get("exit_type", None) is None and missed_followup_visit > 1:
-                        current_journey["exit_type"] = "defaulter"
-
                 current_journey["steps"].append(visit)
         journey.append(current_journey)
         return journey
@@ -161,7 +128,8 @@ class PBWG:
                     form_id = visit.get("form__form_id")
                     current_record["org_unit_id"] = visit.get("org_unit_id", None)
 
-                    visit_date = visit.get("_visit_date", visit.get("visit_date", visit.get("created_at")))
+                    # visit_date = visit.get("_visit_date", visit.get("visit_date", visit.get("created_at")))
+                    visit_date = visit.get("source_created_at", visit.get("_visit_date", visit.get("visit_date", None)))
                     if form_id == "wfp_coda_pbwg_anthropometric":
                         initial_date = visit_date
 


### PR DESCRIPTION
Explain what problem this PR is resolving

Related JIRA tickets : [WC2-471](https://bluesquare.atlassian.net/browse/WC2-471), [WC2-472](https://bluesquare.atlassian.net/browse/WC2-472), [WC2-473](https://bluesquare.atlassian.net/browse/WC2-473)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)


## Changes

Some exit types(dismissed, death and defaulter) was not calculated as expected. Refactored journey mapper function to fix the exit types!

## How to test
From the local instance with wfp coda database, launch with `docker-compose run iaso manage wfp_etl` the ETL script in order to generate data for tableau dashboard. Then check some exity type:
 - defaulter: [http://localhost:8081/wfp/debug/254/](http://localhost:8081/wfp/debug/254/)
 - death: [http://localhost:8081/wfp/debug/431/](http://localhost:8081/wfp/debug/431/) and http://localhost:8081/wfp/debug/315/
 - dismissal for cheating: [http://localhost:8081/wfp/debug/430/](http://localhost:8081/wfp/debug/430/)

## Print screen / video

[Administration-de-Iaso-Iaso.webm](https://github.com/user-attachments/assets/407b3de2-062d-4755-a551-bb3166491302)



[WC2-471]: https://bluesquare.atlassian.net/browse/WC2-471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WC2-472]: https://bluesquare.atlassian.net/browse/WC2-472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WC2-473]: https://bluesquare.atlassian.net/browse/WC2-473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ