### PR TITLE
POLIO-1621 Chronogram detail: make column "Activity" wider by default 

### DIFF
--- a/plugins/polio/js/src/domains/Chronogram/ChronogramDetails/Table/useChronogramDetailsTableColumn.tsx
+++ b/plugins/polio/js/src/domains/Chronogram/ChronogramDetails/Table/useChronogramDetailsTableColumn.tsx
@@ -37,6 +37,7 @@ export const useChronogramDetailsTableColumn = (
                 id: 'description',
                 accessor: row => row.description || row.description_en,
                 sortable: false,
+                width: 800,
             },
             {
                 Header: formatMessage(MESSAGES.labelStartOffsetInDays),


### PR DESCRIPTION
Same as in https://github.com/BLSQ/iaso/pull/1536 but I forgot the Chronogram Detail page.