### PR TITLE
IA-2863 highlight mapped forms

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/forms/components/FormActions.tsx
+++ b/hat/assets/js/apps/Iaso/domains/forms/components/FormActions.tsx
@@ -123,7 +123,8 @@ export const FormActions: FunctionComponent<Props> = ({
                                     url={`/${baseUrls.mappings}/formId/${settings.row.original.id}/order/form_version__form__name,form_version__version_id,mapping__mapping_type/pageSize/20/page/1`}
                                     icon="dhis"
                                     tooltipMessage={MESSAGES.dhis2Mappings}
-                                />
+                                    color={settings.row.original.has_mappings ? "primary": undefined}
+                                />                                
                             </DisplayIfUserHasPerm>
                             <DisplayIfUserHasPerm
                                 permissions={[Permission.FORMS]}

--- a/hat/assets/js/apps/Iaso/domains/forms/types/forms.ts
+++ b/hat/assets/js/apps/Iaso/domains/forms/types/forms.ts
@@ -89,6 +89,7 @@ export type Form = {
     label_keys: string[];
     possible_fields: PossibleField[];
     legend_threshold: ScaleThreshold;
+    has_mappings: boolean;
 };
 
 export type FormDescriptor = {

--- a/iaso/tests/api/test_forms.py
+++ b/iaso/tests/api/test_forms.py
@@ -103,9 +103,6 @@ class FormsAPITestCase(APITestCase):
         self.client.force_authenticate(self.yoda)
         response = self.client.get("/api/forms/", headers={"Content-Type": "application/json"})
         self.assertJSONResponse(response, 200)
-        import pdb
-
-        pdb.set_trace()
         self.assertValidFormListData(response.json(), 2)
 
     def find_forms_data_for(self, response, form):

--- a/iaso/tests/api/test_forms.py
+++ b/iaso/tests/api/test_forms.py
@@ -8,6 +8,11 @@ from iaso.api.common import CONTENT_TYPE_XLSX
 from iaso.models import Form, OrgUnit, Instance
 from iaso.test import APITestCase
 
+from iaso.models import (
+    Mapping,
+    AGGREGATE,
+)
+
 
 class FormsAPITestCase(APITestCase):
     @classmethod
@@ -98,7 +103,27 @@ class FormsAPITestCase(APITestCase):
         self.client.force_authenticate(self.yoda)
         response = self.client.get("/api/forms/", headers={"Content-Type": "application/json"})
         self.assertJSONResponse(response, 200)
+        import pdb
+
+        pdb.set_trace()
         self.assertValidFormListData(response.json(), 2)
+
+    def find_forms_data_for(self, response, form):
+        return [f for f in response.json()["forms"] if f["name"] == form.name][0]
+
+    def test_forms_list_ok_has_mappings_true(self):
+        """GET /forms/ web app happy path: we expect two results one with has_mappings"""
+
+        mapping = Mapping(form=self.form_2, data_source=self.sw_source, mapping_type=AGGREGATE)
+        mapping.save()
+
+        self.client.force_authenticate(self.yoda)
+        response = self.client.get("/api/forms/", headers={"Content-Type": "application/json"})
+        self.assertJSONResponse(response, 200)
+        self.assertValidFormListData(response.json(), 2)
+
+        self.assertTrue(self.find_forms_data_for(response, self.form_2)["has_mappings"])
+        self.assertFalse(self.find_forms_data_for(response, self.form_1)["has_mappings"])
 
     def test_forms_list_filtered_by_org_unit_type(self):
         self.client.force_authenticate(self.yoda)


### PR DESCRIPTION
Related JIRA tickets : IA-2863 highlight forms with mappings.

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [?] Is my code clear enough and well documented
- [?] Are my typescript files well typed
- [-] New translations have been added or updated if new strings have been introduced in the frontend
- [-] My migrations file are included
- [x] Are there enough tests
- [-] Documentation has been included (for new feature)

## Doc
- Tell us where the doc can be found (docs folder, wiki, in the code...)

## Changes

to avoid select n+1, calculating the "has_mappings" based on the mapping_count

## How to test

1. seed : `docker-compose run --rm iaso manage seed_test_data --mode=seed --dhis2version=2.40.4.1`
2. go to http://localhost:8081/dashboard/forms/list

## Print screen / video

![image](https://github.com/user-attachments/assets/8520dc26-d350-46f0-b7c4-0fb5eec2ae22)

## Notes

RAS
