### PR TITLE
POLIO-1642 Chronograms: sort list by "round start date DESC"

### DIFF
--- a/plugins/polio/js/src/domains/Chronogram/Chronogram/Table/ChronogramTable.tsx
+++ b/plugins/polio/js/src/domains/Chronogram/Chronogram/Table/ChronogramTable.tsx
@@ -15,13 +15,14 @@ export const ChronogramTable: FunctionComponent<Props> = ({ params }) => {
     const apiParams: ChronogramParams = {
         ...params,
         limit: params.pageSize || '20',
-        order: params.order || 'id',
+        order: params.order || '-round__started_at',
         page: params.page || '1',
     };
     const { data, isFetching } = useGetChronogram(apiParams);
     const columns = useChronogramTableColumns();
     return (
         <TableWithDeepLink
+            defaultSorted={[{ id: 'round__started_at', desc: true }]}
             baseUrl={baseUrls.chronogram}
             data={data?.results ?? []}
             pages={data?.pages ?? 1}


### PR DESCRIPTION
Sort list of chronograms by "round start date DESC" by default.

Related JIRA tickets : [POLIO-1642](https://bluesquare.atlassian.net/browse/POLIO-1642)

## How to test

- go to http://localhost:8081/dashboard/polio/chronogram/
- the list should be sorted by "round start date DESC" by default

## Print screen

![chronogram](https://github.com/user-attachments/assets/e554120d-6977-4b71-80d4-ed08c704ac64)


[POLIO-1642]: https://bluesquare.atlassian.net/browse/POLIO-1642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ