### PR TITLE
POLIO-1643 Chronograms: display the total number of tasks

### DIFF
--- a/plugins/polio/js/src/domains/Chronogram/Chronogram/Table/useChronogramTableColumns.tsx
+++ b/plugins/polio/js/src/domains/Chronogram/Chronogram/Table/useChronogramTableColumns.tsx
@@ -62,7 +62,8 @@ export const useChronogramTableColumns = (): Column[] => {
             {
                 Header: formatMessage(MESSAGES.labelNumTaskDelayed),
                 id: 'annotated_num_task_delayed',
-                accessor: 'num_task_delayed',
+                Cell: settings =>
+                    `${settings.row.original.num_task_delayed}/${settings.row.original.tasks.length}`,
             },
             {
                 Header: formatMessage(MESSAGES.updatedAt),


### PR DESCRIPTION
Display the total number of tasks in the chronograms list.

Related JIRA tickets : [POLIO-1643](https://bluesquare.atlassian.net/browse/POLIO-1643)

## How to test

- got to http://localhost:8081/dashboard/polio/chronogram/
- in the column `Number of task(s) delayed` you should see the number of task delayed and the total number of tasks

## Print screen

![total](https://github.com/user-attachments/assets/05364423-b7aa-4aed-b056-850de3f3a4ed)


[POLIO-1643]: https://bluesquare.atlassian.net/browse/POLIO-1643?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ