### PR TITLE
IA-3308 Fix form edit: Bring back attachments tab

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/forms/detail.tsx
+++ b/hat/assets/js/apps/Iaso/domains/forms/detail.tsx
@@ -28,6 +28,7 @@ import { useParamsObject } from '../../routing/hooks/useParamsObject';
 import { isFieldValid, isFormValid } from '../../utils/forms';
 import { createForm, updateForm } from '../../utils/requests';
 import { NO_PERIOD } from '../periods/constants';
+import { FormAttachments } from './components/FormAttachments';
 import FormForm from './components/FormFormComponent';
 import FormVersions from './components/FormVersionsComponent';
 import { requiredFields } from './config/index';
@@ -301,6 +302,9 @@ const FormDetail: FunctionComponent = () => {
                                 formId={parseInt(params.formId, 10)}
                                 params={params}
                             />
+                        )}
+                        {tab === 'attachments' && (
+                            <FormAttachments params={params} />
                         )}
                     </>
                 )}


### PR DESCRIPTION
Appears to have been removed by mistake during a rebase:

https://github.com/BLSQ/iaso/commit/25d54f3ac388fd3599fa95b45547745f6c00ad23#diff-b3c1c472886a1ecd26a3a6a2748aaad18466af7eb36c15fdf475a8e4b8a44c6eL305-L307
