### PR TITLE
IA-3205 Backend for multi-projects

### DIFF
--- a/iaso/api/forms.py
+++ b/iaso/api/forms.py
@@ -240,7 +240,9 @@ class FormsViewSet(ModelViewSet):
         if show_deleted == "true":
             form_objects = Form.objects_only_deleted
 
-        queryset = form_objects.filter_for_user_and_app_id(self.request.user, self.request.query_params.get("app_id"))
+        queryset = form_objects.filter_for_user_and_app_id(
+            self.request.user, self.request.query_params.get("app_id")
+        ).filter_on_user_projects(self.request.user)
         org_unit_id = self.request.query_params.get("orgUnitId", None)
         if org_unit_id:
             queryset = queryset.filter(instances__org_unit__id=org_unit_id)

--- a/iaso/api/instances.py
+++ b/iaso/api/instances.py
@@ -167,7 +167,7 @@ class InstancesViewSet(viewsets.ViewSet):
     def get_queryset(self):
         request = self.request
         queryset: InstanceQuerySet = Instance.objects.order_by("-id")
-        queryset = queryset.filter_for_user(request.user)
+        queryset = queryset.filter_for_user(request.user).filter_on_user_projects(user=request.user)
         return queryset
 
     @action(["GET"], detail=False)

--- a/iaso/api/projects/viewsets.py
+++ b/iaso/api/projects/viewsets.py
@@ -29,7 +29,9 @@ class ProjectsViewSet(ModelViewSet):
     def get_queryset(self):
         """Always filter the base queryset by account"""
 
-        return Project.objects.filter(account=self.request.user.iaso_profile.account)
+        return Project.objects.filter(account=self.request.user.iaso_profile.account).filter_on_user_projects(
+            self.request.user
+        )
 
     @action(detail=True, methods=["get"])
     def qr_code(self, request, *args, **kwargs):

--- a/iaso/models/base.py
+++ b/iaso/models/base.py
@@ -953,6 +953,14 @@ class InstanceQuerySet(django_cte.CTEQuerySet):
         new_qs = new_qs.filter(project__account=profile.account_id)
         return new_qs
 
+    def filter_on_user_projects(self, user: User) -> models.QuerySet:
+        if not hasattr(user, "iaso_profile"):
+            return self
+        user_projects_ids = user.iaso_profile.projects.values_list("pk", flat=True)
+        if not user_projects_ids:
+            return self
+        return self.filter(project__in=user_projects_ids)
+
 
 InstanceManager = models.Manager.from_queryset(InstanceQuerySet)
 

--- a/iaso/models/forms.py
+++ b/iaso/models/forms.py
@@ -60,7 +60,7 @@ class FormQuerySet(models.QuerySet):
         return queryset
 
     def filter_on_user_projects(self, user: User) -> models.QuerySet:
-        if user.is_anonymous or user.iaso_profile is None:
+        if user.is_anonymous or not hasattr(user, "iaso_profile"):
             return self
 
         user_projects_ids = user.iaso_profile.projects.values_list("pk", flat=True)

--- a/iaso/models/forms.py
+++ b/iaso/models/forms.py
@@ -60,9 +60,8 @@ class FormQuerySet(models.QuerySet):
         return queryset
 
     def filter_on_user_projects(self, user: User) -> models.QuerySet:
-        if user.is_anonymous or not hasattr(user, "iaso_profile"):
+        if not hasattr(user, "iaso_profile"):
             return self
-
         user_projects_ids = user.iaso_profile.projects.values_list("pk", flat=True)
         if not user_projects_ids:
             return self

--- a/iaso/models/forms.py
+++ b/iaso/models/forms.py
@@ -59,6 +59,15 @@ class FormQuerySet(models.QuerySet):
 
         return queryset
 
+    def filter_on_user_projects(self, user: User) -> models.QuerySet:
+        if user.is_anonymous or user.iaso_profile is None:
+            return self
+
+        user_projects_ids = user.iaso_profile.projects.values_list("pk", flat=True)
+        if not user_projects_ids:
+            return self
+        return self.filter(projects__in=user_projects_ids)
+
 
 class Form(SoftDeletableModel):
     """Metadata about a form

--- a/iaso/models/project.py
+++ b/iaso/models/project.py
@@ -37,6 +37,15 @@ class ProjectQuerySet(models.QuerySet):
 
         raise self.model.DoesNotExist(f"Could not find project for user {user} and app_id {app_id}")
 
+    def filter_on_user_projects(self, user: User) -> models.QuerySet:
+        if user.is_anonymous or user.iaso_profile is None:
+            return self
+
+        user_projects_ids = user.iaso_profile.projects.values_list("pk", flat=True)
+        if not user_projects_ids:
+            return self
+        return self.filter(id__in=user_projects_ids)
+
 
 ProjectManager = models.Manager.from_queryset(ProjectQuerySet)
 

--- a/iaso/models/project.py
+++ b/iaso/models/project.py
@@ -38,9 +38,8 @@ class ProjectQuerySet(models.QuerySet):
         raise self.model.DoesNotExist(f"Could not find project for user {user} and app_id {app_id}")
 
     def filter_on_user_projects(self, user: User) -> models.QuerySet:
-        if user.is_anonymous or not hasattr(user, "iaso_profile"):
+        if not hasattr(user, "iaso_profile"):
             return self
-
         user_projects_ids = user.iaso_profile.projects.values_list("pk", flat=True)
         if not user_projects_ids:
             return self

--- a/iaso/models/project.py
+++ b/iaso/models/project.py
@@ -38,7 +38,7 @@ class ProjectQuerySet(models.QuerySet):
         raise self.model.DoesNotExist(f"Could not find project for user {user} and app_id {app_id}")
 
     def filter_on_user_projects(self, user: User) -> models.QuerySet:
-        if user.is_anonymous or user.iaso_profile is None:
+        if user.is_anonymous or not hasattr(user, "iaso_profile"):
             return self
 
         user_projects_ids = user.iaso_profile.projects.values_list("pk", flat=True)

--- a/iaso/tests/models/test_form.py
+++ b/iaso/tests/models/test_form.py
@@ -1,0 +1,55 @@
+from iaso import models as m
+from iaso.test import TestCase
+
+
+class FormModelTestCase(TestCase):
+    """
+    Test Form model.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.health_account = m.Account.objects.create(name="Global Health Initiative")
+
+        cls.project_1 = m.Project.objects.create(name="Project 1", app_id="org.ghi.p1", account=cls.health_account)
+        cls.project_2 = m.Project.objects.create(name="Project 2", app_id="org.ghi.p2", account=cls.health_account)
+
+        cls.form_1 = m.Form.objects.create(name="Form 1")
+        cls.form_2 = m.Form.objects.create(name="Form 2")
+        cls.form_3 = m.Form.objects.create(name="Form 3")
+        cls.form_4 = m.Form.objects.create(name="Form 4")
+
+        cls.project_1.forms.set([cls.form_1, cls.form_2])
+        cls.project_2.forms.set([cls.form_3, cls.form_4])
+
+        cls.jane = cls.create_user_with_profile(username="jane", account=cls.health_account)
+        cls.jane.iaso_profile.projects.set([cls.project_1, cls.project_2])
+
+        cls.john = cls.create_user_with_profile(username="john", account=cls.health_account)
+        cls.john.iaso_profile.projects.set([cls.project_1])
+
+        cls.jim = cls.create_user_with_profile(username="jim", account=cls.health_account)
+
+        cls.user_without_profile = m.User.objects.create(username="foo")
+
+    def test_filter_on_user_projects(self):
+        total_forms = m.Form.objects.count()
+        self.assertEqual(total_forms, 4)
+
+        jane_forms = m.Form.objects.filter_on_user_projects(user=self.jane)
+        self.assertEqual(jane_forms.count(), 4)
+        self.assertIn(self.form_1, jane_forms)
+        self.assertIn(self.form_2, jane_forms)
+        self.assertIn(self.form_3, jane_forms)
+        self.assertIn(self.form_4, jane_forms)
+
+        john_forms = m.Form.objects.filter_on_user_projects(user=self.john)
+        self.assertEqual(john_forms.count(), 2)
+        self.assertIn(self.form_1, john_forms)
+        self.assertIn(self.form_2, john_forms)
+
+        jim_forms = m.Form.objects.filter_on_user_projects(user=self.jim)
+        self.assertEqual(jim_forms.count(), total_forms)
+
+        user_without_profile_projects = m.Form.objects.filter_on_user_projects(user=self.user_without_profile)
+        self.assertEqual(user_without_profile_projects.count(), total_forms)

--- a/iaso/tests/models/test_project.py
+++ b/iaso/tests/models/test_project.py
@@ -30,14 +30,6 @@ class ProjectModelTestCase(TestCase):
         total_projects = m.Project.objects.count()
         self.assertEqual(total_projects, 3)
 
-        user_without_profile_projects = m.Project.objects.filter_on_user_projects(user=self.user_without_profile)
-        self.assertEqual(user_without_profile_projects.count(), total_projects)
-
-        account_projects = self.global_health.project_set.all()
-        self.assertEqual(account_projects.count(), 2)
-        self.assertIn(self.project_1, account_projects)
-        self.assertIn(self.project_2, account_projects)
-
         jane_projects = m.Project.objects.filter_on_user_projects(user=self.jane)
         self.assertEqual(jane_projects.count(), 2)
         self.assertIn(self.project_1, jane_projects)
@@ -49,3 +41,6 @@ class ProjectModelTestCase(TestCase):
 
         jim_projects = m.Project.objects.filter_on_user_projects(user=self.jim)
         self.assertEqual(jim_projects.count(), total_projects)
+
+        user_without_profile_projects = m.Project.objects.filter_on_user_projects(user=self.user_without_profile)
+        self.assertEqual(user_without_profile_projects.count(), total_projects)

--- a/iaso/tests/models/test_project.py
+++ b/iaso/tests/models/test_project.py
@@ -1,0 +1,51 @@
+from iaso import models as m
+from iaso.test import TestCase
+
+
+class ProjectModelTestCase(TestCase):
+    """
+    Test Project model.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.global_health = m.Account.objects.create(name="Global Health Initiative")
+        cls.other_account = m.Account.objects.create(name="Other Account")
+
+        cls.project_1 = m.Project.objects.create(name="Project 1", app_id="org.ghi.p1", account=cls.global_health)
+        cls.project_2 = m.Project.objects.create(name="Project 2", app_id="org.ghi.p2", account=cls.global_health)
+        cls.project_3 = m.Project.objects.create(name="Project 3", app_id="org.oa.p3", account=cls.other_account)
+
+        cls.jane = cls.create_user_with_profile(username="jane", account=cls.global_health)
+        cls.jane.iaso_profile.projects.set([cls.project_1, cls.project_2])
+
+        cls.john = cls.create_user_with_profile(username="john", account=cls.global_health)
+        cls.john.iaso_profile.projects.set([cls.project_1])
+
+        cls.jim = cls.create_user_with_profile(username="jim", account=cls.global_health)
+
+        cls.user_without_profile = m.User.objects.create(username="foo")
+
+    def test_filter_on_user_projects(self):
+        total_projects = m.Project.objects.count()
+        self.assertEqual(total_projects, 3)
+
+        user_without_profile_projects = m.Project.objects.filter_on_user_projects(user=self.user_without_profile)
+        self.assertEqual(user_without_profile_projects.count(), total_projects)
+
+        account_projects = self.global_health.project_set.all()
+        self.assertEqual(account_projects.count(), 2)
+        self.assertIn(self.project_1, account_projects)
+        self.assertIn(self.project_2, account_projects)
+
+        jane_projects = m.Project.objects.filter_on_user_projects(user=self.jane)
+        self.assertEqual(jane_projects.count(), 2)
+        self.assertIn(self.project_1, jane_projects)
+        self.assertIn(self.project_2, jane_projects)
+
+        john_projects = m.Project.objects.filter_on_user_projects(user=self.john)
+        self.assertEqual(john_projects.count(), 1)
+        self.assertIn(self.project_1, john_projects)
+
+        jim_projects = m.Project.objects.filter_on_user_projects(user=self.jim)
+        self.assertEqual(jim_projects.count(), total_projects)


### PR DESCRIPTION
Backend for multi-projects.

Related JIRA tickets : [IA-3205](https://bluesquare.atlassian.net/browse/IA-3205)

## Changes

This PR is all about filtering.

Users can be associated with projects (`user.iaso_profile.projects`):

- projects to which a user has access can be configured in the "User UI"
- but we don't do anything with this yet (it's informative)

This PR uses this information to filter front-end lists.

When a user is linked to one or more projects:

- only forms linked to these projects should be displayed
- only forms linked to these projects should be available in filters

If the user has no projects, he will continue to see all the projects linked to his account.

## How to test

These lists should be filtered on user's projects by default (if any):

- http://localhost:8081/dashboard/forms/list
- http://localhost:8081/dashboard/forms/submissions

The API endpoint used for filtering projects should also filter on the user's projects by default (if any):

- http://localhost:8081/api/projects/

[IA-3205]: https://bluesquare.atlassian.net/browse/IA-3205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ