### PR TITLE
IA-3168 Fix ghost change requests

### DIFF
--- a/iaso/api/instances.py
+++ b/iaso/api/instances.py
@@ -712,4 +712,5 @@ def import_data(instances, user, app_id):
                 new_reference_instances.append(instance)
                 oucr.save()
                 oucr.new_reference_instances.set(new_reference_instances)
+                oucr.requested_fields = ["new_reference_instances"]
                 oucr.save()

--- a/iaso/api/instances.py
+++ b/iaso/api/instances.py
@@ -707,6 +707,8 @@ def import_data(instances, user, app_id):
             if instance.form in instance.org_unit.org_unit_type.reference_forms.all():
                 oucr = OrgUnitChangeRequest()
                 oucr.org_unit = instance.org_unit
+                if user and not user.is_anonymous:
+                    oucr.created_by = user
                 previous_reference_instances = list(instance.org_unit.reference_instances.all())
                 new_reference_instances = list(filter(lambda i: i.form != instance.form, previous_reference_instances))
                 new_reference_instances.append(instance)

--- a/iaso/tests/api/org_unit_change_requests/test_change_request_on_new_reference_form.py
+++ b/iaso/tests/api/org_unit_change_requests/test_change_request_on_new_reference_form.py
@@ -79,6 +79,7 @@ class AutoChangeRequestForInstanceFormTestCase(APITestCase):
         self.assertEqual(instance.orgunitchangerequest_set.count(), 1)
 
         change_request = instance.orgunitchangerequest_set.first()
+        self.assertIsNone(change_request.created_by)
         self.assertEqual(change_request.new_name, "")
         self.assertIsNone(change_request.new_org_unit_type)
         self.assertEqual(change_request.new_groups.count(), 0)

--- a/iaso/tests/api/org_unit_change_requests/test_change_request_on_new_reference_form.py
+++ b/iaso/tests/api/org_unit_change_requests/test_change_request_on_new_reference_form.py
@@ -76,7 +76,18 @@ class AutoChangeRequestForInstanceFormTestCase(APITestCase):
 
         instance = Instance.objects.get(uuid=uuid)
 
-        self.assertEqual(len(instance.orgunitchangerequest_set.all()), 1)
+        self.assertEqual(instance.orgunitchangerequest_set.count(), 1)
+
+        change_request = instance.orgunitchangerequest_set.first()
+        self.assertEqual(change_request.new_name, "")
+        self.assertIsNone(change_request.new_org_unit_type)
+        self.assertEqual(change_request.new_groups.count(), 0)
+        self.assertIsNone(change_request.new_location)
+        self.assertIsNone(change_request.new_location_accuracy)
+        self.assertIsNone(change_request.new_opening_date)
+        self.assertIsNone(change_request.new_closed_date)
+        self.assertEqual(change_request.new_reference_instances.count(), 1)
+        self.assertEqual(change_request.requested_fields, ["new_reference_instances"])
 
         # checking if no change request is created for a form with the option activated
         uuid2 = "4b7c3954-f69a-4b99-83b1-db73957b32b9"


### PR DESCRIPTION
IA-3168 Fix ghost change requests.

Related JIRA tickets : [IA-3168](https://bluesquare.atlassian.net/browse/IA-3168)

## Changes

This bug was introduced in https://github.com/BLSQ/iaso/pull/1157:

- we are creating change requests outside of the validation steps performed by the API
- as a result "New reference instances" was populated, but not "Requested fields"
- but the UI relies on "Requested fields" to know the fields for which a change is requested

This PR suggests a fix.

To _unghost_ change requests in prod, we have to add the value `new_reference_instances` in the "Requested fields" of the admin where necessary.


[IA-3168]: https://bluesquare.atlassian.net/browse/IA-3168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ