### PR TITLE
WC2-476: ETL: Exclude beneficiary with registration only

### DIFF
--- a/plugins/wfp/common.py
+++ b/plugins/wfp/common.py
@@ -528,7 +528,7 @@ class ETL:
         age = current_record.get("age__int__", None)
         registration_date = current_record.get("registration_date", None)
         calculated_date = None
-        if age_entry is not None and age_entry != "":
+        if (age_entry is not None and age_entry != "") and (age is not None and age != ""):
             beneficiary_age = int(age)
             registered_at = datetime.strptime(registration_date[:10], "%Y-%m-%d").date()
             if age_entry == "years":

--- a/plugins/wfp/management/commands/wfp_etl_Under5.py
+++ b/plugins/wfp/management/commands/wfp_etl_Under5.py
@@ -201,7 +201,7 @@ class Under5:
                 beneficiary.save()
                 logger.info(f"Created new beneficiary")
             else:
-                beneficiary = Beneficiary.objects.filter(entity_id=instance["entity_id"])
+                beneficiary = Beneficiary.objects.filter(entity_id=instance["entity_id"]).first()
 
             logger.info("Retrieving journey linked to beneficiary")
 

--- a/plugins/wfp/management/commands/wfp_etl_Under5.py
+++ b/plugins/wfp/management/commands/wfp_etl_Under5.py
@@ -122,7 +122,7 @@ class Under5:
             i = i + 1
         return list(
             filter(
-                lambda instance: (instance.get("visits") and len(instance.get("visits")) > 0)
+                lambda instance: (instance.get("visits") and len(instance.get("visits")) > 1)
                 and instance.get("gender") is not None
                 and instance.get("birth_date") is not None
                 and instance.get("birth_date") != ""
@@ -192,23 +192,21 @@ class Under5:
             logger.info(
                 f"---------------------------------------- Beneficiary N° {(index+1)} {instance['entity_id']}-----------------------------------"
             )
+            instance["journey"] = self.journeyMapper(instance["visits"])
             beneficiary = Beneficiary()
-            if instance["entity_id"] not in existing_beneficiaries:
+            if instance["entity_id"] not in existing_beneficiaries and len(instance["journey"][0]["visits"]) > 0:
                 beneficiary.gender = instance["gender"]
                 beneficiary.birth_date = instance["birth_date"]
                 beneficiary.entity_id = instance["entity_id"]
                 beneficiary.save()
                 logger.info(f"Created new beneficiary")
             else:
-                beneficiary = Beneficiary.objects.get(entity_id=instance["entity_id"])
-            instance["journey"] = self.journeyMapper(instance["visits"])
+                beneficiary = Beneficiary.objects.filter(entity_id=instance["entity_id"])
+
             logger.info("Retrieving journey linked to beneficiary")
 
             for journey_instance in instance["journey"]:
-                if (
-                    len(journey_instance["visits"]) > 0
-                    and journey_instance.get("nutrition_programme", None) is not None
-                ):
+                if len(journey_instance["visits"]) > 0:
                     journey = self.save_journey(beneficiary, journey_instance)
                     visits = ETL().save_visit(journey_instance["visits"], journey)
                     logger.info(f"Inserted {len(visits)} Visits")

--- a/plugins/wfp/management/commands/wfp_etl_pbwg.py
+++ b/plugins/wfp/management/commands/wfp_etl_pbwg.py
@@ -30,7 +30,7 @@ class PBWG:
                     beneficiary.save()
                     logger.info(f"Created new beneficiary")
             else:
-                beneficiary = Beneficiary.objects.filter(entity_id=instance["entity_id"])
+                beneficiary = Beneficiary.objects.filter(entity_id=instance["entity_id"]).first()
 
             logger.info("Retrieving journey linked to beneficiary")
 


### PR DESCRIPTION
Explain what problem this PR is resolving

Related JIRA tickets : [WC2-476](https://bluesquare.atlassian.net/browse/WC2-476)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)


## Changes

For some cases, there are beneficiaries with registration only without visit or with more that 1 registration. So, excluded all those beneficiaries!

## How to test

From the local instance with wfp coda database, launch with `docker-compose run iaso manage wfp_etl` the ETL script in order to generate data for tableau dashboard. 

Then, check for:
   - Beneficiarys: [http://localhost:8081/admin/wfp/beneficiary/](http://localhost:8081/admin/wfp/beneficiary/)
   - Journeys: [http://localhost:8081/admin/wfp/journey/](http://localhost:8081/admin/wfp/journey/)
   - Visits 0: [http://localhost:8081/admin/wfp/visit/?number=0](http://localhost:8081/admin/wfp/visit/?number=0)
   
You should get the same number of records for the 3 tables!




[WC2-476]: https://bluesquare.atlassian.net/browse/WC2-476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ