### PR TITLE
IA-3298 filter change request

### DIFF
--- a/hat/assets/js/apps/Iaso/constants/urls.ts
+++ b/hat/assets/js/apps/Iaso/constants/urls.ts
@@ -172,6 +172,8 @@ export const baseRouteConfigs: Record<string, RouteConfig> = {
             'projectIds',
             'paymentStatus',
             ...paginationPathParams,
+            'paymentIds',
+            'potentialPaymentIds',
         ],
     },
     registry: {

--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -717,6 +717,8 @@
     "iaso.label.videos": "Videos",
     "iaso.label.view": "View",
     "iaso.label.viewChangeRequestforLot": "View change requests for this payment lot",
+    "iaso.label.viewChangeRequestsForPayment": "View change requests for this payment",
+    "iaso.label.viewChangeRequestsForPotentialPayment": "View change requests for this potential payment",
     "iaso.label.viewChangeRequestsForUser": "View change requests for user",
     "iaso.label.viewDetails": "View details",
     "iaso.label.viewOrgUnit": "View OrgUnit",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -717,6 +717,8 @@
     "iaso.label.videos": "Vidéos",
     "iaso.label.view": "Visualiser",
     "iaso.label.viewChangeRequestforLot": "Voir les demandes de changement pour ce lot de paiements",
+    "iaso.label.viewChangeRequestsForPayment": "Voir les demandes de changements pour ce paiement",
+    "iaso.label.viewChangeRequestsForPotentialPayment": "Voir les demandes de changements pour ce paiement potentiel",
     "iaso.label.viewChangeRequestsForUser": "Voir les demandes de changement pour cet utilisateur",
     "iaso.label.viewDetails": "Voir les détails",
     "iaso.label.viewOrgUnit": "Voir l'unité d'org.",

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/hooks/api/useGetApprovalProposals.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/hooks/api/useGetApprovalProposals.ts
@@ -31,6 +31,8 @@ export const useGetApprovalProposals = (
         with_location: params.withLocation,
         projects: params.projectIds,
         payment_status: params.paymentStatus,
+        payment_ids: params.paymentIds,
+        potential_payment_ids: params.potentialPaymentIds,
     };
 
     const url = makeUrlWithParams(apiUrl, apiParams);

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/types.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/types.ts
@@ -18,6 +18,8 @@ export type ApproveOrgUnitParams = UrlParams & {
     withLocation?: string;
     projectIds?: string;
     paymentStatus?: 'pending' | 'sent' | 'rejected' | 'paid';
+    paymentIds?: string; // comma separated ids
+    potentialPaymentIds?: string; // comma separated ids
 };
 export type Group = {
     id: number;

--- a/hat/assets/js/apps/Iaso/domains/payments/components/PaymentLotActionCell.tsx
+++ b/hat/assets/js/apps/Iaso/domains/payments/components/PaymentLotActionCell.tsx
@@ -32,11 +32,14 @@ export const PaymentLotActionCell = ({
     const userIds = [
         ...new Set(paymentLot.payments.map(payment => payment.user.id)),
     ].join(',');
+    const paymentIds = [
+        ...new Set(paymentLot.payments.map(payment => payment.id)),
+    ].join(',');
     return (
         <>
             <IconButton
                 icon="remove-red-eye"
-                url={`/${baseUrls.orgUnitsChangeRequest}/userIds/${userIds}`}
+                url={`/${baseUrls.orgUnitsChangeRequest}/userIds/${userIds}/paymentIds/${paymentIds}`}
                 // TODO add correct message
                 tooltipMessage={MESSAGES.viewChangeRequestforLot}
             />

--- a/hat/assets/js/apps/Iaso/domains/payments/hooks/config/usePaymentColumns.tsx
+++ b/hat/assets/js/apps/Iaso/domains/payments/hooks/config/usePaymentColumns.tsx
@@ -99,9 +99,9 @@ export const usePaymentColumns = ({
                         return (
                             <IconButton
                                 icon="remove-red-eye"
-                                url={`/${baseUrls.orgUnitsChangeRequest}/userIds/${settings.row.original.user.id}`}
+                                url={`/${baseUrls.orgUnitsChangeRequest}/userIds/${settings.row.original.user.id}/potentialPaymentIds/${settings.row.original.id}`}
                                 tooltipMessage={
-                                    MESSAGES.viewChangeRequestsForUser
+                                    MESSAGES.viewChangeRequestsForPotentialPayment // change text to payment lot
                                 }
                             />
                         );
@@ -126,21 +126,30 @@ export const usePaymentColumns = ({
                     Cell: settings => {
                         const payment = settings.row.original;
                         return (
-                            <EditPaymentDialog
-                                status={payment.status}
-                                id={payment.id}
-                                iconProps={{}}
-                                user={payment.user}
-                                // if potential is false, then we know we're passing saveStatus
-                                saveStatus={
-                                    saveStatus as UseMutateAsyncFunction<
-                                        any,
-                                        any,
-                                        SavePaymentStatusArgs,
-                                        any
-                                    >
-                                }
-                            />
+                            <>
+                                <IconButton
+                                    icon="remove-red-eye"
+                                    url={`/${baseUrls.orgUnitsChangeRequest}/userIds/${settings.row.original.user.id}/paymentIds/${payment.id}`}
+                                    tooltipMessage={
+                                        MESSAGES.viewChangeRequestsForPayment
+                                    }
+                                />
+                                <EditPaymentDialog
+                                    status={payment.status}
+                                    id={payment.id}
+                                    iconProps={{}}
+                                    user={payment.user}
+                                    // if potential is false, then we know we're passing saveStatus
+                                    saveStatus={
+                                        saveStatus as UseMutateAsyncFunction<
+                                            any,
+                                            any,
+                                            SavePaymentStatusArgs,
+                                            any
+                                        >
+                                    }
+                                />
+                            </>
                         );
                     },
                 },

--- a/hat/assets/js/apps/Iaso/domains/payments/messages.ts
+++ b/hat/assets/js/apps/Iaso/domains/payments/messages.ts
@@ -194,6 +194,14 @@ const MESSAGES = defineMessages({
         id: 'iaso.label.viewChangeRequestforLot',
         defaultMessage: 'View change requests for this payment lot',
     },
+    viewChangeRequestsForPotentialPayment: {
+        id: 'iaso.label.viewChangeRequestsForPotentialPayment',
+        defaultMessage: 'View change requests for this potential payment',
+    },
+    viewChangeRequestsForPayment: {
+        id: 'iaso.label.viewChangeRequestsForPayment',
+        defaultMessage: 'View change requests for this payment',
+    },
 });
 
 export default MESSAGES;

--- a/iaso/api/org_unit_change_requests/filters.py
+++ b/iaso/api/org_unit_change_requests/filters.py
@@ -119,7 +119,10 @@ class OrgUnitChangeRequestListFilter(django_filters.rest_framework.FilterSet):
                 f"Expected payment status to be one of {','.join(PaymentStatuses.values)}, got {value}"
             )
         if value == PaymentStatuses.PENDING:
-            pending_filter = Q(payment__isnull=True) | Q(payment__status=PaymentStatuses.PENDING)
+            pending_filter = (
+                Q(payment__isnull=True)
+                & (Q(potential_payment__isnull=False) | Q(status=OrgUnitChangeRequest.Statuses.APPROVED.value))
+            ) | Q(payment__status=PaymentStatuses.PENDING)
             return queryset.filter(pending_filter)
         else:
             return queryset.filter(payment__status=value)

--- a/iaso/api/org_unit_change_requests/filters.py
+++ b/iaso/api/org_unit_change_requests/filters.py
@@ -32,6 +32,10 @@ class OrgUnitChangeRequestListFilter(django_filters.rest_framework.FilterSet):
     status = django_filters.CharFilter(method="filter_status", label=_("Status (comma-separated)"))
     projects = django_filters.CharFilter(method="filter_projects", label=_("Projects IDs (comma-separated)"))
     payment_status = django_filters.CharFilter(method="filter_payment_status", label=_("Payment status"))
+    payment_ids = django_filters.CharFilter(method="filter_payments", label=_("Payment IDs (comma-separated)"))
+    potential_payment_ids = django_filters.CharFilter(
+        method="filter_potential_payments", label=_("Potential Payment IDs (comma-separated)")
+    )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -119,3 +123,13 @@ class OrgUnitChangeRequestListFilter(django_filters.rest_framework.FilterSet):
             return queryset.filter(pending_filter)
         else:
             return queryset.filter(payment__status=value)
+
+    # This filter is used when redirecting from potential payments to see related change requests. It is not otherwise visible in the UI
+    def filter_potential_payments(self, queryset: QuerySet, name: str, value: str) -> QuerySet:
+        potential_payment_ids = parse_comma_separated_numeric_values(value, name)
+        return queryset.filter(potential_payment__in=potential_payment_ids)
+
+    # This filter is used when redirecting from payment lots to see related change requests. It is not otherwise visible in the UI
+    def filter_payments(self, queryset: QuerySet, name: str, value: str) -> QuerySet:
+        payment_ids = parse_comma_separated_numeric_values(value, name)
+        return queryset.filter(payment__in=payment_ids)


### PR DESCRIPTION
Filtering by user was not specific enough

Related JIRA tickets : IA-3257, IA-3298

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are my typescript files well typed
- [x] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
Some comments in the API code

## Changes

- add payment_ids and potential_payments_ids ->comma-separated ids
- add params to url
- add params to useGetApprovalProposals
- Update payment, payment lot and potential payment columns to link to change requests with the correct params
- Add translations
- update TS types


The added query params are only used when linking from payments/payment lots. There's no corresponding filter in the UI, because a dropdown with potential payment ids wouldn't make sense.

We still pass the user ids to make visible that there are active filters

## How to test

DB requirements:
- At least 1 potential payment
- At least 1 payment lot with at least 2 payments
- Change requests not associated with payments or potential payments for at least 1 user from payment and potential payments

Testing:
- Go to potential payments, follow the link to the change requests: you should only see the change requests related to the potential payment (remove the query param in the url to control)
- Do the same with payment lots (the url should show change request for all payments)
- Open a payment (edit icon button) and do the same with an individual payment

## Print screen / video


https://github.com/user-attachments/assets/d487056e-9f3a-463d-9459-4d8a133e77cc




