### PR TITLE
IA-3296 add column to change req table

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/Tables/ReviewOrgUnitChangesTable.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/Tables/ReviewOrgUnitChangesTable.tsx
@@ -27,6 +27,7 @@ import {
 import { UserCell } from '../../../../components/Cells/UserCell';
 import { colorCodes } from '../Dialogs/ReviewOrgUnitChangesInfos';
 import { ColumnCell } from '../../../../types/general';
+import { BreakWordCell } from '../../../../components/Cells/BreakWordCell';
 
 const useColumns = (
     setSelectedChangeRequest: Dispatch<SetStateAction<SelectedChangeRequest>>,
@@ -128,6 +129,12 @@ const useColumns = (
                 id: 'created_by__username',
                 accessor: 'created_by',
                 Cell: UserCell,
+            },
+            {
+                Header: formatMessage(MESSAGES.paymentStatus),
+                id: 'payment_status',
+                accessor: 'payment_status',
+                Cell: BreakWordCell,
             },
             {
                 Header: formatMessage(MESSAGES.updated_at),

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/hooks/api/useGetApprovalProposals.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/hooks/api/useGetApprovalProposals.ts
@@ -7,6 +7,7 @@ import {
     ApproveOrgUnitParams,
 } from '../../types';
 import { apiUrl } from '../../constants';
+import { useLocale } from '../../../../app/contexts/LocaleContext';
 
 const getOrgUnitChangeProposals = (url: string) => {
     return getRequest(url) as Promise<OrgUnitChangeRequestsPaginated>;
@@ -15,6 +16,7 @@ const getOrgUnitChangeProposals = (url: string) => {
 export const useGetApprovalProposals = (
     params: ApproveOrgUnitParams,
 ): UseQueryResult<OrgUnitChangeRequestsPaginated, Error> => {
+    const { locale } = useLocale();
     const apiParams = {
         parent_id: params.parent_id,
         groups: params.groups,
@@ -37,7 +39,8 @@ export const useGetApprovalProposals = (
 
     const url = makeUrlWithParams(apiUrl, apiParams);
     return useSnackQuery({
-        queryKey: ['getApprovalProposals', url],
+        // Including locale in the query key because we need to make a call to update translations coming from the backend
+        queryKey: ['getApprovalProposals', url, locale],
         queryFn: () => getOrgUnitChangeProposals(url),
         options: {
             staleTime: 1000 * 60 * 15, // in MS

--- a/iaso/tests/api/org_unit_change_requests/test_serializers.py
+++ b/iaso/tests/api/org_unit_change_requests/test_serializers.py
@@ -18,6 +18,7 @@ from iaso.api.org_unit_change_requests.serializers import (
     OrgUnitChangeRequestRetrieveSerializer,
 )
 from iaso.models import OrgUnitChangeRequest
+from iaso.models.payments import PaymentStatuses
 from iaso.test import TestCase
 from iaso import models as m
 
@@ -193,10 +194,37 @@ class OrgUnitChangeRequestListSerializerTestCase(TestCase):
                 "created_at": 1696856400.0,
                 "updated_by": None,
                 "updated_at": 1696856400.0,
+                "payment_status": None,
             },
         )
         self.assertCountEqual(serializer.data["requested_fields"], ["new_org_unit_type", "new_location"])
         self.assertCountEqual(serializer.data["approved_fields"], ["new_org_unit_type"])
+
+        # if status is "approved" payment status should be "pending"
+        change_request.status = OrgUnitChangeRequest.Statuses.APPROVED.value
+        change_request.save
+        serializer = OrgUnitChangeRequestListSerializer(change_request)
+        self.assertEqual(serializer.data["payment_status"], PaymentStatuses.PENDING.label)
+
+        # otherwise None
+        change_request.status = OrgUnitChangeRequest.Statuses.NEW.value
+        change_request.save
+        serializer = OrgUnitChangeRequestListSerializer(change_request)
+        self.assertEqual(serializer.data["payment_status"], None)
+
+        # if there's only a potential payment, payment_status should be "pending"
+        potential_payment = m.PotentialPayment.objects.create(user=self.user)
+        change_request.potential_payment = potential_payment
+        change_request.save
+        serializer = OrgUnitChangeRequestListSerializer(change_request)
+        self.assertEqual(serializer.data["payment_status"], PaymentStatuses.PENDING.label)
+
+        # if there's a payment, payment status should be the same as the payment's
+        payment = m.Payment.objects.create(status=PaymentStatuses.PAID.value, user=self.user)
+        change_request.payment = payment
+        change_request.save()
+        serializer = OrgUnitChangeRequestListSerializer(change_request)
+        self.assertEqual(serializer.data["payment_status"], PaymentStatuses.PAID.label)
 
 
 @time_machine.travel("2023-10-13T13:00:00.000Z", tick=False)


### PR DESCRIPTION
Add payment status column to org unit change request table

Related JIRA tickets : IA-3296

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
- Tell us where the doc can be found (docs folder, wiki, in the code...)

## Changes

- Backend:
    - Add serializerMethodField
    - payment_status will be:
        - None if change request status is not APPROVED
        - Pending if no payment, but potential payment
        - Same as payment status if payment
    - update serializer test
- Frontend:
    -  Add column to table  

## How to test

Same DB config as https://github.com/BLSQ/iaso/tree/IA-3257_filter_change_request

Check that the column appears in the table

## Print screen / video


https://github.com/user-attachments/assets/78014475-46e1-4b72-b03d-c0f721bb056e



## Notes

merges  into https://github.com/BLSQ/iaso/tree/IA-3257_filter_change_request
