### PR TITLE
IA-3346 Allow to filter chronograms on `created_at`

### DIFF
--- a/plugins/polio/api/chronogram/filters.py
+++ b/plugins/polio/api/chronogram/filters.py
@@ -1,11 +1,13 @@
 import django_filters
+from dateutil.relativedelta import relativedelta
 
 from django.db.models import QuerySet
-from django.utils.translation import gettext as _
+from django.utils import timezone
+from django.utils.translation import gettext_lazy as _
 
 from iaso.models import OrgUnit
 
-from plugins.polio.models import Campaign, Chronogram, ChronogramTask
+from plugins.polio.models import Chronogram, ChronogramTask
 
 
 def countries(request) -> QuerySet[OrgUnit]:
@@ -19,19 +21,57 @@ def countries(request) -> QuerySet[OrgUnit]:
     )
 
 
+def filter_for_power_bi(queryset: QuerySet) -> QuerySet:
+    """
+    The Power BI dashboard needs to fetch all the data available in the DB.
+
+    Because such an operation is costly, we agreed on fetching only
+    the last 3 months of data.
+
+    However, it seems difficult to compute dynamic queries in Power BI.
+    They can't compute "today - 3 months" and use e.g. `created_at__gte`.
+
+    To solve this, we added a `power_bi_limit=true` param that returns only
+    the last 3 months of data.
+    """
+    three_months_ago = timezone.now() - relativedelta(months=3)
+    return queryset.filter(created_at__gte=three_months_ago)
+
+
 class ChronogramFilter(django_filters.rest_framework.FilterSet):
     country = django_filters.ModelMultipleChoiceFilter(
         field_name="round__campaign__country", queryset=countries, label=_("Country")
     )
-    on_time = django_filters.BooleanFilter(field_name="annotated_is_on_time")
-    search = django_filters.CharFilter(field_name="round__campaign__obr_name", lookup_expr="icontains")
+    on_time = django_filters.BooleanFilter(field_name="annotated_is_on_time", label=_("On time"))
+    search = django_filters.CharFilter(
+        field_name="round__campaign__obr_name", lookup_expr="icontains", label=_("Search")
+    )
+    created_at__gte = django_filters.IsoDateTimeFilter(
+        field_name="created_at", lookup_expr="gte", label=_("Created at greater than or equal to")
+    )
+    power_bi_limit = django_filters.CharFilter(method="filter_power_bi_limit", label=_("Power BI limit"))
 
     class Meta:
         model = Chronogram
         fields = ["search", "country"]
 
+    def filter_power_bi_limit(self, queryset: QuerySet, _, value: str) -> QuerySet:
+        if bool(value) is True:
+            return filter_for_power_bi(queryset)
+        return queryset
+
 
 class ChronogramTaskFilter(django_filters.rest_framework.FilterSet):
+    created_at__gte = django_filters.IsoDateTimeFilter(
+        field_name="created_at", lookup_expr="gte", label=_("Created at greater than or equal to")
+    )
+    power_bi_limit = django_filters.CharFilter(method="filter_power_bi_limit", label=_("Power BI limit"))
+
     class Meta:
         model = ChronogramTask
         fields = ["chronogram_id", "period", "status"]
+
+    def filter_power_bi_limit(self, queryset: QuerySet, _, value: str) -> QuerySet:
+        if bool(value) is True:
+            return filter_for_power_bi(queryset)
+        return queryset

--- a/plugins/polio/api/chronogram/filters.py
+++ b/plugins/polio/api/chronogram/filters.py
@@ -29,7 +29,7 @@ def filter_for_power_bi(queryset: QuerySet) -> QuerySet:
     the last 3 months of data.
 
     However, it seems difficult to compute dynamic queries in Power BI.
-    They can't compute "today - 3 months" and use e.g. `created_at__gte`.
+    They can't compute "today - 3 months" and use `created_at__gte`.
 
     To solve this, we added a `power_bi_limit=true` param that returns only
     the last 3 months of data.
@@ -56,7 +56,7 @@ class ChronogramFilter(django_filters.rest_framework.FilterSet):
         fields = ["search", "country"]
 
     def filter_power_bi_limit(self, queryset: QuerySet, _, value: str) -> QuerySet:
-        if bool(value) is True:
+        if value and value.lower() in ["1", "true"]:
             return filter_for_power_bi(queryset)
         return queryset
 
@@ -72,6 +72,6 @@ class ChronogramTaskFilter(django_filters.rest_framework.FilterSet):
         fields = ["chronogram_id", "period", "status"]
 
     def filter_power_bi_limit(self, queryset: QuerySet, _, value: str) -> QuerySet:
-        if bool(value) is True:
+        if value and value.lower() in ["1", "true"]:
             return filter_for_power_bi(queryset)
         return queryset

--- a/plugins/polio/tests/api/test_chronogram_filters.py
+++ b/plugins/polio/tests/api/test_chronogram_filters.py
@@ -1,0 +1,26 @@
+import datetime
+
+import time_machine
+
+from iaso.test import APITestCase
+
+from plugins.polio.api.chronogram.filters import filter_for_power_bi
+from plugins.polio.models import Chronogram
+
+
+TODAY = datetime.datetime(2024, 8, 23, 16, 0, 0, 0, tzinfo=datetime.timezone.utc)
+
+
+@time_machine.travel(TODAY, tick=False)
+class ChronogramFiltersTestCase(APITestCase):
+    """
+    Test Chronogram Filters.
+    """
+
+    def test_filter_for_power_bi(self):
+        queryset = filter_for_power_bi(Chronogram.objects.all())
+
+        three_months_ago = "2024-05-23 16:00:00+00:00"
+        sql_query = str(queryset.query)
+
+        self.assertIn(f'"created_at" >= {three_months_ago}', sql_query)


### PR DESCRIPTION
Allow to filter chronograms on `created_at`.

Related JIRA tickets : [IA-3346](https://bluesquare.atlassian.net/browse/IA-3346)

## Changes

The Power BI dashboard for chronograms needs to fetch all the data available in the DB.

Because such an operation is costly, we agreed on fetching only the last 3 months of data.

The "clean" way to do that is to add a new filtering param `created_at__gte`:

```
&created_at__gte=2024-07-16
```

This allows us to filter on ISO 8601 formatted dates with great flexibility.

However, it seems difficult to compute dynamic queries in Power BI. They can't compute "today - 3 months" and use `created_at__gte`.

To solve this, we also add a `power_bi_limit=true` param that returns only the last 3 months of data.


## How to test

Use DRF UI:

- http://localhost:8081/api/polio/chronograms/?fields=:all&created_at__gte=2025-01-01
- http://localhost:8081/api/polio/chronograms/?fields=:all&power_bi_limit=1


[IA-3346]: https://bluesquare.atlassian.net/browse/IA-3346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ