### PR TITLE
[WC2-478] Using source_created_at and source_updated_at instead of their server…

### DIFF
--- a/iaso/api/enketo.py
+++ b/iaso/api/enketo.py
@@ -364,6 +364,7 @@ class EnketoSubmissionAPIView(APIView):
             instance.file = main_file
             instance.name = instance.form.name
             instance.json = {}
+            instance.source_updated_at = timezone.now()
             instance.save()
 
             # copy-pasted from the "create" code

--- a/iaso/api/instances.py
+++ b/iaso/api/instances.py
@@ -235,16 +235,8 @@ class InstancesViewSet(viewsets.ViewSet):
         filename = "%s-%s" % (filename, strftime("%Y-%m-%d-%H-%M", gmtime()))
 
         def get_row(instance, **kwargs):
-            created_at_timestamp = (
-                instance.source_created_at.timestamp()
-                if instance.source_created_at
-                else instance.created_at.timestamp()
-            )
-            updated_at_timestamp = (
-                instance.source_updated_at.timestamp()
-                if instance.source_updated_at
-                else instance.updated_at.timestamp()
-            )
+            created_at_timestamp = instance.source_created_at_with_fallback.timestamp()
+            updated_at_timestamp = instance.source_updated_at_with_fallback.timestamp()
             org_unit = instance.org_unit
             file_content = instance.get_and_save_json_of_xml()
 

--- a/iaso/api/mobile/entity.py
+++ b/iaso/api/mobile/entity.py
@@ -74,15 +74,8 @@ class MobileEntityAttributesSerializer(serializers.ModelSerializer):
     id = serializers.CharField(read_only=True, source="uuid")
     org_unit_id = serializers.CharField(read_only=True, source="org_unit.id")
     form_version_id = serializers.SerializerMethodField()
-
-    created_at = serializers.SerializerMethodField()
-    updated_at = serializers.SerializerMethodField()
-
-    def get_created_at(self, instance):
-        return instance.source_created_at.timestamp() if instance.source_created_at else instance.created_at.timestamp()
-
-    def get_updated_at(self, instance):
-        return instance.source_updated_at.timestamp() if instance.source_updated_at else instance.updated_at.timestamp()
+    created_at = TimestampField(read_only=True, source="source_created_at_with_fallback")
+    updated_at = TimestampField(read_only=True, source="source_updated_at_with_fallback")
 
     def get_form_version_id(self, obj):
         if obj.json is None:

--- a/iaso/api/mobile/entity.py
+++ b/iaso/api/mobile/entity.py
@@ -75,8 +75,14 @@ class MobileEntityAttributesSerializer(serializers.ModelSerializer):
     org_unit_id = serializers.CharField(read_only=True, source="org_unit.id")
     form_version_id = serializers.SerializerMethodField()
 
-    created_at = TimestampField()
-    updated_at = TimestampField()
+    created_at = serializers.SerializerMethodField()
+    updated_at = serializers.SerializerMethodField()
+
+    def get_created_at(self, instance):
+        return instance.source_created_at.timestamp() if instance.source_created_at else None
+
+    def get_updated_at(self, instance):
+        return instance.source_updated_at.timestamp() if instance.source_updated_at else None
 
     def get_form_version_id(self, obj):
         if obj.json is None:

--- a/iaso/api/mobile/entity.py
+++ b/iaso/api/mobile/entity.py
@@ -79,10 +79,10 @@ class MobileEntityAttributesSerializer(serializers.ModelSerializer):
     updated_at = serializers.SerializerMethodField()
 
     def get_created_at(self, instance):
-        return instance.source_created_at.timestamp() if instance.source_created_at else None
+        return instance.source_created_at.timestamp() if instance.source_created_at else instance.created_at.timestamp()
 
     def get_updated_at(self, instance):
-        return instance.source_updated_at.timestamp() if instance.source_updated_at else None
+        return instance.source_updated_at.timestamp() if instance.source_updated_at else instance.updated_at.timestamp()
 
     def get_form_version_id(self, obj):
         if obj.json is None:

--- a/iaso/api/mobile/org_units.py
+++ b/iaso/api/mobile/org_units.py
@@ -43,8 +43,8 @@ class ReferenceInstancesFilter(django_filters.rest_framework.FilterSet):
 
 
 class ReferenceInstancesSerializer(serializers.ModelSerializer):
-    created_at = TimestampField()
-    updated_at = TimestampField()
+    created_at = TimestampField(read_only=True, source="source_created_at_with_fallback")
+    updated_at = TimestampField(read_only=True, source="source_updated_at_with_fallback")
 
     class Meta:
         model = Instance

--- a/iaso/dhis2/datavalue_exporter.py
+++ b/iaso/dhis2/datavalue_exporter.py
@@ -32,8 +32,7 @@ def get_event_date(instance, form_mapping):
     event_date_source = MappingVersion.get_event_date_source(form_mapping)
 
     if event_date_source == MappingVersion.EVENT_DATE_SOURCE_FROM_SUBMISSION_CREATED_AT:
-        created_at = instance.source_created_at if instance.source_created_at else instance.created_at
-        return created_at.strftime("%Y-%m-%d")
+        return instance.source_created_at_with_fallback.strftime("%Y-%m-%d")
     if event_date_source == MappingVersion.EVENT_DATE_SOURCE_FROM_SUBMISSION_PERIOD:
         dhis2_period = Period.from_string(instance.period)
         start = dhis2_period.start_date().strftime("%Y-%m-%d")

--- a/iaso/models/base.py
+++ b/iaso/models/base.py
@@ -989,6 +989,14 @@ class Instance(models.Model):
             return False
         return self.org_unit.reference_instances.filter(orgunitreferenceinstance__instance=self).exists()
 
+    @property
+    def source_created_at_with_fallback(self):
+        return self.source_created_at.timestamp() if self.source_created_at else self.created_at.timestamp()
+
+    @property
+    def source_updated_at_with_fallback(self):
+        return self.source_updated_at.timestamp() if self.source_updated_at else self.updated_at.timestamp()
+
     def flag_reference_instance(self, org_unit: "OrgUnit") -> "OrgUnitReferenceInstance":
         if not self.form:
             raise ValidationError(_("The Instance must be linked to a Form."))
@@ -1150,8 +1158,8 @@ class Instance(models.Model):
             "id": self.id,
             "form_id": self.form_id,
             "form_name": self.form.name if self.form else None,
-            "created_at": self.source_created_at.timestamp() if self.source_created_at else self.created_at.timestamp(),
-            "updated_at": self.source_updated_at.timestamp() if self.source_updated_at else self.updated_at.timestamp(),
+            "created_at": self.source_created_at_with_fallback,
+            "updated_at": self.source_updated_at_with_fallback,
             "org_unit": self.org_unit.as_dict() if self.org_unit else None,
             "latitude": self.location.y if self.location else None,
             "longitude": self.location.x if self.location else None,
@@ -1188,8 +1196,8 @@ class Instance(models.Model):
             "file_url": self.file.url if self.file else None,
             "id": self.id,
             "form_id": self.form_id,
-            "created_at": self.source_created_at.timestamp() if self.source_created_at else self.created_at.timestamp(),
-            "updated_at": self.source_updated_at.timestamp() if self.source_updated_at else self.updated_at.timestamp(),
+            "created_at": self.source_created_at_with_fallback,
+            "updated_at": self.source_updated_at_with_fallback,
             "created_by": get_creator_name(self.created_by) if self.created_by else None,
             "org_unit": self.org_unit.as_dict_with_parents() if self.org_unit else None,
             "latitude": self.location.y if self.location else None,
@@ -1221,8 +1229,8 @@ class Instance(models.Model):
             "form_version_id": self.form_version.id if self.form_version else None,
             "form_name": self.form.name,
             "form_descriptor": form_version.get_or_save_form_descriptor() if form_version is not None else None,
-            "created_at": self.source_created_at.timestamp() if self.source_created_at else self.created_at.timestamp(),
-            "updated_at": self.source_updated_at.timestamp() if self.source_updated_at else self.updated_at.timestamp(),
+            "created_at": self.source_created_at_with_fallback,
+            "updated_at": self.source_updated_at_with_fallback,
             "org_unit": self.org_unit.as_dict_with_parents(light=False, light_parents=False) if self.org_unit else None,
             "latitude": self.location.y if self.location else None,
             "longitude": self.location.x if self.location else None,
@@ -1281,8 +1289,8 @@ class Instance(models.Model):
         return {
             "id": self.id,
             "file_url": self.file.url if self.file else None,
-            "created_at": self.source_created_at.timestamp() if self.source_created_at else self.created_at.timestamp(),
-            "updated_at": self.source_updated_at.timestamp() if self.source_updated_at else self.updated_at.timestamp(),
+            "created_at": self.source_created_at_with_fallback,
+            "updated_at": self.source_updated_at_with_fallback,
             "period": self.period,
             "latitude": self.location.y if self.location else None,
             "longitude": self.location.x if self.location else None,

--- a/iaso/models/base.py
+++ b/iaso/models/base.py
@@ -991,11 +991,11 @@ class Instance(models.Model):
 
     @property
     def source_created_at_with_fallback(self):
-        return self.source_created_at.timestamp() if self.source_created_at else self.created_at.timestamp()
+        return self.source_created_at if self.source_created_at else self.created_at
 
     @property
     def source_updated_at_with_fallback(self):
-        return self.source_updated_at.timestamp() if self.source_updated_at else self.updated_at.timestamp()
+        return self.source_updated_at if self.source_updated_at else self.updated_at
 
     def flag_reference_instance(self, org_unit: "OrgUnit") -> "OrgUnitReferenceInstance":
         if not self.form:
@@ -1158,8 +1158,8 @@ class Instance(models.Model):
             "id": self.id,
             "form_id": self.form_id,
             "form_name": self.form.name if self.form else None,
-            "created_at": self.source_created_at_with_fallback,
-            "updated_at": self.source_updated_at_with_fallback,
+            "created_at": self.source_created_at_with_fallback.timestamp(),
+            "updated_at": self.source_updated_at_with_fallback.timestamp(),
             "org_unit": self.org_unit.as_dict() if self.org_unit else None,
             "latitude": self.location.y if self.location else None,
             "longitude": self.location.x if self.location else None,
@@ -1196,8 +1196,8 @@ class Instance(models.Model):
             "file_url": self.file.url if self.file else None,
             "id": self.id,
             "form_id": self.form_id,
-            "created_at": self.source_created_at_with_fallback,
-            "updated_at": self.source_updated_at_with_fallback,
+            "created_at": self.source_created_at_with_fallback.timestamp(),
+            "updated_at": self.source_updated_at_with_fallback.timestamp(),
             "created_by": get_creator_name(self.created_by) if self.created_by else None,
             "org_unit": self.org_unit.as_dict_with_parents() if self.org_unit else None,
             "latitude": self.location.y if self.location else None,
@@ -1229,8 +1229,8 @@ class Instance(models.Model):
             "form_version_id": self.form_version.id if self.form_version else None,
             "form_name": self.form.name,
             "form_descriptor": form_version.get_or_save_form_descriptor() if form_version is not None else None,
-            "created_at": self.source_created_at_with_fallback,
-            "updated_at": self.source_updated_at_with_fallback,
+            "created_at": self.source_created_at_with_fallback.timestamp(),
+            "updated_at": self.source_updated_at_with_fallback.timestamp(),
             "org_unit": self.org_unit.as_dict_with_parents(light=False, light_parents=False) if self.org_unit else None,
             "latitude": self.location.y if self.location else None,
             "longitude": self.location.x if self.location else None,
@@ -1289,8 +1289,8 @@ class Instance(models.Model):
         return {
             "id": self.id,
             "file_url": self.file.url if self.file else None,
-            "created_at": self.source_created_at_with_fallback,
-            "updated_at": self.source_updated_at_with_fallback,
+            "created_at": self.source_created_at_with_fallback.timestamp(),
+            "updated_at": self.source_updated_at_with_fallback.timestamp(),
             "period": self.period,
             "latitude": self.location.y if self.location else None,
             "longitude": self.location.x if self.location else None,


### PR DESCRIPTION
See ticket here: https://bluesquare.atlassian.net/browse/WC2-478


The problem is the wrong ordering of visits in this screen
![Screenshot_20240824-143247 (1)](https://github.com/user-attachments/assets/07cafc73-2a81-461b-baab-37a9356ea748)


As a solution: sending source_created_at and source_updated at to the mobile phones in the mobile entity API because we were sending the update and creation date from the server, which hides the timing between visits at WFP, which is problematic because this timing is essential to find out if a beneficiary is late. 


## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are there enough tests


## How to test
Upload and download entity on the mobile app 
## Print screen / video

