### PR TITLE
IA-3356: replace undeclared var staticUrl with window.STATIC_URL

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/home/HomeOnline.tsx
+++ b/hat/assets/js/apps/Iaso/domains/home/HomeOnline.tsx
@@ -154,7 +154,7 @@ export const HomeOnline: FunctionComponent = () => {
                             {APP_TITLE !== 'Iaso' && LOGO_PATH && (
                                 <img
                                     alt="logo"
-                                    src={`${staticUrl}${LOGO_PATH}`}
+                                    src={`${window.STATIC_URL}${LOGO_PATH}`}
                                     style={{ width: 150, height: 'auto' }}
                                 />
                             )}


### PR DESCRIPTION
unecared variable made the page crash

Related JIRA tickets : IA-3356

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
NA

## Changes

- replace undeclared var `staticUrl` with `window.STATIC_URL`

## How to test

- On a setuper DB: login

## Print screen / video

Before:

![Screenshot 2024-08-26 at 11 50 59](https://github.com/user-attachments/assets/1db46264-4608-49bb-975a-428922f3c7ba)

After: 

![Screenshot 2024-08-26 at 12 19 02](https://github.com/user-attachments/assets/71c2c53d-ab5d-4619-8ac9-403da90d56dc)



## Notes

prod version v1.241b didn't have the bug, so this patch was not hotfixed
