### PR TITLE
IA-3366 Use `docker compose` instead of `docker-compose`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,16 +6,16 @@
 # make test
 # make test TARGET=iaso.tests.api.test_profiles.ProfileAPITestCase
 test:
-	docker-compose exec iaso ./manage.py test \
+	docker compose exec iaso ./manage.py test \
 	--noinput --keepdb --failfast --settings=hat.settings_test \
 	$(TARGET)
 
 # When the migration history is changed, we need to drop the DB before running the tests suite with `--keepdb`.
 drop-test-db:
-	docker-compose exec db psql -U postgres -c "drop database if exists test_iaso"
+	docker compose exec db psql -U postgres -c "drop database if exists test_iaso"
 
 dbshell:
-	docker-compose exec iaso ./manage.py dbshell
+	docker compose exec iaso ./manage.py dbshell
 
 # Django.
 # =============================================================================
@@ -26,4 +26,4 @@ dbshell:
 # make django_admin COMMAND=shell_plus
 # make django_admin COMMAND=createsuperuser
 django_admin:
-	docker-compose exec -ti iaso ./manage.py $(COMMAND)
+	docker compose exec -ti iaso ./manage.py $(COMMAND)

--- a/README.md
+++ b/README.md
@@ -118,14 +118,14 @@ Setup
 -----
 
 
-A running local instance for development can be spin up via docker-compose which will install and
+A running local instance for development can be spin up via docker compose which will install and
 configure all dep in separate container. As such your computer should only need:
 
 -   [git](https://git-scm.com/)
 -   [docker](https://docs.docker.com/engine/installation/)
--   [docker-compose](https://docs.docker.com/compose/)
+-   [docker compose](https://docs.docker.com/compose/)
 
-If docker-compose give you trouble, make sure it can connect to the
+If docker compose give you trouble, make sure it can connect to the
 __docker daemon__.
 
 If you use an Apple Silicon Mac, ensure `export DOCKER_DEFAULT_PLATFORM=linux/amd64` is set.
@@ -157,13 +157,13 @@ cp .env.dist .env
 This will build and download the containers.
 
 ``` bash
-docker-compose build
+docker compose build
 ```
 
 ### 3. Start the database
 
 ``` bash
-docker-compose up db
+docker compose up db
 ```
 (if you get this message: "Database is uninitialized and superuser password is not specified. You must specify POSTGRES_PASSWORD"
  you can set POSTGRES_PASSWORD=postgres in the .env file )
@@ -174,7 +174,7 @@ In a separate bash (without closing yet the started db), launch the migrations
 
 
 ``` bash
-docker-compose run --rm iaso manage migrate
+docker compose run --rm iaso manage migrate
 ```
 (If you get a message saying that the database iaso does not exist, you can connect to your postgres instance using 
 ``` bash
@@ -191,7 +191,7 @@ to create the missing database.)
 To start all the containers (backend, frontend, db)
 
 ``` bash
-docker-compose up
+docker compose up
 ```
 If you get a message saying that entrypoint.sh cannot be find and working on **Windows**, the git repository has an entry point script with Unix line endings (\n). But when the repository was checked out on a windows machine, git decided to try and be clever and replace the line endings in the files with windows line endings (\r\n).
 The solution is to disable git's automatic conversion:
@@ -205,7 +205,7 @@ git reset --hard
 ```
 And then rebuild:
 ``` bash
-docker-compose build
+docker compose build
 ```
 
 
@@ -220,7 +220,7 @@ To log in to the app or the Django admin, a superuser needs to be created
 with:
 
 ``` bash
-docker-compose exec iaso ./manage.py createsuperuser
+docker compose exec iaso ./manage.py createsuperuser
 ```
 
 You can now log in at the admin section: `http://localhost:8081/admin`.
@@ -233,14 +233,14 @@ through the Django admin or loaded via fixtures.
 To create the initial account, project and profile, do the following:
 
 ``` bash
-docker-compose exec iaso ./manage.py create_and_import_data
+docker compose exec iaso ./manage.py create_and_import_data
 ```
 
 And run the following command to populate your database with a tree of
 org units (these are childcare schools in the West of DRC):
 
 ``` bash
-docker-compose exec iaso ./manage.py tree_importer \
+docker compose exec iaso ./manage.py tree_importer \
     --org_unit_csv_file testdata/schools.csv \
     --data_dict testdata/data_dict.json \
     --source_name wb_schools_2019 \
@@ -258,7 +258,7 @@ Alternatively to this step and following steps you can import data from DHIS2 se
 Run the following command to create a form:
 
 ``` bash
-docker-compose exec iaso ./manage.py create_form
+docker compose exec iaso ./manage.py create_form
 ```
 
 At this point, if you want to edit forms directly on your machine using
@@ -283,13 +283,13 @@ First find a running version from play.dhis2.org.
 Take the most recent as the other ones may return a 404.
 Follow the link, eg: https://play.im.dhis2.org/stable-2-40-3-1
 In this example the version is 2.40.3.1.
-Pass it to docker-compose run:
+Pass it to docker compose run:
 
 In a new bash, run the command
 
 
 ``` bash
-docker-compose run --rm iaso manage seed_test_data --mode=seed --dhis2version=2.40.3.1
+docker compose run --rm iaso manage seed_test_data --mode=seed --dhis2version=2.40.3.1
 ```
 
 The hierarchy of OrgUnit, group of OrgUnit, Forms, and their Submissions will be imported. Type of OrgUnit are not
@@ -318,22 +318,22 @@ Each docker container uses the entrypoint.
 The `entrypoint.sh` script offers a range of commands to start services or
 run commands. The full list of commands can be seen in the script. The
 pattern to run a command is
-`docker-compose run <container-name> <entrypoint-command> <...args>`
+`docker compose run <container-name> <entrypoint-command> <...args>`
 
 The following are some examples:
 
-* Run tests                          `docker-compose exec iaso ./manage.py test`
-* Check type hints                   `docker-compose exec iaso mypy .`
-* Create a shell inside the container`docker-compose run iaso bash`
-* Run a shell command                `docker-compose run iaso eval curl http://google.com`
-* Run Django manage.py               `docker-compose exec iaso ./manage.py help`
-* Launch a python shell              `docker-compose exec iaso ./manage.py shell`
-* Launch a postgresql shell          `docker-compose exec iaso ./manage.py dbshell`
-* Create pending ORM migration files `docker-compose exec iaso ./manage.py makemigrations`
-* Apply pending ORM migrations       `docker-compose exec iaso ./manage.py migrate`
-* Show ORM migrations                `docker-compose exec iaso ./manage.py showmigrations`
-* Complie SCSS files for templates   `docker-compose exec iaso ./manage.py compilescss`
-* To run a background worker         `docker-compose run iaso manage tasks_worker`  (see  section Background tasks & Worker)
+* Run tests                          `docker compose exec iaso ./manage.py test`
+* Check type hints                   `docker compose exec iaso mypy .`
+* Create a shell inside the container`docker compose run iaso bash`
+* Run a shell command                `docker compose run iaso eval curl http://google.com`
+* Run Django manage.py               `docker compose exec iaso ./manage.py help`
+* Launch a python shell              `docker compose exec iaso ./manage.py shell`
+* Launch a postgresql shell          `docker compose exec iaso ./manage.py dbshell`
+* Create pending ORM migration files `docker compose exec iaso ./manage.py makemigrations`
+* Apply pending ORM migrations       `docker compose exec iaso ./manage.py migrate`
+* Show ORM migrations                `docker compose exec iaso ./manage.py showmigrations`
+* Complie SCSS files for templates   `docker compose exec iaso ./manage.py compilescss`
+* To run a background worker         `docker compose run iaso manage tasks_worker`  (see  section Background tasks & Worker)
 
 Containers and services
 -----------------------
@@ -354,7 +354,7 @@ All the container definitions for development can be found in the
 
 You can also have a dhis2 and db_dhis2 docker, refer to section below.
 
-### note : docker-compose run VS docker-compose exec
+### note : docker compose run VS docker compose exec
 
 Run launch a new docker container, Exec launch a command in the existing container.
 
@@ -365,16 +365,16 @@ but the containers must already be running (launched manually)
 to run the django manage.py you will need to use `run iaso manage` but `exec iaso ./manage.py`
 
 Also take care that `run` unless evoked with the `--rm` will leave you with a lot of left over containers that take up
-disk space and need to be cleaned occasionally with `docker-compose rm` to reclaim disk space.
+disk space and need to be cleaned occasionally with `docker compose rm` to reclaim disk space.
 
 Enketo
 ------
 
 To submit and edit existing form submission from the browser, an Enketo service is needed. 
 
-To enable the Enketo editor in your local environment, include the additional docker compose configuration file for Enketo. Do so by invoking docker-compose with both files.
+To enable the Enketo editor in your local environment, include the additional docker compose configuration file for Enketo. Do so by invoking docker compose with both files.
 ```
-docker-compose -f docker-compose.yml -f docker/docker-compose-enketo.yml up
+docker compose -f docker-compose.yml -f docker/docker compose-enketo.yml up
 ```
 
 No additional configuration is needed. The first time the docker image is launched, it will download dependencies and do a build witch may take a few minutes. Subsequents launches are faster.
@@ -389,23 +389,23 @@ Database restore and dump
 
 To create a copy of your iaso database in a file (dump) you can use:
 ``` bash
-docker-compose exec db pg_dump -U postgres iaso  -Fc > iaso.dump
+docker compose exec db pg_dump -U postgres iaso  -Fc > iaso.dump
 ```
 
 The dumpfile will be created on your host. The `-Fc` meant it will use an optimised Postgres format (which take less place). If you want the plain sql command use `-Fp`
 
 ### To restore a dump file that you made or that somebody sent you
-0. Ensure the database server is running but not the rest. Close your docker-compose, ensure it is down with `docker-compose down`
-1. Launch the database server with `docker-compose up db` 
+0. Ensure the database server is running but not the rest. Close your docker compose, ensure it is down with `docker compose down`
+1. Launch the database server with `docker compose up db` 
 2. Choose a name for you database. In this example  it will be `iaso5`
-   You can list existing databases using `docker-compose exec db psql -U postgres -l`
-3. Create the database `docker-compose exec db psql -U postgres -c "create database iaso5"`
+   You can list existing databases using `docker compose exec db psql -U postgres -l`
+3. Create the database `docker compose exec db psql -U postgres -c "create database iaso5"`
 4. Restore the dump file to put the data in your database
 ``` bash
-cat iaso.dump | docker-compose exec -T db pg_restore -U postgres -d iaso5 -Fc --no-owner /dev/stdin
+cat iaso.dump | docker compose exec -T db pg_restore -U postgres -d iaso5 -Fc --no-owner /dev/stdin
 ```
 5. Edit your `.env` file to use to this database in the `RDS_DB_NAME` settings.
-6. Start Iaso. Cut your docker-compose (see 0) and relaunch it fully. Warning: Modification in your .env file are not taken into account unless you entirely stop your docker-compose
+6. Start Iaso. Cut your docker compose (see 0) and relaunch it fully. Warning: Modification in your .env file are not taken into account unless you entirely stop your docker compose
 
 Health
 ------
@@ -413,11 +413,11 @@ On the /health/ url you can find listed the Iaso version number, environment, de
 
 Local DHIS2
 -----------
-Experimental. For development if you need a local dhis2 server, you can spin up one in your docker-compose by using the `docker/docker-compose-dhis2.yml ` configuration file.
+Experimental. For development if you need a local dhis2 server, you can spin up one in your docker compose by using the `docker/docker compose-dhis2.yml ` configuration file.
 
-Replace your invocations of `docker-compose` by `docker-compose -f docker-compose.yml -f docker/docker-compose-dhis2.yml` you need to specify both config files. e.g. to launch the cluster:
+Replace your invocations of `docker compose` by `docker compose -f docker-compose.yml -f docker/docker compose-dhis2.yml` you need to specify both config files. e.g. to launch the cluster:
 ``` bash
-docker-compose -f docker-compose.yml -f docker/docker-compose-dhis2.yml up
+docker compose -f docker-compose.yml -f docker/docker compose-dhis2.yml up
 ```
 
 The DHIS2 will be available on your computer on http://localhost:8080 and is reachable from Iaso as http://dhis2:8080. The login and password are admin / district. If you use it as an import source do not set a trailing /
@@ -434,20 +434,20 @@ Download the file, stop all the docker, remove the postgres database directory, 
 
 ``` bash
 wget https://databases.dhis2.org/sierra-leone/2.36.4/dhis2-db-sierra-leone.sql.gz
-docker-compose down
+docker compose down
 sudo rm ../pgdata-dhis2 -r
-docker-compose up db_dhis2
-zcat dhis2-db-sierra-leone.sql.gz| docker-compose exec -T db_dhis2 psql -U dhis dhis2 -f /dev/stdin
-docker-compose up
+docker compose up db_dhis2
+zcat dhis2-db-sierra-leone.sql.gz| docker compose exec -T db_dhis2 psql -U dhis dhis2 -f /dev/stdin
+docker compose up
 cd Projects/blsq/iaso
-docker-compose up dhis2 db_dhis2
+docker compose up dhis2 db_dhis2
 ```
 
 ### Setting up Single Sign On (SSO) with you local DHIS2
 If you want to test the feature with your local dhis2 you can use the following step. This assumes you are running everything in Dockers
 
 0. Launch DHIS2 with iaso within docker compose
-`docker-compose -f docker-compose.yml -f docker/docker-compose-dhis2.yml up`
+`docker compose -f docker-compose.yml -f docker/docker compose-dhis2.yml up`
  With the default docker compose setup, iaso is on port 8081 and dhis2 on port 8081 on your machine
 1. These step assume you have loaded your DHIS2 with the play test data, but it's not mandatory. To see how to do it, look at previous section
 2. Configure an Oauth client in DHIS2: open http://localhost:8080/dhis-web-settings/index.html#/oauth2
@@ -610,7 +610,7 @@ To do so:
  * place the repository in the parent repository of Iaso `../bluesquare-components/`
  * install the dependency for bluesquare-component by running npm install in its directory
  * set the environment variable `LIVE_COMPONENTS=true`
- * start your docker-compose
+ * start your docker compose
 
 ``` bash
 cd ..
@@ -618,7 +618,7 @@ git clone git@github.com:BLSQ/bluesquare-components.git
 cd  bluesquare-components
 npm install
 cd ../iaso
-LIVE_COMPONENTS=true docker-compose up
+LIVE_COMPONENTS=true docker compose up
 ```
 
 This way the page will reload automatically if you make a change to the bluesquare-components code.
@@ -680,7 +680,7 @@ Tests and linting
 For the Python backend, we use the Django builtin test framework. Tests can be executed with
 
 ``` bash
-docker-compose exec iaso ./manage.py test
+docker compose exec iaso ./manage.py test
 ```
 
 Translations
@@ -735,7 +735,7 @@ Troubleshooting
 
 If you need to restart everything
 ``` bash
-docker-compose stop && docker-compose start
+docker compose stop && docker compose start
 ```
 
 If you encounter problems, you can try to rebuild everything from
@@ -743,13 +743,13 @@ scratch.
 
 ``` bash
 # kill containers
-docker-compose kill
+docker compose kill
 # remove `iaso` container
-docker-compose rm -f iaso
+docker compose rm -f iaso
 # build containers
-docker-compose build
+docker compose build
 # start-up containers
-docker-compose up
+docker compose up
 ```
 
 SASS & SCSS
@@ -758,7 +758,7 @@ Scss files are only used to generate the style of the DJango Templates.
 It is not longer part of the webpack app.
 While editing scss files you have to compile it manually with the command:
 
-`docker-compose exec iaso ./manage.py compilescss`
+`docker compose exec iaso ./manage.py compilescss`
 
 If you don't compile it, changes will not be reflected while deploying as we only use css file in production.
 
@@ -839,10 +839,10 @@ These are actually exactly the same steps we use on AWS.
 During local development, by default, the Javascript and CSS will be loaded from
 a webpack server with live reloading of the code. To locally test the compiled
 version as it is in production ( minified and with the same compilation option).
-You can launch docker-compose with the `TEST_PROD=true` environment variable
+You can launch docker compose with the `TEST_PROD=true` environment variable
 set.
 
-e.g `TEST_PROD=true docker-compose up`
+e.g `TEST_PROD=true docker compose up`
 
 This can be useful to reproduce production only bugs. Please also test with this
 configuration whenever you modify webpack.prod.js to validate your changes.
@@ -862,7 +862,7 @@ These functions are marked by the decorator `@task_decorator`. When called, they
 In local development, you can run a worker by using the command:
 
 ```
-docker-compose run iaso manage tasks_worker
+docker compose run iaso manage tasks_worker
 ```
 
 Alternatively, you can call the url `tasks/run_all` which will run all the pending tasks in queue.
@@ -882,7 +882,7 @@ In production on AWS, we use Elastic Beanstalk workers which use a SQS queue. Th
 
 ## Postgres
 
-This is the one you get when running locally with `docker-compose run iaso manage tasks_worker`. Instead of enqueuing the tasks to SQS, we enqueue them to our postgres server.
+This is the one you get when running locally with `docker compose run iaso manage tasks_worker`. Instead of enqueuing the tasks to SQS, we enqueue them to our postgres server.
 
 Our `tasks_worker` process (which runs indefinitely) will listen for new tasks and run them when it gets notified (using PostgreSQL NOTIFY/LISTEN features).
 

--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ To submit and edit existing form submission from the browser, an Enketo service 
 
 To enable the Enketo editor in your local environment, include the additional docker compose configuration file for Enketo. Do so by invoking docker compose with both files.
 ```
-docker compose -f docker-compose.yml -f docker/docker compose-enketo.yml up
+docker compose -f docker-compose.yml -f docker/docker-compose-enketo.yml up
 ```
 
 No additional configuration is needed. The first time the docker image is launched, it will download dependencies and do a build witch may take a few minutes. Subsequents launches are faster.

--- a/README.md
+++ b/README.md
@@ -413,11 +413,11 @@ On the /health/ url you can find listed the Iaso version number, environment, de
 
 Local DHIS2
 -----------
-Experimental. For development if you need a local dhis2 server, you can spin up one in your docker compose by using the `docker/docker compose-dhis2.yml ` configuration file.
+Experimental. For development if you need a local dhis2 server, you can spin up one in your docker compose by using the `docker/docker-compose-dhis2.yml ` configuration file.
 
-Replace your invocations of `docker compose` by `docker compose -f docker-compose.yml -f docker/docker compose-dhis2.yml` you need to specify both config files. e.g. to launch the cluster:
+Replace your invocations of `docker compose` by `docker compose -f docker-compose.yml -f docker/docker-compose-dhis2.yml` you need to specify both config files. e.g. to launch the cluster:
 ``` bash
-docker compose -f docker-compose.yml -f docker/docker compose-dhis2.yml up
+docker compose -f docker-compose.yml -f docker/docker-compose-dhis2.yml up
 ```
 
 The DHIS2 will be available on your computer on http://localhost:8080 and is reachable from Iaso as http://dhis2:8080. The login and password are admin / district. If you use it as an import source do not set a trailing /
@@ -447,7 +447,7 @@ docker compose up dhis2 db_dhis2
 If you want to test the feature with your local dhis2 you can use the following step. This assumes you are running everything in Dockers
 
 0. Launch DHIS2 with iaso within docker compose
-`docker compose -f docker-compose.yml -f docker/docker compose-dhis2.yml up`
+`docker compose -f docker-compose.yml -f docker/docker-compose-dhis2.yml up`
  With the default docker compose setup, iaso is on port 8081 and dhis2 on port 8081 on your machine
 1. These step assume you have loaded your DHIS2 with the play test data, but it's not mandatory. To see how to do it, look at previous section
 2. Configure an Oauth client in DHIS2: open http://localhost:8080/dhis-web-settings/index.html#/oauth2

--- a/docs/pages/dev/how_to/add_new_permission/add_new_permission.md
+++ b/docs/pages/dev/how_to/add_new_permission/add_new_permission.md
@@ -23,7 +23,7 @@
 
 ## 4. Make and run migration
 
-`docker-compose run --rm iaso manage makemigrations && docker-compose run --rm iaso manage migrate`
+`docker compose run --rm iaso manage makemigrations && docker compose run --rm iaso manage migrate`
 
 
 ## 5. Add the permission in the front-end

--- a/docs/pages/dev/how_to/contribute/contribute.md
+++ b/docs/pages/dev/how_to/contribute/contribute.md
@@ -22,7 +22,7 @@ if the formatting is respected!
 For the Python backend, we use the Django builtin test framework. Tests can be executed with
 
 ``` {.sourceCode .bash}
-docker-compose exec iaso ./manage.py test
+docker compose exec iaso ./manage.py test
 ```
 
 ### Translations
@@ -54,7 +54,7 @@ change, either in Python or Javascript. If you need reloading for the bluesquare
 
 If you need to restart everything
 ``` {.sourceCode .shell}
-docker-compose stop && docker-compose start
+docker compose stop && docker compose start
 ```
 
 If you encounter problems, you can try to rebuild everything from
@@ -62,13 +62,13 @@ scratch.
 
 ``` {.sourceCode .shell}
 # kill containers
-docker-compose kill
+docker compose kill
 # remove `iaso` container
-docker-compose rm -f iaso
+docker compose rm -f iaso
 # build containers
-docker-compose build
+docker compose build
 # start-up containers
-docker-compose up
+docker compose up
 ```
 
 ### Jupyter Notebook
@@ -84,10 +84,10 @@ python manage.py shell_plus --notebook
 During local development, by default, the Javascript and CSS will be loaded from
 a webpack server with live reloading of the code. To locally test the compiled
 version as it is in production ( minified and with the same compilation option).
-You can launch docker-compose with the `TEST_PROD=true` environment variable
+You can launch docker compose with the `TEST_PROD=true` environment variable
 set.
 
-e.g `TEST_PROD=true docker-compose up`
+e.g `TEST_PROD=true docker compose up`
 
 This can be useful to reproduce production only bugs. Please also test with this
 configuration whenever you modify webpack.prod.js to validate your changes.

--- a/docs/pages/dev/how_to/create_entities_in_web_ui/create_entities_in_web_ui.md
+++ b/docs/pages/dev/how_to/create_entities_in_web_ui/create_entities_in_web_ui.md
@@ -31,7 +31,7 @@ Repeat as needed
 - Using the filters, search for the reference form(s) that were created in the previous step
 - For each form, create a submission
 
-Note: To be able to create submissions, Enketo needs to be running. This can be done with the following command: `docker compose -f docker-compose.yml -f docker/docker compose-enketo.yml up`
+Note: To be able to create submissions, Enketo needs to be running. This can be done with the following command: `docker compose -f docker-compose.yml -f docker/docker-compose-enketo.yml up`
 
 ## 5. Create `Entities` with the Django admin
 

--- a/docs/pages/dev/how_to/create_entities_in_web_ui/create_entities_in_web_ui.md
+++ b/docs/pages/dev/how_to/create_entities_in_web_ui/create_entities_in_web_ui.md
@@ -31,7 +31,7 @@ Repeat as needed
 - Using the filters, search for the reference form(s) that were created in the previous step
 - For each form, create a submission
 
-Note: To be able to create submissions, Enketo needs to be running. This can be done with the following command: `docker-compose -f docker-compose.yml -f docker/docker-compose-enketo.yml up`
+Note: To be able to create submissions, Enketo needs to be running. This can be done with the following command: `docker compose -f docker-compose.yml -f docker/docker compose-enketo.yml up`
 
 ## 5. Create `Entities` with the Django admin
 
@@ -52,7 +52,7 @@ from django.db import connection
 with connection.cursor() as cursor:
     cursor.execute('CREATE EXTENSION fuzzystrmatch;')
 ```
-Note: To open a python shell in docker: `docker-compose exec iaso ./manage.py shell`
-- In a terminal, launch a task worker: `docker-compose run iaso manage tasks_worker`
+Note: To open a python shell in docker: `docker compose exec iaso ./manage.py shell`
+- In a terminal, launch a task worker: `docker compose run iaso manage tasks_worker`
 - Go to `/api/entityduplicates_analyzes` to launch an algorithm analysis (e.g: inverse)
 - In Iaso web, go to Benefiaries > Duplicates to see if the algorithm matched the duplicates created in previous steps

--- a/docs/pages/dev/how_to/create_registry_in_web_ui/create_registry_in_web_ui.md
+++ b/docs/pages/dev/how_to/create_registry_in_web_ui/create_registry_in_web_ui.md
@@ -30,7 +30,7 @@ Children should also be visible, location (point or shape) is not mandatory.
 - Using the filters, search for a form, doesn't need to be a specific one
 - For each children of the main org unit, create a submission
 
-Note: To be able to create submissions, Enketo needs to be running. This can be done with the following command: `docker compose -f docker-compose.yml -f docker/docker compose-enketo.yml up`
+Note: To be able to create submissions, Enketo needs to be running. This can be done with the following command: `docker compose -f docker-compose.yml -f docker/docker-compose-enketo.yml up`
 
 
 ## 5. Test registry page

--- a/docs/pages/dev/how_to/create_registry_in_web_ui/create_registry_in_web_ui.md
+++ b/docs/pages/dev/how_to/create_registry_in_web_ui/create_registry_in_web_ui.md
@@ -30,7 +30,7 @@ Children should also be visible, location (point or shape) is not mandatory.
 - Using the filters, search for a form, doesn't need to be a specific one
 - For each children of the main org unit, create a submission
 
-Note: To be able to create submissions, Enketo needs to be running. This can be done with the following command: `docker-compose -f docker-compose.yml -f docker/docker-compose-enketo.yml up`
+Note: To be able to create submissions, Enketo needs to be running. This can be done with the following command: `docker compose -f docker-compose.yml -f docker/docker compose-enketo.yml up`
 
 
 ## 5. Test registry page

--- a/docs/pages/dev/how_to/rebuild_front/rebuild_front.md
+++ b/docs/pages/dev/how_to/rebuild_front/rebuild_front.md
@@ -9,7 +9,7 @@ docker rmi -f iaso-webpack:latest
 
 ### Build the new Docker image:
 ```
-docker-compose build --no-cache webpack
+docker compose build --no-cache webpack
 ```
 
 

--- a/docs/pages/dev/how_to/setup_dev_env/setup_dev_env.md
+++ b/docs/pages/dev/how_to/setup_dev_env/setup_dev_env.md
@@ -146,7 +146,7 @@ To submit and edit existing form submission from the browser, an Enketo service 
 
 To enable the Enketo editor in your local environment, include the additional docker compose configuration file for Enketo. Do so by invoking docker compose with both files.
 ```
-docker compose -f docker-compose.yml -f docker/docker compose-enketo.yml up
+docker compose -f docker-compose.yml -f docker/docker-compose-enketo.yml up
 ```
 
 No additional configuration is needed. The first time the docker image is launched, it will download dependencies and do a build witch may take a few minutes. Subsequents launches are faster.

--- a/docs/pages/dev/how_to/setup_dev_env/setup_dev_env.md
+++ b/docs/pages/dev/how_to/setup_dev_env/setup_dev_env.md
@@ -187,11 +187,11 @@ On the /health/ url you can find listed the Iaso version number, environment, de
 
 ### 15. Set up a local DHIS2 server
 -----------
-Experimental. For development if you need a local dhis2 server, you can spin up one in your docker compose by using the `docker/docker compose-dhis2.yml ` configuration file.
+Experimental. For development if you need a local dhis2 server, you can spin up one in your docker compose by using the `docker/docker-compose-dhis2.yml ` configuration file.
 
-Replace your invocations of `docker compose` by `docker compose -f docker-compose.yml -f docker/docker compose-dhis2.yml` you need to specify both config files. e.g to launch the cluster:
+Replace your invocations of `docker compose` by `docker compose -f docker-compose.yml -f docker/docker-compose-dhis2.yml` you need to specify both config files. e.g to launch the cluster:
 ```
-docker compose -f docker-compose.yml -f docker/docker compose-dhis2.yml up
+docker compose -f docker-compose.yml -f docker/docker-compose-dhis2.yml up
 ```
 
 The DHIS2 will be available on your computer on http://localhost:8080 and is reachable from Iaso as http://dhis2:8080. The login and password are admin / district. If you use it as an import source do not set a trailing /
@@ -221,7 +221,7 @@ docker compose up dhis2 db_dhis2
 If you want to test the feature with your local dhis2 you can use the following step. This assume you are running everything in Docker containers
 
 0. Launch DHIS2 with iaso within docker compose
-`docker compose -f docker-compose.yml -f docker/docker compose-dhis2.yml up`
+`docker compose -f docker-compose.yml -f docker/docker-compose-dhis2.yml up`
  With the default docker compose setup, iaso is on port 8081 and dhis2 on port 8081 on your machine
 1. These step assume you have loaded your DHIS2 with the play test data but it's not mandatory. To see how to do it, look at previous section
 2. Configure an Oauth client in DHIS2: open http://localhost:8080/dhis-web-settings/index.html#/oauth2

--- a/docs/pages/dev/how_to/setup_dev_env/setup_dev_env.md
+++ b/docs/pages/dev/how_to/setup_dev_env/setup_dev_env.md
@@ -1,14 +1,14 @@
 # Setup a dev environment
 
 
-A running local instance for development can be spun up via docker-compose which will install and
+A running local instance for development can be spun up via docker compose which will install and
 configure all deps in separate container. As such your computer should only need:
 
 -   [git](https://git-scm.com/)
 -   [docker](https://docs.docker.com/engine/installation/)
--   [docker-compose](https://docs.docker.com/compose/)
+-   [docker compose](https://docs.docker.com/compose/)
 
-If docker-compose give you trouble, make sure it can connect to the
+If docker compose give you trouble, make sure it can connect to the
 __docker daemon__.
 
 If you use an Apple Silicon Mac, ensure `export DOCKER_DEFAULT_PLATFORM=linux/amd64` is set.
@@ -39,19 +39,19 @@ All the commands here need to be run in the project directory in which the repos
 This will build and download the containers.
 
 ``` {.sourceCode .bash}
-docker-compose build
+docker compose build
 ```
 
 ### 3. Start the database
 
 ``` {.sourceCode .bash}
-docker-compose up db
+docker compose up db
 ```
 
 ### 4. Run migrations
 
 ``` {.sourceCode .bash}
-docker-compose run --rm iaso manage migrate
+docker compose run --rm iaso manage migrate
 ```
 If you get a message saying that the database iaso does not exist, you can connect to your postgres instance using 
 ```
@@ -67,7 +67,7 @@ to create the missing database.
 To start all the containers (backend, frontend, db)
 
 ``` {.sourceCode .bash}
-docker-compose up
+docker compose up
 ```
 
 The web server will be reachable at `http://localhost:8081`.
@@ -80,7 +80,7 @@ To login to the app or the Django admin, a superuser needs to be created
 with:
 
 ``` {.sourceCode .bash}
-docker-compose exec iaso ./manage.py createsuperuser
+docker compose exec iaso ./manage.py createsuperuser
 ```
 
 You can now login in the admin at `http://localhost:8081/admin`.
@@ -93,7 +93,7 @@ through the Django admin or loaded via fixtures.
 To create the initial account, project and profile, do the following:
 
 ``` {.sourceCode .bash}
-docker-compose exec iaso ./manage.py create_and_import_data
+docker compose exec iaso ./manage.py create_and_import_data
 ```
 
 You can now login on `http://localhost:8081` but still need to import your own data.
@@ -105,7 +105,7 @@ An alternative to this and the following steps is to [import data from DHIS2](#1
 Run the following command to create a form:
 
 ``` {.sourceCode .bash}
-docker-compose exec iaso ./manage.py create_form
+docker compose exec iaso ./manage.py create_form
 ```
 
 At this point, if you want to edit forms directly on your machine using
@@ -127,7 +127,7 @@ You can now start to develop additional features on Iaso!
 Alternatively or in addition to steps 7-8, you can import data from the DHIS2 demo server (play.dhis2.org):
 
 ``` {.sourceCode .bash}
-docker-compose run --rm iaso manage seed_test_data --mode=seed --dhis2version=2.35.3
+docker compose run --rm iaso manage seed_test_data --mode=seed --dhis2version=2.35.3
 ```
 
 The hierarchy of OrgUnit, group of OrgUnit, Forms, and their Submissions will be imported. OrgUnit types are not
@@ -144,9 +144,9 @@ Log in to  <http://127.0.0.1:8081/dashboard> with :
 
 To submit and edit existing form submission from the browser, an Enketo service is needed. 
 
-To enable the Enketo editor in your local environment, include the additional docker compose configuration file for Enketo. Do so by invoking docker-compose with both files.
+To enable the Enketo editor in your local environment, include the additional docker compose configuration file for Enketo. Do so by invoking docker compose with both files.
 ```
-docker-compose -f docker-compose.yml -f docker/docker-compose-enketo.yml up
+docker compose -f docker-compose.yml -f docker/docker compose-enketo.yml up
 ```
 
 No additional configuration is needed. The first time the docker image is launched, it will download dependencies and do a build witch may take a few minutes. Subsequents launches are faster.
@@ -161,24 +161,24 @@ To seed your DB with typical example forms editable by Enketo, see [import data 
 
 To create a copy of your iaso database in a file (dump) you can use:
 ```
-docker-compose exec db pg_dump -U postgres iaso  -Fc > iaso.dump
+docker compose exec db pg_dump -U postgres iaso  -Fc > iaso.dump
 ```
 
 The dumpfile will be created on your host. The `-Fc` meant it will use an optimised Postgres format (which take less place). If you want the plain sql command use `-Fp`
 
 ### 13. Restore database from dump
 
-0. Ensure the database server is running but not the rest. Close your docker-compose, ensure it is down with `docker-compose down`
-1. Launch the database server with `docker-compose up db` 
+0. Ensure the database server is running but not the rest. Close your docker compose, ensure it is down with `docker compose down`
+1. Launch the database server with `docker compose up db` 
 2. Choose a name for you database. In this example  it will be `iaso5`
-   You can list existing databases using `docker-compose exec db psql -U postgres -l`
-3. Create the database `docker-compose exec db psql -U postgres -c "create database iaso5"`
+   You can list existing databases using `docker compose exec db psql -U postgres -l`
+3. Create the database `docker compose exec db psql -U postgres -c "create database iaso5"`
 4. Restore the dump file to put the data in your database
 ```
-cat iaso.dump | docker-compose exec -T db pg_restore -U postgres -d iaso5 -Fc --no-owner /dev/stdin
+cat iaso.dump | docker compose exec -T db pg_restore -U postgres -d iaso5 -Fc --no-owner /dev/stdin
 ```
 5. Edit your `.env` file to use to this database in the `RDS_DB_NAME` settings.
-6. Start Iaso. Cut your docker-compose (see 0) and relaunch it fully. Warning: Modification in your .env file are not taken into account unless you entirely stop your docker-compose
+6. Start Iaso. Cut your docker compose (see 0) and relaunch it fully. Warning: Modification in your .env file are not taken into account unless you entirely stop your docker compose
 
 
 ### 14. Health
@@ -187,11 +187,11 @@ On the /health/ url you can find listed the Iaso version number, environment, de
 
 ### 15. Set up a local DHIS2 server
 -----------
-Experimental. For development if you need a local dhis2 server, you can spin up one in your docker-compose by using the `docker/docker-compose-dhis2.yml ` configuration file.
+Experimental. For development if you need a local dhis2 server, you can spin up one in your docker compose by using the `docker/docker compose-dhis2.yml ` configuration file.
 
-Replace your invocations of `docker-compose` by `docker-compose -f docker-compose.yml -f docker/docker-compose-dhis2.yml` you need to specify both config files. e.g to launch the cluster:
+Replace your invocations of `docker compose` by `docker compose -f docker-compose.yml -f docker/docker compose-dhis2.yml` you need to specify both config files. e.g to launch the cluster:
 ```
-docker-compose -f docker-compose.yml -f docker/docker-compose-dhis2.yml up
+docker compose -f docker-compose.yml -f docker/docker compose-dhis2.yml up
 ```
 
 The DHIS2 will be available on your computer on http://localhost:8080 and is reachable from Iaso as http://dhis2:8080. The login and password are admin / district. If you use it as an import source do not set a trailing /
@@ -208,20 +208,20 @@ Download the file, stop all the docker, remove the postgres database directory, 
 
 ```
 wget https://databases.dhis2.org/sierra-leone/2.36.4/dhis2-db-sierra-leone.sql.gz
-docker-compose down
+docker compose down
 sudo rm ../pgdata-dhis2 -r
-docker-compose up db_dhis2
-zcat dhis2-db-sierra-leone.sql.gz| docker-compose exec -T db_dhis2 psql -U dhis dhis2 -f /dev/stdin
-docker-compose up
+docker compose up db_dhis2
+zcat dhis2-db-sierra-leone.sql.gz| docker compose exec -T db_dhis2 psql -U dhis dhis2 -f /dev/stdin
+docker compose up
 cd Projects/blsq/iaso
-docker-compose up dhis2 db_dhis2
+docker compose up dhis2 db_dhis2
 ```
 
 ### 17. Set up Single Sign On (SSO) with a local DHIS2
 If you want to test the feature with your local dhis2 you can use the following step. This assume you are running everything in Docker containers
 
 0. Launch DHIS2 with iaso within docker compose
-`docker-compose -f docker-compose.yml -f docker/docker-compose-dhis2.yml up`
+`docker compose -f docker-compose.yml -f docker/docker compose-dhis2.yml up`
  With the default docker compose setup, iaso is on port 8081 and dhis2 on port 8081 on your machine
 1. These step assume you have loaded your DHIS2 with the play test data but it's not mandatory. To see how to do it, look at previous section
 2. Configure an Oauth client in DHIS2: open http://localhost:8080/dhis-web-settings/index.html#/oauth2
@@ -336,7 +336,7 @@ To do so:
  * place the repository in the parent repository of Iaso `../bluesquare-components/`
  * install the dependency for bluesquare-component by running npm install in its directory
  * set the environment variable `LIVE_COMPONENTS=true`
- * start your docker-compose
+ * start your docker compose
 
 ```
 cd ..
@@ -344,7 +344,7 @@ git clone git@github.com:BLSQ/bluesquare-components.git
 cd  bluesquare-components
 npm install
 cd ../iaso
-LIVE_COMPONENTS=true docker-compose up
+LIVE_COMPONENTS=true docker compose up
 ```
 
 This way the page will reload automatically if you make a change to the bluesquare-components code.
@@ -357,7 +357,7 @@ If you encounter any problem, first check that your repo is on the correct branc
 
 In local development, you can run a worker for background tasks by using the command:
 ```
-docker-compose run iaso manage tasks_worker
+docker compose run iaso manage tasks_worker
 ```
 
 Alternatively, you can call the url `tasks/run_all` which will run all the pending tasks in queue.

--- a/docs/pages/dev/how_to/setup_dev_env/setuper.md
+++ b/docs/pages/dev/how_to/setup_dev_env/setuper.md
@@ -23,30 +23,30 @@ Once the script has run, you can log in to your server using the account name as
 
 1. Backup your DB
 
-        docker-compose exec db pg_dump -U postgres iaso  -Fc > ~/Desktop/iaso.dump
+        docker compose exec db pg_dump -U postgres iaso  -Fc > ~/Desktop/iaso.dump
 
 1. Use an empty DB
 
         # Find your Iaso DB.
-        docker-compose exec db psql -U postgres -l
+        docker compose exec db psql -U postgres -l
 
         # Delete your Iaso DB.
-        docker-compose exec db psql -U postgres -c "drop database if exists iaso"
+        docker compose exec db psql -U postgres -c "drop database if exists iaso"
 
         # Create your Iaso DB.
-        docker-compose exec db psql -U postgres -c "create database iaso"
+        docker compose exec db psql -U postgres -c "create database iaso"
 
 1. Run the Django server in a first terminal (this will run DB migrations)
 
-        docker-compose up iaso
+        docker compose up iaso
 
 1. Run a worker in a second terminal
 
-        docker-compose run iaso manage tasks_worker
+        docker compose run iaso manage tasks_worker
 
 1. Create a superuser
 
-        docker-compose exec iaso ./manage.py createsuperuser
+        docker compose exec iaso ./manage.py createsuperuser
 
 1. Prepare the setuper (it requires a local Python 3)
 

--- a/docs/pages/dev/reference/docker/docker.md
+++ b/docs/pages/dev/reference/docker/docker.md
@@ -9,21 +9,21 @@ run commands. The full list of commands can be seen in the script. The
 pattern to run a command is
 
 ```bash
-docker-compose run <container-name> <entrypoint-command> <...args>
+docker compose run <container-name> <entrypoint-command> <...args>
 ```
 
 The following are some examples:
 
-* Run tests                    `docker-compose exec iaso ./manage.py test`
-* Create a shell inside the container    `docker-compose run iaso bash`
-* Run a shell command          `docker-compose run iaso eval curl http://google.com`
-* Run Django manage.py         `docker-compose exec iaso ./manage.py help`
-* Launch a python shell        `docker-compose exec iaso ./manage.py shell`
-* Launch a postgresql shell    `docker-compose exec iaso ./manage.py dbshell`
-* Create pending ORM migration files `docker-compose exec iaso ./manage.py makemigrations`
-* Apply pending ORM migrations `docker-compose exec iaso ./manage.py migrate`
-* Show ORM migrations          `docker-compose exec iaso ./manage.py showmigrations`
-* To run a background worker   `docker-compose run iaso manage tasks_worker`
+* Run tests                    `docker compose exec iaso ./manage.py test`
+* Create a shell inside the container    `docker compose run iaso bash`
+* Run a shell command          `docker compose run iaso eval curl http://google.com`
+* Run Django manage.py         `docker compose exec iaso ./manage.py help`
+* Launch a python shell        `docker compose exec iaso ./manage.py shell`
+* Launch a postgresql shell    `docker compose exec iaso ./manage.py dbshell`
+* Create pending ORM migration files `docker compose exec iaso ./manage.py makemigrations`
+* Apply pending ORM migrations `docker compose exec iaso ./manage.py migrate`
+* Show ORM migrations          `docker compose exec iaso ./manage.py showmigrations`
+* To run a background worker   `docker compose run iaso manage tasks_worker`
 
 ### Containers and services
 
@@ -33,9 +33,9 @@ The following are some examples:
 
 All the container definitions for development can be found in `docker-compose.yml`.
 
-### docker-compose run vs. docker-compose exec
+### docker compose run vs. docker compose exec
 
-`docker-compose run` launches a new docker container, `docker-compose exec` launches a command in the existing container.
+`docker compose run` launches a new docker container, `docker compose exec` launches a command in the existing container.
 
 So `run` will ensure the dependencies like the database are up before executing. `exec` main advantage is that it is faster
 but the containers must already be running (launched manually) 
@@ -44,4 +44,4 @@ but the containers must already be running (launched manually)
 to run the django manage.py you will need to use `run iaso manage` but `exec iaso ./manage.py`
 
 Also take care that `run` unless evoked with the `--rm` will leave you with a lot of left over containers that take up
-disk space and need to be cleaned occasionally with `docker-compose rm` to reclaim disk space.
+disk space and need to be cleaned occasionally with `docker compose rm` to reclaim disk space.

--- a/docs/pages/dev/reference/front-end_reference/front-end_reference.md
+++ b/docs/pages/dev/reference/front-end_reference/front-end_reference.md
@@ -141,7 +141,7 @@ Testing the production build
 
    .. code:: shell
 
-      TEST_PROD=true docker-compose up
+      TEST_PROD=true docker compose up
 
 When the setup is run with ``TEST_PROD=true``, it will exit the unneeded containers
 ``webpack`` and ``jupyter``. It will also run the webpack build during startup, so
@@ -151,7 +151,7 @@ JS Unit Testing
 ---------------
 
 ```shell
-    docker-compose run hat test_js
+    docker compose run hat test_js
 ```
 
 
@@ -164,13 +164,13 @@ upgrading packages in ``package.json``.
 
 .. code:: shell
 
-    docker-compose build
+    docker compose build
 
 or
 
 .. code:: shell
 
-    docker-compose up --build
+    docker compose up --build
 
 
 Translations
@@ -210,4 +210,4 @@ When depending on a local version of the library:
 
 - Your local folder should be on the same level as the iaso folder, so that the path to the tgz file in your package.json is : ../bluesquare-components/bluesquare-components-0.1.0.tgz
 
-- Run ``docker-compose build --build-arg LIBRARY=<name-of-the-library-image>``
+- Run ``docker compose build --build-arg LIBRARY=<name-of-the-library-image>``

--- a/docs/pages/dev/reference/guidelines/back-end/back-end.md
+++ b/docs/pages/dev/reference/guidelines/back-end/back-end.md
@@ -192,7 +192,7 @@ We configure the Iaso deployement (the server) via environment flags. So if you 
 
 Note :There are of course some exceptions and thus some settings are configured in the Database. Notably for the Polio plugins. But please keep that exceptional.
 
-You can change your own local configuration in the file `.env`. Do note that if you make any modification in your `.env` or  in your `docker-compose.yml` file. You will need to restart the whole docker-compose for it to take effect (Ctrl-c your current docker-compose and bring it back up with `docker-compose up`
+You can change your own local configuration in the file `.env`. Do note that if you make any modification in your `.env` or  in your `docker-compose.yml` file. You will need to restart the whole docker compose for it to take effect (Ctrl-c your current docker compose and bring it back up with `docker compose up`
 
 
 If you add a new Environement variable to allow some configuration:

--- a/hat/assets/README.rst
+++ b/hat/assets/README.rst
@@ -144,7 +144,7 @@ Testing the production build
 
    .. code:: shell
 
-      TEST_PROD=true docker-compose up
+      TEST_PROD=true docker compose up
 
 When the setup is run with ``TEST_PROD=true``, it will exit the unneeded containers
 ``webpack`` and ``jupyter``. It will also run the webpack build during startup, so
@@ -155,7 +155,7 @@ JS Unit Testing
 
 .. code:: shell
 
-    docker-compose run hat test_js
+    docker compose run hat test_js
 
 
 Adding new assets in package.json
@@ -166,13 +166,13 @@ upgrading packages in ``package.json``.
 
 .. code:: shell
 
-    docker-compose build
+    docker compose build
 
 or
 
 .. code:: shell
 
-    docker-compose up --build
+    docker compose up --build
 
 
 Translations
@@ -215,4 +215,4 @@ When depending on a local version of the library:
 
 - Your local folder should be on the same level as the iaso folder, so that the path to the tgz file in your package.json is : ../bluesquare-components/bluesquare-components-0.1.0.tgz
 
-- Run ``docker-compose build --build-arg LIBRARY=<name-of-the-library-image>``
+- Run ``docker compose build --build-arg LIBRARY=<name-of-the-library-image>``

--- a/hat/assets/js/cypress/README.md
+++ b/hat/assets/js/cypress/README.md
@@ -23,7 +23,7 @@ Setup
 - To run the backend on a fresh database instance with a test user you can launch a django testserver. Alternatively see below to run on your current database.
   - in docker:
 ```
-docker-compose run   -p 8000:8000 iaso manage testserver --addrport 0.0.0.0:8000 --noinput iaso/fixtures/user.yaml
+docker compose run   -p 8000:8000 iaso manage testserver --addrport 0.0.0.0:8000 --noinput iaso/fixtures/user.yaml
 ```
   - outside docker
 ```

--- a/iaso/api/enketo.py
+++ b/iaso/api/enketo.py
@@ -38,7 +38,7 @@ def public_url_for_enketo(request: HttpRequest, path):
 
     resolved_path = request.build_absolute_uri(path)
 
-    # This hack allow it to work in the docker-compose environment, where the server name from outside the container
+    # This hack allow it to work in the docker compose environment, where the server name from outside the container
     # network are not the same that in the inside.
     if enketo_settings().get("ENKETO_DEV"):
         resolved_path = resolved_path.replace("localhost:8081", "iaso:8081")

--- a/iaso/enketo/README.md
+++ b/iaso/enketo/README.md
@@ -17,7 +17,7 @@ To populate your Iaso database with Form and Org Unit, as well as sample submiss
 
 First Run:
 ```
-docker-compose  up
+docker compose  up
 
 docker exec -it iaso_1 bash -c './manage.py seed_test_data --mode=seed --dhis2version=2.31.8'
 ```

--- a/iaso/management/commands/fix_submissions_select_multiple.py
+++ b/iaso/management/commands/fix_submissions_select_multiple.py
@@ -9,7 +9,7 @@ import iaso.models as m
 # testing on a small subset on your dev env
 #
 #    docker compose run --rm iaso manage seed_test_data --mode=seed --dhis2version=2.40.4.1
-#    docker-compose run --rm iaso manage fix_submissions_select_multiple
+#    docker compose run --rm iaso manage fix_submissions_select_multiple
 
 
 class Command(BaseCommand):

--- a/iaso/management/commands/list_account_files.py
+++ b/iaso/management/commands/list_account_files.py
@@ -78,7 +78,7 @@ def model_and_fields_with_files(account_id_to_keep):
 # for the moment I kept the "copy_account_files" command since I'm not sharing the download script here
 # if the the next extract is working well, we should probably delete the copy_account_files_command
 #
-# exemple usage : docker-compose run --rm iaso manage list_account_files --account 17
+# exemple usage : docker compose run --rm iaso manage list_account_files --account 17
 
 
 class Command(BaseCommand):

--- a/iaso/management/commands/seed_test_data.py
+++ b/iaso/management/commands/seed_test_data.py
@@ -406,7 +406,7 @@ class Command(BaseCommand):
         print("  now you need to start ngrok")
         print("     with : ngrok http 8081")
         print("     adapt .env and set the FILE_SERVER_URL to the ngrok https url in Forwarding section")
-        print("     restart iaso (so .env is reloaded) : docker-compose up")
+        print("     restart iaso (so .env is reloaded) : docker compose up")
         print("  install the generic iaso mobile app and launch the app")
         print("        https://play.google.com/store/apps/details?id=com.bluesquarehub.iaso")
         print("     in the menu ")

--- a/locust/README.md
+++ b/locust/README.md
@@ -13,5 +13,5 @@ and allows a lot of flexibility.
 https://docs.locust.io/en/stable/running-in-docker.html
 
 ```shell
-docker-compose up --scale worker=4
+docker compose up --scale worker=4
 ```

--- a/plugins/polio/README.md
+++ b/plugins/polio/README.md
@@ -213,5 +213,5 @@ This way doesn't require the task worker to be running.
 - Either use the preparedness sheet linked in the ticket, or generate a new one
 - If generating a new one: delete data in several cells
 - Call the url  `/tasks/launch_task/plugins.polio.tasks.weekly_email.send_email/polio_cron_task_user/`
-- in the terminal launch the task worker **tasks_worker**, run`docker-compose run iaso manage tasks_worker`
+- in the terminal launch the task worker **tasks_worker**, run`docker compose run iaso manage tasks_worker`
 - The output should show you an email with no errors (see screenshot). Such emails are printed out in the console, but not sent. If the list of errors is not empty, there's a bug in this PR.

--- a/plugins/wfp/README.md
+++ b/plugins/wfp/README.md
@@ -26,7 +26,7 @@ Both have default value of `redis://localhost:6379`
   plugins.wfp.tasks.generate_random_data
 ```
 
-7. Run python test `docker-compose run iaso manage test -k ETL`
+7. Run python test `docker compose run iaso manage test -k ETL`
 
 
 Once the ETL has run, users having access to the admin interface can also use the 

--- a/setuper/README.md
+++ b/setuper/README.md
@@ -23,30 +23,30 @@ Once the script has run, you can log in to your server using the account name as
 
 1. Backup your DB
 
-        docker-compose exec db pg_dump -U postgres iaso  -Fc > ~/Desktop/iaso.dump
+        docker compose exec db pg_dump -U postgres iaso  -Fc > ~/Desktop/iaso.dump
 
 1. Use an empty DB
 
         # Find your Iaso DB.
-        docker-compose exec db psql -U postgres -l
+        docker compose exec db psql -U postgres -l
 
         # Delete your Iaso DB.
-        docker-compose exec db psql -U postgres -c "drop database if exists iaso"
+        docker compose exec db psql -U postgres -c "drop database if exists iaso"
 
         # Create your Iaso DB.
-        docker-compose exec db psql -U postgres -c "create database iaso"
+        docker compose exec db psql -U postgres -c "create database iaso"
 
 1. Run the Django server in a first terminal (this will run DB migrations)
 
-        docker-compose up iaso
+        docker compose up iaso
 
 1. Run a worker in a second terminal
 
-        docker-compose run iaso manage tasks_worker
+        docker compose run iaso manage tasks_worker
 
 1. Create a superuser
 
-        docker-compose exec iaso ./manage.py createsuperuser
+        docker compose exec iaso ./manage.py createsuperuser
 
 1. Prepare the setuper (it requires a local Python 3)
 


### PR DESCRIPTION
[IA-3366](https://bluesquare.atlassian.net/browse/IA-3366)

Use `docker compose` instead of `docker-compose`:

- Docker for Mac [now returns "command not found"](https://docs.docker.com/desktop/release-notes/#for-mac-2) when running `docker-compose`
- [the recommended command-line syntax is `docker compose`](https://docs.docker.com/compose/migrate/#docker-compose-vs-docker-compose)

[IA-3366]: https://bluesquare.atlassian.net/browse/IA-3366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ