### PR TITLE
IA-3379: Allow the mobile app to download all groups

### DIFF
--- a/iaso/api/mobile/groups.py
+++ b/iaso/api/mobile/groups.py
@@ -1,3 +1,5 @@
+from typing import Dict, Any
+
 from django.db.models.query import QuerySet
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
@@ -8,17 +10,34 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
-from iaso.api.query_params import APP_ID
+from iaso.api.query_params import APP_ID, SHOW_DELETED
 from iaso.api.serializers import AppIdSerializer
-from iaso.models import Group, Project
+from iaso.models import Group, Project, SourceVersion
 
 
 class MobileGroupSerializer(serializers.ModelSerializer):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.source_version = kwargs["context"].get("source_version")
+
+    erased = serializers.SerializerMethodField()
+
+    def get_erased(self, obj: Group):
+        return obj.source_version.id != self.source_version
+
+    @staticmethod
+    def include_source_version(
+        context: Dict[str, Any], source_version: SourceVersion
+    ) -> Dict[str, Any]:
+        context["source_version"] = source_version.id
+        return context
+
     class Meta:
         model = Group
         fields = [
             "id",
             "name",
+            "erased",
         ]
 
 
@@ -43,19 +62,49 @@ class MobileGroupsViewSet(ListModelMixin, GenericViewSet):
         type=openapi.TYPE_STRING,
     )
 
+    show_deleted_param = openapi.Parameter(
+        name=SHOW_DELETED,
+        in_=openapi.IN_QUERY,
+        required=False,
+        description="Include deleted groups",
+        type=openapi.TYPE_BOOLEAN,
+        default=False,
+    )
+
     @swagger_auto_schema(
         responses={
             200: f"List of groups for the given '{APP_ID}'.",
             400: f"Parameter '{APP_ID}' is required.",
             404: f"Project for given '{APP_ID}' doesn't exist.",
         },
-        manual_parameters=[app_id_param],
+        manual_parameters=[app_id_param, show_deleted_param],
     )
     def list(self, request: Request, *args, **kwargs) -> Response:
         return super().list(request, *args, **kwargs)
 
+    def get_serializer_context(self) -> Dict[str, Any]:
+        context = super().get_serializer_context()
+        return self.serializer_class.include_source_version(
+            context, self.get_project().account.default_version
+        )
+
+    def get_project(self):
+        app_id = AppIdSerializer(data=self.request.query_params).get_app_id(
+            raise_exception=True
+        )
+        project_qs = Project.objects.select_related(
+            "account__default_version__data_source"
+        )
+        return get_object_or_404(project_qs, app_id=app_id)
+
     def get_queryset(self) -> QuerySet:
-        app_id = AppIdSerializer(data=self.request.query_params).get_app_id(raise_exception=True)
-        project_qs = Project.objects.select_related("account__default_version")
-        project = get_object_or_404(project_qs, app_id=app_id)
-        return Group.objects.filter(source_version=project.account.default_version)
+        objects = Group.objects
+        if self.request.query_params.get(SHOW_DELETED) != "true":
+            objects = objects.filter(
+                source_version=self.get_project().account.default_version
+            )
+        else:
+            objects = objects.filter(
+                source_version__data_source=self.get_project().account.default_version.data_source
+            )
+        return objects

--- a/iaso/api/mobile/groups.py
+++ b/iaso/api/mobile/groups.py
@@ -26,9 +26,7 @@ class MobileGroupSerializer(serializers.ModelSerializer):
         return obj.source_version.id != self.source_version
 
     @staticmethod
-    def include_source_version(
-        context: Dict[str, Any], source_version: SourceVersion
-    ) -> Dict[str, Any]:
+    def include_source_version(context: Dict[str, Any], source_version: SourceVersion) -> Dict[str, Any]:
         context["source_version"] = source_version.id
         return context
 
@@ -84,27 +82,17 @@ class MobileGroupsViewSet(ListModelMixin, GenericViewSet):
 
     def get_serializer_context(self) -> Dict[str, Any]:
         context = super().get_serializer_context()
-        return self.serializer_class.include_source_version(
-            context, self.get_project().account.default_version
-        )
+        return self.serializer_class.include_source_version(context, self.get_project().account.default_version)
 
     def get_project(self):
-        app_id = AppIdSerializer(data=self.request.query_params).get_app_id(
-            raise_exception=True
-        )
-        project_qs = Project.objects.select_related(
-            "account__default_version__data_source"
-        )
+        app_id = AppIdSerializer(data=self.request.query_params).get_app_id(raise_exception=True)
+        project_qs = Project.objects.select_related("account__default_version__data_source")
         return get_object_or_404(project_qs, app_id=app_id)
 
     def get_queryset(self) -> QuerySet:
         objects = Group.objects
         if self.request.query_params.get(SHOW_DELETED) != "true":
-            objects = objects.filter(
-                source_version=self.get_project().account.default_version
-            )
+            objects = objects.filter(source_version=self.get_project().account.default_version)
         else:
-            objects = objects.filter(
-                source_version__data_source=self.get_project().account.default_version.data_source
-            )
+            objects = objects.filter(source_version__data_source=self.get_project().account.default_version.data_source)
         return objects

--- a/iaso/tests/api/test_mobile_groups.py
+++ b/iaso/tests/api/test_mobile_groups.py
@@ -11,19 +11,11 @@ class MobileGroupsAPITestCase(APITestCase):
         cls.now = now()
 
         cls.data_source = m.DataSource.objects.create(name="Default source")
-        cls.source_version_1 = m.SourceVersion.objects.create(
-            data_source=cls.data_source, number=1
-        )
-        cls.source_version_2 = m.SourceVersion.objects.create(
-            data_source=cls.data_source, number=2
-        )
+        cls.source_version_1 = m.SourceVersion.objects.create(data_source=cls.data_source, number=1)
+        cls.source_version_2 = m.SourceVersion.objects.create(data_source=cls.data_source, number=2)
 
-        account_nigeria = m.Account.objects.create(
-            name="Nigeria", default_version=cls.source_version_2
-        )
-        account_cameroon = m.Account.objects.create(
-            name="Cameroon", default_version=cls.source_version_1
-        )
+        account_nigeria = m.Account.objects.create(name="Nigeria", default_version=cls.source_version_2)
+        account_cameroon = m.Account.objects.create(name="Cameroon", default_version=cls.source_version_1)
 
         cls.user_nigeria = cls.create_user_with_profile(
             username="user_nigeria",
@@ -47,15 +39,9 @@ class MobileGroupsAPITestCase(APITestCase):
             account=account_cameroon,
         )
 
-        cls.group_nigeria_1 = m.Group.objects.create(
-            name="Hospitals", source_version=cls.source_version_1
-        )
-        cls.group_nigeria_2 = m.Group.objects.create(
-            name="Villages", source_version=cls.source_version_2
-        )
-        cls.group_cameroon = m.Group.objects.create(
-            name="North", source_version=cls.source_version_1
-        )
+        cls.group_nigeria_1 = m.Group.objects.create(name="Hospitals", source_version=cls.source_version_1)
+        cls.group_nigeria_2 = m.Group.objects.create(name="Villages", source_version=cls.source_version_2)
+        cls.group_cameroon = m.Group.objects.create(name="North", source_version=cls.source_version_1)
 
     def test_api_mobile_groups_list_without_app_id(self):
         """GET /api/mobile/groups/ without app_id"""
@@ -71,9 +57,7 @@ class MobileGroupsAPITestCase(APITestCase):
         """GET /api/mobile/groups/ with app_id"""
 
         # Groups with `source_version_1`.
-        response = self.client.get(
-            "/api/mobile/groups/", {APP_ID: self.project_cameroon.app_id}
-        )
+        response = self.client.get("/api/mobile/groups/", {APP_ID: self.project_cameroon.app_id})
         self.assertJSONResponse(response, 200)
         self.assertEqual(len(response.data), 2)
         expected_data = [
@@ -84,14 +68,10 @@ class MobileGroupsAPITestCase(APITestCase):
 
         # Groups with `source_version_2`.
         ## Without all versions
-        response = self.client.get(
-            "/api/mobile/groups/", {APP_ID: self.project_nigeria.app_id}
-        )
+        response = self.client.get("/api/mobile/groups/", {APP_ID: self.project_nigeria.app_id})
         self.assertJSONResponse(response, 200)
         self.assertEqual(len(response.data), 1)
-        expected_data = [
-            {"id": self.group_nigeria_2.pk, "name": "Villages", "erased": False}
-        ]
+        expected_data = [{"id": self.group_nigeria_2.pk, "name": "Villages", "erased": False}]
         self.assertCountEqual(response.data, expected_data)
 
         ## With all versions

--- a/iaso/tests/api/test_mobile_groups.py
+++ b/iaso/tests/api/test_mobile_groups.py
@@ -1,7 +1,7 @@
 from django.utils.timezone import now
 
 from iaso import models as m
-from iaso.api.query_params import APP_ID
+from iaso.api.query_params import APP_ID, SHOW_DELETED
 from iaso.test import APITestCase
 
 
@@ -11,29 +11,51 @@ class MobileGroupsAPITestCase(APITestCase):
         cls.now = now()
 
         cls.data_source = m.DataSource.objects.create(name="Default source")
-        cls.source_version_1 = m.SourceVersion.objects.create(data_source=cls.data_source, number=1)
-        cls.source_version_2 = m.SourceVersion.objects.create(data_source=cls.data_source, number=2)
+        cls.source_version_1 = m.SourceVersion.objects.create(
+            data_source=cls.data_source, number=1
+        )
+        cls.source_version_2 = m.SourceVersion.objects.create(
+            data_source=cls.data_source, number=2
+        )
 
-        account_nigeria = m.Account.objects.create(name="Nigeria", default_version=cls.source_version_2)
-        account_cameroon = m.Account.objects.create(name="Cameroon", default_version=cls.source_version_1)
+        account_nigeria = m.Account.objects.create(
+            name="Nigeria", default_version=cls.source_version_2
+        )
+        account_cameroon = m.Account.objects.create(
+            name="Cameroon", default_version=cls.source_version_1
+        )
 
         cls.user_nigeria = cls.create_user_with_profile(
-            username="user_nigeria", account=account_nigeria, permissions=["iaso_org_units"]
+            username="user_nigeria",
+            account=account_nigeria,
+            permissions=["iaso_org_units"],
         )
         cls.user_cameroon = cls.create_user_with_profile(
-            username="user_cameroon", account=account_cameroon, permissions=["iaso_org_units"]
+            username="user_cameroon",
+            account=account_cameroon,
+            permissions=["iaso_org_units"],
         )
 
         cls.project_nigeria = m.Project.objects.create(
-            name="Nigeria health pyramid", app_id="nigeria.health.pyramid", account=account_nigeria
+            name="Nigeria health pyramid",
+            app_id="nigeria.health.pyramid",
+            account=account_nigeria,
         )
         cls.project_cameroon = m.Project.objects.create(
-            name="Cameroon health map", app_id="cameroon.health.map", account=account_cameroon
+            name="Cameroon health map",
+            app_id="cameroon.health.map",
+            account=account_cameroon,
         )
 
-        cls.group_nigeria_1 = m.Group.objects.create(name="Hospitals", source_version=cls.source_version_1)
-        cls.group_nigeria_2 = m.Group.objects.create(name="Villages", source_version=cls.source_version_2)
-        cls.group_cameroon = m.Group.objects.create(name="North", source_version=cls.source_version_1)
+        cls.group_nigeria_1 = m.Group.objects.create(
+            name="Hospitals", source_version=cls.source_version_1
+        )
+        cls.group_nigeria_2 = m.Group.objects.create(
+            name="Villages", source_version=cls.source_version_2
+        )
+        cls.group_cameroon = m.Group.objects.create(
+            name="North", source_version=cls.source_version_1
+        )
 
     def test_api_mobile_groups_list_without_app_id(self):
         """GET /api/mobile/groups/ without app_id"""
@@ -49,18 +71,39 @@ class MobileGroupsAPITestCase(APITestCase):
         """GET /api/mobile/groups/ with app_id"""
 
         # Groups with `source_version_1`.
-        response = self.client.get("/api/mobile/groups/", {APP_ID: self.project_cameroon.app_id})
+        response = self.client.get(
+            "/api/mobile/groups/", {APP_ID: self.project_cameroon.app_id}
+        )
         self.assertJSONResponse(response, 200)
         self.assertEqual(len(response.data), 2)
         expected_data = [
-            {"id": self.group_nigeria_1.pk, "name": "Hospitals"},
-            {"id": self.group_cameroon.pk, "name": "North"},
+            {"id": self.group_nigeria_1.pk, "name": "Hospitals", "erased": False},
+            {"id": self.group_cameroon.pk, "name": "North", "erased": False},
         ]
         self.assertCountEqual(response.data, expected_data)
 
         # Groups with `source_version_2`.
-        response = self.client.get("/api/mobile/groups/", {APP_ID: self.project_nigeria.app_id})
+        ## Without all versions
+        response = self.client.get(
+            "/api/mobile/groups/", {APP_ID: self.project_nigeria.app_id}
+        )
         self.assertJSONResponse(response, 200)
         self.assertEqual(len(response.data), 1)
-        expected_data = [{"id": self.group_nigeria_2.pk, "name": "Villages"}]
+        expected_data = [
+            {"id": self.group_nigeria_2.pk, "name": "Villages", "erased": False}
+        ]
+        self.assertCountEqual(response.data, expected_data)
+
+        ## With all versions
+        response = self.client.get(
+            "/api/mobile/groups/",
+            {APP_ID: self.project_nigeria.app_id, SHOW_DELETED: "true"},
+        )
+        self.assertJSONResponse(response, 200)
+        self.assertEqual(len(response.data), 3)
+        expected_data = [
+            {"id": self.group_nigeria_1.pk, "name": "Hospitals", "erased": True},
+            {"id": self.group_cameroon.pk, "name": "North", "erased": True},
+            {"id": self.group_nigeria_2.pk, "name": "Villages", "erased": False},
+        ]
         self.assertCountEqual(response.data, expected_data)


### PR DESCRIPTION
This adds a query parameter `showDeleted` for the mobile app to download groups from all source_version.

Related JIRA tickets : IA-3379

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [X] Are there enough tests

## Doc
- In the code as swagger annotations

## Changes

Allow to pass `showDeleted=true` to the endpoint to retrieve all source_versions, even the ones not used by the project.

## How to test

Call the endpoint with and without the parameter `showDeleted=true`
