### PR TITLE
Fix black in Docker doesn't use the configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # see Black section in README
 repos:
 -   repo: https://github.com/ambv/black
-    rev: 23.3.0
+    rev: 23.12.1
     hooks:
     - id: black
       language_version: python3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       - ./tsconfig.json:/opt/app/tsconfig.json
       - ./babel-register.js:/opt/app/babel-register.js
       - ./mypy.ini:/opt/app/mypy.ini
+      - ./pyproject.toml:/opt/app/pyproject.toml
       # test data
       - ./testdata:/opt/app/testdata
       # jupyter notebooks


### PR DESCRIPTION
When running `docker compose exec iaso black`, black didn't use the provided configuration (`pyproject.toml`).
This is due to the fact that the file was not exposed to Docker.

Also, the pre-commit hook configuration used a different version of black than the one in `requirements.txt`.

## Changes

- Add `pyproject.toml` in the files exposed to Docker
- Change black's version in the pre-commit hook configuration file.

## How to test

Run `docker compose exec iaso black -v` and check that it doesn't reformat any files.

Also, with -v, it should show that it found the `pyproject.toml` configuration.