### PR TITLE
POLIO-1660: Stocks: rename 'action' to 'title' in destruction reports

### DIFF
--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/CreateEditDestruction.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/CreateEditDestruction.tsx
@@ -80,7 +80,7 @@ export const CreateEditDestruction: FunctionComponent<Props> = ({
             >
                 <Box mb={2} mt={2}>
                     <Field
-                        label={formatMessage(MESSAGES.action)}
+                        label={formatMessage(MESSAGES.title)}
                         name="action"
                         component={TextInput}
                         required

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Table/columns.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Table/columns.tsx
@@ -133,7 +133,7 @@ export const useDestructionTableColumns = (
     return useMemo(() => {
         const columns = [
             {
-                Header: formatMessage(MESSAGES.action),
+                Header: formatMessage(MESSAGES.title),
                 accessor: 'action',
                 id: 'action',
                 sortable: true,


### PR DESCRIPTION
Explain what problem this PR is resolving
- Stocks: rename 'action' to 'title' in destruction reports
Related JIRA tickets : POLIO-1660

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
- Tell us where the doc can be found (docs folder, wiki, in the code...)

## Changes
- Rename the Action input label into Title on  Destruction reports form
- Rename the Action column into Title on Destruction reports list

## How to test
- Polio -> Vaccine module --> stock management --> stock variation --> Destruction reports(tab)

## Print screen / video
[Screencast from 2024-08-28 18-11-00.webm](https://github.com/user-attachments/assets/d211938a-72df-47f8-a303-3fe33e37d017)


## Notes

Things that the reviewers should know: known bugs that are out of the scope of the PR, other trade-offs that were made.
If the PR depends on a PR in bluesquare-components, or merges into another PR (i.o. main), it should also be mentioned here
