### PR TITLE
POLIO-1653 POLIO-1654 Fix for sorting not working on API for Vaccine Stock Management

### DIFF
--- a/plugins/polio/api/vaccines/stock_management.py
+++ b/plugins/polio/api/vaccines/stock_management.py
@@ -418,16 +418,20 @@ class VaccineStockSubitemBase(ModelViewSet):
 
     def get_queryset(self):
         vaccine_stock_id = self.request.query_params.get("vaccine_stock")
+        order = self.request.query_params.get("order")
 
         if self.model_class is None:
             raise NotImplementedError("model_class must be defined")
 
-        if vaccine_stock_id is None:
-            return self.model_class.objects.filter(vaccine_stock__account=self.request.user.iaso_profile.account)
-        else:
-            return self.model_class.objects.filter(
-                vaccine_stock=vaccine_stock_id, vaccine_stock__account=self.request.user.iaso_profile.account
-            )
+        queryset = self.model_class.objects.filter(vaccine_stock__account=self.request.user.iaso_profile.account)
+
+        if vaccine_stock_id is not None:
+            queryset = queryset.filter(vaccine_stock=vaccine_stock_id)
+
+        if order:
+            queryset = queryset.order_by(order)
+
+        return queryset
 
 
 class OutgoingStockMovementSerializer(serializers.ModelSerializer):

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/VaccineStockVariation.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/VaccineStockVariation.tsx
@@ -48,7 +48,9 @@ const baseUrl = baseUrls.stockVariation;
 type VaccineStockVariationParams = Partial<UrlParams> & StockVariationParams;
 
 export const VaccineStockVariation: FunctionComponent = () => {
-    const params = useParamsObject(baseUrl) as VaccineStockVariationParams;
+    const params = useParamsObject(
+        baseUrl,
+    ) as unknown as VaccineStockVariationParams;
     const goBack = useGoBack(
         `${baseUrls.stockManagementDetails}/id/${params.id}`,
         true,
@@ -183,7 +185,7 @@ export const VaccineStockVariation: FunctionComponent = () => {
                                 isFetching={isFetchingDestructions}
                                 defaultSorted={[
                                     {
-                                        id: 'destruction_reception_rrt',
+                                        id: 'rrt_destruction_report_reception_date',
                                         desc: true,
                                     },
                                 ]}

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/hooks/api.ts
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/hooks/api.ts
@@ -165,7 +165,6 @@ export const useGetFormAList = (
         id: vaccine_stock,
     } = params;
 
-    console.log(params);
     const safeParams = useUrlParams(
         {
             order,
@@ -175,10 +174,9 @@ export const useGetFormAList = (
         } as Partial<UrlParams>,
         {
             order: '-form_a_reception_date',
+            pageSize: 20,
         },
     );
-
-    console.log(safeParams);
 
     const apiParams = useApiParams(safeParams);
     const queryString = new URLSearchParams(apiParams).toString();
@@ -202,12 +200,18 @@ export const useGetDestructionList = (
         destructionPageSize: pageSize,
         id: vaccine_stock,
     } = params;
-    const safeParams = useUrlParams({
-        order,
-        page,
-        pageSize,
-        vaccine_stock,
-    } as Partial<UrlParams>);
+    const safeParams = useUrlParams(
+        {
+            order,
+            page,
+            pageSize,
+            vaccine_stock,
+        } as Partial<UrlParams>,
+        {
+            order: '-rrt_destruction_report_reception_date',
+            pageSize: 20,
+        },
+    );
     const apiParams = useApiParams(safeParams);
     const queryString = new URLSearchParams(apiParams).toString();
     return useSnackQuery({
@@ -230,12 +234,18 @@ export const useGetIncidentList = (
         incidentPageSize: pageSize,
         id: vaccine_stock,
     } = params;
-    const safeParams = useUrlParams({
-        order,
-        page,
-        pageSize,
-        vaccine_stock,
-    } as Partial<UrlParams>);
+    const safeParams = useUrlParams(
+        {
+            order,
+            page,
+            pageSize,
+            vaccine_stock,
+        } as Partial<UrlParams>,
+        {
+            order: '-incident_report_received_by_rrt',
+            pageSize: 20,
+        },
+    );
     const apiParams = useApiParams(safeParams);
     const queryString = new URLSearchParams(apiParams).toString();
     return useSnackQuery({

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/hooks/api.ts
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/hooks/api.ts
@@ -164,12 +164,22 @@ export const useGetFormAList = (
         formaPageSize: pageSize,
         id: vaccine_stock,
     } = params;
-    const safeParams = useUrlParams({
-        order,
-        page,
-        pageSize,
-        vaccine_stock,
-    } as Partial<UrlParams>);
+
+    console.log(params);
+    const safeParams = useUrlParams(
+        {
+            order,
+            page,
+            pageSize,
+            vaccine_stock,
+        } as Partial<UrlParams>,
+        {
+            order: '-form_a_reception_date',
+        },
+    );
+
+    console.log(safeParams);
+
     const apiParams = useApiParams(safeParams);
     const queryString = new URLSearchParams(apiParams).toString();
     return useSnackQuery({

--- a/plugins/polio/tests/test_vaccine_stock_management.py
+++ b/plugins/polio/tests/test_vaccine_stock_management.py
@@ -11,6 +11,7 @@ from iaso.test import APITestCase
 from plugins.polio import models as pm
 
 BASE_URL = "/api/polio/vaccine/vaccine_stock/"
+BASE_URL_SUB_RESOURCES = "/api/polio/vaccine/stock/"
 
 
 class VaccineStockManagementAPITestCase(APITestCase):
@@ -341,3 +342,192 @@ class VaccineStockManagementAPITestCase(APITestCase):
         response = self.client.delete(f"{BASE_URL}{self.vaccine_stock.pk}/")
         self.assertEqual(response.status_code, 204)
         self.assertIsNone(pm.VaccineStock.objects.filter(pk=self.vaccine_stock.pk).first())
+
+    def test_incident_report_list(self):
+        self.client.force_authenticate(self.user_rw_perms)
+
+        response = self.client.get(
+            f"{BASE_URL_SUB_RESOURCES}incident_report/?vaccine_stock={self.vaccine_stock.pk}&page=1&limit=20"
+        )
+
+        # Check that the response status code is 200
+        self.assertEqual(response.status_code, 200)
+
+        # Parse the response data
+        data = response.json()
+
+        # Check that the response data contains the expected keys
+        self.assertIn("count", data)
+        self.assertIn("results", data)
+
+        # Check that the results list is not empty
+        self.assertGreater(len(data["results"]), 0)
+
+        # Validate the structure of the first result
+        first_result = data["results"][0]
+        expected_keys = {
+            "id",
+            "vaccine_stock",
+            "date_of_incident_report",
+            "usable_vials",
+            "unusable_vials",
+            "stock_correction",
+        }
+        self.assertTrue(expected_keys.issubset(first_result.keys()))
+
+        # Check that the vaccine_stock in the results matches the requested vaccine_stock
+        for result in data["results"]:
+            self.assertEqual(result["vaccine_stock"], self.vaccine_stock.pk)
+
+            # Add a new test which adds the order=date_of_incident_report and verify that the results are ordered by date_of_incident_report
+
+    def test_incident_report_list_ordered_by_date(self):
+        self.client.force_authenticate(self.user_rw_perms)
+
+        response = self.client.get(
+            f"{BASE_URL_SUB_RESOURCES}incident_report/?vaccine_stock={self.vaccine_stock.pk}&page=1&limit=20&order=date_of_incident_report"
+        )
+
+        # Check that the response status code is 200
+        self.assertEqual(response.status_code, 200)
+
+        # Parse the response data
+        data = response.json()
+
+        # Check that the response data contains the expected keys
+        self.assertIn("count", data)
+        self.assertIn("results", data)
+
+        # Check that the results list is not empty
+        self.assertGreater(len(data["results"]), 0)
+
+        # Verify that the results are ordered by date_of_incident_report
+        dates = [result["date_of_incident_report"] for result in data["results"]]
+        self.assertEqual(dates, sorted(dates))
+
+    def test_destruction_report_list(self):
+        self.client.force_authenticate(self.user_rw_perms)
+
+        response = self.client.get(
+            f"{BASE_URL_SUB_RESOURCES}destruction_report/?vaccine_stock={self.vaccine_stock.pk}&page=1&limit=20"
+        )
+
+        # Check that the response status code is 200
+        self.assertEqual(response.status_code, 200)
+
+        # Parse the response data
+        data = response.json()
+
+        # Check that the response data contains the expected keys
+        self.assertIn("count", data)
+        self.assertIn("results", data)
+
+        # Check that the results list is not empty
+        self.assertGreater(len(data["results"]), 0)
+
+        # Validate the structure of the first result
+        first_result = data["results"][0]
+        expected_keys = {
+            "id",
+            "vaccine_stock",
+            "destruction_report_date",
+            "rrt_destruction_report_reception_date",
+            "action",
+            "unusable_vials_destroyed",
+            "lot_numbers",
+        }
+        self.assertTrue(expected_keys.issubset(first_result.keys()))
+
+        # Check that the vaccine_stock in the results matches the requested vaccine_stock
+        for result in data["results"]:
+            self.assertEqual(result["vaccine_stock"], self.vaccine_stock.pk)
+
+            # Add a new test which adds the order=date_of_incident_report and verify that the results are ordered by date_of_incident_report
+
+    def test_destruction_report_list_ordered_by_date(self):
+        self.client.force_authenticate(self.user_rw_perms)
+
+        response = self.client.get(
+            f"{BASE_URL_SUB_RESOURCES}destruction_report/?vaccine_stock={self.vaccine_stock.pk}&page=1&limit=20&order=destruction_report_date"
+        )
+
+        # Check that the response status code is 200
+        self.assertEqual(response.status_code, 200)
+
+        # Parse the response data
+        data = response.json()
+
+        # Check that the response data contains the expected keys
+        self.assertIn("count", data)
+        self.assertIn("results", data)
+
+        # Check that the results list is not empty
+        self.assertGreater(len(data["results"]), 0)
+
+        # Verify that the results are ordered by date_of_incident_report
+        dates = [result["destruction_report_date"] for result in data["results"]]
+        self.assertEqual(dates, sorted(dates))
+
+    def test_outgoing_stock_movement_list(self):
+        self.client.force_authenticate(self.user_rw_perms)
+
+        response = self.client.get(
+            f"{BASE_URL_SUB_RESOURCES}outgoing_stock_movement/?vaccine_stock={self.vaccine_stock.pk}&page=1&limit=20"
+        )
+
+        # Check that the response status code is 200
+        self.assertEqual(response.status_code, 200)
+
+        # Parse the response data
+        data = response.json()
+
+        # Check that the response data contains the expected keys
+        self.assertIn("count", data)
+        self.assertIn("results", data)
+
+        # Check that the results list is not empty
+        self.assertGreater(len(data["results"]), 0)
+
+        # Validate the structure of the first result
+        first_result = data["results"][0]
+        expected_keys = {
+            "id",
+            "campaign",
+            "vaccine_stock",
+            "report_date",
+            "form_a_reception_date",
+            "usable_vials_used",
+            "lot_numbers",
+            "missing_vials",
+        }
+        self.assertTrue(expected_keys.issubset(first_result.keys()))
+
+        # Check that the vaccine_stock in the results matches the requested vaccine_stock
+        for result in data["results"]:
+            self.assertEqual(result["vaccine_stock"], self.vaccine_stock.pk)
+
+            # Add a new test which adds the order=date_of_incident_report and verify that the results are ordered by date_of_incident_report
+
+    def test_outgoing_stock_movement_list_ordered_by_date(self):
+        self.client.force_authenticate(self.user_rw_perms)
+
+        response = self.client.get(
+            f"{BASE_URL_SUB_RESOURCES}outgoing_stock_movement/?vaccine_stock={self.vaccine_stock.pk}&page=1&limit=20&order=form_a_reception_date"
+        )
+
+        # Check that the response status code is 200
+        self.assertEqual(response.status_code, 200)
+
+        # Parse the response data
+        data = response.json()
+
+        # Check that the response data contains the expected keys
+        self.assertIn("count", data)
+        self.assertIn("results", data)
+
+        # Check that the results list is not empty
+        self.assertGreater(len(data["results"]), 0)
+
+        # Verify that the results are ordered by date_of_incident_report
+        dates = [result["form_a_reception_date"] for result in data["results"]]
+        self.assertEqual(dates, sorted(dates))


### PR DESCRIPTION
API For FormA, Incident Report and Destruction Report ignores the order paramater and doesnt sort properly its results. This fixes it.

Related JIRA tickets : POLIO-1653 POLIO-1654

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are there enough tests


## Changes

Its a simple change on the API side as the Viewsets for these 3 models inherit from a common base viewset.
Another few changes to make it work on the frontend.
Finally added some tests as this area was under-tested ...

## How to test

When you go in Vaccine Module > Vaccine Stock Management then the details of a Vaccine Stock then Stock variation page, You should be able to order the lists under the 3 tabs Form A, Destruction Reports, Incident Reports

