### PR TITLE
POLIO-1658 Order VARs and VRFs in reverse date order

### DIFF
--- a/plugins/polio/api/vaccines/supply_chain.py
+++ b/plugins/polio/api/vaccines/supply_chain.py
@@ -400,7 +400,7 @@ class VaccineRequestFormListSerializer(serializers.ModelSerializer):
 
     # comma separated list of all
     def get_po_numbers(self, obj):
-        pre_alerts = obj.vaccineprealert_set.all()
+        pre_alerts = obj.vaccineprealert_set.all().order_by("-estimated_arrival_time")
         if not pre_alerts:
             return ""
         return ", ".join([pre_alert.po_number for pre_alert in pre_alerts])
@@ -422,14 +422,14 @@ class VaccineRequestFormListSerializer(serializers.ModelSerializer):
 
     # Comma Separated List of all estimated arrival times
     def get_eta(self, obj):
-        pre_alerts = obj.vaccineprealert_set.all()
+        pre_alerts = obj.vaccineprealert_set.all().order_by("-estimated_arrival_time")
         if not pre_alerts:
             return ""
         return ", ".join([str(pre_alert.estimated_arrival_time) for pre_alert in pre_alerts])
 
     # Comma Separated List of all arrival report dates
     def get_var(self, obj):
-        arrival_reports = obj.vaccinearrivalreport_set.all()
+        arrival_reports = obj.vaccinearrivalreport_set.all().order_by("-arrival_report_date")
         if not arrival_reports:
             return ""
         return ", ".join([str(report.arrival_report_date) for report in arrival_reports])


### PR DESCRIPTION
Everything is in the title and this is quite simple. When you have multiple VAR or VRF they should be ordered by reverse date (as requested)

Related JIRA tickets : POLIO-1658

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are there enough tests
## Changes

Add some `order_by`

## How to test

Go to **Polio > Vaccine Module > Supply Chain** and verify that the dates are in reverse order inside one line.

## Print screen / video

<img width="1128" alt="Screenshot 2024-09-05 at 09 47 41" src="https://github.com/user-attachments/assets/270cf27c-cefa-4a0e-a653-054a11dde08b">

