### PR TITLE
IA-3377: Fix Form accepts invalid parameter for periods

### DIFF
--- a/iaso/api/forms.py
+++ b/iaso/api/forms.py
@@ -172,15 +172,22 @@ class FormSerializer(DynamicFieldsModelSerializer):
                 raise serializers.ValidationError({"org_unit_type_ids": "Invalid org unit type ids"})
 
         # If the period type is None, some period-specific fields must have specific values
-        if "period_type" in data and data["period_type"] is None:
+        if "period_type" in data:
             tracker_errors = {}
-            if data["periods_before_allowed"] != 0:
-                tracker_errors["periods_before_allowed"] = "Should be 0"
-            if data["periods_after_allowed"] != 0:
-                tracker_errors["periods_after_allowed"] = "Should be 0"
+            if data["period_type"] is None:
+                if data["periods_before_allowed"] != 0:
+                    tracker_errors["periods_before_allowed"] = "Should be 0 when period type is not specified"
+                if data["periods_after_allowed"] != 0:
+                    tracker_errors["periods_after_allowed"] = "Should be 0 when period type is not specified"
+            else:
+                before = data.get("periods_before_allowed", 0)
+                after = data.get("periods_after_allowed", 0)
+                if before + after < 1:
+                    tracker_errors[
+                        "periods_allowed"
+                    ] = "periods_before_allowed + periods_after_allowed should be greater than or equal to 1"
             if tracker_errors:
                 raise serializers.ValidationError(tracker_errors)
-
         return data
 
     def update(self, form, validated_data):

--- a/iaso/tests/api/test_mobileforms.py
+++ b/iaso/tests/api/test_mobileforms.py
@@ -202,6 +202,8 @@ class MobileFormsAPITestCase(APITestCase):
             data={
                 "name": "test form 1",
                 "period_type": "MONTH",
+                "periods_before_allowed": 0,
+                "periods_after_allowed": 1,
                 "project_ids": [self.project_1.id],
                 "org_unit_type_ids": [self.jedi_council.id, self.jedi_academy.id],
             },
@@ -354,6 +356,8 @@ class MobileFormsAPITestCase(APITestCase):
             data={
                 "name": "test form 2 (updated)",
                 "period_type": "QUARTER",
+                "periods_before_allowed": 0,
+                "periods_after_allowed": 1,
                 "single_per_period": True,
                 "device_field": "deviceid",
                 "location_field": "location",


### PR DESCRIPTION
When the mobile application receives a value for the `period_type` and the sum of `periods_before_allowed` and `periods_after_allowed` is less than 1, it doesn't know how to handle that and crashes.

Related JIRA tickets: IA-3377

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well-documented
- [X] Are there enough tests

## Changes

Added some more validation

## How to test

Try to create a form with a period type and set 0 for the period before and after.
