### PR TITLE
IA-3412 add mobile group_sets endpoint

### DIFF
--- a/iaso/api/mobile/group_sets.py
+++ b/iaso/api/mobile/group_sets.py
@@ -1,0 +1,80 @@
+from django.db.models import Q, ExpressionWrapper, BooleanField, Value
+from django.db.models.query import QuerySet
+from drf_yasg import openapi
+from drf_yasg.utils import swagger_auto_schema
+from rest_framework import permissions, serializers
+from rest_framework.generics import get_object_or_404
+from rest_framework.mixins import ListModelMixin
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.viewsets import GenericViewSet
+
+from iaso.api.query_params import APP_ID, SHOW_DELETED
+from iaso.api.serializers import AppIdSerializer
+from iaso.models import GroupSet, Project
+
+
+class MobileGroupSetSerializer(serializers.ModelSerializer):
+    erased = serializers.BooleanField(read_only=True, source="annotated_erased")
+
+    # using none() to avoid leaking other project info
+    # see __init__ to filter based on user access
+    group_ids = serializers.PrimaryKeyRelatedField(source="groups", many=True, read_only=True)
+
+    class Meta:
+        model = GroupSet
+        fields = [
+            "id",
+            "name",
+            "group_ids",
+            "group_belonging",
+            "erased",
+        ]
+
+
+class MobileGroupSetsViewSet(ListModelMixin, GenericViewSet):
+    """Groups API for Mobile.
+
+    Allows to retrieve a list of groups from the API.
+
+    Returns a lighter payload adapted for the mobile application.
+
+    `GET /api/mobile/group_sets/?app_id=some.app.id`
+    """
+
+    permission_classes = [permissions.AllowAny]
+    serializer_class = MobileGroupSetSerializer
+
+    app_id_param = openapi.Parameter(
+        name=APP_ID,
+        in_=openapi.IN_QUERY,
+        required=True,
+        description="Application id (`Project.app_id`)",
+        type=openapi.TYPE_STRING,
+    )
+
+    @swagger_auto_schema(
+        responses={
+            200: f"List of groupset for the given '{APP_ID}'.",
+            400: f"Parameter '{APP_ID}' is required.",
+            404: f"Project for given '{APP_ID}' doesn't exist.",
+        },
+        manual_parameters=[app_id_param],
+    )
+    def list(self, request: Request, *args, **kwargs) -> Response:
+        return super().list(request, *args, **kwargs)
+
+    def get_project(self):
+        app_id = AppIdSerializer(data=self.request.query_params).get_app_id(raise_exception=True)
+        project_qs = Project.objects.select_related("account__default_version__data_source")
+        return get_object_or_404(project_qs, app_id=app_id)
+
+    def get_queryset(self) -> QuerySet:
+        qs = GroupSet.objects.filter(source_version__data_source=self.get_project().account.default_version.data_source)
+        qs = qs.annotate(
+            annotated_erased=ExpressionWrapper(
+                ~Q(source_version=self.get_project().account.default_version), output_field=BooleanField()
+            )
+        )
+
+        return qs

--- a/iaso/api/mobile/group_sets.py
+++ b/iaso/api/mobile/group_sets.py
@@ -33,9 +33,9 @@ class MobileGroupSetSerializer(serializers.ModelSerializer):
 
 
 class MobileGroupSetsViewSet(ListModelMixin, GenericViewSet):
-    """Groups API for Mobile.
+    """Groupsets API for Mobile.
 
-    Allows to retrieve a list of groups from the API.
+    Allows to retrieve a list of groupsets from the API.
 
     Returns a lighter payload adapted for the mobile application.
 

--- a/iaso/api/mobile/group_sets.py
+++ b/iaso/api/mobile/group_sets.py
@@ -70,11 +70,12 @@ class MobileGroupSetsViewSet(ListModelMixin, GenericViewSet):
         return get_object_or_404(project_qs, app_id=app_id)
 
     def get_queryset(self) -> QuerySet:
-        qs = GroupSet.objects.filter(source_version__data_source=self.get_project().account.default_version.data_source)
+        default_version = self.get_project().account.default_version
+        # limit to the default datasource
+        qs = GroupSet.objects.filter(source_version__data_source=default_version.data_source)
+        # mark as erased if they don't belong to the default version
         qs = qs.annotate(
-            annotated_erased=ExpressionWrapper(
-                ~Q(source_version=self.get_project().account.default_version), output_field=BooleanField()
-            )
+            annotated_erased=ExpressionWrapper(~Q(source_version=default_version), output_field=BooleanField())
         )
 
         return qs

--- a/iaso/tests/api/test_mobile_groupsets.py
+++ b/iaso/tests/api/test_mobile_groupsets.py
@@ -13,7 +13,9 @@ class MobileGroupSetsAPITestCase(APITestCase):
         cls.data_source_nig = m.DataSource.objects.create(name="Default source nig")
         cls.data_source_cam = m.DataSource.objects.create(name="Default source cam")
         cls.source_version_1_cam = m.SourceVersion.objects.create(data_source=cls.data_source_cam, number=1)
+
         cls.source_version_2_nig = m.SourceVersion.objects.create(data_source=cls.data_source_nig, number=2)
+        cls.source_version_3_nig = m.SourceVersion.objects.create(data_source=cls.data_source_nig, number=3)
 
         account_cameroon = m.Account.objects.create(name="Cameroon", default_version=cls.source_version_1_cam)
         account_nigeria = m.Account.objects.create(name="Nigeria", default_version=cls.source_version_2_nig)
@@ -50,6 +52,15 @@ class MobileGroupSetsAPITestCase(APITestCase):
         cls.group_set_1_nigeria = m.GroupSet.objects.create(name="contracts", source_version=cls.source_version_2_nig)
         cls.group_set_1_nigeria.groups.add(cls.group_nigeria_1_hospital)
         cls.group_set_1_nigeria.groups.add(cls.group_nigeria_1_healthcenter)
+
+        cls.group_nigeria_2_hospital = m.Group.objects.create(name="Hospitals", source_version=cls.source_version_3_nig)
+        cls.group_nigeria_2_healthcenter = m.Group.objects.create(
+            name="Health Centers", source_version=cls.source_version_3_nig
+        )
+
+        cls.group_set_2_nigeria = m.GroupSet.objects.create(name="contracts", source_version=cls.source_version_3_nig)
+        cls.group_set_2_nigeria.groups.add(cls.group_nigeria_2_hospital)
+        cls.group_set_2_nigeria.groups.add(cls.group_nigeria_2_healthcenter)
 
         cls.group_cameroon_north = m.Group.objects.create(name="North", source_version=cls.source_version_1_cam)
         cls.group_cameroon_south = m.Group.objects.create(name="South", source_version=cls.source_version_1_cam)
@@ -94,7 +105,15 @@ class MobileGroupSetsAPITestCase(APITestCase):
             "erased": False,
         }
 
+        record_nigeria_2 = {
+            "id": self.group_set_2_nigeria.id,
+            "name": "contracts",
+            "group_ids": [self.group_nigeria_2_hospital.id, self.group_nigeria_2_healthcenter.id],
+            "group_belonging": "SINGLE",
+            "erased": True,
+        }
+
         # Groups with `source_version_2`.
         ## Without all versions
         response = self.client.get("/api/mobile/group_sets/", {APP_ID: self.project_nigeria.app_id})
-        self.assertEqual(json.dumps(response.data), json.dumps([record_nigeria]))
+        self.assertEqual(json.dumps(response.data), json.dumps([record_nigeria, record_nigeria_2]))

--- a/iaso/tests/api/test_mobile_groupsets.py
+++ b/iaso/tests/api/test_mobile_groupsets.py
@@ -1,0 +1,100 @@
+from django.utils.timezone import now
+import json
+from iaso import models as m
+from iaso.api.query_params import APP_ID, SHOW_DELETED
+from iaso.test import APITestCase
+
+
+class MobileGroupSetsAPITestCase(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.now = now()
+
+        cls.data_source_nig = m.DataSource.objects.create(name="Default source nig")
+        cls.data_source_cam = m.DataSource.objects.create(name="Default source cam")
+        cls.source_version_1_cam = m.SourceVersion.objects.create(data_source=cls.data_source_cam, number=1)
+        cls.source_version_2_nig = m.SourceVersion.objects.create(data_source=cls.data_source_nig, number=2)
+
+        account_cameroon = m.Account.objects.create(name="Cameroon", default_version=cls.source_version_1_cam)
+        account_nigeria = m.Account.objects.create(name="Nigeria", default_version=cls.source_version_2_nig)
+
+        cls.user_nigeria = cls.create_user_with_profile(
+            username="user_nigeria",
+            account=account_nigeria,
+            permissions=["iaso_org_units"],
+        )
+        cls.user_cameroon = cls.create_user_with_profile(
+            username="user_cameroon",
+            account=account_cameroon,
+            permissions=["iaso_org_units"],
+        )
+
+        cls.project_nigeria = m.Project.objects.create(
+            name="Nigeria health pyramid",
+            app_id="nigeria.health.pyramid",
+            account=account_nigeria,
+        )
+        cls.project_cameroon = m.Project.objects.create(
+            name="Cameroon health map",
+            app_id="cameroon.health.map",
+            account=account_cameroon,
+        )
+
+        cls.group_nigeria_1_hospital = m.Group.objects.create(name="Hospitals", source_version=cls.source_version_2_nig)
+        cls.group_nigeria_1_healthcenter = m.Group.objects.create(
+            name="Health Centers", source_version=cls.source_version_2_nig
+        )
+
+        cls.group_nigeria_2_villages = m.Group.objects.create(name="Villages", source_version=cls.source_version_2_nig)
+
+        cls.group_set_1_nigeria = m.GroupSet.objects.create(name="contracts", source_version=cls.source_version_2_nig)
+        cls.group_set_1_nigeria.groups.add(cls.group_nigeria_1_hospital)
+        cls.group_set_1_nigeria.groups.add(cls.group_nigeria_1_healthcenter)
+
+        cls.group_cameroon_north = m.Group.objects.create(name="North", source_version=cls.source_version_1_cam)
+        cls.group_cameroon_south = m.Group.objects.create(name="South", source_version=cls.source_version_1_cam)
+
+        cls.group_set_2_cameroon_region = m.GroupSet.objects.create(
+            name="region", source_version=cls.source_version_1_cam
+        )
+        cls.group_set_2_cameroon_region.groups.add(cls.group_cameroon_north)
+        cls.group_set_2_cameroon_region.groups.add(cls.group_cameroon_south)
+        cls.maxDiff = None
+
+    def test_api_mobile_groupsets_list_without_app_id(self):
+        response = self.client.get("/api/mobile/group_sets/")
+        self.assertJSONResponse(response, 400)
+
+    def test_api_mobile_groupsets_list_with_unknown_app_id(self):
+        """GET /api/mobile/groups/ with unknown app_id"""
+        response = self.client.get("/api/mobile/group_sets/", {APP_ID: "foo"})
+        self.assertJSONResponse(response, 404)
+
+    def test_api_mobile_groupsets_list_with_app_id(self):
+        """GET /api/mobile/groups/ with app_id"""
+
+        record_cameroon = {
+            "id": self.group_set_2_cameroon_region.id,
+            "name": "region",
+            "group_ids": [self.group_cameroon_north.id, self.group_cameroon_south.id],
+            "group_belonging": "SINGLE",
+            "erased": False,
+        }
+
+        # Groups with `source_version_1`.
+        response = self.client.get("/api/mobile/group_sets/", {APP_ID: self.project_cameroon.app_id})
+        self.assertJSONResponse(response, 200)
+        self.assertEqual(json.dumps(response.data), json.dumps([record_cameroon]))
+
+        record_nigeria = {
+            "id": self.group_set_1_nigeria.id,
+            "name": "contracts",
+            "group_ids": [self.group_nigeria_1_hospital.id, self.group_nigeria_1_healthcenter.id],
+            "group_belonging": "SINGLE",
+            "erased": False,
+        }
+
+        # Groups with `source_version_2`.
+        ## Without all versions
+        response = self.client.get("/api/mobile/group_sets/", {APP_ID: self.project_nigeria.app_id})
+        self.assertEqual(json.dumps(response.data), json.dumps([record_nigeria]))

--- a/iaso/urls.py
+++ b/iaso/urls.py
@@ -65,6 +65,7 @@ from .api.mobile.bulk_uploads import MobileBulkUploadsViewSet
 from .api.mobile.entity import MobileEntityViewSet
 from .api.mobile.entity_type import MobileEntityTypesViewSet
 from .api.mobile.groups import MobileGroupsViewSet
+from .api.mobile.group_sets import MobileGroupSetsViewSet
 from .api.mobile.org_units import MobileOrgUnitViewSet
 from .api.mobile.reports import MobileReportsViewSet
 from .api.mobile.storage import MobileStoragePasswordViewSet
@@ -137,6 +138,7 @@ router.register(r"algorithmsruns", AlgorithmsRunsViewSet, basename="algorithmsru
 router.register(r"groups", GroupsViewSet, basename="groups")
 router.register(r"group_sets", GroupSetsViewSet, basename="group_sets")
 router.register(r"mobile/groups", MobileGroupsViewSet, basename="groupsmobile")
+router.register(r"mobile/group_sets", MobileGroupSetsViewSet, basename="groupsetsmobile")
 router.register(r"completeness", CompletenessViewSet, basename="completeness")
 router.register(r"v2/completeness_stats", CompletenessStatsV2ViewSet, basename="completeness_stats")
 router.register(r"exportrequests", ExportRequestsViewSet, basename="exportrequests")


### PR DESCRIPTION
Have a dedicated endpoint for groupsets

Related JIRA tickets : IA-3412

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
- Tell us where the doc can be found (docs folder, wiki, in the code...)

## Changes


## How to test

1. seed (or use setuper) 

```
docker-compose run --rm iaso manage seed_test_data --mode=seed --dhis2version=2.40.4.1
```

2. then access `http://localhost:8081/api/mobile/group_sets/?app_id=org.bluesquare.play`
   (adapt app_id based on )

3. trigger new versions in the datasource and should see groupsets with erased true and false

![image](https://github.com/user-attachments/assets/23ee89e0-354c-4518-927d-ede71d4578db)


the field "erased" mean if it exist in the "default version" of the datasource

## Print screen / video

![image](https://github.com/user-attachments/assets/7138dd53-10c3-4f60-8a94-532375e42620)

## Notes

Things that the reviewers should know: known bugs that are out of the scope of the PR, other trade-offs that were made.
If the PR depends on a PR in bluesquare-components, or merges into another PR (i.o. main), it should also be mentioned here
