### PR TITLE
WC2-483 Small fix on the date filters for entities

### DIFF
--- a/iaso/api/entity.py
+++ b/iaso/api/entity.py
@@ -172,7 +172,7 @@ class EntityViewSet(ModelViewSet):
 
             date_to_dt = datetime.datetime.max
             if date_to:
-                datetime.datetime.strptime(date_to, "%Y-%m-%d")
+                parsed_date = datetime.datetime.strptime(date_to, "%Y-%m-%d")
                 date_to_dt = datetime.datetime.combine(parsed_date, datetime.time.max).replace(tzinfo=pytz.UTC)
 
             instances_within_range = Instance.objects.annotate(

--- a/iaso/api/entity.py
+++ b/iaso/api/entity.py
@@ -3,6 +3,7 @@ import datetime
 import io
 import json
 import math
+import pytz
 from time import gmtime, strftime
 from typing import Any, List, Union
 
@@ -164,8 +165,15 @@ class EntityViewSet(ModelViewSet):
             queryset = queryset.filter(attributes__org_unit__path__descendants=parent.path)
 
         if date_from or date_to:
-            date_from_dt = datetime.datetime.strptime(date_from, "%Y-%m-%d") if date_from else datetime.datetime.min
-            date_to_dt = datetime.datetime.strptime(date_to, "%Y-%m-%d") if date_to else datetime.datetime.max
+            date_from_dt = datetime.datetime.min
+            if date_from:
+                parsed_date = datetime.datetime.strptime(date_from, "%Y-%m-%d")
+                date_from_dt = datetime.datetime.combine(parsed_date, datetime.time.min).replace(tzinfo=pytz.UTC)
+
+            date_to_dt = datetime.datetime.max
+            if date_to:
+                datetime.datetime.strptime(date_to, "%Y-%m-%d")
+                date_to_dt = datetime.datetime.combine(parsed_date, datetime.time.max).replace(tzinfo=pytz.UTC)
 
             instances_within_range = Instance.objects.annotate(
                 creation_timestamp=Coalesce("source_created_at", "created_at")


### PR DESCRIPTION
For the end date, it would filter on greater or equal to for example '2024-02-05T00:00:00+00:00'. The correct check would be on the end of day, to also include visits on this day, e.g. '2024-02-05T23:59:59.999999+00:00'

Related JIRA tickets : https://bluesquare.atlassian.net/browse/WC2-483

## How to test

Go to entities page and filter on some dates. If you chose an interval of 1 date, you'll never have any results. With this fix, you get the correct results.
