### PR TITLE
IA-3418: HOTFIX empty payment lots

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/payments/hooks/requests/useGetPotentialPayments.tsx
+++ b/hat/assets/js/apps/Iaso/domains/payments/hooks/requests/useGetPotentialPayments.tsx
@@ -8,7 +8,13 @@ import { apiDateFormat, formatDateString } from '../../../../utils/dates';
 
 const apiUrl = '/api/potential_payments/';
 
-const getPotentialPayments = (options: PotentialPaymentParams) => {
+const getPotentialPayments = (url: string) => {
+    return getRequest(url) as Promise<PotentialPaymentPaginated>;
+};
+
+export const useGetPotentialPayments = (
+    params: PotentialPaymentParams,
+): UseQueryResult<PotentialPaymentPaginated, Error> => {
     const {
         change_requests__created_at_after,
         change_requests__created_at_before,
@@ -17,10 +23,10 @@ const getPotentialPayments = (options: PotentialPaymentParams) => {
         users,
         user_roles,
         page,
-    } = options;
+    } = params;
     const apiParams = {
-        order: options.order || 'user__last_name',
-        limit: options.pageSize || 10,
+        order: params.order || 'user__last_name',
+        limit: params.pageSize || 10,
         page,
         change_requests__created_at_after: formatDateString(
             change_requests__created_at_after,
@@ -37,18 +43,10 @@ const getPotentialPayments = (options: PotentialPaymentParams) => {
         users,
         user_roles,
     };
-
     const url = makeUrlWithParams(apiUrl, apiParams);
-
-    return getRequest(url) as Promise<PotentialPaymentPaginated>;
-};
-
-export const useGetPotentialPayments = (
-    params: PotentialPaymentParams,
-): UseQueryResult<PotentialPaymentPaginated, Error> => {
     return useSnackQuery({
-        queryKey: ['potentialPayments', params],
-        queryFn: () => getPotentialPayments(params),
+        queryKey: ['potentialPayments', url],
+        queryFn: () => getPotentialPayments(url),
         options: {
             staleTime: 1000 * 60 * 15, // in MS
             cacheTime: 1000 * 60 * 5,

--- a/iaso/admin.py
+++ b/iaso/admin.py
@@ -710,6 +710,7 @@ class OrgUnitChangeRequestAdmin(admin.ModelAdmin):
         "old_reference_instances",
         "old_opening_date",
         "old_closed_date",
+        "potential_payment",
     )
     raw_id_fields = (
         "org_unit",
@@ -801,6 +802,19 @@ class ConfigAdmin(admin.ModelAdmin):
 @admin.register(PotentialPayment)
 class PotentialPaymentAdmin(admin.ModelAdmin):
     formfield_overrides = {models.JSONField: {"widget": IasoJSONEditorWidget}}
+    list_display = ("id", "change_request_ids")
+
+    def change_request_ids(self, obj):
+        change_requests = obj.change_requests.all()
+        if change_requests:
+            return format_html(
+                ", ".join(
+                    f'<a href="/admin/iaso/orgunitchangerequest/{cr.id}/change/">{cr.id}</a>' for cr in change_requests
+                )
+            )
+        return "-"
+
+    change_request_ids.short_description = "Change Request IDs"
 
 
 @admin.register(Payment)

--- a/iaso/admin.py
+++ b/iaso/admin.py
@@ -454,9 +454,9 @@ class EntityAdmin(admin.ModelAdmin):
     def get_form(self, request, obj=None, **kwargs):
         # In the <select> for the entity type, we also want to indicate the account name
         form = super().get_form(request, obj, **kwargs)
-        form.base_fields["entity_type"].label_from_instance = (
-            lambda entity: f"{entity.name} (Account: {entity.account.name})"
-        )
+        form.base_fields[
+            "entity_type"
+        ].label_from_instance = lambda entity: f"{entity.name} (Account: {entity.account.name})"
         return form
 
     readonly_fields = ("created_at",)
@@ -624,9 +624,9 @@ class WorkflowAdmin(admin.ModelAdmin):
     def get_form(self, request, obj=None, **kwargs):
         # In the <select> for the entity type, we also want to indicate the account name
         form = super().get_form(request, obj, **kwargs)
-        form.base_fields["entity_type"].label_from_instance = (
-            lambda entity: f"{entity.name} (Account: {entity.account.name})"
-        )
+        form.base_fields[
+            "entity_type"
+        ].label_from_instance = lambda entity: f"{entity.name} (Account: {entity.account.name})"
         return form
 
     def get_queryset(self, request):


### PR DESCRIPTION
Users who tried to create payment lots from potential payments would sometimes end up with an empty payment lot

Related JIRA tickets : IA-3418

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
NA

## Changes

-  use `url` i.o params as `queryKey`, because the 'account' redirection would cause a second call to the APi with a race condition. This would sometimes result in 2 potential payments being created, which allowed the creation of empty payment lots down the line

## How to test

You need at least one approved change request with a non-null `created-by` field

- Open the django admin, go to potential payments
- In another tab, open the inspector and go to Potential Payments page

--> The inpsector should show only one call to the potential payments API
--> Refresh the admin: only 1new potential payment should appear

## Print screen / video

https://github.com/user-attachments/assets/d01a4f13-779b-4f3a-bad7-8c5a94323cbc




## Notes

HOTFIX on v1.243
