### PR TITLE
IA-3165: Submissions visible columns Scroll

### DIFF
--- a/hat/assets/js/apps/Iaso/components/tables/ColumnSelectDrawer/styles.ts
+++ b/hat/assets/js/apps/Iaso/components/tables/ColumnSelectDrawer/styles.ts
@@ -22,7 +22,7 @@ export const useStyles = makeStyles(theme => ({
         width: '100%',
     },
     list: {
-        height: `calc(100vh - ${theme.spacing(8)}px)`,
+        height: `calc(100vh - ${theme.spacing(8)})`,
         overflowY: 'auto',
         overflowX: 'hidden',
     },


### PR DESCRIPTION
While visiting submission page for a specific form and click on visible columns button, you cannot scroll. If you refresh the page its working

https://github.com/user-attachments/assets/cda0bcc4-ca55-48c0-9ce5-eb9d4ddc12a0



Related JIRA tickets : IA-3165

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

I removed a double px string in the main container css, it seems to fix the isssue:



## How to test

Take a new browser page
Load forms page and navigate to submissions for a form (with lots of fields and a form descriptor)) using the icon button in the table
click on visible columns button, scroll should be enabled

## Print screen / video


https://github.com/user-attachments/assets/d2927cb1-5933-4b40-8827-853aab11a570


