### PR TITLE
POLIO-1668: Move Chronogram into Vaccine module in the Menu

### DIFF
--- a/plugins/polio/js/src/constants/menu.tsx
+++ b/plugins/polio/js/src/constants/menu.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable react/jsx-props-no-spreading */
-import React from 'react';
 import AccountBalanceWalletIcon from '@mui/icons-material/AccountBalanceWallet';
 import AssessmentIcon from '@mui/icons-material/Assessment';
 import CalendarToday from '@mui/icons-material/CalendarToday';
@@ -20,25 +19,26 @@ import SettingsIcon from '@mui/icons-material/Settings';
 import StorageIcon from '@mui/icons-material/Storage';
 import StorefrontIcon from '@mui/icons-material/Storefront';
 import WatchLaterIcon from '@mui/icons-material/WatchLater';
-import MESSAGES from './messages';
+import React from 'react';
 import { MenuItem } from '../../../../../hat/assets/js/apps/Iaso/domains/app/types';
+import MESSAGES from './messages';
 import {
-    campaignsPath,
-    groupedCampaignsPath,
+    budgetPath,
     calendarPath,
-    lqasCountryPath,
-    lqasAfroPath,
+    campaignsPath,
+    chronogramPath,
+    countryConfigPath,
+    groupedCampaignsPath,
     imGlobalPath,
     imIhhPath,
     imOhhPath,
-    budgetPath,
+    lqasAfroPath,
+    lqasCountryPath,
     nopvAuthPath,
-    supplychainPath,
-    stockManagementPath,
     notificationPath,
-    countryConfigPath,
     reasonsForDelayConfigPath,
-    chronogramPath,
+    stockManagementPath,
+    supplychainPath,
 } from './routes';
 
 export const menu: MenuItem[] = [
@@ -143,6 +143,12 @@ export const menu: MenuItem[] = [
                         permissions: stockManagementPath.permissions,
                         icon: props => <StorageIcon {...props} />,
                     },
+                    {
+                        label: MESSAGES.chronogram,
+                        key: 'chronogram',
+                        permissions: chronogramPath.permissions,
+                        icon: props => <PendingActionsIcon {...props} />,
+                    },
                 ],
             },
             {
@@ -150,12 +156,6 @@ export const menu: MenuItem[] = [
                 key: 'notifications',
                 permissions: notificationPath.permissions,
                 icon: props => <NotificationsActiveIcon {...props} />,
-            },
-            {
-                label: MESSAGES.chronogram,
-                key: 'chronogram',
-                permissions: chronogramPath.permissions,
-                icon: props => <PendingActionsIcon {...props} />,
             },
             {
                 label: MESSAGES.configuration,

--- a/plugins/polio/js/src/constants/urls.ts
+++ b/plugins/polio/js/src/constants/urls.ts
@@ -1,10 +1,10 @@
-import { paginationPathParams } from '../../../../../hat/assets/js/apps/Iaso/routing/common';
 import {
     RouteConfig,
     extractParams,
     extractParamsConfig,
     extractUrls,
 } from '../../../../../hat/assets/js/apps/Iaso/constants/urls';
+import { paginationPathParams } from '../../../../../hat/assets/js/apps/Iaso/routing/common';
 import {
     DESTRUCTION,
     FORM_A,
@@ -37,7 +37,7 @@ export const STOCK_MANAGEMENT = `${VACCINE_MODULE}/stockmanagement`;
 export const STOCK_MANAGEMENT_DETAILS = `${STOCK_MANAGEMENT}/details`;
 export const STOCK_VARIATION = `${STOCK_MANAGEMENT}/variation`;
 export const NOTIFICATIONS_BASE_URL = 'polio/notifications';
-export const CHRONOGRAM_BASE_URL = 'polio/chronogram';
+export const CHRONOGRAM_BASE_URL = `${VACCINE_MODULE}/chronogram`;
 export const CHRONOGRAM_TEMPLATE_TASK = `${CHRONOGRAM_BASE_URL}/templateTask`;
 export const CHRONOGRAM_DETAILS = `${CHRONOGRAM_BASE_URL}/details`;
 

--- a/plugins/polio/js/src/domains/Chronogram/ChronogramTemplateTask/index.tsx
+++ b/plugins/polio/js/src/domains/Chronogram/ChronogramTemplateTask/index.tsx
@@ -1,5 +1,5 @@
-import React, { FunctionComponent } from 'react';
 import { Box, Grid } from '@mui/material';
+import React, { FunctionComponent } from 'react';
 
 import { LoadingSpinner, useGoBack, useSafeIntl } from 'bluesquare-components';
 
@@ -9,14 +9,14 @@ import { useStyles } from '../../../styles/theme';
 
 import { baseUrls } from '../../../constants/urls';
 
-import MESSAGES from './messages';
-import { ChronogramParams } from '../Chronogram/types';
-import { ChronogramTaskMetaData } from '../types';
-import { ChronogramTemplateTaskParams } from './types';
-import { ChronogramTemplateTaskTable } from './Table/ChronogramTemplateTaskTable';
-import { CreateChronogramTemplateTaskModal } from './Modals/ChronogramTemplateTaskCreateEditModal';
-import { defaultParams } from '../constants';
 import { useOptionChronogramTask } from '../api/useOptionChronogram';
+import { ChronogramParams } from '../Chronogram/types';
+import { defaultParams } from '../constants';
+import { ChronogramTaskMetaData } from '../types';
+import MESSAGES from './messages';
+import { CreateChronogramTemplateTaskModal } from './Modals/ChronogramTemplateTaskCreateEditModal';
+import { ChronogramTemplateTaskTable } from './Table/ChronogramTemplateTaskTable';
+import { ChronogramTemplateTaskParams } from './types';
 
 export const ChronogramTemplateTask: FunctionComponent = () => {
     const params = useParamsObject(
@@ -36,7 +36,7 @@ export const ChronogramTemplateTask: FunctionComponent = () => {
         <>
             <TopBar
                 title={formatMessage(MESSAGES.chronogramTemplateTaskTitle)}
-                displayBackButton={true}
+                displayBackButton
                 goBack={() => goBack()}
             />
             {isFetchingMetaData && <LoadingSpinner />}


### PR DESCRIPTION
Move Chronogram into Vaccine module in the Menu

Related JIRA tickets :POLIO-1668

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)



## Changes

 Adapt menu, and routes to move the chronogram list, details and templates pages under vaccine stock

## How to test

Open menu, polio/vaccine module/ chronogram, open a detail or a template, come back

## Print screen / video



https://github.com/user-attachments/assets/47e34486-e983-4c40-90c6-c0df6a83e009

