### PR TITLE
SANRUSSC24-23 Add delete project, fix delete accounts

### DIFF
--- a/iaso/management/commands/delete_accounts.py
+++ b/iaso/management/commands/delete_accounts.py
@@ -149,7 +149,8 @@ class Command(BaseCommand):
                         )
 
                 for entity in Entity.objects_include_deleted.filter(account=account):
-                    print("Entity attributes", entity.attributes.delete())
+                    if entity and entity.attributes:
+                        print("Entity attributes", entity.attributes.delete())
 
                 print("Entity", Entity.objects_include_deleted.filter(account=account).delete())
 
@@ -481,6 +482,9 @@ class Command(BaseCommand):
         dump_diffs(counts_before, counts_after)
         print("******* Review external credentials left")
         for ext_cred in ExternalCredentials.objects.all():
-            print(ext_cred.url, ext_cred.login, ext_cred.name)
+            print(ext_cred.id, ext_cred.url, ext_cred.login, ext_cred.name)
 
+        print(
+            "\ncredential ids used in datasource\n", list(DataSource.objects.values_list("credentials_id", flat=True))
+        )
         print("Done !")

--- a/iaso/management/commands/delete_project.py
+++ b/iaso/management/commands/delete_project.py
@@ -1,0 +1,119 @@
+import traceback
+import datetime
+from collections import defaultdict
+
+import django
+from django.contrib.auth.models import User
+from django.contrib.sessions.models import Session
+from django.contrib.contenttypes.models import ContentType
+from django.core.management.base import BaseCommand
+from django.db import connection
+from django.db.models import Count
+from django.db.models import Q
+from django.db.models import TextField
+from django.db.models.functions import Cast
+
+from hat.audit.models import Modification
+from iaso.models import Account, OrgUnitType, CommentIaso, StoragePassword, StorageDevice, StorageLogEntry
+from iaso.models import BulkCreateUserCsvFile
+from iaso.models import ExportLog, ExportRequest
+from iaso.models.base import DataSource, ExternalCredentials, Instance, Mapping, Profile, InstanceFile, InstanceLock
+from iaso.models.base import Task, QUEUED, KILLED
+from iaso.models.entity import Entity, EntityType
+from iaso.models.forms import Form
+from iaso.models.microplanning import Assignment, Team, Planning
+from iaso.models.org_unit import OrgUnit, OrgUnitReferenceInstance
+from iaso.models.pages import Page
+from iaso.models.project import Project
+from iaso.models.device import Device
+
+from django_sql_dashboard.models import Dashboard
+
+
+def flatten(l):
+    return [item for sublist in l for item in sublist]
+
+
+def fullname(m):
+    if m is None:
+        return ""
+    return m.__module__ + "." + m.__name__
+
+
+def dump_counts():
+    counts = defaultdict()
+    print("******************* COUNTS")
+    for ct in ContentType.objects.all():
+        m = None
+        if ct.model_class():
+            try:
+                m = ct.model_class()
+                count = m._default_manager.count()
+                # print(m.__module__, m.__name__, count)
+                counts[fullname(m)] = count
+            except:
+                # don't know why (abstract model ? missing migration) but I had to add this catch statement
+                # the error raised below :
+                # db_1       | 2022-10-19 08:30:32.838 UTC [153] ERROR:  relation "menupermissions_custompermissionsupport" does not exist at character 35
+                # db_1       | 2022-10-19 08:30:32.838 UTC [153] STATEMENT:  SELECT COUNT(*) AS "__count" FROM "menupermissions_custompermissionsupport"
+                print(fullname(m), "not available")
+
+    print("******************* ")
+
+    return counts
+
+
+class Command(BaseCommand):
+    help = "Local hosting delete a project, forms, instances,..."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--account-to-keep", type=int)
+        parser.add_argument("--project-app-id-to-delete", type=str)
+
+    def handle(self, *args, **options):
+        print("delete Project")
+
+        account_id_to_keep = options.get("account_to_keep")
+        if account_id_to_keep is None:
+            for account in Account.objects.order_by("id").all():
+                print(account.id, account.name)
+            raise Exception("No account id provided via --account-to-keep")
+        for account in Account.objects.order_by("id").all():
+            print(account.id, account.name)
+        account_to_keep = Account.objects.get(pk=account_id_to_keep)
+        print("*****")
+        print("keeping", account_id_to_keep, account_to_keep)
+
+        project_app_id_to_delete = options.get("project_app_id_to_delete")
+
+        for project in account.project_set.order_by("id").all():
+            print(project.id, project.name, project.app_id)
+
+        project = account_to_keep.project_set.get(app_id=project_app_id_to_delete)
+
+        print("deleting vector_control_apiimport")
+        Form.objects.raw(
+            f"delete vector_control_apiimport where headers->>'QUERY_STRING' like 'app_id={project.app_id}%'"
+        )
+        forms = Form.objects_include_deleted.filter(projects__in=[project])
+
+        print(
+            "InstanceFile delete",
+            InstanceFile.objects.filter(instance__in=Instance.objects.filter(project=project)).delete(),
+        )
+        print("Instance delete", Instance.objects.filter(project=project).delete())
+        print("InstanceFile delete", InstanceFile.objects.filter(instance__form__in=forms).delete())
+        print("Instance delete", Instance.objects.filter(form__in=forms).delete())
+        print("Mapping", Mapping.objects.filter(form__in=forms).delete())
+        print("Forms", [f.name for f in forms])
+        for f in forms:
+            try:
+                print("Instance delete", Instance.objects.filter(form__in=forms).delete())
+                f.delete_hard()
+            except:
+                print(
+                    "can't hard delete form ",
+                    f,
+                )
+
+        print("project", project.delete())

--- a/iaso/management/commands/delete_project.py
+++ b/iaso/management/commands/delete_project.py
@@ -11,10 +11,7 @@ class Command(BaseCommand):
         parser.add_argument("--account-to-keep", type=int)
         parser.add_argument("--project-app-id-to-delete", type=str)
 
-    def handle(self, *args, **options):
-        print("delete Project")
-
-        account_id_to_keep = options.get("account_to_keep")
+    def _get_account(self, account_id_to_keep):
         if account_id_to_keep is None:
             for account in Account.objects.order_by("id").all():
                 print(account.id, account.name)
@@ -24,14 +21,16 @@ class Command(BaseCommand):
         account_to_keep = Account.objects.get(pk=account_id_to_keep)
         print("*****")
         print("keeping", account_id_to_keep, account_to_keep)
+        return account_to_keep
 
-        project_app_id_to_delete = options.get("project_app_id_to_delete")
+    def _get_project(self, account_to_keep, project_app_id_to_delete):
+        for project in account_to_keep.project_set.order_by("id").all():
+            print(project.id, "\t", project.name, "\t", project.app_id)
 
-        for project in account.project_set.order_by("id").all():
-            print(project.id, project.name, project.app_id)
+        project_to_delete = account_to_keep.project_set.get(app_id=project_app_id_to_delete)
+        return project_to_delete
 
-        project = account_to_keep.project_set.get(app_id=project_app_id_to_delete)
-
+    def _delete_project(self, project):
         print("deleting vector_control_apiimport")
         Form.objects.raw(
             f"delete vector_control_apiimport where headers->>'QUERY_STRING' like 'app_id={project.app_id}%'"
@@ -43,7 +42,10 @@ class Command(BaseCommand):
             InstanceFile.objects.filter(instance__in=Instance.objects.filter(project=project)).delete(),
         )
         print("Instance delete", Instance.objects.filter(project=project).delete())
-        print("InstanceFile delete", InstanceFile.objects.filter(instance__form__in=forms).delete())
+        print(
+            "InstanceFile delete",
+            InstanceFile.objects.filter(instance__form__in=forms).delete(),
+        )
         print("Instance delete", Instance.objects.filter(form__in=forms).delete())
         print("Mapping", Mapping.objects.filter(form__in=forms).delete())
         print("Forms", [f.name for f in forms])
@@ -58,3 +60,9 @@ class Command(BaseCommand):
                 )
 
         print("project", project.delete())
+
+    def handle(self, *args, **options):
+        print("delete Project")
+        account_to_keep = self._get_account(options.get("account_to_keep"))
+        project = self._get_project(account_to_keep, options.get("project_app_id_to_delete"))
+        self._delete_project(project)

--- a/iaso/management/commands/delete_project.py
+++ b/iaso/management/commands/delete_project.py
@@ -12,12 +12,10 @@ class Command(BaseCommand):
         parser.add_argument("--project-app-id-to-delete", type=str)
 
     def _get_account(self, account_id_to_keep):
-        if account_id_to_keep is None:
-            for account in Account.objects.order_by("id").all():
-                print(account.id, account.name)
-            raise Exception("No account id provided via --account-to-keep")
         for account in Account.objects.order_by("id").all():
             print(account.id, account.name)
+        if account_id_to_keep is None:
+            raise Exception("No account id provided via --account-to-keep")
         account_to_keep = Account.objects.get(pk=account_id_to_keep)
         print("*****")
         print("keeping", account_id_to_keep, account_to_keep)

--- a/iaso/management/commands/delete_project.py
+++ b/iaso/management/commands/delete_project.py
@@ -30,39 +30,6 @@ from iaso.models.device import Device
 from django_sql_dashboard.models import Dashboard
 
 
-def flatten(l):
-    return [item for sublist in l for item in sublist]
-
-
-def fullname(m):
-    if m is None:
-        return ""
-    return m.__module__ + "." + m.__name__
-
-
-def dump_counts():
-    counts = defaultdict()
-    print("******************* COUNTS")
-    for ct in ContentType.objects.all():
-        m = None
-        if ct.model_class():
-            try:
-                m = ct.model_class()
-                count = m._default_manager.count()
-                # print(m.__module__, m.__name__, count)
-                counts[fullname(m)] = count
-            except:
-                # don't know why (abstract model ? missing migration) but I had to add this catch statement
-                # the error raised below :
-                # db_1       | 2022-10-19 08:30:32.838 UTC [153] ERROR:  relation "menupermissions_custompermissionsupport" does not exist at character 35
-                # db_1       | 2022-10-19 08:30:32.838 UTC [153] STATEMENT:  SELECT COUNT(*) AS "__count" FROM "menupermissions_custompermissionsupport"
-                print(fullname(m), "not available")
-
-    print("******************* ")
-
-    return counts
-
-
 class Command(BaseCommand):
     help = "Local hosting delete a project, forms, instances,..."
 

--- a/iaso/management/commands/delete_project.py
+++ b/iaso/management/commands/delete_project.py
@@ -1,33 +1,7 @@
-import traceback
-import datetime
-from collections import defaultdict
-
-import django
-from django.contrib.auth.models import User
-from django.contrib.sessions.models import Session
-from django.contrib.contenttypes.models import ContentType
 from django.core.management.base import BaseCommand
-from django.db import connection
-from django.db.models import Count
-from django.db.models import Q
-from django.db.models import TextField
-from django.db.models.functions import Cast
-
-from hat.audit.models import Modification
-from iaso.models import Account, OrgUnitType, CommentIaso, StoragePassword, StorageDevice, StorageLogEntry
-from iaso.models import BulkCreateUserCsvFile
-from iaso.models import ExportLog, ExportRequest
-from iaso.models.base import DataSource, ExternalCredentials, Instance, Mapping, Profile, InstanceFile, InstanceLock
-from iaso.models.base import Task, QUEUED, KILLED
-from iaso.models.entity import Entity, EntityType
+from iaso.models import Account
+from iaso.models.base import Instance, Mapping, InstanceFile
 from iaso.models.forms import Form
-from iaso.models.microplanning import Assignment, Team, Planning
-from iaso.models.org_unit import OrgUnit, OrgUnitReferenceInstance
-from iaso.models.pages import Page
-from iaso.models.project import Project
-from iaso.models.device import Device
-
-from django_sql_dashboard.models import Dashboard
 
 
 class Command(BaseCommand):


### PR DESCRIPTION
an error prevented to delete other accounts (entity attributes).
and this project needed to delete some projects within the account before transfering to local hosting, a new command has been added.

Related JIRA tickets : [SANRUSSC24-23](https://bluesquare.atlassian.net/browse/SANRUSSC24-23)

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
- the delete project command is specific to this project, see the jira for its usage

## Changes

delete a project, it's forms and instance (instance file), audits

## How to test

this is a lengthy process
 - https://github.com/BLSQ/ops-runbooks/blob/main/local-hosting/iaso-produce-tenant-dump.md#produce-a-db-dump-with-only-clienttenant-data
 - https://bluesquare.atlassian.net/browse/SANRUSSC24-23

## Print screen / video

Upload here print screens or videos showing the changes

## Notes




[SANRUSSC24-23]: https://bluesquare.atlassian.net/browse/SANRUSSC24-23?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ