### PR TITLE
POLIO-1663: Supply Chain: Reorder lines so that summary table has the correct order to match VARs with their PO

### DIFF
--- a/plugins/polio/api/vaccines/supply_chain.py
+++ b/plugins/polio/api/vaccines/supply_chain.py
@@ -398,21 +398,32 @@ class VaccineRequestFormListSerializer(serializers.ModelSerializer):
             "updated_at",
         ]
 
-    # comma separated list of all
-    def get_po_numbers(self, obj):
+    def get_prefetched_data(self, obj):
+        # Prefetch vaccineprea_lert and vaccinearrival_report to reduce the number of queries in the DB
         pre_alerts = obj.vaccineprealert_set.all().order_by("-estimated_arrival_time")
+        arrival_reports = obj.vaccinearrivalreport_set.filter(po_number__in=[p.po_number for p in pre_alerts]).order_by(
+            "-arrival_report_date"
+        )
 
-        if not pre_alerts:
-            return ""
+        # Get arrival reports matching by po_number
+        arrival_report_matching = {}
+        for report in arrival_reports:
+            if report.po_number not in arrival_report_matching:
+                arrival_report_matching[report.po_number] = []
+            arrival_report_matching[report.po_number].append(report)
+
+        return pre_alerts, arrival_report_matching
+
+    # Comma separated list of all
+    def get_po_numbers(self, obj):
+        pre_alerts, arrival_report_matching = self.get_prefetched_data(obj)
 
         po_numbers = []
         for pre_alert in pre_alerts:
-            matching_po_numbers = obj.vaccinearrivalreport_set.filter(po_number=pre_alert.po_number).order_by(
-                "-arrival_report_date"
-            )
-            if matching_po_numbers:
-                for match in matching_po_numbers:
-                    po_numbers.append(str(match.po_number))
+            matching_reports = arrival_report_matching.get(pre_alert.po_number, [])
+            if matching_reports:
+                for report in matching_reports:
+                    po_numbers.append(str(report.po_number))
             else:
                 po_numbers.append(pre_alert.po_number)
         return ",".join(po_numbers)
@@ -434,18 +445,13 @@ class VaccineRequestFormListSerializer(serializers.ModelSerializer):
 
     # Comma Separated List of all estimated arrival times
     def get_eta(self, obj):
-        pre_alerts = obj.vaccineprealert_set.all().order_by("-estimated_arrival_time")
-
-        if not pre_alerts:
-            return ""
+        pre_alerts, arrival_report_matching = self.get_prefetched_data(obj)
 
         estimated_arrival_dates = []
         for pre_alert in pre_alerts:
-            matching_dates = obj.vaccinearrivalreport_set.filter(po_number=pre_alert.po_number).order_by(
-                "-arrival_report_date"
-            )
-            if matching_dates:
-                for match in matching_dates:
+            matching_reports = arrival_report_matching.get(pre_alert.po_number, [])
+            if matching_reports:
+                for _ in matching_reports:
                     estimated_arrival_dates.append(str(pre_alert.estimated_arrival_time))
             else:
                 estimated_arrival_dates.append(str(pre_alert.estimated_arrival_time))
@@ -453,15 +459,14 @@ class VaccineRequestFormListSerializer(serializers.ModelSerializer):
 
     # Comma Separated List of all arrival report dates
     def get_var(self, obj):
-        pre_alerts = obj.vaccineprealert_set.all().order_by("-estimated_arrival_time")
+        pre_alerts, arrival_report_matching = self.get_prefetched_data(obj)
+
         arrival_report_dates = []
         for pre_alert in pre_alerts:
-            matching_arrival_report = obj.vaccinearrivalreport_set.filter(po_number=pre_alert.po_number).order_by(
-                "-arrival_report_date"
-            )
-            if matching_arrival_report:
-                for match in matching_arrival_report:
-                    arrival_report_dates.append(str(match.arrival_report_date))
+            matching_reports = arrival_report_matching.get(pre_alert.po_number, [])
+            if matching_reports:
+                for report in matching_reports:
+                    arrival_report_dates.append(str(report.arrival_report_date))
             else:
                 arrival_report_dates.append("")
         return ",".join(arrival_report_dates)

--- a/plugins/polio/tests/test_vaccine_supply_chain.py
+++ b/plugins/polio/tests/test_vaccine_supply_chain.py
@@ -691,5 +691,4 @@ class VaccineSupplyChainAPITestCase(APITestCase):
 
         # Verify that the "var" field is a comma-separated list of dates in reverse order
         expected_var = ",".join(dates)
-        print(response.data["results"])
         self.assertEqual(response.data["results"][1]["var"], expected_var)

--- a/plugins/polio/tests/test_vaccine_supply_chain.py
+++ b/plugins/polio/tests/test_vaccine_supply_chain.py
@@ -663,12 +663,22 @@ class VaccineSupplyChainAPITestCase(APITestCase):
         request_form = pm.VaccineRequestForm.objects.first()
 
         # Create multiple VaccineArrivalReport instances with different dates
+        po_numbers = ["777777-1", "777777-2", "777777-3"]
+
         dates = ["2024-04-20", "2024-04-19", "2024-04-18"]
-        for date in dates:
+        for i, date in enumerate(dates):
             pm.VaccineArrivalReport.objects.create(
                 request_form=request_form,
+                po_number=po_numbers[i],
                 arrival_report_date=datetime.datetime.strptime(date, "%Y-%m-%d").date(),
                 doses_received=1000,
+            )
+            pm.VaccinePreAlert.objects.create(
+                date_pre_alert_reception=datetime.datetime.strptime(date, "%Y-%m-%d").date(),
+                request_form=request_form,
+                po_number=po_numbers[i],
+                estimated_arrival_time=datetime.datetime.strptime(date, "%Y-%m-%d").date(),
+                doses_shipped=100,
             )
 
         # Make a GET request to the list endpoint with ordering by start_date
@@ -680,5 +690,6 @@ class VaccineSupplyChainAPITestCase(APITestCase):
         self.assertEqual(response.status_code, 200)
 
         # Verify that the "var" field is a comma-separated list of dates in reverse order
-        expected_var = ", ".join(dates)
+        expected_var = ",".join(dates)
+        print(response.data["results"])
         self.assertEqual(response.data["results"][1]["var"], expected_var)


### PR DESCRIPTION
Explain what problem this PR is resolving
- Supply Chain: Reorder lines so that summary table has the correct order to match VARs with their PO
Related JIRA tickets : [POLIO-1663](https://bluesquare.atlassian.net/browse/POLIO-1663)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
- Tell us where the doc can be found (docs folder, wiki, in the code...)

## Changes
- Changes on get_po_numbers, get_eta and get_var methods in VaccineRequestFormListSerializer

## How to test
- Polio --> Vaccine module --> supply chain
- Check if Po numbers, estimated date of arrival and Var are matching

## Print screen / video
[Screencast from 2024-09-17 09-46-35.webm](https://github.com/user-attachments/assets/db3db87c-17b5-4fbc-960f-cccc27db90e7)


## Notes

Things that the reviewers should know: known bugs that are out of the scope of the PR, other trade-offs that were made.
If the PR depends on a PR in bluesquare-components, or merges into another PR (i.o. main), it should also be mentioned here


[POLIO-1663]: https://bluesquare.atlassian.net/browse/POLIO-1663?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ