### PR TITLE
IA-3432 Add a button to relaunch a failed task

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -1281,6 +1281,7 @@
     "iaso.tasks.polioNotificationImport.errors": "{count} error(s). The following data couldn't be imported.",
     "iaso.tasks.progress": "Progress",
     "iaso.tasks.queued": "Queued",
+    "iaso.tasks.relaunch": "Relaunch the task",
     "iaso.tasks.running": "Running",
     "iaso.tasks.skipped": "Skipped",
     "iaso.tasks.status": "Name & status",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -1281,6 +1281,7 @@
     "iaso.tasks.polioNotificationImport.errors": "{count} erreur(s). L'import des données suivantes a échoué.",
     "iaso.tasks.progress": "Avancement",
     "iaso.tasks.queued": "En attente",
+    "iaso.tasks.relaunch": "Relancer la tâche",
     "iaso.tasks.running": "En cours d'exécution",
     "iaso.tasks.skipped": "Ignorée",
     "iaso.tasks.status": "Nom & état",

--- a/hat/assets/js/apps/Iaso/domains/tasks/components/TaskDetails.tsx
+++ b/hat/assets/js/apps/Iaso/domains/tasks/components/TaskDetails.tsx
@@ -31,7 +31,11 @@ const TaskDetails: FunctionComponent<Props> = ({ task }) => {
     const { formatMessage } = useSafeIntl();
 
     const taskHasDownloadableFile =
-        task.result && task.result.data && task.result.data.startsWith('file:');
+        task.result &&
+        task.result.data &&
+        (typeof task.result.data === 'string' ||
+            task.result.data instanceof String) &&
+        task.result.data.startsWith('file:');
 
     const { data } = useQuery(
         ['taskDetails', task.id],

--- a/hat/assets/js/apps/Iaso/domains/tasks/config.tsx
+++ b/hat/assets/js/apps/Iaso/domains/tasks/config.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from 'react';
 import { Chip } from '@mui/material';
+import ReplayIcon from '@mui/icons-material/Replay';
 import {
     IconButton,
     displayDateFromTimestamp,
@@ -51,6 +52,7 @@ type TaskColumn = Partial<Column> & { expander?: boolean; Expander?: any };
 
 export const useTasksTableColumns = (
     killTaskAction: UseMutateAsyncFunction<any, any, any, any>,
+    relaunchTaskAction: UseMutateAsyncFunction<any, any, any, any>,
     hasPolioNotificationsPerm: boolean,
 ): TaskColumn[] => {
     const { formatMessage } = useSafeIntl();
@@ -171,6 +173,17 @@ export const useTasksTableColumns = (
                                     tooltipMessage={MESSAGES.killTask}
                                 />
                             )}
+                        {settings.row.original.status === 'ERRORED' && (
+                            <IconButton
+                                onClick={() =>
+                                    relaunchTaskAction({
+                                        id: settings.row.original.id,
+                                    })
+                                }
+                                overrideIcon={ReplayIcon}
+                                tooltipMessage={MESSAGES.relaunch}
+                            />
+                        )}
                         {settings.row.original.should_be_killed === true &&
                             settings.row.original.status === 'RUNNING' &&
                             formatMessage(MESSAGES.killSignalSent)}
@@ -195,6 +208,11 @@ export const useTasksTableColumns = (
                 Expander,
             },
         ],
-        [formatMessage, hasPolioNotificationsPerm, killTaskAction],
+        [
+            formatMessage,
+            hasPolioNotificationsPerm,
+            killTaskAction,
+            relaunchTaskAction,
+        ],
     );
 };

--- a/hat/assets/js/apps/Iaso/domains/tasks/index.js
+++ b/hat/assets/js/apps/Iaso/domains/tasks/index.js
@@ -57,6 +57,13 @@ const Tasks = () => {
         ['tasks'],
     );
 
+    const { mutateAsync: relaunchTaskAction } = useSnackMutation(
+        task => patchRequest(`/api/tasks/${task.id}/relaunch/`, task),
+        MESSAGES.patchTaskSuccess,
+        MESSAGES.patchTaskError,
+        ['tasks'],
+    );
+
     const urlParams = {
         limit: params.pageSize ? params.pageSize : 10,
         order: params.order ? params.order : `-${defaultOrder}`,
@@ -79,6 +86,7 @@ const Tasks = () => {
 
     const columns = useTasksTableColumns(
         killTaskAction,
+        relaunchTaskAction,
         hasPolioNotificationsPerm,
     );
 

--- a/hat/assets/js/apps/Iaso/domains/tasks/messages.js
+++ b/hat/assets/js/apps/Iaso/domains/tasks/messages.js
@@ -106,6 +106,10 @@ const MESSAGES = defineMessages({
             "{count} error(s). The following data couldn't be imported.",
         id: 'iaso.tasks.polioNotificationImport.errors',
     },
+    relaunch: {
+        defaultMessage: 'Relaunch the task',
+        id: 'iaso.tasks.relaunch',
+    },
 });
 
 export default MESSAGES;

--- a/iaso/api/tasks/__init__.py
+++ b/iaso/api/tasks/__init__.py
@@ -128,6 +128,9 @@ class TaskSourceViewSet(ModelViewSet):
         current_user = request.user
 
         if current_user.has_perm(permission.DATA_TASKS) or task.launcher == request.user:
+            if task.status != ERRORED:
+                raise serializers.ValidationError({"status": f"You cannot relaunch a task with status {task.status}."})
+
             task.status = QUEUED
             task.launcher = current_user
             task.save()

--- a/iaso/api/tasks/__init__.py
+++ b/iaso/api/tasks/__init__.py
@@ -6,6 +6,7 @@ from django.utils.text import slugify
 from django.shortcuts import get_object_or_404
 from gql.transport.requests import RequestsHTTPTransport
 from gql import Client, gql
+from lazy_services import LazyService  # type: ignore
 from rest_framework import permissions, serializers, status
 from rest_framework.decorators import action
 from rest_framework.response import Response
@@ -13,10 +14,11 @@ from rest_framework.response import Response
 from iaso.models.json_config import Config
 from ..common import ModelViewSet, TimestampField, UserSerializer, HasPermission
 from hat.menupermissions import models as permission
-from iaso.models.base import ERRORED, RUNNING, SKIPPED, KILLED, SUCCESS, Task
+from iaso.models.base import ERRORED, RUNNING, SKIPPED, KILLED, SUCCESS, QUEUED, Task
 from iaso.utils.s3_client import generate_presigned_url_from_s3
 
 
+task_service = LazyService("BACKGROUND_TASK_SERVICE")
 logger = logging.getLogger(__name__)
 
 
@@ -87,7 +89,7 @@ class TaskSourceViewSet(ModelViewSet):
         return Task.objects.select_related("launcher").filter(account=profile.account).order_by(*order)
 
     def get_permissions(self):
-        if self.action == "retrieve":
+        if self.action in ["retrieve", "relaunch"]:
             # we handle additional permissions inside the action
             self.permission_classes = [permissions.IsAuthenticated]
         return super().get_permissions()
@@ -119,6 +121,29 @@ class TaskSourceViewSet(ModelViewSet):
             raise serializers.ValidationError(
                 {"presigned_url": "Could not create a presigned URL, are you sure the task generated a file?"}
             )
+
+    @action(detail=True, methods=["patch"], url_path="relaunch")
+    def relaunch(self, request, pk):
+        task = get_object_or_404(Task, pk=pk)
+        current_user = request.user
+
+        if current_user.has_perm(permission.DATA_TASKS) or task.launcher == request.user:
+            task.status = QUEUED
+            task.launcher = current_user
+            task.save()
+            task.queue_answer = task_service.enqueue(
+                module_name=task.params["module"],
+                method_name=task.params["method"],
+                args=task.params["args"],
+                kwargs=task.params["kwargs"],
+                task_id=task.id,
+            )
+            task.save()
+
+            serializer = self.get_serializer(task)
+            return Response(serializer.data)
+        else:
+            return Response(status=status.HTTP_403_FORBIDDEN)
 
 
 class ExternalTaskSerializer(TaskSerializer):

--- a/iaso/tasks/run_deduplication_algo.py
+++ b/iaso/tasks/run_deduplication_algo.py
@@ -16,6 +16,6 @@ def run_deduplication_algo(algo_name=None, algo_params=None, task=None):
 
     finished_at = datetime.now()
     the_duration = (finished_at - started_at).total_seconds()
-    task.report_success_with_result(f"Finished in {the_duration} seconds", results)
+    task.report_success_with_result(f"Finished in {the_duration} seconds")
 
     return results

--- a/iaso/tests/api/test_tasks.py
+++ b/iaso/tests/api/test_tasks.py
@@ -4,6 +4,7 @@ import time_machine
 from django.utils import timezone
 
 from iaso import models as m
+from iaso.models.base import ERRORED
 from iaso.api.tasks import TaskSerializer
 from iaso.test import APITestCase, TestCase
 
@@ -109,10 +110,10 @@ class IasoTasksTestCase(APITestCase):
         old_version = m.SourceVersion.objects.create(number=1, data_source=source)
         cls.new_version = m.SourceVersion.objects.create(number=2, data_source=source)
 
-        account = m.Account(name="Cobra Kai", default_version=cls.new_version)
-        account.save()
+        cls.account = m.Account(name="Cobra Kai", default_version=cls.new_version)
+        cls.account.save()
 
-        cls.project = m.Project(name="The Show", app_id="com.cobrakai.show", account=account)
+        cls.project = m.Project(name="The Show", app_id="com.cobrakai.show", account=cls.account)
         cls.project.save()
 
         org_unit_type = m.OrgUnitType(name="Dojo", short_name="dojo")
@@ -121,8 +122,10 @@ class IasoTasksTestCase(APITestCase):
         source.projects.add(cls.project)
         m.OrgUnit.objects.create(version=old_version, name="Myagi", org_unit_type=org_unit_type, source_ref="nomercy")
         cls.source = source
-        cls.johnny = cls.create_user_with_profile(username="johnny", account=account, permissions=["iaso_data_tasks"])
-        cls.miguel = cls.create_user_with_profile(username="miguel", account=account, permissions=[])
+        cls.johnny = cls.create_user_with_profile(
+            username="johnny", account=cls.account, permissions=["iaso_data_tasks"]
+        )
+        cls.miguel = cls.create_user_with_profile(username="miguel", account=cls.account, permissions=[])
 
     def test_tasks_user_without_permissions_access(self):
         self.client.force_authenticate(self.miguel)
@@ -138,7 +141,7 @@ class IasoTasksTestCase(APITestCase):
         task = m.Task.objects.create(
             progress_value=1,
             end_value=1,
-            account=self.johnny.iaso_profile.account,
+            account=self.account,
             launcher=self.johnny,
             status="Success",
             name="The best task",
@@ -163,6 +166,42 @@ class IasoTasksTestCase(APITestCase):
             launcher=self.miguel,
         )
         response = self.client.get(f"/api/tasks/{task_by_miguel.id}/")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["id"], task_by_miguel.id)
+
+        """
+        But not one launched by someone else
+        """
+        task_by_johnny = m.Task.objects.create(
+            account=self.johnny.iaso_profile.account,
+            launcher=self.johnny,
+        )
+        response = self.client.get(f"/api/tasks/{task_by_johnny.id}/")
+        self.assertEqual(response.status_code, 403)
+
+    def test_relaunch_own_task(self):
+        """
+        A user can relaunch a task they launched themselves
+        """
+        self.client.force_authenticate(self.miguel)
+
+        task_by_miguel = m.Task.objects.create(
+            account=self.miguel.iaso_profile.account,
+            launcher=self.miguel,
+            status=ERRORED,
+            params={
+                "args": [],
+                "kwargs": {
+                    "user_id": 1,
+                    "password": "XXXXXXXXXX",
+                    "project_id": self.project.id,
+                },
+                "method": "export_mobile_app_setup_for_user",
+                "module": "iaso.tasks.export_mobile_app_setup_for_user",
+            },
+        )
+
+        response = self.client.patch(f"/api/tasks/{task_by_miguel.id}/relaunch/")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["id"], task_by_miguel.id)
 


### PR DESCRIPTION
This PR:
- adds a relaunch button on the tasks page
- adds an API endpoint to allow relaunching a failed task. The task should be in status `ERRORED` and you should have the `TASKS` permission (or you are the launcher of the task) to be able to do this.

Related JIRA tickets : https://bluesquare.atlassian.net/browse/IA-3432

## How to test

Give yourself the tasks permission, launch a task (making sure it'll fail). See the relaunch button appear, click it.

## Print screen / video

![image](https://github.com/user-attachments/assets/0678dcf4-2aa0-45cf-ba5c-d1b0f3fe3d29)
