### PR TITLE
WC2-515: Integrate CIAM with multi-account setup

### DIFF
--- a/plugins/wfp_auth/views.py
+++ b/plugins/wfp_auth/views.py
@@ -17,6 +17,7 @@ from django.contrib.sites.shortcuts import get_current_site
 from django.core.exceptions import PermissionDenied
 from django.core.mail import EmailMultiAlternatives
 from django.http import HttpRequest, JsonResponse
+from django.shortcuts import get_object_or_404
 from django.template import loader
 from django.views.decorators.csrf import csrf_exempt
 from oauthlib.oauth2 import OAuth2Error
@@ -114,7 +115,7 @@ class WFP2Adapter(Auth0OAuth2Adapter):
         uid = extra_data["sub"].lower().strip()
         app_id = AppIdSerializer(data=self.request.query_params).get_app_id(raise_exception=False)
         if app_id:
-            account = Project.objects.get(app_id=app_id).account
+            account = get_object_or_404(Project, app_id=app_id).account
         else:
             account = Account.objects.get(name=self.settings["IASO_ACCOUNT_NAME"])
 


### PR DESCRIPTION
When connecting with CIAM, Iaso only connects you to the configured default account.
With the new multi-account setup, we need to be able to authenticate to different accounts based on the app_id

Related JIRA tickets: WC2-515

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well-documented
- [ ] Are there enough tests

## Changes

When exchanging the CIAM token for an Iaso token, Iaso will look for an `app_id` parameter, allowing it to connect to the correct account.

## How to test

We'll have to deploy it on DEV and test it there.


