### PR TITLE
WC2-511 Improve the handling of soft-deleted and/or merged entities

### DIFF
--- a/hat/assets/js/apps/Iaso/components/stars/StarSvgComponent.js
+++ b/hat/assets/js/apps/Iaso/components/stars/StarSvgComponent.js
@@ -7,6 +7,7 @@ function StarSvg(props) {
         <svg
             style={{
                 width: starWidth,
+                height: starWidth,
             }}
         >
             <g data-name="bg-star" className="bg-star">

--- a/hat/audit/models.py
+++ b/hat/audit/models.py
@@ -25,6 +25,7 @@ PAYMENT_LOT_API = "payment_lot_api"
 ORG_UNIT_CHANGE_REQUEST_API = "org_unit_change_request_api"
 DJANGO_ADMIN = "django_admin"
 BULK_UPLOAD = "bulk_upload"
+BULK_UPLOAD_MERGED_ENTITY = "bulk_upload_merged_entity"
 ENTITY_DUPLICATE_MERGE = "entity_duplicate_merge"
 
 

--- a/hat/audit/models.py
+++ b/hat/audit/models.py
@@ -24,6 +24,8 @@ PAYMENT_API = "payment_api"
 PAYMENT_LOT_API = "payment_lot_api"
 ORG_UNIT_CHANGE_REQUEST_API = "org_unit_change_request_api"
 DJANGO_ADMIN = "django_admin"
+BULK_UPLOAD = "bulk_upload"
+ENTITY_DUPLICATE_MERGE = "entity_duplicate_merge"
 
 
 def dict_compare(d1, d2):

--- a/iaso/api/common.py
+++ b/iaso/api/common.py
@@ -78,7 +78,7 @@ def safe_api_import(key: str, fallback_status=200):
                 with transaction.atomic():
                     response = f(self, api_import, request, *args, **kwargs)
             except Exception as e:
-                logger.error("Exception" + str(e))  # For logs
+                logger.exception("Exception" + str(e))  # For logs
                 api_import.has_problem = True
                 api_import.exception = format_exc()
                 response = Response({"res": "a problem happened, but your data was saved"}, status=fallback_status)

--- a/iaso/api/deduplication/entity_duplicate.py
+++ b/iaso/api/deduplication/entity_duplicate.py
@@ -1,7 +1,7 @@
 from logging import getLogger
 import math
 import xml.etree.ElementTree as ET
-from copy import deepcopy
+from copy import copy, deepcopy
 from typing import Dict, Optional
 from uuid import UUID, uuid4
 
@@ -17,6 +17,7 @@ from rest_framework.decorators import action
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from hat.audit.models import ENTITY_DUPLICATE_MERGE, log_modification
 import iaso.api.deduplication.filters as dedup_filters  # type: ignore
 import iaso.models.base as base
 from iaso.api.common import HasPermission, Paginator
@@ -240,7 +241,7 @@ def copy_instance(inst: Instance, new_entity: Entity):
     return new_inst
 
 
-def merge_entities(e1: Entity, e2: Entity, merge_def: Dict):
+def merge_entities(e1: Entity, e2: Entity, merge_def: Dict, current_user):
     new_entity_uuid = uuid4()
     new_attributes = merge_attributes(e1, e2, new_entity_uuid, merge_def)
 
@@ -262,11 +263,16 @@ def merge_entities(e1: Entity, e2: Entity, merge_def: Dict):
     for inst in e2.instances.exclude(id=e2.attributes_id):
         copy_instance(inst, new_entity)
 
-    if e1.attributes is not None:
-        e1.attributes.soft_delete()
-
-    if e2.attributes is not None:
-        e2.attributes.soft_delete()
+    instances_to_soft_delete = [
+        e1.attributes,
+        e2.attributes,
+        *e1.instances.all(),
+        *e2.instances.all(),
+    ]
+    for inst in set(instances_to_soft_delete):  # use set() to remove duplicates
+        original = copy(inst)
+        inst.soft_delete()
+        log_modification(original, inst, ENTITY_DUPLICATE_MERGE, user=current_user)
 
     e1.merged_to = new_entity
     e1.save()
@@ -275,12 +281,6 @@ def merge_entities(e1: Entity, e2: Entity, merge_def: Dict):
 
     e1.delete()
     e2.delete()
-
-    for inst in e1.instances.all():
-        inst.soft_delete()
-
-    for inst in e2.instances.all():
-        inst.soft_delete()
 
     return new_entity
 
@@ -355,7 +355,22 @@ class EntityDuplicatePostSerializer(serializers.Serializer):
             e1 = validated_data["entity1"]
             e2 = validated_data["entity2"]
 
-            new_entity = merge_entities(e1, e2, validated_data["merge"])
+            current_user = self.context.get("request").user
+            new_entity = merge_entities(e1, e2, validated_data["merge"], current_user)
+
+            # Leave audit trail from both entity reference forms to the new merged one
+            log_modification(
+                e1.attributes,
+                new_entity.attributes,
+                ENTITY_DUPLICATE_MERGE,
+                user=current_user,
+            )
+            log_modification(
+                e2.attributes,
+                new_entity.attributes,
+                ENTITY_DUPLICATE_MERGE,
+                user=current_user,
+            )
 
             # needs to add the id of the new entity as metadata to the entity duplicate
             ed.metadata["new_entity_id"] = new_entity.pk

--- a/iaso/api/deduplication/entity_duplicate.py
+++ b/iaso/api/deduplication/entity_duplicate.py
@@ -255,7 +255,7 @@ def merge_entities(e1: Entity, e2: Entity, merge_def: Dict, current_user: User):
     )
 
     new_entity.save()
-    new_attributes.entity_id = new_entity.id
+    new_attributes.entity = new_entity
     new_attributes.save()
 
     for inst in e1.instances.exclude(id=e1.attributes_id):

--- a/iaso/api/deduplication/entity_duplicate.py
+++ b/iaso/api/deduplication/entity_duplicate.py
@@ -5,6 +5,7 @@ from copy import copy, deepcopy
 from typing import Dict, Optional
 from uuid import UUID, uuid4
 
+from django.contrib.auth.models import User
 from django.core.files.base import ContentFile
 from django.db.models import Q
 from django.http import JsonResponse
@@ -241,7 +242,7 @@ def copy_instance(inst: Instance, new_entity: Entity):
     return new_inst
 
 
-def merge_entities(e1: Entity, e2: Entity, merge_def: Dict, current_user):
+def merge_entities(e1: Entity, e2: Entity, merge_def: Dict, current_user: User):
     new_entity_uuid = uuid4()
     new_attributes = merge_attributes(e1, e2, new_entity_uuid, merge_def)
 

--- a/iaso/api/instances.py
+++ b/iaso/api/instances.py
@@ -722,7 +722,6 @@ def import_data(instances, user, app_id):
             entity, created = Entity.objects_include_deleted.get_or_create(
                 uuid=entityUuid, entity_type_id=entityTypeId, account=project.account
             )
-            instance.entity = entity
 
             if entity.deleted_at:
                 logger.info(
@@ -731,7 +730,19 @@ def import_data(instances, user, app_id):
                     instance.uuid,
                     instance.name,
                 )
-                instance.deleted = True
+                if entity.merged_to:
+                    active_entity = entity.merged_to
+                    logger.info(
+                        f"Adding new instance %s %s to merged entity %s",
+                        instance.uuid,
+                        instance.name,
+                        active_entity.uuid,
+                    )
+                    entity = active_entity
+                else:
+                    instance.deleted = True
+
+            instance.entity = entity
 
             # If instance's form is the same as the type reference form, set the instance as reference_instance
             if entity.entity_type.reference_form == instance.form:

--- a/iaso/api/instances.py
+++ b/iaso/api/instances.py
@@ -732,6 +732,8 @@ def import_data(instances, user, app_id):
                 )
                 if entity.merged_to:
                     active_entity = entity.merged_to
+                    while active_entity.deleted_at and active_entity.merged_to:
+                        active_entity = active_entity.merged_to
                     logger.info(
                         f"Adding new instance %s %s to merged entity %s",
                         instance.uuid,

--- a/iaso/api/instances.py
+++ b/iaso/api/instances.py
@@ -720,7 +720,12 @@ def import_data(instances, user, app_id):
             instance.entity = entity
 
             if entity.deleted_at:
-                logger.info(f"Entity %s was soft-deleted (%s)", entity.uuid, str(entity.deleted_at))
+                logger.info(
+                    f"Entity %s is soft-deleted for instance %s %s",
+                    entity.uuid,
+                    instance.uuid,
+                    instance.name,
+                )
                 instance.deleted = True
 
             # If instance's form is the same as the type reference form, set the instance as reference_instance

--- a/iaso/models/base.py
+++ b/iaso/models/base.py
@@ -1031,7 +1031,7 @@ class Instance(models.Model):
         ]
 
     def __str__(self):
-        return "%s %s" % (self.form, self.name)
+        return "%s %s %s" % (self.id, self.form, self.name)
 
     @property
     def is_instance_of_reference_form(self) -> bool:

--- a/iaso/models/base.py
+++ b/iaso/models/base.py
@@ -5,7 +5,6 @@ import random
 import re
 import time
 import typing
-from copy import copy
 from functools import reduce
 from io import StringIO
 from logging import getLogger
@@ -1341,17 +1340,13 @@ class Instance(models.Model):
             "correlation_id": self.correlation_id,
         }
 
-    def soft_delete(self, user: typing.Optional[User] = None):
-        original = copy(self)
+    def soft_delete(self):
         self.deleted = True
         self.save()
-        log_modification(original, self, INSTANCE_API, user=user)
 
-    def restore(self, user: typing.Optional[User] = None):
-        original = copy(self)
+    def restore(self):
         self.deleted = False
         self.save()
-        log_modification(original, self, INSTANCE_API, user=user)
 
     def can_user_modify(self, user):
         """Check only for lock, assume user have other perms"""

--- a/iaso/tasks/process_mobile_bulk_upload.py
+++ b/iaso/tasks/process_mobile_bulk_upload.py
@@ -87,7 +87,7 @@ def process_mobile_bulk_upload(api_import_id, project_id, task=None):
                 stats["new_instance_files"] = len(new_instance_files) + duplicated_count
 
     except Exception as e:
-        logger.error("Exception! Rolling back import: " + str(e))
+        logger.exception("Exception! Rolling back import: " + str(e))
         api_import.has_problem = True
         api_import.exception = format_exc()
         api_import.save()

--- a/iaso/tasks/process_mobile_bulk_upload.py
+++ b/iaso/tasks/process_mobile_bulk_upload.py
@@ -170,6 +170,9 @@ def update_merged_entity_ref_form_if_needed(instance, incoming_updated_at, file,
         return
 
     active_entity = entity.merged_to
+    while active_entity.deleted_at and active_entity.merged_to:
+        active_entity = active_entity.merged_to
+
     if entity.attributes == instance and incoming_updated_at > active_entity.attributes.source_updated_at:
         instance_to_update = active_entity.attributes
         logger.info(

--- a/iaso/tests/api/test_deleted_entities.py
+++ b/iaso/tests/api/test_deleted_entities.py
@@ -81,7 +81,7 @@ class EntityAPITestCase(APITestCase):
         self.entity2.attributes = instance2
         self.entity2.save()
 
-        new_entity = merge_entities(self.entity1, self.entity2, {})
+        new_entity = merge_entities(self.entity1, self.entity2, {}, self.user)
 
         self.client.force_authenticate(self.user)
 

--- a/iaso/tests/api/test_deleted_entities.py
+++ b/iaso/tests/api/test_deleted_entities.py
@@ -1,4 +1,5 @@
 from django.contrib.auth.models import AnonymousUser
+from django.core.files import File
 
 from iaso import models as m
 from iaso.models import Entity, EntityType, Instance
@@ -69,17 +70,18 @@ class EntityAPITestCase(APITestCase):
 
     def test_get_merged_entities(self):
         # Add proper attributes or the merge will fail
-        instance1 = Instance.objects.create(form=self.form, period="202002")
-        instance1.entity = self.entity1
-        instance1.save()
-        self.entity1.attributes = instance1
-        self.entity1.save()
+        with open("iaso/fixtures/instance_form_1_1.xml", "rb") as f:
+            instance1 = Instance.objects.create(form=self.form, period="202002", file=File(f))
+            instance1.entity = self.entity1
+            instance1.save()
+            self.entity1.attributes = instance1
+            self.entity1.save()
 
-        instance2 = Instance.objects.create(form=self.form, period="202002")
-        instance2.entity = self.entity2
-        instance2.save()
-        self.entity2.attributes = instance2
-        self.entity2.save()
+            instance2 = Instance.objects.create(form=self.form, period="202002", file=File(f))
+            instance2.entity = self.entity2
+            instance2.save()
+            self.entity2.attributes = instance2
+            self.entity2.save()
 
         new_entity = merge_entities(self.entity1, self.entity2, {}, self.user)
 

--- a/iaso/tests/fixtures/mobile_bulk_uploads/disasi_only/3f0ed68e-bfcf-4395-a2a5-a5821390ae1b/20_56_bd75c228-ee48-4df6-9226-d6360d0e6b6c_2024-04-05_16-08-56.xml
+++ b/iaso/tests/fixtures/mobile_bulk_uploads/disasi_only/3f0ed68e-bfcf-4395-a2a5-a5821390ae1b/20_56_bd75c228-ee48-4df6-9226-d6360d0e6b6c_2024-04-05_16-08-56.xml
@@ -1,0 +1,61 @@
+<?xml version='1.0'?>
+<data id="trypelim_registration" version="2024032701" xmlns:h="http://www.w3.org/1999/xhtml"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa"
+    xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:orx="http://openrosa.org/xforms"
+    xmlns:odk="http://www.opendatakit.org/xforms">
+    <Registration>
+        <last_name>Makulo</last_name>
+        <post_name />
+        <first_name>Disasi</first_name>
+        <mother_last_name>t</mother_last_name>
+        <_full_name>Disasi Makulo</_full_name>
+        <phone_number />
+        <gender>F</gender>
+    </Registration>
+    <birth_group>
+        <birth_year_is_known>no</birth_year_is_known>
+    </birth_group>
+    <residency_group>
+        <residency_type>resident</residency_type>
+    </residency_group>
+    <profession_group>
+        <profession_type>unemployed</profession_type>
+    </profession_group>
+    <repeat_case_group>
+        <repeat_case_type>no</repeat_case_type>
+    </repeat_case_group>
+    <is_absent>0</is_absent>
+    <first_test_done>1</first_test_done>
+    <is_suspect>1</is_suspect>
+    <is_not_done>0</is_not_done>
+    <clinical_signs_done>0</clinical_signs_done>
+    <has_clinical_signs>0</has_clinical_signs>
+    <is_confirmed_positive>0</is_confirmed_positive>
+    <is_confirmed_negative>0</is_confirmed_negative>
+    <is_trypanolyse_positive>0</is_trypanolyse_positive>
+    <is_qpcr_positive>0</is_qpcr_positive>
+    <trypelim_profile>UM</trypelim_profile>
+    <confirmation_pg_done>0</confirmation_pg_done>
+    <test_ctcwoo_done>0</test_ctcwoo_done>
+    <test_maect_done>0</test_maect_done>
+    <confirmation_pg_not_done>0</confirmation_pg_not_done>
+    <test_ctcwoo_not_done>0</test_ctcwoo_not_done>
+    <test_maect_not_done>0</test_maect_not_done>
+    <plresearch_not_done>0</plresearch_not_done>
+    <stade>0</stade>
+    <white_cells_count>0</white_cells_count>
+    <presence_trypanosomes>0</presence_trypanosomes>
+    <pl_stad_presence_trypanosome>0</pl_stad_presence_trypanosome>
+    <pl_stad_is_not_done>0</pl_stad_is_not_done>
+    <pl_stad_globules_blanc>0</pl_stad_globules_blanc>
+    <pl_stad_is_done>0</pl_stad_is_done>
+    <is_treatment_ongoing>0</is_treatment_ongoing>
+    <number_of_previous_treatments>0</number_of_previous_treatments>
+    <infection_location>0</infection_location>
+    <infection_type_selected>0</infection_type_selected>
+    <manque_confirmation_done>0</manque_confirmation_done>
+    <is_deceased>0</is_deceased>
+    <meta>
+        <instanceID>uuid:63e653b6-bca1-4a6d-93d9-6db455c342db</instanceID>
+    </meta>
+</data>

--- a/iaso/tests/fixtures/mobile_bulk_uploads/disasi_only/a5362052-408f-44f8-8abc-2a520c01ea10/16_12_127775b2-06a2-4ae6-b2bd-cf64143a9dfe_2024-04-05_16-09-42.xml
+++ b/iaso/tests/fixtures/mobile_bulk_uploads/disasi_only/a5362052-408f-44f8-8abc-2a520c01ea10/16_12_127775b2-06a2-4ae6-b2bd-cf64143a9dfe_2024-04-05_16-09-42.xml
@@ -1,0 +1,23 @@
+<?xml version='1.0'?>
+<data id="trypelim_CATT" version="2024031801" xmlns:ev="http://www.w3.org/2001/xml-events"
+    xmlns:orx="http://openrosa.org/xforms" xmlns:odk="http://www.opendatakit.org/xforms"
+    xmlns:h="http://www.w3.org/1999/xhtml" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns:jr="http://openrosa.org/javarosa">
+    <trypelim_profile>UM</trypelim_profile>
+    <serie_id>ad893d6d-355f-4ffe-a575-cea6bbe5914f</serie_id>
+    <CATT>
+        <absent>no</absent>
+        <position>1</position>
+        <result>positive</result>
+    </CATT>
+    <quality_control_group>
+        <rdt_control_picture>1712326156339.png</rdt_control_picture>
+    </quality_control_group>
+    <is_suspect>1</is_suspect>
+    <is_not_done>0</is_not_done>
+    <first_test_done>1</first_test_done>
+    <is_absent>0</is_absent>
+    <meta>
+        <instanceID>uuid:03b91754-6b59-4cb4-b786-aef7690c8a48</instanceID>
+    </meta>
+</data>

--- a/iaso/tests/fixtures/mobile_bulk_uploads/disasi_only/instances.json
+++ b/iaso/tests/fixtures/mobile_bulk_uploads/disasi_only/instances.json
@@ -1,0 +1,32 @@
+[
+    {
+        "id": "a5362052-408f-44f8-8abc-2a520c01ea10",
+        "created_at": 1.71232618245e9,
+        "updated_at": 1.71232618245e9,
+        "file": "/storage/emulated/0/Android/data/org.bluesquare/files/Documents/instances/16_12_2024-04-05_16-09-42/16_12_127775b2-06a2-4ae6-b2bd-cf64143a9dfe_2024-04-05_16-09-42.xml",
+        "name": "CATT",
+        "formId": "2",
+        "orgUnitId": "9dcb6991-c72c-416d-ba38-4556c62b400f",
+        "entityUuid": "3f0ed68e-bfcf-4395-a2a5-a5821390ae1b",
+        "entityTypeId": "1",
+        "latitude": 50.6429501,
+        "longitude": 4.6004282,
+        "altitude": 128.3000030517578,
+        "accuracy": 12.74
+    },
+    {
+        "id": "3f0ed68e-bfcf-4395-a2a5-a5821390ae1b",
+        "created_at": 1.712326150005e9,
+        "updated_at": 1.712326150005e9,
+        "file": "/storage/emulated/0/Android/data/org.bluesquare/files/Documents/instances/20_56_2024-04-05_16-08-56/20_56_bd75c228-ee48-4df6-9226-d6360d0e6b6c_2024-04-05_16-08-56.xml",
+        "name": "Enregistrement",
+        "formId": "1",
+        "orgUnitId": "9dcb6991-c72c-416d-ba38-4556c62b400f",
+        "entityUuid": "3f0ed68e-bfcf-4395-a2a5-a5821390ae1b",
+        "entityTypeId": "1",
+        "latitude": 50.6429429,
+        "longitude": 4.6004524,
+        "altitude": 128.3000030517578,
+        "accuracy": 14.929
+    }
+]

--- a/iaso/tests/fixtures/mobile_bulk_uploads/disasi_only/orgUnits.json
+++ b/iaso/tests/fixtures/mobile_bulk_uploads/disasi_only/orgUnits.json
@@ -1,0 +1,16 @@
+[
+    {
+        "id": "9dcb6991-c72c-416d-ba38-4556c62b400f",
+        "accuracy": 12.884,
+        "altitude": 128.3000030517578,
+        "latitude": 50.6429494,
+        "longitude": 4.6004297,
+        "name": "New Org Unit",
+        "validation_status": "",
+        "org_unit_type_id": "5",
+        "parent_id": "4",
+        "time": 1712326428477,
+        "created_at": 1.712326429884e9,
+        "updated_at": 1.712326429884e9
+    }
+]

--- a/iaso/tests/models/test_instance.py
+++ b/iaso/tests/models/test_instance.py
@@ -520,40 +520,13 @@ class InstanceModelTestCase(TestCase, InstanceBase):
 
         return (alderaan, sluis, dagobah, first_council, second_council, first_academy, second_academy)
 
-    def test_org_unit_soft_delete_no_one(self):
+    def test_org_unit_soft_delete(self):
         instance = self.create_form_instance(
             form=self.form_1, period="202001", org_unit=self.jedi_council_coruscant, project=None
         )
-
         self.assertFalse(instance.deleted)
-        self.assertEqual(0, Modification.objects.count())
-
         instance.soft_delete()
-
         self.assertTrue(instance.deleted)
-        self.assertEqual(1, Modification.objects.count())
-        modification = Modification.objects.first()
-        self.assertIsNone(modification.user)
-        self.assertEqual(INSTANCE_API, modification.source)
-        self.assertEqual(instance.id, int(modification.object_id))
-        self.assertNotEqual(modification.past_value, modification.new_value)
-        self.assertFalse(modification.past_value[0]["fields"]["deleted"])
-        self.assertTrue(modification.new_value[0]["fields"]["deleted"])
-
-    def test_org_unit_soft_delete_someone(self):
-        instance = self.create_form_instance(
-            form=self.form_1, period="202002", org_unit=self.jedi_council_coruscant, project=None
-        )
-
-        self.assertFalse(instance.deleted)
-        self.assertEqual(0, Modification.objects.count())
-
-        instance.soft_delete(user=self.yoda)
-
-        self.assertTrue(instance.deleted)
-        self.assertEqual(1, Modification.objects.count())
-        modification = Modification.objects.first()
-        self.assertEqual(self.yoda, modification.user)
 
 
 class InstanceAPITestCase(APITestCase, InstanceBase):


### PR DESCRIPTION
Quite a few changes here:

### Bulk upload: correcly handle incoming data for soft-deleted and merged entities

Upon an incoming entity, there are several options:

1. New entity: regular flow
2. Existing entity:
	a. Non-deleted entity: add new forms, update reference form if timestamp more recent
	b. Soft-deleted entity X:
		- If because of merge:
			1. Find the "active" entity and add new forms on this entity
			2. If X's ref form is updated, also update the "active" entities reference form
		- If not because of merge: Add/update forms with status deleted

*Some clarification with an example:

1. Consider entity A,  B and C
3. We merge A and B into D
4. Now we merge C and D into E
5. When we receive data from the mobile app for entity A, we:
	- Add data to A (everything with status soft-deleted)
	- Add data to D (everything with status soft-deleted)
	- Add new submissions to E
	- Update any forms that have a newer timestamp
	- If a reference form is updated on A, then we also update E's reference form (if the timestamp is newer). (By update we mean the XML file, data such as the UUID)
	
### Audit logging

Because things get complex, it's important we can figure out where data changes came from. To this end:
  - Correctly log instance modification on entity merge. We didn't keep an audit trail on these actions. Refactored a bit to put the logging in the instances API instead of directly on the `soft_delete()` method. There can be multiple sources of soft delete, this allows us to be more granular.
  - Add audit logging to bulk upload form updates (and differentiate between a regular one and a merged entity, can be useful for displaying advance version histories in the future)

Related JIRA tickets : https://bluesquare.atlassian.net/browse/WC2-511

## How to test

Complicated, but to really test this you need to:
1. Get a Iaso app with bulk upload enabled (e.g. the WFP CODA2 app)
2. Enable developer mode and change the server URL to your localhost (e.g. with ngrok)
3. Have your localhost setup with some entity types etc (with setuper it works well)
4. Create 2 entities with the same name on your mobile device
5. Launch the duplicate detection algo
6. Merge the 2 entities, your mobile device will not be aware of this
7. Add a form on your phone's entity (either one of the two) and sync to server
8. You should now see that the file was correctly attached to the merged entity