### PR TITLE
IA-3438: Restricted project

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/users/components/UsersInfos.js
+++ b/hat/assets/js/apps/Iaso/domains/users/components/UsersInfos.js
@@ -1,16 +1,17 @@
 /* eslint-disable no-param-reassign */
-import React, { useCallback } from 'react';
-import PropTypes from 'prop-types';
-import isEmpty from 'lodash/isEmpty';
 import { Grid } from '@mui/material';
 import { useSafeIntl } from 'bluesquare-components';
+import isEmpty from 'lodash/isEmpty';
+import PropTypes from 'prop-types';
+import React, { useCallback, useMemo } from 'react';
 import InputComponent from '../../../components/forms/InputComponent.tsx';
 import { APP_LOCALES } from '../../app/constants';
 
 import { useGetProjectsDropdownOptions } from '../../projects/hooks/requests.ts';
 
-import MESSAGES from '../messages.ts';
 import { InputWithInfos } from '../../../components/InputWithInfos.tsx';
+import { useCurrentUser } from '../../../utils/usersUtils.ts';
+import MESSAGES from '../messages.ts';
 
 const UsersInfos = ({
     setFieldValue,
@@ -18,6 +19,7 @@ const UsersInfos = ({
     initialData,
     allowSendEmailInvitation,
 }) => {
+    const loggedUser = useCurrentUser();
     const { formatMessage } = useSafeIntl();
     const isEmailAdressExist = isEmpty(currentUser.email.value);
     const sendUserEmailInvitation = !!isEmailAdressExist;
@@ -38,6 +40,21 @@ const UsersInfos = ({
     }
     const { data: allProjects, isFetching: isFetchingProjects } =
         useGetProjectsDropdownOptions();
+
+    const availableProjects = useMemo(() => {
+        if (!loggedUser || !loggedUser.projects) {
+            return [];
+        }
+        if (loggedUser.projects.length === 0) {
+            return allProjects;
+        }
+        return loggedUser.projects.map(project => {
+            return {
+                value: project.id.toString(),
+                label: project.name,
+            };
+        });
+    }, [allProjects, loggedUser]);
 
     const isInitialDataEmpty = isEmpty(initialData)
         ? MESSAGES.password
@@ -151,7 +168,7 @@ const UsersInfos = ({
                         type="select"
                         multi
                         label={MESSAGES.projects}
-                        options={allProjects}
+                        options={availableProjects}
                         loading={isFetchingProjects}
                     />
                     <InputComponent


### PR DESCRIPTION
When we have a local "admin" user who is himself restricted to one project and has user geo permissions, I would expect this user to be able to create new users for their OU children within the same project. However, all the projects gets listed in the dropdown.

Related JIRA tickets : IA-3438

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

If the current user has a list of limited projects, we use those one's in the list of projects while creating a new user.

## How to test

Log in as Admin A:
Ensure that Admin A is limited to specific projects, for example, projects X and Y.

Create a New User:
Using Admin A's account, go to the user management section and initiate the creation of a new user (User B).
Observe the list of projects available for assignment.
Verify Project List:

Confirm that only projects X and Y are available in the project list.
Ensure that no other projects are visible or selectable.


## Print screen / video

Admin profile:
![Screenshot 2024-09-19 at 12 50 58](https://github.com/user-attachments/assets/c5e3936f-ae81-4bbb-ab28-3a566d0d85c2)

Creating user with admin profile:
![Screenshot 2024-09-19 at 12 51 49](https://github.com/user-attachments/assets/82527953-4e9e-44b4-b789-ef2edaa2c196)



