### PR TITLE
WC2-503 Fix: Avoid deleted entities in duplicate analysis

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/entities/constants.ts
+++ b/hat/assets/js/apps/Iaso/domains/entities/constants.ts
@@ -1,5 +1,5 @@
 export const ALGORITHM_DROPDOWN = [
-    { label: 'namesim', value: 'namesim' },
     { label: 'levenshtein', value: 'levenshtein' },
-    { label: 'invert', value: 'invert' },
+    // { label: 'namesim', value: 'namesim' },
+    // { label: 'invert', value: 'invert' },
 ];

--- a/hat/audit/models.py
+++ b/hat/audit/models.py
@@ -23,6 +23,7 @@ PAYMENT_API_BULK = "payment_api_bulk"
 PAYMENT_API = "payment_api"
 PAYMENT_LOT_API = "payment_lot_api"
 ORG_UNIT_CHANGE_REQUEST_API = "org_unit_change_request_api"
+DJANGO_ADMIN = "django_admin"
 
 
 def dict_compare(d1, d2):

--- a/iaso/api/deduplication/entity_duplicate.py
+++ b/iaso/api/deduplication/entity_duplicate.py
@@ -292,14 +292,17 @@ class EntityDuplicatePostSerializer(serializers.Serializer):
         try:
             entity1 = Entity.objects.get(pk=data["entity1_id"])
         except Entity.DoesNotExist:
+            logger.exception(f"Entity merge failed: entity 1 does not exist: {data}")
             raise serializers.ValidationError("Entity 1 does not exist")
 
         try:
             entity2 = Entity.objects.get(pk=data["entity2_id"])
         except Entity.DoesNotExist:
+            logger.exception(f"Entity merge failed: entity 2 does not exist: {data}")
             raise serializers.ValidationError("Entity 2 does not exist")
 
         if entity1.entity_type != entity2.entity_type:
+            logger.exception(f"Entity merge failed: Entities must be of the same type: {data}")
             raise serializers.ValidationError("Entities must be of the same type")
 
         if data["ignore"] == False:  # merge the duplicates


### PR DESCRIPTION
The algorithm already correctly excludes soft-deleted entities. The issue is when an entity was soft-deleted, its pending duplicate entities were not, resulting in errors upon merging.

**At the moment, the only way to soft-delete an entity is via the Django admin, so that's where we corrected this.**

Related JIRA tickets : https://bluesquare.atlassian.net/browse/WC2-503

## The fix

Override Entity Django admin delete: The Django admin delete simply called `delete()` on the entity. This commit overrides the default Django admin function and:

- soft delete the entity
- soft delete its attached form instances
- delete potential EntityDuplicates

Also: 
- Removed other duplcite algos from dropdown in the frontend. At the moment, only levenshtein is supported.
- Send a Sentry when merging soft-deleted entities. This shouldn't happen.

## How to test

Hit "Delete" button for an entity in the Django admin.