### PR TITLE
IA-3146-bis: adding support for webp image

### DIFF
--- a/iaso/api/instances.py
+++ b/iaso/api/instances.py
@@ -4,7 +4,6 @@ import ntpath
 from time import gmtime, strftime
 from typing import Any, Dict, Union
 
-
 import pandas as pd
 from django.contrib.auth.models import User
 from django.contrib.gis.geos import Point
@@ -179,7 +178,7 @@ class InstancesViewSet(viewsets.ViewSet):
 
         image_only = request.GET.get("image_only", "false").lower() == "true"
         if image_only:
-            image_extensions = ["jpg", "jpeg", "png", "gif", "bmp", "tiff"]
+            image_extensions = ["jpg", "jpeg", "png", "gif", "bmp", "tiff", "webp"]
             queryset = queryset.filter(file_extension__in=image_extensions)
 
         paginator = common.Paginator()


### PR DESCRIPTION
webp are filtered out while filtering attachment with image only

Related JIRA tickets : IA-3146

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

added webp to list of possible extensions

## How to test

You need  a webp image and create one instance files linked to an instance that is linked to an org unit.
YOu can do it using the admin or with enketo and a form using images. 


