### PR TITLE
POLIO-1682: Polio filter does not filter on polio campaigns on RRT hub

### DIFF
--- a/plugins/polio/js/src/domains/Calendar/campaignCalendar/CampaignsFilters.tsx
+++ b/plugins/polio/js/src/domains/Calendar/campaignCalendar/CampaignsFilters.tsx
@@ -33,9 +33,14 @@ type Props = {
     disableOnlyDeleted?: boolean;
     isCalendar?: boolean;
     isEmbedded?: boolean;
+    setCampaignType: React.Dispatch<React.SetStateAction<string>>;
+    campaignType?: string;
 };
 
-const getRedirectUrl = (isCalendar: boolean, isEmbedded: boolean): string => {
+export const getRedirectUrl = (
+    isCalendar: boolean,
+    isEmbedded: boolean,
+): string => {
     if (isCalendar && isEmbedded) {
         return baseUrls.embeddedCalendar;
     }
@@ -51,6 +56,8 @@ export const CampaignsFilters: FunctionComponent<Props> = ({
     disableOnlyDeleted = false,
     isCalendar = false,
     isEmbedded = false,
+    setCampaignType,
+    campaignType,
 }) => {
     const redirectUrl = getRedirectUrl(isCalendar, isEmbedded);
     const redirectToReplace = useRedirectToReplace();
@@ -58,9 +65,6 @@ export const CampaignsFilters: FunctionComponent<Props> = ({
     const [filtersUpdated, setFiltersUpdated] = useState(false);
     const [countries, setCountries] = useState(params.countries);
     const [orgUnitGroups, setOrgUnitGroups] = useState(params.orgUnitGroups);
-    const [campaignType, setCampaignType] = useState(
-        isEmbedded ? params.campaignType ?? 'polio' : params.campaignType,
-    );
     const [campaignCategory, setCampaignCategory] = useState(
         isEmbedded ? params.campaignCategory ?? 'all' : params.campaignCategory,
     );
@@ -95,6 +99,7 @@ export const CampaignsFilters: FunctionComponent<Props> = ({
         if (filtersUpdated) {
             setFiltersUpdated(false);
             const urlParams = {
+                ...params,
                 countries,
                 search: search && search !== '' ? search : undefined,
                 roundStartFrom:
@@ -117,6 +122,7 @@ export const CampaignsFilters: FunctionComponent<Props> = ({
         }
     }, [
         filtersUpdated,
+        params,
         countries,
         search,
         roundStartFrom,
@@ -127,7 +133,6 @@ export const CampaignsFilters: FunctionComponent<Props> = ({
         campaignGroups,
         orgUnitGroups,
         filtersFilled,
-        params?.periodType,
         notShowTest,
         redirectToReplace,
         redirectUrl,


### PR DESCRIPTION
Campaign page should always filter with polio set as default value.
On /dashboard/polio/embeddedCalendar/ too

Explain what problem this PR is resolving

Related JIRA tickets :POLIO-1682

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

Redirect  to `campaignType/polio` if no `campaignType`


## How to test

Open `/dashboard/polio/embeddedCalendar/`, you should be redirect to `/dashboard/polio/embeddedCalendar/campaignType/polio`.
check that only polio campaigns are displayed, play with filters.

## Print screen / video


https://github.com/user-attachments/assets/5763ff8c-b35c-4b83-aaff-7eabf4898aa0

