### PR TITLE
IA3451: History on OrgUnit doesn't work anymore on staging

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/users/history/UserHistoryLogDetails.tsx
+++ b/hat/assets/js/apps/Iaso/domains/users/history/UserHistoryLogDetails.tsx
@@ -1,11 +1,11 @@
-import React, { FunctionComponent } from 'react';
+import { Container, Grid } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 import {
     LoadingSpinner,
     commonStyles,
     useSafeIntl,
 } from 'bluesquare-components';
-import { Container, Grid } from '@mui/material';
-import { makeStyles } from '@mui/styles';
+import React, { FunctionComponent } from 'react';
 import { useGetLogDetails } from '../../../hooks/useGetLogDetails';
 import MESSAGES from '../messages';
 import { UserLogCompare } from './UserLogCompare';
@@ -26,7 +26,10 @@ type Props = {
 export const UserHistoryLogDetails: FunctionComponent<Props> = ({ logId }) => {
     const { formatMessage } = useSafeIntl();
     const classes = useStyles();
-    const { data: log, isFetching: loading } = useGetLogDetails(logId);
+    const { data: log, isFetching: loading } = useGetLogDetails(
+        logId,
+        'userlogs',
+    );
     return (
         <Container maxWidth={false} className={classes.root}>
             {loading && <LoadingSpinner />}

--- a/hat/assets/js/apps/Iaso/hooks/useGetLogDetails.tsx
+++ b/hat/assets/js/apps/Iaso/hooks/useGetLogDetails.tsx
@@ -4,10 +4,11 @@ import { useSnackQuery } from '../libs/apiHooks';
 
 export const useGetLogDetails = (
     logId: string | number,
+    apiKey = 'logs',
 ): UseQueryResult<any> => {
     return useSnackQuery({
-        queryKey: ['log-details', logId],
-        queryFn: () => getRequest(`/api/userlogs/${logId}/`),
+        queryKey: [apiKey, logId],
+        queryFn: () => getRequest(`/api/${apiKey}/${logId}/`),
         options: {
             keepPreviousData: true,
             staleTime: 60000,


### PR DESCRIPTION
Details call to logs is not working anymore on org units

Related JIRA tickets : IA-3451

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)


## Changes

Use `userlogs` or `logs` while using `useGetLogDetails`

## How to test

Open org unit logs and open the detail.
Make the same using on users logs
Both should work

