### PR TITLE
POLIO-1687 Filter by campaign and round date

### DIFF
--- a/plugins/polio/api/dashboards/supply_chain.py
+++ b/plugins/polio/api/dashboards/supply_chain.py
@@ -111,7 +111,7 @@ class VaccineRequestFormDashboardSerializer(serializers.ModelSerializer):
         if first_round_start_date is not None and next_campaign_start_date is not None:
             sel_qs = DestructionReport.objects.filter(
                 vaccine_stock=vaccine_stock,
-                rrt_destruction_report_reception_date__gt=first_round_start_date,
+                rrt_destruction_report_reception_date__gte=first_round_start_date,
                 rrt_destruction_report_reception_date__lt=next_campaign_start_date,
             )
         elif first_round_start_date is not None:

--- a/plugins/polio/api/dashboards/supply_chain.py
+++ b/plugins/polio/api/dashboards/supply_chain.py
@@ -74,13 +74,9 @@ class VaccineRequestFormDashboardSerializer(serializers.ModelSerializer):
             .first()
         )
 
-        last_round_end_date = (
-            Round.objects.filter(campaign=obj.campaign).order_by("-ended_at").values_list("ended_at", flat=True).first()
-        )
-
         campaigns_after_last_round = Campaign.objects.filter(
             country=vaccine_stock.country,
-            rounds__started_at__gt=last_round_end_date,
+            rounds__started_at__gt=first_round_start_date,
             account=self.context["request"].user.iaso_profile.account,
         ).order_by("rounds__started_at")
 

--- a/plugins/polio/api/dashboards/supply_chain.py
+++ b/plugins/polio/api/dashboards/supply_chain.py
@@ -82,9 +82,9 @@ class VaccineRequestFormDashboardSerializer(serializers.ModelSerializer):
             Campaign.objects.filter(
                 country=vaccine_stock.country,
                 rounds__started_at__gt=first_round_start_date,
-                rounds__number=1,
                 account=self.context["request"].user.iaso_profile.account,
             )
+            .exclude(id=obj.campaign.id)  # We dont want to considerate the current campaign
             .order_by("id")
             .distinct("id")
             .values_list("id", flat=True)

--- a/plugins/polio/api/dashboards/supply_chain.py
+++ b/plugins/polio/api/dashboards/supply_chain.py
@@ -73,9 +73,23 @@ class VaccineRequestFormDashboardSerializer(serializers.ModelSerializer):
             .first()
         )
 
-        if first_round_start_date is not None:
+        last_round_end_date = (
+            Round.objects.filter(campaign=obj.campaign).order_by("-ended_at").values_list("ended_at", flat=True).first()
+        )
+
+        if first_round_start_date is not None and last_round_end_date is not None:
+            sel_qs = DestructionReport.objects.filter(
+                vaccine_stock=vaccine_stock,
+                rrt_destruction_report_reception_date__gt=first_round_start_date,
+                rrt_destruction_report_reception_date__lt=last_round_end_date,
+            )
+        elif first_round_start_date is not None:
             sel_qs = DestructionReport.objects.filter(
                 vaccine_stock=vaccine_stock, rrt_destruction_report_reception_date__gt=first_round_start_date
+            )
+        elif last_round_end_date is not None:
+            sel_qs = DestructionReport.objects.filter(
+                vaccine_stock=vaccine_stock, rrt_destruction_report_reception_date__lt=last_round_end_date
             )
         else:
             sel_qs = DestructionReport.objects.filter(vaccine_stock=vaccine_stock)

--- a/plugins/polio/api/dashboards/supply_chain.py
+++ b/plugins/polio/api/dashboards/supply_chain.py
@@ -11,6 +11,7 @@ from plugins.polio.models import (
     VaccineRequestForm,
     VaccineStock,
 )
+from plugins.polio.models.base import Round
 
 
 class VaccineRequestFormDashboardSerializer(serializers.ModelSerializer):
@@ -34,8 +35,10 @@ class VaccineRequestFormDashboardSerializer(serializers.ModelSerializer):
         )
 
         representation["stock_in_hand"] = self.get_stock_in_hand(instance, vaccine_stock)
-        representation["form_a_reception_date"] = self.get_form_a_reception_date(vaccine_stock)
-        representation["destruction_report_reception_date"] = self.get_destruction_report_reception_date(vaccine_stock)
+        representation["form_a_reception_date"] = self.get_form_a_reception_date(instance, vaccine_stock)
+        representation["destruction_report_reception_date"] = self.get_destruction_report_reception_date(
+            instance, vaccine_stock
+        )
 
         return representation
 
@@ -54,18 +57,31 @@ class VaccineRequestFormDashboardSerializer(serializers.ModelSerializer):
 
         return self.context["stock_in_hand_cache"][cache_key]
 
-    def get_form_a_reception_date(self, vaccine_stock):
+    def get_form_a_reception_date(self, obj, vaccine_stock):
         latest_outgoing_stock_movement = (
-            OutgoingStockMovement.objects.filter(vaccine_stock=vaccine_stock).order_by("-form_a_reception_date").first()
+            OutgoingStockMovement.objects.filter(vaccine_stock=vaccine_stock, campaign=obj.campaign)
+            .order_by("-form_a_reception_date")
+            .first()
         )
         return latest_outgoing_stock_movement.form_a_reception_date if latest_outgoing_stock_movement else None
 
-    def get_destruction_report_reception_date(self, vaccine_stock):
-        latest_destruction_report = (
-            DestructionReport.objects.filter(vaccine_stock=vaccine_stock)
-            .order_by("-rrt_destruction_report_reception_date")
+    def get_destruction_report_reception_date(self, obj, vaccine_stock):
+        first_round_start_date = (
+            Round.objects.filter(campaign=obj.campaign)
+            .order_by("started_at")
+            .values_list("started_at", flat=True)
             .first()
         )
+
+        if first_round_start_date is not None:
+            sel_qs = DestructionReport.objects.filter(
+                vaccine_stock=vaccine_stock, rrt_destruction_report_reception_date__gt=first_round_start_date
+            )
+        else:
+            sel_qs = DestructionReport.objects.filter(vaccine_stock=vaccine_stock)
+
+        latest_destruction_report = sel_qs.order_by("-rrt_destruction_report_reception_date").first()
+
         return latest_destruction_report.rrt_destruction_report_reception_date if latest_destruction_report else None
 
 

--- a/plugins/polio/tests/test_supply_chain_dashboards.py
+++ b/plugins/polio/tests/test_supply_chain_dashboards.py
@@ -147,7 +147,7 @@ class SupplyChainDashboardsAPITestCase(APITestCase):
     def test_vrf_new_fields(self):
         self.client.force_authenticate(self.authorized_user_read)
 
-        with self.assertNumQueries(16):
+        with self.assertNumQueries(15):
             response = self.client.get(self.vrf_url)
 
         jr = self.assertJSONResponse(response, 200)
@@ -237,20 +237,18 @@ class SupplyChainDashboardsAPITestCase(APITestCase):
             missing_vials=6,
         )
 
-        # Should appear only in 2nd VRF
         DestructionReport.objects.create(
             vaccine_stock=self.vaccine_stock,
-            rrt_destruction_report_reception_date=date(2024, 1, 8),
-            destruction_report_date=date.today(),
+            rrt_destruction_report_reception_date=date(2023, 3, 3),
+            destruction_report_date=date(2023, 3, 3),
             unusable_vials_destroyed=6,
             action="destroyed",
         )
 
-        # Shoud be ignored as outside date range
         last_dr = DestructionReport.objects.create(
             vaccine_stock=self.vaccine_stock,
             rrt_destruction_report_reception_date=date(2024, 2, 15),
-            destruction_report_date=date.today(),
+            destruction_report_date=date(2024, 2, 15),
             unusable_vials_destroyed=6,
             action="destroyed",
         )


### PR DESCRIPTION
The APIs for the Vaccine Dashboard are returning Form A and Destruction Report dates from other campaigns in Same Country/Vaccine. This adds filtering by Campaign and Campaign Round Dates

Related JIRA tickets : POLIO-1687

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are there enough tests

## Changes

Additional filtering in the APIs per campaign (when available) and campaign round dates.

## How to test

A new campaign in the future should not return the FormA and Destruction reports dates of pre-existing campaigns