### PR TITLE
IA-3456 limit the scope of the get on default_version

### DIFF
--- a/iaso/api/instances.py
+++ b/iaso/api/instances.py
@@ -686,6 +686,7 @@ class InstancesViewSet(viewsets.ViewSet):
 
 def import_data(instances, user, app_id):
     project = Project.objects.get_for_user_and_app_id(user, app_id)
+    default_version = project.account.default_version
 
     for instance_data in instances:
         uuid = instance_data.get("id", None)
@@ -709,7 +710,7 @@ def import_data(instances, user, app_id):
         if str(tentative_org_unit_id).isdigit():
             instance.org_unit_id = tentative_org_unit_id
         else:
-            org_unit = OrgUnit.objects.get(uuid=tentative_org_unit_id)
+            org_unit = OrgUnit.objects.filter(version=default_version).get(uuid=tentative_org_unit_id)
             instance.org_unit = org_unit
 
         instance.form_id = instance_data.get("formId")

--- a/iaso/api/mobile/org_units.py
+++ b/iaso/api/mobile/org_units.py
@@ -337,10 +337,18 @@ def bbox_merge(a: Optional[tuple], b: Optional[tuple]) -> Optional[tuple]:
     )
 
 
+def orgunits_for_default_version_qs(default_version):
+    "The uuid is supposed to be unique per source_version"
+    return OrgUnit.objects.filter(version=default_version)
+
+
 def import_data(org_units, user, app_id):
     new_org_units = []
     project = Project.objects.get_for_user_and_app_id(user, app_id)
     org_units = sorted(org_units, key=get_timestamp)
+
+    project = Project.objects.get_for_user_and_app_id(user, app_id)
+    default_version = project.account.default_version
 
     for org_unit in org_units:
         uuid = org_unit.get("id", None)
@@ -351,7 +359,7 @@ def import_data(org_units, user, app_id):
         if latitude and longitude:
             altitude = org_unit.get("altitude", 0)
             org_unit_location = Point(x=longitude, y=latitude, z=altitude, srid=4326)
-        org_unit_db, created = OrgUnit.objects.get_or_create(uuid=uuid)
+        org_unit_db, created = orgunits_for_default_version_qs(default_version).get_or_create(uuid=uuid)
 
         if created:
             org_unit_db.custom = True
@@ -368,14 +376,17 @@ def import_data(org_units, user, app_id):
                 if str.isdigit(parent_id):
                     org_unit_db.parent_id = parent_id
                 else:
-                    parent_org_unit = OrgUnit.objects.get(uuid=parent_id)
+                    parent_org_unit = orgunits_for_default_version_qs(default_version).get(uuid=parent_id)
                     org_unit_db.parent_id = parent_org_unit.id
+            # TODO should org_unit_db.parent_id is "ok" for the project/account ?
 
             org_unit_type_id = org_unit.get(
                 "orgUnitTypeId", None
             )  # there exist versions of the mobile app in the wild with both orgUnitTypeId and org_unit_type_id
             if not org_unit_type_id:
                 org_unit_type_id = org_unit.get("org_unit_type_id", None)
+
+            # TODO should we verify the org_unit_type is "ok" for the project/account ?
             org_unit_db.org_unit_type_id = org_unit_type_id
 
             t = org_unit.get("created_at", None)

--- a/iaso/api/org_units.py
+++ b/iaso/api/org_units.py
@@ -777,6 +777,7 @@ def import_data(org_units: List[Dict], user, app_id):
     project = Project.objects.get_for_user_and_app_id(user, app_id)
     if project.account.default_version.data_source.read_only:
         raise Exception("Creation of org unit not authorized on default data source")
+    default_version = project.account.default_version
     for org_unit in org_units:
         uuid = org_unit.get("id", None)
         latitude = org_unit.get("latitude", None)
@@ -786,7 +787,7 @@ def import_data(org_units: List[Dict], user, app_id):
         if latitude and longitude:
             altitude = org_unit.get("altitude", 0)
             org_unit_location = Point(x=longitude, y=latitude, z=altitude, srid=4326)
-        org_unit_db, created = OrgUnit.objects.get_or_create(uuid=uuid)
+        org_unit_db, created = OrgUnit.objects.filter(version=default_version).get_or_create(uuid=uuid)
 
         if created:
             org_unit_db.custom = True
@@ -801,7 +802,7 @@ def import_data(org_units: List[Dict], user, app_id):
                 if str.isdigit(parent_id):
                     org_unit_db.parent_id = parent_id
                 else:
-                    parent_org_unit = OrgUnit.objects.get(uuid=parent_id)
+                    parent_org_unit = OrgUnit.objects.filter(version=default_version).get(uuid=parent_id)
                     org_unit_db.parent_id = parent_org_unit.id
 
             # there exist versions of the mobile app in the wild with both orgUnitTypeId and org_unit_type_id

--- a/iaso/tests/api/test_mobile_orgunits.py
+++ b/iaso/tests/api/test_mobile_orgunits.py
@@ -320,3 +320,43 @@ class MobileOrgUnitAPITestCase(APITestCase):
         self.client.force_authenticate(self.user)
         response = self.client.get(BASE_URL, data={APP_ID: BASE_APP_ID, IDS: f"{self.goku.id},-1,{self.goten.id}"})
         self.assertEqual(response.status_code, 404)
+
+    def test_post_to_create_orgunit_uuid_not_so_unique(self):
+        """
+        make sure we don't cross walls between account when using uuid
+        """
+        OTHER_BASE_APP_ID = "the.gallagher.brothers"
+
+        other_account = Account.objects.create(name="Oasis")
+        other_project = Project.objects.create(name="Reformation", app_id=OTHER_BASE_APP_ID, account=other_account)
+        other_user = self.create_user_with_profile(
+            username="Liam", account=other_account, permissions=["iaso_org_units"]
+        )
+        other_sw_source = DataSource.objects.create(name="Morning Glory")
+        other_sw_source.projects.add(other_project)
+        other_sw_version_1 = SourceVersion.objects.create(data_source=other_sw_source, number=1)
+        other_account.default_version = other_sw_version_1
+        other_account.save()
+
+        NOT_SO_UNIQUE_ID = "notsounique"
+
+        self.client.force_authenticate(other_user)
+        response = self.client.post(
+            BASE_URL + "?app_id=" + OTHER_BASE_APP_ID,
+            data=[{"name": "Don't Look Back in Anger", "created_at": 1, "id": NOT_SO_UNIQUE_ID}],
+            format="json",
+        )
+
+        orgunit_other = response.json()
+
+        self.client.force_authenticate(self.user)
+        response = self.client.post(
+            BASE_URL + "?app_id=" + BASE_APP_ID,
+            data=[{"name": "Don't Look Back in Anger", "created_at": 1, "id": NOT_SO_UNIQUE_ID}],
+            format="json",
+        )
+
+        orgunit = response.json()
+
+        self.assertEqual(orgunit_other[0]["name"], orgunit[0]["name"])
+        self.assertNotEqual(orgunit_other[0]["id"], orgunit[0]["id"])


### PR DESCRIPTION
A first PR that will limit the search in the account default_version

Fixes a scope problem where we can have non unique uuid 
 - don't look in other accounts
 - other datasource of that account
 - or other version of the default datasource

`get_or_create` suffer of race conditions, where duplicates are still possible
but it will be fixed in another PR, because we need to cleanup duplicates first.

Related JIRA tickets : IA-3456

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
- Tell us where the doc can be found (docs folder, wiki, in the code...)

## Changes


## How to test

 - seed 2 accounts
   - `docker-compose run --rm iaso manage seed_test_data --mode=seed --dhis2version=2.40.4.1`
   - `docker-compose run --rm iaso manage seed_test_data --mode=seed --dhis2version=2.39.6`
   - 
 - modify the project "app_id" via django admin
 - ![image](https://github.com/user-attachments/assets/474c9499-6e0f-489a-9263-e6438f995a90)

 - create an orgunit via the mobile

```
curl -vvv -u 'testemailstable-2-39-6:testemailstable-2-39-6' -H "Content-Type: application/json" -d '[{"name":"hello","created_at": 1, "id": "notsounique"}]' 'http://localhost:8081/api/mobile/orgunits/?app_id=org.bluesquare.play2396'
```

it should return something like

```
[{"name":"hello","short_name":"hello","id":708601,"source":"reference_play_teststable-2-39-6","source_id":9,"source_ref":null,"parent_id":null,"org_unit_type_id":null,"org_unit_type_name":null,"org_unit_type_depth":null,"created_at":1.0,"updated_at":1727274027.827538,"aliases":null,"validation_status":"NEW","latitude":null,"longitude":null,"altitude":null,"has_geo_json":false,"version":1,"opening_date":null,"closed_date":null}]
```

 - copy via a shell or sql the uuid to another another orgunit in the other account


```
[{"name":"hello","short_name":"hello","id":708602,"source":"reference_play_teststable-2-40-4-1","source_id":1,"source_ref":null,"parent_id":null,"org_unit_type_id":null,"org_unit_type_name":null,"org_unit_type_depth":null,"created_at":1.0,"updated_at":1727274268.123855,"aliases":null,"validation_status":"NEW","latitude":null,"longitude":null,"altitude":null,"has_geo_json":false,"version":1,"opening_date":null,"closed_date":null}]```

```


![image](https://github.com/user-attachments/assets/d1c71e43-1d59-4f08-913f-0c34e5300d61)


note : 
 - no error, 
 - different id, 
 - different source_id returned

- after that you'll need to fix the orgunit type (or the orgunits page won't load)

## Print screen / video

Upload here print screens or videos showing the changes

## Notes


