### PR TITLE
IA-3246: External storage appears on home page whereas the module is deactivated

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/home/hooks/useHomeButtons.tsx
+++ b/hat/assets/js/apps/Iaso/domains/home/hooks/useHomeButtons.tsx
@@ -45,7 +45,7 @@ export const useHomeButtons = (): Button[] => {
                 },
                 {
                     label: formatMessage(MESSAGES.storages),
-                    permissions: paths.entityTypesPath.permissions,
+                    permissions: paths.storagesPath.permissions,
                     Icon: <Storage />,
                     url: `/${baseUrls.storages}`,
                 },


### PR DESCRIPTION
Explain what problem this PR is resolving

Related JIRA tickets : [IA-3246](https://bluesquare.atlassian.net/browse/IA-3246)

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)


## Changes

Fixed the path to storage permissions on the home page.

## How to test

From setuper folder, launch `python3 setuper.py` to create data and login with the created account.
Then check the home page: http://localhost:8081/dashboard/home/. 

You should just see modules linked to permissions allowed to the current user.

## Print screen / video

[home_page.webm](https://github.com/user-attachments/assets/28a5c407-d0ba-4adb-94ca-c42f6e9690a6)



[IA-3246]: https://bluesquare.atlassian.net/browse/IA-3246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ