### PR TITLE
IA-3059: Add a card linking to user management on the welcome page

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/home/hooks/useHomeButtons.tsx
+++ b/hat/assets/js/apps/Iaso/domains/home/hooks/useHomeButtons.tsx
@@ -1,5 +1,10 @@
 import React, { ReactElement, useMemo } from 'react';
-import { ListAlt, Storage, Assignment } from '@mui/icons-material/';
+import {
+    ListAlt,
+    Storage,
+    Assignment,
+    SupervisorAccount,
+} from '@mui/icons-material/';
 import { useSafeIntl } from 'bluesquare-components';
 
 import OrgUnitSvg from '../../../components/svg/OrgUnitSvgComponent';
@@ -42,6 +47,12 @@ export const useHomeButtons = (): Button[] => {
                     permissions: paths.entityTypesPath.permissions,
                     Icon: <BeneficiarySvg />,
                     url: `/${baseUrls.entities}`,
+                },
+                {
+                    label: formatMessage(MESSAGES.users),
+                    permissions: paths.usersPath.permissions,
+                    Icon: <SupervisorAccount />,
+                    url: `/${baseUrls.users}`,
                 },
                 {
                     label: formatMessage(MESSAGES.storages),

--- a/hat/assets/js/apps/Iaso/domains/home/messages.ts
+++ b/hat/assets/js/apps/Iaso/domains/home/messages.ts
@@ -21,4 +21,8 @@ export const MESSAGES = defineMessages({
         defaultMessage: 'Planning',
         id: 'iaso.label.planning',
     },
+    users: {
+        defaultMessage: 'Users',
+        id: 'iaso.label.users',
+    },
 });


### PR DESCRIPTION
Explain what problem this PR is resolving

Related JIRA tickets : [IA-3059](https://bluesquare.atlassian.net/browse/IA-3059)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)


## Changes

Added a card linked to user management on the welcome page.

## How to test

From setuper folder, launch `python3 setuper.py` to create data and login with the created account.

Then check the home page: http://localhost:8081/dashboard/home/.

You should just see a card **Users** linked to user management on the welcome page.

## Print screen / video

![Iaso-09-26-2024_03_10_PM](https://github.com/user-attachments/assets/269bb9d6-7bae-48d8-ad4a-9763f06b1082)



[IA-3059]: https://bluesquare.atlassian.net/browse/IA-3059?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ