### PR TITLE
IA-3448: remove home title

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/home/HomeOnline.tsx
+++ b/hat/assets/js/apps/Iaso/domains/home/HomeOnline.tsx
@@ -1,5 +1,5 @@
 import MenuIcon from '@mui/icons-material/Menu';
-import { Box, Container, Grid, IconButton, Typography } from '@mui/material';
+import { Box, Container, Grid, IconButton } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import React, { FunctionComponent, useContext } from 'react';
 import { Link } from 'react-router-dom';
@@ -29,11 +29,6 @@ const useStyles = makeStyles(theme => ({
         textAlign: 'center',
         '& svg': { filter: 'drop-shadow(0px 0px 24px rgba(0, 0, 0, 0.24))' },
         '& img': { filter: 'drop-shadow(0px 0px 24px rgba(0, 0, 0, 0.24))' },
-    },
-    title: {
-        fontFamily: '"DINAlternate-Bold", "DIN Alternate", sans-serif',
-        fontSize: 50,
-        textAlign: 'center',
     },
     text: {
         fontFamily: '"DINAlternate-Bold", "DIN Alternate", sans-serif',
@@ -162,9 +157,6 @@ export const HomeOnline: FunctionComponent = () => {
                                 <LogoSvg width={150} height={160} />
                             )}
                         </Box>
-                        <Typography className={classes.title}>
-                            {APP_TITLE}
-                        </Typography>
                     </Box>
                 </Box>
 


### PR DESCRIPTION
APP_TITLE should be removed form home online page
![image](https://github.com/user-attachments/assets/845a6d33-7df5-4bf2-8344-a092926d61d9)


Related JIRA tickets : IA-3448
## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
- Tell us where the doc can be found (docs folder, wiki, in the code...)

## Changes

Deleted Typography

## How to test

You need to activate home home page in feature flag and visit home page, title should be removed

## Print screen / video

<img width="984" alt="Screenshot 2024-09-27 at 17 03 53" src="https://github.com/user-attachments/assets/9f9b0011-17a3-477a-8b99-974cd99902d6">

