### PR TITLE
IA-3458: Change the setuper default Project label into "Main Project"

### DIFF
--- a/iaso/api/setup_account.py
+++ b/iaso/api/setup_account.py
@@ -86,9 +86,7 @@ class SetupAccountSerializer(serializers.Serializer):
         # Create a setup_account project with an app_id represented by the account name
         app_id = validated_data["account_name"].replace(" ", ".").replace("-", ".")
 
-        initial_project = Project.objects.create(
-            name=validated_data["account_name"] + " project", account=account, app_id=app_id
-        )
+        initial_project = Project.objects.create(name="Main Project", account=account, app_id=app_id)
 
         # Link data source to projects and source version
         data_source.projects.set([initial_project])

--- a/iaso/tests/api/test_setup_account.py
+++ b/iaso/tests/api/test_setup_account.py
@@ -150,7 +150,7 @@ class SetupAccountApiTestCase(APITestCase):
         self.assertEqual(response.status_code, 201)
 
         created_account = m.Account.objects.filter(name="initial_project_account test-appid")
-        created_project = m.Project.objects.filter(name="initial_project_account test-appid project")
+        created_project = m.Project.objects.filter(name="Main Project")
         created_data_source = m.DataSource.objects.filter(name="initial_project_account test-appid")
         self.assertEqual(len(created_project), 1)
 


### PR DESCRIPTION
Explain what problem this PR is resolving

Related JIRA tickets : [IA-3458](https://bluesquare.atlassian.net/browse/IA-3458)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)


## Changes

Changed the created default project name to **Main Project**

## How to test

From setuper folder, launch `python3 setuper.py` to create data and login with the created account.

Then check the [Projects page](http://localhost:8081/dashboard/settings/projects/).  You should see **Main Project** as default one.


## Print screen / video

![Iaso-Projects](https://github.com/user-attachments/assets/cbea0325-a8f7-4fdc-9e98-4419f1db0cec)


[IA-3458]: https://bluesquare.atlassian.net/browse/IA-3458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ