### PR TITLE
IA-3409: Planning screen do not load geographic data

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/assignments/hooks/requests/useGetOrgUnits.ts
+++ b/hat/assets/js/apps/Iaso/domains/assignments/hooks/requests/useGetOrgUnits.ts
@@ -9,10 +9,10 @@ import { makeUrlWithParams } from '../../../../libs/utils';
 
 import { OrgUnit, PaginatedOrgUnits } from '../../../orgUnits/types/orgUnit';
 
-import { BaseLocation, Locations } from '../../types/locations';
 import { Profile } from '../../../../utils/usersUtils';
-import { DropdownTeamsOptions } from '../../types/team';
 import { AssignmentsApi } from '../../types/assigment';
+import { BaseLocation, Locations } from '../../types/locations';
+import { DropdownTeamsOptions } from '../../types/team';
 
 import { getOrgUnitAssignation } from '../../utils';
 
@@ -57,7 +57,7 @@ const mapLocation = ({
         };
         if (!orgUnitParentIds.find(ou => ou === orgUnit.id)) {
             if (parseInt(baseOrgunitType, 10) === orgUnit.org_unit_type_id) {
-                if (orgUnit.geo_json) {
+                if (orgUnit.has_geo_json && orgUnit.geo_json) {
                     const shape = {
                         ...baseLocation,
                         geoJson: orgUnit.geo_json,


### PR DESCRIPTION
Frontend is checking the presence of a geojson in the payload, not the has_geo_json value. Setuper is adding empty values in the geojson.... then markers are in the shapes sections

Related JIRA tickets : IA-3409

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
- Tell us where the doc can be found (docs folder, wiki, in the code...)

## Changes

checking presence of geoJson and tha value of has_geo_json

## How to test

Difficult to test, you can use the setuper to fille up org units and try, or edit an org unit in you db 
It has been deployed on staging for test:
https://iaso-staging.bluesquare.org/dashboard/planning/assignments/accountId/156/planningId/69/team/207/baseOrgunitType/920/tab/map



## Print screen / video

 
<img width="1653" alt="Screenshot 2024-10-01 at 11 53 44" src="https://github.com/user-attachments/assets/f111fb6a-61dc-413a-86b0-01f06e7f49a0">

