### PR TITLE
POLIO-1681: Permission "Vaccine chronogram - Write limited" should allow users to edit "Reponsible" field (open text)

### DIFF
--- a/plugins/polio/api/chronogram/serializers.py
+++ b/plugins/polio/api/chronogram/serializers.py
@@ -27,7 +27,7 @@ class ChronogramTaskSerializer(DynamicFieldsModelSerializer, serializers.ModelSe
 
         # Restrict writable fields for the `POLIO_CHRONOGRAM_RESTRICTED_WRITE` permission.
         if user and user.has_perm(iaso_permission.POLIO_CHRONOGRAM_RESTRICTED_WRITE):
-            allowed_fields = ["status", "comment"]
+            allowed_fields = ["status", "user_in_charge", "comment"]
             read_only_fields = [field for field in fields if field not in allowed_fields]
             for field in read_only_fields:
                 fields[field].read_only = True

--- a/plugins/polio/js/src/domains/Chronogram/ChronogramDetails/Modals/ChronogramTaskCreateEditModal.tsx
+++ b/plugins/polio/js/src/domains/Chronogram/ChronogramDetails/Modals/ChronogramTaskCreateEditModal.tsx
@@ -16,11 +16,10 @@ import { EditIconButton } from '../../../../../../../../hat/assets/js/apps/Iaso/
 import { InputWithInfos } from '../../../../../../../../hat/assets/js/apps/Iaso/components/InputWithInfos';
 
 import MESSAGES from '../messages';
-import { ChronogramTask } from '../../Chronogram/types';
+import { ChronogramTask, Chronogram } from '../../Chronogram/types';
 import { NumberInput } from '../../../../components/Inputs/NumberInput';
 import { SingleSelect } from '../../../../components/Inputs/SingleSelect';
 
-import { Chronogram } from '../../Chronogram/types';
 import { ChronogramTaskMetaData } from '../../types';
 import { useChronogramTaskSchema } from '../hooks/validation';
 import { useCreateEditChronogramTask } from '../api/useCreateEditChronogramTask';
@@ -72,6 +71,10 @@ const CreateEditChronogramTaskModal: FunctionComponent<Props> = ({
     const currentUser = useCurrentUser();
     const userHasReadAndWritePerm = userHasPermission(
         Permission.POLIO_CHRONOGRAM,
+        currentUser,
+    );
+    const userHasRestrictedWritePerm = userHasPermission(
+        Permission.POLIO_CHRONOGRAM_RESTRICTED_WRITE,
         currentUser,
     );
 
@@ -155,7 +158,10 @@ const CreateEditChronogramTaskModal: FunctionComponent<Props> = ({
                         label={formatMessage(MESSAGES.labelUserInCharge)}
                         name="user_in_charge"
                         component={TextInput}
-                        disabled={!userHasReadAndWritePerm}
+                        disabled={
+                            !userHasReadAndWritePerm &&
+                            !userHasRestrictedWritePerm
+                        }
                     />
                 </Box>
                 <Box mb={2}>


### PR DESCRIPTION
Explain what problem this PR is resolving
- Permission "Vaccine chronogram - Write limited" should allow users to edit "Reponsible" field (open text)
Related JIRA tickets : [POLIO-1681](https://bluesquare.atlassian.net/browse/POLIO-1681)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes
- Make disabled the responsible field only when the user hasn't all the two permissions: **Polio chronogram - Read and Write** and **Polio chronogram (user) - Restricted Write**
- Add the **user_in_charge** in the allowed fields to be modified when the user has **Polio chronogram (user) - Restricted Write** permission

## How to test
- Add or edit user and remove the **Polio chronogram - Read and Write** and add **Polio chronogram (user) - Restricted Write** to him
- Go Polio ---> Vaccine Module ---> Chronogram
- Edit a chronogram Task and check if the user can update the responsible field

## Print screen / video
[Screencast from 2024-10-01 15-41-52.webm](https://github.com/user-attachments/assets/95f923bf-2a83-44be-a009-e153bcc000e7)




[POLIO-1681]: https://bluesquare.atlassian.net/browse/POLIO-1681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ