### PR TITLE
IA-3472 bug groupset multiple projects same datasource

### DIFF
--- a/iaso/api/group_sets/serializers.py
+++ b/iaso/api/group_sets/serializers.py
@@ -77,7 +77,7 @@ class GroupSetSerializer(DynamicFieldsModelSerializer):
         if request:
             user = request.user
             if "group_ids" in self.fields:
-                self.fields["group_ids"].child_relation.queryset = Group.objects.filter_for_user(user)
+                self.fields["group_ids"].child_relation.queryset = Group.objects.filter_for_user(user).distinct()
 
     def validate(self, attrs: typing.MutableMapping):
         data = self.context["request"].data

--- a/iaso/models/data_source.py
+++ b/iaso/models/data_source.py
@@ -81,7 +81,7 @@ class SourceVersionQuerySet(models.QuerySet):
             return self.none()
 
         if user and user.is_authenticated:
-            queryset = queryset.filter(data_source__projects__account=user.iaso_profile.account)
+            queryset = queryset.filter(data_source__projects__account=user.iaso_profile.account).distinct()
 
         return queryset
 

--- a/iaso/tests/api/test_group_sets.py
+++ b/iaso/tests/api/test_group_sets.py
@@ -2,7 +2,7 @@ from django.utils.timezone import now
 from rest_framework import status
 
 from iaso import models as m
-from iaso.models import GroupSet
+from iaso.models import GroupSet, SourceVersion
 from iaso.test import APITestCase
 from hat.audit.models import Modification
 
@@ -20,6 +20,7 @@ class GroupSetsAPITestCase(APITestCase):
         star_wars = m.Account.objects.create(name="Star Wars", default_version=cls.source_version_1)
         marvel = m.Account.objects.create(name="Marvel")
 
+        cls.acccount_1 = star_wars
         cls.acccount_1_user_1 = cls.create_user_with_profile(
             username="yoda", account=star_wars, permissions=["iaso_org_units"]
         )
@@ -43,9 +44,14 @@ class GroupSetsAPITestCase(APITestCase):
 
         cls.project_1.data_sources.add(cls.data_source)
         cls.project_1.save()
+
+        cls.project_2.data_sources.add(cls.data_source)
+        cls.project_2.save()
+
         cls.data_source.account = star_wars
         cls.data_source.default_version = cls.source_version_1
         cls.data_source.projects.add(cls.project_1)
+        cls.data_source.projects.add(cls.project_2)
         cls.data_source.save()
 
         cls.data_source_2.account = star_wars
@@ -53,6 +59,7 @@ class GroupSetsAPITestCase(APITestCase):
         cls.data_source_2.save()
 
         cls.acccount_1_user_1.iaso_profile.projects.add(cls.project_1)
+        cls.acccount_1_user_1.iaso_profile.projects.add(cls.project_2)
 
     def test_authentification_required_for_get_list(self):
         response = self.client.get("/api/group_sets/", format="json")

--- a/iaso/tests/api/test_mobile_groupsets.py
+++ b/iaso/tests/api/test_mobile_groupsets.py
@@ -36,11 +36,19 @@ class MobileGroupSetsAPITestCase(APITestCase):
             app_id="nigeria.health.pyramid",
             account=account_nigeria,
         )
+        cls.project_nigeria_pev = m.Project.objects.create(
+            name="Nigeria pev",
+            app_id="nigeria.health.pev",
+            account=account_nigeria,
+        )
         cls.project_cameroon = m.Project.objects.create(
             name="Cameroon health map",
             app_id="cameroon.health.map",
             account=account_cameroon,
         )
+
+        cls.data_source_nig.projects.add(cls.project_nigeria)
+        cls.data_source_nig.projects.add(cls.project_nigeria_pev)
 
         cls.group_nigeria_1_hospital = m.Group.objects.create(name="Hospitals", source_version=cls.source_version_2_nig)
         cls.group_nigeria_1_healthcenter = m.Group.objects.create(
@@ -72,6 +80,17 @@ class MobileGroupSetsAPITestCase(APITestCase):
         cls.group_set_2_cameroon_region.groups.add(cls.group_cameroon_south)
         cls.maxDiff = None
 
+        cls.user_nigeria.iaso_profile.projects.add(cls.project_nigeria)
+        cls.user_nigeria.iaso_profile.projects.add(cls.project_nigeria_pev)
+
+        # verify the fixture creates a case where
+        # this filter creates a cardinal product / cross join
+        # of source versions
+        version_ids = m.SourceVersion.objects.filter(
+            data_source__projects__account=cls.user_nigeria.iaso_profile.account
+        ).values_list("id", flat=True)
+        assert 4 == len(version_ids)
+
     def test_api_mobile_groupsets_list_without_app_id(self):
         response = self.client.get("/api/mobile/group_sets/")
         self.assertJSONResponse(response, 400)
@@ -96,6 +115,32 @@ class MobileGroupSetsAPITestCase(APITestCase):
         response = self.client.get("/api/mobile/group_sets/", {APP_ID: self.project_cameroon.app_id})
         self.assertJSONResponse(response, 200)
         self.assertEqual(json.dumps(response.data), json.dumps([record_cameroon]))
+
+        record_nigeria = {
+            "id": self.group_set_1_nigeria.id,
+            "name": "contracts",
+            "group_ids": [self.group_nigeria_1_hospital.id, self.group_nigeria_1_healthcenter.id],
+            "group_belonging": "SINGLE",
+            "erased": False,
+        }
+
+        record_nigeria_2 = {
+            "id": self.group_set_2_nigeria.id,
+            "name": "contracts",
+            "group_ids": [self.group_nigeria_2_hospital.id, self.group_nigeria_2_healthcenter.id],
+            "group_belonging": "SINGLE",
+            "erased": True,
+        }
+
+        # Groups with `source_version_2`.
+        ## Without all versions
+        response = self.client.get("/api/mobile/group_sets/", {APP_ID: self.project_nigeria.app_id})
+        self.assertEqual(json.dumps(response.data), json.dumps([record_nigeria, record_nigeria_2]))
+
+    def test_api_mobile_groupsets_list_with_app_id_and_authenticated(self):
+        """GET /api/mobile/groups/ with app_id"""
+
+        self.client.force_authenticate(self.user_nigeria)
 
         record_nigeria = {
             "id": self.group_set_1_nigeria.id,


### PR DESCRIPTION
when a datasource is assigned to multiple projects that the user have access to then 
various "for_user" scopes returns multiple records with the same id.

Related JIRA tickets : IA-3472

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
- Tell us where the doc can be found (docs folder, wiki, in the code...)

## Changes


## How to test

launcher the setuper in main
try to create a groupset it should return error (MultipleObjectReturned)
switch to this branch it should be fixed (same fun in the list of groupsets and update)

## Print screen / video

Upload here print screens or videos showing the changes

## Notes

Things that the reviewers should know: known bugs that are out of the scope of the PR, other trade-offs that were made.
If the PR depends on a PR in bluesquare-components, or merges into another PR (i.o. main), it should also be mentioned here
