### PR TITLE
POLIO-1671: remove non polio from lqas afro map

### DIFF
--- a/plugins/polio/api/lqas_im/lqasim_zoom_in_map.py
+++ b/plugins/polio/api/lqas_im/lqasim_zoom_in_map.py
@@ -15,6 +15,7 @@ from iaso.utils import geojson_queryset
 from plugins.polio.api.common import LQASStatus, RoundSelection, determine_status_for_district, make_safe_bbox
 from plugins.polio.api.lqas_im.base_viewset import LqasAfroViewset
 from plugins.polio.models import Campaign, Round
+from plugins.polio.models.base import CampaignType
 
 
 def get_latest_active_campaign_and_rounds(org_unit, start_date_after, end_date_before):
@@ -36,9 +37,11 @@ def get_latest_active_campaign_and_rounds(org_unit, start_date_after, end_date_b
         .exclude(campaign__is_test=True)
         .order_by("-started_at")[:1]
     )
+    polio_campaign_type = CampaignType.objects.get(name=CampaignType.POLIO)
     latest_active_campaign = (
         Campaign.objects.filter(id__in=Subquery(latest_active_round_qs.values("campaign")))
         .filter(deleted_at=None)
+        .filter(campaign_types=polio_campaign_type)
         .exclude(is_test=True)
         .prefetch_related("rounds")
         .first()

--- a/plugins/polio/api/lqas_im/lqasim_zoom_in_map.py
+++ b/plugins/polio/api/lqas_im/lqasim_zoom_in_map.py
@@ -20,7 +20,10 @@ from plugins.polio.models.base import CampaignType
 
 def get_latest_active_campaign_and_rounds(org_unit, start_date_after, end_date_before):
     today = dt.date.today()
-    latest_active_round_qs = Round.objects.filter(campaign__country=org_unit)
+    polio_campaign_type = CampaignType.objects.get(name=CampaignType.POLIO)
+    latest_active_round_qs = Round.objects.filter(
+        campaign__country=org_unit, campaign__campaign_types=polio_campaign_type
+    )
     if start_date_after is not None:
         latest_active_round_qs = latest_active_round_qs.filter(started_at__gte=start_date_after)
     if end_date_before is not None:
@@ -41,7 +44,6 @@ def get_latest_active_campaign_and_rounds(org_unit, start_date_after, end_date_b
     latest_active_campaign = (
         Campaign.objects.filter(id__in=Subquery(latest_active_round_qs.values("campaign")))
         .filter(deleted_at=None)
-        .filter(campaign_types=polio_campaign_type)
         .exclude(is_test=True)
         .prefetch_related("rounds")
         .first()

--- a/plugins/polio/api/lqas_im/lqasim_zoom_in_map.py
+++ b/plugins/polio/api/lqas_im/lqasim_zoom_in_map.py
@@ -40,7 +40,6 @@ def get_latest_active_campaign_and_rounds(org_unit, start_date_after, end_date_b
         .exclude(campaign__is_test=True)
         .order_by("-started_at")[:1]
     )
-    polio_campaign_type = CampaignType.objects.get(name=CampaignType.POLIO)
     latest_active_campaign = (
         Campaign.objects.filter(id__in=Subquery(latest_active_round_qs.values("campaign")))
         .filter(deleted_at=None)

--- a/plugins/polio/tests/test_lqas_map.py
+++ b/plugins/polio/tests/test_lqas_map.py
@@ -19,6 +19,7 @@ from plugins.polio.api.common import (
     reduce_to_country_status,
 )
 from plugins.polio.models import Campaign, CampaignScope, Round, RoundScope
+from plugins.polio.models.base import CampaignType
 
 
 class PolioLqasAfroMapTestCase(APITestCase):
@@ -136,6 +137,8 @@ class PolioLqasAfroMapTestCase(APITestCase):
             version=cls.source_version,
             simplified_geom=cls.country_3_geo_json,
         )
+        cls.polio_type,created = CampaignType.objects.get_or_create(name=CampaignType.POLIO)
+        cls.measles_type,created = CampaignType.objects.get_or_create(name=CampaignType.MEASLES)
 
         # Campaign 1. Scope at campaign level
         cls.campaign_1 = Campaign.objects.create(
@@ -144,6 +147,7 @@ class PolioLqasAfroMapTestCase(APITestCase):
             separate_scopes_per_round=False,
             initial_org_unit=cls.country_org_unit_1,
         )
+        
         cls.campaign1_scope_group = Group.objects.create(
             name="campaign1scope", domain="POLIO", source_version=cls.source_version
         )
@@ -169,6 +173,7 @@ class PolioLqasAfroMapTestCase(APITestCase):
             ended_at=cls.campaign1_round2_end.strftime("%Y-%m-%d"),
             campaign=cls.campaign_1,
         )
+        cls.campaign_1.campaign_types.add(cls.polio_type)
 
         # Campaign 2. Scope at round level
         cls.campaign_2 = Campaign.objects.create(
@@ -210,6 +215,8 @@ class PolioLqasAfroMapTestCase(APITestCase):
         cls.campaign2_round2_scope = RoundScope.objects.create(
             round=cls.campaign2_round2, vaccine="nOPV2", group=cls.campaign2_round2_scope_org_units
         )
+        cls.campaign_2.campaign_types.add(cls.polio_type)
+
         # Creating a campign with round ending at date.max to check if it is exluded from results
         cls.excluded_campaign = Campaign.objects.create(
             obr_name="EXCLUDEDCAMPAIGN",

--- a/plugins/polio/tests/test_lqas_map.py
+++ b/plugins/polio/tests/test_lqas_map.py
@@ -137,8 +137,8 @@ class PolioLqasAfroMapTestCase(APITestCase):
             version=cls.source_version,
             simplified_geom=cls.country_3_geo_json,
         )
-        cls.polio_type,created = CampaignType.objects.get_or_create(name=CampaignType.POLIO)
-        cls.measles_type,created = CampaignType.objects.get_or_create(name=CampaignType.MEASLES)
+        cls.polio_type, created = CampaignType.objects.get_or_create(name=CampaignType.POLIO)
+        cls.measles_type, created = CampaignType.objects.get_or_create(name=CampaignType.MEASLES)
 
         # Campaign 1. Scope at campaign level
         cls.campaign_1 = Campaign.objects.create(
@@ -147,7 +147,7 @@ class PolioLqasAfroMapTestCase(APITestCase):
             separate_scopes_per_round=False,
             initial_org_unit=cls.country_org_unit_1,
         )
-        
+
         cls.campaign1_scope_group = Group.objects.create(
             name="campaign1scope", domain="POLIO", source_version=cls.source_version
         )

--- a/plugins/polio/tests/test_lqas_map.py
+++ b/plugins/polio/tests/test_lqas_map.py
@@ -427,7 +427,6 @@ class PolioLqasAfroMapTestCase(APITestCase):
         self.assertEqual(response.status_code, 200)
         content = json.loads(response.content)
         results = content["results"]
-        print("results", results)
         # Test details of data for first country
         self.assertEqual(len(results), 2)
         results_for_first_country = next(


### PR DESCRIPTION

Related JIRA tickets : POLIO-1671

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [X] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
NA

## Changes

- Add filter on campaign type when getting campaigns for afro map
- Update test

## How to test

- Check lqas afro map on polio staging
- Deploy this branch on polio staging
- Check map again: non polio campaigns are gone

## Print screen / video

Before (staging)
<img width="1426" alt="Screenshot 2024-10-02 at 15 17 03" src="https://github.com/user-attachments/assets/91a39d86-1fe8-4a14-93d6-26a05e19a037">

After (staging)
<img width="1426" alt="Screenshot 2024-10-02 at 15 27 23" src="https://github.com/user-attachments/assets/a094cc44-0160-41d9-9d71-98f7b136729e">

