### PR TITLE
IA-3457: Create a User Role in the setuper

### DIFF
--- a/setuper/setuper.py
+++ b/setuper/setuper.py
@@ -8,6 +8,7 @@ from default_healthFacility_form import setup_health_facility_level_default_form
 from review_change_proposal import setup_review_change_proposal
 from create_submission_with_picture import create_submission_with_picture
 from additional_projects import create_projects, link_new_projects_to_main_data_source
+from user_roles_permissions import create_user_role
 import string
 import random
 import argparse
@@ -59,6 +60,7 @@ def create_account(server_url, username, password, additional_projects):
     print("Creating account:", account_name)
     iaso_client = setup_account(account_name, server_url, username, password)
     setup_orgunits(iaso_client=iaso_client)
+    create_user_role(iaso_client)
 
     if seed_default_health_facility_form:
         setup_health_facility_level_default_form(account_name, iaso_client=iaso_client)

--- a/setuper/user_roles_permissions.py
+++ b/setuper/user_roles_permissions.py
@@ -1,0 +1,7 @@
+def create_user_role(iaso_client):
+    print("-- Setting up a user role")
+
+    payload = {"name": "Data Manager", "permissions": ["iaso_update_submission", "iaso_org_units"]}
+    user_role = iaso_client.post("/api/userroles/", json=payload)
+
+    return user_role


### PR DESCRIPTION
Explain what problem this PR is resolving

Related JIRA tickets : [IA-3457](https://bluesquare.atlassian.net/browse/IA-3457)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)


## Changes

Created a user role "Data Manager" with permissions Forms & submissions - Read & Write, and Org Units - Read & Write.

## How to test

From setuper folder, launch setuper via `python3 setuper.py`  to generate test data.
Then login with the created account and open User roles page: [http://localhost:8081/dashboard/settings/userRoles/](http://localhost:8081/dashboard/settings/userRoles/). You should see the user role **Data Manager**.

## Print screen / video

![Iaso-User-roles](https://github.com/user-attachments/assets/63282a39-318d-4e08-9a49-8c3fbe70e818)

![Iaso-User-roles-1](https://github.com/user-attachments/assets/5f562161-0733-414a-9160-0009ebcbfdc3)



[IA-3457]: https://bluesquare.atlassian.net/browse/IA-3457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ