### PR TITLE
POLIO-1684: Vaccine Stocks: aligning text of Incident Report Discard Point on Usable/Unusable summary page

### DIFF
--- a/plugins/polio/api/vaccines/stock_management.py
+++ b/plugins/polio/api/vaccines/stock_management.py
@@ -291,7 +291,7 @@ class VaccineStockCalculator:
                 results.append(
                     {
                         "date": report.date_of_incident_report,
-                        "action": report.get_stock_correction_display(),  # for every field FOO that has choices set, the object will have a get_FOO_display() method
+                        "action": report.stock_correction,  # for every field FOO that has choices set, the object will have a get_FOO_display() method
                         "vials_in": report.unusable_vials or 0,
                         "doses_in": (report.unusable_vials or 0) * self.get_doses_per_vial(),
                         "vials_out": None,

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/Details/Table/useVaccineStockManagementDetailsColumns.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/Details/Table/useVaccineStockManagementDetailsColumns.tsx
@@ -92,6 +92,12 @@ export const useVaccineStockManagementDetailsColumnsUnusable = (): Column[] => {
                 Header: formatMessage(MESSAGES.action),
                 accessor: 'action',
                 id: 'action',
+                Cell: settings => {
+                    const { action } = settings.row.original;
+                    return MESSAGES[action]
+                        ? formatMessage(MESSAGES[action])
+                        : action;
+                },
             },
             {
                 Header: formatMessage(MESSAGES.vials_in),


### PR DESCRIPTION
Explain what problem this PR is resolving
-Vaccine Stocks: aligning text of Incident Report Discard Point on Usable/Unusable summary page
Related JIRA tickets : [POLIO-1684](https://bluesquare.atlassian.net/browse/POLIO-1684)
## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
- Tell us where the doc can be found (docs folder, wiki, in the code...)

## Changes
- Use key instead of value
- And translate it

## How to test
- Polio ---> Vaccine module ---> Stock management
- View a stock details
- Check if VM reached discard point is same on both Usable and Unusable

## Print screen / video

[Screencast from 2024-10-03 09-32-43.webm](https://github.com/user-attachments/assets/e4ceaf1d-c05e-407e-b731-ef05905abde3)


## Notes

Things that the reviewers should know: known bugs that are out of the scope of the PR, other trade-offs that were made.
If the PR depends on a PR in bluesquare-components, or merges into another PR (i.o. main), it should also be mentioned here


[POLIO-1684]: https://bluesquare.atlassian.net/browse/POLIO-1684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ