### PR TITLE
IA-3485 don't sync groupset or groups without source-ref

### DIFF
--- a/iaso/diffing/differ.py
+++ b/iaso/diffing/differ.py
@@ -58,11 +58,12 @@ class Differ:
         if not ignore_groups:
             groups_with_with_groupset = []
             for group_set in GroupSet.objects.filter(source_version=version):
-                field_names.append("groupset:" + group_set.source_ref + ":" + group_set.name)
-                for group in group_set.groups.all():
-                    groups_with_with_groupset.append(group.id)
+                if group_set.source_ref:
+                    field_names.append("groupset:" + group_set.source_ref + ":" + group_set.name)
+                    for group in group_set.groups.all():
+                        groups_with_with_groupset.append(group.id)
             for group in Group.objects.filter(source_version=version):
-                if group.id not in groups_with_with_groupset:
+                if group.id not in groups_with_with_groupset and group.source_ref:
                     field_names.append("group:" + group.source_ref + ":" + group.name)
 
         self.iaso_logger.info("will compare the following fields ", field_names)


### PR DESCRIPTION
Related JIRA tickets : IA-3485

## Self proofreading checklist

 - no test sorry
 
## Doc

## Changes




## How to test

see IA-2933
 + create a group without a source_ref
 + create a groupset without a source_ref containing groups with source_ref
 + create a groupset with groups without a source_ref
 + modify orgunits to use these groups

then launch the diff or export

## Print screen / video

before : 

```
iaso-1     | ERROR    2024-10-04 15:36:09,094 django.request -- Internal Server Error: /api/sourceversions/diff.csv/
iaso-1     | Traceback (most recent call last):
iaso-1     |   File "/usr/local/lib/python3.9/site-packages/django/core/handlers/exception.py", line 55, in inner
iaso-1     |     response = get_response(request)
iaso-1     |   File "/usr/local/lib/python3.9/site-packages/django/core/handlers/base.py", line 197, in _get_response
iaso-1     |     response = wrapped_callback(request, *callback_args, **callback_kwargs)
iaso-1     |   File "/usr/local/lib/python3.9/site-packages/django/views/decorators/csrf.py", line 56, in wrapper_view
iaso-1     |     return view_func(*args, **kwargs)
iaso-1     |   File "/usr/local/lib/python3.9/site-packages/rest_framework/viewsets.py", line 125, in view
iaso-1     |     return self.dispatch(request, *args, **kwargs)
iaso-1     |   File "/usr/local/lib/python3.9/site-packages/rest_framework/views.py", line 509, in dispatch
iaso-1     |     response = self.handle_exception(exc)
iaso-1     |   File "/usr/local/lib/python3.9/site-packages/rest_framework/views.py", line 469, in handle_exception
iaso-1     |     self.raise_uncaught_exception(exc)
iaso-1     |   File "/usr/local/lib/python3.9/site-packages/rest_framework/views.py", line 480, in raise_uncaught_exception
iaso-1     |     raise exc
iaso-1     |   File "/usr/local/lib/python3.9/site-packages/rest_framework/views.py", line 506, in dispatch
iaso-1     |     response = handler(request, *args, **kwargs)
iaso-1     |   File "/opt/app/iaso/api/source_versions.py", line 153, in diff_csv
iaso-1     |     response = HttpResponse(serializer.generate_csv(), content_type=CONTENT_TYPE_CSV)
iaso-1     |   File "/opt/app/iaso/api/source_versions_serializers.py", line 84, in generate_csv
iaso-1     |     diffs, fields = Differ(iaso_logger).diff(
iaso-1     |   File "/opt/app/iaso/diffing/differ.py", line 61, in diff
iaso-1     |     field_names.append("groupset:" + group_set.source_ref + ":" + group_set.name)
iaso-1     | TypeError: can only concatenate str (not "NoneType") to str
```

or in the export task

```
Traceback (most recent call last):
  File "/opt/app/beanstalk_worker/__init__.py", line 32, in wrapper
    func(*args, task=the_task, **kwargs)
  File "/opt/app/iaso/tasks/dhis2_ou_exporter.py", line 40, in dhis2_ou_exporter
    diffs, fields = Differ(iaso_logger).diff(
  File "/opt/app/iaso/diffing/differ.py", line 61, in diff
    field_names.append("groupset:" + group_set.source_ref + ":" + group_set.name)
TypeError: can only concatenate str (not "NoneType") to str
```

after it will be omitted in the diff and in the export.

## Notes


