### PR TITLE
IA-3470: Have reference submissions linked to each Org unit in setuper

### DIFF
--- a/setuper/create_submission_with_picture.py
+++ b/setuper/create_submission_with_picture.py
@@ -25,7 +25,12 @@ def define_health_facility_reference_form(iaso_client):
         f"/api/v2/orgunittypes/{health_facility_type['id']}/", json=health_facility_type
     )
     form_ids = [form["id"] for form in update_reference_forms.get("reference_forms")]
-    org_unit_type_reference_forms = {"org_unit_type_id": health_facility_type["id"], "form_ids": form_ids}
+    org_unit_type_reference_forms = {
+        "org_unit_type_id": health_facility_type["id"],
+        "form_ids": form_ids,
+        "number_of_org_units": health_facility_type["units_count"],
+    }
+
     return org_unit_type_reference_forms
 
 
@@ -33,7 +38,7 @@ def create_submission_with_picture(account_name, iaso_client):
     print("-- Creating submissions with picture")
     form = define_health_facility_reference_form(iaso_client=iaso_client)
     # fetch orgunit ids
-    limit = 10
+    limit = form["number_of_org_units"]
     orgunits = iaso_client.get("/api/orgunits/", params={"limit": limit, "orgUnitTypeId": form["org_unit_type_id"]})[
         "orgunits"
     ]


### PR DESCRIPTION
Explain what problem this PR is resolving

Related JIRA tickets : [IA-3470](https://bluesquare.atlassian.net/browse/IA-3470)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)


## Changes

Creating reference submission for each org unit belong to the org unit type linked to a reference form.


## How to test

From setuper folder, launch setuper via `python3 setuper.py --additional_projects` to generate test data. Then login with the created account and open [Form submissions page](http://localhost:8081/dashboard/forms/submissions/) and in the **Forms filter**, apply filter form for a form defined as reference form(e.g: Data for Health facility/Données Formation sanitaire). You should see for each org unit a reference submission.

## Print screen / video

[Iaso.webm](https://github.com/user-attachments/assets/95c65871-d5ca-403d-ba72-4cdb4104ca4a)


[IA-3470]: https://bluesquare.atlassian.net/browse/IA-3470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ