### PR TITLE
IA-3445 Org Unit Type restrictions in `Profile` (backend)

### DIFF
--- a/iaso/api/org_unit_change_request_configurations/views_mobile.py
+++ b/iaso/api/org_unit_change_request_configurations/views_mobile.py
@@ -1,3 +1,5 @@
+from itertools import chain
+
 import django_filters
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
@@ -17,7 +19,7 @@ from iaso.api.org_unit_change_request_configurations.serializers import (
 )
 from iaso.api.query_params import APP_ID
 from iaso.api.serializers import AppIdSerializer
-from iaso.models import OrgUnitChangeRequestConfiguration
+from iaso.models import OrgUnitChangeRequestConfiguration, Project
 
 
 class MobileOrgUnitChangeRequestConfigurationViewSet(ListModelMixin, viewsets.GenericViewSet):
@@ -35,14 +37,56 @@ class MobileOrgUnitChangeRequestConfigurationViewSet(ListModelMixin, viewsets.Ge
     )
 
     def get_queryset(self):
+        """
+        Because some Org Unit Type restrictions are also configurable at the `Profile` level,
+        we implement the following logic here:
+
+        1. If `Profile.editable_org_unit_types` empty:
+
+            - return `OrgUnitChangeRequestConfiguration`
+
+        2. If `Profile.editable_org_unit_types` not empty:
+
+            2a. for org_unit_type not in `Profile.editable_org_unit_types`:
+                - return a dynamic configuration that says `org_units_editable: False`
+                - regardless of any existing `OrgUnitChangeRequestConfiguration`
+
+            2b. for org_unit_type in `Profile.editable_org_unit_types`:
+                - return either the existing `OrgUnitChangeRequestConfiguration` or nothing
+
+        """
         app_id = AppIdSerializer(data=self.request.query_params).get_app_id(raise_exception=True)
-        return (
+
+        org_unit_change_request_configurations = (
             OrgUnitChangeRequestConfiguration.objects.filter(project__app_id=app_id)
             .select_related("org_unit_type")
             .prefetch_related(
                 "possible_types", "possible_parent_types", "group_sets", "editable_reference_forms", "other_groups"
             )
-            .order_by("id")
+            .order_by("org_unit_type_id")
+        )
+
+        user_editable_org_unit_type_ids = set(
+            self.request.user.iaso_profile.editable_org_unit_types.values_list("id", flat=True)
+        )
+
+        if not user_editable_org_unit_type_ids:
+            return org_unit_change_request_configurations
+
+        project_org_unit_types = set(Project.objects.get(app_id=app_id).unit_types.values_list("id", flat=True))
+
+        non_editable_org_unit_type_ids = project_org_unit_types - user_editable_org_unit_type_ids
+
+        dynamic_configurations = [
+            OrgUnitChangeRequestConfiguration(org_unit_type_id=org_unit_type_id, org_units_editable=False)
+            for org_unit_type_id in non_editable_org_unit_type_ids
+        ]
+
+        return list(
+            chain(
+                org_unit_change_request_configurations.exclude(org_unit_type__in=non_editable_org_unit_type_ids),
+                dynamic_configurations,
+            )
         )
 
     @swagger_auto_schema(manual_parameters=[app_id_param])

--- a/iaso/api/org_unit_change_request_configurations/views_mobile.py
+++ b/iaso/api/org_unit_change_request_configurations/views_mobile.py
@@ -85,7 +85,7 @@ class MobileOrgUnitChangeRequestConfigurationViewSet(ListModelMixin, viewsets.Ge
             ]
 
             # Because we're merging unsaved instances with a queryset (which is a representation of a database query),
-            # we have to sort the resulting list manually we have to keep the pagination working properly.
+            # we have to sort the resulting list manually to keep the pagination working properly.
             queryset = list(
                 chain(
                     queryset.exclude(org_unit_type__in=non_editable_org_unit_type_ids),

--- a/iaso/api/org_unit_change_request_configurations/views_mobile.py
+++ b/iaso/api/org_unit_change_request_configurations/views_mobile.py
@@ -63,7 +63,7 @@ class MobileOrgUnitChangeRequestConfigurationViewSet(ListModelMixin, viewsets.Ge
             .prefetch_related(
                 "possible_types", "possible_parent_types", "group_sets", "editable_reference_forms", "other_groups"
             )
-            .order_by("org_unit_type_id")
+            .order_by("id")
         )
 
         user_editable_org_unit_type_ids = set(
@@ -82,6 +82,8 @@ class MobileOrgUnitChangeRequestConfigurationViewSet(ListModelMixin, viewsets.Ge
             for org_unit_type_id in non_editable_org_unit_type_ids
         ]
 
+        # A queryset is a representation of a database query, so it's difficult to add unsaved objects manually.
+        # This trick will return a list but some features like `order_by` will not work for unsaved objects.
         return list(
             chain(
                 org_unit_change_request_configurations.exclude(org_unit_type__in=non_editable_org_unit_type_ids),

--- a/iaso/api/org_unit_change_request_configurations/views_mobile.py
+++ b/iaso/api/org_unit_change_request_configurations/views_mobile.py
@@ -4,7 +4,6 @@ import django_filters
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
 
-from rest_framework import filters
 from rest_framework import viewsets
 from rest_framework.mixins import ListModelMixin
 from rest_framework.request import Request
@@ -24,7 +23,7 @@ from iaso.models import OrgUnitChangeRequestConfiguration, Project
 
 class MobileOrgUnitChangeRequestConfigurationViewSet(ListModelMixin, viewsets.GenericViewSet):
     permission_classes = [HasOrgUnitsChangeRequestConfigurationReadPermission]
-    filter_backends = [filters.OrderingFilter, django_filters.rest_framework.DjangoFilterBackend]
+    filter_backends = [django_filters.rest_framework.DjangoFilterBackend]
     serializer_class = MobileOrgUnitChangeRequestConfigurationListSerializer
     pagination_class = OrgUnitChangeRequestConfigurationPagination
 
@@ -37,60 +36,71 @@ class MobileOrgUnitChangeRequestConfigurationViewSet(ListModelMixin, viewsets.Ge
     )
 
     def get_queryset(self):
-        """
-        Because some Org Unit Type restrictions are also configurable at the `Profile` level,
-        we implement the following logic here:
-
-        1. If `Profile.editable_org_unit_types` empty:
-
-            - return `OrgUnitChangeRequestConfiguration`
-
-        2. If `Profile.editable_org_unit_types` not empty:
-
-            2a. for org_unit_type not in `Profile.editable_org_unit_types`:
-                - return a dynamic configuration that says `org_units_editable: False`
-                - regardless of any existing `OrgUnitChangeRequestConfiguration`
-
-            2b. for org_unit_type in `Profile.editable_org_unit_types`:
-                - return either the existing `OrgUnitChangeRequestConfiguration` or nothing
-
-        """
         app_id = AppIdSerializer(data=self.request.query_params).get_app_id(raise_exception=True)
-
-        org_unit_change_request_configurations = (
+        return (
             OrgUnitChangeRequestConfiguration.objects.filter(project__app_id=app_id)
             .select_related("org_unit_type")
             .prefetch_related(
                 "possible_types", "possible_parent_types", "group_sets", "editable_reference_forms", "other_groups"
             )
-            .order_by("id")
+            .order_by("org_unit_type_id")
         )
+
+    @swagger_auto_schema(manual_parameters=[app_id_param])
+    def list(self, request: Request, *args, **kwargs) -> Response:
+        """
+        Because some Org Unit Type restrictions are also configurable at the `Profile` level,
+        we implement the following logic in the list view:
+
+        1. If `Profile.editable_org_unit_types` empty:
+
+            - return `OrgUnitChangeRequestConfiguration` content
+
+        2. If `Profile.editable_org_unit_types` not empty:
+
+            a. for org_unit_type not in `Profile.editable_org_unit_types`:
+
+                - return a dynamic configuration that says `org_units_editable: False`
+                - regardless of any existing `OrgUnitChangeRequestConfiguration`
+
+            b. for org_unit_type in `Profile.editable_org_unit_types`:
+
+                - return either the existing `OrgUnitChangeRequestConfiguration` content or nothing
+
+        """
+        app_id = AppIdSerializer(data=self.request.query_params).get_app_id(raise_exception=True)
+        queryset = self.get_queryset()
 
         user_editable_org_unit_type_ids = set(
             self.request.user.iaso_profile.editable_org_unit_types.values_list("id", flat=True)
         )
 
-        if not user_editable_org_unit_type_ids:
-            return org_unit_change_request_configurations
+        if user_editable_org_unit_type_ids:
+            project_org_unit_types = set(Project.objects.get(app_id=app_id).unit_types.values_list("id", flat=True))
+            non_editable_org_unit_type_ids = project_org_unit_types - user_editable_org_unit_type_ids
 
-        project_org_unit_types = set(Project.objects.get(app_id=app_id).unit_types.values_list("id", flat=True))
+            dynamic_configurations = [
+                OrgUnitChangeRequestConfiguration(org_unit_type_id=org_unit_type_id, org_units_editable=False)
+                for org_unit_type_id in non_editable_org_unit_type_ids
+            ]
 
-        non_editable_org_unit_type_ids = project_org_unit_types - user_editable_org_unit_type_ids
-
-        dynamic_configurations = [
-            OrgUnitChangeRequestConfiguration(org_unit_type_id=org_unit_type_id, org_units_editable=False)
-            for org_unit_type_id in non_editable_org_unit_type_ids
-        ]
-
-        # A queryset is a representation of a database query, so it's difficult to add unsaved objects manually.
-        # This trick will return a list but some features like `order_by` will not work for unsaved objects.
-        return list(
-            chain(
-                org_unit_change_request_configurations.exclude(org_unit_type__in=non_editable_org_unit_type_ids),
-                dynamic_configurations,
+            # Because we're merging unsaved instances with a queryset (which is a representation of a database query),
+            # we have to sort the resulting list manually we have to keep the pagination working properly.
+            queryset = list(
+                chain(
+                    queryset.exclude(org_unit_type__in=non_editable_org_unit_type_ids),
+                    dynamic_configurations,
+                )
             )
-        )
+            # Unsaved instances do not have an `id`, so we're sorting on `org_unit_type_id` in all cases.
+            queryset = sorted(queryset, key=lambda item: item.org_unit_type_id)
 
-    @swagger_auto_schema(manual_parameters=[app_id_param])
-    def list(self, request: Request, *args, **kwargs) -> Response:
-        return super().list(request, *args, **kwargs)
+        queryset = self.filter_queryset(queryset)
+
+        page = self.paginate_queryset(queryset)
+        if page is not None:
+            serializer = self.get_serializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
+
+        serializer = self.get_serializer(queryset, many=True)
+        return Response(serializer.data)

--- a/iaso/api/profiles/profiles.py
+++ b/iaso/api/profiles/profiles.py
@@ -220,7 +220,7 @@ class ProfilesViewSet(viewsets.ViewSet):
 
     def get_queryset(self):
         account = self.request.user.iaso_profile.account
-        return Profile.objects.filter(account=account)
+        return Profile.objects.filter(account=account).prefetch_related("editable_org_unit_types")
 
     def list(self, request):
         limit = request.GET.get("limit", None)
@@ -275,6 +275,7 @@ class ProfilesViewSet(viewsets.ViewSet):
             "org_units__parent__org_unit_type",
             "org_units__parent__parent__org_unit_type",
             "projects",
+            "editable_org_unit_types",
         )
         if request.GET.get("csv"):
             return self.list_export(queryset=queryset, file_format=FileFormatEnum.CSV)

--- a/iaso/api/profiles/profiles.py
+++ b/iaso/api/profiles/profiles.py
@@ -500,7 +500,7 @@ class ProfilesViewSet(viewsets.ViewSet):
         return result
 
     def validate_editable_org_unit_types(self, request):
-        editable_org_unit_type_ids = request.data.get("editable_org_unit_type_ids", None)
+        editable_org_unit_type_ids = request.data.get("editable_org_unit_type_ids", [])
         editable_org_unit_types = OrgUnitType.objects.filter(pk__in=editable_org_unit_type_ids)
         if editable_org_unit_types.count() != len(editable_org_unit_type_ids):
             raise ValidationError("Invalid editable org unit type submitted.")

--- a/iaso/api/profiles/profiles.py
+++ b/iaso/api/profiles/profiles.py
@@ -500,13 +500,11 @@ class ProfilesViewSet(viewsets.ViewSet):
         return result
 
     def validate_editable_org_unit_types(self, request):
-        result = []
         editable_org_unit_type_ids = request.data.get("editable_org_unit_type_ids", None)
-        if editable_org_unit_type_ids:
-            for editable_org_unit_type_id in editable_org_unit_type_ids:
-                item = get_object_or_404(OrgUnitType, pk=editable_org_unit_type_id)
-                result.append(item)
-        return result
+        editable_org_unit_types = OrgUnitType.objects.filter(pk__in=editable_org_unit_type_ids)
+        if editable_org_unit_types.count() != len(editable_org_unit_type_ids):
+            raise ValidationError("Invalid editable org unit type submitted.")
+        return editable_org_unit_types
 
     @staticmethod
     def update_user_own_profile(request):

--- a/iaso/models/base.py
+++ b/iaso/models/base.py
@@ -1467,7 +1467,7 @@ class Profile(models.Model):
                 "phone_number": self.phone_number.as_e164 if self.phone_number else None,
                 "country_code": region_code_for_number(self.phone_number).lower() if self.phone_number else None,
                 "projects": [p.as_dict() for p in self.projects.all().order_by("name")],
-                "editable_org_unit_type_ids": list(self.editable_org_unit_types.values_list("id", flat=True)),
+                "editable_org_unit_type_ids": [out.pk for out in self.editable_org_unit_types.all()],
             }
         else:
             return {
@@ -1490,7 +1490,7 @@ class Profile(models.Model):
                 "phone_number": self.phone_number.as_e164 if self.phone_number else None,
                 "country_code": region_code_for_number(self.phone_number).lower() if self.phone_number else None,
                 "projects": [p.as_dict() for p in self.projects.all()],
-                "editable_org_unit_type_ids": list(self.editable_org_unit_types.values_list("id", flat=True)),
+                "editable_org_unit_type_ids": [out.pk for out in self.editable_org_unit_types.all()],
             }
 
     def as_short_dict(self):
@@ -1504,7 +1504,7 @@ class Profile(models.Model):
             "user_id": self.user.id,
             "phone_number": self.phone_number.as_e164 if self.phone_number else None,
             "country_code": region_code_for_number(self.phone_number).lower() if self.phone_number else None,
-            "editable_org_unit_type_ids": list(self.editable_org_unit_types.values_list("id", flat=True)),
+            "editable_org_unit_type_ids": [out.pk for out in self.editable_org_unit_types.all()],
         }
 
     def has_a_team(self):

--- a/iaso/models/base.py
+++ b/iaso/models/base.py
@@ -1514,9 +1514,10 @@ class Profile(models.Model):
         return False
 
     def has_org_unit_write_permission(self, org_unit_type_id: int) -> bool:
-        if not self.editable_org_unit_types.exists():
+        editable_org_unit_type_ids = self.editable_org_unit_types.values_list("id", flat=True)
+        if not editable_org_unit_type_ids:
             return True
-        return self.editable_org_unit_types.filter(id=org_unit_type_id).exists()
+        return org_unit_type_id in editable_org_unit_type_ids
 
 
 class ExportRequest(models.Model):

--- a/iaso/models/base.py
+++ b/iaso/models/base.py
@@ -1513,6 +1513,11 @@ class Profile(models.Model):
             return True
         return False
 
+    def has_org_unit_write_permission(self, org_unit_type_id: int) -> bool:
+        if not self.editable_org_unit_types.exists():
+            return True
+        return self.editable_org_unit_types.filter(id=org_unit_type_id).exists()
+
 
 class ExportRequest(models.Model):
     id = models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")

--- a/iaso/models/base.py
+++ b/iaso/models/base.py
@@ -1508,8 +1508,12 @@ class Profile(models.Model):
             return True
         return False
 
-    def has_org_unit_write_permission(self, org_unit_type_id: int) -> bool:
-        editable_org_unit_type_ids = self.editable_org_unit_types.values_list("id", flat=True)
+    def has_org_unit_write_permission(
+        self, org_unit_type_id: int, prefetched_editable_org_unit_type_ids: list = None
+    ) -> bool:
+        editable_org_unit_type_ids = prefetched_editable_org_unit_type_ids or list(
+            self.editable_org_unit_types.values_list("id", flat=True)
+        )
         if not editable_org_unit_type_ids:
             return True
         return org_unit_type_id in editable_org_unit_type_ids

--- a/iaso/models/base.py
+++ b/iaso/models/base.py
@@ -1,5 +1,3 @@
-import datetime
-import mimetypes
 import operator
 import random
 import re
@@ -15,7 +13,6 @@ import django_cte
 from bs4 import BeautifulSoup as Soup  # type: ignore
 from django import forms as dj_forms
 from django.contrib import auth
-from django.contrib.auth import models as authModels
 from django.contrib.auth.models import AnonymousUser, User
 from django.contrib.gis.db.models.fields import PointField
 from django.contrib.gis.geos import Point
@@ -33,7 +30,6 @@ from django.utils.translation import gettext_lazy as _
 from phonenumber_field.modelfields import PhoneNumberField
 from phonenumbers.phonenumberutil import region_code_for_number
 
-from hat.audit.models import INSTANCE_API, log_modification
 from hat.menupermissions.constants import MODULES
 from iaso.models.data_source import DataSource, SourceVersion
 from iaso.models.org_unit import OrgUnit, OrgUnitReferenceInstance
@@ -43,7 +39,6 @@ from iaso.utils.file_utils import get_file_type
 from .. import periods
 from ..utils.emoji import fix_emoji
 from ..utils.jsonlogic import jsonlogic_to_q
-from ..utils.models.common import get_creator_name
 from .device import Device, DeviceOwnership
 from .forms import Form, FormVersion
 from .project import Project

--- a/iaso/tests/api/org_unit_change_request_configurations/test_org_unit_change_request_configs_mobile.py
+++ b/iaso/tests/api/org_unit_change_request_configurations/test_org_unit_change_request_configs_mobile.py
@@ -60,74 +60,104 @@ class MobileOrgUnitChangeRequestConfigurationAPITestCase(OUCRCAPIBase):
         self.assertEqual(new_org_unit_type_3_config, None)
 
         self.assertEqual(5, len(results))  # 3 OUCRCs from setup + 2 dynamic OUCRCs.
+
+        ou_type_fire_pokemons_config = next(
+            (config for config in results if config["org_unit_type_id"] == self.ou_type_fire_pokemons.pk)
+        )
         self.assertEqual(
-            json.loads(json.dumps(response.data["results"])),
-            [
-                {
-                    "created_at": self.oucrc_type_fire.created_at.timestamp(),
-                    "editable_fields": ["name", "aliases", "location", "opening_date", "closing_date"],
-                    "editable_reference_form_ids": list(
-                        self.oucrc_type_fire.editable_reference_forms.values_list("id", flat=True)
-                    ),
-                    "group_set_ids": list(self.oucrc_type_fire.group_sets.values_list("id", flat=True)),
-                    "org_unit_type_id": self.ou_type_fire_pokemons.pk,
-                    "org_units_editable": True,
-                    "other_group_ids": list(self.oucrc_type_fire.other_groups.values_list("id", flat=True)),
-                    "possible_parent_type_ids": list(
-                        self.oucrc_type_fire.possible_parent_types.values_list("id", flat=True)
-                    ),
-                    "possible_type_ids": list(self.oucrc_type_fire.possible_types.values_list("id", flat=True)),
-                    "updated_at": self.oucrc_type_fire.updated_at.timestamp(),
-                },
-                {
-                    "created_at": None,
-                    "editable_fields": [],
-                    "editable_reference_form_ids": [],
-                    "group_set_ids": [],
-                    "org_unit_type_id": self.ou_type_rock_pokemons.pk,
-                    "org_units_editable": False,
-                    "other_group_ids": [],
-                    "possible_parent_type_ids": [],
-                    "possible_type_ids": [],
-                    "updated_at": None,
-                },
-                {
-                    "created_at": None,
-                    "editable_fields": [],
-                    "editable_reference_form_ids": [],
-                    "group_set_ids": [],
-                    "org_unit_type_id": self.ou_type_water_pokemons.pk,
-                    "org_units_editable": False,
-                    "other_group_ids": [],
-                    "possible_parent_type_ids": [],
-                    "possible_type_ids": [],
-                    "updated_at": None,
-                },
-                {
-                    "created_at": None,
-                    "editable_fields": [],
-                    "editable_reference_form_ids": [],
-                    "group_set_ids": [],
-                    "org_unit_type_id": new_org_unit_type_1.id,
-                    "org_units_editable": False,
-                    "other_group_ids": [],
-                    "possible_parent_type_ids": [],
-                    "possible_type_ids": [],
-                    "updated_at": None,
-                },
-                {
-                    "created_at": None,
-                    "editable_fields": [],
-                    "editable_reference_form_ids": [],
-                    "group_set_ids": [],
-                    "org_unit_type_id": new_org_unit_type_2.id,
-                    "org_units_editable": False,
-                    "other_group_ids": [],
-                    "possible_parent_type_ids": [],
-                    "possible_type_ids": [],
-                    "updated_at": None,
-                },
-            ],
+            ou_type_fire_pokemons_config,
+            {
+                "org_unit_type_id": self.ou_type_fire_pokemons.pk,
+                "org_units_editable": True,
+                "editable_fields": ["name", "aliases", "location", "opening_date", "closing_date"],
+                "possible_type_ids": list(self.oucrc_type_fire.possible_types.values_list("id", flat=True)),
+                "possible_parent_type_ids": list(
+                    self.oucrc_type_fire.possible_parent_types.values_list("id", flat=True)
+                ),
+                "group_set_ids": list(self.oucrc_type_fire.group_sets.values_list("id", flat=True)),
+                "editable_reference_form_ids": list(
+                    self.oucrc_type_fire.editable_reference_forms.values_list("id", flat=True)
+                ),
+                "other_group_ids": list(self.oucrc_type_fire.other_groups.values_list("id", flat=True)),
+                "created_at": self.oucrc_type_fire.created_at.timestamp(),
+                "updated_at": self.oucrc_type_fire.updated_at.timestamp(),
+            },
+        )
+
+        ou_type_rock_pokemons_config = next(
+            (config for config in results if config["org_unit_type_id"] == self.ou_type_rock_pokemons.pk)
+        )
+        self.assertEqual(
+            ou_type_rock_pokemons_config,
+            {
+                "org_unit_type_id": self.ou_type_rock_pokemons.pk,
+                "org_units_editable": False,
+                "editable_fields": [],
+                "possible_type_ids": [],
+                "possible_parent_type_ids": [],
+                "group_set_ids": [],
+                "editable_reference_form_ids": [],
+                "other_group_ids": [],
+                "created_at": None,
+                "updated_at": None,
+            },
+        )
+
+        ou_type_water_pokemons_config = next(
+            (config for config in results if config["org_unit_type_id"] == self.ou_type_water_pokemons.pk)
+        )
+        self.assertEqual(
+            ou_type_water_pokemons_config,
+            {
+                "org_unit_type_id": self.ou_type_water_pokemons.pk,
+                "org_units_editable": False,
+                "editable_fields": [],
+                "possible_type_ids": [],
+                "possible_parent_type_ids": [],
+                "group_set_ids": [],
+                "editable_reference_form_ids": [],
+                "other_group_ids": [],
+                "created_at": None,
+                "updated_at": None,
+            },
+        )
+
+        new_org_unit_type_1_config = next(
+            (config for config in results if config["org_unit_type_id"] == new_org_unit_type_1.pk)
+        )
+        self.assertEqual(
+            new_org_unit_type_1_config,
+            {
+                "org_unit_type_id": new_org_unit_type_1.pk,
+                "org_units_editable": False,
+                "editable_fields": [],
+                "possible_type_ids": [],
+                "possible_parent_type_ids": [],
+                "group_set_ids": [],
+                "editable_reference_form_ids": [],
+                "other_group_ids": [],
+                "created_at": None,
+                "updated_at": None,
+            },
+        )
+
+        new_org_unit_type_2_config = next(
+            (config for config in results if config["org_unit_type_id"] == new_org_unit_type_2.pk)
+        )
+        self.assertEqual(
+            new_org_unit_type_2_config,
+            {
+                "org_unit_type_id": new_org_unit_type_2.pk,
+                "org_units_editable": False,
+                "editable_fields": [],
+                "possible_type_ids": [],
+                "possible_parent_type_ids": [],
+                "group_set_ids": [],
+                "editable_reference_form_ids": [],
+                "other_group_ids": [],
+                "created_at": None,
+                "updated_at": None,
+            },
         )
 
     def test_list_without_auth(self):

--- a/iaso/tests/api/org_unit_change_request_configurations/test_org_unit_change_request_configs_mobile.py
+++ b/iaso/tests/api/org_unit_change_request_configurations/test_org_unit_change_request_configs_mobile.py
@@ -1,5 +1,8 @@
+import json
+
 from rest_framework import status
 
+from iaso import models as m
 from iaso.tests.api.org_unit_change_request_configurations.common_base_with_setup import OUCRCAPIBase
 
 
@@ -12,18 +15,120 @@ class MobileOrgUnitChangeRequestConfigurationAPITestCase(OUCRCAPIBase):
 
     def test_list_ok(self):
         self.client.force_authenticate(self.user_ash_ketchum)
-        with self.assertNumQueries(7):
+        with self.assertNumQueries(8):
             # get_queryset
-            #   1. COUNT(*) OrgUnitChangeRequestConfiguration
-            #   2. SELECT OrgUnitChangeRequestConfiguration
-            #   3. PREFETCH OrgUnitChangeRequestConfiguration.possible_types
-            #   4. PREFETCH OrgUnitChangeRequestConfiguration.possible_parent_types
-            #   5. PREFETCH OrgUnitChangeRequestConfiguration.group_sets
-            #   6. PREFETCH OrgUnitChangeRequestConfiguration.editable_reference_forms
-            #   7. PREFETCH OrgUnitChangeRequestConfiguration.other_groups
+            #   1. SELECT user_editable_org_unit_type_ids
+            #   2. COUNT(*) OrgUnitChangeRequestConfiguration
+            #   3. SELECT OrgUnitChangeRequestConfiguration
+            #   4. PREFETCH OrgUnitChangeRequestConfiguration.possible_types
+            #   5. PREFETCH OrgUnitChangeRequestConfiguration.possible_parent_types
+            #   6. PREFETCH OrgUnitChangeRequestConfiguration.group_sets
+            #   7. PREFETCH OrgUnitChangeRequestConfiguration.editable_reference_forms
+            #   8. PREFETCH OrgUnitChangeRequestConfiguration.other_groups
             response = self.client.get(f"{self.MOBILE_OUCRC_API_URL}?app_id={self.app_id}")
             self.assertJSONResponse(response, status.HTTP_200_OK)
             self.assertEqual(3, len(response.data["results"]))  # the 3 OUCRCs from setup
+
+    def test_list_ok_with_restricted_write_permission_for_user(self):
+        # Add new Org Unit Types.
+        new_org_unit_type_1 = m.OrgUnitType.objects.create(name="Hospital")
+        new_org_unit_type_1.projects.add(self.project_johto)
+        new_org_unit_type_2 = m.OrgUnitType.objects.create(name="Health facility")
+        new_org_unit_type_2.projects.add(self.project_johto)
+        new_org_unit_type_3 = m.OrgUnitType.objects.create(name="District")
+        new_org_unit_type_3.projects.add(self.project_johto)
+        self.assertEqual(self.project_johto.unit_types.count(), 6)
+
+        self.user_ash_ketchum.iaso_profile.editable_org_unit_types.set(
+            # Only org units of this type are now writable for this user.
+            [self.ou_type_fire_pokemons, new_org_unit_type_3]
+        )
+
+        self.client.force_authenticate(self.user_ash_ketchum)
+
+        response = self.client.get(f"{self.MOBILE_OUCRC_API_URL}?app_id={self.app_id}")
+        self.assertJSONResponse(response, status.HTTP_200_OK)
+        results = response.data["results"]
+
+        # The user has write access on `new_org_unit_type_3` at his Profile level
+        # and there is no existing configuration for `new_org_unit_type_3`, so this
+        # Org Unit Type should not be in the response meaning the user has full
+        # write perms on this type.
+        new_org_unit_type_3_config = next(
+            (config for config in results if config["org_unit_type_id"] == new_org_unit_type_3.pk), None
+        )
+        self.assertEqual(new_org_unit_type_3_config, None)
+
+        self.assertEqual(5, len(results))  # 3 OUCRCs from setup + 2 dynamic OUCRCs.
+        self.assertEqual(
+            json.loads(json.dumps(response.data["results"])),
+            [
+                {
+                    "created_at": self.oucrc_type_fire.created_at.timestamp(),
+                    "editable_fields": ["name", "aliases", "location", "opening_date", "closing_date"],
+                    "editable_reference_form_ids": list(
+                        self.oucrc_type_fire.editable_reference_forms.values_list("id", flat=True)
+                    ),
+                    "group_set_ids": list(self.oucrc_type_fire.group_sets.values_list("id", flat=True)),
+                    "org_unit_type_id": self.ou_type_fire_pokemons.pk,
+                    "org_units_editable": True,
+                    "other_group_ids": list(self.oucrc_type_fire.other_groups.values_list("id", flat=True)),
+                    "possible_parent_type_ids": list(
+                        self.oucrc_type_fire.possible_parent_types.values_list("id", flat=True)
+                    ),
+                    "possible_type_ids": list(self.oucrc_type_fire.possible_types.values_list("id", flat=True)),
+                    "updated_at": self.oucrc_type_fire.updated_at.timestamp(),
+                },
+                {
+                    "created_at": None,
+                    "editable_fields": [],
+                    "editable_reference_form_ids": [],
+                    "group_set_ids": [],
+                    "org_unit_type_id": self.ou_type_rock_pokemons.pk,
+                    "org_units_editable": False,
+                    "other_group_ids": [],
+                    "possible_parent_type_ids": [],
+                    "possible_type_ids": [],
+                    "updated_at": None,
+                },
+                {
+                    "created_at": None,
+                    "editable_fields": [],
+                    "editable_reference_form_ids": [],
+                    "group_set_ids": [],
+                    "org_unit_type_id": self.ou_type_water_pokemons.pk,
+                    "org_units_editable": False,
+                    "other_group_ids": [],
+                    "possible_parent_type_ids": [],
+                    "possible_type_ids": [],
+                    "updated_at": None,
+                },
+                {
+                    "created_at": None,
+                    "editable_fields": [],
+                    "editable_reference_form_ids": [],
+                    "group_set_ids": [],
+                    "org_unit_type_id": new_org_unit_type_1.id,
+                    "org_units_editable": False,
+                    "other_group_ids": [],
+                    "possible_parent_type_ids": [],
+                    "possible_type_ids": [],
+                    "updated_at": None,
+                },
+                {
+                    "created_at": None,
+                    "editable_fields": [],
+                    "editable_reference_form_ids": [],
+                    "group_set_ids": [],
+                    "org_unit_type_id": new_org_unit_type_2.id,
+                    "org_units_editable": False,
+                    "other_group_ids": [],
+                    "possible_parent_type_ids": [],
+                    "possible_type_ids": [],
+                    "updated_at": None,
+                },
+            ],
+        )
 
     def test_list_without_auth(self):
         response = self.client.get(f"{self.MOBILE_OUCRC_API_URL}?app_id={self.app_id}")

--- a/iaso/tests/api/org_unit_change_request_configurations/test_org_unit_change_request_configs_mobile.py
+++ b/iaso/tests/api/org_unit_change_request_configurations/test_org_unit_change_request_configs_mobile.py
@@ -51,7 +51,7 @@ class MobileOrgUnitChangeRequestConfigurationAPITestCase(OUCRCAPIBase):
             self.assertJSONResponse(response, status.HTTP_200_OK)
 
         results = response.data["results"]
-        self.assertEqual(5, len(results))  # 3 OUCRCs from setup + 2 dynamic OUCRCs.
+        self.assertEqual(5, len(results))
 
         # `new_org_unit_type_3` should not be in the response because the user
         # have full write permission on it:
@@ -63,6 +63,9 @@ class MobileOrgUnitChangeRequestConfigurationAPITestCase(OUCRCAPIBase):
         self.assertEqual(
             results,
             [
+                # The user has write access on `ou_type_fire_pokemons` at his Profile level,
+                # and there is an existing configuration for `ou_type_fire_pokemons`, so we
+                # return the configuration.
                 {
                     "org_unit_type_id": self.ou_type_fire_pokemons.pk,
                     "org_units_editable": True,
@@ -79,6 +82,8 @@ class MobileOrgUnitChangeRequestConfigurationAPITestCase(OUCRCAPIBase):
                     "created_at": self.oucrc_type_fire.created_at.timestamp(),
                     "updated_at": self.oucrc_type_fire.updated_at.timestamp(),
                 },
+                # Because of the configuration of his Profile, the user can't write on `ou_type_rock_pokemons`,
+                # so we override the existing configuration.
                 {
                     "org_unit_type_id": self.ou_type_rock_pokemons.pk,
                     "org_units_editable": False,
@@ -91,6 +96,8 @@ class MobileOrgUnitChangeRequestConfigurationAPITestCase(OUCRCAPIBase):
                     "created_at": None,
                     "updated_at": None,
                 },
+                # Because of the configuration of his Profile, the user can't write on `ou_type_water_pokemons`,
+                # so we override the existing configuration.
                 {
                     "org_unit_type_id": self.ou_type_water_pokemons.pk,
                     "org_units_editable": False,
@@ -103,6 +110,8 @@ class MobileOrgUnitChangeRequestConfigurationAPITestCase(OUCRCAPIBase):
                     "created_at": None,
                     "updated_at": None,
                 },
+                # Because of the configuration of his Profile, the user can't write on `new_org_unit_type_1`,
+                # and since there is no existing configuration, we add a dynamic one.
                 {
                     "org_unit_type_id": new_org_unit_type_1.pk,
                     "org_units_editable": False,
@@ -115,6 +124,8 @@ class MobileOrgUnitChangeRequestConfigurationAPITestCase(OUCRCAPIBase):
                     "created_at": None,
                     "updated_at": None,
                 },
+                # Because of the configuration of his Profile, the user can't write on `new_org_unit_type_2`,
+                # and since there is no existing configuration, we add a dynamic one.
                 {
                     "org_unit_type_id": new_org_unit_type_2.pk,
                     "org_units_editable": False,

--- a/iaso/tests/api/test_org_units_bulk_update.py
+++ b/iaso/tests/api/test_org_units_bulk_update.py
@@ -260,7 +260,7 @@ class OrgUnitsBulkUpdateAPITestCase(APITestCase):
 
         response = self.client.post(
             f"/api/tasks/create/orgunitsbulkupdate/",
-            data={"select_all": True, "validation_status": m.OrgUnit.VALIDATION_VALID},
+            data={"select_all": True, "validation_status": m.OrgUnit.VALIDATION_REJECTED},
             format="json",
         )
         self.assertJSONResponse(response, 201)
@@ -271,10 +271,6 @@ class OrgUnitsBulkUpdateAPITestCase(APITestCase):
         # Run the task.
         self.runAndValidateTask(task, "SUCCESS")
 
-        for org_unit in [self.jedi_squad_endor_1, self.jedi_squad_endor_2]:
-            org_unit.refresh_from_db()
-            self.assertEqual(org_unit.validation_status, m.OrgUnit.VALIDATION_VALID)
-
         self.assertEqual(2, am.Modification.objects.count())
 
         task.refresh_from_db()
@@ -282,6 +278,14 @@ class OrgUnitsBulkUpdateAPITestCase(APITestCase):
         self.assertIn("3 skipped", task.progress_message)
 
         self.yoda.iaso_profile.editable_org_unit_types.clear()
+
+        for org_unit in [self.jedi_squad_endor_1, self.jedi_squad_endor_2]:
+            org_unit.refresh_from_db()
+            self.assertEqual(org_unit.validation_status, m.OrgUnit.VALIDATION_REJECTED)
+
+        for org_unit in [self.jedi_council_corruscant, self.jedi_council_endor, self.jedi_council_brussels]:
+            org_unit.refresh_from_db()
+            self.assertEqual(org_unit.validation_status, m.OrgUnit.VALIDATION_VALID)
 
     @tag("iaso_only")
     def test_org_unit_bulkupdate_select_all_with_search(self):

--- a/iaso/tests/api/test_org_units_bulk_update.py
+++ b/iaso/tests/api/test_org_units_bulk_update.py
@@ -247,7 +247,7 @@ class OrgUnitsBulkUpdateAPITestCase(APITestCase):
         self.assertEqual(5, am.Modification.objects.count())
 
     @tag("iaso_only")
-    def test_org_unit_bulkupdate_select_all_without_write_permission(self):
+    def test_org_unit_bulkupdate_select_all_with_restricted_write_permission_for_user(self):
         """
         Check that we cannot bulk edit all org units if writing rights are limited
         by a set of org unit types that we are allowed to modify.

--- a/iaso/tests/api/test_org_units_bulk_update.py
+++ b/iaso/tests/api/test_org_units_bulk_update.py
@@ -60,7 +60,7 @@ class OrgUnitsBulkUpdateAPITestCase(APITestCase):
             location=cls.mock_point,
             validation_status=m.OrgUnit.VALIDATION_VALID,
         )
-        cls.jedi_squad_endor = m.OrgUnit.objects.create(
+        cls.jedi_squad_endor_1 = m.OrgUnit.objects.create(
             parent=cls.jedi_council_endor,
             org_unit_type=cls.jedi_squad,
             version=sw_version_1,
@@ -72,7 +72,7 @@ class OrgUnitsBulkUpdateAPITestCase(APITestCase):
             validation_status=m.OrgUnit.VALIDATION_VALID,
             source_ref="F9w3VW1cQmb",
         )
-        cls.jedi_squad_endor = m.OrgUnit.objects.create(
+        cls.jedi_squad_endor_2 = m.OrgUnit.objects.create(
             parent=cls.jedi_council_endor,
             org_unit_type=cls.jedi_squad,
             version=sw_version_1,
@@ -245,6 +245,43 @@ class OrgUnitsBulkUpdateAPITestCase(APITestCase):
             self.assertEqual(jedi_council.validation_status, m.OrgUnit.VALIDATION_VALID)
 
         self.assertEqual(5, am.Modification.objects.count())
+
+    @tag("iaso_only")
+    def test_org_unit_bulkupdate_select_all_without_write_permission(self):
+        """
+        Check that we cannot bulk edit all org units if writing rights are limited
+        by a set of org unit types that we are allowed to modify.
+        """
+        self.yoda.iaso_profile.editable_org_unit_types.set(
+            # Only org units of this type are now writable.
+            [self.jedi_squad]
+        )
+        self.client.force_authenticate(self.yoda)
+
+        response = self.client.post(
+            f"/api/tasks/create/orgunitsbulkupdate/",
+            data={"select_all": True, "validation_status": m.OrgUnit.VALIDATION_VALID},
+            format="json",
+        )
+        self.assertJSONResponse(response, 201)
+        data = response.json()
+        task = self.assertValidTaskAndInDB(data["task"], status="QUEUED", name="org_unit_bulk_update")
+        self.assertEqual(task.launcher, self.yoda)
+
+        # Run the task.
+        self.runAndValidateTask(task, "SUCCESS")
+
+        for org_unit in [self.jedi_squad_endor_1, self.jedi_squad_endor_2]:
+            org_unit.refresh_from_db()
+            self.assertEqual(org_unit.validation_status, m.OrgUnit.VALIDATION_VALID)
+
+        self.assertEqual(2, am.Modification.objects.count())
+
+        task.refresh_from_db()
+        self.assertIn("2 modified", task.progress_message)
+        self.assertIn("3 skipped", task.progress_message)
+
+        self.yoda.iaso_profile.editable_org_unit_types.clear()
 
     @tag("iaso_only")
     def test_org_unit_bulkupdate_select_all_with_search(self):

--- a/iaso/tests/api/test_orgunits.py
+++ b/iaso/tests/api/test_orgunits.py
@@ -607,6 +607,22 @@ class OrgUnitAPITestCase(APITestCase):
         response = self.set_up_org_unit_creation()
         self.assertJSONResponse(response, 403)
 
+    def test_create_org_unit_without_write_permission(self):
+        """
+        Check that we cannot create an org unit if writing rights are limited
+        by a set of org unit types that we are allowed to modify.
+        """
+        self.yoda.iaso_profile.editable_org_unit_types.set(
+            # Only org units of this type are now writable.
+            [self.jedi_squad]
+        )
+        self.client.force_authenticate(self.yoda)
+        response = self.set_up_org_unit_creation()
+        json_response = self.assertJSONResponse(response, 400)
+        self.assertEqual(json_response[0]["errorKey"], "org_unit_type_id")
+        self.assertEqual(json_response[0]["errorMessage"], "You cannot create or edit an Org unit of this type")
+        self.yoda.iaso_profile.editable_org_unit_types.clear()
+
     def test_create_org_unit(self):
         """Check that we can create org unit with only org units management permission"""
         self.client.force_authenticate(self.yoda)
@@ -998,6 +1014,31 @@ class OrgUnitAPITestCase(APITestCase):
             data=data,
         )
         self.assertJSONResponse(response, 403)
+
+    def test_edit_org_unit_without_write_permission(self):
+        """
+        Check that we cannot edit an org unit if writing rights are limited
+        by a set of org unit types that we are allowed to modify.
+        """
+        org_unit = m.OrgUnit.objects.create(
+            name="Foo",
+            org_unit_type=self.jedi_council,
+            version=self.star_wars.default_version,
+        )
+        self.yoda.iaso_profile.editable_org_unit_types.set(
+            # Only org units of this type are now writable.
+            [self.jedi_squad]
+        )
+        self.client.force_authenticate(self.yoda)
+        response = self.client.patch(
+            f"/api/orgunits/{org_unit.id}/",
+            format="json",
+            data={"name": "New name"},
+        )
+        json_response = self.assertJSONResponse(response, 400)
+        self.assertEqual(json_response[0]["errorKey"], "org_unit_type_id")
+        self.assertEqual(json_response[0]["errorMessage"], "You cannot create or edit an Org unit of this type")
+        self.yoda.iaso_profile.editable_org_unit_types.clear()
 
     def test_edit_org_unit_edit_bad_group_fail(self):
         """Check for a previous bug if an org unit is already member of a bad group

--- a/iaso/tests/api/test_orgunits.py
+++ b/iaso/tests/api/test_orgunits.py
@@ -607,7 +607,7 @@ class OrgUnitAPITestCase(APITestCase):
         response = self.set_up_org_unit_creation()
         self.assertJSONResponse(response, 403)
 
-    def test_create_org_unit_without_write_permission(self):
+    def test_create_org_unit_with_restricted_write_permission_for_user(self):
         """
         Check that we cannot create an org unit if writing rights are limited
         by a set of org unit types that we are allowed to modify.
@@ -1015,7 +1015,7 @@ class OrgUnitAPITestCase(APITestCase):
         )
         self.assertJSONResponse(response, 403)
 
-    def test_edit_org_unit_without_write_permission(self):
+    def test_edit_org_unit_with_restricted_write_permission_for_user(self):
         """
         Check that we cannot edit an org unit if writing rights are limited
         by a set of org unit types that we are allowed to modify.

--- a/iaso/tests/api/test_profiles.py
+++ b/iaso/tests/api/test_profiles.py
@@ -296,7 +296,7 @@ class ProfileAPITestCase(APITestCase):
         """GET /profiles/ with auth (user has read only permissions)"""
 
         self.client.force_authenticate(self.jane)
-        with self.assertNumQueries(17):
+        with self.assertNumQueries(11):
             response = self.client.get("/api/profiles/")
         self.assertJSONResponse(response, 200)
         profile_url = "/api/profiles/%s/" % self.jane.iaso_profile.id

--- a/iaso/tests/models/test_profile.py
+++ b/iaso/tests/models/test_profile.py
@@ -27,11 +27,11 @@ class ProfileModelTestCase(TestCase):
             self.assertTrue(self.profile1.has_org_unit_write_permission(org_unit_type_country.pk))
 
         self.profile1.editable_org_unit_types.set([org_unit_type_country])
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(1):
             self.assertFalse(self.profile1.has_org_unit_write_permission(org_unit_type_region.pk))
         self.profile1.editable_org_unit_types.clear()
 
         self.profile1.editable_org_unit_types.set([org_unit_type_region])
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(1):
             self.assertTrue(self.profile1.has_org_unit_write_permission(org_unit_type_region.pk))
         self.profile1.editable_org_unit_types.clear()

--- a/iaso/tests/models/test_profile.py
+++ b/iaso/tests/models/test_profile.py
@@ -18,3 +18,20 @@ class ProfileModelTestCase(TestCase):
     def test_user_has_team(self):
         self.assertTrue(self.profile1.has_a_team())
         self.assertFalse(self.profile2.has_a_team())
+
+    def test_has_org_unit_write_permission(self):
+        org_unit_type_country = m.OrgUnitType.objects.create(name="Country")
+        org_unit_type_region = m.OrgUnitType.objects.create(name="Region")
+
+        with self.assertNumQueries(1):
+            self.assertTrue(self.profile1.has_org_unit_write_permission(org_unit_type_country.pk))
+
+        self.profile1.editable_org_unit_types.set([org_unit_type_country])
+        with self.assertNumQueries(2):
+            self.assertFalse(self.profile1.has_org_unit_write_permission(org_unit_type_region.pk))
+        self.profile1.editable_org_unit_types.clear()
+
+        self.profile1.editable_org_unit_types.set([org_unit_type_region])
+        with self.assertNumQueries(2):
+            self.assertTrue(self.profile1.has_org_unit_write_permission(org_unit_type_region.pk))
+        self.profile1.editable_org_unit_types.clear()


### PR DESCRIPTION
Allow to edit/create org units based on a set of org unit types.

Related JIRA tickets : [IA-3445](https://bluesquare.atlassian.net/browse/IA-3445)

## Changes

- optimise the number of queries in `validate_editable_org_unit_types`
- add `Profile.has_org_unit_write_permission()`
- for users without write perms, prevent:
    - creation of org units
    - update of org units
    - bulk update of org units
- handle `Profile.editable_org_unit_types` in the mobile org unit change request configuration API

## How to test

See unit tests.

## Notes

This PR:

- builds on #1687 to ensure that the business logic is implemented in the backend
- is inspired by #1658 (but do some things differently)

The scope of this PR is limited to the `Profile` model. We'll work on the `UserRole` model in another one.


[IA-3445]: https://bluesquare.atlassian.net/browse/IA-3445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ