### PR TITLE
IA-3395: Associate a favourite picture for each Org Unit in the setuper

### DIFF
--- a/setuper/create_submission_with_picture.py
+++ b/setuper/create_submission_with_picture.py
@@ -1,6 +1,7 @@
 import uuid
 from datetime import datetime
 from submissions import submission2xml, org_unit_gps_point, submission_org_unit_gps_point
+from org_unit_pictures import associate_favorite_picture
 import random
 
 
@@ -124,3 +125,5 @@ def create_submission_with_picture(account_name, iaso_client):
                     "reference_instance_action": "flag",
                 }
                 iaso_client.patch(f"/api/orgunits/{org_unit_id}/", json=org_unit_reference_submission)
+
+    associate_favorite_picture(iaso_client)

--- a/setuper/org_unit_pictures.py
+++ b/setuper/org_unit_pictures.py
@@ -1,0 +1,22 @@
+import random
+
+
+def associate_favorite_picture(iaso_client):
+    org_unit_types = iaso_client.get("/api/v2/orgunittypes/")["orgUnitTypes"]
+    health_facility_type = [out for out in org_unit_types if out["name"] == "Health facility/Formation sanitaire - HF"][
+        0
+    ]
+    orgunits = iaso_client.get(
+        "/api/orgunits/",
+        params={"limit": health_facility_type["units_count"], "orgUnitTypeId": health_facility_type["id"]},
+    )["orgunits"]
+
+    for orgunit in orgunits:
+        org_unit_id = orgunit["id"]
+        linked_pictures = iaso_client.get(
+            "/api/instances/attachments/", params={"orgUnitId": org_unit_id, "image_only": True}
+        )
+        picture_ids = [picture["id"] for picture in linked_pictures]
+        default_image = random.choice(picture_ids)
+        favorite_image = {"default_image": default_image}
+        iaso_client.patch(f"/api/orgunits/{org_unit_id}/", json=favorite_image)


### PR DESCRIPTION
**This PR has to be merged after that one :** https://github.com/BLSQ/iaso/pull/1689


Related JIRA tickets : [IA-3395](https://bluesquare.atlassian.net/browse/IA-3395)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)


## Changes

Associating a favorite picture to each org unit with pictures in submissions.

## How to test

From setuper folder, launch setuper via `python3 setuper.py --additional_projects` to generate test data. Then login with the created account and open [Org Units page](http://localhost:8081/dashboard/orgunits/list/) and filter on the health facility org unit type for example with name **CMA Boromo**. Open the org unit page and go on the **[IMAGES](http://localhost:8081/dashboard/orgunits/detail/accountId/1/orgUnitId/57/)** tab. You should see a seleced image for the org unit.


## Print screen / video

[Iaso.webm](https://github.com/user-attachments/assets/1bb0128b-e0da-415e-a6cd-642d30ca9660)


[IA-3395]: https://bluesquare.atlassian.net/browse/IA-3395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ