### PR TITLE
WC2-515: Fix appId is ignored and always return first user

### DIFF
--- a/plugins/wfp_auth/views.py
+++ b/plugins/wfp_auth/views.py
@@ -117,8 +117,11 @@ class WFP2Adapter(Auth0OAuth2Adapter):
         # `self.request.query_params` is not set yet. Using `request.query_params` results in:
         # `'WSGIRequest' object has no attribute 'query_params'`
         app_id = request.GET.get(APP_ID, None)
+
         if app_id:
             account = get_object_or_404(Project, app_id=app_id).account
+            if app_id != self.settings["IASO_ACCOUNT_NAME"]:
+                uid = f"{app_id}_{uid}"
         else:
             account = Account.objects.get(name=self.settings["IASO_ACCOUNT_NAME"])
 


### PR DESCRIPTION
When logging in with an account that already has a `SocialAccount`, the `app_id` is ignored and the first account is always returned. This creates a new `SocialAccount` when the appId is different.

Related JIRA tickets : WC2-515

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented

## Changes

In order to create a new `SocialAccount`, the `app_id` is suffixed to the `SocialAccount`'s `uid` field. This is done only if the appId is different than the default one to stay retrocompatible.

## How to test

Setup your environment to use `wfp_auth` , to do that, you need to provide the following configuration to your environment:
```
WFP_AUTH_CLIENT_ID="blabla"
WFP_AUTH_ACCOUNT="<name of your default account>"
```

Make sure you have two accounts and a project in each.

Then, with a valid token, call:
```bash
curl --json '{"token":"<token>"}' 'http://localhost:8081/accounts/wfp/token/?app_id=<project_in_account_1>&app_version=2280'
curl --json '{"token":"<token>"}' 'http://localhost:8081/accounts/wfp/token/?app_id=<project_in_account_2>&app_version=2280'
```
You can then paste the access token you received from both call into https://jwt.io/ and see that the user_id is different.
