### PR TITLE
IA-3531, IA-3532, IA-3521: low-energy stuff

### DIFF
--- a/hat/assets/js/apps/Iaso/constants/menu.tsx
+++ b/hat/assets/js/apps/Iaso/constants/menu.tsx
@@ -422,4 +422,4 @@ export const useMenuItems = (): MenuItems => {
     }, [admin, basicItems, currentUser, pluginsMenu]);
     return items;
 };
-export const DOC_URL = 'https://docs.openiaso.com/en/latest/';
+export const DOC_URL = 'https://docs.openiaso.com';

--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -564,7 +564,7 @@
     "iaso.label.linkOffOrgUnitReferenceSubmission": "Unlink reference submission from orgUnit",
     "iaso.label.linkOrgUnitReferenceSubmission": "Link OrgUnit to reference submission",
     "iaso.label.links": "Links",
-    "iaso.label.linksList": "Liste de correspondances",
+    "iaso.label.linksList": "Links List",
     "iaso.label.list": "List",
     "iaso.label.loading": "Loading",
     "iaso.label.location": "Location",

--- a/hat/assets/js/apps/Iaso/domains/assignments/components/AssignmentsMap.tsx
+++ b/hat/assets/js/apps/Iaso/domains/assignments/components/AssignmentsMap.tsx
@@ -14,7 +14,6 @@ import { Locations, OrgUnitMarker, OrgUnitShape } from '../types/locations';
 
 import MarkersListComponent from '../../../components/maps/markers/MarkersListComponent';
 import { Tile } from '../../../components/maps/tools/TilesSwitchControl';
-import { MapInfo } from './MapInfo';
 import { MapLegend } from './MapLegend';
 import { OrgUnitPopup } from './OrgUnitPopup';
 
@@ -188,7 +187,8 @@ export const AssignmentsMap: FunctionComponent<Props> = ({
                     isFetchingOrgUnitTypes={isFetchingOrgUnitTypes}
                 />
                 <MapLegend />
-                <MapInfo />
+                {/* TODO uncomment when feature is reinstated */}
+                {/* <MapInfo /> */}
                 {selectedLocation && (
                     <OrgUnitPopup
                         top={anchorPoint.y}


### PR DESCRIPTION
IA-3521: remove info legend about (disabled) right click feature on assignments map
IA-3531: update link to iaso docs
IA-3532: fix english translation of Links List

Related JIRA tickets : IA-3531, IA-3532, IA-3521

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
N/A

## Changes

IA-3521: remove info legend about (disabled) right click feature on assignments map
IA-3531: update link to iaso docs
IA-3532: fix english translation of Links List

## How to test

- Open iaso's sidebar menu and test link to doc
- Set iaso in EN and open side bar menu > Org units > Data sources > Matching: french translation should be gone
- Go to Plannings > list > see : the question mak icon should be gone (bottom left corner of the map)

