### PR TITLE
IA-3536 doc deploy error

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -74,8 +74,7 @@ mkdocs-material-extensions==1.1.1
     # via mkdocs-material
 mkdocs-mermaid2-plugin==0.6.0
     # via -r ./requirements.in
-mkdocs-static-i18n==0.56
-    # via -r ./requirements.in
+mkdocs-static-i18n==1.2.3
 mkdocstrings[python]==0.20.0
     # via
     #   -r ./requirements.in

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -53,7 +53,7 @@ markupsafe==2.1.2
     #   mkdocstrings
 mergedeep==1.3.4
     # via mkdocs
-mkdocs==1.4.2
+mkdocs==1.5.2
     # via
     #   -r ./requirements.in
     #   mkdocs-autorefs


### PR DESCRIPTION
Doc not building because bad config in requirements.txt

Related JIRA tickets : IA-3536

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
- Tell us where the doc can be found (docs folder, wiki, in the code...)

## Changes
Bumped versions of mkdocs and mkdocs-static-i18n

## How to test 

Install /docs/requirements.txt locally and run mkdocs serve
