### PR TITLE
WC2-584: [Web] Duplicate pair details: visual improvements

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/entities/duplicates/details/hooks/useGetInstancesForEntity.ts
+++ b/hat/assets/js/apps/Iaso/domains/entities/duplicates/details/hooks/useGetInstancesForEntity.ts
@@ -18,7 +18,7 @@ export const useGetInstancesForEntity = ({
         entityId?: string;
         with_descriptor?: 'true' | 'false';
     } = {
-        order: '-created_at',
+        order: 'source_created_at',
         with_descriptor: 'true',
     };
     if (entityId) {

--- a/hat/assets/js/apps/Iaso/domains/entities/duplicates/details/submissions/ExpandableLabel.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/duplicates/details/submissions/ExpandableLabel.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import {
+    IconButton as IconButtonComponent,
+    displayDateFromTimestamp,
+} from 'bluesquare-components';
+import { Stack, Typography } from '@mui/material';
+import MESSAGES from '../../messages';
+import { baseUrls } from '../../../../../constants/urls';
+import { Instance } from '../../../../instances/types/instance';
+
+interface Props {
+    instance: Instance;
+}
+
+const ExpandableLabel: React.FunctionComponent<Props> = ({ instance }) => {
+    return (
+        <Stack direction="row" spacing={1} alignItems="center">
+            <Typography variant="h6">
+                {`${instance.form_name} - ${displayDateFromTimestamp(instance.source_created_at)}`}
+            </Typography>
+            <IconButtonComponent
+                size="small"
+                url={`/${baseUrls.instanceDetail}/instanceId/${instance?.id}`}
+                icon="remove-red-eye"
+                tooltipMessage={MESSAGES.submissionTitle}
+                color="primary"
+            />
+        </Stack>
+    );
+};
+
+export default ExpandableLabel;

--- a/hat/assets/js/apps/Iaso/domains/entities/duplicates/details/submissions/SubmissionsForEntity.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/duplicates/details/submissions/SubmissionsForEntity.tsx
@@ -36,7 +36,7 @@ export const SubmissionsForEntity: FunctionComponent<Props> = ({
                             )}
 
                             <ExpandableItem
-                                // This warning message on label should be fixed in bluesquare-component
+                                // This warning message on label should be fixed in bluesquare-components
                                 label={<ExpandableLabel instance={instance} />}
                                 titleColor="primary"
                                 titleVariant="h5"

--- a/hat/assets/js/apps/Iaso/domains/entities/duplicates/details/submissions/SubmissionsForEntity.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/duplicates/details/submissions/SubmissionsForEntity.tsx
@@ -1,11 +1,11 @@
 import React, { FunctionComponent } from 'react';
-import { useSafeIntl, ExpandableItem } from 'bluesquare-components';
+import { ExpandableItem } from 'bluesquare-components';
 import { Divider } from '@mui/material';
 import { InstanceDetailRaw } from '../../../../instances/compare/components/InstanceDetailRaw';
 import { useGetInstancesForEntity } from '../hooks/useGetInstancesForEntity';
-import MESSAGES from '../../messages';
 import WidgetPaperComponent from '../../../../../components/papers/WidgetPaperComponent';
 import { NoSubmission } from './NoSubmission';
+import ExpandableLabel from './ExpandableLabel';
 
 type Props = {
     entityId?: string;
@@ -16,7 +16,6 @@ export const SubmissionsForEntity: FunctionComponent<Props> = ({
     entityId,
     title = 'Entity',
 }) => {
-    const { formatMessage } = useSafeIntl();
     const {
         data = { instances: [] },
         isLoading,
@@ -37,9 +36,8 @@ export const SubmissionsForEntity: FunctionComponent<Props> = ({
                             )}
 
                             <ExpandableItem
-                                label={`${formatMessage(
-                                    MESSAGES.submissionTitle,
-                                )} - ${instance.id}`}
+                                // This warning message on label should be fixed in bluesquare-component
+                                label={<ExpandableLabel instance={instance} />}
                                 titleColor="primary"
                                 titleVariant="h5"
                             >

--- a/hat/assets/js/apps/Iaso/domains/instances/types/instance.ts
+++ b/hat/assets/js/apps/Iaso/domains/instances/types/instance.ts
@@ -56,6 +56,7 @@ export type Instance = {
     is_instance_of_reference_form: boolean;
     is_reference_instance: boolean;
     entity: Beneficiary;
+    source_created_at: number;
 };
 
 export type InstanceLogDetail = {

--- a/hat/assets/js/cypress/integration/14 - duplicates/details.spec.js
+++ b/hat/assets/js/cypress/integration/14 - duplicates/details.spec.js
@@ -3,6 +3,8 @@
 import { find } from 'lodash';
 import superUser from '../../fixtures/profiles/me/superuser.json';
 import duplicatesInfos from '../../fixtures/duplicates/list-details.json';
+import instancesAInfos from '../../fixtures/duplicates/instances-a.json';
+import instancesBInfos from '../../fixtures/duplicates/instances-b.json';
 
 let interceptFlag = false;
 const siteBaseUrl = Cypress.env('siteBaseUrl');
@@ -153,12 +155,15 @@ describe('Duplicate details', () => {
             testCellIsEmpty(3, 3);
 
             // SUBMISSIONS
+            console.log(
+                cy.get('[data-test="duplicate-submissions-a"]').find('h5'),
+            );
             cy.get('[data-test="duplicate-submissions-a"]')
                 .find('h5')
-                .should('contain', 'Submission - 883');
+                .should('contain', instancesAInfos.instances[0].form_name);
             cy.get('[data-test="duplicate-submissions-b"]')
                 .find('h5')
-                .should('contain', 'Submission - 163');
+                .should('contain', instancesBInfos.instances[0].form_name);
 
             cy.get('[data-test="duplicate-submissions-a"]')
                 .find('.MuiButtonBase-root')

--- a/hat/assets/js/cypress/integration/14 - duplicates/details.spec.js
+++ b/hat/assets/js/cypress/integration/14 - duplicates/details.spec.js
@@ -22,14 +22,14 @@ const mockPage = () => {
     }).as('getDetailsDuplicate');
     cy.intercept(
         'GET',
-        '/api/instances/?order=-created_at&with_descriptor=true&entityId=163',
+        '/api/instances/?order=source_created_at&with_descriptor=true&entityId=163',
         {
             fixture: 'duplicates/instances-a.json',
         },
     ).as('getDetailsInstanceA');
     cy.intercept(
         'GET',
-        '/api/instances/?order=-created_at&with_descriptor=true&entityId=883',
+        '/api/instances/?order=source_created_at&with_descriptor=true&entityId=883',
         {
             fixture: 'duplicates/instances-b.json',
         },


### PR DESCRIPTION
Explain what problem this PR is resolving
- [Web] Duplicate pair details: visual improvements
Related JIRA tickets : [WC2-584](https://bluesquare.atlassian.net/browse/WC2-584)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
- Tell us where the doc can be found (docs folder, wiki, in the code...)

## Changes
- Changed the label for ExpandableItem for submissions

## How to test
- Go to Beneficiaries ---> Duplicates ---> see details
- Check the Submissions for Beneficiary A and Submissions for Beneficiary B order and appearance.

## Print screen / video
[Screencast from 2024-10-12 13-21-19.webm](https://github.com/user-attachments/assets/931f7d72-6a5b-4b7f-92e8-471c89fa946a)



## Notes

Things that the reviewers should know: known bugs that are out of the scope of the PR, other trade-offs that were made.
If the PR depends on a PR in bluesquare-components, or merges into another PR (i.o. main), it should also be mentioned here


[WC2-584]: https://bluesquare.atlassian.net/browse/WC2-584?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ