### PR TITLE
IA-3500: Change request -  No select box for the form upon approval

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/instances/compare/components/InstanceDetail.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/compare/components/InstanceDetail.tsx
@@ -1,7 +1,7 @@
-import React, { FunctionComponent } from 'react';
 import { TypographyVariant } from '@mui/material';
-import { useGetInstance } from '../hooks/useGetInstance';
+import React, { FunctionComponent } from 'react';
 import { Instance } from '../../types/instance';
+import { useGetInstance } from '../hooks/useGetInstance';
 import { InstanceDetailRaw } from './InstanceDetailRaw';
 
 type Props = {
@@ -9,6 +9,7 @@ type Props = {
     showTitle?: boolean;
     height?: string | number;
     titleVariant?: TypographyVariant;
+    titleColor?: string;
 };
 
 const InstanceDetail: FunctionComponent<Props> = ({
@@ -16,6 +17,7 @@ const InstanceDetail: FunctionComponent<Props> = ({
     showTitle = true,
     height,
     titleVariant,
+    titleColor,
 }) => {
     const {
         data,
@@ -32,6 +34,7 @@ const InstanceDetail: FunctionComponent<Props> = ({
             showTitle={showTitle}
             height={height}
             titleVariant={titleVariant}
+            titleColor={titleColor}
         />
     );
 };

--- a/hat/assets/js/apps/Iaso/domains/instances/compare/components/InstanceDetailRaw.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/compare/components/InstanceDetailRaw.tsx
@@ -1,23 +1,23 @@
-import React, { FunctionComponent } from 'react';
 import { Box, Typography, TypographyVariant } from '@mui/material';
 import {
-    useSafeIntl,
-    LoadingSpinner,
     IconButton as IconButtonComponent,
+    LoadingSpinner,
+    useSafeIntl,
 } from 'bluesquare-components';
+import React, { FunctionComponent } from 'react';
 
+import { Accordion } from '../../../../components/Accordion/Accordion';
+import { AccordionDetails } from '../../../../components/Accordion/AccordionDetails';
+import { AccordionSummary } from '../../../../components/Accordion/AccordionSummary';
 import ErrorPaperComponent from '../../../../components/papers/ErrorPaperComponent';
-import MESSAGES from '../messages';
+import { baseUrls } from '../../../../constants/urls';
 import InstanceDetailsInfos from '../../components/InstanceDetailsInfos';
 import InstanceDetailsLocation from '../../components/InstanceDetailsLocation';
 import InstanceFileContent from '../../components/InstanceFileContent';
-import { Instance } from '../../types/instance';
 import InstancesFilesList from '../../components/InstancesFilesListComponent';
+import { Instance } from '../../types/instance';
 import { getInstancesFilesList } from '../../utils';
-import { Accordion } from '../../../../components/Accordion/Accordion';
-import { AccordionSummary } from '../../../../components/Accordion/AccordionSummary';
-import { AccordionDetails } from '../../../../components/Accordion/AccordionDetails';
-import { baseUrls } from '../../../../constants/urls';
+import MESSAGES from '../messages';
 
 type Props = {
     data?: Instance;
@@ -26,6 +26,7 @@ type Props = {
     showTitle?: boolean;
     titleVariant?: TypographyVariant;
     height?: string | number;
+    titleColor?: string;
 };
 
 const styles = {
@@ -46,6 +47,7 @@ export const InstanceDetailRaw: FunctionComponent<Props> = ({
     showTitle = true,
     titleVariant = 'h5',
     height = '70vh',
+    titleColor = 'secondary',
 }) => {
     const { formatMessage } = useSafeIntl();
 
@@ -68,7 +70,7 @@ export const InstanceDetailRaw: FunctionComponent<Props> = ({
         <>
             {showTitle && (
                 <Box display="flex" alignItems="center">
-                    <Typography variant={titleVariant} color="secondary">
+                    <Typography variant={titleVariant} color={titleColor}>
                         {`${formatMessage(MESSAGES.submissionTitle)} - ${
                             data?.id
                         }`}

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/Components/HighlightFieldsChanges.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/Components/HighlightFieldsChanges.tsx
@@ -63,7 +63,6 @@ export const HighlightFields: FunctionComponent<Props> = ({
             };
         });
     }, [fieldType, oldFieldValues, newFieldValues]);
-
     return (
         <TableRow sx={{ verticalAlign: 'top' }}>
             <TableCell>{field.label}</TableCell>

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/hooks/useNewFields.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/hooks/useNewFields.tsx
@@ -68,6 +68,7 @@ const ReferenceInstances: FunctionComponent<ReferenceInstancesProps> = ({
                         instanceId={`${instance.id}`}
                         height="150px"
                         titleVariant="subtitle2"
+                        titleColor="inherit"
                     />
                 </Box>
             ))}

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/hooks/useNewFields.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/hooks/useNewFields.tsx
@@ -183,21 +183,27 @@ export const useNewFields = (
                         <></>
                     ),
             },
+            new_location_accuracy: {
+                label: formatMessage(MESSAGES.accuracy),
+                order: 6,
+                fieldType: '',
+                formatValue: val => <span>{val.toString()}</span>,
+            },
             new_opening_date: {
                 label: formatMessage(MESSAGES.openingDate),
-                order: 6,
+                order: 7,
                 fieldType: '',
                 formatValue: val => <span>{moment(val).format('L')}</span>,
             },
             new_closed_date: {
                 label: formatMessage(MESSAGES.closingDate),
-                order: 7,
+                order: 8,
                 fieldType: '',
                 formatValue: val => <span>{moment(val).format('L')}</span>,
             },
             new_reference_instances: {
                 label: formatMessage(MESSAGES.multiReferenceInstancesLabel),
-                order: 8,
+                order: 9,
                 fieldType: '',
                 formatValue: val => (
                     <ReferenceInstances

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/messages.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/messages.ts
@@ -213,6 +213,10 @@ const MESSAGES = defineMessages({
         id: 'iaso.label.paymentStatus',
         defaultMessage: 'Payment status',
     },
+    accuracy: {
+        id: 'iaso.label.accuracy',
+        defaultMessage: 'Accuracy',
+    },
 });
 
 export default MESSAGES;


### PR DESCRIPTION
[This](https://iaso-staging.bluesquare.org/dashboard/orgunits/changeRequest/accountId/177/) change request cannot be approved totally. It looks like reference form cannot be approved.

In fact this change request as a new field accuracy and frontend is not displaying it.

Secondary color of the submission title is leading to confusion (using orange)

Related JIRA tickets : IA-3500
## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- added accuracy new field
- change title color to `inherit` form above

## How to test

You need a change request with new_accuracy filed fill up and `new_location_accuracy` in requested fields.

Visit the change request on the dashboard and check that you can approve all changes now

## Print screen / video


https://github.com/user-attachments/assets/5bda49a8-68aa-4b45-a185-a2448987d32b


https://github.com/user-attachments/assets/b9f8540f-2d99-46af-b73f-df2cf8a597f2


https://github.com/user-attachments/assets/7758a808-b532-4734-a735-0da3c1a5d522


