### PR TITLE
IA-3539: DATASOURCES: remove "close and launch" task button if no task permission

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/dataSources/components/AddTaskComponent.js
+++ b/hat/assets/js/apps/Iaso/domains/dataSources/components/AddTaskComponent.js
@@ -12,6 +12,9 @@ import { useSnackMutation } from '../../../libs/apiHooks.ts';
 import MESSAGES from '../messages';
 import { sendDhisOuImporterRequest } from '../requests';
 import { VersionDescription } from './VersionDescription.tsx';
+import { userHasPermission } from '../../users/utils';
+import * as Permission from '../../../utils/permissions.ts';
+import { useCurrentUser } from '../../../utils/usersUtils';
 
 const initialFormState = sourceCredentials => {
     return {
@@ -30,6 +33,7 @@ const AddTask = ({
     sourceVersionNumber,
     sourceCredentials,
 }) => {
+    const currentUser = useCurrentUser();
     const [form, setFormField, , setFormState] = useFormState(
         initialFormState(sourceCredentials),
     );
@@ -176,6 +180,18 @@ const AddTask = ({
             ]}
         />
     );
+    const hasTaskPermission = userHasPermission(
+        Permission.DATA_TASKS,
+        currentUser,
+    );
+
+    const additionalButtonProps = hasTaskPermission
+        ? {
+              additionalButton: true,
+              additionalMessage: MESSAGES.goToCurrentTask,
+              onAdditionalButtonClick: onRedirect,
+          }
+        : {};
     return (
         <ConfirmCancelDialogComponent
             renderTrigger={renderTrigger}
@@ -186,9 +202,7 @@ const AddTask = ({
             cancelMessage={MESSAGES.cancel}
             maxWidth="sm"
             allowConfirm={allowConfirm}
-            additionalButton
-            additionalMessage={MESSAGES.goToCurrentTask}
-            onAdditionalButtonClick={onRedirect}
+            {...additionalButtonProps}
         >
             {mutation.isLoading && <LoadingSpinner />}
 

--- a/hat/assets/js/apps/Iaso/domains/dataSources/components/CopySourceVersion/CopySourceVersion.tsx
+++ b/hat/assets/js/apps/Iaso/domains/dataSources/components/CopySourceVersion/CopySourceVersion.tsx
@@ -18,6 +18,9 @@ import {
     useDataSourceVersions,
 } from '../../requests';
 import { WarningMessage } from './CopyVersionWarnings';
+import { userHasPermission } from '../../../users/utils';
+import * as Permission from '../../../../utils/permissions';
+import { useCurrentUser } from '../../../../utils/usersUtils';
 
 type Props = {
     dataSourceId: number;
@@ -74,6 +77,7 @@ export const CopySourceVersion: FunctionComponent<Props> = ({
     dataSourceId,
     dataSourceVersionNumber,
 }) => {
+    const currentUser = useCurrentUser();
     const { formatMessage } = useSafeIntl();
     const redirectTo = useRedirectTo();
     const [destinationSourceId, setDestinationSourceId] =
@@ -92,6 +96,7 @@ export const CopySourceVersion: FunctionComponent<Props> = ({
         [allSourceVersions, destinationSourceId, formatMessage],
     );
     const nextVersionNumber =
+        // eslint-disable-next-line no-unsafe-optional-chaining
         sourceVersionsDropDown[sourceVersionsDropDown?.length - 1]?.value ?? 1;
     const [destinationVersionNumber, setDestinationVersionNumber] =
         useState(nextVersionNumber);
@@ -151,6 +156,11 @@ export const CopySourceVersion: FunctionComponent<Props> = ({
             setDestinationVersionNumber(nextVersionNumber);
     }, [destinationVersionNumber, nextVersionNumber]);
 
+    const hasTaskPermission = userHasPermission(
+        Permission.DATA_TASKS,
+        currentUser,
+    );
+
     return (
         <ConfirmCancelDialogComponent
             id="copySourceVersionModal"
@@ -166,13 +176,15 @@ export const CopySourceVersion: FunctionComponent<Props> = ({
                     versionNumber: dataSourceVersionNumber,
                 },
             }}
-            additionalButton
-            additionalMessage={MESSAGES.goToCurrentTask}
-            onAdditionalButtonClick={onRedirect}
             onCancel={onCancel}
             dataTestId="copy-source-version-modal"
             allowConfirm={allowConfirm}
-            allowConfimAdditionalButton={allowConfirm}
+            allowConfimAdditionalButton={allowConfirm && hasTaskPermission}
+            additionalButton={hasTaskPermission}
+            additionalMessage={
+                hasTaskPermission ? MESSAGES.goToCurrentTask : undefined
+            }
+            onAdditionalButtonClick={hasTaskPermission ? onRedirect : undefined}
         >
             <>
                 <Box mb={2}>

--- a/hat/assets/js/apps/Iaso/domains/dataSources/components/EditSourceVersion.tsx
+++ b/hat/assets/js/apps/Iaso/domains/dataSources/components/EditSourceVersion.tsx
@@ -77,11 +77,11 @@ export const EditSourceVersion: FunctionComponent<Props> = ({
             titleMessage={{
                 ...MESSAGES.editSourceVersion,
             }}
-            additionalButton
-            additionalMessage={MESSAGES.goToCurrentTask}
             onCancel={onCancel}
             allowConfirm={allowConfirm}
             // This is to avoid complaints from TS compiler
+            additionalButton={false}
+            additionalMessage={undefined}
             allowConfimAdditionalButton={undefined}
             onAdditionalButtonClick={undefined}
         >

--- a/hat/assets/js/apps/Iaso/domains/dataSources/components/ImportGeoPkgDialog.js
+++ b/hat/assets/js/apps/Iaso/domains/dataSources/components/ImportGeoPkgDialog.js
@@ -16,6 +16,9 @@ import { useSnackMutation } from '../../../libs/apiHooks.ts';
 import MESSAGES from '../messages';
 import { postGeoPkg } from '../requests';
 import { VersionDescription } from './VersionDescription.tsx';
+import { userHasPermission } from '../../users/utils';
+import * as Permission from '../../../utils/permissions.ts';
+import { useCurrentUser } from '../../../utils/usersUtils';
 
 const initialFormState = () => ({
     file: null,
@@ -30,6 +33,7 @@ const ImportGeoPkgDialog = ({
     versionNumber,
     projects,
 }) => {
+    const currentUser = useCurrentUser();
     const [form, setFormField, , setFormState] =
         useFormState(initialFormState());
     const { formatMessage } = useSafeIntl();
@@ -85,6 +89,19 @@ const ImportGeoPkgDialog = ({
     const allowConfirm = Boolean(
         !mutation.isLoading && form.file.value && form.project.value,
     );
+
+    const hasTaskPermission = userHasPermission(
+        Permission.DATA_TASKS,
+        currentUser,
+    );
+
+    const additionalButtonProps = hasTaskPermission
+        ? {
+              additionalButton: true,
+              additionalMessage: MESSAGES.goToCurrentTask,
+              onAdditionalButtonClick: onRedirect,
+          }
+        : {};
     return (
         <ConfirmCancelDialogComponent
             renderTrigger={renderTrigger}
@@ -93,11 +110,9 @@ const ImportGeoPkgDialog = ({
             cancelMessage={MESSAGES.cancel}
             maxWidth="sm"
             allowConfirm={allowConfirm}
-            additionalButton
-            additionalMessage={MESSAGES.goToCurrentTask}
             onConfirm={onConfirm}
-            onAdditionalButtonClick={onRedirect}
             onClosed={reset}
+            {...additionalButtonProps}
         >
             {mutation.isLoading && <LoadingSpinner />}
             <Grid container spacing={4}>


### PR DESCRIPTION
Explain what problem this PR is resolving
- DATASOURCES: remove "close and launch" task button if no task permission
Related JIRA tickets : [IA-3539](https://bluesquare.atlassian.net/browse/IA-3539)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes
- Not allow additionalButton(Launch and show task) when the user has not DATA_TASK permission

## How to test
- Edit or Create a user without the DATA_TASK permission
- Go in Org Units ---> Data Source
- Try edit a datasource versions and check if the launch and show task button still there

## Print screen / video
[Screencast from 2024-10-15 11-08-54.webm](https://github.com/user-attachments/assets/cbcf072a-06c1-40e2-b679-02ed1c5b19c2)



[IA-3539]: https://bluesquare.atlassian.net/browse/IA-3539?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ