### PR TITLE
IA-3557 IA-3558  I Groupsets fixes

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/groupSets/hooks/requests.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/groupSets/hooks/requests.ts
@@ -24,7 +24,7 @@ interface GetGroupSetsParams {
 
 export const useGetGroupSets = params => {
     const newParams: GetGroupSetsParams = {
-        limit: params.pageSize || '20',
+        limit: params.pageSize || '10',
         order: params.order || 'id',
         page: params.page || '1',
     };

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/groupSets/hooks/requests.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/groupSets/hooks/requests.ts
@@ -43,7 +43,7 @@ export const useGetGroupSets = params => {
         newParams as Record<string, string>,
     );
     return useSnackQuery(
-        ['group_sets', searchParams.toString()],
+        ['groupSets', searchParams.toString()],
         () =>
             getRequest(
                 `/api/group_sets/?${searchParams.toString()}&fields=id,name,groups,created_at,updated_at`,
@@ -58,7 +58,7 @@ export const useGetGroupSets = params => {
 
 export const useGetGroupSet = groupSetId => {
     return useSnackQuery(
-        ['group_sets', groupSetId],
+        ['groupSet', groupSetId],
         () => {
             // if create
             if (groupSetId === 'new') {
@@ -80,7 +80,7 @@ export const useSaveGroupSet = (): UseMutationResult<any, any, any, any> =>
         },
         undefined,
         undefined,
-        ['group_sets'],
+        ['groupSets', 'groupSet'],
     );
 
 export const useDeleteGroupSet = () =>
@@ -88,7 +88,7 @@ export const useDeleteGroupSet = () =>
         body => deleteRequest(`/api/group_sets/${body.id}/`),
         MESSAGES.deleteSuccess,
         MESSAGES.deleteError,
-        ['group_sets'],
+        ['groupSets', 'groupSet'],
     );
 
 const mapChoices = choices =>

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/groupSets/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/groupSets/index.tsx
@@ -3,7 +3,6 @@ import { makeStyles } from '@mui/styles';
 import {
     AddButton as AddButtonComponent,
     commonStyles,
-    LoadingSpinner,
     Table,
     useRedirectTo,
     useSafeIntl,
@@ -39,7 +38,6 @@ const GroupSets = () => {
     };
     return (
         <>
-            {isLoading && <LoadingSpinner />}
             <TopBar
                 title={formatMessage(MESSAGES.groupSets)}
                 displayBackButton={false}
@@ -65,11 +63,13 @@ const GroupSets = () => {
                         columns={tableColumns}
                         count={data?.count ?? 0}
                         baseUrl={baseUrl}
-                        params={params}
                         redirectTo={(_, newParams) =>
                             redirectTo(baseUrl, newParams)
                         }
                         marginTop={false}
+                        extraProps={{
+                            loading: isLoading,
+                        }}
                     />
                 )}
             </Box>


### PR DESCRIPTION
IA-3557: Pagination on group sets is buggy leading to non existant pages
IA-3558: Create or update the list of group sets is not refreshing group sets dropdown values

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- IA-3557: Align default pagination limit with default table pagination
- IA-3558: align queryKey to reload dropdown values

## How to test

- make sure you have more than 10 group sets, play with the pagination and go to the last page
- create or change a group set and edit a OUCRC, dropdown for group sets should contain your changes

## Print screen / video

- IA-3557: 

https://github.com/user-attachments/assets/95a6c693-6bbd-4105-997d-329f3ff41d0f


- IA-3558: 

https://github.com/user-attachments/assets/45f32a7a-6cbc-4a7a-97e1-7af630110339



