### PR TITLE
IA-3516 Adapt token API endpoint for multi account users

### DIFF
--- a/hat/settings.py
+++ b/hat/settings.py
@@ -414,7 +414,11 @@ REST_FRAMEWORK = {
     ),
 }
 
-SIMPLE_JWT = {"ACCESS_TOKEN_LIFETIME": timedelta(days=3650), "REFRESH_TOKEN_LIFETIME": timedelta(days=3651)}
+SIMPLE_JWT = {
+    "ACCESS_TOKEN_LIFETIME": timedelta(days=3650),
+    "REFRESH_TOKEN_LIFETIME": timedelta(days=3651),
+    "TOKEN_OBTAIN_SERIALIZER": "iaso.serializers.CustomTokenObtainPairSerializer",
+}
 
 AWS_S3_REGION_NAME = os.getenv("AWS_S3_REGION_NAME", "eu-central-1")
 AWS_ACCESS_KEY_ID = os.getenv("AWS_ACCESS_KEY_ID")

--- a/iaso/api/profiles/profiles.py
+++ b/iaso/api/profiles/profiles.py
@@ -356,7 +356,7 @@ class ProfilesViewSet(viewsets.ViewSet):
         pk = kwargs.get("pk")
         if pk == PK_ME:
             # if the user is a main_user, login as an account user
-            # TODO: remember the last account_user
+            # TODO: This is not a clean side-effect and should be improved.
             if request.user.tenant_users.exists():
                 account_user = request.user.tenant_users.first().account_user
                 account_user.backend = "django.contrib.auth.backends.ModelBackend"

--- a/iaso/serializers.py
+++ b/iaso/serializers.py
@@ -1,0 +1,35 @@
+from django.contrib.auth.models import User
+
+from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
+
+from iaso.models import Project
+
+
+class CustomTokenObtainPairSerializer(TokenObtainPairSerializer):
+    def validate(self, attrs):
+        """
+        Override this method to be able to take into account the app_id query param.
+
+        If the user is a multi-account user, we return a token for the correct
+        "account user" (based on the `app_id`) instead of the main user that was
+        used for logging in.
+        """
+        data = super().validate(attrs)
+
+        if self.user.tenant_users.exists():
+            request = self.context.get("request")
+            if request:
+                app_id = request.query_params.get("app_id", None)
+                project = Project.objects.get(app_id=app_id)
+
+                account_user = User.objects.filter(
+                    tenant_user__main_user=self.user,
+                    iaso_profile__account=project.account,
+                ).first()
+
+                refresh = self.get_token(account_user)
+
+                data["refresh"] = str(refresh)
+                data["access"] = str(refresh.access_token)
+
+        return data

--- a/iaso/serializers.py
+++ b/iaso/serializers.py
@@ -1,6 +1,7 @@
 from django.contrib.auth.models import User
 
 from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
+from rest_framework_simplejwt.exceptions import AuthenticationFailed
 
 from iaso.models import Project
 
@@ -8,24 +9,33 @@ from iaso.models import Project
 class CustomTokenObtainPairSerializer(TokenObtainPairSerializer):
     def validate(self, attrs):
         """
-        Override this method to be able to take into account the app_id query param.
+        Override this method to be able to handle multi-account users.
 
         If the user is a multi-account user, we return a token for the correct
-        "account user" (based on the `app_id`) instead of the main user that was
-        used for logging in.
+        "account user" (based on the `app_id` query params) instead of the
+        main user that was used for logging in.
         """
         data = super().validate(attrs)
+
+        err_msg = "No active account found with the given credentials"
 
         if self.user.tenant_users.exists():
             request = self.context.get("request")
             if request:
                 app_id = request.query_params.get("app_id", None)
-                project = Project.objects.get(app_id=app_id)
+
+                try:
+                    project = Project.objects.get(app_id=app_id)
+                except Project.DoesNotExist:
+                    raise AuthenticationFailed(err_msg)
 
                 account_user = User.objects.filter(
                     tenant_user__main_user=self.user,
                     iaso_profile__account=project.account,
                 ).first()
+
+                if account_user is None:
+                    raise AuthenticationFailed(err_msg)
 
                 refresh = self.get_token(account_user)
 


### PR DESCRIPTION
This PR enables the login with username/password for multi-account users on the mobile app.

If a user request a token to api/token, there are now 2 options:
- The user is a regular user --> nothing changes
- The user is a multi-account user --> we check if the user has a "account_user" associated (via the `TenantUser` model) with an account that has a link to the project specified in the `app_id` query params. In this case, the endpoint returns a token for this account_user

Related JIRA tickets : https://bluesquare.atlassian.net/browse/IA-3516

## Changes

The `TokenObtainPairSerializer` had to be overridden to be able to change the behaviour and have access to the query params.
This was done based on the implementation here:
https://github.com/jazzband/djangorestframework-simplejwt/blob/master/rest_framework_simplejwt/serializers.py#L69
And the documentation here:
https://django-rest-framework-simplejwt.readthedocs.io/en/latest/customizing_token_claims.html

## How to test

Using the mobile app, you can set up a multi-account scenario and then test with the "Switch account" to change the app_id, and log out and login.

## Notes

CIAM login will find the user simply based on email + account (from the app_id). If not found, it creates the user, but without permissions.

So this works, but doesn't result in users that are able to use the country switch in the dashboard. Those users, we need to create by hand and make sure the email is the same on all users.

I suppose this is acceptable for now. We can always, via the Django admin, convert users like this into "real" multi account users that have the account toggle in the web dashboard.
