### PR TITLE
POLIO-1692: create VRF on multiple vaccine campaign is not working

### DIFF
--- a/plugins/polio/api/campaigns/campaigns.py
+++ b/plugins/polio/api/campaigns/campaigns.py
@@ -414,7 +414,12 @@ class CampaignSerializer(serializers.ModelSerializer):
         return campaign
 
     # Vaccines with real scope
-    vaccines = serializers.CharField(read_only=True)
+    vaccines = serializers.SerializerMethodField(read_only=True)
+
+    def get_vaccines(self, obj):
+        if obj.vaccines:
+            return ",".join([vaccine.strip() for vaccine in obj.vaccines.split(",")])
+        return ""
 
     class Meta:
         model = Campaign


### PR DESCRIPTION
Api is returning something like this  "vaccines": "bOPV, mOPV2, nOPV2"
Frontend is populating options with those value including white spaces, leading to an error while trying to save a VRF with " mOPV2" as vaccine

Related JIRA tickets :POLIO-1692

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- change serializer to return a list without white spaces

## How to test

You need a campaign with different vaccine used in the scope.
Try to create a vaccine supply entry for this campaign.

## Print screen / video


https://github.com/user-attachments/assets/33081e53-10b7-4f4d-aec9-311b55d14ae2

