### PR TITLE
[IA-3572] Setuper error after worker timeout

### DIFF
--- a/setuper/iaso_api_client.py
+++ b/setuper/iaso_api_client.py
@@ -3,6 +3,9 @@ import time
 
 
 class IasoClient:
+    ASYNC_TASK_TIMEOUT = 120
+    ASYNC_TASK_WAIT_STEP = 5
+
     def __init__(self, server_url):
         self.debug = False
         self.server_url = server_url
@@ -74,15 +77,18 @@ class IasoClient:
         print(f"\tWaiting for async task '{task_to_wait['task']['name']}'")
         count = 0
         imported = False
-        while not imported and count < 120:
+        while not imported and count < self.ASYNC_TASK_TIMEOUT:
             task = self.get(f"/api/tasks/{task_to_wait['task']['id']}")
             imported = task["status"] == "SUCCESS"
 
             if task["status"] == "ERRORED":
                 raise Exception(f"Task failed {task}")
-            time.sleep(2)
-            count += 5
+            time.sleep(self.ASYNC_TASK_WAIT_STEP)
+            count += self.ASYNC_TASK_WAIT_STEP
             print("\t\tWaiting:", count, "s elapsed", task.get("progress_message"))
+        raise Exception(
+            f"Couldn't find an available worker after {self.ASYNC_TASK_TIMEOUT} seconds. Please make sure a worker is running."
+        )
 
     def log(self, arg1, arg2=None):
         if self.debug:


### PR DESCRIPTION
Setuper now fails when there is a worker timeout.

Related JIRA tickets : IA-3572

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
/

## Changes

Error after worker timeout in setuper

## How to test

Run the setuper without having a worker running in the background.
(Tip: change the timeout value in the setuper `IasoClient` if you don't want to wait 2 minutes to see the result :wink:) 

## Print screen / video

![image](https://github.com/user-attachments/assets/8b161e95-5be5-4ff2-b25f-d5108c29d1d1)


## Notes

/
