### PR TITLE
[IA-3571] Added account_name parameter to setuper command

### DIFF
--- a/setuper/README.md
+++ b/setuper/README.md
@@ -69,11 +69,19 @@ Once the script has run, you can log in to your server using the account name as
 
         python3 setuper.py
 
-2. If you want to create additional projects like:
+   There are some optional parameters you can pass to this command:
+
+   - If you want to create additional projects like:
       - Planning
       - Georegistry/Géoregistre
       - Vaccination
 
-    You will need to add param `--additional_projects`:
+       You will need to add param `--additional_projects` or `-a`:
 
-        python3 setuper.py --additional_projects
+           python3 setuper.py --additional_projects
+
+   - If you want to choose the name that will be used for the account/project/user/... (max 147 characters, only a-z, A-Z, 0-9)
+
+       You will need to add param `-n <name>`:
+
+           python3 setuper.py -n ThisNameWasCarefullyChosen

--- a/setuper/setuper.py
+++ b/setuper/setuper.py
@@ -1,3 +1,5 @@
+import re
+
 from iaso_api_client import IasoClient
 from micro_planning import setup_users_teams_micro_planning
 from data_collection import setup_instances
@@ -55,8 +57,30 @@ def setup_account(account_name, server_url, username, password):
     return iaso_client
 
 
-def create_account(server_url, username, password, additional_projects):
-    account_name = "".join(random.choices(string.ascii_lowercase, k=7))
+def validate_account_name(name: str) -> str:
+    random_name = "".join(random.choices(string.ascii_lowercase, k=7))
+    if not name:  # the user didn't pass a name as parameter
+        return random_name
+
+    # In all the places where this name is used, the shortest field is the Django User.username (150 chars)
+    # However, the setuper can create multiple accounts with a '.xx' suffix, so we need to keep some space
+    NAME_MAX_LENGTH = 147
+    if len(name) > NAME_MAX_LENGTH:
+        raise Exception(f"Account name is too long - {NAME_MAX_LENGTH} characters maximum")
+
+    # I wanted to include "-" in the pattern, but the API converts them to "." and then it breaks stuff later on
+    # Not sure how accents in app_id will be handled, so let's avoid them out of caution
+    pattern = re.compile("[A-Za-z0-9]+")
+    if not pattern.fullmatch(name):
+        raise Exception("Account name must be alphanumeric (0-9, a-z, A-Z)")
+
+    return name
+
+
+def create_account(
+    server_url: str, username: str, password: str, optional_account_name: str, additional_projects: bool
+):
+    account_name = validate_account_name(optional_account_name)
     print("Creating account:", account_name)
     iaso_client = setup_account(account_name, server_url, username, password)
     setup_orgunits(iaso_client=iaso_client)
@@ -95,12 +119,14 @@ if __name__ == "__main__":
     parser.add_argument("-u", "--username", type=str, help="User name")
     parser.add_argument("-p", "--password", type=str, help="Password")
     parser.add_argument("-s", "--server_url", type=str, help="Server URL")
+    parser.add_argument("-n", "--name", help="Account name (max 147 characters; a-z, A-Z, 0-9)")
     parser.add_argument("-a", "--additional_projects", action="store_true")
 
     args = parser.parse_args()
     server_url = args.server_url
     username = args.username
     password = args.password
+    account_name = args.name
     additional_projects = args.additional_projects
 
     if server_url is None or username is None or password is None:
@@ -122,4 +148,4 @@ if __name__ == "__main__":
     if not server_url or not username or not password:
         sys.exit(f"ERROR: Values for server url, user name and password are all required")
 
-    create_account(server_url, username, password, additional_projects)
+    create_account(server_url, username, password, account_name, additional_projects)

--- a/setuper/setuper.py
+++ b/setuper/setuper.py
@@ -58,9 +58,8 @@ def setup_account(account_name, server_url, username, password):
 
 
 def validate_account_name(name: str) -> str:
-    random_name = "".join(random.choices(string.ascii_lowercase, k=7))
     if not name:  # the user didn't pass a name as parameter
-        return random_name
+        return "".join(random.choices(string.ascii_lowercase, k=7))
 
     # In all the places where this name is used, the shortest field is the Django User.username (150 chars)
     # However, the setuper can create multiple accounts with a '.xx' suffix, so we need to keep some space


### PR DESCRIPTION
Allows users to choose a name for the account/project/user/... created by the setuper.

Related JIRA tickets : IA-3571

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [x] Documentation has been included (for new feature)

## Doc
Documentation in the code

## Changes

Added an optional parameter to the setuper command for choosing the name of the account/project/user/...

## How to test

Run the setuper command with the `-n` parameter. 
If you don't add it, the behavior stays the same.

## Print screen / video

![image](https://github.com/user-attachments/assets/244abb17-07e1-4c4e-a059-d74fed581152)
![image](https://github.com/user-attachments/assets/e63e30f3-8491-4c4e-8e5b-6dff3595b7a8)



## Notes

During the morning SUM, we discussed the possibility of having random names generated (instead of random string). As nothing specific was decided, I didn't implement this feature.
