### PR TITLE
POLIO-1694: Add start date to Campaign Scope download

### DIFF
--- a/plugins/polio/api/campaigns/campaigns.py
+++ b/plugins/polio/api/campaigns/campaigns.py
@@ -1093,6 +1093,7 @@ class CampaignViewSet(ModelViewSet):
             {"title": "Admin 0", "width": 25},
             {"title": "OBR Name", "width": 25},
             {"title": "Round Number", "width": 35},
+            {"title": "Start date", "width": 35},
             {"title": "Vaccine", "width": 35},
         ]
 
@@ -1146,6 +1147,7 @@ class CampaignViewSet(ModelViewSet):
             org_unit.get("org_unit_parent_of_parent_name"),
             org_unit.get("obr_name"),
             org_unit.get("round_number"),
+            org_unit.get("start_date"),
             org_unit.get("vaccine"),
         ]
 
@@ -1219,6 +1221,7 @@ class CampaignViewSet(ModelViewSet):
                 item["org_unit_parent_of_parent_name"] = org_unit.parent.parent.name
                 item["obr_name"] = campaign.obr_name
                 item["round_number"] = "R" + str(round.number)
+                item["start_date"] = round.started_at
                 item["vaccine"] = scope.vaccine
                 org_units_list.append(item)
         return org_units_list


### PR DESCRIPTION
Explain what problem this PR is resolving
- Add start date to Campaign Scope download
Related JIRA tickets : [POLIO-1694](https://bluesquare.atlassian.net/browse/POLIO-1694)
## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
- Tell us where the doc can be found (docs folder, wiki, in the code...)

## Changes
- Add the start date at the right of Round number in the campaign scope download

## How to test
- Polio --> Calendar 
- Check if the scope download contains the start date

## Print screen / video
[Screencast from 2024-10-18 14-56-39.webm](https://github.com/user-attachments/assets/369d890e-52b4-4290-8bcc-3f566788f267)


## Notes

Things that the reviewers should know: known bugs that are out of the scope of the PR, other trade-offs that were made.
If the PR depends on a PR in bluesquare-components, or merges into another PR (i.o. main), it should also be mentioned here


[POLIO-1694]: https://bluesquare.atlassian.net/browse/POLIO-1694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ