### PR TITLE
[IA-3570] Add HF form to setuper .georegistry project

### DIFF
--- a/setuper/additional_projects.py
+++ b/setuper/additional_projects.py
@@ -10,7 +10,10 @@ def projects_mapper(account_name):
             "name": "Georegistry/Géoregistre",
             "app_id": f"{account_name}.georegistry",
             "feature_flags": ["REQUIRE_AUTHENTICATION", "TAKE_GPS_ON_FORM", "MOBILE_ORG_UNIT_REGISTRY"],
-            "linked_forms": ["Registry - Population Health area"],
+            "linked_forms": [
+                "Registry - Population Health area",
+                "Data for Health facility/Données Formation sanitaire",
+            ],
         },
         {
             "name": "Vaccination",


### PR DESCRIPTION
Add HF form to setuper .georegistry project.
This form was removed at some point, but it broke the mobile app, so we're putting it back.

Related JIRA tickets : IA-3570

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
/

## Changes

/

## How to test

Run the setuper command.
Make sure that the `"Data for Health facility/Données Formation sanitaire"` is linked to the `.georegistry` project.
Log into the .georegistry project on the mobile app.
Make sure that initial data can be loaded without any error.

## Print screen / video

![image](https://github.com/user-attachments/assets/2a8b8019-3c1a-441e-94db-55622c8da218)


## Notes
/