### PR TITLE
[IA-3587] Fix setuper timeout after task success

### DIFF
--- a/setuper/iaso_api_client.py
+++ b/setuper/iaso_api_client.py
@@ -86,9 +86,11 @@ class IasoClient:
             time.sleep(self.ASYNC_TASK_WAIT_STEP)
             count += self.ASYNC_TASK_WAIT_STEP
             print("\t\tWaiting:", count, "s elapsed", task.get("progress_message"))
-        raise Exception(
-            f"Couldn't find an available worker after {self.ASYNC_TASK_TIMEOUT} seconds. Please make sure a worker is running."
-        )
+
+        if not imported:
+            raise Exception(
+                f"Couldn't find an available worker after {self.ASYNC_TASK_TIMEOUT} seconds. Please make sure a worker is running."
+            )
 
     def log(self, arg1, arg2=None):
         if self.debug:


### PR DESCRIPTION
Fix setuper timeout error mistakenly triggered after task success

Related JIRA tickets : IA-3587

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
/

## Changes

/

## How to test

Run a successful setuper command with a worker. Make sure that the worker completes the task and that the setuper does not crash.

## Print screen / video

/

## Notes

/
