### PR TITLE
IA-3591: Allow to launch an analysis when there is no any duplicates

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/entities/duplicates/list/AnalyseAction.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/duplicates/list/AnalyseAction.tsx
@@ -39,8 +39,9 @@ export const AnalyseAction: FunctionComponent<Props> = ({
             {!latestAnalysis &&
                 !isFetchingLatestAnalysis &&
                 formatMessage(MESSAGES.noAnalysis)}
-            {latestAnalysis && (
-                <>
+
+            <>
+                {latestAnalysis && (
                     <Box mr="auto">
                         <Box display="flex" alignItems="center">
                             <Box display="inline-block" mr={1}>
@@ -67,7 +68,9 @@ export const AnalyseAction: FunctionComponent<Props> = ({
                             </Tooltip>
                         </Box>
                     </Box>
-                    <Grid container spacing={1} justifyContent="flex-end">
+                )}
+                <Grid container spacing={1} justifyContent="flex-end">
+                    {latestAnalysis && (
                         <Grid item>
                             <Box mb={2} mt={2}>
                                 <Button
@@ -86,14 +89,14 @@ export const AnalyseAction: FunctionComponent<Props> = ({
                                 </Button>
                             </Box>
                         </Grid>
-                        <Grid item>
-                            <Box mb={2} mt={2}>
-                                <AnalysisModal iconProps={{}} />
-                            </Box>
-                        </Grid>
+                    )}
+                    <Grid item>
+                        <Box mb={2} mt={2}>
+                            <AnalysisModal iconProps={{}} />
+                        </Box>
                     </Grid>
-                </>
-            )}
+                </Grid>
+            </>
         </Box>
     );
 };


### PR DESCRIPTION
Explain what problem this PR is resolving
- Entity duplicates: cannot launch initial analysis from web
Related JIRA tickets : [IA-3591](https://bluesquare.atlassian.net/browse/IA-3591)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
- Tell us where the doc can be found (docs folder, wiki, in the code...)

## Changes
-  Moved the launch analysis button from the check of the latestAnalysis

## How to test
- Beneficiarie ---> duplicates
- Empty the already launched analysis and check if the launch analysis button stay there

## Print screen / video

![Screenshot from 2024-10-24 09-43-15](https://github.com/user-attachments/assets/04eaf281-7a71-483a-ae98-a0b4d45bddfa)



[IA-3591]: https://bluesquare.atlassian.net/browse/IA-3591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ