### PR TITLE
IA-3466 Implement permissions for users with org unit types restrictions

### DIFF
--- a/iaso/api/profiles/profiles.py
+++ b/iaso/api/profiles/profiles.py
@@ -529,7 +529,9 @@ class ProfilesViewSet(viewsets.ViewSet):
                 invalid_names = ", ".join(
                     name for name in OrgUnitType.objects.filter(pk__in=invalid_ids).values_list("name", flat=True)
                 )
-                raise ValidationError(f"The user does not have rights on the following org unit types: {invalid_names}")
+                raise PermissionDenied(
+                    f"The user does not have rights on the following org unit types: {invalid_names}"
+                )
 
         return editable_org_unit_types
 

--- a/iaso/api/profiles/profiles.py
+++ b/iaso/api/profiles/profiles.py
@@ -529,7 +529,6 @@ class ProfilesViewSet(viewsets.ViewSet):
 
     def check_profile_editable_org_unit_types(self, iaso_profile: Profile, org_unit_type_ids_to_check: Set[int]):
         user_editable_org_unit_type_ids = iaso_profile.get_editable_org_unit_type_ids()
-
         invalid_ids = [
             org_unit_type_id
             for org_unit_type_id in org_unit_type_ids_to_check

--- a/iaso/api/profiles/profiles.py
+++ b/iaso/api/profiles/profiles.py
@@ -730,14 +730,9 @@ class ProfilesViewSet(viewsets.ViewSet):
         org_units = self.validate_org_units(request, user.profile)
         profile.org_units.set(org_units)
 
-        # link the profile to user roles
-        user_roles = request.data.get("user_roles", [])
-        for user_role_id in user_roles:
-            # Get only a user role linked to the account's user
-            user_role_item = get_object_or_404(UserRole, pk=user_role_id, account=current_account)
-            user_group_item = get_object_or_404(models.Group, pk=user_role_item.group.id)
-            profile.user.groups.add(user_group_item)
-            profile.user_roles.add(user_role_item)
+        user_roles_data = self.validate_user_roles(request)
+        if user_roles_data.get("user_roles"):
+            profile.user_roles.set(user_roles_data["user_roles"])
 
         projects = request.data.get("projects", [])
         profile.projects.clear()

--- a/iaso/api/profiles/profiles.py
+++ b/iaso/api/profiles/profiles.py
@@ -801,7 +801,11 @@ class ProfilesViewSet(viewsets.ViewSet):
         if phone_number is not None:
             profile.phone_number = phone_number
 
+        editable_org_unit_types = self.validate_editable_org_unit_types(request)
+        profile.editable_org_unit_types.add(*editable_org_unit_types)
+
         profile.save()
+
         audit_logger = ProfileAuditLogger()
         source = f"{PROFILE_API}_mobile" if is_mobile_request(request) else PROFILE_API
         audit_logger.log_modification(instance=profile, old_data_dump=None, request_user=request.user, source=source)

--- a/iaso/models/base.py
+++ b/iaso/models/base.py
@@ -1547,8 +1547,12 @@ class Profile(models.Model):
         return False
 
     def get_editable_org_unit_type_ids(self) -> set[int]:
-        ids_in_user_roles = set(self.user_roles.values_list("editable_org_unit_types", flat=True))
-        ids_in_user_profile = set(self.editable_org_unit_types.values_list("id", flat=True))
+        ids_in_user_roles = set(
+            self.user_roles.exclude(**{"editable_org_unit_types": None}).values_list(
+                "editable_org_unit_types", flat=True
+            )
+        )
+        ids_in_user_profile = set(self.editable_org_unit_types.exclude(**{"id": None}).values_list("id", flat=True))
         return ids_in_user_profile.union(ids_in_user_roles)
 
     def has_org_unit_write_permission(

--- a/iaso/models/base.py
+++ b/iaso/models/base.py
@@ -1547,8 +1547,12 @@ class Profile(models.Model):
         return False
 
     def get_editable_org_unit_type_ids(self) -> set[int]:
-        ids_in_user_roles = set(self.user_roles.values_list("editable_org_unit_types", flat=True))
-        ids_in_user_profile = set(self.editable_org_unit_types.values_list("id", flat=True))
+        ids_in_user_roles = set(
+            self.user_roles.exclude(editable_org_unit_types__isnull=True).values_list(
+                "editable_org_unit_types", flat=True
+            )
+        )
+        ids_in_user_profile = set(self.editable_org_unit_types.exclude(id__isnull=True).values_list("id", flat=True))
         return ids_in_user_profile.union(ids_in_user_roles)
 
     def has_org_unit_write_permission(

--- a/iaso/models/base.py
+++ b/iaso/models/base.py
@@ -1547,12 +1547,8 @@ class Profile(models.Model):
         return False
 
     def get_editable_org_unit_type_ids(self) -> set[int]:
-        ids_in_user_roles = set(
-            self.user_roles.exclude(**{"editable_org_unit_types": None}).values_list(
-                "editable_org_unit_types", flat=True
-            )
-        )
-        ids_in_user_profile = set(self.editable_org_unit_types.exclude(**{"id": None}).values_list("id", flat=True))
+        ids_in_user_roles = set(self.user_roles.values_list("editable_org_unit_types", flat=True))
+        ids_in_user_profile = set(self.editable_org_unit_types.values_list("id", flat=True))
         return ids_in_user_profile.union(ids_in_user_roles)
 
     def has_org_unit_write_permission(

--- a/iaso/tests/api/test_org_units_bulk_update.py
+++ b/iaso/tests/api/test_org_units_bulk_update.py
@@ -247,7 +247,7 @@ class OrgUnitsBulkUpdateAPITestCase(APITestCase):
         self.assertEqual(5, am.Modification.objects.count())
 
     @tag("iaso_only")
-    def test_org_unit_bulkupdate_select_all_with_restricted_write_permission_for_user(self):
+    def test_org_unit_bulkupdate_select_all_should_fail_with_restricted_editable_org_unit_types(self):
         """
         Check that we cannot bulk edit all org units if writing rights are limited
         by a set of org unit types that we are allowed to modify.

--- a/iaso/tests/api/test_orgunits.py
+++ b/iaso/tests/api/test_orgunits.py
@@ -607,7 +607,7 @@ class OrgUnitAPITestCase(APITestCase):
         response = self.set_up_org_unit_creation()
         self.assertJSONResponse(response, 403)
 
-    def test_create_org_unit_with_restricted_write_permission_for_user(self):
+    def test_create_org_unit_should_fail_with_restricted_editable_org_unit_types(self):
         """
         Check that we cannot create an org unit if writing rights are limited
         by a set of org unit types that we are allowed to modify.
@@ -1015,7 +1015,7 @@ class OrgUnitAPITestCase(APITestCase):
         )
         self.assertJSONResponse(response, 403)
 
-    def test_edit_org_unit_with_restricted_write_permission_for_user(self):
+    def test_edit_org_unit_should_fail_with_restricted_editable_org_unit_types(self):
         """
         Check that we cannot edit an org unit if writing rights are limited
         by a set of org unit types that we are allowed to modify.

--- a/iaso/tests/api/test_profiles.py
+++ b/iaso/tests/api/test_profiles.py
@@ -3,7 +3,7 @@ import typing
 import jsonschema
 import numpy as np
 import pandas as pd
-from django.conf import settings
+
 from django.contrib.auth.models import Group, Permission
 from django.core import mail
 from django.test import override_settings

--- a/iaso/tests/api/test_profiles.py
+++ b/iaso/tests/api/test_profiles.py
@@ -537,7 +537,7 @@ class ProfileAPITestCase(APITestCase):
         self.assertEqual(user_user_role.id, self.user_role.id)
         self.assertEqual(user_user_role.group.name, self.group.name)
 
-    def test_create_user_with_unauthorized_field_org_units(self):
+    def test_create_user_should_fail_with_restricted_editable_org_unit_types_for_field_orgunits(self):
         """
         The user is restricted to one org unit type.
         Creating a user with unauthorized values in `org_units` should fail.
@@ -571,7 +571,7 @@ class ProfileAPITestCase(APITestCase):
             response.data["detail"], "The user does not have rights on the following org unit types: Jedi Council"
         )
 
-    def test_create_user_with_unauthorized_field_editable_org_unit_type_ids(self):
+    def test_create_user_should_fail_with_restricted_editable_org_unit_types_for_field_editableorgunittypeids(self):
         """
         The user is restricted to one org unit type.
         Creating a user with unauthorized values in `editable_org_unit_type_ids` should fail.
@@ -1074,7 +1074,7 @@ class ProfileAPITestCase(APITestCase):
         response = self.client.patch(f"/api/profiles/{jum.id}/", data=data, format="json")
         self.assertEqual(response.status_code, 200)
 
-    def test_update_user_with_unauthorized_field_editable_org_unit_type_ids(self):
+    def test_update_user_should_fail_with_restricted_editable_org_unit_types_for_field_editableorgunittypeids(self):
         """
         The user is restricted to one org unit type.
         Updating a user with unauthorized values in `editable_org_unit_type_ids` should fail.

--- a/iaso/tests/api/test_profiles.py
+++ b/iaso/tests/api/test_profiles.py
@@ -624,6 +624,7 @@ class ProfileAPITestCase(APITestCase):
             "email": "unittest_last_name",
             "org_units": [{"id": self.jedi_council_corruscant.id}],
             "user_permissions": ["iaso_forms"],
+            "editable_org_unit_type_ids": [self.jedi_squad.id],
         }
         response = self.client.post("/api/profiles/", data=data, format="json")
         self.assertEqual(response.status_code, 200)
@@ -634,6 +635,9 @@ class ProfileAPITestCase(APITestCase):
         self.assertEqual(response_data["is_superuser"], False)
 
         profile = m.Profile.objects.get(pk=response_data["id"])
+        self.assertEqual(profile.editable_org_unit_types.count(), 1)
+        self.assertEqual(profile.editable_org_unit_types.first(), self.jedi_squad)
+
         user = profile.user
         self.assertEqual(user.username, data["user_name"])
         self.assertEqual(user.first_name, data["first_name"])

--- a/iaso/tests/api/test_profiles.py
+++ b/iaso/tests/api/test_profiles.py
@@ -517,7 +517,7 @@ class ProfileAPITestCase(APITestCase):
 
         self.assertEqual(response.status_code, 403)
 
-    def test_create_user_with_user_roles(self):
+    def test_create_user_with_user_roles_and_permissions(self):
         self.client.force_authenticate(self.jim)
         data = {
             "user_name": "unittest_user_name",
@@ -536,6 +536,10 @@ class ProfileAPITestCase(APITestCase):
         self.assertValidProfileData(response_data)
         self.assertEqual(user_user_role.id, self.user_role.id)
         self.assertEqual(user_user_role.group.name, self.group.name)
+
+        user = m.User.objects.get(username="unittest_user_name")
+        self.assertEqual(user.user_permissions.count(), 1)
+        self.assertEqual(user.user_permissions.first().codename, "iaso_forms")
 
     def test_create_user_should_fail_with_restricted_editable_org_unit_types_for_field_orgunits(self):
         """

--- a/iaso/tests/api/test_profiles.py
+++ b/iaso/tests/api/test_profiles.py
@@ -682,8 +682,10 @@ class ProfileAPITestCase(APITestCase):
         }
 
         response = self.client.post("/api/profiles/", data=data, format="json")
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.data, ["The user does not have rights on the following org unit types: Jedi Council"])
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(
+            response.data["detail"], "The user does not have rights on the following org unit types: Jedi Council"
+        )
 
     @override_settings(DEFAULT_FROM_EMAIL="sender@test.com", DNS_DOMAIN="iaso-test.bluesquare.org")
     def test_create_profile_with_send_email(self):
@@ -1068,8 +1070,10 @@ class ProfileAPITestCase(APITestCase):
             "editable_org_unit_type_ids": [self.jedi_council.id],
         }
         response = self.client.patch(f"/api/profiles/{jum.id}/", data=data, format="json")
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.data, ["The user does not have rights on the following org unit types: Jedi Council"])
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(
+            response.data["detail"], "The user does not have rights on the following org unit types: Jedi Council"
+        )
 
     def test_user_with_managed_permission_cannot_create_users(self):
         self.jam.iaso_profile.org_units.set([self.jedi_council_corruscant.id])

--- a/iaso/tests/api/test_profiles.py
+++ b/iaso/tests/api/test_profiles.py
@@ -654,7 +654,11 @@ class ProfileAPITestCase(APITestCase):
         self.assertEqual(org_units.count(), 1)
         self.assertEqual(org_units[0].name, "Corruscant Jedi Council")
 
-    def test_create_for_user_with_org_unit_type_restrictions(self):
+    def test_create_editable_org_unit_type(self):
+        """
+        Test that `Profile.editable_org_unit_type` is constraint at user creation time.
+        """
+
         user = self.jam
 
         self.assertTrue(user.has_perm(permission.USERS_MANAGED))
@@ -1035,7 +1039,10 @@ class ProfileAPITestCase(APITestCase):
         response = self.client.patch(f"/api/profiles/{jum.id}/", data=data, format="json")
         self.assertEqual(response.status_code, 200)
 
-    def test_patch_for_user_with_org_unit_type_restrictions(self):
+    def test_patch_editable_org_unit_type(self):
+        """
+        Test that `Profile.editable_org_unit_type` is constraint at user edition time.
+        """
         user = self.jam
 
         self.assertTrue(user.has_perm(permission.USERS_MANAGED))

--- a/iaso/tests/api/test_profiles_bulk_update.py
+++ b/iaso/tests/api/test_profiles_bulk_update.py
@@ -47,7 +47,6 @@ class ProfileBulkUpdateAPITestCase(APITestCase):
         sw_source.projects.add(cls.project)
         cls.sw_source = sw_source
         sw_version_1 = m.SourceVersion.objects.create(data_source=sw_source, number=1)
-        # sw_version_2 = m.SourceVersion.objects.create(data_source=sw_source, number=2)
         star_wars.default_version = sw_version_1
         star_wars.save()
         cls.jedi_council = m.OrgUnitType.objects.create(name="Jedi Council", short_name="Cnc")
@@ -311,6 +310,51 @@ class ProfileBulkUpdateAPITestCase(APITestCase):
         self.assertNotIn(
             self.user_role_3,
             self.chewie.iaso_profile.user_roles.all(),
+        )
+
+    @tag("iaso_only")
+    def test_profile_bulkupdate_should_fail_for_restriced_editable_org_unit_types(self):
+        user = self.obi_wan
+        self.assertTrue(user.has_perm(permission.USERS_MANAGED))
+        self.assertFalse(user.has_perm(permission.USERS_ADMIN))
+
+        user.iaso_profile.editable_org_unit_types.set(
+            # Only org units of this type is now writable.
+            [self.jedi_council]
+        )
+
+        other_org_unit_type = m.OrgUnitType.objects.create(name="Country")
+        self.jedi_council_endor.name = "The Gambia"
+        self.jedi_council_endor.org_unit_type = other_org_unit_type
+        self.jedi_council_endor.save()
+
+        self.client.force_authenticate(user)
+
+        payload = {
+            "select_all": False,
+            "selected_ids": [self.luke.iaso_profile.pk, self.chewie.iaso_profile.pk],
+            "language": "fr",
+            "location_ids_added": [self.jedi_council_endor.pk],
+            "location_ids_removed": None,
+            "projects_ids_added": None,
+            "projects_ids_removed": None,
+            "roles_id_added": None,
+            "roles_id_removed": None,
+            "organization": "Bluesquare",
+        }
+        response = self.client.post(f"/api/tasks/create/profilesbulkupdate/", data=payload, format="json")
+
+        data = response.json()
+        task = self.assertValidTaskAndInDB(data["task"], status="QUEUED", name="profiles_bulk_update")
+        self.assertEqual(task.launcher, user)
+
+        task = self.runAndValidateTask(task, "ERRORED")
+        self.assertEqual(
+            task.result["message"],
+            (
+                f"User with permission {permission.USERS_MANAGED} cannot change the org unit The Gambia "
+                f"because he does not have rights on the following org unit type: Country"
+            ),
         )
 
     @tag("iaso_only")

--- a/iaso/tests/api/test_profiles_bulk_update.py
+++ b/iaso/tests/api/test_profiles_bulk_update.py
@@ -17,7 +17,7 @@ def saveUserProfile(user):
     user.iaso_profile.save()
 
 
-class OrgUnitsBulkUpdateAPITestCase(APITestCase):
+class ProfileBulkUpdateAPITestCase(APITestCase):
     @classmethod
     def setUpTestData(cls):
         star_wars = m.Account.objects.create(name="Star Wars")

--- a/iaso/tests/api/test_profiles_bulk_update.py
+++ b/iaso/tests/api/test_profiles_bulk_update.py
@@ -313,7 +313,7 @@ class ProfileBulkUpdateAPITestCase(APITestCase):
         )
 
     @tag("iaso_only")
-    def test_profile_bulkupdate_should_fail_for_restriced_editable_org_unit_types(self):
+    def test_profile_bulkupdate_should_fail_with_restricted_editable_org_unit_types(self):
         user = self.obi_wan
         self.assertTrue(user.has_perm(permission.USERS_MANAGED))
         self.assertFalse(user.has_perm(permission.USERS_ADMIN))

--- a/iaso/tests/models/test_profile.py
+++ b/iaso/tests/models/test_profile.py
@@ -72,6 +72,8 @@ class ProfileModelTestCase(TestCase):
         self.profile1.user_roles.clear()
 
     def test_with_editable_org_unit_types(self):
+        self.assertEqual(self.profile1.get_editable_org_unit_type_ids(), set())
+
         org_unit_type_country = m.OrgUnitType.objects.create(name="Country")
         org_unit_type_region = m.OrgUnitType.objects.create(name="Region")
         org_unit_type_district = m.OrgUnitType.objects.create(name="District")

--- a/iaso/tests/test_create_users_from_csv.py
+++ b/iaso/tests/test_create_users_from_csv.py
@@ -1,16 +1,21 @@
-import io
 import csv
+import io
 
-from django.contrib.auth.models import User, Permission, Group
-from django.core.files.uploadedfile import SimpleUploadedFile
 import jsonschema
+
 from rest_framework import serializers
+
+from django.contrib.auth.models import User, Permission
+from django.core.files.uploadedfile import SimpleUploadedFile
+
+from hat.menupermissions import models as permission
+from hat.menupermissions.constants import MODULES
 from iaso import models as m
 from iaso.api.profiles.bulk_create_users import BulkCreateUserFromCsvViewSet
-from iaso.models import Profile, BulkCreateUserCsvFile, UserRole
+from iaso.models import Profile, BulkCreateUserCsvFile
 from iaso.test import APITestCase
-from hat.menupermissions.constants import MODULES
 from iaso.tests.api.test_profiles import PROFILE_LOG_SCHEMA
+
 
 BASE_URL = "/api/bulkcreateuser/"
 
@@ -547,6 +552,61 @@ class BulkCreateCsvTestCase(APITestCase):
         self.assertEqual(new_user.iaso_profile.org_units.count(), 1)
         self.assertEqual(new_user.iaso_profile.org_units.first(), org_unit_a)
         self.assertEqual(org_unit_a.version_id, self.account1.default_version_id)
+
+    def test_should_create_user_with_the_correct_org_unit(self):
+        self.source.projects.set([self.project])
+        org_unit = self.org_unit_child
+        user = self.yoda
+
+        org_unit_type_region = m.OrgUnitType.objects.create(name="Region")
+        org_unit_type_country = m.OrgUnitType.objects.create(name="Country")
+
+        org_unit.org_unit_type = org_unit_type_country
+        org_unit.save()
+
+        user.iaso_profile.org_units.add(org_unit)
+        user.iaso_profile.editable_org_unit_types.set(
+            # Only org units of this type is now writable.
+            [org_unit_type_region]
+        )
+
+        user.user_permissions.add(Permission.objects.get(codename=permission._USERS_MANAGED))
+        user.user_permissions.remove(Permission.objects.get(codename=permission._USERS_ADMIN))
+        self.assertTrue(user.has_perm(permission.USERS_MANAGED))
+        self.assertFalse(user.has_perm(permission.USERS_ADMIN))
+
+        self.client.force_authenticate(user)
+
+        csv_str = io.StringIO()
+        writer = csv.DictWriter(csv_str, fieldnames=self.CSV_HEADER)
+        writer.writeheader()
+        writer.writerow(
+            {
+                "username": "john",
+                "password": "yodnj!30dln",
+                "email": "john@foo.com",
+                "first_name": "John",
+                "last_name": "Doe",
+                "orgunit": f"{org_unit.id}",
+                "orgunit__source_ref": "",
+                "profile_language": "fr",
+                "dhis2_id": "",
+                "permissions": "",
+                "user_roles": "",
+                "projects": "",
+                "phone_number": "",
+                "organization": "",
+            }
+        )
+        csv_bytes = csv_str.getvalue().encode()
+        csv_file = SimpleUploadedFile("users.csv", csv_bytes)
+
+        response = self.client.post(f"{BASE_URL}", {"file": csv_file})
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.data,
+            {"error": "Operation aborted. You don't have rights on the following org unit types: Country"},
+        )
 
     def test_valid_phone_number(self):
         phone_number = "+12345678912"


### PR DESCRIPTION
Implement additional permissions for users with org unit types restrictions.

Related JIRA tickets : [IA-3466](https://bluesquare.atlassian.net/browse/IA-3466)

## Changes

- implement additional permissions for users with org unit types restrictions:

    - in bulk create users (via CSV)
    - in `api/profiles` update and create
    - in profile bulk update

- add validation in `api/profiles` **create** the same way it's implemented in **update**
    - also move methods inside the class so they are logically grouped

## How to test

Use the UI or check the unit tests


[IA-3466]: https://bluesquare.atlassian.net/browse/IA-3466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ