### PR TITLE
WC2-586 Fix: WFP redirecting to a 404

### DIFF
--- a/plugins/wfp_auth/views.py
+++ b/plugins/wfp_auth/views.py
@@ -179,7 +179,7 @@ class WFPCallbackView(OAuth2View):
                 request,
                 social_account.user,
                 email_verification=False,
-                redirect_url=request.GET.get("next", "/dashboard/"),
+                redirect_url=request.GET.get("next", "/"),
             )
         except (
             PermissionDenied,


### PR DESCRIPTION
A very small fix for:

/dashboard results in a 404.
Instead redirect to the root at the end of the CIAM login, and let the server figure out where it needs to go.

Related JIRA tickets : https://bluesquare.atlassian.net/browse/WC2-586