### PR TITLE
A few small fixes and improvements

### DIFF
--- a/iaso/admin.py
+++ b/iaso/admin.py
@@ -358,6 +358,13 @@ class InstanceAdmin(admin.GeoModelAdmin):
         )
         return queryset
 
+    def formfield_for_foreignkey(self, db_field, request, **kwargs):
+        if db_field.name == "entity":
+            kwargs["queryset"] = (
+                Entity.objects_include_deleted.all()
+            )  # use the manager that includes soft-deleted objects
+        return super().formfield_for_foreignkey(db_field, request, **kwargs)
+
 
 @admin.register(InstanceFile)
 @admin_attr_decorator

--- a/iaso/admin.py
+++ b/iaso/admin.py
@@ -360,9 +360,9 @@ class InstanceAdmin(admin.GeoModelAdmin):
 
     def formfield_for_foreignkey(self, db_field, request, **kwargs):
         if db_field.name == "entity":
-            kwargs["queryset"] = (
-                Entity.objects_include_deleted.all()
-            )  # use the manager that includes soft-deleted objects
+            kwargs[
+                "queryset"
+            ] = Entity.objects_include_deleted.all()  # use the manager that includes soft-deleted objects
         return super().formfield_for_foreignkey(db_field, request, **kwargs)
 
 

--- a/iaso/api/instances.py
+++ b/iaso/api/instances.py
@@ -385,6 +385,7 @@ class InstancesViewSet(viewsets.ViewSet):
             queryset = queryset.prefetch_related("org_unit__reference_instances")
             queryset = queryset.prefetch_related("org_unit__org_unit_type__reference_forms")
             queryset = queryset.prefetch_related("org_unit__version__data_source")
+            queryset = queryset.prefetch_related("project")
             if limit:
                 limit = int(limit)
                 page_offset = int(page_offset)

--- a/iaso/models/entity.py
+++ b/iaso/models/entity.py
@@ -191,7 +191,7 @@ class Entity(SoftDeletableModel):
         verbose_name_plural = "Entities"
 
     def __str__(self):
-        return f"{self.name}"
+        return "%s %s %s %d" % (self.entity_type.name, self.uuid, self.name, self.id)
 
     def as_small_dict(self):
         return {


### PR DESCRIPTION
- Small improvements on Django admin for entities:
  - The link from the instance to the entity was not shown since the
`entity.name` is (almost) always empty. Change the str repr of the model
to fix this.
  - In the admin, allow saving an instance on a soft-deleted entity by
overriding the entity relation manager.
- Performance: Add missing "project" `prefetch_related` on instances API

Related JIRA tickets : No JIRA ticket, just small improvements
