### PR TITLE
WC2-589 Fix: Don't fail if correlation_field is blank

### DIFF
--- a/iaso/models/base.py
+++ b/iaso/models/base.py
@@ -1105,7 +1105,7 @@ class Instance(models.Model):
     def convert_correlation(self):
         if not self.correlation_id:
             identifier = str(self.id)
-            if self.form.correlation_field is not None and self.json:
+            if self.form.correlation_field and self.json:
                 identifier += self.json.get(self.form.correlation_field, None)
                 identifier = identifier.zfill(3)
             random_number = random.choice("1234567890")


### PR DESCRIPTION
The explicit check on `is not None` would allow empty strings to pass, resulting in error:
```
TypeError: can only concatenate str (not "NoneType") to str
```

Simply checking on `self.form.correlation_field` will give `False` for both `None` and `""`.

Related JIRA tickets : https://bluesquare.atlassian.net/browse/WC2-589