### PR TITLE
IA-3289: remove "null" label on Org unit bulk edit modal

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitsMultiActionsDialog.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitsMultiActionsDialog.tsx
@@ -302,7 +302,6 @@ export const OrgUnitsMultiActionsDialog: FunctionComponent<Props> = ({
                             type="select"
                             options={orgUnitTypes || []}
                             label={MESSAGES.org_unit_type}
-                            isSearchable
                         />
                     )}
                 </div>
@@ -327,6 +326,7 @@ export const OrgUnitsMultiActionsDialog: FunctionComponent<Props> = ({
                                 type="radio"
                                 options={validationStatusOptions || []}
                                 loading={isLoadingValidationStatusOptions}
+                                labelString=""
                             />
                         </div>
                     )}

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/index.tsx
@@ -88,7 +88,7 @@ const useStyles = makeStyles(theme => ({
 const baseUrl = baseUrls.orgUnits;
 export const OrgUnits: FunctionComponent = () => {
     // HOOKS
-    const params = useParamsObject(baseUrl) as OrgUnitParams;
+    const params = useParamsObject(baseUrl) as unknown as OrgUnitParams;
     const queryClient = useQueryClient();
     const navigate = useNavigate();
     const classes: Record<string, string> = useStyles();


### PR DESCRIPTION
Explain what problem this PR is resolving

Related JIRA tickets : IA-3289

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
N/A
## Changes

- passed an empty string as `labelString` prop to prevent `InputComponent` from dispaying `null`
- removed unused prop

## How to test

Go to Org units list page, select several org units then open bulk edition menu and check the "validation status" box

## Print screen / video

![Screenshot 2024-10-28 at 17 48 23](https://github.com/user-attachments/assets/040ec494-a448-4408-bf46-c728b37522db)



