### PR TITLE
[IA-3601] Force QR code refresh after app_id update

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -641,6 +641,7 @@
     "iaso.label.polio": "Polio",
     "iaso.label.project": "Project",
     "iaso.label.project.featureFlags": "Project feature flags",
+    "iaso.label.project.qrCodeError": "Can't load project QR code",
     "iaso.label.projects": "Projects",
     "iaso.label.published": "Published",
     "iaso.label.publishingStatus": "Publishing status",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -641,6 +641,7 @@
     "iaso.label.polio": "Polio",
     "iaso.label.project": "Projet",
     "iaso.label.project.featureFlags": "Options du projet",
+    "iaso.label.project.qrCodeError": "Erreur de chargement du code QR du project",
     "iaso.label.projects": "Projets",
     "iaso.label.published": "Publié",
     "iaso.label.publishingStatus": "Statut de publication",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -641,7 +641,7 @@
     "iaso.label.polio": "Polio",
     "iaso.label.project": "Projet",
     "iaso.label.project.featureFlags": "Options du projet",
-    "iaso.label.project.qrCodeError": "Erreur de chargement du code QR du project",
+    "iaso.label.project.qrCodeError": "Erreur de chargement du code QR du projet",
     "iaso.label.projects": "Projets",
     "iaso.label.published": "Publié",
     "iaso.label.publishingStatus": "Statut de publication",

--- a/hat/assets/js/apps/Iaso/domains/projects/components/ProjectInfos.tsx
+++ b/hat/assets/js/apps/Iaso/domains/projects/components/ProjectInfos.tsx
@@ -3,9 +3,11 @@ import React, { FunctionComponent } from 'react';
 import InputComponent from '../../../components/forms/InputComponent';
 
 import MESSAGES from '../messages';
+import { useGetProjectQRCode } from '../hooks/requests/useGetProjectQRCode';
+import { LoadingSpinner } from 'bluesquare-components';
 
 type Form = {
-    value: string | null;
+    value: string | undefined;
     errors: Array<string>;
 };
 
@@ -23,37 +25,43 @@ type Props = {
 const ProjectInfos: FunctionComponent<Props> = ({
     setFieldValue,
     currentProject,
-}) => (
-    <>
-        <InputComponent
-            keyValue="name"
-            onChange={(key, value) => setFieldValue(key, value)}
-            value={currentProject.name.value}
-            errors={currentProject.name.errors}
-            type="text"
-            label={MESSAGES.projectName}
-            required
-        />
-        <InputComponent
-            keyValue="app_id"
-            onChange={(key, value) => setFieldValue(key, value)}
-            value={currentProject.app_id.value}
-            errors={currentProject.app_id.errors}
-            type="text"
-            label={MESSAGES.appId}
-            required
-        />
-        {currentProject.id?.value && (
-            <div style={{ textAlign: 'center' }}>
-                <img
-                    width={200}
-                    height={200}
-                    alt="QRCode"
-                    src={`/api/projects/${currentProject.id?.value}/qr_code/`}
-                />
-            </div>
-        )}
-    </>
-);
+}) => {
+    const { data: qrCode, isFetching: fetchingProjectQRCode } =
+        useGetProjectQRCode(currentProject?.id.value);
+
+    return (
+        <>
+            <InputComponent
+                keyValue="name"
+                onChange={(key, value) => setFieldValue(key, value)}
+                value={currentProject.name.value}
+                errors={currentProject.name.errors}
+                type="text"
+                label={MESSAGES.projectName}
+                required
+            />
+            <InputComponent
+                keyValue="app_id"
+                onChange={(key, value) => setFieldValue(key, value)}
+                value={currentProject.app_id.value}
+                errors={currentProject.app_id.errors}
+                type="text"
+                label={MESSAGES.appId}
+                required
+            />
+            {fetchingProjectQRCode && <LoadingSpinner />}
+            {!fetchingProjectQRCode &&
+                <div style={{ textAlign: 'center' }}>
+                    <img
+                        width={200}
+                        height={200}
+                        alt="QRCode"
+                        src={qrCode}
+                    />
+                </div>
+            }
+        </>
+    );
+}
 
 export { ProjectInfos };

--- a/hat/assets/js/apps/Iaso/domains/projects/hooks/requests/useGetProjectQRCode.ts
+++ b/hat/assets/js/apps/Iaso/domains/projects/hooks/requests/useGetProjectQRCode.ts
@@ -1,0 +1,21 @@
+import { UseQueryResult } from 'react-query';
+import { getRequestImage } from '../../../../libs/Api';
+import { useSnackQuery } from '../../../../libs/apiHooks';
+import MESSAGES from '../../messages';
+
+export const useGetProjectQRCode = (projectId?: string): UseQueryResult<String, Error> => {
+
+    return useSnackQuery({
+        queryKey: ['projectQRCode', projectId],
+        queryFn: () => getRequestImage(`/api/projects/${projectId}/qr_code/`),
+        snackErrorMsg: MESSAGES.qrCodeError,
+        options: {
+            enabled: Boolean(projectId),
+            staleTime: 0,
+            cacheTime: 0,
+            select: (blob) => {
+                return URL.createObjectURL(blob);
+            }
+        },
+    });
+};

--- a/hat/assets/js/apps/Iaso/domains/projects/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/projects/index.tsx
@@ -22,7 +22,7 @@ const useStyles = makeStyles(theme => ({
 }));
 
 export const Projects: FunctionComponent = () => {
-    const params = useParamsObject(baseUrls.projects) as UrlParams;
+    const params = useParamsObject(baseUrls.projects) as unknown as UrlParams;
     const classes: Record<string, string> = useStyles();
     const { formatMessage } = useSafeIntl();
     const redirectTo = useRedirectTo();

--- a/hat/assets/js/apps/Iaso/domains/projects/messages.ts
+++ b/hat/assets/js/apps/Iaso/domains/projects/messages.ts
@@ -300,6 +300,10 @@ const MESSAGES = defineMessages({
         defaultMessage: 'Project feature flags',
         id: 'iaso.label.project.featureFlags',
     },
+    qrCodeError: {
+      defaultMessage: "Can't load project QR code",
+      id: 'iaso.label.project.qrCodeError',
+    },
 });
 
 export default MESSAGES;

--- a/hat/assets/js/apps/Iaso/libs/Api.ts
+++ b/hat/assets/js/apps/Iaso/libs/Api.ts
@@ -96,6 +96,17 @@ export const getRequest = async (
         return response.json();
     });
 };
+export const getRequestImage = async (
+    url: string,
+    signal?: Nullable<AbortSignal>,
+): Promise<Blob> => {
+    return iasoFetch(url, {
+        headers: { 'Accept-Language': moment.locale() },
+        signal,
+    }).then(response => {
+        return response.blob();
+    });
+};
 
 export const basePostRequest = (
     url: string,


### PR DESCRIPTION
Force QR code refresh after app_id update

Related JIRA tickets : IA-3601

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
/

## Changes

- Added a new `getRequestImage` to fetch blob instead of json
- Added a new hook for fetching a project QR code

## How to test
- Go to the Projects list in the web app and choose a project
- Scan the QR code
- Edit the project app_id, save and reopen the project modal window to see the QR code
- Scan the QR code again - it should be updated and match the new project app_id (before, you had to refresh the page and clear the cache to get the new QR code) 

## Print screen / video

/

## Notes

/
