### PR TITLE
[IA-3413] Update OrgUnit status after Change Request rejection

### DIFF
--- a/iaso/models/org_unit.py
+++ b/iaso/models/org_unit.py
@@ -754,6 +754,10 @@ class OrgUnitChangeRequest(models.Model):
         self.updated_by = user
         self.status = self.Statuses.REJECTED
         self.rejection_comment = rejection_comment
+        if self.kind == OrgUnitChangeRequest.Kind.ORG_UNIT_CREATION:
+            rejected_org_unit = self.org_unit
+            rejected_org_unit.validation_status = OrgUnit.VALIDATION_REJECTED
+            rejected_org_unit.save()
         self.save()
 
     def approve(self, user: User, approved_fields: typing.List[str], rejection_comment: str = "") -> None:
@@ -762,6 +766,10 @@ class OrgUnitChangeRequest(models.Model):
         self.status = self.Statuses.APPROVED
         self.rejection_comment = rejection_comment
         self.approved_fields = approved_fields
+        if self.kind == OrgUnitChangeRequest.Kind.ORG_UNIT_CREATION:
+            approved_org_unit = self.org_unit
+            approved_org_unit.validation_status = OrgUnit.VALIDATION_VALID
+            approved_org_unit.save()
         self.save()
 
     def __apply_changes(self, user: User, approved_fields: typing.List[str]) -> None:
@@ -785,9 +793,6 @@ class OrgUnitChangeRequest(models.Model):
                 new_value = getattr(self, field_name)
                 org_unit_field_name = field_name.replace("new_", "")
                 setattr(self.org_unit, org_unit_field_name, new_value)
-
-        if self.org_unit.validation_status == self.org_unit.VALIDATION_NEW:
-            self.org_unit.validation_status = self.org_unit.VALIDATION_VALID
 
         self.org_unit.save()
 

--- a/iaso/tests/api/org_unit_change_requests/test_org_unit_change_requests.py
+++ b/iaso/tests/api/org_unit_change_requests/test_org_unit_change_requests.py
@@ -270,6 +270,8 @@ class OrgUnitChangeRequestAPITestCase(APITestCase):
 
         change_request.refresh_from_db()
         self.assertEqual(change_request.status, change_request.Statuses.REJECTED)
+        self.org_unit.refresh_from_db()
+        self.assertEqual(self.org_unit.validation_status, m.OrgUnit.VALIDATION_REJECTED)
 
     @time_machine.travel(DT, tick=False)
     def test_partial_update_approve(self):
@@ -295,6 +297,7 @@ class OrgUnitChangeRequestAPITestCase(APITestCase):
         self.org_unit.refresh_from_db()
         self.assertEqual(self.org_unit.name, "Foo")
         self.assertIsNone(self.org_unit.closed_date)
+        self.assertEqual(self.org_unit.validation_status, m.OrgUnit.VALIDATION_VALID)
 
     def test_partial_update_approve_fail_wrong_status(self):
         self.client.force_authenticate(self.user_with_review_perm)

--- a/iaso/tests/models/test_org_unit_change_request.py
+++ b/iaso/tests/models/test_org_unit_change_request.py
@@ -192,6 +192,7 @@ class OrgUnitChangeRequestModelTestCase(TestCase):
         self.assertEqual(change_request.updated_at, self.DT)
         self.assertEqual(change_request.updated_by, self.user)
         self.assertEqual(change_request.rejection_comment, "Foo Bar Baz.")
+        self.assertEqual(change_request.org_unit.validation_status, m.OrgUnit.VALIDATION_REJECTED)
 
     @time_machine.travel(DT, tick=False)
     def test_approve(self):
@@ -248,7 +249,6 @@ class OrgUnitChangeRequestModelTestCase(TestCase):
         self.assertIn("parent", diff["modified"])
         self.assertIn("org_unit_type", diff["modified"])
         self.assertIn("location", diff["modified"])
-        self.assertIn("validation_status", diff["modified"])
 
         self.assertEqual(diff["modified"]["name"]["before"], "Hôpital Général")
         self.assertEqual(diff["modified"]["name"]["after"], "New name given in a change request")


### PR DESCRIPTION
When a `ChangeRequest` for creating a new `OrgUnit` is rejected, the status of the `OrgUnit` is now changed to `OrgUnit.VALIDATION_REJECTED`.

Related JIRA tickets : IA-3413

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
/

## Changes

- `OrgUnit` status is now updated after approval/rejection
- The `OrgUnit` status update is no longer logged (otherwise we would need to add some logs to the rejection process too)

## How to test
- Have your local setup ready to use the mobile app to generate change requests for creating new `OrgUnits` (ngrok + adding "Sub org unit types to create" in the `OrgUnitType` web configuration)
- Create a new `OrgUnit` with your mobile app and upload the `ChangeRequest`
- Reject the `ChangeRequest` through the web interface
- Check the `OrgUnit`'s status

## Print screen / video

[Screencast from 2024-10-30 14-50-33.webm](https://github.com/user-attachments/assets/0f821d2e-48ea-4eca-8286-89e5a158ae6b)


## Notes

I removed the `OrgUnit` status update from the logging unit tests since I'm updating this status in another place that is not logged. If we want to keep that, we should change how approval/rejections are logged, because nothing happens when there is a rejection.
