### PR TITLE
[IA-3291] Remove prints in unit tests

### DIFF
--- a/iaso/tasks/create_payment_lot.py
+++ b/iaso/tasks/create_payment_lot.py
@@ -84,8 +84,6 @@ def create_payment_lot(
         # We want to filter out potential payments assigned to another task.
         # Since the task is assigned in the view after it's created, we filter out potential payments with no task or with the current task assigned (for safety)
         potential_payments = PotentialPayment.objects.filter(id__in=potential_payment_ids)
-        for p in potential_payments:
-            print(p.task.id)
         potential_payments_for_lot = potential_payments.filter(task=the_task)
         # potential_payments_for_lot = potential_payments.filter((Q(task__isnull=True) | Q(task=the_task)))
         payment_lot.potential_payments.add(*potential_payments_for_lot, bulk=False)

--- a/iaso/tests/api/test_orgunits.py
+++ b/iaso/tests/api/test_orgunits.py
@@ -554,13 +554,13 @@ class OrgUnitAPITestCase(APITestCase):
         response_descendant = self.client.get(f"/api/orgunits/{descendant_org_unit.id}/")
         self.assertJSONResponse(response_descendant, 200)
         descendant_instances_count = response_descendant.json()["instances_count"]
-        self.assertEquals(descendant_instances_count, 1)
+        self.assertEqual(descendant_instances_count, 1)
 
         # Test the parent instances count
         response_parent = self.client.get(f"/api/orgunits/{parent_org_unit.id}/")
         self.assertJSONResponse(response_parent, 200)
         parent_instances_count = response_parent.json()["instances_count"]
-        self.assertEquals(parent_instances_count, 2)
+        self.assertEqual(parent_instances_count, 2)
 
     def test_can_retrieve_org_units_in_csv_format(self):
         self.client.force_authenticate(self.yoda)

--- a/iaso/tests/gpkg/test_import_with_sub_org_unit_type.py
+++ b/iaso/tests/gpkg/test_import_with_sub_org_unit_type.py
@@ -25,7 +25,9 @@ class OrgUnitImportFromGPKG(APITestCase):
         self.assertJSONResponse(response, 200)
         response_data = response.json()
 
-        updated_with_sub_types = update_org_unit_sub_type(self.client, self.project.id, response_data["orgUnitTypes"])
+        updated_with_sub_types = update_org_unit_sub_type(
+            self.client, self.project.id, response_data["orgUnitTypes"], False
+        )
 
         for org_unit_type_with in updated_with_sub_types:
             self.assertJSONResponse(org_unit_type_with, 200)

--- a/iaso/tests/tasks/test_export_mobile_app_setup_for_user.py
+++ b/iaso/tests/tasks/test_export_mobile_app_setup_for_user.py
@@ -25,7 +25,6 @@ def mocked_iaso_client_get(*args, **kwargs):
     elif url.startswith("/api/formattachments/"):
         return {"results": []}
     else:
-        print(args)
         # for all other calls, return an empty array
         return []
 

--- a/plugins/polio/api/vaccines/supply_chain.py
+++ b/plugins/polio/api/vaccines/supply_chain.py
@@ -327,7 +327,6 @@ class VaccineRequestFormPostSerializer(serializers.ModelSerializer):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        print("VaccineRequestFormPostSerializer instance created with data: %s", self.initial_data)
 
     def to_representation(self, instance):
         ret = super().to_representation(instance)

--- a/plugins/polio/tests/test_im_refresh_hh_data.py
+++ b/plugins/polio/tests/test_im_refresh_hh_data.py
@@ -194,8 +194,6 @@ class RefreshIMHouseholdDataTestCase(APITestCase):
         response = self.client.get(f"{self.action_url}?country_id={self.country_org_unit.id}")
         response = self.assertJSONResponse(response, 200)
         task = response["task"]
-        print("RESPONSE", response)
-        print("TASK", task)
         self.assertEqual(task["id"], self.task1.id)
         self.assertEqual(task["ended_at"], self.task1.ended_at)
         self.assertEqual(task["status"], self.task1.status)

--- a/plugins/polio/tests/test_im_refresh_hh_ohh_data.py
+++ b/plugins/polio/tests/test_im_refresh_hh_ohh_data.py
@@ -194,8 +194,6 @@ class RefreshIMHouseholdDataTestCase(APITestCase):
         response = self.client.get(f"{self.action_url}?country_id={self.country_org_unit.id}")
         response = self.assertJSONResponse(response, 200)
         task = response["task"]
-        print("RESPONSE", response)
-        print("TASK", task)
         self.assertEqual(task["id"], self.task1.id)
         self.assertEqual(task["ended_at"], self.task1.ended_at)
         self.assertEqual(task["status"], self.task1.status)

--- a/plugins/polio/tests/test_im_refresh_ohh_data.py
+++ b/plugins/polio/tests/test_im_refresh_ohh_data.py
@@ -194,8 +194,6 @@ class RefreshIMOutOfHouseholdDataTestCase(APITestCase):
         response = self.client.get(f"{self.action_url}?country_id={self.country_org_unit.id}")
         response = self.assertJSONResponse(response, 200)
         task = response["task"]
-        print("RESPONSE", response)
-        print("TASK", task)
         self.assertEqual(task["id"], self.task1.id)
         self.assertEqual(task["ended_at"], self.task1.ended_at)
         self.assertEqual(task["status"], self.task1.status)

--- a/setuper/pyramid.py
+++ b/setuper/pyramid.py
@@ -32,8 +32,9 @@ def setup_orgunits(iaso_client):
     iaso_client.wait_task_completion(task)
 
 
-def update_org_unit_sub_type(iaso_client, project_id, org_unit_types):
-    print("-- Updating org unit sub type")
+def update_org_unit_sub_type(iaso_client, project_id, org_unit_types, verbose: bool = True):
+    if verbose:
+        print("-- Updating org unit sub type")
     updated_with_sub_types = []
     for org_unit_type in org_unit_types:
         org_unit_type_level = org_unit_type["depth"]


### PR DESCRIPTION
[IA-3291] Remove prints in unit tests

Related JIRA tickets : IA-3291

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
/

## Changes
/

## How to test

Run tests or check the automatic action here, see if there are still some prints in the results.

## Print screen / video
![image](https://github.com/user-attachments/assets/86708311-e796-4066-81fa-39f9d5db3f16)



## Notes
I'd say we should definitely:
- fix the issue with the `iaso.PotentialPayment.user: (fields.W342) Setting unique=True on a ForeignKey has the same effect as using a OneToOneField.` 
- get rid of prints in the migration files as well


[IA-3291]: https://bluesquare.atlassian.net/browse/IA-3291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ