### PR TITLE
IA-3174: Map view popup: Update the instance default fields

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -386,6 +386,7 @@
     "iaso.instance.missingGeolocation": "Cannot find an instance with geolocation",
     "iaso.instance.NoLocksHistory": "There's no history",
     "iaso.instance.org_unit": "Org unit",
+    "iaso.instance.org_unit_type_name": "Org unit type",
     "iaso.instance.patchInstanceError": "An error occurred while saving submission",
     "iaso.instance.patchInstanceSuccesfull": "Submission saved successfully",
     "iaso.instance.period": "Period",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -386,7 +386,7 @@
     "iaso.instance.missingGeolocation": "Aucune soumission trouvée avec une localisation",
     "iaso.instance.NoLocksHistory": "Il n'y a pas d'historique",
     "iaso.instance.org_unit": "Unités d'organisation",
-    "iaso.instance.org_unit_type_name": "Type d'unités d'org.",
+    "iaso.instance.org_unit_type_name": "Type d'unité d'org.",
     "iaso.instance.patchInstanceError": "Une erreur est survenue lors de la sauvegarde de la soumission",
     "iaso.instance.patchInstanceSuccesfull": "Soumission sauvée avec succès",
     "iaso.instance.period": "Période",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -386,6 +386,7 @@
     "iaso.instance.missingGeolocation": "Aucune soumission trouvée avec une localisation",
     "iaso.instance.NoLocksHistory": "Il n'y a pas d'historique",
     "iaso.instance.org_unit": "Unités d'organisation",
+    "iaso.instance.org_unit_type_name": "Type d'unités d'org.",
     "iaso.instance.patchInstanceError": "Une erreur est survenue lors de la sauvegarde de la soumission",
     "iaso.instance.patchInstanceSuccesfull": "Soumission sauvée avec succès",
     "iaso.instance.period": "Période",

--- a/hat/assets/js/apps/Iaso/domains/instances/compare/components/InstanceDetailRaw.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/compare/components/InstanceDetailRaw.tsx
@@ -18,6 +18,7 @@ import InstancesFilesList from '../../components/InstancesFilesListComponent';
 import { Instance } from '../../types/instance';
 import { getInstancesFilesList } from '../../utils';
 import MESSAGES from '../messages';
+import { INSTANCE_METAS_FIELDS } from '../../constants';
 
 type Props = {
     data?: Instance;
@@ -100,7 +101,10 @@ export const InstanceDetailRaw: FunctionComponent<Props> = ({
                     </AccordionSummary>
                     <AccordionDetails>
                         <Box p={2}>
-                            <InstanceDetailsInfos currentInstance={data} />
+                            <InstanceDetailsInfos
+                                instance_metas_fields={INSTANCE_METAS_FIELDS}
+                                currentInstance={data}
+                            />
                         </Box>
                     </AccordionDetails>
                 </Accordion>

--- a/hat/assets/js/apps/Iaso/domains/instances/components/InstanceDetailsInfos.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/InstanceDetailsInfos.js
@@ -4,12 +4,16 @@ import get from 'lodash/get';
 
 import { useSafeIntl } from 'bluesquare-components';
 import InstanceDetailsField from './InstanceDetailsField';
-import { INSTANCE_METAS_FIELDS } from '../constants';
+
 import MESSAGES from '../messages';
 
-const InstanceDetailsInfos = ({ currentInstance, fieldsToHide }) => {
+const InstanceDetailsInfos = ({
+    currentInstance,
+    fieldsToHide,
+    instance_metas_fields,
+}) => {
     const { formatMessage } = useSafeIntl();
-    const fields = INSTANCE_METAS_FIELDS.filter(
+    const fields = instance_metas_fields.filter(
         f =>
             f.type === 'info' &&
             !fieldsToHide.includes(f.translationKey ?? f.key),
@@ -52,5 +56,6 @@ InstanceDetailsInfos.defaultProps = {
 InstanceDetailsInfos.propTypes = {
     currentInstance: PropTypes.object.isRequired,
     fieldsToHide: PropTypes.array,
+    instance_metas_fields: PropTypes.array.isRequired,
 };
 export default InstanceDetailsInfos;

--- a/hat/assets/js/apps/Iaso/domains/instances/components/InstancePopUp/InstancePopUp.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/InstancePopUp/InstancePopUp.tsx
@@ -1,11 +1,6 @@
 import { Theme } from '@mui/material/styles';
 import L from 'leaflet';
-import React, {
-    createRef,
-    FunctionComponent,
-    useCallback,
-    useMemo,
-} from 'react';
+import React, { createRef, FunctionComponent, useCallback } from 'react';
 import { Popup, useMap } from 'react-leaflet';
 
 import { Box, Card, CardContent, CardMedia, Grid } from '@mui/material';
@@ -19,15 +14,14 @@ import {
     useSafeIntl,
 } from 'bluesquare-components';
 import ConfirmDialog from '../../../../components/dialogs/ConfirmDialogComponent';
-import InstanceDetailsField from '../InstanceDetailsField';
 import InstanceDetailsInfos from '../InstanceDetailsInfos';
 
 import { baseUrls } from '../../../../constants/urls';
 import { usePopupState } from '../../../../utils/map/usePopupState';
-import { getOrgUnitsTree } from '../../../orgUnits/utils';
 import { useGetInstance } from '../../../registry/hooks/useGetInstances';
 import MESSAGES from '../../messages';
 import { Instance } from '../../types/instance';
+import { INSTANCE_MAP_METAS_FIELDS } from '../../constants';
 
 const useStyles = makeStyles((theme: Theme) => ({
     ...(commonStyles(theme) as Record<string, any>),
@@ -71,13 +65,6 @@ export const InstancePopup: FunctionComponent<Props> = ({
 
     const hasHero = (currentInstance?.files?.length ?? 0) > 0;
 
-    const orgUnitTree: any[] = useMemo(() => {
-        if (currentInstance?.org_unit) {
-            return getOrgUnitsTree(currentInstance.org_unit).reverse();
-        }
-        return [];
-    }, [currentInstance?.org_unit]);
-
     return (
         <Popup className={classes.popup} ref={popup} pane="popupPane">
             {isLoading && <LoadingSpinner />}
@@ -87,37 +74,19 @@ export const InstancePopup: FunctionComponent<Props> = ({
                         <CardMedia
                             // TS doesn't recognize the href prop, but MUI passes it down to the native (root) element
                             // @ts-ignore
-                            href={currentInstance.files[0]}
+                            href={currentInstance?.files.slice(-1)[0]}
                             className={classes.popupCardMedia}
-                            image={currentInstance.files[0]}
+                            image={currentInstance?.files.slice(-1)[0]}
                             component="div"
                         />
                     )}
                     <CardContent className={classes.popupCardContent}>
                         <InstanceDetailsInfos
+                            instance_metas_fields={INSTANCE_MAP_METAS_FIELDS}
                             currentInstance={currentInstance}
                             fieldsToHide={['device_id']}
                         />
-                        {currentInstance.org_unit && (
-                            <InstanceDetailsField
-                                label={formatMessage(MESSAGES.groups)}
-                                value={
-                                    currentInstance.org_unit.groups &&
-                                    currentInstance.org_unit.groups.length > 0
-                                        ? currentInstance.org_unit.groups
-                                              .map(g => g.name)
-                                              .join(', ')
-                                        : null
-                                }
-                            />
-                        )}
-                        {orgUnitTree.map(o => (
-                            <InstanceDetailsField
-                                key={o.id}
-                                label={o.org_unit_type_name}
-                                value={o ? o.name : null}
-                            />
-                        ))}
+
                         <Box className={classes.actionBox}>
                             <Grid
                                 container

--- a/hat/assets/js/apps/Iaso/domains/instances/constants.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/constants.js
@@ -12,6 +12,7 @@ import OrgUnitTooltip from '../orgUnits/components/OrgUnitTooltip';
 import { LinkToPlanning } from '../plannings/components/LinkToPlanning.tsx';
 import { usePrettyPeriod } from '../periods/utils';
 import MESSAGES from './messages';
+import { LinkToOrgUnit } from '../orgUnits/components/LinkToOrgUnit';
 
 export const INSTANCE_STATUS_READY = 'READY';
 export const INSTANCE_STATUS_ERROR = 'ERROR';
@@ -30,6 +31,68 @@ const PrettyPeriod = ({ value }) => {
     const formatPeriod = usePrettyPeriod();
     return formatPeriod(value);
 };
+export const INSTANCE_MAP_METAS_FIELDS = [
+    {
+        key: 'org_unit_type_name',
+        type: 'info',
+        renderValue: data => {
+            return data.org_unit.org_unit_type.name;
+        },
+    },
+    {
+        key: 'org_unit_name',
+        type: 'info',
+        renderValue: data => {
+            return <LinkToOrgUnit orgUnit={data.org_unit} />;
+        },
+    },
+    {
+        key: 'parent',
+        type: 'info',
+        renderValue: data => {
+            return <LinkToOrgUnit orgUnit={data.org_unit.parent} />;
+        },
+    },
+    {
+        key: 'form_name',
+        type: 'info',
+        renderValue: data => {
+            return (
+                <LinkToForm formId={data.form_id} formName={data.form_name} />
+            );
+        },
+    },
+    {
+        key: 'created_by',
+        type: 'info',
+        renderValue: data => {
+            return data.created_by
+                ? getDisplayName(data.created_by)
+                : textPlaceholder;
+        },
+    },
+    {
+        key: 'created_at',
+        render: value => displayDateFromTimestamp(value),
+        type: 'info',
+    },
+    {
+        key: 'org_unit',
+        render: value => {
+            if (!value) return null;
+            return (
+                <OrgUnitTooltip
+                    key={value.id}
+                    orgUnit={value}
+                    domComponent="span"
+                >
+                    <OrgUnitLabel orgUnit={value} withType withSource={false} />
+                </OrgUnitTooltip>
+            );
+        },
+        type: 'location',
+    },
+];
 
 export const INSTANCE_METAS_FIELDS = [
     {

--- a/hat/assets/js/apps/Iaso/domains/instances/details.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/details.tsx
@@ -39,6 +39,7 @@ import {
 } from './hooks/useReassignInstance';
 import MESSAGES from './messages';
 import { getInstancesFilesList } from './utils';
+import { INSTANCE_METAS_FIELDS } from './constants';
 
 const useStyles = makeStyles(theme => ({
     ...commonStyles(theme),
@@ -162,6 +163,9 @@ const InstanceDetails: FunctionComponent = () => {
                                 id="infos"
                             >
                                 <InstanceDetailsInfos
+                                    instance_metas_fields={
+                                        INSTANCE_METAS_FIELDS
+                                    }
                                     currentInstance={currentInstance}
                                 />
 

--- a/hat/assets/js/apps/Iaso/domains/instances/messages.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/messages.js
@@ -623,6 +623,18 @@ const MESSAGES = defineMessages({
         id: 'iaso.label.project',
         defaultMessage: 'Project',
     },
+    org_unit_type_name: {
+        id: 'iaso.instance.org_unit_type_name',
+        defaultMessage: 'Org unit type',
+    },
+    org_unit_name: {
+        id: 'iaso.instance.org_unit',
+        defaultMessage: 'Org unit',
+    },
+    parent: {
+        id: 'iaso.label.parent',
+        defaultMessage: 'Parent',
+    },
 });
 
 export default MESSAGES;


### PR DESCRIPTION
Explain what problem this PR is resolving
- Map view popup: Update the instance default fields
Related JIRA tickets : [IA-3174](https://bluesquare.atlassian.net/browse/IA-3174)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [x] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
- Tell us where the doc can be found (docs folder, wiki, in the code...)

## Changes
- Add new constant INSTANCE_MAP_METAS_FIELDS with updated instances info

## How to test
- Form --> Submissions
- Go on the map
- Click on a map marker and check which information are displayed

## Print screen / video
[Screencast from 2024-11-03 19-30-52.webm](https://github.com/user-attachments/assets/bbbda3c8-b09d-466a-a0c4-33728cbf9eea)

## Notes

Things that the reviewers should know: known bugs that are out of the scope of the PR, other trade-offs that were made.
If the PR depends on a PR in bluesquare-components, or merges into another PR (i.o. main), it should also be mentioned here


[IA-3174]: https://bluesquare.atlassian.net/browse/IA-3174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ