### PR TITLE
IA-3641: temporarily disable groups filter

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -511,6 +511,7 @@
     "iaso.label.export": "Export",
     "iaso.label.exportRequests": "Export requests",
     "iaso.label.exportSelection": "Export {count} submissions",
+    "iaso.label.featureDisabled": "Feature temporarily disabled",
     "iaso.label.featureFlags": "Feature flags",
     "iaso.label.field": "Field",
     "iaso.label.fields": "Fields",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -511,6 +511,7 @@
     "iaso.label.export": "Export",
     "iaso.label.exportRequests": "Demandes d'export",
     "iaso.label.exportSelection": "Exporter {count} soumissions",
+    "iaso.label.featureDisabled": "Fonctionnalité temporairement désactivée",
     "iaso.label.featureFlags": "Options",
     "iaso.label.field": "Champ",
     "iaso.label.fields": "Champs",

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/Filter/ReviewOrgUnitChangesFilter.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/Filter/ReviewOrgUnitChangesFilter.tsx
@@ -8,7 +8,8 @@ import { baseUrls } from '../../../../constants/urls';
 import MESSAGES from '../messages';
 import { OrgUnitTreeviewModal } from '../../components/TreeView/OrgUnitTreeviewModal';
 import { useGetOrgUnit } from '../../components/TreeView/requests';
-import { useGetGroupDropdown } from '../../hooks/requests/useGetGroups';
+// IA-3641 uncomment when UI has been refactored to limlit size of API call
+// import { useGetGroupDropdown } from '../../hooks/requests/useGetGroups';
 import { useGetOrgUnitTypesDropdownOptions } from '../../orgUnitTypes/hooks/useGetOrgUnitTypesDropdownOptions';
 import { DropdownOptions } from '../../../../types/utils';
 import DatesRange from '../../../../components/filters/DatesRange';
@@ -31,8 +32,12 @@ export const ReviewOrgUnitChangesFilter: FunctionComponent<Props> = ({
     const { filters, handleSearch, handleChange, filtersUpdated } =
         useFilterState({ baseUrl, params });
     const { data: initialOrgUnit } = useGetOrgUnit(params.parent_id);
-    const { data: groupOptions, isLoading: isLoadingGroups } =
-        useGetGroupDropdown({});
+    // IA-3641 hard coding values fro groups dropdown until refactor
+    // const { data: groupOptions, isLoading: isLoadingGroups } =
+    //     useGetGroupDropdown({});
+    const groupOptions = [];
+    const isLoadingGroups = false;
+    // IA-3641 -----END
     const { data: orgUnitTypeOptions, isLoading: isLoadingTypes } =
         useGetOrgUnitTypesDropdownOptions();
     const { data: forms, isFetching: isLoadingForms } = useGetForms();
@@ -112,6 +117,8 @@ export const ReviewOrgUnitChangesFilter: FunctionComponent<Props> = ({
                     options={groupOptions}
                     loading={isLoadingGroups}
                     labelString={formatMessage(MESSAGES.group)}
+                    disabled
+                    helperText={formatMessage(MESSAGES.featureDisabled)}
                 />
             </Grid>
             <Grid item xs={12} md={4} lg={3}>

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/messages.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/messages.ts
@@ -217,6 +217,10 @@ const MESSAGES = defineMessages({
         id: 'iaso.label.accuracy',
         defaultMessage: 'Accuracy',
     },
+    featureDisabled: {
+        id: 'iaso.label.featureDisabled',
+        defaultMessage: 'Feature temporarily disabled',
+    },
 });
 
 export default MESSAGES;


### PR DESCRIPTION
Groups API made OU change reqiest page crash, and sometimes server as well

Related JIRA tickets : IA-3628, IA-3641

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [x] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
Left explanatory comments in the code

## Changes

- Disabled groups filter
- Added explanation in helper text
- removed call to goups API

## How to test

Go to change requests page: the group filter should be deactivated, with a message; there should be no call to the groups API

## Print screen / video

![Screenshot 2024-11-04 at 12 43 54](https://github.com/user-attachments/assets/3ed2d9c4-254a-452a-8c04-5700762bcc38)



## Notes

This ports to main the IA-3628 part of https://github.com/BLSQ/iaso/pull/1756
