### PR TITLE
IA-3607 fix payment disappearing after bulk update

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/payments/LotsPayments.tsx
+++ b/hat/assets/js/apps/Iaso/domains/payments/LotsPayments.tsx
@@ -14,10 +14,7 @@ import { RefreshButton } from '../../components/Buttons/RefreshButton';
 import { useParamsObject } from '../../routing/hooks/useParamsObject';
 
 const getRowProps = row => {
-    if (
-        row.original.task?.status === 'QUEUED' ||
-        row.original.task?.status === 'RUNNING'
-    ) {
+    if (row.original.task) {
         return {
             'data-test': 'paymentLotRow',
             sx: {

--- a/hat/assets/js/apps/Iaso/domains/payments/components/PaymentLotActionCell.tsx
+++ b/hat/assets/js/apps/Iaso/domains/payments/components/PaymentLotActionCell.tsx
@@ -25,9 +25,7 @@ export const PaymentLotActionCell = ({
             mark_payments_as_sent: true,
         });
     }, [paymentLot.id, markAsSent]);
-    const disableButtons =
-        paymentLot.task?.status === 'QUEUED' ||
-        paymentLot.task?.status === 'RUNNING';
+    const disableButtons = Boolean(paymentLot.task);
     const userIds = [
         ...new Set(paymentLot.payments.map(payment => payment.user.id)),
     ].join(',');
@@ -39,8 +37,8 @@ export const PaymentLotActionCell = ({
             <IconButton
                 icon="remove-red-eye"
                 url={`/${baseUrls.orgUnitsChangeRequest}/userIds/${userIds}/paymentIds/${paymentIds}`}
-                // TODO add correct message
                 tooltipMessage={MESSAGES.viewChangeRequestforLot}
+                disabled={disableButtons}
             />
 
             {paymentLot.status === 'new' && (
@@ -56,11 +54,13 @@ export const PaymentLotActionCell = ({
                 iconProps={{ disabled: disableButtons }}
                 paymentLot={paymentLot}
             />
-            <ExternalLinkIconButton
-                tooltipMessage={MESSAGES.download_payments}
-                overrideIcon={FileDownloadIcon}
-                url={`/api/payments/lots/${paymentLot.id}/?xlsx=true`}
-            />
+            {!disableButtons && (
+                <ExternalLinkIconButton
+                    tooltipMessage={MESSAGES.download_payments}
+                    overrideIcon={FileDownloadIcon}
+                    url={`/api/payments/lots/${paymentLot.id}/?xlsx=true`}
+                />
+            )}
         </>
     );
 };

--- a/iaso/api/payments/views.py
+++ b/iaso/api/payments/views.py
@@ -98,8 +98,12 @@ class PaymentLotsViewSet(ModelViewSet):
     http_method_names = ["get", "post", "patch", "head", "options", "trace"]
 
     def get_queryset(self):
-        # Filter out PaymentLot with task because they're still being created by the worker
-        queryset = PaymentLot.objects.filter(task__isnull=True)
+        payments = (
+            Payment.objects.filter(created_by__iaso_profile__account=self.request.user.iaso_profile.account)
+            .values_list("payment_lot_id", flat=True)
+            .distinct()
+        )
+        queryset = PaymentLot.objects.filter(id__in=payments)
 
         change_requests_prefetch = Prefetch(
             "payments__change_requests",

--- a/iaso/api/payments/views.py
+++ b/iaso/api/payments/views.py
@@ -206,6 +206,8 @@ class PaymentLotsViewSet(ModelViewSet):
             # the mark_as_sent query_param is used to only update related_payments' statuses, so we don't perform any other update when it's true
             if mark_as_sent:
                 task = mark_payments_as_read(payment_lot_id=instance.pk, api=PAYMENT_LOT_API, user=request.user)
+                instance.task = task
+                instance.save()
                 return Response(
                     {"task": TaskSerializer(instance=task).data},
                     status=status.HTTP_201_CREATED,

--- a/iaso/tasks/payments_bulk_update.py
+++ b/iaso/tasks/payments_bulk_update.py
@@ -6,7 +6,7 @@ from beanstalk_worker import task_decorator
 from hat.audit import models as audit_models
 from iaso.api.payments.serializers import PaymentLotAuditLogger
 from iaso.models import Task
-from iaso.models.base import ERRORED
+from iaso.models.base import ERRORED, KILLED, KilledException
 from iaso.models.payments import Payment, PaymentLot, PaymentStatuses
 from django.utils import timezone
 from django.core.exceptions import ObjectDoesNotExist
@@ -19,6 +19,19 @@ def end_task_and_update_payment_lot(payment_lot, task, message):
     task.save()
     payment_lot.task = None
     payment_lot.save()
+
+
+def report_progress_and_stop_if_killed_and_update_payment_lot(
+    payment_lot, task, progress_message, progress_value=None, end_value=None
+):
+    try:
+        task.report_progress_and_stop_if_killed(
+            progress_message=progress_message, progress_value=progress_value, end_value=end_value
+        )
+    except KilledException:
+        payment_lot.task = None
+        payment_lot.save()
+        raise KilledException("Killed by user")
 
 
 def update_payment_from_bulk(user, payment, *, status, api):
@@ -48,7 +61,6 @@ def payments_bulk_update(
     """
     start = time()
     the_task = task
-    the_task.report_progress_and_stop_if_killed(progress_message="Searching for Payments to modify")
     if not payment_lot_id:
         the_task.status = ERRORED
         the_task.ended_at = timezone.now()
@@ -62,7 +74,10 @@ def payments_bulk_update(
             the_task.ended_at = timezone.now()
             the_task.result = {"result": ERRORED, "message": "Payment Lot not found"}
             the_task.save()
-
+        # Handle killing task after retrieving payment lot, so payment lot's task field can be updated
+        report_progress_and_stop_if_killed_and_update_payment_lot(
+            payment_lot=payment_lot, task=the_task, progress_message="Searching for Payments to modify"
+        )
         # audit stuff
         payment_log_audit = PaymentLotAuditLogger()
         old_payment_lot = payment_log_audit.serialize_instance(payment_lot)
@@ -88,8 +103,12 @@ def payments_bulk_update(
         with transaction.atomic():
             for index, payment in enumerate(queryset.iterator()):
                 res_string = "%.2f sec, processed %i payments" % (time() - start, index)
-                the_task.report_progress_and_stop_if_killed(
-                    progress_message=res_string, end_value=total, progress_value=index
+                report_progress_and_stop_if_killed_and_update_payment_lot(
+                    payment_lot=payment_lot,
+                    task=the_task,
+                    progress_message=res_string,
+                    end_value=total,
+                    progress_value=index,
                 )
                 update_payment_from_bulk(user, payment, status=status, api=api)
             # Update PaymentLot status if needed. Since the bulk update doesn't necessarily include
@@ -124,7 +143,7 @@ def mark_payments_as_read(
     """
     start = time()
     the_task = task
-    the_task.report_progress_and_stop_if_killed(progress_message="Searching for Payments to modify")
+
     try:
         payment_lot = PaymentLot.objects.get(id=payment_lot_id)
     except ObjectDoesNotExist:
@@ -132,6 +151,11 @@ def mark_payments_as_read(
         the_task.ended_at = timezone.now()
         the_task.result = {"result": ERRORED, "message": "Payment Lot not found"}
         the_task.save()
+    # Handling task being killed after we get the payment_lot, so we can set it's task field back to None if the task is killed
+    report_progress_and_stop_if_killed_and_update_payment_lot(
+        payment_lot=payment_lot, task=the_task, progress_message="Searching for Payments to modify"
+    )
+
     payments = Payment.objects.filter(payment_lot=payment_lot)
     total = payments.count()
 
@@ -144,8 +168,12 @@ def mark_payments_as_read(
     with transaction.atomic():
         for index, payment in enumerate(payments.iterator()):
             res_string = "%.2f sec, processed %i payments" % (time() - start, index)
-            the_task.report_progress_and_stop_if_killed(
-                progress_message=res_string, end_value=total, progress_value=index
+            report_progress_and_stop_if_killed_and_update_payment_lot(
+                payment_lot=payment_lot,
+                task=the_task,
+                progress_message=res_string,
+                end_value=total,
+                progress_value=index,
             )
             update_payment_from_bulk(user, payment, status=PaymentStatuses.SENT, api=api)
 

--- a/iaso/tasks/payments_bulk_update.py
+++ b/iaso/tasks/payments_bulk_update.py
@@ -151,7 +151,7 @@ def mark_payments_as_read(
         the_task.ended_at = timezone.now()
         the_task.result = {"result": ERRORED, "message": "Payment Lot not found"}
         the_task.save()
-    # Handling task being killed after we get the payment_lot, so we can set it's task field back to None if the task is killed
+    # Handling task being killed after we get the payment_lot, so we can set its task field back to None if the task is killed
     report_progress_and_stop_if_killed_and_update_payment_lot(
         payment_lot=payment_lot, task=the_task, progress_message="Searching for Payments to modify"
     )

--- a/iaso/tests/models/test_payments.py
+++ b/iaso/tests/models/test_payments.py
@@ -3,7 +3,6 @@ from django.test import TestCase
 from iaso import models as m
 from django.contrib.auth.models import User
 from datetime import datetime
-from psycopg2.errors import UniqueViolation
 
 from iaso.models.payments import PaymentStatuses
 


### PR DESCRIPTION
Payment lots were not shown in the UI after bulk update because their `task` field was not updated properly

Related JIRA tickets : IA-3607

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
- Tell us where the doc can be found (docs folder, wiki, in the code...)

## Changes

- Backend:
    - bulk update: set `PaymentLot` task field to None when task succeeds or raises
    - mark as read: idem
    - Handle the case where the task is killed, so that the payment lot is still correctly updated (`task` field set to `None`)
- Front-end:
    - disable Payment Lot action butttons in table if PaymentLot task is not null
    - set row background color to yellow to indicate that Payment Lot has a task running

## How to test

setup:  DB with payment lots, and an active worker

- Go to payments lots page
- open payment lot. 
- Select one or several payment with the table checkbox
- Edit and save payment(s)

- The payment lot row should be yellow and the buttons deactivated
- Refresh page: when the change has been processed, the row should be back to normal with active buttons

- repeat operation with the mark as read action button. The behaviour should be the same

## Print screen / video

https://github.com/user-attachments/assets/81b9bd94-c88c-4aa8-9c35-4ee7aa5614ad


## Notes



This ports to main and expands changes made in HOTFIX_IA-3609_IA-3607 for IA-3607
