### PR TITLE
IA-3578: Default select in dropdown: Have old version on the left and most recent version on the right

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -392,6 +392,7 @@
     "iaso.instance.queryBuilder": "Search in submitted fields",
     "iaso.instance.removeLockAction": "Unlock the submission",
     "iaso.instance.selectedOrgUnit": "Selected Org unit",
+    "iaso.instance.selectVersionToCompare": "Please select the version to compare",
     "iaso.instance.source_created_at": "Created on device",
     "iaso.instance.table.label.instanceHeaderTooltip": "Label: {label} - Name: {key}",
     "iaso.instance.title": "Submissions",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -392,6 +392,7 @@
     "iaso.instance.queryBuilder": "Rechercher dans les champs soumis",
     "iaso.instance.removeLockAction": "Déverrouiller la soumission",
     "iaso.instance.selectedOrgUnit": "Unité d'org. sélectionnée",
+    "iaso.instance.selectVersionToCompare": "Veuillez sélectionner la version à comparer",
     "iaso.instance.source_created_at": "Création sur appareil",
     "iaso.instance.table.label.instanceHeaderTooltip": "Label: {label} - Nom: {key}",
     "iaso.instance.title": "Soumissions",

--- a/hat/assets/js/apps/Iaso/domains/instances/compare/components/CompareInstanceLogs.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/compare/components/CompareInstanceLogs.tsx
@@ -94,15 +94,17 @@ export const CompareInstanceLogs: FunctionComponent = () => {
             const newParams: Params = {
                 ...params,
             };
-            if (!params.logA && instanceLogsDropdown[0]?.value) {
-                newParams.logA = instanceLogsDropdown[0]?.value.toString();
+            const logADropDownValue = instanceLogsDropdown?.slice(-1)[0]?.value;
+            const loagBDropDownValue = instanceLogsDropdown[0]?.value;
+            if (!params.logA && logADropDownValue) {
+                newParams.logA = logADropDownValue.toString();
             }
-            if (!params.logB && instanceLogsDropdown[1]?.value) {
-                newParams.logB = instanceLogsDropdown[1]?.value.toString();
+            if (!params.logB && loagBDropDownValue) {
+                newParams.logB = loagBDropDownValue.toString();
             }
             if (
-                (!params.logA && instanceLogsDropdown[0]?.value) ||
-                (!params.logB && instanceLogsDropdown[1]?.value)
+                (!params.logA && logADropDownValue) ||
+                (!params.logB && loagBDropDownValue)
             ) {
                 redirectToReplace(baseUrls.compareInstanceLogs, newParams);
             }
@@ -111,10 +113,10 @@ export const CompareInstanceLogs: FunctionComponent = () => {
     }, [instanceLogsDropdown, params]);
     useEffect(() => {
         setLogAInitialValue(
-            instanceLogsDropdown && instanceLogsDropdown[0]?.value,
+            instanceLogsDropdown && instanceLogsDropdown?.slice(-1)[0]?.value,
         );
         setLogBInitialValue(
-            instanceLogsDropdown && instanceLogsDropdown[1]?.value,
+            instanceLogsDropdown && instanceLogsDropdown[0]?.value,
         );
     }, [instanceLogsDropdown, isFetchingInstanceLogs]);
 

--- a/hat/assets/js/apps/Iaso/domains/instances/compare/components/CompareInstanceLogs.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/compare/components/CompareInstanceLogs.tsx
@@ -13,7 +13,6 @@ import {
     useGetInstanceLogs,
     useGetInstanceLogDetail,
 } from '../hooks/useGetInstanceLogs';
-import InputComponent from '../../../../components/forms/InputComponent';
 import TopBar from '../../../../components/nav/TopBarComponent';
 import ErrorPaperComponent from '../../../../components/papers/ErrorPaperComponent';
 import { InstanceLogDetail } from './InstanceLogDetail';
@@ -134,35 +133,36 @@ export const CompareInstanceLogs: FunctionComponent = () => {
                 goBack={goBack}
             />
             <Box className={classes.containerFullHeightNoTabPadded}>
-                <Grid container spacing={2}>
-                    <Grid xs={12} md={6} item>
-                        <InputComponent
-                            clearable={false}
-                            type="select"
-                            keyValue="logA"
-                            onChange={handleChange}
+                <Grid
+                    container
+                    spacing={3}
+                    display="flex"
+                    justifyContent="flex-end"
+                >
+                    <Grid xs={12} md={4.5} item>
+                        <InstanceLogInfos
+                            log="logA"
+                            logTitle="Version A"
+                            dropDownHandleChange={handleChange}
                             value={params.logA || logAInitialValue}
                             label={MESSAGES.instanceLogsVersionA}
+                            user={instanceLogA?.user}
+                            infos={instanceLogContent.logA}
+                            loading={isInstanceLogAFetching}
                             options={instanceLogsDropdown?.filter(
                                 instance =>
                                     instance.value !==
                                     (parseInt(params.logB, 10) ||
                                         logBInitialValue),
                             )}
-                            loading={isFetchingInstanceLogs}
-                        />
-                        <InstanceLogInfos
-                            user={instanceLogA?.user}
-                            infos={instanceLogContent.logA}
-                            loading={isInstanceLogAFetching}
+                            dropDownLoading={isFetchingInstanceLogs}
                         />
                     </Grid>
-                    <Grid xs={12} md={6} item>
-                        <InputComponent
-                            clearable={false}
-                            type="select"
-                            keyValue="logB"
-                            onChange={handleChange}
+                    <Grid xs={12} md={4.5} item>
+                        <InstanceLogInfos
+                            log="logB"
+                            logTitle="Version B"
+                            dropDownHandleChange={handleChange}
                             value={params.logB || logBInitialValue}
                             label={MESSAGES.instanceLogsVersionB}
                             options={instanceLogsDropdown?.filter(
@@ -172,12 +172,9 @@ export const CompareInstanceLogs: FunctionComponent = () => {
                                         logAInitialValue),
                             )}
                             loading={isFetchingInstanceLogs}
-                        />
-
-                        <InstanceLogInfos
                             user={instanceLogA?.user}
                             infos={instanceLogContent.logB}
-                            loading={isInstanceLogBFetching}
+                            dropDownLoading={isInstanceLogBFetching}
                         />
                     </Grid>
 

--- a/hat/assets/js/apps/Iaso/domains/instances/compare/components/CompareInstanceLogs.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/compare/components/CompareInstanceLogs.tsx
@@ -94,22 +94,22 @@ export const CompareInstanceLogs: FunctionComponent = () => {
                 ...params,
             };
             const logADropDownValue = instanceLogsDropdown?.slice(-1)[0]?.value;
-            const loagBDropDownValue = instanceLogsDropdown[0]?.value;
+            const logBDropDownValue = instanceLogsDropdown[0]?.value;
             if (!params.logA && logADropDownValue) {
                 newParams.logA = logADropDownValue.toString();
             }
-            if (!params.logB && loagBDropDownValue) {
-                newParams.logB = loagBDropDownValue.toString();
+            if (!params.logB && logBDropDownValue) {
+                newParams.logB = logBDropDownValue.toString();
             }
             if (
                 (!params.logA && logADropDownValue) ||
-                (!params.logB && loagBDropDownValue)
+                (!params.logB && logBDropDownValue)
             ) {
                 redirectToReplace(baseUrls.compareInstanceLogs, newParams);
             }
         }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [instanceLogsDropdown, params]);
+    }, [instanceLogsDropdown, params, redirectToReplace]);
+
     useEffect(() => {
         setLogAInitialValue(
             instanceLogsDropdown && instanceLogsDropdown?.slice(-1)[0]?.value,

--- a/hat/assets/js/apps/Iaso/domains/instances/compare/components/InstanceLogContentBasic.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/compare/components/InstanceLogContentBasic.tsx
@@ -44,13 +44,17 @@ export const InstanceLogContentBasic: FunctionComponent<Props> = ({
             <TableHead>
                 <TableRow>
                     <TableCell
-                        width="25.3%"
+                        width="25.35%"
                         align="left"
                         className={classes.tableCellHead}
                     >
                         {formatMessage(MESSAGES.label)}
                     </TableCell>
-                    <TableCell align="left" className={classes.tableCellHead}>
+                    <TableCell
+                        width="37.35%"
+                        align="left"
+                        className={classes.tableCellHead}
+                    >
                         <Typography
                             color={
                                 fileContent?.logA?.deleted ? 'error' : 'inherit'
@@ -59,7 +63,11 @@ export const InstanceLogContentBasic: FunctionComponent<Props> = ({
                             {formatMessage(MESSAGES.instanceLogsVersionA)}
                         </Typography>
                     </TableCell>
-                    <TableCell align="left" className={classes.tableCellHead}>
+                    <TableCell
+                        width="37.35%"
+                        align="left"
+                        className={classes.tableCellHead}
+                    >
                         <Typography
                             color={
                                 fileContent?.logB?.deleted ? 'error' : undefined

--- a/hat/assets/js/apps/Iaso/domains/instances/compare/components/InstanceLogContentBasic.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/compare/components/InstanceLogContentBasic.tsx
@@ -9,6 +9,7 @@ import {
 import { makeStyles } from '@mui/styles';
 import { useSafeIntl, IntlFormatMessage } from 'bluesquare-components';
 
+import classNames from 'classnames';
 import { FileContent } from '../../types/instance';
 import MESSAGES from '../messages';
 import InstanceLogContentBodyTable from './InstanceLogContentBodyTable';
@@ -29,6 +30,16 @@ const useStyles = makeStyles(theme => ({
         // @ts-ignore
         borderBottom: `1px solid ${theme.palette.ligthGray.border}  !important`,
     },
+    labelTableCellFixWith: {
+        width: '25.35%',
+        maxWidth: '25.35%',
+        minWidth: '25.35%',
+    },
+    versionValueTableCellFix: {
+        width: '37.35%',
+        maxWidth: '37.35%',
+        minWidth: '37.35%',
+    },
 }));
 
 export const InstanceLogContentBasic: FunctionComponent<Props> = ({
@@ -44,16 +55,20 @@ export const InstanceLogContentBasic: FunctionComponent<Props> = ({
             <TableHead>
                 <TableRow>
                     <TableCell
-                        width="25.35%"
                         align="left"
-                        className={classes.tableCellHead}
+                        className={classNames(
+                            classes.tableCellHead,
+                            classes.labelTableCellFixWith,
+                        )}
                     >
                         {formatMessage(MESSAGES.label)}
                     </TableCell>
                     <TableCell
-                        width="37.35%"
                         align="left"
-                        className={classes.tableCellHead}
+                        className={classNames(
+                            classes.tableCellHead,
+                            classes.versionValueTableCellFix,
+                        )}
                     >
                         <Typography
                             color={
@@ -64,9 +79,11 @@ export const InstanceLogContentBasic: FunctionComponent<Props> = ({
                         </Typography>
                     </TableCell>
                     <TableCell
-                        width="37.35%"
                         align="left"
-                        className={classes.tableCellHead}
+                        className={classNames(
+                            classes.tableCellHead,
+                            classes.versionValueTableCellFix,
+                        )}
                     >
                         <Typography
                             color={

--- a/hat/assets/js/apps/Iaso/domains/instances/compare/components/InstanceLogContentBasic.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/compare/components/InstanceLogContentBasic.tsx
@@ -24,7 +24,8 @@ const useStyles = makeStyles(theme => ({
         backgroundColor: 'transparent',
         borderTop: 'none !important',
         borderLeft: 'none !important',
-        borderRight: 'none !important',
+        // @ts-ignore
+        borderRight: `1px solid ${theme.palette.ligthGray.border}  !important`,
         // @ts-ignore
         borderBottom: `1px solid ${theme.palette.ligthGray.border}  !important`,
     },
@@ -42,7 +43,11 @@ export const InstanceLogContentBasic: FunctionComponent<Props> = ({
         <Table>
             <TableHead>
                 <TableRow>
-                    <TableCell align="left" className={classes.tableCellHead}>
+                    <TableCell
+                        width="25.3%"
+                        align="left"
+                        className={classes.tableCellHead}
+                    >
                         {formatMessage(MESSAGES.label)}
                     </TableCell>
                     <TableCell align="left" className={classes.tableCellHead}>

--- a/hat/assets/js/apps/Iaso/domains/instances/compare/components/InstanceLogContentBodyTable.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/compare/components/InstanceLogContentBodyTable.tsx
@@ -14,7 +14,8 @@ const useStyles = makeStyles(theme => ({
         backgroundColor: 'transparent',
         borderTop: 'none !important',
         borderLeft: 'none !important',
-        borderRight: 'none !important',
+        // @ts-ignore
+        borderRight: `1px solid ${theme.palette.ligthGray.border}  !important`,
         // @ts-ignore
         borderBottom: `1px solid ${theme.palette.ligthGray.border}  !important`,
     },

--- a/hat/assets/js/apps/Iaso/domains/instances/compare/components/InstanceLogInfos.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/compare/components/InstanceLogInfos.tsx
@@ -6,10 +6,9 @@ import {
     textPlaceholder,
 } from 'bluesquare-components';
 
-import { Grid, Box } from '@mui/material';
+import { Grid, Box, Card, Typography } from '@mui/material';
 import moment from 'moment';
 import { usePrettyPeriod } from '../../../periods/utils';
-import WidgetPaper from '../../../../components/papers/WidgetPaperComponent';
 
 import { getDisplayName, User } from '../../../../utils/usersUtils';
 import { LinkToOrgUnit } from '../../../orgUnits/components/LinkToOrgUnit';
@@ -18,14 +17,29 @@ import { useGetOrgUnitDetail } from '../../../orgUnits/hooks/requests/useGetOrgU
 import MESSAGES from '../messages';
 import { LinkToForm } from '../../../forms/components/LinkToForm';
 import InstanceLogInfosRow from './InstanceLogInfosRow';
+import InputComponent from '../../../../components/forms/InputComponent';
 
 type Props = {
+    log: string;
+    dropDownHandleChange: (key: string, value: string) => void;
+    value: string | number | undefined;
+    label: any;
+    options: any;
+    dropDownLoading: boolean;
     user: User | undefined;
     infos: Record<string, any> | undefined;
     loading: boolean;
+    logTitle: string;
 };
 
 export const InstanceLogInfos: FunctionComponent<Props> = ({
+    log,
+    logTitle,
+    dropDownHandleChange,
+    value,
+    label,
+    options,
+    dropDownLoading,
     user,
     infos,
     loading,
@@ -35,15 +49,56 @@ export const InstanceLogInfos: FunctionComponent<Props> = ({
         useSafeIntl();
 
     const { data: currentOrgUnit } = useGetOrgUnitDetail(infos?.org_unit);
-
+    const firstLogInfos = [
+        // Modified by
+        {
+            label: formatMessage(MESSAGES.last_modified_by),
+            value: user ? getDisplayName(user) : textPlaceholder,
+            index: 1,
+        },
+        // Updated at
+        {
+            label: formatMessage(MESSAGES.updated),
+            value: moment(infos?.updated_at).format('LTS'),
+            index: 2,
+        },
+        // OrgUnit hyperlink
+        {
+            label: formatMessage(MESSAGES.org_unit),
+            value: <LinkToOrgUnit orgUnit={currentOrgUnit} />,
+            index: 3,
+        },
+        // Form hyperlink
+        {
+            label: formatMessage(MESSAGES.form),
+            value: <LinkToForm formId={infos?.form} formName={infos?.name} />,
+            index: 4,
+        },
+    ];
+    const secondLogInfos = [
+        // Form version
+        {
+            label: formatMessage(MESSAGES.form_version),
+            value: infos?.json._version,
+            index: 5,
+        },
+        // Period
+        {
+            label: formatMessage(MESSAGES.period),
+            value: formatPeriod(infos?.period),
+            index: 6,
+        },
+        // Deleted
+        {
+            label: formatMessage(MESSAGES.deleted),
+            value: formatMessage(infos?.deleted ? MESSAGES.yes : MESSAGES.no),
+            valueColor: infos?.deleted ? 'error' : 'inherit',
+            index: 7,
+        },
+    ];
     return (
         <Box mt={2}>
-            <WidgetPaper
-                expandable
-                isExpanded
-                title={formatMessage(MESSAGES.infos)}
-                padded
-            >
+            <Card>
                 {loading && (
                     <LoadingSpinner
                         fixed={false}
@@ -53,50 +108,56 @@ export const InstanceLogInfos: FunctionComponent<Props> = ({
                     />
                 )}
                 {!loading && (
-                    <Grid container spacing={1}>
-                        <InstanceLogInfosRow
-                            label={formatMessage(MESSAGES.last_modified_by)}
-                            value={
-                                user ? getDisplayName(user) : textPlaceholder
-                            }
-                        />
-                        <InstanceLogInfosRow
-                            label={formatMessage(MESSAGES.updated)}
-                            value={moment(infos?.updated_at).format('LTS')}
-                        />
-                        <InstanceLogInfosRow
-                            label={formatMessage(MESSAGES.org_unit)}
-                            value={<LinkToOrgUnit orgUnit={currentOrgUnit} />}
-                            isValueLink
-                        />
-                        <InstanceLogInfosRow
-                            label={formatMessage(MESSAGES.form)}
-                            value={
-                                <LinkToForm
-                                    formId={infos?.form}
-                                    formName={infos?.name}
-                                />
-                            }
-                            isValueLink
-                        />
-                        <InstanceLogInfosRow
-                            label={formatMessage(MESSAGES.form_version)}
-                            value={infos?.json._version}
-                        />
-                        <InstanceLogInfosRow
-                            label={formatMessage(MESSAGES.period)}
-                            value={formatPeriod(infos?.period)}
-                        />
-                        <InstanceLogInfosRow
-                            label={formatMessage(MESSAGES.deleted)}
-                            value={formatMessage(
-                                infos?.deleted ? MESSAGES.yes : MESSAGES.no,
-                            )}
-                            valueColor={infos?.deleted ? 'error' : 'inherit'}
-                        />
+                    <Grid container spacing={2} padding={2}>
+                        <Grid item xs={12}>
+                            <Typography variant="h5" fontWeight="bold">
+                                {logTitle}
+                            </Typography>
+                        </Grid>
+
+                        <Grid item xs={12}>
+                            <Typography variant="body2" fontWeight="bold">
+                                {formatMessage(MESSAGES.selectVersionToCompare)}
+                            </Typography>
+                            <InputComponent
+                                clearable={false}
+                                type="select"
+                                keyValue={log}
+                                onChange={dropDownHandleChange}
+                                value={value}
+                                label={label}
+                                options={options}
+                                loading={dropDownLoading}
+                            />
+                        </Grid>
+
+                        <Grid item xs={12}>
+                            <Grid container spacing={2}>
+                                <Grid item xs={12} md={6}>
+                                    {firstLogInfos.map(logInfo => (
+                                        <InstanceLogInfosRow
+                                            key={logInfo.index}
+                                            label={logInfo.label}
+                                            value={logInfo.value}
+                                        />
+                                    ))}
+                                </Grid>
+
+                                <Grid item xs={12} md={6}>
+                                    {secondLogInfos.map(logInfo => (
+                                        <InstanceLogInfosRow
+                                            key={logInfo.index}
+                                            label={logInfo.label}
+                                            value={logInfo.value}
+                                            valueColor={logInfo.valueColor}
+                                        />
+                                    ))}
+                                </Grid>
+                            </Grid>
+                        </Grid>
                     </Grid>
                 )}
-            </WidgetPaper>
+            </Card>
         </Box>
     );
 };

--- a/hat/assets/js/apps/Iaso/domains/instances/compare/components/InstanceLogInfos.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/compare/components/InstanceLogInfos.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, useMemo } from 'react';
 import {
     useSafeIntl,
     LoadingSpinner,
@@ -49,53 +49,76 @@ export const InstanceLogInfos: FunctionComponent<Props> = ({
         useSafeIntl();
 
     const { data: currentOrgUnit } = useGetOrgUnitDetail(infos?.org_unit);
-    const firstLogInfos = [
-        // Modified by
-        {
-            label: formatMessage(MESSAGES.last_modified_by),
-            value: user ? getDisplayName(user) : textPlaceholder,
-            index: 1,
-        },
-        // Updated at
-        {
-            label: formatMessage(MESSAGES.updated),
-            value: moment(infos?.updated_at).format('LTS'),
-            index: 2,
-        },
-        // OrgUnit hyperlink
-        {
-            label: formatMessage(MESSAGES.org_unit),
-            value: <LinkToOrgUnit orgUnit={currentOrgUnit} />,
-            index: 3,
-        },
-        // Form hyperlink
-        {
-            label: formatMessage(MESSAGES.form),
-            value: <LinkToForm formId={infos?.form} formName={infos?.name} />,
-            index: 4,
-        },
-    ];
-    const secondLogInfos = [
-        // Form version
-        {
-            label: formatMessage(MESSAGES.form_version),
-            value: infos?.json._version,
-            index: 5,
-        },
-        // Period
-        {
-            label: formatMessage(MESSAGES.period),
-            value: formatPeriod(infos?.period),
-            index: 6,
-        },
-        // Deleted
-        {
-            label: formatMessage(MESSAGES.deleted),
-            value: formatMessage(infos?.deleted ? MESSAGES.yes : MESSAGES.no),
-            valueColor: infos?.deleted ? 'error' : 'inherit',
-            index: 7,
-        },
-    ];
+    const firstLogInfos = useMemo(
+        () => [
+            // Modified by
+            {
+                label: formatMessage(MESSAGES.last_modified_by),
+                value: user ? getDisplayName(user) : textPlaceholder,
+                index: 1,
+            },
+            // Updated at
+            {
+                label: formatMessage(MESSAGES.updated),
+                value: moment(infos?.updated_at).format('LTS'),
+                index: 2,
+            },
+            // OrgUnit hyperlink
+            {
+                label: formatMessage(MESSAGES.org_unit),
+                value: <LinkToOrgUnit orgUnit={currentOrgUnit} />,
+                index: 3,
+            },
+            // Form hyperlink
+            {
+                label: formatMessage(MESSAGES.form),
+                value: (
+                    <LinkToForm formId={infos?.form} formName={infos?.name} />
+                ),
+                index: 4,
+            },
+        ],
+        [
+            currentOrgUnit,
+            formatMessage,
+            infos?.form,
+            infos?.name,
+            infos?.updated_at,
+            user,
+        ],
+    );
+    const secondLogInfos = useMemo(
+        () => [
+            // Form version
+            {
+                label: formatMessage(MESSAGES.form_version),
+                value: infos?.json._version,
+                index: 5,
+            },
+            // Period
+            {
+                label: formatMessage(MESSAGES.period),
+                value: formatPeriod(infos?.period),
+                index: 6,
+            },
+            // Deleted
+            {
+                label: formatMessage(MESSAGES.deleted),
+                value: formatMessage(
+                    infos?.deleted ? MESSAGES.yes : MESSAGES.no,
+                ),
+                valueColor: infos?.deleted ? 'error' : 'inherit',
+                index: 7,
+            },
+        ],
+        [
+            formatMessage,
+            formatPeriod,
+            infos?.deleted,
+            infos?.json._version,
+            infos?.period,
+        ],
+    );
     return (
         <Box mt={2}>
             <Card>

--- a/hat/assets/js/apps/Iaso/domains/instances/compare/components/InstanceLogInfosRow.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/compare/components/InstanceLogInfosRow.tsx
@@ -1,43 +1,26 @@
 import React, { ReactNode } from 'react';
-import { Grid, Typography } from '@mui/material';
+import { Stack, Typography } from '@mui/material';
 
 interface Props {
     label: string;
     value: ReactNode | string;
     valueColor?: string;
-    isValueLink?: boolean;
 }
 
 const InstanceLogInfosRow: React.FunctionComponent<Props> = ({
     label,
     value,
     valueColor = 'inherit',
-    isValueLink = false,
 }) => (
-    <>
-        <Grid
-            xs={5}
-            container
-            alignItems="center"
-            item
-            justifyContent="flex-end"
-        >
-            <Typography variant="body2" color={valueColor}>
-                {label} :
-            </Typography>
-        </Grid>
-        <Grid
-            xs={7}
-            container
-            alignItems="center"
-            item
-            justifyContent="flex-start"
-        >
-            <Typography variant="body2" color={valueColor}>
-                {isValueLink ? value : value}
-            </Typography>
-        </Grid>
-    </>
+    <Stack direction="row" spacing={1} alignItems="center">
+        <Typography variant="body2" color={valueColor}>
+            <b>{label} :</b>
+        </Typography>
+
+        <Typography variant="body2" color={valueColor}>
+            {value}
+        </Typography>
+    </Stack>
 );
 
 export default InstanceLogInfosRow;

--- a/hat/assets/js/apps/Iaso/domains/instances/compare/messages.ts
+++ b/hat/assets/js/apps/Iaso/domains/instances/compare/messages.ts
@@ -97,6 +97,10 @@ const MESSAGES = defineMessages({
         id: 'iaso.mappings.label.formVersion',
         defaultMessage: 'Form version',
     },
+    selectVersionToCompare: {
+        id: 'iaso.instance.selectVersionToCompare',
+        defaultMessage: 'Please select the version to compare',
+    },
 });
 
 export default MESSAGES;


### PR DESCRIPTION
Explain what problem this PR is resolving
- Default select in dropdown: Have old version on the left and most recent version on the right
Related JIRA tickets : [IA-3578](https://bluesquare.atlassian.net/browse/IA-3578)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [x] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
- Tell us where the doc can be found (docs folder, wiki, in the code...)

## Changes
- Render the old version on the left and the recent one on the right as default versions to compare
- Change the way Instance log informations are displayed

## How to test
- Forms ---> Submissions 
- See the details of one submissions
- See all versions(History)
- Check the default selected version both on A version and B version

## Print screen / video
[Screencast from 2024-11-04 18-42-17.webm](https://github.com/user-attachments/assets/468e7a27-5d9c-4f2e-a686-42b10b1b7b95)

## Notes

Things that the reviewers should know: known bugs that are out of the scope of the PR, other trade-offs that were made.
If the PR depends on a PR in bluesquare-components, or merges into another PR (i.o. main), it should also be mentioned here


[IA-3578]: https://bluesquare.atlassian.net/browse/IA-3578?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ