### PR TITLE
IA-3609: prevent edition of project field by non admin

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -1455,6 +1455,7 @@
     "iaso.users.selectAllHelperText": "Leave empty to select all",
     "iaso.users.selectedOrgUnits": "Org units selected",
     "iaso.users.update": "Update user",
+    "iaso.users.userAdminOnly": "Can only be edited by user admin",
     "iaso.users.userPermissions": "User permissions",
     "iaso.users.usersHistory": "Users history",
     "iaso.users.warningModalMessage": "You are about to save a user with no permissions. This user will have access to the mobile application but not to the features of the web interface.",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -1454,6 +1454,7 @@
     "iaso.users.selectAllHelperText": "Laisser vide pour tout sélectionner",
     "iaso.users.selectedOrgUnits": "Unité d'organisation sélectionnées",
     "iaso.users.update": "Mettre l'utilisateur à jour",
+    "iaso.users.userAdminOnly": "Edition pour les administrateurs uniquement",
     "iaso.users.userPermissions": "Permissions d'utilisateur",
     "iaso.users.usersHistory": "Historique des utilisateurs",
     "iaso.users.warningModalMessage": "Vous êtes sur le point de sauvegarder un utilisateur sans permissions. Cet utilisateur aura accès à l'application mobile mais pas aux fonctionnalités de l'interface web.",

--- a/hat/assets/js/apps/Iaso/domains/users/components/UsersInfos.js
+++ b/hat/assets/js/apps/Iaso/domains/users/components/UsersInfos.js
@@ -12,6 +12,8 @@ import { useGetProjectsDropdownOptions } from '../../projects/hooks/requests.ts'
 import { InputWithInfos } from '../../../components/InputWithInfos.tsx';
 import { useCurrentUser } from '../../../utils/usersUtils.ts';
 import MESSAGES from '../messages.ts';
+import { userHasPermission } from '../utils.js';
+import { USERS_ADMIN } from '../../../utils/permissions';
 
 const UsersInfos = ({
     setFieldValue,
@@ -20,6 +22,7 @@ const UsersInfos = ({
     allowSendEmailInvitation,
 }) => {
     const loggedUser = useCurrentUser();
+    const isLoggedUserAdmin = userHasPermission(USERS_ADMIN, loggedUser);
     const { formatMessage } = useSafeIntl();
     const isEmailAdressExist = isEmpty(currentUser.email.value);
     const sendUserEmailInvitation = !!isEmailAdressExist;
@@ -170,6 +173,12 @@ const UsersInfos = ({
                         label={MESSAGES.projects}
                         options={availableProjects}
                         loading={isFetchingProjects}
+                        disabled={!isLoggedUserAdmin}
+                        helperText={
+                            !isLoggedUserAdmin
+                                ? formatMessage(MESSAGES.userAdminOnly)
+                                : undefined
+                        }
                     />
                     <InputComponent
                         keyValue="language"

--- a/hat/assets/js/apps/Iaso/domains/users/messages.ts
+++ b/hat/assets/js/apps/Iaso/domains/users/messages.ts
@@ -510,6 +510,10 @@ const MESSAGES = defineMessages({
         id: 'iaso.users.selectAllHelperText',
         defaultMessage: 'Leave empty to select all',
     },
+    userAdminOnly: {
+        id: 'iaso.users.userAdminOnly',
+        defaultMessage: 'Can only be edited by user admin',
+    },
 });
 
 export default MESSAGES;


### PR DESCRIPTION
passing empty list will overwrite existing projects

Related JIRA tickets : IA-3609

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
- Tell us where the doc can be found (docs folder, wiki, in the code...)

## Changes

- Bock edition of projects in UserInfos if logged user doesn't have USERS_ADMIN permission
- Add helperText with explanation

## How to test

- create a user with the USERS_MANAGED permission
- create a user with non-empty projects field, with same location as previous user
- Log in as first user
- Try to update second user

"Projects" field should be disabled and show a message

## Print screen / video

<img width="1420" alt="Screenshot 2024-11-05 at 15 03 08" src="https://github.com/user-attachments/assets/09bda8a4-83af-48da-a771-6e3430e7974e">



