### PR TITLE
IA-3660: convert org unit id to int in validation

### DIFF
--- a/iaso/api/profiles/profiles.py
+++ b/iaso/api/profiles/profiles.py
@@ -421,6 +421,8 @@ class ProfilesViewSet(viewsets.ViewSet):
             projects = self.validate_projects(request, profile)
             editable_org_unit_types = self.validate_editable_org_unit_types(request)
         except ProfileError as error:
+            # Delete profile if error since we're creating a new user
+            profile.delete()
             return JsonResponse(
                 {"errorKey": error.field, "errorMessage": error.detail},
                 status=status.HTTP_400_BAD_REQUEST,
@@ -657,7 +659,7 @@ class ProfilesViewSet(viewsets.ViewSet):
             )
 
         for org_unit in org_units:
-            org_unit_id = org_unit.get("id")
+            org_unit_id = int(org_unit.get("id"))
             if (
                 managed_org_units
                 and org_unit_id not in managed_org_units


### PR DESCRIPTION
Trying to assign a location to a userwould always cause a 403 and still create a user with no location restriction and no location

Related JIRA tickets : IA-3660

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc


## Changes

- convert org_unit_id. to int in validate_org_units
- in profile API: delete created empty profile if validation raises error

## How to test

- Create 2 users  with a location at the root of the org unit pyramid:
    - one with the user admin permission
    - one with the geo-limited permission
- With each user:
    - Create a user with a  location and any permission

--> Both cases should return a 200


## Print screen / video

Upload here print screens or videos showing the changes

## Notes
HOTFIX: tag v1.247a
