### PR TITLE
IA-3654: Org Unit Pop up: wrong count for instances

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/hooks/requests/useGetOrgUnitDetail.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/hooks/requests/useGetOrgUnitDetail.ts
@@ -6,13 +6,20 @@ import { useSnackQuery } from '../../../../libs/apiHooks';
 import { OrgUnit } from '../../types/orgUnit';
 
 import MESSAGES from '../../messages';
+import { makeUrlWithParams } from '../../../../libs/utils';
 
 export const useGetOrgUnitDetail = (
     id?: number,
 ): UseQueryResult<OrgUnit, Error> => {
+    const params: Record<string, any> = {
+        instances_count: true,
+    };
+
+    const url = makeUrlWithParams(`/api/orgunits/${id}/`, params);
+
     return useSnackQuery({
         queryKey: ['orgunitdetail', id],
-        queryFn: () => getRequest(`/api/orgunits/${id}/`),
+        queryFn: () => getRequest(url),
         snackErrorMsg: MESSAGES.fetchOrgUnitError,
         options: {
             enabled: Boolean(id),

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/hooks/requests/useGetOrgUnitDetail.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/hooks/requests/useGetOrgUnitDetail.ts
@@ -6,20 +6,13 @@ import { useSnackQuery } from '../../../../libs/apiHooks';
 import { OrgUnit } from '../../types/orgUnit';
 
 import MESSAGES from '../../messages';
-import { makeUrlWithParams } from '../../../../libs/utils';
 
 export const useGetOrgUnitDetail = (
     id?: number,
 ): UseQueryResult<OrgUnit, Error> => {
-    const params: Record<string, any> = {
-        instances_count: true,
-    };
-
-    const url = makeUrlWithParams(`/api/orgunits/${id}/`, params);
-
     return useSnackQuery({
         queryKey: ['orgunitdetail', id],
-        queryFn: () => getRequest(url),
+        queryFn: () => getRequest(`/api/orgunits/${id}/`),
         snackErrorMsg: MESSAGES.fetchOrgUnitError,
         options: {
             enabled: Boolean(id),

--- a/iaso/api/org_units.py
+++ b/iaso/api/org_units.py
@@ -763,9 +763,14 @@ class OrgUnitViewSet(viewsets.ViewSet):
 
     def retrieve(self, request, pk=None):
         org_unit: OrgUnit = get_object_or_404(
-            self.get_queryset().prefetch_related("reference_instances").annotate(instances_count=Count("instance")),
+            self.get_queryset().prefetch_related("reference_instances"),
             pk=pk,
         )
+
+        if request.query_params.get("instances_count"):
+            instances_count = org_unit.descendants().aggregate(Count("instance"))["instance__count"]
+            org_unit.instances_count = instances_count
+
         self.check_object_permissions(request, org_unit)
         res = org_unit.as_dict_with_parents(light=False, light_parents=False)
         res["geo_json"] = None

--- a/iaso/api/org_units.py
+++ b/iaso/api/org_units.py
@@ -766,10 +766,9 @@ class OrgUnitViewSet(viewsets.ViewSet):
             self.get_queryset().prefetch_related("reference_instances"),
             pk=pk,
         )
-
-        if request.query_params.get("instances_count"):
-            instances_count = org_unit.descendants().aggregate(Count("instance"))["instance__count"]
-            org_unit.instances_count = instances_count
+        # Get instances count for the Org unit and its descendants
+        instances_count = org_unit.descendants().aggregate(Count("instance"))["instance__count"]
+        org_unit.instances_count = instances_count
 
         self.check_object_permissions(request, org_unit)
         res = org_unit.as_dict_with_parents(light=False, light_parents=False)

--- a/iaso/tests/api/test_orgunits.py
+++ b/iaso/tests/api/test_orgunits.py
@@ -551,13 +551,13 @@ class OrgUnitAPITestCase(APITestCase):
             json={"name": "b", "age": 19, "gender": "F"},
         )
         # Test the descendant instances count
-        response_descendant = self.client.get(f"/api/orgunits/{descendant_org_unit.id}/?instances_count=true/")
+        response_descendant = self.client.get(f"/api/orgunits/{descendant_org_unit.id}/")
         self.assertJSONResponse(response_descendant, 200)
         descendant_instances_count = response_descendant.json()["instances_count"]
         self.assertEquals(descendant_instances_count, 1)
 
         # Test the parent instances count
-        response_parent = self.client.get(f"/api/orgunits/{parent_org_unit.id}/?instances_count=true/")
+        response_parent = self.client.get(f"/api/orgunits/{parent_org_unit.id}/")
         self.assertJSONResponse(response_parent, 200)
         parent_instances_count = response_parent.json()["instances_count"]
         self.assertEquals(parent_instances_count, 2)


### PR DESCRIPTION
Explain what problem this PR is resolving
- Org Unit Pop up: wrong count for instances
Related JIRA tickets : [IA-3654](https://bluesquare.atlassian.net/browse/IA-3654)
## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
- Tell us where the doc can be found (docs folder, wiki, in the code...)

## Changes
- Add instances_count as a parameter to the retrieve api query
- Get all instances for the orgUnit include the ones for its descendants

## How to test

- Org units --> Org units list
- Filter on parent
- Map tab
- Click on map marker for org Unit and check if the submissions count is correct


## Print screen / video
[Screencast from 2024-11-07 16-24-39.webm](https://github.com/user-attachments/assets/ead61488-d1c4-4ed6-baec-b8ec847c6612)


[IA-3654]: https://bluesquare.atlassian.net/browse/IA-3654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ