### PR TITLE
WC2-601: Allow user to redirect to entity page from entity debug page for both WFP account(South Sudan and Nigeria)

### DIFF
--- a/plugins/wfp/templates/debug.html
+++ b/plugins/wfp/templates/debug.html
@@ -38,7 +38,7 @@
         <tr>
             <th>Link</th>
             <td><a
-                    href="/dashboard/entities/details/accountId/1/entityId/{{entity.id}}">/dashboard/entities/details/accountId/1/entityId/{{entity.id}}</a>
+                    href="/dashboard/entities/details/accountId/{{beneficiary.account.id}}/entityId/{{entity.id}}">/dashboard/entities/details/accountId/{{beneficiary.account.id}}/entityId/{{entity.id}}</a>
             </td>
         </tr>
     </table>


### PR DESCRIPTION
Explain what problem this PR is resolving

Related JIRA tickets : [WC2-601](https://bluesquare.atlassian.net/browse/WC2-601)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)


## Changes

Allow user to access to entity debug page and redirecting to entity page according to the account the entity belongs to.

## How to test

From the local instance with wfp coda database, run ETL script to generate data for: 
- South Sudan : `docker compose run iaso manage etl_ssd`
- Nigeria :  `docker compose run iaso manage etl_ng`

Then, try to access to debug page for beneficiary belongs to account:
   - South Sudan: http://localhost:8081/wfp/debug/579/
   - NIgeria: http://localhost:8081/wfp/debug/661/

## Print screen / video

![localhost-8081-wfp-debug-579-](https://github.com/user-attachments/assets/479643e5-2cb6-4edb-af47-a3bffc51e312)

![localhost-8081-wfp-debug-661](https://github.com/user-attachments/assets/bdf34281-95b0-45a5-8c4b-198af8a1e3bd)


[WC2-601]: https://bluesquare.atlassian.net/browse/WC2-601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ