### PR TITLE
IA-3665: Instance popup is empty 

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/orgUnitMap/OrgUnitMap/FormsMarkers.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/orgUnitMap/OrgUnitMap/FormsMarkers.tsx
@@ -36,7 +36,7 @@ export const FormsMarkers: FunctionComponent<Props> = ({
                             keyId={f.id}
                             PopupComponent={InstancePopup}
                             popupProps={o => ({
-                                orgUnitId: o.id,
+                                instanceId: o.id,
                             })}
                             updateOrgUnitLocation={updateOrgUnitLocation}
                         />


### PR DESCRIPTION
While visiting the detail of an org unit and trying to see linked submissions on map tab, clicking on a marker is leading to an empty pop-up.

We should see the details of the submission.

https://iaso.bluesquare.org/dashboard/orgunits/detail/accountId/42/orgUnitId/2414236/levels/[2410011,2413950,2414230,2414235,2414236]/tab/map

Account: carte_sanitaire_cameroun

Related JIRA tickets : IA-3665

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)


## Changes

Pass correct instanceId to popup

## How to test

You need an instance linked to an org unit with a geolocation.
Open the details of this org unit, go to map tab, select the form on the right. Click on the marker

## Print screen / video

https://github.com/user-attachments/assets/2880e8b0-170d-46bb-ad39-14509905e186


