### PR TITLE
WC2-603_WC2-604: ETL debug page not showing first visit or shows exit date for ben not yet exited

### DIFF
--- a/plugins/wfp/common.py
+++ b/plugins/wfp/common.py
@@ -303,7 +303,7 @@ class ETL:
             missed_followup_visit = self.missed_followup_visit(
                 visits, anthropometric_visit_forms, next_visit_date[:10], nextSecondVisitDate, next_visit_days
             )
-        if missed_followup_visit > 0 and next_visit_date != "" and nextSecondVisitDate != "":
+        if missed_followup_visit > 1 and next_visit_date != "" and nextSecondVisitDate != "":
             exit = {"exit_type": "defaulter", "end_date": nextSecondVisitDate}
         return exit
 

--- a/plugins/wfp/common.py
+++ b/plugins/wfp/common.py
@@ -298,7 +298,7 @@ class ETL:
 
             if next_visit_date is not None and next_visit_date != "":
                 nextSecondVisitDate = datetime.strptime(next_visit_date[:10], "%Y-%m-%d").date() + timedelta(
-                    days=int(next_visit_days) + 1
+                    days=int(next_visit_days)
                 )
             missed_followup_visit = self.missed_followup_visit(
                 visits, anthropometric_visit_forms, next_visit_date[:10], nextSecondVisitDate, next_visit_days

--- a/plugins/wfp/common.py
+++ b/plugins/wfp/common.py
@@ -254,6 +254,8 @@ class ETL:
             "child_assistance_admission",
             "wfp_coda_pbwg_assistance",
             "wfp_coda_pbwg_assistance_followup",
+            "assistance_admission_otp",
+            "assistance_admission_2nd_visit_otp",
         ]:
             if visit.get("next_visit__date__", None) is not None and visit.get("next_visit__date__", None) != "":
                 next_visit_date = visit.get("next_visit__date__", None)
@@ -327,6 +329,8 @@ class ETL:
         exit = None
 
         if visit["form_id"] in followup_forms:
+            if visit["form_id"] != default_admission_form:
+                current_journey["visits"].append(visit)
             end_date = visit.get("end_date", visit.get("source_created_at", ""))
             current_journey["end_date"] = (
                 end_date if end_date is not None else visit.get("source_created_at", None).strftime("%Y-%m-%d")
@@ -621,9 +625,9 @@ class ETL:
     def save_entity_journey(self, journey, beneficiary, record, entity_type):
         journey.beneficiary = beneficiary
         journey.programme_type = entity_type
-        journey.admission_criteria = record["admission_criteria"]
+        journey.admission_criteria = record.get("admission_criteria")
         journey.admission_type = record.get("admission_type", None)
-        journey.nutrition_programme = record["nutrition_programme"]
+        journey.nutrition_programme = record.get("nutrition_programme")
         journey.exit_type = record.get("exit_type", None)
         journey.instance_id = record.get("instance_id", None)
         journey.start_date = record.get("start_date", None)

--- a/plugins/wfp/management/commands/nigeria/Under5.py
+++ b/plugins/wfp/management/commands/nigeria/Under5.py
@@ -142,7 +142,7 @@ class NG_Under5:
             logger.info("Retrieving journey linked to beneficiary")
 
             for journey_instance in instance["journey"]:
-                if len(journey_instance["visits"]) > 0:
+                if journey_instance.get("nutrition_programme") is not None and len(journey_instance["visits"]) > 0:
                     journey = self.save_journey(beneficiary, journey_instance)
                     visits = ETL().save_visit(journey_instance["visits"], journey)
                     logger.info(f"Inserted {len(visits)} Visits")


### PR DESCRIPTION
Explain what problem this PR is resolving

Related JIRA tickets : [WC2-603](https://bluesquare.atlassian.net/browse/WC2-603), [WC2-604](https://bluesquare.atlassian.net/browse/WC2-604)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)


## Changes

Fixed ETL to store both admission and followup visits linked to beneficiary.  The bug was mainly appearing for Nigeria data.

## How to test

From the local instance with wfp coda database, run ETL script to generate data for:
- Nigeria:  `docker compose run iaso manage etl_ng`
- South Sudan: `docker compose run iaso manage etl_ssd`

Then, try to access to debug page for beneficiary belongs to account:

- Nigeria: [http://localhost:8081/wfp/debug/684/](http://localhost:8081/wfp/debug/684/)
- South Sudan: [http://localhost:8081/wfp/debug/323/](http://localhost:8081/wfp/debug/323/)

You should see all visits linked to beneficiary and correct exit date when beneficiary has discharged.

## Print screen / video

**1. Nigeria**

![image](https://github.com/user-attachments/assets/6ee5b098-78c4-4370-afaa-a14158d72de0)


**2. South Sudan**

![image](https://github.com/user-attachments/assets/283d19a3-a8de-48d1-9950-d1defc32f345)



[WC2-603]: https://bluesquare.atlassian.net/browse/WC2-603?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WC2-604]: https://bluesquare.atlassian.net/browse/WC2-604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ