### PR TITLE
WC2-523: Show correct nfc cards count

### DIFF
--- a/iaso/api/entity.py
+++ b/iaso/api/entity.py
@@ -7,7 +7,7 @@ import pytz
 from time import gmtime, strftime
 from typing import Any, List, Union
 
-from iaso.models.storage import StorageDevice, StorageLogEntry
+from iaso.models.storage import StorageDevice
 import xlsxwriter  # type: ignore
 from django.core.paginator import Paginator
 from django.db.models import Exists, Max, OuterRef, Q, Count
@@ -84,11 +84,8 @@ class EntitySerializer(serializers.ModelSerializer):
         return _get_duplicates(entity)
 
     def get_nfc_cards(self, entity: Entity):
-        nfc_log_entries_count = StorageDevice.objects.filter(entity=entity, type=StorageDevice.NFC).aggregate(
-            total_logs=Count("log_entries")
-        )["total_logs"]
-
-        return nfc_log_entries_count or 0
+        nfc_count = StorageDevice.objects.filter(entity=entity, type=StorageDevice.NFC).count()
+        return nfc_count
 
     @staticmethod
     def get_entity_type_name(obj: Entity):

--- a/iaso/models/entity.py
+++ b/iaso/models/entity.py
@@ -193,13 +193,11 @@ class Entity(SoftDeletableModel):
     def __str__(self):
         return "%s %s %s %d" % (self.entity_type.name, self.uuid, self.name, self.id)
 
-    def get_nfc_cards(self, instance):
-        from iaso.models.storage import StorageDevice, StorageLogEntry
+    def get_nfc_cards(self):
+        from iaso.models.storage import StorageDevice
 
-        nfc_devices = StorageDevice.objects.filter(entity=self, type=StorageDevice.NFC)
-        nfc_log_entries_count = StorageLogEntry.objects.filter(device__in=nfc_devices, instances=instance).count()
-
-        return nfc_log_entries_count
+        nfc_count = StorageDevice.objects.filter(entity=self, type=StorageDevice.NFC).count()
+        return nfc_count
 
     def as_small_dict(self):
         return {
@@ -215,7 +213,7 @@ class Entity(SoftDeletableModel):
 
     def as_small_dict_with_nfc_cards(self, instance):
         entity_dict = self.as_small_dict()
-        entity_dict["nfc_cards"] = self.get_nfc_cards(instance)
+        entity_dict["nfc_cards"] = self.get_nfc_cards()
         return entity_dict
 
     def as_dict(self):


### PR DESCRIPTION
Explain what problem this PR is resolving
- Show correct nfc cards count
Related JIRA tickets : [WC2-523](https://bluesquare.atlassian.net/browse/WC2-523)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
- Tell us where the doc can be found (docs folder, wiki, in the code...)

## Changes
- Count nfc cards storage devices linked to an entity instead of the storage entries

## How to test
- Create a StorageDevice linked to that entity with NFC type
- Check the nfc cards on the beneficiary details page and on the instance details page

## Print screen / video
[Screencast from 2024-11-13 17-11-07.webm](https://github.com/user-attachments/assets/fb3730a9-aa7e-4ecf-bd90-56e387dd1b26)


## Notes

Things that the reviewers should know: known bugs that are out of the scope of the PR, other trade-offs that were made.
If the PR depends on a PR in bluesquare-components, or merges into another PR (i.o. main), it should also be mentioned here


[WC2-523]: https://bluesquare.atlassian.net/browse/WC2-523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ