### PR TITLE
IA-3600: handle zero in select dropdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6535,7 +6535,7 @@
         },
         "node_modules/bluesquare-components": {
             "version": "1.0.0",
-            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#e5465de2bf466a242b9554bfb863e7704facac91",
+            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#38e7adc1ffb430f86ae59284765aa13177d1a228",
             "dependencies": {
                 "@babel/plugin-transform-class-properties": "^7.24.6",
                 "@babel/plugin-transform-object-rest-spread": "^7.24.6",


### PR DESCRIPTION
Select dropdowns couldn't handle a `value` of 0 because it was considered falsy

Related JIRA tickets : IA-3600

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc

N/A

## Changes

- Update bluesquare-components as it was handled there: https://github.com/BLSQ/bluesquare-components/pull/167

## How to test

- On a polio DB, go to supplychain
- Open the details view for a VRF for campaign that has a round 0. Create it if necessary via the "Campaigns page"

--> The "Rounds". select box should not be error state once it has loaded


## Print screen / video

https://github.com/user-attachments/assets/a17b8902-1408-4218-8538-ff4aaa3366d2

## Notes

None

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
