### PR TITLE
POLIO-1731 Fix scope CSV download

### DIFF
--- a/plugins/polio/api/campaigns/campaigns.py
+++ b/plugins/polio/api/campaigns/campaigns.py
@@ -1218,8 +1218,17 @@ class CampaignViewSet(ModelViewSet):
                 item = {}
                 item["id"] = org_unit.id
                 item["org_unit_name"] = org_unit.name
-                item["org_unit_parent_name"] = org_unit.parent.name
-                item["org_unit_parent_of_parent_name"] = org_unit.parent.parent.name
+
+                if org_unit.parent:
+                    item["org_unit_parent_name"] = org_unit.parent.name
+                else:
+                    item["org_unit_parent_name"] = ""
+
+                if org_unit.parent and org_unit.parent.parent:
+                    item["org_unit_parent_of_parent_name"] = org_unit.parent.parent.name
+                else:
+                    item["org_unit_parent_of_parent_name"] = ""
+
                 item["obr_name"] = campaign.obr_name
                 item["round_number"] = "R" + str(round.number)
                 item["start_date"] = round.started_at

--- a/plugins/polio/tests/api/test_campaigns_views.py
+++ b/plugins/polio/tests/api/test_campaigns_views.py
@@ -103,3 +103,72 @@ class CampaignCreateAllRoundsScopesCsvViewTestCase(APITestCase):
         response_csv = response.getvalue().decode("utf-8")
         expected_csv = "ID,Admin 2,Admin 1,Admin 0,OBR Name,Round Number,Start date,Vaccine\r\n"
         self.assertEqual(response_csv, expected_csv)
+
+
+@time_machine.travel(TODAY, tick=False)
+class CsvCampaignScopesExportViewTestCase(APITestCase):
+    """
+    Test CampaignViewSet.csv_campaign_scopes_export.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.data_source = m.DataSource.objects.create(name="Data Source")
+        cls.source_version = m.SourceVersion.objects.create(data_source=cls.data_source, number=1)
+        cls.account = m.Account.objects.create(name="Account", default_version=cls.source_version)
+        cls.user = cls.create_user_with_profile(
+            email="john@polio.org",
+            username="john",
+            first_name="John",
+            last_name="Doe",
+            account=cls.account,
+        )
+
+        cls.org_unit_a = m.OrgUnit.objects.create(
+            name="A",
+            org_unit_type=m.OrgUnitType.objects.create(category="COUNTRY"),
+            validation_status=m.OrgUnit.VALIDATION_VALID,
+            version=cls.source_version,
+        )
+        cls.org_unit_b = m.OrgUnit.objects.create(
+            name="B",
+            org_unit_type=m.OrgUnitType.objects.create(category="REGION"),
+            validation_status=m.OrgUnit.VALIDATION_VALID,
+            version=cls.source_version,
+            parent=cls.org_unit_a,
+        )
+        cls.org_unit_c = m.OrgUnit.objects.create(
+            name="C",
+            org_unit_type=m.OrgUnitType.objects.create(category="DISTRICT"),
+            validation_status=m.OrgUnit.VALIDATION_VALID,
+            version=cls.source_version,
+            parent=cls.org_unit_b,
+        )
+
+        cls.group = m.Group.objects.create(name="Group", domain="POLIO", source_version=cls.source_version)
+        cls.group.org_units.add(cls.org_unit_a)
+        cls.group.org_units.add(cls.org_unit_b)
+        cls.group.org_units.add(cls.org_unit_c)
+
+        cls.campaign = Campaign.objects.create(obr_name="Campaign OBR name", account=cls.account)
+        cls.round = Round.objects.create(number=1, campaign=cls.campaign, started_at=TODAY.date())
+        cls.campaign_scope = CampaignScope.objects.create(campaign=cls.campaign, group=cls.group)
+
+    def test_get_csv_campaign_scopes_export_ok(self):
+        self.client.force_authenticate(self.user)
+        response = self.client.get(f"/api/polio/campaigns/csv_campaign_scopes_export/?&round={self.round.pk}")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.get("Content-Disposition"),
+            "attachment; filename=campaign-Campaign OBR name--R1--org_units-2024-10-21-11-00.csv",
+        )
+
+        response_csv = response.getvalue().decode("utf-8")
+        expected_csv = (
+            "ID,Admin 2,Admin 1,Admin 0,OBR Name,Round Number,Start date,Vaccine\r\n"
+            f"{self.org_unit_a.pk},A,,,Campaign OBR name,R1,2024-10-21,\r\n"
+            f"{self.org_unit_b.pk},B,A,,Campaign OBR name,R1,2024-10-21,\r\n"
+            f"{self.org_unit_c.pk},C,B,A,Campaign OBR name,R1,2024-10-21,\r\n"
+        )
+        self.assertEqual(response_csv, expected_csv)


### PR DESCRIPTION
Fix scope CSV download when org units have no parent.

Related JIRA tickets : [POLIO-1731](https://bluesquare.atlassian.net/browse/POLIO-1731)

Related Sentry Issue: [6063926259](https://bluesquareorg.sentry.io/issues/6063926259)

## Changes

This PR:

- fixes the scope CSV download when org units have no parent
- adds a unit test to ensure it's working as expected

## How to test

Go to:

http://localhost:8081/api/polio/campaigns/csv_campaign_scopes_export/?&round=1507

Instead of 1507, use a round with a `CampaignScope` having a `Group` of org unit containing at least one org unit without parent.

[POLIO-1731]: https://bluesquare.atlassian.net/browse/POLIO-1731?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ