### PR TITLE
POLIO-1727: Form A 'Round' appears buggy

### DIFF
--- a/plugins/polio/js/src/components/Inputs/SingleSelect.tsx
+++ b/plugins/polio/js/src/components/Inputs/SingleSelect.tsx
@@ -13,6 +13,7 @@ type Props = {
     required?: boolean;
     disabled?: boolean;
     onChange?: (_keyValue: string, value: any) => void;
+    isLoading?: boolean;
 };
 
 export const SingleSelect: FunctionComponent<Props> = ({
@@ -25,6 +26,7 @@ export const SingleSelect: FunctionComponent<Props> = ({
     clearable = true,
     withMarginTop = false,
     required = false,
+    isLoading = false,
 }) => {
     const hasError =
         form.errors &&
@@ -35,7 +37,7 @@ export const SingleSelect: FunctionComponent<Props> = ({
             keyValue={field.name}
             type="select"
             withMarginTop={withMarginTop}
-            value={field.value}
+            value={!isLoading ? field.value : undefined}
             options={options}
             disabled={disabled}
             clearable={clearable}
@@ -50,6 +52,7 @@ export const SingleSelect: FunctionComponent<Props> = ({
                 }
             }}
             errors={hasError ? [get(form.errors, field.name)] : []}
+            loading={isLoading}
         />
     );
 };


### PR DESCRIPTION
Single select used with formik in polio plugin is not using loading state at all, so while loading the select is in error state

Related JIRA tickets :POLIO-1727

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

Pass isLoading to InputComponent

## How to test

Edit a FormA while having a few campaigns in your DB

## Print screen / video


https://github.com/user-attachments/assets/0931033f-1b50-4038-b9f6-0a3e351c0c9f



## Notes

While opening Form A dialog, a call is made to campaign api, this call is quite heavy and takes time. 
We should probably investigate on improving this endpoint and probably create a dedicated Api endpoint for the dropdowns no ?

![ ](https://github.com/user-attachments/assets/a909e493-4cfc-45f3-8fa5-021378e1b474)
