### PR TITLE
IA-3676 Exclude soft deleted instances from the mobile reference instances API

### DIFF
--- a/iaso/api/mobile/org_units.py
+++ b/iaso/api/mobile/org_units.py
@@ -311,7 +311,7 @@ class MobileOrgUnitViewSet(ModelViewSet):
         except ValueError:
             org_unit = get_object_or_404(authorized_org_units, uuid=pk)
 
-        reference_instances = org_unit.reference_instances.all().order_by("id")
+        reference_instances = org_unit.reference_instances(manager="non_deleted_objects").all().order_by("id")
 
         filtered_reference_instances = ReferenceInstancesFilter(request.query_params, reference_instances).qs
 

--- a/iaso/api/mobile/org_units.py
+++ b/iaso/api/mobile/org_units.py
@@ -311,7 +311,7 @@ class MobileOrgUnitViewSet(ModelViewSet):
         except ValueError:
             org_unit = get_object_or_404(authorized_org_units, uuid=pk)
 
-        reference_instances = org_unit.reference_instances.all()
+        reference_instances = org_unit.reference_instances.all().order_by("id")
 
         filtered_reference_instances = ReferenceInstancesFilter(request.query_params, reference_instances).qs
 

--- a/iaso/models/base.py
+++ b/iaso/models/base.py
@@ -958,7 +958,7 @@ class InstanceQuerySet(django_cte.CTEQuerySet):
         return new_qs
 
 
-class InstanceManager(models.Manager):
+class NonDeletedInstanceManager(models.Manager):
     def get_queryset(self):
         """
         Exclude soft deleted instances from all results.
@@ -1024,7 +1024,8 @@ class Instance(models.Model):
 
     last_export_success_at = models.DateTimeField(null=True, blank=True)
 
-    objects = InstanceManager.from_queryset(InstanceQuerySet)()
+    objects = models.Manager.from_queryset(InstanceQuerySet)()
+    non_deleted_objects = NonDeletedInstanceManager.from_queryset(InstanceQuerySet)()
 
     # Is instance SoftDeleted. It doesn't use the SoftDeleteModel deleted_at like the rest for historical reason.
     deleted = models.BooleanField(default=False)

--- a/iaso/models/base.py
+++ b/iaso/models/base.py
@@ -958,7 +958,12 @@ class InstanceQuerySet(django_cte.CTEQuerySet):
         return new_qs
 
 
-InstanceManager = models.Manager.from_queryset(InstanceQuerySet)
+class InstanceManager(models.Manager):
+    def get_queryset(self):
+        """
+        Exclude soft deleted instances from all results.
+        """
+        return super().get_queryset().filter(deleted=False)
 
 
 class Instance(models.Model):
@@ -1019,7 +1024,7 @@ class Instance(models.Model):
 
     last_export_success_at = models.DateTimeField(null=True, blank=True)
 
-    objects = InstanceManager()
+    objects = InstanceManager.from_queryset(InstanceQuerySet)()
 
     # Is instance SoftDeleted. It doesn't use the SoftDeleteModel deleted_at like the rest for historical reason.
     deleted = models.BooleanField(default=False)

--- a/iaso/tests/api/test_mobile_orgunits.py
+++ b/iaso/tests/api/test_mobile_orgunits.py
@@ -302,6 +302,36 @@ class MobileOrgUnitAPITestCase(APITestCase):
             },
         )
 
+        # Ensure soft deleted instances are not returned.
+
+        instance2.deleted = True
+        instance2.save()
+
+        response = self.client.get(f"{BASE_URL}{self.raditz.pk}/reference_instances/", data=params)
+        self.assertJSONResponse(response, 200)
+        self.assertEqual(
+            response.data,
+            {
+                "count": 1,
+                "instances": [
+                    {
+                        "id": instance1.pk,
+                        "uuid": None,
+                        "form_id": form1.id,
+                        "form_version_id": form_version1.id,
+                        "created_at": 1698310800.0,
+                        "updated_at": 1698310800.0,
+                        "json": {"key": "foo"},
+                    },
+                ],
+                "has_next": False,
+                "has_previous": False,
+                "page": 1,
+                "pages": 1,
+                "limit": 10,
+            },
+        )
+
     def test_post_to_retrieve_list(self):
         self.client.force_authenticate(self.user)
         response = self.client.get(


### PR DESCRIPTION
Soft-deleted instances were still returned as reference instances to the mobile.

Related JIRA tickets : [IA-3676](https://bluesquare.atlassian.net/browse/IA-3676)

## Changes

Use a custom manager to exclude soft deleted instances from queries.

## How to test

Soft delete an instance, then ensure you can't see it anywhere in API results of `/api/mobile/orgunits/{org_unit_id}/reference_instances/`.

Or just look at the unit test.


[IA-3676]: https://bluesquare.atlassian.net/browse/IA-3676?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ