### PR TITLE
IA-3677 Exclude soft deleted instances from change requests

### DIFF
--- a/iaso/api/org_unit_change_requests/views.py
+++ b/iaso/api/org_unit_change_requests/views.py
@@ -65,24 +65,28 @@ class OrgUnitChangeRequestViewSet(viewsets.ModelViewSet):
 
     def get_queryset(self):
         org_units = OrgUnit.objects.filter_for_user(self.request.user)
-        org_units_change_requests = OrgUnitChangeRequest.objects.select_related(
-            "created_by",
-            "updated_by",
-            "org_unit__parent",
-            "org_unit__org_unit_type",
-            "new_parent",
-            "old_parent",
-            "new_org_unit_type",
-            "old_org_unit_type",
-        ).prefetch_related(
-            "org_unit__groups",
-            Prefetch("org_unit__reference_instances", queryset=Instance.non_deleted_objects.select_related("form")),
-            "org_unit__reference_instances__form",
-            "new_groups",
-            "old_groups",
-            Prefetch("new_reference_instances", queryset=Instance.non_deleted_objects.select_related("form")),
-            Prefetch("old_reference_instances", queryset=Instance.non_deleted_objects.select_related("form")),
-            "org_unit__org_unit_type__projects",
+        org_units_change_requests = (
+            OrgUnitChangeRequest.objects.select_related(
+                "created_by",
+                "updated_by",
+                "org_unit__parent",
+                "org_unit__org_unit_type",
+                "new_parent",
+                "old_parent",
+                "new_org_unit_type",
+                "old_org_unit_type",
+            )
+            .prefetch_related(
+                "org_unit__groups",
+                Prefetch("org_unit__reference_instances", queryset=Instance.non_deleted_objects.select_related("form")),
+                "org_unit__reference_instances__form",
+                "new_groups",
+                "old_groups",
+                Prefetch("new_reference_instances", queryset=Instance.non_deleted_objects.select_related("form")),
+                Prefetch("old_reference_instances", queryset=Instance.non_deleted_objects.select_related("form")),
+                "org_unit__org_unit_type__projects",
+            )
+            .exclude_soft_deleted_new_reference_instances()
         )
         return org_units_change_requests.filter(org_unit__in=org_units)
 

--- a/iaso/api/org_unit_change_requests/views.py
+++ b/iaso/api/org_unit_change_requests/views.py
@@ -2,8 +2,9 @@ import csv
 from datetime import datetime
 
 import django_filters
+from django.db.models import Prefetch
 from django.http import HttpResponse
-from django.utils import timezone
+
 from rest_framework import filters, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import PermissionDenied, ValidationError
@@ -23,7 +24,7 @@ from iaso.api.org_unit_change_requests.serializers import (
     OrgUnitChangeRequestWriteSerializer,
 )
 from iaso.api.serializers import AppIdSerializer
-from iaso.models import OrgUnit, OrgUnitChangeRequest
+from iaso.models import OrgUnit, OrgUnitChangeRequest, Instance
 from iaso.utils.models.common import get_creator_name
 
 
@@ -75,11 +76,12 @@ class OrgUnitChangeRequestViewSet(viewsets.ModelViewSet):
             "old_org_unit_type",
         ).prefetch_related(
             "org_unit__groups",
+            Prefetch("org_unit__reference_instances", queryset=Instance.non_deleted_objects.select_related("form")),
             "org_unit__reference_instances__form",
             "new_groups",
             "old_groups",
-            "new_reference_instances__form",
-            "old_reference_instances__form",
+            Prefetch("new_reference_instances", queryset=Instance.non_deleted_objects.select_related("form")),
+            Prefetch("old_reference_instances", queryset=Instance.non_deleted_objects.select_related("form")),
             "org_unit__org_unit_type__projects",
         )
         return org_units_change_requests.filter(org_unit__in=org_units)

--- a/iaso/api/org_unit_change_requests/views_mobile.py
+++ b/iaso/api/org_unit_change_requests/views_mobile.py
@@ -4,7 +4,7 @@ from rest_framework import filters
 from rest_framework import viewsets
 from rest_framework.mixins import ListModelMixin
 
-from django.db.models import Prefetch
+from django.db.models import Count, Prefetch, Q
 
 from iaso.api.org_unit_change_requests.filters import MobileOrgUnitChangeRequestListFilter
 from iaso.api.org_unit_change_requests.pagination import OrgUnitChangeRequestPagination
@@ -34,4 +34,10 @@ class MobileOrgUnitChangeRequestViewSet(ListModelMixin, viewsets.GenericViewSet)
                 "new_groups",
                 Prefetch("new_reference_instances", queryset=Instance.non_deleted_objects.all()),
             )
+            .annotate(
+                annotated_new_reference_instances_count=Count(
+                    "new_reference_instances", filter=Q(new_reference_instances__deleted=False)
+                )
+            )
+            .exclude_soft_deleted_new_reference_instances()
         )

--- a/iaso/api/org_unit_change_requests/views_mobile.py
+++ b/iaso/api/org_unit_change_requests/views_mobile.py
@@ -4,12 +4,14 @@ from rest_framework import filters
 from rest_framework import viewsets
 from rest_framework.mixins import ListModelMixin
 
+from django.db.models import Prefetch
+
 from iaso.api.org_unit_change_requests.filters import MobileOrgUnitChangeRequestListFilter
 from iaso.api.org_unit_change_requests.pagination import OrgUnitChangeRequestPagination
 from iaso.api.org_unit_change_requests.permissions import HasOrgUnitsChangeRequestPermission
 from iaso.api.org_unit_change_requests.serializers import MobileOrgUnitChangeRequestListSerializer
 from iaso.api.serializers import AppIdSerializer
-from iaso.models import OrgUnit, OrgUnitChangeRequest
+from iaso.models import Instance, OrgUnit, OrgUnitChangeRequest
 
 
 class MobileOrgUnitChangeRequestViewSet(ListModelMixin, viewsets.GenericViewSet):
@@ -30,6 +32,6 @@ class MobileOrgUnitChangeRequestViewSet(ListModelMixin, viewsets.GenericViewSet)
             .select_related("org_unit")
             .prefetch_related(
                 "new_groups",
-                "new_reference_instances",
+                Prefetch("new_reference_instances", queryset=Instance.non_deleted_objects.all()),
             )
         )

--- a/iaso/tests/api/org_unit_change_requests/test_org_unit_change_requests.py
+++ b/iaso/tests/api/org_unit_change_requests/test_org_unit_change_requests.py
@@ -6,10 +6,7 @@ from iaso.api.org_unit_change_requests.views import OrgUnitChangeRequestViewSet
 from iaso.utils.models.common import get_creator_name
 import time_machine
 
-from django.contrib.auth.models import Group
-
 from iaso.test import APITestCase
-from django.contrib.gis.geos import Point
 from iaso import models as m
 
 
@@ -59,12 +56,16 @@ class OrgUnitChangeRequestAPITestCase(APITestCase):
         org_unit_type.projects.set([project])
         user.iaso_profile.org_units.set([org_unit])
 
+        cls.form_3 = form_3
+        cls.instance_1 = instance_1
+        cls.instance_2 = instance_2
+        cls.instance_3 = instance_3
         cls.org_unit = org_unit
+        cls.org_unit_change_request_csv_columns = OrgUnitChangeRequestViewSet.org_unit_change_request_csv_columns()
         cls.org_unit_type = org_unit_type
         cls.project = project
         cls.user = user
         cls.user_with_review_perm = user_with_review_perm
-        cls.org_unit_change_request_csv_columns = OrgUnitChangeRequestViewSet.org_unit_change_request_csv_columns()
         cls.version = version
 
     def test_list_ok(self):
@@ -73,7 +74,7 @@ class OrgUnitChangeRequestAPITestCase(APITestCase):
 
         self.client.force_authenticate(self.user)
 
-        with self.assertNumQueries(12):
+        with self.assertNumQueries(10):
             # filter_for_user_and_app_id
             #   1. SELECT OrgUnit
             # get_queryset
@@ -81,14 +82,12 @@ class OrgUnitChangeRequestAPITestCase(APITestCase):
             #   3. SELECT OrgUnitChangeRequest
             # prefetch
             #   4. PREFETCH OrgUnit.groups
-            #   5. PREFETCH OrgUnit.reference_instances
-            #   6. PREFETCH OrgUnit.reference_instances__form
-            #   7. PREFETCH OrgUnitChangeRequest.new_groups
-            #   8. PREFETCH OrgUnitChangeRequest.old_groups
-            #   9. PREFETCH OrgUnitChangeRequest.new_reference_instances
-            #  10. PREFETCH OrgUnitChangeRequest.old_reference_instances
-            #  11. PREFETCH OrgUnitChangeRequest.{new/old}_reference_instances__form
-            #  12. PREFETCH OrgUnitChangeRequest.org_unit_type.projects
+            #   5. PREFETCH OrgUnit.reference_instances__form
+            #   6. PREFETCH OrgUnitChangeRequest.new_groups
+            #   7. PREFETCH OrgUnitChangeRequest.old_groups
+            #   8. PREFETCH OrgUnitChangeRequest.new_reference_instances__form
+            #   9. PREFETCH OrgUnitChangeRequest.old_reference_instances__form
+            #  10. PREFETCH OrgUnitChangeRequest.org_unit_type.projects
             response = self.client.get("/api/orgunits/changes/")
             self.assertJSONResponse(response, 200)
             self.assertEqual(2, len(response.data["results"]))
@@ -100,10 +99,47 @@ class OrgUnitChangeRequestAPITestCase(APITestCase):
     def test_retrieve_ok(self):
         change_request = m.OrgUnitChangeRequest.objects.create(org_unit=self.org_unit, new_name="Foo")
         self.client.force_authenticate(self.user)
-        with self.assertNumQueries(11):
+        with self.assertNumQueries(9):
             response = self.client.get(f"/api/orgunits/changes/{change_request.pk}/")
         self.assertJSONResponse(response, 200)
         self.assertEqual(response.data["id"], change_request.pk)
+
+    def test_retrieve_should_not_include_soft_deleted_intances(self):
+        change_request = m.OrgUnitChangeRequest.objects.create(org_unit=self.org_unit, new_name="Foo")
+        change_request.new_reference_instances.set([self.instance_1.pk])
+        change_request.old_reference_instances.set([self.instance_2.pk])
+
+        m.OrgUnitReferenceInstance.objects.filter(org_unit=self.org_unit).delete()
+        m.OrgUnitReferenceInstance.objects.create(org_unit=self.org_unit, form=self.form_3, instance=self.instance_3)
+
+        self.client.force_authenticate(self.user)
+
+        with self.assertNumQueries(9):
+            response = self.client.get(f"/api/orgunits/changes/{change_request.pk}/")
+            self.assertJSONResponse(response, 200)
+            self.assertEqual(response.data["id"], change_request.pk)
+            self.assertEqual(len(response.data["new_reference_instances"]), 1)
+            self.assertEqual(response.data["new_reference_instances"][0]["id"], self.instance_1.pk)
+            self.assertEqual(len(response.data["old_reference_instances"]), 1)
+            self.assertEqual(response.data["old_reference_instances"][0]["id"], self.instance_2.pk)
+            self.assertEqual(len(response.data["org_unit"]["reference_instances"]), 1)
+            self.assertEqual(response.data["org_unit"]["reference_instances"][0]["id"], self.instance_3.pk)
+
+        # Soft delete instances.
+        self.instance_1.deleted = True
+        self.instance_1.save()
+        self.instance_2.deleted = True
+        self.instance_2.save()
+        self.instance_3.deleted = True
+        self.instance_3.save()
+
+        with self.assertNumQueries(9):
+            response = self.client.get(f"/api/orgunits/changes/{change_request.pk}/")
+            self.assertJSONResponse(response, 200)
+            self.assertEqual(response.data["id"], change_request.pk)
+            self.assertEqual(len(response.data["new_reference_instances"]), 0)
+            self.assertEqual(len(response.data["old_reference_instances"]), 0)
+            self.assertEqual(len(response.data["org_unit"]["reference_instances"]), 0)
 
     def test_retrieve_without_auth(self):
         change_request = m.OrgUnitChangeRequest.objects.create(org_unit=self.org_unit, new_name="Foo")

--- a/iaso/tests/models/test_org_unit_change_request.py
+++ b/iaso/tests/models/test_org_unit_change_request.py
@@ -304,3 +304,20 @@ class OrgUnitChangeRequestModelTestCase(TestCase):
 
         self.assertEqual(diff["modified"]["closed_date"]["before"], "2055-01-01")
         self.assertIsNone(diff["modified"]["closed_date"]["after"])
+
+    def test_exclude_soft_deleted_new_reference_instances(self):
+        change_request = m.OrgUnitChangeRequest.objects.create(
+            org_unit=self.org_unit, requested_fields=["new_reference_instances"]
+        )
+        change_request.new_reference_instances.set([self.new_instance1, self.new_instance2])
+
+        change_requests = m.OrgUnitChangeRequest.objects.exclude_soft_deleted_new_reference_instances()
+        self.assertEqual(change_requests.count(), 1)
+
+        self.new_instance1.deleted = True
+        self.new_instance1.save()
+        self.new_instance2.deleted = True
+        self.new_instance2.save()
+
+        change_requests = m.OrgUnitChangeRequest.objects.exclude_soft_deleted_new_reference_instances()
+        self.assertEqual(change_requests.count(), 0)

--- a/iaso/tests/models/test_org_unit_change_request.py
+++ b/iaso/tests/models/test_org_unit_change_request.py
@@ -5,11 +5,9 @@ import time_machine
 
 from django.contrib.gis.geos import Point
 from django.core.exceptions import ValidationError
-from django.utils import timezone
 
 from hat.audit.models import Modification
 from iaso import models as m
-from iaso.models.deduplication import ValidationStatus
 from iaso.test import TestCase
 
 


### PR DESCRIPTION
Exclude soft deleted instances from change requests.

Related JIRA tickets : [IA-3677](https://bluesquare.atlassian.net/browse/IA-3677)

## Changes

1. exclude soft deleted instances from change requests
2. exclude the full change request when `new_reference_instances` is the only requested change but instances have all been soft-deleted

## How to test

- create a change request with a related reference instance
- soft delete the instance
- it shouldn't appear anymore in the change request

[IA-3677]: https://bluesquare.atlassian.net/browse/IA-3677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ