### PR TITLE
[IA-3689] Fixed validated OrgUnitType count

### DIFF
--- a/iaso/api/org_unit_types/serializers.py
+++ b/iaso/api/org_unit_types/serializers.py
@@ -181,7 +181,7 @@ class OrgUnitTypeSerializerV2(DynamicFieldsModelSerializer):
     def get_units_count(self, obj: OrgUnitType):
         orgUnits = OrgUnit.objects.filter_for_user_and_app_id(
             self.context["request"].user, self.context["request"].query_params.get("app_id")
-        ).filter(Q(validated=True) & Q(org_unit_type__id=obj.id))
+        ).filter(Q(validation_status=OrgUnit.VALIDATION_VALID) & Q(org_unit_type__id=obj.id))
         orgunits_count = orgUnits.count()
         return orgunits_count
 


### PR DESCRIPTION
Fixed a bug which caused the count of validated `OrgUnits` on the list of `OrgUnitType`  to be wrong.

Related JIRA tickets : IA-3689

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc

/

## Changes

/

## How to test
- IMPORTANT: create a new `OrgUnit` though the mobile app (choose any type you want) + validate its related `ChangeRequest`
- Check the count on the `OrgUnitType` list page and compare it to the count on the `OrgUnit` page, with a filter on the selected `OrgUnitType`
  - if you do this on `main`, you will have different numbers
  - if you do this on this branch, you should have the same numbers 


## Print screen / video
![1732120176148737972](https://github.com/user-attachments/assets/b2d1dad3-c660-45db-b732-34968060dfb0)

![173212017614873797](https://github.com/user-attachments/assets/47bd170f-982d-4971-bac4-5fefa4ec7574)



## Notes

I didn't get rid of the `OrgUnit.validated` attribute, I will create a dedicated ticket for that. 

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
