### PR TITLE
POLIO-1728: Stocks: Add column 'Round' on Form A summary page

### DIFF
--- a/plugins/polio/api/vaccines/stock_management.py
+++ b/plugins/polio/api/vaccines/stock_management.py
@@ -438,6 +438,7 @@ class VaccineStockSubitemBase(ModelViewSet):
 class OutgoingStockMovementSerializer(serializers.ModelSerializer):
     campaign = serializers.CharField(source="campaign.obr_name")
     document = serializers.FileField(required=False)
+    round_number = serializers.SerializerMethodField()
 
     class Meta:
         model = OutgoingStockMovement
@@ -453,7 +454,11 @@ class OutgoingStockMovementSerializer(serializers.ModelSerializer):
             "document",
             "comment",
             "round",
+            "round_number",
         ]
+
+    def get_round_number(self, obj):
+        return obj.round.number if obj.round else None
 
     def extract_campaign_data(self, validated_data):
         campaign_data = validated_data.pop("campaign", None)

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Table/columns.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Table/columns.tsx
@@ -36,6 +36,12 @@ export const useFormATableColumns = (
                 sortable: true,
             },
             {
+                Header: formatMessage(MESSAGES.round),
+                accessor: 'round_number',
+                id: 'round__number',
+                sortable: true,
+            },
+            {
                 Header: formatMessage(MESSAGES.form_a_reception_date),
                 accessor: 'form_a_reception_date',
                 id: 'form_a_reception_date',

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Table/columns.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Table/columns.tsx
@@ -40,6 +40,10 @@ export const useFormATableColumns = (
                 accessor: 'round_number',
                 id: 'round__number',
                 sortable: true,
+                Cell: settings =>
+                    settings.row.original.round_number
+                        ? settings.row.original.round_number
+                        : textPlaceholder,
             },
             {
                 Header: formatMessage(MESSAGES.form_a_reception_date),


### PR DESCRIPTION
What problem is this PR solving? Explain here in one sentence.
- Stocks: Add column 'Round' on Form A summary page
Related JIRA tickets : [POLIO-1728](https://bluesquare.atlassian.net/browse/POLIO-1728)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes
- Just added Round(number) on the Form A summary page(Stocks management)

## How to test
- Polio --> Vaccine module --> Stock management --> stock details --> Stock variation
- Check on the Form A tab if the round number column is there

## Print screen / video
![Screenshot-from-2024-11-21-10-07-12-11-21-2024_10_07_AM](https://github.com/user-attachments/assets/6266a6f7-41a3-4e2d-90dc-879d1eb00d2d)

## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.


[POLIO-1728]: https://bluesquare.atlassian.net/browse/POLIO-1728?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ