### PR TITLE
POLIO-1705: Supply Chain: stylistic changes deciphering rows within entry

### DIFF
--- a/hat/assets/js/apps/Iaso/components/Cells/DateTimeCell.tsx
+++ b/hat/assets/js/apps/Iaso/components/Cells/DateTimeCell.tsx
@@ -6,6 +6,7 @@ import moment from 'moment';
 
 import React, { ReactElement } from 'react';
 import { apiDateFormats } from '../../utils/dates';
+import { SubTable } from './SubTable';
 /* DateTimeCell
    For use in Table's columns to display DateTime
  */
@@ -50,11 +51,10 @@ export const MultiDateCell = (cellInfo: {
     const value = cellInfo?.value ?? '';
     const valueAsList = value.split(',');
     return (
-        <>
-            {valueAsList.map((lineData, index) => (
-                <div key={`${lineData}${index}`}>{convertToDate(lineData)}</div>
-            ))}
-        </>
+        <SubTable
+            values={valueAsList}
+            renderValue={lineData => convertToDate(lineData)}
+        />
     );
 };
 

--- a/hat/assets/js/apps/Iaso/components/Cells/SubTable.tsx
+++ b/hat/assets/js/apps/Iaso/components/Cells/SubTable.tsx
@@ -1,9 +1,15 @@
-import { Table, TableBody, TableCell, TableRow } from '@mui/material';
+import {
+    Table,
+    TableBody,
+    TableCell,
+    TableProps,
+    TableRow,
+} from '@mui/material';
 import { textPlaceholder } from 'bluesquare-components';
 import React, { FunctionComponent } from 'react';
 import { SxStyles } from '../../types/general';
 
-type SubTableProps = {
+type SubTableProps = TableProps & {
     values: any[];
     renderValue: (value: any) => string;
 };
@@ -24,9 +30,10 @@ const styles: SxStyles = {
 export const SubTable: FunctionComponent<SubTableProps> = ({
     values,
     renderValue,
+    ...tableProps
 }) => {
     return (
-        <Table sx={styles.table}>
+        <Table sx={styles.table} {...tableProps}>
             <TableBody>
                 {values.length === 0 ? (
                     <TableRow>

--- a/hat/assets/js/apps/Iaso/components/Cells/SubTable.tsx
+++ b/hat/assets/js/apps/Iaso/components/Cells/SubTable.tsx
@@ -1,0 +1,62 @@
+import { Table, TableBody, TableCell, TableRow } from '@mui/material';
+import { textPlaceholder } from 'bluesquare-components';
+import React, { FunctionComponent } from 'react';
+import { SxStyles } from '../../types/general';
+
+type SubTableProps = {
+    values: any[];
+    renderValue: (value: any) => string;
+};
+
+const styles: SxStyles = {
+    table: {
+        borderCollapse: 'collapse',
+        width: '100%',
+        height: '100%',
+    },
+    tableCell: {
+        textAlign: 'center',
+        padding: '0px',
+        height: '30px',
+    },
+};
+
+export const SubTable: FunctionComponent<SubTableProps> = ({
+    values,
+    renderValue,
+}) => {
+    return (
+        <Table sx={styles.table}>
+            <TableBody>
+                {values.length === 0 ? (
+                    <TableRow>
+                        <TableCell
+                            sx={{
+                                ...styles.tableCell,
+                                borderBottom: 'none',
+                            }}
+                        >
+                            {textPlaceholder}
+                        </TableCell>
+                    </TableRow>
+                ) : (
+                    values.map((value, index) => (
+                        <TableRow key={`${renderValue(value)}${index}`}>
+                            <TableCell
+                                sx={{
+                                    ...styles.tableCell,
+                                    borderBottom:
+                                        index === values.length - 1
+                                            ? 'none'
+                                            : '1px solid rgba(224, 224, 224, 1)',
+                                }}
+                            >
+                                {renderValue(value) ?? textPlaceholder}
+                            </TableCell>
+                        </TableRow>
+                    ))
+                )}
+            </TableBody>
+        </Table>
+    );
+};

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Table/VaccineSupplyChainTable.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Table/VaccineSupplyChainTable.tsx
@@ -1,11 +1,17 @@
-import React, { FunctionComponent } from 'react';
 import { UrlParams } from 'bluesquare-components';
-import { baseUrls } from '../../../../constants/urls';
+import React, { FunctionComponent } from 'react';
 import { TableWithDeepLink } from '../../../../../../../../hat/assets/js/apps/Iaso/components/tables/TableWithDeepLink';
-import { useVaccineSupplyChainTableColumns } from './useVaccineSupplyChainTableColumns';
+import { baseUrls } from '../../../../constants/urls';
 import { useGetVrfList } from '../hooks/api/vrf';
+import { useVaccineSupplyChainTableColumns } from './useVaccineSupplyChainTableColumns';
 
 type Props = { params: Partial<UrlParams> };
+
+const getCellProps = () => ({
+    style: {
+        padding: '0px',
+    },
+});
 
 export const VaccineSupplyChainTable: FunctionComponent<Props> = ({
     params,
@@ -23,6 +29,7 @@ export const VaccineSupplyChainTable: FunctionComponent<Props> = ({
             columnSelectorEnabled
             columnSelectorButtonType="button"
             marginTop={false}
+            cellProps={getCellProps}
             extraProps={{
                 loading: isFetching,
                 params,

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Table/useVaccineSupplyChainTableColumns.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Table/useVaccineSupplyChainTableColumns.tsx
@@ -1,25 +1,21 @@
-import React, { ReactElement, useMemo } from 'react';
-import {
-    Column,
-    IconButton,
-    textPlaceholder,
-    useSafeIntl,
-} from 'bluesquare-components';
 import EditIcon from '@mui/icons-material/Edit';
-import { baseUrls } from '../../../../constants/urls';
-import { NumberCell } from '../../../../../../../../hat/assets/js/apps/Iaso/components/Cells/NumberCell';
-import { useCurrentUser } from '../../../../../../../../hat/assets/js/apps/Iaso/utils/usersUtils';
+import { Column, IconButton, useSafeIntl } from 'bluesquare-components';
+import React, { ReactElement, useMemo } from 'react';
 import {
     DateCell,
     MultiDateCell,
 } from '../../../../../../../../hat/assets/js/apps/Iaso/components/Cells/DateTimeCell';
-import MESSAGES from '../messages';
+import { NumberCell } from '../../../../../../../../hat/assets/js/apps/Iaso/components/Cells/NumberCell';
+import { SubTable } from '../../../../../../../../hat/assets/js/apps/Iaso/components/Cells/SubTable';
 import DeleteDialog from '../../../../../../../../hat/assets/js/apps/Iaso/components/dialogs/DeleteDialogComponent';
-import { useDeleteVrf } from '../hooks/api/vrf';
 import { userHasPermission } from '../../../../../../../../hat/assets/js/apps/Iaso/domains/users/utils';
-import { POLIO_SUPPLY_CHAIN_WRITE } from '../../../../../../../../hat/assets/js/apps/Iaso/utils/permissions';
-import { SupplyChainList } from '../types';
 import { ColumnCell } from '../../../../../../../../hat/assets/js/apps/Iaso/types/general';
+import { POLIO_SUPPLY_CHAIN_WRITE } from '../../../../../../../../hat/assets/js/apps/Iaso/utils/permissions';
+import { useCurrentUser } from '../../../../../../../../hat/assets/js/apps/Iaso/utils/usersUtils';
+import { baseUrls } from '../../../../constants/urls';
+import { useDeleteVrf } from '../hooks/api/vrf';
+import MESSAGES from '../messages';
+import { SupplyChainList } from '../types';
 
 export const useVaccineSupplyChainTableColumns = (): Column[] => {
     const { formatMessage } = useSafeIntl();
@@ -95,27 +91,26 @@ export const useVaccineSupplyChainTableColumns = (): Column[] => {
                 Cell: ({
                     row: { original },
                 }: ColumnCell<SupplyChainList>): ReactElement => {
-                    const poNumbers = original?.po_numbers ?? '';
-                    const poNumbersList = poNumbers.split(',');
+                    const poNumbers = original?.po_numbers;
+                    const poNumbersList = poNumbers ? poNumbers.split(',') : [];
                     return (
-                        <>
-                            {poNumbersList.map(poNumber => (
-                                <div key={poNumber}>
-                                    {poNumber ?? textPlaceholder}
-                                </div>
-                            ))}
-                        </>
+                        <SubTable
+                            values={poNumbersList}
+                            renderValue={poNumber => poNumber}
+                        />
                     );
                 },
             },
             {
                 Header: formatMessage(MESSAGES.estimatedDateOfArrival),
                 accessor: 'eta',
+                id: 'eta',
                 Cell: MultiDateCell,
             },
             {
                 Header: 'VAR',
                 accessor: 'var',
+                id: 'var',
                 Cell: MultiDateCell,
             },
         ];


### PR DESCRIPTION
The client has asked for ‘light lines’ in order to decipher the different rows within an entry. (Please disregard my terrible screenshot edits, but a guiding idea of what this could perhaps look like?). Open to ideas using lines, shading, or anything else that would be possible?

Related JIRA tickets :POLIO-1705

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)



## Changes

Explain the changes that were made.

The idea is not to list exhaustively all the changes made (GitHub already provides a full diff), but to help the reviewers better understand:

Add sub table component to use in a cell

## How to test

Open supply chain table with existing pre-alert and var
PO numbers and date should be separated by lines

<img width="1638" alt="Screenshot 2024-11-21 at 10 50 08" src="https://github.com/user-attachments/assets/356bc86a-e88c-4288-a329-72753a01d4fa">


## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
