### PR TITLE
POLIO-1740: Snack bars not showing correct status in supplychain

### DIFF
--- a/plugins/polio/api/vaccines/supply_chain.py
+++ b/plugins/polio/api/vaccines/supply_chain.py
@@ -1,9 +1,8 @@
-import json
 from logging import getLogger
 from typing import Any
 
 from django import forms
-from django.core.files.base import ContentFile
+from django.db import IntegrityError
 from django.db.models import Max, Min, Sum
 from django.db.models.functions import Coalesce
 from django.utils import timezone
@@ -269,7 +268,10 @@ class PatchArrivalReportSerializer(serializers.Serializer):
                         setattr(ar, key, item[key])
 
                 if is_different:
-                    ar.save()
+                    try:
+                        ar.save()
+                    except IntegrityError as e:
+                        raise serializers.ValidationError(str(e))
 
                 arrival_reports.append(ar)
 

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/utils.ts
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/utils.ts
@@ -190,7 +190,6 @@ export const makeHandleSubmit =
                         setInitialValues(newInitialValues);
                         formik.setErrors(newErrors);
                         formik.setTouched(newTouched);
-                        console.log('newValues', newValues);
                         formik.setValues(newValues);
                     }
                 },

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/hooks/api/useSaveSupplyChainForm.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/hooks/api/useSaveSupplyChainForm.tsx
@@ -88,10 +88,6 @@ export const useSaveVaccineSupplyChainForm = (): UseMutationResult<
         showSucessSnackBar: false,
         ignoreErrorCodes: [400],
         options: {
-            onError(error, variables, context) {
-                console.log('ERROR', error);
-                console.log('VARIABLES', variables);
-            },
             // Setting the cache value with the response onSuccess, so we can reset the form state (touched, etc) without losing data
             onSuccess: (
                 data: SupplyChainResponse,

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/hooks/api/useSaveSupplyChainForm.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/hooks/api/useSaveSupplyChainForm.tsx
@@ -13,25 +13,23 @@ import { handleVrfPromiseErrors, saveVrf } from './vrf';
 
 const saveSupplyChainForm = async (supplyChainData: SupplyChainFormData) => {
     if (supplyChainData.saveAll === true && supplyChainData?.vrf?.id) {
-        const promises: Promise<PromiseSettledResult<any>[]>[] = [];
+        const promises: Promise<any>[][] = [];
 
         // update all tabs
         if (supplyChainData.changedTabs.includes(VRF)) {
-            promises.push(Promise.allSettled(saveVrf(supplyChainData.vrf)));
+            promises.push(saveVrf(supplyChainData.vrf));
         }
         if (supplyChainData.changedTabs.includes(PREALERT)) {
-            promises.push(
-                Promise.allSettled(saveTab(PREALERT, supplyChainData)),
-            );
+            promises.push(saveTab(PREALERT, supplyChainData));
         }
         if (supplyChainData.changedTabs.includes(VAR)) {
-            promises.push(Promise.allSettled(saveTab(VAR, supplyChainData)));
+            promises.push(saveTab(VAR, supplyChainData));
         }
 
         const allUpdates = (await Promise.allSettled(
-            promises,
+            promises.flat(),
             // The first level of nesting will only contain fulfilled promised. The rejected ones will be at least 1 level deep
-        )) as PromiseFulfilledResult<PromiseSettledResult<any>[]>[];
+        )) as PromiseFulfilledResult<any>[];
         return parsePromiseResults(allUpdates);
     }
     // We can't save prealerts or var if there's no preexisting vrf

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/hooks/api/useSaveSupplyChainForm.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/hooks/api/useSaveSupplyChainForm.tsx
@@ -88,6 +88,10 @@ export const useSaveVaccineSupplyChainForm = (): UseMutationResult<
         showSucessSnackBar: false,
         ignoreErrorCodes: [400],
         options: {
+            onError(error, variables, context) {
+                console.log('ERROR', error);
+                console.log('VARIABLES', variables);
+            },
             // Setting the cache value with the response onSuccess, so we can reset the form state (touched, etc) without losing data
             onSuccess: (
                 data: SupplyChainResponse,

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/hooks/api/utils.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/hooks/api/utils.tsx
@@ -133,51 +133,33 @@ export const normalizePromiseResult = (
     return result;
 };
 
-export const findPromiseOrigin = (
-    settledPromise: PromiseSettledResult<any>[],
-): Optional<TabValue> => {
-    if (!settledPromise) {
-        throw new Error(
-            `findPromiseOrigin expected PromiseSettledResult, got ${settledPromise}`,
-        );
+export const findPromiseOrigin = (url: string): Optional<TabValue> => {
+    if (!url) {
+        return VRF;
     }
 
-    // @ts-ignore
-    const { value, reason } = settledPromise[0] ?? {};
-
-    // If there's no arrival reports or no pre alerts, settledPromise may be an empty array.
-    // In this case we return undefined to skip adding an entry to the aggregated response when using saveAll
-    if (!value && !reason) {
-        return undefined;
-    }
-    const foundValue = value
-        ? Object.keys(value)[0]
-        : Object.keys(reason.details)[0];
-    // Since there's only 1 vrf, the form of the response doesn't provide a key.
-    // Since it's also the only tab in that situation, we can infer that if the found value is neither VAR nor PRREALERT, it must be VRF
-    return foundValue === VAR || foundValue === PREALERT ? foundValue : VRF;
+    if (url.includes(PREALERT)) return PREALERT;
+    if (url.includes(VAR)) return VAR;
+    return VRF;
 };
 
 export const addEntryToResponse = (
     response: Record<string, any>,
-    update: PromiseFulfilledResult<PromiseSettledResult<any>[]>,
+    update: PromiseFulfilledResult<any>,
 ): void => {
-    const key = findPromiseOrigin(update.value);
+    const key = findPromiseOrigin(update.value.url);
     if (key) {
-        const convertedArray: any[] = (
-            update.value as PromiseSettledResult<any>[]
-        ).map(item => normalizePromiseResult(item));
-        response[key] = convertedArray;
+        if (!response[key]) {
+            response[key] = [];
+        }
+        response[key].push(normalizePromiseResult(update));
     }
 };
 
 export const parsePromiseResults = (
     allUpdates: PromiseFulfilledResult<PromiseSettledResult<any>[]>[],
-): Record<string, ParsedSettledPromise<any> | ParsedSettledPromise<any>[]> => {
-    const response: Record<
-        string,
-        ParsedSettledPromise<any> | ParsedSettledPromise<any>[]
-    > = {};
+): Record<string, ParsedSettledPromise<any>> => {
+    const response: Record<string, ParsedSettledPromise<any>> = {};
     allUpdates.forEach(update => {
         addEntryToResponse(response, update);
     });

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/hooks/api/utils.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/hooks/api/utils.tsx
@@ -1,9 +1,5 @@
 import { openSnackBar } from '../../../../../../../../../hat/assets/js/apps/Iaso/components/snackBars/EventDispatcher';
-import {
-    deleteRequest,
-    patchRequest,
-    postRequest,
-} from '../../../../../../../../../hat/assets/js/apps/Iaso/libs/Api';
+import { deleteRequest } from '../../../../../../../../../hat/assets/js/apps/Iaso/libs/Api';
 
 import {
     errorSnackBar,
@@ -197,25 +193,25 @@ export const handlePromiseErrors = ({
     data,
     key,
 }: HandlePromiseErrorsArgs): void => {
-    const failedPromises = data.filter(item => item.status === 'rejected');
+    const failedPromises = data.filter(item => item.value.status >= 400);
+
     if (failedPromises.length === 0) {
         const messageKey = `${key}ApiSuccess`;
         openSnackBar(succesfullSnackBar(key, MESSAGES[messageKey]));
     } else {
-        const failedEndpoints = failedPromises.map(item => item.value.message);
-        if (failedEndpoints.find(msg => msg.includes('add'))) {
+        const failedEndpoints = failedPromises.map(item => item.value.url);
+        if (failedEndpoints.find(url => url.includes('add'))) {
             const messageKey = `${key}CreateError`;
             openSnackBar(
                 errorSnackBar(
                     key,
                     MESSAGES[messageKey],
-                    failedPromises.find(item =>
-                        item.value.message.includes('add'),
-                    )?.value,
+                    failedPromises.find(item => item.value.url.includes('add'))
+                        ?.value.statusText,
                 ),
             );
         }
-        if (failedEndpoints.find(msg => msg.includes('update'))) {
+        if (failedEndpoints.find(url => url.includes('update'))) {
             const messageKey = `${key}UpdateError`;
 
             openSnackBar(
@@ -223,12 +219,12 @@ export const handlePromiseErrors = ({
                     key,
                     MESSAGES[messageKey],
                     failedPromises.find(item =>
-                        item.value.message.includes('update'),
-                    )?.value,
+                        item.value.url.includes('update'),
+                    )?.value.statusText,
                 ),
             );
         }
-        if (failedEndpoints.find(msg => msg.includes('delete'))) {
+        if (failedEndpoints.find(url => url.includes('delete'))) {
             const messageKey = `${key}DeleteError`;
             openSnackBar(
                 errorSnackBar(
@@ -236,7 +232,7 @@ export const handlePromiseErrors = ({
                     MESSAGES[messageKey],
                     failedPromises.find(item =>
                         item.value.message.includes('delete'),
-                    )?.value,
+                    )?.value.statusText,
                 ),
             );
         }

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/hooks/api/vrf.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/hooks/api/vrf.tsx
@@ -3,10 +3,10 @@ import {
     renderTagsWithTooltip,
     textPlaceholder,
 } from 'bluesquare-components';
-import { PostArg } from 'hat/assets/js/apps/Iaso/types/general';
 import moment from 'moment';
 import { useMemo } from 'react';
 import { UseMutationResult, UseQueryResult } from 'react-query';
+import { PostArg } from '../../../../../../../../../hat/assets/js/apps/Iaso/types/general';
 import { openSnackBar } from '../../../../../../../../../hat/assets/js/apps/Iaso/components/snackBars/EventDispatcher';
 import {
     errorSnackBar,


### PR DESCRIPTION
User didn't get error message in UI when trying to create/update prealert or VAR with duplicate PO

Related JIRA tickets : POLIO-1740

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc

Bug fix: N/A

## Changes

Explain the changes that were made.

- Catch IntegrityError in the API and return a 400 instead
- Fix error handling in the front-end:
    - remove nested Promises for saveAll button
    - refactor error handling code accordingly 

## How to test

- Go to Vaccine module> Supplychain
- Open an existing enty
- Open a new tab and copy the url there, so you have 2 tabs open on the same page
- In the first page, add a prealert.
- Save
- Go to the second tab
- Try to add a prealert with teh same PO number
- Save
- The error snackbar should pop up and the data not be saved
- Do the same with arrival reports

## Print screen / video


https://github.com/user-attachments/assets/3e1d275e-19bb-453b-a914-078ea1dade1b




## Notes

Things that the reviewers should know:
HOTFIXABLE on v1.248a-polio

new tag: v1.248b-polio

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
