### PR TITLE
IA-3704: Adding code field in the result returned by entitytypes mobile endpoint

### DIFF
--- a/iaso/api/mobile/entity_type.py
+++ b/iaso/api/mobile/entity_type.py
@@ -25,6 +25,7 @@ class MobileEntityTypeSerializer(serializers.ModelSerializer):
             "reference_form",
             "entities_count",
             "account",
+            "code",
             "fields_detail_info_view",
             "fields_list_view",
             "fields_duplicate_search",

--- a/iaso/tests/api/test_entity_types.py
+++ b/iaso/tests/api/test_entity_types.py
@@ -234,19 +234,25 @@ class EntityTypeAPITestCase(APITestCase):
 
     def test_get_mobile_entity_types(self):
         self.client.force_authenticate(self.yoda)
-
+        account = self.yoda.iaso_profile.account
+        name = "beneficiary"
+        code = f"{name}_{account.id}"
         # same account as logged user
-        EntityType.objects.create(
-            name="beneficiary", reference_form=self.form_1, account=self.yoda.iaso_profile.account
-        )
+        EntityType.objects.create(name=name, reference_form=self.form_1, account=account, code=code)
 
         # different account
-        EntityType.objects.create(name="beneficiary", reference_form=self.form_1, account=self.the_gang)
+        EntityType.objects.create(
+            name=name,
+            reference_form=self.form_1,
+            account=self.the_gang,
+            code=f"{name}_{self.the_gang.id}",
+        )
 
         response = self.client.get(f"/api/mobile/entitytypes/?app_id={self.project.app_id}")
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["count"], 1)
+        self.assertEqual(response.json()["results"][0]["code"], code)
 
     def test_get_entities_by_entity_type(self):
         self.client.force_authenticate(self.yoda)


### PR DESCRIPTION
What problem is this PR solving? Explain here in one sentence.

Related JIRA tickets : [IA-3704](https://bluesquare.atlassian.net/browse/IA-3704)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests
- [ ] Documentation has been included (for new feature)


## Changes

Added code field in the endpoint mobile entity type results.


## How to test

From a local iaso instance, load the results from endpoint mobile entitytypes with app_id parameter.

e.g: http://localhost:8081/api/mobile/entitytypes/?app_id=fwdajrk


## Print screen / video

![image (6)](https://github.com/user-attachments/assets/c93789cc-75ff-400a-b5ca-b610e3a6ed67)


## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.


[IA-3704]: https://bluesquare.atlassian.net/browse/IA-3704?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ