### PR TITLE
IA-3713: fix type of org unit id, improve perm check

### DIFF
--- a/iaso/tests/api/test_profiles.py
+++ b/iaso/tests/api/test_profiles.py
@@ -1112,19 +1112,19 @@ class ProfileAPITestCase(APITestCase):
 
     def test_update_user_should_fail_when_assigning_an_org_unit_outside_of_the_author_own_health_pyramid(self):
         user = self.jam
-        user.iaso_profile.org_units.set([self.jedi_squad_1])
+        user.iaso_profile.org_units.set([self.org_unit_from_sub_type])
 
         self.assertTrue(user.has_perm(permission.USERS_MANAGED))
         self.assertFalse(user.has_perm(permission.USERS_ADMIN))
 
         profile_to_modify = Profile.objects.get(user=self.jum)
-        profile_to_modify.org_units.set([self.jedi_squad_1])
+        profile_to_modify.org_units.set([self.org_unit_from_sub_type])
 
         self.client.force_authenticate(user)
         data = {
             "user_name": "new_user_name",
             "org_units": [
-                {"id": self.jedi_council_corruscant.pk},
+                {"id": self.org_unit_from_parent_type.pk},
                 {"id": "foo"},
                 {"bar": "foo"},
             ],
@@ -1135,7 +1135,7 @@ class ProfileAPITestCase(APITestCase):
             response.data["detail"],
             (
                 f"User with menupermissions.iaso_users_managed cannot assign an OrgUnit outside "
-                f"of their own health pyramid. Trying to assign {self.jedi_council_corruscant.pk}."
+                f"of their own health pyramid. Trying to assign {self.org_unit_from_parent_type.pk}."
             ),
         )
 


### PR DESCRIPTION
- convert string id from API to int
- skip location check if user has user admin perm (users can have both)

What problem is this PR solving? Explain here in one sentence.

Related JIRA tickets : IA-3713

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

- Explicitly exclude users with the `USERS_ADMIN` permission from the location check, since users can have both `USERS_MANAGED` and `USERS_ADMIN` permissions
- convert ids received from API to int to fix equality checks

## How to test
- Create a geo-limited user with user admin perm
- Create a geo-limited user with users managed perm

admin perm should be able to create users outside their pyramid
geo-limited user should be able to create users within their pyramid


## Print screen / video

https://github.com/user-attachments/assets/788e8ed9-e78e-4431-b0a9-55aed583adb7


https://github.com/user-attachments/assets/aec0ec81-68e3-4a11-a96d-9e4d8d3d3a34



## Notes

- hotixable on v1.248a
- new tag v1.248b

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
