### PR TITLE
WC2-590:  z-index and click surface issues on account toggle

### DIFF
--- a/hat/assets/js/apps/Iaso/components/nav/TopBarComponent.js
+++ b/hat/assets/js/apps/Iaso/components/nav/TopBarComponent.js
@@ -44,8 +44,14 @@ const styles = theme => ({
 const useStyles = makeStyles(styles);
 
 function TopBar(props) {
-    const { title, children, displayBackButton, goBack, displayMenuButton } =
-        props;
+    const {
+        title,
+        children,
+        displayBackButton,
+        goBack,
+        displayMenuButton,
+        disableShadow,
+    } = props;
     const classes = useStyles();
 
     const { APP_TITLE } = useContext(ThemeConfigContext);
@@ -65,6 +71,7 @@ function TopBar(props) {
             color="primary"
             id="top-bar"
             sx={{ zIndex: 10 }}
+            elevation={disableShadow ? 0 : 4}
         >
             <Toolbar className={classes.root}>
                 <Grid
@@ -145,6 +152,7 @@ TopBar.defaultProps = {
     goBack: () => null,
     title: '',
     displayMenuButton: true,
+    disableShadow: false,
 };
 
 TopBar.propTypes = {
@@ -153,6 +161,7 @@ TopBar.propTypes = {
     displayBackButton: PropTypes.bool,
     goBack: PropTypes.func,
     displayMenuButton: PropTypes.bool,
+    disableShadow: PropTypes.bool,
 };
 
 export default TopBar;

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitFiltersContainer.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitFiltersContainer.tsx
@@ -60,7 +60,7 @@ const useStyles = makeStyles(theme => ({
     },
     tabsContainer: {
         backgroundColor: `${theme.palette.primary.main} !important`,
-        zIndex: '900 !important',
+        zIndex: '9 !important',
         position: 'fixed',
         top: '64px !important',
     },

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/index.tsx
@@ -1,26 +1,26 @@
-import React, {
-    FunctionComponent,
-    useMemo,
-    useState,
-    useEffect,
-    useCallback,
-} from 'react';
-import { Box, Tabs, Tab } from '@mui/material';
+import { Box, Tab, Tabs } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import {
     commonStyles,
-    useSafeIntl,
     LoadingSpinner,
-    useSkipEffectOnMount,
     makeRedirectionUrl,
+    useSafeIntl,
+    useSkipEffectOnMount,
 } from 'bluesquare-components';
+import React, {
+    FunctionComponent,
+    useCallback,
+    useEffect,
+    useMemo,
+    useState,
+} from 'react';
 import { useQueryClient } from 'react-query';
 
 // COMPONENTS
 import { useNavigate } from 'react-router-dom';
 import DownloadButtonsComponent from '../../components/DownloadButtonsComponent';
-import { OrgUnitFiltersContainer } from './components/OrgUnitFiltersContainer';
 import TopBar from '../../components/nav/TopBarComponent';
+import { OrgUnitFiltersContainer } from './components/OrgUnitFiltersContainer';
 import { OrgUnitsMap } from './components/OrgUnitsMap';
 import { TableList } from './components/TableList';
 // COMPONENTS
@@ -31,25 +31,25 @@ import { Search } from './types/search';
 // TYPES
 
 // UTILS
-import { decodeSearch } from './utils';
-import { convertObjectToString } from '../../utils/dataManipulation';
 import { getChipColors } from '../../constants/chipColors';
+import { convertObjectToString } from '../../utils/dataManipulation';
+import { decodeSearch } from './utils';
 // UTILS
 
 // CONSTANTS
+import { MENU_HEIGHT_WITHOUT_TABS } from '../../constants/uiConstants';
 import { baseUrls } from '../../constants/urls';
 import MESSAGES from './messages';
-import { MENU_HEIGHT_WITHOUT_TABS } from '../../constants/uiConstants';
 // CONSTANTS
 
 // HOOKS
+import { useParamsObject } from '../../routing/hooks/useParamsObject';
+import { useBulkSaveOrgUnits } from './hooks/requests/useBulkSaveOrgUnits';
 import {
     useGetOrgUnits,
     useGetOrgUnitsLocations,
 } from './hooks/requests/useGetOrgUnits';
-import { useBulkSaveOrgUnits } from './hooks/requests/useBulkSaveOrgUnits';
 import { useGetApiParams } from './hooks/useGetApiParams';
-import { useParamsObject } from '../../routing/hooks/useParamsObject';
 // HOOKS
 
 const useStyles = makeStyles(theme => ({
@@ -239,7 +239,7 @@ export const OrgUnits: FunctionComponent = () => {
     return (
         <>
             {isLoading && <LoadingSpinner fixed={false} absolute />}
-            <TopBar title={formatMessage(MESSAGES.title)} />
+            <TopBar title={formatMessage(MESSAGES.title)} disableShadow />
 
             <Box className={classes.container}>
                 <OrgUnitFiltersContainer


### PR DESCRIPTION
 z-index and click surface issues on account toggle while visiting org unit search page
![image](https://github.com/user-attachments/assets/3c8acd85-aa39-4c73-b165-efb744ffd692)


Related JIRA tickets WC2-590

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)


## Changes

reduce z-index, new prop to remove elevation from `TopBar`
## How to test


## Print screen / video
![Screenshot 2024-11-25 at 14 39 37](https://github.com/user-attachments/assets/6ab25bb4-34ca-441b-ab77-eb07afbaed3e)

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
