### PR TITLE
IA-3758: Modules Cypress tests fix

### DIFF
--- a/hat/assets/js/cypress/integration/15 - modules/list.spec.js
+++ b/hat/assets/js/cypress/integration/15 - modules/list.spec.js
@@ -96,12 +96,12 @@ describe('Modules', () => {
             apiKey: 'modules',
         });
 
-        testPagination({
-            baseUrl,
-            apiPath: '/api/modules/',
-            apiKey: 'results',
-            withSearch: false,
-            fixture: listFixture,
-        });
+        // testPagination({
+        //     baseUrl,
+        //     apiPath: '/api/modules/**',
+        //     apiKey: 'results',
+        //     withSearch: false,
+        //     fixture: listFixture,
+        // });
     });
 });

--- a/hat/assets/js/cypress/integration/15 - modules/list.spec.js
+++ b/hat/assets/js/cypress/integration/15 - modules/list.spec.js
@@ -95,13 +95,5 @@ describe('Modules', () => {
             columns: 2,
             apiKey: 'modules',
         });
-
-        // testPagination({
-        //     baseUrl,
-        //     apiPath: '/api/modules/**',
-        //     apiKey: 'results',
-        //     withSearch: false,
-        //     fixture: listFixture,
-        // });
     });
 });


### PR DESCRIPTION
What problem is this PR solving? Explain here in one sentence.
- Modules Cypress tests fix
Related JIRA tickets : [IA-3758](https://bluesquare.atlassian.net/browse/IA-3758)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes
- Commented the testPagination as the pagination is not diplayed on the modules table(showPagination={false})

## How to test
- Run cypress on modules ---> list

## Print screen / video

## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.


[IA-3758]: https://bluesquare.atlassian.net/browse/IA-3758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ