### PR TITLE
IA-3753: deleted instance details page and change request not working

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -440,7 +440,7 @@
     "iaso.label.cancel": "Cancel",
     "iaso.label.catchment": "Catchment",
     "iaso.label.changeRequestConfig": "Change Request Configuration",
-    "iaso.label.changeRequests": "Change requets",
+    "iaso.label.changeRequests": "Change requests",
     "iaso.label.changeStatus": "Change status",
     "iaso.label.checkDHIS": "Test settings",
     "iaso.label.children": "Children",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -406,6 +406,7 @@
     "iaso.instance.warningSoftDeleted": "This instance has been soft-deleted and won't appear in instance search or completeness counts.",
     "iaso.instance.warningSoftDeletedDerived": "If this form generates other derived instances, they might not be updated either.",
     "iaso.instance.warningSoftDeletedExport": "If this instance was exported, this doesn't mean these data has been deleted from dhis2.",
+    "iaso.instances.disabledReason": "Change request is not available as submission is deleted",
     "iaso.instances.editLocationWithInstanceGps": "Push GPS from submission",
     "iaso.instances.forceExport": "Force Export",
     "iaso.instances.label.created_by__username": "Created by",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -406,6 +406,7 @@
     "iaso.instance.warningSoftDeleted": "Cette soumission a été marquée comme effacée, elle n'apparaitra plus dans les recherches ou les tableaux de complétude.",
     "iaso.instance.warningSoftDeletedDerived": "Si ce formulaire sert à générer des soumissions dérivées, celle-ci prendra toujours en compte cette soumission, c'est à vous de décider si vous les regénérez.",
     "iaso.instance.warningSoftDeletedExport": "Si l'soumission a été exportée précédemment, les données dans dhis2 sont sans doute toujours présentes.",
+    "iaso.instances.disabledReason": "La demande de changement n'est pas disponible car la soumission a été supprimée",
     "iaso.instances.editLocationWithInstanceGps": "Pousser le GPS à partir de la soumission",
     "iaso.instances.forceExport": "Forcer l'export des soumissions déjà exportées",
     "iaso.instances.label.created_by__username": "Crée par",

--- a/hat/assets/js/apps/Iaso/domains/instances/components/InstanceDetailsChangeRequests.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/InstanceDetailsChangeRequests.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react';
+import InfoIcon from '@mui/icons-material/Info';
 import {
     Table,
     TableBody,
@@ -6,19 +6,23 @@ import {
     TableContainer,
     TableHead,
     TableRow,
+    Tooltip,
     useTheme,
 } from '@mui/material';
 import { IconButton, useSafeIntl } from 'bluesquare-components';
-import { Instance } from '../types/instance';
-import MESSAGES from '../messages';
+import React, { FunctionComponent } from 'react';
 import { baseUrls } from '../../../constants/urls';
 import { colorCodes } from '../../orgUnits/reviewChanges/Components/ReviewOrgUnitChangesInfos';
+import MESSAGES from '../messages';
+import { Instance } from '../types/instance';
 
 type Props = {
     currentInstance: Instance;
+    disabled?: boolean;
 };
 const InstanceDetailsChangeRequests: FunctionComponent<Props> = ({
     currentInstance,
+    disabled = false,
 }) => {
     const { formatMessage } = useSafeIntl();
     const theme = useTheme();
@@ -50,11 +54,28 @@ const InstanceDetailsChangeRequests: FunctionComponent<Props> = ({
                                     )}
                                 </TableCell>
                                 <TableCell>
-                                    <IconButton
-                                        url={`/${baseUrls.orgUnitsChangeRequestDetail}/changeRequestId/${changeRequest.id}`}
-                                        icon="remove-red-eye"
-                                        tooltipMessage={MESSAGES.status}
-                                    />
+                                    {!disabled && (
+                                        <IconButton
+                                            url={`/${baseUrls.orgUnitsChangeRequestDetail}/changeRequestId/${changeRequest.id}`}
+                                            icon="remove-red-eye"
+                                            tooltipMessage={MESSAGES.status}
+                                        />
+                                    )}
+                                    {disabled && (
+                                        <Tooltip
+                                            title={formatMessage(
+                                                MESSAGES.disabledReason,
+                                            )}
+                                            arrow
+                                        >
+                                            <InfoIcon
+                                                color="primary"
+                                                sx={{
+                                                    cursor: 'pointer',
+                                                }}
+                                            />
+                                        </Tooltip>
+                                    )}
                                 </TableCell>
                             </TableRow>
                         );

--- a/hat/assets/js/apps/Iaso/domains/instances/components/InstanceDetailsChangeRequests.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/InstanceDetailsChangeRequests.tsx
@@ -46,7 +46,9 @@ const InstanceDetailsChangeRequests: FunctionComponent<Props> = ({
                             <TableRow key={changeRequest.id}>
                                 <TableCell
                                     sx={{
-                                        color: theme.palette[statusColor].main,
+                                        color: disabled
+                                            ? theme.palette.text.disabled
+                                            : theme.palette[statusColor].main,
                                     }}
                                 >
                                     {formatMessage(

--- a/hat/assets/js/apps/Iaso/domains/instances/details.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/details.tsx
@@ -26,6 +26,7 @@ import { ClassNames } from '../../types/utils';
 import { BeneficiaryBaseInfo } from '../entities/components/BeneficiaryBaseInfo';
 import { useGetBeneficiaryFields } from '../entities/hooks/useGetBeneficiaryFields';
 import { useGetInstance } from './compare/hooks/useGetInstance';
+import InstanceDetailsChangeRequests from './components/InstanceDetailsChangeRequests';
 import InstanceDetailsExportRequests from './components/InstanceDetailsExportRequests';
 import InstanceDetailsInfos from './components/InstanceDetailsInfos';
 import InstanceDetailsLocation from './components/InstanceDetailsLocation';
@@ -33,14 +34,13 @@ import InstanceDetailsLocksHistory from './components/InstanceDetailsLocksHistor
 import InstanceFileContent from './components/InstanceFileContent';
 import InstancesFilesList from './components/InstancesFilesListComponent';
 import SpeedDialInstance from './components/SpeedDialInstance';
+import { INSTANCE_METAS_FIELDS } from './constants';
 import {
     ReassignInstancePayload,
     useReassignInstance,
 } from './hooks/useReassignInstance';
 import MESSAGES from './messages';
 import { getInstancesFilesList } from './utils';
-import { INSTANCE_METAS_FIELDS } from './constants';
-import InstanceDetailsChangeRequests from './components/InstanceDetailsChangeRequests';
 
 const useStyles = makeStyles(theme => ({
     ...commonStyles(theme),
@@ -232,6 +232,7 @@ const InstanceDetails: FunctionComponent = () => {
                                 >
                                     <InstanceDetailsChangeRequests
                                         currentInstance={currentInstance}
+                                        disabled={currentInstance.deleted}
                                     />
                                 </WidgetPaper>
                             )}

--- a/hat/assets/js/apps/Iaso/domains/instances/messages.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/messages.js
@@ -651,6 +651,11 @@ const MESSAGES = defineMessages({
         defaultMessage: 'Approved',
         id: 'iaso.label.approved',
     },
+    disabledReason: {
+        defaultMessage:
+            'Change request is not available as submission is deleted',
+        id: 'iaso.instances.disabledReason',
+    },
 });
 
 export default MESSAGES;


### PR DESCRIPTION
Change proposal cannot be found after the associated submission was deleted. Maybe the change request status and shortcut should be removed or greyed after soft deletion of the submission?

Related JIRA tickets : IA-3753

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

Display a info icon if instance is deleted

## How to test

You need an instance linked to a change request both should also be linked to the same org unit
Soft delete the instance, link to change request should not be available

## Print screen / video
<img width="571" alt="Screenshot 2024-12-06 at 13 55 58" src="https://github.com/user-attachments/assets/55d87dbf-bf51-48e5-b223-2fa8f1087a66">


## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
