### PR TITLE
IA-3749: Account switcher broke the account creation page

### DIFF
--- a/hat/assets/js/apps/Iaso/components/nav/AccountSwitch.tsx
+++ b/hat/assets/js/apps/Iaso/components/nav/AccountSwitch.tsx
@@ -61,8 +61,7 @@ export const AccountSwitch: FunctionComponent<Props> = ({
         prevOpen.current = open;
     }, [open]);
     const menuListKeyDownHandler = React.useCallback(handleListKeyDown, []);
-
-    if (currentUser.other_accounts.length === 0) {
+    if (currentUser.other_accounts?.length === 0) {
         return (
             <Typography
                 variant="body2"

--- a/hat/assets/js/apps/Iaso/components/nav/CurrentUser/index.tsx
+++ b/hat/assets/js/apps/Iaso/components/nav/CurrentUser/index.tsx
@@ -69,8 +69,12 @@ export const CurrentUserInfos: FunctionComponent<Props> = ({
             >
                 {currentUser?.user_name}
             </Box>
-            <Box sx={{ mx: 1 }}>-</Box>
-            <AccountSwitch />
+            {currentUser.account && (
+                <>
+                    <Box sx={{ mx: 1 }}>-</Box>
+                    <AccountSwitch />
+                </>
+            )}
             <Popover
                 id="mouse-over-popover"
                 className={classes.popover}

--- a/hat/assets/js/apps/Iaso/domains/setup/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/setup/index.tsx
@@ -42,7 +42,9 @@ const useStyles = makeStyles(theme => ({
     confirmMessageIcon: {
         fontSize: 120,
         display: 'block',
-        margin: '0 auto',
+        marginRight: theme.spacing(1),
+        position: 'relative',
+        top: 5,
     },
 }));
 


### PR DESCRIPTION
To reproduce: log in as a user with no profile (you can just create a user in the admin) 

Related JIRA tickets : IA-3749

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)


## Changes

hide account switch if no account, small visual glitch on confirm message

## How to test

Create a user without a Iaso profile, try to connect to Iaso dashboard.

## Print screen / video

![Screenshot 2024-12-06 at 15 08 35](https://github.com/user-attachments/assets/e919687e-808e-44f1-84da-2128ffd2956b)

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
