### PR TITLE
IA-3748: Group sets fixes

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/groupSets/config.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/groupSets/config.tsx
@@ -1,14 +1,14 @@
-import React, { useMemo } from 'react';
-import { Column, IconButton, useSafeIntl } from 'bluesquare-components';
 import { Chip } from '@mui/material';
 import { makeStyles } from '@mui/styles';
+import { Column, IconButton, useSafeIntl } from 'bluesquare-components';
+import React, { useMemo } from 'react';
 import { DateTimeCell } from '../../../components/Cells/DateTimeCell';
-import MESSAGES from './messages';
-import { baseUrls } from '../../../constants/urls';
 import { DisplayIfUserHasPerm } from '../../../components/DisplayIfUserHasPerm';
+import { baseUrls } from '../../../constants/urls';
+import MESSAGES from './messages';
 
-import * as Permission from '../../../utils/permissions';
 import DeleteDialog from '../../../components/dialogs/DeleteDialogComponent';
+import * as Permission from '../../../utils/permissions';
 
 export const baseUrl = baseUrls.groupSets;
 
@@ -51,6 +51,7 @@ export const useGroupSetsTableColumns = (deleteGroupSet): Column[] => {
                                     className={classes.groupChip}
                                     label={g.name}
                                     color="primary"
+                                    key={g.id}
                                 />
                             ))}
                         </span>

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/groupSets/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/groupSets/index.tsx
@@ -3,13 +3,12 @@ import { makeStyles } from '@mui/styles';
 import {
     AddButton as AddButtonComponent,
     commonStyles,
-    Table,
-    useRedirectTo,
-    useSafeIntl,
+    useSafeIntl
 } from 'bluesquare-components';
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import TopBar from '../../../components/nav/TopBarComponent';
+import { TableWithDeepLink } from '../../../components/tables/TableWithDeepLink';
 import { baseUrls } from '../../../constants/urls';
 import { useParamsObject } from '../../../routing/hooks/useParamsObject';
 import { Filters } from './components/Filters';
@@ -23,7 +22,6 @@ const useStyles = makeStyles(theme => ({
 const baseUrl = baseUrls.groupSets;
 const GroupSets = () => {
     const params = useParamsObject(baseUrl);
-    const redirectTo = useRedirectTo();
     const classes = useStyles();
     const { mutate: deleteGroupSet } = useDeleteGroupSet();
     const tableColumns = useGroupSetsTableColumns(deleteGroupSet);
@@ -33,8 +31,7 @@ const GroupSets = () => {
     const navigate = useNavigate();
     const isLoading = isFetching;
     const createGroupSet = () => {
-        // how to use the paths ?
-        navigate('/orgunits/configuration/groupSet/groupSetId/new');
+        navigate(`/${baseUrls.groupSetDetail}/groupSetId/new`);
     };
     return (
         <>
@@ -56,20 +53,18 @@ const GroupSets = () => {
                 </Box>
 
                 {tableColumns && (
-                    <Table
+                    <TableWithDeepLink
                         data={data?.group_sets ?? []}
                         pages={data?.pages ?? 1}
                         defaultSorted={[{ id: 'name', desc: false }]}
                         columns={tableColumns}
                         count={data?.count ?? 0}
                         baseUrl={baseUrl}
-                        redirectTo={(_, newParams) =>
-                            redirectTo(baseUrl, newParams)
-                        }
                         marginTop={false}
                         extraProps={{
                             loading: isLoading,
                         }}
+                        params={params}
                     />
                 )}
             </Box>


### PR DESCRIPTION
Changing pagination number is reseting filters on group sets page
Related JIRA tickets : IA-3748

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)


## Changes

- fixed key issue in a cell
- use `TablewithDeepLink`
- use baseUrl for navigation to creation


## How to test

Open group sets page and play with filters and pagination

## Print screen / video

https://github.com/user-attachments/assets/00e80b8e-d7b8-4944-9052-c33df24c22b4



## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
