### PR TITLE
POLIO-1745: config cron for stock history

### DIFF
--- a/cron.yaml
+++ b/cron.yaml
@@ -15,3 +15,6 @@ cron:
  - name: "vaccine_authorization_update_expired_entries"
    url: "/tasks/launch_task/plugins.polio.tasks.vaccine_authorizations_mail_alerts.vaccine_authorization_update_expired_entries/polio_cron_task_user/"
    schedule: "0 3 * * *"
+ - name: "vaccine_stock_history_update_for_rounds"
+   url: "/tasks/launch_task/plugins.polio.tasks.archive_vaccine_stock_for_rounds.archive_vaccine_stock_for_rounds/polio_cron_task_user/"
+   schedule: "0 2 * * *"


### PR DESCRIPTION
We need a cron job to keep vaccine stock history up to date

Related JIRA tickets :  POLIO-1745

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc

N/A

## Changes

- Add a cron config in cron.yaml to update round history everyday at 2 a.m.

## How to test

The cron task can be launched by POSTing on `/api/tasks/create/archivevaccinestock`

## Print screen / video

N/A


The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
