### PR TITLE
IA-3287: fix crash on backdropclick

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/instances/components/CreateReAssignDialogComponent.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/CreateReAssignDialogComponent.tsx
@@ -110,6 +110,7 @@ export const CreateReAssignDialogComponent: FunctionComponent<Props> = ({
             maxWidth="xs"
             allowConfirm={allowConfirm}
             closeDialog={closeDialog}
+            onClose={closeDialog}
             onCancel={closeDialog}
         >
             {isPeriodRequired && (


### PR DESCRIPTION
backdrop click when editing org unit in instance detail would crash page

Related JIRA tickets : IA-3287

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc

N/A

## Changes
- Add missing `onClose` prop

## How to test

 Go to and instance detail
open the speed dial
select edit org unit/period
click outside the modal
it should close

## Print screen / video


https://github.com/user-attachments/assets/e5370b38-df73-47c0-94b2-42fa392eedac



## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
