### PR TITLE
IA-3582: UserExperience - Incoherent wording - "Total d'instance" vs "Total de soumission"

### DIFF
--- a/iaso/api/org_units.py
+++ b/iaso/api/org_units.py
@@ -264,9 +264,9 @@ class OrgUnitViewSet(viewsets.ViewSet):
             ]
             counts_by_forms = []
             for frm in forms:
-                columns.append({"title": "Total d'instances " + frm.name, "width": 15})
+                columns.append({"title": "Total de soumissions " + frm.name, "width": 15})
                 counts_by_forms.append("form_" + str(frm.id) + "_instances")
-            columns.append({"title": "Total d'instances", "width": 15})
+            columns.append({"title": "Total de soumissions", "width": 15})
 
             for group in groups:
                 group.org_units__ids = list(group.org_units.values_list("id", flat=True))


### PR DESCRIPTION
What problem is this PR solving? Explain here in one sentence.

Related JIRA tickets : [IA-3582](https://bluesquare.atlassian.net/browse/IA-3582)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)


## Changes

Changed the column name **Total d'instance** to **Total de soumissions** in the exported org units list csv/xlsx file

## How to test

From the org units list, after searching the org units, launch csv or xlsx export. You should see a collumn with name **Total de soumissions** 


## Print screen / video

![image](https://github.com/user-attachments/assets/b06cb822-de70-4ef3-8cd3-e27325b9cc48)



## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.


[IA-3582]: https://bluesquare.atlassian.net/browse/IA-3582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ