### PR TITLE
WC2-523 Add storage logs to bulk update

### DIFF
--- a/iaso/tasks/process_mobile_bulk_upload.py
+++ b/iaso/tasks/process_mobile_bulk_upload.py
@@ -30,11 +30,13 @@ from hat.audit.models import BULK_UPLOAD, BULK_UPLOAD_MERGED_ENTITY, log_modific
 from hat.sync.views import create_instance_file, process_instance_file
 from iaso.api.instances import import_data as import_instances
 from iaso.api.mobile.org_units import import_data as import_org_units
+from iaso.api.storage import import_storage_logs
 from iaso.models import Project, Instance
 from iaso.utils.s3_client import download_file
 
 INSTANCES_JSON = "instances.json"
 ORG_UNITS_JSON = "orgUnits.json"
+STORAGE_LOGS_JSON = "storageLogs.json"
 
 logger = logging.getLogger(__name__)
 
@@ -87,6 +89,11 @@ def process_mobile_bulk_upload(api_import_id, project_id, task=None):
 
                 duplicated_count = duplicate_instance_files(new_instance_files)
                 stats["new_instance_files"] = len(new_instance_files) + duplicated_count
+
+                if STORAGE_LOGS_JSON in zip_ref.namelist():
+                    logger.info("Processing storage logs")
+                    storage_logs_data = read_json_file_from_zip(zip_ref, STORAGE_LOGS_JSON)
+                    import_storage_logs(storage_logs_data, user)
 
     except Exception as e:
         logger.exception("Exception! Rolling back import: " + str(e))

--- a/iaso/tests/fixtures/mobile_bulk_uploads/storage_logs_and_change_requests/5475bfcf-5a3f-4170-9d88-245d89352362/3_2_809f9a76-3f3f-4033-aefb-98f47fb2ccaf_2024-12-03_12-46-06.xml
+++ b/iaso/tests/fixtures/mobile_bulk_uploads/storage_logs_and_change_requests/5475bfcf-5a3f-4170-9d88-245d89352362/3_2_809f9a76-3f3f-4033-aefb-98f47fb2ccaf_2024-12-03_12-46-06.xml
@@ -1,0 +1,15 @@
+<?xml version='1.0'?>
+<data id="test_profile" version="2024052202" xmlns:h="http://www.w3.org/1999/xhtml"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa"
+    xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:orx="http://openrosa.org/xforms"
+    xmlns:odk="http://www.opendatakit.org/xforms">
+    <Form>
+        <last_name>test</last_name>
+        <first_name>teszt</first_name>
+        <gender>m</gender>
+    </Form>
+    <previous_value />
+    <meta>
+        <instanceID>uuid:38e7cfff-4489-46ba-87e5-e436c7e8d815</instanceID>
+    </meta>
+</data>

--- a/iaso/tests/fixtures/mobile_bulk_uploads/storage_logs_and_change_requests/instances.json
+++ b/iaso/tests/fixtures/mobile_bulk_uploads/storage_logs_and_change_requests/instances.json
@@ -1,0 +1,13 @@
+[
+    {
+        "id": "5475bfcf-5a3f-4170-9d88-245d89352362",
+        "created_at": 1.733226371386e9,
+        "updated_at": 1.733226371386e9,
+        "file": "/storage/emulated/0/Android/data/com.bluesquarehub.iaso/files/Documents/iaso/instances/3_2_2024-12-03_12-46-06/3_2_809f9a76-3f3f-4033-aefb-98f47fb2ccaf_2024-12-03_12-46-06.xml",
+        "name": "Test profile",
+        "formId": "1",
+        "orgUnitId": "1",
+        "entityUuid": "5475bfcf-5a3f-4170-9d88-245d89352362",
+        "entityTypeId": "1"
+    }
+]

--- a/iaso/tests/fixtures/mobile_bulk_uploads/storage_logs_and_change_requests/storageLogs.json
+++ b/iaso/tests/fixtures/mobile_bulk_uploads/storage_logs_and_change_requests/storageLogs.json
@@ -1,0 +1,21 @@
+[
+    {
+        "id": "ff023d13-25fa-43c5-9717-5f427b929cb6",
+        "storage_id": "BGJGcuxqgA==",
+        "storage_type": "NFC",
+        "operation_type": "RESET",
+        "instances": [],
+        "org_unit_id": "1",
+        "performed_at": 1.733226445771e9
+    },
+    {
+        "id": "da14ef24-74a1-4f7b-9621-6e33e88773b8",
+        "storage_id": "BGJGcuxqgA==",
+        "storage_type": "NFC",
+        "entity_id": "5475bfcf-5a3f-4170-9d88-245d89352362",
+        "instances": ["5475bfcf-5a3f-4170-9d88-245d89352362"],
+        "org_unit_id": "1",
+        "performed_at": 1729839290.867,
+        "operation_type": "WRITE_PROFILE"
+    }
+]

--- a/iaso/tests/tasks/test_process_mobile_bulk_upload.py
+++ b/iaso/tests/tasks/test_process_mobile_bulk_upload.py
@@ -616,3 +616,59 @@ class ProcessMobileBulkUploadTest(TestCase):
         self.assertEqual(ent1.instances.count() + ent2.instances.count(), 3)
         err_msg = f"Multiple non-deleted entities for UUID {ent1.uuid}, entity_type_id {self.default_entity_type.id}"
         mock_logger.exception.assert_called_once_with(err_msg)
+
+    def test_storage_logs(self, mock_download_file):
+        entity_uuid = "5475bfcf-5a3f-4170-9d88-245d89352362"
+        files_for_zip = [
+            "instances.json",
+            "storageLogs.json",
+            entity_uuid,  # the folder with XML submission
+        ]
+        with zipfile.ZipFile(f"/tmp/{entity_uuid}.zip", "w", zipfile.ZIP_DEFLATED) as zipf:
+            add_to_zip(zipf, zip_fixture_dir("storage_logs_and_change_requests"), files_for_zip)
+
+        mock_download_file.return_value = f"/tmp/{entity_uuid}.zip"
+
+        self.assertEqual(m.Entity.objects.count(), 0)
+        self.assertEqual(m.Instance.objects.count(), 0)
+        self.assertEqual(m.StorageDevice.objects.count(), 0)
+        self.assertEqual(m.StorageLogEntry.objects.count(), 0)
+
+        process_mobile_bulk_upload(
+            api_import_id=self.api_import.id,
+            project_id=self.project.id,
+            task=self.task,
+            _immediate=True,
+        )
+
+        mock_download_file.assert_called_once()
+
+        # check Task status and result
+        self.task.refresh_from_db()
+        self.assertEqual(self.task.status, m.SUCCESS)
+        self.api_import.refresh_from_db()
+        self.assertEqual(self.api_import.import_type, "bulk")
+        self.assertFalse(self.api_import.has_problem)
+
+        # Instances (Submissions) + Entity were created
+        self.assertEqual(m.Entity.objects.count(), 1)
+        entity = m.Entity.objects.get(uuid=entity_uuid)
+        self.assertEqual(m.Instance.objects.count(), 1)
+        instance = m.Instance.objects.get(uuid=entity_uuid)
+
+        # Storage logs
+        self.assertEqual(m.StorageDevice.objects.count(), 1)
+        self.assertEqual(m.StorageLogEntry.objects.count(), 2)
+        storage_device = m.StorageDevice.objects.first()
+        self.assertEqual(storage_device.type, "NFC")
+        self.assertEqual(storage_device.org_unit_id, 1)
+        self.assertEqual(storage_device.entity, entity)
+
+        reset_log = m.StorageLogEntry.objects.get(operation_type="RESET")
+        self.assertEqual(reset_log.org_unit_id, 1)
+        self.assertIsNone(reset_log.entity)
+
+        write_log = m.StorageLogEntry.objects.get(operation_type="WRITE_PROFILE")
+        self.assertEqual(write_log.org_unit_id, 1)
+        self.assertEqual(write_log.entity, entity)
+        self.assertEqual(list(write_log.instances.all()), [instance])


### PR DESCRIPTION
- Move the storage logs view to a function so we can call it from the bulk upload
- Call said function in the bulk upload
- Add a test for all this

Related JIRA tickets : https://bluesquare.atlassian.net/browse/WC2-523

### Why?

Now that we use the bulk upload on WFP, what happens is (in this order):

1. Mobile app uploads all forms in a zip file
2.  Mobile app uploads the storage logs

Since the first step is executed in an async job, the entity is sometimes not yet created when request 2 hits the server.

The solution is to add the storage logs to the bulk upload zip so it's processed as part of the bulk upload.

### How to test?

Difficult... Honestly I'd say if the code looks reasonable, we deploy to QA and test with a new apk that adds the storage logs correctly.