### PR TITLE
WC2-615 Delete instances and entities: Add option to filter on entity_type_id

### DIFF
--- a/plugins/wfp/templates/delete_all_instances_and_entities.html
+++ b/plugins/wfp/templates/delete_all_instances_and_entities.html
@@ -8,12 +8,20 @@
         <form method="post">
             {% csrf_token %}
 
-            <label for="dry_run">Dry Run:</label><br />
-            <input type="checkbox" id="dry_run" name="dry_run" /><br />
-
-            <label for="account">Account:</label><br />
-            <input type="text" id="account" name="account" /><br />
-
+            <label for="dry_run">Dry Run:</label>
+            <input type="checkbox" id="dry_run" name="dry_run" />
+            <br />
+            <br />
+            <label for="account">Account ID:</label>
+            <input type="text" id="account" name="account" />
+            <br />
+            <br />
+            <label for="entity_type_id">
+                [Optional] only delete entities for a specific entity type:
+            </label>
+            <input type="text" id="entity_type_id" name="entity_type_id" />
+            <br />
+            <br />
             <input type="submit" value="DELETE EVERYTHING!" />
         </form>
     </body>

--- a/plugins/wfp/views.py
+++ b/plugins/wfp/views.py
@@ -34,6 +34,7 @@ def delete_beneficiaries_analytics(request):
 def delete_all_instances_and_entities(request):
     dry_run = request.POST.get("dry_run", False)
     account = request.POST.get("account", None)
+    entity_type_id = request.POST.get("entity_type_id", None)
 
     if request.method == "POST":
         out = io.StringIO()
@@ -41,6 +42,7 @@ def delete_all_instances_and_entities(request):
             "delete_all_instances_and_entities",
             dry_run=dry_run == "on",
             account=account,
+            entity_type_id=entity_type_id,
             stdout=out,
         )
         output = out.getvalue()


### PR DESCRIPTION
Context: When we don't have direct DB access, we cannot remove an `EntityType` when there are already entities associated, because the Django admin only allows soft deletion of entities.

Now on WFP we need to remove some incorrect entity types (on QA). There was already a little script, executable via a simple page, to remove all entities and instances on an account. I just updated this to be able to filter on a specific `entity_type_id`.

Related JIRA tickets : https://bluesquare.atlassian.net/browse/WC2-615

### Beautiful page:

![image](https://github.com/user-attachments/assets/97ae2f80-80fb-421a-8a1b-ed9ae6c59870)
