### PR TITLE
IA-3781: Orgunit detail double call to api/groups

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/details.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/details.js
@@ -218,7 +218,7 @@ const OrgUnitDetail = () => {
             } = orgUnitRevision.fields;
 
             const coordinates = location
-                ? wktToGeoJSON(location)?.coordinates ?? []
+                ? (wktToGeoJSON(location)?.coordinates ?? [])
                 : [];
             const [longitude, latitude] = coordinates;
             const aliases = revisionAliases

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/hooks.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/hooks.js
@@ -77,7 +77,9 @@ export const useOrgUnitDetailData = (
             snackErrorMsg: MESSAGES.fetchGroupsError,
             options: {
                 select: data => data.groups,
-                enabled: tab === 'children' || tab === 'infos',
+                enabled:
+                    (tab === 'children' || tab === 'infos') &&
+                    (Boolean(originalOrgUnit) || isNewOrgunit),
                 ...cacheOptions,
             },
         },


### PR DESCRIPTION
While visiting the detail of an org unit a first call is made to fetch all the groups, then a second one filtering on datasource.

 First one is useless and leads to loading issues on playground where we have more than 5000 groups
<img width="1898" alt="Screenshot 2024-12-12 at 12 55 35" src="https://github.com/user-attachments/assets/228e0925-4ba2-435c-b64b-80533818f34f" />



Related JIRA tickets : IA-3781
## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)


## Changes

Disable call to groups if current org unit is still loading

## How to test

Visit the detail on an org unit and check the requests, only one call to groups should be done filtering per datasource id

If a specific config is required explain it here: dataset, account, profile, etc.


## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
