### PR TITLE
IA-3784: API: Use count of org unit types only if necessary

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/details.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/details.js
@@ -218,7 +218,7 @@ const OrgUnitDetail = () => {
             } = orgUnitRevision.fields;
 
             const coordinates = location
-                ? wktToGeoJSON(location)?.coordinates ?? []
+                ? (wktToGeoJSON(location)?.coordinates ?? [])
                 : [];
             const [longitude, latitude] = coordinates;
             const aliases = revisionAliases

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/hooks.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/hooks.js
@@ -77,7 +77,9 @@ export const useOrgUnitDetailData = (
             snackErrorMsg: MESSAGES.fetchGroupsError,
             options: {
                 select: data => data.groups,
-                enabled: tab === 'children' || tab === 'infos',
+                enabled:
+                    (tab === 'children' || tab === 'infos') &&
+                    (Boolean(originalOrgUnit) || isNewOrgunit),
                 ...cacheOptions,
             },
         },

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/orgUnitTypes/hooks/useGetOrgUnitTypes.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/orgUnitTypes/hooks/useGetOrgUnitTypes.ts
@@ -3,12 +3,12 @@ import { getRequest } from '../../../../libs/Api';
 import { useSnackQuery } from '../../../../libs/apiHooks';
 import { makeUrlWithParams } from '../../../../libs/utils';
 import {
-    PaginatedOrgUnitTypes,
     OrgUnitTypesParams,
+    PaginatedOrgUnitTypes,
 } from '../../types/orgunitTypes';
 
 const queryParamsMap = new Map([['projectIds', 'project_ids']]);
-const apiParamsKeys = ['order', 'page', 'limit', 'search'];
+const apiParamsKeys = ['order', 'page', 'limit', 'search', 'with_units_count'];
 
 const getParams = (params: OrgUnitTypesParams) => {
     const { pageSize, ...urlParams } = params;

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/orgUnitTypes/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/orgUnitTypes/index.tsx
@@ -1,25 +1,25 @@
-import React, { FunctionComponent } from 'react';
 import { Box, Grid } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import {
-    commonStyles,
     AddButton,
-    useSafeIntl,
     Column,
+    commonStyles,
+    useSafeIntl,
 } from 'bluesquare-components';
+import React, { FunctionComponent } from 'react';
 
 import TopBar from '../../../components/nav/TopBarComponent';
-import { OrgUnitsTypesDialog } from './components/OrgUnitsTypesDialog';
 import { TableWithDeepLink } from '../../../components/tables/TableWithDeepLink';
+import { OrgUnitsTypesDialog } from './components/OrgUnitsTypesDialog';
 
 import { baseUrls } from '../../../constants/urls';
 import { OrgUnitTypesParams } from '../types/orgunitTypes';
 import MESSAGES from './messages';
 
-import { useGetColumns } from './config/tableColumns';
-import { useGetOrgUnitTypes } from './hooks/useGetOrgUnitTypes';
 import { useParamsObject } from '../../../routing/hooks/useParamsObject';
 import { Filters } from './components/Filters';
+import { useGetColumns } from './config/tableColumns';
+import { useGetOrgUnitTypes } from './hooks/useGetOrgUnitTypes';
 
 const baseUrl = baseUrls.orgUnitTypes;
 
@@ -32,7 +32,10 @@ const OrgUnitTypes: FunctionComponent = () => {
     const classes: Record<string, string> = useStyles();
     const { formatMessage } = useSafeIntl();
     const columns: Column[] = useGetColumns();
-    const { data, isFetching } = useGetOrgUnitTypes(params);
+    const { data, isFetching } = useGetOrgUnitTypes({
+        ...params,
+        with_units_count: true,
+    });
     return (
         <>
             <TopBar

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/orgUnitTypes/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/orgUnitTypes/index.tsx
@@ -28,7 +28,7 @@ const useStyles = makeStyles(theme => ({
 }));
 
 const OrgUnitTypes: FunctionComponent = () => {
-    const params = useParamsObject(baseUrl) as OrgUnitTypesParams;
+    const params = useParamsObject(baseUrl) as unknown as OrgUnitTypesParams;
     const classes: Record<string, string> = useStyles();
     const { formatMessage } = useSafeIntl();
     const columns: Column[] = useGetColumns();

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/types/orgunitTypes.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/types/orgunitTypes.ts
@@ -50,4 +50,5 @@ export interface PaginatedOrgUnitTypes extends Pagination {
 export type OrgUnitTypesParams = UrlParams & {
     accountId?: string;
     search?: string;
+    with_units_count?: boolean;
 };

--- a/iaso/api/org_unit_types/serializers.py
+++ b/iaso/api/org_unit_types/serializers.py
@@ -3,8 +3,9 @@ import typing
 from django.db.models import Q
 from rest_framework import serializers
 
-from iaso.models import Form, OrgUnitType, OrgUnit, Project
-from ..common import TimestampField, DynamicFieldsModelSerializer
+from iaso.models import Form, OrgUnit, OrgUnitType, Project
+
+from ..common import DynamicFieldsModelSerializer, TimestampField
 from ..forms import FormSerializer
 from ..projects.serializers import ProjectSerializer
 
@@ -79,6 +80,10 @@ class OrgUnitTypeSerializerV1(DynamicFieldsModelSerializer):
 
     # Fixme make this directly in db !
     def get_units_count(self, obj: OrgUnitType):
+        # Skip computation if the parameter is not present
+        if not self.context["request"].query_params.get("with_units_count"):
+            return None
+
         orgUnits = OrgUnit.objects.filter_for_user_and_app_id(
             self.context["request"].user, self.context["request"].query_params.get("app_id")
         ).filter(Q(validated=True) & Q(org_unit_type__id=obj.id))
@@ -120,6 +125,12 @@ class OrgUnitTypeSerializerV1(DynamicFieldsModelSerializer):
             if self.context["request"].user.iaso_profile.account != project.account:
                 raise serializers.ValidationError({"project_ids": "Invalid project ids"})
         return data
+
+    def to_representation(self, instance):
+        # Remove units_count from fields if not requested
+        if not self.context["request"].query_params.get("with_units_count"):
+            self.fields.pop("units_count", None)
+        return super().to_representation(instance)
 
 
 class OrgUnitTypeSerializerV2(DynamicFieldsModelSerializer):
@@ -179,6 +190,10 @@ class OrgUnitTypeSerializerV2(DynamicFieldsModelSerializer):
 
     # Fixme make this directly in db !
     def get_units_count(self, obj: OrgUnitType):
+        # Skip computation if the parameter is not present
+        if not self.context["request"].query_params.get("with_units_count"):
+            return None
+
         orgUnits = OrgUnit.objects.filter_for_user_and_app_id(
             self.context["request"].user, self.context["request"].query_params.get("app_id")
         ).filter(Q(validation_status=OrgUnit.VALIDATION_VALID) & Q(org_unit_type__id=obj.id))
@@ -243,6 +258,12 @@ class OrgUnitTypeSerializerV2(DynamicFieldsModelSerializer):
                 raise serializers.ValidationError({"project_ids": "Invalid project ids"})
         validate_reference_forms(data)
         return data
+
+    def to_representation(self, instance):
+        # Remove units_count from fields if not requested
+        if not self.context["request"].query_params.get("with_units_count"):
+            self.fields.pop("units_count", None)
+        return super().to_representation(instance)
 
 
 class OrgUnitTypesDropdownSerializer(serializers.ModelSerializer):

--- a/iaso/tests/api/test_org_unit_types_v2.py
+++ b/iaso/tests/api/test_org_unit_types_v2.py
@@ -134,7 +134,7 @@ class OrgUnitTypesAPITestCase(APITestCase):
         self.data_source_1.projects.set([self.ead, self.esd])
 
         self.client.force_authenticate(self.jane)
-        response = self.client.get("/api/v2/orgunittypes/?order=id")
+        response = self.client.get("/api/v2/orgunittypes/?order=id&with_units_count=true")
         self.assertJSONResponse(response, 200)
 
         response_data = response.json()["orgUnitTypes"]
@@ -153,6 +153,27 @@ class OrgUnitTypesAPITestCase(APITestCase):
 
         for other_types in response_data[2:]:
             self.assertEqual(other_types["units_count"], 0)
+
+    def test_org_unit_types_list_without_units_count(self):
+        """GET /orgunittypes/ without with_units_count should not include units_count in response"""
+
+        # Create some org units to ensure there would be counts if requested
+        m.OrgUnit.objects.create(
+            name="OU 1 ok",
+            org_unit_type=self.org_unit_type_1,
+            validation_status=m.OrgUnit.VALIDATION_VALID,
+            version=self.version_1,
+        )
+
+        self.client.force_authenticate(self.jane)
+        response = self.client.get("/api/v2/orgunittypes/?order=id")
+        self.assertJSONResponse(response, 200)
+
+        response_data = response.json()["orgUnitTypes"]
+
+        # Verify units_count is not present in any of the returned org unit types
+        for org_unit_type in response_data:
+            self.assertNotIn("units_count", org_unit_type)
 
     def test_org_unit_types_retrieve_without_auth_or_app_id(self):
         """GET /orgunittypes/<org_unit_type_id>/ without auth or app id should result in a 200 empty response"""


### PR DESCRIPTION
We are only using unit_counts on org unit types page. We can remove it from other calls. This should improve a lot pages loading
Related JIRA tickets : IA-3784

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

- adapt serializer to compute and show unit counts only while requested
- adapt front to ask for unit counts on ou type list page

## How to test

-  visit org unit types page and make sure you still have the count of org units
- visit api/v2/orgunittypes/ and make sure you don't have `units_count`


## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
