### PR TITLE
POLIO-1785, POLIO-1786: change vaccine repo table defaults

### DIFF
--- a/plugins/polio/api/vaccines/repository_forms.py
+++ b/plugins/polio/api/vaccines/repository_forms.py
@@ -159,8 +159,9 @@ class VaccineRepositoryFormsViewSet(GenericViewSet, ListModelMixin):
         "started_at",
         "vaccine_name",
         "number",
+        "campaign_started_at",
     ]
-    ordering = ["-started_at"]
+    ordering = ["-campaign_started_at"]
     search_fields = ["campaign__country__name", "campaign__obr_name"]
     permission_classes = [permissions.IsAuthenticatedOrReadOnly]
     default_page_size = 20

--- a/plugins/polio/api/vaccines/repository_forms.py
+++ b/plugins/polio/api/vaccines/repository_forms.py
@@ -164,7 +164,7 @@ class VaccineRepositoryFormsViewSet(GenericViewSet, ListModelMixin):
     ordering = ["-campaign_started_at"]
     search_fields = ["campaign__country__name", "campaign__obr_name"]
     permission_classes = [permissions.IsAuthenticatedOrReadOnly]
-    default_page_size = 20
+    default_page_size = 50
 
     file_type_param = openapi.Parameter(
         "file_type",

--- a/plugins/polio/js/src/domains/VaccineModule/Repository/forms/hooks/useGetVaccineReporting.ts
+++ b/plugins/polio/js/src/domains/VaccineModule/Repository/forms/hooks/useGetVaccineReporting.ts
@@ -15,8 +15,8 @@ const getVaccineReporting = params => {
     return getRequest(`/api/polio/vaccine/repository/?${queryString}`);
 };
 export const tableDefaults = {
-    order: 'started_at',
-    limit: 10,
+    order: '-campaign_started_at',
+    limit: 50,
     page: 1,
 };
 


### PR DESCRIPTION


What problem is this PR solving? Explain here in one sentence.

Related JIRA tickets :  POLIO-1785, POLIO-1786

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

- POLIO-1785: defauklt order = campaign start date desc
- POLIO-1786: default limit = 50

## How to test

Go to vaccine repo list:

- check bottom of table: results per page should be 50
- check ordering: most recent campaign should be first (but rounds asc withing campaign)

## Print screen / video

![Screenshot 2024-12-13 at 15 40 35](https://github.com/user-attachments/assets/6ceefc3c-e9d2-4d49-9be9-11b47b591de8)


![Screenshot 2024-12-13 at 15 40 49](https://github.com/user-attachments/assets/a00ce3e7-72f1-44f1-8ed1-ced837759a1e)


## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
