### PR TITLE
IA-3790: Only 1 editable OUT on OU creation page while 2 were configured

### DIFF
--- a/iaso/api/profiles/profiles.py
+++ b/iaso/api/profiles/profiles.py
@@ -1,5 +1,5 @@
 import copy
-from typing import Any, List, Optional, Union, Set
+from typing import Any, List, Optional, Set, Union
 
 from django.conf import settings
 from django.contrib.auth import login, models, update_session_auth_hash
@@ -28,7 +28,8 @@ from hat.menupermissions.models import CustomPermissionSupport
 from iaso.api.common import CONTENT_TYPE_CSV, CONTENT_TYPE_XLSX, FileFormatEnum
 from iaso.api.profiles.audit import ProfileAuditLogger
 from iaso.api.profiles.bulk_create_users import BULK_CREATE_USER_COLUMNS_LIST
-from iaso.models import OrgUnit, OrgUnitType, Profile, Project, TenantUser, UserRole
+from iaso.models import (OrgUnit, OrgUnitType, Profile, Project, TenantUser,
+                         UserRole)
 from iaso.utils import is_mobile_request
 from iaso.utils.module_permissions import account_module_permissions
 
@@ -232,9 +233,9 @@ class ProfilesViewSet(viewsets.ViewSet):
                 account_user = request.user.tenant_users.first().account_user
                 account_user.backend = "django.contrib.auth.backends.ModelBackend"
                 login(request, account_user)
-
+            queryset = self.get_queryset()
             try:
-                profile = request.user.iaso_profile
+                profile = queryset.get(user=request.user)
                 profile_dict = profile.as_dict()
                 return Response(profile_dict)
             except Profile.DoesNotExist:

--- a/iaso/api/profiles/profiles.py
+++ b/iaso/api/profiles/profiles.py
@@ -28,8 +28,7 @@ from hat.menupermissions.models import CustomPermissionSupport
 from iaso.api.common import CONTENT_TYPE_CSV, CONTENT_TYPE_XLSX, FileFormatEnum
 from iaso.api.profiles.audit import ProfileAuditLogger
 from iaso.api.profiles.bulk_create_users import BULK_CREATE_USER_COLUMNS_LIST
-from iaso.models import (OrgUnit, OrgUnitType, Profile, Project, TenantUser,
-                         UserRole)
+from iaso.models import OrgUnit, OrgUnitType, Profile, Project, TenantUser, UserRole
 from iaso.utils import is_mobile_request
 from iaso.utils.module_permissions import account_module_permissions
 


### PR DESCRIPTION
While configuring available org unit types (ate least 2) in a user role. Assigning this role to a user.
This user should be able to select org unit types selected in user roles when creating a org unit, only one is visible

Related JIRA tickets : IA-3790

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)


## Changes

- apply queryset to `/me` endpoint

## How to test


## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
