### PR TITLE
IA-3786: Editable OU can't be defined when user role includes OU write permission

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/userRoles/types/userRoles.ts
+++ b/hat/assets/js/apps/Iaso/domains/userRoles/types/userRoles.ts
@@ -6,6 +6,7 @@ export type UserRole = {
     created_at: string;
     updated_at?: string;
     editable_org_unit_type_ids?: number[];
+    permissions?: string[];
 };
 export type UserRolesFilterParams = {
     name?: string;

--- a/hat/assets/js/apps/Iaso/domains/users/components/UsersDialog.tsx
+++ b/hat/assets/js/apps/Iaso/domains/users/components/UsersDialog.tsx
@@ -75,9 +75,7 @@ const UserDialogComponent: FunctionComponent<Props> = ({
     const [tab, setTab] = useState('infos');
     const [openWarning, setOpenWarning] = useState<boolean>(false);
     const [hasNoOrgUnitManagementWrite, setHasNoOrgUnitManagementWrite] =
-        useState<boolean>(
-            !user.permissions.value.includes(Permissions.ORG_UNITS),
-        );
+        useState<boolean>(false);
     const saveUser = useCallback(() => {
         const currentUser: any = {};
         Object.keys(user).forEach(key => {
@@ -158,20 +156,25 @@ const UserDialogComponent: FunctionComponent<Props> = ({
         return '';
     }, [formatMessage, isPhoneNumberUpdated, isUserWithoutPermissions]);
 
+    const allUserRolesPermissions = useMemo(
+        () =>
+            user.user_roles_permissions.value.flatMap(role => role.permissions),
+        [user.user_roles_permissions.value],
+    );
+
     const allUserUserRolesPermissions = useMemo(() => {
         const allUserPermissions = user.user_permissions.value;
-        const allUserRolesPermissions =
-            user.user_roles_permissions.value.flatMap(role => role.permissions);
+
         return [
             ...new Set([...allUserPermissions, ...allUserRolesPermissions]),
         ];
-    }, [user.user_permissions.value, user.user_roles_permissions.value]);
+    }, [allUserRolesPermissions, user.user_permissions.value]);
 
     useEffect(() => {
         setHasNoOrgUnitManagementWrite(
             !allUserUserRolesPermissions.includes(Permissions.ORG_UNITS),
         );
-    }, [allUserUserRolesPermissions]);
+    }, [allUserRolesPermissions.length, allUserUserRolesPermissions]);
     return (
         <>
             <WarningModal
@@ -270,11 +273,6 @@ const UserDialogComponent: FunctionComponent<Props> = ({
                             currentUser={user}
                             handleChange={permissions => {
                                 setFieldValue('user_permissions', permissions);
-                                setHasNoOrgUnitManagementWrite(
-                                    !permissions.includes(
-                                        Permissions.ORG_UNITS,
-                                    ),
-                                );
                             }}
                             setFieldValue={(key, value) =>
                                 setFieldValue(key, value)

--- a/hat/assets/js/apps/Iaso/domains/users/components/UsersDialog.tsx
+++ b/hat/assets/js/apps/Iaso/domains/users/components/UsersDialog.tsx
@@ -10,6 +10,7 @@ import {
 import React, {
     FunctionComponent,
     useCallback,
+    useEffect,
     useMemo,
     useState,
 } from 'react';
@@ -156,6 +157,21 @@ const UserDialogComponent: FunctionComponent<Props> = ({
         }
         return '';
     }, [formatMessage, isPhoneNumberUpdated, isUserWithoutPermissions]);
+
+    const allUserUserRolesPermissions = useMemo(() => {
+        const allUserPermissions = user.user_permissions.value;
+        const allUserRolesPermissions =
+            user.user_roles_permissions.value.flatMap(role => role.permissions);
+        return [
+            ...new Set([...allUserPermissions, ...allUserRolesPermissions]),
+        ];
+    }, [user.user_permissions.value, user.user_roles_permissions.value]);
+
+    useEffect(() => {
+        setHasNoOrgUnitManagementWrite(
+            !allUserUserRolesPermissions.includes(Permissions.ORG_UNITS),
+        );
+    }, [allUserUserRolesPermissions]);
     return (
         <>
             <WarningModal


### PR DESCRIPTION
What problem is this PR solving? Explain here in one sentence.
- Editable OU can't be defined when user role includes OU write permission
Related JIRA tickets : [IA-3786](https://bluesquare.atlassian.net/browse/IA-3786)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

Explain the changes that were made.
- Before the check of the OrgUnit write permission whas only on user permissions, for now I check on both user and userrole permissions

## How to test
- Create or edit a user 
- Remove from the user permissions the Organisation units management permission
- Add to the user a userRole which has the Organisation units management permission
- Check it you can edit the org unit write types

## Print screen / video
[Screencast from 2024-12-16 15-12-06.webm](https://github.com/user-attachments/assets/e293dff4-3095-4a9c-9a72-5cc5cef72664)

## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.


[IA-3786]: https://bluesquare.atlassian.net/browse/IA-3786?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ