### PR TITLE
IA-2674: [MOBILE-API]: filter entity types on reference form projects

### DIFF
--- a/iaso/api/mobile/entity.py
+++ b/iaso/api/mobile/entity.py
@@ -1,22 +1,14 @@
 from django_filters.rest_framework import DjangoFilterBackend  # type: ignore
-from rest_framework import filters, serializers
+from rest_framework import filters, permissions, serializers
+from rest_framework.exceptions import AuthenticationFailed, NotFound, ParseError
 from rest_framework.pagination import PageNumberPagination
-from rest_framework import permissions
-from rest_framework.exceptions import ParseError, AuthenticationFailed, NotFound
-from iaso.api.common import Paginator
 
-
-from iaso.api.common import DeletionFilterBackend, ModelViewSet, TimestampField, HasPermission
+from hat.menupermissions import models as permission
+from iaso.api.common import DeletionFilterBackend, HasPermission, ModelViewSet, Paginator, TimestampField
 from iaso.api.query_params import LIMIT, PAGE
 from iaso.api.serializers import AppIdSerializer
-from iaso.models import Entity, FormVersion, Instance
-from iaso.models.entity import (
-    InvalidJsonContentError,
-    InvalidLimitDateError,
-    UserNotAuthError,
-    ProjectNotFoundError,
-)
-from hat.menupermissions import models as permission
+from iaso.models import Entity, EntityType, FormVersion, Instance, Project
+from iaso.models.entity import InvalidJsonContentError, InvalidLimitDateError, ProjectNotFoundError, UserNotAuthError
 
 
 def filter_for_mobile_entity(queryset, request):
@@ -184,8 +176,13 @@ class MobileEntityViewSet(ModelViewSet):
         user = self.request.user
         app_id = AppIdSerializer(data=self.request.query_params).get_app_id(raise_exception=True)
 
-        queryset = filter_on_user_and_app_id(Entity.objects, user, app_id)
+        project = Project.objects.get_for_user_and_app_id(user, app_id)
 
+        entity_types = EntityType.objects.filter(reference_form__projects=project).only("id")
+
+        queryset = Entity.objects.filter(entity_type__in=entity_types)
+
+        queryset = filter_on_user_and_app_id(queryset, user, app_id)
         queryset = filter_for_mobile_entity(queryset, self.request)
 
         queryset = queryset.select_related("entity_type").prefetch_related(

--- a/iaso/api/mobile/entity_type.py
+++ b/iaso/api/mobile/entity_type.py
@@ -109,7 +109,8 @@ class MobileEntityTypesViewSet(ModelViewSet):
             if project.account is None:
                 raise NotFound(f"Project Account is None for app_id {app_id}")
 
-            queryset = queryset.filter(account=project.account)
+            # queryset = queryset.filter(account=project.account)
+            queryset = queryset.filter(reference_form__projects=project)
 
         except Project.DoesNotExist:
             raise NotFound(f"Project Not Found for app_id {app_id} and User")

--- a/iaso/tests/api/test_entities.py
+++ b/iaso/tests/api/test_entities.py
@@ -1,10 +1,10 @@
 import datetime
 import json
-import pytz
 import time
 import uuid
 from unittest import mock
 
+import pytz
 from django.contrib.auth.models import AnonymousUser
 from django.core.files import File
 
@@ -68,6 +68,8 @@ class EntityAPITestCase(APITestCase):
         cls.create_form_instance(
             form=cls.form_1, period="202003", org_unit=cls.jedi_council_corruscant, project=cls.project, uuid=uuid.uuid4
         )
+
+        cls.form_1.projects.add(cls.project)
 
         cls.entity_type = EntityType.objects.create(
             name="Type 1",


### PR DESCRIPTION
`api/mobile/entitytype/?app_id=YOUR_APP_ID` is currently returning also types linked to form from other projects.
`api/mobile/entities/?app_id=YOUR_APP_ID` should make the same
Related JIRA tickets : IA-2674

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)


## Changes

- adapt `get_queryset` to filter types not linked to `app_id`

## How to test

- You need at least 2 entity types with two differents reference_form. Those forms need to be linked to two different projects.

- play with `api/mobile/entitytype/?app_id=YOUR_APP_ID`  whrer YOUR_APP_ID is the app_id of the project you want
- only one type should be displayed
- repeat the process with entities linked to those types


## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
