### PR TITLE
[IA-3797] Fixed error login without profile

### DIFF
--- a/iaso/api/profiles/profiles.py
+++ b/iaso/api/profiles/profiles.py
@@ -232,8 +232,8 @@ class ProfilesViewSet(viewsets.ViewSet):
                 account_user = request.user.tenant_users.first().account_user
                 account_user.backend = "django.contrib.auth.backends.ModelBackend"
                 login(request, account_user)
-            queryset = self.get_queryset()
             try:
+                queryset = self.get_queryset()
                 profile = queryset.get(user=request.user)
                 profile_dict = profile.as_dict()
                 return Response(profile_dict)


### PR DESCRIPTION
Fixed error when logging in as a user that doesn't have any `iaso_profile`.

Related JIRA tickets : IA-3797

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc

/

## Changes

/


## How to test
- Create a new user through the Django admin panel (don't create any profile)
- Try to login as this new user
- Notice that there is no 500 error

## Print screen / video
![image](https://github.com/user-attachments/assets/b8ec5b41-4270-4524-a23f-0517a99f156e)


## Notes
/

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
