### PR TITLE
WC2-631: Investigate why ETL is failing on prod

### DIFF
--- a/plugins/wfp/management/commands/nigeria/Under5.py
+++ b/plugins/wfp/management/commands/nigeria/Under5.py
@@ -110,13 +110,11 @@ class NG_Under5:
         )
 
     def run(self):
-        children_type = ["ng_-_tsfp_child_3", "ng_-_otp_child_3"]
-        entity_type = ETL(children_type)
-        type = EntityType.objects.get(code="ng_-_tsfp_child_3")
+        entity_type = ETL(["child_under_5_3"])
         account = entity_type.account_related_to_entity_type()
         beneficiaries = entity_type.retrieve_entities()
 
-        logger.info(f"Instances linked to Child Under 5 program: {beneficiaries.count()} for {type.name} on {account}")
+        logger.info(f"Instances linked to Child Under 5 program: {beneficiaries.count()} for {account}")
         entities = sorted(list(beneficiaries), key=itemgetter("entity_id"))
         existing_beneficiaries = ETL().existing_beneficiaries()
         instances = self.group_visit_by_entity(entities)

--- a/plugins/wfp/management/commands/south_sudan/Pbwg.py
+++ b/plugins/wfp/management/commands/south_sudan/Pbwg.py
@@ -13,7 +13,7 @@ class PBWG:
         entity_type = ETL(["pbwg_1"])
         account = entity_type.account_related_to_entity_type()
         beneficiaries = entity_type.retrieve_entities()
-        logger.info(f"Instances linked to PBWG program: {beneficiaries.count()}")
+        logger.info(f"Instances linked to PBWG program: {beneficiaries.count()} for {account}")
         entities = sorted(list(beneficiaries), key=itemgetter("entity_id"))
         existing_beneficiaries = ETL().existing_beneficiaries()
         instances = self.group_visit_by_entity(entities)

--- a/plugins/wfp/management/commands/south_sudan/Under5.py
+++ b/plugins/wfp/management/commands/south_sudan/Under5.py
@@ -140,7 +140,7 @@ class Under5:
         entity_type = ETL(["child_under_5_1"])
         account = entity_type.account_related_to_entity_type()
         beneficiaries = entity_type.retrieve_entities()
-        logger.info(f"Instances linked to Child Under 5 program: {beneficiaries.count()}")
+        logger.info(f"Instances linked to Child Under 5 program: {beneficiaries.count()} for {account}")
         entities = sorted(list(beneficiaries), key=itemgetter("entity_id"))
         existing_beneficiaries = ETL().existing_beneficiaries()
         instances = self.group_visit_by_entity(entities)

--- a/plugins/wfp/tasks.py
+++ b/plugins/wfp/tasks.py
@@ -37,6 +37,7 @@ def etl_ssd():
     ETL().journey_with_visit_and_steps_per_visit(child_account, "U5")
 
     pbwg_account = ETL(["pbwg_1"]).account_related_to_entity_type()
+    Beneficiary.objects.all().filter(account=pbwg_account).delete()
     PBWG().run()
     logger.info(
         f"----------------------------- Aggregating PBWG journey for {pbwg_account} per org unit, admission and period(month and year) -----------------------------"

--- a/plugins/wfp/tasks.py
+++ b/plugins/wfp/tasks.py
@@ -14,7 +14,8 @@ logger = logging.getLogger(__name__)
 def etl_ng():
     """Extract beneficiary data from Iaso tables and store them in the format expected by existing tableau dashboards"""
     logger.info("Starting ETL for Nigeria")
-    account = ETL(["ng_-_tsfp_child_3", "ng_-_otp_child_3"]).account_related_to_entity_type()
+    account = ETL(["child_under_5_3"]).account_related_to_entity_type()
+    Beneficiary.objects.all().filter(account=account).delete()
     NG_Under5().run()
 
     logger.info(
@@ -27,6 +28,7 @@ def etl_ng():
 def etl_ssd():
     logger.info("Starting ETL for South Sudan")
     child_account = ETL(["child_under_5_1"]).account_related_to_entity_type()
+    Beneficiary.objects.all().filter(account=child_account).delete()
     Under5().run()
 
     logger.info(


### PR DESCRIPTION
What problem is this PR solving? Explain here in one sentence.

Related JIRA tickets : [WC2-631](https://bluesquare.atlassian.net/browse/WC2-631)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)


## Changes

- Deleting existing analytics data before generate freshed one. 
- Adapting nigeria script to merged (TSFP/OTP) in one entity type Children under 5


## How to test

From the local instance with wfp coda database, run ETL script to generate data for:
-  South Sudan: `docker compose run iaso manage etl_ssd `
- Nigeria: `docker compose run iaso manage etl_ng`

## Print screen / video

[Uploading Administration-de-Iaso-Iaso.webm…]()


## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.


[WC2-631]: https://bluesquare.atlassian.net/browse/WC2-631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ