### PR TITLE
IA-3804: Fix setuper using units_count

### DIFF
--- a/iaso/api/org_unit_types/serializers.py
+++ b/iaso/api/org_unit_types/serializers.py
@@ -81,7 +81,9 @@ class OrgUnitTypeSerializerV1(DynamicFieldsModelSerializer):
     # Fixme make this directly in db !
     def get_units_count(self, obj: OrgUnitType):
         # Show count if it's a detail view OR if with_units_count parameter is present
-        if self.context.get('view_action') == 'retrieve' or self.context["request"].query_params.get("with_units_count"):
+        if self.context.get("view_action") == "retrieve" or self.context["request"].query_params.get(
+            "with_units_count"
+        ):
             orgUnits = OrgUnit.objects.filter_for_user_and_app_id(
                 self.context["request"].user, self.context["request"].query_params.get("app_id")
             ).filter(Q(validated=True) & Q(org_unit_type__id=obj.id))
@@ -189,7 +191,9 @@ class OrgUnitTypeSerializerV2(DynamicFieldsModelSerializer):
     # Fixme make this directly in db !
     def get_units_count(self, obj: OrgUnitType):
         # Show count if it's a detail view OR if with_units_count parameter is present
-        if self.context.get('view_action') == 'retrieve' or self.context["request"].query_params.get("with_units_count"):
+        if self.context.get("view_action") == "retrieve" or self.context["request"].query_params.get(
+            "with_units_count"
+        ):
             orgUnits = OrgUnit.objects.filter_for_user_and_app_id(
                 self.context["request"].user, self.context["request"].query_params.get("app_id")
             ).filter(Q(validation_status=OrgUnit.VALIDATION_VALID) & Q(org_unit_type__id=obj.id))
@@ -257,7 +261,9 @@ class OrgUnitTypeSerializerV2(DynamicFieldsModelSerializer):
 
     def to_representation(self, instance):
         # Remove units_count from fields if not requested
-        if  not self.context.get('view_action') == 'retrieve' and not self.context["request"].query_params.get("with_units_count"):
+        if not self.context.get("view_action") == "retrieve" and not self.context["request"].query_params.get(
+            "with_units_count"
+        ):
             self.fields.pop("units_count", None)
         return super().to_representation(instance)
 

--- a/iaso/api/org_unit_types/viewsets.py
+++ b/iaso/api/org_unit_types/viewsets.py
@@ -47,7 +47,7 @@ class OrgUnitTypeViewSet(ModelViewSet):
 
     def get_serializer_context(self):
         context = super().get_serializer_context()
-        context['view_action'] = self.action
+        context["view_action"] = self.action
         return context
 
 
@@ -109,5 +109,5 @@ class OrgUnitTypeViewSetV2(ModelViewSet):
 
     def get_serializer_context(self):
         context = super().get_serializer_context()
-        context['view_action'] = self.action
+        context["view_action"] = self.action
         return context

--- a/iaso/api/org_unit_types/viewsets.py
+++ b/iaso/api/org_unit_types/viewsets.py
@@ -45,6 +45,11 @@ class OrgUnitTypeViewSet(ModelViewSet):
 
         return queryset.order_by("depth").distinct().order_by(*orders)
 
+    def get_serializer_context(self):
+        context = super().get_serializer_context()
+        context['view_action'] = self.action
+        return context
+
 
 class OrgUnitTypeViewSetV2(ModelViewSet):
     """Org unit types API
@@ -101,3 +106,8 @@ class OrgUnitTypeViewSetV2(ModelViewSet):
 
         serializer = self.get_serializer(queryset, many=True)
         return Response(serializer.data)
+
+    def get_serializer_context(self):
+        context = super().get_serializer_context()
+        context['view_action'] = self.action
+        return context

--- a/setuper/create_submission_with_picture.py
+++ b/setuper/create_submission_with_picture.py
@@ -10,7 +10,7 @@ import random
 
 
 def define_health_facility_reference_form(iaso_client):
-    org_unit_types = iaso_client.get("/api/v2/orgunittypes/")["orgUnitTypes"]
+    org_unit_types = iaso_client.get("/api/v2/orgunittypes/?with_units_count=true")["orgUnitTypes"]
     health_facility_type = [out for out in org_unit_types if out["name"] == "Health facility/Formation sanitaire - HF"][
         0
     ]

--- a/setuper/data_collection.py
+++ b/setuper/data_collection.py
@@ -12,7 +12,7 @@ import random
 def setup_instances(account_name, iaso_client):
     print("-- Setting up a form")
     project_id = iaso_client.get("/api/projects/")["projects"][0]["id"]
-    org_unit_types = iaso_client.get("/api/v2/orgunittypes/")["orgUnitTypes"]
+    org_unit_types = iaso_client.get("/api/v2/orgunittypes/?with_units_count=true")["orgUnitTypes"]
     org_unit_type_ids = [
         out["id"] for out in org_unit_types if out["name"] != "Health facility/Formation sanitaire - HF"
     ]

--- a/setuper/org_unit_pictures.py
+++ b/setuper/org_unit_pictures.py
@@ -2,7 +2,7 @@ import random
 
 
 def associate_favorite_picture(iaso_client):
-    org_unit_types = iaso_client.get("/api/v2/orgunittypes/")["orgUnitTypes"]
+    org_unit_types = iaso_client.get("/api/v2/orgunittypes/?with_units_count=true")["orgUnitTypes"]
 
     for org_unit_type in org_unit_types:
         orgunits = iaso_client.get(


### PR DESCRIPTION
setuper is broken after removing units_count from org unit types api
Related JIRA tickets : IA-3804

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)


## Changes

- pass params for list calls
- add unit count on org uni types detail calls

## How to test

- make sure setuper can complete
- visit org unit list page and make sure unit counts are displayed



## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
