### PR TITLE
IA-3807: Front hot reload is broken

### DIFF
--- a/hat/webpack.dev.js
+++ b/hat/webpack.dev.js
@@ -183,13 +183,28 @@ module.exports = {
         },
         host: '0.0.0.0',
         port: 3000,
-
+        hot: true,
         devMiddleware: {
             writeToDisk: true,
+        },
+        static: {
+            directory: path.join(__dirname, 'assets'),
+            publicPath: '/',
+        },
+        client: {
+            overlay: true,
+            progress: true,
+        },
+        watchFiles: {
+            paths: ['src/**/*', 'assets/**/*'],
+            options: {
+                usePolling: true,
+            },
         },
     },
 
     plugins: [
+        new webpack.HotModuleReplacementPlugin(),
         new CleanWebpackPlugin(),
         new webpack.NormalModuleReplacementPlugin(
             /^__intl\/messages\/en$/,


### PR DESCRIPTION
Front hot reload is broken

Related JIRA tickets : IA-3807

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)


## Changes

Fix webpack dev config 

## How to test

run` npm run dev`,  ouvre un fichier, faire un log, sauver, voir si la page se rafraichi et affiche le log


## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
