### PR TITLE
POLIO-1805: report type filter not working

### DIFF
--- a/plugins/polio/js/src/domains/VaccineModule/Repository/reports/Filters.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/Repository/reports/Filters.tsx
@@ -30,7 +30,9 @@ export const Filters: FunctionComponent<Props> = ({ params, redirectUrl }) => {
 
     const [filtersUpdated, setFiltersUpdated] = useState(false);
     const [countries, setCountries] = useState(params.reportCountries);
-    const [fileType, setFileType] = useState(params.reportFileType || 'INCIDENT,DESTRUCTION');
+    const [fileType, setFileType] = useState(
+        params.reportFileType || 'INCIDENT,DESTRUCTION',
+    );
     const [vaccineName, setVaccineName] = useState(params.reportVaccineName);
     const [countryBlocks, setCountryBlocks] = useState(
         params.reportCountryBlock,

--- a/plugins/polio/js/src/domains/VaccineModule/Repository/reports/hooks/useVaccineRepositoryReportsColumns.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/Repository/reports/hooks/useVaccineRepositoryReportsColumns.tsx
@@ -3,10 +3,13 @@ import { useMemo } from 'react';
 import { DocumentsCells } from '../../components/DocumentsCell';
 import MESSAGES from '../../messages';
 
-export const useVaccineRepositoryReportsColumns = (): Column[] => {
+export const useVaccineRepositoryReportsColumns = (
+    params: Record<string, any>,
+): Column[] => {
     const { formatMessage } = useSafeIntl();
-    return useMemo(
-        () => [
+    const { reportFileType } = params;
+    return useMemo(() => {
+        const columns: Column[] = [
             {
                 Header: formatMessage(MESSAGES.country),
                 id: 'country__name',
@@ -19,19 +22,24 @@ export const useVaccineRepositoryReportsColumns = (): Column[] => {
                 accessor: 'vaccine',
                 width: 20,
             },
-            {
+        ];
+
+        if (reportFileType !== 'DESTRUCTION') {
+            columns.push({
                 Header: formatMessage(MESSAGES.incidentReports),
                 accessor: 'incident_report_data',
                 Cell: DocumentsCells,
                 sortable: false,
-            },
-            {
+            });
+        }
+        if (reportFileType !== 'INCIDENT') {
+            columns.push({
                 Header: formatMessage(MESSAGES.destructionReports),
                 accessor: 'destruction_report_data',
                 Cell: DocumentsCells,
                 sortable: false,
-            },
-        ],
-        [formatMessage],
-    );
+            });
+        }
+        return columns;
+    }, [reportFileType, formatMessage]);
 };

--- a/plugins/polio/js/src/domains/VaccineModule/Repository/reports/index.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/Repository/reports/index.tsx
@@ -40,7 +40,7 @@ export const Reports: FunctionComponent<Props> = ({ params }) => {
     const redirectUrl = isEmbedded ? embeddedVaccineRepositoryUrl : baseUrl;
 
     const { data, isFetching } = useGetVaccineRepositoryReports(reportParams);
-    const columns = useVaccineRepositoryReportsColumns();
+    const columns = useVaccineRepositoryReportsColumns(reportParams);
     return (
         <>
             <Filters params={params} redirectUrl={redirectUrl} />
@@ -59,6 +59,7 @@ export const Reports: FunctionComponent<Props> = ({ params }) => {
                 extraProps={{
                     loading: isFetching,
                     defaultPageSize: tableDefaults.limit,
+                    columns,
                 }}
             />
         </>


### PR DESCRIPTION
The file type filter is not working as it should on the new ‘Report’ tab for destruction-incident reports. This should function the same for the first ‘Forms’ tab. When a file-type is selected, it’s the only type that appears

Related JIRA tickets POLIO-1805

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

Show/hide columns using url param

## How to test

Go to vaccine repository page and play with file type filters

## Print screen / video

https://github.com/user-attachments/assets/d1761831-0d12-466d-856c-a8f2c2234894




## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
