### PR TITLE
POLIO-1761: fix subactivity map overflow glitch

### DIFF
--- a/plugins/polio/js/src/domains/Campaigns/SubActivities/components/Modal/CreateEditSubActivity.tsx
+++ b/plugins/polio/js/src/domains/Campaigns/SubActivities/components/Modal/CreateEditSubActivity.tsx
@@ -22,6 +22,7 @@ import { CampaignFormValues, Round } from '../../../../../constants/types';
 import { SubActivityScopeField } from '../SubActivityScopeField';
 import { useSubActivityValidation } from '../../hooks/useSubActivityValidation';
 import { SubActivityFormValues } from '../../types';
+import { MuiWidth } from 'bluesquare-components/dist/types/components/Modal/SimpleModal';
 
 type Props = {
     closeDialog: () => void;
@@ -111,76 +112,78 @@ export const CreateEditSubActivity: FunctionComponent<Props> = ({
                 maxWidth="xl"
                 closeOnConfirm={false}
             >
-                <Box minWidth="70vw">
+                <Box>
                     <Box mb={4} mt={2}>
                         <Divider />
                     </Box>
                     {formik.isSubmitting && <LoadingSpinner />}
-                    <Grid container>
-                        <Grid item xs={6}>
-                            <Box mr={2}>
-                                <Field
-                                    component={TextInput}
-                                    name="name"
-                                    label={formatMessage(MESSAGES.name)}
-                                    shrinkLabel={false}
-                                    required
-                                />
-                            </Box>
-                        </Grid>
-                        <Grid item xs={6}>
-                            <Field
-                                component={DateInput}
-                                name="start_date"
-                                label={formatMessage(MESSAGES.startDate)}
-                                required
-                            />
-                        </Grid>
-                        <Grid container item xs={6}>
+                    <Box maxWidth="1500px">
+                        <Grid container>
                             <Grid item xs={6}>
                                 <Box mr={2}>
                                     <Field
-                                        component={SingleSelect}
-                                        name="age_unit"
-                                        options={ageRangeOptions}
-                                        label={formatMessage(MESSAGES.ageUnit)}
+                                        component={TextInput}
+                                        name="name"
+                                        label={formatMessage(MESSAGES.name)}
+                                        shrinkLabel={false}
+                                        required
                                     />
                                 </Box>
                             </Grid>
-                            <Grid item xs={3}>
-                                <Box mr={2}>
-                                    <Field
-                                        component={NumberInput}
-                                        name="age_min"
-                                        label={formatMessage(MESSAGES.ageMin)}
-                                    />
-                                </Box>
+                            <Grid item xs={6}>
+                                <Field
+                                    component={DateInput}
+                                    name="start_date"
+                                    label={formatMessage(MESSAGES.startDate)}
+                                    required
+                                />
                             </Grid>
-                            <Grid item xs={3}>
-                                <Box mr={2}>
-                                    <Field
-                                        component={NumberInput}
-                                        name="age_max"
-                                        label={formatMessage(MESSAGES.ageMax)}
-                                    />
-                                </Box>
+                            <Grid container item xs={6}>
+                                <Grid item xs={6}>
+                                    <Box mr={2}>
+                                        <Field
+                                            component={SingleSelect}
+                                            name="age_unit"
+                                            options={ageRangeOptions}
+                                            label={formatMessage(MESSAGES.ageUnit)}
+                                        />
+                                    </Box>
+                                </Grid>
+                                <Grid item xs={3}>
+                                    <Box mr={2}>
+                                        <Field
+                                            component={NumberInput}
+                                            name="age_min"
+                                            label={formatMessage(MESSAGES.ageMin)}
+                                        />
+                                    </Box>
+                                </Grid>
+                                <Grid item xs={3}>
+                                    <Box mr={2}>
+                                        <Field
+                                            component={NumberInput}
+                                            name="age_max"
+                                            label={formatMessage(MESSAGES.ageMax)}
+                                        />
+                                    </Box>
+                                </Grid>
+                            </Grid>
+                            <Grid item xs={6}>
+                                <Field
+                                    component={DateInput}
+                                    name="end_date"
+                                    label={formatMessage(MESSAGES.endDate)}
+                                    required
+                                />
+                            </Grid>
+                            <Grid item xs={12}>
+                                <SubActivityScopeField
+                                    campaign={campaign}
+                                    round={round}
+                                />
                             </Grid>
                         </Grid>
-                        <Grid item xs={6}>
-                            <Field
-                                component={DateInput}
-                                name="end_date"
-                                label={formatMessage(MESSAGES.endDate)}
-                                required
-                            />
-                        </Grid>
-                        <Grid item xs={12}>
-                            <SubActivityScopeField
-                                campaign={campaign}
-                                round={round}
-                            />
-                        </Grid>
-                    </Grid>
+                    </Box>
                 </Box>
             </ConfirmCancelModal>
         </FormikProvider>

--- a/plugins/polio/js/src/domains/Campaigns/SubActivities/components/Modal/CreateEditSubActivity.tsx
+++ b/plugins/polio/js/src/domains/Campaigns/SubActivities/components/Modal/CreateEditSubActivity.tsx
@@ -117,7 +117,7 @@ export const CreateEditSubActivity: FunctionComponent<Props> = ({
                         <Divider />
                     </Box>
                     {formik.isSubmitting && <LoadingSpinner />}
-                    <Box maxWidth="1500px">
+                    <Box>
                         <Grid container>
                             <Grid item xs={6}>
                                 <Box mr={2}>


### PR DESCRIPTION
What problem is this PR solving? Explain here in one sentence.

Related JIRA tickets : POLIO-1761

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes
 -Apply maxWidth to the `Grid` containing the map

## How to test

Open the create subactivity modal
 either use a big screen or use the browser's dev tools to increase the width. There should be no overflow

## Print screen / video

![Screenshot 2024-12-19 at 17 06 33](https://github.com/user-attachments/assets/73813247-86fc-4c41-8695-e2cb4149dc6d)


## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
