### PR TITLE
IA-3793 validate xlsform allow xls cleanup trailing blanks

### DIFF
--- a/iaso/api/form_versions.py
+++ b/iaso/api/form_versions.py
@@ -106,6 +106,8 @@ class FormVersionSerializer(DynamicFieldsModelSerializer):
             # keep xls_file empty to highlight the input in the UI
             raise serializers.ValidationError({"xls_file": "", "xls_file_validation_errors": validation_errors})
 
+        data["xls_file"].seek(0)
+
         # handle xls to xml conversion
         try:
             previous_form_version = FormVersion.objects.latest_version(form)

--- a/iaso/odk/validator.py
+++ b/iaso/odk/validator.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import re
+import os
 
 
 #
@@ -32,6 +33,12 @@ def parse_sheet(excel_file, sheet_name):
     excel_data = excel_file.parse(sheet_name=sheet_name, keep_default_na=False)
     excel_data = excel_data.reset_index()
     excel_data.rename(columns={"index": "line_number"}, inplace=True)
+
+    cleanable_columns = ["name", "list_name", "list name"]
+    for column_name in cleanable_columns:
+        if column_name in excel_data.columns:
+            excel_data[column_name] = excel_data[column_name].apply(lambda x: x.rstrip() if isinstance(x, str) else x)
+
     rows = excel_data.to_dict(orient="records")
 
     return rows
@@ -62,9 +69,6 @@ def get_list_name_from_select(question):
     if "select_one" in q_type:
         return q_type.split("select_one ")[1]
     if "select one" in q_type:
-        import pdb
-
-        pdb.set_trace()
         return q_type.split("select one ")[1]
     return None
 
@@ -85,7 +89,10 @@ def group_by_lambda(collection, field_name_lambda):
 
 
 def validate_xls_form(xls_file):
-    excel_file = pd.ExcelFile(xls_file, engine="openpyxl")
+    file_extension = os.path.splitext(xls_file.name)[1].lower()
+    engine = "xlrd" if file_extension == ".xls" else "openpyxl"
+
+    excel_file = pd.ExcelFile(xls_file, engine=engine)
 
     question_rows = parse_sheet(excel_file, "survey")
 


### PR DESCRIPTION
from feedbacks from first tests : handle xls and xlsx, remove trailing blanks in name and list_name

Related JIRA tickets : IA-3793

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

from feedbacks from first tests : handle xls and xlsx, remove trailing blanks in name and list_name


## How to test

see https://github.com/BLSQ/iaso/pull/1881

## Print screen / video



## Notes


## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: handle xls and xlsx, remove trailing blanks in name and list_name before validation

Refs: IA-3793
```
