### PR TITLE
IA-1676: prevent fetching of instances table data when on map tab

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/instances/index.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/index.js
@@ -61,7 +61,7 @@ const Instances = () => {
 
     const [formIds, setFormIds] = useState(params.formIds?.split(','));
     const formId = formIds?.length === 1 ? formIds[0] : undefined;
-
+    const showTable = tab === 'list' && tableColumns.length > 0;
     const { possibleFields, isLoading: isLoadingPossibleFields } =
         useGetPossibleFields(formId);
     const fieldsSearchApi = useMemo(() => {
@@ -99,12 +99,15 @@ const Instances = () => {
             select: result => result.instances,
         },
     );
-    const { data, isFetching: fetchingList } = useSnackQuery(
-        ['instances', apiParams],
-        () => fetchInstancesAsDict(getEndpointUrl(apiParams)),
-        snackMessages.fetchInstanceDictError,
-        { keepPreviousData: true, enabled: !isLoadingPossibleFields },
-    );
+    const { data, isFetching: fetchingList } = useSnackQuery({
+        queryKey: ['instances', apiParams, showTable],
+        queryFn: () => fetchInstancesAsDict(getEndpointUrl(apiParams)),
+        snackErrorMsg: snackMessages.fetchInstanceDictError,
+        options: {
+            keepPreviousData: true,
+            enabled: !isLoadingPossibleFields && showTable,
+        },
+    });
     // Move to delete when we port dialog to react-query
     const refetchInstances = () => queryClient.invalidateQueries(['instances']);
 
@@ -222,7 +225,7 @@ const Instances = () => {
                         </Box>
                     </Tooltip>
                 </Box>
-                {tab === 'list' && tableColumns.length > 0 && (
+                {showTable && (
                     <TableWithDeepLink
                         data={data?.instances ?? []}
                         pages={data?.pages}


### PR DESCRIPTION
When switching tabs on instances pages, table data would be fetched when on map tab

Related JIRA tickets : IA-1676
## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

- Disable "list"  query when tab not active


## Notes

This may break cypress

## How to test
Go to instances page, switch between tabs and check the network calls

## Print screen / video


https://github.com/user-attachments/assets/d76b1e7c-d343-411a-9d75-bf9cf985db4b


## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
