### PR TITLE
POLIO-1810: make check on grouped campaigns null safe

### DIFF
--- a/plugins/polio/js/src/domains/Campaigns/CampaignsList/Dashboard.tsx
+++ b/plugins/polio/js/src/domains/Campaigns/CampaignsList/Dashboard.tsx
@@ -44,7 +44,7 @@ export const Dashboard: FunctionComponent = () => {
             campaigns: rawCampaigns.campaigns.map(campaign => ({
                 ...campaign,
                 grouped_campaigns:
-                    campaign.grouped_campaigns.length > 0
+                    (campaign.grouped_campaigns?.length ?? 0) > 0
                         ? campaign.grouped_campaigns
                         : null,
             })),


### PR DESCRIPTION
What problem is this PR solving? Explain here in one sentence.

Related JIRA tickets :  POLIO-1810


## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

make check on grouped campaigns null safe in Dashboard.tsx

## How to test

This is an edge case that I couldn't reproduce "naturally" so:
- mock an API response from the campaigns API where a campaign doesn't have the `grouped_campaigns` key value

## Print screen / video

NA

See Jira ticket for mink to initial sentry error

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
