### PR TITLE
POLIO-1797 paginate dashboard endpoints

### DIFF
--- a/plugins/polio/api/dashboards/rounds.py
+++ b/plugins/polio/api/dashboards/rounds.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers
-from iaso.api.common import ModelViewSet
+from iaso.api.common import EtlModelViewset
 from plugins.polio.api.permission_classes import PolioReadPermission
 from plugins.polio.models import Round
 
@@ -12,7 +12,7 @@ class RoundDashboardSerializer(serializers.ModelSerializer):
         exclude = ["preparedness_spreadsheet_url"]
 
 
-class RoundDashboardViewSet(ModelViewSet):
+class RoundDashboardViewSet(EtlModelViewset):
     http_method_names = ["get"]
     permission_classes = [PolioReadPermission]
     model = Round

--- a/plugins/polio/api/dashboards/spreadsheetimport.py
+++ b/plugins/polio/api/dashboards/spreadsheetimport.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers
-from iaso.api.common import ModelViewSet
+from iaso.api.common import EtlModelViewset
 from plugins.polio.api.permission_classes import PolioReadPermission
 from plugins.polio.models import SpreadSheetImport
 
@@ -10,7 +10,7 @@ class SpreadSheetImportDashboardSerializer(serializers.ModelSerializer):
         fields = "__all__"
 
 
-class SpreadSheetImportViewSet(ModelViewSet):
+class SpreadSheetImportViewSet(EtlModelViewset):
     """
     GET /api/polio/dashboards/preparedness_sheets/
     Returns all Preparedness sheet snapshots

--- a/plugins/polio/api/dashboards/supply_chain.py
+++ b/plugins/polio/api/dashboards/supply_chain.py
@@ -3,7 +3,7 @@ from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_page
 from rest_framework import serializers
 
-from iaso.api.common import ModelViewSet
+from iaso.api.common import EtlModelViewset, ModelViewSet
 from plugins.polio.api.vaccines.stock_management import VaccineStockCalculator
 from plugins.polio.api.vaccines.supply_chain import VaccineSupplyChainReadWritePerm
 from plugins.polio.models import (
@@ -130,7 +130,7 @@ class VaccineRequestFormDashboardSerializer(serializers.ModelSerializer):
         return latest_destruction_report.rrt_destruction_report_reception_date if latest_destruction_report else None
 
 
-class VaccineRequestFormDashboardViewSet(ModelViewSet):
+class VaccineRequestFormDashboardViewSet(EtlModelViewset):
     """
     GET /api/polio/dashboards/vaccine_request_forms/
     Returns all vaccine request forms for the user's account.
@@ -164,7 +164,7 @@ class VaccinePreAlertDashboardSerializer(serializers.ModelSerializer):
         fields = "__all__"
 
 
-class PreAlertDashboardViewSet(ModelViewSet):
+class PreAlertDashboardViewSet(EtlModelViewset):
     """
     GET /api/polio/dashboards/pre_alerts/
     Returns all vaccine pre alerts for the user's account.
@@ -186,7 +186,7 @@ class VaccineArrivalReportDashboardSerializer(serializers.ModelSerializer):
         fields = "__all__"
 
 
-class VaccineArrivalReportDashboardViewSet(ModelViewSet):
+class VaccineArrivalReportDashboardViewSet(EtlModelViewset):
     """
     GET /api/polio/dashboards/arrival_reports/
     Returns all vaccine arrival reports for the user's account.

--- a/plugins/polio/api/dashboards/vaccine_stock_history.py
+++ b/plugins/polio/api/dashboards/vaccine_stock_history.py
@@ -1,6 +1,6 @@
 import django_filters
 from rest_framework import serializers
-from iaso.api.common import ModelViewSet
+from iaso.api.common import EtlModelViewset
 from plugins.polio.api.permission_classes import PolioReadPermission
 from plugins.polio.models.base import VaccineStockHistory
 from django.utils.translation import gettext_lazy as _
@@ -36,7 +36,7 @@ class VaccineStockHistoryFilter(django_filters.rest_framework.FilterSet):
         return queryset.filter(round__id=value)
 
 
-class VaccineStockHistoryDashboardViewSet(ModelViewSet):
+class VaccineStockHistoryDashboardViewSet(EtlModelViewset):
     """
     GET /api/polio/dashboards/vaccine_stock_history/
     Returns all Preparedness sheet snapshots

--- a/plugins/polio/tests/api/dashboards/test_preparednesssheet_dashboard.py
+++ b/plugins/polio/tests/api/dashboards/test_preparednesssheet_dashboard.py
@@ -1,6 +1,4 @@
-from datetime import date
 from iaso.models.base import Account
-from iaso.models.org_unit import OrgUnit, OrgUnitType
 from iaso.test import APITestCase
 from plugins.polio.models import SpreadSheetImport
 from hat.menupermissions import models as permission
@@ -45,3 +43,18 @@ class SupplyChainDashboardsAPITestCase(APITestCase):
         self.client.force_authenticate(self.authorized_user_admin)
         response = self.client.get(self.url)
         self.assertJSONResponse(response, 200)
+
+    def test_default_pagination_is_added(self):
+        self.client.force_authenticate(self.user)
+        response = self.client.get(f"{self.url}/")
+        data = self.assertJSONResponse(response, 200)
+        self.assertEqual(data["page"], 1)
+        self.assertEqual(data["limit"], 20)
+
+    def test_max_page_size_is_enforced(self):
+        default_max_page_size = 1000  # default value from EtlPaginator
+        self.client.force_authenticate(self.user)
+        response = self.client.get(f"{self.url}/?limit=2000&page=1")
+        data = self.assertJSONResponse(response, 200)
+        self.assertEqual(data["page"], 1)
+        self.assertEqual(data["limit"], default_max_page_size)

--- a/plugins/polio/tests/api/dashboards/test_rounds_dashboards.py
+++ b/plugins/polio/tests/api/dashboards/test_rounds_dashboards.py
@@ -1,4 +1,3 @@
-from datetime import date
 from iaso.models.base import Account
 from iaso.models.org_unit import OrgUnit, OrgUnitType
 from iaso.test import APITestCase
@@ -60,3 +59,18 @@ class SupplyChainDashboardsAPITestCase(APITestCase):
         self.assertEqual(len(results), 1)
         round = results[0]
         self.assertEqual(round["id"], self.round.pk)
+
+    def test_default_pagination_is_added(self):
+        self.client.force_authenticate(self.user)
+        response = self.client.get(f"{self.url}")
+        data = self.assertJSONResponse(response, 200)
+        self.assertEqual(data["page"], 1)
+        self.assertEqual(data["limit"], 20)
+
+    def test_max_page_size_is_enforced(self):
+        default_max_page_size = 1000  # default value from EtlPaginator
+        self.client.force_authenticate(self.user)
+        response = self.client.get(f"{self.url}?limit=2000&page=1")
+        data = self.assertJSONResponse(response, 200)
+        self.assertEqual(data["page"], 1)
+        self.assertEqual(data["limit"], default_max_page_size)

--- a/plugins/polio/tests/api/dashboards/test_subactivities.py
+++ b/plugins/polio/tests/api/dashboards/test_subactivities.py
@@ -1,14 +1,9 @@
 import datetime
-
-from django.contrib.auth.models import AnonymousUser
-from django.utils.timezone import now
-
 from iaso.models.base import Group
 from iaso.models.org_unit import OrgUnitType
 from iaso.test import APITestCase
 from plugins.polio.models import SubActivity, SubActivityScope
 from plugins.polio.tests.api.test import PolioTestCaseMixin
-from plugins.polio.tests.test_api import PolioAPITestCase
 
 BASE_URL = "/api/polio/dashboards/subactivities"
 

--- a/plugins/polio/tests/api/dashboards/test_supply_chain_dashboards.py
+++ b/plugins/polio/tests/api/dashboards/test_supply_chain_dashboards.py
@@ -270,3 +270,36 @@ class SupplyChainDashboardsAPITestCase(APITestCase):
         # Check if the latest dates are returned
         self.assertEqual(vrf2["form_a_reception_date"], str(new_forma.form_a_reception_date))
         self.assertEqual(vrf2["destruction_report_reception_date"], str(last_dr.rrt_destruction_report_reception_date))
+
+    def test_default_pagination_is_added(self):
+        self.client.force_authenticate(self.user)
+        response = self.client.get(f"{self.vrf_url}/")
+        data = self.assertJSONResponse(response, 200)
+        self.assertEqual(data["page"], 1)
+        self.assertEqual(data["limit"], 20)
+        response = self.client.get(f"{self.pre_alerts_url}/")
+        data = self.assertJSONResponse(response, 200)
+        self.assertEqual(data["page"], 1)
+        self.assertEqual(data["limit"], 20)
+        response = self.client.get(f"{self.arrival_reports_url}/")
+        data = self.assertJSONResponse(response, 200)
+        self.assertEqual(data["page"], 1)
+        self.assertEqual(data["limit"], 20)
+
+    def test_max_page_size_is_enforced(self):
+        default_max_page_size = 1000  # default value from EtlPaginator
+        self.client.force_authenticate(self.user)
+        response = self.client.get(f"{self.vrf_url}?limit=2000&page=1")
+        data = self.assertJSONResponse(response, 200)
+        self.assertEqual(data["page"], 1)
+        self.assertEqual(data["limit"], default_max_page_size)
+        self.client.force_authenticate(self.user)
+        response = self.client.get(f"{self.pre_alerts_url}?limit=2000&page=1")
+        data = self.assertJSONResponse(response, 200)
+        self.assertEqual(data["page"], 1)
+        self.assertEqual(data["limit"], default_max_page_size)
+        self.client.force_authenticate(self.user)
+        response = self.client.get(f"{self.arrival_reports_url}?limit=2000&page=1")
+        data = self.assertJSONResponse(response, 200)
+        self.assertEqual(data["page"], 1)
+        self.assertEqual(data["limit"], default_max_page_size)


### PR DESCRIPTION
endpoints consumed for ETL are not always paginated by default

Related JIRA tickets : POLIO-1797

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
NA

## Changes

- group `/polio/dashboards/` endpoints in same folder
- Make all viewsets inherit `EtlModelViewset`
- add test on default pagination query params


## How to test

With Django API, test endpoints: pagination (limit=20&page=1) should be added to the API if not passed as queryparams directly

## Print screen / video
NA

## Notes

commit:

fix: paginate dashboard endpoints

refs: POLIO-1797
