### PR TITLE
[POLIO-1795] Create new Budget API for dashboards

### DIFF
--- a/plugins/polio/api/dashboards/budget.py
+++ b/plugins/polio/api/dashboards/budget.py
@@ -1,0 +1,51 @@
+from rest_framework import permissions, serializers
+
+from hat.menupermissions import models as permission
+from iaso.api.common import EtlModelViewset, HasPermission
+from plugins.polio.budget.models import BudgetProcess
+from plugins.polio.models import Round
+
+
+class RoundsNestedSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Round
+        fields = [
+            "id",
+            "number",
+        ]
+
+
+class BudgetDashboardSerializer(serializers.ModelSerializer):
+    obr_name = serializers.SerializerMethodField()
+    rounds = RoundsNestedSerializer(many=True)
+
+    class Meta:
+        model = BudgetProcess
+        fields = "__all__"
+
+    def get_obr_name(self, budget):
+        filtered_queryset = budget.rounds.filter(campaign__deleted_at__isnull=True, campaign__isnull=False)
+        if not filtered_queryset:
+            return ""
+
+        return filtered_queryset.first().campaign.obr_name
+
+
+class BudgetDashboardViewSet(EtlModelViewset):
+    """
+    GET /api/polio/dashboards/budgets/
+    Returns all BudgetProcesses for the user's account, excluding those related to deleted campaigns
+    Simple endpoint that returns all model fields to facilitate data manipulation by OpenHexa or PowerBI
+    """
+
+    http_method_names = ["get"]
+    permission_classes = [permissions.IsAuthenticated, HasPermission(permission.POLIO_BUDGET)]
+    model = BudgetProcess
+    serializer_class = BudgetDashboardSerializer
+
+    def get_queryset(self):
+        return BudgetProcess.objects.filter(
+            deleted_at__isnull=True,
+            rounds__campaign__deleted_at__isnull=True,
+            rounds__campaign__account=self.request.user.iaso_profile.account,
+        ).prefetch_related("rounds", "rounds__campaign").order_by("id")

--- a/plugins/polio/api/dashboards/budget.py
+++ b/plugins/polio/api/dashboards/budget.py
@@ -44,8 +44,13 @@ class BudgetDashboardViewSet(EtlModelViewset):
     serializer_class = BudgetDashboardSerializer
 
     def get_queryset(self):
-        return BudgetProcess.objects.filter(
-            deleted_at__isnull=True,
-            rounds__campaign__deleted_at__isnull=True,
-            rounds__campaign__account=self.request.user.iaso_profile.account,
-        ).prefetch_related("rounds", "rounds__campaign").order_by("id")
+        return (
+            BudgetProcess.objects.filter(
+                deleted_at__isnull=True,
+                rounds__campaign__deleted_at__isnull=True,
+                rounds__campaign__account=self.request.user.iaso_profile.account,
+            )
+            .prefetch_related("rounds", "rounds__campaign")
+            .distinct()
+            .order_by("id")
+        )

--- a/plugins/polio/api/dashboards/campaign.py
+++ b/plugins/polio/api/dashboards/campaign.py
@@ -1,0 +1,28 @@
+from rest_framework import permissions, serializers
+
+from iaso.api.common import EtlModelViewset
+from plugins.polio.models import Campaign
+
+
+class CampaignDashboardSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Campaign
+        exclude = ["geojson"]
+
+
+class CampaignDashboardViewSet(EtlModelViewset):
+    """
+    GET /api/polio/dashboards/campaigns/
+    Returns all campaigns for the user's account, excluding those that are deleted
+    Simple endpoint that returns all model fields to facilitate data manipulation by OpenHexa or PowerBI
+    """
+
+    http_method_names = ["get"]
+    permission_classes = [permissions.IsAuthenticatedOrReadOnly]
+    model = Campaign
+    serializer_class = CampaignDashboardSerializer
+
+    def get_queryset(self):
+        return Campaign.objects.filter(
+            account=self.request.user.iaso_profile.account, deleted_at__isnull=True
+        )

--- a/plugins/polio/api/dashboards/campaign.py
+++ b/plugins/polio/api/dashboards/campaign.py
@@ -18,11 +18,9 @@ class CampaignDashboardViewSet(EtlModelViewset):
     """
 
     http_method_names = ["get"]
-    permission_classes = [permissions.IsAuthenticatedOrReadOnly]
+    permission_classes = [permissions.IsAuthenticated]
     model = Campaign
     serializer_class = CampaignDashboardSerializer
 
     def get_queryset(self):
-        return Campaign.objects.filter(
-            account=self.request.user.iaso_profile.account, deleted_at__isnull=True
-        )
+        return Campaign.objects.filter(account=self.request.user.iaso_profile.account, deleted_at__isnull=True)

--- a/plugins/polio/api/urls.py
+++ b/plugins/polio/api/urls.py
@@ -1,5 +1,7 @@
 from rest_framework import routers
 
+from plugins.polio.api.dashboards.budget import BudgetDashboardViewSet
+from plugins.polio.api.dashboards.campaign import CampaignDashboardViewSet
 # TOFIX: Still haven't understood the exact problem but this should be
 # the first import to avoid some 'BudgetProcess' errors in tests:
 # `AttributeError: 'str' object has no attribute '_meta'`
@@ -124,6 +126,16 @@ router.register(
     r"polio/dashboards/arrival_reports",
     VaccineArrivalReportDashboardViewSet,
     basename="dashboard_arrival_reports",
+)
+router.register(
+    r"polio/dashboards/budgets",
+    BudgetDashboardViewSet,
+    basename="dashboard_budgets",
+)
+router.register(
+    r"polio/dashboards/campaigns",
+    CampaignDashboardViewSet,
+    basename="dashboard_campaigns",
 )
 router.register(
     r"polio/dashboards/rounds",

--- a/plugins/polio/api/urls.py
+++ b/plugins/polio/api/urls.py
@@ -2,6 +2,7 @@ from rest_framework import routers
 
 from plugins.polio.api.dashboards.budget import BudgetDashboardViewSet
 from plugins.polio.api.dashboards.campaign import CampaignDashboardViewSet
+
 # TOFIX: Still haven't understood the exact problem but this should be
 # the first import to avoid some 'BudgetProcess' errors in tests:
 # `AttributeError: 'str' object has no attribute '_meta'`

--- a/plugins/polio/tests/api/dashboards/test_budget_process.py
+++ b/plugins/polio/tests/api/dashboards/test_budget_process.py
@@ -1,16 +1,10 @@
-import datetime
-
-from django.contrib.auth.models import AnonymousUser
-from django.utils.timezone import now
 from rest_framework import status
 
-from iaso.models.base import Group
 from iaso.models.org_unit import OrgUnitType
 from iaso.test import APITestCase
 from plugins.polio.budget.models import BudgetProcess, BudgetStep
-from plugins.polio.models import SubActivity, SubActivityScope, CampaignType, Round
+from plugins.polio.models import CampaignType, Round
 from plugins.polio.tests.api.test import PolioTestCaseMixin
-from plugins.polio.tests.test_api import PolioAPITestCase
 
 BASE_URL = "/api/polio/dashboards/budgets/"
 
@@ -39,12 +33,17 @@ class BudgetDashboardAPITestCase(APITestCase, PolioTestCaseMixin):
         # Budget Processes.
         cls.budget_process_1 = BudgetProcess.objects.create(created_by=cls.user, current_state_label="budget 1")
         cls.budget_process_2 = BudgetProcess.objects.create(created_by=cls.user, current_state_label="budget 2")
-        cls.budget_process_deleted = BudgetProcess.objects.create(created_by=cls.user, deleted_at="2024-01-06", current_state_label="budget deleted")
+        cls.budget_process_deleted = BudgetProcess.objects.create(
+            created_by=cls.user, deleted_at="2024-01-06", current_state_label="budget deleted"
+        )
 
         # Rounds.
         cls.round_1.budget_process = cls.budget_process_1
+        cls.round_1.save()
         cls.round_2.budget_process = cls.budget_process_1
+        cls.round_2.save()
         cls.round_3.budget_process = cls.budget_process_2
+        cls.round_3.save()
         cls.round_4 = Round.objects.create(number=4, campaign=cls.campaign, budget_process=None)
 
         # Budget Steps.
@@ -53,6 +52,11 @@ class BudgetDashboardAPITestCase(APITestCase, PolioTestCaseMixin):
 
     def test_anonymous_user_cannot_get(self):
         self.client.force_authenticate(self.anon)
+        response = self.client.get(f"{BASE_URL}")
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_missing_permission(self):
+        self.client.force_authenticate(self.user_no_perms)
         response = self.client.get(f"{BASE_URL}")
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
@@ -71,17 +75,103 @@ class BudgetDashboardAPITestCase(APITestCase, PolioTestCaseMixin):
         self.assertEqual(data["page"], 1)
         self.assertEqual(data["limit"], default_max_page_size)
 
-    def test_get_budget_processes(self):
+    def test_list_budget_processes(self):
         self.client.force_authenticate(self.user)
         response = self.client.get(f"{BASE_URL}")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         results = response.data["results"]
         self.assertEqual(len(results), 2)
         self.assertEqual(results[0]["id"], self.budget_process_1.id)
+        self.assertEqual(results[0]["obr_name"], self.campaign.obr_name)
+        self.assertEqual(results[1]["id"], self.budget_process_2.id)
 
-    # test with deleted campaign
-    # test the result other than ID
-    # test with another account
-    # test with rounds without campaign
+    def test_list_with_deleted_campaign(self):
+        # Setting up new campaign with rounds and budget processes, then we delete it
+        new_campaign, new_round_1, new_round_2, new_round_3, self.country, self.district = self.create_campaign(
+            obr_name="New Campaign",
+            account=self.account,
+            source_version=self.source_version,
+            country_ou_type=self.country_type,
+            district_ou_type=self.district_type,
+        )
+        new_campaign.campaign_types.set([self.polio_type])
+        new_budget_process_1 = BudgetProcess.objects.create(created_by=self.user, current_state_label="New budget 1")
+        new_budget_process_2 = BudgetProcess.objects.create(created_by=self.user, current_state_label="New budget 2")
+        new_round_1.budget_process = new_budget_process_1
+        new_round_1.save()
+        new_round_2.budget_process = new_budget_process_1
+        new_round_2.save()
+        new_round_3.budget_process = new_budget_process_2
+        new_round_3.save()
+        new_campaign.delete()
 
+        # Now we check that we only have the initial ones
+        self.client.force_authenticate(self.user)
+        response = self.client.get(f"{BASE_URL}")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = response.data["results"]
+        self.assertEqual(len(results), 2)  # both from the setup
+        self.assertEqual(results[0]["id"], self.budget_process_1.id)
+        self.assertEqual(results[1]["id"], self.budget_process_2.id)
 
+    def test_list_with_other_account(self):
+        # Setting up new campaign with rounds and budget processes, in another account
+        new_account, new_data_source, new_source_version, new_project = self.create_account_datasource_version_project(
+            "New Account", "New Data source", "New Project"
+        )
+        new_campaign, new_round_1, new_round_2, new_round_3, self.country, self.district = self.create_campaign(
+            obr_name="New Campaign",
+            account=new_account,
+            source_version=new_source_version,
+            country_ou_type=self.country_type,
+            district_ou_type=self.district_type,
+        )
+        new_campaign.campaign_types.set([self.polio_type])
+        new_budget_process_1 = BudgetProcess.objects.create(created_by=self.user, current_state_label="New budget 1")
+        new_budget_process_2 = BudgetProcess.objects.create(created_by=self.user, current_state_label="New budget 2")
+        new_round_1.budget_process = new_budget_process_1
+        new_round_1.save()
+        new_round_2.budget_process = new_budget_process_1
+        new_round_2.save()
+        new_round_3.budget_process = new_budget_process_2
+        new_round_3.save()
+
+        # Now we check that we only have the initial ones
+        self.client.force_authenticate(self.user)
+        response = self.client.get(f"{BASE_URL}")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = response.data["results"]
+        self.assertEqual(len(results), 2)  # both from the setup
+        self.assertEqual(results[0]["id"], self.budget_process_1.id)
+        self.assertEqual(results[1]["id"], self.budget_process_2.id)
+
+    def test_list_with_rounds_without_campaign(self):
+        # Since this is an issue, we want to make sure that campaignless rounds do not interfere
+        new_campaign, new_round_1, new_round_2, new_round_3, self.country, self.district = self.create_campaign(
+            obr_name="New Campaign",
+            account=self.account,
+            source_version=self.source_version,
+            country_ou_type=self.country_type,
+            district_ou_type=self.district_type,
+        )
+        new_campaign.campaign_types.set([self.polio_type])
+        new_budget_process_1 = BudgetProcess.objects.create(created_by=self.user, current_state_label="New budget 1")
+        new_budget_process_2 = BudgetProcess.objects.create(created_by=self.user, current_state_label="New budget 2")
+        new_round_1.campaign = None
+        new_round_1.budget_process = new_budget_process_1
+        new_round_1.save()
+        new_round_2.campaign = None
+        new_round_2.budget_process = new_budget_process_1
+        new_round_2.save()
+        new_round_3.budget_process = new_budget_process_2
+        new_round_3.save()
+
+        self.client.force_authenticate(self.user)
+        response = self.client.get(f"{BASE_URL}")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = response.data["results"]
+        self.assertEqual(len(results), 3)  # both from the setup + new_budget_process_2
+        self.assertEqual(results[0]["id"], self.budget_process_1.id)
+        self.assertEqual(results[1]["id"], self.budget_process_2.id)
+        self.assertEqual(results[2]["id"], new_budget_process_2.id)
+        self.assertEqual(results[2]["obr_name"], new_campaign.obr_name)

--- a/plugins/polio/tests/api/dashboards/test_budget_process.py
+++ b/plugins/polio/tests/api/dashboards/test_budget_process.py
@@ -1,0 +1,87 @@
+import datetime
+
+from django.contrib.auth.models import AnonymousUser
+from django.utils.timezone import now
+from rest_framework import status
+
+from iaso.models.base import Group
+from iaso.models.org_unit import OrgUnitType
+from iaso.test import APITestCase
+from plugins.polio.budget.models import BudgetProcess, BudgetStep
+from plugins.polio.models import SubActivity, SubActivityScope, CampaignType, Round
+from plugins.polio.tests.api.test import PolioTestCaseMixin
+from plugins.polio.tests.test_api import PolioAPITestCase
+
+BASE_URL = "/api/polio/dashboards/budgets/"
+
+
+class BudgetDashboardAPITestCase(APITestCase, PolioTestCaseMixin):
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.account, cls.data_source, cls.source_version, cls.project = cls.create_account_datasource_version_project(
+            "Account", "Data source", "Project"
+        )
+        cls.user, cls.anon, cls.user_no_perms = cls.create_base_users(cls.account, ["iaso_polio_budget"])
+        cls.country_type = OrgUnitType.objects.create(name="COUNTRY", short_name="COUNTRY")
+        cls.district_type = OrgUnitType.objects.create(name="DISTRICT", short_name="DISTRICT")
+        # Campaign type.
+        cls.polio_type = CampaignType.objects.get(name=CampaignType.POLIO)
+
+        cls.campaign, cls.round_1, cls.round_2, cls.round_3, cls.country, cls.district = cls.create_campaign(
+            obr_name="Test Campaign",
+            account=cls.account,
+            source_version=cls.source_version,
+            country_ou_type=cls.country_type,
+            district_ou_type=cls.district_type,
+        )
+        cls.campaign.campaign_types.set([cls.polio_type])
+
+        # Budget Processes.
+        cls.budget_process_1 = BudgetProcess.objects.create(created_by=cls.user, current_state_label="budget 1")
+        cls.budget_process_2 = BudgetProcess.objects.create(created_by=cls.user, current_state_label="budget 2")
+        cls.budget_process_deleted = BudgetProcess.objects.create(created_by=cls.user, deleted_at="2024-01-06", current_state_label="budget deleted")
+
+        # Rounds.
+        cls.round_1.budget_process = cls.budget_process_1
+        cls.round_2.budget_process = cls.budget_process_1
+        cls.round_3.budget_process = cls.budget_process_2
+        cls.round_4 = Round.objects.create(number=4, campaign=cls.campaign, budget_process=None)
+
+        # Budget Steps.
+        cls.budget_step_1 = BudgetStep.objects.create(budget_process=cls.budget_process_1, created_by=cls.user)
+        cls.budget_step_2 = BudgetStep.objects.create(budget_process=cls.budget_process_1, created_by=cls.user)
+
+    def test_anonymous_user_cannot_get(self):
+        self.client.force_authenticate(self.anon)
+        response = self.client.get(f"{BASE_URL}")
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_default_pagination_is_added(self):
+        self.client.force_authenticate(self.user)
+        response = self.client.get(f"{BASE_URL}")
+        data = self.assertJSONResponse(response, status.HTTP_200_OK)
+        self.assertEqual(data["page"], 1)
+        self.assertEqual(data["limit"], 20)
+
+    def test_max_page_size_is_enforced(self):
+        default_max_page_size = 1000  # default value from EtlPaginator
+        self.client.force_authenticate(self.user)
+        response = self.client.get(f"{BASE_URL}?limit=2000&page=1")
+        data = self.assertJSONResponse(response, status.HTTP_200_OK)
+        self.assertEqual(data["page"], 1)
+        self.assertEqual(data["limit"], default_max_page_size)
+
+    def test_get_budget_processes(self):
+        self.client.force_authenticate(self.user)
+        response = self.client.get(f"{BASE_URL}")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = response.data["results"]
+        self.assertEqual(len(results), 2)
+        self.assertEqual(results[0]["id"], self.budget_process_1.id)
+
+    # test with deleted campaign
+    # test the result other than ID
+    # test with another account
+    # test with rounds without campaign
+
+

--- a/plugins/polio/tests/api/dashboards/test_campaign.py
+++ b/plugins/polio/tests/api/dashboards/test_campaign.py
@@ -1,0 +1,106 @@
+from rest_framework import status
+
+from iaso.models.org_unit import OrgUnitType
+from iaso.test import APITestCase
+from plugins.polio.budget.models import BudgetProcess, BudgetStep
+from plugins.polio.models import CampaignType, Round
+from plugins.polio.tests.api.test import PolioTestCaseMixin
+
+BASE_URL = "/api/polio/dashboards/campaigns/"
+
+
+class CampaignDashboardAPITestCase(APITestCase, PolioTestCaseMixin):
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.account, cls.data_source, cls.source_version, cls.project = cls.create_account_datasource_version_project(
+            "Account", "Data source", "Project"
+        )
+        cls.user, cls.anon, cls.user_no_perms = cls.create_base_users(cls.account, ["iaso_polio_budget"])
+        cls.country_type = OrgUnitType.objects.create(name="COUNTRY", short_name="COUNTRY")
+        cls.district_type = OrgUnitType.objects.create(name="DISTRICT", short_name="DISTRICT")
+        # Campaign type.
+        cls.polio_type = CampaignType.objects.get(name=CampaignType.POLIO)
+
+        cls.campaign_1, cls.round_1, cls.round_2, cls.round_3, cls.country, cls.district = cls.create_campaign(
+            obr_name="Test Campaign 1",
+            account=cls.account,
+            source_version=cls.source_version,
+            country_ou_type=cls.country_type,
+            district_ou_type=cls.district_type,
+        )
+        cls.campaign_1.campaign_types.set([cls.polio_type])
+
+        cls.campaign_2, _, _, _, _, _ = cls.create_campaign(
+            obr_name="Test Campaign 2",
+            account=cls.account,
+            source_version=cls.source_version,
+            country_ou_type=cls.country_type,
+            district_ou_type=cls.district_type,
+        )
+        cls.campaign_2.campaign_types.set([cls.polio_type])
+
+        cls.campaign_3_deleted, _, _, _, _, _ = cls.create_campaign(
+            obr_name="Test Campaign 3",
+            account=cls.account,
+            source_version=cls.source_version,
+            country_ou_type=cls.country_type,
+            district_ou_type=cls.district_type,
+        )
+        cls.campaign_3_deleted.campaign_types.set([cls.polio_type])
+        cls.campaign_3_deleted.delete()
+
+    def test_anonymous_user_cannot_get(self):
+        self.client.force_authenticate(self.anon)
+        response = self.client.get(f"{BASE_URL}")
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_default_pagination_is_added(self):
+        self.client.force_authenticate(self.user)
+        response = self.client.get(f"{BASE_URL}")
+        data = self.assertJSONResponse(response, status.HTTP_200_OK)
+        self.assertEqual(data["page"], 1)
+        self.assertEqual(data["limit"], 20)
+
+    def test_max_page_size_is_enforced(self):
+        default_max_page_size = 1000  # default value from EtlPaginator
+        self.client.force_authenticate(self.user)
+        response = self.client.get(f"{BASE_URL}?limit=2000&page=1")
+        data = self.assertJSONResponse(response, status.HTTP_200_OK)
+        self.assertEqual(data["page"], 1)
+        self.assertEqual(data["limit"], default_max_page_size)
+
+    def test_list_campaigns(self):
+        self.client.force_authenticate(self.user)
+        response = self.client.get(f"{BASE_URL}")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = response.data["results"]
+        self.assertEqual(len(results), 2)
+        self.assertEqual(results[0]["id"], str(self.campaign_1.id))
+        self.assertEqual(results[0]["obr_name"], self.campaign_1.obr_name)
+        self.assertEqual(results[1]["id"], str(self.campaign_2.id))
+        self.assertEqual(results[1]["obr_name"], self.campaign_2.obr_name)
+
+    def test_list_with_other_account(self):
+        # Setting up new campaign with rounds and budget processes, in another account
+        new_account, new_data_source, new_source_version, new_project = self.create_account_datasource_version_project(
+            "New Account", "New Data source", "New Project"
+        )
+        new_campaign, new_round_1, new_round_2, new_round_3, self.country, self.district = self.create_campaign(
+            obr_name="New Campaign",
+            account=new_account,
+            source_version=new_source_version,
+            country_ou_type=self.country_type,
+            district_ou_type=self.district_type,
+        )
+        new_campaign.campaign_types.set([self.polio_type])
+
+        # Now we check that we only have the initial ones
+        self.client.force_authenticate(self.user)
+        response = self.client.get(f"{BASE_URL}")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = response.data["results"]
+        self.assertEqual(len(results), 2)  # both from the setup
+        self.assertEqual(results[0]["id"], str(self.campaign_1.id))
+        self.assertEqual(results[0]["obr_name"], self.campaign_1.obr_name)
+        self.assertEqual(results[1]["id"], str(self.campaign_2.id))
+        self.assertEqual(results[1]["obr_name"], self.campaign_2.obr_name)


### PR DESCRIPTION
Create new Campaign & Budget API for dashboards

Related JIRA tickets : POLIO-1795

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc

/

## Changes

Added 2 new API endpoints:
- `/api/polio/dashboards/campaigns`
- `/api/polio/dashboards/budgets`


## How to test

Go to the API and send some GET requests.
Make sure that soft-deleted data does not appear.

## Print screen / video
![image](https://github.com/user-attachments/assets/81dac041-1c83-49db-b41b-3363d082ad21)


## Notes

A new OpenHEXA pipeline will need to be created after this is deployed.



## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
