### PR TITLE
IA-3806: Change request filters bug

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/Filter/ReviewOrgUnitChangesFilter.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/Filter/ReviewOrgUnitChangesFilter.tsx
@@ -175,30 +175,37 @@ export const ReviewOrgUnitChangesFilter: FunctionComponent<Props> = ({
     // handle dataSource and sourceVersion change
     const handleDataSourceVersionChange = useCallback(
         (key, newValue) => {
+            let selectedVersion = null;
             if (key === 'source') {
                 setDataSource(newValue);
                 const selectedSource = dataSources?.filter(
                     source => source.value === newValue,
                 )[0];
-                setSelectedVersionId(
-                    selectedSource?.original?.default_version.id.toString(),
-                );
-                handleChange(
-                    'source_version_id',
-                    selectedSource?.original?.default_version.id,
-                );
+
+                selectedVersion =
+                    selectedSource?.original?.default_version.id.toString();
             } else {
-                setSelectedVersionId(newValue.toString());
-                handleChange('source_version_id', newValue);
+                selectedVersion = newValue.toString();
             }
             // Reset the group filter state
-            handleChange('groups', []);
+            handleChange('groups', null);
+            filters.groups = null;
+            // Reset selected version
+            setSelectedVersionId(selectedVersion || '');
+            if (selectedVersion) {
+                handleChange('source_version_id', selectedVersion);
+            }
             // Reset the parent_id and groups params
             delete newParams.parent_id;
             delete newParams.groups;
-            redirectToReplace(baseUrl, newParams);
         },
-        [dataSources, handleChange, newParams, redirectToReplace],
+        [
+            dataSources,
+            filters,
+            handleChange,
+            newParams.groups,
+            newParams.parent_id,
+        ],
     );
 
     const getVersionLabel = useGetVersionLabel(dataSources);

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/Filter/ReviewOrgUnitChangesFilter.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/Filter/ReviewOrgUnitChangesFilter.tsx
@@ -50,12 +50,11 @@ export const ReviewOrgUnitChangesFilter: FunctionComponent<Props> = ({
     params,
 }) => {
     const redirectToReplace = useRedirectToReplace();
-    const newParams = useMemo(() => params, [params]);
 
     const defaultSourceVersion = useDefaultSourceVersion();
     const [selectedVersionId, setSelectedVersionId] = useState<string>(
-        newParams.source_version_id
-            ? newParams.source_version_id
+        params.source_version_id
+            ? params.source_version_id
             : defaultSourceVersion.version.id.toString(),
     );
 
@@ -76,27 +75,35 @@ export const ReviewOrgUnitChangesFilter: FunctionComponent<Props> = ({
     const { data: paymentStatuses, isFetching: isFetchingPaymentStatuses } =
         usePaymentStatusOptions();
 
+    const updateParams = (paramsToUpdate, selectedVersion) => {
+        const newParams = {
+            ...paramsToUpdate,
+            source_version_id: selectedVersion,
+        };
+        return newParams;
+    };
+
     // Redirect to default version
     useEffect(() => {
-        if (!newParams.source_version_id) {
-            newParams.source_version_id = selectedVersionId;
-            redirectToReplace(baseUrl, newParams);
+        if (!params.source_version_id) {
+            const updatedParams = updateParams(params, selectedVersionId);
+            redirectToReplace(baseUrl, updatedParams);
         }
-    }, [newParams, selectedVersionId, redirectToReplace]);
+    }, [selectedVersionId, redirectToReplace, params]);
 
     // Get the source when the source_version_id exists
     const sourceParam = useMemo(
         () =>
-            newParams.source_version_id
+            params.source_version_id
                 ? dataSources?.filter(source =>
                       source.original.versions.some(
                           version =>
                               version.id.toString() ===
-                              newParams.source_version_id,
+                              params.source_version_id,
                       ),
                   )[0].value
                 : undefined,
-        [dataSources, newParams.source_version_id],
+        [dataSources, params.source_version_id],
     );
 
     const [dataSource, setDataSource] = useState<string>(
@@ -190,22 +197,16 @@ export const ReviewOrgUnitChangesFilter: FunctionComponent<Props> = ({
             // Reset the group filter state
             handleChange('groups', null);
             filters.groups = null;
+
             // Reset selected version
             setSelectedVersionId(selectedVersion || '');
             if (selectedVersion) {
                 handleChange('source_version_id', selectedVersion);
             }
-            // Reset the parent_id and groups params
-            delete newParams.parent_id;
-            delete newParams.groups;
+            // Reset the parent_id
+            filters.parent_id = null;
         },
-        [
-            dataSources,
-            filters,
-            handleChange,
-            newParams.groups,
-            newParams.parent_id,
-        ],
+        [dataSources, filters, handleChange],
     );
 
     const getVersionLabel = useGetVersionLabel(dataSources);


### PR DESCRIPTION
What problem is this PR solving? Explain here in one sentence.

Related JIRA tickets : [IA-3806](https://bluesquare.atlassian.net/browse/IA-3806)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes
- Reset params and filters on groups

## How to test
- Filters on groups, dataSource and source_versions

## Print screen / video
[Screencast from 2025-01-10 10-18-52.webm](https://github.com/user-attachments/assets/7b734ae9-37e2-43a3-8c2d-dcfcce6da9d6)



## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.


[IA-3806]: https://bluesquare.atlassian.net/browse/IA-3806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ