### PR TITLE
WC2-645: ETL debug page not showing any visit

### DIFF
--- a/plugins/wfp/common.py
+++ b/plugins/wfp/common.py
@@ -254,6 +254,7 @@ class ETL:
         nextSecondVisitDate = ""
         missed_followup_visit = 0
         if visit["form_id"] in [
+            "child_assistance_2nd_visit_tsfp",
             "child_assistance_follow_up",
             "child_assistance_admission",
             "wfp_coda_pbwg_assistance",

--- a/plugins/wfp/management/commands/nigeria/Under5.py
+++ b/plugins/wfp/management/commands/nigeria/Under5.py
@@ -64,7 +64,11 @@ class NG_Under5:
                         ),
                     )
 
-                    if form_id in ["Anthropometric visit child", "anthropometric_admission_otp"]:
+                    if form_id in [
+                        "anthropometric_admission",
+                        "Anthropometric visit child",
+                        "anthropometric_admission_otp",
+                    ]:
                         initial_weight = current_weight
                         instances[i]["initial_weight"] = initial_weight
                         visit_date = visit.get(
@@ -127,7 +131,8 @@ class NG_Under5:
                 f"---------------------------------------- Beneficiary N° {(index+1)} {instance['entity_id']}-----------------------------------"
             )
             instance["journey"] = self.journeyMapper(
-                instance["visits"], ["Anthropometric visit child", "anthropometric_admission_otp"]
+                instance["visits"],
+                ["Anthropometric visit child", "anthropometric_admission", "anthropometric_admission_otp"],
             )
             beneficiary = Beneficiary()
             if instance["entity_id"] not in existing_beneficiaries and len(instance["journey"][0]["visits"]) > 0:
@@ -170,9 +175,9 @@ class NG_Under5:
 
         if len(visit_nutrition_program) > 0:
             nutrition_programme = ETL().program_mapper(visit_nutrition_program[0])
-            if nutrition_programme == "TSFP-MAM":
+            if nutrition_programme in ["TSFP_MAM", "TSFP-MAM", "TSFP"]:
                 current_journey["nutrition_programme"] = "TSFP"
-            elif nutrition_programme == "OTP-SAM":
+            elif nutrition_programme in ["OTP_SAM", "OTP-SAM", "OTP"]:
                 current_journey["nutrition_programme"] = "OTP"
             else:
                 current_journey["nutrition_programme"] = nutrition_programme


### PR DESCRIPTION
What problem is this PR solving? Explain here in one sentence.

Related JIRA tickets : [WC2-645](https://bluesquare.atlassian.net/browse/WC2-645)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)


## Changes

For Nigeria, as programs TSFP and OTP has beeen renamed, the script was not generating journey linked to beneficiary. So, added the new form id created after merged children Under 5 types.

## How to test

From the local instance with wfp coda database containing Nigeria data, run ETL script to generate data:  `docker compose run iaso manage etl_ng`

Then login on django admin and check on tables:

[Beneficiary](http://localhost:8081/admin/wfp/beneficiary/?account__id__exact=3)
[Journey](http://localhost:8081/admin/wfp/journey/?beneficiary__account__id__exact=3)
[Visits](http://localhost:8081/admin/wfp/visit/?journey__beneficiary__account__id__exact=3)
[Steps](http://localhost:8081/admin/wfp/step/?visit__journey__beneficiary__account__id__exact=3)
[Monthly statistics](http://localhost:8081/admin/wfp/monthlystatistics/?account__id__exact=3)

You should see data on all analytics tables and a debug page for any [beneficiary](http://localhost:8081/wfp/debug/980/) with visit as well


## Print screen / video

[Uploading Sélectionnez-l’objet-journey-à-changer-Iaso.webm…]()


## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.


[WC2-645]: https://bluesquare.atlassian.net/browse/WC2-645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ