### PR TITLE
IA-3840: Profiles location children filter

### DIFF
--- a/iaso/api/profiles/profiles.py
+++ b/iaso/api/profiles/profiles.py
@@ -118,7 +118,6 @@ def get_filtered_profiles(
 
             if not parent:
                 queryset = queryset_current
-
             else:
                 queryset = (
                     original_queryset.filter(
@@ -130,11 +129,9 @@ def get_filtered_profiles(
 
         if children_ou and not parent_ou:
             queryset_current = original_queryset.filter(user__iaso_profile__org_units__pk=location)
-            children_ous = OrgUnit.objects.filter(parent__pk=location)
-            queryset = (
-                original_queryset.filter(user__iaso_profile__org_units__in=[ou.pk for ou in children_ous])
-                | queryset_current
-            )
+            # Get all descendants in hierarchy instead of just direct children
+            descendant_ous = OrgUnit.objects.hierarchy(ou).exclude(id=ou.id)
+            queryset = original_queryset.filter(user__iaso_profile__org_units__in=descendant_ous) | queryset_current
 
         if parent_ou and children_ou:
             if not parent:
@@ -146,10 +143,9 @@ def get_filtered_profiles(
 
             queryset_current = original_queryset.filter(user__iaso_profile__org_units__pk=location)
 
-            children_ous = OrgUnit.objects.filter(parent__pk=location)
-            queryset_children = original_queryset.filter(
-                user__iaso_profile__org_units__in=children_ous.values_list("id", flat=True)
-            )
+            # Get all descendants in hierarchy instead of just direct children
+            descendant_ous = OrgUnit.objects.hierarchy(ou).exclude(id=ou.id)
+            queryset_children = original_queryset.filter(user__iaso_profile__org_units__in=descendant_ous)
 
             queryset = queryset_current | queryset_parent | queryset_children
 

--- a/iaso/tests/api/test_profiles.py
+++ b/iaso/tests/api/test_profiles.py
@@ -1677,6 +1677,10 @@ class ProfileAPITestCase(APITestCase):
             parent=child_of_child,
         )
 
+        # Clear existing org units first to avoid interference
+        for profile in m.Profile.objects.all():
+            profile.org_units.clear()
+
         # Assign users to different levels of the hierarchy
         self.jane.iaso_profile.org_units.set([self.org_unit_from_parent_type])  # Root
         self.jim.iaso_profile.org_units.set([self.child_org_unit])  # Child
@@ -1699,6 +1703,10 @@ class ProfileAPITestCase(APITestCase):
 
     def test_profile_list_search_by_parent_and_children_ou(self):
         """Test that searching with both parent and children flags returns the complete hierarchy"""
+        # Clear existing org units first
+        for profile in m.Profile.objects.all():
+            profile.org_units.clear()
+
         # Setup hierarchy
         parent_of_root = m.OrgUnit.objects.create(
             org_unit_type=self.parent_org_unit_type,
@@ -1731,6 +1739,10 @@ class ProfileAPITestCase(APITestCase):
     def test_profile_list_search_by_children_ou_no_duplicates(self):
         """Test that searching by children org units doesn't return duplicate profiles
         when a user is assigned to multiple levels"""
+        # Clear existing org units first
+        for profile in m.Profile.objects.all():
+            profile.org_units.clear()
+
         # Assign a user to multiple levels in the hierarchy
         self.jane.iaso_profile.org_units.set(
             [

--- a/iaso/tests/api/test_profiles.py
+++ b/iaso/tests/api/test_profiles.py
@@ -4,7 +4,6 @@ import jsonschema
 import numpy as np
 import pandas as pd
 from django.contrib.auth import get_user_model
-
 from django.contrib.auth.models import Group, Permission
 from django.core import mail
 from django.test import override_settings
@@ -1660,3 +1659,92 @@ class ProfileAPITestCase(APITestCase):
         self.assertEqual(new_value["first_name"], "")
         self.assertEqual(new_value["language"], "fr")
         self.assertNotIn("password", new_value.keys())
+
+    def test_profile_list_search_by_children_ou_deep_hierarchy(self):
+        """Test that searching by children org units returns profiles from all levels of the hierarchy"""
+        # Create a deeper hierarchy
+        child_of_child = m.OrgUnit.objects.create(
+            org_unit_type=self.parent_org_unit_type,
+            version=self.account.default_version,
+            name="Child of child org unit",
+            parent=self.child_org_unit,
+        )
+
+        grand_child = m.OrgUnit.objects.create(
+            org_unit_type=self.parent_org_unit_type,
+            version=self.account.default_version,
+            name="Grand child org unit",
+            parent=child_of_child,
+        )
+
+        # Assign users to different levels of the hierarchy
+        self.jane.iaso_profile.org_units.set([self.org_unit_from_parent_type])  # Root
+        self.jim.iaso_profile.org_units.set([self.child_org_unit])  # Child
+        self.jam.iaso_profile.org_units.set([child_of_child])  # Child of child
+        self.jom.iaso_profile.org_units.set([grand_child])  # Grand child
+
+        self.client.force_authenticate(self.jane)
+        response = self.client.get(f"/api/profiles/?location={self.org_unit_from_parent_type.pk}&ouChildren=true")
+
+        self.assertEqual(response.status_code, 200)
+        profiles = response.json()["profiles"]
+        usernames = [p["user_name"] for p in profiles]
+
+        # Should include users from all levels
+        self.assertEqual(len(profiles), 4)
+        self.assertIn("janedoe", usernames)  # Root level
+        self.assertIn("jim", usernames)  # Child level
+        self.assertIn("jam", usernames)  # Child of child level
+        self.assertIn("jom", usernames)  # Grand child level
+
+    def test_profile_list_search_by_parent_and_children_ou(self):
+        """Test that searching with both parent and children flags returns the complete hierarchy"""
+        # Setup hierarchy
+        parent_of_root = m.OrgUnit.objects.create(
+            org_unit_type=self.parent_org_unit_type,
+            version=self.account.default_version,
+            name="Parent of root",
+        )
+        self.org_unit_from_parent_type.parent = parent_of_root
+        self.org_unit_from_parent_type.save()
+
+        # Assign users to different levels
+        self.jane.iaso_profile.org_units.set([parent_of_root])  # Parent
+        self.jim.iaso_profile.org_units.set([self.org_unit_from_parent_type])  # Current
+        self.jam.iaso_profile.org_units.set([self.child_org_unit])  # Child
+
+        self.client.force_authenticate(self.jane)
+        response = self.client.get(
+            f"/api/profiles/?location={self.org_unit_from_parent_type.pk}&ouParent=true&ouChildren=true"
+        )
+
+        self.assertEqual(response.status_code, 200)
+        profiles = response.json()["profiles"]
+        usernames = [p["user_name"] for p in profiles]
+
+        # Should include users from parent, current and child levels
+        self.assertEqual(len(profiles), 3)
+        self.assertIn("janedoe", usernames)  # Parent level
+        self.assertIn("jim", usernames)  # Current level
+        self.assertIn("jam", usernames)  # Child level
+
+    def test_profile_list_search_by_children_ou_no_duplicates(self):
+        """Test that searching by children org units doesn't return duplicate profiles
+        when a user is assigned to multiple levels"""
+        # Assign a user to multiple levels in the hierarchy
+        self.jane.iaso_profile.org_units.set(
+            [
+                self.org_unit_from_parent_type,  # Root
+                self.child_org_unit,  # Child
+            ]
+        )
+
+        self.client.force_authenticate(self.jane)
+        response = self.client.get(f"/api/profiles/?location={self.org_unit_from_parent_type.pk}&ouChildren=true")
+
+        self.assertEqual(response.status_code, 200)
+        profiles = response.json()["profiles"]
+
+        # Should only include the user once despite being in multiple levels
+        self.assertEqual(len(profiles), 1)
+        self.assertEqual(profiles[0]["user_name"], "janedoe")


### PR DESCRIPTION
Users : Checkbox "Users with access to children org unit only" work only for direct children, while it should work for all children (N-1 N-2, etc)

Related JIRA tickets : IA-3840

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

Adapt profiles filtering to return Users with access to children org unit only on  all children

## How to test

Go to Users page
Link a user to a lower level org unit. 
Click on Users with access to children org unit only
Select a parent of this org unit, not the direct parent.
Search, you should find your user


## Print screen / video
![Screenshot 2025-01-10 at 16 30 44](https://github.com/user-attachments/assets/e011712c-b570-44ba-afac-5bf9d7d3cf0a)
![Screenshot 2025-01-10 at 16 30 20](https://github.com/user-attachments/assets/7cb8c3aa-922c-4bd2-826a-883302f90cf4)


## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
