### PR TITLE
IA-713: "ids:" search in form tab (text entry) without coma isn't working

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -417,6 +417,7 @@
     "iaso.instances.label.created_by__username": "Created by",
     "iaso.instances.modificationDateFrom": "Modification date from",
     "iaso.instances.modificationDateTo": "Modification date to",
+    "iaso.instances.searchParams": "Use prefix “ids:” for internal submissions ID search. You can also search multiple IDs at once, separated by a comma or a space. E.g. “ids: 123456, 654321” or ids: 123456 654321”",
     "iaso.instances.sentDateFrom": "Sent date From",
     "iaso.instances.sentDateTo": "Sent date to",
     "iaso.instances.showDeleted": "Show only deleted",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -417,6 +417,7 @@
     "iaso.instances.label.created_by__username": "Crée par",
     "iaso.instances.modificationDateFrom": "Date de modification à partir de",
     "iaso.instances.modificationDateTo": "Date de modification jusqu'à",
+    "iaso.instances.searchParams": "Utilisez le préfixe “ids:” pour rechercher des ID de soumissions internes. Vous pouvez également rechercher plusieurs ID à la fois, séparés par une virgule ou un espace. Par exemple : “ids: 123456, 654321” or “ids: 123456 654321”",
     "iaso.instances.sentDateFrom": "Date d'envoi à partir de",
     "iaso.instances.sentDateTo": "Date d'envoi jusqu'à",
     "iaso.instances.showDeleted": "Montrer seulement les soumissions effacées",

--- a/hat/assets/js/apps/Iaso/domains/instances/components/InstancesFiltersComponent.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/InstancesFiltersComponent.js
@@ -216,7 +216,7 @@ const InstancesFiltersComponent = ({
                     formState.startPeriod.value,
                     formState.endPeriod.value,
                 );
-            } catch (e) {
+            } catch {
                 return true;
             }
         }
@@ -262,16 +262,20 @@ const InstancesFiltersComponent = ({
 
             <Grid container spacing={2}>
                 <Grid item xs={12} sm={6} md={3}>
-                    <InputComponent
-                        keyValue="search"
-                        onChange={handleFormChange}
-                        value={formState.search.value || ''}
-                        type="search"
-                        label={MESSAGES.textSearch}
-                        onEnterPressed={() => handleSearch()}
-                        onErrorChange={setTextSearchError}
-                        blockForbiddenChars
-                    />
+                    <InputWithInfos
+                        infos={formatMessage(MESSAGES.searchParams)}
+                    >
+                        <InputComponent
+                            keyValue="search"
+                            onChange={handleFormChange}
+                            value={formState.search.value || ''}
+                            type="search"
+                            label={MESSAGES.textSearch}
+                            onEnterPressed={() => handleSearch()}
+                            onErrorChange={setTextSearchError}
+                            blockForbiddenChars
+                        />
+                    </InputWithInfos>
                     <InputComponent
                         keyValue="projectIds"
                         onChange={handleFormChange}

--- a/hat/assets/js/apps/Iaso/domains/instances/messages.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/messages.js
@@ -714,6 +714,11 @@ const MESSAGES = defineMessages({
         defaultMessage: 'Close',
         id: 'blsq.buttons.label.close',
     },
+    searchParams: {
+        defaultMessage:
+            'Use prefix “ids:” for internal submissions ID search. You can also search multiple IDs at once, separated by a comma or a space. E.g. “ids: 123456, 654321” or “ids: 123456 654321”',
+        id: 'iaso.instances.searchParams',
+    },
 });
 
 export default MESSAGES;

--- a/iaso/models/base.py
+++ b/iaso/models/base.py
@@ -885,7 +885,7 @@ class InstanceQuerySet(django_cte.CTEQuerySet):
             if search.startswith("ids:"):
                 ids_str = search.replace("ids:", "")
                 try:
-                    ids = [int(i.strip()) for i in ids_str.split(",")]
+                    ids = re.findall("[A-Za-z0-9_-]+", ids_str)
                     queryset = queryset.filter(id__in=ids)
                 except:
                     queryset = queryset.filter(id__in=[])


### PR DESCRIPTION
What problem is this PR solving? Explain here in one sentence.
- "ids:" search in form tab (text entry) without coma isn't working
Related JIRA tickets : [IA-713](https://bluesquare.atlassian.net/browse/IA-713)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

Explain the changes that were made.
- Added a tooltip on search component
- Define a Regex that let the search on ids separate by space

## How to test
- Go to submissions page
- try to search with ids separated by spaces like "ids: 154 545"

## Print screen / video
[Screencast from 2025-01-13 12-04-20.webm](https://github.com/user-attachments/assets/01041ee4-75cd-4483-bc72-3c57abf7f570)


## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.


[IA-713]: https://bluesquare.atlassian.net/browse/IA-713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ