### PR TITLE
IA-3814: add search by name to data sources page

### DIFF
--- a/hat/assets/js/apps/Iaso/constants/urls.ts
+++ b/hat/assets/js/apps/Iaso/constants/urls.ts
@@ -321,7 +321,7 @@ export const baseRouteConfigs: Record<string, RouteConfig> = {
     },
     sources: {
         url: 'settings/sources/list',
-        params: ['accountId', 'projectIds', ...paginationPathParams],
+        params: ['accountId', 'projectIds', 'name', ...paginationPathParams],
     },
     sourceDetails: {
         url: 'settings/source/details',

--- a/hat/assets/js/apps/Iaso/domains/dataSources/components/Filters.tsx
+++ b/hat/assets/js/apps/Iaso/domains/dataSources/components/Filters.tsx
@@ -1,15 +1,12 @@
-import { Button, Grid } from '@mui/material';
-import React, { FunctionComponent, useCallback, useState } from 'react';
 import SearchIcon from '@mui/icons-material/Search';
+import { Button, Grid } from '@mui/material';
 import { makeStyles } from '@mui/styles';
-import {
-    commonStyles,
-    useRedirectTo,
-    useSafeIntl,
-} from 'bluesquare-components';
+import { commonStyles, useSafeIntl } from 'bluesquare-components';
+import React, { FunctionComponent } from 'react';
 import InputComponent from '../../../components/forms/InputComponent';
-import MESSAGES from '../messages';
+import { useFilterState } from '../../../hooks/useFilterState';
 import { useGetProjectsDropdownOptions } from '../../projects/hooks/requests';
+import MESSAGES from '../messages';
 
 const useStyles = makeStyles(theme => ({
     ...commonStyles(theme),
@@ -29,42 +26,16 @@ type Props = {
 };
 
 export const Filters: FunctionComponent<Props> = ({ baseUrl, params }) => {
-    const [filtersUpdated, setFiltersUpdated] = useState(false);
+    const { filters, filtersUpdated, handleChange, handleSearch } =
+        useFilterState({ baseUrl, params, withPagination: true });
     const classes = useStyles();
     const { formatMessage } = useSafeIntl();
     const { data: allProjects, isFetching: isFetchingProjects } =
         useGetProjectsDropdownOptions();
-    const [filters, setFilters] = useState({
-        projectIds: params.projectIds,
-    });
-
-    const handleChange = useCallback(
-        (key, value) => {
-            setFiltersUpdated(true);
-            setFilters({
-                ...filters,
-                [key]: value,
-            });
-        },
-        [filters],
-    );
-
-    const redirectTo = useRedirectTo();
-    const handleSearch = useCallback(() => {
-        if (filtersUpdated) {
-            setFiltersUpdated(false);
-            const tempParams = {
-                ...params,
-                ...filters,
-            };
-            tempParams.page = '1';
-            redirectTo(baseUrl, tempParams);
-        }
-    }, [filtersUpdated, params, filters, redirectTo, baseUrl]);
 
     return (
         <Grid container spacing={2}>
-            <Grid item xs={12} sm={6} md={3}>
+            <Grid item xs={12} sm={3} md={3}>
                 <InputComponent
                     keyValue="projectIds"
                     onChange={handleChange}
@@ -78,12 +49,24 @@ export const Filters: FunctionComponent<Props> = ({ baseUrl, params }) => {
                     multi
                 />
             </Grid>
+            <Grid item xs={12} sm={3} md={3}>
+                <InputComponent
+                    keyValue="name"
+                    onChange={handleChange}
+                    value={filters.name}
+                    type="search"
+                    label={MESSAGES.name}
+                    onEnterPressed={handleSearch}
+                    clearable
+                    multi
+                />
+            </Grid>
 
             <Grid
                 item
                 xs={12}
                 sm={6}
-                md={9}
+                md={6}
                 container
                 justifyContent="flex-end"
                 alignItems="center"

--- a/iaso/api/data_sources.py
+++ b/iaso/api/data_sources.py
@@ -261,7 +261,7 @@ class DataSourceViewSet(ModelViewSet):
         if filter_empty_versions:
             sources = sources.annotate(version_count=Count("versions")).filter(version_count__gt=0)
         if name:
-            sources = sources.filter(name__contains=name)
+            sources = sources.filter(name__icontains=name)
         if project_ids:
             sources = sources.filter(projects__in=project_ids.split(","))
         if linked_to:

--- a/iaso/api/data_sources.py
+++ b/iaso/api/data_sources.py
@@ -249,6 +249,7 @@ class DataSourceViewSet(ModelViewSet):
         order = self.request.GET.get("order", "name").split(",")
         filter_empty_versions = self.request.GET.get("filter_empty_versions", "false").lower() == "true"
         project_ids = self.request.GET.get("project_ids")
+        name = self.request.GET.get("name", None)
 
         sources = (
             DataSource.objects.select_related("default_version", "credentials")
@@ -259,6 +260,8 @@ class DataSourceViewSet(ModelViewSet):
 
         if filter_empty_versions:
             sources = sources.annotate(version_count=Count("versions")).filter(version_count__gt=0)
+        if name:
+            sources = sources.filter(name__contains=name)
         if project_ids:
             sources = sources.filter(projects__in=project_ids.split(","))
         if linked_to:


### PR DESCRIPTION
users need to be able to search data source by name

Related JIRA tickets : IA-3814
## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

Add filter the front + back end + add tests

## How to test
Go to data sources and play with filters


## Print screen / video


https://github.com/user-attachments/assets/06d89aee-7614-4d54-96f7-aeea372507b2





## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
