### PR TITLE
POLIO-1823: Polio vaccine supply chain & stock management permissions: Rename Read and Write to respectively Non-admin Admin

### DIFF
--- a/hat/menupermissions/constants.py
+++ b/hat/menupermissions/constants.py
@@ -246,12 +246,12 @@ READ_EDIT_PERMISSIONS = {
         "write": "iaso_polio_chronogram",
     },
     "iaso_polio_vaccine_supply_chain_permissions": {
-        "read": "iaso_polio_vaccine_supply_chain_read",
-        "write": "iaso_polio_vaccine_supply_chain_write",
+        "no_admin": "iaso_polio_vaccine_supply_chain_read",
+        "admin": "iaso_polio_vaccine_supply_chain_write",
     },
     "iaso_polio_vaccine_stock_management_permissions": {
-        "read": "iaso_polio_vaccine_stock_management_read",
-        "write": "iaso_polio_vaccine_stock_management_write",
+        "no_admin": "iaso_polio_vaccine_stock_management_read",
+        "admin": "iaso_polio_vaccine_stock_management_write",
     },
     "iaso_polio_vaccine_authorization_permissions": {
         "no_admin": "iaso_polio_vaccine_authorizations_read_only",


### PR DESCRIPTION
What problem is this PR solving? Explain here in one sentence.
- Polio vaccine supply chain & stock management permissions: Rename Read and Write to respectively Non-admin Admin
Related JIRA tickets : [POLIO-1823](https://bluesquare.atlassian.net/browse/POLIO-1823)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes
- Changed read and write permissions respectively to no-admin and admin for vaccine supply chain and stock management 

## How to test
- Edit a user or user role and check on permissions tab if the permission's have changed 

## Print screen / video

![Screenshot from 2025-01-15 09-01-40](https://github.com/user-attachments/assets/dff267a0-0293-4702-b682-ceb640f2061d)

## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.


[POLIO-1823]: https://bluesquare.atlassian.net/browse/POLIO-1823?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ