### PR TITLE
WC2-594 + IA-3745 + IA-3841 Improvements and fixes for multi-account users

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -1488,6 +1488,7 @@
     "iaso.users.selectedOrgUnits": "Org units selected",
     "iaso.users.update": "Update user",
     "iaso.users.userAdminOnly": "Can only be edited by user admin",
+    "iaso.users.multiAccountUserInfoDisabledWarning": "This user is a multi-account user. For this user, you can only edit settings specific to this Iaso account \"{account}\", such as their permissions.",
     "iaso.users.userPermissions": "User permissions",
     "iaso.users.userRoleOrgUnitTypeRestrictionWarning": "Org Unit Type Write restrictions from User role apply to this user. Refer to the user role configuration for more details",
     "iaso.users.usersHistory": "Users history",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -1487,7 +1487,7 @@
     "iaso.users.selectedOrgUnits": "Unité d'organisation sélectionnées",
     "iaso.users.update": "Mettre l'utilisateur à jour",
     "iaso.users.userAdminOnly": "Edition pour les administrateurs uniquement",
-    "iaso.users.multiAccountUserInfoDisabledWarning": "Cet utilisateur est un utilisateur multicompte. Pour cet utilisateur, vous ne pouvez modifier que les paramètres spécifiques à ce Iaso compte \"{account}\", tels que ses autorisations.",
+    "iaso.users.multiAccountUserInfoDisabledWarning": "Cet utilisateur est un utilisateur multicompte. Pour cet utilisateur, vous ne pouvez modifier que les paramètres spécifiques à ce compte Iaso \"{account}\", tels que ses autorisations.",
     "iaso.users.userPermissions": "Permissions d'utilisateur",
     "iaso.users.userRoleOrgUnitTypeRestrictionWarning": "Des restrictions d'écriture de rôle d’utilisateur s’appliquent à cet utilisateur. Consulter le rôle d’utilisateur en question pour plus de détails",
     "iaso.users.usersHistory": "Historique des utilisateurs",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -1487,6 +1487,7 @@
     "iaso.users.selectedOrgUnits": "Unité d'organisation sélectionnées",
     "iaso.users.update": "Mettre l'utilisateur à jour",
     "iaso.users.userAdminOnly": "Edition pour les administrateurs uniquement",
+    "iaso.users.multiAccountUserInfoDisabledWarning": "Cet utilisateur est un utilisateur multicompte. Pour cet utilisateur, vous ne pouvez modifier que les paramètres spécifiques à ce Iaso compte \"{account}\", tels que ses autorisations.",
     "iaso.users.userPermissions": "Permissions d'utilisateur",
     "iaso.users.userRoleOrgUnitTypeRestrictionWarning": "Des restrictions d'écriture de rôle d’utilisateur s’appliquent à cet utilisateur. Consulter le rôle d’utilisateur en question pour plus de détails",
     "iaso.users.usersHistory": "Historique des utilisateurs",

--- a/hat/assets/js/apps/Iaso/domains/users/components/UsersInfos.js
+++ b/hat/assets/js/apps/Iaso/domains/users/components/UsersInfos.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-param-reassign */
-import { Grid } from '@mui/material';
+import { Alert, Grid, SxProps, Theme } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 import { useSafeIntl, InputWithInfos } from 'bluesquare-components';
 import isEmpty from 'lodash/isEmpty';
 import PropTypes from 'prop-types';
@@ -14,6 +15,12 @@ import MESSAGES from '../messages.ts';
 import { userHasPermission } from '../utils.js';
 import { USERS_ADMIN } from '../../../utils/permissions';
 
+const useStyles = makeStyles(theme => ({
+    alert: {
+        marginBottom: theme.spacing(1),
+    },
+}));
+
 const UsersInfos = ({
     setFieldValue,
     currentUser,
@@ -23,12 +30,15 @@ const UsersInfos = ({
     const loggedUser = useCurrentUser();
     const isLoggedUserAdmin = userHasPermission(USERS_ADMIN, loggedUser);
     const { formatMessage } = useSafeIntl();
+    const classes = useStyles();
+
     const isEmailAdressExist = isEmpty(currentUser.email.value);
     const sendUserEmailInvitation = !!isEmailAdressExist;
     const sendUserIEmailnvitationLabel = isEmailAdressExist
         ? MESSAGES.sentEmailInvitationWhenAdresseExist
         : MESSAGES.sentEmailInvitation;
     let passwordDisabled = false;
+
     if (currentUser.send_email_invitation) {
         if (sendUserEmailInvitation) {
             // eslint-disable-next-line no-param-reassign
@@ -72,8 +82,20 @@ const UsersInfos = ({
         [setFieldValue],
     );
 
+    const isMultiAccountUser = currentUser.has_multiple_accounts.value;
+
     return (
         <form>
+            {isMultiAccountUser && (
+                <Alert severity="info" className={classes.alert}>
+                    {formatMessage(
+                        MESSAGES.multiAccountUserInfoDisabledWarning,
+                        {
+                            account: loggedUser.account.name,
+                        },
+                    )}
+                </Alert>
+            )}
             <Grid container spacing={2}>
                 <Grid item sm={12} md={6}>
                     <InputComponent
@@ -86,6 +108,7 @@ const UsersInfos = ({
                         type="text"
                         label={MESSAGES.userName}
                         required
+                        disabled={isMultiAccountUser}
                     />
                     <InputComponent
                         keyValue="first_name"
@@ -94,6 +117,7 @@ const UsersInfos = ({
                         errors={currentUser.first_name.errors}
                         type="text"
                         label={MESSAGES.firstName}
+                        disabled={isMultiAccountUser}
                     />
                     <InputComponent
                         keyValue="last_name"
@@ -102,6 +126,7 @@ const UsersInfos = ({
                         errors={currentUser.last_name.errors}
                         type="text"
                         label={MESSAGES.lastName}
+                        disabled={isMultiAccountUser}
                     />
                     <InputComponent
                         keyValue="email"
@@ -110,6 +135,7 @@ const UsersInfos = ({
                         errors={currentUser.email.errors}
                         type="email"
                         label={MESSAGES.email}
+                        disabled={isMultiAccountUser}
                     />
                     <InputComponent
                         keyValue="password"
@@ -123,7 +149,7 @@ const UsersInfos = ({
                             initialData ? isInitialDataEmpty : MESSAGES.password
                         }
                         required={!initialData}
-                        disabled={passwordDisabled}
+                        disabled={passwordDisabled || isMultiAccountUser}
                     />
                 </Grid>
                 <Grid item sm={12} md={6}>

--- a/hat/assets/js/apps/Iaso/domains/users/components/UsersInfos.spec.js
+++ b/hat/assets/js/apps/Iaso/domains/users/components/UsersInfos.spec.js
@@ -25,6 +25,7 @@ const currentUser = {
     home_page: '/settings/users/management',
     projects: [1],
     user_roles: [1],
+    has_multiple_accounts: { value: false },
 };
 
 const renderComponent = initialData => {

--- a/hat/assets/js/apps/Iaso/domains/users/components/useInitialUser.ts
+++ b/hat/assets/js/apps/Iaso/domains/users/components/useInitialUser.ts
@@ -96,6 +96,10 @@ export const useInitialUser = (
                 ),
                 errors: [],
             },
+            has_multiple_accounts: {
+                value: get(initialData, 'other_accounts', []).length > 0,
+                errors: [],
+            },
         };
     }, [initialData]);
     const [user, setUser] = useState<UserDialogData>(initialUser);

--- a/hat/assets/js/apps/Iaso/domains/users/messages.ts
+++ b/hat/assets/js/apps/Iaso/domains/users/messages.ts
@@ -528,6 +528,11 @@ const MESSAGES = defineMessages({
         defaultMessage:
             'Org Unit Type Write restrictions from User role apply to this user. Refer to the user role configuration for more details',
     },
+    multiAccountUserInfoDisabledWarning: {
+        id: 'iaso.users.multiAccountUserInfoDisabledWarning',
+        defaultMessage:
+            'This user is a multi-account user. For this user, you can only edit settings specific to this account, such as their permissions.',
+    },
 });
 
 export default MESSAGES;

--- a/hat/assets/js/apps/Iaso/domains/users/types.ts
+++ b/hat/assets/js/apps/Iaso/domains/users/types.ts
@@ -27,6 +27,7 @@ export type UserDialogData = {
     projects: ValueAndErrors<Project[] | null>;
     editable_org_unit_type_ids: ValueAndErrors<number[] | null>;
     user_roles_editable_org_unit_type_ids: ValueAndErrors<number[] | []>;
+    has_multiple_accounts: ValueAndErrors<boolean>;
 };
 
 export type InitialUserData = Partial<Profile> & { is_superuser?: boolean };

--- a/iaso/api/accounts.py
+++ b/iaso/api/accounts.py
@@ -91,6 +91,6 @@ class AccountViewSet(ModelViewSet):
         if user_to_login:
             user_to_login.backend = "django.contrib.auth.backends.ModelBackend"
             login(request, user_to_login)
-            return Response(user_to_login.iaso_profile.account.as_dict())
+            return Response({}, status=status.HTTP_200_OK)
         else:
             return Response(status=status.HTTP_404_NOT_FOUND)

--- a/iaso/api/accounts.py
+++ b/iaso/api/accounts.py
@@ -80,7 +80,7 @@ class AccountViewSet(ModelViewSet):
         # TODO: Make sure the account_id is present
         self.permission_classes = [permissions.IsAuthenticated, HasAccountPermission]
         self.check_permissions(request)
-        account_id = int(request.data.get("account_id", None))
+        account_id = int(request.data["account_id"]) if request.data.get("account_id") else None
 
         current_user = request.user
         account_users = current_user.tenant_user.get_all_account_users()
@@ -91,6 +91,7 @@ class AccountViewSet(ModelViewSet):
         if user_to_login:
             user_to_login.backend = "django.contrib.auth.backends.ModelBackend"
             login(request, user_to_login)
+            # Return an empty response since no data is needed by the frontend
             return Response({}, status=status.HTTP_200_OK)
         else:
             return Response(status=status.HTTP_404_NOT_FOUND)

--- a/iaso/api/profiles/profiles.py
+++ b/iaso/api/profiles/profiles.py
@@ -627,7 +627,8 @@ class ProfilesViewSet(viewsets.ViewSet):
         return response
 
     def validate_user_name(self, request, user):
-        if is_multi_account_user(user): return # username cannot be updated for multi-account users
+        if is_multi_account_user(user):
+            return  # username cannot be updated for multi-account users
 
         username = request.data.get("user_name")
         if not username:

--- a/iaso/api/profiles/profiles.py
+++ b/iaso/api/profiles/profiles.py
@@ -95,6 +95,7 @@ def get_filtered_profiles(
     if search:
         queryset = queryset.filter(
             Q(user__username__icontains=search)
+            | Q(user__tenant_user__main_user__username__icontains=search)
             | Q(user__first_name__icontains=search)
             | Q(user__last_name__icontains=search)
         ).distinct()

--- a/iaso/tests/api/test_account.py
+++ b/iaso/tests/api/test_account.py
@@ -112,7 +112,6 @@ class AccountAPITestCase(APITestCase):
         j = self.assertJSONResponse(response, 400)
         self.assertEqual(j, {"Error": "Account not allowed to access this default_source"})
 
-
     def test_switch_account(self):
         # Create a main user without profile
         main_user = m.User.objects.create(username="main_user")

--- a/iaso/tests/api/test_account.py
+++ b/iaso/tests/api/test_account.py
@@ -1,3 +1,5 @@
+from django.contrib import auth
+
 from iaso import models as m
 from iaso.test import APITestCase
 
@@ -126,5 +128,6 @@ class AccountAPITestCase(APITestCase):
         self.client.force_authenticate(account_user_ghi)
         response = self.client.patch("/api/accounts/switch/", {"account_id": self.wha.pk})
 
-        j = self.assertJSONResponse(response, 200)
-        self.assertEqual(j["name"], "Worldwide Health Aid")
+        self.assertJSONResponse(response, 200)
+        logged_in_user = auth.get_user(self.client)
+        self.assertEqual(logged_in_user.iaso_profile.account.name, "Worldwide Health Aid")

--- a/iaso/tests/api/test_account.py
+++ b/iaso/tests/api/test_account.py
@@ -111,3 +111,21 @@ class AccountAPITestCase(APITestCase):
         response = self.client.put(f"/api/accounts/{self.ghi.pk}/", {"default_version": self.wha_version.pk})
         j = self.assertJSONResponse(response, 400)
         self.assertEqual(j, {"Error": "Account not allowed to access this default_source"})
+
+
+    def test_switch_account(self):
+        # Create a main user without profile
+        main_user = m.User.objects.create(username="main_user")
+        main_user.save()
+
+        # And 2 account users with profile
+        account_user_ghi = self.create_user_with_profile(username="User_A", account=self.ghi)
+        m.TenantUser.objects.create(main_user=main_user, account_user=account_user_ghi)
+        account_user_wha = self.create_user_with_profile(username="User_B", account=self.wha)
+        m.TenantUser.objects.create(main_user=main_user, account_user=account_user_wha)
+
+        self.client.force_authenticate(account_user_ghi)
+        response = self.client.patch("/api/accounts/switch/", {"account_id": self.wha.pk})
+
+        j = self.assertJSONResponse(response, 200)
+        self.assertEqual(j["name"], "Worldwide Health Aid")

--- a/iaso/utils/__init__.py
+++ b/iaso/utils/__init__.py
@@ -128,5 +128,6 @@ def is_mobile_request(request):
     # Check if the User-Agent string contains keywords typical of mobile devices
     return any(mobile in user_agent.lower() for mobile in ["mobile", "android", "iphone", "ipad", "windows phone"])
 
+
 def is_multi_account_user(user):
     return hasattr(user, "tenant_user")

--- a/iaso/utils/__init__.py
+++ b/iaso/utils/__init__.py
@@ -127,3 +127,6 @@ def is_mobile_request(request):
     user_agent = request.META.get("HTTP_USER_AGENT", "")
     # Check if the User-Agent string contains keywords typical of mobile devices
     return any(mobile in user_agent.lower() for mobile in ["mobile", "android", "iphone", "ipad", "windows phone"])
+
+def is_multi_account_user(user):
+    return hasattr(user, "tenant_user")


### PR DESCRIPTION
This PR contains several improvements for multi-account users:

- Search on the users page will also search the tenant user's main user if any. Multi-account users are displayed with the main user's first/last/user-name instead of the real account's `auth_user`. E.g. I have a main user `bram`, but I have `bjans_ihp` or `bjans_civ_carte_sanitaire` depending on the account. On the user's page, I am shown as `bram`. With this change, search on `bram`, will also show me in the results.
- For the same reason, we don't allow editing of the personal data of multi-account users (see screenshot)
- Small fix: don't require `SOURCES` permission for account switch

Related JIRA tickets:
- https://bluesquare.atlassian.net/browse/WC2-594
- https://bluesquare.atlassian.net/browse/IA-3745
- https://bluesquare.atlassian.net/browse/IA-3841


## Print screen / video

![image](https://github.com/user-attachments/assets/275d985a-4f30-491c-afba-fc40dd8d8264)
