### PR TITLE
[IA-3878] Fix `created_at` is `null` when downloading OUCRC

### DIFF
--- a/iaso/api/org_unit_change_request_configurations/views_mobile.py
+++ b/iaso/api/org_unit_change_request_configurations/views_mobile.py
@@ -1,9 +1,9 @@
 from itertools import chain
 
 import django_filters
+from django.utils import timezone
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
-
 from rest_framework import viewsets
 from rest_framework.mixins import ListModelMixin
 from rest_framework.request import Request
@@ -78,7 +78,12 @@ class MobileOrgUnitChangeRequestConfigurationViewSet(ListModelMixin, viewsets.Ge
             non_editable_org_unit_type_ids = project_org_unit_types - user_editable_org_unit_type_ids
 
             dynamic_configurations = [
-                OrgUnitChangeRequestConfiguration(org_unit_type_id=org_unit_type_id, org_units_editable=False)
+                OrgUnitChangeRequestConfiguration(
+                    org_unit_type_id=org_unit_type_id,
+                    org_units_editable=False,
+                    created_at=timezone.now(),
+                    updated_at=timezone.now(),
+                )
                 for org_unit_type_id in non_editable_org_unit_type_ids
             ]
 

--- a/iaso/tests/api/org_unit_change_request_configurations/test_org_unit_change_request_configs_mobile.py
+++ b/iaso/tests/api/org_unit_change_request_configurations/test_org_unit_change_request_configs_mobile.py
@@ -1,3 +1,8 @@
+import datetime
+import time_machine
+
+from django.utils import timezone
+
 from rest_framework import status
 
 from django.contrib.auth.models import Group
@@ -5,7 +10,10 @@ from django.contrib.auth.models import Group
 from iaso import models as m
 from iaso.tests.api.org_unit_change_request_configurations.common_base_with_setup import OUCRCAPIBase
 
+CREATED_AT = datetime.datetime(2025, 1, 20, 10, 31, 0, 0, tzinfo=timezone.utc)
 
+
+@time_machine.travel(CREATED_AT, tick=False)
 class MobileOrgUnitChangeRequestConfigurationAPITestCase(OUCRCAPIBase):
     """
     Test mobile OUCRCViewSet.
@@ -104,8 +112,8 @@ class MobileOrgUnitChangeRequestConfigurationAPITestCase(OUCRCAPIBase):
                     "group_set_ids": [],
                     "editable_reference_form_ids": [],
                     "other_group_ids": [],
-                    "created_at": None,
-                    "updated_at": None,
+                    "created_at": CREATED_AT.timestamp(),
+                    "updated_at": CREATED_AT.timestamp(),
                 },
                 # Because of the configuration of his Profile, the user can't write on `ou_type_water_pokemons`,
                 # so we override the existing configuration.
@@ -118,8 +126,8 @@ class MobileOrgUnitChangeRequestConfigurationAPITestCase(OUCRCAPIBase):
                     "group_set_ids": [],
                     "editable_reference_form_ids": [],
                     "other_group_ids": [],
-                    "created_at": None,
-                    "updated_at": None,
+                    "created_at": CREATED_AT.timestamp(),
+                    "updated_at": CREATED_AT.timestamp(),
                 },
                 # Because of the configuration of his Profile, the user can't write on `new_org_unit_type_1`,
                 # and since there is no existing configuration, we add a dynamic one.
@@ -132,8 +140,8 @@ class MobileOrgUnitChangeRequestConfigurationAPITestCase(OUCRCAPIBase):
                     "group_set_ids": [],
                     "editable_reference_form_ids": [],
                     "other_group_ids": [],
-                    "created_at": None,
-                    "updated_at": None,
+                    "created_at": CREATED_AT.timestamp(),
+                    "updated_at": CREATED_AT.timestamp(),
                 },
                 # Because of the configuration of his Profile, the user can't write on `new_org_unit_type_2`,
                 # and since there is no existing configuration, we add a dynamic one.
@@ -146,8 +154,8 @@ class MobileOrgUnitChangeRequestConfigurationAPITestCase(OUCRCAPIBase):
                     "group_set_ids": [],
                     "editable_reference_form_ids": [],
                     "other_group_ids": [],
-                    "created_at": None,
-                    "updated_at": None,
+                    "created_at": CREATED_AT.timestamp(),
+                    "updated_at": CREATED_AT.timestamp(),
                 },
             ],
         )


### PR DESCRIPTION
When creating on-the-fly configurations to restrict OrgUnit Change Request creation, the `created_at` and `updated_at` dates were not set. This resulted in the backend sending `null` for those required fields.

Those fields are now set to the current date and time to fix the issue in the mobile app.

Related JIRA tickets : IA-3878
## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [X] Are there enough tests


## Changes

On-the-fly OUCRCs' `created_at` and `updated_at` fields are now set to the current date and time.

## How to test

Before the fix is applied, apply OrgUnit type restriction onto a user. 
Ensure the registry feature is enabled for the project you wish to log in to.
Log in with the previously configured user account.
The application should fail, saying the `created_at` is null.
Apply the fix and retry; this step should now succeed.


## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
