### PR TITLE
POLIO-1703: input in doses or vials

### DIFF
--- a/hat/assets/js/apps/Iaso/components/forms/InputComponent.tsx
+++ b/hat/assets/js/apps/Iaso/components/forms/InputComponent.tsx
@@ -16,7 +16,7 @@ import {
     translateOptions,
     useSafeIntl,
 } from 'bluesquare-components';
-import React, { ReactNode, useMemo, useState } from 'react';
+import React, { FocusEventHandler, ReactNode, useMemo, useState } from 'react';
 import { useLocale } from '../../domains/app/contexts/LocaleContext';
 import MESSAGES from '../../domains/forms/messages';
 import {
@@ -64,7 +64,10 @@ export type InputComponentProps = {
     value?: any;
     errors?: string[];
     onChange?: (key: string, value: any, countryData?: BaseCountryData) => void;
-
+    onBlur?: FocusEventHandler<HTMLInputElement | HTMLTextAreaElement>;
+    onFocus?:
+        | FocusEventHandler<HTMLInputElement | HTMLTextAreaElement>
+        | undefined;
     options?: any[];
     disabled?: boolean;
     multiline?: boolean;
@@ -133,6 +136,8 @@ const InputComponent: React.FC<InputComponentProps> = ({
     value,
     errors = [],
     onChange = () => null,
+    onBlur,
+    onFocus,
     options = [],
     disabled = false,
     multiline = false,
@@ -249,6 +254,8 @@ const InputComponent: React.FC<InputComponentProps> = ({
                         }}
                         setFieldError={setFieldError}
                         dataTestId={dataTestId}
+                        onBlur={onBlur}
+                        onFocus={onFocus}
                         {...localizedNumberOptions}
                     />
                 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -6403,8 +6403,7 @@
         },
         "node_modules/bluesquare-components": {
             "version": "1.0.0",
-            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#e68834e32f6060a30585924b369c64a511c3fd73",
-            "license": "Apache-2.0",
+            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#ebcb3b01a9dbec610b95313e4ac09df910121f31",
             "dependencies": {
                 "@babel/plugin-transform-class-properties": "^7.24.6",
                 "@babel/plugin-transform-object-rest-spread": "^7.24.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
                 "abortcontroller-polyfill": "^1.7.5",
                 "array-flat-polyfill": "^1.0.1",
                 "babel-plugin-formatjs": "^10.3.4",
-                "bluesquare-components": "github:BLSQ/bluesquare-components#POLIO-1703_add_Blur_management_to_NumberInput",
+                "bluesquare-components": "github:BLSQ/bluesquare-components#IA-2850_react-router_update_dev",
                 "classnames": "^2.2.6",
                 "color": "^3.1.2",
                 "dom-to-pdf": "^0.3.1",
@@ -6403,7 +6403,8 @@
         },
         "node_modules/bluesquare-components": {
             "version": "1.0.0",
-            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#757604f90946e4c27507c9723266f90dc6430b52",
+            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#e68834e32f6060a30585924b369c64a511c3fd73",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@babel/plugin-transform-class-properties": "^7.24.6",
                 "@babel/plugin-transform-object-rest-spread": "^7.24.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
                 "abortcontroller-polyfill": "^1.7.5",
                 "array-flat-polyfill": "^1.0.1",
                 "babel-plugin-formatjs": "^10.3.4",
-                "bluesquare-components": "github:BLSQ/bluesquare-components#IA-2850_react-router_update_dev",
+                "bluesquare-components": "github:BLSQ/bluesquare-components#POLIO-1703_add_Blur_management_to_NumberInput",
                 "classnames": "^2.2.6",
                 "color": "^3.1.2",
                 "dom-to-pdf": "^0.3.1",
@@ -6403,7 +6403,7 @@
         },
         "node_modules/bluesquare-components": {
             "version": "1.0.0",
-            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#e68834e32f6060a30585924b369c64a511c3fd73",
+            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#757604f90946e4c27507c9723266f90dc6430b52",
             "dependencies": {
                 "@babel/plugin-transform-class-properties": "^7.24.6",
                 "@babel/plugin-transform-object-rest-spread": "^7.24.6",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
         "abortcontroller-polyfill": "^1.7.5",
         "array-flat-polyfill": "^1.0.1",
         "babel-plugin-formatjs": "^10.3.4",
-        "bluesquare-components": "github:BLSQ/bluesquare-components#IA-2850_react-router_update_dev",
+        "bluesquare-components": "github:BLSQ/bluesquare-components#POLIO-1703_add_Blur_management_to_NumberInput",
         "classnames": "^2.2.6",
         "color": "^3.1.2",
         "dom-to-pdf": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
         "abortcontroller-polyfill": "^1.7.5",
         "array-flat-polyfill": "^1.0.1",
         "babel-plugin-formatjs": "^10.3.4",
-        "bluesquare-components": "github:BLSQ/bluesquare-components#POLIO-1703_add_Blur_management_to_NumberInput",
+        "bluesquare-components": "github:BLSQ/bluesquare-components#IA-2850_react-router_update_dev",
         "classnames": "^2.2.6",
         "color": "^3.1.2",
         "dom-to-pdf": "^0.3.1",

--- a/plugins/polio/js/src/components/Inputs/NumberInput.tsx
+++ b/plugins/polio/js/src/components/Inputs/NumberInput.tsx
@@ -1,5 +1,9 @@
 import { get } from 'lodash';
-import React, { FunctionComponent } from 'react';
+import React, {
+    FocusEventHandler,
+    FunctionComponent,
+    useCallback,
+} from 'react';
 import InputComponent from '../../../../../../hat/assets/js/apps/Iaso/components/forms/InputComponent';
 
 type Props = {
@@ -20,6 +24,11 @@ type Props = {
         decimalSeparator?: '.' | ',';
         thousandSeparator?: '.' | ',';
     };
+    onChange?: (value: number) => void;
+    onFocus?:
+        | FocusEventHandler<HTMLInputElement | HTMLTextAreaElement>
+        | undefined;
+    onBlur?: FocusEventHandler<HTMLInputElement | HTMLTextAreaElement>;
 };
 
 export const NumberInput: FunctionComponent<Props> = ({
@@ -28,6 +37,9 @@ export const NumberInput: FunctionComponent<Props> = ({
     form,
     min,
     max,
+    onChange,
+    onBlur,
+    onFocus,
     numberInputOptions = {},
     withMarginTop = false,
     disabled = false,
@@ -36,6 +48,19 @@ export const NumberInput: FunctionComponent<Props> = ({
     const hasError =
         form.errors &&
         Boolean(get(form.errors, field.name) && get(form.touched, field.name));
+
+    const handleChange = useCallback(
+        (_keyValue, value) => {
+            if (onChange) {
+                onChange(value);
+            } else {
+                form.setFieldTouched(field.name, true);
+                form.setFieldValue(field.name, value);
+            }
+        },
+        [field.name, form, onChange],
+    );
+
     return (
         <InputComponent
             withMarginTop={withMarginTop}
@@ -43,12 +68,11 @@ export const NumberInput: FunctionComponent<Props> = ({
             type="number"
             value={field.value}
             labelString={label}
-            onChange={(_keyValue, value) => {
-                form.setFieldTouched(field.name, true);
-                form.setFieldValue(field.name, value);
-            }}
+            onChange={handleChange}
             min={min}
             max={max}
+            onBlur={onBlur}
+            onFocus={onFocus}
             errors={hasError ? [get(form.errors, field.name)] : []}
             disabled={disabled}
             required={required}

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/PreAlerts/PreAlert.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/PreAlerts/PreAlert.tsx
@@ -153,13 +153,7 @@ export const PreAlert: FunctionComponent<Props> = ({ index, vaccine }) => {
                                 required
                             />
                         </Grid>
-                        <Grid
-                            container
-                            item
-                            xs={6}
-                            md={4}
-                            alignContent="center"
-                        >
+                        <Grid item xs={6} md={4}>
                             <Field
                                 label={formatMessage(MESSAGES.vials_shipped)}
                                 name={`pre_alerts[${index}].vials_shipped`}
@@ -207,6 +201,7 @@ export const PreAlert: FunctionComponent<Props> = ({ index, vaccine }) => {
                                             );
                                         }
                                     }}
+                                    // @ts-ignore
                                     document={
                                         values?.pre_alerts?.[index]?.document
                                     }

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/PreAlerts/PreAlert.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/PreAlerts/PreAlert.tsx
@@ -3,12 +3,11 @@ import { Box, Grid, Paper, Typography } from '@mui/material';
 import { IconButton, useSafeIntl } from 'bluesquare-components';
 import classNames from 'classnames';
 import { Field, useFormikContext } from 'formik';
-import React, { FunctionComponent, useCallback, useMemo } from 'react';
+import React, { FunctionComponent, useCallback, useMemo, useRef } from 'react';
 import { DeleteIconButton } from '../../../../../../../../../hat/assets/js/apps/Iaso/components/Buttons/DeleteIconButton';
 import { NumberCell } from '../../../../../../../../../hat/assets/js/apps/Iaso/components/Cells/NumberCell';
 import DocumentUploadWithPreview from '../../../../../../../../../hat/assets/js/apps/Iaso/components/files/pdf/DocumentUploadWithPreview';
 import { processErrorDocsBase } from '../../../../../../../../../hat/assets/js/apps/Iaso/components/files/pdf/utils';
-import { Optional } from '../../../../../../../../../hat/assets/js/apps/Iaso/types/utils';
 import { NumberInput, TextInput } from '../../../../../components/Inputs';
 import { DateInput } from '../../../../../components/Inputs/DateInput';
 import { dosesPerVial } from '../../hooks/utils';
@@ -32,16 +31,17 @@ export const PreAlert: FunctionComponent<Props> = ({ index, vaccine }) => {
     const doses_per_vial_default = vaccine ? dosesPerVial[vaccine] : undefined;
     const doses_per_vial =
         pre_alerts?.[index].doses_per_vial ?? doses_per_vial_default;
-    const current_vials_shipped = doses_per_vial
-        ? Math.ceil(
-              ((pre_alerts?.[index].doses_shipped as Optional<number>) ?? 0) /
-                  doses_per_vial,
-          )
-        : 0;
+    // const [isDosesFocused, setIsDosesFocused] = useState<boolean>(false);
+    // const [isVialsFocused, setIsVialsFocused] = useState<boolean>(false);
+
+    // Use refs to track focused state to reduce renders and avoid sluggish UI
+    const dosesRef = useRef<boolean>(false);
+    const vialsRef = useRef<boolean>(false);
 
     const documentErrors = useMemo(() => {
         return processErrorDocsBase(errors[index]?.document);
     }, [errors, index]);
+
     const onDelete = useCallback(() => {
         if (values?.pre_alerts?.[index].id) {
             setFieldValue(`pre_alerts[${index}].to_delete`, true);
@@ -55,6 +55,48 @@ export const PreAlert: FunctionComponent<Props> = ({ index, vaccine }) => {
             }
         }
     }, [index, setFieldTouched, setFieldValue, values?.pre_alerts]);
+
+    const handleVialsShippedUpdate = useCallback(
+        (value: number) => {
+            if (vialsRef.current) {
+                const dosesShipped = value * (doses_per_vial ?? 0);
+                setFieldValue(`pre_alerts[${index}].vials_shipped`, value);
+                setFieldValue(
+                    `pre_alerts[${index}].doses_shipped`,
+                    dosesShipped,
+                );
+            }
+        },
+        [doses_per_vial, index, setFieldValue],
+    );
+    const handleDosesShippedUpdate = useCallback(
+        (value: number) => {
+            if (dosesRef.current) {
+                const vialsShipped = doses_per_vial
+                    ? Math.ceil((value ?? 0) / doses_per_vial)
+                    : 0;
+                setFieldValue(`pre_alerts[${index}].doses_shipped`, value);
+                setFieldValue(
+                    `pre_alerts[${index}].vials_shipped`,
+                    vialsShipped,
+                );
+            }
+        },
+        [doses_per_vial, index, setFieldValue],
+    );
+    const onDosesFocus = () => {
+        dosesRef.current = true;
+    };
+    const onDosesBlur = () => {
+        dosesRef.current = false;
+    };
+    const onVialsFocus = () => {
+        vialsRef.current = true;
+    };
+    const onVialsBlur = () => {
+        vialsRef.current = false;
+    };
+
     return (
         <div className={classes.container}>
             <Paper
@@ -105,6 +147,27 @@ export const PreAlert: FunctionComponent<Props> = ({ index, vaccine }) => {
                                 name={`pre_alerts[${index}].doses_shipped`}
                                 component={NumberInput}
                                 disabled={markedForDeletion}
+                                onChange={handleDosesShippedUpdate}
+                                onFocus={onDosesFocus}
+                                onBlur={onDosesBlur}
+                                required
+                            />
+                        </Grid>
+                        <Grid
+                            container
+                            item
+                            xs={6}
+                            md={4}
+                            alignContent="center"
+                        >
+                            <Field
+                                label={formatMessage(MESSAGES.vials_shipped)}
+                                name={`pre_alerts[${index}].vials_shipped`}
+                                component={NumberInput}
+                                disabled={markedForDeletion}
+                                onChange={handleVialsShippedUpdate}
+                                onFocus={onVialsFocus}
+                                onBlur={onVialsBlur}
                                 required
                             />
                         </Grid>
@@ -124,25 +187,6 @@ export const PreAlert: FunctionComponent<Props> = ({ index, vaccine }) => {
                                         MESSAGES.doses_per_vial,
                                     )}:`}{' '}
                                     <NumberCell value={doses_per_vial} />
-                                </Typography>
-                            </Box>
-                        </Grid>
-                        <Grid
-                            container
-                            item
-                            xs={6}
-                            md={4}
-                            alignContent="center"
-                        >
-                            <Box>
-                                <Typography
-                                    variant="button"
-                                    sx={uneditableTextStyling}
-                                >
-                                    {`${formatMessage(
-                                        MESSAGES.vials_shipped,
-                                    )}:`}{' '}
-                                    <NumberCell value={current_vials_shipped} />
                                 </Typography>
                             </Box>
                         </Grid>

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/VAR/VaccineArrivalReport.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/VAR/VaccineArrivalReport.tsx
@@ -37,7 +37,6 @@ export const VaccineArrivalReport: FunctionComponent<Props> = ({
     const doses_per_vial_default = vaccine ? dosesPerVial[vaccine] : undefined;
     const doses_per_vial =
         arrival_reports?.[index].doses_per_vial ?? doses_per_vial_default;
-
     const poNumberOptions = useMemo(() => {
         return (
             (
@@ -74,11 +73,30 @@ export const VaccineArrivalReport: FunctionComponent<Props> = ({
                     `${VAR}[${index}].doses_shipped`,
                     preAlert.doses_shipped,
                 );
+                const dosesShipped = preAlert.doses_shipped ?? 0;
+                const dosesShippedAsNumber =
+                    typeof dosesShipped === 'number'
+                        ? dosesShipped
+                        : parseInt(dosesShipped ?? '0', 10);
+                setFieldValue(
+                    `${VAR}[${index}].vials_shipped`,
+                    Math.ceil(
+                        dosesShippedAsNumber /
+                            parseInt(doses_per_vial ?? 1, 10),
+                    ),
+                );
             }
-            setFieldValue(key, value);
+            // Call setFieldTouched before setFieldValue to avoid validation bug
             setFieldTouched(key, true);
+            setFieldValue(key, value);
         },
-        [index, setFieldTouched, setFieldValue, values.pre_alerts],
+        [
+            doses_per_vial,
+            index,
+            setFieldTouched,
+            setFieldValue,
+            values.pre_alerts,
+        ],
     );
 
     const handleDosesShippedUpdate = useCallback(

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/VAR/VaccineArrivalReport.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/VAR/VaccineArrivalReport.tsx
@@ -149,36 +149,28 @@ export const VaccineArrivalReport: FunctionComponent<Props> = ({
         [doses_per_vial, index, setFieldValue],
     );
     const onDosesShippedFocused = () => {
-        // setIsDosesShippedFocused(true);
         dosesShippedRef.current = true;
     };
     const onDosesShippedBlur = () => {
-        // setIsDosesShippedFocused(false);
         dosesShippedRef.current = false;
     };
     const onDosesReceivedFocused = () => {
-        // setIsDosesReceivedFocused(true);
         dosesReceivedRef.current = true;
     };
     const onDosesReceivedBlur = () => {
         dosesReceivedRef.current = false;
-        // setIsDosesReceivedFocused(false);
     };
     const onVialsShippedFocused = () => {
-        // setIsVialsShippedFocused(true);
         vialsShippedRef.current = true;
     };
     const onVialsShippedBlur = () => {
-        // setIsVialsShippedFocused(false);
         vialsShippedRef.current = false;
     };
     const onVialsReceivedFocused = () => {
         vialsReceivedRef.current = true;
-        // setIsVialsReceivedFocused(true);
     };
     const onVialsReceivedBlur = () => {
         vialsReceivedRef.current = false;
-        // setIsVialsReceivedFocused(false);
     };
 
     return (
@@ -244,15 +236,6 @@ export const VaccineArrivalReport: FunctionComponent<Props> = ({
                     </Grid>
                     <Grid container item xs={12} spacing={2}>
                         <Grid item xs={6} md={3}>
-                            <Typography
-                                variant="button"
-                                sx={uneditableTextStyling}
-                            >
-                                {`${formatMessage(MESSAGES.doses_per_vial)}:`}{' '}
-                                <NumberCell value={doses_per_vial} />
-                            </Typography>
-                        </Grid>
-                        <Grid item xs={6} md={3}>
                             <Field
                                 label={formatMessage(MESSAGES.vials_shipped)}
                                 name={`${VAR}[${index}].vials_shipped`}
@@ -275,6 +258,23 @@ export const VaccineArrivalReport: FunctionComponent<Props> = ({
                                 onChange={handleVialsReceivedUpdate}
                                 required
                             />
+                        </Grid>
+                        <Grid
+                            container
+                            item
+                            xs={6}
+                            md={3}
+                            alignContent="center"
+                        >
+                            <Box>
+                                <Typography
+                                    variant="button"
+                                    sx={uneditableTextStyling}
+                                >
+                                    {`${formatMessage(MESSAGES.doses_per_vial)}:`}{' '}
+                                    <NumberCell value={doses_per_vial} />
+                                </Typography>
+                            </Box>
                         </Grid>
                     </Grid>
                 </Grid>

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/VAR/VaccineArrivalReport.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/VAR/VaccineArrivalReport.tsx
@@ -3,7 +3,7 @@ import { Box, Grid, Paper, Typography } from '@mui/material';
 import { IconButton, useSafeIntl } from 'bluesquare-components';
 import classNames from 'classnames';
 import { Field, useFormikContext } from 'formik';
-import React, { FunctionComponent, useCallback, useMemo } from 'react';
+import React, { FunctionComponent, useCallback, useMemo, useRef } from 'react';
 import { DeleteIconButton } from '../../../../../../../../../hat/assets/js/apps/Iaso/components/Buttons/DeleteIconButton';
 import { NumberCell } from '../../../../../../../../../hat/assets/js/apps/Iaso/components/Cells/NumberCell';
 import { Optional } from '../../../../../../../../../hat/assets/js/apps/Iaso/types/utils';
@@ -28,22 +28,15 @@ export const VaccineArrivalReport: FunctionComponent<Props> = ({
     const { arrival_reports } = values as SupplyChainFormData;
     const markedForDeletion = arrival_reports?.[index].to_delete ?? false;
     const uneditableTextStyling = markedForDeletion ? grayText : undefined;
+    // Use refs to track focused state to reduce renders and avoid sluggish UI
+    const dosesReceivedRef = useRef<boolean>(false);
+    const vialsReceivedRef = useRef<boolean>(false);
+    const dosesShippedRef = useRef<boolean>(false);
+    const vialsShippedRef = useRef<boolean>(false);
 
     const doses_per_vial_default = vaccine ? dosesPerVial[vaccine] : undefined;
     const doses_per_vial =
         arrival_reports?.[index].doses_per_vial ?? doses_per_vial_default;
-    const current_vials_shipped = doses_per_vial
-        ? Math.ceil(
-              ((arrival_reports?.[index].doses_shipped as Optional<number>) ??
-                  0) / doses_per_vial,
-          )
-        : 0;
-    const current_vials_received = doses_per_vial
-        ? Math.ceil(
-              ((arrival_reports?.[index].doses_received as Optional<number>) ??
-                  0) / doses_per_vial,
-          )
-        : 0;
 
     const poNumberOptions = useMemo(() => {
         return (
@@ -70,6 +63,7 @@ export const VaccineArrivalReport: FunctionComponent<Props> = ({
                 })
         );
     }, [values?.arrival_reports, values.pre_alerts]);
+
     const handleChangePoNumber = useCallback(
         (key, value) => {
             const preAlert = values.pre_alerts?.find(
@@ -86,6 +80,107 @@ export const VaccineArrivalReport: FunctionComponent<Props> = ({
         },
         [index, setFieldTouched, setFieldValue, values.pre_alerts],
     );
+
+    const handleDosesShippedUpdate = useCallback(
+        (value: number) => {
+            if (dosesShippedRef.current) {
+                const vialsShipped = doses_per_vial
+                    ? Math.ceil(
+                          ((value as Optional<number>) ?? 0) / doses_per_vial,
+                      )
+                    : 0;
+                setFieldValue(`arrival_reports[${index}].doses_shipped`, value);
+                setFieldValue(
+                    `arrival_reports[${index}].vials_shipped`,
+                    vialsShipped,
+                );
+            }
+        },
+        [doses_per_vial, index, setFieldValue],
+    );
+    const handleDosesReceivedUpdate = useCallback(
+        (value: number) => {
+            if (dosesReceivedRef.current) {
+                const vialsReceived = doses_per_vial
+                    ? Math.ceil(
+                          ((value as Optional<number>) ?? 0) / doses_per_vial,
+                      )
+                    : 0;
+                setFieldValue(
+                    `arrival_reports[${index}].doses_received`,
+                    value,
+                );
+                setFieldValue(
+                    `arrival_reports[${index}].vials_received`,
+                    vialsReceived,
+                );
+            }
+        },
+        [doses_per_vial, index, setFieldValue],
+    );
+
+    const handleVialsShippededUpdate = useCallback(
+        (value: number) => {
+            if (vialsShippedRef.current) {
+                const dosesShipped = value * (doses_per_vial ?? 0);
+                setFieldValue(`arrival_reports[${index}].vials_shipped`, value);
+                setFieldValue(
+                    `arrival_reports[${index}].doses_shipped`,
+                    dosesShipped,
+                );
+            }
+        },
+        [doses_per_vial, index, setFieldValue],
+    );
+    const handleVialsReceivedUpdate = useCallback(
+        (value: number) => {
+            if (vialsReceivedRef.current) {
+                const dosesReceived = value * (doses_per_vial ?? 0);
+                setFieldValue(
+                    `arrival_reports[${index}].vials_received`,
+                    value,
+                );
+                setFieldValue(
+                    `arrival_reports[${index}].doses_received`,
+                    dosesReceived,
+                );
+            }
+        },
+        [doses_per_vial, index, setFieldValue],
+    );
+    const onDosesShippedFocused = () => {
+        // setIsDosesShippedFocused(true);
+        dosesShippedRef.current = true;
+    };
+    const onDosesShippedBlur = () => {
+        // setIsDosesShippedFocused(false);
+        dosesShippedRef.current = false;
+    };
+    const onDosesReceivedFocused = () => {
+        // setIsDosesReceivedFocused(true);
+        dosesReceivedRef.current = true;
+    };
+    const onDosesReceivedBlur = () => {
+        dosesReceivedRef.current = false;
+        // setIsDosesReceivedFocused(false);
+    };
+    const onVialsShippedFocused = () => {
+        // setIsVialsShippedFocused(true);
+        vialsShippedRef.current = true;
+    };
+    const onVialsShippedBlur = () => {
+        // setIsVialsShippedFocused(false);
+        vialsShippedRef.current = false;
+    };
+    const onVialsReceivedFocused = () => {
+        vialsReceivedRef.current = true;
+        // setIsVialsReceivedFocused(true);
+    };
+    const onVialsReceivedBlur = () => {
+        vialsReceivedRef.current = false;
+        // setIsVialsReceivedFocused(false);
+    };
+
     return (
         <div className={classes.container}>
             <Paper
@@ -127,6 +222,9 @@ export const VaccineArrivalReport: FunctionComponent<Props> = ({
                                 name={`${VAR}[${index}].doses_shipped`}
                                 component={NumberInput}
                                 disabled={markedForDeletion}
+                                onFocus={onDosesShippedFocused}
+                                onBlur={onDosesShippedBlur}
+                                onChange={handleDosesShippedUpdate}
                                 required
                             />
                         </Grid>
@@ -137,6 +235,9 @@ export const VaccineArrivalReport: FunctionComponent<Props> = ({
                                 name={`${VAR}[${index}].doses_received`}
                                 component={NumberInput}
                                 disabled={markedForDeletion}
+                                onFocus={onDosesReceivedFocused}
+                                onBlur={onDosesReceivedBlur}
+                                onChange={handleDosesReceivedUpdate}
                                 required
                             />
                         </Grid>
@@ -152,22 +253,28 @@ export const VaccineArrivalReport: FunctionComponent<Props> = ({
                             </Typography>
                         </Grid>
                         <Grid item xs={6} md={3}>
-                            <Typography
-                                variant="button"
-                                sx={uneditableTextStyling}
-                            >
-                                {`${formatMessage(MESSAGES.vials_shipped)}:`}{' '}
-                                <NumberCell value={current_vials_shipped} />
-                            </Typography>
+                            <Field
+                                label={formatMessage(MESSAGES.vials_shipped)}
+                                name={`${VAR}[${index}].vials_shipped`}
+                                component={NumberInput}
+                                disabled={markedForDeletion}
+                                onFocus={onVialsShippedFocused}
+                                onBlur={onVialsShippedBlur}
+                                onChange={handleVialsShippededUpdate}
+                                required
+                            />
                         </Grid>
                         <Grid item xs={6} md={3}>
-                            <Typography
-                                variant="button"
-                                sx={uneditableTextStyling}
-                            >
-                                {`${formatMessage(MESSAGES.vials_received)}:`}{' '}
-                                <NumberCell value={current_vials_received} />
-                            </Typography>
+                            <Field
+                                label={formatMessage(MESSAGES.vials_received)}
+                                name={`${VAR}[${index}].vials_received`}
+                                component={NumberInput}
+                                disabled={markedForDeletion}
+                                onFocus={onVialsReceivedFocused}
+                                onBlur={onVialsReceivedBlur}
+                                onChange={handleVialsReceivedUpdate}
+                                required
+                            />
                         </Grid>
                     </Grid>
                 </Grid>

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/VaccineSupplyChainDetails.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/VaccineSupplyChainDetails.tsx
@@ -93,7 +93,7 @@ export const VaccineSupplyChainDetails: FunctionComponent = () => {
         initialValues,
         // required to enable data refresh after save
         enableReinitialize: true,
-        // bypassing formik's onSubmit so we can re-use a custom fucntion for save and save all
+        // bypassing formik's onSubmit so we can re-use a custom function for save and save all
         onSubmit: () => undefined,
         validationSchema,
     });

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/hooks/validation.ts
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/hooks/validation.ts
@@ -166,9 +166,7 @@ const useVrfShape = () => {
             .integer()
             .typeError(formatMessage(MESSAGES.positiveInteger)),
         comments: yup.string().nullable(),
-        document: yup
-            .mixed()
-            .nullable()
+        document: yup.mixed().nullable(),
     });
 };
 
@@ -199,9 +197,7 @@ const usePreAlertShape = () => {
             .min(0, formatMessage(MESSAGES.positiveInteger))
             .integer()
             .typeError(formatMessage(MESSAGES.positiveInteger)),
-        document: yup
-            .mixed()
-            .nullable()
+        document: yup.mixed().nullable(),
     });
 };
 const useArrivalReportShape = () => {


### PR DESCRIPTION
user need to be able to input vaccine amounts in doses and vials

Related JIRA tickets : POLIO-1703

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc

Added some comments in the code

## Changes

⚠️ requires https://github.com/BLSQ/bluesquare-components/pull/174 on bluesquare-components

- Change TextFields to NumberInput
- use refs and focus events to prevent circular state updates onChange
- reorganize layout a bit
- add `onFocus` and `onBlur` props to `InputComponent`
- fixed a bug when saving po number in arrival reports 

## How to test

- Update dep to bluesquare-components
- Go to supplychain in vaccine module
- Create and update prealerts and arrival reports

## Print screen / video


https://github.com/user-attachments/assets/ae1e3b5b-8f31-4eb7-997c-9d5fd6fbee1e


https://github.com/user-attachments/assets/2510bb6c-c1f8-4a0b-8898-233c19d977bd


## Notes

⚠️ requires https://github.com/BLSQ/bluesquare-components/pull/174 on bluesquare-components

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
