### PR TITLE
[IA-3882] Fix some endpoints return 200 with empty value when authentication is required but not satisfied

### DIFF
--- a/iaso/api/forms.py
+++ b/iaso/api/forms.py
@@ -20,12 +20,13 @@ from iaso.utils.date_and_time import timestamp_to_datetime
 from .common import CONTENT_TYPE_CSV, CONTENT_TYPE_XLSX, DynamicFieldsModelSerializer, ModelViewSet, TimestampField
 from .enketo import public_url_for_enketo
 from .projects import ProjectSerializer
+from ..permissions import IsAuthenticatedOrReadOnlyWhenNoAuthenticationRequired
 
 
-class HasFormPermission(permissions.BasePermission):
+class HasFormPermission(IsAuthenticatedOrReadOnlyWhenNoAuthenticationRequired):
     def has_permission(self, request, view):
         if request.method in permissions.SAFE_METHODS:
-            return True
+            return super().has_permission(request, view)
 
         return request.user.is_authenticated and request.user.has_perm(permission.FORMS)
 

--- a/iaso/api/mobile/org_units.py
+++ b/iaso/api/mobile/org_units.py
@@ -23,6 +23,7 @@ from iaso.api.query_params import APP_ID, LIMIT, PAGE, IDS
 from iaso.api.serializers import AppIdSerializer
 from iaso.models import Instance, OrgUnit, Project, FeatureFlag
 from hat.menupermissions import models as permission
+from iaso.permissions import IsAuthenticatedOrReadOnlyWhenNoAuthenticationRequired
 
 
 class MobileOrgUnitsSetPagination(Paginator):
@@ -122,7 +123,7 @@ class MobileOrgUnitSerializer(serializers.ModelSerializer):
         return org_unit.location.z if org_unit.location else None
 
 
-class HasOrgUnitPermission(permissions.BasePermission):
+class HasOrgUnitPermission(IsAuthenticatedOrReadOnlyWhenNoAuthenticationRequired):
     def has_object_permission(self, request, view, obj):
         if not (
             request.user.is_authenticated

--- a/iaso/api/org_unit_types/viewsets.py
+++ b/iaso/api/org_unit_types/viewsets.py
@@ -6,6 +6,7 @@ from rest_framework.decorators import action
 from iaso.models import OrgUnitType
 from .serializers import OrgUnitTypeSerializerV1, OrgUnitTypeSerializerV2, OrgUnitTypesDropdownSerializer
 from ..common import ModelViewSet
+from ...permissions import IsAuthenticatedOrReadOnlyWhenNoAuthenticationRequired
 
 DEFAULT_ORDER = "name"
 
@@ -22,7 +23,7 @@ class OrgUnitTypeViewSet(ModelViewSet):
     GET /api/orgunittypes/
     """
 
-    permission_classes = [permissions.IsAuthenticatedOrReadOnly]
+    permission_classes = [IsAuthenticatedOrReadOnlyWhenNoAuthenticationRequired]
     serializer_class = OrgUnitTypeSerializerV1
     results_key = "orgUnitTypes"
     http_method_names = ["get", "post", "patch", "put", "delete", "head", "options", "trace"]
@@ -92,7 +93,7 @@ class OrgUnitTypeViewSetV2(ModelViewSet):
         return queryset.order_by("depth").distinct().order_by(*orders)
 
     @action(
-        permission_classes=[permissions.IsAuthenticatedOrReadOnly],
+        permission_classes=[IsAuthenticatedOrReadOnlyWhenNoAuthenticationRequired],
         detail=False,
         methods=["GET"],
         serializer_class=OrgUnitTypesDropdownSerializer,

--- a/iaso/permissions.py
+++ b/iaso/permissions.py
@@ -1,4 +1,8 @@
 from rest_framework import permissions
+from rest_framework.exceptions import NotAuthenticated
+
+from iaso.api.serializers import AppIdSerializer
+from iaso.models import Project
 
 
 class ReadOnly(permissions.BasePermission):
@@ -6,3 +10,21 @@ class ReadOnly(permissions.BasePermission):
         if request.method in permissions.SAFE_METHODS:
             return True
         return False
+
+
+class IsAuthenticatedOrReadOnlyWhenNoAuthenticationRequired(permissions.IsAuthenticatedOrReadOnly):
+    def has_permission(self, request, view):
+        app_id = AppIdSerializer(data=request.query_params).get_app_id(raise_exception=False)
+        if app_id is not None:
+            try:
+                project = Project.objects.get(app_id=app_id)
+                if not bool(request.user and request.user.is_authenticated):
+                    if project.needs_authentication:
+                        raise NotAuthenticated()
+                elif request.user.iaso_profile.account.id != project.account.id:
+                    raise NotAuthenticated()
+
+            except Project.DoesNotExist:
+                return super().has_permission(request, view)
+
+        return super().has_permission(request, view)

--- a/iaso/tests/api/test_form_versions.py
+++ b/iaso/tests/api/test_form_versions.py
@@ -8,6 +8,7 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import override_settings
 
 from iaso import models as m
+from iaso.api.query_params import APP_ID
 from iaso.test import APITestCase
 
 
@@ -31,7 +32,10 @@ class FormsVersionAPITestCase(APITestCase):
         cls.sith_council = m.OrgUnitType.objects.create(name="Sith Council", short_name="Cnc")
 
         cls.project = m.Project.objects.create(
-            name="Hydroponic gardens", app_id="stars.empire.agriculture.hydroponics", account=star_wars
+            name="Hydroponic gardens",
+            app_id="stars.empire.agriculture.hydroponics",
+            account=star_wars,
+            needs_authentication=True,
         )
         cls.project.unit_types.add(cls.sith_council)
 
@@ -393,6 +397,26 @@ class FormsVersionAPITestCase(APITestCase):
             format="multipart",
         )
         self.assertJSONResponse(response, 400)
+
+    def test_formversions_list_without_auth_for_project_requiring_auth(self):
+        """GET /formversions/ without auth for project which requires it: 401"""
+
+        response = self.client.get("/api/formversions/", {APP_ID: self.project.app_id})
+        self.assertJSONResponse(response, 401)
+
+    def test_formversions_list_with_wrong_auth_for_project_requiring_auth(self):
+        """GET /formversions/ with wrong auth for project which requires it: 401"""
+
+        self.client.force_authenticate(user=self.batman)
+        response = self.client.get("/api/formversions/", {APP_ID: self.project.app_id})
+        self.assertJSONResponse(response, 401)
+
+    def test_formversions_list_with_auth_for_project_requiring_auth(self):
+        """GET /formversions/ with auth for project which requires it: 200"""
+
+        self.client.force_authenticate(user=self.yoda)
+        response = self.client.get("/api/formversions/", {APP_ID: self.project.app_id})
+        self.assertJSONResponse(response, 200)
 
     def assertValidFormVersionData(
         self, form_version_data: typing.Mapping, *, check_annotated_fields: bool = True

--- a/iaso/tests/api/test_forms.py
+++ b/iaso/tests/api/test_forms.py
@@ -5,6 +5,7 @@ from django.utils.timezone import now
 
 from iaso import models as m
 from iaso.api.common import CONTENT_TYPE_XLSX
+from iaso.api.query_params import APP_ID
 from iaso.models import Form, OrgUnit, Instance
 from iaso.test import APITestCase
 
@@ -38,7 +39,10 @@ class FormsAPITestCase(APITestCase):
         cls.sith_guild = m.OrgUnitType.objects.create(name="Sith guild", short_name="Sith")
 
         cls.project_1 = m.Project.objects.create(
-            name="Hydroponic gardens", app_id="stars.empire.agriculture.hydroponics", account=star_wars
+            name="Hydroponic gardens",
+            app_id="stars.empire.agriculture.hydroponics",
+            account=star_wars,
+            needs_authentication=True,
         )
         cls.project_2 = m.Project.objects.create(
             name="New Land Speeder concept", app_id="stars.empire.agriculture.land_speeder", account=star_wars
@@ -87,6 +91,26 @@ class FormsAPITestCase(APITestCase):
         self.assertJSONResponse(response, 200)
 
         self.assertValidFormListData(response.json(), 0)
+
+    def test_forms_list_without_auth_for_project_requiring_auth(self):
+        """GET /forms/ without auth for project which requires it: 401"""
+
+        response = self.client.get("/api/forms/", {APP_ID: self.project_1.app_id})
+        self.assertJSONResponse(response, 401)
+
+    def test_forms_list_with_wrong_auth_for_project_requiring_auth(self):
+        """GET /forms/ with wrong auth for project which requires it: 401"""
+
+        self.client.force_authenticate(user=self.iron_man)
+        response = self.client.get("/api/forms/", {APP_ID: self.project_1.app_id})
+        self.assertJSONResponse(response, 401)
+
+    def test_forms_list_with_auth_for_project_requiring_auth(self):
+        """GET /forms/ with auth for project which requires it: 200"""
+
+        self.client.force_authenticate(user=self.yoda)
+        response = self.client.get("/api/forms/", {APP_ID: self.project_1.app_id})
+        self.assertJSONResponse(response, 200)
 
     def test_forms_list_empty_for_user(self):
         """GET /forms/ with a user that has no access to any form"""
@@ -194,7 +218,7 @@ class FormsAPITestCase(APITestCase):
 
     def test_forms_list_ok_hide_derived_forms(self):
         """GET /forms/ web app happy path: we expect 1 results if one of the form is marked as derived"""
-
+        self.client.force_authenticate(self.yoda)
         response = self.client.get(f"/api/forms/?app_id={self.project_1.app_id}")
         self.assertJSONResponse(response, 200)
         self.assertValidFormListData(response.json(), 2)

--- a/iaso/tests/api/test_mobile_orgunits.py
+++ b/iaso/tests/api/test_mobile_orgunits.py
@@ -29,8 +29,15 @@ class MobileOrgUnitAPITestCase(APITestCase):
     @classmethod
     def setUpTestData(cls):
         cls.account = account = Account.objects.create(name="Dragon Ball")
-        cls.project = project = Project.objects.create(name="Saiyans", app_id=BASE_APP_ID, account=account)
+        cls.account2 = account2 = Account.objects.create(name="Saint Seiya")
+        cls.project = project = Project.objects.create(
+            name="Saiyans",
+            app_id=BASE_APP_ID,
+            account=account,
+            needs_authentication=True,
+        )
         cls.user = user = cls.create_user_with_profile(username="user", account=account, permissions=["iaso_org_units"])
+        cls.user2 = cls.create_user_with_profile(username="user2", account=account2, permissions=["iaso_org_units"])
         cls.sw_source = sw_source = DataSource.objects.create(name="Vegeta Planet")
         sw_source.projects.add(project)
         cls.sw_version_1 = sw_version_1 = SourceVersion.objects.create(data_source=sw_source, number=1)
@@ -105,6 +112,26 @@ class MobileOrgUnitAPITestCase(APITestCase):
 
         group_2.org_units.set([bardock, goku])
         user.iaso_profile.org_units.set([raditz, goku])
+
+    def test_orgunits_list_without_auth_for_project_requiring_auth(self):
+        """GET /mobile/orgunits/ without auth for project which requires it: 401"""
+
+        response = self.client.get(BASE_URL, {APP_ID: self.project.app_id})
+        self.assertJSONResponse(response, 401)
+
+    def test_orgunits_list_with_wrong_auth_for_project_requiring_auth(self):
+        """GET /mobile/orgunits/ with wrong auth for project which requires it: 401"""
+
+        self.client.force_authenticate(user=self.user2)
+        response = self.client.get(BASE_URL, {APP_ID: self.project.app_id})
+        self.assertJSONResponse(response, 401)
+
+    def test_orgunits_list_with_auth_for_project_requiring_auth(self):
+        """GET /mobile/orgunits/ with auth for project which requires it: 200"""
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(BASE_URL, {APP_ID: self.project.app_id})
+        self.assertJSONResponse(response, 200)
 
     def test_org_unit_have_correct_parent_id_without_limit(self):
         self.client.force_authenticate(self.user)


### PR DESCRIPTION
When logged out or connected with a user account linked to another account, accessing forms, formversions, orgunits, and orgunitypes endpoints return a 200 answer with an empty body when the project requires authentication.

This is an issue when switching projects in the Iaso Demo application and other applications where changing appId is possible (E.g.: Pathways).

By returning a 401 in those cases, the mobile application can adequately handle this and direct the user to the login page.

Related JIRA tickets : IA-3882

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well documented
- [X] Are there enough tests

## Changes

Adding a new permission class and applying it where it makes sense.

## How to test

Before the fix, accessing the specified endpoint for a project that requires authentication while being logged out would return a 200. 
After the fix, it should return a 401.
Same goes when logged in with a user account from another account than the project's account. 


## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
