### PR TITLE
IA-3880: HOTFIX: show groups source +version

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/groupSets/config.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/groupSets/config.tsx
@@ -41,19 +41,24 @@ export const useGroupSetsTableColumns = (deleteGroupSet): Column[] => {
                 sortable: false,
                 width: 200,
                 Cell: settings => {
-                    settings.row.original.groups.sort((a, b) =>
-                        a.name > b.name ? 1 : b.name > a.name ? -1 : 0,
-                    );
+                    const groups = settings.row.original.groups.sort((a, b) => {
+                        if (a.name > b.name) return 1;
+                        if (b.name > a.name) return -1;
+                        return 0;
+                    });
                     return (
                         <span>
-                            {settings.row.original.groups.map(g => (
-                                <Chip
-                                    className={classes.groupChip}
-                                    label={g.name}
-                                    color="primary"
-                                    key={g.id}
-                                />
-                            ))}
+                            {groups.map(group => {
+                                const label = `${group.name} (${group.source_version.data_source.name}) - ${group.source_version.number}`;
+                                return (
+                                    <Chip
+                                        className={classes.groupChip}
+                                        label={label}
+                                        color="primary"
+                                        key={group.id}
+                                    />
+                                );
+                            })}
                         </span>
                     );
                 },

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/hooks/requests/useGetGroupSets.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/hooks/requests/useGetGroupSets.ts
@@ -26,7 +26,7 @@ export const useGetGroupSetsDropdown = (
                 return data.map(groupSet => {
                     return {
                         value: groupSet.id,
-                        label: groupSet.name,
+                        label: groupSet.label,
                         original: groupSet,
                     };
                 });

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/hooks/requests/useGetGroups.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/hooks/requests/useGetGroups.ts
@@ -100,7 +100,7 @@ export const useGetGroupDropdown = (
                 return data.map(group => {
                     return {
                         value: group.id,
-                        label: group.name,
+                        label: group.label,
                         original: group,
                     };
                 });

--- a/iaso/api/group_sets/views.py
+++ b/iaso/api/group_sets/views.py
@@ -29,10 +29,18 @@ class GroupSetPagination(Paginator):
 
 
 class GroupSetDropdownSerializer(serializers.ModelSerializer):
+    label = serializers.SerializerMethodField()
+
+    def get_label(self, obj):
+        datasource = obj.source_version.data_source.name
+        version = obj.source_version.number
+        name = obj.name
+        return f"{name} ({datasource} - {version})"
+
     class Meta:
         model = GroupSet
-        fields = ["id", "name"]
-        read_only_fields = ["id", "name"]
+        fields = ["id", "name", "label"]
+        read_only_fields = ["id", "name", "label"]
 
 
 class GroupSetsViewSet(ModelViewSet):

--- a/iaso/api/groups.py
+++ b/iaso/api/groups.py
@@ -72,13 +72,18 @@ class GroupSerializer(serializers.ModelSerializer):
 
 
 class GroupDropdownSerializer(serializers.ModelSerializer):
+    label = serializers.SerializerMethodField()
+
+    def get_label(self, obj):
+        datasource = obj.source_version.data_source.name
+        version_number = obj.source_version.number
+        name = obj.name
+        return f"{name} ({datasource} - {version_number})"
+
     class Meta:
         model = Group
-        fields = [
-            "id",
-            "name",
-        ]
-        read_only_fields = ["id", "name"]
+        fields = ["id", "name", "label"]
+        read_only_fields = ["id", "name", "label"]
 
 
 class GroupsViewSet(ModelViewSet):

--- a/iaso/api/org_unit_change_request_configurations/views_mobile.py
+++ b/iaso/api/org_unit_change_request_configurations/views_mobile.py
@@ -1,9 +1,9 @@
 from itertools import chain
 
 import django_filters
+from django.utils import timezone
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
-
 from rest_framework import viewsets
 from rest_framework.mixins import ListModelMixin
 from rest_framework.request import Request
@@ -78,7 +78,12 @@ class MobileOrgUnitChangeRequestConfigurationViewSet(ListModelMixin, viewsets.Ge
             non_editable_org_unit_type_ids = project_org_unit_types - user_editable_org_unit_type_ids
 
             dynamic_configurations = [
-                OrgUnitChangeRequestConfiguration(org_unit_type_id=org_unit_type_id, org_units_editable=False)
+                OrgUnitChangeRequestConfiguration(
+                    org_unit_type_id=org_unit_type_id,
+                    org_units_editable=False,
+                    created_at=timezone.now(),
+                    updated_at=timezone.now(),
+                )
                 for org_unit_type_id in non_editable_org_unit_type_ids
             ]
 

--- a/iaso/tests/api/org_unit_change_request_configurations/test_org_unit_change_request_configs_mobile.py
+++ b/iaso/tests/api/org_unit_change_request_configurations/test_org_unit_change_request_configs_mobile.py
@@ -1,3 +1,8 @@
+import datetime
+import time_machine
+
+from django.utils import timezone
+
 from rest_framework import status
 
 from django.contrib.auth.models import Group
@@ -5,7 +10,10 @@ from django.contrib.auth.models import Group
 from iaso import models as m
 from iaso.tests.api.org_unit_change_request_configurations.common_base_with_setup import OUCRCAPIBase
 
+CREATED_AT = datetime.datetime(2025, 1, 20, 10, 31, 0, 0, tzinfo=timezone.utc)
 
+
+@time_machine.travel(CREATED_AT, tick=False)
 class MobileOrgUnitChangeRequestConfigurationAPITestCase(OUCRCAPIBase):
     """
     Test mobile OUCRCViewSet.
@@ -104,8 +112,8 @@ class MobileOrgUnitChangeRequestConfigurationAPITestCase(OUCRCAPIBase):
                     "group_set_ids": [],
                     "editable_reference_form_ids": [],
                     "other_group_ids": [],
-                    "created_at": None,
-                    "updated_at": None,
+                    "created_at": CREATED_AT.timestamp(),
+                    "updated_at": CREATED_AT.timestamp(),
                 },
                 # Because of the configuration of his Profile, the user can't write on `ou_type_water_pokemons`,
                 # so we override the existing configuration.
@@ -118,8 +126,8 @@ class MobileOrgUnitChangeRequestConfigurationAPITestCase(OUCRCAPIBase):
                     "group_set_ids": [],
                     "editable_reference_form_ids": [],
                     "other_group_ids": [],
-                    "created_at": None,
-                    "updated_at": None,
+                    "created_at": CREATED_AT.timestamp(),
+                    "updated_at": CREATED_AT.timestamp(),
                 },
                 # Because of the configuration of his Profile, the user can't write on `new_org_unit_type_1`,
                 # and since there is no existing configuration, we add a dynamic one.
@@ -132,8 +140,8 @@ class MobileOrgUnitChangeRequestConfigurationAPITestCase(OUCRCAPIBase):
                     "group_set_ids": [],
                     "editable_reference_form_ids": [],
                     "other_group_ids": [],
-                    "created_at": None,
-                    "updated_at": None,
+                    "created_at": CREATED_AT.timestamp(),
+                    "updated_at": CREATED_AT.timestamp(),
                 },
                 # Because of the configuration of his Profile, the user can't write on `new_org_unit_type_2`,
                 # and since there is no existing configuration, we add a dynamic one.
@@ -146,8 +154,8 @@ class MobileOrgUnitChangeRequestConfigurationAPITestCase(OUCRCAPIBase):
                     "group_set_ids": [],
                     "editable_reference_form_ids": [],
                     "other_group_ids": [],
-                    "created_at": None,
-                    "updated_at": None,
+                    "created_at": CREATED_AT.timestamp(),
+                    "updated_at": CREATED_AT.timestamp(),
                 },
             ],
         )


### PR DESCRIPTION
What problem is this PR solving? Explain here in one sentence.

Related JIRA tickets : IA-3880

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc

N/A

## Changes

- Add `label` field in `GroupDropDownSerializer` and `GroupSetDropDownSerializer`
- Use label in `useGetGroupSets` and `useGetGroupsDropdown`

## How to test

- Go to group sets: groups source and version should be visible:
    - in table
    - in create/edit modal    

- Go to org unit change requests:
    - source + version should be visible in  groups dropdown

- Go to change request config page:
    - source + version should be visible in create/edit modal
    - idem for group sets 

## Print screen / video
![Screenshot 2025-01-21 at 12 11 15](https://github.com/user-attachments/assets/c5d0671d-a267-4fdd-b8d0-a3909bbc50c5)


![Screenshot 2025-01-21 at 12 11 39](https://github.com/user-attachments/assets/27eb5bd2-2b09-434a-b850-d1b94d9fe1b0)

![Screenshot 2025-01-21 at 12 10 53](https://github.com/user-attachments/assets/c0928032-2ae8-4f86-befa-091844ce55b8)

## Notes

- This PR is hotfixable on v1.251a
- It should be deployed but not merged, as additional work is necessary for the feature to be complete. This hotfix aims to unblock a specific user

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
