### PR TITLE
IA-3883 try to debug flacky test on github ci

### DIFF
--- a/iaso/tests/api/test_instances.py
+++ b/iaso/tests/api/test_instances.py
@@ -1699,6 +1699,14 @@ class InstancesAPITestCase(APITestCase):
         self.assertEqual(response_yoda.status_code, 200)
         self.assertValidInstanceListData(response_yoda.json(), 4)
         instances = response_yoda.json()["instances"]
+        print("\n**** api response")
+        for i in instances:
+            print(i.get("id"), i.get("updated_at"), i.get("created_at"))
+
+        print("**** db content")
+        for i in Instance.objects.all():
+            print(i.id, i.updated_at, i.created_at)
+
         self.assertEqual(self.instance_1.id, instances[0].get("id"))
         self.assertEqual(self.instance_4.id, instances[1].get("id"))
         self.assertEqual(self.instance_5.id, instances[3].get("id"))

--- a/iaso/tests/api/test_instances.py
+++ b/iaso/tests/api/test_instances.py
@@ -2471,7 +2471,7 @@ class InstancesAPITestCase(APITestCase):
             self.assertListEqual(sorted(actual_instances_ids), sorted([i.id for i in expected_instances]))
         except AssertionError as e:
             print("expected ", api_response.json(), "to contains", expected_instances, " but", e)
-            print("exected ids ", [i.id for i in expected_instances])
+            print("expected ids ", [i.id for i in expected_instances])
             print("actual ids ", [x.get("id") for x in api_response.json()["instances"]])
             print("instance_1", self.instance_1.id)
             print("instance_2", self.instance_2.id)


### PR DESCRIPTION
the tests around instances endpoints are flacky.


Related JIRA tickets : IA-3883

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes


the default order on updated_at seem to be non deterministic in certain cases
various fixes have implemented across tests generally testing api filters (either using `sorted()` or adding `order=-id`

Here I reuse a shared assertion to apply the same solution (not caring about the order) but also giving more context to actually debug it when assertion are wrong


## How to test

check the CI.

## Print screen / video

![image](https://github.com/user-attachments/assets/e80abbd0-839e-4530-bb3b-bd5a0962fabb)


## Notes

I know I use print but I think it's ok here (only happen on failure so either the test is again flacky, and the additional log will help us, or a modification in the setup changes the results)

Another option would be to throw a new AssertionError with that message but I fear it would make debugging less clear since it will probably "override" the stacktrace or at least hide it more.

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: flacky instances tests

Refs: IA-3883
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
