### PR TITLE
IA-3469: Adding ROBOTS.TXT

### DIFF
--- a/hat/urls.py
+++ b/hat/urls.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin, auth
 from django.db import models
+from django.http import HttpResponse
 from django.shortcuts import render
 from django.urls import include, path, re_path
 from django.views.generic import RedirectView, TemplateView
@@ -14,11 +15,12 @@ from drf_yasg import openapi
 from drf_yasg.views import get_schema_view
 from rest_framework import permissions
 
-from iaso.views import ModelDataView, health, page
+from iaso.views import ModelDataView, health, page, robots_txt
 
 admin.site.site_header = "Administration de Iaso"
 admin.site.site_title = "Iaso"
 admin.site.index_title = "Administration de Iaso"
+
 
 if settings.MAINTENANCE_MODE:
     urlpatterns = [
@@ -67,6 +69,7 @@ else:
         urlpatterns += [path("accounts/", include(provider_urlpatterns))]
 
     urlpatterns += [
+        path("robots.txt", robots_txt),
         path("", RedirectView.as_view(pattern_name="dashboard:home_iaso", permanent=False), name="index"),
         path("_health/", health),
         path("_health", health),  # same without slash otherwise AWS complain about redirect

--- a/iaso/views.py
+++ b/iaso/views.py
@@ -145,6 +145,12 @@ def health(request):
     return JsonResponse(res)
 
 
+def robots_txt(request):
+    content = """User-agent: *
+Disallow: /"""
+    return HttpResponse(content, content_type="text/plain")
+
+
 import json
 
 from django.contrib.contenttypes.fields import GenericForeignKey


### PR DESCRIPTION
Add a robots.txt blocking the search for iaso.bluesquare.org (and the web app in particular
Related JIRA tickets : IA-3469

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)


## Changes

Adding  dedicated view in urls

## How to test

Visit http://localhost:8081/robots.txt, you should see 

<img width="478" alt="Screenshot 2025-01-22 at 09 16 04" src="https://github.com/user-attachments/assets/516482af-ea86-41ba-a3fb-db089eff1465" />


## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
