### PR TITLE
IA-3885: Sentry should not be enabled on public pages

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/app/contexts/SentryProvider.tsx
+++ b/hat/assets/js/apps/Iaso/domains/app/contexts/SentryProvider.tsx
@@ -32,6 +32,7 @@ export type SentryConfig = {
 
 type Props = {
     children: React.ReactNode;
+    isCurrentRouteAnonymous: boolean;
 };
 
 const SentryContext = createContext<SentryContextType | undefined>(undefined);
@@ -103,7 +104,10 @@ const MESSAGES = defineMessages({
         id: 'iaso.analytics.consent.accept',
     },
 });
-export const SentryProvider: FunctionComponent<Props> = ({ children }) => {
+export const SentryProvider: FunctionComponent<Props> = ({
+    children,
+    isCurrentRouteAnonymous,
+}) => {
     const [showDialog, setShowDialog] = useState(false);
     const [hasConsent, setHasConsent] = useState(
         () => localStorage.getItem('sentry-consent') === 'true',
@@ -111,7 +115,10 @@ export const SentryProvider: FunctionComponent<Props> = ({ children }) => {
     const { formatMessage } = useSafeIntl();
 
     useEffect(() => {
-        if (window.SENTRY_CONFIG?.SENTRY_FRONT_ENABLED) {
+        if (
+            window.SENTRY_CONFIG?.SENTRY_FRONT_ENABLED &&
+            !isCurrentRouteAnonymous
+        ) {
             const hasStoredConsent = localStorage.getItem('sentry-consent');
             if (
                 !hasStoredConsent &&
@@ -125,7 +132,7 @@ export const SentryProvider: FunctionComponent<Props> = ({ children }) => {
                 }
             }
         }
-    }, []);
+    }, [isCurrentRouteAnonymous]);
 
     const handleConsent = useCallback((consent: boolean) => {
         localStorage.setItem('sentry-consent', consent.toString());

--- a/hat/assets/js/apps/Iaso/domains/app/hooks/useRoutes.tsx
+++ b/hat/assets/js/apps/Iaso/domains/app/hooks/useRoutes.tsx
@@ -23,6 +23,7 @@ type Result = {
     routes: ReactElement | null;
     nonDashboardRoutes: ReactElement | null;
     isLoadingRoutes: boolean;
+    isCurrentRouteAnonymous: boolean;
 };
 
 const useHomeOnlineComponent = (): ElementType | undefined => {
@@ -185,12 +186,13 @@ export const useRoutes = (userHomePage?: string): Result => {
             currentRoute?.baseUrl === baseUrls.home,
         false,
     );
+    const isCurrentRouteAnonymous = Boolean(currentRoute?.allowAnonymous);
     const redirections = useRedirections({
         hasNoAccount,
         isFetchingCurrentUser,
         pluginRedirections,
         userHomePage,
-        allowAnonymous: Boolean(currentRoute?.allowAnonymous),
+        allowAnonymous: isCurrentRouteAnonymous,
     });
     // routes should protectedRoutes change if currentUser has changed
     const routes: ReactElement | null = useMemo(
@@ -226,7 +228,13 @@ export const useRoutes = (userHomePage?: string): Result => {
             routes,
             nonDashboardRoutes,
             isLoadingRoutes: isFetchingCurrentUser,
+            isCurrentRouteAnonymous,
         }),
-        [routes, isFetchingCurrentUser, nonDashboardRoutes],
+        [
+            routes,
+            isFetchingCurrentUser,
+            nonDashboardRoutes,
+            isCurrentRouteAnonymous,
+        ],
     );
 };

--- a/hat/assets/js/apps/Iaso/domains/app/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/app/index.tsx
@@ -2,9 +2,9 @@ import { LoadingSpinner } from 'bluesquare-components';
 import React, { FunctionComponent } from 'react';
 import { BrowserRouter } from 'react-router-dom';
 import { useSnackBars } from '../../components/snackBars/useSnackBars';
+import { InputContextProvider } from './contexts/InputContext';
 import { SentryProvider } from './contexts/SentryProvider';
 import { useRoutes } from './hooks/useRoutes';
-import { InputContextProvider } from './contexts/InputContext';
 
 type Props = {
     userHomePage?: string;
@@ -13,7 +13,12 @@ type Props = {
 const dashboardBasename = '/dashboard';
 
 const App: FunctionComponent<Props> = ({ userHomePage }) => {
-    const { nonDashboardRoutes, routes, isLoadingRoutes } = useRoutes(
+    const {
+        nonDashboardRoutes,
+        routes,
+        isLoadingRoutes,
+        isCurrentRouteAnonymous,
+    } = useRoutes(
         userHomePage && userHomePage !== '' ? userHomePage : undefined,
     );
     useSnackBars();
@@ -24,7 +29,7 @@ const App: FunctionComponent<Props> = ({ userHomePage }) => {
         return <LoadingSpinner />;
     }
     return (
-        <SentryProvider>
+        <SentryProvider isCurrentRouteAnonymous={isCurrentRouteAnonymous}>
             <BrowserRouter
                 basename={isDashboardPath ? dashboardBasename : undefined}
             >


### PR DESCRIPTION
While visiting embedding pages on Polio, we should not see the cookies pop-up.

Related JIRA tickets : IA-3885
## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

disable SENTRY on public pages

## How to test

You need a SENTRY account set in your env variable and to remove all your cookies on localhost. Then visit a public page like the polio calendar or the vaccine stocks


## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
