### PR TITLE
POLIO-1832: SIA calendar: target population should not say "0" when no data entered

### DIFF
--- a/plugins/polio/js/src/domains/Calendar/campaignCalendar/popper/RoundPopper.tsx
+++ b/plugins/polio/js/src/domains/Calendar/campaignCalendar/popper/RoundPopper.tsx
@@ -2,7 +2,11 @@ import React, { FunctionComponent } from 'react';
 
 import CloseIcon from '@mui/icons-material/Close';
 import { Box, Button, Grid, IconButton, Paper, Popper } from '@mui/material';
-import { getTableUrl, useSafeIntl } from 'bluesquare-components';
+import {
+    getTableUrl,
+    textPlaceholder,
+    useSafeIntl,
+} from 'bluesquare-components';
 
 import { CsvButton } from '../../../../../../../../hat/assets/js/apps/Iaso/components/Buttons/CsvButton';
 import { SxStyles } from '../../../../../../../../hat/assets/js/apps/Iaso/types/general';
@@ -101,7 +105,9 @@ export const RoundPopper: FunctionComponent<Props> = ({
                             {formatMessage(MESSAGES.targetPopulation)}:
                         </Grid>
                         <Grid item sm={6} container justifyContent="flex-start">
-                            {formatNumber(round.target_population)}
+                            {round.target_population
+                                ? formatNumber(round.target_population)
+                                : textPlaceholder}
                         </Grid>
 
                         <Grid item sm={6} container justifyContent="flex-end">


### PR DESCRIPTION
SIA calendar: target population should not say "0" when no data entered
Related JIRA tickets POLIO-1832

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

 display placeholder if no target population

## How to test

Open round popup on calendar on a round without target population. You should see a placeholder instead of 0


## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
