### PR TITLE
IA-3852 Ensure that whitespaces are being trimmed when rejecting a change request

### DIFF
--- a/iaso/tests/api/org_unit_change_requests/test_serializers.py
+++ b/iaso/tests/api/org_unit_change_requests/test_serializers.py
@@ -690,7 +690,7 @@ class OrgUnitChangeRequestReviewSerializerTestCase(TestCase):
     def test_validate(self):
         data = {
             "status": OrgUnitChangeRequest.Statuses.REJECTED,
-            "rejection_comment": "",
+            "rejection_comment": "       ",
         }
         serializer = OrgUnitChangeRequestReviewSerializer(data=data)
         with self.assertRaises(ValidationError) as error:

--- a/iaso/tests/api/org_unit_change_requests/test_serializers.py
+++ b/iaso/tests/api/org_unit_change_requests/test_serializers.py
@@ -690,6 +690,15 @@ class OrgUnitChangeRequestReviewSerializerTestCase(TestCase):
     def test_validate(self):
         data = {
             "status": OrgUnitChangeRequest.Statuses.REJECTED,
+            "rejection_comment": "",
+        }
+        serializer = OrgUnitChangeRequestReviewSerializer(data=data)
+        with self.assertRaises(ValidationError) as error:
+            serializer.is_valid(raise_exception=True)
+        self.assertEqual(error.exception.detail["non_field_errors"][0], "A `rejection_comment` must be provided.")
+
+        data = {
+            "status": OrgUnitChangeRequest.Statuses.REJECTED,
             "rejection_comment": "       ",
         }
         serializer = OrgUnitChangeRequestReviewSerializer(data=data)


### PR DESCRIPTION
Ensure that whitespaces are being trimmed when rejecting a change request.

Related JIRA tickets : [IA-3852](https://bluesquare.atlassian.net/browse/IA-3852)

## Changes

The code is already working as expected. I just modified a test to get a proof.

Here is how it works:

```python
In [1]: from iaso.api.org_unit_change_requests.serializers import OrgUnitChangeRequestReviewSerializer

In [2]: serializer = OrgUnitChangeRequestReviewSerializer()

In [3]: print(repr(serializer))
OrgUnitChangeRequestReviewSerializer():
    status = ChoiceField(choices=[('new', 'New'), ('rejected', 'Rejected'), ('approved', 'Approved')], required=False)
    approved_fields = ListField(child=CharField(allow_blank=True, label='Approved fields', max_length=30, required=False), help_text='List of approved fields names (only a subset can be approved).', required=False)
    rejection_comment = CharField(allow_blank=True, required=False, style={'base_template': 'textarea.html'})

In [4]: fields = serializer.get_fields()

In [5]: fields["rejection_comment"].trim_whitespace
Out[5]: True
```

You can see that `trim_whitespace` is set to `True` [as defined in DRF](https://github.com/encode/django-rest-framework/blob/78e0b84ac9c2dcd9b42be1397b6aae611e6da148/rest_framework/fields.py#L733C14-L733C31).

## Video

https://github.com/user-attachments/assets/b464f0c6-c237-483a-93cb-9fd39385389c


[IA-3852]: https://bluesquare.atlassian.net/browse/IA-3852?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ