### PR TITLE
POLIO-1835: input error visual glitch

### DIFF
--- a/plugins/polio/js/src/components/Inputs/TextInput.js
+++ b/plugins/polio/js/src/components/Inputs/TextInput.js
@@ -1,7 +1,7 @@
-import React, { useCallback } from 'react';
-import PropTypes from 'prop-types';
 import { TextField } from '@mui/material';
 import { get } from 'lodash';
+import PropTypes from 'prop-types';
+import React, { useCallback } from 'react';
 
 export const TextInput = ({
     field = {},
@@ -27,6 +27,11 @@ export const TextInput = ({
         <TextField
             InputLabelProps={{
                 shrink: Boolean(field.value ?? value ?? '') || shrinkLabel,
+            }}
+            FormHelperTextProps={{
+                sx: {
+                    mb: 1,
+                },
             }}
             fullWidth
             variant="outlined"

--- a/plugins/polio/js/src/components/Inputs/TextInput.js
+++ b/plugins/polio/js/src/components/Inputs/TextInput.js
@@ -28,11 +28,6 @@ export const TextInput = ({
             InputLabelProps={{
                 shrink: Boolean(field.value ?? value ?? '') || shrinkLabel,
             }}
-            FormHelperTextProps={{
-                sx: {
-                    mb: 1,
-                },
-            }}
             fullWidth
             variant="outlined"
             size="medium"

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/PreAlerts/PreAlert.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/PreAlerts/PreAlert.tsx
@@ -117,31 +117,6 @@ export const PreAlert: FunctionComponent<Props> = ({ index, vaccine }) => {
                                 disabled={markedForDeletion}
                                 required
                             />
-                        </Grid>
-                        <Grid item xs={6} md={4}>
-                            <Field
-                                label={formatMessage(MESSAGES.po_number)}
-                                name={`pre_alerts[${index}].po_number`}
-                                component={TextInput}
-                                disabled={markedForDeletion}
-                                shrinkLabel={false}
-                                required
-                            />
-                        </Grid>
-                        <Grid item xs={6} md={4}>
-                            <Field
-                                label={formatMessage(
-                                    MESSAGES.estimated_arrival_time,
-                                )}
-                                name={`pre_alerts[${index}].estimated_arrival_time`}
-                                component={DateInput}
-                                disabled={markedForDeletion}
-                                required
-                            />
-                        </Grid>
-                    </Grid>
-                    <Grid container item xs={12} spacing={2}>
-                        <Grid item xs={6} md={4}>
                             <Field
                                 label={formatMessage(MESSAGES.doses_shipped)}
                                 name={`pre_alerts[${index}].doses_shipped`}
@@ -152,41 +127,7 @@ export const PreAlert: FunctionComponent<Props> = ({ index, vaccine }) => {
                                 onBlur={onDosesBlur}
                                 required
                             />
-                        </Grid>
-                        <Grid item xs={6} md={4}>
-                            <Field
-                                label={formatMessage(MESSAGES.vials_shipped)}
-                                name={`pre_alerts[${index}].vials_shipped`}
-                                component={NumberInput}
-                                disabled={markedForDeletion}
-                                onChange={handleVialsShippedUpdate}
-                                onFocus={onVialsFocus}
-                                onBlur={onVialsBlur}
-                                required
-                            />
-                        </Grid>
-                        <Grid
-                            container
-                            item
-                            xs={6}
-                            md={4}
-                            alignContent="center"
-                        >
-                            <Box>
-                                <Typography
-                                    variant="button"
-                                    sx={uneditableTextStyling}
-                                >
-                                    {`${formatMessage(
-                                        MESSAGES.doses_per_vial,
-                                    )}:`}{' '}
-                                    <NumberCell value={doses_per_vial} />
-                                </Typography>
-                            </Box>
-                        </Grid>
-
-                        <Grid item xs={12} md={4}>
-                            <Box>
+                            <Box mt={2}>
                                 <DocumentUploadWithPreview
                                     errors={documentErrors}
                                     onFilesSelect={files => {
@@ -206,6 +147,50 @@ export const PreAlert: FunctionComponent<Props> = ({ index, vaccine }) => {
                                         values?.pre_alerts?.[index]?.document
                                     }
                                 />
+                            </Box>
+                        </Grid>
+                        <Grid item xs={6} md={4}>
+                            <Box mb={2}>
+                                <Field
+                                    label={formatMessage(MESSAGES.po_number)}
+                                    name={`pre_alerts[${index}].po_number`}
+                                    component={TextInput}
+                                    disabled={markedForDeletion}
+                                    shrinkLabel={false}
+                                    required
+                                />
+                            </Box>
+                            <Field
+                                label={formatMessage(MESSAGES.vials_shipped)}
+                                name={`pre_alerts[${index}].vials_shipped`}
+                                component={NumberInput}
+                                disabled={markedForDeletion}
+                                onChange={handleVialsShippedUpdate}
+                                onFocus={onVialsFocus}
+                                onBlur={onVialsBlur}
+                                required
+                            />
+                        </Grid>
+                        <Grid item xs={6} md={4}>
+                            <Field
+                                label={formatMessage(
+                                    MESSAGES.estimated_arrival_time,
+                                )}
+                                name={`pre_alerts[${index}].estimated_arrival_time`}
+                                component={DateInput}
+                                disabled={markedForDeletion}
+                                required
+                            />
+                            <Box>
+                                <Typography
+                                    variant="button"
+                                    sx={uneditableTextStyling}
+                                >
+                                    {`${formatMessage(
+                                        MESSAGES.doses_per_vial,
+                                    )}:`}{' '}
+                                    <NumberCell value={doses_per_vial} />
+                                </Typography>
                             </Box>
                         </Grid>
                     </Grid>

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/VAR/VaccineArrivalReport.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/VAR/VaccineArrivalReport.tsx
@@ -203,16 +203,28 @@ export const VaccineArrivalReport: FunctionComponent<Props> = ({
                     <Grid container item xs={12} spacing={2}>
                         <Grid item xs={6} md={3}>
                             {/* TODO Add errors */}
+                            <Box mb={2}>
+                                <Field
+                                    label={formatMessage(MESSAGES.po_number)}
+                                    name={`${VAR}[${index}].po_number`}
+                                    component={Select}
+                                    shrinkLabel={false}
+                                    freeSolo
+                                    options={poNumberOptions}
+                                    disabled={markedForDeletion}
+                                    required
+                                    onChange={handleChangePoNumber}
+                                />
+                            </Box>
                             <Field
-                                label={formatMessage(MESSAGES.po_number)}
-                                name={`${VAR}[${index}].po_number`}
-                                component={Select}
-                                shrinkLabel={false}
-                                freeSolo
-                                options={poNumberOptions}
+                                label={formatMessage(MESSAGES.vials_shipped)}
+                                name={`${VAR}[${index}].vials_shipped`}
+                                component={NumberInput}
                                 disabled={markedForDeletion}
+                                onFocus={onVialsShippedFocused}
+                                onBlur={onVialsShippedBlur}
+                                onChange={handleVialsShippededUpdate}
                                 required
-                                onChange={handleChangePoNumber}
                             />
                         </Grid>
                         <Grid item xs={6} md={3}>
@@ -223,6 +235,16 @@ export const VaccineArrivalReport: FunctionComponent<Props> = ({
                                 name={`${VAR}[${index}].arrival_report_date`}
                                 component={DateInput}
                                 disabled={markedForDeletion}
+                                required
+                            />
+                            <Field
+                                label={formatMessage(MESSAGES.vials_received)}
+                                name={`${VAR}[${index}].vials_received`}
+                                component={NumberInput}
+                                disabled={markedForDeletion}
+                                onFocus={onVialsReceivedFocused}
+                                onBlur={onVialsReceivedBlur}
+                                onChange={handleVialsReceivedUpdate}
                                 required
                             />
                         </Grid>
@@ -237,6 +259,15 @@ export const VaccineArrivalReport: FunctionComponent<Props> = ({
                                 onChange={handleDosesShippedUpdate}
                                 required
                             />
+                            <Box mt={2}>
+                                <Typography
+                                    variant="button"
+                                    sx={uneditableTextStyling}
+                                >
+                                    {`${formatMessage(MESSAGES.doses_per_vial)}:`}{' '}
+                                    <NumberCell value={doses_per_vial} />
+                                </Typography>
+                            </Box>
                         </Grid>
 
                         <Grid item xs={6} md={3}>
@@ -250,49 +281,6 @@ export const VaccineArrivalReport: FunctionComponent<Props> = ({
                                 onChange={handleDosesReceivedUpdate}
                                 required
                             />
-                        </Grid>
-                    </Grid>
-                    <Grid container item xs={12} spacing={2}>
-                        <Grid item xs={6} md={3}>
-                            <Field
-                                label={formatMessage(MESSAGES.vials_shipped)}
-                                name={`${VAR}[${index}].vials_shipped`}
-                                component={NumberInput}
-                                disabled={markedForDeletion}
-                                onFocus={onVialsShippedFocused}
-                                onBlur={onVialsShippedBlur}
-                                onChange={handleVialsShippededUpdate}
-                                required
-                            />
-                        </Grid>
-                        <Grid item xs={6} md={3}>
-                            <Field
-                                label={formatMessage(MESSAGES.vials_received)}
-                                name={`${VAR}[${index}].vials_received`}
-                                component={NumberInput}
-                                disabled={markedForDeletion}
-                                onFocus={onVialsReceivedFocused}
-                                onBlur={onVialsReceivedBlur}
-                                onChange={handleVialsReceivedUpdate}
-                                required
-                            />
-                        </Grid>
-                        <Grid
-                            container
-                            item
-                            xs={6}
-                            md={3}
-                            alignContent="center"
-                        >
-                            <Box>
-                                <Typography
-                                    variant="button"
-                                    sx={uneditableTextStyling}
-                                >
-                                    {`${formatMessage(MESSAGES.doses_per_vial)}:`}{' '}
-                                    <NumberCell value={doses_per_vial} />
-                                </Typography>
-                            </Box>
                         </Grid>
                     </Grid>
                 </Grid>


### PR DESCRIPTION
Playing around with supply chain and noticed the PO number prompt is partly hidden when it appears - please see Jam 
https://jam.dev/c/6c7422b6-51b9-4a44-90ee-0b71b3746fe0

Related JIRA tickets :POLIO-1835

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)


## Changes

Review the order of the fields with the grid

❌ Current Row-Based Layout (Problematic)
```
┌──────────────────────────────────────────────────┐
│ Grid Container                                   │
│ ┌────────────────────────────────────────────┐   │
│ │ Row Grid Container 1                       │   │
│ │ ┌─────────┐ ┌─────────┐ ┌─────────┐        │   │
│ │ │Input 1  │ │Input 2  │ │Input 3  │        │   │
│ │ │Error 1  │ │Error 2  │ │Error 3  │        │   │
│ │ └─────────┘ └─────────┘ └─────────┘        │   │
│ └────────────────────────────────────────────┘   │
│ ┌────────────────────────────────────────────┐   │
│ │ Row Grid Container 2                       │   │
│ │ ┌─────────┐ ┌─────────┐ ┌─────────┐        │   │
│ │ │Input 4  │ │Input 5  │ │Input 6  │        │   │
│ │ │Error 4  │ │Error 5  │ │Error 6  │        │   │
│ │ └─────────┘ └─────────┘ └─────────┘        │   │
│ └────────────────────────────────────────────┘   │
└──────────────────────────────────────────────────┘
```

✅ Recommended Column-Based Layout

```
┌──────────────────────────────────────────────────┐
│ Grid Container                                   │
│ ┌──────────┐ ┌──────────┐ ┌──────────┐           │
│ │Column 1  │ │Column 2  │ │Column 3  │           │
│ │Input 1   │ │Input 2   │ │Input 3   │           │
│ │Error 1   │ │Error 2   │ │Error 3   │           │
│ │          │ │          │ │          │           │
│ │Input 4   │ │Input 5   │ │Input 6   │           │
│ │Error 4   │ │Error 5   │ │Error 6   │           │
│ └──────────┘ └──────────┘ └──────────┘           │
└──────────────────────────────────────────────────┘
```
Benefits are: 
- Better error message handling (they stay within their column)
- More consistent spacing
- Cleaner responsive behavior
- Simpler grid nesting


## How to test

Go to supply chain, open the detail, add a pre alert , input some vials shipped and give focus to po number input


If a specific config is required explain it here: dataset, account, profile, etc.

## Print screen / video

![Screenshot 2025-01-24 at 10 26 33](https://github.com/user-attachments/assets/1b70d3eb-b817-4907-9c3e-0b42df67c22e)


## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
