### PR TITLE
POLIO-1837: fix nopv-bopv dropdown in polio

### DIFF
--- a/plugins/polio/api/campaigns/campaigns.py
+++ b/plugins/polio/api/campaigns/campaigns.py
@@ -152,7 +152,7 @@ class CampaignSerializer(serializers.ModelSerializer):
         return ""
 
     def get_single_vaccines(self, obj):
-        return obj.vaccines_extended
+        return obj.single_vaccines_extended
 
     def get_top_level_org_unit_name(self, campaign):
         if campaign.country:


### PR DESCRIPTION
The nOPV2&bOPV vaccine should be split into component vaccines in dropdown

Related JIRA tickets : POLIO-1837

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

- use the right model method

## How to test

Explain how to test your PR.

Create a campaign with nOPV2 & bOPV vaccine then go to supply chain and create a vrf for the campaign: the dropdown should show both vaccines separately

## Print screen / video

https://github.com/user-attachments/assets/766d411e-be1a-42c0-b35a-be207cac71a9



## Notes

Can be hotfixed on v1.252a

Tagged as v1.252b

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
