### PR TITLE
WC2-661: ETL adaptation: ration PBWG

### DIFF
--- a/plugins/wfp/common.py
+++ b/plugins/wfp/common.py
@@ -470,7 +470,7 @@ class ETL:
                 "quantity": quantity,
             }
             given_assistance.append(assistance)
-        elif step.get("ration_type") is not None:
+        elif step.get("ration_type") is not None and step.get("ration_type") != "":
             if step.get("ration_type") in ["csb", "csb1", "csb2"]:
                 quantity = step.get("_csb_packets")
             elif step.get("ration_type") == "lndf":

--- a/plugins/wfp/common.py
+++ b/plugins/wfp/common.py
@@ -470,7 +470,7 @@ class ETL:
                 "quantity": quantity,
             }
             given_assistance.append(assistance)
-        elif step.get("ration_type"):
+        elif step.get("ration_type") is not None:
             if step.get("ration_type") in ["csb", "csb1", "csb2"]:
                 quantity = step.get("_csb_packets")
             elif step.get("ration_type") == "lndf":


### PR DESCRIPTION
What problem is this PR solving? Explain here in one sentence.

Related JIRA tickets : [WC2-661](https://bluesquare.atlassian.net/browse/WC2-661)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)


## Changes

Included quantity given for ration type CSB.

## How to test

From the local instance with wfp coda database containing Nigeria data, run ETL script to generate data: `docker compose run iaso manage etl_ng`

Then login on django admin and check on table Step by filtering on Nigeria and any ration type csb:

e.g: http://localhost:8081/wfp/debug/980/

You should see the csb packet given as quantity

## Print screen / video

![Sélectionnez-l’objet-step-à-changer-Iaso](https://github.com/user-attachments/assets/7b886d6d-b465-4e7b-961e-8b2bf0e4a096)


## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.


[WC2-661]: https://bluesquare.atlassian.net/browse/WC2-661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ