### PR TITLE
IA-3905: Move JS imports sort logic to eslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -186,7 +186,25 @@
                 ],
                 "react/prop-types": "off",
                 "react/require-default-props": "off",
-                "valid-typeof": "warn"
+                "valid-typeof": "warn",
+                "import/order": [
+                    "error",
+                    {
+                        "groups": ["builtin", "external", "internal", "parent", "sibling", "index"],
+                        "pathGroups": [
+                            {
+                                "pattern": "react",
+                                "group": "external",
+                                "position": "before"
+                            }
+                        ],
+                        "pathGroupsExcludedImportTypes": ["react"],
+                        "alphabetize": {
+                            "order": "asc",
+                            "caseInsensitive": true
+                        }
+                    }
+                ]
             }
         }
     ],
@@ -308,7 +326,25 @@
             }
         ],
         "react/prop-types": "warn",
-        "valid-typeof": "warn"
+        "valid-typeof": "warn",
+        "import/order": [
+            "error",
+            {
+                "groups": ["builtin", "external", "internal", "parent", "sibling", "index"],
+                "pathGroups": [
+                    {
+                        "pattern": "react",
+                        "group": "external",
+                        "position": "before"
+                    }
+                ],
+                "pathGroupsExcludedImportTypes": ["react"],
+                "alphabetize": {
+                    "order": "asc",
+                    "caseInsensitive": true
+                }
+            }
+        ]
     },
     "settings": {
         "import/resolver": {

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/VaccineRequestForm/VaccineRequestForm.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/VaccineRequestForm/VaccineRequestForm.tsx
@@ -1,15 +1,15 @@
-import { Box, Grid, Typography } from '@mui/material';
-import { useSafeIntl } from 'bluesquare-components';
-import { Field, useFormikContext } from 'formik';
 import React, {
     FunctionComponent,
     useCallback,
     useEffect,
     useMemo,
 } from 'react';
-import InputComponent from '../../../../../../../../../hat/assets/js/apps/Iaso/components/forms/InputComponent';
+import { Box, Grid, Typography } from '@mui/material';
+import { useSafeIntl } from 'bluesquare-components';
+import { Field, useFormikContext } from 'formik';
 import DocumentUploadWithPreview from '../../../../../../../../../hat/assets/js/apps/Iaso/components/files/pdf/DocumentUploadWithPreview';
 import { processErrorDocsBase } from '../../../../../../../../../hat/assets/js/apps/Iaso/components/files/pdf/utils';
+import InputComponent from '../../../../../../../../../hat/assets/js/apps/Iaso/components/forms/InputComponent';
 import { NumberInput } from '../../../../../components/Inputs';
 import { DateInput } from '../../../../../components/Inputs/DateInput';
 import { MultiSelect } from '../../../../../components/Inputs/MultiSelect';


### PR DESCRIPTION
For now automatic sort on the import is done using vscode config. We should use Eslint so we can:

have it on other IDE with the same logic

be able to write custom logic on the sort (putting react on top)

IA-3905

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

Write eslint rules for import and add it to eslint config

## How to test

Open a TSX, TS, JS files, and save it. Import should be ordered with react on top


## Print screen / video
![Screenshot 2025-02-04 at 13 08 31](https://github.com/user-attachments/assets/8df2ccae-1932-4634-a7cf-124cb2b60d5f)



## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
