### PR TITLE
IA-3898: Groups section items overflow container, scrollbar over elements.

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitInfos.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitInfos.tsx
@@ -27,6 +27,12 @@ import { OrgUnitMultiReferenceInstances } from './OrgUnitMultiReferenceInstances
 import { useGetOrgUnit } from './TreeView/requests';
 
 const useStyles = makeStyles(theme => ({
+    '@global': {
+        body: {
+            overflowX: 'hidden !important',
+            overflowY: 'auto !important',
+        },
+    },
     speedDialTop: {
         top: theme.spacing(12.5),
     },


### PR DESCRIPTION
Unless zooming out on my page and making content harder to read, I can't see my dropdown list anymore when there are many groups selected on an OU page
![image](https://github.com/user-attachments/assets/66c55ef5-1e3a-48a9-a878-67efe96cf20f)


Related JIRA tickets : IA-3898

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)


## Changes

Override body css  overflow to make options available

## How to test

Make sure you have lot's of groups available. assign a lot to an org unit and try to edit the groups option.
You should be able to see the whole list

## Print screen / video

https://github.com/user-attachments/assets/0e9bca0e-f4dc-4441-accb-f20c08dc9579


## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
