### PR TITLE
IA-3907 Enhance change requests CSV export

### DIFF
--- a/iaso/api/org_unit_change_requests/views.py
+++ b/iaso/api/org_unit_change_requests/views.py
@@ -38,7 +38,7 @@ class OrgUnitChangeRequestViewSet(viewsets.ModelViewSet):
     CSV_HEADER_COLUMNS = [
         "Id",
         "Org unit ID",
-        "Org unit source ref",
+        "External reference",
         "Name",
         "Parent",
         "Org unit type",

--- a/iaso/api/org_unit_change_requests/views.py
+++ b/iaso/api/org_unit_change_requests/views.py
@@ -35,8 +35,10 @@ from iaso.utils.models.common import get_creator_name
 
 
 class OrgUnitChangeRequestViewSet(viewsets.ModelViewSet):
-    CSV_COLUMNS = [
+    CSV_HEADER_COLUMNS = [
         "Id",
+        "Org unit ID",
+        "Org unit source ref",
         "Name",
         "Parent",
         "Org unit type",
@@ -215,11 +217,13 @@ class OrgUnitChangeRequestViewSet(viewsets.ModelViewSet):
         response = HttpResponse(content_type=CONTENT_TYPE_CSV)
 
         writer = csv.writer(response)
-        writer.writerow(self.CSV_COLUMNS)
+        writer.writerow(self.CSV_HEADER_COLUMNS)
 
         for change_request in filtered_org_unit_changes_requests:
             row = [
                 change_request.id,
+                change_request.org_unit_id,
+                change_request.org_unit.source_ref,
                 change_request.org_unit.name,
                 change_request.org_unit.parent.name if change_request.org_unit.parent else None,
                 change_request.org_unit.org_unit_type.name,

--- a/iaso/api/org_unit_change_requests/views.py
+++ b/iaso/api/org_unit_change_requests/views.py
@@ -38,20 +38,12 @@ class OrgUnitChangeRequestViewSet(viewsets.ModelViewSet):
     CSV_HEADER_COLUMNS = [
         "Id",
         "Org unit ID",
-        "Org unit external reference",
-        "New name",
-        "New parent",
-        "New org unit type",
-        "New groups",
-        "New status",
-        "Current parent 1",
-        "Current parent 2",
-        "Current parent 3",
-        "Current parent 4",
-        "Ref ext current parent 1",
-        "Ref ext current parent 2",
-        "Ref ext current parent 3",
-        "Ref ext current parent 4",
+        "External reference",
+        "Name",
+        "Parent",
+        "Org unit type",
+        "Groups",
+        "Status",
         "Created",
         "Created by",
         "Updated",
@@ -217,9 +209,7 @@ class OrgUnitChangeRequestViewSet(viewsets.ModelViewSet):
     @action(detail=False, methods=["get"])
     def export_to_csv(self, request):
         filename = "%s--%s" % ("review-change-proposals", datetime.now().strftime("%Y-%m-%d"))
-        org_unit_changes_requests = (
-            self.get_queryset().select_related("org_unit__parent__parent__parent__parent").order_by("org_unit__name")
-        )
+        org_unit_changes_requests = self.get_queryset().order_by("org_unit__name")
         filtered_org_unit_changes_requests = OrgUnitChangeRequestListFilter(
             request.GET, queryset=org_unit_changes_requests
         ).qs
@@ -230,15 +220,6 @@ class OrgUnitChangeRequestViewSet(viewsets.ModelViewSet):
         writer.writerow(self.CSV_HEADER_COLUMNS)
 
         for change_request in filtered_org_unit_changes_requests:
-            ancestors = {}
-            ancestor = change_request.org_unit.parent
-            i = 1
-            while ancestor:
-                ancestors[f"Parent {i}"] = ancestor.name
-                ancestors[f"Ref ext parent {i}"] = ancestor.source_ref
-                i += 1
-                ancestor = ancestor.parent
-
             row = [
                 change_request.id,
                 change_request.org_unit_id,
@@ -248,21 +229,12 @@ class OrgUnitChangeRequestViewSet(viewsets.ModelViewSet):
                 change_request.org_unit.org_unit_type.name,
                 ",".join(group.name for group in change_request.org_unit.groups.all()),
                 change_request.get_status_display(),
-                ancestors.get("Parent 1"),
-                ancestors.get("Parent 2"),
-                ancestors.get("Parent 3"),
-                ancestors.get("Parent 4"),
-                ancestors.get("Ref ext parent 1"),
-                ancestors.get("Ref ext parent 2"),
-                ancestors.get("Ref ext parent 3"),
-                ancestors.get("Ref ext parent 4"),
                 datetime.strftime(change_request.created_at, "%Y-%m-%d"),
                 get_creator_name(change_request.created_by) if change_request.created_by else None,
                 datetime.strftime(change_request.updated_at, "%Y-%m-%d"),
                 get_creator_name(change_request.updated_by) if change_request.updated_by else None,
             ]
             writer.writerow(row)
-
         filename = filename + ".csv"
         response["Content-Disposition"] = "attachment; filename=" + filename
         return response

--- a/iaso/api/org_unit_change_requests/views.py
+++ b/iaso/api/org_unit_change_requests/views.py
@@ -35,6 +35,19 @@ from iaso.utils.models.common import get_creator_name
 
 
 class OrgUnitChangeRequestViewSet(viewsets.ModelViewSet):
+    CSV_COLUMNS = [
+        "Id",
+        "Name",
+        "Parent",
+        "Org unit type",
+        "Groups",
+        "Status",
+        "Created",
+        "Created by",
+        "Updated",
+        "Updated by",
+    ]
+
     filter_backends = [filters.OrderingFilter, django_filters.rest_framework.DjangoFilterBackend]
     filterset_class = OrgUnitChangeRequestListFilter
     ordering_fields = [
@@ -191,21 +204,6 @@ class OrgUnitChangeRequestViewSet(viewsets.ModelViewSet):
 
         return Response({"task": TaskSerializer(instance=task).data})
 
-    @staticmethod
-    def org_unit_change_request_csv_columns():
-        return [
-            "Id",
-            "Name",
-            "Parent",
-            "Org unit type",
-            "Groups",
-            "Status",
-            "Created",
-            "Created by",
-            "Updated",
-            "Updated by",
-        ]
-
     @action(detail=False, methods=["get"])
     def export_to_csv(self, request):
         filename = "%s--%s" % ("review-change-proposals", datetime.now().strftime("%Y-%m-%d"))
@@ -217,8 +215,7 @@ class OrgUnitChangeRequestViewSet(viewsets.ModelViewSet):
         response = HttpResponse(content_type=CONTENT_TYPE_CSV)
 
         writer = csv.writer(response)
-        headers = self.org_unit_change_request_csv_columns()
-        writer.writerow(headers)
+        writer.writerow(self.CSV_COLUMNS)
 
         for change_request in filtered_org_unit_changes_requests:
             row = [

--- a/iaso/tests/api/org_unit_change_requests/test_org_unit_change_requests.py
+++ b/iaso/tests/api/org_unit_change_requests/test_org_unit_change_requests.py
@@ -25,6 +25,7 @@ class OrgUnitChangeRequestAPITestCase(TaskAPITestCase):
         org_unit = m.OrgUnit.objects.create(
             org_unit_type=org_unit_type,
             version=version,
+            source_ref="112244",
             uuid="1539f174-4c53-499c-85de-7a58458c49ef",
             closed_date=cls.DT.date(),
         )
@@ -490,11 +491,13 @@ class OrgUnitChangeRequestAPITestCase(TaskAPITestCase):
         self.assertEqual(len(data), 3)
 
         data_headers = data[0]
-        self.assertEqual(data_headers, OrgUnitChangeRequestViewSet.CSV_COLUMNS)
+        self.assertEqual(data_headers, OrgUnitChangeRequestViewSet.CSV_HEADER_COLUMNS)
 
         first_data_row = data[1]
         expected_row_data = [
             str(change_request.id),
+            str(change_request.org_unit_id),
+            "112244",
             change_request.org_unit.name,
             change_request.org_unit.parent.name if change_request.org_unit.parent else "",
             change_request.org_unit.org_unit_type.name,

--- a/iaso/tests/api/org_unit_change_requests/test_org_unit_change_requests.py
+++ b/iaso/tests/api/org_unit_change_requests/test_org_unit_change_requests.py
@@ -61,7 +61,6 @@ class OrgUnitChangeRequestAPITestCase(TaskAPITestCase):
         cls.instance_2 = instance_2
         cls.instance_3 = instance_3
         cls.org_unit = org_unit
-        cls.org_unit_change_request_csv_columns = OrgUnitChangeRequestViewSet.org_unit_change_request_csv_columns()
         cls.org_unit_type = org_unit_type
         cls.project = project
         cls.user = user
@@ -491,10 +490,7 @@ class OrgUnitChangeRequestAPITestCase(TaskAPITestCase):
         self.assertEqual(len(data), 3)
 
         data_headers = data[0]
-        self.assertEqual(
-            data_headers,
-            self.org_unit_change_request_csv_columns,
-        )
+        self.assertEqual(data_headers, OrgUnitChangeRequestViewSet.CSV_COLUMNS)
 
         first_data_row = data[1]
         expected_row_data = [

--- a/iaso/tests/api/org_unit_change_requests/test_org_unit_change_requests.py
+++ b/iaso/tests/api/org_unit_change_requests/test_org_unit_change_requests.py
@@ -23,6 +23,7 @@ class OrgUnitChangeRequestAPITestCase(TaskAPITestCase):
         version = m.SourceVersion.objects.create(number=1, data_source=data_source)
         org_unit_type = m.OrgUnitType.objects.create(name="Org unit type")
         org_unit = m.OrgUnit.objects.create(
+            name="Org unit",
             org_unit_type=org_unit_type,
             version=version,
             source_ref="112244",
@@ -471,12 +472,48 @@ class OrgUnitChangeRequestAPITestCase(TaskAPITestCase):
         """
         It tests the CSV export for the org change requests list.
         """
-        change_request = m.OrgUnitChangeRequest.objects.create(org_unit=self.org_unit, new_name="Foo")
-        m.OrgUnitChangeRequest.objects.create(org_unit=self.org_unit, new_name="Bar")
-
         self.client.force_authenticate(self.user)
 
-        response = self.client.get("/api/orgunits/changes/export_to_csv/")
+        # Burkina pyramid.
+        burkina = m.OrgUnit.objects.create(
+            name="Burkina Faso",
+            source_ref="11111",
+            org_unit_type=m.OrgUnitType.objects.create(category="COUNTRY"),
+            validation_status=m.OrgUnit.VALIDATION_VALID,
+            path=["1"],
+            version=self.version,
+        )
+        burkina_region = m.OrgUnit.objects.create(
+            name="Boucle du Mouhon",
+            source_ref="22222",
+            parent=burkina,
+            org_unit_type=m.OrgUnitType.objects.create(category="REGION"),
+            validation_status=m.OrgUnit.VALIDATION_VALID,
+            path=["1", "2"],
+            version=self.version,
+        )
+        burkina_district = m.OrgUnit.objects.create(
+            name="Banwa",
+            source_ref="33333",
+            parent=burkina_region,
+            org_unit_type=m.OrgUnitType.objects.create(category="DISTRICT"),
+            validation_status=m.OrgUnit.VALIDATION_VALID,
+            path=["1", "2", "3"],
+            version=self.version,
+        )
+        burkina_district.calculate_paths()
+
+        self.user.iaso_profile.org_units.add(burkina, burkina_region, burkina_district)
+
+        # Create change requests.
+        change_request = m.OrgUnitChangeRequest.objects.create(org_unit=burkina_district, new_name="Foo")
+        m.OrgUnitChangeRequest.objects.create(org_unit=burkina_region, new_name="Bar")
+        m.OrgUnitChangeRequest.objects.create(org_unit=burkina, new_name="Baz")
+        m.OrgUnitChangeRequest.objects.create(org_unit=self.org_unit, new_name="Qux")
+
+        with self.assertNumQueries(9):
+            response = self.client.get("/api/orgunits/changes/export_to_csv/")
+
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.get("Content-Disposition"),
@@ -488,27 +525,32 @@ class OrgUnitChangeRequestAPITestCase(TaskAPITestCase):
         reader = csv.reader(io.StringIO(response_string), delimiter=",")
 
         data = list(reader)
-        self.assertEqual(len(data), 3)
+        self.assertEqual(len(data), 5)
 
         data_headers = data[0]
         self.assertEqual(data_headers, OrgUnitChangeRequestViewSet.CSV_HEADER_COLUMNS)
 
         first_data_row = data[1]
-        expected_row_data = [
-            str(change_request.id),
-            str(change_request.org_unit_id),
-            "112244",
-            change_request.org_unit.name,
-            change_request.org_unit.parent.name if change_request.org_unit.parent else "",
-            change_request.org_unit.org_unit_type.name,
-            ",".join(group.name for group in change_request.org_unit.groups.all()),
-            str(change_request.get_status_display()),
-            datetime.datetime.strftime(change_request.created_at, "%Y-%m-%d"),
-            get_creator_name(change_request.created_by) if change_request.created_by else "",
-            datetime.datetime.strftime(change_request.updated_at, "%Y-%m-%d"),
-            get_creator_name(change_request.updated_by) if change_request.updated_by else "",
-        ]
-        self.assertEqual(
-            first_data_row,
-            expected_row_data,
-        )
+        expected_first_data_row = {
+            "Id": str(change_request.id),
+            "Org unit ID": str(change_request.org_unit_id),
+            "Org unit external reference": "33333",
+            "New name": change_request.org_unit.name,
+            "New parent": change_request.org_unit.parent.name if change_request.org_unit.parent else "",
+            "New org unit type": change_request.org_unit.org_unit_type.name,
+            "New groups": ",".join(group.name for group in change_request.org_unit.groups.all()),
+            "New status": str(change_request.get_status_display()),
+            "Current parent 1": "Boucle du Mouhon",
+            "Current parent 2": "Burkina Faso",
+            "Current parent 3": "",
+            "Current parent 4": "",
+            "Ref ext current parent 1": "22222",
+            "Ref ext current parent 2": "11111",
+            "Ref ext current parent 3": "",
+            "Ref ext current parent 4": "",
+            "Created": datetime.datetime.strftime(change_request.created_at, "%Y-%m-%d"),
+            "Created by": get_creator_name(change_request.created_by) if change_request.created_by else "",
+            "Updated": datetime.datetime.strftime(change_request.updated_at, "%Y-%m-%d"),
+            "Updated by": get_creator_name(change_request.updated_by) if change_request.updated_by else "",
+        }
+        self.assertEqual(first_data_row, list(expected_first_data_row.values()))


### PR DESCRIPTION
Enhance the change requests CSV export.

Related JIRA tickets : [IA-3907](https://bluesquare.atlassian.net/browse/IA-3907)

## Changes

Enhance the downloadable CSV for change requests to include:

- the Org Unit ID
- the Org Unit External Reference

## How to test

Export change requests as CSV and look at the following new columns:

![new](https://github.com/user-attachments/assets/a966fa86-340c-462c-bfbe-73815a2f51d0)

[IA-3907]: https://bluesquare.atlassian.net/browse/IA-3907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ