### PR TITLE
POLIO-1842: Supply Chain: VAR saving error

### DIFF
--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/VAR/VaccineArrivalReport.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/VAR/VaccineArrivalReport.tsx
@@ -23,7 +23,7 @@ export const VaccineArrivalReport: FunctionComponent<Props> = ({
 }) => {
     const classes: Record<string, string> = usePaperStyles();
     const { formatMessage } = useSafeIntl();
-    const { values, setFieldValue, setFieldTouched } =
+    const { values, setFieldValue, setFieldTouched, setValues } =
         useFormikContext<SupplyChainFormData>();
     const { arrival_reports } = values as SupplyChainFormData;
     const markedForDeletion = arrival_reports?.[index].to_delete ?? false;
@@ -99,6 +99,22 @@ export const VaccineArrivalReport: FunctionComponent<Props> = ({
         ],
     );
 
+    const handleSetValues = useCallback(
+        newValues => {
+            setValues(prevValues => ({
+                ...prevValues,
+                arrival_reports: prevValues.arrival_reports?.map((report, i) =>
+                    i === index
+                        ? {
+                              ...report,
+                              ...newValues,
+                          }
+                        : report,
+                ),
+            }));
+        },
+        [index, setValues],
+    );
     const handleDosesShippedUpdate = useCallback(
         (value: number) => {
             if (dosesShippedRef.current) {
@@ -107,15 +123,15 @@ export const VaccineArrivalReport: FunctionComponent<Props> = ({
                           ((value as Optional<number>) ?? 0) / doses_per_vial,
                       )
                     : 0;
-                setFieldValue(`arrival_reports[${index}].doses_shipped`, value);
-                setFieldValue(
-                    `arrival_reports[${index}].vials_shipped`,
-                    vialsShipped,
-                );
+                handleSetValues({
+                    doses_shipped: value,
+                    vials_shipped: vialsShipped,
+                });
             }
         },
-        [doses_per_vial, index, setFieldValue],
+        [doses_per_vial, handleSetValues],
     );
+
     const handleDosesReceivedUpdate = useCallback(
         (value: number) => {
             if (dosesReceivedRef.current) {
@@ -124,48 +140,41 @@ export const VaccineArrivalReport: FunctionComponent<Props> = ({
                           ((value as Optional<number>) ?? 0) / doses_per_vial,
                       )
                     : 0;
-                setFieldValue(
-                    `arrival_reports[${index}].doses_received`,
-                    value,
-                );
-                setFieldValue(
-                    `arrival_reports[${index}].vials_received`,
-                    vialsReceived,
-                );
+                handleSetValues({
+                    doses_received: value,
+                    vials_received: vialsReceived,
+                });
             }
         },
-        [doses_per_vial, index, setFieldValue],
+        [doses_per_vial, handleSetValues],
     );
 
     const handleVialsShippededUpdate = useCallback(
         (value: number) => {
             if (vialsShippedRef.current) {
                 const dosesShipped = value * (doses_per_vial ?? 0);
-                setFieldValue(`arrival_reports[${index}].vials_shipped`, value);
-                setFieldValue(
-                    `arrival_reports[${index}].doses_shipped`,
-                    dosesShipped,
-                );
+                handleSetValues({
+                    vials_shipped: value,
+                    doses_shipped: dosesShipped,
+                });
             }
         },
-        [doses_per_vial, index, setFieldValue],
+        [doses_per_vial, handleSetValues],
     );
+
     const handleVialsReceivedUpdate = useCallback(
         (value: number) => {
             if (vialsReceivedRef.current) {
                 const dosesReceived = value * (doses_per_vial ?? 0);
-                setFieldValue(
-                    `arrival_reports[${index}].vials_received`,
-                    value,
-                );
-                setFieldValue(
-                    `arrival_reports[${index}].doses_received`,
-                    dosesReceived,
-                );
+                handleSetValues({
+                    vials_received: value,
+                    doses_received: dosesReceived,
+                });
             }
         },
-        [doses_per_vial, index, setFieldValue],
+        [doses_per_vial, handleSetValues],
     );
+
     const onDosesShippedFocused = () => {
         dosesShippedRef.current = true;
     };


### PR DESCRIPTION
Copy pasting doses received on a new VAR is not validating form

Related JIRA tickets :POLIO-1842

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)


## Changes

Replace multiple `setFieldValue` with one `setValues` to avoid multiple state changes

## How to test

Follow the first video while editing a supply chain for a country

## Print screen / video

https://github.com/user-attachments/assets/83497eda-c194-465e-8c5d-56e273d196c0


## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
