### PR TITLE
IA-3905: automatically remove unused imports with eslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -217,7 +217,8 @@
     },
     "plugins": [
         "formatjs",
-        "prettier"
+        "prettier",
+        "unused-imports"
     ],
     "rules": {
         "@typescript-eslint/no-unused-vars": [
@@ -343,6 +344,16 @@
                     "order": "asc",
                     "caseInsensitive": true
                 }
+            }
+        ],
+        "unused-imports/no-unused-imports": "error",
+        "unused-imports/no-unused-vars": [
+            "warn",
+            {
+                "vars": "all",
+                "varsIgnorePattern": "^_",
+                "args": "after-used",
+                "argsIgnorePattern": "^_"
             }
         ]
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -104,6 +104,7 @@
                 "eslint-plugin-prettier": "^5.1.3",
                 "eslint-plugin-react": "^7.14.2",
                 "eslint-plugin-react-hooks": "^4.2.0",
+                "eslint-plugin-unused-imports": "^4.1.4",
                 "eslint-webpack-plugin": "^2.5.4",
                 "file-loader": "^6.2.0",
                 "jsdom": "^24.1.0",
@@ -9392,6 +9393,21 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/eslint-plugin-unused-imports": {
+            "version": "4.1.4",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-4.1.4.tgz",
+            "integrity": "sha512-YptD6IzQjDardkl0POxnnRBhU1OEePMV0nd6siHaRBbd+lyh6NAhFEobiznKU7kTsSsDeSD62Pe7kAM1b7dAZQ==",
+            "dev": true,
+            "peerDependencies": {
+                "@typescript-eslint/eslint-plugin": "^8.0.0-0 || ^7.0.0 || ^6.0.0 || ^5.0.0",
+                "eslint": "^9.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@typescript-eslint/eslint-plugin": {
+                    "optional": true
+                }
             }
         },
         "node_modules/eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
         "eslint-plugin-prettier": "^5.1.3",
         "eslint-plugin-react": "^7.14.2",
         "eslint-plugin-react-hooks": "^4.2.0",
+        "eslint-plugin-unused-imports": "^4.1.4",
         "eslint-webpack-plugin": "^2.5.4",
         "file-loader": "^6.2.0",
         "jsdom": "^24.1.0",


### PR DESCRIPTION
Automatically remove unused imports with eslint

Related JIRA tickets : IA-3905

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)


## Changes

Added a dep, changed eslint config

## How to test

Run `npm ci`, import somthin on a ts, js file and save it, it should be automatically removed.

To apply eslint on each save you can use this config on VSC (add this to you settings.json:
```

    "[javascript]": {
        "editor.formatOnSave": true,
        "editor.defaultFormatter": "esbenp.prettier-vscode",
        "editor.codeActionsOnSave": {"source.fixAll.eslint": "always"},
    },
    "[typescript]": {
        "editor.formatOnSave": true,
        "editor.defaultFormatter": "esbenp.prettier-vscode",
        "editor.codeActionsOnSave": {"source.fixAll.eslint": "always"},
    },
    "[typescriptreact]": {
        "editor.formatOnSave": true,
        "editor.defaultFormatter": "esbenp.prettier-vscode",
        "editor.codeActionsOnSave": {"source.fixAll.eslint": "always"},
    },
```


## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
