### PR TITLE
POLIO-1722 add endpoint to refresh OpenHexa VRF data

### DIFF
--- a/plugins/polio/api/urls.py
+++ b/plugins/polio/api/urls.py
@@ -88,7 +88,7 @@ router.register(r"polio/vaccineauthorizations", VaccineAuthorizationViewSet, bas
 router.register(r"polio/powerbirefresh", LaunchPowerBIRefreshViewSet, basename="powerbirefresh")
 router.register(r"polio/rounds", RoundViewSet, basename="rounds")
 router.register(r"polio/reasonsfordelay", ReasonForDelayViewSet, basename="reasonsfordelay")
-router.register(r"polio/tasks/refreshlqas", RefreshVrfDataViewset, basename="refreshvrf")
+router.register(r"polio/tasks/refreshvrf", RefreshVrfDataViewset, basename="refreshvrf")
 router.register(r"polio/tasks/refreshlqas", RefreshLQASDataViewset, basename="refreshlqas")
 router.register(r"polio/tasks/refreshim/hh", RefreshIMHouseholdDataViewset, basename="refreshimhh")
 router.register(r"polio/tasks/refreshim/ohh", RefreshIMOutOfHouseholdDataViewset, basename="refreshimohh")

--- a/plugins/polio/api/urls.py
+++ b/plugins/polio/api/urls.py
@@ -56,6 +56,7 @@ from plugins.polio.tasks.api.refresh_im_data import (
     RefreshIMOutOfHouseholdDataViewset,
 )
 from plugins.polio.tasks.api.refresh_lqas_data import RefreshLQASDataViewset
+from plugins.polio.tasks.api.refresh_vrf_dashboard_data import RefreshVrfDataViewset
 
 router = routers.SimpleRouter()
 router.register(r"polio/orgunits", PolioOrgunitViewSet, basename="PolioOrgunit")
@@ -87,6 +88,7 @@ router.register(r"polio/vaccineauthorizations", VaccineAuthorizationViewSet, bas
 router.register(r"polio/powerbirefresh", LaunchPowerBIRefreshViewSet, basename="powerbirefresh")
 router.register(r"polio/rounds", RoundViewSet, basename="rounds")
 router.register(r"polio/reasonsfordelay", ReasonForDelayViewSet, basename="reasonsfordelay")
+router.register(r"polio/tasks/refreshlqas", RefreshVrfDataViewset, basename="refreshvrf")
 router.register(r"polio/tasks/refreshlqas", RefreshLQASDataViewset, basename="refreshlqas")
 router.register(r"polio/tasks/refreshim/hh", RefreshIMHouseholdDataViewset, basename="refreshimhh")
 router.register(r"polio/tasks/refreshim/ohh", RefreshIMOutOfHouseholdDataViewset, basename="refreshimohh")

--- a/plugins/polio/tasks/api/refresh_vrf_dashboard_data.py
+++ b/plugins/polio/tasks/api/refresh_vrf_dashboard_data.py
@@ -37,3 +37,10 @@ class RefreshVrfDataViewset(ExternalTaskModelViewSet):
         task.status = status
         task.save()
         return Response({"task": TaskSerializer(instance=task).data})
+
+    def get_queryset(self):
+        # user = self.request.user
+        user = User.objects.filter(username="openhexa_iaso_user")
+        account = user.iaso_profile.account
+        queryset = Task.objects.filter(account=account).filter(external=True)
+        return queryset

--- a/plugins/polio/tasks/api/refresh_vrf_dashboard_data.py
+++ b/plugins/polio/tasks/api/refresh_vrf_dashboard_data.py
@@ -22,7 +22,6 @@ class RefreshVrfDataViewset(ExternalTaskModelViewSet):
         # Workaround: we need ro reive a user id an validate it in the serializer
         user = User.objects.get(username="openhexa_iaso_user")
         slug = VRF_CONFIG_SLUG
-        user = request.user
         task = Task.objects.create(
             created_by=user,
             launcher=user,

--- a/plugins/polio/tasks/api/refresh_vrf_dashboard_data.py
+++ b/plugins/polio/tasks/api/refresh_vrf_dashboard_data.py
@@ -19,8 +19,7 @@ class RefreshVrfDataViewset(ExternalTaskModelViewSet):
     # Overriding the list method because powerBI sends a GET request
     # So we have to have a GET that behaves like a POST
     def list(self, request):
-        # Workaround: we need ro reive a user id an validate it in the serializer
-        user = User.objects.get(username="openhexa_iaso_user")
+        user = request.user
         slug = VRF_CONFIG_SLUG
         task = Task.objects.create(
             created_by=user,
@@ -38,8 +37,7 @@ class RefreshVrfDataViewset(ExternalTaskModelViewSet):
         return Response({"task": TaskSerializer(instance=task).data})
 
     def get_queryset(self):
-        # user = self.request.user
-        user = User.objects.get(username="openhexa_iaso_user")
+        user = self.request.user
         account = user.iaso_profile.account
         queryset = Task.objects.filter(account=account).filter(external=True)
         return queryset

--- a/plugins/polio/tasks/api/refresh_vrf_dashboard_data.py
+++ b/plugins/polio/tasks/api/refresh_vrf_dashboard_data.py
@@ -1,0 +1,39 @@
+from iaso.api.tasks.serializers import TaskSerializer
+from iaso.api.tasks.views import ExternalTaskModelViewSet
+from iaso.models.base import RUNNING, Task
+from rest_framework.response import Response
+from datetime import datetime
+from django.contrib.auth.models import User
+
+
+VRF_TASK_NAME = "Refresh VRF dashboard data"
+VRF_CONFIG_SLUG = "vrf-pipeline-config"
+
+
+class RefreshVrfDataViewset(ExternalTaskModelViewSet):
+    http_method_names = ["get"]
+    model = Task
+    task_name = VRF_TASK_NAME
+    config_slug = VRF_CONFIG_SLUG
+
+    # Overriding the list method because powerBI sends a GET request
+    # So we have to have a GET that behaves like a POST
+    def list(self, request):
+        # Worrkaround: we need ro reive a user id an validate it in the serializer
+        user = User.objects.filter(username="openhexa_iaso_user")
+        slug = VRF_CONFIG_SLUG
+        user = request.user
+        task = Task.objects.create(
+            created_by=user,
+            launcher=user,
+            account=user.iaso_profile.account,
+            name=VRF_TASK_NAME,
+            status=RUNNING,
+            external=True,
+            started_at=datetime.now(),
+            should_be_killed=False,
+        )
+        status = self.launch_task(slug=slug, task_id=task.pk)
+        task.status = status
+        task.save()
+        return Response({"task": TaskSerializer(instance=task).data})

--- a/plugins/polio/tasks/api/refresh_vrf_dashboard_data.py
+++ b/plugins/polio/tasks/api/refresh_vrf_dashboard_data.py
@@ -11,7 +11,7 @@ VRF_CONFIG_SLUG = "vrf-pipeline-config"
 
 
 class RefreshVrfDataViewset(ExternalTaskModelViewSet):
-    http_method_names = ["get"]
+    http_method_names = ["get", "patch"]
     model = Task
     task_name = VRF_TASK_NAME
     config_slug = VRF_CONFIG_SLUG
@@ -19,7 +19,7 @@ class RefreshVrfDataViewset(ExternalTaskModelViewSet):
     # Overriding the list method because powerBI sends a GET request
     # So we have to have a GET that behaves like a POST
     def list(self, request):
-        # Worrkaround: we need ro reive a user id an validate it in the serializer
+        # Workaround: we need ro reive a user id an validate it in the serializer
         user = User.objects.filter(username="openhexa_iaso_user")
         slug = VRF_CONFIG_SLUG
         user = request.user

--- a/plugins/polio/tasks/api/refresh_vrf_dashboard_data.py
+++ b/plugins/polio/tasks/api/refresh_vrf_dashboard_data.py
@@ -20,7 +20,7 @@ class RefreshVrfDataViewset(ExternalTaskModelViewSet):
     # So we have to have a GET that behaves like a POST
     def list(self, request):
         # Workaround: we need ro reive a user id an validate it in the serializer
-        user = User.objects.filter(username="openhexa_iaso_user")
+        user = User.objects.get(username="openhexa_iaso_user")
         slug = VRF_CONFIG_SLUG
         user = request.user
         task = Task.objects.create(
@@ -40,7 +40,7 @@ class RefreshVrfDataViewset(ExternalTaskModelViewSet):
 
     def get_queryset(self):
         # user = self.request.user
-        user = User.objects.filter(username="openhexa_iaso_user")
+        user = User.objects.get(username="openhexa_iaso_user")
         account = user.iaso_profile.account
         queryset = Task.objects.filter(account=account).filter(external=True)
         return queryset

--- a/plugins/polio/tests/test_refresh_vrf.py
+++ b/plugins/polio/tests/test_refresh_vrf.py
@@ -13,10 +13,6 @@ class RefreshVrfDataTestCase(APITestCase):
         cls.url = "/api/polio/tasks/refreshvrf/"
         cls.account = account = m.Account.objects.create(name="test account")
         cls.user = cls.create_user_with_profile(username="test user", account=account, permissions=["iaso_polio"])
-        # FIXME: temporary set up. The user id should be passed as query param
-        cls.openhexa_iaso_user = cls.create_user_with_profile(
-            username="openhexa_iaso_user", account=account, permissions=["iaso_polio", "iaso_polio_config"]
-        )
 
         cls.external_task1 = m.Task.objects.create(
             status=RUNNING, account=account, launcher=cls.user, name="external task 1", external=True
@@ -80,7 +76,7 @@ class RefreshVrfDataTestCase(APITestCase):
         response = self.assertJSONResponse(response, 200)
         task = response["task"]
         self.assertEqual(task["status"], RUNNING)
-        self.assertEqual(task["launcher"]["username"], self.openhexa_iaso_user.username)
+        self.assertEqual(task["launcher"]["username"], self.user.username)
         self.assertEqual(task["name"], VRF_TASK_NAME)
 
     @patch.object(RefreshVrfDataViewset, "launch_task", mock_openhexa_call_skipped)
@@ -92,7 +88,7 @@ class RefreshVrfDataTestCase(APITestCase):
         response = self.assertJSONResponse(response, 200)
         task = response["task"]
         self.assertEqual(task["status"], SKIPPED)
-        self.assertEqual(task["launcher"]["username"], self.openhexa_iaso_user.username)
+        self.assertEqual(task["launcher"]["username"], self.user.username)
         self.assertEqual(task["name"], VRF_TASK_NAME)
 
     @patch.object(RefreshVrfDataViewset, "launch_task", mock_openhexa_call_running)

--- a/plugins/polio/tests/test_refresh_vrf.py
+++ b/plugins/polio/tests/test_refresh_vrf.py
@@ -1,0 +1,143 @@
+from datetime import datetime
+from iaso import models as m
+from iaso.test import APITestCase
+from iaso.models.base import RUNNING, KILLED, SUCCESS, SKIPPED
+from iaso.models.json_config import Config
+from unittest.mock import patch
+from plugins.polio.tasks.api.refresh_vrf_dashboard_data import VRF_CONFIG_SLUG, VRF_TASK_NAME, RefreshVrfDataViewset
+
+
+class RefreshVrfDataTestCase(APITestCase):
+    @classmethod
+    def setUp(cls):
+        cls.url = "/api/polio/tasks/refreshvrf/"
+        cls.account = account = m.Account.objects.create(name="test account")
+        cls.user = cls.create_user_with_profile(username="test user", account=account, permissions=["iaso_polio"])
+        # FIXME: temporary set up. The user id should be passed as query param
+        cls.openhexa_iaso_user = cls.create_user_with_profile(
+            username="openhexa_iaso_user", account=account, permissions=["iaso_polio", "iaso_polio_config"]
+        )
+
+        cls.external_task1 = m.Task.objects.create(
+            status=RUNNING, account=account, launcher=cls.user, name="external task 1", external=True
+        )
+        cls.external_task2 = m.Task.objects.create(
+            status=RUNNING, account=account, launcher=cls.user, name="external task 2", external=True
+        )
+        cls.project = m.Project.objects.create(name="Polio", app_id="polio.rapid.outbreak.taskforce", account=account)
+        cls.data_source = m.DataSource.objects.create(name="Default source")
+        cls.data_source.projects.add(cls.project)
+        cls.data_source.save()
+        cls.source_version = m.SourceVersion.objects.create(data_source=cls.data_source, number=1)
+        cls.account.default_version = cls.source_version
+        cls.account.save()
+
+        cls.task1 = m.Task.objects.create(
+            status=RUNNING,
+            account=account,
+            launcher=cls.user,
+            name=VRF_CONFIG_SLUG,
+            started_at=datetime.now(),
+            external=True,
+        )
+        cls.task2 = m.Task.objects.create(
+            status=RUNNING, account=account, launcher=cls.user, name="task 2", external=True
+        )
+
+        cls.json_config = {
+            "pipeline": "pipeline",
+            "openhexa_url": "https://yippie.openhexa.xyz/",
+            "openhexa_token": "token",
+            "pipeline_version": 1,
+            "oh_pipeline_target": "staging",
+        }
+        cls.vrf_config = Config.objects.create(slug=VRF_CONFIG_SLUG, content=cls.json_config)
+
+    def mock_openhexa_call_success(self, slug=None, config=None, id_field=None, task_id=None):
+        return SUCCESS
+
+    def mock_openhexa_call_skipped(self, slug=None, config=None, id_field=None, task_id=None):
+        return SKIPPED
+
+    def mock_openhexa_call_running(self, slug=None, config=None, id_field=None, task_id=None):
+        return RUNNING
+
+    def test_no_auth_needed(self):
+        user_no_perm = self.create_user_with_profile(username="test user2", account=self.account, permissions=[])
+        self.client.force_authenticate(user_no_perm)
+        response = self.client.get(
+            self.url,
+            format="json",
+        )
+        self.assertJSONResponse(response, 200)
+
+    @patch.object(RefreshVrfDataViewset, "launch_task", mock_openhexa_call_running)
+    def test_create_external_task(self):
+        self.client.force_authenticate(self.user)
+        response = self.client.get(
+            self.url,
+        )
+        response = self.assertJSONResponse(response, 200)
+        task = response["task"]
+        self.assertEqual(task["status"], RUNNING)
+        self.assertEqual(task["launcher"]["username"], self.openhexa_iaso_user.username)
+        self.assertEqual(task["name"], VRF_TASK_NAME)
+
+    @patch.object(RefreshVrfDataViewset, "launch_task", mock_openhexa_call_skipped)
+    def test_create_external_task_pipeline_already_running(self):
+        self.client.force_authenticate(self.user)
+        response = self.client.get(
+            self.url,
+        )
+        response = self.assertJSONResponse(response, 200)
+        task = response["task"]
+        self.assertEqual(task["status"], SKIPPED)
+        self.assertEqual(task["launcher"]["username"], self.openhexa_iaso_user.username)
+        self.assertEqual(task["name"], VRF_TASK_NAME)
+
+    @patch.object(RefreshVrfDataViewset, "launch_task", mock_openhexa_call_running)
+    def test_patch_external_task(self):
+        self.client.force_authenticate(self.user)
+        response = self.client.get(
+            self.url,
+        )
+        response = self.assertJSONResponse(response, 200)
+        task = response["task"]
+        task_id = task["id"]
+        self.assertEqual(task["status"], RUNNING)
+        self.assertEqual(task["progress_value"], 0)
+        self.assertEqual(task["end_value"], 0)
+
+        response = self.client.patch(
+            f"{self.url}{task_id}/", format="json", data={"status": SUCCESS, "progress_value": 21}
+        )
+        response = self.assertJSONResponse(response, 200)
+        task = response
+        self.assertEqual(task["id"], task_id)
+        self.assertEqual(task["status"], SUCCESS)
+        self.assertEqual(task["progress_value"], 21)
+        self.assertEqual(task["end_value"], 0)
+
+    @patch.object(RefreshVrfDataViewset, "launch_task", mock_openhexa_call_running)
+    def test_kill_external_task(self):
+        self.client.force_authenticate(self.user)
+        response = self.client.get(
+            self.url,
+        )
+        response = self.assertJSONResponse(response, 200)
+        task = response["task"]
+        task_id = task["id"]
+        print("Task", task)
+        self.assertEqual(task["status"], RUNNING)
+
+        response = self.client.patch(
+            f"{self.url}{task_id}/",
+            format="json",
+            data={
+                "should_be_killed": True,
+            },
+        )
+        response = self.assertJSONResponse(response, 200)
+        task = response
+        self.assertEqual(task["id"], task_id)
+        self.assertEqual(task["status"], KILLED)


### PR DESCRIPTION
PowerBi can't refresh data handled by OpenHexa pipelines so we need an endpoint in iaso to handle that

Related JIRA tickets : IA-XXX, WC2-XXX, POLIO-1722

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc
NA

## Changes
 - Add an endpoint using `ExternalTaskViewset`
 - Override list method to behave like POST, because powerBI can't POST

## How to test

- Login to OpenHexa's polio workspace
- Deploy the branch on staging
- go to api/polio/tasks/refreshvrf/:
    - A new task should be visible in the tasks list
    - In openHexa, the pipeline should have run, with the task id ans "staging" as parameters
    - in OpenHExa, the DB table `VaccineRequestFormsStaging` should have been updated

## Print screen / video

![Screenshot 2025-02-10 at 12 31 28](https://github.com/user-attachments/assets/345ff0b7-a4d8-406a-ad6f-7baff65fac92)


## Notes

Once the PR is merged, there are additional steps to perform to switch to prod:
- Update the powerBI dashboard so that the refresh button attacks the new API. Make a copy of the dashbaord that points to staging data first
- Then: 
    - Add the vrf-pipeline-config` to prod. It can be copied from staging, with just the `target` adpated.
    - Update the prod dashboard
    - Delete the old Jupyter notebook, since the code now lives on github  

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
