### PR TITLE
[IA-2674] Only return Workflows for the requested project

### DIFF
--- a/iaso/api/workflows/mobile.py
+++ b/iaso/api/workflows/mobile.py
@@ -7,6 +7,7 @@ from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
 from iaso.api.common import TimestampField
+from iaso.api.serializers import AppIdSerializer
 from iaso.models import WorkflowVersion, Project, WorkflowFollowup
 from iaso.models.workflow import WorkflowVersionsStatus, WorkflowChange
 
@@ -79,7 +80,7 @@ class MobileWorkflowViewSet(GenericViewSet):
 
     @swagger_auto_schema(manual_parameters=[app_id_param])
     def list(self, request, *args, **kwargs):
-        app_id = request.GET.get("app_id", None)
+        app_id = AppIdSerializer(data=request.query_params).get_app_id(raise_exception=False)
 
         if app_id is None:
             return Response(status=404, data="No app_id provided")
@@ -93,8 +94,9 @@ class MobileWorkflowViewSet(GenericViewSet):
         return Response({"workflows": serializer.data})
 
     def get_queryset(self, **kwargs):
+        app_id = AppIdSerializer(data=self.request.query_params).get_app_id(raise_exception=False)
         return (
-            WorkflowVersion.objects.filter_for_user(self.request.user)
+            WorkflowVersion.objects.filter_for_user_and_app_id(user=self.request.user, app_id=app_id)
             .filter(status=WorkflowVersionsStatus.PUBLISHED)
             .order_by("workflow__pk", "-created_at")
             .distinct("workflow__pk")

--- a/iaso/models/workflow.py
+++ b/iaso/models/workflow.py
@@ -1,5 +1,6 @@
 import typing
 import uuid
+from typing import Optional
 
 from django.contrib.auth.models import User, AnonymousUser
 from django.db import models
@@ -75,6 +76,14 @@ class WorkflowVersionQuerySet(models.QuerySet):
 
         if user and user.is_authenticated:
             queryset = queryset.filter(workflow__entity_type__account=user.iaso_profile.account)
+
+        return queryset
+
+    def filter_for_user_and_app_id(self, user: typing.Union[User, AnonymousUser, None], app_id: Optional[str]):
+        queryset = self.filter_for_user(user)
+
+        if app_id is not None:
+            queryset = queryset.filter(workflow__entity_type__reference_form__projects__app_id=app_id)
 
         return queryset
 

--- a/iaso/tests/api/test_entity_types.py
+++ b/iaso/tests/api/test_entity_types.py
@@ -6,7 +6,6 @@ from django.core.files import File
 from iaso import models as m
 from iaso.models import Entity, EntityType, FormVersion, Instance, Project
 from iaso.test import APITestCase
-from iaso.tests.api.workflows.base import var_dump
 
 
 class EntityTypeAPITestCase(APITestCase):

--- a/iaso/tests/api/workflows/base.py
+++ b/iaso/tests/api/workflows/base.py
@@ -9,7 +9,6 @@ from iaso import models as m
 from iaso.models import Workflow, WorkflowVersion
 from iaso.models.workflow import WorkflowVersionsStatus, WorkflowChange, WorkflowFollowup
 from iaso.test import APITestCase
-from iaso.tests.utils.test_utils import var_dump
 
 
 class BaseWorkflowsAPITestCase(APITestCase):
@@ -41,6 +40,12 @@ class BaseWorkflowsAPITestCase(APITestCase):
             account=blue_adults,
         )
 
+        cls.project_blue_adults_2 = m.Project.objects.create(
+            name="Blue Adults Project_2",
+            app_id="blue.adults.project_2",
+            account=blue_adults,
+        )
+
         cls.project_blue_childrens = m.Project.objects.create(
             name="Blue Childrens Project",
             app_id="blue.childrens.project",
@@ -53,6 +58,14 @@ class BaseWorkflowsAPITestCase(APITestCase):
 
         cls.form_adults_blue_2 = m.Form.objects.create(
             name="Blue Adults Form 2", form_id="adults_form_blue_2", created_at=cls.now
+        )
+
+        cls.form_adults_blue_3 = m.Form.objects.create(
+            name="Blue Adults Form 3", form_id="adults_form_blue_3", created_at=cls.now
+        )
+
+        cls.form_adults_blue_4 = m.Form.objects.create(
+            name="Blue Adults Form 4", form_id="adults_form_blue_4", created_at=cls.now
         )
 
         form_adults_blue_mock = mock.MagicMock(spec=File)
@@ -85,6 +98,10 @@ class BaseWorkflowsAPITestCase(APITestCase):
         cls.project_blue_adults.forms.add(cls.form_adults_blue_2)
         cls.project_blue_adults.save()
 
+        cls.project_blue_adults_2.forms.add(cls.form_adults_blue_3)
+        cls.project_blue_adults_2.forms.add(cls.form_adults_blue_4)
+        cls.project_blue_adults_2.save()
+
         cls.et_children_blue = m.EntityType.objects.create(
             name="Children of Blue",
             created_at=cls.now,
@@ -113,12 +130,20 @@ class BaseWorkflowsAPITestCase(APITestCase):
             account=blue_adults,
             reference_form=cls.form_adults_blue,
         )
-        # This is added to check if the error on get returning more than one entitytype accure again(WC2-500)
-        differen_account = m.Account.objects.create(name="Different Account")
+
+        cls.et_adults_blue_3 = m.EntityType.objects.create(
+            name="Adults of Blue 3",
+            created_at=cls.now,
+            account=blue_adults,
+            reference_form=cls.form_adults_blue_3,
+        )
+
+        # This is added to check if the error on get returning more than one EntityType occurs again(WC2-500)
+        different_account = m.Account.objects.create(name="Different Account")
         cls.et_adults_blue_2_same_name_different_account = m.EntityType.objects.create(
             name="Adults of Blue 2",
             created_at=cls.now,
-            account=differen_account,
+            account=different_account,
             reference_form=cls.form_adults_blue,
         )
 
@@ -184,3 +209,24 @@ class BaseWorkflowsAPITestCase(APITestCase):
         )
 
         followup2.forms.add(cls.form_adults_blue_2)
+
+        cls.workflow_et_adults_blue_2 = Workflow.objects.create(entity_type=cls.et_adults_blue_3)
+
+        cls.workflow_version_et_adults_blue_2 = WorkflowVersion.objects.create(
+            workflow=cls.workflow_et_adults_blue_2,
+            name="workflow_et_adults_blue_2 V1",
+            status=WorkflowVersionsStatus.PUBLISHED,
+        )
+
+        WorkflowChange.objects.create(
+            form=cls.form_adults_blue_4,
+            workflow_version=cls.workflow_version_et_adults_blue_2,
+            mapping={"mon_champ": "mon_champ"},
+        )
+
+        followup_3 = WorkflowFollowup.objects.create(
+            order=1,
+            condition={"==": [1, 1]},
+            workflow_version=cls.workflow_version_et_adults_blue_2,
+        )
+        followup_3.forms.add(cls.form_adults_blue_4)

--- a/iaso/tests/api/workflows/test_workflows.py
+++ b/iaso/tests/api/workflows/test_workflows.py
@@ -102,7 +102,7 @@ class WorkflowsAPITestCase(BaseWorkflowsAPITestCase):
         response = self.client.get(f"{BASE_API}?limit=2")
 
         self.assertJSONResponse(response, 200)
-        self.assertEqual(response.json()["count"], 5)  # 4 versions available
+        self.assertEqual(response.json()["count"], 6)
 
         try:
             jsonschema.validate(instance=response.data, schema=set_tl_schema)

--- a/iaso/tests/api/workflows/test_workflows_mobile.py
+++ b/iaso/tests/api/workflows/test_workflows_mobile.py
@@ -68,4 +68,4 @@ class WorkflowsMobileAPITestCase(BaseWorkflowsAPITestCase):
         except jsonschema.exceptions.ValidationError as ex:
             self.fail(msg=str(ex))
 
-        assert len(response.data["workflows"]) == 2
+        self.assertEqual(len(response.data["workflows"]), 2)


### PR DESCRIPTION
Only return Workflows for the requested project

Related JIRA tickets : IA-2674

## Self proofreading checklist

- [X] Did I use eslint and black formatters
- [X] Is my code clear enough and well-documented
- [X] Are there enough tests

## Changes

After we changed the API (#1875) to return only the entity types linked to the requested project (through the `app_id` parameter), the mobile app could receive invalid workflow configurations linked to other projects. This PR fixes this issue and filters the Workflows based on the app_id parameter.

## How to test

- Create two entity types linked to different projects (through their reference form), each with its workflow.
- Query the mobile API to retrieve only the workflow of one project.
- Ensure that only the correct workflow was returned.

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
