### PR TITLE
SNT-2 Add API endpionts for MetricType and MetricValue

### DIFF
--- a/iaso/api/metrics/serializers.py
+++ b/iaso/api/metrics/serializers.py
@@ -1,0 +1,25 @@
+from rest_framework import serializers
+from iaso.models import MetricType, MetricValue
+
+
+class MetricTypeSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = MetricType
+        fields = [
+            "id",
+            "account",
+            "name",
+            "description",
+            "source",
+            "units",
+            "comments",
+            "created_at",
+            "updated_at",
+        ]
+        read_only_fields = ["created_at", "updated_at"]
+
+
+class MetricValueSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = MetricValue
+        fields = ["id", "metric_type", "org_unit", "year", "value"]

--- a/iaso/api/metrics/views.py
+++ b/iaso/api/metrics/views.py
@@ -1,0 +1,27 @@
+from django_filters.rest_framework import DjangoFilterBackend
+from rest_framework import viewsets
+
+
+from iaso.models import MetricType, MetricValue
+from .serializers import MetricTypeSerializer, MetricValueSerializer
+
+# TODO for both viewsets: permission_classes
+
+
+class MetricTypeViewSet(viewsets.ModelViewSet):
+    serializer_class = MetricTypeSerializer
+    ordering_fields = ["id", "name"]
+    http_method_names = ["get", "options"]
+
+    def get_queryset(self):
+        return MetricType.objects.filter(account=self.request.user.iaso_profile.account)
+
+
+class MetricValueViewSet(viewsets.ModelViewSet):
+    serializer_class = MetricValueSerializer
+    queryset = MetricValue.objects.all()
+    filter_backends = [DjangoFilterBackend]
+    filterset_fields = ["metric_type_id", "org_unit_id"]
+
+    def get_queryset(self):
+        return MetricValue.objects.filter(metric_type__account=self.request.user.iaso_profile.account)

--- a/iaso/urls.py
+++ b/iaso/urls.py
@@ -62,6 +62,7 @@ from .api.instances import InstancesViewSet
 from .api.links import LinkViewSet
 from .api.logs import LogsViewSet
 from .api.mapping_versions import MappingVersionsViewSet
+from .api.metrics.views import MetricTypeViewSet, MetricValueViewSet
 from .api.microplanning import AssignmentViewSet, MobilePlanningViewSet, PlanningViewSet, TeamViewSet
 from .api.mobile.bulk_uploads import MobileBulkUploadsViewSet
 from .api.mobile.entity import MobileEntityViewSet, MobileEntityDeletedViewSet
@@ -210,6 +211,8 @@ router.register(r"modules", ModulesViewSet, basename="modules")
 router.register(r"configs", ConfigViewSet, basename="jsonconfigs")
 router.register(r"mobile/bulkupload", MobileBulkUploadsViewSet, basename="mobilebulkupload")
 router.register(r"superset/token", SupersetTokenViewSet, basename="supersettoken")
+router.register(r"metrictypes", MetricTypeViewSet, basename="metrictypes")
+router.register(r"metricvalues", MetricValueViewSet, basename="metricvalues")
 router.registry.extend(plugins_router.registry)
 
 urlpatterns: URLList = [


### PR DESCRIPTION
Simple API endpoints for metrics:

- `GET /api/metrictypes/`
- `GET /api/metricvalues/?org_unit_id=97`

We can ignore permissions for now since this PR is set to merge only into `snt-malaria` branch. We can clean up and merge into Iaso main after the demo.