### PR TITLE
IA-3930: [HOT-FIX] autocomplete duplicate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6403,7 +6403,7 @@
         },
         "node_modules/bluesquare-components": {
             "version": "1.0.0",
-            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#ebcb3b01a9dbec610b95313e4ac09df910121f31",
+            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#f4216b6ac1ea1d2539064496380328a2b36d785e",
             "dependencies": {
                 "@babel/plugin-transform-class-properties": "^7.24.6",
                 "@babel/plugin-transform-object-rest-spread": "^7.24.6",


### PR DESCRIPTION
A- Services de base is duplicated 4 times for an unknown reason for the SNIS - DHIS2 version 1.
A fifth apparent duplication is due to another group carrying the same name but different ref, so  that one isn't of concern here.
When one of the first 4 is selected, all the 3 others appear selected too, which prevents selecting simultaneously the same group several times. However the expected behavior would be for it to appear only once in the first place.

![Screenshot 2025-02-12 at 14 31 39](https://github.com/user-attachments/assets/6e6c7c75-13b5-478e-be1b-6e299d79e7f9)
=> A- Services de Base (SNIS - DHIS2 - 1) should be present only twice
Related JIRA tickets : IA-3930

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

Changed blsq-component to add a specific key on option item list

## How to test

Deployed on prod and visible here https://iaso.bluesquare.org/dashboard/orgunits/detail/accountId/22/orgUnitId/3083324/levels/[2324664,2332601,2334100,3083324]/tab/infos
see JAM for more infos

## Print screen / video


![Screenshot 2025-02-12 at 14 37 27](https://github.com/user-attachments/assets/fed4fbdf-1919-4d59-b3e8-eec9c6c9b5fd)
## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
