### PR TITLE
POLIO-1847 Fixe bug

### DIFF
--- a/plugins/polio/api/vaccines/stock_management.py
+++ b/plugins/polio/api/vaccines/stock_management.py
@@ -6,6 +6,7 @@ from drf_yasg.utils import swagger_auto_schema
 from rest_framework import filters, serializers, status
 from rest_framework.decorators import action
 from rest_framework.filters import OrderingFilter, SearchFilter
+from django_filters.rest_framework import FilterSet, NumberFilter
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.exceptions import ValidationError
@@ -816,9 +817,18 @@ class EarmarkedStockSerializer(serializers.ModelSerializer):
         return None
 
 
+class EarmarkedStockFilter(FilterSet):
+    vaccine_stock = NumberFilter(field_name="vaccine_stock_id")
+
+    class Meta:
+        model = EarmarkedStock
+        fields = ["vaccine_stock"]
+
+
 class EarmarkedStockViewSet(VaccineStockSubitemEdit):
     serializer_class = EarmarkedStockSerializer
     model_class = EarmarkedStock
+    filterset_class = EarmarkedStockFilter
 
     def get_queryset(self):
         return EarmarkedStock.objects.filter(


### PR DESCRIPTION
Fix bug in earmark stocks displaying for all vaccine_stocks instead of filter for the current vaccine_stock

Related JIRA tickets :POLIO-1847

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented

## Changes
Add some filtering on API Viewset


## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
