### PR TITLE
IA-3949: Filter Groups per version id on org unit details page 

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/hooks.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/hooks.js
@@ -1,11 +1,11 @@
+import { useCallback, useMemo } from 'react';
+import { useQueryClient } from 'react-query';
 import { getRequest, patchRequest, postRequest } from 'Iaso/libs/Api.ts';
 import {
     useSnackMutation,
     useSnackQueries,
     useSnackQuery,
 } from 'Iaso/libs/apiHooks.ts';
-import { useCallback, useMemo } from 'react';
-import { useQueryClient } from 'react-query';
 import { getChipColors, getOtChipColors } from '../../constants/chipColors';
 import { useCheckUserHasWriteTypePermission } from '../../utils/usersUtils.ts';
 import MESSAGES from './messages.ts';
@@ -27,9 +27,14 @@ export const useOrgUnitDetailData = (
                 onSuccess: ou => setCurrentOrgUnit(ou),
             },
         );
-    const groupsDataSourceQueryParams = originalOrgUnit?.source_id
-        ? `?dataSource=${originalOrgUnit.source_id}`
-        : undefined;
+    let groupsDataSourceQueryParams;
+    if (originalOrgUnit?.version_id) {
+        groupsDataSourceQueryParams = `?version=${originalOrgUnit.version_id}`;
+    } else if (originalOrgUnit?.source_id) {
+        groupsDataSourceQueryParams = `?dataSource=${originalOrgUnit.source_id}`;
+    } else {
+        groupsDataSourceQueryParams = undefined;
+    }
     const groupsQueryParams = isNewOrgunit
         ? '?defaultVersion=true'
         : groupsDataSourceQueryParams;

--- a/iaso/models/org_unit.py
+++ b/iaso/models/org_unit.py
@@ -2,7 +2,6 @@ import logging
 import operator
 import typing
 import uuid
-
 from copy import deepcopy
 from functools import reduce
 
@@ -25,7 +24,6 @@ from iaso.models.data_source import SourceVersion
 from ..utils.expressions import ArraySubquery
 from ..utils.models.common import get_creator_name
 from .project import Project
-
 
 if typing.TYPE_CHECKING:
     from iaso.models import Account
@@ -488,6 +486,7 @@ class OrgUnit(TreeModel):
             res["source"] = self.version.data_source.name if self.version else None
             res["source_id"] = self.version.data_source.id if self.version else None
             res["version"] = self.version.number if self.version else None
+            res["version_id"] = self.version.id if self.version else None
         if hasattr(self, "search_index"):
             res["search_index"] = self.search_index
 


### PR DESCRIPTION
While visiting the details of an org unit, the list of possible groups should be filtered on the version id used to create the org unit, not only the data source. It leads to load more than 5000 groups on playground 

![Screenshot 2025-02-14 at 13 04 27](https://github.com/user-attachments/assets/7b437520-2e2a-400b-9533-9b75c1aa4a8f)


Related JIRA tickets : IA-3949

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)


## Changes

- added version_id to org unit details dict
- change hook logic to pass version if it exists

## How to test

Visit the detail of an org unit created with a datasrouce having a default version.
Call to api to get groups should be made with the correct version id 

![Screenshot 2025-02-14 at 13 04 38](https://github.com/user-attachments/assets/14e5c3c4-58b4-4855-aa34-118f8ba9f15b)

## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
