### PR TITLE
POLIO-1852 modify api endpoint to add earmarks values

### DIFF
--- a/plugins/polio/api/vaccines/stock_management.py
+++ b/plugins/polio/api/vaccines/stock_management.py
@@ -531,6 +531,7 @@ class VaccineStockSerializer(serializers.ModelSerializer):
     stock_of_usable_vials = serializers.SerializerMethodField()
     stock_of_unusable_vials = serializers.SerializerMethodField()
     vials_destroyed = serializers.SerializerMethodField()
+    stock_of_earmarked_vials = serializers.SerializerMethodField()
 
     class Meta:
         model = VaccineStock
@@ -543,6 +544,7 @@ class VaccineStockSerializer(serializers.ModelSerializer):
             "vials_used",
             "stock_of_usable_vials",
             "stock_of_unusable_vials",
+            "stock_of_earmarked_vials",
             "vials_destroyed",
         ]
         list_serializer_class = VaccineStockListSerializer
@@ -561,6 +563,9 @@ class VaccineStockSerializer(serializers.ModelSerializer):
 
     def get_vials_destroyed(self, obj):
         return obj.calculator.get_vials_destroyed()
+
+    def get_stock_of_earmarked_vials(self, obj):
+        return obj.calculator.get_total_of_earmarked()[0]
 
 
 class VaccineStockCreateSerializer(serializers.ModelSerializer):

--- a/plugins/polio/api/vaccines/stock_management.py
+++ b/plugins/polio/api/vaccines/stock_management.py
@@ -1064,7 +1064,9 @@ class VaccineStockManagementViewSet(ModelViewSet):
             VaccineStock.objects.filter(
                 account=self.request.user.iaso_profile.account, country__id__in=accessible_org_units_ids
             )
-            .prefetch_related("destructionreport_set", "incidentreport_set", "outgoingstockmovement_set")
+            .prefetch_related(
+                "destructionreport_set", "incidentreport_set", "outgoingstockmovement_set", "earmarked_stocks"
+            )
             .distinct()
             .order_by("id")
         )

--- a/plugins/polio/tests/test_vaccine_stock_management.py
+++ b/plugins/polio/tests/test_vaccine_stock_management.py
@@ -192,6 +192,7 @@ class VaccineStockManagementAPITestCase(APITestCase):
             stock["stock_of_usable_vials"], 21
         )  # 20 received - 13 used + 15 found in inventory -1 removed from inventory
         self.assertEqual(stock["stock_of_unusable_vials"], 27)
+        self.assertEqual(stock["stock_of_earmarked_vials"], 0)
         self.assertEqual(stock["vials_destroyed"], 3)  # 3 destroyed
 
     def test_usable_vials_endpoint(self):


### PR DESCRIPTION
For the polio Usable/Unusable/Earmarks dashboard we need to add the earmarked totals to the API.

Related JIRA tickets : POLIO-1852

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented


## Changes

Using existing VaccineStockCalculator to add the earmarked totals to `/api/polio/vaccine/vaccine_stock/` endpoint.

## How to test

Call the endpoint and see if you have a `stock_of_earmarked_vials` field

## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
