### PR TITLE
IA-3902-forms-slow

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,8 +41,8 @@ services:
             SENTRY_ENVIRONMENT:
             SENTRY_URL:
             SENTRY_FRONT_ENABLED:
-            RDS_HOSTNAME: db
-            RDS_DB_NAME:
+            RDS_HOSTNAME: smestach-iaso.ct2pysztqwxb.eu-central-1.rds.amazonaws.com
+            RDS_DB_NAME: iaso
             THEME_PRIMARY_COLOR:
             THEME_SECONDARY_COLOR:
             THEME_PRIMARY_BACKGROUND_COLOR: #OpenHexa API token
@@ -61,12 +61,12 @@ services:
             LOGO_PATH:
             APP_TITLE:
             SHOW_NAME_WITH_LOGO:
-            RDS_USERNAME: postgres
-            RDS_PASSWORD: postgres
+            RDS_USERNAME: iaso
+            RDS_PASSWORD: 6WzLYgL2nYatuiYEzHnK
             DB_READONLY_USERNAME: postgres
             DB_READONLY_PASSWORD: postgres
             DEBUG: 'true'
-            DEBUG_SQL:
+            DEBUG_SQL: 'true'
             DNS_DOMAIN:
             TEST_PROD:
             SECRET_KEY: secret

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,8 +41,8 @@ services:
             SENTRY_ENVIRONMENT:
             SENTRY_URL:
             SENTRY_FRONT_ENABLED:
-            RDS_HOSTNAME: smestach-iaso.ct2pysztqwxb.eu-central-1.rds.amazonaws.com
-            RDS_DB_NAME: iaso
+            RDS_HOSTNAME: db
+            RDS_DB_NAME:
             THEME_PRIMARY_COLOR:
             THEME_SECONDARY_COLOR:
             THEME_PRIMARY_BACKGROUND_COLOR: #OpenHexa API token
@@ -61,12 +61,12 @@ services:
             LOGO_PATH:
             APP_TITLE:
             SHOW_NAME_WITH_LOGO:
-            RDS_USERNAME: iaso
-            RDS_PASSWORD: 6WzLYgL2nYatuiYEzHnK
+            RDS_USERNAME: postgres
+            RDS_PASSWORD: postgres
             DB_READONLY_USERNAME: postgres
             DB_READONLY_PASSWORD: postgres
             DEBUG: 'true'
-            DEBUG_SQL: 'true'
+            DEBUG_SQL:
             DNS_DOMAIN:
             TEST_PROD:
             SECRET_KEY: secret

--- a/iaso/api/forms.py
+++ b/iaso/api/forms.py
@@ -148,7 +148,7 @@ class FormSerializer(DynamicFieldsModelSerializer):
 
     @staticmethod
     def get_latest_form_version(obj: Form):
-        return obj.latest_version.as_dict() if obj.latest_version is not None else None
+        return obj.latest_version.as_dict() if obj.latest_version else None
 
     @staticmethod
     def get_org_unit_types(obj: Form):
@@ -334,6 +334,21 @@ class FormsViewSet(ModelViewSet):
         search = self.request.query_params.get("search", None)
         if search:
             queryset = queryset.filter(name__icontains=search)
+
+        # prefetch all relations returned by default ex /api/forms/?order=name&limit=50&page=1
+        queryset = queryset.prefetch_related(
+            "form_versions",
+            "projects",
+            "projects__feature_flags",
+            "reference_of_org_unit_types",
+            "org_unit_types",
+            "org_unit_types__reference_forms",
+            "org_unit_types__sub_unit_types",
+            "org_unit_types__allow_creating_sub_unit_types",
+        )
+
+        # optimize latest version loading to not trigger a select n+1 on form_version
+        queryset = queryset.with_latest_version()
 
         # TODO: allow this only from a predefined list for security purposes
         order = self.request.query_params.get("order", "instance_updated_at").split(",")

--- a/iaso/models/forms.py
+++ b/iaso/models/forms.py
@@ -145,7 +145,7 @@ class Form(SoftDeletableModel):
                 return self.latest_versions[0]
             return None
         except AttributeError as e:
-            print("WARN form loaded without approtiate queryset.with_latest_version(), might trigger n+1 select")
+            # WARN form loaded without approtiate queryset.with_latest_version(), might trigger n+1 select
             return self.form_versions.order_by("-created_at").first()
 
     def __str__(self):

--- a/iaso/models/forms.py
+++ b/iaso/models/forms.py
@@ -2,6 +2,8 @@ import pathlib
 import typing
 from uuid import uuid4
 
+from django.db.models import Subquery, OuterRef, Prefetch
+
 from django.contrib.auth.models import AnonymousUser, User
 from django.contrib.postgres.fields import ArrayField
 from django.core.files.uploadedfile import SimpleUploadedFile
@@ -57,6 +59,21 @@ class FormQuerySet(models.QuerySet):
             except Project.DoesNotExist:
                 return self.none()
 
+        return queryset
+
+    def with_latest_version(self):
+        queryset = self
+        queryset = queryset.annotate(
+            latest_version_id=Subquery(
+                FormVersion.objects.filter(form=OuterRef("pk")).order_by("-created_at").values("id")[:1]
+            )
+        )
+
+        latest_versions = FormVersion.objects.filter(id__in=queryset.values_list("latest_version_id", flat=True))
+
+        queryset = queryset.prefetch_related(
+            Prefetch("form_versions", queryset=latest_versions, to_attr="latest_versions")
+        )
         return queryset
 
 
@@ -122,7 +139,14 @@ class Form(SoftDeletableModel):
 
     @property
     def latest_version(self):
-        return self.form_versions.order_by("-created_at").first()
+        # attribute filled by queryset.with_latest_version() on FormQuerySet
+        try:
+            if len(self.latest_versions) > 0:
+                return self.latest_versions[0]
+            return None
+        except AttributeError as e:
+            print("WARN form loaded without approtiate queryset.with_latest_version(), might trigger n+1 select")
+            return self.form_versions.order_by("-created_at").first()
 
     def __str__(self):
         return "%s %s " % (self.name, self.form_id)


### PR DESCRIPTION
performance improvement by pre loading various relationship of the form
and some hack to load the latest_version based on annotate instead of computed property.

Related JIRA tickets : IA-3902

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

performance improvement by pre loading various relationship of the form
and some hack to load the latest_version based on annotate instead of computed property.

## How to test

Seed and go to the form screen or the instance screen check the form picklist

on http://localhost:8081/api/forms/?order=name&limit=50&page=1 in copy on realistic data
- Total queries: 18 in 11.9643s 
- Total queries: 18 in 9.3936s
vs without the changes
- Total queries: 479 in 20.3505s

## Print screen / video


## Notes

Since it's not easy to identify all the places we used `latest_version` and adapt the loading of the form with an extra `.with_latest_version()`.

I kept it backward compatible and still do the 
```
self.form_versions.order_by("-created_at").first()
```
when the extra attribute latest_versions is not there.


## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
