### PR TITLE
IA-3881: Change request - Although not changing groups, groups seems to have change

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/Components/HighlightFieldsChanges.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/Components/HighlightFieldsChanges.tsx
@@ -1,9 +1,9 @@
+import React, { FunctionComponent, useMemo } from 'react';
 import { Box, TableCell, TableRow } from '@mui/material';
 import { some, sortBy, uniqBy } from 'lodash';
-import React, { FunctionComponent, useMemo } from 'react';
 import InputComponent from '../../../../components/forms/InputComponent';
-import { ReviewOrgUnitChangesDetailsTableRow } from '../Tables/details/ReviewOrgUnitChangesDetailsTableRow';
 import { NewOrgUnitField } from '../hooks/useNewFields';
+import { ReviewOrgUnitChangesDetailsTableRow } from '../Tables/details/ReviewOrgUnitChangesDetailsTableRow';
 import {
     ExtendedNestedGroup,
     NestedGroup,
@@ -41,6 +41,9 @@ export const HighlightFields: FunctionComponent<Props> = ({
         if (fieldType && fieldType === 'array') {
             changedFieldWithOldValues = sortBy(oldFieldValues, 'name');
             changedFieldWithNewValues = sortBy(newFieldValues, 'name');
+            if (newFieldValues?.length === 0) {
+                changedFieldWithNewValues = changedFieldWithOldValues;
+            }
         }
         const changedFieldValues = uniqBy(
             changedFieldWithOldValues.concat(changedFieldWithNewValues),
@@ -63,6 +66,7 @@ export const HighlightFields: FunctionComponent<Props> = ({
             };
         });
     }, [fieldType, oldFieldValues, newFieldValues]);
+
     return (
         <TableRow sx={{ verticalAlign: 'top' }}>
             <TableCell>{field.label}</TableCell>


### PR DESCRIPTION
What problem is this PR solving? Explain here in one sentence.

Related JIRA tickets : [IA-3881](https://bluesquare.atlassian.net/browse/IA-3881)

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)


## Changes

Keep old values for org unit when there is no new values


## How to test

Create a 2 new change request for org units with groups by specify:
- new name and open/close date for org unit for the first one.
- new name, new groups and open/close date for org unit for the second one.

## Print screen / video

![Change-proposals-for-Test-2](https://github.com/user-attachments/assets/7920a20f-c333-4717-8f43-f5152a6d24cf)

![image](https://github.com/user-attachments/assets/66520493-6bef-49b9-8d8e-5e599bc6a4f0)



## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.


[IA-3881]: https://bluesquare.atlassian.net/browse/IA-3881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ