### PR TITLE
HOTFIX:  POLIO-1722 update refreshpowerbi endpoint

### DIFF
--- a/hat/templates/iaso/pages/refresh_data_set_snippet.html
+++ b/hat/templates/iaso/pages/refresh_data_set_snippet.html
@@ -7,8 +7,7 @@
           headers: {
             'Content-Type': 'application/json'
           },
-          body: JSON.stringify(data),
-          credentials: 'include'
+          body: JSON.stringify(data)
         })
         var label = document.getElementById('refreshingLabel')
         label.style.display = 'block'

--- a/hat/templates/iaso/pages/refresh_data_set_snippet.html
+++ b/hat/templates/iaso/pages/refresh_data_set_snippet.html
@@ -7,7 +7,8 @@
           headers: {
             'Content-Type': 'application/json'
           },
-          body: JSON.stringify(data)
+          body: JSON.stringify(data),
+          credentials: 'include'
         })
         var label = document.getElementById('refreshingLabel')
         label.style.display = 'block'

--- a/iaso/api/tasks/views.py
+++ b/iaso/api/tasks/views.py
@@ -161,7 +161,8 @@ class ExternalTaskModelViewSet(ModelViewSet):
     # config is the pipeline specific config (the args of the pipeline method grouped in a dict)
     # task_id will be passed by the task decorator
     # id_field is a field to filter from to find the relevant active run, eg: a country id for lqas refresh
-    def launch_task(self, slug, config={}, task_id=None, id_field=None):
+    @staticmethod
+    def launch_task(slug, config={}, task_id=None, id_field=None):
         try:
             # The config Model should be moved to Iaso as well
             pipeline_config = get_object_or_404(Config, slug=slug)

--- a/iaso/utils/powerbi.py
+++ b/iaso/utils/powerbi.py
@@ -1,5 +1,12 @@
 import requests
+import time
+from django.http import Http404
 from django.shortcuts import get_object_or_404
+from datetime import datetime
+from iaso.api.tasks.views import ExternalTaskModelViewSet
+from iaso.models.base import RUNNING, SUCCESS, Task
+from django.contrib.auth.models import User
+
 
 SP_AUTH_URL = "https://login.microsoftonline.com/{tenant_id}/oauth2/token"
 POWERBI_RESOURCE = "https://analysis.windows.net/powerbi/api"
@@ -42,12 +49,67 @@ def get_powerbi_report_token(group_id, report_id):
     return get_powerbi_report_token_with_sp(sp_access_token, group_id, report_id)
 
 
+def get_openhexa_config_for_data_set_id(data_set_id):
+    from iaso.models.json_config import Config
+
+    dataset_config = None
+    oh_conf = Config.objects.filter(slug="openhexa_powerbi")
+    if oh_conf.exists():
+        oh_conf = oh_conf.first()
+        oh_config = oh_conf.content
+        dataset_config = oh_config[data_set_id]
+    return dataset_config
+
+
+def launch_external_task(dataset_config):
+    user_id = dataset_config["user_id"]
+    try:
+        user = User.objects.get(id=user_id)
+    except User.DoesNotExist:
+        raise Http404(f"No user found for id {user_id}")
+    task = Task.objects.create(
+        created_by=user,
+        launcher=user,
+        account=user.iaso_profile.account,
+        name=dataset_config["task_name"],
+        status=RUNNING,
+        external=True,
+        started_at=datetime.now(),
+        should_be_killed=False,
+    )
+    status = ExternalTaskModelViewSet.launch_task(slug=dataset_config["config"], task_id=task.pk)
+    task.status = status
+    task.save()
+    return task
+
+
+def monitor_task_and_raise_if_fail(dataset_config, task):
+    expected_run_time = dataset_config["expected_run_time"] if dataset_config["expected_run_time"] else 60
+    additional_timeout = dataset_config["additional_timeout"] if dataset_config["additional_timeout"] else 30
+    max_attempts = dataset_config["timeout_count"] if dataset_config["timeout_count"] else 2
+    attempts = 0
+    while task.status == RUNNING and attempts < max_attempts:
+        if attempts == 0:
+            time.sleep(expected_run_time)
+        else:
+            time.sleep(additional_timeout)
+        task.refresh_from_db()
+        attempts += 1
+    if task.status != SUCCESS:
+        raise Http404(f'{dataset_config["task_name"]} failed with status {task.status}')
+
+
 def launch_dataset_refresh(group_id, data_set_id):
     # FIXME : import is not extra but will do till we move this model
     from iaso.models.json_config import Config
 
     conf = get_object_or_404(Config, slug="powerbi_sp")
     config = conf.content
+    dataset_config = get_openhexa_config_for_data_set_id(data_set_id)
+
+    if dataset_config:
+        task = launch_external_task(dataset_config)
+        monitor_task_and_raise_if_fail(dataset_config, task)
 
     sp_access_token = get_powerbi_service_principal_token(
         config["tenant_id"], config["client_id"], config["secret_value"]

--- a/iaso/utils/powerbi.py
+++ b/iaso/utils/powerbi.py
@@ -1,12 +1,13 @@
-import requests
 import time
+from datetime import datetime
+
+import requests
+from django.contrib.auth.models import User
 from django.http import Http404
 from django.shortcuts import get_object_or_404
-from datetime import datetime
+
 from iaso.api.tasks.views import ExternalTaskModelViewSet
 from iaso.models.base import RUNNING, SUCCESS, Task
-from django.contrib.auth.models import User
-
 
 SP_AUTH_URL = "https://login.microsoftonline.com/{tenant_id}/oauth2/token"
 POWERBI_RESOURCE = "https://analysis.windows.net/powerbi/api"
@@ -57,7 +58,12 @@ def get_openhexa_config_for_data_set_id(data_set_id):
     if oh_conf.exists():
         oh_conf = oh_conf.first()
         oh_config = oh_conf.content
-        dataset_config = oh_config[data_set_id]
+        # Convert data_set_id to string if it's a UUID
+        data_set_id_str = str(data_set_id)
+        if data_set_id_str in oh_config:
+            dataset_config = oh_config[data_set_id_str]
+        else:
+            raise KeyError(f"Data set ID {data_set_id_str} not found in configuration.")
     return dataset_config
 
 

--- a/plugins/polio/api/dashboards/launch_powerbi.py
+++ b/plugins/polio/api/dashboards/launch_powerbi.py
@@ -1,7 +1,5 @@
-from django.utils.decorators import method_decorator
-from django.views.decorators.clickjacking import xframe_options_exempt
 from drf_yasg.utils import swagger_auto_schema
-from rest_framework import serializers, status, viewsets
+from rest_framework import permissions, serializers, status, viewsets
 from rest_framework.response import Response
 
 from iaso.utils.powerbi import launch_dataset_refresh
@@ -15,8 +13,9 @@ class PowerBIRefreshSerializer(serializers.Serializer):
 @swagger_auto_schema()
 class LaunchPowerBIRefreshViewSet(viewsets.ViewSet):
     serializer_class = PowerBIRefreshSerializer
+    # Open to all to make it work while calling this api from a iframe in RRT
+    permission_classes = [permissions.AllowAny]
 
-    @method_decorator(xframe_options_exempt)
     def create(self, request):
         serializer = self.serializer_class(data=request.data)
         serializer.is_valid(raise_exception=True)
@@ -24,14 +23,7 @@ class LaunchPowerBIRefreshViewSet(viewsets.ViewSet):
         data_set_id = serializer.validated_data["data_set_id"]
         group_id = serializer.validated_data["group_id"]
         # Perform actions using uuid1 and uuid2
+        response_data = {"message": f"Received data_set_id: {data_set_id}, group_id: {group_id}"}
         launch_dataset_refresh(group_id, data_set_id)
 
-        response_data = {"message": f"Received data_set_id: {data_set_id}, group_id: {group_id}"}
-        response = Response(response_data, status=status.HTTP_201_CREATED)
-        response["Content-Security-Policy"] = "frame-ancestors 'self' afro-rrt-who.hub.arcgis.com"
-
-        # Set SameSite attribute for cookies
-        response.set_cookie("sessionid", request.COOKIES.get("sessionid"), samesite="None", secure=True)
-        response.set_cookie("csrftoken", request.COOKIES.get("csrftoken"), samesite="None", secure=True)
-
-        return response
+        return Response(response_data, status=status.HTTP_201_CREATED)

--- a/plugins/polio/api/dashboards/launch_powerbi.py
+++ b/plugins/polio/api/dashboards/launch_powerbi.py
@@ -30,4 +30,8 @@ class LaunchPowerBIRefreshViewSet(viewsets.ViewSet):
         response = Response(response_data, status=status.HTTP_201_CREATED)
         response["Content-Security-Policy"] = "frame-ancestors 'self' afro-rrt-who.hub.arcgis.com"
 
+        # Set SameSite attribute for cookies
+        response.set_cookie("sessionid", request.COOKIES.get("sessionid"), samesite="None", secure=True)
+        response.set_cookie("csrftoken", request.COOKIES.get("csrftoken"), samesite="None", secure=True)
+
         return response

--- a/plugins/polio/api/dashboards/launch_powerbi.py
+++ b/plugins/polio/api/dashboards/launch_powerbi.py
@@ -1,3 +1,5 @@
+from django.utils.decorators import method_decorator
+from django.views.decorators.clickjacking import xframe_options_exempt
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import serializers, status, viewsets
 from rest_framework.response import Response
@@ -14,6 +16,7 @@ class PowerBIRefreshSerializer(serializers.Serializer):
 class LaunchPowerBIRefreshViewSet(viewsets.ViewSet):
     serializer_class = PowerBIRefreshSerializer
 
+    @method_decorator(xframe_options_exempt)
     def create(self, request):
         serializer = self.serializer_class(data=request.data)
         serializer.is_valid(raise_exception=True)

--- a/plugins/polio/api/dashboards/launch_powerbi.py
+++ b/plugins/polio/api/dashboards/launch_powerbi.py
@@ -24,7 +24,10 @@ class LaunchPowerBIRefreshViewSet(viewsets.ViewSet):
         data_set_id = serializer.validated_data["data_set_id"]
         group_id = serializer.validated_data["group_id"]
         # Perform actions using uuid1 and uuid2
-        response_data = {"message": f"Received data_set_id: {data_set_id}, group_id: {group_id}"}
         launch_dataset_refresh(group_id, data_set_id)
 
-        return Response(response_data, status=status.HTTP_201_CREATED)
+        response_data = {"message": f"Received data_set_id: {data_set_id}, group_id: {group_id}"}
+        response = Response(response_data, status=status.HTTP_201_CREATED)
+        response["Content-Security-Policy"] = "frame-ancestors 'self' afro-rrt-who.hub.arcgis.com"
+
+        return response

--- a/plugins/polio/tasks/api/refresh_vrf_dashboard_data.py
+++ b/plugins/polio/tasks/api/refresh_vrf_dashboard_data.py
@@ -3,7 +3,6 @@ from iaso.api.tasks.views import ExternalTaskModelViewSet
 from iaso.models.base import RUNNING, Task
 from rest_framework.response import Response
 from datetime import datetime
-from django.contrib.auth.models import User
 
 
 VRF_TASK_NAME = "Refresh VRF dashboard data"

--- a/plugins/polio/tests/test_refresh_lqas_data.py
+++ b/plugins/polio/tests/test_refresh_lqas_data.py
@@ -1,12 +1,9 @@
 from datetime import datetime
-import json
 from iaso import models as m
 from iaso.test import APITestCase
 from iaso.models.base import RUNNING, KILLED, SUCCESS, SKIPPED
-
 from iaso.models.json_config import Config
 from plugins.polio.tasks.api.refresh_lqas_data import LQAS_CONFIG_SLUG, RefreshLQASDataViewset
-import os
 from unittest.mock import patch
 
 

--- a/plugins/polio/tests/test_refresh_powerbi.py
+++ b/plugins/polio/tests/test_refresh_powerbi.py
@@ -1,0 +1,116 @@
+from datetime import datetime
+from iaso import models as m
+from iaso.api.tasks.views import ExternalTaskModelViewSet
+from iaso.test import APITestCase
+from iaso.models.base import RUNNING, KILLED, SUCCESS, SKIPPED
+from iaso.models.json_config import Config
+from iaso.utils.powerbi import get_openhexa_config_for_data_set_id, launch_external_task, monitor_task_and_raise_if_fail
+from plugins.polio.tasks.api.refresh_lqas_data import LQAS_CONFIG_SLUG, RefreshLQASDataViewset
+from unittest.mock import patch
+
+# ('/api/polio/powerbirefresh/', {
+#           method: 'POST',
+#           headers: {
+#             'Content-Type': 'application/json'
+#           },
+#           body: JSON.stringify(data)
+#         })
+
+
+class RefreshPowerBITestCase(APITestCase):
+    @classmethod
+    def setUp(cls):
+        cls.url = "/api/polio/powerbirefresh/"
+        cls.account = account = m.Account.objects.create(name="test account")
+        cls.user = cls.create_user_with_profile(username="test user", account=account, permissions=["iaso_polio"])
+
+        cls.external_task1 = m.Task.objects.create(
+            status=RUNNING, account=account, launcher=cls.user, name="external task 1", external=True
+        )
+        cls.external_task2 = m.Task.objects.create(
+            status=RUNNING, account=account, launcher=cls.user, name="external task 2", external=True
+        )
+        cls.project = m.Project.objects.create(name="Polio", app_id="polio.rapid.outbreak.taskforce", account=account)
+        cls.data_source = m.DataSource.objects.create(name="Default source")
+        cls.data_source.projects.add(cls.project)
+        cls.data_source.save()
+        cls.source_version = m.SourceVersion.objects.create(data_source=cls.data_source, number=1)
+        cls.account.default_version = cls.source_version
+        cls.account.save()
+
+        cls.task1 = m.Task.objects.create(
+            status=RUNNING,
+            account=account,
+            launcher=cls.user,
+            name=LQAS_CONFIG_SLUG,
+            started_at=datetime.now(),
+            external=True,
+        )
+        cls.task2 = m.Task.objects.create(
+            status=RUNNING, account=account, launcher=cls.user, name="task 2", external=True
+        )
+
+        cls.pipeline_json = {
+            "pipeline": "pipeline",
+            "openhexa_url": "https://yippie.openhexa.xyz/",
+            "openhexa_token": "token",
+            "pipeline_version": 1,
+            "oh_pipeline_target": "staging",
+        }
+        cls.slug = "slug"
+        cls.dataset_id = "dataset_id"
+        cls.pipeline_config = Config.objects.create(slug=cls.slug, content=cls.pipeline_json)
+        cls.dataset_json = {
+            f"{cls.dataset_id}": {
+                "config": f"{cls.slug}",
+                "user_id": cls.user.pk,
+                "task_name": "Refresh dashboard",
+                "timeout_count": 2,
+                "expected_run_time": 1,
+                "additional_timeout": 1,
+            }
+        }
+        cls.openhexa_config = Config.objects.create(slug="openhexa_powerbi", content=cls.dataset_json)
+
+    def mock_openhexa_call_success(slug=None, config=None, id_field=None, task_id=None):
+        return SUCCESS
+
+    def mock_openhexa_call_skipped(slug=None, config=None, id_field=None, task_id=None):
+        return SKIPPED
+
+    def mock_openhexa_call_running(slug=None, config=None, id_field=None, task_id=None):
+        return RUNNING
+
+    def test_get_openhexa_config_for_data_set_id(self):
+        dataset_config = get_openhexa_config_for_data_set_id(self.dataset_id)
+        self.assertDictEqual(dataset_config, self.dataset_json[self.dataset_id])
+
+    @patch.object(ExternalTaskModelViewSet, "launch_task", mock_openhexa_call_running)
+    def test_launch_external_task(self):
+        dataset_config = self.dataset_json[self.dataset_id]
+        task = launch_external_task(dataset_config)
+        self.assertEqual(task.status, RUNNING)
+        self.assertTrue(task.external)
+        self.assertEqual(task.account, self.account)
+        self.assertEqual(task.launcher, self.user)
+        self.assertEqual(task.created_by, self.user)
+
+    @patch.object(ExternalTaskModelViewSet, "launch_task", mock_openhexa_call_running)
+    def test_monitor_task_and_fail(self):
+        dataset_config = self.dataset_json[self.dataset_id]
+        task = launch_external_task(dataset_config)
+        with self.assertRaises(Exception) as raisedException:
+            monitor_task_and_raise_if_fail(dataset_config, task)
+        exception_message = raisedException.exception
+        self.assertEqual("Refresh dashboard failed with status RUNNING", str(exception_message))
+
+    @patch.object(ExternalTaskModelViewSet, "launch_task", mock_openhexa_call_success)
+    def test_monitor_task_and_success(self):
+        dataset_config = self.dataset_json[self.dataset_id]
+        task = launch_external_task(dataset_config)
+        hasException = False
+        try:
+            monitor_task_and_raise_if_fail(dataset_config, task)
+        except:
+            hasException = True
+        self.assertFalse(hasException)


### PR DESCRIPTION
- Add methods to launch OH pipeline if config exists

What problem is this PR solving? Explain here in one sentence.

Related JIRA tickets : POLIO-1722

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

Add methods to launch openhexa pipeline and only refresh the rest of powerBi dataset if pipeline succeeds
add unit test for these methods

## How to test

No idea, dashboards are in prod and there's no setup to test this locally

## Print screen / video



## Notes

Can be hotfixed on v1.253c-polio-prerelease

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
