### PR TITLE
IA-3968: Navigation of pages (Orgunit Search) is reset to 1 after going to page 2

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/TableList.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/TableList.tsx
@@ -1,73 +1,53 @@
+import React, {
+    FunctionComponent,
+    useCallback,
+    useMemo,
+    useState,
+} from 'react';
 import EditIcon from '@mui/icons-material/Settings';
 import { Box } from '@mui/material';
 import {
     selectionInitialState,
     setTableSelection,
-    Table,
-    useRedirectToReplace,
     useSafeIntl,
     useSkipEffectOnMount,
 } from 'bluesquare-components';
-import React, {
-    Dispatch,
-    FunctionComponent,
-    SetStateAction,
-    useCallback,
-    useMemo,
-    useState,
-} from 'react';
 
-// COMPONENTS
 import { UseMutateAsyncFunction } from 'react-query';
-import { OrgUnitsMultiActionsDialog } from './OrgUnitsMultiActionsDialog';
-// COMPONENTS
 
-// TYPES
-import { Result as OrgUnitResult } from '../hooks/requests/useGetOrgUnits';
-import { OrgUnit, OrgUnitParams } from '../types/orgUnit';
-import { Search } from '../types/search';
-import { Selection } from '../types/selection';
-// TYPES
-
-// UTILS
-import { decodeSearch } from '../utils';
-// UTILS
-
-// CONSTANTS
+import { TableWithDeepLink } from '../../../components/tables/TableWithDeepLink';
 import { baseUrls } from '../../../constants/urls';
-import MESSAGES from '../messages';
-// CONSTANTS
 
-// HOOKS
-import { convertObjectToString } from '../../../utils/dataManipulation';
+import { useQueryUpdateListener } from '../../../hooks/useQueryUpdateListener';
 import { ORG_UNITS } from '../../../utils/permissions';
 import {
     useCheckUserHasWriteTypePermission,
     useCurrentUser,
 } from '../../../utils/usersUtils';
 import { userHasPermission } from '../../users/utils';
+import { Result as OrgUnitResult } from '../hooks/requests/useGetOrgUnits';
 import { useGetOrgUnitsTableColumns } from '../hooks/useGetOrgUnitsTableColumns';
-// HOOKS
+import MESSAGES from '../messages';
+import { OrgUnit, OrgUnitParams } from '../types/orgUnit';
+import { Search } from '../types/search';
+import { Selection } from '../types/selection';
+import { decodeSearch } from '../utils';
+import { OrgUnitsMultiActionsDialog } from './OrgUnitsMultiActionsDialog';
 
 type Props = {
     params: OrgUnitParams;
-    resetPageToOne: string;
     orgUnitsData?: OrgUnitResult;
     saveMulti: UseMutateAsyncFunction<unknown, unknown, unknown, unknown>;
-    setResetPageToOne: Dispatch<SetStateAction<string>>;
 };
 
 const baseUrl = baseUrls.orgUnits;
 export const TableList: FunctionComponent<Props> = ({
     params,
-    resetPageToOne,
     orgUnitsData,
     saveMulti,
-    setResetPageToOne,
 }) => {
     const { formatMessage } = useSafeIntl();
 
-    const redirectToReplace = useRedirectToReplace();
     const currentUser = useCurrentUser();
     const [multiActionPopupOpen, setMultiActionPopupOpen] =
         useState<boolean>(false);
@@ -117,17 +97,13 @@ export const TableList: FunctionComponent<Props> = ({
         [checkUserHasWriteTypePermission],
     );
 
-    const handleTableParamsChange = useCallback(
-        newParams => {
-            setResetPageToOne(convertObjectToString(newParams));
-            redirectToReplace(baseUrl, newParams);
+    useQueryUpdateListener({
+        queryKey: 'orgunits',
+        onUpdate: () => {
+            handleTableSelection('reset');
         },
-        [redirectToReplace, setResetPageToOne],
-    );
+    });
 
-    useSkipEffectOnMount(() => {
-        handleTableSelection('reset');
-    }, [resetPageToOne]);
     return (
         <>
             <OrgUnitsMultiActionsDialog
@@ -138,8 +114,7 @@ export const TableList: FunctionComponent<Props> = ({
                 saveMulti={saveMulti}
             />
             <Box mt={-4}>
-                <Table
-                    resetPageToOne={resetPageToOne}
+                <TableWithDeepLink
                     data={orgUnitsData?.orgunits || []}
                     count={orgUnitsData?.count}
                     pages={orgUnitsData?.pages}
@@ -149,7 +124,7 @@ export const TableList: FunctionComponent<Props> = ({
                     marginTop={false}
                     extraProps={{
                         columns,
-                        data: orgUnitsData,
+                        data: orgUnitsData?.orgunits || [],
                     }}
                     multiSelect
                     selection={selection}
@@ -158,7 +133,6 @@ export const TableList: FunctionComponent<Props> = ({
                         handleTableSelection(selectionType, items, totalCount)
                     }
                     getIsSelectionDisabled={getIsSelectionDisabled}
-                    onTableParamsChange={handleTableParamsChange}
                 />
             </Box>
         </>

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/TableList.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/TableList.tsx
@@ -10,7 +10,6 @@ import {
     selectionInitialState,
     setTableSelection,
     useSafeIntl,
-    useSkipEffectOnMount,
 } from 'bluesquare-components';
 
 import { UseMutateAsyncFunction } from 'react-query';
@@ -113,7 +112,7 @@ export const TableList: FunctionComponent<Props> = ({
                 selection={selection}
                 saveMulti={saveMulti}
             />
-            <Box mt={-4}>
+            <Box mt={-4} pb={2}>
                 <TableWithDeepLink
                     data={orgUnitsData?.orgunits || []}
                     count={orgUnitsData?.count}

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/hooks/requests/useGetOrgUnits.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/hooks/requests/useGetOrgUnits.ts
@@ -1,17 +1,15 @@
+import { Pagination } from 'bluesquare-components';
 import { UseQueryResult } from 'react-query';
 
-import { Pagination } from 'bluesquare-components';
 import { getRequest } from '../../../../libs/Api';
 import { useSnackQuery } from '../../../../libs/apiHooks';
 
+import { Locations } from '../../components/OrgUnitsMap';
 import { OrgUnit } from '../../types/orgUnit';
 import { Search } from '../../types/search';
 
-import { ApiParams } from '../useGetApiParams';
-
-import { Locations } from '../../components/OrgUnitsMap';
-
 import { mapOrgUnitByLocation } from '../../utils';
+import { ApiParams } from '../useGetApiParams';
 
 export type Count = {
     index: number;
@@ -27,7 +25,6 @@ type Props = {
     callback?: () => void;
     isSearchActive: boolean;
     enabled?: boolean;
-    resetPageToOne: string;
 };
 
 type PropsLocation = {
@@ -35,7 +32,6 @@ type PropsLocation = {
     searches: Search[];
     isSearchActive: boolean;
     enabled?: boolean;
-    resetPageToOne: string;
 };
 
 export const useGetOrgUnits = ({
@@ -43,12 +39,11 @@ export const useGetOrgUnits = ({
     isSearchActive,
     callback = () => null,
     enabled = false,
-    resetPageToOne,
 }: Props): UseQueryResult<Result, Error> => {
     const onSuccess = () => callback();
     const queryString = new URLSearchParams(params);
     return useSnackQuery({
-        queryKey: ['orgunits', resetPageToOne],
+        queryKey: ['orgunits', params],
         queryFn: () => getRequest(`/api/orgunits/?${queryString.toString()}`),
         options: {
             enabled,
@@ -70,11 +65,10 @@ export const useGetOrgUnitsLocations = ({
     searches,
     isSearchActive,
     enabled = false,
-    resetPageToOne,
 }: PropsLocation): UseQueryResult<Locations | undefined, Error> => {
     const queryString = new URLSearchParams(params);
     return useSnackQuery({
-        queryKey: ['orgunitslocations', resetPageToOne],
+        queryKey: ['orgunitslocations', params],
         queryFn: () => getRequest(`/api/orgunits/?${queryString.toString()}`),
         options: {
             enabled,

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/index.tsx
@@ -1,3 +1,9 @@
+import React, {
+    FunctionComponent,
+    useCallback,
+    useMemo,
+    useState,
+} from 'react';
 import { Box, Tab, Tabs } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import {
@@ -6,48 +12,27 @@ import {
     makeRedirectionUrl,
     useSafeIntl,
 } from 'bluesquare-components';
-import React, {
-    FunctionComponent,
-    useCallback,
-    useMemo,
-    useState,
-} from 'react';
-
-// COMPONENTS
 import { useNavigate } from 'react-router-dom';
 import DownloadButtonsComponent from '../../components/DownloadButtonsComponent';
 import TopBar from '../../components/nav/TopBarComponent';
+import { getChipColors } from '../../constants/chipColors';
+import { MENU_HEIGHT_WITHOUT_TABS } from '../../constants/uiConstants';
+import { baseUrls } from '../../constants/urls';
+import { useParamsObject } from '../../routing/hooks/useParamsObject';
 import { OrgUnitFiltersContainer } from './components/OrgUnitFiltersContainer';
 import { OrgUnitsMap } from './components/OrgUnitsMap';
 import { TableList } from './components/TableList';
-// COMPONENTS
-
-// TYPES
-import { OrgUnitParams } from './types/orgUnit';
-import { Search } from './types/search';
-// TYPES
-
-// UTILS
-import { getChipColors } from '../../constants/chipColors';
-import { convertObjectToString } from '../../utils/dataManipulation';
-import { decodeSearch } from './utils';
-// UTILS
-
-// CONSTANTS
-import { MENU_HEIGHT_WITHOUT_TABS } from '../../constants/uiConstants';
-import { baseUrls } from '../../constants/urls';
-import MESSAGES from './messages';
-// CONSTANTS
-
-// HOOKS
-import { useParamsObject } from '../../routing/hooks/useParamsObject';
 import { useBulkSaveOrgUnits } from './hooks/requests/useBulkSaveOrgUnits';
 import {
     useGetOrgUnits,
     useGetOrgUnitsLocations,
 } from './hooks/requests/useGetOrgUnits';
 import { useGetApiParams } from './hooks/useGetApiParams';
-// HOOKS
+import MESSAGES from './messages';
+import { OrgUnitParams } from './types/orgUnit';
+import { Search } from './types/search';
+
+import { decodeSearch } from './utils';
 
 const useStyles = makeStyles(theme => ({
     ...commonStyles(theme),
@@ -88,9 +73,6 @@ export const OrgUnits: FunctionComponent = () => {
     // HOOKS
 
     // STATE
-    const [resetPageToOne, setResetPageToOne] = useState<string>(
-        convertObjectToString(params),
-    );
     const [tab, setTab] = useState<string>(params.tab ?? 'list');
     // STATE
 
@@ -121,7 +103,6 @@ export const OrgUnits: FunctionComponent = () => {
             params: apiParams,
             isSearchActive,
             enabled: isSearchActive, // this is required to count result in search tab
-            resetPageToOne,
         });
     const {
         data: orgUnitsDataLocation,
@@ -131,7 +112,6 @@ export const OrgUnits: FunctionComponent = () => {
         searches,
         isSearchActive,
         enabled: tab === 'map' && isSearchActive,
-        resetPageToOne,
     });
     // REQUESTS HOOKS
 
@@ -161,7 +141,6 @@ export const OrgUnits: FunctionComponent = () => {
             if (newParams.searchActive !== 'true') {
                 tempParams.searchActive = true;
             }
-            setResetPageToOne(convertObjectToString(tempParams));
             navigate(makeRedirectionUrl(baseUrl, tempParams), {
                 replace: true,
             });
@@ -242,9 +221,7 @@ export const OrgUnits: FunctionComponent = () => {
                             <TableList
                                 params={params}
                                 saveMulti={saveMulti}
-                                resetPageToOne={resetPageToOne}
                                 orgUnitsData={orgUnitsData}
-                                setResetPageToOne={setResetPageToOne}
                             />
                         )}
 

--- a/hat/assets/js/apps/Iaso/hooks/useQueryUpdateListener.ts
+++ b/hat/assets/js/apps/Iaso/hooks/useQueryUpdateListener.ts
@@ -1,0 +1,31 @@
+import { useEffect } from 'react';
+import { useQueryClient, QueryKey } from 'react-query';
+
+type UseQueryUpdateListenerProps = {
+    queryKey: QueryKey;
+    onUpdate: () => void;
+};
+
+export const useQueryUpdateListener = ({
+    queryKey,
+    onUpdate,
+}: UseQueryUpdateListenerProps) => {
+    const queryClient = useQueryClient();
+
+    useEffect(() => {
+        const unsubscribe = queryClient.getQueryCache().subscribe(event => {
+            if (
+                event?.type === 'queryUpdated' &&
+                (event?.query?.queryKey === queryKey ||
+                    (Array.isArray(event?.query?.queryKey) &&
+                        event?.query?.queryKey.some(key => key === queryKey)))
+            ) {
+                onUpdate();
+            }
+        });
+
+        return () => {
+            unsubscribe();
+        };
+    }, [queryClient, queryKey, onUpdate]);
+};


### PR DESCRIPTION
Filter org units by 'New' validation status (00:04)

Click the 'Search' button (00:06)

Navigate to page 2 (00:10)

Navigate to page 3 (00:17)

Observe the page reverts back to page 1 (00:20)

[JamScreenRecording-IA-3968.webm](https://github.com/user-attachments/assets/19a18398-5cc2-4cbb-bd80-6b3bdade2a4a)


Related JIRA tickets : IA-3968

## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [x] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

Explain the changes that were made.

- remove `resetPageToOne` logic
- use `TableWithDeepLink`
- new  `useQueryUpdateListener` hook to watch a react-query dataset and trigger a function. on update

## How to test

Launch a search on org units. 
multi select some
Change you filters and search again, selection should be enmpty
Also make sure pagination is working corectly

## Print screen / video

https://github.com/user-attachments/assets/23527ad4-e8ab-4ecc-b4a3-7fbef151af8d


## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
