### PR TITLE
HOTFIX: POLIO-1853: Make launch powerbi endpoint public

### DIFF
--- a/hat/templates/iaso/pages/refresh_data_set_snippet.html
+++ b/hat/templates/iaso/pages/refresh_data_set_snippet.html
@@ -7,8 +7,7 @@
           headers: {
             'Content-Type': 'application/json'
           },
-          body: JSON.stringify(data),
-          credentials: 'include'
+          body: JSON.stringify(data)
         })
         var label = document.getElementById('refreshingLabel')
         label.style.display = 'block'

--- a/hat/templates/iaso/pages/refresh_data_set_snippet.html
+++ b/hat/templates/iaso/pages/refresh_data_set_snippet.html
@@ -7,7 +7,8 @@
           headers: {
             'Content-Type': 'application/json'
           },
-          body: JSON.stringify(data)
+          body: JSON.stringify(data),
+          credentials: 'include'
         })
         var label = document.getElementById('refreshingLabel')
         label.style.display = 'block'

--- a/plugins/polio/api/dashboards/launch_powerbi.py
+++ b/plugins/polio/api/dashboards/launch_powerbi.py
@@ -1,7 +1,5 @@
-from django.utils.decorators import method_decorator
-from django.views.decorators.clickjacking import xframe_options_exempt
 from drf_yasg.utils import swagger_auto_schema
-from rest_framework import serializers, status, viewsets
+from rest_framework import permissions, serializers, status, viewsets
 from rest_framework.response import Response
 
 from iaso.utils.powerbi import launch_dataset_refresh
@@ -15,8 +13,9 @@ class PowerBIRefreshSerializer(serializers.Serializer):
 @swagger_auto_schema()
 class LaunchPowerBIRefreshViewSet(viewsets.ViewSet):
     serializer_class = PowerBIRefreshSerializer
+    # Open to all to make it work while calling this api from a iframe in RRT
+    permission_classes = [permissions.AllowAny]
 
-    @method_decorator(xframe_options_exempt)
     def create(self, request):
         serializer = self.serializer_class(data=request.data)
         serializer.is_valid(raise_exception=True)
@@ -24,14 +23,7 @@ class LaunchPowerBIRefreshViewSet(viewsets.ViewSet):
         data_set_id = serializer.validated_data["data_set_id"]
         group_id = serializer.validated_data["group_id"]
         # Perform actions using uuid1 and uuid2
+        response_data = {"message": f"Received data_set_id: {data_set_id}, group_id: {group_id}"}
         launch_dataset_refresh(group_id, data_set_id)
 
-        response_data = {"message": f"Received data_set_id: {data_set_id}, group_id: {group_id}"}
-        response = Response(response_data, status=status.HTTP_201_CREATED)
-        response["Content-Security-Policy"] = "frame-ancestors 'self' afro-rrt-who.hub.arcgis.com"
-
-        # Set SameSite attribute for cookies
-        response.set_cookie("sessionid", request.COOKIES.get("sessionid"), samesite="None", secure=True)
-        response.set_cookie("csrftoken", request.COOKIES.get("csrftoken"), samesite="None", secure=True)
-
-        return response
+        return Response(response_data, status=status.HTTP_201_CREATED)

--- a/plugins/polio/api/dashboards/launch_powerbi.py
+++ b/plugins/polio/api/dashboards/launch_powerbi.py
@@ -30,4 +30,8 @@ class LaunchPowerBIRefreshViewSet(viewsets.ViewSet):
         response = Response(response_data, status=status.HTTP_201_CREATED)
         response["Content-Security-Policy"] = "frame-ancestors 'self' afro-rrt-who.hub.arcgis.com"
 
+        # Set SameSite attribute for cookies
+        response.set_cookie("sessionid", request.COOKIES.get("sessionid"), samesite="None", secure=True)
+        response.set_cookie("csrftoken", request.COOKIES.get("csrftoken"), samesite="None", secure=True)
+
         return response

--- a/plugins/polio/api/dashboards/launch_powerbi.py
+++ b/plugins/polio/api/dashboards/launch_powerbi.py
@@ -1,3 +1,5 @@
+from django.utils.decorators import method_decorator
+from django.views.decorators.clickjacking import xframe_options_exempt
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import serializers, status, viewsets
 from rest_framework.response import Response
@@ -14,6 +16,7 @@ class PowerBIRefreshSerializer(serializers.Serializer):
 class LaunchPowerBIRefreshViewSet(viewsets.ViewSet):
     serializer_class = PowerBIRefreshSerializer
 
+    @method_decorator(xframe_options_exempt)
     def create(self, request):
         serializer = self.serializer_class(data=request.data)
         serializer.is_valid(raise_exception=True)

--- a/plugins/polio/api/dashboards/launch_powerbi.py
+++ b/plugins/polio/api/dashboards/launch_powerbi.py
@@ -24,7 +24,10 @@ class LaunchPowerBIRefreshViewSet(viewsets.ViewSet):
         data_set_id = serializer.validated_data["data_set_id"]
         group_id = serializer.validated_data["group_id"]
         # Perform actions using uuid1 and uuid2
-        response_data = {"message": f"Received data_set_id: {data_set_id}, group_id: {group_id}"}
         launch_dataset_refresh(group_id, data_set_id)
 
-        return Response(response_data, status=status.HTTP_201_CREATED)
+        response_data = {"message": f"Received data_set_id: {data_set_id}, group_id: {group_id}"}
+        response = Response(response_data, status=status.HTTP_201_CREATED)
+        response["Content-Security-Policy"] = "frame-ancestors 'self' afro-rrt-who.hub.arcgis.com"
+
+        return response


### PR DESCRIPTION
Vaccine supplly dashboard is embedded on RRT hub dashboard. Due to x-frame-option config, the sessions id is not passed while calling the endpoint to trigger a refresh of power bi. 

We decide to put this endpoint to public to avoid the issue.
Related JIRA tickets : POLIO-1853

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes
permission_classes = [permissions.AllowAny]
## How to test

Go to https://afro-rrt-who.hub.arcgis.com/pages/vaccine-management and click at the button. It should launch the refresh. After a while timestamp on the top should be refreshed. 
You can also consult openhaxa pipeline and iaso tasks

If a specific config is required explain it here: dataset, account, profile, etc.

## Print screen / video

Upload here print screens or videos showing the changes.

## Notes

⚠️ This has been already deployed to production on polio server, this is a hot-fix

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
