### PR TITLE
IA-3967: Org unit search use default version

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/home/hooks/useGetOrgunitsExtraPath.ts
+++ b/hat/assets/js/apps/Iaso/domains/home/hooks/useGetOrgunitsExtraPath.ts
@@ -5,11 +5,16 @@ import { locationLimitMax } from '../../orgUnits/constants/orgUnitConstants';
 
 export const useGetOrgunitsExtraPath = (): string => {
     const currentUser = useCurrentUser();
-    const defaultSourceVersionId =
-        getDefaultSourceVersion(currentUser)?.source?.id;
+    const defaultSourceVersion = getDefaultSourceVersion(currentUser);
+
+    let sourceOrVersionParam = '';
+    if (defaultSourceVersion?.version?.id) {
+        sourceOrVersionParam = `,"version":${defaultSourceVersion.version.id}`;
+    } else if (defaultSourceVersion?.source?.id) {
+        sourceOrVersionParam = `,"source":${defaultSourceVersion.source.id}`;
+    }
+
     return `/locationLimit/${locationLimitMax}/order/id/pageSize/20/page/1/searchTabIndex/0/searches/[{"validation_status":"all","color":"${getChipColors(
         0,
-    ).replace('#', '')}"${
-        defaultSourceVersionId ? `,"source":${defaultSourceVersionId}` : ''
-    }}]`;
+    ).replace('#', '')}"${sourceOrVersionParam}}]`;
 };


### PR DESCRIPTION
Default version is not used while launching an org unit search

Related JIRA tickets : IA-3967

## Self proofreading checklist

- [ ] Did I use eslint and black formatters
- [ ] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)


## Changes

Set default search option to use also default version of data source if set, source if no default version

## How to test

Use a source without version by default, make sure the search uses only the source id
Add a default version to this source, make source ou search is using this version as deafult

## Print screen / video


https://github.com/user-attachments/assets/fae3b85a-1ec6-4bae-aa24-8c9a49878fb1


## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
