### PR TITLE
IA-3964: Disclaimer in top bar appears on top if multi account activated

### DIFF
--- a/hat/assets/js/apps/Iaso/components/nav/TopBarComponent.js
+++ b/hat/assets/js/apps/Iaso/components/nav/TopBarComponent.js
@@ -72,6 +72,17 @@ function TopBar(props) {
             elevation={disableShadow ? 0 : 4}
         >
             <Toolbar className={classes.root}>
+                {Disclaimer && (
+                    <Box
+                        sx={{
+                            position: 'absolute',
+                            bottom: theme.spacing(0.25),
+                            right: theme.spacing(7),
+                        }}
+                    >
+                        <Disclaimer />
+                    </Box>
+                )}
                 <Grid
                     container
                     justifyContent="space-between"
@@ -146,17 +157,6 @@ function TopBar(props) {
                         </Grid>
                     )}
                 </Grid>
-                {Disclaimer && (
-                    <Box
-                        sx={{
-                            position: 'absolute',
-                            bottom: theme.spacing(0.25),
-                            right: theme.spacing(7),
-                        }}
-                    >
-                        <Disclaimer />
-                    </Box>
-                )}
             </Toolbar>
             {children}
         </AppBar>


### PR DESCRIPTION
Disclaimer in top bar appears on top if multi account activated

Related JIRA tickets : IA-3964
## Self proofreading checklist

- [x] Did I use eslint and black formatters
- [x] Is my code clear enough and well documented
- [ ] Are my typescript files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

Put disclaimer before the rest

## How to test

You need a multi account set and polio plugin activated, open account switch, disclaimer should pass beneath


## Print screen / video


![Screenshot 2025-02-21 at 16 08 51](https://github.com/user-attachments/assets/ae6d474d-3f8e-4368-ac8f-ef009e2d8d66)



## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
