### PR TITLE
WC2-680 Django admin: improve management of multi-account users

### DIFF
--- a/hat/templates/admin/auth/user/change_form.html
+++ b/hat/templates/admin/auth/user/change_form.html
@@ -1,0 +1,17 @@
+{% extends "admin/change_form.html" %}
+
+{% block object-tools-items %}
+    {{ block.super }}
+
+    {% if not original.tenant_user %}
+        <li>
+            <a href="{% url 'admin:edit-multi-account' user_id=original.pk %}" class="button">
+                {% if original.tenant_users.exists %}
+                    Edit multi-account settings
+                {% else %}
+                    Convert to multi-account
+                {% endif %}
+            </a>
+        </li>
+    {% endif %}
+{% endblock %}

--- a/hat/templates/admin/edit_multi_account_user.html
+++ b/hat/templates/admin/edit_multi_account_user.html
@@ -1,0 +1,19 @@
+{% extends "admin/base_site.html" %}
+
+{% block content %}
+  <h1>Convert {{ user.username }} to a multi-account user</h1>
+  {% if user.iaso_profile and user.iaso_profile.account %}
+    <p>This user already has access to account: <strong>{{user.iaso_profile.account}}</strong>
+  {% endif %}
+  <p>Please select the accounts to which this user should additionally have access.</p>
+
+  <form method="post">{% csrf_token %}
+    {{ form.as_p }}
+    <input type="hidden" name="action" value="edit_multi_account_user">
+    <input type="hidden" name="apply" value="true">
+    <input type="submit" value="Apply">
+  </form>
+  <p>
+    <strong>Warning: permissions on new accounts should be set in the user management in the dashboard.</strong>
+  </p>
+{% endblock %}

--- a/iaso/admin/__init__.py
+++ b/iaso/admin/__init__.py
@@ -1,0 +1,10 @@
+from django.contrib import admin
+from django.contrib.auth.models import User
+
+from .base import IasoJSONEditorWidget
+from .user_admin import UserAdmin
+
+# unregister old user admin
+admin.site.unregister(User)
+# register new user admin
+admin.site.register(User, UserAdmin)

--- a/iaso/admin/__init__.py
+++ b/iaso/admin/__init__.py
@@ -1,8 +1,9 @@
 from django.contrib import admin
 from django.contrib.auth.models import User
 
-from .base import IasoJSONEditorWidget
+from .base import IasoJSONEditorWidget  # noqa: F401
 from .user_admin import UserAdmin
+
 
 # unregister old user admin
 admin.site.unregister(User)

--- a/iaso/admin/base.py
+++ b/iaso/admin/base.py
@@ -21,7 +21,7 @@ from iaso.utils.admin.custom_filters import (
     has_relation_filter_factory,
 )
 
-from .models import (
+from ..models import (
     Account,
     AccountFeatureFlag,
     AlgorithmRun,
@@ -78,9 +78,9 @@ from .models import (
     WorkflowFollowup,
     WorkflowVersion,
 )
-from .models.data_store import JsonDataStore
-from .models.microplanning import Assignment, Planning, Team
-from .utils.gis import convert_2d_point_to_3d
+from ..models.data_store import JsonDataStore
+from ..models.microplanning import Assignment, Planning, Team
+from ..utils.gis import convert_2d_point_to_3d
 
 
 class EntityAutocompleteFilter(SimpleListFilter):
@@ -441,13 +441,6 @@ class GroupAdmin(admin.ModelAdmin):
 
     def org_unit_count(self, obj):
         return obj.org_units.count()
-
-
-@admin_attr_decorator
-class UserAdmin(admin.GeoModelAdmin):
-    search_fields = ("username", "email", "first_name", "last_name", "iaso_profile__account__name")
-    list_filter = ("iaso_profile__account", "is_staff", "is_superuser", "is_active")
-    list_display = ("id", "username", "email", "first_name", "last_name", "iaso_profile", "is_superuser")
 
 
 @admin.register(Profile)
@@ -1026,7 +1019,7 @@ class GroupSetAdmin(admin.ModelAdmin):
 class TenantUserAdmin(admin.ModelAdmin):
     list_display = (
         "main_user",
-        "account_user",
+        "account_user_link",
         "account",
         "created_at",
         "updated_at",
@@ -1037,6 +1030,11 @@ class TenantUserAdmin(admin.ModelAdmin):
     search_fields = ("main_user__username", "account_user__username", "account_user__iaso_profile__account__name")
     raw_id_fields = ("main_user", "account_user")
     readonly_fields = ("created_at", "updated_at", "account", "all_account_users", "other_accounts")
+
+    def account_user_link(self, obj):
+        # Create a link to the User change page in the admin
+        url = reverse("admin:auth_user_change", args=[obj.account_user.pk])
+        return format_html('<a href="{}">{}</a>', url, obj.account_user.username)
 
     def get_urls(self):
         urls = super().get_urls()

--- a/iaso/admin/user_admin.py
+++ b/iaso/admin/user_admin.py
@@ -1,0 +1,134 @@
+from django.contrib import messages
+from django.contrib.auth.admin import UserAdmin as AuthUserAdmin
+from django.contrib.auth.models import User
+from django.contrib.gis import forms
+from django.db import transaction
+from django.db.models import Exists, OuterRef
+from django.shortcuts import redirect, render, get_object_or_404
+from django.urls import path
+
+from iaso.admin.base import admin_attr_decorator
+from iaso.models import Account, Profile, TenantUser
+
+
+class MultiAccountForm(forms.Form):
+    accounts = forms.ModelMultipleChoiceField(
+        queryset=Account.objects.none(),  # Set empty queryset by default
+        widget=forms.CheckboxSelectMultiple,
+        required=True,
+        label="Select Accounts",
+    )
+
+    def __init__(self, *args, **kwargs):
+        existing_accounts = kwargs.pop("existing_accounts", [])
+        super().__init__(*args, **kwargs)
+
+        # Set the queryset to exclude existing accounts
+        account_ids = [account.pk for account in existing_accounts]
+        self.fields["accounts"].queryset = Account.objects.exclude(pk__in=account_ids)
+
+
+@admin_attr_decorator
+class UserAdmin(AuthUserAdmin):
+    list_display = AuthUserAdmin.list_display + ("accounts",)
+
+    def accounts(self, user):
+        if user.tenant_users.exists():  # Multi-account user
+            return [
+                tu.account_user.iaso_profile and tu.account_user.iaso_profile.account.name
+                for tu in user.tenant_users.all()
+            ]
+        else:  # Regular user
+            return user.iaso_profile and user.iaso_profile.account
+
+    def get_queryset(self, request):
+        queryset = super().get_queryset(request)
+        queryset = queryset.prefetch_related(
+            "iaso_profile__account",
+            "tenant_users__account_user__iaso_profile__account",
+        )
+
+        # If request is for list, hide the multi-account "account_users".
+        # That way we only show regular + main multi-account users.
+        # Don't filter for edit screen so we can still access via /tenantuser.
+        if request.resolver_match.url_name == "auth_user_changelist":
+            queryset = queryset.annotate(
+                has_tenant_user=Exists(TenantUser.objects.filter(account_user=OuterRef("pk")))
+            ).filter(has_tenant_user=False)
+
+        return queryset
+
+    def get_urls(self):
+        urls = super().get_urls()
+        custom_urls = [
+            path(
+                "<int:user_id>/edit-multi-account/",
+                self.admin_site.admin_view(self.edit_multi_account_user),
+                name="edit-multi-account",
+            ),
+        ]
+        return custom_urls + urls
+
+    def edit_multi_account_user(self, request, user_id):
+        user = get_object_or_404(User, pk=user_id)
+
+        if request.method == "POST":
+            form = MultiAccountForm(request.POST)
+            if form.is_valid():
+                if hasattr(user, "iaso_profile") and not user.tenant_users.exists():
+                    # If user is not yet multi-account: Move existing account to
+                    # tenant_user structure
+                    existing_profile = user.iaso_profile
+                    existing_account = existing_profile.account
+                    new_account_user = self._create_new_account_user_for(user, existing_account)
+                    existing_profile.user = new_account_user
+                    existing_profile.save()
+                    TenantUser.objects.create(
+                        main_user=user,
+                        account_user=new_account_user,
+                    )
+
+                for account in form.cleaned_data["accounts"]:
+                    with transaction.atomic():
+                        new_account_user = self._create_new_account_user_for(user, account)
+                        Profile.objects.create(account=account, user=new_account_user)
+                        TenantUser.objects.create(
+                            main_user=user,
+                            account_user=new_account_user,
+                        )
+
+                messages.success(
+                    request,
+                    f"User {user.username} has been linked to selected accounts.",
+                )
+                return redirect("admin:auth_user_change", user.id)
+
+            return redirect("admin:auth_user_change", user_id=user.id)
+
+        else:
+            if user.tenant_users.exists():  # Multi-account user
+                linked_accounts = [
+                    tu.account_user.iaso_profile and tu.account_user.iaso_profile.account
+                    for tu in user.tenant_users.all()
+                ]
+            elif hasattr(user, "iaso_profile"):  # Regular user
+                linked_accounts = [user.iaso_profile.account]
+            else:
+                linked_accounts = []
+            form = MultiAccountForm(existing_accounts=linked_accounts)
+
+        return render(
+            request,
+            "admin/edit_multi_account_user.html",
+            {"form": form, "user": user},
+        )
+
+    def _create_new_account_user_for(self, user, account):
+        return User.objects.create(
+            username=f"{user.username}_account_{str(account.id)}",
+            first_name=user.first_name,
+            last_name=user.last_name,
+            email=user.email,
+            is_superuser=user.is_superuser,
+            is_staff=user.is_staff,
+        )


### PR DESCRIPTION
https://bluesquare.atlassian.net/browse/WC2-680

### Improve the Django UserAdmin:

Several things here:
- Customize the `UserAdmin` to override the base Django one. Note that the existing one was not really working. By unregistering and re-registering the Django one, we can override the main Django one.
- Add the "accounts" column, displaying either: the account the user belongs to, or the list of accounts in case of multi-account users.
- Add default filtering on the user list to not display the  "account_users", users that only exist technically to support
multi-account users. To avoid losing total access to these, add a link to the actual user from the tenant user list.
- Add a custom action on the user details page: "Convert to multi-account" or "Edit multi-account" which bring you to a page where you can _add_ access to accounts for said user. This action creates the correct new users + profiles + links to tenant users.
- Extra: A refactoring to start to break up the >1000 lines `admin.py` file.

![admin-multi-account-1](https://github.com/user-attachments/assets/a8b958f1-8704-4fa6-bf9d-f33b5d08cae5)
![image](https://github.com/user-attachments/assets/33ef136c-35b1-4f70-bab4-82e7f6746745)
![admin-multi-account](https://github.com/user-attachments/assets/31c532fb-3c85-49f4-a914-34a10c5d376d)