### PR TITLE
IA-3994: fix cypress

### DIFF
--- a/hat/assets/js/cypress/fixtures/groups/dropdownlist.json
+++ b/hat/assets/js/cypress/fixtures/groups/dropdownlist.json
@@ -1,18 +1,22 @@
 [
     {
         "id": 1,
-        "name": "GROUP TEST 1"
+        "name": "GROUP TEST 1",
+        "label": "GROUP TEST 1 (datsource - version)"
     },
     {
         "id": 2,
-        "name": "GROUP TEST 2"
+        "name": "GROUP TEST 2",
+        "label": "GROUP TEST 2 (datsource - version)"
     },
     {
         "id": 3,
-        "name": "GORONS"
+        "name": "GORONS",
+        "label": "GORONS (datsource - version)"
     },
     {
         "id": 4,
-        "name": "GERUDO"
+        "name": "GERUDO",
+        "label": "GERUDO (datsource - version)"
     }
 ]

--- a/hat/assets/js/cypress/integration/05 - orgUnits/list.spec.js
+++ b/hat/assets/js/cypress/integration/05 - orgUnits/list.spec.js
@@ -1,18 +1,39 @@
 /// <reference types="cypress" />
-import superUser from '../../fixtures/profiles/me/superuser.json';
+import { search, searchWithForbiddenChars } from '../../constants/search';
 import orgUnits from '../../fixtures/orgunits/list.json';
+import superUser from '../../fixtures/profiles/me/superuser.json';
+import {
+    makeDataSourcesFromSeed,
+    makeSourceVersionsFromSeed,
+} from '../../support/dummyData';
 import { testPagination } from '../../support/testPagination';
 import { testSearchField } from '../../support/testSearchField';
-import { search, searchWithForbiddenChars } from '../../constants/search';
 
 const siteBaseUrl = Cypress.env('siteBaseUrl');
 const baseUrl = `${siteBaseUrl}/dashboard/orgunits/list`;
+
+const dataSourceSeeds = Array(11)
+    .fill()
+    .map((_el, index) => ({
+        id: index + 1,
+        name: `datasource-${index + 1}`,
+        versions: 3,
+        defaultVersion: index % 2 > 0 ? 1 : null,
+    }));
+
+const sourceVersions = makeSourceVersionsFromSeed(dataSourceSeeds);
+const datasources = makeDataSourcesFromSeed(
+    dataSourceSeeds,
+    sourceVersions.versions,
+);
 
 const goToPage = () => {
     cy.login();
     cy.intercept('GET', '/api/profiles/me/**', {
         fixture: 'profiles/me/superuser.json',
     });
+    cy.intercept('GET', '/api/datasources/**', datasources);
+    cy.intercept('GET', '/api/sourceversions/**', sourceVersions);
     cy.intercept('GET', '/api/groups/**', {
         fixture: 'groups/list.json',
     });
@@ -33,8 +54,7 @@ describe('OrgUnits', () => {
             };
             cy.intercept('GET', '/api/profiles/me/**', fakeUser);
             cy.visit(baseUrl);
-            const errorCode = cy.get('#error-code');
-            errorCode.should('contain', '403');
+            cy.get('#error-code').should('contain', '403');
         });
 
         describe('Search field', () => {
@@ -52,8 +72,7 @@ describe('OrgUnits', () => {
             cy.visit(baseUrl);
             cy.get('[data-test="search-button"]').click();
             cy.wait('@getOrgunits').then(() => {
-                const table = cy.get('table');
-                table.should('have.length', 1);
+                cy.get('table').should('have.length', 1);
             });
         });
 

--- a/hat/assets/js/cypress/integration/06 - orgUnits tabs/detailChildrenTab.spec.js
+++ b/hat/assets/js/cypress/integration/06 - orgUnits tabs/detailChildrenTab.spec.js
@@ -52,7 +52,7 @@ const newFilters = {
     },
     childrenParamsGroup: {
         value: [0],
-        urlValue: '4',
+        urlValue: '1',
         selector: '#childrenParamsGroup',
         type: 'multi',
     },
@@ -158,9 +158,13 @@ const goToPage = () => {
     cy.intercept('GET', '/api/v2/orgunittypes/dropdown/', {
         fixture: `orgunittypes/dropdown-list.json`,
     });
-    cy.intercept('GET', '/api/groups/**', {
-        fixture: `groups/list.json`,
+    cy.intercept('GET', '/api/groups/dropdown/**', {
+        fixture: `groups/dropdownlist.json`,
     });
+    cy.intercept('GET', '/api/instances/**', []);
+    // cy.intercept('GET', '/api/groups/**', {
+    //     fixture: `groups/list.json`,
+    // });
     cy.intercept('GET', `/api/orgunits/${orgUnit.id}`, {
         fixture: 'orgunits/details.json',
     }).as('getOuDetail');

--- a/hat/assets/js/cypress/integration/06 - orgUnits tabs/detailInfosTab.spec.js
+++ b/hat/assets/js/cypress/integration/06 - orgUnits tabs/detailInfosTab.spec.js
@@ -106,12 +106,15 @@ const mockCalls = () => {
     cy.intercept('GET', '/api/v2/orgunittypes/', {
         fixture: `orgunittypes/list.json`,
     }).as('OUTypes');
+    cy.intercept('GET', '/api/groups/dropdown/**/*', {
+        fixture: `groups/dropdownlist.json`,
+    }).as('groupsOptions');
     cy.intercept('GET', '/api/groups/', {
         fixture: `groups/list.json`,
     }).as('groups');
-    cy.intercept('GET', '/api/groups/**/*', {
-        fixture: `groups/list.json`,
-    }).as('groupsDetails');
+    // cy.intercept('GET', '/api/groups/**/*', {
+    //     fixture: `groups/list.json`,
+    // }).as('groupsDetails');
     cy.intercept('GET', '/api/validationstatus/', {
         fixture: `misc/validationStatuses.json`,
     }).as('statuses');
@@ -202,7 +205,7 @@ describe('infos tab', () => {
 
     it('should render correct infos', () => {
         cy.visit(baseUrl);
-        cy.wait('@getOuDetail').then(() => {
+        cy.wait(['@getOuDetail', '@groupsOptions']).then(() => {
             testEditableInfos(orgUnit);
             testReadableInfos(orgUnit);
         });


### PR DESCRIPTION
broken cypress tests in org units

Related JIRA tickets : IA-3994

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

fox mock calls to groups dropdown, add missing mock call to datasources

## How to test

run the cypress tets on the branch manually

## Print screen / video

N/A

## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
