### PR TITLE
POLIO-1861 Fix cannot create VRF bug

### DIFF
--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/VaccineRequestForm/VaccineRequestForm.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/VaccineRequestForm/VaccineRequestForm.tsx
@@ -25,6 +25,10 @@ import { useSharedStyles } from '../shared';
 
 type Props = { className?: string; vrfData: any };
 
+export const isFieldDisabledEdit = (inputData: any | undefined): boolean => {
+    return inputData ? !inputData.can_edit : false;
+};
+
 export const VaccineRequestForm: FunctionComponent<Props> = ({
     className,
     vrfData,
@@ -113,7 +117,7 @@ export const VaccineRequestForm: FunctionComponent<Props> = ({
                             label={formatMessage(MESSAGES.vrfType)}
                             name="vrf.vrf_type"
                             component={SingleSelect}
-                            disabled={!vrfData?.can_edit}
+                            disabled={isFieldDisabledEdit(vrfData)}
                             required
                             withMarginTop
                             isLoading={
@@ -132,7 +136,7 @@ export const VaccineRequestForm: FunctionComponent<Props> = ({
                                 label={formatMessage(MESSAGES.country)}
                                 name="vrf.country"
                                 component={SingleSelect}
-                                disabled={!vrfData?.can_edit}
+                                disabled={isFieldDisabledEdit(vrfData)}
                                 required
                                 withMarginTop
                                 isLoading={
@@ -147,7 +151,8 @@ export const VaccineRequestForm: FunctionComponent<Props> = ({
                                 name="vrf.campaign"
                                 component={SingleSelect}
                                 disabled={
-                                    !values?.vrf?.country || !vrfData?.can_edit
+                                    !values?.vrf?.country ||
+                                    isFieldDisabledEdit(vrfData)
                                 }
                                 required
                                 options={campaigns}
@@ -163,7 +168,8 @@ export const VaccineRequestForm: FunctionComponent<Props> = ({
                                 name="vrf.vaccine_type"
                                 component={SingleSelect}
                                 disabled={
-                                    !values?.vrf?.campaign || !vrfData?.can_edit
+                                    !values?.vrf?.campaign ||
+                                    isFieldDisabledEdit(vrfData)
                                 }
                                 required
                                 options={vaccines}
@@ -180,7 +186,7 @@ export const VaccineRequestForm: FunctionComponent<Props> = ({
                                 component={MultiSelect}
                                 disabled={
                                     !values?.vrf?.vaccine_type ||
-                                    !vrfData?.can_edit
+                                    isFieldDisabledEdit(vrfData)
                                 }
                                 required
                                 withMarginTop
@@ -203,7 +209,9 @@ export const VaccineRequestForm: FunctionComponent<Props> = ({
                                             )}
                                             name="vrf.date_vrf_signature"
                                             component={DateInput}
-                                            disabled={!vrfData?.can_edit}
+                                            disabled={isFieldDisabledEdit(
+                                                vrfData,
+                                            )}
                                         />
                                     </Box>
                                 </Grid>
@@ -215,7 +223,9 @@ export const VaccineRequestForm: FunctionComponent<Props> = ({
                                             )}
                                             name="vrf.quantities_ordered_in_doses"
                                             component={NumberInput}
-                                            disabled={!vrfData?.can_edit}
+                                            disabled={isFieldDisabledEdit(
+                                                vrfData,
+                                            )}
                                         />
                                     </Box>
                                 </Grid>
@@ -228,7 +238,9 @@ export const VaccineRequestForm: FunctionComponent<Props> = ({
                                             )}
                                             name="vrf.wastage_rate_used_on_vrf"
                                             component={NumberInput}
-                                            disabled={!vrfData?.can_edit}
+                                            disabled={isFieldDisabledEdit(
+                                                vrfData,
+                                            )}
                                             numberInputOptions={{
                                                 suffix: '%',
                                                 max: 100,
@@ -244,7 +256,9 @@ export const VaccineRequestForm: FunctionComponent<Props> = ({
                                             )}
                                             name="vrf.date_vrf_reception"
                                             component={DateInput}
-                                            disabled={!vrfData?.can_edit}
+                                            disabled={isFieldDisabledEdit(
+                                                vrfData,
+                                            )}
                                         />
                                     </Box>
                                 </Grid>
@@ -257,7 +271,7 @@ export const VaccineRequestForm: FunctionComponent<Props> = ({
                                         )}
                                         name="vrf.date_vrf_submission_to_orpg"
                                         component={DateInput}
-                                        disabled={!vrfData?.can_edit}
+                                        disabled={isFieldDisabledEdit(vrfData)}
                                     />
                                 </Grid>
                                 <Grid item xs={6} md={3}>
@@ -267,7 +281,7 @@ export const VaccineRequestForm: FunctionComponent<Props> = ({
                                         )}
                                         name="vrf.quantities_approved_by_orpg_in_doses"
                                         component={NumberInput}
-                                        disabled={!vrfData?.can_edit}
+                                        disabled={isFieldDisabledEdit(vrfData)}
                                     />
                                 </Grid>
                                 <Grid item xs={6} md={3}>
@@ -277,7 +291,7 @@ export const VaccineRequestForm: FunctionComponent<Props> = ({
                                         )}
                                         name="vrf.date_rrt_orpg_approval"
                                         component={DateInput}
-                                        disabled={!vrfData?.can_edit}
+                                        disabled={isFieldDisabledEdit(vrfData)}
                                     />
                                 </Grid>
                                 <Grid item xs={6} md={3}>
@@ -287,7 +301,7 @@ export const VaccineRequestForm: FunctionComponent<Props> = ({
                                         )}
                                         name="vrf.target_population"
                                         component={NumberInput}
-                                        disabled={!vrfData?.can_edit}
+                                        disabled={isFieldDisabledEdit(vrfData)}
                                     />
                                 </Grid>
                             </Grid>
@@ -299,7 +313,7 @@ export const VaccineRequestForm: FunctionComponent<Props> = ({
                                         )}
                                         name="vrf.date_vrf_submitted_to_dg"
                                         component={DateInput}
-                                        disabled={!vrfData?.can_edit}
+                                        disabled={isFieldDisabledEdit(vrfData)}
                                     />
                                 </Grid>
                                 <Grid item xs={6} md={3}>
@@ -309,7 +323,7 @@ export const VaccineRequestForm: FunctionComponent<Props> = ({
                                         )}
                                         name="vrf.quantities_approved_by_dg_in_doses"
                                         component={NumberInput}
-                                        disabled={!vrfData?.can_edit}
+                                        disabled={isFieldDisabledEdit(vrfData)}
                                     />
                                 </Grid>
                                 <Grid item xs={6} md={3}>
@@ -319,7 +333,7 @@ export const VaccineRequestForm: FunctionComponent<Props> = ({
                                         )}
                                         name="vrf.date_dg_approval"
                                         component={DateInput}
-                                        disabled={!vrfData?.can_edit}
+                                        disabled={isFieldDisabledEdit(vrfData)}
                                     />
                                 </Grid>
                                 <Grid item xs={6} md={3}>
@@ -338,7 +352,9 @@ export const VaccineRequestForm: FunctionComponent<Props> = ({
                                                     );
                                                 }
                                             }}
-                                            disabled={!vrfData?.can_edit}
+                                            disabled={isFieldDisabledEdit(
+                                                vrfData,
+                                            )}
                                             document={values?.vrf?.document}
                                         />
                                     </Box>
@@ -353,7 +369,7 @@ export const VaccineRequestForm: FunctionComponent<Props> = ({
                                         // errors={errors.comment ? errors.comment : []}
                                         label={MESSAGES.comments}
                                         onChange={onCommentChange}
-                                        disabled={!vrfData?.can_edit}
+                                        disabled={isFieldDisabledEdit(vrfData)}
                                         withMarginTop={false}
                                     />
                                 </Grid>


### PR DESCRIPTION
Cannot create VRF After permissions change

Related JIRA tickets : POLIO-1861

⚠️ This has been release on polio prod as a hotfix with tag v1.254a-supply-chain-cannot-create-vrf

## Self proofreading checklist

- [ ] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

Explain the changes that were made.

The idea is not to list exhaustively all the changes made (GitHub already provides a full diff), but to help the reviewers better understand:

- which specific file changes go together, e.g: when creating a table in the front-end, there usually is a config file that goes with it
- the reasoning behind some changes, e.g: deleted files because they are now redundant
- the behaviour to expect, e.g: tooltip has purple background color because the client likes it so, changed a key in the API response to be consistent with other endpoints

## How to test

Explain how to test your PR.

If a specific config is required explain it here: dataset, account, profile, etc.

## Print screen / video

Upload here print screens or videos showing the changes.

## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
