### PR TITLE
POLIO-1855: prevent region scope selection to add invalid org units

### DIFF
--- a/plugins/polio/js/src/domains/Campaigns/Scope/ScopeForm.tsx
+++ b/plugins/polio/js/src/domains/Campaigns/Scope/ScopeForm.tsx
@@ -1,23 +1,22 @@
-import { Field, useFormikContext } from 'formik';
 import React, { FunctionComponent, useMemo, useState } from 'react';
-import { useDebounce } from 'use-debounce';
 import { TabContext, TabList, TabPanel } from '@mui/lab';
 import { Box, Grid, Tab } from '@mui/material';
 import { useSafeIntl, useSkipEffectOnMount } from 'bluesquare-components';
+import { Field, useFormikContext } from 'formik';
+import { useDebounce } from 'use-debounce';
 
 import { BooleanInput } from '../../../components/Inputs';
 
 import MESSAGES from '../../../constants/messages';
-import { useStyles } from '../../../styles/theme';
-
-import { ScopeField } from './ScopeField';
-import { useFilteredDistricts } from './Scopes/utils';
-import { useGetGeoJson } from './hooks/useGetGeoJson';
-import { useGetParentOrgUnit } from './hooks/useGetParentOrgUnit';
 
 import { CampaignFormValues } from '../../../constants/types';
+import { useStyles } from '../../../styles/theme';
 import { useIsPolioCampaign } from '../hooks/useIsPolioCampaignCheck';
+import { useGetGeoJson } from './hooks/useGetGeoJson';
+import { useGetParentOrgUnit } from './hooks/useGetParentOrgUnit';
+import { ScopeField } from './ScopeField';
 import { FilteredDistricts, Round } from './Scopes/types';
+import { useFilteredDistricts } from './Scopes/utils';
 
 export const scopeFormFields = ['separate_scopes_per_round', 'scopes'];
 

--- a/plugins/polio/js/src/domains/Campaigns/Scope/hooks/useGetGeoJson.ts
+++ b/plugins/polio/js/src/domains/Campaigns/Scope/hooks/useGetGeoJson.ts
@@ -1,9 +1,9 @@
 // @ts-ignore
+import _ from 'lodash';
+import { UseQueryResult } from 'react-query';
 import { getRequest } from 'Iaso/libs/Api';
 // @ts-ignore
 import { useSnackQuery } from 'Iaso/libs/apiHooks';
-import _ from 'lodash';
-import { UseQueryResult } from 'react-query';
 
 type Params = {
     // eslint-disable-next-line camelcase


### PR DESCRIPTION
When selecting a polio  campaign scope with the toggle button, users would unknowingly select rejected org units

Related JIRA tickets : POLIO-1855

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [x] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

N/A

## Changes

- in `ScopeInput`, filter out org units with status !== "VALID", when determining the region scope this will:
    - unselect the region scope, including rejected org units, if all valid org units are already in the scope
    - select the region scope with only the valid org units if not all valid org units for the region are in scope, eg: one of the districts is actually a rejected version of the org unit. In this case, the scope might change, although it will not be visible to the user on the map interface.

## How to test

- On a polio test DB, find an org unit of type "DISTRICT" with a rejected duplicate, eg: NOKOU
- Keep the id of the duplicate
- In the campaigns tab, create a new campaign for the country
- Add the whole region to the scope
- Check the scope id in the API payload
- in the org units page, open details page for the rejected version of the org unit
- In the group dropdown, find the scope of the created campaign, select it and save
- Go the campaigns page: the org unit count of the campaign should have increased by 1.
- Using the list view, search for the duplicate by name: there should be 2 entries
- toggle the region selector
- select the region: all org units should unselect
- select the region again: all org units should be selected
- Use the search input in the scope tab to look for the duplicated org unit: there should be only one version, the valid one

repeat with separate scopes per round
repeat but don't select the whole region: everything should behave the same, except that teh whole region will be selected and the rejected org unit will be removed at the same time (the scope will not be unselected first)

## Print screen / video

https://github.com/user-attachments/assets/e53884b3-b84e-4a31-bbbb-f1a51638562a



## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
