### PR TITLE
IA-3996: Group filter doesn't seem to work on OU list

### DIFF
--- a/iaso/api/org_unit_search.py
+++ b/iaso/api/org_unit_search.py
@@ -69,7 +69,9 @@ def build_org_units_queryset(queryset, params, profile):
                 queryset = queryset.filter(source_ref__in=[])
                 print("Failed parsing refs in search", search)
         else:
-            queryset = queryset.filter(Q(name__icontains=search) | Q(aliases__contains=[search]))
+            queryset = queryset.filter(
+                Q(name__icontains=search) | Q(aliases__contains=[search])
+            )
 
     if group:
         if isinstance(group, str):
@@ -78,7 +80,7 @@ def build_org_units_queryset(queryset, params, profile):
             group_ids = [group]
         else:
             group_ids = group
-        queryset = queryset.filter(groups__in=group_ids)
+        queryset = queryset.filter(groups__in=group_ids).distinct("id")
 
     if source:
         source = DataSource.objects.get(id=source)
@@ -103,7 +105,9 @@ def build_org_units_queryset(queryset, params, profile):
         queryset = queryset.filter(instance__created_at__lte=date_to)
 
     if date_from is not None and date_to is not None:
-        queryset = queryset.filter(instance__created_at__range=[date_from, date_to]).distinct("id")
+        queryset = queryset.filter(
+            instance__created_at__range=[date_from, date_to]
+        ).distinct("id")
 
     if has_instances is not None:
         if has_instances == "true":
@@ -138,13 +142,17 @@ def build_org_units_queryset(queryset, params, profile):
     # We need a few things for empty location comparisons:
     # 1. An annotated queryset (geography fields exposed as geometries)
     queryset = queryset.annotate(location_as_geom=Cast("location", PointField(dim=3)))
-    queryset = queryset.annotate(simplified_geom_as_geom=Cast("simplified_geom", MultiPolygonField()))
+    queryset = queryset.annotate(
+        simplified_geom_as_geom=Cast("simplified_geom", MultiPolygonField())
+    )
     # 2. Empty features to compare to
     empty_point = GEOSGeometry("POINT EMPTY", srid=4326)
     empty_multipolygon = GEOSGeometry("MULTIPOLYGON EMPTY", srid=4326)
 
     has_location = Q(location__isnull=False) & (~Q(location_as_geom=empty_point))
-    has_simplified_geom = Q(simplified_geom__isnull=False) & (~Q(simplified_geom_as_geom=empty_multipolygon))
+    has_simplified_geom = Q(simplified_geom__isnull=False) & (
+        ~Q(simplified_geom_as_geom=empty_multipolygon)
+    )
 
     if geography == "location":
         queryset = queryset.filter(has_location)
@@ -209,7 +217,9 @@ def build_org_units_queryset(queryset, params, profile):
         queryset = queryset.filter(sub_source=source_id)
 
     if org_unit_type_category:
-        queryset = queryset.filter(org_unit_type__category=org_unit_type_category.upper())
+        queryset = queryset.filter(
+            org_unit_type__category=org_unit_type_category.upper()
+        )
 
     if ignore_empty_names:
         queryset = queryset.filter(~Q(name=""))
@@ -217,9 +227,13 @@ def build_org_units_queryset(queryset, params, profile):
     if path_depth is not None:
         queryset = queryset.filter(path__depth=path_depth)
     if opening_date:
-        queryset = queryset.filter(opening_date=datetime.strptime(opening_date, "%d-%m-%Y").date())
+        queryset = queryset.filter(
+            opening_date=datetime.strptime(opening_date, "%d-%m-%Y").date()
+        )
     if closed_date:
-        queryset = queryset.filter(closed_date=datetime.strptime(closed_date, "%d-%m-%Y").date())
+        queryset = queryset.filter(
+            closed_date=datetime.strptime(closed_date, "%d-%m-%Y").date()
+        )
     if not direct_children:
         queryset = queryset.exclude(pk=org_unit_parent_id)
 
@@ -238,7 +252,11 @@ def annotate_query(queryset, count_instances, count_per_form, forms):
         queryset = queryset.annotate(
             instances_count=Count(
                 "instance",
-                filter=(~Q(instance__file="") & ~Q(instance__device__test_device=True) & ~Q(instance__deleted=True)),
+                filter=(
+                    ~Q(instance__file="")
+                    & ~Q(instance__device__test_device=True)
+                    & ~Q(instance__deleted=True)
+                ),
             )
         )
 

--- a/iaso/tests/api/test_orgunits.py
+++ b/iaso/tests/api/test_orgunits.py
@@ -18,17 +18,25 @@ class OrgUnitAPITestCase(APITestCase):
         cls.star_wars = star_wars = m.Account.objects.create(name="Star Wars")
         marvel = m.Account.objects.create(name="MCU")
         cls.project = project = m.Project.objects.create(
-            name="Hydroponic gardens", app_id="stars.empire.agriculture.hydroponics", account=star_wars
+            name="Hydroponic gardens",
+            app_id="stars.empire.agriculture.hydroponics",
+            account=star_wars,
         )
         sw_source = m.DataSource.objects.create(name="Evil Empire")
         sw_source.projects.add(project)
         cls.sw_source = sw_source
-        cls.sw_version_1 = sw_version_1 = m.SourceVersion.objects.create(data_source=sw_source, number=1)
-        cls.sw_version_2 = sw_version_2 = m.SourceVersion.objects.create(data_source=sw_source, number=2)
+        cls.sw_version_1 = sw_version_1 = m.SourceVersion.objects.create(
+            data_source=sw_source, number=1
+        )
+        cls.sw_version_2 = sw_version_2 = m.SourceVersion.objects.create(
+            data_source=sw_source, number=2
+        )
         star_wars.default_version = sw_version_1
         star_wars.save()
 
-        cls.jedi_squad = jedi_squad = m.OrgUnitType.objects.create(name="Jedi Squad", short_name="Jds")
+        cls.jedi_squad = jedi_squad = m.OrgUnitType.objects.create(
+            name="Jedi Squad", short_name="Jds"
+        )
         jedi_squad.projects.add(project)
         jedi_squad.save()
         cls.reference_form = reference_form = m.Form.objects.create(
@@ -49,28 +57,40 @@ class OrgUnitAPITestCase(APITestCase):
             Polygon([[-1.3, 2.5], [-1.7, 2.8], [-1.1, 4.1], [-1.3, 2.5]])
         )
         cls.mock_point = mock_point = Point(x=4, y=50, z=100)
-        cls.mock_multipolygon_empty = mock_multipolygon_empty = GEOSGeometry("MULTIPOLYGON EMPTY", srid=4326)
+        cls.mock_multipolygon_empty = mock_multipolygon_empty = GEOSGeometry(
+            "MULTIPOLYGON EMPTY", srid=4326
+        )
 
-        cls.elite_group = elite_group = m.Group.objects.create(name="Elite councils", source_version=sw_version_1)
+        cls.elite_group = elite_group = m.Group.objects.create(
+            name="Elite councils", source_version=sw_version_1
+        )
         cls.unofficial_group = m.Group.objects.create(name="Unofficial Jedi councils")
         cls.another_group = m.Group.objects.create(name="Another group")
 
-        cls.jedi_council_corruscant = jedi_council_corruscant = m.OrgUnit.objects.create(
-            org_unit_type=jedi_council,
-            version=sw_version_1,
-            name="Corruscant Jedi Council",
-            geom=mock_multipolygon,
-            catchment=mock_multipolygon,
-            validation_status=m.OrgUnit.VALIDATION_VALID,
-            source_ref="PvtAI4RUMkr",
+        cls.jedi_council_corruscant = jedi_council_corruscant = (
+            m.OrgUnit.objects.create(
+                org_unit_type=jedi_council,
+                version=sw_version_1,
+                name="Corruscant Jedi Council",
+                geom=mock_multipolygon,
+                catchment=mock_multipolygon,
+                validation_status=m.OrgUnit.VALIDATION_VALID,
+                source_ref="PvtAI4RUMkr",
+            )
         )
 
         cls.instance_related_to_reference_form = cls.create_form_instance(
-            form=reference_form, period="202003", org_unit=jedi_council_corruscant, project=project
+            form=reference_form,
+            period="202003",
+            org_unit=jedi_council_corruscant,
+            project=project,
         )
 
         cls.instance_not_related_to_reference_form = cls.create_form_instance(
-            form=not_a_reference_form, period="202003", org_unit=jedi_council_corruscant, project=project
+            form=not_a_reference_form,
+            period="202003",
+            org_unit=jedi_council_corruscant,
+            project=project,
         )
 
         jedi_council_corruscant.groups.set([elite_group])
@@ -128,24 +148,48 @@ class OrgUnitAPITestCase(APITestCase):
             validation_status=m.OrgUnit.VALIDATION_VALID,
         )
 
-        cls.yoda = cls.create_user_with_profile(username="yoda", account=star_wars, permissions=["iaso_org_units"])
+        cls.yoda = cls.create_user_with_profile(
+            username="yoda", account=star_wars, permissions=["iaso_org_units"]
+        )
         cls.user_read_permission = cls.create_user_with_profile(
-            username="user_read_permission", account=star_wars, permissions=["iaso_org_units_read"]
+            username="user_read_permission",
+            account=star_wars,
+            permissions=["iaso_org_units_read"],
         )
         cls.luke = cls.create_user_with_profile(
-            username="luke", account=star_wars, permissions=["iaso_org_units"], org_units=[jedi_council_endor]
+            username="luke",
+            account=star_wars,
+            permissions=["iaso_org_units"],
+            org_units=[jedi_council_endor],
         )
-        cls.raccoon = cls.create_user_with_profile(username="raccoon", account=marvel, permissions=["iaso_org_units"])
+        cls.raccoon = cls.create_user_with_profile(
+            username="raccoon", account=marvel, permissions=["iaso_org_units"]
+        )
 
         cls.form_1 = form_1 = m.Form.objects.create(
             name="Hydroponics study", period_type=m.MONTH, single_per_period=True
         )
 
-        cls.create_form_instance(form=form_1, period="202001", org_unit=jedi_council_corruscant, project=project)
+        cls.create_form_instance(
+            form=form_1,
+            period="202001",
+            org_unit=jedi_council_corruscant,
+            project=project,
+        )
 
-        cls.create_form_instance(form=form_1, period="202001", org_unit=jedi_council_corruscant, project=project)
+        cls.create_form_instance(
+            form=form_1,
+            period="202001",
+            org_unit=jedi_council_corruscant,
+            project=project,
+        )
 
-        cls.create_form_instance(form=form_1, period="202003", org_unit=jedi_council_corruscant, project=project)
+        cls.create_form_instance(
+            form=form_1,
+            period="202003",
+            org_unit=jedi_council_corruscant,
+            project=project,
+        )
 
     def test_org_unit_search_with_ids(self):
         """GET /orgunits/ with a search based on refs"""
@@ -273,7 +317,10 @@ class OrgUnitAPITestCase(APITestCase):
         # council and Endor Jedi council are kept
         self.assertEqual(json_response["count"], 2)
         returned_ou_ids = {ou["id"] for ou in json_response["orgunits"]}
-        self.assertEqual(returned_ou_ids, {self.jedi_council_corruscant.id, self.jedi_council_endor.id})
+        self.assertEqual(
+            returned_ou_ids,
+            {self.jedi_council_corruscant.id, self.jedi_council_endor.id},
+        )
 
     def test_org_unit_search_geography_location(self):
         """GET /orgunits/ filtered so only OUs with a point location are returned"""
@@ -288,7 +335,9 @@ class OrgUnitAPITestCase(APITestCase):
         # Only Endor Jedi Squad 1 have non-empty points inthe location field
         self.assertEqual(json_response["count"], 2)
         returned_ou_ids = {ou["id"] for ou in json_response["orgunits"]}
-        self.assertEqual(returned_ou_ids, {self.jedi_squad_endor.id, self.jedi_council_brussels.id})
+        self.assertEqual(
+            returned_ou_ids, {self.jedi_squad_endor.id, self.jedi_council_brussels.id}
+        )
 
     def test_org_unit_search_geography_shape(self):
         """GET /orgunits/ filtered so only OUs with a shape location are returned"""
@@ -303,7 +352,9 @@ class OrgUnitAPITestCase(APITestCase):
         # Only Endor Jedi Squad 1 have non-empty points in the simplified_geom field
         self.assertEqual(json_response["count"], 2)
         returned_ou_ids = {ou["id"] for ou in json_response["orgunits"]}
-        self.assertEqual(returned_ou_ids, {self.jedi_squad_endor_2.id, self.jedi_council_brussels.id})
+        self.assertEqual(
+            returned_ou_ids, {self.jedi_squad_endor_2.id, self.jedi_council_brussels.id}
+        )
 
     def test_org_unit_search_geography_with_shape_true(self):
         """GET /orgunits/ filtered so only OUs with a shape location are returned"""
@@ -318,7 +369,9 @@ class OrgUnitAPITestCase(APITestCase):
         # Only Endor Jedi Squad 1 have non-empty points in the simplified_geom field
         self.assertEqual(json_response["count"], 2)
         returned_ou_ids = {ou["id"] for ou in json_response["orgunits"]}
-        self.assertEqual(returned_ou_ids, {self.jedi_squad_endor_2.id, self.jedi_council_brussels.id})
+        self.assertEqual(
+            returned_ou_ids, {self.jedi_squad_endor_2.id, self.jedi_council_brussels.id}
+        )
 
     def test_org_unit_search_geography_with_shape_false(self):
         """GET /orgunits/ filtered so only OUs without a shape location are returned"""
@@ -332,7 +385,12 @@ class OrgUnitAPITestCase(APITestCase):
         self.assertEqual(json_response["count"], 3)
         returned_ou_ids = {ou["id"] for ou in json_response["orgunits"]}
         self.assertEqual(
-            returned_ou_ids, {self.jedi_squad_endor.id, self.jedi_council_corruscant.id, self.jedi_council_endor.id}
+            returned_ou_ids,
+            {
+                self.jedi_squad_endor.id,
+                self.jedi_council_corruscant.id,
+                self.jedi_council_endor.id,
+            },
         )
 
     def test_org_unit_search_geography_with_location_true(self):
@@ -347,7 +405,9 @@ class OrgUnitAPITestCase(APITestCase):
         json_response = response.json()
         self.assertEqual(json_response["count"], 2)
         returned_ou_ids = {ou["id"] for ou in json_response["orgunits"]}
-        self.assertEqual(returned_ou_ids, {self.jedi_squad_endor.id, self.jedi_council_brussels.id})
+        self.assertEqual(
+            returned_ou_ids, {self.jedi_squad_endor.id, self.jedi_council_brussels.id}
+        )
 
     def test_org_unit_search_geography_with_location_false(self):
         """GET /orgunits/ filtered so only OUs without a point location are returned"""
@@ -362,7 +422,12 @@ class OrgUnitAPITestCase(APITestCase):
         self.assertEqual(json_response["count"], 3)
         returned_ou_ids = {ou["id"] for ou in json_response["orgunits"]}
         self.assertEqual(
-            returned_ou_ids, {self.jedi_council_corruscant.id, self.jedi_council_endor.id, self.jedi_squad_endor_2.id}
+            returned_ou_ids,
+            {
+                self.jedi_council_corruscant.id,
+                self.jedi_council_endor.id,
+                self.jedi_squad_endor_2.id,
+            },
         )
 
     def test_org_units_tree_super_user(self):
@@ -374,7 +439,10 @@ class OrgUnitAPITestCase(APITestCase):
         )
 
         super_user = self.create_user_with_profile(
-            username="superUser", is_superuser=True, account=self.star_wars, permissions=["iaso_org_units"]
+            username="superUser",
+            is_superuser=True,
+            account=self.star_wars,
+            permissions=["iaso_org_units"],
         )
         super_user.iaso_profile.org_units.set([org_unit_country])
         super_user.save()
@@ -396,7 +464,9 @@ class OrgUnitAPITestCase(APITestCase):
         )
 
         user_manager = self.create_user_with_profile(
-            username="userManager", account=self.star_wars, permissions=["iaso_org_units"]
+            username="userManager",
+            account=self.star_wars,
+            permissions=["iaso_org_units"],
         )
         user_manager.iaso_profile.org_units.set([org_unit_country])
         user_manager.save()
@@ -552,7 +622,9 @@ class OrgUnitAPITestCase(APITestCase):
             json={"name": "b", "age": 19, "gender": "F"},
         )
         # Test the descendant instances count
-        response_descendant = self.client.get(f"/api/orgunits/{descendant_org_unit.id}/")
+        response_descendant = self.client.get(
+            f"/api/orgunits/{descendant_org_unit.id}/"
+        )
         self.assertJSONResponse(response_descendant, 200)
         descendant_instances_count = response_descendant.json()["instances_count"]
         self.assertEqual(descendant_instances_count, 1)
@@ -566,7 +638,8 @@ class OrgUnitAPITestCase(APITestCase):
     def test_can_retrieve_org_units_in_csv_format(self):
         self.client.force_authenticate(self.yoda)
         response = self.client.get(
-            f"/api/orgunits/{self.jedi_squad_endor.id}/?format=csv", headers={"Content-Type": "text/csv"}
+            f"/api/orgunits/{self.jedi_squad_endor.id}/?format=csv",
+            headers={"Content-Type": "text/csv"},
         )
         self.assertFileResponse(response, 200, "text/csv; charset=utf-8")
 
@@ -596,8 +669,12 @@ class OrgUnitAPITestCase(APITestCase):
         first_row_name = first_row[1]
         self.assertEqual(first_row_name, self.jedi_council_brussels.name)
 
-    def assertValidOrgUnitListData(self, *, list_data: typing.Mapping, expected_length: int):
-        self.assertValidListData(list_data=list_data, results_key="orgUnits", expected_length=expected_length)
+    def assertValidOrgUnitListData(
+        self, *, list_data: typing.Mapping, expected_length: int
+    ):
+        self.assertValidListData(
+            list_data=list_data, results_key="orgUnits", expected_length=expected_length
+        )
         for org_unit_data in list_data["orgUnits"]:
             self.assertValidOrgUnitData(org_unit_data)
 
@@ -666,7 +743,10 @@ class OrgUnitAPITestCase(APITestCase):
         response = self.set_up_org_unit_creation()
         json_response = self.assertJSONResponse(response, 400)
         self.assertEqual(json_response[0]["errorKey"], "org_unit_type_id")
-        self.assertEqual(json_response[0]["errorMessage"], "You cannot create or edit an Org unit of this type")
+        self.assertEqual(
+            json_response[0]["errorMessage"],
+            "You cannot create or edit an Org unit of this type",
+        )
         self.yoda.iaso_profile.editable_org_unit_types.clear()
 
     def test_create_org_unit(self):
@@ -710,7 +790,11 @@ class OrgUnitAPITestCase(APITestCase):
         response = self.client.post(
             "/api/orgunits/create_org_unit/",
             format="json",
-            data={"name": "Test ou", "org_unit_type_id": self.jedi_council.pk, "opening_date": "01-01-2024"},
+            data={
+                "name": "Test ou",
+                "org_unit_type_id": self.jedi_council.pk,
+                "opening_date": "01-01-2024",
+            },
         )
 
         jr = self.assertJSONResponse(response, 200)
@@ -747,7 +831,11 @@ class OrgUnitAPITestCase(APITestCase):
         response = self.client.post(
             "/api/orgunits/create_org_unit/",
             format="json",
-            data={"name": "Test ou", "org_unit_type_id": self.jedi_council.pk, "groups": [34]},
+            data={
+                "name": "Test ou",
+                "org_unit_type_id": self.jedi_council.pk,
+                "groups": [34],
+            },
         )
         self.assertJSONResponse(response, 404)
         # we didn't create any new orgunit
@@ -792,8 +880,12 @@ class OrgUnitAPITestCase(APITestCase):
         self.assertNoCreation()
 
     def test_create_org_unit_group_ok_same_version(self):
-        group_1 = m.Group.objects.create(name="bla", source_version=self.star_wars.default_version)
-        group_2 = m.Group.objects.create(name="bla2", source_version=self.star_wars.default_version)
+        group_1 = m.Group.objects.create(
+            name="bla", source_version=self.star_wars.default_version
+        )
+        group_2 = m.Group.objects.create(
+            name="bla2", source_version=self.star_wars.default_version
+        )
         self.client.force_authenticate(self.yoda)
         response = self.client.post(
             "/api/orgunits/create_org_unit/",
@@ -854,7 +946,9 @@ class OrgUnitAPITestCase(APITestCase):
                 "id": None,
                 "name": "Test ou with no reference instance",
                 "org_unit_type_id": self.jedi_council.pk,
-                "reference_instances_ids": [self.instance_not_related_to_reference_form.id],
+                "reference_instances_ids": [
+                    self.instance_not_related_to_reference_form.id
+                ],
                 "groups": [],
                 "sub_source": "",
                 "status": False,
@@ -908,7 +1002,9 @@ class OrgUnitAPITestCase(APITestCase):
         instance = self.instance_related_to_reference_form
 
         # Create a reference instance.
-        m.OrgUnitReferenceInstance.objects.create(org_unit=org_unit, instance=instance, form=form)
+        m.OrgUnitReferenceInstance.objects.create(
+            org_unit=org_unit, instance=instance, form=form
+        )
         self.assertIn(instance, org_unit.reference_instances.all())
 
         # GET /api/orgunits/id.
@@ -928,7 +1024,9 @@ class OrgUnitAPITestCase(APITestCase):
         return org_unit, instance, data
 
     def test_edit_org_unit_unflag_reference_instance(self):
-        org_unit, instance, data = self.set_up_edit_org_flag_reference_instance(self.yoda)
+        org_unit, instance, data = self.set_up_edit_org_flag_reference_instance(
+            self.yoda
+        )
         response = self.client.patch(
             f"/api/orgunits/{org_unit.id}/",
             format="json",
@@ -939,7 +1037,9 @@ class OrgUnitAPITestCase(APITestCase):
         self.assertEqual(response.data["reference_instances"], [])
 
     def test_edit_org_unit_reference_instance_read_permission(self):
-        org_unit, _, data = self.set_up_edit_org_flag_reference_instance(self.user_read_permission)
+        org_unit, _, data = self.set_up_edit_org_flag_reference_instance(
+            self.user_read_permission
+        )
         response = self.client.patch(
             f"/api/orgunits/{org_unit.id}/",
             format="json",
@@ -967,7 +1067,9 @@ class OrgUnitAPITestCase(APITestCase):
         self.assertCreated({Modification: 1})
         ou = m.OrgUnit.objects.get(id=jr["id"])
         self.assertEqual(ou.id, old_ou.id)
-        self.assertIn(self.instance_related_to_reference_form, ou.reference_instances.all())
+        self.assertIn(
+            self.instance_related_to_reference_form, ou.reference_instances.all()
+        )
         self.assertEqual(len(response.data["reference_instances"]), 1)
 
     def test_edit_org_unit_flag_wrong_reference_instance(self):
@@ -991,7 +1093,10 @@ class OrgUnitAPITestCase(APITestCase):
         old_ou.refresh_from_db()
         # check the orgunit has not beee modified
         self.assertEqual(old_modification_date, old_ou.updated_at)
-        self.assertNotIn(self.instance_not_related_to_reference_form, old_ou.reference_instances.all())
+        self.assertNotIn(
+            self.instance_not_related_to_reference_form,
+            old_ou.reference_instances.all(),
+        )
 
     def set_up_org_unit_partial_update(self):
         ou = m.OrgUnit(version=self.sw_version_1)
@@ -1010,7 +1115,9 @@ class OrgUnitAPITestCase(APITestCase):
 
     def test_edit_org_unit_partial_update(self):
         """Check that we can only modify a part of the file with org units management permission"""
-        ou, group_a, group_b, old_modification_date, data = self.set_up_org_unit_partial_update()
+        ou, group_a, group_b, old_modification_date, data = (
+            self.set_up_org_unit_partial_update()
+        )
         self.client.force_authenticate(self.yoda)
         response = self.client.patch(
             f"/api/orgunits/{ou.id}/",
@@ -1024,16 +1131,22 @@ class OrgUnitAPITestCase(APITestCase):
         self.assertEqual(ou.name, "test ou")
         self.assertEqual(ou.source_ref, "new source ref")
         self.assertQuerySetEqual(ou.groups.all().order_by("name"), [group_a, group_b])
-        self.assertEqual(ou.geom.wkt, MultiPolygon(Polygon([(0, 0), (0, 1), (1, 1), (0, 0)])).wkt)
+        self.assertEqual(
+            ou.geom.wkt, MultiPolygon(Polygon([(0, 0), (0, 1), (1, 1), (0, 0)])).wkt
+        )
         self.assertEqual(response.data["reference_instances"], [])
 
-    def test_edit_org_unit_partial_update_remove_geojson_geom_simplified_geom_should_be_consistent(self):
+    def test_edit_org_unit_partial_update_remove_geojson_geom_simplified_geom_should_be_consistent(
+        self,
+    ):
         """Check that if we remove the geojson both simplified_geom and geom are empty"""
         ou = m.OrgUnit(version=self.sw_version_1)
         ou.name = "test ou"
         ou.source_ref = "b"
         ou.geom = MultiPolygon(Polygon([(0, 0), (0, 1), (1, 1), (0, 0)]))
-        ou.simplified_geom = simplify_geom(MultiPolygon(Polygon([(0, 0), (0, 1), (1, 1), (0, 0)])))
+        ou.simplified_geom = simplify_geom(
+            MultiPolygon(Polygon([(0, 0), (0, 1), (1, 1), (0, 0)]))
+        )
         ou.save()
         old_modification_date = ou.updated_at
         self.client.force_authenticate(self.yoda)
@@ -1083,7 +1196,10 @@ class OrgUnitAPITestCase(APITestCase):
         )
         json_response = self.assertJSONResponse(response, 400)
         self.assertEqual(json_response[0]["errorKey"], "org_unit_type_id")
-        self.assertEqual(json_response[0]["errorMessage"], "You cannot create or edit an Org unit of this type")
+        self.assertEqual(
+            json_response[0]["errorMessage"],
+            "You cannot create or edit an Org unit of this type",
+        )
         self.yoda.iaso_profile.editable_org_unit_types.clear()
 
     def test_edit_org_unit_edit_bad_group_fail(self):
@@ -1295,7 +1411,9 @@ class OrgUnitAPITestCase(APITestCase):
         ]
 
         response = self.client.post(
-            "/api/mobile/orgunits/?app_id=stars.empire.agriculture.hydroponics", data=data, format="json"
+            "/api/mobile/orgunits/?app_id=stars.empire.agriculture.hydroponics",
+            data=data,
+            format="json",
         )
         orgunits = OrgUnit.objects.all().count()
 
@@ -1331,7 +1449,11 @@ class OrgUnitAPITestCase(APITestCase):
         ids_in_response = [ou["id"] for ou in org_units]
 
         # list of all the indirect children of the jedi_council_endor OU
-        ou_ids_list = [self.jedi_squad_endor.pk, self.jedi_squad_endor_2.pk, jedi_squad_endor_2_children.pk]
+        ou_ids_list = [
+            self.jedi_squad_endor.pk,
+            self.jedi_squad_endor_2.pk,
+            jedi_squad_endor_2_children.pk,
+        ]
 
         self.assertEqual(sorted(ids_in_response), sorted(ou_ids_list))
 
@@ -1399,3 +1521,14 @@ class OrgUnitAPITestCase(APITestCase):
         self.assertValidOrgUnitData(jr)
         ou = m.OrgUnit.objects.get(id=jr["id"])
         self.assertIsNone(ou.default_image)
+
+    def test_search_org_unit_based_on_group_and_type(self):
+        self.client.force_authenticate(self.yoda)
+        response = self.client.get(
+            f'/api/orgunits/?limit=20&order=id&page=1&searches=[{{"validation_status":"all","group":"{self.elite_group.pk}","orgUnitTypeId":"{self.jedi_council.pk}"}}]'
+        )
+        org_units = self.assertJSONResponse(response, 200)
+        self.assertEqual(org_units["count"], 1)
+        self.assertEqual(org_units["page"], 1)
+        first_org_unit = org_units["orgunits"][0]
+        self.assertEqual(first_org_unit["id"], self.jedi_council_corruscant.pk)

--- a/iaso/tests/api/test_orgunits.py
+++ b/iaso/tests/api/test_orgunits.py
@@ -1524,8 +1524,13 @@ class OrgUnitAPITestCase(APITestCase):
 
     def test_search_org_unit_based_on_group_and_type(self):
         self.client.force_authenticate(self.yoda)
+        self.jedi_council_corruscant.groups.set(
+            [self.elite_group, self.unofficial_group, self.another_group]
+        )
+        self.jedi_council_corruscant.save()
+
         response = self.client.get(
-            f'/api/orgunits/?limit=20&order=id&page=1&searches=[{{"validation_status":"all","group":"{self.elite_group.pk}","orgUnitTypeId":"{self.jedi_council.pk}"}}]'
+            f'/api/orgunits/?limit=20&order=id&page=1&searches=[{{"validation_status":"all","group":"{self.elite_group.pk},{self.unofficial_group.pk},{self.another_group.pk}","orgUnitTypeId":"{self.jedi_council.pk}"}}]'
         )
         org_units = self.assertJSONResponse(response, 200)
         self.assertEqual(org_units["count"], 1)


### PR DESCRIPTION
What problem is this PR solving? Explain here in one sentence.

Related JIRA tickets : [IA-3996](https://bluesquare.atlassian.net/browse/IA-3996)

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

Added distinct id when filter org unit by groups

## How to test

From org unit list, try to filter org unit by selecting several groups.


## Print screen / video

[Iaso-Org-units-Group_and_Type-filter.webm](https://github.com/user-attachments/assets/d0f64e24-e534-497d-be23-06ae2f0b1e50)


## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.


[IA-3996]: https://bluesquare.atlassian.net/browse/IA-3996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ