### PR TITLE
IA-3976: Validation should appear above Payments in the menu

### DIFF
--- a/hat/assets/js/apps/Iaso/constants/menu.tsx
+++ b/hat/assets/js/apps/Iaso/constants/menu.tsx
@@ -182,25 +182,6 @@ const menuItems = (
             ],
         },
         {
-            label: formatMessage(MESSAGES.payments),
-            key: 'payments',
-            icon: props => <PaymentsIcon {...props} />,
-            subMenu: [
-                {
-                    label: formatMessage(MESSAGES.potentialPayments),
-                    permissions: paths.potentialPaymentsPath.permissions,
-                    key: 'potential',
-                    icon: props => <PriceCheckIcon {...props} />,
-                },
-                {
-                    label: formatMessage(MESSAGES.lots),
-                    permissions: paths.potentialPaymentsPath.permissions,
-                    key: 'lots',
-                    icon: props => <AccountBalanceIcon {...props} />,
-                },
-            ],
-        },
-        {
             label: formatMessage(MESSAGES.validation),
             icon: props => <RuleIcon {...props} />,
             key: 'validation',
@@ -217,6 +198,25 @@ const menuItems = (
                         paths.orgUnitsChangeRequestConfiguration.permissions,
                     key: `${CHANGE_REQUEST_CONFIG}`,
                     icon: props => <CategoryIcon {...props} />,
+                },
+            ],
+        },
+        {
+            label: formatMessage(MESSAGES.payments),
+            key: 'payments',
+            icon: props => <PaymentsIcon {...props} />,
+            subMenu: [
+                {
+                    label: formatMessage(MESSAGES.potentialPayments),
+                    permissions: paths.potentialPaymentsPath.permissions,
+                    key: 'potential',
+                    icon: props => <PriceCheckIcon {...props} />,
+                },
+                {
+                    label: formatMessage(MESSAGES.lots),
+                    permissions: paths.potentialPaymentsPath.permissions,
+                    key: 'lots',
+                    icon: props => <AccountBalanceIcon {...props} />,
                 },
             ],
         },


### PR DESCRIPTION
What problem is this PR solving? Explain here in one sentence.

Related JIRA tickets : [IA-3976](https://bluesquare.atlassian.net/browse/IA-3976)

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

Moved Validation above Payments in the menu

## How to test

Check in the menu if **Validation** appears above **Payments**

## Print screen / video

![Iaso-03-05-2025_10_16_AM](https://github.com/user-attachments/assets/6ca291d2-1c96-45a9-80e0-83e099c9eedf)


## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.


[IA-3976]: https://bluesquare.atlassian.net/browse/IA-3976?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ