### PR TITLE
IA-3981: Update forgotten password sentence

### DIFF
--- a/hat/locale/fr/LC_MESSAGES/django.po
+++ b/hat/locale/fr/LC_MESSAGES/django.po
@@ -66,8 +66,8 @@ msgid "Login"
 msgstr "Connexion"
 
 #: hat/templates/iaso/login.html:44
-msgid "Forgot password"
-msgstr "Oublié votre mot de passe?"
+msgid "Forgot password?"
+msgstr "Mot de passe oublié?"
 
 #: hat/templates/iaso/reset_password_complete.html:13
 #, python-format

--- a/hat/templates/iaso/login.html
+++ b/hat/templates/iaso/login.html
@@ -41,7 +41,7 @@
           {% include "./icons/eye.html" %}
           {% include "./icons/eye-slash.html" %}
         </button>
-        <p class="login-link"><a href="{% url 'forgot_password' %}">{% trans 'Forgot password' %}</a></p>
+        <p class="login-link"><a href="{% url 'forgot_password' %}">{% trans 'Forgot password?' %}</a></p>
       </form>
       {% include "./language_picker.html" %}
     </div>


### PR DESCRIPTION
What problem is this PR solving? Explain here in one sentence.

Related JIRA tickets : [IA-3981](https://bluesquare.atlassian.net/browse/IA-3981?atlOrigin=eyJpIjoiN2RkZDVhMDFkYTUyNDkxNzgyYjA2MTAwYjBlNGEwNTYiLCJwIjoiaiJ9)

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

Fix forgotten password sentence(english and french version) from login page

## How to test

Open login page and check the forgotten password sentence by switching between english and french. 
You should see correct sentence for:
- French : **Mot de passe oublié?**
- English : **Forgot password?**


## Print screen / video

[Forgot password sentence.webm](https://github.com/user-attachments/assets/5338d3bb-dcff-4f9d-bccb-72d2a76018ed)


## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.


[IA-3981]: https://bluesquare.atlassian.net/browse/IA-3981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ