### PR TITLE
IA-3850: SETUPER: Update forms with the latest ones from GDHF account

### DIFF
--- a/setuper/additional_projects.py
+++ b/setuper/additional_projects.py
@@ -40,7 +40,6 @@ def projects_mapper(account_name):
                 "Pregnant women follow-up",
                 "Child/Enfant - Registration/Enregistrement",
                 "Child/Enfant - Follow-up/Suivi",
-                "Dénombrement / Enumeration",
             ],
         },
         {
@@ -54,13 +53,6 @@ def projects_mapper(account_name):
                 "ENTITY",
             ],
             "linked_forms": [
-                "Registry - Population Health area",
-                "Registration Vaccination Pregnant Women",
-                "Pregnant women follow-up",
-                "Equipment/Pop/Social mob./Microplans",
-                "Child/Enfant - Registration/Enregistrement",
-                "Child/Enfant - Follow-up/Suivi",
-                "Data for Health facility/Données Formation sanitaire",
                 "Dénombrement / Enumeration",
                 "Distribution",
             ],


### PR DESCRIPTION
@tdethier , a small change has been requested to allocate forms to projects by following the same config as the one from account: lauretest/lauretest from [staging](https://iaso-staging.bluesquare.org/dashboard/forms/list/accountId/268/)

Related JIRA tickets : [IA-3850](https://bluesquare.atlassian.net/browse/IA-3850)

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

Updated forms by allocating them to the right projects from GDHF account.

## How to test

From setuper folder, launch setuper via `python3 setuper.py --additional_projects` to generate test data. Then login with the created account and open [Forms page](http://localhost:8081/dashboard/forms/list/) and filter on Projects for LLIN campaign. Check if you can see new forms (Distribution, Dénombrement / Enumeration) and submissions for each new form.

## Print screen / video

![image](https://github.com/user-attachments/assets/9a30dfba-7e9c-49be-9c1c-ca92fd22beea)

## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.


[IA-3850]: https://bluesquare.atlassian.net/browse/IA-3850?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ