### PR TITLE
IA-4002: Fix deploy doc

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -160,7 +160,7 @@ jobs:
 
             - name: Cache dependencies
               id: cache
-              uses: actions/cache@v3
+              uses: actions/cache@v4
               with:
                   path: ./node_modules
                   key: node_modules-20221121-${{ hashFiles('package-lock.json') }}

--- a/.github/workflows/deploy_doc.yml
+++ b/.github/workflows/deploy_doc.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           python-version: 3.9
       - name: Install mkDocs and dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         id: cache-venv
         with:
             path: ./venv/


### PR DESCRIPTION
deployment of doc failing due to deprecated GH action

Related JIRA tickets : IA-4002

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)


## Changes

Align `actions/cache` versions

## How to test

Deploy of doc was successful [here](https://github.com/BLSQ/iaso/actions/runs/13695242248) 

