### PR TITLE
IA-4021 Add some fields to the entities and instances CSV/XLSX exports

### DIFF
--- a/iaso/api/entity.py
+++ b/iaso/api/entity.py
@@ -86,7 +86,9 @@ class EntitySerializer(serializers.ModelSerializer):
         return _get_duplicates(entity)
 
     def get_nfc_cards(self, entity: Entity):
-        nfc_count = StorageDevice.objects.filter(entity=entity, type=StorageDevice.NFC).count()
+        nfc_count = StorageDevice.objects.filter(
+            entity=entity, type=StorageDevice.NFC
+        ).count()
         return nfc_count
 
     @staticmethod
@@ -125,7 +127,11 @@ class EntityViewSet(ModelViewSet):
 
     results_key = "entities"
     remove_results_key_if_paginated = True
-    filter_backends = [filters.OrderingFilter, DjangoFilterBackend, DeletionFilterBackend]
+    filter_backends = [
+        filters.OrderingFilter,
+        DjangoFilterBackend,
+        DeletionFilterBackend,
+    ]
     permission_classes = [permissions.IsAuthenticated, HasPermission(permission.ENTITIES)]  # type: ignore
 
     def get_serializer_class(self):
@@ -162,7 +168,9 @@ class EntityViewSet(ModelViewSet):
             queryset = queryset.filter(attributes__form__name__icontains=form_name)
         if search:
             queryset = queryset.filter(
-                Q(name__icontains=search) | Q(uuid__icontains=search) | Q(attributes__json__icontains=search)
+                Q(name__icontains=search)
+                | Q(uuid__icontains=search)
+                | Q(attributes__json__icontains=search)
             )
         if by_uuid:
             queryset = queryset.filter(uuid=by_uuid)
@@ -172,18 +180,24 @@ class EntityViewSet(ModelViewSet):
             queryset = queryset.filter(entity_type_id__in=entity_type_ids.split(","))
         if org_unit_id:
             parent = OrgUnit.objects.get(id=org_unit_id)
-            queryset = queryset.filter(attributes__org_unit__path__descendants=parent.path)
+            queryset = queryset.filter(
+                attributes__org_unit__path__descendants=parent.path
+            )
 
         if date_from or date_to:
             date_from_dt = datetime.datetime.min
             if date_from:
                 parsed_date = datetime.datetime.strptime(date_from, "%Y-%m-%d")
-                date_from_dt = datetime.datetime.combine(parsed_date, datetime.time.min).replace(tzinfo=pytz.UTC)
+                date_from_dt = datetime.datetime.combine(
+                    parsed_date, datetime.time.min
+                ).replace(tzinfo=pytz.UTC)
 
             date_to_dt = datetime.datetime.max
             if date_to:
                 parsed_date = datetime.datetime.strptime(date_to, "%Y-%m-%d")
-                date_to_dt = datetime.datetime.combine(parsed_date, datetime.time.max).replace(tzinfo=pytz.UTC)
+                date_to_dt = datetime.datetime.combine(
+                    parsed_date, datetime.time.max
+                ).replace(tzinfo=pytz.UTC)
 
             instances_within_range = Instance.objects.annotate(
                 creation_timestamp=Coalesce("source_created_at", "created_at")
@@ -198,9 +212,13 @@ class EntityViewSet(ModelViewSet):
         if created_by_id:
             queryset = queryset.filter(attributes__created_by_id=created_by_id)
         if created_by_team_id:
-            queryset = queryset.filter(attributes__created_by__teams__id=created_by_team_id)
+            queryset = queryset.filter(
+                attributes__created_by__teams__id=created_by_team_id
+            )
         if groups:
-            queryset = queryset.filter(attributes__org_unit__groups__in=groups.split(","))
+            queryset = queryset.filter(
+                attributes__org_unit__groups__in=groups.split(",")
+            )
 
         if fields_search:
             q = entities_jsonlogic_to_q(json.loads(fields_search))
@@ -216,9 +234,16 @@ class EntityViewSet(ModelViewSet):
         account = request.user.iaso_profile.account
         # Avoid duplicates
         if Entity.objects.filter(attributes=instance):
-            raise serializers.ValidationError({"attributes": "Entity with this attribute already exists."})
+            raise serializers.ValidationError(
+                {"attributes": "Entity with this attribute already exists."}
+            )
 
-        entity = Entity.objects.create(name=data["name"], entity_type=entity_type, attributes=instance, account=account)
+        entity = Entity.objects.create(
+            name=data["name"],
+            entity_type=entity_type,
+            attributes=instance,
+            account=account,
+        )
         serializer = EntitySerializer(entity, many=False)
         return Response(serializer.data)
 
@@ -233,12 +258,21 @@ class EntityViewSet(ModelViewSet):
                 # Avoid duplicates
                 if Entity.objects.filter(attributes=instance):
                     raise serializers.ValidationError(
-                        {"attributes": "Entity with the attribute '{0}' already exists.".format(entity["attributes"])}
+                        {
+                            "attributes": "Entity with the attribute '{0}' already exists.".format(
+                                entity["attributes"]
+                            )
+                        }
                     )
-                entity_type = get_object_or_404(EntityType, pk=int(entity["entity_type"]))
+                entity_type = get_object_or_404(
+                    EntityType, pk=int(entity["entity_type"])
+                )
                 account = request.user.iaso_profile.account
                 Entity.objects.create(
-                    name=entity["name"], entity_type=entity_type, attributes=instance, account=account
+                    name=entity["name"],
+                    entity_type=entity_type,
+                    attributes=instance,
+                    account=account,
                 )
                 created_entities.append(entity)
             return JsonResponse(created_entities, safe=False)
@@ -270,7 +304,9 @@ class EntityViewSet(ModelViewSet):
 
         # annotate with last instance on Entity, to allow ordering by it
         entities = queryset.annotate(
-            last_saved_instance=Max(Coalesce("instances__source_created_at", "instances__created_at"))
+            last_saved_instance=Max(
+                Coalesce("instances__source_created_at", "instances__created_at")
+            )
         )
         result_list = []
         columns_list: List[Any] = []
@@ -318,7 +354,9 @@ class EntityViewSet(ModelViewSet):
             attributes_longitude = None
             file_content = None
             if attributes is not None and entity.attributes is not None:
-                file_content = entity.attributes.get_and_save_json_of_xml().get("file_content", None)
+                file_content = entity.attributes.get_and_save_json_of_xml().get(
+                    "file_content", None
+                )
                 attributes_pk = attributes.pk
                 attributes_ou = entity.attributes.org_unit.as_dict_for_entity() if entity.attributes.org_unit else None  # type: ignore
                 attributes_latitude = attributes.location.y if attributes.location else None  # type: ignore
@@ -346,7 +384,9 @@ class EntityViewSet(ModelViewSet):
             }
             if entity_type_ids is not None and len(entity_type_ids.split(",")) == 1:
                 columns_list = []
-                possible_fields_list = entity.entity_type.reference_form.possible_fields or []
+                possible_fields_list = (
+                    entity.entity_type.reference_form.possible_fields or []
+                )
                 for items in possible_fields_list:
                     for k, v in items.items():
                         if k == "name" and v in entity.entity_type.fields_list_view:
@@ -355,7 +395,11 @@ class EntityViewSet(ModelViewSet):
                     for k, v in entity.attributes.json.items():
                         if k in list(entity.entity_type.fields_list_view):
                             result[k] = v
-                columns_list = [i for n, i in enumerate(columns_list) if i not in columns_list[n + 1 :]]
+                columns_list = [
+                    i
+                    for n, i in enumerate(columns_list)
+                    if i not in columns_list[n + 1 :]
+                ]
                 columns_list = [c for c in columns_list if len(c) > 2]
             result_list.append(result)
         if is_export:
@@ -365,6 +409,7 @@ class EntityViewSet(ModelViewSet):
                 {"title": "Entity Type", "width": 20},
                 {"title": "Creation Date", "width": 20},
                 {"title": "HC", "width": 20},
+                {"title": "HC ID", "width": 20},
                 {"title": "Last update", "width": 20},
             ]
             for col in columns_list:
@@ -380,7 +425,9 @@ class EntityViewSet(ModelViewSet):
 
                 last_saved_instance = entity["last_saved_instance"]
                 if last_saved_instance is not None:
-                    last_saved_instance = last_saved_instance.strftime(EXPORTS_DATETIME_FORMAT)
+                    last_saved_instance = last_saved_instance.strftime(
+                        EXPORTS_DATETIME_FORMAT
+                    )
 
                 values = [
                     entity["id"],
@@ -388,6 +435,7 @@ class EntityViewSet(ModelViewSet):
                     entity["entity_type"],
                     created_at,
                     entity["org_unit"]["name"] if entity["org_unit"] else "",
+                    entity["org_unit"]["id"] if entity["org_unit"] else "",
                     last_saved_instance,
                 ]
                 for col in columns_list:
@@ -403,7 +451,10 @@ class EntityViewSet(ModelViewSet):
                 )
             if csv_format:
                 response = StreamingHttpResponse(
-                    streaming_content=(iter_items(result_list, Echo(), columns, get_row)), content_type=CONTENT_TYPE_CSV
+                    streaming_content=(
+                        iter_items(result_list, Echo(), columns, get_row)
+                    ),
+                    content_type=CONTENT_TYPE_CSV,
                 )
                 filename = filename + ".csv"
             response["Content-Disposition"] = "attachment; filename=%s" % filename
@@ -450,7 +501,14 @@ class EntityViewSet(ModelViewSet):
         instances = Instance.objects.filter(entity=entity)
         xlsx = request.GET.get("xlsx", None)
         csv_exp = request.GET.get("csv", None)
-        fields = ["Submissions for the form", "Created", "Last Sync", "Org Unit", "Submitter", "Actions"]
+        fields = [
+            "Submissions for the form",
+            "Created",
+            "Last Sync",
+            "Org Unit",
+            "Submitter",
+            "Actions",
+        ]
         date = datetime.datetime.now().strftime("%Y-%m-%d")
 
         if xlsx:
@@ -470,8 +528,12 @@ class EntityViewSet(ModelViewSet):
                 col = 0
                 data = [
                     i.form.name,
-                    i.source_created_at.strftime(EXPORTS_DATETIME_FORMAT) if i.source_created_at else None,
-                    i.source_updated_at.strftime(EXPORTS_DATETIME_FORMAT) if i.source_updated_at else None,
+                    i.source_created_at.strftime(EXPORTS_DATETIME_FORMAT)
+                    if i.source_created_at
+                    else None,
+                    i.source_updated_at.strftime(EXPORTS_DATETIME_FORMAT)
+                    if i.source_updated_at
+                    else None,
                     i.org_unit.name,
                     i.created_by.username,
                     "",
@@ -499,8 +561,12 @@ class EntityViewSet(ModelViewSet):
             for i in instances:
                 data_list = [
                     i.form.name,
-                    i.source_created_at.strftime(EXPORTS_DATETIME_FORMAT) if i.source_created_at else None,
-                    i.source_updated_at.strftime(EXPORTS_DATETIME_FORMAT) if i.source_updated_at else None,
+                    i.source_created_at.strftime(EXPORTS_DATETIME_FORMAT)
+                    if i.source_created_at
+                    else None,
+                    i.source_updated_at.strftime(EXPORTS_DATETIME_FORMAT)
+                    if i.source_updated_at
+                    else None,
                     i.org_unit.name,
                     i.created_by.username,
                     "",

--- a/iaso/api/instances.py
+++ b/iaso/api/instances.py
@@ -235,6 +235,7 @@ class InstancesViewSet(viewsets.ViewSet):
             {"title": "Date de création", "width": 20},
             {"title": "Date de modification", "width": 20},
             {"title": "Créé par", "width": 20},
+            {"title": "Créé par id", "width": 20},
             {"title": "Status", "width": 20},
             {"title": "Entité", "width": 20},
             {"title": "Org unit", "width": 20},
@@ -297,6 +298,7 @@ class InstancesViewSet(viewsets.ViewSet):
                 timestamp_to_datetime(created_at_timestamp),
                 timestamp_to_datetime(updated_at_timestamp),
                 get_creator_name(instance.created_by) if instance.created_by else None,
+                instance.created_by_id,
                 instance.status,
                 # Special format for UUID to stay consistent with other UUIDs coming from file_content_template
                 f"uuid:{instance.entity.uuid}" if instance.entity else None,

--- a/iaso/api/instances.py
+++ b/iaso/api/instances.py
@@ -238,6 +238,7 @@ class InstancesViewSet(viewsets.ViewSet):
             {"title": "Créé par id", "width": 20},
             {"title": "Status", "width": 20},
             {"title": "Entité", "width": 20},
+            {"title": "Entité id", "width": 20},
             {"title": "Org unit", "width": 20},
             {"title": "Org unit id", "width": 20},
             {"title": "Référence externe", "width": 20},
@@ -302,6 +303,7 @@ class InstancesViewSet(viewsets.ViewSet):
                 instance.status,
                 # Special format for UUID to stay consistent with other UUIDs coming from file_content_template
                 f"uuid:{instance.entity.uuid}" if instance.entity else None,
+                instance.entity_id,
                 instance.org_unit.name,
                 instance.org_unit.id,
                 instance.org_unit.source_ref,

--- a/iaso/tests/api/test_entities.py
+++ b/iaso/tests/api/test_entities.py
@@ -1,4 +1,6 @@
 import datetime
+import csv
+import io
 import json
 import time
 import uuid
@@ -11,6 +13,7 @@ from django.contrib.auth.models import AnonymousUser
 from django.core.files import File
 
 from iaso import models as m
+from iaso.api.common import EXPORTS_DATETIME_FORMAT
 from iaso.models import Entity, EntityType, FormVersion, Instance, Project
 from iaso.models.deduplication import ValidationStatus
 from iaso.test import APITestCase
@@ -19,56 +22,74 @@ from iaso.test import APITestCase
 class EntityAPITestCase(APITestCase):
     @classmethod
     def setUpTestData(cls):
-        star_wars = m.Account.objects.create(name="Star Wars")
-        cls.star_wars = star_wars
-
-        space_balls = m.Account.objects.create(name="Space Balls")
-
-        sw_source = m.DataSource.objects.create(name="Galactic Empire")
+        cls.account = m.Account.objects.create(name="Account")
+        sw_source = m.DataSource.objects.create(name="Source")
         cls.sw_source = sw_source
         sw_version = m.SourceVersion.objects.create(data_source=sw_source, number=1)
-        star_wars.default_version = sw_version
-        star_wars.save()
+        cls.account.default_version = sw_version
+        cls.account.save()
         cls.sw_version = sw_version
 
         cls.anon = AnonymousUser()
 
         cls.project = m.Project.objects.create(
-            name="Hydroponic gardens", app_id="stars.empire.agriculture.hydroponics", account=star_wars
+            name="Project", app_id="project", account=cls.account
         )
 
         cls.yop_solo = cls.create_user_with_profile(
-            username="yop solo", account=space_balls, permissions=["iaso_entities"]
+            username="yop solo",
+            account=m.Account.objects.create(name="Account 2"),
+            permissions=["iaso_entities"],
         )
 
-        cls.jedi_council = m.OrgUnitType.objects.create(name="Jedi Council", short_name="Cnc")
-
-        cls.jedi_council_corruscant = m.OrgUnit.objects.create(
-            name="Coruscant Jedi Council", validation_status=m.OrgUnit.VALIDATION_VALID
+        cls.ou_country = m.OrgUnit.objects.create(
+            name="Burkina Faso (validated)",
+            validation_status=m.OrgUnit.VALIDATION_VALID,
         )
-        cls.jedi_council_corruscant_unvalidated = m.OrgUnit.objects.create(name="Coruscant Jedi Council")
+        cls.ou_country_unvalidated = m.OrgUnit.objects.create(
+            name="Burkina Faso (unvalidated)"
+        )
 
-        cls.yoda = cls.create_user_with_profile(username="yoda", account=star_wars, permissions=["iaso_entities"])
+        cls.yoda = cls.create_user_with_profile(
+            username="yoda", account=cls.account, permissions=["iaso_entities"]
+        )
 
         cls.user_without_ou = cls.create_user_with_profile(
-            username="user_without_ou", account=star_wars, permissions=["iaso_entities"]
+            username="user_without_ou",
+            account=cls.account,
+            permissions=["iaso_entities"],
         )
 
         cls.form_1 = m.Form.objects.create(
-            name="Hydroponics study", period_type=m.MONTH, single_per_period=True, form_id="form_1"
+            name="Hydroponics study",
+            period_type=m.MONTH,
+            single_per_period=True,
+            form_id="form_1",
         )
 
         cls.create_form_instance(
-            form=cls.form_1, period="202001", org_unit=cls.jedi_council_corruscant, project=cls.project, uuid=uuid.uuid4
+            form=cls.form_1,
+            org_unit=cls.ou_country,
+            project=cls.project,
+            uuid=uuid.uuid4,
         )
         cls.create_form_instance(
-            form=cls.form_1, period="202002", org_unit=cls.jedi_council_corruscant, project=cls.project, uuid=uuid.uuid4
+            form=cls.form_1,
+            org_unit=cls.ou_country,
+            project=cls.project,
+            uuid=uuid.uuid4,
         )
         cls.create_form_instance(
-            form=cls.form_1, period="202002", org_unit=cls.jedi_council_corruscant, project=cls.project, uuid=uuid.uuid4
+            form=cls.form_1,
+            org_unit=cls.ou_country,
+            project=cls.project,
+            uuid=uuid.uuid4,
         )
         cls.create_form_instance(
-            form=cls.form_1, period="202003", org_unit=cls.jedi_council_corruscant, project=cls.project, uuid=uuid.uuid4
+            form=cls.form_1,
+            org_unit=cls.ou_country,
+            project=cls.project,
+            uuid=uuid.uuid4,
         )
 
         cls.form_1.projects.add(cls.project)
@@ -76,17 +97,13 @@ class EntityAPITestCase(APITestCase):
         cls.entity_type = EntityType.objects.create(
             name="Type 1",
             reference_form=cls.form_1,
-            account=cls.star_wars,
+            account=cls.account,
         )
 
     def test_create_single_entity(self):
         self.client.force_authenticate(self.yoda)
 
-        instance = Instance.objects.create(
-            org_unit=self.jedi_council_corruscant,
-            form=self.form_1,
-            period="202002",
-        )
+        instance = Instance.objects.create(org_unit=self.ou_country, form=self.form_1)
 
         payload = {
             "name": "New Client",
@@ -103,11 +120,11 @@ class EntityAPITestCase(APITestCase):
         self.client.force_authenticate(self.yoda)
 
         instance = Instance.objects.create(
-            org_unit=self.jedi_council_corruscant, form=self.form_1, period="202002", uuid=uuid.uuid4()
+            org_unit=self.ou_country, form=self.form_1, uuid=uuid.uuid4()
         )
 
         second_instance = Instance.objects.create(
-            org_unit=self.jedi_council_corruscant, form=self.form_1, period="202002", uuid=uuid.uuid4()
+            org_unit=self.ou_country, form=self.form_1, uuid=uuid.uuid4()
         )
 
         payload = (
@@ -125,7 +142,9 @@ class EntityAPITestCase(APITestCase):
             },
         )
 
-        response = self.client.post("/api/entities/bulk_create/", data=payload, format="json")
+        response = self.client.post(
+            "/api/entities/bulk_create/", data=payload, format="json"
+        )
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.json()), 2)
@@ -134,7 +153,7 @@ class EntityAPITestCase(APITestCase):
         self.client.force_authenticate(self.yoda)
 
         instance = Instance.objects.create(
-            org_unit=self.jedi_council_corruscant, form=self.form_1, period="202002", uuid=uuid.uuid4()
+            org_unit=self.ou_country, form=self.form_1, uuid=uuid.uuid4()
         )
 
         payload = (
@@ -152,7 +171,9 @@ class EntityAPITestCase(APITestCase):
             },
         )
 
-        response = self.client.post("/api/entities/bulk_create/", data=payload, format="json")
+        response = self.client.post(
+            "/api/entities/bulk_create/", data=payload, format="json"
+        )
 
         self.assertEqual(response.status_code, 400)
 
@@ -160,11 +181,11 @@ class EntityAPITestCase(APITestCase):
         self.client.force_authenticate(self.yoda)
 
         instance = Instance.objects.create(
-            org_unit=self.jedi_council_corruscant, form=self.form_1, period="202002", uuid=uuid.uuid4()
+            org_unit=self.ou_country, form=self.form_1, uuid=uuid.uuid4()
         )
 
         second_instance = Instance.objects.create(
-            org_unit=self.jedi_council_corruscant, form=self.form_1, period="202002", uuid=uuid.uuid4()
+            org_unit=self.ou_country, form=self.form_1, uuid=uuid.uuid4()
         )
 
         payload = (
@@ -193,11 +214,11 @@ class EntityAPITestCase(APITestCase):
         self.client.force_authenticate(self.yoda)
 
         instance = Instance.objects.create(
-            org_unit=self.jedi_council_corruscant, form=self.form_1, period="202002", uuid=uuid.uuid4()
+            org_unit=self.ou_country, form=self.form_1, uuid=uuid.uuid4()
         )
 
         second_instance = Instance.objects.create(
-            org_unit=self.jedi_council_corruscant, form=self.form_1, period="202002", uuid=uuid.uuid4()
+            org_unit=self.ou_country, form=self.form_1, uuid=uuid.uuid4()
         )
 
         payload = (
@@ -218,7 +239,9 @@ class EntityAPITestCase(APITestCase):
         self.client.post("/api/entities/bulk_create/", data=payload, format="json")
 
         entity = Entity.objects.create(
-            name="New Client 3", entity_type=self.entity_type, account=self.yoda.iaso_profile.account
+            name="New Client 3",
+            entity_type=self.entity_type,
+            account=self.yoda.iaso_profile.account,
         )
 
         entity.refresh_from_db()
@@ -228,7 +251,9 @@ class EntityAPITestCase(APITestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.json()["result"]), 3)
 
-        response = self.client.get(f"/api/entities/?entity_type_id={self.entity_type.pk}", format="json")
+        response = self.client.get(
+            f"/api/entities/?entity_type_id={self.entity_type.pk}", format="json"
+        )
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.json()["result"]), 3)
@@ -246,9 +271,8 @@ class EntityAPITestCase(APITestCase):
         self.client.force_authenticate(self.yoda)
 
         instance = Instance.objects.create(
-            org_unit=self.jedi_council_corruscant,
+            org_unit=self.ou_country,
             form=self.form_1,
-            period="202002",
             json={"name": "c", "age": 30, "gender": "F"},
         )
 
@@ -276,7 +300,9 @@ class EntityAPITestCase(APITestCase):
         self.assertEqual(the_result["id"], newly_added_entity.id)
 
         # Case 3: search by entity UUID
-        response = self.client.get(f"/api/entities/?search={newly_added_entity.uuid}", format="json")
+        response = self.client.get(
+            f"/api/entities/?search={newly_added_entity.uuid}", format="json"
+        )
         self.assertEqual(len(response.json()["result"]), 1)
         self.assertEqual(the_result["id"], newly_added_entity.id)
 
@@ -306,24 +332,32 @@ class EntityAPITestCase(APITestCase):
 
         # Create 2 entities: one on date1, one on date2
         instance1 = Instance.objects.create(form=self.form_1, source_created_at=date1)
-        entity1 = Entity.objects.create(entity_type=entity_type, attributes=instance1, account=self.star_wars)
+        entity1 = Entity.objects.create(
+            entity_type=entity_type, attributes=instance1, account=self.account
+        )
         instance1.entity = entity1
         instance1.save()
 
         instance2 = Instance.objects.create(form=self.form_1, source_created_at=date2)
-        entity2 = Entity.objects.create(entity_type=entity_type, attributes=instance2, account=self.star_wars)
+        entity2 = Entity.objects.create(
+            entity_type=entity_type, attributes=instance2, account=self.account
+        )
         instance2.entity = entity2
         instance2.save()
 
         # Search on specific date
-        response = self.client.get(f"/api/entities/?dateFrom={date1_str}&dateTo={date1_str}")
+        response = self.client.get(
+            f"/api/entities/?dateFrom={date1_str}&dateTo={date1_str}"
+        )
         self.assertEqual(len(response.json()["result"]), 1)
         results = response.json()["result"]
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0]["id"], entity1.id)
 
         # Search on date range
-        response = self.client.get(f"/api/entities/?dateFrom={date1_str}&dateTo={date2_str}")
+        response = self.client.get(
+            f"/api/entities/?dateFrom={date1_str}&dateTo={date2_str}"
+        )
         results = response.json()["result"]
         self.assertEqual(len(results), 2)
         self.assertEqual([r["id"] for r in results], [entity1.id, entity2.id])
@@ -355,7 +389,7 @@ class EntityAPITestCase(APITestCase):
 
         # Entity 1 - Female from Bujumbura
         ent1_instance1 = Instance.objects.create(
-            org_unit=self.jedi_council_corruscant,
+            org_unit=self.ou_country,
             form=self.form_1,
             json={"gender": "F"},
         )
@@ -363,12 +397,12 @@ class EntityAPITestCase(APITestCase):
             name="Ent 1",
             entity_type=self.entity_type,
             attributes=ent1_instance1,
-            account=self.star_wars,
+            account=self.account,
         )
         ent1_instance1.entity = ent1
         ent1_instance1.save()
         Instance.objects.create(
-            org_unit=self.jedi_council_corruscant,
+            org_unit=self.ou_country,
             form=self.form_2,
             json={"residence": "Bujumbura"},
             entity=ent1,
@@ -376,7 +410,7 @@ class EntityAPITestCase(APITestCase):
 
         # Entity 2 - Male from Kinshasa
         ent2_instance1 = Instance.objects.create(
-            org_unit=self.jedi_council_corruscant,
+            org_unit=self.ou_country,
             form=self.form_1,
             json={"gender": "M"},
         )
@@ -384,18 +418,18 @@ class EntityAPITestCase(APITestCase):
             name="Ent 1",
             entity_type=self.entity_type,
             attributes=ent2_instance1,
-            account=self.star_wars,
+            account=self.account,
         )
         ent2_instance1.entity = ent2
         ent2_instance1.save()
         Instance.objects.create(
-            org_unit=self.jedi_council_corruscant,
+            org_unit=self.ou_country,
             form=self.form_2,
             json={"residence": "Kinshasa"},
             entity=ent2,
         )
         Instance.objects.create(
-            org_unit=self.jedi_council_corruscant,
+            org_unit=self.ou_country,
             form=self.form_2,
             json={"residence": "Accra"},
             entity=ent2,
@@ -404,7 +438,11 @@ class EntityAPITestCase(APITestCase):
         # gender f AND SOME residence Bujumbura
         response = self.client.get(
             "/api/entities/",
-            {"fields_search": self._generate_json_filter("and", "some", "F", "Bujumbura")},
+            {
+                "fields_search": self._generate_json_filter(
+                    "and", "some", "F", "Bujumbura"
+                )
+            },
         )
         self.assertEqual(len(response.json()["result"]), 1)
         the_result = response.json()["result"][0]
@@ -413,14 +451,22 @@ class EntityAPITestCase(APITestCase):
         # gender m AND SOME residence Bujumbura
         response = self.client.get(
             "/api/entities/",
-            {"fields_search": self._generate_json_filter("and", "some", "M", "Bujumbura")},
+            {
+                "fields_search": self._generate_json_filter(
+                    "and", "some", "M", "Bujumbura"
+                )
+            },
         )
         self.assertEqual(len(response.json()["result"]), 0)
 
         # gender f OR SOME residence Kinshasa
         response = self.client.get(
             "/api/entities/",
-            {"fields_search": self._generate_json_filter("or", "some", "F", "Kinshasa")},
+            {
+                "fields_search": self._generate_json_filter(
+                    "or", "some", "F", "Kinshasa"
+                )
+            },
         )
         self.assertEqual(len(response.json()["result"]), 2)
         result_ids = [r["id"] for r in response.json()["result"]]
@@ -429,7 +475,11 @@ class EntityAPITestCase(APITestCase):
         # gender m AND SOME residence Kinshasa
         response = self.client.get(
             "/api/entities/",
-            {"fields_search": self._generate_json_filter("and", "some", "M", "Kinshasa")},
+            {
+                "fields_search": self._generate_json_filter(
+                    "and", "some", "M", "Kinshasa"
+                )
+            },
         )
         self.assertEqual(len(response.json()["result"]), 1)
         the_result = response.json()["result"][0]
@@ -438,7 +488,11 @@ class EntityAPITestCase(APITestCase):
         # gender M AND ALL residence Kinshasa
         response = self.client.get(
             "/api/entities/",
-            {"fields_search": self._generate_json_filter("and", "all", "M", "Kinshasa")},
+            {
+                "fields_search": self._generate_json_filter(
+                    "and", "all", "M", "Kinshasa"
+                )
+            },
         )
         self.assertEqual(len(response.json()["result"]), 0)
 
@@ -466,9 +520,8 @@ class EntityAPITestCase(APITestCase):
         self.client.force_authenticate(self.yoda)
 
         instance = Instance.objects.create(
-            org_unit=self.jedi_council_corruscant,
+            org_unit=self.ou_country,
             form=self.form_1,
-            period="202002",
         )
 
         payload = {
@@ -480,7 +533,9 @@ class EntityAPITestCase(APITestCase):
 
         self.client.post("/api/entities/", data=payload, format="json")
 
-        response = self.client.get(f"/api/entities/{Entity.objects.last().pk}/", format="json")
+        response = self.client.get(
+            f"/api/entities/{Entity.objects.last().pk}/", format="json"
+        )
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["id"], Entity.objects.last().pk)
@@ -503,7 +558,9 @@ class EntityAPITestCase(APITestCase):
         self.client.force_authenticate(self.yoda)
 
         instance = Instance.objects.create(
-            org_unit=self.jedi_council_corruscant, form=self.form_1, period="202002", uuid=uuid.uuid4()
+            org_unit=self.ou_country,
+            form=self.form_1,
+            uuid=uuid.uuid4(),
         )
 
         payload_post = {
@@ -515,9 +572,15 @@ class EntityAPITestCase(APITestCase):
 
         self.client.post("/api/entities/", data=payload_post, format="json")
 
-        payload = {"name": "New Client-2", "entity_type": self.entity_type.pk, "attributes": instance.pk}
+        payload = {
+            "name": "New Client-2",
+            "entity_type": self.entity_type.pk,
+            "attributes": instance.pk,
+        }
 
-        response = self.client.patch(f"/api/entities/{Entity.objects.last().pk}/", data=payload, format="json")
+        response = self.client.patch(
+            f"/api/entities/{Entity.objects.last().pk}/", data=payload, format="json"
+        )
 
         self.assertEqual(response.status_code, 200)
 
@@ -525,11 +588,15 @@ class EntityAPITestCase(APITestCase):
         self.client.force_authenticate(self.yoda)
 
         instance = Instance.objects.create(
-            org_unit=self.jedi_council_corruscant, form=self.form_1, period="202002", uuid=uuid.uuid4()
+            org_unit=self.ou_country,
+            form=self.form_1,
+            uuid=uuid.uuid4(),
         )
 
         second_instance = Instance.objects.create(
-            org_unit=self.jedi_council_corruscant, form=self.form_1, period="202002", uuid=uuid.uuid4()
+            org_unit=self.ou_country,
+            form=self.form_1,
+            uuid=uuid.uuid4(),
         )
 
         payload = (
@@ -572,15 +639,13 @@ class EntityAPITestCase(APITestCase):
         self.client.force_authenticate(self.yoda)
 
         instance = Instance.objects.create(
-            org_unit=self.jedi_council_corruscant,
+            org_unit=self.ou_country,
             form=self.form_1,
-            period="202002",
         )
 
         second_instance = Instance.objects.create(
-            org_unit=self.jedi_council_corruscant,
+            org_unit=self.ou_country,
             form=self.form_1,
-            period="202002",
         )
 
         Entity.objects.create(
@@ -602,81 +667,82 @@ class EntityAPITestCase(APITestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.json()["result"]), 1)
 
-    @mock.patch("iaso.api.entity.gmtime", lambda: time.struct_time((2021, 7, 18, 14, 57, 0, 1, 291, 0)))
-    def test_export_entity(self):
+    @mock.patch(
+        "iaso.api.entity.gmtime",
+        lambda: time.struct_time((2021, 7, 18, 14, 57, 0, 1, 291, 0)),
+    )
+    def test_export_entities(self):
         self.client.force_authenticate(self.yoda)
-        # entity_type = EntityType.objects.create(
-        #     name="Type 1",
-        #     reference_form=self.form_1,
-        #     fields_detail_info_view=["something", "else"],
-        #     fields_list_view=["something", "else"],
-        # )
 
-        instance = Instance.objects.create(
-            org_unit=self.jedi_council_corruscant,
-            form=self.form_1,
-            period="202002",
-        )
-
-        second_instance = Instance.objects.create(
-            org_unit=self.jedi_council_corruscant,
-            form=self.form_1,
-            period="202002",
-        )
-
-        Entity.objects.create(
-            name="New Client",
+        instance = Instance.objects.create(org_unit=self.ou_country, form=self.form_1)
+        entity = Entity.objects.create(
             entity_type=self.entity_type,
             attributes=instance,
-            account=self.yop_solo.iaso_profile.account,
-        )
-
-        Entity.objects.create(
-            name="New Client",
-            entity_type=self.entity_type,
-            attributes=second_instance,
             account=self.yoda.iaso_profile.account,
         )
 
         # export all entities type as csv
         response = self.client.get("/api/entities/?csv=true/")
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.get("Content-Disposition"), "attachment; filename=entities-2021-07-18-14-57.csv")
+        self.assertEqual(
+            response.get("Content-Disposition"),
+            "attachment; filename=entities-2021-07-18-14-57.csv",
+        )
 
         # export all entities type as xlsx
         response = self.client.get("/api/entities/?xlsx=true/")
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.get("Content-Disposition"), "attachment; filename=entities-2021-07-18-14-57.xlsx")
+        self.assertEqual(
+            response.get("Content-Disposition"),
+            "attachment; filename=entities-2021-07-18-14-57.xlsx",
+        )
 
         # export specific entity type as xlsx
-        response = self.client.get(f"/api/entities/?entity_type_ids={self.entity_type.pk}&xlsx=true/")
+        response = self.client.get(
+            f"/api/entities/?entity_type_ids={self.entity_type.pk}&xlsx=true/"
+        )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.get("Content-Disposition"), "attachment; filename=entities-2021-07-18-14-57.xlsx")
+        self.assertEqual(
+            response.get("Content-Disposition"),
+            "attachment; filename=entities-2021-07-18-14-57.xlsx",
+        )
 
         # export specific entity type as csv
-        response = self.client.get(f"/api/entities/?entity_type_ids={self.entity_type.pk}&csv=true/")
+        response = self.client.get(
+            f"/api/entities/?entity_type_ids={self.entity_type.pk}&csv=true/"
+        )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.get("Content-Disposition"), "attachment; filename=entities-2021-07-18-14-57.csv")
+        self.assertEqual(
+            response.get("Content-Disposition"),
+            "attachment; filename=entities-2021-07-18-14-57.csv",
+        )
 
-        # TODO: we should also check the content of the files
+        # Check the contents of the last CSV file
+        response_csv = response.getvalue().decode("utf-8")
+        response_string = "".join(s for s in response_csv)
+        data = list(csv.reader(io.StringIO(response_string), delimiter=","))
+        row_to_test = data[len(data) - 1]
+
+        expected_row = [
+            str(entity.id),
+            str(entity.uuid),
+            entity.entity_type.name,
+            entity.created_at.strftime(EXPORTS_DATETIME_FORMAT),
+            instance.org_unit.name,
+            str(instance.org_unit.id),
+            "",
+        ]
+        self.assertEqual(row_to_test, expected_row)
 
     def test_handle_export_entity_type_empty_field_list(self):
         self.client.force_authenticate(self.yoda)
 
-        instance = Instance.objects.create(
-            org_unit=self.jedi_council_corruscant,
-            form=self.form_1,
-            period="202002",
-        )
-
+        instance = Instance.objects.create(org_unit=self.ou_country, form=self.form_1)
         entity = Entity.objects.create(
-            name="New Client",
             entity_type=self.entity_type,
             account=self.yop_solo.iaso_profile.account,
         )
-
         entity.attributes = instance
-
         entity.save()
 
         response = self.client.get("/api/entities/?xlsx=true/")
@@ -685,20 +751,17 @@ class EntityAPITestCase(APITestCase):
     def test_entity_mobile(self):
         self.client.force_authenticate(self.yoda)
 
-        self.yoda.iaso_profile.org_units.set([self.jedi_council_corruscant])
+        self.yoda.iaso_profile.org_units.set([self.ou_country])
 
         self.form_1.form_id = "A_FORM_ID"
-
         self.form_1.json = {"_version": "A_FORM_ID"}
-
         self.form_1.save()
 
         FormVersion.objects.create(form=self.form_1, version_id="A_FORM_ID")
 
         instance = Instance.objects.create(
-            org_unit=self.jedi_council_corruscant,
+            org_unit=self.ou_country,
             form=self.form_1,
-            period="202002",
             project=self.project,
             uuid="9335359a-9f80-422d-997a-68ae7e39d9g3",
         )
@@ -712,11 +775,12 @@ class EntityAPITestCase(APITestCase):
             attributes=instance,
             account=self.yoda.iaso_profile.account,
         )
-
         instance.entity = entity
         instance.save()
 
-        response = self.client.get(f"/api/mobile/entities/?app_id={self.project.app_id}")
+        response = self.client.get(
+            f"/api/mobile/entities/?app_id={self.project.app_id}"
+        )
 
         data = response.json().get("results")[0]
 
@@ -724,7 +788,9 @@ class EntityAPITestCase(APITestCase):
         self.assertEqual(data.get("id"), str(entity.uuid))
         self.assertEqual(data.get("defining_instance_id"), str(instance.uuid))
 
-        response = self.client.get(f"/api/mobile/entities/{entity.uuid}/?app_id={self.project.app_id}")
+        response = self.client.get(
+            f"/api/mobile/entities/{entity.uuid}/?app_id={self.project.app_id}"
+        )
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(data.get("id"), str(entity.uuid))
@@ -733,18 +799,15 @@ class EntityAPITestCase(APITestCase):
         self.client.force_authenticate(self.yoda)
 
         self.form_1.form_id = "A_FORM_ID"
-
         self.form_1.json = {"_version": "A_FORM_ID"}
         self.form_1.projects.add(self.project)
-
         self.form_1.save()
 
         FormVersion.objects.create(form=self.form_1, version_id="A_FORM_ID")
 
         instance = Instance.objects.create(
-            org_unit=self.jedi_council_corruscant,
+            org_unit=self.ou_country,
             form=self.form_1,
-            period="202002",
             project=self.project,
             uuid="9335359a-9f80-422d-997a-68ae7e39d9g3",
         )
@@ -762,9 +825,8 @@ class EntityAPITestCase(APITestCase):
         instance.save()
 
         instance2 = Instance.objects.create(
-            org_unit=self.jedi_council_corruscant,
+            org_unit=self.ou_country,
             form=self.form_1,
-            period="202002",
             project=self.project,
             uuid="9335359a-9f80-422d-997a-68ae7e39d9g6",
         )
@@ -782,13 +844,14 @@ class EntityAPITestCase(APITestCase):
         instance2.save()
 
         instance_unvalidated_ou = Instance.objects.create(
-            org_unit=self.jedi_council_corruscant_unvalidated,
+            org_unit=self.ou_country_unvalidated,
             form=self.form_1,
-            period="202002",
             project=self.project,
             uuid="9335359a-9f80-422d-997a-68ae7e39d9g4",
         )
-        instance_unvalidated_ou.file = File(open("iaso/tests/fixtures/test_entity_data2.xml", "rb"))
+        instance_unvalidated_ou.file = File(
+            open("iaso/tests/fixtures/test_entity_data2.xml", "rb")
+        )
         instance_unvalidated_ou.json = {
             "name": "Prince of Euphor",
             "father_name": "Professor Procyon",
@@ -802,13 +865,14 @@ class EntityAPITestCase(APITestCase):
         instance_unvalidated_ou.save()
 
         instance_entity_no_attributes = Instance.objects.create(
-            org_unit=self.jedi_council_corruscant,
+            org_unit=self.ou_country,
             form=self.form_1,
-            period="202002",
             project=self.project,
             uuid="9335359a-9f80-422d-997a-68ae7e39d9g5",
         )
-        instance_entity_no_attributes.file = File(open("iaso/tests/fixtures/test_entity_data2.xml", "rb"))
+        instance_entity_no_attributes.file = File(
+            open("iaso/tests/fixtures/test_entity_data2.xml", "rb")
+        )
         instance_entity_no_attributes.json = {
             "name": "Prince of Euphor",
             "father_name": "Professor Procyon",
@@ -821,7 +885,9 @@ class EntityAPITestCase(APITestCase):
         }
         instance_entity_no_attributes.save()
 
-        self.form_1.instances.set([instance, instance_unvalidated_ou, instance_entity_no_attributes])
+        self.form_1.instances.set(
+            [instance, instance_unvalidated_ou, instance_entity_no_attributes]
+        )
         self.form_1.save()
 
         entity = Entity.objects.create(
@@ -855,15 +921,23 @@ class EntityAPITestCase(APITestCase):
         instance_entity_no_attributes.entity = entity_no_attributes
         instance_entity_no_attributes.save()
 
-        response = self.client.get(f"/api/mobile/entities/?app_id={self.project.app_id}")
+        response = self.client.get(
+            f"/api/mobile/entities/?app_id={self.project.app_id}"
+        )
 
         response_json = response.json()
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response_json.get("count"), 2)
-        self.assertEqual(response_json.get("results")[0].get("entity_type_id"), str(self.entity_type.id))
+        self.assertEqual(
+            response_json.get("results")[0].get("entity_type_id"),
+            str(self.entity_type.id),
+        )
         self.assertEqual(len(response_json.get("results")[0].get("instances")), 1)
-        self.assertEqual(response_json.get("results")[1].get("entity_type_id"), str(self.entity_type.id))
+        self.assertEqual(
+            response_json.get("results")[1].get("entity_type_id"),
+            str(self.entity_type.id),
+        )
         self.assertEqual(len(response_json.get("results")[1].get("instances")), 0)
 
     def test_access_respect_appid_mobile(self):
@@ -871,8 +945,10 @@ class EntityAPITestCase(APITestCase):
 
         app_id = "APP_ID"
 
-        project = Project.objects.create(name="Project 1", app_id=app_id, account=self.star_wars)
-        project.account = self.star_wars
+        project = Project.objects.create(
+            name="Project 1", app_id=app_id, account=self.account
+        )
+        project.account = self.account
         project.save()
 
         self.form_1.projects.add(project)
@@ -880,13 +956,14 @@ class EntityAPITestCase(APITestCase):
         # we should return only the entities whose instaces/attributes are linked to this project.
 
         instance_app_id = Instance.objects.create(
-            org_unit=self.jedi_council_corruscant,
+            org_unit=self.ou_country,
             form=self.form_1,
-            period="202002",
             project=project,
             uuid="9335359a-9f80-422d-997a-68ae7e39d9g3",
         )
-        instance_app_id.file = File(open("iaso/tests/fixtures/test_entity_data2.xml", "rb"))
+        instance_app_id.file = File(
+            open("iaso/tests/fixtures/test_entity_data2.xml", "rb")
+        )
         instance_app_id.json = {
             "name": "Prince of Euphor",
             "father_name": "Professor Procyon",
@@ -909,7 +986,9 @@ class EntityAPITestCase(APITestCase):
         instance_app_id.entity = entity_app_id
         instance_app_id.save()
 
-        FormVersion.objects.create(version_id="2022090602", form_id=instance_app_id.form.id)
+        FormVersion.objects.create(
+            version_id="2022090602", form_id=instance_app_id.form.id
+        )
 
         self.form_1.instances.add(instance_app_id)
         self.form_1.save()
@@ -919,7 +998,9 @@ class EntityAPITestCase(APITestCase):
         response_json = response.json()
 
         self.assertEqual(response_json["count"], 1)
-        self.assertEqual(response_json["results"][0]["entity_type_id"], str(self.entity_type.id))
+        self.assertEqual(
+            response_json["results"][0]["entity_type_id"], str(self.entity_type.id)
+        )
 
         response_entity_instance = response_json["results"][0]["instances"]
 
@@ -927,26 +1008,48 @@ class EntityAPITestCase(APITestCase):
         self.assertEqual(response_entity_instance[0]["json"], instance_app_id.json)
 
     def test_retrieve_entities_user_geo_restrictions(self):
-        version = self.star_wars.default_version
-        province_type = m.OrgUnitType.objects.create(name="Province", short_name="province", depth=1)
-        district_type = m.OrgUnitType.objects.create(name="District", short_name="district", depth=2)
-        village_type = m.OrgUnitType.objects.create(name="Village", short_name="village", depth=3)
-        province = m.OrgUnit.objects.create(name="Province", org_unit_type=province_type, version=version)
+        version = self.account.default_version
+        province_type = m.OrgUnitType.objects.create(
+            name="Province", short_name="province", depth=1
+        )
+        district_type = m.OrgUnitType.objects.create(
+            name="District", short_name="district", depth=2
+        )
+        village_type = m.OrgUnitType.objects.create(
+            name="Village", short_name="village", depth=3
+        )
+        province = m.OrgUnit.objects.create(
+            name="Province", org_unit_type=province_type, version=version
+        )
         district_1 = m.OrgUnit.objects.create(
-            name="District 1", org_unit_type=district_type, version=version, parent=province
+            name="District 1",
+            org_unit_type=district_type,
+            version=version,
+            parent=province,
         )
         village_1 = m.OrgUnit.objects.create(
-            name="Village 1", org_unit_type=village_type, version=version, parent=district_1
+            name="Village 1",
+            org_unit_type=village_type,
+            version=version,
+            parent=district_1,
         )
         district_2 = m.OrgUnit.objects.create(
-            name="District 2", org_unit_type=district_type, version=version, parent=province
+            name="District 2",
+            org_unit_type=district_type,
+            version=version,
+            parent=province,
         )
         village_2 = m.OrgUnit.objects.create(
-            name="Village 2", org_unit_type=village_type, version=version, parent=district_2
+            name="Village 2",
+            org_unit_type=village_type,
+            version=version,
+            parent=district_2,
         )
 
         user_manager = self.create_user_with_profile(
-            username="userManager", account=self.star_wars, permissions=["iaso_entities"]
+            username="userManager",
+            account=self.account,
+            permissions=["iaso_entities"],
         )
         user_manager.iaso_profile.org_units.set([district_1])
         user_manager.save()
@@ -954,14 +1057,18 @@ class EntityAPITestCase(APITestCase):
         self.client.force_authenticate(user_manager)
 
         # Village 1 (district 1): instance + entity
-        instance_1 = Instance.objects.create(org_unit=village_1, form=self.form_1, period="202002")
-        entity = Entity.objects.create(entity_type=self.entity_type, attributes=instance_1, account=self.star_wars)
+        instance_1 = Instance.objects.create(org_unit=village_1, form=self.form_1)
+        entity = Entity.objects.create(
+            entity_type=self.entity_type, attributes=instance_1, account=self.account
+        )
         instance_1.entity = entity
         instance_1.save()
 
         # Village 2 (district 2): instance + entity
-        instance_2 = Instance.objects.create(org_unit=village_2, form=self.form_1, period="202002")
-        entity_2 = Entity.objects.create(entity_type=self.entity_type, attributes=instance_2, account=self.star_wars)
+        instance_2 = Instance.objects.create(org_unit=village_2, form=self.form_1)
+        entity_2 = Entity.objects.create(
+            entity_type=self.entity_type, attributes=instance_2, account=self.account
+        )
         instance_2.entity = entity_2
         instance_2.save()
 
@@ -983,28 +1090,38 @@ class EntityAPITestCase(APITestCase):
         self.form_2 = m.Form.objects.create(name="Form 2", form_id="form_2")
 
         # Create Entity with ref instance
-        ent_ref_instance = Instance.objects.create(org_unit=self.jedi_council_corruscant, form=self.form_1)
+        ent_ref_instance = Instance.objects.create(
+            org_unit=self.ou_country, form=self.form_1
+        )
         ent = Entity.objects.create(
             entity_type=self.entity_type,
             attributes=ent_ref_instance,
-            account=self.star_wars,
+            account=self.account,
         )
         ent_ref_instance.entity = ent
         ent_ref_instance.save()
 
         # Add two more instances to the entity
-        inst1 = Instance.objects.create(org_unit=self.jedi_council_corruscant, form=self.form_2, entity=ent)
-        inst2 = Instance.objects.create(org_unit=self.jedi_council_corruscant, form=self.form_2, entity=ent)
+        inst1 = Instance.objects.create(
+            org_unit=self.ou_country, form=self.form_2, entity=ent
+        )
+        inst2 = Instance.objects.create(
+            org_unit=self.ou_country, form=self.form_2, entity=ent
+        )
 
         # Create duplicate pairs for the entity: a PENDING and a VALIDATED one
         m.EntityDuplicate.objects.create(
             entity1=ent,
-            entity2=Entity.objects.create(entity_type=self.entity_type, account=self.star_wars),
+            entity2=Entity.objects.create(
+                entity_type=self.entity_type, account=self.account
+            ),
             validation_status=ValidationStatus.PENDING,
         )
         m.EntityDuplicate.objects.create(
             entity1=ent,
-            entity2=Entity.objects.create(entity_type=self.entity_type, account=self.star_wars),
+            entity2=Entity.objects.create(
+                entity_type=self.entity_type, account=self.account
+            ),
             validation_status=ValidationStatus.VALIDATED,
         )
         self.assertEqual(m.EntityDuplicate.objects.count(), 2)

--- a/iaso/tests/api/test_entities.py
+++ b/iaso/tests/api/test_entities.py
@@ -1,5 +1,5 @@
-import datetime
 import csv
+import datetime
 import io
 import json
 import time
@@ -32,32 +32,21 @@ class EntityAPITestCase(APITestCase):
 
         cls.anon = AnonymousUser()
 
-        cls.project = m.Project.objects.create(
-            name="Project", app_id="project", account=cls.account
-        )
+        cls.project = m.Project.objects.create(name="Project", app_id="project", account=cls.account)
 
         cls.yop_solo = cls.create_user_with_profile(
-            username="yop solo",
-            account=m.Account.objects.create(name="Account 2"),
-            permissions=["iaso_entities"],
+            username="yop solo", account=m.Account.objects.create(name="Account 2"), permissions=["iaso_entities"]
         )
 
         cls.ou_country = m.OrgUnit.objects.create(
-            name="Burkina Faso (validated)",
-            validation_status=m.OrgUnit.VALIDATION_VALID,
+            name="Burkina Faso (validated)", validation_status=m.OrgUnit.VALIDATION_VALID
         )
-        cls.ou_country_unvalidated = m.OrgUnit.objects.create(
-            name="Burkina Faso (unvalidated)"
-        )
+        cls.ou_country_unvalidated = m.OrgUnit.objects.create(name="Burkina Faso (unvalidated)")
 
-        cls.yoda = cls.create_user_with_profile(
-            username="yoda", account=cls.account, permissions=["iaso_entities"]
-        )
+        cls.yoda = cls.create_user_with_profile(username="yoda", account=cls.account, permissions=["iaso_entities"])
 
         cls.user_without_ou = cls.create_user_with_profile(
-            username="user_without_ou",
-            account=cls.account,
-            permissions=["iaso_entities"],
+            username="user_without_ou", account=cls.account, permissions=["iaso_entities"]
         )
 
         cls.form_1 = m.Form.objects.create(
@@ -67,38 +56,14 @@ class EntityAPITestCase(APITestCase):
             form_id="form_1",
         )
 
-        cls.create_form_instance(
-            form=cls.form_1,
-            org_unit=cls.ou_country,
-            project=cls.project,
-            uuid=uuid.uuid4,
-        )
-        cls.create_form_instance(
-            form=cls.form_1,
-            org_unit=cls.ou_country,
-            project=cls.project,
-            uuid=uuid.uuid4,
-        )
-        cls.create_form_instance(
-            form=cls.form_1,
-            org_unit=cls.ou_country,
-            project=cls.project,
-            uuid=uuid.uuid4,
-        )
-        cls.create_form_instance(
-            form=cls.form_1,
-            org_unit=cls.ou_country,
-            project=cls.project,
-            uuid=uuid.uuid4,
-        )
+        cls.create_form_instance(form=cls.form_1, org_unit=cls.ou_country, project=cls.project, uuid=uuid.uuid4)
+        cls.create_form_instance(form=cls.form_1, org_unit=cls.ou_country, project=cls.project, uuid=uuid.uuid4)
+        cls.create_form_instance(form=cls.form_1, org_unit=cls.ou_country, project=cls.project, uuid=uuid.uuid4)
+        cls.create_form_instance(form=cls.form_1, org_unit=cls.ou_country, project=cls.project, uuid=uuid.uuid4)
 
         cls.form_1.projects.add(cls.project)
 
-        cls.entity_type = EntityType.objects.create(
-            name="Type 1",
-            reference_form=cls.form_1,
-            account=cls.account,
-        )
+        cls.entity_type = EntityType.objects.create(name="Type 1", reference_form=cls.form_1, account=cls.account)
 
     def test_create_single_entity(self):
         self.client.force_authenticate(self.yoda)
@@ -119,13 +84,9 @@ class EntityAPITestCase(APITestCase):
     def test_create_multiples_entity(self):
         self.client.force_authenticate(self.yoda)
 
-        instance = Instance.objects.create(
-            org_unit=self.ou_country, form=self.form_1, uuid=uuid.uuid4()
-        )
+        instance = Instance.objects.create(org_unit=self.ou_country, form=self.form_1, uuid=uuid.uuid4())
 
-        second_instance = Instance.objects.create(
-            org_unit=self.ou_country, form=self.form_1, uuid=uuid.uuid4()
-        )
+        second_instance = Instance.objects.create(org_unit=self.ou_country, form=self.form_1, uuid=uuid.uuid4())
 
         payload = (
             {
@@ -142,9 +103,7 @@ class EntityAPITestCase(APITestCase):
             },
         )
 
-        response = self.client.post(
-            "/api/entities/bulk_create/", data=payload, format="json"
-        )
+        response = self.client.post("/api/entities/bulk_create/", data=payload, format="json")
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.json()), 2)
@@ -152,9 +111,7 @@ class EntityAPITestCase(APITestCase):
     def test_create_entity_same_attributes(self):
         self.client.force_authenticate(self.yoda)
 
-        instance = Instance.objects.create(
-            org_unit=self.ou_country, form=self.form_1, uuid=uuid.uuid4()
-        )
+        instance = Instance.objects.create(org_unit=self.ou_country, form=self.form_1, uuid=uuid.uuid4())
 
         payload = (
             {
@@ -171,22 +128,16 @@ class EntityAPITestCase(APITestCase):
             },
         )
 
-        response = self.client.post(
-            "/api/entities/bulk_create/", data=payload, format="json"
-        )
+        response = self.client.post("/api/entities/bulk_create/", data=payload, format="json")
 
         self.assertEqual(response.status_code, 400)
 
     def test_retrieve_entity(self):
         self.client.force_authenticate(self.yoda)
 
-        instance = Instance.objects.create(
-            org_unit=self.ou_country, form=self.form_1, uuid=uuid.uuid4()
-        )
+        instance = Instance.objects.create(org_unit=self.ou_country, form=self.form_1, uuid=uuid.uuid4())
 
-        second_instance = Instance.objects.create(
-            org_unit=self.ou_country, form=self.form_1, uuid=uuid.uuid4()
-        )
+        second_instance = Instance.objects.create(org_unit=self.ou_country, form=self.form_1, uuid=uuid.uuid4())
 
         payload = (
             {
@@ -213,13 +164,9 @@ class EntityAPITestCase(APITestCase):
     def test_retrieve_entity_without_attributes(self):
         self.client.force_authenticate(self.yoda)
 
-        instance = Instance.objects.create(
-            org_unit=self.ou_country, form=self.form_1, uuid=uuid.uuid4()
-        )
+        instance = Instance.objects.create(org_unit=self.ou_country, form=self.form_1, uuid=uuid.uuid4())
 
-        second_instance = Instance.objects.create(
-            org_unit=self.ou_country, form=self.form_1, uuid=uuid.uuid4()
-        )
+        second_instance = Instance.objects.create(org_unit=self.ou_country, form=self.form_1, uuid=uuid.uuid4())
 
         payload = (
             {
@@ -251,9 +198,7 @@ class EntityAPITestCase(APITestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.json()["result"]), 3)
 
-        response = self.client.get(
-            f"/api/entities/?entity_type_id={self.entity_type.pk}", format="json"
-        )
+        response = self.client.get(f"/api/entities/?entity_type_id={self.entity_type.pk}", format="json")
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.json()["result"]), 3)
@@ -300,9 +245,7 @@ class EntityAPITestCase(APITestCase):
         self.assertEqual(the_result["id"], newly_added_entity.id)
 
         # Case 3: search by entity UUID
-        response = self.client.get(
-            f"/api/entities/?search={newly_added_entity.uuid}", format="json"
-        )
+        response = self.client.get(f"/api/entities/?search={newly_added_entity.uuid}", format="json")
         self.assertEqual(len(response.json()["result"]), 1)
         self.assertEqual(the_result["id"], newly_added_entity.id)
 
@@ -332,32 +275,24 @@ class EntityAPITestCase(APITestCase):
 
         # Create 2 entities: one on date1, one on date2
         instance1 = Instance.objects.create(form=self.form_1, source_created_at=date1)
-        entity1 = Entity.objects.create(
-            entity_type=entity_type, attributes=instance1, account=self.account
-        )
+        entity1 = Entity.objects.create(entity_type=entity_type, attributes=instance1, account=self.account)
         instance1.entity = entity1
         instance1.save()
 
         instance2 = Instance.objects.create(form=self.form_1, source_created_at=date2)
-        entity2 = Entity.objects.create(
-            entity_type=entity_type, attributes=instance2, account=self.account
-        )
+        entity2 = Entity.objects.create(entity_type=entity_type, attributes=instance2, account=self.account)
         instance2.entity = entity2
         instance2.save()
 
         # Search on specific date
-        response = self.client.get(
-            f"/api/entities/?dateFrom={date1_str}&dateTo={date1_str}"
-        )
+        response = self.client.get(f"/api/entities/?dateFrom={date1_str}&dateTo={date1_str}")
         self.assertEqual(len(response.json()["result"]), 1)
         results = response.json()["result"]
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0]["id"], entity1.id)
 
         # Search on date range
-        response = self.client.get(
-            f"/api/entities/?dateFrom={date1_str}&dateTo={date2_str}"
-        )
+        response = self.client.get(f"/api/entities/?dateFrom={date1_str}&dateTo={date2_str}")
         results = response.json()["result"]
         self.assertEqual(len(results), 2)
         self.assertEqual([r["id"] for r in results], [entity1.id, entity2.id])
@@ -438,11 +373,7 @@ class EntityAPITestCase(APITestCase):
         # gender f AND SOME residence Bujumbura
         response = self.client.get(
             "/api/entities/",
-            {
-                "fields_search": self._generate_json_filter(
-                    "and", "some", "F", "Bujumbura"
-                )
-            },
+            {"fields_search": self._generate_json_filter("and", "some", "F", "Bujumbura")},
         )
         self.assertEqual(len(response.json()["result"]), 1)
         the_result = response.json()["result"][0]
@@ -451,22 +382,14 @@ class EntityAPITestCase(APITestCase):
         # gender m AND SOME residence Bujumbura
         response = self.client.get(
             "/api/entities/",
-            {
-                "fields_search": self._generate_json_filter(
-                    "and", "some", "M", "Bujumbura"
-                )
-            },
+            {"fields_search": self._generate_json_filter("and", "some", "M", "Bujumbura")},
         )
         self.assertEqual(len(response.json()["result"]), 0)
 
         # gender f OR SOME residence Kinshasa
         response = self.client.get(
             "/api/entities/",
-            {
-                "fields_search": self._generate_json_filter(
-                    "or", "some", "F", "Kinshasa"
-                )
-            },
+            {"fields_search": self._generate_json_filter("or", "some", "F", "Kinshasa")},
         )
         self.assertEqual(len(response.json()["result"]), 2)
         result_ids = [r["id"] for r in response.json()["result"]]
@@ -475,11 +398,7 @@ class EntityAPITestCase(APITestCase):
         # gender m AND SOME residence Kinshasa
         response = self.client.get(
             "/api/entities/",
-            {
-                "fields_search": self._generate_json_filter(
-                    "and", "some", "M", "Kinshasa"
-                )
-            },
+            {"fields_search": self._generate_json_filter("and", "some", "M", "Kinshasa")},
         )
         self.assertEqual(len(response.json()["result"]), 1)
         the_result = response.json()["result"][0]
@@ -488,11 +407,7 @@ class EntityAPITestCase(APITestCase):
         # gender M AND ALL residence Kinshasa
         response = self.client.get(
             "/api/entities/",
-            {
-                "fields_search": self._generate_json_filter(
-                    "and", "all", "M", "Kinshasa"
-                )
-            },
+            {"fields_search": self._generate_json_filter("and", "all", "M", "Kinshasa")},
         )
         self.assertEqual(len(response.json()["result"]), 0)
 
@@ -533,9 +448,7 @@ class EntityAPITestCase(APITestCase):
 
         self.client.post("/api/entities/", data=payload, format="json")
 
-        response = self.client.get(
-            f"/api/entities/{Entity.objects.last().pk}/", format="json"
-        )
+        response = self.client.get(f"/api/entities/{Entity.objects.last().pk}/", format="json")
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["id"], Entity.objects.last().pk)
@@ -578,9 +491,7 @@ class EntityAPITestCase(APITestCase):
             "attributes": instance.pk,
         }
 
-        response = self.client.patch(
-            f"/api/entities/{Entity.objects.last().pk}/", data=payload, format="json"
-        )
+        response = self.client.patch(f"/api/entities/{Entity.objects.last().pk}/", data=payload, format="json")
 
         self.assertEqual(response.status_code, 200)
 
@@ -638,15 +549,8 @@ class EntityAPITestCase(APITestCase):
     def test_retrieve_entity_only_same_account(self):
         self.client.force_authenticate(self.yoda)
 
-        instance = Instance.objects.create(
-            org_unit=self.ou_country,
-            form=self.form_1,
-        )
-
-        second_instance = Instance.objects.create(
-            org_unit=self.ou_country,
-            form=self.form_1,
-        )
+        instance = Instance.objects.create(org_unit=self.ou_country, form=self.form_1)
+        second_instance = Instance.objects.create(org_unit=self.ou_country, form=self.form_1)
 
         Entity.objects.create(
             name="New Client",
@@ -654,7 +558,6 @@ class EntityAPITestCase(APITestCase):
             attributes=instance,
             account=self.yop_solo.iaso_profile.account,
         )
-
         Entity.objects.create(
             name="New Client",
             entity_type=self.entity_type,
@@ -684,38 +587,22 @@ class EntityAPITestCase(APITestCase):
         # export all entities type as csv
         response = self.client.get("/api/entities/?csv=true/")
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(
-            response.get("Content-Disposition"),
-            "attachment; filename=entities-2021-07-18-14-57.csv",
-        )
+        self.assertEqual(response.get("Content-Disposition"), "attachment; filename=entities-2021-07-18-14-57.csv")
 
         # export all entities type as xlsx
         response = self.client.get("/api/entities/?xlsx=true/")
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(
-            response.get("Content-Disposition"),
-            "attachment; filename=entities-2021-07-18-14-57.xlsx",
-        )
+        self.assertEqual(response.get("Content-Disposition"), "attachment; filename=entities-2021-07-18-14-57.xlsx")
 
         # export specific entity type as xlsx
-        response = self.client.get(
-            f"/api/entities/?entity_type_ids={self.entity_type.pk}&xlsx=true/"
-        )
+        response = self.client.get(f"/api/entities/?entity_type_ids={self.entity_type.pk}&xlsx=true/")
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(
-            response.get("Content-Disposition"),
-            "attachment; filename=entities-2021-07-18-14-57.xlsx",
-        )
+        self.assertEqual(response.get("Content-Disposition"), "attachment; filename=entities-2021-07-18-14-57.xlsx")
 
         # export specific entity type as csv
-        response = self.client.get(
-            f"/api/entities/?entity_type_ids={self.entity_type.pk}&csv=true/"
-        )
+        response = self.client.get(f"/api/entities/?entity_type_ids={self.entity_type.pk}&csv=true/")
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(
-            response.get("Content-Disposition"),
-            "attachment; filename=entities-2021-07-18-14-57.csv",
-        )
+        self.assertEqual(response.get("Content-Disposition"), "attachment; filename=entities-2021-07-18-14-57.csv")
 
         # Check the contents of the last CSV file
         response_csv = response.getvalue().decode("utf-8")
@@ -778,9 +665,7 @@ class EntityAPITestCase(APITestCase):
         instance.entity = entity
         instance.save()
 
-        response = self.client.get(
-            f"/api/mobile/entities/?app_id={self.project.app_id}"
-        )
+        response = self.client.get(f"/api/mobile/entities/?app_id={self.project.app_id}")
 
         data = response.json().get("results")[0]
 
@@ -788,9 +673,7 @@ class EntityAPITestCase(APITestCase):
         self.assertEqual(data.get("id"), str(entity.uuid))
         self.assertEqual(data.get("defining_instance_id"), str(instance.uuid))
 
-        response = self.client.get(
-            f"/api/mobile/entities/{entity.uuid}/?app_id={self.project.app_id}"
-        )
+        response = self.client.get(f"/api/mobile/entities/{entity.uuid}/?app_id={self.project.app_id}")
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(data.get("id"), str(entity.uuid))
@@ -849,9 +732,7 @@ class EntityAPITestCase(APITestCase):
             project=self.project,
             uuid="9335359a-9f80-422d-997a-68ae7e39d9g4",
         )
-        instance_unvalidated_ou.file = File(
-            open("iaso/tests/fixtures/test_entity_data2.xml", "rb")
-        )
+        instance_unvalidated_ou.file = File(open("iaso/tests/fixtures/test_entity_data2.xml", "rb"))
         instance_unvalidated_ou.json = {
             "name": "Prince of Euphor",
             "father_name": "Professor Procyon",
@@ -870,9 +751,7 @@ class EntityAPITestCase(APITestCase):
             project=self.project,
             uuid="9335359a-9f80-422d-997a-68ae7e39d9g5",
         )
-        instance_entity_no_attributes.file = File(
-            open("iaso/tests/fixtures/test_entity_data2.xml", "rb")
-        )
+        instance_entity_no_attributes.file = File(open("iaso/tests/fixtures/test_entity_data2.xml", "rb"))
         instance_entity_no_attributes.json = {
             "name": "Prince of Euphor",
             "father_name": "Professor Procyon",
@@ -885,9 +764,7 @@ class EntityAPITestCase(APITestCase):
         }
         instance_entity_no_attributes.save()
 
-        self.form_1.instances.set(
-            [instance, instance_unvalidated_ou, instance_entity_no_attributes]
-        )
+        self.form_1.instances.set([instance, instance_unvalidated_ou, instance_entity_no_attributes])
         self.form_1.save()
 
         entity = Entity.objects.create(
@@ -921,9 +798,7 @@ class EntityAPITestCase(APITestCase):
         instance_entity_no_attributes.entity = entity_no_attributes
         instance_entity_no_attributes.save()
 
-        response = self.client.get(
-            f"/api/mobile/entities/?app_id={self.project.app_id}"
-        )
+        response = self.client.get(f"/api/mobile/entities/?app_id={self.project.app_id}")
 
         response_json = response.json()
 
@@ -945,9 +820,7 @@ class EntityAPITestCase(APITestCase):
 
         app_id = "APP_ID"
 
-        project = Project.objects.create(
-            name="Project 1", app_id=app_id, account=self.account
-        )
+        project = Project.objects.create(name="Project 1", app_id=app_id, account=self.account)
         project.account = self.account
         project.save()
 
@@ -961,9 +834,7 @@ class EntityAPITestCase(APITestCase):
             project=project,
             uuid="9335359a-9f80-422d-997a-68ae7e39d9g3",
         )
-        instance_app_id.file = File(
-            open("iaso/tests/fixtures/test_entity_data2.xml", "rb")
-        )
+        instance_app_id.file = File(open("iaso/tests/fixtures/test_entity_data2.xml", "rb"))
         instance_app_id.json = {
             "name": "Prince of Euphor",
             "father_name": "Professor Procyon",
@@ -986,9 +857,7 @@ class EntityAPITestCase(APITestCase):
         instance_app_id.entity = entity_app_id
         instance_app_id.save()
 
-        FormVersion.objects.create(
-            version_id="2022090602", form_id=instance_app_id.form.id
-        )
+        FormVersion.objects.create(version_id="2022090602", form_id=instance_app_id.form.id)
 
         self.form_1.instances.add(instance_app_id)
         self.form_1.save()
@@ -998,9 +867,7 @@ class EntityAPITestCase(APITestCase):
         response_json = response.json()
 
         self.assertEqual(response_json["count"], 1)
-        self.assertEqual(
-            response_json["results"][0]["entity_type_id"], str(self.entity_type.id)
-        )
+        self.assertEqual(response_json["results"][0]["entity_type_id"], str(self.entity_type.id))
 
         response_entity_instance = response_json["results"][0]["instances"]
 
@@ -1009,18 +876,10 @@ class EntityAPITestCase(APITestCase):
 
     def test_retrieve_entities_user_geo_restrictions(self):
         version = self.account.default_version
-        province_type = m.OrgUnitType.objects.create(
-            name="Province", short_name="province", depth=1
-        )
-        district_type = m.OrgUnitType.objects.create(
-            name="District", short_name="district", depth=2
-        )
-        village_type = m.OrgUnitType.objects.create(
-            name="Village", short_name="village", depth=3
-        )
-        province = m.OrgUnit.objects.create(
-            name="Province", org_unit_type=province_type, version=version
-        )
+        province_type = m.OrgUnitType.objects.create(name="Province", short_name="province", depth=1)
+        district_type = m.OrgUnitType.objects.create(name="District", short_name="district", depth=2)
+        village_type = m.OrgUnitType.objects.create(name="Village", short_name="village", depth=3)
+        province = m.OrgUnit.objects.create(name="Province", org_unit_type=province_type, version=version)
         district_1 = m.OrgUnit.objects.create(
             name="District 1",
             org_unit_type=district_type,
@@ -1058,17 +917,13 @@ class EntityAPITestCase(APITestCase):
 
         # Village 1 (district 1): instance + entity
         instance_1 = Instance.objects.create(org_unit=village_1, form=self.form_1)
-        entity = Entity.objects.create(
-            entity_type=self.entity_type, attributes=instance_1, account=self.account
-        )
+        entity = Entity.objects.create(entity_type=self.entity_type, attributes=instance_1, account=self.account)
         instance_1.entity = entity
         instance_1.save()
 
         # Village 2 (district 2): instance + entity
         instance_2 = Instance.objects.create(org_unit=village_2, form=self.form_1)
-        entity_2 = Entity.objects.create(
-            entity_type=self.entity_type, attributes=instance_2, account=self.account
-        )
+        entity_2 = Entity.objects.create(entity_type=self.entity_type, attributes=instance_2, account=self.account)
         instance_2.entity = entity_2
         instance_2.save()
 
@@ -1090,9 +945,7 @@ class EntityAPITestCase(APITestCase):
         self.form_2 = m.Form.objects.create(name="Form 2", form_id="form_2")
 
         # Create Entity with ref instance
-        ent_ref_instance = Instance.objects.create(
-            org_unit=self.ou_country, form=self.form_1
-        )
+        ent_ref_instance = Instance.objects.create(org_unit=self.ou_country, form=self.form_1)
         ent = Entity.objects.create(
             entity_type=self.entity_type,
             attributes=ent_ref_instance,
@@ -1102,26 +955,18 @@ class EntityAPITestCase(APITestCase):
         ent_ref_instance.save()
 
         # Add two more instances to the entity
-        inst1 = Instance.objects.create(
-            org_unit=self.ou_country, form=self.form_2, entity=ent
-        )
-        inst2 = Instance.objects.create(
-            org_unit=self.ou_country, form=self.form_2, entity=ent
-        )
+        inst1 = Instance.objects.create(org_unit=self.ou_country, form=self.form_2, entity=ent)
+        inst2 = Instance.objects.create(org_unit=self.ou_country, form=self.form_2, entity=ent)
 
         # Create duplicate pairs for the entity: a PENDING and a VALIDATED one
         m.EntityDuplicate.objects.create(
             entity1=ent,
-            entity2=Entity.objects.create(
-                entity_type=self.entity_type, account=self.account
-            ),
+            entity2=Entity.objects.create(entity_type=self.entity_type, account=self.account),
             validation_status=ValidationStatus.PENDING,
         )
         m.EntityDuplicate.objects.create(
             entity1=ent,
-            entity2=Entity.objects.create(
-                entity_type=self.entity_type, account=self.account
-            ),
+            entity2=Entity.objects.create(entity_type=self.entity_type, account=self.account),
             validation_status=ValidationStatus.VALIDATED,
         )
         self.assertEqual(m.EntityDuplicate.objects.count(), 2)

--- a/iaso/tests/api/test_instances.py
+++ b/iaso/tests/api/test_instances.py
@@ -1054,7 +1054,8 @@ class InstancesAPITestCase(TaskAPITestCase):
             f"{self.instance_1.source_updated_at.strftime('%Y-%m-%d %H:%M:%S')},"
             "yoda (Yo Da),"
             "READY,"
-            ","
+            ","  # entity UUID
+            ","  # entity ID
             "Coruscant Jedi Council,"
             f"{self.jedi_council_corruscant.id},"
             "jedi_council_corruscant_ref,"
@@ -1070,6 +1071,11 @@ class InstancesAPITestCase(TaskAPITestCase):
         export_id = "TESTING"
         period = "200605"
         with patch("django.utils.timezone.now", lambda: new_date):
+            entity = m.Entity.objects.create(
+                uuid=uuid4(),
+                entity_type=m.EntityType.objects.create(account=self.star_wars),
+                account=self.star_wars,
+            )
             # Explicitly set source fields to None because the test helpers will set default values otherwise
             sourceless_instance = self.create_form_instance(
                 form=self.form_4,
@@ -1081,6 +1087,7 @@ class InstancesAPITestCase(TaskAPITestCase):
                 source_created_at=None,
                 source_updated_at=None,
                 json={"test": "test"},
+                entity=entity,
             )
 
         self.client.force_authenticate(self.yoda)
@@ -1106,7 +1113,8 @@ class InstancesAPITestCase(TaskAPITestCase):
             f"{sourceless_instance.updated_at.strftime('%Y-%m-%d %H:%M:%S')},"
             "yoda (Yo Da),"
             "READY,"
-            ","
+            ","  # entity UUID
+            ","  # entity ID
             "Coruscant Jedi Council,"
             f"{self.jedi_council_corruscant.id},"
             "jedi_council_corruscant_ref,"

--- a/iaso/tests/api/test_instances.py
+++ b/iaso/tests/api/test_instances.py
@@ -1053,6 +1053,7 @@ class InstancesAPITestCase(TaskAPITestCase):
             f"{self.instance_1.source_created_at.strftime('%Y-%m-%d %H:%M:%S')},"
             f"{self.instance_1.source_updated_at.strftime('%Y-%m-%d %H:%M:%S')},"
             "yoda (Yo Da),"
+            f"{self.instance_1.created_by_id},"
             "READY,"
             ","  # entity UUID
             ","  # entity ID
@@ -1112,9 +1113,10 @@ class InstancesAPITestCase(TaskAPITestCase):
             f"{sourceless_instance.created_at.strftime('%Y-%m-%d %H:%M:%S')},"
             f"{sourceless_instance.updated_at.strftime('%Y-%m-%d %H:%M:%S')},"
             "yoda (Yo Da),"
+            f"{self.instance_1.created_by_id},"
             "READY,"
-            ","  # entity UUID
-            ","  # entity ID
+            f"uuid:{sourceless_instance.entity.uuid},"
+            f"{sourceless_instance.entity.id},"
             "Coruscant Jedi Council,"
             f"{self.jedi_council_corruscant.id},"
             "jedi_council_corruscant_ref,"


### PR DESCRIPTION
PR based on a request from Claire + a few changes I needed for Trypelim (and that are relevant for Iaso)

- SLEEP-1520 Add created_by_id to instance CSV export
- SLEEP-1513 Add entity_id to instance CSV export
- Add org unit id to entities CSV/XLSX export
- New tests and refactoring (remove Star Wars references from `test_entities.py`)