### PR TITLE
IA-4022: Instance upload bug with same OrgUnit UUID

### DIFF
--- a/iaso/api/instances.py
+++ b/iaso/api/instances.py
@@ -805,7 +805,7 @@ def import_data(instances, user, app_id):
         if str(tentative_org_unit_id).isdigit():
             instance.org_unit_id = tentative_org_unit_id
         else:
-            org_unit = OrgUnit.objects.get(uuid=tentative_org_unit_id)
+            org_unit = OrgUnit.objects.get(uuid=tentative_org_unit_id, version_id=project.account.default_version_id)
             instance.org_unit = org_unit
 
         instance.form_id = instance_data.get("formId")

--- a/iaso/tests/api/test_instances.py
+++ b/iaso/tests/api/test_instances.py
@@ -22,13 +22,12 @@ from iaso import models as m
 from iaso.api import query_params as query
 from iaso.models import FormVersion, Instance, InstanceLock
 from iaso.models.microplanning import Planning, Team
-from iaso.test import APITestCase
-
+from iaso.tests.tasks.task_api_test_case import TaskAPITestCase
 
 MOCK_DATE = datetime.datetime(2020, 2, 2, 2, 2, 2, tzinfo=pytz.utc)
 
 
-class InstancesAPITestCase(APITestCase):
+class InstancesAPITestCase(TaskAPITestCase):
     @classmethod
     @mock.patch("django.utils.timezone.now", lambda: MOCK_DATE)
     def setUpTestData(cls):
@@ -55,11 +54,13 @@ class InstancesAPITestCase(APITestCase):
 
         cls.jedi_council = m.OrgUnitType.objects.create(name="Jedi Council", short_name="Cnc")
 
+        cls.jedi_council_corruscant_uuid = str(uuid4())
         cls.jedi_council_corruscant = m.OrgUnit.objects.create(
             name="Coruscant Jedi Council",
             source_ref="jedi_council_corruscant_ref",
             version=sw_version,
             validation_status="VALID",
+            uuid=cls.jedi_council_corruscant_uuid,
         )
         cls.ou_top_1 = m.OrgUnit.objects.create(
             name="ou_top_1",
@@ -501,6 +502,60 @@ class InstancesAPITestCase(APITestCase):
         pre_existing_instance.refresh_from_db()
         self.assertEqual("RDC Collecte Data DPS_2_2019-08-08_11-54-46.xml", pre_existing_instance.file_name)
         self.assertEqual("Mobile app name", pre_existing_instance.name)
+
+    def test_instance_create_with_org_unit_in_multiple_source_versions(self):
+        """POST /api/instances/ an instance with an orgunit that has been copied in multiple source versions"""
+
+        # First, let's create a user that has permissions to do all of this
+        super_yoda = self.create_user_with_profile(account=self.star_wars, username="super yoda", permissions=["iaso_sources", "iaso_submissions", "iaso_org_units"])
+
+        # Then, let's copy the existing source version through an API call (couldn't call task directly)
+        self.client.force_authenticate(super_yoda)
+        response = self.client.post(
+            "/api/copyversion/",
+            data={
+                "source_source_id": self.sw_source.id,
+                "source_version_number": self.sw_version.number,
+                "destination_source_id": self.sw_source.id,
+                "destination_version_number": str(self.sw_version.number + 1),
+            },
+            format="json",
+        )
+        response_json = self.assertJSONResponse(response, status.HTTP_200_OK)
+        task = self.assertValidTaskAndInDB(response_json["task"], status="QUEUED", name="copy_version")
+        self.runAndValidateTask(task, "SUCCESS")
+
+        # Make sure that there are multiple orgunits with the same UUID
+        self.assertGreater(m.OrgUnit.objects.filter(uuid=self.jedi_council_corruscant_uuid).count(), 1)
+
+        # Now, let's create an instance with that orgunit
+        instance_uuid = str(uuid4())
+        instance_name = "Testing if multiple OrgUnit UUIDs still fail"
+        body = [
+            {
+                "id": instance_uuid,
+                "latitude": 4.4,
+                "created_at": 1565258153704,
+                "updated_at": 1565258153704,
+                "orgUnitId": self.jedi_council_corruscant.uuid,
+                "formId": self.form_1.id,
+                "longitude": 4.4,
+                "accuracy": 10,
+                "altitude": 100,
+                "file": "\/storage\/emulated\/0\/odk\/instances\/RDC Collecte Data DPS_2_2019-08-08_11-54-46\/RDC Collecte Data DPS_2_2019-08-08_11-54-46.xml",
+                "name": instance_name,
+            },
+        ]
+        response = self.client.post(
+            "/api/instances/?app_id=stars.empire.agriculture.hydroponics", data=body, format="json"
+        )
+        self.assertEqual(response.status_code, 200)
+
+        self.assertAPIImport("instance", request_body=body, has_problems=False)
+
+        last_instance = m.Instance.objects.order_by("-id").first()
+        self.assertEqual(last_instance.uuid, instance_uuid)
+        self.assertEqual(last_instance.name, instance_name)
 
     def test_instance_list_by_form_id_ok(self):
         """GET /instances/?form_id=form_id"""

--- a/iaso/tests/api/test_instances.py
+++ b/iaso/tests/api/test_instances.py
@@ -24,6 +24,7 @@ from iaso.models import FormVersion, Instance, InstanceLock
 from iaso.models.microplanning import Planning, Team
 from iaso.tests.tasks.task_api_test_case import TaskAPITestCase
 
+
 MOCK_DATE = datetime.datetime(2020, 2, 2, 2, 2, 2, tzinfo=pytz.utc)
 
 


### PR DESCRIPTION
Fix Instance upload bug when there are multiple OrgUnit with the same UUID.
This scenario typically happens when a SourceVersion is copied.

Related JIRA tickets : IA-4022

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

/

## Changes
/

## How to test

- Make sure that you have at least 2 OrgUnits that have the same UUID (through a copy of SourceVersion)
- Upload a new instance that uses the OrgUnit UUID
- Check if the upload was successful

## Print screen / video
/

## Notes

In the unit tests, I tried calling the function that copies source versions directly, but I couldn't make it work since it has to be triggered by a task. Instead, I made an API call that does it for me. It's a bit weird, but it works :man_shrugging: 

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
