### PR TITLE
POLIO-1866: show earmarked in summary

### DIFF
--- a/plugins/polio/api/vaccines/stock_management.py
+++ b/plugins/polio/api/vaccines/stock_management.py
@@ -1179,10 +1179,10 @@ class VaccineStockManagementViewSet(ModelViewSet):
             total_unusable_vials,
             total_unusable_doses,
         ) = calculator.get_total_of_unusable_vials()
-        # (
-        #     total_earmarked_vials,
-        #     total_earmarked_doses,
-        # ) = calculator.get_total_of_earmarked()
+        (
+            total_earmarked_vials,
+            total_earmarked_doses,
+        ) = calculator.get_total_of_earmarked()
 
         summary_data = {
             "country_id": vaccine_stock.country.id,
@@ -1191,8 +1191,8 @@ class VaccineStockManagementViewSet(ModelViewSet):
             "total_usable_vials": total_usable_vials,
             "total_unusable_vials": total_unusable_vials,
             "total_usable_doses": total_usable_doses,
-            # "total_earmarked_vials": total_earmarked_vials,
-            # "total_earmarked_doses": total_earmarked_doses,
+            "total_earmarked_vials": total_earmarked_vials,
+            "total_earmarked_doses": total_earmarked_doses,
             "total_unusable_doses": total_unusable_doses,
         }
 

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/Details/Summary/VaccineStockManagementSummary.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/Details/Summary/VaccineStockManagementSummary.tsx
@@ -62,7 +62,7 @@ export const VaccineStockManagementSummary: FunctionComponent<Props> = ({
                             isLoading={isLoading}
                         />
                     )}
-                    {/* <PaperTableRow
+                    <PaperTableRow
                         label={formatMessage(MESSAGES.earmarked_vials)}
                         value={data?.total_earmarked_vials}
                         isLoading={isLoading}
@@ -71,7 +71,7 @@ export const VaccineStockManagementSummary: FunctionComponent<Props> = ({
                         label={formatMessage(MESSAGES.earmarked_doses)}
                         value={data?.total_earmarked_doses}
                         isLoading={isLoading}
-                    /> */}
+                    />
                 </TableBody>
             </Table>
         </WidgetPaper>


### PR DESCRIPTION
Earmarked stock should be shown in summary

Related JIRA tickets : POLIO-1866

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [x] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

- uncomment relevant code

## How to test

Explain how to test your PR.

Go to a vaccine stock details

## Print screen / video

![Screenshot 2025-03-12 at 11 27 43](https://github.com/user-attachments/assets/bebf59f4-a440-423f-be72-894656e7e7a5)


## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
