### PR TITLE
IA-3998: Configuration OU type - Uppercase in search are not accepted

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6404,7 +6404,7 @@
         },
         "node_modules/bluesquare-components": {
             "version": "1.0.0",
-            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#7f94fd31bfd5b22f197b8a729e1a3cfa2de2656f",
+            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#855256c4f689d1c6e11ec0d8cc20973635841460",
             "dependencies": {
                 "@babel/plugin-transform-class-properties": "^7.24.6",
                 "@babel/plugin-transform-object-rest-spread": "^7.24.6",


### PR DESCRIPTION
While editing an org unit type in the dialog. Using uppercase letter in the search leads to strange behavior:

- the uppercase letter disappears after releasing `shift`
- impossible to use multi-selection while holding `shift` key

Related JIRA tickets : IA-3998

## Self proofreading checklist

- [ ] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)


## Changes

Handling of keyboard listener was not  doing his job correctly and triggering too many event for the same keyboard key

## How to test

Open ou type dialog to update existing type.
Make sure you have other OUT with a Uppercase letter at the beginning.
try to search for this OUT in the dropdown of sub OUT, uppercase letter should stay.
Try to hold shift key and make a multiselection

## Print screen / video

https://github.com/user-attachments/assets/87069273-a315-4f57-b206-b8e3914c185e

