### PR TITLE
fix: ProductFruits should not break on public pages

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/app/components/ProductFruits.tsx
+++ b/hat/assets/js/apps/Iaso/domains/app/components/ProductFruits.tsx
@@ -4,6 +4,11 @@ import { useCurrentUser } from '../../../utils/usersUtils';
 
 const ProductFruitsComponent = () => {
     const currentUser = useCurrentUser();
+
+    if (!window.PRODUCT_FRUITS_WORKSPACE_CODE || !currentUser) {
+        return null;
+    }
+
     const userInfo = useMemo(() => {
         return {
             username: `${currentUser.account.name}-${currentUser.id}`,
@@ -13,9 +18,7 @@ const ProductFruitsComponent = () => {
             },
         };
     }, [currentUser]);
-    if (!window.PRODUCT_FRUITS_WORKSPACE_CODE || !currentUser) {
-        return null;
-    }
+
     return (
         <ProductFruits
             workspaceCode={window.PRODUCT_FRUITS_WORKSPACE_CODE}


### PR DESCRIPTION
When `currentUser` is undefined, the component broke. The early return check should be higher up in the component.