### PR TITLE
[IA-4034] Workflow copy error - name too long

### DIFF
--- a/iaso/api/workflows/utils.py
+++ b/iaso/api/workflows/utils.py
@@ -5,6 +5,8 @@ from copy import deepcopy
 from django.shortcuts import get_object_or_404
 from rest_framework import serializers
 
+from iaso.models import WorkflowVersion
+
 
 def validate_version_id(version_id, user):
     from iaso.models import EntityType, WorkflowVersion
@@ -31,7 +33,11 @@ def make_deep_copy_with_relations(orig_version):
     new_version = deepcopy(orig_version)
     new_version.id = None
     new_version.uuid = uuid.uuid4()
-    new_version.name = "Copy of " + orig_version.name
+    new_name_prefix = "Copy of "
+    if len(new_name_prefix + orig_version.name) > WorkflowVersion.NAME_MAX_LENGTH:
+        new_version.name = f"Copy of version {orig_version.id}"
+    else:
+        new_version.name = new_name_prefix + orig_version.name
     new_version.status = WorkflowVersionsStatus.DRAFT
     new_version.save()
 

--- a/iaso/models/workflow.py
+++ b/iaso/models/workflow.py
@@ -95,12 +95,13 @@ class WorkflowVersion(SoftDeletableModel):
         changes -> WorkflowChange
         follow_ups -> WorkflowFollowup
     """
+    NAME_MAX_LENGTH = 50
 
     workflow = models.ForeignKey(Workflow, on_delete=models.CASCADE, related_name="workflow_versions")
 
     uuid = models.UUIDField(default=uuid.uuid4, unique=True)
 
-    name = models.CharField(max_length=50, default="No Name")
+    name = models.CharField(max_length=NAME_MAX_LENGTH, default="No Name")
     status = models.CharField(
         max_length=12,
         choices=WorkflowVersionsStatus.choices,

--- a/iaso/tests/api/workflows/test_workflows.py
+++ b/iaso/tests/api/workflows/test_workflows.py
@@ -202,6 +202,33 @@ class WorkflowsAPITestCase(BaseWorkflowsAPITestCase):
         except WorkflowVersion.DoesNotExist as ex:
             self.fail(msg=str(ex))
 
+    def test_new_version_from_copy_with_name_too_long(self):
+        self.client.force_authenticate(self.blue_adult_1)
+
+        self.workflow_version_et_adults_blue_with_followups_and_changes.name = "this is going to be a 50-character name = max size"
+        self.workflow_version_et_adults_blue_with_followups_and_changes.save()
+        self.workflow_version_et_adults_blue_with_followups_and_changes.refresh_from_db()
+
+        response = self.client.post(
+            f"{BASE_API}{self.workflow_version_et_adults_blue_with_followups_and_changes.pk}/copy/"
+        )
+
+        self.assertJSONResponse(response, 200)
+
+        try:
+            jsonschema.validate(instance=response.data, schema=post_answer_schema)
+        except jsonschema.exceptions.ValidationError as ex:
+            self.fail(msg=str(ex))
+
+        try:
+            w_version = WorkflowVersion.objects.get(pk=response.data["version_id"])
+
+            assert w_version.pk == response.data["version_id"]
+            assert w_version.name == f"Copy of version {self.workflow_version_et_adults_blue_with_followups_and_changes.id}"
+
+        except WorkflowVersion.DoesNotExist as ex:
+            self.fail(msg=str(ex))
+
     def test_version_search_by_name(self):
         self.client.force_authenticate(self.blue_adult_1)
 


### PR DESCRIPTION
Fixes a 500 error triggered by copying a workflow with a name that is too long.

Related JIRA tickets : IA-4034

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

/

## Changes

Changes the way copies are named if it exceeds the maximum length.

## How to test
- Have a workflow with a name of 45 to 50 characters
- Copy it
- Notice that there is no crash. Its name is different than the usual "Copy of <name of the previous workflow>"

## Print screen / video

/

## Notes

/

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
