### PR TITLE
Hotfix POLIO-1869: re-add earmarked stock to vaccine_stock list API

### DIFF
--- a/plugins/polio/api/vaccines/stock_management.py
+++ b/plugins/polio/api/vaccines/stock_management.py
@@ -568,7 +568,7 @@ class VaccineStockSerializer(serializers.ModelSerializer):
     stock_of_usable_vials = serializers.SerializerMethodField()
     stock_of_unusable_vials = serializers.SerializerMethodField()
     vials_destroyed = serializers.SerializerMethodField()
-    # stock_of_earmarked_vials = serializers.SerializerMethodField()
+    stock_of_earmarked_vials = serializers.SerializerMethodField()
 
     class Meta:
         model = VaccineStock
@@ -581,7 +581,7 @@ class VaccineStockSerializer(serializers.ModelSerializer):
             "vials_used",
             "stock_of_usable_vials",
             "stock_of_unusable_vials",
-            # "stock_of_earmarked_vials",
+            "stock_of_earmarked_vials",
             "vials_destroyed",
         ]
         list_serializer_class = VaccineStockListSerializer


### PR DESCRIPTION
removing a line in the API of vaccine stocks broke an OpenHexa pipeline


Related JIRA tickets :POLIO-1869

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

- re-added `stock_of_earmarked_vials` to the payload of `/api/polio/vaccine/vaccine_stock/`

## How to test

- Check the API response
- Check that the earmarked don't pop up in the front-end of vaccine stocks

## Notes

v1.255d

forked from v1.255c

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
