### PR TITLE
IA-4041 Fix a `ProgrammingError` exception in `/api/orgunits/`

### DIFF
--- a/iaso/api/org_units.py
+++ b/iaso/api/org_units.py
@@ -204,7 +204,8 @@ class OrgUnitViewSet(viewsets.ViewSet):
 
                 # Avoid a `SELECT DISTINCT ON expressions must match initial ORDER BY expressions` exception
                 # because `build_org_units_queryset()` can set `.distinct()` clauses.
-                queryset = queryset.distinct(*order)
+                if queryset.query.combinator != "union":  # `.distinct()` is not allowed with `.union()`.
+                    queryset = queryset.distinct(*order)
 
                 paginator = Paginator(queryset, limit)
                 page = paginator.page(1)

--- a/iaso/api/org_units.py
+++ b/iaso/api/org_units.py
@@ -201,6 +201,11 @@ class OrgUnitViewSet(viewsets.ViewSet):
                 return Response({"orgUnits": org_units})
             if as_location:
                 limit = int(limit)
+
+                # Avoid a `SELECT DISTINCT ON expressions must match initial ORDER BY expressions` exception
+                # because `build_org_units_queryset()` can set `.distinct()` clauses.
+                queryset = queryset.distinct(*order)
+
                 paginator = Paginator(queryset, limit)
                 page = paginator.page(1)
                 org_units = []

--- a/iaso/tests/api/test_orgunits.py
+++ b/iaso/tests/api/test_orgunits.py
@@ -533,6 +533,11 @@ class OrgUnitAPITestCase(APITestCase):
         for orgunit in response_data["orgUnits"]:
             self.assertEqual(orgunit["parent_id"], None)
 
+    def test_org_unit_list_with_as_location(self):
+        self.client.force_authenticate(self.yoda)
+        response = self.client.get("/api/orgunits/?asLocation=true&limit=1&group=1")
+        self.assertJSONResponse(response, 200)
+
     def test_org_unit_retrieve_without_auth_or_app_id(self):
         """GET /orgunits/<org_unit_id>/ without auth or app id should result in a 200 empty response"""
 


### PR DESCRIPTION
Fix `SELECT DISTINCT ON expressions must match initial ORDER BY expressions`.

Related JIRA tickets : [IA-4041](https://bluesquare.atlassian.net/browse/IA-4041)

## How to test

Try this URL locally:

```http://localhost:8081/api/orgunits/?asLocation=true&limit=1&group=846&app_id=com.poliooutbreaks.app```

It should work without triggering a `ProgrammingError`.

[IA-4041]: https://bluesquare.atlassian.net/browse/IA-4041?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ