### PR TITLE
IA-4054: add null check on ref form

### DIFF
--- a/iaso/models/entity.py
+++ b/iaso/models/entity.py
@@ -79,7 +79,7 @@ class EntityType(models.Model):
             "name": self.name,
             "created_at": self.created_at,
             "updated_at": self.updated_at,
-            "reference_form": self.reference_form.as_dict(),
+            "reference_form": self.reference_form.as_dict() if self.reference_form else None,
             "account": self.account.as_dict(),
         }
 

--- a/iaso/models/workflow.py
+++ b/iaso/models/workflow.py
@@ -95,6 +95,7 @@ class WorkflowVersion(SoftDeletableModel):
         changes -> WorkflowChange
         follow_ups -> WorkflowFollowup
     """
+
     NAME_MAX_LENGTH = 50
 
     workflow = models.ForeignKey(Workflow, on_delete=models.CASCADE, related_name="workflow_versions")

--- a/iaso/tests/api/workflows/test_workflows.py
+++ b/iaso/tests/api/workflows/test_workflows.py
@@ -205,7 +205,9 @@ class WorkflowsAPITestCase(BaseWorkflowsAPITestCase):
     def test_new_version_from_copy_with_name_too_long(self):
         self.client.force_authenticate(self.blue_adult_1)
 
-        self.workflow_version_et_adults_blue_with_followups_and_changes.name = "this is going to be a 50-character name = max size"
+        self.workflow_version_et_adults_blue_with_followups_and_changes.name = (
+            "this is going to be a 50-character name = max size"
+        )
         self.workflow_version_et_adults_blue_with_followups_and_changes.save()
         self.workflow_version_et_adults_blue_with_followups_and_changes.refresh_from_db()
 
@@ -224,7 +226,10 @@ class WorkflowsAPITestCase(BaseWorkflowsAPITestCase):
             w_version = WorkflowVersion.objects.get(pk=response.data["version_id"])
 
             assert w_version.pk == response.data["version_id"]
-            assert w_version.name == f"Copy of version {self.workflow_version_et_adults_blue_with_followups_and_changes.id}"
+            assert (
+                w_version.name
+                == f"Copy of version {self.workflow_version_et_adults_blue_with_followups_and_changes.id}"
+            )
 
         except WorkflowVersion.DoesNotExist as ex:
             self.fail(msg=str(ex))

--- a/iaso/tests/models/test_entity.py
+++ b/iaso/tests/models/test_entity.py
@@ -9,7 +9,9 @@ class EntityTypeModelTestCase(TestCase):
 
     @classmethod
     def setUpTestData(cls):
-        cls.account, cls.data_source, cls.source_version, cls.project = cls.create_account_datasource_version_project("source", "account", "project")
+        cls.account, cls.data_source, cls.source_version, cls.project = cls.create_account_datasource_version_project(
+            "source", "account", "project"
+        )
 
     def test_entity_type_no_reference_form(self):
         """

--- a/iaso/tests/models/test_entity.py
+++ b/iaso/tests/models/test_entity.py
@@ -1,0 +1,29 @@
+from iaso import models as m
+from iaso.test import TestCase
+
+
+class EntityTypeModelTestCase(TestCase):
+    """
+    Test EntityType model.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.account, cls.data_source, cls.source_version, cls.project = cls.create_account_datasource_version_project("source", "account", "project")
+
+    def test_entity_type_no_reference_form(self):
+        """
+        Checks that the as_dict method does not crash when there is no reference form - IA-4054
+        """
+        name = "EntityType"
+        entity_type = m.EntityType.objects.create(
+            name=name,
+            code="Code",
+            account=self.account,
+        )
+        entity_dict = entity_type.as_dict()
+        self.assertIsNotNone(entity_dict["created_at"])
+        self.assertIsNotNone(entity_dict["updated_at"])
+        self.assertIsNotNone(entity_dict["account"])
+        self.assertIsNone(entity_dict["reference_form"])
+        self.assertEqual(entity_dict["name"], name)


### PR DESCRIPTION
See [Sentry](https://bluesquareorg.sentry.io/issues/6421229642/?alert_rule_id=2913169&alert_timestamp=1742310392480&alert_type=email&environment=staging&notification_uuid=8d594215-aed0-4f2d-a571-d2c7162bf96e&project=5530884&referrer=alert_email)

Related JIRA tickets : IA-4054

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

Added a null check

## How to test

Dunno

## Print screen / video


## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
