### PR TITLE
IA-4032: Embedded links read only permission - should allow to see the list of dashboards per user allowed only

### DIFF
--- a/iaso/api/pages.py
+++ b/iaso/api/pages.py
@@ -4,7 +4,7 @@ from rest_framework import permissions, serializers
 
 from hat.menupermissions import models as permission
 from iaso.api.common import ModelViewSet
-from iaso.models import Page
+from iaso.models import Page, User
 
 
 class PagesSerializer(serializers.ModelSerializer):
@@ -65,7 +65,8 @@ class PagesViewSet(ModelViewSet):
         user = self.request.user
         order = self.request.query_params.get("order", "created_at").split(",")
         
-        queryset = Page.objects.filter(account__users=user.iaso_profile.account.users)
+        users = User.objects.filter(iaso_profile__account=user.iaso_profile.account)
+        queryset = Page.objects.filter(users__in=users)
         if user.has_perm(permission.PAGES) and not user.has_perm(permission.PAGE_WRITE):
             queryset = queryset.filter(users=user)
 

--- a/iaso/api/pages.py
+++ b/iaso/api/pages.py
@@ -64,8 +64,10 @@ class PagesViewSet(ModelViewSet):
     def get_queryset(self):
         user = self.request.user
         order = self.request.query_params.get("order", "created_at").split(",")
-        if user.has_perm(permission.PAGES) and not user.has_perm(permission.PAGE_WRITE):
-            return Page.objects.filter(users=user).order_by(*order).distinct()
         
-        return Page.objects.filter(users__iaso_profile__account=user.iaso_profile.account).order_by(*order).distinct()
+        queryset = Page.objects.filter(account__users=user.iaso_profile.account.users)
+        if user.has_perm(permission.PAGES) and not user.has_perm(permission.PAGE_WRITE):
+            queryset = queryset.filter(users=user)
+
+        return queryset.order_by(*order).distinct()
     

--- a/iaso/api/pages.py
+++ b/iaso/api/pages.py
@@ -1,4 +1,3 @@
-from django.contrib.auth.models import User
 from django.utils.translation import gettext_lazy as _
 from django_filters.rest_framework import BooleanFilter, CharFilter, FilterSet
 from rest_framework import permissions, serializers
@@ -65,5 +64,8 @@ class PagesViewSet(ModelViewSet):
     def get_queryset(self):
         user = self.request.user
         order = self.request.query_params.get("order", "created_at").split(",")
-        users = User.objects.filter(iaso_profile__account=user.iaso_profile.account)
-        return Page.objects.filter(users__in=users).order_by(*order).distinct()
+        if user.has_perm(permission.PAGES) and not user.has_perm(permission.PAGE_WRITE):
+            return Page.objects.filter(users=user).order_by(*order).distinct()
+        
+        return Page.objects.filter(users__iaso_profile__account=user.iaso_profile.account).order_by(*order).distinct()
+    

--- a/iaso/tests/api/test_pages.py
+++ b/iaso/tests/api/test_pages.py
@@ -28,10 +28,10 @@ class PagesAPITestCase(APITestCase):
         cls.fifth_user = cls.create_user_with_profile(
             username="fifth user", account=first_account, permissions=["iaso_page_write"]
         )
-        cls.userNoWritePermission = cls.create_user_with_profile(
+        cls.user_no_write_permission = cls.create_user_with_profile(
             username="NoWritePermission", account=first_account, permissions=["iaso_pages"]
         )
-        cls.userNoIasoPagesPermission = cls.create_user_with_profile(
+        cls.user_no_iaso_pages_permission = cls.create_user_with_profile(
             username="userNoIasoPagesPermission", account=first_account
         )
 
@@ -58,7 +58,7 @@ class PagesAPITestCase(APITestCase):
 
     def test_pages_list_without_pages_permission(self):
         """GET /pages/ without iaso_pages permission should result in a 403"""
-        self.client.force_login(self.userNoIasoPagesPermission)
+        self.client.force_login(self.user_no_iaso_pages_permission)
 
         response = self.client.get("/api/pages/")
         self.assertJSONResponse(response, 403)
@@ -69,14 +69,14 @@ class PagesAPITestCase(APITestCase):
         self.create_page(name="TEST2", slug="test_2", needs_authentication=True, users=[self.second_user.pk])
 
         # Check when the user has only read permission but not embedded links linked to him
-        self.client.force_login(self.userNoWritePermission)
+        self.client.force_login(self.user_no_write_permission)
         response = self.client.get("/api/pages/")
         self.assertJSONResponse(response, 200)
         self.assertEqual(len(response.json()["results"]), 0)
 
         # Check when the user has only read permission but has some embedded links linked to him
-        self.create_page(name="TEST3", slug="test_3", needs_authentication=True, users=[self.userNoWritePermission.pk])
-        self.client.force_login(self.userNoWritePermission)
+        self.create_page(name="TEST3", slug="test_3", needs_authentication=True, users=[self.user_no_write_permission.pk])
+        self.client.force_login(self.user_no_write_permission)
         response = self.client.get("/api/pages/")
         self.assertJSONResponse(response, 200)
         self.assertEqual(len(response.json()["results"]), 1)
@@ -131,7 +131,7 @@ class PagesAPITestCase(APITestCase):
 
     def test_create_page_with_no_write_permission(self):
         """POST /pages/ without write page permission should result in a 403"""
-        self.client.force_login(self.userNoWritePermission)
+        self.client.force_login(self.user_no_write_permission)
 
         response = self.client.post(
             "/api/pages/",
@@ -165,7 +165,7 @@ class PagesAPITestCase(APITestCase):
             format="json",
         )
 
-        self.client.force_login(self.userNoWritePermission)
+        self.client.force_login(self.user_no_write_permission)
         page = Page.objects.last().pk
 
         response = self.client.delete(


### PR DESCRIPTION
What problem is this PR solving? Explain here in one sentence.
- Embedded links read only permission - should allow to see the list of dashboards per user allowed only
Related JIRA tickets : [IA-4032](https://bluesquare.atlassian.net/browse/IA-4032)

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes
- Filter on the connected user when he has only read permission

## How to test
- Create a user on edit one with read only permission for embedded links
- Create or edit two embedded links, one linked to to the created user and the other one not linked to him
- Connect with the user and go to embedded links
- You should see only the one pages linked to the connected user

## Print screen / video
[Screencast from 2025-03-19 09-43-14.webm](https://github.com/user-attachments/assets/85c2b23f-aae6-4b5e-bdb8-41dddca932f7)

## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.


[IA-4032]: https://bluesquare.atlassian.net/browse/IA-4032?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ