### PR TITLE
IA-4041 Fix a `ProgrammingError` exception in `/api/orgunits/` (bis)

### DIFF
--- a/iaso/api/org_units.py
+++ b/iaso/api/org_units.py
@@ -167,6 +167,12 @@ class OrgUnitViewSet(viewsets.ViewSet):
             if limit and not as_location:
                 limit = int(limit)
                 page_offset = int(page_offset)
+
+                # Avoid a `SELECT DISTINCT ON expressions must match initial ORDER BY expressions` exception
+                # because `build_org_units_queryset()` can set `.distinct()` clauses.
+                if queryset.query.combinator != "union":  # `.distinct()` is not allowed with `.union()`.
+                    queryset = queryset.distinct(*order)
+
                 paginator = Paginator(queryset, limit)
 
                 if page_offset > paginator.num_pages:

--- a/iaso/tests/api/test_orgunits.py
+++ b/iaso/tests/api/test_orgunits.py
@@ -533,9 +533,22 @@ class OrgUnitAPITestCase(APITestCase):
         for orgunit in response_data["orgUnits"]:
             self.assertEqual(orgunit["parent_id"], None)
 
-    def test_org_unit_list_with_as_location(self):
+    def test_org_unit_list_with_as_location_with_group(self):
+        """
+        Test that `build_org_units_queryset()` which sets `.distinct()` clauses
+        when the `group` param is used doesn't cause `Paginator` to fail.
+        """
         self.client.force_authenticate(self.yoda)
         response = self.client.get("/api/orgunits/?asLocation=true&limit=1&group=1")
+        self.assertJSONResponse(response, 200)
+
+    def test_org_unit_list_without_as_location_with_group(self):
+        """
+        Test that `build_org_units_queryset()` which sets `.distinct()` clauses
+        when the `group` param is used doesn't cause `Paginator` to fail.
+        """
+        self.client.force_authenticate(self.yoda)
+        response = self.client.get("/api/orgunits/?limit=1&group=1")
         self.assertJSONResponse(response, 200)
 
     def test_org_unit_retrieve_without_auth_or_app_id(self):


### PR DESCRIPTION
Fix `SELECT DISTINCT ON expressions must match initial ORDER BY expressions` at another place.

Related JIRA tickets : [IA-4041](https://bluesquare.atlassian.net/browse/IA-4041)

## How to test

Try this URL locally:

```http://localhost:8081/api/orgunits/?limit=1&group&group=846```

It should work without triggering a `ProgrammingError`.

[IA-4041]: https://bluesquare.atlassian.net/browse/IA-4041?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ