### PR TITLE
IA-4043 Add an "Is reference instance" column in the CSV/XLS export of instances

### DIFF
--- a/iaso/api/instances.py
+++ b/iaso/api/instances.py
@@ -224,6 +224,7 @@ class InstancesViewSet(viewsets.ViewSet):
         """WIP: Helper function to divide the huge list method"""
         columns = [
             {"title": "ID du formulaire", "width": 20},
+            {"title": "Soumission de référence", "width": 20},
             {"title": "Version du formulaire", "width": 20},
             {"title": "Export id", "width": 20},
             {"title": "Latitude", "width": 40},
@@ -285,6 +286,7 @@ class InstancesViewSet(viewsets.ViewSet):
 
             instance_values = [
                 instance.id,
+                str(instance.is_reference_instance),
                 file_content.get("_version") if file_content else None,
                 instance.export_id,
                 instance.location.y if instance.location else None,
@@ -391,8 +393,11 @@ class InstancesViewSet(viewsets.ViewSet):
         # 2. Prepare queryset (common part between searches and exports)
         queryset = self.get_queryset()
         queryset = queryset.exclude(file="").exclude(device__test_device=True)
-        queryset = queryset.prefetch_related("form")
-        queryset = queryset.prefetch_related("created_by")
+        queryset = queryset.select_related("org_unit__version__data_source", "project")
+        queryset = queryset.prefetch_related(
+            "created_by", "form", "org_unit__reference_instances", "org_unit__org_unit_type__reference_forms"
+        )
+
         queryset = queryset.for_filters(**filters)
         queryset = queryset.order_by(*orders)
         # IA-1023 = allow to sort instances by form version
@@ -408,10 +413,6 @@ class InstancesViewSet(viewsets.ViewSet):
             queryset = queryset.filter(org_unit__validation_status=org_unit_status)
 
         if not file_export:
-            queryset = queryset.prefetch_related("org_unit__reference_instances")
-            queryset = queryset.prefetch_related("org_unit__org_unit_type__reference_forms")
-            queryset = queryset.prefetch_related("org_unit__version__data_source")
-            queryset = queryset.prefetch_related("project")
             if limit:
                 limit = int(limit)
                 page_offset = int(page_offset)


### PR DESCRIPTION
Add an "Is reference instance" column in the CSV/XLS export of instances.

Related JIRA tickets : [IA-4043](https://bluesquare.atlassian.net/browse/IA-4043)

## How to test

1. Go to `http://localhost:8081/dashboard/forms/submissions/`
2. Choose a `Form` to enable the CSV/XLS export feature
3. Download the list as CSV and XLS
4. You should see a new column _Soumission de référence_

## Screenshots

![csv](https://github.com/user-attachments/assets/178effee-bbd2-4000-b3c4-b73df49ed363)

![xls](https://github.com/user-attachments/assets/7a518e88-1ab6-4f99-a3b1-fe3fb5141e8e)



[IA-4043]: https://bluesquare.atlassian.net/browse/IA-4043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ