### PR TITLE
POLIO-1876: fix campaign filter

### DIFF
--- a/plugins/polio/api/campaigns/campaigns.py
+++ b/plugins/polio/api/campaigns/campaigns.py
@@ -836,7 +836,9 @@ class CampaignViewSet(ModelViewSet):
             campaigns = campaigns.filter(is_preventive=True)
         if campaign_category == "on_hold":
             campaigns = campaigns.filter(on_hold=True)
-        if campaign_category == "regular":
+        if campaign_category == "regular" and on_hold == "true":
+            campaigns = campaigns.filter(is_preventive=False).filter(is_test=False)
+        if campaign_category == "regular" and on_hold == "false":
             campaigns = campaigns.filter(is_preventive=False).filter(is_test=False).filter(on_hold=False)
         if campaign_groups:
             campaigns = campaigns.filter(grouped_campaigns__in=campaign_groups.split(","))

--- a/plugins/polio/models/base.py
+++ b/plugins/polio/models/base.py
@@ -449,6 +449,7 @@ class Round(models.Model):
             and self.started_at >= timezone.now().date()
             and self.campaign
             and self.campaign.has_polio_type
+            and not self.campaign.is_test
             and not self.chronograms.valid().exists()
         ):
             ChronogramTemplateTask.objects.create_chronogram(round=self, created_by=None, account=self.campaign.account)

--- a/plugins/polio/tests/models/test_round_models.py
+++ b/plugins/polio/tests/models/test_round_models.py
@@ -101,3 +101,45 @@ class RoundModelTestCase(APITestCase, PolioTestCaseMixin):
         self.assertEqual(
             round_4.chronograms.valid().count(), 0, "No chronogram should be created for non-Polio campaigns."
         )
+
+        test_campaign, _, _, _, _, _ = self.create_campaign(
+            "TEST_CAMPAIGN",
+            self.account,
+            self.source_version,
+            self.ou_type_country,
+            self.ou_type_district,
+            "TEST_COUNTRY",
+            "TEST_DISTRICT",
+        )
+        test_campaign.is_test = True
+        test_campaign.campaign_types.add(polio_type)
+        test_campaign.save()
+        test_campaign.refresh_from_db()
+
+        round_5 = pm.Round.objects.create(number=1, campaign=test_campaign, started_at=now.date())
+        round_5.add_chronogram()
+        self.assertEqual(
+            round_5.chronograms.valid().count(), 0, "No chronogram should be created for test campaigns."
+        )
+
+        campaign_on_hold, _, _, _, _, _ = self.create_campaign(
+            "CAMPAIGN_ON_HOLD",
+            self.account,
+            self.source_version,
+            self.ou_type_country,
+            self.ou_type_district,
+            "COUNTRY_ON_HOLD",
+            "DISTRICT_ON_HOLD",
+        )
+        campaign_on_hold.on_hold = True
+        campaign_on_hold.campaign_types.add(polio_type)
+        campaign_on_hold.save()
+        campaign_on_hold.refresh_from_db()
+
+        round_6 = pm.Round.objects.create(number=1, campaign=campaign_on_hold, started_at=now.date())
+        round_6.add_chronogram()
+        self.assertEqual(
+            round_6.chronograms.valid().count(), 1, "A new chronogram should be created for a campaign on hold."
+        )
+
+


### PR DESCRIPTION
vrf campaign filter would not show on hold campaigns, chronogram would show test campaigns

Related JIRA tickets :POLIO-1876

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

- tweak the campaign API filter logic to avoid contradictory behaviour with `on_hold` param

## How to test
Go to campaigns and test filter by campaign category: 
- Standard campaign should not include on hold campaigns
- Go to VRF and test country selection on create:
    - After country selection, campaign dropdown should how on hold campaigns but not test campaigns 
- Go to chronograms: create modal should not show on hold or test campaigns 

## Print screen / video

https://github.com/user-attachments/assets/63b813e3-5318-42ad-87b1-a4ab79b5d6cd


https://github.com/user-attachments/assets/7765e6ad-ff6f-4cc2-944f-73dd37890275



## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
