### PR TITLE
[IA-4040] Fix start_dev compilemessages

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -68,7 +68,7 @@ case "$1" in
     ./scripts/wait_for_dbs.sh
     ./manage.py migrate --noinput
     ./manage.py createcachetable
-    ./manage.py compilemessages
+    ./manage.py compile_translations
     ./manage.py runserver 0.0.0.0:8081
   ;;
   "start_celery_beat" )


### PR DESCRIPTION
Use the new command for compiling messages in the `start_dev` entrypoint of the start up script.

Related JIRA tickets : IA-4040

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

/

## Changes

Use the new command for compiling messages in the `start_dev` entrypoint of the start up script.

## How to test

- Start your local docker installation
- Notice that the backend compiles all messages during start up 
- Stop your local docker installation
- Edit one of the `.po` files
- Restart your local docker installation
- Notice that the message during start up changed, since the file had to be recompiled

## Print screen / video

Example of logs during backend start up: most files were already compiled, but one of them was changed, so it had to be recompiled.
 
![image](https://github.com/user-attachments/assets/3dd32131-6de6-4cfb-90db-9fbd3282c257)


## Notes

The `make_translations` command was not added, because it stops the backend if any translation is missing... which will definitely be annoying whenever you're working on a feature that creates new translation strings.


## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
