### PR TITLE
IA-4019: Language switch selected color is not very visible on Prod

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/home/components/LangSwitch.tsx
+++ b/hat/assets/js/apps/Iaso/domains/home/components/LangSwitch.tsx
@@ -24,7 +24,7 @@ const useStyles = makeStyles(theme => ({
         paddingRight: theme.spacing(3),
     },
     languageSwithActive: {
-        color: theme.palette.secondary.light,
+        color: theme.palette.warning.light,
         cursor: 'text',
     },
 }));

--- a/hat/assets/js/apps/Iaso/domains/home/components/LangSwitch.tsx
+++ b/hat/assets/js/apps/Iaso/domains/home/components/LangSwitch.tsx
@@ -24,7 +24,7 @@ const useStyles = makeStyles(theme => ({
         paddingRight: theme.spacing(3),
     },
     languageSwithActive: {
-        color: theme.palette.warning.light,
+        color: theme.palette.secondary.main,
         cursor: 'text',
     },
 }));

--- a/hat/settings.py
+++ b/hat/settings.py
@@ -607,7 +607,7 @@ APP_TITLE = os.environ.get("APP_TITLE", "Iaso")
 FAVICON_PATH = os.environ.get("FAVICON_PATH", "images/iaso-favicon.png")
 LOGO_PATH = os.environ.get("LOGO_PATH", "images/logo.png")
 THEME_PRIMARY_COLOR = os.environ.get("THEME_PRIMARY_COLOR", "#006699")
-THEME_SECONDARY_COLOR = os.environ.get("THEME_SECONDARY_COLOR", "#0066CC")
+THEME_SECONDARY_COLOR = os.environ.get("THEME_SECONDARY_COLOR", "#ff7961")
 THEME_PRIMARY_BACKGROUND_COLOR = os.environ.get("THEME_PRIMARY_BACKGROUND_COLOR", "#F5F5F5")
 SHOW_NAME_WITH_LOGO = os.environ.get("SHOW_NAME_WITH_LOGO", "yes")
 


### PR DESCRIPTION
What problem is this PR solving? Explain here in one sentence.

Related JIRA tickets : [IA-4019](https://bluesquare.atlassian.net/browse/IA-4019)

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

Changed the theme color for active language

## How to test

Login with any user, switch between language in the top bar and check if the active language is visible with orange color!

## Print screen / video

Tested by changing theme colors in env vars :

1. Without any color theme defined in env vars: 
![image](https://github.com/user-attachments/assets/703b9631-dc9b-48e6-806d-21b215ac98c1)

2. With some theme in env vars : 

![image](https://github.com/user-attachments/assets/21e5314b-4a5f-498e-9a69-699d744693a6)

## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.


[IA-4019]: https://bluesquare.atlassian.net/browse/IA-4019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ