### PR TITLE
IA-2548 Enhancements and fix for the audit module

### DIFF
--- a/hat/audit/models.py
+++ b/hat/audit/models.py
@@ -129,6 +129,7 @@ class Modification(models.Model):
 
 
 def log_modification(
+    # `v1` should be either a deepcopy or a serialized instance.
     v1: Optional[Union[AnyModelInstance, list[dict[str, Any]]]],
     v2: Optional[AnyModelInstance],
     source: Optional[str],

--- a/hat/audit/models.py
+++ b/hat/audit/models.py
@@ -174,4 +174,5 @@ def log_modification(
             logger.error("log_modification() called with only `updated_at`.", extra={"modification": modification})
             return None
 
-    return modification.save()
+    modification.save()
+    return modification

--- a/hat/audit/models.py
+++ b/hat/audit/models.py
@@ -55,7 +55,8 @@ def dict_compare(d1, d2):
 
 
 def serialize_instance(instance: AnyModelInstance) -> list[dict[str, Any]]:
-    return json.loads(serializers.serialize("json", [instance]))
+    serialized_instance = serializers.serialize("json", [instance])
+    return json.loads(serialized_instance)
 
 
 class IasoJsonEncoder(json.JSONEncoder):
@@ -170,6 +171,8 @@ def log_modification(
             return None
 
         # Only `updated_at` was modified.
+        # This can happen when the only thing that was modified was a reverse relationship
+        # because Django's serializer doesn't support reverse relationships.
         if not any([added, removed]) and len(modified.keys()) == 1 and "updated_at" in modified:
             logger.error("log_modification() called with only `updated_at`.", extra={"modification": modification})
             return None

--- a/hat/audit/models.py
+++ b/hat/audit/models.py
@@ -141,8 +141,8 @@ def log_modification(
 
     if v1:
         # If `v1` is a list, it means it's already been serialized.
-        # This avoids issues related to the `call-by-sharing` evaluation strategy of Python.
-        # See unit tests to understand the issue.
+        # This avoids issues related to the `call-by-sharing` evaluation strategy of Python
+        # where two instances are sharing the same m2m objects.
         if isinstance(v1, list):
             modification.object_id = v1[0]["pk"]
             modification.past_value = v1

--- a/hat/audit/tests.py
+++ b/hat/audit/tests.py
@@ -1,3 +1,5 @@
+import logging
+
 from hat.audit import models as audit_models
 from iaso import models as m
 from iaso.test import TestCase
@@ -7,6 +9,12 @@ class AuditMethodsTestCase(TestCase):
     """
     Test methods in the `audit` module.
     """
+
+    def setUp(self):
+        logging.disable(logging.NOTSET)
+
+    def tearDown(self):
+        logging.disable(logging.CRITICAL)
 
     @classmethod
     def setUpTestData(cls):

--- a/hat/audit/tests.py
+++ b/hat/audit/tests.py
@@ -1,38 +1,45 @@
+from django.core.exceptions import ValidationError
+
 from hat.audit import models as audit_models
 from iaso import models as m
 from iaso.test import TestCase
 
 
-class LogModificationTestCase(TestCase):
+class AuditMethodsTestCase(TestCase):
     """
-    Test log_modification().
+    Test methods in the `audit` module.
     """
 
     @classmethod
     def setUpTestData(cls):
+        cls.org_unit_type = m.OrgUnitType.objects.create(name="Org unit type")
         cls.org_unit = m.OrgUnit.objects.create(
-            org_unit_type=m.OrgUnitType.objects.create(name="Org unit type"),
+            org_unit_type=cls.org_unit_type,
             name="Hôpital Général",
         )
         cls.account = m.Account.objects.create(name="Account")
         cls.user = cls.create_user_with_profile(username="user", account=cls.account)
 
+    def test_serialize_instance(self):
+        json_data = audit_models.serialize_instance(self.org_unit)
+
+        self.assertIsInstance(json_data, list)
+        self.assertEqual(len(json_data), 1)
+
+        json_instance = json_data[0]
+        self.assertIsInstance(json_instance, dict)
+        self.assertEqual(json_instance["model"], "iaso.orgunit")
+        self.assertEqual(json_instance["pk"], self.org_unit.pk)
+        self.assertIsInstance(json_instance["fields"], dict)
+
     def test_log_modification_with_nothing(self):
-        modification = audit_models.log_modification(
-            self.org_unit, self.org_unit, source=audit_models.ORG_UNIT_API, user=self.user
-        )
-        self.assertIsNone(modification)
+        with self.assertRaises(ValidationError) as error:
+            audit_models.log_modification(
+                self.org_unit, self.org_unit, source=audit_models.ORG_UNIT_API, user=self.user
+            )
+        self.assertEqual(error.exception.message, "Nothing to log.")
 
-    def test_log_modification_with_only_updated_at(self):
-        original_copy = m.OrgUnit.objects.get(pk=self.org_unit.pk)
-        self.org_unit.save()
-
-        modification = audit_models.log_modification(
-            original_copy, self.org_unit, source=audit_models.ORG_UNIT_API, user=self.user
-        )
-        self.assertIsNone(modification)
-
-    def test_log_modification_for_name(self):
+    def test_log_modification_for_simple_field(self):
         original_copy = m.OrgUnit.objects.get(pk=self.org_unit.pk)
 
         self.org_unit.name = "Foo"
@@ -55,3 +62,65 @@ class LogModificationTestCase(TestCase):
         self.assertEqual(len(diffs["modified"].keys()), 2)
         self.assertIn("name", diffs["modified"].keys())
         self.assertIn("updated_at", diffs["modified"].keys())
+
+    def test_log_modification_for_m2m_field_with_original_as_shallow_copy(self):
+        """
+        This is how NOT to call `log_modification()` when there are m2m relations.
+
+        Because of the evaluation strategy of Python, two instances of a model
+        will reference the same m2m objects (call-by-sharing).
+        """
+        original_copy = m.OrgUnitType.objects.get(pk=self.org_unit_type.pk)
+        self.assertEqual(original_copy.reference_forms.count(), 0)
+
+        form_1 = m.Form.objects.create(name="Form 1")
+        form_2 = m.Form.objects.create(name="Form 2")
+        self.org_unit_type.reference_forms.add(form_1, form_2)
+        self.assertEqual(self.org_unit_type.reference_forms.count(), 2)
+
+        modification = audit_models.log_modification(
+            original_copy, self.org_unit_type, source=audit_models.ORG_UNIT_API, user=self.user
+        )
+
+        # This is the bug!
+        old_reference_forms = modification.past_value[0]["fields"]["reference_forms"]
+        new_reference_forms = modification.new_value[0]["fields"]["reference_forms"]
+        self.assertEqual(old_reference_forms, new_reference_forms)
+
+        diffs = modification.field_diffs()
+        self.assertEqual(len(diffs["added"].keys()), 0)
+        self.assertEqual(len(diffs["removed"].keys()), 0)
+        self.assertEqual(len(diffs["modified"].keys()), 0)
+
+    def test_log_modification_for_m2m_field_with_original_as_serialized_copy(self):
+        """
+        This is how you should call `log_modification()` when there are m2m relations.
+
+        The `past_value` should be serialized before performing any modification.
+        """
+        original_copy = m.OrgUnitType.objects.get(pk=self.org_unit_type.pk)
+        self.assertEqual(original_copy.reference_forms.count(), 0)
+
+        serialized_original_copy = audit_models.serialize_instance(original_copy)
+
+        form_1 = m.Form.objects.create(name="Form 1")
+        form_2 = m.Form.objects.create(name="Form 2")
+        self.org_unit_type.reference_forms.add(form_1, form_2)
+        self.assertEqual(self.org_unit_type.reference_forms.count(), 2)
+
+        modification = audit_models.log_modification(
+            serialized_original_copy, self.org_unit_type, source=audit_models.ORG_UNIT_API, user=self.user
+        )
+
+        old_reference_forms = modification.past_value[0]["fields"]["reference_forms"]
+        new_reference_forms = modification.new_value[0]["fields"]["reference_forms"]
+        self.assertEqual(len(old_reference_forms), 0)
+        self.assertEqual(len(new_reference_forms), 2)
+        self.assertIn(form_1.pk, new_reference_forms)
+        self.assertIn(form_2.pk, new_reference_forms)
+
+        diffs = modification.field_diffs()
+        self.assertEqual(len(diffs["added"].keys()), 0)
+        self.assertEqual(len(diffs["removed"].keys()), 0)
+        self.assertEqual(len(diffs["modified"].keys()), 1)
+        self.assertIn("reference_forms", diffs["modified"].keys())

--- a/hat/audit/tests.py
+++ b/hat/audit/tests.py
@@ -31,7 +31,7 @@ class AuditMethodsTestCase(TestCase):
         self.assertIsInstance(json_instance["fields"], dict)
 
     def test_log_modification_with_nothing(self):
-        with self.assertLogs(level="ERROR") as caught_msg:
+        with self.assertLogs(logger=audit_models.logger, level="ERROR") as caught_msg:
             audit_models.log_modification(
                 self.org_unit, self.org_unit, source=audit_models.ORG_UNIT_API, user=self.user
             )
@@ -42,7 +42,7 @@ class AuditMethodsTestCase(TestCase):
         original_copy = m.OrgUnit.objects.get(pk=self.org_unit.pk)
         self.org_unit.save()
 
-        with self.assertLogs(level="ERROR") as caught_msg:
+        with self.assertLogs(logger=audit_models.logger, level="ERROR") as caught_msg:
             audit_models.log_modification(
                 original_copy, self.org_unit, source=audit_models.ORG_UNIT_API, user=self.user
             )

--- a/hat/audit/tests.py
+++ b/hat/audit/tests.py
@@ -31,7 +31,7 @@ class AuditMethodsTestCase(TestCase):
         self.assertIsInstance(json_instance["fields"], dict)
 
     def test_log_modification_with_nothing(self):
-        with self.assertLogs("hat.audit", level="ERROR") as caught_msg:
+        with self.assertLogs(level="ERROR") as caught_msg:
             audit_models.log_modification(
                 self.org_unit, self.org_unit, source=audit_models.ORG_UNIT_API, user=self.user
             )
@@ -42,8 +42,8 @@ class AuditMethodsTestCase(TestCase):
         original_copy = m.OrgUnit.objects.get(pk=self.org_unit.pk)
         self.org_unit.save()
 
-        with self.assertLogs("hat.audit", level="ERROR") as caught_msg:
-            modification = audit_models.log_modification(
+        with self.assertLogs(level="ERROR") as caught_msg:
+            audit_models.log_modification(
                 original_copy, self.org_unit, source=audit_models.ORG_UNIT_API, user=self.user
             )
         self.assertEqual(len(caught_msg.output), 1)

--- a/hat/audit/tests.py
+++ b/hat/audit/tests.py
@@ -1,0 +1,57 @@
+from hat.audit import models as audit_models
+from iaso import models as m
+from iaso.test import TestCase
+
+
+class LogModificationTestCase(TestCase):
+    """
+    Test log_modification().
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.org_unit = m.OrgUnit.objects.create(
+            org_unit_type=m.OrgUnitType.objects.create(name="Org unit type"),
+            name="Hôpital Général",
+        )
+        cls.account = m.Account.objects.create(name="Account")
+        cls.user = cls.create_user_with_profile(username="user", account=cls.account)
+
+    def test_log_modification_with_nothing(self):
+        modification = audit_models.log_modification(
+            self.org_unit, self.org_unit, source=audit_models.ORG_UNIT_API, user=self.user
+        )
+        self.assertIsNone(modification)
+
+    def test_log_modification_with_only_updated_at(self):
+        original_copy = m.OrgUnit.objects.get(pk=self.org_unit.pk)
+        self.org_unit.save()
+
+        modification = audit_models.log_modification(
+            original_copy, self.org_unit, source=audit_models.ORG_UNIT_API, user=self.user
+        )
+        self.assertIsNone(modification)
+
+    def test_log_modification_for_name(self):
+        original_copy = m.OrgUnit.objects.get(pk=self.org_unit.pk)
+
+        self.org_unit.name = "Foo"
+        self.org_unit.save()
+
+        modification = audit_models.log_modification(
+            original_copy, self.org_unit, source=audit_models.ORG_UNIT_API, user=self.user
+        )
+
+        self.assertIsInstance(modification, audit_models.Modification)
+        self.assertEqual(modification.source, audit_models.ORG_UNIT_API)
+        self.assertEqual(modification.user, self.user)
+
+        diffs = modification.field_diffs()
+
+        self.assertEqual(len(diffs["added"].keys()), 0)
+
+        self.assertEqual(len(diffs["removed"].keys()), 0)
+
+        self.assertEqual(len(diffs["modified"].keys()), 2)
+        self.assertIn("name", diffs["modified"].keys())
+        self.assertIn("updated_at", diffs["modified"].keys())

--- a/hat/audit/tests.py
+++ b/hat/audit/tests.py
@@ -83,9 +83,15 @@ class AuditMethodsTestCase(TestCase):
 
     def test_log_modification_for_m2m_field_with_original_as_serialized_copy(self):
         """
-        This is how you should call `log_modification()` when there are m2m relations.
+        Test that calling `log_modification()` when there are foreign keys
+        or many-to-many relations works as expected.
 
-        The `past_value` should be serialized before performing any modification.
+        The right way to do this is to ensure that the instance has been
+        serialized before performing any modification on it.
+
+        This avoids issues related to the `call-by-sharing` evaluation
+        strategy of Python where two instances are sharing the same
+        complex objects.
         """
         original_copy = m.OrgUnitType.objects.get(pk=self.org_unit_type.pk)
         self.assertEqual(original_copy.reference_forms.count(), 0)

--- a/iaso/api/group_sets/serializers.py
+++ b/iaso/api/group_sets/serializers.py
@@ -168,6 +168,7 @@ class GroupSetSerializer(DynamicFieldsModelSerializer):
 
     def update(self, instance, validated_data):
         original_copy = GroupSet.objects.get(pk=instance.id)
+        original_copy = audit_models.serialize_instance(original_copy)
 
         self.ensure_clean_validated_data(validated_data)
         # patch behaviour

--- a/iaso/tests/api/test_org_units_bulk_update.py
+++ b/iaso/tests/api/test_org_units_bulk_update.py
@@ -377,7 +377,10 @@ class OrgUnitsBulkUpdateAPITestCase(APITestCase):
             jedi_council.refresh_from_db()
             self.assertIn(self.another_group, jedi_council.groups.all())
 
-        self.assertEqual(5, am.Modification.objects.count())
+        # Django's serializer doesn't support reverse relationships.
+        # Because the only thing we have modified here is the `groups` (which is a reverse relationship),
+        # there will be no entry in the `Modification` history.
+        self.assertEqual(0, am.Modification.objects.count())
 
     def test_task_kill(self):
         """Launch the task and then kill it

--- a/iaso/tests/api/test_org_units_bulk_update.py
+++ b/iaso/tests/api/test_org_units_bulk_update.py
@@ -225,6 +225,8 @@ class OrgUnitsBulkUpdateAPITestCase(APITestCase):
     def test_org_unit_bulkupdate_select_all(self):
         """POST /orgunits/bulkupdate happy path (select all)"""
 
+        m.OrgUnit.objects.update(validation_status=m.OrgUnit.VALIDATION_NEW)
+
         self.client.force_authenticate(self.yoda)
         response = self.client.post(
             "/api/tasks/create/orgunitsbulkupdate/",


### PR DESCRIPTION
Enhancements and fix for the audit module.

Related JIRA tickets : [IA-2548](https://bluesquare.atlassian.net/browse/IA-2548)

## Changes

- add type hints and comments to clarify how the audit module works
- add unit tests demonstrating some edge cases
- log empty modifications or modifications with only `updated_at`
- fix a bug in the groupsets API where the past version was not deep copied or serialized

## How to test

This is covered by unit tests.

[IA-2548]: https://bluesquare.atlassian.net/browse/IA-2548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ