### PR TITLE
IA-4082: Registry - bug when displaying data

### DIFF
--- a/iaso/api/org_units.py
+++ b/iaso/api/org_units.py
@@ -163,6 +163,8 @@ class OrgUnitViewSet(viewsets.ViewSet):
 
         queryset = queryset.order_by(*order)
 
+        distinct_fields = [item.replace("-", "") for item in order]
+
         if not is_export:
             if limit and not as_location:
                 limit = int(limit)
@@ -171,7 +173,7 @@ class OrgUnitViewSet(viewsets.ViewSet):
                 # Avoid a `SELECT DISTINCT ON expressions must match initial ORDER BY expressions` exception
                 # because `build_org_units_queryset()` can set `.distinct()` clauses.
                 if queryset.query.combinator != "union":  # `.distinct()` is not allowed with `.union()`.
-                    queryset = queryset.distinct(*order)
+                    queryset = queryset.distinct(*distinct_fields)
 
                 paginator = Paginator(queryset, limit)
 
@@ -211,7 +213,7 @@ class OrgUnitViewSet(viewsets.ViewSet):
                 # Avoid a `SELECT DISTINCT ON expressions must match initial ORDER BY expressions` exception
                 # because `build_org_units_queryset()` can set `.distinct()` clauses.
                 if queryset.query.combinator != "union":  # `.distinct()` is not allowed with `.union()`.
-                    queryset = queryset.distinct(*order)
+                    queryset = queryset.distinct(*distinct_fields)
 
                 paginator = Paginator(queryset, limit)
                 page = paginator.page(1)

--- a/iaso/tests/api/test_orgunits.py
+++ b/iaso/tests/api/test_orgunits.py
@@ -1503,3 +1503,18 @@ class OrgUnitAPITestCase(APITestCase):
         self.assertEqual(org_units["page"], 1)
         first_org_unit = org_units["orgunits"][0]
         self.assertEqual(first_org_unit["id"], self.jedi_council_corruscant.pk)
+    
+    def test_descending_order_without_as_location(self):
+        self.client.force_authenticate(self.yoda)
+        response = self.client.get(
+            "/api/orgunits/?limit=20&order=-name&page=1"
+        )
+        self.assertEqual(response.status_code, 200)
+    
+    def test_descending_order_with_as_location(self):
+        self.client.force_authenticate(self.yoda)
+        response = self.client.get(
+            "/api/orgunits/?limit=20&order=-name&page=1&asLocation=true"
+        )
+        self.assertEqual(response.status_code, 200)
+


### PR DESCRIPTION
What problem is this PR solving? Explain here in one sentence.
- Registry - bug when displaying data
Related JIRA tickets : [IA-4082](https://bluesquare.atlassian.net/browse/IA-4082)

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes
- Remove the '-' when the ordering is descending

## How to test
- Go to registry
- Check if the error : `{
  "name": "ApiError",
  "status": 500,
  "message": "Error on GET /api/orgunits/?validation_status=VALID&orgUnitParentId=29682&onlyDirectChildren=true&limit=10&order=-name&page=1&orgUnitTypeId=6"
}` appear again

## Print screen / video
[Screencast from 2025-03-27 18-40-33.webm](https://github.com/user-attachments/assets/56dee2da-e5f1-4576-a68d-5217f56a3ec5)



## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.


[IA-4082]: https://bluesquare.atlassian.net/browse/IA-4082?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ