### PR TITLE
POLIO-1912 Fix incorrect balances on country stock cards

### DIFF
--- a/plugins/polio/api/vaccines/public_vaccine_stock.py
+++ b/plugins/polio/api/vaccines/public_vaccine_stock.py
@@ -51,9 +51,13 @@ class PublicVaccineStockViewset(ViewSet):
         if action_type and "forma" not in action_type:
             data_list = [el for el in data_list if el["type"] == action_type]
         if action_type and action_type == "forma_used_vials":
-            data_list = [el for el in data_list if "Form A - Vials Used" in el["action"]]
+            data_list = [
+                el for el in data_list if "Form A - Vials Used" in el["action"]
+            ]
         if action_type and action_type == "forma_missing_vials":
-            data_list = [el for el in data_list if "Form A - Missing Vials" in el["action"]]
+            data_list = [
+                el for el in data_list if "Form A - Missing Vials" in el["action"]
+            ]
         return data_list
 
     def sort_results(self, data_list, request):
@@ -64,7 +68,10 @@ class PublicVaccineStockViewset(ViewSet):
         return sorted(data_list, key=lambda x: x[order], reverse=reverse)
 
     def _get_json_data(self, queryset, usable):
-        all_entries = [stock.usable_vials() if usable else stock.unusable_vials() for stock in queryset]
+        all_entries = [
+            stock.usable_vials() if usable else stock.unusable_vials()
+            for stock in queryset
+        ]
         all_entries = sum(all_entries, [])
         return all_entries
 
@@ -87,9 +94,9 @@ class PublicVaccineStockViewset(ViewSet):
             if entry["doses_in"]:
                 total_doses += entry["doses_in"]
             if entry["vials_out"]:
-                total_vials += entry["vials_out"]
+                total_vials -= entry["vials_out"]
             if entry["doses_out"]:
-                total_doses += entry["doses_out"]
+                total_doses -= entry["doses_out"]
 
         return total_vials, total_doses
 
@@ -113,7 +120,9 @@ class PublicVaccineStockViewset(ViewSet):
                 total_out += entry["doses_out"]
         return total_in, total_out
 
-    def _paginate_response(self, request, json_data, earmarked_vials=None, earmarked_doses=None):
+    def _paginate_response(
+        self, request, json_data, earmarked_vials=None, earmarked_doses=None
+    ):
         total_vials, total_doses = self._compute_totals(json_data)
         # Adding some pagination to avoid crashing the front-end
         page = int(request.query_params.get("page", "1"))  # validate
@@ -133,7 +142,10 @@ class PublicVaccineStockViewset(ViewSet):
             "movements": unusable_to_display,
         }
         if pages > 0 and page > pages:
-            return Response({"result": f"Maximum page is {pages}, entered {page}"}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"result": f"Maximum page is {pages}, entered {page}"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         return Response(
             {
                 "count": count,
@@ -156,7 +168,9 @@ class PublicVaccineStockViewset(ViewSet):
         all_usable = self._get_json_data(queryset, usable=True)
         sorted_usable = self._apply_filter_and_sort(all_usable, request)
 
-        return self._paginate_response(request, sorted_usable, earmarked_vials, earmarked_doses)
+        return self._paginate_response(
+            request, sorted_usable, earmarked_vials, earmarked_doses
+        )
 
     @action(
         detail=False,
@@ -199,10 +213,14 @@ class PublicVaccineStockViewset(ViewSet):
                 country_name = OrgUnit.objects.get(id=int(country)).name
                 filename_details = f"{filename_details}-{country_name}"
             except Model.DoesNotExist:
-                return Response({"results": f"Country with id {country} not found"}, status=status.HTTP_400_BAD_REQUEST)
+                return Response(
+                    {"results": f"Country with id {country} not found"},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
             except Model.MultipleObjectsReturned:
                 return Response(
-                    {"results": f"Country id {country} returned multiple objects"}, status=status.HTTP_400_BAD_REQUEST
+                    {"results": f"Country id {country} returned multiple objects"},
+                    status=status.HTTP_400_BAD_REQUEST,
                 )
 
         if vaccine is not None:


### PR DESCRIPTION
Incorrect balances on public country stock cards.

Related JIRA tickets : POLIO-1912

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?

## Changes

Simply corrected a computation mistake

## How to test

See print-screen below. I you visit the public country stock card page. It should display the same totals as if you go in Vaccine Stock Management and then view the details for this country.

## Print screen / video

<img width="1482" alt="Screenshot 2025-03-28 at 13 59 25" src="https://github.com/user-attachments/assets/d074e522-05e2-4c21-a10b-4244d7243912" />

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
