### PR TITLE
POLIO-1845: fine tuning

### DIFF
--- a/plugins/polio/js/src/domains/Calendar/Calendar.tsx
+++ b/plugins/polio/js/src/domains/Calendar/Calendar.tsx
@@ -291,7 +291,7 @@ export const Calendar: FunctionComponent = () => {
                                     orders={orders}
                                     campaigns={filteredCampaigns}
                                     calendarData={calendarData}
-                                    loadingCampaigns={isLoading}
+                                    loadingCampaigns={isFetching}
                                     isPdf={isPdf}
                                     url={currentUrl}
                                     isLogged={isLogged}

--- a/plugins/polio/js/src/domains/Campaigns/hooks/api/useSaveCampaign.ts
+++ b/plugins/polio/js/src/domains/Campaigns/hooks/api/useSaveCampaign.ts
@@ -80,7 +80,6 @@ const save = (body: CampaignFormValues) => {
                     dispatchError(MESSAGES.subActivitySaveError, error);
                 })
                 .finally(() => {
-                    dispatchSuccess(MESSAGES.campaignSaved);
                     return campaign;
                 });
         })


### PR DESCRIPTION
While edting a campaign using calendar page, while saving sub activities we have a double snackbar confirming the save.After that if you close the dialog, the calendar is refreshing but the loader is not present

Related JIRA tickets : POLIO-1845

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

display loader, remove double snackbar while editing sub activities

## How to test

Edit a campaign using the calendar. Change a sub activity and save. You should have only one snackbar. 
Close the dialog, you should see a loader on the calendar to refresh the data

## Print screen / video

https://github.com/user-attachments/assets/a91f9f51-d9de-4fc4-a9d7-056729e677ec
