### PR TITLE
IA-3750: QR Image link broken when no app id yet

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/projects/components/ProjectInfos.tsx
+++ b/hat/assets/js/apps/Iaso/domains/projects/components/ProjectInfos.tsx
@@ -1,10 +1,10 @@
 import React, { FunctionComponent } from 'react';
 
+import { LoadingSpinner } from 'bluesquare-components';
 import InputComponent from '../../../components/forms/InputComponent';
 
-import MESSAGES from '../messages';
 import { useGetProjectQRCode } from '../hooks/requests/useGetProjectQRCode';
-import { LoadingSpinner } from 'bluesquare-components';
+import MESSAGES from '../messages';
 
 type Form = {
     value: string | undefined;
@@ -27,7 +27,7 @@ const ProjectInfos: FunctionComponent<Props> = ({
     currentProject,
 }) => {
     const { data: qrCode, isFetching: fetchingProjectQRCode } =
-        useGetProjectQRCode(currentProject?.id.value);
+        useGetProjectQRCode(currentProject?.id?.value);
 
     return (
         <>
@@ -50,18 +50,13 @@ const ProjectInfos: FunctionComponent<Props> = ({
                 required
             />
             {fetchingProjectQRCode && <LoadingSpinner />}
-            {!fetchingProjectQRCode &&
+            {!fetchingProjectQRCode && qrCode && (
                 <div style={{ textAlign: 'center' }}>
-                    <img
-                        width={200}
-                        height={200}
-                        alt="QRCode"
-                        src={qrCode}
-                    />
+                    <img width={200} height={200} alt="QRCode" src={qrCode} />
                 </div>
-            }
+            )}
         </>
     );
-}
+};
 
 export { ProjectInfos };


### PR DESCRIPTION
What problem is this PR solving? Explain here in one sentence.

Related JIRA tickets : [IA-3750](https://bluesquare.atlassian.net/browse/IA-3750)

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

Display the QR code image only if it exists!

## How to test

Open [projects page](http://localhost:8081/dashboard/settings/projects/) and try to create a new project! When open a form the create a new project, the QR code doesn't yet exist and is not shown, but when try to edit an existing project, the QR code is shown in the form!

## Print screen / video

[Iaso-Projects.webm](https://github.com/user-attachments/assets/c4d0de51-8d97-4910-92cf-0712925e41f4)


## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.


[IA-3750]: https://bluesquare.atlassian.net/browse/IA-3750?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ