### PR TITLE
[IA-4105] Update make_translations comment format

### DIFF
--- a/hat/locale/fr/LC_MESSAGES/django.po
+++ b/hat/locale/fr/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-24 14:18+0000\n"
+"POT-Creation-Date: 2025-04-02 08:35+0000\n"
 "PO-Revision-Date: 2025-02-05 14:41+0100\n"
 "Last-Translator: Olivier Le Thanh Duong <olivier@lethanh.be>\n"
 "Language-Team: \n"
@@ -18,385 +18,385 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 3.5\n"
 
-#: hat/menupermissions/models.py:250
+#: hat/menupermissions/models.py
 msgid "Formulaires"
 msgstr "Formulaires"
 
-#: hat/menupermissions/models.py:251
+#: hat/menupermissions/models.py
 msgid "Statistiques pour les formulaires"
 msgstr "Statistiques pour les formulaires"
 
-#: hat/menupermissions/models.py:252
+#: hat/menupermissions/models.py
 msgid "Correspondances avec DHIS2"
 msgstr "Correspondances avec DHIS2"
 
-#: hat/menupermissions/models.py:253
+#: hat/menupermissions/models.py
 msgid "modules"
 msgstr "modules"
 
-#: hat/menupermissions/models.py:254
+#: hat/menupermissions/models.py
 msgid "Complétude des données"
 msgstr "Complétude des données"
 
-#: hat/menupermissions/models.py:255
+#: hat/menupermissions/models.py
 msgid "Unités d'organisations"
 msgstr "Unités d'organisations"
 
-#: hat/menupermissions/models.py:256
+#: hat/menupermissions/models.py
 msgid "Lire les unités d'organisations"
 msgstr "Lire les unités d'organisations"
 
-#: hat/menupermissions/models.py:257
+#: hat/menupermissions/models.py
 msgid "Editer le Registre"
 msgstr "Editer le Registre"
 
-#: hat/menupermissions/models.py:258
+#: hat/menupermissions/models.py
 msgid "Lire le Registre"
 msgstr "Lire le Registre"
 
-#: hat/menupermissions/models.py:259
+#: hat/menupermissions/models.py
 msgid "Correspondances sources"
 msgstr "Correspondances sources"
 
-#: hat/menupermissions/models.py:260 hat/menupermissions/models.py:337
+#: hat/menupermissions/models.py
 msgid "Users"
 msgstr "Utilisateurs"
 
-#: hat/menupermissions/models.py:261
+#: hat/menupermissions/models.py
 msgid "Users managed"
 msgstr "Utilisateurs gérés"
 
-#: hat/menupermissions/models.py:262
+#: hat/menupermissions/models.py
 msgid "Pages"
 msgstr "Pages"
 
-#: hat/menupermissions/models.py:263
+#: hat/menupermissions/models.py
 msgid "Projets"
 msgstr "Projets"
 
-#: hat/menupermissions/models.py:264
+#: hat/menupermissions/models.py
 msgid "Sources"
 msgstr "Sources"
 
-#: hat/menupermissions/models.py:265
+#: hat/menupermissions/models.py
 msgid "Can change the default version of a data source"
 msgstr "Peut modifier la version par défaut d'une source de données"
 
-#: hat/menupermissions/models.py:266
+#: hat/menupermissions/models.py
 msgid "Tâches"
 msgstr "Tâches"
 
-#: hat/menupermissions/models.py:267
+#: hat/menupermissions/models.py
 msgid "Soumissions"
 msgstr "Soumissions"
 
-#: hat/menupermissions/models.py:268
+#: hat/menupermissions/models.py
 msgid "Editer soumissions"
 msgstr "Editer soumissions"
 
-#: hat/menupermissions/models.py:269
+#: hat/menupermissions/models.py
 msgid "Editer le planning"
 msgstr "Editer le planning"
 
-#: hat/menupermissions/models.py:270
+#: hat/menupermissions/models.py
 msgid "Lire le planning"
 msgstr "Lire le planning"
 
-#: hat/menupermissions/models.py:271 hat/menupermissions/models.py:333
+#: hat/menupermissions/models.py
 msgid "Reports"
 msgstr "Rapports"
 
-#: hat/menupermissions/models.py:272
+#: hat/menupermissions/models.py
 msgid "Equipes"
 msgstr "Equipes"
 
-#: hat/menupermissions/models.py:273
+#: hat/menupermissions/models.py
 msgid "Attributions"
 msgstr "Attributions"
 
-#: hat/menupermissions/models.py:274
+#: hat/menupermissions/models.py
 msgid "Budget Polio"
 msgstr "Budget Polio"
 
-#: hat/menupermissions/models.py:275
+#: hat/menupermissions/models.py
 msgid "Entities"
 msgstr "Entités"
 
-#: hat/menupermissions/models.py:276
+#: hat/menupermissions/models.py
 msgid "Write entity type"
 msgstr "Écrire type d'entité"
 
-#: hat/menupermissions/models.py:277
+#: hat/menupermissions/models.py
 msgid "Storages"
 msgstr "Stockages"
 
-#: hat/menupermissions/models.py:278
+#: hat/menupermissions/models.py
 msgid "Completeness stats"
 msgstr "Statistiques de complétude"
 
-#: hat/menupermissions/models.py:279
+#: hat/menupermissions/models.py
 msgid "Workflows"
 msgstr "Flux de travail"
 
-#: hat/menupermissions/models.py:280
+#: hat/menupermissions/models.py
 msgid "Budget Polio Admin"
 msgstr "Administration Budget Polio"
 
-#: hat/menupermissions/models.py:281
+#: hat/menupermissions/models.py
 msgid "Read Entity duplicates"
 msgstr "Lire les doublons d'entités"
 
-#: hat/menupermissions/models.py:282
+#: hat/menupermissions/models.py
 msgid "Write Entity duplicates"
 msgstr "Écrire les doublons d'entités"
 
-#: hat/menupermissions/models.py:283
+#: hat/menupermissions/models.py
 msgid "Manage user roles"
 msgstr "Gérer les rôles utilisateurs"
 
-#: hat/menupermissions/models.py:284
+#: hat/menupermissions/models.py
 msgid "Read data store"
 msgstr "Lire le stockage de données"
 
-#: hat/menupermissions/models.py:285
+#: hat/menupermissions/models.py
 msgid "Write data store"
 msgstr "Écrire dans le stockage de données"
 
-#: hat/menupermissions/models.py:286
+#: hat/menupermissions/models.py
 msgid "Org unit types"
 msgstr "Types d'unités d'organisation"
 
-#: hat/menupermissions/models.py:287
+#: hat/menupermissions/models.py
 msgid "Org unit groups"
 msgstr "Groupes d'unités d'organisation"
 
-#: hat/menupermissions/models.py:288
+#: hat/menupermissions/models.py
 msgid "Org unit change request review"
 msgstr "Révision des demandes de modification d'unités d'organisation"
 
-#: hat/menupermissions/models.py:289
+#: hat/menupermissions/models.py
 msgid "Org unit change request configurations"
 msgstr "Configurations des demandes de modification d'unités d'organisation"
 
-#: hat/menupermissions/models.py:290
+#: hat/menupermissions/models.py
 msgid "Write data source"
 msgstr "Écrire source de données"
 
-#: hat/menupermissions/models.py:291
+#: hat/menupermissions/models.py
 msgid "Write page"
 msgstr "Écrire page"
 
-#: hat/menupermissions/models.py:292
+#: hat/menupermissions/models.py
 msgid "Payments page"
 msgstr "Page des paiements"
 
-#: hat/menupermissions/models.py:295
+#: hat/menupermissions/models.py
 msgid "Polio"
 msgstr "Polio"
 
-#: hat/menupermissions/models.py:296
+#: hat/menupermissions/models.py
 msgid "Polio config"
 msgstr "Configuration Polio"
 
-#: hat/menupermissions/models.py:297
+#: hat/menupermissions/models.py
 msgid "Polio chronogram"
 msgstr "Chronogramme Polio"
 
-#: hat/menupermissions/models.py:298
+#: hat/menupermissions/models.py
 msgid "Polio chronogram user (restricted write)"
 msgstr "Utilisateur chronogramme Polio (écriture restreinte)"
 
-#: hat/menupermissions/models.py:299
+#: hat/menupermissions/models.py
 msgid "Polio notifications"
 msgstr "Notifications Polio"
 
-#: hat/menupermissions/models.py:300
+#: hat/menupermissions/models.py
 msgid "Polio Vaccine Authorizations Read Only"
 msgstr "Autorisations vaccin Polio (lecture seule)"
 
-#: hat/menupermissions/models.py:301
+#: hat/menupermissions/models.py
 msgid "Polio Vaccine Authorizations Admin"
 msgstr "Administration des autorisations vaccin Polio"
 
-#: hat/menupermissions/models.py:302
+#: hat/menupermissions/models.py
 msgid "Polio Vaccine Supply Chain Read"
 msgstr "Lecture chaîne d'approvisionnement vaccin Polio"
 
-#: hat/menupermissions/models.py:303
+#: hat/menupermissions/models.py
 msgid "Polio Vaccine Supply Chain Write"
 msgstr "Écriture chaîne d'approvisionnement vaccin Polio"
 
-#: hat/menupermissions/models.py:304
+#: hat/menupermissions/models.py
 msgid "Polio Vaccine Stock Management Read"
 msgstr "Lecture gestion des stocks vaccin Polio"
 
-#: hat/menupermissions/models.py:305
+#: hat/menupermissions/models.py
 msgid "Polio Vaccine Stock Management Write"
 msgstr "Écriture gestion des stocks vaccin Polio"
 
-#: hat/menupermissions/models.py:306
+#: hat/menupermissions/models.py
 #, fuzzy
 #| msgid "Polio Vaccine Authorizations Admin"
 msgid "Polio Vaccine Stock Earmarks Non Admin"
 msgstr "Administration des autorisations vaccin Polio"
 
-#: hat/menupermissions/models.py:307
+#: hat/menupermissions/models.py
 #, fuzzy
 #| msgid "Polio Vaccine Authorizations Admin"
 msgid "Polio Vaccine Stock Earmarks Admin"
 msgstr "Administration des autorisations vaccin Polio"
 
-#: hat/menupermissions/models.py:310
+#: hat/menupermissions/models.py
 msgid "Areas"
 msgstr "Zones"
 
-#: hat/menupermissions/models.py:311
+#: hat/menupermissions/models.py
 msgid "Edit areas"
 msgstr "Éditer les zones"
 
-#: hat/menupermissions/models.py:312
+#: hat/menupermissions/models.py
 msgid "Edit areas shapes"
 msgstr "Éditer les formes des zones"
 
-#: hat/menupermissions/models.py:313
+#: hat/menupermissions/models.py
 msgid "Cases"
 msgstr "Cas"
 
-#: hat/menupermissions/models.py:314
+#: hat/menupermissions/models.py
 msgid "Cases analysis"
 msgstr "Analyse des cas"
 
-#: hat/menupermissions/models.py:315
+#: hat/menupermissions/models.py
 msgid "Coordinations"
 msgstr "Coordinations"
 
-#: hat/menupermissions/models.py:316
+#: hat/menupermissions/models.py
 msgid "Devices"
 msgstr "Appareils"
 
-#: hat/menupermissions/models.py:317
+#: hat/menupermissions/models.py
 msgid "Téléchargement de données"
 msgstr "Téléchargement de données"
 
-#: hat/menupermissions/models.py:318
+#: hat/menupermissions/models.py
 msgid "Doublons"
 msgstr "Doublons"
 
-#: hat/menupermissions/models.py:319
+#: hat/menupermissions/models.py
 msgid "Edition d'un patient"
 msgstr "Edition d'un patient"
 
-#: hat/menupermissions/models.py:320
+#: hat/menupermissions/models.py
 msgid "Health facilities"
 msgstr "Établissements de santé"
 
-#: hat/menupermissions/models.py:321
+#: hat/menupermissions/models.py
 msgid "Labo"
 msgstr "Labo"
 
-#: hat/menupermissions/models.py:322
+#: hat/menupermissions/models.py
 msgid "Labo import"
 msgstr "Import labo"
 
-#: hat/menupermissions/models.py:323
+#: hat/menupermissions/models.py
 msgid "Locator"
 msgstr "Localisateur"
 
-#: hat/menupermissions/models.py:324
+#: hat/menupermissions/models.py
 msgid "Macroplanning"
 msgstr "Macroplanification"
 
-#: hat/menupermissions/models.py:325
+#: hat/menupermissions/models.py
 msgid "Microplanning"
 msgstr "Microplanification"
 
-#: hat/menupermissions/models.py:326
+#: hat/menupermissions/models.py
 msgid "Modifications"
 msgstr "Modifications"
 
-#: hat/menupermissions/models.py:327
+#: hat/menupermissions/models.py
 msgid "Plannings"
 msgstr "Planifications"
 
-#: hat/menupermissions/models.py:328
+#: hat/menupermissions/models.py
 msgid "Plannings template"
 msgstr "Modèle de planifications"
 
-#: hat/menupermissions/models.py:329
+#: hat/menupermissions/models.py
 msgid "Quality control"
 msgstr "Contrôle qualité"
 
-#: hat/menupermissions/models.py:330
+#: hat/menupermissions/models.py
 msgid "Reconciliation"
 msgstr "Réconciliation"
 
-#: hat/menupermissions/models.py:331
+#: hat/menupermissions/models.py
 msgid "Routes"
 msgstr "Routes"
 
-#: hat/menupermissions/models.py:332
+#: hat/menupermissions/models.py
 msgid "Graphs"
 msgstr "Graphiques"
 
-#: hat/menupermissions/models.py:334
+#: hat/menupermissions/models.py
 msgid "Upload of cases files"
 msgstr "Téléversement des fichiers de cas"
 
-#: hat/menupermissions/models.py:335
+#: hat/menupermissions/models.py
 msgid "Upload of villages files"
 msgstr "Téléversement des fichiers de villages"
 
-#: hat/menupermissions/models.py:336
+#: hat/menupermissions/models.py
 msgid "Teams"
 msgstr "Équipes"
 
-#: hat/menupermissions/models.py:338
+#: hat/menupermissions/models.py
 msgid "Vector control"
 msgstr "Contrôle vectoriel"
 
-#: hat/menupermissions/models.py:339
+#: hat/menupermissions/models.py
 msgid "Vector control import Gpx"
 msgstr "Import GPX contrôle vectoriel"
 
-#: hat/menupermissions/models.py:340
+#: hat/menupermissions/models.py
 msgid "Villages"
 msgstr "Villages"
 
-#: hat/menupermissions/models.py:341
+#: hat/menupermissions/models.py
 msgid "Work zones"
 msgstr "Zones de travail"
 
-#: hat/menupermissions/models.py:342
+#: hat/menupermissions/models.py
 msgid "Zones"
 msgstr "Zones"
 
-#: hat/menupermissions/models.py:343
+#: hat/menupermissions/models.py
 msgid "Edit zones"
 msgstr "Éditer les zones"
 
-#: hat/menupermissions/models.py:344
+#: hat/menupermissions/models.py
 msgid "Edit zones shapes"
 msgstr "Éditer les formes des zones"
 
-#: hat/settings.py:356
+#: hat/settings.py
 msgid "French"
 msgstr "Français"
 
-#: hat/settings.py:357
+#: hat/settings.py
 msgid "English"
 msgstr "Anglais"
 
-#: hat/templates/iaso/forgot_password.html:13
-#: hat/templates/iaso/reset_password_confirmation.html:15
+#: hat/templates/iaso/forgot_password.html
+#: hat/templates/iaso/reset_password_confirmation.html
 msgid "Submit"
 msgstr "Envoyer"
 
-#: hat/templates/iaso/forgot_password.html:14
-#: hat/templates/iaso/forgot_password_confirmation.html:13
+#: hat/templates/iaso/forgot_password.html
+#: hat/templates/iaso/forgot_password_confirmation.html
 msgid "Go back to login"
 msgstr "Retour à la connexion"
 
-#: hat/templates/iaso/forgot_password_confirmation.html:11
+#: hat/templates/iaso/forgot_password_confirmation.html
 msgid ""
 "We've emailed you instructions for setting your password, if an account "
 "exists with the email you entered. You should receive them shortly."
@@ -404,7 +404,7 @@ msgstr ""
 "Un courriel avec les instructions pour enregistrer un nouveau mot de passe "
 "vous a été envoyé. Vous devriez le recevoir sous peu."
 
-#: hat/templates/iaso/forgot_password_confirmation.html:12
+#: hat/templates/iaso/forgot_password_confirmation.html
 msgid ""
 "If you don't receive an email, please make sure you've entered the address "
 "you registered with, and check your spam folder."
@@ -412,7 +412,7 @@ msgstr ""
 "Si vous ne recevez pas de courriel, vérifiez que vous avez bien entré votre "
 "adresse d'enregistrement et vérifiez votre dossier spam."
 
-#: hat/templates/iaso/login.html:30
+#: hat/templates/iaso/login.html
 msgid ""
 "Your account doesn't have access to this page. To proceed, please login with "
 "an account that has access.\n"
@@ -422,27 +422,27 @@ msgstr ""
 "avec un autre utilisateur.\n"
 "          "
 
-#: hat/templates/iaso/login.html:35
+#: hat/templates/iaso/login.html
 msgid "Please login to see this page."
 msgstr "Veuillez vous connecter pour voir cette page."
 
-#: hat/templates/iaso/login.html:41
+#: hat/templates/iaso/login.html
 msgid "Your username and password didn't match. Please try again."
 msgstr "Nom d'utilisateur ou mot de passe incorrect."
 
-#: hat/templates/iaso/login.html:47
+#: hat/templates/iaso/login.html
 msgid "Login"
 msgstr "Connexion"
 
-#: hat/templates/iaso/login.html:54
+#: hat/templates/iaso/login.html
 msgid "Learn more"
 msgstr "En savoir plus"
 
-#: hat/templates/iaso/login.html:56
+#: hat/templates/iaso/login.html
 msgid "Forgot password"
 msgstr "Mot de passe oublié ?"
 
-#: hat/templates/iaso/reset_password_complete.html:13
+#: hat/templates/iaso/reset_password_complete.html
 #, python-format
 msgid ""
 "\n"
@@ -455,7 +455,7 @@ msgstr ""
 "href=\"%(login_url)s\">connecter</a>.\n"
 "        "
 
-#: hat/templates/iaso/reset_password_confirmation.html:21
+#: hat/templates/iaso/reset_password_confirmation.html
 msgid ""
 "The password reset link is invalid, possibly because it has already been "
 "used or expired. Please request a new password reset by clicking on this "
@@ -464,15 +464,15 @@ msgstr ""
 "parce qu'il a déjà été utilisé ou a expiré. Veuillez demander une nouvelle "
 "réinitialisation de mot de passe en cliquant sur ce "
 
-#: hat/templates/iaso/reset_password_confirmation.html:21
+#: hat/templates/iaso/reset_password_confirmation.html
 msgid "link."
 msgstr "lien."
 
-#: hat/templates/iaso/reset_password_email.html:3
+#: hat/templates/iaso/reset_password_email.html
 msgid "Hello,"
 msgstr "Bonjour,"
 
-#: hat/templates/iaso/reset_password_email.html:5
+#: hat/templates/iaso/reset_password_email.html
 #, python-format
 msgid ""
 "A password reset has been request for your account \"%(username)s\" on "
@@ -481,11 +481,11 @@ msgstr ""
 "Une demande de réinitialisation de mot de passe a été effectuée pour votre "
 "compte \"%(username)s\" sur %(site_name)s,"
 
-#: hat/templates/iaso/reset_password_email.html:6
+#: hat/templates/iaso/reset_password_email.html
 msgid "to proceed please click the link below:"
 msgstr "pour continuer, veuillez cliquer sur le lien suivant :"
 
-#: hat/templates/iaso/reset_password_email.html:10
+#: hat/templates/iaso/reset_password_email.html
 msgid ""
 "If clicking the link above doesn't work, please copy and paste the URL in a "
 "new browser window instead."
@@ -493,7 +493,7 @@ msgstr ""
 "Si cliquer sur le lien ne fonctionne pas, veuillez copier coller l'url dans "
 "une fenêtre de votre navigateur à la place."
 
-#: hat/templates/iaso/reset_password_email.html:12
+#: hat/templates/iaso/reset_password_email.html
 msgid ""
 "If you did not request a password reset, you can ignore this e-mail - no "
 "passwords will be changed."
@@ -501,16 +501,16 @@ msgstr ""
 "Si vous n'avez pas demandé cette réinitialisation, vous pouvez ignorer ce "
 "courriel, aucun mot de passe ne sera modifié."
 
-#: hat/templates/iaso/reset_password_email.html:14
+#: hat/templates/iaso/reset_password_email.html
 msgid "Sincerely,"
 msgstr "Sincèrement,"
 
-#: hat/templates/iaso/reset_password_email.html:15
+#: hat/templates/iaso/reset_password_email.html
 #, python-format
 msgid "The %(site_name)s Team."
 msgstr "L'équipe %(site_name)s."
 
-#: hat/templates/iaso/reset_password_subject.txt:2
+#: hat/templates/iaso/reset_password_subject.txt
 #, python-format
 msgid "Password reset on %(site_name)s"
 msgstr "Réinitialisation du mot de passe sur %(site_name)s"

--- a/iaso/locale/fr/LC_MESSAGES/django.po
+++ b/iaso/locale/fr/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-24 14:18+0000\n"
+"POT-Creation-Date: 2025-04-02 08:35+0000\n"
 "PO-Revision-Date: 2025-02-06 10:24+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,25 +18,24 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 3.5\n"
 
-#: iaso/api/comment.py:23
+#: iaso/api/comment.py
 #, python-brace-format
 msgid "Model {value} does not exist."
 msgstr "Le modèle {value} n'existe pas."
 
-#: iaso/api/comment.py:24
+#: iaso/api/comment.py
 msgid "Invalid value."
 msgstr "Valeur invalide"
 
-#: iaso/api/data_source_versions_synchronization/filters.py:10
+#: iaso/api/data_source_versions_synchronization/filters.py
 msgid "Created at greater than or equal to"
 msgstr "Créé à une date supérieure ou égale à"
 
-#: iaso/api/enketo.py:122 iaso/api/enketo.py:131 iaso/api/logs.py:130
-#: iaso/api/logs.py:156
+#: iaso/api/enketo.py iaso/api/logs.py
 msgid "Unauthorized"
 msgstr "Non autorisé"
 
-#: iaso/api/enketo.py:150
+#: iaso/api/enketo.py
 msgid ""
 "There are multiple submissions for this period and organizational unit, "
 "please log in the dashboard to fix."
@@ -44,23 +43,23 @@ msgstr ""
 "Il y a plusieurs soumissions pour cette période et cette unité "
 "organisationnelle, veuillez vous connecter au tableau de bord pour corriger."
 
-#: iaso/api/group_sets/filters.py:23
+#: iaso/api/group_sets/filters.py
 msgid "Search by groupset's name"
 msgstr "Rechercher par nom de groupe"
 
-#: iaso/api/group_sets/filters.py:26
+#: iaso/api/group_sets/filters.py
 msgid "SourceVersion id"
 msgstr "ID de version source"
 
-#: iaso/api/group_sets/filters.py:29
+#: iaso/api/group_sets/filters.py
 msgid "Limit to default version source"
 msgstr "Limiter à la version source par défaut"
 
-#: iaso/api/group_sets/filters.py:33
+#: iaso/api/group_sets/filters.py
 msgid "Limit search to coma seperated project ids"
 msgstr "Limiter la recherche aux IDs de projets séparés par des virgules"
 
-#: iaso/api/logs.py:123
+#: iaso/api/logs.py
 msgid ""
 "objectId and contentType parameters are required. contentType Can be one of "
 "iaso.orgunit, iaso.form, iaso.instance"
@@ -68,318 +67,316 @@ msgstr ""
 "Les paramètres objectId et contentType sont requis. contentType peut être "
 "l'un des suivants : iaso.orgunit, iaso.form, iaso.instance"
 
-#: iaso/api/org_unit_change_request_configurations/filters.py:10
-#: iaso/api/org_unit_change_requests/filters.py:29
+#: iaso/api/org_unit_change_request_configurations/filters.py
+#: iaso/api/org_unit_change_requests/filters.py
 msgid "Project ID"
 msgstr "ID du projet"
 
-#: iaso/api/org_unit_change_request_configurations/filters.py:11
-#: iaso/api/org_unit_change_requests/filters.py:26
+#: iaso/api/org_unit_change_request_configurations/filters.py
+#: iaso/api/org_unit_change_requests/filters.py
 msgid "Org unit type ID"
 msgstr "ID du type d'unité organisationnelle"
 
-#: iaso/api/org_unit_change_request_configurations/filters.py:13
+#: iaso/api/org_unit_change_request_configurations/filters.py
 msgid "Created by - Users IDs (comma-separated)"
 msgstr "Créé par - IDs utilisateurs (séparés par des virgules)"
 
-#: iaso/api/org_unit_change_requests/filters.py:24
+#: iaso/api/org_unit_change_requests/filters.py
 msgid "IDs (comma-separated)"
 msgstr "IDs (séparés par des virgules)"
 
-#: iaso/api/org_unit_change_requests/filters.py:25
+#: iaso/api/org_unit_change_requests/filters.py
 msgid "Org unit ID"
 msgstr "ID de l'unité organisationnelle"
 
-#: iaso/api/org_unit_change_requests/filters.py:27
-#: iaso/api/org_unit_tree/filters.py:13
+#: iaso/api/org_unit_change_requests/filters.py
+#: iaso/api/org_unit_tree/filters.py
 msgid "Parent ID"
 msgstr "ID du parent"
 
-#: iaso/api/org_unit_change_requests/filters.py:28
+#: iaso/api/org_unit_change_requests/filters.py
 msgid "Groups IDs (comma-separated)"
 msgstr "IDs des groupes (séparés par des virgules)"
 
-#: iaso/api/org_unit_change_requests/filters.py:32
+#: iaso/api/org_unit_change_requests/filters.py
 msgid "Data source synchronization ID"
 msgstr "ID de synchronisation de source de données"
 
-#: iaso/api/org_unit_change_requests/filters.py:35
+#: iaso/api/org_unit_change_requests/filters.py
 msgid "Forms IDs (comma-separated)"
 msgstr "IDs des formulaires (séparés par des virgules)"
 
-#: iaso/api/org_unit_change_requests/filters.py:36
+#: iaso/api/org_unit_change_requests/filters.py
 msgid "Users IDs (comma-separated)"
 msgstr "IDs des utilisateurs (séparés par des virgules)"
 
-#: iaso/api/org_unit_change_requests/filters.py:37
+#: iaso/api/org_unit_change_requests/filters.py
 msgid "User roles IDs (comma-separated)"
 msgstr "IDs des rôles utilisateurs (séparés par des virgules)"
 
-#: iaso/api/org_unit_change_requests/filters.py:38
+#: iaso/api/org_unit_change_requests/filters.py
 msgid "With or without location"
 msgstr "Avec ou sans localisation"
 
-#: iaso/api/org_unit_change_requests/filters.py:39
+#: iaso/api/org_unit_change_requests/filters.py
 msgid "Status (comma-separated)"
 msgstr "Statut (séparés par des virgules)"
 
-#: iaso/api/org_unit_change_requests/filters.py:40
+#: iaso/api/org_unit_change_requests/filters.py
 msgid "Projects IDs (comma-separated)"
 msgstr "IDs des projets (séparés par des virgules)"
 
-#: iaso/api/org_unit_change_requests/filters.py:41
+#: iaso/api/org_unit_change_requests/filters.py
 msgid "Payment status"
 msgstr "Statut de paiement"
 
-#: iaso/api/org_unit_change_requests/filters.py:42
+#: iaso/api/org_unit_change_requests/filters.py
 msgid "Payment IDs (comma-separated)"
 msgstr "IDs des paiements (séparés par des virgules)"
 
-#: iaso/api/org_unit_change_requests/filters.py:44
+#: iaso/api/org_unit_change_requests/filters.py
 msgid "Potential Payment IDs (comma-separated)"
 msgstr "IDs des paiements potentiels (séparés par des virgules)"
 
-#: iaso/api/org_unit_change_requests/filters.py:46
+#: iaso/api/org_unit_change_requests/filters.py
 msgid "Source version ID"
 msgstr "ID de version source"
 
-#: iaso/api/org_unit_tree/filters.py:12
+#: iaso/api/org_unit_tree/filters.py
 msgid "Ignore empty names"
 msgstr "Ignorer les noms vides"
 
-#: iaso/api/org_unit_tree/filters.py:14
+#: iaso/api/org_unit_tree/filters.py
 msgid "Data source ID"
 msgstr "ID de source de données"
 
-#: iaso/api/org_unit_tree/filters.py:16
+#: iaso/api/org_unit_tree/filters.py
 msgid "Validation status"
 msgstr "Statut de validation"
 
-#: iaso/api/org_units.py:446 iaso/api/org_units.py:728
+#: iaso/api/org_units.py
 msgid "You cannot create or edit an Org unit of this type"
 msgstr ""
 "Vous ne pouvez pas créer ou modifier une unité organisationnelle de ce type"
 
-#: iaso/api/org_units.py:472
+#: iaso/api/org_units.py
 #, python-brace-format
 msgid "Invalid validation status : {validation_status}"
 msgstr "Statut de validation invalide : {validation_status}"
 
-#: iaso/api/org_units.py:556 iaso/api/org_units.py:741
+#: iaso/api/org_units.py
 msgid "You cannot create an Org Unit without a parent"
 msgstr "Vous ne pouvez pas créer une unité organisationnelle sans parent"
 
-#: iaso/api/org_units.py:572 iaso/api/org_units.py:749
+#: iaso/api/org_units.py
 msgid "Group must be in the same source version"
 msgstr "Le groupe doit être dans la même version source"
 
-#: iaso/api/org_units.py:586
+#: iaso/api/org_units.py
 msgid "InstanceFile with id {} does not exist"
 msgstr "Le fichier d'instance avec l'id {} n'existe pas"
 
-#: iaso/api/org_units.py:653
+#: iaso/api/org_units.py
 msgid "Unauthorized version id"
 msgstr "ID de version non autorisé"
 
-#: iaso/api/org_units.py:664
+#: iaso/api/org_units.py
 msgid "Org unit name is required"
 msgstr "Le nom de l'unité organisationnelle est requis"
 
-#: iaso/api/org_units.py:689
+#: iaso/api/org_units.py
 msgid "Opening date must be anterior to closed date"
 msgstr "La date d'ouverture doit être antérieure à la date de fermeture"
 
-#: iaso/api/org_units.py:711
+#: iaso/api/org_units.py
 msgid "Can't parse geom"
 msgstr "Impossible d'analyser la géométrie"
 
-#: iaso/api/org_units.py:722
+#: iaso/api/org_units.py
 msgid "Org unit type is required"
 msgstr "Le type d'unité organisationnelle est requis"
 
-#: iaso/api/org_units.py:735
+#: iaso/api/org_units.py
 msgid "Parent is not in the same version"
 msgstr "Le parent n'est pas dans la même version"
 
-#: iaso/api/pages.py:37
+#: iaso/api/pages.py
 msgid "Limit result by name or slug"
 msgstr "Limiter les résultats par nom ou slug"
 
-#: iaso/api/pages.py:39
+#: iaso/api/pages.py
 msgid "Limit on authentication required or not"
 msgstr "Limiter selon si l'authentification est requise ou non"
 
-#: iaso/api/pages.py:41 iaso/api/payments/views.py:348
-#: iaso/api/payments/views.py:379
+#: iaso/api/pages.py iaso/api/payments/views.py
 msgid "User ID"
 msgstr "ID utilisateur"
 
-#: iaso/api/payments/views.py:346 iaso/api/payments/views.py:377
+#: iaso/api/payments/views.py
 msgid "ID"
 msgstr "ID"
 
-#: iaso/api/payments/views.py:347 iaso/api/payments/views.py:378
+#: iaso/api/payments/views.py
 msgid "Status"
 msgstr "Statut"
 
-#: iaso/api/payments/views.py:349 iaso/api/payments/views.py:380
+#: iaso/api/payments/views.py
 msgid "User Username"
 msgstr "Nom d'utilisateur"
 
-#: iaso/api/payments/views.py:350 iaso/api/payments/views.py:381
+#: iaso/api/payments/views.py
 msgid "User Phone"
 msgstr "Téléphone de l'utilisateur"
 
-#: iaso/api/payments/views.py:351 iaso/api/payments/views.py:382
+#: iaso/api/payments/views.py
 msgid "User Last Name"
 msgstr "Nom de famille de l'utilisateur"
 
-#: iaso/api/payments/views.py:352 iaso/api/payments/views.py:383
+#: iaso/api/payments/views.py
 msgid "User First Name"
 msgstr "Prénom de l'utilisateur"
 
-#: iaso/api/payments/views.py:353 iaso/api/payments/views.py:384
+#: iaso/api/payments/views.py
 msgid "Change Requests"
 msgstr "Demandes de modification"
 
-#: iaso/api/payments/views.py:354 iaso/api/payments/views.py:385
+#: iaso/api/payments/views.py
 msgid "Total Change Requests Count"
 msgstr "Nombre total de demandes de modification"
 
-#: iaso/api/payments/views.py:355 iaso/api/payments/views.py:386
+#: iaso/api/payments/views.py
 msgid "Org Unit Creation Count"
 msgstr "Nombre de créations d'unités organisationnelles"
 
-#: iaso/api/payments/views.py:356 iaso/api/payments/views.py:387
+#: iaso/api/payments/views.py
 msgid "Org Unit Change Count"
 msgstr "Nombre de modifications d'unités organisationnelles"
 
-#: iaso/api/payments/views.py:359 iaso/api/payments/views.py:390
+#: iaso/api/payments/views.py
 #, python-format
 msgid "Form: %(name)s"
 msgstr "Formulaire : %(name)s"
 
-#: iaso/api/profiles/profile_logs.py:30
+#: iaso/api/profiles/profile_logs.py
 msgid "User IDs"
 msgstr "IDs utilisateurs"
 
-#: iaso/api/profiles/profile_logs.py:31
+#: iaso/api/profiles/profile_logs.py
 msgid "Modified by"
 msgstr "Modifié par"
 
-#: iaso/api/profiles/profile_logs.py:32
+#: iaso/api/profiles/profile_logs.py
 msgid "Location"
 msgstr "Localisation"
 
-#: iaso/api/profiles/profiles.py:346 iaso/api/profiles/profiles.py:632
+#: iaso/api/profiles/profiles.py
 msgid "Nom d'utilisateur requis"
 msgstr "Nom d'utilisateur requis"
 
-#: iaso/api/profiles/profiles.py:349 iaso/api/profiles/profiles.py:365
-#: iaso/api/profiles/profiles.py:637
+#: iaso/api/profiles/profiles.py
 msgid "Nom d'utilisateur existant"
 msgstr "Nom d'utilisateur existant"
 
-#: iaso/api/profiles/profiles.py:351
+#: iaso/api/profiles/profiles.py
 msgid "Mot de passe requis"
 msgstr "Mot de passe requis"
 
-#: iaso/api/profiles/profiles.py:772
+#: iaso/api/profiles/profiles.py
 msgid "Both phone number and country code must be provided"
 msgstr "Le numéro de téléphone et le code pays doivent être fournis"
 
-#: iaso/api/profiles/profiles.py:781 iaso/tests/api/test_profiles.py:1302
+#: iaso/api/profiles/profiles.py iaso/tests/api/test_profiles.py
 msgid "Invalid phone number"
 msgstr "Numéro de téléphone invalide"
 
-#: iaso/models/base.py:64
+#: iaso/models/base.py
 msgid "Aggregate"
 msgstr "Agrégé"
 
-#: iaso/models/base.py:65
+#: iaso/models/base.py
 msgid "Event"
 msgstr "Événement"
 
-#: iaso/models/base.py:66
+#: iaso/models/base.py
 msgid "Event Tracker"
 msgstr "Suivi d'événement"
 
-#: iaso/models/base.py:67
+#: iaso/models/base.py
 msgid "Derived"
 msgstr "Dérivé"
 
-#: iaso/models/base.py:79
+#: iaso/models/base.py
 msgid "Queued"
 msgstr "En file d'attente"
 
-#: iaso/models/base.py:80
+#: iaso/models/base.py
 msgid "Running"
 msgstr "En cours"
 
-#: iaso/models/base.py:81
+#: iaso/models/base.py
 msgid "Exported"
 msgstr "Exporté"
 
-#: iaso/models/base.py:82
+#: iaso/models/base.py
 msgid "Errored"
 msgstr "En erreur"
 
-#: iaso/models/base.py:83
+#: iaso/models/base.py
 msgid "Skipped"
 msgstr "Ignoré"
 
-#: iaso/models/base.py:84
+#: iaso/models/base.py
 msgid "Killed"
 msgstr "Arrêté"
 
-#: iaso/models/base.py:85
+#: iaso/models/base.py
 msgid "Success"
 msgstr "Succès"
 
-#: iaso/models/base.py:432
+#: iaso/models/base.py
 msgid "Polio"
 msgstr "Polio"
 
-#: iaso/models/base.py:554
+#: iaso/models/base.py
 msgid "SINGLE"
 msgstr "UNIQUE"
 
-#: iaso/models/base.py:555
+#: iaso/models/base.py
 msgid "MULTIPLE"
 msgstr "MULTIPLE"
 
-#: iaso/models/base.py:1083
+#: iaso/models/base.py
 msgid "The Instance must be linked to a Form."
 msgstr "L'instance doit être liée à un formulaire."
 
-#: iaso/models/base.py:1085
+#: iaso/models/base.py
 msgid "The OrgUnit must be linked to a OrgUnitType."
 msgstr ""
 "L'unité organisationnelle doit être liée à un type d'unité organisationnelle."
 
-#: iaso/models/base.py:1087
+#: iaso/models/base.py
 msgid "The submission must be an instance of a reference form."
 msgstr "La soumission doit être une instance d'un formulaire de référence."
 
-#: iaso/models/base.py:1674
+#: iaso/models/base.py
 msgid "Immediate export of instances to DHIS2"
 msgstr "Export immédiat des instances vers DHIS2"
 
-#: iaso/models/base.py:1679
+#: iaso/models/base.py
 msgid "GPS localization on start of instance on mobile"
 msgstr "Localisation GPS au démarrage de l'instance sur mobile"
 
-#: iaso/models/base.py:1684
+#: iaso/models/base.py
 msgid "Require authentication on mobile"
 msgstr "Authentification requise sur mobile"
 
-#: iaso/models/base.py:1691
+#: iaso/models/base.py
 msgid "Mobile: Limit download of orgunit to what the user has access to"
 msgstr ""
 "Mobile : Limiter le téléchargement des unités organisationnelles à celles "
 "auxquelles l'utilisateur a accès"
 
-#: iaso/models/base.py:1699
+#: iaso/models/base.py
 msgid ""
 "Saving a form as finalized on mobile triggers an upload attempt immediately "
 "+ everytime network becomes available"
@@ -388,11 +385,11 @@ msgstr ""
 "tentative de téléchargement immédiatement + à chaque fois que le réseau "
 "devient disponible"
 
-#: iaso/models/comment.py:21
+#: iaso/models/comment.py
 msgid "content type"
 msgstr "type de contenu"
 
-#: iaso/models/data_source.py:211
+#: iaso/models/data_source.py
 msgid ""
 "Used in the UI e.g. to filter Change Requests by Data Source Synchronization "
 "operations."
@@ -400,254 +397,253 @@ msgstr ""
 "Utilisé dans l'interface utilisateur pour filtrer les demandes de "
 "modification par opérations de synchronisation de source de données."
 
-#: iaso/models/data_source.py:217
+#: iaso/models/data_source.py
 msgid ""
 "The version of the pyramid for which we want to generate change requests."
 msgstr ""
 "La version de la pyramide pour laquelle nous voulons générer des demandes de "
 "modification."
 
-#: iaso/models/data_source.py:223
+#: iaso/models/data_source.py
 msgid "The version of the pyramid to use as a comparison."
 msgstr "La version de la pyramide à utiliser comme comparaison."
 
-#: iaso/models/data_source.py:227
+#: iaso/models/data_source.py
 msgid "The diff used to create change requests."
 msgstr "La différence utilisée pour créer des demandes de modification."
 
-#: iaso/models/data_source.py:229
+#: iaso/models/data_source.py
 msgid "A string representation of the parameters used for the diff."
 msgstr ""
 "Une représentation sous forme de chaîne des paramètres utilisés pour la "
 "différence."
 
-#: iaso/models/data_source.py:232
+#: iaso/models/data_source.py
 msgid ""
 "The number of change requests that will be generated to create an org unit."
 msgstr ""
 "Le nombre de demandes de modification qui seront générées pour créer une "
 "unité organisationnelle."
 
-#: iaso/models/data_source.py:235
+#: iaso/models/data_source.py
 msgid ""
 "The number of change requests that will be generated to update an org unit."
 msgstr ""
 "Le nombre de demandes de modification qui seront générées pour mettre à jour "
 "une unité organisationnelle."
 
-#: iaso/models/data_source.py:244
+#: iaso/models/data_source.py
 msgid "The background task that used the diff to create change requests."
 msgstr ""
 "La tâche en arrière-plan qui a utilisé la différence pour créer des demandes "
 "de modification."
 
-#: iaso/models/data_source.py:256
+#: iaso/models/data_source.py
 msgid "Data source synchronization"
 msgstr "Synchronisation de source de données"
 
-#: iaso/models/deduplication.py:8 iaso/models/payments.py:7
+#: iaso/models/deduplication.py iaso/models/payments.py
 msgid "Pending"
 msgstr "En attente"
 
-#: iaso/models/deduplication.py:9
+#: iaso/models/deduplication.py
 msgid "Validated"
 msgstr "Validé"
 
-#: iaso/models/deduplication.py:10
+#: iaso/models/deduplication.py
 msgid "Ignored"
 msgstr "Ignoré"
 
-#: iaso/models/deduplication.py:14
+#: iaso/models/deduplication.py
 msgid "Duplicate"
 msgstr "Doublon"
 
-#: iaso/models/deduplication.py:15
+#: iaso/models/deduplication.py
 msgid "Cousin"
 msgstr "Cousin"
 
-#: iaso/models/deduplication.py:16
+#: iaso/models/deduplication.py
 msgid "Produced"
 msgstr "Produit"
 
-#: iaso/models/device.py:56
+#: iaso/models/device.py
 msgid "Car"
 msgstr "Voiture"
 
-#: iaso/models/device.py:56
+#: iaso/models/device.py
 msgid "Foot"
 msgstr "À pied"
 
-#: iaso/models/device.py:56
+#: iaso/models/device.py
 msgid "Truc"
 msgstr "Truc"
 
-#: iaso/models/forms.py:88
+#: iaso/models/forms.py
 msgid "Day"
 msgstr "Jour"
 
-#: iaso/models/forms.py:89
+#: iaso/models/forms.py
 msgid "Month"
 msgstr "Mois"
 
-#: iaso/models/forms.py:90
+#: iaso/models/forms.py
 msgid "Quarter"
 msgstr "Trimestre"
 
-#: iaso/models/forms.py:91
+#: iaso/models/forms.py
 msgid "Quarter Nov"
 msgstr "Trimestre Nov"
 
-#: iaso/models/forms.py:92
+#: iaso/models/forms.py
 msgid "Six-month"
 msgstr "Semestre"
 
-#: iaso/models/forms.py:93
+#: iaso/models/forms.py
 msgid "Year"
 msgstr "Année"
 
-#: iaso/models/forms.py:94
+#: iaso/models/forms.py
 msgid "Financial Nov"
 msgstr "Financier Nov"
 
-#: iaso/models/forms.py:98
+#: iaso/models/forms.py
 msgid "No change request"
 msgstr "Pas de demande de modification"
 
-#: iaso/models/forms.py:99
+#: iaso/models/forms.py
 msgid "Create change request if form is reference form"
 msgstr ""
 "Créer une demande de modification si le formulaire est un formulaire de "
 "référence"
 
-#: iaso/models/org_unit.py:119
+#: iaso/models/org_unit.py
 msgid "Country"
 msgstr "Pays"
 
-#: iaso/models/org_unit.py:120
+#: iaso/models/org_unit.py
 msgid "Region"
 msgstr "Région"
 
-#: iaso/models/org_unit.py:121
+#: iaso/models/org_unit.py
 msgid "District"
 msgstr "District"
 
-#: iaso/models/org_unit.py:122
+#: iaso/models/org_unit.py
 msgid "Health Facility"
 msgstr "Établissement de santé"
 
-#: iaso/models/org_unit.py:266
+#: iaso/models/org_unit.py
 msgid "new"
 msgstr "nouveau"
 
-#: iaso/models/org_unit.py:267
+#: iaso/models/org_unit.py
 msgid "valid"
 msgstr "valide"
 
-#: iaso/models/org_unit.py:268
+#: iaso/models/org_unit.py
 msgid "rejected"
 msgstr "rejeté"
 
-#: iaso/models/org_unit.py:653
+#: iaso/models/org_unit.py
 msgid "Org Unit Creation"
 msgstr "Création d'unité organisationnelle"
 
-#: iaso/models/org_unit.py:654
+#: iaso/models/org_unit.py
 msgid "Org Unit Change"
 msgstr "Modification d'unité organisationnelle"
 
-#: iaso/models/org_unit.py:657 iaso/models/payments.py:59
+#: iaso/models/org_unit.py iaso/models/payments.py
 msgid "New"
 msgstr "Nouveau"
 
-#: iaso/models/org_unit.py:658 iaso/models/payments.py:9
+#: iaso/models/org_unit.py iaso/models/payments.py
 msgid "Rejected"
 msgstr "Rejeté"
 
-#: iaso/models/org_unit.py:659
+#: iaso/models/org_unit.py
 msgid "Approved"
 msgstr "Approuvé"
 
-#: iaso/models/org_unit.py:739
+#: iaso/models/org_unit.py
 msgid "Org unit change request"
 msgstr "Demande de modification d'unité organisationnelle"
 
-#: iaso/models/org_unit_change_request_configuration.py:42
+#: iaso/models/org_unit_change_request_configuration.py
 msgid "Creation"
 msgstr "Création"
 
-#: iaso/models/org_unit_change_request_configuration.py:43
+#: iaso/models/org_unit_change_request_configuration.py
 msgid "Edition"
 msgstr "Édition"
 
-#: iaso/models/org_unit_change_request_configuration.py:103
+#: iaso/models/org_unit_change_request_configuration.py
 msgid "Org unit change request configuration"
 msgstr "Configuration de demande de modification d'unité organisationnelle"
 
-#: iaso/models/pages.py:15
+#: iaso/models/pages.py
 msgid "Raw html"
 msgstr "HTML brut"
 
-#: iaso/models/pages.py:16
+#: iaso/models/pages.py
 msgid "Text"
 msgstr "Texte"
 
-#: iaso/models/pages.py:17
+#: iaso/models/pages.py
 msgid "Iframe"
 msgstr "Iframe"
 
-#: iaso/models/pages.py:18
+#: iaso/models/pages.py
 msgid "PowerBI report"
 msgstr "Rapport PowerBI"
 
-#: iaso/models/pages.py:19
+#: iaso/models/pages.py
 msgid "Superset dashboard"
 msgstr "Tableau de bord Superset"
 
-#: iaso/models/payments.py:8 iaso/models/payments.py:60
+#: iaso/models/payments.py
 msgid "Sent"
 msgstr "Envoyé"
 
-#: iaso/models/payments.py:10 iaso/models/payments.py:61
+#: iaso/models/payments.py
 msgid "Paid"
 msgstr "Payé"
 
-#: iaso/models/payments.py:64
+#: iaso/models/payments.py
 msgid "Partially Paid"
 msgstr "Partiellement payé"
 
-#: iaso/tasks/copy_version.py:41
-#: iaso/tasks/export_mobile_app_setup_for_user.py:55
-#: iaso/tasks/process_mobile_bulk_upload.py:52
+#: iaso/tasks/copy_version.py iaso/tasks/export_mobile_app_setup_for_user.py
+#: iaso/tasks/process_mobile_bulk_upload.py
 msgid "Starting"
 msgstr "Démarrage"
 
-#: iaso/tasks/copy_version.py:65
+#: iaso/tasks/copy_version.py
 msgid "Copying groups"
 msgstr "Copie des groupes"
 
-#: iaso/tasks/copy_version.py:106
+#: iaso/tasks/copy_version.py
 msgid "Copying org units"
 msgstr "Copie des unités organisationnelles"
 
-#: iaso/tasks/copy_version.py:120
+#: iaso/tasks/copy_version.py
 msgid "Fixing parents"
 msgstr "Correction des parents"
 
-#: iaso/utils/serializer/id_or_uuid_field.py:12
+#: iaso/utils/serializer/id_or_uuid_field.py
 msgid "This field is required."
 msgstr "Ce champ est requis."
 
-#: iaso/utils/serializer/id_or_uuid_field.py:13
+#: iaso/utils/serializer/id_or_uuid_field.py
 #, python-brace-format
 msgid "Invalid pk or uuid \"{pk_value}\" - object does not exist."
 msgstr "Clé primaire ou uuid invalide \"{pk_value}\" - l'objet n'existe pas."
 
-#: iaso/utils/serializer/id_or_uuid_field.py:14
+#: iaso/utils/serializer/id_or_uuid_field.py
 #, python-brace-format
 msgid "Incorrect type. Expected pk or uuid value, received {data_type}."
 msgstr ""
 "Type incorrect. Valeur de clé primaire ou uuid attendue, reçu {data_type}."
 
-#: iaso/utils/serializer/three_dim_point_field.py:18
+#: iaso/utils/serializer/three_dim_point_field.py
 msgid "Enter a valid location."
 msgstr "Entrez une localisation valide."

--- a/iaso/management/commands/make_translations.py
+++ b/iaso/management/commands/make_translations.py
@@ -21,6 +21,7 @@ class Command(BaseCommand):
             "--extension=py",
             "--extension=html",
             "--verbosity=0",  # Ensure detailed output
+            "--add-location=file",
         ] + IGNORE_ARGS
 
         try:

--- a/plugins/polio/locale/fr/LC_MESSAGES/django.po
+++ b/plugins/polio/locale/fr/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-24 14:18+0000\n"
+"POT-Creation-Date: 2025-04-02 08:35+0000\n"
 "PO-Revision-Date: 2025-02-05 14:43+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,543 +18,538 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 3.5\n"
 
-#: plugins/polio/api/campaigns/campaigns.py:179
+#: plugins/polio/api/campaigns/campaigns.py
 msgid "Round {} ended"
 msgstr "Round {} terminé"
 
-#: plugins/polio/api/campaigns/campaigns.py:181
+#: plugins/polio/api/campaigns/campaigns.py
 msgid "Round {} started"
 msgstr "Round {} commencé"
 
-#: plugins/polio/api/campaigns/campaigns.py:182
+#: plugins/polio/api/campaigns/campaigns.py
 msgid "Preparing"
 msgstr "Préparation"
 
-#: plugins/polio/api/chronogram/filters.py:48
+#: plugins/polio/api/chronogram/filters.py
 msgid "Campaigns"
 msgstr "Campagnes"
 
-#: plugins/polio/api/chronogram/filters.py:51
-#: plugins/polio/api/notifications/filters.py:20
+#: plugins/polio/api/chronogram/filters.py
+#: plugins/polio/api/notifications/filters.py
 msgid "Country"
 msgstr "Pays"
 
-#: plugins/polio/api/chronogram/filters.py:53
+#: plugins/polio/api/chronogram/filters.py
 msgid "On time"
 msgstr "À temps"
 
-#: plugins/polio/api/chronogram/filters.py:55
-#: plugins/polio/budget/filters.py:16
+#: plugins/polio/api/chronogram/filters.py plugins/polio/budget/filters.py
 msgid "Search"
 msgstr "Recherche"
 
-#: plugins/polio/api/chronogram/filters.py:58
-#: plugins/polio/api/chronogram/filters.py:74
+#: plugins/polio/api/chronogram/filters.py
 msgid "Created at greater than or equal to"
 msgstr "Créé à une date supérieure ou égale à"
 
-#: plugins/polio/api/chronogram/filters.py:60
-#: plugins/polio/api/chronogram/filters.py:76
+#: plugins/polio/api/chronogram/filters.py
 msgid "Power BI limit"
 msgstr "Limite Power BI"
 
-#: plugins/polio/api/dashboards/vaccine_stock_history.py:19
+#: plugins/polio/api/dashboards/vaccine_stock_history.py
 msgid "Vaccine"
 msgstr "Vaccin"
 
-#: plugins/polio/api/dashboards/vaccine_stock_history.py:20
+#: plugins/polio/api/dashboards/vaccine_stock_history.py
 msgid "Campaign OBR name"
 msgstr "Nom de la campagne OBR"
 
-#: plugins/polio/api/dashboards/vaccine_stock_history.py:21
+#: plugins/polio/api/dashboards/vaccine_stock_history.py
 msgid "Country ID"
 msgstr "ID du Pays"
 
-#: plugins/polio/api/dashboards/vaccine_stock_history.py:22
+#: plugins/polio/api/dashboards/vaccine_stock_history.py
 msgid "Round ID"
 msgstr "ID du round"
 
-#: plugins/polio/budget/filters.py:12
+#: plugins/polio/budget/filters.py
 msgid "Countries IDs (comma-separated)"
 msgstr "ID des pays (séparés par des virgules)"
 
-#: plugins/polio/budget/filters.py:14
+#: plugins/polio/budget/filters.py
 msgid "Org unit group IDs (comma-separated)"
 msgstr "ID des groupes d'unités d'org (séparés par des virgules)"
 
-#: plugins/polio/budget/models.py:90 plugins/polio/models/base.py:789
+#: plugins/polio/budget/models.py plugins/polio/models/base.py
 msgid "Disbursed to CO (WHO)"
 msgstr "Versé au CO (OMS)"
 
-#: plugins/polio/budget/models.py:95 plugins/polio/models/base.py:794
+#: plugins/polio/budget/models.py plugins/polio/models/base.py
 msgid "Disbursed to MOH (WHO)"
 msgstr "Versé au ministère de la santé (OMS)"
 
-#: plugins/polio/budget/models.py:100 plugins/polio/models/base.py:799
+#: plugins/polio/budget/models.py plugins/polio/models/base.py
 msgid "Disbursed to CO (UNICEF)"
 msgstr "Versé au CO (UNICEF)"
 
-#: plugins/polio/budget/models.py:105 plugins/polio/models/base.py:804
+#: plugins/polio/budget/models.py plugins/polio/models/base.py
 msgid "Disbursed to MOH (UNICEF)"
 msgstr "Versé au ministère de la santé (UNICEF)"
 
-#: plugins/polio/budget/models.py:192
+#: plugins/polio/budget/models.py
 #, python-format
 msgid "Error in template: %(error)s"
 msgstr "Erreur dans le template : %(error)s"
 
-#: plugins/polio/models/base.py:46
+#: plugins/polio/models/base.py
 msgid "PV1"
 msgstr "PV1"
 
-#: plugins/polio/models/base.py:47
+#: plugins/polio/models/base.py
 msgid "PV2"
 msgstr "PV2"
 
-#: plugins/polio/models/base.py:48
+#: plugins/polio/models/base.py
 msgid "PV3"
 msgstr "PV3"
 
-#: plugins/polio/models/base.py:49 plugins/polio/models/base.py:1746
+#: plugins/polio/models/base.py
 msgid "cVDPV2"
 msgstr "cVDPV2"
 
-#: plugins/polio/models/base.py:50 plugins/polio/models/base.py:1757
+#: plugins/polio/models/base.py
 msgid "WPV1"
 msgstr "WPV1"
 
-#: plugins/polio/models/base.py:51
+#: plugins/polio/models/base.py
 msgid "PV1 & cVDPV2"
 msgstr "PV1 & cVDPV2"
 
-#: plugins/polio/models/base.py:52
+#: plugins/polio/models/base.py
 msgid "cVDPV1 & cVDPV2"
 msgstr "cVDPV1 & cVDPV2"
 
-#: plugins/polio/models/base.py:56 plugins/polio/models/base.py:63
+#: plugins/polio/models/base.py
 msgid "mOPV2"
 msgstr "mOPV2"
 
-#: plugins/polio/models/base.py:57 plugins/polio/models/base.py:64
-#: plugins/polio/models/base.py:1747
+#: plugins/polio/models/base.py
 msgid "nOPV2"
 msgstr "nOPV2"
 
-#: plugins/polio/models/base.py:58 plugins/polio/models/base.py:65
+#: plugins/polio/models/base.py
 msgid "bOPV"
 msgstr "bOPV"
 
-#: plugins/polio/models/base.py:59
+#: plugins/polio/models/base.py
 msgid "nOPV2 & bOPV"
 msgstr "nOPV2 & bOPV"
 
-#: plugins/polio/models/base.py:81
+#: plugins/polio/models/base.py
 msgid "WHO"
 msgstr "WHO"
 
-#: plugins/polio/models/base.py:82
+#: plugins/polio/models/base.py
 msgid "UNICEF"
 msgstr "UNICEF"
 
-#: plugins/polio/models/base.py:83
+#: plugins/polio/models/base.py
 msgid "National"
 msgstr "National"
 
-#: plugins/polio/models/base.py:84
+#: plugins/polio/models/base.py
 msgid "MOH"
 msgstr "Ministère de la santé"
 
-#: plugins/polio/models/base.py:85
+#: plugins/polio/models/base.py
 msgid "PROVINCE"
 msgstr "PROVINCE"
 
-#: plugins/polio/models/base.py:86
+#: plugins/polio/models/base.py
 msgid "District"
 msgstr "District"
 
-#: plugins/polio/models/base.py:90 plugins/polio/models/base.py:1848
+#: plugins/polio/models/base.py
 msgid "Pending"
 msgstr "En attente"
 
-#: plugins/polio/models/base.py:91 plugins/polio/models/base.py:104
-#: plugins/polio/models/base.py:1287
+#: plugins/polio/models/base.py
 msgid "Ongoing"
 msgstr "En cours"
 
-#: plugins/polio/models/base.py:92 plugins/polio/models/base.py:106
+#: plugins/polio/models/base.py
 msgid "Finished"
 msgstr "Terminé"
 
-#: plugins/polio/models/base.py:96
+#: plugins/polio/models/base.py
 msgid "Approved"
 msgstr "Approuvé"
 
-#: plugins/polio/models/base.py:97
+#: plugins/polio/models/base.py
 msgid "To Submit"
 msgstr "À soumettre"
 
-#: plugins/polio/models/base.py:98
+#: plugins/polio/models/base.py
 msgid "Submitted"
 msgstr "Soumis"
 
-#: plugins/polio/models/base.py:99
+#: plugins/polio/models/base.py
 msgid "Reviewed by RRT"
 msgstr "Revue par RRT"
 
-#: plugins/polio/models/base.py:103
+#: plugins/polio/models/base.py
 msgid "Queued"
 msgstr "En file d'attente"
 
-#: plugins/polio/models/base.py:105
+#: plugins/polio/models/base.py
 msgid "Failed"
 msgstr "Échec"
 
-#: plugins/polio/models/base.py:110
+#: plugins/polio/models/base.py
 msgid "Direct"
 msgstr "Direct"
 
-#: plugins/polio/models/base.py:111
+#: plugins/polio/models/base.py
 msgid "DFC"
 msgstr "DFC"
 
-#: plugins/polio/models/base.py:112
+#: plugins/polio/models/base.py
 msgid "Mobile Payment"
 msgstr "Paiement mobile"
 
-#: plugins/polio/models/base.py:117
+#: plugins/polio/models/base.py
 msgid "initial_data"
 msgstr "données initiales"
 
-#: plugins/polio/models/base.py:118
+#: plugins/polio/models/base.py
 msgid "encoding_error"
 msgstr "erreur d'encodage"
 
-#: plugins/polio/models/base.py:119
+#: plugins/polio/models/base.py
 msgid "public_holday"
 msgstr "jour férié"
 
-#: plugins/polio/models/base.py:120
+#: plugins/polio/models/base.py
 msgid "other_activities"
 msgstr "autres activités"
 
-#: plugins/polio/models/base.py:121
+#: plugins/polio/models/base.py
 msgid "moh_decision"
 msgstr "décision du ministère de la santé"
 
-#: plugins/polio/models/base.py:122
+#: plugins/polio/models/base.py
 msgid "campaign_synchronization"
 msgstr "synchronisation de la campagne"
 
-#: plugins/polio/models/base.py:123
+#: plugins/polio/models/base.py
 msgid "preparedness_level_not_reached"
 msgstr "niveau de préparation non atteint"
 
-#: plugins/polio/models/base.py:124
+#: plugins/polio/models/base.py
 msgid "funds_not_received_ops_level"
 msgstr "fonds non reçus au niveau opérationnel"
 
-#: plugins/polio/models/base.py:125
+#: plugins/polio/models/base.py
 msgid "funds_not_arrived_in_country"
 msgstr "fonds non arrivés dans le pays"
 
-#: plugins/polio/models/base.py:126
+#: plugins/polio/models/base.py
 msgid "vaccines_not_delivered_ops_level"
 msgstr "vaccins non livrés au niveau opérationnel"
 
-#: plugins/polio/models/base.py:127
+#: plugins/polio/models/base.py
 msgid "vaccines_not_arrived_in_country"
 msgstr "vaccins non arrivés dans le pays"
 
-#: plugins/polio/models/base.py:128
+#: plugins/polio/models/base.py
 msgid "security_context"
 msgstr "contexte sécuritaire"
 
-#: plugins/polio/models/base.py:129
+#: plugins/polio/models/base.py
 msgid "campaign_moved_forward_by_moh"
 msgstr "campagne avancée par le ministère de la santé"
 
-#: plugins/polio/models/base.py:130
+#: plugins/polio/models/base.py
 msgid "vrf_not_signed"
 msgstr "VRF non signé"
 
-#: plugins/polio/models/base.py:131
+#: plugins/polio/models/base.py
 msgid "four_weeks_gap_betwenn_rounds"
 msgstr "écart de quatre semaines entre les rounds"
 
-#: plugins/polio/models/base.py:132
+#: plugins/polio/models/base.py
 msgid "other_vaccination_campaigns"
 msgstr "autres campagnes de vaccination"
 
-#: plugins/polio/models/base.py:135
+#: plugins/polio/models/base.py
 msgid "pending_liquidation_of_previous_sia_funding"
 msgstr "liquidation en attente du financement SIA précédent"
 
-#: plugins/polio/models/base.py:140
+#: plugins/polio/models/base.py
 msgid "years"
 msgstr "années"
 
-#: plugins/polio/models/base.py:141
+#: plugins/polio/models/base.py
 msgid "months"
 msgstr "mois"
 
-#: plugins/polio/models/base.py:220
+#: plugins/polio/models/base.py
 msgid "name"
 msgstr "nom"
 
-#: plugins/polio/models/base.py:682
+#: plugins/polio/models/base.py
 msgid "When the campaign starts"
 msgstr "Quand la campagne commence"
 
-#: plugins/polio/models/base.py:689
+#: plugins/polio/models/base.py
 msgid "Outbreak declaration date"
 msgstr "Date de déclaration du foyer"
 
-#: plugins/polio/models/base.py:696
+#: plugins/polio/models/base.py
 msgid "cVDPV2 Notification"
 msgstr "Notification cVDPV2"
 
-#: plugins/polio/models/base.py:702
+#: plugins/polio/models/base.py
 msgid "PV Notification"
 msgstr "Notification PV"
 
-#: plugins/polio/models/base.py:708
+#: plugins/polio/models/base.py
 msgid "PV2 Notification"
 msgstr "Notification PV2"
 
-#: plugins/polio/models/base.py:719 plugins/polio/models/base.py:733
+#: plugins/polio/models/base.py
 msgid "1st Draft Submission"
 msgstr "Soumission du 1er projet"
 
-#: plugins/polio/models/base.py:728
+#: plugins/polio/models/base.py
 msgid "Field Investigation Date"
 msgstr "Date de l'enquête sur le terrain"
 
-#: plugins/polio/models/base.py:738
+#: plugins/polio/models/base.py
 msgid "RRT/OPRTT Approval"
 msgstr "Approbation du RRT/OPRTT"
 
-#: plugins/polio/models/base.py:743
+#: plugins/polio/models/base.py
 msgid "AG/nOPV Group"
 msgstr "Groupe AG/nOPV"
 
-#: plugins/polio/models/base.py:748
+#: plugins/polio/models/base.py
 msgid "DG Authorization"
 msgstr "Autorisation DG"
 
-#: plugins/polio/models/base.py:1156
+#: plugins/polio/models/base.py
 msgid "National Score"
 msgstr "Score national"
 
-#: plugins/polio/models/base.py:1157
+#: plugins/polio/models/base.py
 msgid "Regional Score"
 msgstr "Score régional"
 
-#: plugins/polio/models/base.py:1158
+#: plugins/polio/models/base.py
 msgid "District Score"
 msgstr "Score du district"
 
-#: plugins/polio/models/base.py:1288
+#: plugins/polio/models/base.py
 msgid "Validated"
 msgstr "Validé"
 
-#: plugins/polio/models/base.py:1289
+#: plugins/polio/models/base.py
 msgid "Sent for signature"
 msgstr "Envoyé pour signature"
 
-#: plugins/polio/models/base.py:1290
+#: plugins/polio/models/base.py
 msgid "Expired"
 msgstr "Expiré"
 
-#: plugins/polio/models/base.py:1347
+#: plugins/polio/models/base.py
 msgid "Normal"
 msgstr "Normal"
 
-#: plugins/polio/models/base.py:1348
+#: plugins/polio/models/base.py
 msgid "Missing"
 msgstr "Manquant"
 
-#: plugins/polio/models/base.py:1349
+#: plugins/polio/models/base.py
 msgid "Not Required"
 msgstr "Non requis"
 
-#: plugins/polio/models/base.py:1616
+#: plugins/polio/models/base.py
 msgid "VVM reached the discard point"
 msgstr "La VVM a atteint le point de rejet"
 
-#: plugins/polio/models/base.py:1617
+#: plugins/polio/models/base.py
 msgid "Vaccine expired"
 msgstr "Vaccin expiré"
 
-#: plugins/polio/models/base.py:1618
+#: plugins/polio/models/base.py
 msgid "Losses"
 msgstr "Pertes"
 
-#: plugins/polio/models/base.py:1619
+#: plugins/polio/models/base.py
 msgid "Return"
 msgstr "Retour"
 
-#: plugins/polio/models/base.py:1620
+#: plugins/polio/models/base.py
 msgid "Stealing"
 msgstr "Vols"
 
-#: plugins/polio/models/base.py:1621
+#: plugins/polio/models/base.py
 #, fuzzy
 #| msgid "Physical Inventory"
 msgid "Add to Physical Inventory"
 msgstr "Inventaire physique"
 
-#: plugins/polio/models/base.py:1622
+#: plugins/polio/models/base.py
 #, fuzzy
 #| msgid "Physical Inventory"
 msgid "remove from Physical Inventory"
 msgstr "Inventaire physique"
 
-#: plugins/polio/models/base.py:1623
+#: plugins/polio/models/base.py
 msgid "Broken"
 msgstr "Cassé"
 
-#: plugins/polio/models/base.py:1624
+#: plugins/polio/models/base.py
 msgid "Unreadable label"
 msgstr "Étiquette illisible"
 
-#: plugins/polio/models/base.py:1659
+#: plugins/polio/models/base.py
 msgid "Created"
 msgstr "Créé"
 
-#: plugins/polio/models/base.py:1660
+#: plugins/polio/models/base.py
 msgid "Used"
 msgstr "Utilisé"
 
-#: plugins/polio/models/base.py:1661
+#: plugins/polio/models/base.py
 #, fuzzy
 #| msgid "Return"
 msgid "Returned"
 msgstr "Retourné"
 
-#: plugins/polio/models/base.py:1744
+#: plugins/polio/models/base.py
 msgid "aVDPV"
 msgstr "aVDPV"
 
-#: plugins/polio/models/base.py:1745
+#: plugins/polio/models/base.py
 msgid "cVDPV1"
 msgstr "cVDPV1"
 
-#: plugins/polio/models/base.py:1748
+#: plugins/polio/models/base.py
 msgid "Sabin"
 msgstr "Sabin"
 
-#: plugins/polio/models/base.py:1749
+#: plugins/polio/models/base.py
 msgid "SABIN 1"
 msgstr "SABIN 1"
 
-#: plugins/polio/models/base.py:1750
+#: plugins/polio/models/base.py
 msgid "SABIN 2"
 msgstr "SABIN 2"
 
-#: plugins/polio/models/base.py:1751
+#: plugins/polio/models/base.py
 msgid "SABIN 3"
 msgstr "SABIN 3"
 
-#: plugins/polio/models/base.py:1752
+#: plugins/polio/models/base.py
 msgid "VDPV"
 msgstr "VDPV"
 
-#: plugins/polio/models/base.py:1753
+#: plugins/polio/models/base.py
 msgid "VDPV1"
 msgstr "VDPV1"
 
-#: plugins/polio/models/base.py:1754
+#: plugins/polio/models/base.py
 msgid "VDPV2"
 msgstr "VDPV2"
 
-#: plugins/polio/models/base.py:1755
+#: plugins/polio/models/base.py
 msgid "VDPV3"
 msgstr "VDPV3"
 
-#: plugins/polio/models/base.py:1756
+#: plugins/polio/models/base.py
 msgid "VPV2"
 msgstr "VPV2"
 
-#: plugins/polio/models/base.py:1762
+#: plugins/polio/models/base.py
 msgid "Accute Flaccid Paralysis"
 msgstr "Paralysie flasque aiguë"
 
-#: plugins/polio/models/base.py:1764
+#: plugins/polio/models/base.py
 msgid "Contact Case"
 msgstr "Cas contact"
 
-#: plugins/polio/models/base.py:1765
+#: plugins/polio/models/base.py
 msgid "Community"
 msgstr "Communauté"
 
-#: plugins/polio/models/base.py:1766
+#: plugins/polio/models/base.py
 msgid "Contact"
 msgstr "Contact"
 
-#: plugins/polio/models/base.py:1767
+#: plugins/polio/models/base.py
 msgid "Environmental"
 msgstr "Environnement"
 
-#: plugins/polio/models/base.py:1768
+#: plugins/polio/models/base.py
 msgid "Healthy Children"
 msgstr "Enfants en bonne santé"
 
-#: plugins/polio/models/base.py:1769
+#: plugins/polio/models/base.py
 msgid "Other"
 msgstr "Autre"
 
-#: plugins/polio/models/base.py:1817
+#: plugins/polio/models/base.py
 msgid "Notification"
 msgstr "Notification"
 
-#: plugins/polio/models/base.py:1847
+#: plugins/polio/models/base.py
 msgid "New"
 msgstr "Nouveau"
 
-#: plugins/polio/models/base.py:1849 plugins/polio/models/chronogram.py:139
+#: plugins/polio/models/base.py plugins/polio/models/chronogram.py
 msgid "Done"
 msgstr "Terminé"
 
-#: plugins/polio/models/base.py:1866
+#: plugins/polio/models/base.py
 msgid "Notification import"
 msgstr "Importation de notification"
 
-#: plugins/polio/models/chronogram.py:28
+#: plugins/polio/models/chronogram.py
 msgid "Before"
 msgstr "Avant"
 
-#: plugins/polio/models/chronogram.py:29
+#: plugins/polio/models/chronogram.py
 msgid "During"
 msgstr "Pendant"
 
-#: plugins/polio/models/chronogram.py:30
+#: plugins/polio/models/chronogram.py
 msgid "After"
 msgstr "Après"
 
-#: plugins/polio/models/chronogram.py:78
+#: plugins/polio/models/chronogram.py
 msgid "Chronogram"
 msgstr "Chronogramme"
 
-#: plugins/polio/models/chronogram.py:137
+#: plugins/polio/models/chronogram.py
 msgid "Not started"
 msgstr "Pas commencé"
 
-#: plugins/polio/models/chronogram.py:138
+#: plugins/polio/models/chronogram.py
 msgid "In progress"
 msgstr "En cours"
 
-#: plugins/polio/models/chronogram.py:140
+#: plugins/polio/models/chronogram.py
 msgid "N/A"
 msgstr "N/A"
 
-#: plugins/polio/models/chronogram.py:161
+#: plugins/polio/models/chronogram.py
 msgid "Chronogram Task"
 msgstr "Tâche de chronogramme"
 
-#: plugins/polio/models/chronogram.py:215
+#: plugins/polio/models/chronogram.py
 msgid "Chronogram Template Task"
 msgstr "Modèle de tâche de chronogramme"
 
-#: plugins/polio/preparedness/spreadsheet_manager.py:201
+#: plugins/polio/preparedness/spreadsheet_manager.py
 msgid "No country found for campaign"
 msgstr "Aucun pays trouvé pour la campagne"

--- a/plugins/wfp/locale/fr/LC_MESSAGES/django.po
+++ b/plugins/wfp/locale/fr/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-03 10:30+0000\n"
+"POT-Creation-Date: 2025-04-02 08:35+0000\n"
 "PO-Revision-Date: 2025-02-05 14:41+0100\n"
 "Last-Translator: Olivier Le Thanh Duong <olivier@lethanh.be>\n"
 "Language-Team: \n"
@@ -18,126 +18,126 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 3.5\n"
 
-#: plugins/wfp/models.py:8
+#: plugins/wfp/models.py
 msgid "Male"
 msgstr "Homme"
 
-#: plugins/wfp/models.py:8
+#: plugins/wfp/models.py
 msgid "Female"
 msgstr "Femme"
 
-#: plugins/wfp/models.py:11
+#: plugins/wfp/models.py
 msgid "Death"
 msgstr "Décès"
 
-#: plugins/wfp/models.py:12
+#: plugins/wfp/models.py
 msgid "Cured"
 msgstr "Guéri"
 
-#: plugins/wfp/models.py:13
+#: plugins/wfp/models.py
 msgid "Dismissal"
 msgstr "Renvoi"
 
-#: plugins/wfp/models.py:14
+#: plugins/wfp/models.py
 msgid "Voluntary Withdrawal"
 msgstr "Retrait volontaire"
 
-#: plugins/wfp/models.py:15
+#: plugins/wfp/models.py
 msgid "Transfer To OTP"
 msgstr "Transfert vers OTP"
 
-#: plugins/wfp/models.py:16
+#: plugins/wfp/models.py
 msgid "Transfer To TSFP"
 msgstr "Transfert vers TSFP"
 
-#: plugins/wfp/models.py:17
+#: plugins/wfp/models.py
 msgid "Non respondent"
 msgstr "Non répondant"
 
-#: plugins/wfp/models.py:18
+#: plugins/wfp/models.py
 msgid "Transferred out"
 msgstr "Transféré"
 
-#: plugins/wfp/models.py:19
+#: plugins/wfp/models.py
 msgid "Defaulter"
 msgstr "Défaillant"
 
-#: plugins/wfp/models.py:20
+#: plugins/wfp/models.py
 msgid "Other"
 msgstr "Autre"
 
-#: plugins/wfp/models.py:24
+#: plugins/wfp/models.py
 msgid "TSFP"
 msgstr "TSFP"
 
-#: plugins/wfp/models.py:25
+#: plugins/wfp/models.py
 msgid "OTP"
 msgstr "OTP"
 
-#: plugins/wfp/models.py:26
+#: plugins/wfp/models.py
 msgid "Breastfeeding"
 msgstr "Allaitement"
 
-#: plugins/wfp/models.py:27
+#: plugins/wfp/models.py
 msgid "Pregnant"
 msgstr "Enceinte"
 
-#: plugins/wfp/models.py:30
+#: plugins/wfp/models.py
 msgid "PLW"
 msgstr "FAP"
 
-#: plugins/wfp/models.py:30
+#: plugins/wfp/models.py
 msgid "U5"
 msgstr "M5"
 
-#: plugins/wfp/models.py:33
+#: plugins/wfp/models.py
 msgid "MUAC"
 msgstr "PB"
 
-#: plugins/wfp/models.py:34
+#: plugins/wfp/models.py
 msgid "WHZ"
 msgstr "PTZ"
 
-#: plugins/wfp/models.py:35
+#: plugins/wfp/models.py
 msgid "OEDEMA"
 msgstr "ŒDÈME"
 
-#: plugins/wfp/models.py:36
+#: plugins/wfp/models.py
 msgid "By wasted child"
 msgstr "Par enfant émacié"
 
-#: plugins/wfp/models.py:40
+#: plugins/wfp/models.py
 msgid "New case"
 msgstr "Nouveau cas"
 
-#: plugins/wfp/models.py:41
+#: plugins/wfp/models.py
 msgid "Readmission as non-respondent"
 msgstr "Réadmission comme non-répondant"
 
-#: plugins/wfp/models.py:42
+#: plugins/wfp/models.py
 msgid "Referred from OTP (SAM)"
 msgstr "Référé de l'OTP (MAS)"
 
-#: plugins/wfp/models.py:43
+#: plugins/wfp/models.py
 msgid "Referred from SC"
 msgstr "Référé du SC"
 
-#: plugins/wfp/models.py:44
+#: plugins/wfp/models.py
 msgid "Referred from TSFP (MAM)"
 msgstr "Référé du TSFP (MAM)"
 
-#: plugins/wfp/models.py:45
+#: plugins/wfp/models.py
 msgid "Relapse"
 msgstr "Rechute"
 
-#: plugins/wfp/models.py:46
+#: plugins/wfp/models.py
 msgid "Returned defaulter"
 msgstr "Défaillant de retour"
 
-#: plugins/wfp/models.py:47
+#: plugins/wfp/models.py
 msgid "Returned referral"
 msgstr "Référence retournée"
 
-#: plugins/wfp/models.py:48
+#: plugins/wfp/models.py
 msgid "Transfer from other TSFP"
 msgstr "Transfert d'un autre TSFP"

--- a/plugins/wfp_auth/locale/fr/LC_MESSAGES/django.po
+++ b/plugins/wfp_auth/locale/fr/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-05 16:28+0000\n"
+"POT-Creation-Date: 2025-04-02 08:35+0000\n"
 "PO-Revision-Date: 2025-02-05 14:41+0100\n"
 "Last-Translator: Olivier Le Thanh Duong <olivier@lethanh.be>\n"
 "Language-Team: \n"
@@ -18,11 +18,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 3.5\n"
 
-#: plugins/wfp_auth/templates/wfp_auth/login_subtemplate.html:4
+#: plugins/wfp_auth/templates/wfp_auth/login_subtemplate.html
 msgid "Login via WFP CIAM"
 msgstr "Connexion via WFP CIAM"
 
-#: plugins/wfp_auth/templates/wfp_auth/new_account_email.html:2
+#: plugins/wfp_auth/templates/wfp_auth/new_account_email.html
 #, python-format
 msgid ""
 "\n"
@@ -58,8 +58,8 @@ msgstr ""
 "Ceci est un message automatique généré par le système d'authentification "
 "%(site_name)s.\n"
 "\n"
-"Un nouveau compte utilisateur, %(first_name)s %(last_name)s `%(username)s`, a "
-"été créé avec succès via le serveur d'authentification WFP.\n"
+"Un nouveau compte utilisateur, %(first_name)s %(last_name)s `%(username)s`, "
+"a été créé avec succès via le serveur d'authentification WFP.\n"
 "Cependant, le compte ne dispose actuellement d'aucune permission attribuée. "
 "Cette absence de permissions empêche l'utilisateur d'utiliser pleinement nos "
 "services.\n"
@@ -81,7 +81,8 @@ msgstr ""
 "Cordialement,\n"
 "L'équipe %(site_name)s.\n"
 
-#: plugins/wfp_auth/templates/wfp_auth/new_account_subject.txt:2
+#: plugins/wfp_auth/templates/wfp_auth/new_account_subject.txt
 #, python-format
 msgid "New User Account %(username)s Awaiting Access Permissions"
-msgstr "Nouveau compte utilisateur %(username)s en attente de permissions d'accès"
+msgstr ""
+"Nouveau compte utilisateur %(username)s en attente de permissions d'accès"


### PR DESCRIPTION
Update `make_translations` comment format to avoid having conflicts during merge/rebase

Related JIRA tickets : IA-4105

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

/

## Changes

- Removed the line number in each comment

## How to test

- Run the `make_translations` command
- Check inside a `.po` file -> there shouldn't be any line number in comments


## Print screen / video

![image](https://github.com/user-attachments/assets/4b53451d-e703-400d-ae5c-bc3d9fec3cf3)


## Notes

If we ever have to send our `.po` files to a translator one day, we can always generate new ones with line numbers by commenting the flag and keep our version without line numbers in the codebase.

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
