### PR TITLE
POLIO-1873: vrf changes

### DIFF
--- a/plugins/polio/js/src/constants/translations/en.json
+++ b/plugins/polio/js/src/constants/translations/en.json
@@ -599,7 +599,7 @@
     "iaso.polio.label.pv_notified_at": "PV Notification",
     "iaso.polio.label.quantities_approved_by_dg_in_doses": "Quantity approved by DG in doses",
     "iaso.polio.label.quantities_approved_by_orpg_in_doses": "Quantity approved by ORPG in doses",
-    "iaso.polio.label.quantities_ordered_in_doses": "Quantity ordered in doses",
+    "iaso.polio.label.quantities_ordered_in_doses": "Quantity needed in doses",
     "iaso.polio.label.quantity": "Quantity",
     "iaso.polio.label.Radio": "Radio",
     "iaso.polio.label.ratioCaregiversInformed": "Ratio caregivers informed",

--- a/plugins/polio/js/src/constants/translations/fr.json
+++ b/plugins/polio/js/src/constants/translations/fr.json
@@ -598,7 +598,7 @@
     "iaso.polio.label.pv_notified_at": "Date de Notification PV",
     "iaso.polio.label.quantities_approved_by_dg_in_doses": "Quantité approvée par DG (doses)",
     "iaso.polio.label.quantities_approved_by_orpg_in_doses": "Quantité approvée par ORPG (doses)",
-    "iaso.polio.label.quantities_ordered_in_doses": "Quantité commandée (doses)",
+    "iaso.polio.label.quantities_ordered_in_doses": "Quantité nécessaire (doses)",
     "iaso.polio.label.quantity": "Quantité",
     "iaso.polio.label.Radio": "Radio",
     "iaso.polio.label.ratioCaregiversInformed": "Ratio parents informés",

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/VaccineRequestForm/VaccineRequestForm.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/VaccineRequestForm/VaccineRequestForm.tsx
@@ -197,73 +197,64 @@ export const VaccineRequestForm: FunctionComponent<Props> = ({
                                 renderTags={renderRoundTag}
                             />
                         </Grid>
+                        <Grid item xs={6} md={3}>
+                            <Field
+                                label={formatMessage(
+                                    MESSAGES.quantities_ordered_in_doses,
+                                )}
+                                name="vrf.quantities_ordered_in_doses"
+                                component={NumberInput}
+                                disabled={isFieldDisabledEdit(vrfData)}
+                            />
+                        </Grid>
+
+                        <Grid item xs={6} md={3}>
+                            <Field
+                                label={formatMessage(MESSAGES.wastageRatio)}
+                                name="vrf.wastage_rate_used_on_vrf"
+                                component={NumberInput}
+                                disabled={isFieldDisabledEdit(vrfData)}
+                                numberInputOptions={{
+                                    suffix: '%',
+                                    max: 100,
+                                }}
+                            />
+                        </Grid>
+                        <Grid item xs={6} md={3}>
+                            <Field
+                                label={formatMessage(MESSAGES.targetPopulation)}
+                                name="vrf.target_population"
+                                component={NumberInput}
+                                disabled={isFieldDisabledEdit(vrfData)}
+                            />
+                        </Grid>
+
+                        {isNormalType && (
+                            <Grid item xs={6} md={3}>
+                                <Field
+                                    label={formatMessage(
+                                        MESSAGES.date_vrf_signature,
+                                    )}
+                                    name="vrf.date_vrf_signature"
+                                    component={DateInput}
+                                    disabled={isFieldDisabledEdit(vrfData)}
+                                />
+                            </Grid>
+                        )}
                     </Grid>
                     {isNormalType && (
                         <>
                             <Grid container item xs={12} spacing={2}>
                                 <Grid item xs={6} md={3}>
-                                    <Box mt={2}>
-                                        <Field
-                                            label={formatMessage(
-                                                MESSAGES.date_vrf_signature,
-                                            )}
-                                            name="vrf.date_vrf_signature"
-                                            component={DateInput}
-                                            disabled={isFieldDisabledEdit(
-                                                vrfData,
-                                            )}
-                                        />
-                                    </Box>
+                                    <Field
+                                        label={formatMessage(
+                                            MESSAGES.date_vrf_reception,
+                                        )}
+                                        name="vrf.date_vrf_reception"
+                                        component={DateInput}
+                                        disabled={isFieldDisabledEdit(vrfData)}
+                                    />
                                 </Grid>
-                                <Grid item xs={6} md={3}>
-                                    <Box mt={2}>
-                                        <Field
-                                            label={formatMessage(
-                                                MESSAGES.quantities_ordered_in_doses,
-                                            )}
-                                            name="vrf.quantities_ordered_in_doses"
-                                            component={NumberInput}
-                                            disabled={isFieldDisabledEdit(
-                                                vrfData,
-                                            )}
-                                        />
-                                    </Box>
-                                </Grid>
-
-                                <Grid item xs={6} md={3}>
-                                    <Box mt={2}>
-                                        <Field
-                                            label={formatMessage(
-                                                MESSAGES.wastageRatio,
-                                            )}
-                                            name="vrf.wastage_rate_used_on_vrf"
-                                            component={NumberInput}
-                                            disabled={isFieldDisabledEdit(
-                                                vrfData,
-                                            )}
-                                            numberInputOptions={{
-                                                suffix: '%',
-                                                max: 100,
-                                            }}
-                                        />
-                                    </Box>
-                                </Grid>
-                                <Grid item xs={6} md={3}>
-                                    <Box mt={2}>
-                                        <Field
-                                            label={formatMessage(
-                                                MESSAGES.date_vrf_reception,
-                                            )}
-                                            name="vrf.date_vrf_reception"
-                                            component={DateInput}
-                                            disabled={isFieldDisabledEdit(
-                                                vrfData,
-                                            )}
-                                        />
-                                    </Box>
-                                </Grid>
-                            </Grid>
-                            <Grid container item xs={12} spacing={2}>
                                 <Grid item xs={6} md={3}>
                                     <Field
                                         label={formatMessage(
@@ -291,16 +282,6 @@ export const VaccineRequestForm: FunctionComponent<Props> = ({
                                         )}
                                         name="vrf.date_rrt_orpg_approval"
                                         component={DateInput}
-                                        disabled={isFieldDisabledEdit(vrfData)}
-                                    />
-                                </Grid>
-                                <Grid item xs={6} md={3}>
-                                    <Field
-                                        label={formatMessage(
-                                            MESSAGES.targetPopulation,
-                                        )}
-                                        name="vrf.target_population"
-                                        component={NumberInput}
                                         disabled={isFieldDisabledEdit(vrfData)}
                                     />
                                 </Grid>

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/messages.ts
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/messages.ts
@@ -220,7 +220,7 @@ const MESSAGES = defineMessages({
     },
     quantities_ordered_in_doses: {
         id: 'iaso.polio.label.quantities_ordered_in_doses',
-        defaultMessage: 'Quantity ordered in doses',
+        defaultMessage: 'Quantity needed in doses',
     },
     date_vrf_reception: {
         id: 'iaso.polio.label.date_vrf_reception',


### PR DESCRIPTION
-please rename the field “quantity ordered” to “quantity needed” 

-include the 3 fields in red for VRF that are missing or not required

![image](https://github.com/user-attachments/assets/6b2c1699-79a0-490b-b1d6-cc8f9c2f49d8)

Related JIRA tickets :  POLIO-1873

## Self proofreading checklist

- [ ] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)


## Changes

- Wording change
- Change order of inputs

## How to test

Explain how to test your PR.

Create a new VRF in supply chain, change the type of VRF, fields in red should always be present
quantity ordered should be renamed to quantity needed

## Print screen / video


https://github.com/user-attachments/assets/8666c0ee-dd89-4bab-9fc3-8627823b185a


