### PR TITLE
IA-4038 Fix to not delete `opening_date` and `closed_date` in `PATCH` requests

### DIFF
--- a/hat/audit/admin.py
+++ b/hat/audit/admin.py
@@ -11,7 +11,8 @@ class ModificationAdmin(admin.ModelAdmin):
     autocomplete_fields = ("user",)
     date_hierarchy = "created_at"
     formfield_overrides = {models.JSONField: {"widget": IasoJSONEditorWidget}}
-    list_display = ("object_id", "source", "created_at")
+    list_display = ("id", "object_id", "source", "created_at")
+    list_display_links = ("id", "object_id")
     list_filter = ("content_type",)
     raw_id_fields = ("org_unit_change_request",)
     search_fields = ("id", "source")

--- a/iaso/api/org_units.py
+++ b/iaso/api/org_units.py
@@ -591,16 +591,9 @@ class OrgUnitViewSet(viewsets.ViewSet):
             else:
                 org_unit.default_image = None
 
-        opening_date = request.data.get("opening_date")
-        if opening_date:
-            org_unit.opening_date = self.get_date(opening_date)
+        org_unit.opening_date = self.get_date(request.data.get("opening_date"))
+        org_unit.closed_date = self.get_date(request.data.get("closed_date"))
 
-        if "closed_date" in request.data:
-            closed_date = request.data.get("closed_date", None)
-            org_unit.closed_date = None if not closed_date else self.get_date(closed_date)
-        closed_date = request.data.get("closed_date")
-        if closed_date:
-            org_unit.closed_date = self.get_date(closed_date)
         if not errors:
             org_unit.save()
             if new_groups is not None:
@@ -623,11 +616,11 @@ class OrgUnitViewSet(viewsets.ViewSet):
         return Response(errors, status=400)
 
     def get_date(self, date: str) -> Union[datetime.date, None]:
-        date_input_formats = ["%d-%m-%Y", "%d/%m/%Y"]
+        date_input_formats = ["%d-%m-%Y", "%d/%m/%Y", "%Y-%m-%d", "%Y/%m/%d"]
         for date_input_format in date_input_formats:
             try:
                 return datetime.strptime(date, date_input_format).date()
-            except ValueError:
+            except (ValueError, TypeError):
                 pass
         return None
 

--- a/iaso/tests/api/test_orgunits.py
+++ b/iaso/tests/api/test_orgunits.py
@@ -1253,19 +1253,19 @@ class OrgUnitAPITestCase(APITestCase):
         self.assertEqual(ou.opening_date, datetime.date(2024, 1, 1))
         self.assertEqual(ou.closed_date, datetime.date(2025, 1, 1))
 
-        data = {"opening_date": "01/01/2024", "closed_date": "01/01/2025"}
+        data = {"opening_date": "10/02/2024", "closed_date": "12/12/2025"}
         response = self.client.patch(f"/api/orgunits/{ou.id}/", format="json", data=data)
         self.assertJSONResponse(response, 200)
         ou.refresh_from_db()
-        self.assertEqual(ou.opening_date, datetime.date(2024, 1, 1))
-        self.assertEqual(ou.closed_date, datetime.date(2025, 1, 1))
+        self.assertEqual(ou.opening_date, datetime.date(2024, 2, 10))
+        self.assertEqual(ou.closed_date, datetime.date(2025, 12, 12))
 
-        data = {"opening_date": "2024-01-01", "closed_date": "2025-01-01"}
+        data = {"opening_date": "2024-06-22", "closed_date": "2025-10-30"}
         response = self.client.patch(f"/api/orgunits/{ou.id}/", format="json", data=data)
         self.assertJSONResponse(response, 200)
         ou.refresh_from_db()
-        self.assertEqual(ou.opening_date, datetime.date(2024, 1, 1))
-        self.assertEqual(ou.closed_date, datetime.date(2025, 1, 1))
+        self.assertEqual(ou.opening_date, datetime.date(2024, 6, 22))
+        self.assertEqual(ou.closed_date, datetime.date(2025, 10, 30))
 
         data = {"opening_date": None, "closed_date": ""}
         response = self.client.patch(f"/api/orgunits/{ou.id}/", format="json", data=data)


### PR DESCRIPTION
Fix to not delete `opening_date` and `closed_date` during a `PATCH` request.

Related JIRA tickets : [IA-4038](https://bluesquare.atlassian.net/browse/IA-4038)

## Changes

In some places (like the history tab of the detail of an org unit), the frontend is sending dates in the `%Y-%m-%d` format in `PATCH` requests.

This format was not supported by the backend which was always retuning `None` and thus erasing those dates!

This fix adds support for the `%Y-%m-%d` date format.

## How to test

1. go to the `infos` tab of the detail of an org unit
2. add an `opening_date` and a `closed_date`
3. save
4. delete `opening_date` and `closed_date`
5. go to the `history` tab
6. restore the version with an `opening_date` and a `closed_date`
7. return to the `infos` tab
8. refresh
9. `opening_date` and `closed_date` should have been restored

![fix](https://github.com/user-attachments/assets/20aadfb0-ad38-44d8-baa0-2ec8a4d355c3)


[IA-4038]: https://bluesquare.atlassian.net/browse/IA-4038?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ