### PR TITLE
[IA-3940] Fix duplicated groups creation

### DIFF
--- a/iaso/api/groups.py
+++ b/iaso/api/groups.py
@@ -63,10 +63,8 @@ class GroupSerializer(serializers.ModelSerializer):
         default_version = self._fetch_user_default_source_version()
         if "source_ref" in attrs:
             # Check if the source_ref is already used by another group
-            existing_group = Group.objects.filter(
-                source_ref=attrs["source_ref"], source_version=default_version
-            ).first()
-            if existing_group:
+            potential_group = Group.objects.filter(source_ref=attrs["source_ref"], source_version=default_version)
+            if potential_group.exists():
                 raise serializers.ValidationError(
                     {"source_ref": "This source ref is already used by another group in your default version"}
                 )


### PR DESCRIPTION
Prevent users from manually creating Groups with already existing `source_ref`.

Related JIRA tickets : IA-3940

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

/

## Changes

Added a check on `source_ref` during Group creation

## How to test

- Go to the Groups page
- Copy a source ref
- Create a new Group & use the existing `source_ref`
- You should see an error

## Print screen / video

![image](https://github.com/user-attachments/assets/57d14740-ca78-441b-b883-05055c5c26c6)


## Notes

/

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
