### PR TITLE
POLIO-1884 destruction warning

### DIFF
--- a/plugins/polio/api/vaccines/stock_management.py
+++ b/plugins/polio/api/vaccines/stock_management.py
@@ -6,7 +6,7 @@ from django.utils.dateparse import parse_date
 from django_filters.rest_framework import FilterSet, NumberFilter
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
-from rest_framework import filters, permissions, serializers, status, viewsets
+from rest_framework import filters, permissions, serializers, status
 from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError
 from rest_framework.filters import SearchFilter
@@ -370,6 +370,7 @@ class DestructionReportSerializer(serializers.ModelSerializer):
             non_admin_perm=permission.POLIO_VACCINE_STOCK_MANAGEMENT_READ,
         )
 
+
 class DestructionReportViewSet(VaccineStockSubitemBase):
     serializer_class = DestructionReportSerializer
     model_class = DestructionReport
@@ -379,44 +380,39 @@ class DestructionReportViewSet(VaccineStockSubitemBase):
             non_admin_perm=permission.POLIO_VACCINE_STOCK_MANAGEMENT_READ,
         )
     ]
-    @action(detail=False, methods=['GET'])
+
+    @action(detail=False, methods=["GET"])
     def check_duplicate(self, request):
-        vaccine_stock_id = request.query_params.get('vaccine_stock')
-        destruction_report_date = request.query_params.get('destruction_report_date')
-        unusable_vials_destroyed = request.query_params.get('unusable_vials_destroyed')
-        destruction_report_id = request.query_params.get('destruction_report_id')
+        vaccine_stock_id = request.query_params.get("vaccine_stock")
+        destruction_report_date = request.query_params.get("destruction_report_date")
+        unusable_vials_destroyed = request.query_params.get("unusable_vials_destroyed")
+        destruction_report_id = request.query_params.get("destruction_report_id")
 
         if not all([vaccine_stock_id, destruction_report_date, unusable_vials_destroyed]):
-            return Response(
-                {"error": "Missing required parameters"},
-                status=status.HTTP_400_BAD_REQUEST
-            )
+            return Response({"error": "Missing required parameters"}, status=status.HTTP_400_BAD_REQUEST)
 
         # Check if vaccine stock exists
         try:
             vaccine_stock = VaccineStock.objects.get(id=vaccine_stock_id)
         except VaccineStock.DoesNotExist:
-            return Response(
-                {"error": "Vaccine stock not found"},
-                status=status.HTTP_404_NOT_FOUND
-            )
+            return Response({"error": "Vaccine stock not found"}, status=status.HTTP_404_NOT_FOUND)
 
         # Build the filter query
         filter_query = {
-            'vaccine_stock_id': vaccine_stock_id,
-            'destruction_report_date': destruction_report_date,
-            'unusable_vials_destroyed': unusable_vials_destroyed
+            "vaccine_stock_id": vaccine_stock_id,
+            "destruction_report_date": destruction_report_date,
+            "unusable_vials_destroyed": unusable_vials_destroyed,
         }
 
         # If editing an existing report, exclude it from the duplicate check
         if destruction_report_id:
-            existing_destruction = DestructionReport.objects.exclude(id=destruction_report_id).filter(**filter_query).exists()
+            existing_destruction = (
+                DestructionReport.objects.exclude(id=destruction_report_id).filter(**filter_query).exists()
+            )
         else:
             existing_destruction = DestructionReport.objects.filter(**filter_query).exists()
 
-        return Response({
-            "duplicate_exists": existing_destruction
-        })
+        return Response({"duplicate_exists": existing_destruction})
 
 
 class EarmarkedStockSerializer(serializers.ModelSerializer):

--- a/plugins/polio/api/vaccines/stock_management.py
+++ b/plugins/polio/api/vaccines/stock_management.py
@@ -392,9 +392,7 @@ class DestructionReportViewSet(VaccineStockSubitemBase):
             return Response({"error": "Missing required parameters"}, status=status.HTTP_400_BAD_REQUEST)
 
         # Check if vaccine stock exists
-        try:
-            vaccine_stock = VaccineStock.objects.get(id=vaccine_stock_id)
-        except VaccineStock.DoesNotExist:
+        if not VaccineStock.objects.filter(id=vaccine_stock_id).exists():
             return Response({"error": "Vaccine stock not found"}, status=status.HTTP_404_NOT_FOUND)
 
         # Build the filter query

--- a/plugins/polio/js/src/constants/translations/en.json
+++ b/plugins/polio/js/src/constants/translations/en.json
@@ -428,6 +428,7 @@
     "iaso.polio.label.dosesShipped": "Doses shipped",
     "iaso.polio.label.download": "Download",
     "iaso.polio.label.downloadScopesToCsv": "Download scopes",
+    "iaso.polio.label.duplicate_destruction": "A destruction report with the same date and unusable vials destroyed already exists",
     "iaso.polio.label.earmarked": "Earmarked",
     "iaso.polio.label.earmarked_doses": "Earmarked doses",
     "iaso.polio.label.earmarked_stock__created": "Earmarked stock - Created",

--- a/plugins/polio/js/src/constants/translations/fr.json
+++ b/plugins/polio/js/src/constants/translations/fr.json
@@ -591,6 +591,7 @@
     "iaso.polio.label.preparednessSomeWarningsDuringTheParsing": "Avertissement : l'application a rencontré des problèmes lors de l'analyse de la feuille de préparation.",
     "iaso.polio.label.preparednesSyncStatus": "Status de la préparation",
     "iaso.polio.label.preparing": "En préparation",
+    "iaso.polio.label.duplicate_destruction": "Un rapport de destruction avec la même date et le même nombre de flacons inutilisables existe déjà",
     "iaso.polio.label.previousEndDate": "Date de fin précédente",
     "iaso.polio.label.previousStartDate": "Date de début précédente",
     "iaso.polio.label.provinceOption": "PROVINCE",

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/CreateEditDestruction.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/CreateEditDestruction.tsx
@@ -8,6 +8,7 @@ import {
 } from 'bluesquare-components';
 import { Field, FormikProvider, useFormik } from 'formik';
 import { isEqual } from 'lodash';
+import { useDebounce } from 'use-debounce';
 import { EditIconButton } from '../../../../../../../../../hat/assets/js/apps/Iaso/components/Buttons/EditIconButton';
 import DocumentUploadWithPreview from '../../../../../../../../../hat/assets/js/apps/Iaso/components/files/pdf/DocumentUploadWithPreview';
 import { processErrorDocsBase } from '../../../../../../../../../hat/assets/js/apps/Iaso/components/files/pdf/utils';
@@ -62,10 +63,19 @@ export const CreateEditDestruction: FunctionComponent<Props> = ({
         validationSchema,
     });
 
+    const [debouncedDate] = useDebounce(
+        formik.values.destruction_report_date,
+        500,
+    );
+    const [debouncedVials] = useDebounce(
+        formik.values.unusable_vials_destroyed,
+        500,
+    );
+
     const { data: hasDuplicatesData } = useCheckDestructionDuplicate({
         vaccineStockId,
-        destructionReportDate: formik.values.destruction_report_date,
-        unusableVialsDestroyed: formik.values.unusable_vials_destroyed,
+        destructionReportDate: debouncedDate,
+        unusableVialsDestroyed: debouncedVials,
         destructionReportId: destruction?.id,
     });
     const titleMessage = destruction?.id ? MESSAGES.edit : MESSAGES.create;

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/CreateEditDestruction.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/CreateEditDestruction.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent, useMemo } from 'react';
-import { Box } from '@mui/material';
+import { Alert, Box } from '@mui/material';
 import {
     AddButton,
     ConfirmCancelModal,
@@ -44,12 +44,6 @@ export const CreateEditDestruction: FunctionComponent<Props> = ({
 }) => {
     const { formatMessage } = useSafeIntl();
     const { mutateAsync: save } = useSaveDestruction();
-    const { data: hasDuplicatesData } = useCheckDestructionDuplicate({
-        vaccineStockId,
-        destructionReportDate: destruction?.destruction_report_date,
-        unusableVialsDestroyed: destruction?.unusable_vials_destroyed,
-    });
-    console.log('hasDuplicatesData', hasDuplicatesData);
     const validationSchema = useDestructionValidation();
     const formik = useFormik<any>({
         initialValues: {
@@ -68,6 +62,12 @@ export const CreateEditDestruction: FunctionComponent<Props> = ({
         validationSchema,
     });
 
+    const { data: hasDuplicatesData } = useCheckDestructionDuplicate({
+        vaccineStockId,
+        destructionReportDate: formik.values.destruction_report_date,
+        unusableVialsDestroyed: formik.values.unusable_vials_destroyed,
+        destructionReportId: destruction?.id,
+    });
     const titleMessage = destruction?.id ? MESSAGES.edit : MESSAGES.create;
     const title = `${countryName} - ${vaccine}: ${formatMessage(
         titleMessage,
@@ -154,6 +154,13 @@ export const CreateEditDestruction: FunctionComponent<Props> = ({
                         document={formik.values.document}
                     />
                 </Box>
+                {hasDuplicatesData?.duplicate_exists && (
+                    <Box mb={2}>
+                        <Alert severity="warning">
+                            {formatMessage(MESSAGES.duplicate_destruction)}
+                        </Alert>
+                    </Box>
+                )}
             </ConfirmCancelModal>
         </FormikProvider>
     );

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/CreateEditDestruction.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/CreateEditDestruction.tsx
@@ -1,3 +1,4 @@
+import React, { FunctionComponent, useMemo } from 'react';
 import { Box } from '@mui/material';
 import {
     AddButton,
@@ -7,7 +8,6 @@ import {
 } from 'bluesquare-components';
 import { Field, FormikProvider, useFormik } from 'formik';
 import { isEqual } from 'lodash';
-import React, { FunctionComponent, useMemo } from 'react';
 import { EditIconButton } from '../../../../../../../../../hat/assets/js/apps/Iaso/components/Buttons/EditIconButton';
 import DocumentUploadWithPreview from '../../../../../../../../../hat/assets/js/apps/Iaso/components/files/pdf/DocumentUploadWithPreview';
 import { processErrorDocsBase } from '../../../../../../../../../hat/assets/js/apps/Iaso/components/files/pdf/utils';
@@ -17,7 +17,10 @@ import {
     TextInput,
 } from '../../../../../components/Inputs';
 import { Vaccine } from '../../../../../constants/types';
-import { useSaveDestruction } from '../../hooks/api';
+import {
+    useCheckDestructionDuplicate,
+    useSaveDestruction,
+} from '../../hooks/api';
 import MESSAGES from '../../messages';
 import { useDestructionValidation } from './validation';
 
@@ -41,6 +44,12 @@ export const CreateEditDestruction: FunctionComponent<Props> = ({
 }) => {
     const { formatMessage } = useSafeIntl();
     const { mutateAsync: save } = useSaveDestruction();
+    const { data: hasDuplicatesData } = useCheckDestructionDuplicate({
+        vaccineStockId,
+        destructionReportDate: destruction?.destruction_report_date,
+        unusableVialsDestroyed: destruction?.unusable_vials_destroyed,
+    });
+    console.log('hasDuplicatesData', hasDuplicatesData);
     const validationSchema = useDestructionValidation();
     const formik = useFormik<any>({
         initialValues: {

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Table/VaccineStockVariationTable.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Table/VaccineStockVariationTable.tsx
@@ -1,8 +1,8 @@
 import React, { FunctionComponent } from 'react';
 import { Column, UrlParams } from 'bluesquare-components';
 import { SimpleTableWithDeepLink } from '../../../../../../../../../hat/assets/js/apps/Iaso/components/tables/SimpleTableWithDeepLink';
-import { StockVariationTab } from '../../types';
 import { baseUrls } from '../../../../../constants/urls';
+import { StockVariationTab } from '../../types';
 
 type Props = {
     params: Partial<UrlParams>;
@@ -28,6 +28,7 @@ export const VaccineStockVariationTable: FunctionComponent<Props> = ({
             params={params}
             paramsPrefix={paramsPrefix}
             columns={columns}
+            isFetching={isFetching}
             defaultSorted={defaultSorted}
             baseUrl={baseUrls.stockVariation}
             marginTop={false}

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/hooks/api.ts
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/hooks/api.ts
@@ -677,3 +677,45 @@ export const useDeleteEarmarked = (): UseMutationResult => {
         ],
     });
 };
+
+const checkDestructionDuplicate = (
+    vaccineStockId: string,
+    destructionReportDate: string,
+    unusableVialsDestroyed: number,
+) => {
+    return getRequest(
+        `${modalUrl}destruction_report/check_duplicate/?vaccine_stock=${vaccineStockId}&destruction_report_date=${destructionReportDate}&unusable_vials_destroyed=${unusableVialsDestroyed}`,
+    );
+};
+
+export const useCheckDestructionDuplicate = ({
+    vaccineStockId,
+    destructionReportDate,
+    unusableVialsDestroyed,
+}: {
+    vaccineStockId: string;
+    destructionReportDate: string;
+    unusableVialsDestroyed: number;
+}) => {
+    return useSnackQuery({
+        queryKey: [
+            'destruction-duplicate',
+            vaccineStockId,
+            destructionReportDate,
+            unusableVialsDestroyed,
+        ],
+        queryFn: () =>
+            checkDestructionDuplicate(
+                vaccineStockId,
+                destructionReportDate,
+                unusableVialsDestroyed,
+            ),
+        options: {
+            enabled: Boolean(
+                vaccineStockId &&
+                    destructionReportDate &&
+                    unusableVialsDestroyed,
+            ),
+        },
+    });
+};

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/hooks/api.ts
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/hooks/api.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { UrlParams, useSafeIntl } from 'bluesquare-components';
+import moment from 'moment';
 import { UseMutationResult, UseQueryResult } from 'react-query';
 import {
     FormattedApiParams,
@@ -682,20 +683,27 @@ const checkDestructionDuplicate = (
     vaccineStockId: string,
     destructionReportDate: string,
     unusableVialsDestroyed: number,
+    destructionReportId?: string,
 ) => {
-    return getRequest(
-        `${modalUrl}destruction_report/check_duplicate/?vaccine_stock=${vaccineStockId}&destruction_report_date=${destructionReportDate}&unusable_vials_destroyed=${unusableVialsDestroyed}`,
-    );
+    const baseUrl = `${modalUrl}destruction_report/check_duplicate/?vaccine_stock=${vaccineStockId}&destruction_report_date=${destructionReportDate}&unusable_vials_destroyed=${unusableVialsDestroyed}`;
+
+    const url = destructionReportId
+        ? `${baseUrl}&destruction_report_id=${destructionReportId}`
+        : baseUrl;
+
+    return getRequest(url);
 };
 
 export const useCheckDestructionDuplicate = ({
     vaccineStockId,
     destructionReportDate,
     unusableVialsDestroyed,
+    destructionReportId,
 }: {
     vaccineStockId: string;
     destructionReportDate: string;
     unusableVialsDestroyed: number;
+    destructionReportId?: string;
 }) => {
     return useSnackQuery({
         queryKey: [
@@ -703,19 +711,24 @@ export const useCheckDestructionDuplicate = ({
             vaccineStockId,
             destructionReportDate,
             unusableVialsDestroyed,
+            destructionReportId,
         ],
         queryFn: () =>
             checkDestructionDuplicate(
                 vaccineStockId,
                 destructionReportDate,
                 unusableVialsDestroyed,
+                destructionReportId,
             ),
         options: {
             enabled: Boolean(
                 vaccineStockId &&
                     destructionReportDate &&
-                    unusableVialsDestroyed,
+                    unusableVialsDestroyed &&
+                    moment(destructionReportDate, 'YYYY-MM-DD', true).isValid(),
             ),
+            staleTime: 1000 * 60 * 15, // in MS
+            keepPreviousData: false,
         },
     });
 };

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/messages.ts
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/messages.ts
@@ -401,6 +401,11 @@ const MESSAGES = defineMessages({
         id: 'iaso.polio.label.temporary_campaign_name',
         defaultMessage: 'Temporary campaign name',
     },
+    duplicate_destruction: {
+        id: 'iaso.polio.label.duplicate_destruction',
+        defaultMessage:
+            'A destruction report with the same date and unusable vials destroyed already exists',
+    },
 });
 
 export default MESSAGES;

--- a/plugins/polio/tests/test_vaccine_stock_management.py
+++ b/plugins/polio/tests/test_vaccine_stock_management.py
@@ -1000,3 +1000,104 @@ class VaccineStockManagementAPITestCase(APITestCase):
 
             self.assertEqual(response.status_code, 201)
             self.assertIn("document_path_6", response.data["document"])
+
+    def test_check_duplicate_destruction_report(self):
+        self.client.force_authenticate(self.user_rw_perms)
+
+        # Create a destruction report
+        destruction_data = {
+            "vaccine_stock": self.vaccine_stock.id,
+            "destruction_report_date": "2024-01-01",
+            "rrt_destruction_report_reception_date": "2024-01-02",
+            "unusable_vials_destroyed": 5,
+            "action": "Destroyed due to expiration",
+        }
+
+        response = self.client.post(
+            f"{BASE_URL_SUB_RESOURCES}destruction_report/",
+            destruction_data,
+            format="json",
+        )
+        self.assertEqual(response.status_code, 201)
+
+        # Test checking for duplicate with same details
+        response = self.client.get(
+            f"{BASE_URL_SUB_RESOURCES}destruction_report/check_duplicate/",
+            {
+                "vaccine_stock": self.vaccine_stock.id,
+                "destruction_report_date": "2024-01-01",
+                "unusable_vials_destroyed": 5,
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json()["duplicate_exists"])
+
+        # Test checking with different date
+        response = self.client.get(
+            f"{BASE_URL_SUB_RESOURCES}destruction_report/check_duplicate/",
+            {
+                "vaccine_stock": self.vaccine_stock.id,
+                "destruction_report_date": "2024-01-02",
+                "unusable_vials_destroyed": 5,
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.json()["duplicate_exists"])
+
+        # Test checking with different vials count
+        response = self.client.get(
+            f"{BASE_URL_SUB_RESOURCES}destruction_report/check_duplicate/",
+            {
+                "vaccine_stock": self.vaccine_stock.id,
+                "destruction_report_date": "2024-01-01",
+                "unusable_vials_destroyed": 6,
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.json()["duplicate_exists"])
+
+        # Test with missing parameters
+        response = self.client.get(
+            f"{BASE_URL_SUB_RESOURCES}destruction_report/check_duplicate/",
+            {
+                "vaccine_stock": self.vaccine_stock.id,
+                "destruction_report_date": "2024-01-01",
+            },
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("error", response.json())
+
+        # Test with invalid vaccine stock ID
+        response = self.client.get(
+            f"{BASE_URL_SUB_RESOURCES}destruction_report/check_duplicate/",
+            {
+                "vaccine_stock": 99999,
+                "destruction_report_date": "2024-01-01",
+                "unusable_vials_destroyed": 5,
+            },
+        )
+        self.assertEqual(response.status_code, 404)
+
+        # Test permissions - anonymous user
+        self.client.force_authenticate(user=self.anon)
+        response = self.client.get(
+            f"{BASE_URL_SUB_RESOURCES}destruction_report/check_duplicate/",
+            {
+                "vaccine_stock": self.vaccine_stock.id,
+                "destruction_report_date": "2024-01-01",
+                "unusable_vials_destroyed": 5,
+            },
+        )
+        self.assertEqual(response.status_code, 403)
+
+        # Test permissions - user without read rights
+        self.client.force_authenticate(user=self.user_no_perms)
+        response = self.client.get(
+            f"{BASE_URL_SUB_RESOURCES}destruction_report/check_duplicate/",
+            {
+                "vaccine_stock": self.vaccine_stock.id,
+                "destruction_report_date": "2024-01-01",
+                "unusable_vials_destroyed": 5,
+            },
+        )
+        self.assertEqual(response.status_code, 403)

--- a/plugins/polio/tests/test_vaccine_stock_management.py
+++ b/plugins/polio/tests/test_vaccine_stock_management.py
@@ -1053,7 +1053,6 @@ class VaccineStockManagementAPITestCase(APITestCase):
             format="json",
         )
         self.assertEqual(response.status_code, 201)
-        second_report_id = response.json()["id"]
 
         # Test checking for duplicate while editing first report (should find second report)
         response = self.client.get(


### PR DESCRIPTION
Add a warning when an destruction report has the exact same amount and same date

Related JIRA tickets :POLIO-1884

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [x] Are my typescript files well typed?
- [x] New translations have been added or updated if new strings have been introduced in the frontend
- [x] My migrations file are included
- [x] Are there enough tests?
- [ ] Documentation has been included (for new feature)


## Changes

- adding endpoint to check if a duplicate exists
- testing endpoint
- customize form to display a warning if a duplicate exists 

## How to test

Edit a stock variation for a country. Try to add two destruction report with the same report date and amount of vials, a warning should be displayed

## Print screen / video

https://github.com/user-attachments/assets/19141acc-4839-401b-931f-2be1789ef507



