### PR TITLE
IA-4113 Avoid deleting shapes when performing a `PATCH` request on the org unit API

### DIFF
--- a/iaso/api/org_units.py
+++ b/iaso/api/org_units.py
@@ -1,4 +1,5 @@
 import json
+import logging
 
 from copy import deepcopy
 from datetime import datetime
@@ -30,6 +31,8 @@ from iaso.utils.gis import simplify_geom
 
 from ..utils.models.common import get_creator_name, get_org_unit_parents_ref
 
+
+logger = logging.getLogger(__name__)
 
 # noinspection PyMethodMayBeStatic
 
@@ -492,11 +495,9 @@ class OrgUnitViewSet(viewsets.ViewSet):
             org_unit.simplified_geom = request.data["simplified_geom"]
 
         if "geo_json" in request.data and request.data["geo_json"]:
-            errors.append(
-                {
-                    "errorKey": "geo_json",
-                    "errorMessage": _("This field is deprecated. Use the `geom` field to modify the geometry."),
-                }
+            logger.warning(
+                "The `geo_json` field is deprecated. Use the `geom` field to modify the geometry.",
+                extra={"request_data": request.data},
             )
 
         if "catchment" in request.data:

--- a/iaso/locale/fr/LC_MESSAGES/django.po
+++ b/iaso/locale/fr/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-04-02 08:35+0000\n"
+"POT-Creation-Date: 2025-04-08 08:42+0000\n"
 "PO-Revision-Date: 2025-02-06 10:24+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -165,6 +165,14 @@ msgid "Invalid validation status : {validation_status}"
 msgstr "Statut de validation invalide : {validation_status}"
 
 #: iaso/api/org_units.py
+msgid "Can't parse geom"
+msgstr "Impossible d'analyser la géométrie"
+
+#: iaso/api/org_units.py
+msgid "This field is deprecated. Use the `geom` field to modify the geometry."
+msgstr "Ce champ est obsolète. Utilisez le champ `geom` pour modifier la géométrie."
+
+#: iaso/api/org_units.py
 msgid "You cannot create an Org Unit without a parent"
 msgstr "Vous ne pouvez pas créer une unité organisationnelle sans parent"
 
@@ -187,10 +195,6 @@ msgstr "Le nom de l'unité organisationnelle est requis"
 #: iaso/api/org_units.py
 msgid "Opening date must be anterior to closed date"
 msgstr "La date d'ouverture doit être antérieure à la date de fermeture"
-
-#: iaso/api/org_units.py
-msgid "Can't parse geom"
-msgstr "Impossible d'analyser la géométrie"
 
 #: iaso/api/org_units.py
 msgid "Org unit type is required"

--- a/iaso/locale/fr/LC_MESSAGES/django.po
+++ b/iaso/locale/fr/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-04-08 08:42+0000\n"
+"POT-Creation-Date: 2025-04-08 09:16+0000\n"
 "PO-Revision-Date: 2025-02-06 10:24+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -167,10 +167,6 @@ msgstr "Statut de validation invalide : {validation_status}"
 #: iaso/api/org_units.py
 msgid "Can't parse geom"
 msgstr "Impossible d'analyser la géométrie"
-
-#: iaso/api/org_units.py
-msgid "This field is deprecated. Use the `geom` field to modify the geometry."
-msgstr "Ce champ est obsolète. Utilisez le champ `geom` pour modifier la géométrie."
 
 #: iaso/api/org_units.py
 msgid "You cannot create an Org Unit without a parent"
@@ -651,3 +647,9 @@ msgstr ""
 #: iaso/utils/serializer/three_dim_point_field.py
 msgid "Enter a valid location."
 msgstr "Entrez une localisation valide."
+
+#~ msgid ""
+#~ "This field is deprecated. Use the `geom` field to modify the geometry."
+#~ msgstr ""
+#~ "Ce champ est obsolète. Utilisez le champ `geom` pour modifier la "
+#~ "géométrie."

--- a/iaso/tests/api/test_orgunits.py
+++ b/iaso/tests/api/test_orgunits.py
@@ -1301,21 +1301,6 @@ class OrgUnitAPITestCase(APITestCase):
         self.assertIsNone(ou.geom)
         self.assertIsNone(ou.simplified_geom)
 
-    def test_deprecated_geo_json_field(self):
-        org_unit = m.OrgUnit.objects.create(version=self.sw_version_1)
-
-        self.client.force_authenticate(self.yoda)
-
-        data = {"geo_json": str(Polygon([(0, 0), (0, 1), (1, 1), (0, 0)]))}
-        response = self.client.patch(f"/api/orgunits/{org_unit.id}/", format="json", data=data)
-        json_response = self.assertJSONResponse(response, 400)
-
-        self.assertEqual(json_response[0]["errorKey"], "geo_json")
-        self.assertEqual(
-            json_response[0]["errorMessage"],
-            "This field is deprecated. Use the `geom` field to modify the geometry.",
-        )
-
     def test_edit_org_unit_partial_update_read_permission(self):
         """Check that we can only modify a part of the file with org units read only permission"""
         ou, _, _, _, data = self.set_up_org_unit_partial_update()


### PR DESCRIPTION
Avoid deleting shapes when performing a `PATCH` request on the org unit API.

Related JIRA tickets : [IA-4113](https://bluesquare.atlassian.net/browse/IA-4113)

## How to test

Go to the history of an org unit which has a geo shape.

You should be able to restore a subset of its field from an old version without deleting its shape.


[IA-4113]: https://bluesquare.atlassian.net/browse/IA-4113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ