### PR TITLE
POLIO-1915: Country blocks bug

### DIFF
--- a/plugins/polio/js/src/domains/Budget/BudgetFilters.tsx
+++ b/plugins/polio/js/src/domains/Budget/BudgetFilters.tsx
@@ -1,14 +1,14 @@
-import { Box, Grid, useMediaQuery, useTheme } from '@mui/material';
 import React, { FunctionComponent, useState } from 'react';
+import { Box, Grid, useMediaQuery, useTheme } from '@mui/material';
 import { UrlParams } from 'bluesquare-components';
 import { FilterButton } from '../../../../../../hat/assets/js/apps/Iaso/components/FilterButton';
 import InputComponent from '../../../../../../hat/assets/js/apps/Iaso/components/forms/InputComponent';
-import { useFilterState } from '../../../../../../hat/assets/js/apps/Iaso/hooks/useFilterState';
-import MESSAGES from '../../constants/messages';
-import { DropdownOptions } from '../../../../../../hat/assets/js/apps/Iaso/types/utils';
-import { useGetCountries } from '../../hooks/useGetCountries';
 import { useGetGroupDropdown } from '../../../../../../hat/assets/js/apps/Iaso/domains/orgUnits/hooks/requests/useGetGroups';
+import { useFilterState } from '../../../../../../hat/assets/js/apps/Iaso/hooks/useFilterState';
+import { DropdownOptions } from '../../../../../../hat/assets/js/apps/Iaso/types/utils';
+import MESSAGES from '../../constants/messages';
 import { baseUrls } from '../../constants/urls';
+import { useGetCountries } from '../../hooks/useGetCountries';
 
 type Props = {
     params: Partial<UrlParams> & {
@@ -38,7 +38,7 @@ export const BudgetFilters: FunctionComponent<Props> = ({
     const isXSLayout = useMediaQuery(theme.breakpoints.down('xs'));
     const { data, isFetching: isFetchingCountries } = useGetCountries();
     const { data: groupedOrgUnits, isFetching: isFetchingGroupedOrgUnits } =
-        useGetGroupDropdown({ blockOfCountries: 'True' });
+        useGetGroupDropdown({ blockOfCountries: 'true' });
     const countriesList = (data && data.orgUnits) || [];
     return (
         <Box mb={isXSLayout ? 4 : 2}>

--- a/plugins/polio/js/src/domains/Calendar/campaignCalendar/CampaignsFilters.tsx
+++ b/plugins/polio/js/src/domains/Calendar/campaignCalendar/CampaignsFilters.tsx
@@ -143,7 +143,7 @@ export const CampaignsFilters: FunctionComponent<Props> = ({
         useGetGroupedCampaigns();
     // Pass the appId to have it works in the embedded calendar where the user is not connected
     const { data: groupedOrgUnits, isFetching: isFetchingGroupedOrgUnits } =
-        useGetGroupDropdown({ blockOfCountries: 'True', appId });
+        useGetGroupDropdown({ blockOfCountries: 'true', appId });
     const groupedCampaignsOptions = useMemo(
         () =>
             groupedCampaigns?.results.map(result => ({

--- a/plugins/polio/js/src/domains/VaccineModule/Nopv2Authorisations/Filters/Nopv2AuthorisationsFilters.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/Nopv2Authorisations/Filters/Nopv2AuthorisationsFilters.tsx
@@ -2,18 +2,18 @@ import React, { FunctionComponent } from 'react';
 import { Box, Grid } from '@mui/material';
 import { useSafeIntl } from 'bluesquare-components';
 import { FilterButton } from '../../../../../../../../hat/assets/js/apps/Iaso/components/FilterButton';
-import { useFilterState } from '../../../../../../../../hat/assets/js/apps/Iaso/hooks/useFilterState';
 import InputComponent from '../../../../../../../../hat/assets/js/apps/Iaso/components/forms/InputComponent';
-import MESSAGES from '../../../../constants/messages';
-import { appId } from '../../../../constants/app';
 import { useGetGroupDropdown } from '../../../../../../../../hat/assets/js/apps/Iaso/domains/orgUnits/hooks/requests/useGetGroups';
+import { userHasPermission } from '../../../../../../../../hat/assets/js/apps/Iaso/domains/users/utils';
+import { useFilterState } from '../../../../../../../../hat/assets/js/apps/Iaso/hooks/useFilterState';
+import { useCurrentUser } from '../../../../../../../../hat/assets/js/apps/Iaso/utils/usersUtils';
+import { appId } from '../../../../constants/app';
+import MESSAGES from '../../../../constants/messages';
+import { VACCINE_AUTH_ADMIN } from '../../../../constants/permissions';
+import { baseUrls } from '../../../../constants/urls';
+import { CreateAuthorisationModal } from '../Details/Modals/CreateEdit/CreateEditAuthorisationModal';
 import { useStatusOptions } from '../hooks/statuses';
 import { VaccineAuthParams } from '../types';
-import { CreateAuthorisationModal } from '../Details/Modals/CreateEdit/CreateEditAuthorisationModal';
-import { useCurrentUser } from '../../../../../../../../hat/assets/js/apps/Iaso/utils/usersUtils';
-import { userHasPermission } from '../../../../../../../../hat/assets/js/apps/Iaso/domains/users/utils';
-import { baseUrls } from '../../../../constants/urls';
-import { VACCINE_AUTH_ADMIN } from '../../../../constants/permissions';
 
 const baseUrl = baseUrls.nopv2Auth;
 type Props = { params: VaccineAuthParams };
@@ -25,7 +25,7 @@ export const Nopv2AuthorisationsFilters: FunctionComponent<Props> = ({
     const { filters, handleSearch, handleChange, filtersUpdated } =
         useFilterState({ baseUrl, params });
     const { data: countryBlocksOptions, isFetching: isFetchingCountryBlocks } =
-        useGetGroupDropdown({ blockOfCountries: 'True', appId });
+        useGetGroupDropdown({ blockOfCountries: 'true', appId });
     const statusOptions = useStatusOptions();
     const currentUser = useCurrentUser();
 

--- a/plugins/polio/js/src/domains/VaccineModule/Repository/forms/Filters.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/Repository/forms/Filters.tsx
@@ -1,19 +1,19 @@
-import FiltersIcon from '@mui/icons-material/FilterList';
-import { Box, Button, Grid } from '@mui/material';
-import { useRedirectToReplace } from 'bluesquare-components';
 import React, {
     FunctionComponent,
     useCallback,
     useEffect,
     useState,
 } from 'react';
+import FiltersIcon from '@mui/icons-material/FilterList';
+import { Box, Button, Grid } from '@mui/material';
+import { useRedirectToReplace } from 'bluesquare-components';
 import { FormattedMessage } from 'react-intl';
 import InputComponent from '../../../../../../../../hat/assets/js/apps/Iaso/components/forms/InputComponent';
 import { useGetGroupDropdown } from '../../../../../../../../hat/assets/js/apps/Iaso/domains/orgUnits/hooks/requests/useGetGroups';
+import { appId } from '../../../../constants/app';
 import MESSAGES from '../../../../constants/messages';
 import { useGetCountries } from '../../../../hooks/useGetCountries';
 
-import { appId } from '../../../../constants/app';
 import { singleVaccinesList } from '../../SupplyChain/constants';
 import { useGetFileTypes } from '../hooks/useGetFileTypes';
 import { VaccineRepositoryParams } from '../types';
@@ -61,7 +61,7 @@ export const Filters: FunctionComponent<Props> = ({ params, redirectUrl }) => {
     const { data, isFetching: isFetchingCountries } = useGetCountries();
     // Pass the appId to have it works in the embedded vaccine stock where the user is not connected
     const { data: groupedOrgUnits, isFetching: isFetchingGroupedOrgUnits } =
-        useGetGroupDropdown({ blockOfCountries: 'True', appId });
+        useGetGroupDropdown({ blockOfCountries: 'true', appId });
 
     const countriesList = (data && data.orgUnits) || [];
 

--- a/plugins/polio/js/src/domains/VaccineModule/Repository/reports/Filters.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/Repository/reports/Filters.tsx
@@ -1,20 +1,20 @@
-import FiltersIcon from '@mui/icons-material/FilterList';
-import { Box, Button, Grid } from '@mui/material';
-import { useRedirectToReplace } from 'bluesquare-components';
 import React, {
     FunctionComponent,
     useCallback,
     useEffect,
     useState,
 } from 'react';
+import FiltersIcon from '@mui/icons-material/FilterList';
+import { Box, Button, Grid } from '@mui/material';
+import { useRedirectToReplace } from 'bluesquare-components';
 import { FormattedMessage } from 'react-intl';
 import InputComponent from '../../../../../../../../hat/assets/js/apps/Iaso/components/forms/InputComponent';
 import { useGetGroupDropdown } from '../../../../../../../../hat/assets/js/apps/Iaso/domains/orgUnits/hooks/requests/useGetGroups';
+import { appId } from '../../../../constants/app';
 import MESSAGES from '../../../../constants/messages';
 
 import { useGetCountries } from '../../../../hooks/useGetCountries';
 
-import { appId } from '../../../../constants/app';
 import { singleVaccinesList } from '../../SupplyChain/constants';
 import { useGetReportFileTypes } from '../hooks/useGetFileTypes';
 import { VaccineRepositoryParams } from '../types';
@@ -65,7 +65,7 @@ export const Filters: FunctionComponent<Props> = ({ params, redirectUrl }) => {
     const { data, isFetching: isFetchingCountries } = useGetCountries();
     // Pass the appId to have it works in the embedded vaccine stock where the user is not connected
     const { data: groupedOrgUnits, isFetching: isFetchingGroupedOrgUnits } =
-        useGetGroupDropdown({ blockOfCountries: 'True', appId });
+        useGetGroupDropdown({ blockOfCountries: 'true', appId });
 
     const countriesList = (data && data.orgUnits) || [];
 

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/Filters/VaccineStockManagementFilters.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/Filters/VaccineStockManagementFilters.tsx
@@ -1,15 +1,15 @@
 import React, { FunctionComponent } from 'react';
 import { Box, Grid } from '@mui/material';
 import { useSafeIntl } from 'bluesquare-components';
-import { useGetGroupDropdown } from '../../../../../../../../hat/assets/js/apps/Iaso/domains/orgUnits/hooks/requests/useGetGroups';
 import { FilterButton } from '../../../../../../../../hat/assets/js/apps/Iaso/components/FilterButton';
-import { useFilterState } from '../../../../../../../../hat/assets/js/apps/Iaso/hooks/useFilterState';
 import InputComponent from '../../../../../../../../hat/assets/js/apps/Iaso/components/forms/InputComponent';
-import MESSAGES from '../messages';
-import { useGetCountriesOptions } from '../../SupplyChain/hooks/api/vrf';
-import { StockManagementListParams } from '../types';
+import { useGetGroupDropdown } from '../../../../../../../../hat/assets/js/apps/Iaso/domains/orgUnits/hooks/requests/useGetGroups';
+import { useFilterState } from '../../../../../../../../hat/assets/js/apps/Iaso/hooks/useFilterState';
 import { baseUrls } from '../../../../constants/urls';
 import { singleVaccinesList } from '../../SupplyChain/constants';
+import { useGetCountriesOptions } from '../../SupplyChain/hooks/api/vrf';
+import MESSAGES from '../messages';
+import { StockManagementListParams } from '../types';
 
 const baseUrl = baseUrls.stockManagement;
 type Props = { params: StockManagementListParams };
@@ -23,7 +23,7 @@ export const VaccineStockManagementFilters: FunctionComponent<Props> = ({
     // TODO refactor and move this hook
     const { data: countries, isFetching } = useGetCountriesOptions();
     const { data: groupedOrgUnits, isFetching: isFetchingGroupedOrgUnits } =
-        useGetGroupDropdown({ blockOfCountries: 'True' });
+        useGetGroupDropdown({ blockOfCountries: 'true' });
     return (
         <>
             <Grid container spacing={2}>

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Filters/VaccineSupplyChainFilters.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Filters/VaccineSupplyChainFilters.tsx
@@ -1,15 +1,15 @@
 import React, { FunctionComponent } from 'react';
 import { Box, Grid } from '@mui/material';
 import { DatePicker, useSafeIntl } from 'bluesquare-components';
-import { baseUrls } from '../../../../constants/urls';
 import { FilterButton } from '../../../../../../../../hat/assets/js/apps/Iaso/components/FilterButton';
-import { useFilterState } from '../../../../../../../../hat/assets/js/apps/Iaso/hooks/useFilterState';
 import InputComponent from '../../../../../../../../hat/assets/js/apps/Iaso/components/forms/InputComponent';
-import MESSAGES from '../messages';
-import { apiDateFormat } from '../../../../../../../../hat/assets/js/apps/Iaso/utils/dates';
-import { useGetCountriesOptions } from '../hooks/api/vrf';
 import { useGetGroupDropdown } from '../../../../../../../../hat/assets/js/apps/Iaso/domains/orgUnits/hooks/requests/useGetGroups';
+import { useFilterState } from '../../../../../../../../hat/assets/js/apps/Iaso/hooks/useFilterState';
+import { apiDateFormat } from '../../../../../../../../hat/assets/js/apps/Iaso/utils/dates';
+import { baseUrls } from '../../../../constants/urls';
 import { singleVaccinesList } from '../constants';
+import { useGetCountriesOptions } from '../hooks/api/vrf';
+import MESSAGES from '../messages';
 
 type Props = { params: any };
 
@@ -21,7 +21,7 @@ export const VaccineSupplyChainFilters: FunctionComponent<Props> = ({
         useFilterState({ baseUrl: baseUrls.vaccineSupplyChain, params });
     const { data: countries, isFetching } = useGetCountriesOptions();
     const { data: groupedOrgUnits, isFetching: isFetchingGroupedOrgUnits } =
-        useGetGroupDropdown({ blockOfCountries: 'True' });
+        useGetGroupDropdown({ blockOfCountries: 'true' });
     return (
         <Grid container spacing={2}>
             <Grid item xs={6} md={3} lg={3}>


### PR DESCRIPTION
https://jam.dev/c/9d946691-bb5a-4045-a8ae-ff59c6d4d814 

Country block filter throughout the platform is now giving a bug, showing all possible groups/scopes. This should be showcasing ESARO/WCARO and the WHO ones for WEST, EAST, LAKE Chad

Related JIRA tickets : POLIO-1915

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [x] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)


## Changes

Api now uses 'true' as value for 'blockOfCountries', frontend is sending 'True'

## How to test

visit campaing page, block of country filter should display only block of countries
