### PR TITLE
IA-4044: SETUPER : Add DHIS2 Sierra Leone demo account to data sources

### DIFF
--- a/setuper/additional_projects.py
+++ b/setuper/additional_projects.py
@@ -154,7 +154,7 @@ def add_new_dhis2_data_source(account_name, iaso_client):
         "project_ids": [],
         "credentials": {
             "dhis_name": "Dhis2 Sierra Leone Play",
-            "dhis_url": "https://play.im.dhis2.org/stable-2-40-7/",
+            "dhis_url": "https://play.im.dhis2.org/stable-2-41-3-1/",
             "dhis_login": "admin",
             "dhis_password": "district",
         },

--- a/setuper/submissions.py
+++ b/setuper/submissions.py
@@ -54,8 +54,6 @@ def create_default_reference_submission(account_name, iaso_client, org_unit_id, 
         f"/api/instances/?app_id={account_name}",
         params={"orgUnitId": org_unit_id, "form_ids": form_id},
     )["instances"]
-
-    print("SUMISSION LINKED TO ORG UNIT ...:", submissions_linked_to_org_unit)
     reference_submission = [
         submission["id"] for submission in submissions_linked_to_org_unit if submission["uuid"] == uuid
     ]


### PR DESCRIPTION
What problem is this PR solving? Explain here in one sentence.

Related JIRA tickets : [IA-4044](https://bluesquare.atlassian.net/browse/IA-4044)

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)


## Changes

Added new data source linked to dhis2 play!


## How to test

From setuper folder, launch setuper via python3 setuper.py --additional_projects to generate test data. Then login with the created account open [data source page](http://localhost:8081/dashboard/settings/sources/l). Check if you can see data source with **Dhis2 Sierra Leone** in name. Open the data source in edit mode. You should see dhis2 params in config for the data source 

## Print screen / video

[Iaso-datasource.webm](https://github.com/user-attachments/assets/62750ae3-02c4-406f-9301-1fd5045bf137)


## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.


[IA-4044]: https://bluesquare.atlassian.net/browse/IA-4044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ