### PR TITLE
IA-4116 Fix sync versions doesn't support `groups`

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/dataSources/hooks/useCreateJsonDiffAsync.ts
+++ b/hat/assets/js/apps/Iaso/domains/dataSources/hooks/useCreateJsonDiffAsync.ts
@@ -57,12 +57,14 @@ const createJsonDiffAsync = async ({
     }
 
     // Options
-    const nonEmptyFields = fieldsToExport.filter(field => field !== 'geometry');
+    const nonEmptyFields = fieldsToExport.filter(
+        field => field !== 'geometry' && field !== 'groups',
+    );
     if (nonEmptyFields.length > 0) {
         params.field_names = nonEmptyFields;
     }
 
-    params.ignore_groups = true;
+    params.ignore_groups = !fieldsToExport.includes('groups');
     params.show_deleted_org_units = false;
 
     return patchRequest(

--- a/iaso/diffing/differ.py
+++ b/iaso/diffing/differ.py
@@ -58,6 +58,8 @@ class Differ:
     ):
         if field_names is None:
             field_names = ["name", "geometry", "parent", "opening_date", "closed_date"]
+        elif not isinstance(field_names, list):
+            field_names = list(field_names)
         if not ignore_groups:
             groups_with_with_groupset = []
             for group_set in GroupSet.objects.filter(source_version=version):

--- a/iaso/models/data_source.py
+++ b/iaso/models/data_source.py
@@ -308,7 +308,6 @@ class DataSourceVersionsSynchronization(models.Model):
             "show_deleted_org_units": show_deleted_org_units,
             "field_names": field_names,
         }
-
         diffs, _ = Differ(logger_to_use or logger).diff(**differ_params)
 
         # Reduce the size of the diff that will be stored in the DB.

--- a/iaso/models/data_source.py
+++ b/iaso/models/data_source.py
@@ -204,7 +204,8 @@ class DataSourceVersionsSynchronization(models.Model):
 
     """
 
-    SYNCHRONIZABLE_FIELDS = ["name", "parent", "opening_date", "closed_date", "groups"]
+    SYNCHRONIZABLE_FIELDS = ["name", "parent", "opening_date", "closed_date"]
+    # `groups` are synchronizable, but are handled via the `ignore_groups` param of the `Differ`.
 
     name = models.CharField(
         max_length=255,
@@ -307,6 +308,7 @@ class DataSourceVersionsSynchronization(models.Model):
             "show_deleted_org_units": show_deleted_org_units,
             "field_names": field_names,
         }
+
         diffs, _ = Differ(logger_to_use or logger).diff(**differ_params)
 
         # Reduce the size of the diff that will be stored in the DB.

--- a/iaso/tests/diffing/test_differ.py
+++ b/iaso/tests/diffing/test_differ.py
@@ -21,7 +21,7 @@ class DifferTestCase(PyramidBaseTest):
     Test Differ.
     """
 
-    def test_full_python_diff(self):
+    def test_full_diff(self):
         """
         Test that the full diff works as expected.
         """
@@ -69,7 +69,7 @@ class DifferTestCase(PyramidBaseTest):
         country_diff = next((diff for diff in diffs if diff.org_unit.org_unit_type == self.org_unit_type_country), None)
         self.assertEqual(country_diff.status, "modified")
         country_diff_comparisons = [comparison.as_dict() for comparison in country_diff.comparisons]
-        self.assertEqual(8, len(country_diff_comparisons))
+        self.assertEqual(7, len(country_diff_comparisons))
         self.assertDictEqual(
             country_diff_comparisons[0],
             {
@@ -123,25 +123,15 @@ class DifferTestCase(PyramidBaseTest):
         self.assertDictEqual(
             country_diff_comparisons[5],
             {
-                "field": "group:group-a:Group A",
-                "before": [{"id": "group-a", "name": "Group A", "iaso_id": self.group_a1.pk}],
-                "after": [{"id": "group-a", "name": "Group A", "iaso_id": self.group_a2.pk}],
-                "status": "same",
-                "distance": 0,
-            },
-        )
-        self.assertDictEqual(
-            country_diff_comparisons[6],
-            {
-                "field": "group:group-b:Group B",
-                "before": [{"id": "group-b", "name": "Group B", "iaso_id": self.group_b.pk}],
+                "field": "groupset:groupset-a:GroupSet A",
+                "before": [{"id": "group-a", "name": "Group A"}, {"id": "group-b", "name": "Group B"}],
                 "after": [],
                 "status": "deleted",
                 "distance": None,
             },
         )
         self.assertDictEqual(
-            country_diff_comparisons[7],
+            country_diff_comparisons[6],
             {
                 "field": "group:group-c:Group C",
                 "before": [],
@@ -154,7 +144,7 @@ class DifferTestCase(PyramidBaseTest):
         region_diff = next((diff for diff in diffs if diff.org_unit.org_unit_type == self.org_unit_type_region), None)
         self.assertEqual(region_diff.status, "modified")
         region_diff_comparisons = [comparison.as_dict() for comparison in region_diff.comparisons]
-        self.assertEqual(8, len(region_diff_comparisons))
+        self.assertEqual(7, len(region_diff_comparisons))
         self.assertDictEqual(
             region_diff_comparisons[0],
             {
@@ -208,7 +198,7 @@ class DifferTestCase(PyramidBaseTest):
         self.assertDictEqual(
             region_diff_comparisons[5],
             {
-                "field": "group:group-a:Group A",
+                "field": "groupset:groupset-a:GroupSet A",
                 "before": [],
                 "after": [],
                 "status": "same",
@@ -217,16 +207,6 @@ class DifferTestCase(PyramidBaseTest):
         )
         self.assertDictEqual(
             region_diff_comparisons[6],
-            {
-                "field": "group:group-b:Group B",
-                "before": [],
-                "after": [],
-                "status": "same",
-                "distance": 0,
-            },
-        )
-        self.assertDictEqual(
-            region_diff_comparisons[7],
             {
                 "field": "group:group-c:Group C",
                 "before": [],
@@ -241,7 +221,7 @@ class DifferTestCase(PyramidBaseTest):
         )
         self.assertEqual(district_diff.status, "modified")
         district_diff_comparisons = [comparison.as_dict() for comparison in district_diff.comparisons]
-        self.assertEqual(8, len(district_diff_comparisons))
+        self.assertEqual(7, len(district_diff_comparisons))
         self.assertDictEqual(
             district_diff_comparisons[0],
             {
@@ -295,7 +275,7 @@ class DifferTestCase(PyramidBaseTest):
         self.assertDictEqual(
             district_diff_comparisons[5],
             {
-                "field": "group:group-a:Group A",
+                "field": "groupset:groupset-a:GroupSet A",
                 "before": [],
                 "after": [],
                 "status": "same",
@@ -303,17 +283,7 @@ class DifferTestCase(PyramidBaseTest):
             },
         )
         self.assertDictEqual(
-            district_diff_comparisons[6],
-            {
-                "field": "group:group-b:Group B",
-                "before": [],
-                "after": [],
-                "status": "same",
-                "distance": 0,
-            },
-        )
-        self.assertDictEqual(
-            region_diff_comparisons[7],
+            region_diff_comparisons[6],
             {
                 "field": "group:group-c:Group C",
                 "before": [],
@@ -322,3 +292,18 @@ class DifferTestCase(PyramidBaseTest):
                 "distance": 0,
             },
         )
+
+    def test_diff_for_groups_only(self):
+        """
+        Test that we can compare `groups` and `groupsets` only.
+        """
+        diffs, fields = Differ(test_logger).diff(
+            version=self.source_version_to_update,
+            version_ref=self.source_version_to_compare_with,
+            ignore_groups=False,
+            field_names=(),
+        )
+        self.assertTrue(len(diffs) > 0)
+        for diff in diffs:
+            for comparison in diff.comparisons:
+                self.assertTrue(comparison.field.startswith("group"))

--- a/iaso/tests/diffing/utils.py
+++ b/iaso/tests/diffing/utils.py
@@ -40,6 +40,13 @@ class PyramidBaseTest(TestCase):
             name="Group C", source_ref="group-c", source_version=cls.source_version_to_compare_with
         )
 
+        # GroupSet in the pyramid to update.
+
+        cls.groupset_a = m.GroupSet.objects.create(
+            name="GroupSet A", source_ref="groupset-a", source_version=cls.source_version_to_update
+        )
+        cls.groupset_a.groups.set([cls.group_a1, cls.group_b])
+
         cls.multi_polygon = MultiPolygon(Polygon([(0, 0), (0, 1), (1, 1), (0, 0)]))
 
         # Angola pyramid to update.


### PR DESCRIPTION
Fix sync versions doesn't support `groups`

Related JIRA tickets : [IA-4116](https://bluesquare.atlassian.net/browse/IA-4116)

https://bluesquareorg.sentry.io/issues/6528791735/

[IA-4116]: https://bluesquare.atlassian.net/browse/IA-4116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ