### PR TITLE
IA-4013: SETUPER: Enable payments module & catchment edit functionality

### DIFF
--- a/hat/menupermissions/constants.py
+++ b/hat/menupermissions/constants.py
@@ -111,16 +111,36 @@ MODULES = [
     },
     {"name": "Default", "codename": "DEFAULT", "fr_name": "Par défaut"},
     {"name": "DHIS2 mapping", "codename": "DHIS2_MAPPING", "fr_name": "Mappage DHIS2"},
-    {"name": "Embedded links", "codename": "EMBEDDED_LINKS", "fr_name": "Liens intégrés"},
+    {
+        "name": "Embedded links",
+        "codename": "EMBEDDED_LINKS",
+        "fr_name": "Liens intégrés",
+    },
     {"name": "Entities", "codename": "ENTITIES", "fr_name": "Entités"},
-    {"name": "External storage", "codename": "EXTERNAL_STORAGE", "fr_name": "Stockage externe"},
+    {
+        "name": "External storage",
+        "codename": "EXTERNAL_STORAGE",
+        "fr_name": "Stockage externe",
+    },
     {"name": "Planning", "codename": "PLANNING", "fr_name": "Planification"},
     {"name": "Polio project", "codename": "POLIO_PROJECT", "fr_name": "Projet Polio"},
     {"name": "Registry", "codename": "REGISTRY", "fr_name": "Registre"},
     {"name": "Payments", "codename": "PAYMENTS", "fr_name": "Paiements"},
-    {"name": "Completeness per Period", "codename": "COMPLETENESS_PER_PERIOD", "fr_name": "Complétude par période"},
-    {"name": "Trypelim project", "codename": "TRYPELIM_PROJECT", "fr_name": "Projet Trypelim"},
-    {"name": "Data validation", "codename": "DATA_VALIDATION", "fr_name": "Validation des données"},
+    {
+        "name": "Completeness per Period",
+        "codename": "COMPLETENESS_PER_PERIOD",
+        "fr_name": "Complétude par période",
+    },
+    {
+        "name": "Trypelim project",
+        "codename": "TRYPELIM_PROJECT",
+        "fr_name": "Projet Trypelim",
+    },
+    {
+        "name": "Data validation",
+        "codename": "DATA_VALIDATION",
+        "fr_name": "Validation des données",
+    },
 ]
 
 FEATUREFLAGES_TO_EXCLUDE = {
@@ -134,6 +154,13 @@ FEATUREFLAGES_TO_EXCLUDE = {
         "WRITE_ON_NFC_CARDS",
     ],
 }
+
+DEFAULT_ACCOUNT_FEATURE_FLAGS = [
+    "SHOW_PAGES",
+    "SHOW_BENEFICIARY_TYPES_IN_LIST_MENU",
+    "SHOW_LINK_INSTANCE_REFERENCE",
+    "SHOW_HOME_ONLINE",
+]
 
 PERMISSIONS_PRESENTATION = {
     "forms": [
@@ -243,17 +270,32 @@ PERMISSIONS_PRESENTATION = {
 }
 
 READ_EDIT_PERMISSIONS = {
-    "iaso_submission_permissions": {"read": "iaso_submissions", "write": "iaso_update_submission"},
-    "iaso_org_unit_permissions": {"read": "iaso_org_units_read", "write": "iaso_org_units"},
-    "iaso_registry_permissions": {"read": "iaso_registry_read", "write": "iaso_registry_write"},
+    "iaso_submission_permissions": {
+        "read": "iaso_submissions",
+        "write": "iaso_update_submission",
+    },
+    "iaso_org_unit_permissions": {
+        "read": "iaso_org_units_read",
+        "write": "iaso_org_units",
+    },
+    "iaso_registry_permissions": {
+        "read": "iaso_registry_read",
+        "write": "iaso_registry_write",
+    },
     "iaso_source_permissions": {"read": "iaso_sources", "write": "iaso_write_sources"},
     "iaso_entity_duplicate_permissions": {
         "read": "iaso_entity_duplicates_read",
         "write": "iaso_entity_duplicates_write",
     },
-    "iaso_planning_permissions": {"read": "iaso_planning_read", "write": "iaso_planning_write"},
+    "iaso_planning_permissions": {
+        "read": "iaso_planning_read",
+        "write": "iaso_planning_write",
+    },
     "iaso_page_permissions": {"read": "iaso_pages", "write": "iaso_page_write"},
-    "iaso_polio_budget_permissions": {"read": "iaso_polio_budget", "write": "iaso_polio_budget_admin"},
+    "iaso_polio_budget_permissions": {
+        "read": "iaso_polio_budget",
+        "write": "iaso_polio_budget_admin",
+    },
     "iaso_polio_chronogram_permissions": {
         "read": "iaso_polio_chronogram_restricted_write",
         "write": "iaso_polio_chronogram",

--- a/iaso/api/setup_account.py
+++ b/iaso/api/setup_account.py
@@ -28,6 +28,7 @@ class SetupAccountSerializer(serializers.Serializer):
     user_manual_path = serializers.CharField(required=False)
     modules = serializers.JSONField(required=True, initial=["DEFAULT"])  # type: ignore
     analytics_script = serializers.CharField(required=False)
+    feature_flags = serializers.JSONField(required=False)
 
     def validate_account_name(self, value):
         if Account.objects.filter(name=value).exists():
@@ -75,13 +76,17 @@ class SetupAccountSerializer(serializers.Serializer):
             modules=account_modules,
             analytics_script=validated_data.get("analytics_script", ""),
         )
-        account_feature_flags = [
-            "SHOW_HOME_ONLINE",
-            "SHOW_BENEFICIARY_TYPES_IN_LIST_MENU",
-            "SHOW_PAGES",
-            "SHOW_LINK_INSTANCE_REFERENCE",
-        ]
-        account.feature_flags.set(account_feature_flags)
+
+        if validated_data.get("feature_flags") == None:
+            account_feature_flags = [
+                "SHOW_HOME_ONLINE",
+                "SHOW_BENEFICIARY_TYPES_IN_LIST_MENU",
+                "SHOW_PAGES",
+                "SHOW_LINK_INSTANCE_REFERENCE",
+            ]
+            account.feature_flags.set(account_feature_flags)
+        else:
+            account.feature_flags.set(validated_data.get("feature_flags"))
 
         # Create a setup_account project with an app_id represented by the account name
         app_id = validated_data["account_name"].replace(" ", ".").replace("-", ".")

--- a/iaso/api/setup_account.py
+++ b/iaso/api/setup_account.py
@@ -61,10 +61,9 @@ class SetupAccountSerializer(serializers.Serializer):
     def validate_feature_flags(self, feature_flags):
         default_account_feature_flags = AccountFeatureFlag.objects.all()
         account_feature_flags = [feature_flag.code for feature_flag in default_account_feature_flags]
-        if len(feature_flags) > 0:
-            for feature_flag in feature_flags:
-                if feature_flag not in account_feature_flags:
-                    raise serializers.ValidationError("invalid_account_feature_flag")
+        for feature_flag in feature_flags:
+            if feature_flag not in account_feature_flags:
+                raise serializers.ValidationError("invalid_account_feature_flag")
         return feature_flags
 
     def create(self, validated_data):

--- a/iaso/tests/api/test_setup_account.py
+++ b/iaso/tests/api/test_setup_account.py
@@ -1,9 +1,9 @@
 from django.contrib.auth.models import Permission, User
 
 from hat.menupermissions.constants import (
+    DEFAULT_ACCOUNT_FEATURE_FLAGS,
     MODULE_PERMISSIONS,
     MODULES,
-    DEFAULT_ACCOUNT_FEATURE_FLAGS,
 )
 from hat.menupermissions.models import CustomPermissionSupport
 from iaso import models as m

--- a/iaso/tests/api/test_setup_account.py
+++ b/iaso/tests/api/test_setup_account.py
@@ -17,6 +17,13 @@ class SetupAccountApiTestCase(APITestCase):
         account.save()
         cls.account = account
         cls.MODULES = [module["codename"] for module in MODULES]
+        cls.ACCOUNT_FEATURE_FLAGS = [
+            "SHOW_HOME_ONLINE",
+            "SHOW_BENEFICIARY_TYPES_IN_LIST_MENU",
+            "SHOW_PAGES",
+            "SHOW_LINK_INSTANCE_REFERENCE",
+            "ALLOW_CATCHMENT_EDITION",
+        ]
         user = m.User.objects.create(username="link")
         user.set_password("tiredofplayingthesameagain")
         user.save()
@@ -163,3 +170,19 @@ class SetupAccountApiTestCase(APITestCase):
         data_source = created_data_source.first()
         project_data_sources = project.data_sources.filter(pk=data_source.id)
         self.assertEqual(project_data_sources.first(), data_source)
+
+    def test_setup_account_with_feature_flags(self):
+        self.client.force_authenticate(self.admin)
+        data = {
+            "account_name": "initial_project_account test-appid",
+            "user_username": "username",
+            "user_first_name": "firstname",
+            "user_last_name": "lastname",
+            "password": "password",
+            "modules": self.MODULES,
+            "feature_flags": self.ACCOUNT_FEATURE_FLAGS,
+        }
+        response = self.client.post("/api/setupaccount/", data=data, format="json")
+        self.assertEqual(response.status_code, 201)
+        account = response.json()
+        self.assertEqual(account["feature_flags"], self.ACCOUNT_FEATURE_FLAGS)

--- a/iaso/tests/api/test_setup_account.py
+++ b/iaso/tests/api/test_setup_account.py
@@ -199,8 +199,7 @@ class SetupAccountApiTestCase(APITestCase):
         response = self.client.post("/api/setupaccount/", data=data, format="json")
         self.assertEqual(response.status_code, 201)
         created_account = m.Account.objects.filter(name="account with no feature test-featureappid")
-        account_feature_flags = created_account.first().feature_flags.all()
-        feature_flags = [feature_flag.code for feature_flag in account_feature_flags]
+        feature_flags = created_account.first().feature_flags.values_list("code", flat=True)
         self.assertEqual(sorted(feature_flags), sorted(DEFAULT_ACCOUNT_FEATURE_FLAGS))
 
     def test_setup_account_with_at_leat_an_invalid_feature_flags(self):

--- a/setuper/setuper.py
+++ b/setuper/setuper.py
@@ -64,6 +64,14 @@ def setup_account(account_name, server_url, username, password):
             "DATA_COLLECTION_FORMS",
             "DHIS2_MAPPING",
             "DATA_VALIDATION",
+            "PAYMENTS",
+        ],
+        "feature_flags": [
+            "SHOW_HOME_ONLINE",
+            "SHOW_BENEFICIARY_TYPES_IN_LIST_MENU",
+            "SHOW_PAGES",
+            "SHOW_LINK_INSTANCE_REFERENCE",
+            "ALLOW_CATCHMENT_EDITION",
         ],
     }
     iaso_admin_client = admin_login(server_url, username, password)


### PR DESCRIPTION
What problem is this PR solving? Explain here in one sentence.

Related JIRA tickets : [IA-4013](https://bluesquare.atlassian.net/browse/IA-4013)

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)


## Changes

- Allowed to provide feature flags payload when setting up a new account via `/api/setupaccount/`
- Added new module **PAYMENTS** to account and a list of feature flags

## How to test

From setuper folder, launch setuper via `python3 setuper.py --additional_projects` to generate test data. Then login with admin user from django admin. Check modules and feature linked to the created account, you should see the module **"PAYMENTS"** and feature flags **"ALLOW_CATCHMENT_EDITION"**


## Print screen / video

![qufipcm-Modification-de-account-Iaso-04-09-2025_05_05_PM](https://github.com/user-attachments/assets/e72f559a-75d2-4e66-a4b3-a1324eff34b6)


## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.


[IA-4013]: https://bluesquare.atlassian.net/browse/IA-4013?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ