### PR TITLE
[IA-4111] Fix update OrgUnits with default image

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitImages.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitImages.tsx
@@ -51,15 +51,15 @@ export const OrgUnitImages: FunctionComponent<Props> = ({
     };
     const isDefaultImage = useCallback(
         (imageId: number) => {
-            return imageId === orgUnit?.default_image?.id;
+            return imageId === orgUnit?.default_image_id;
         },
-        [orgUnit?.default_image?.id],
+        [orgUnit?.default_image_id],
     );
     const handleImageFavoriteClick = useCallback(
-        (imageid: number) => {
+        (imageId: number) => {
             saveOu({
                 id: params.orgUnitId,
-                default_image: isDefaultImage(imageid) ? null : imageid,
+                default_image_id: isDefaultImage(imageId) ? null : imageId,
             });
         },
         [saveOu, params.orgUnitId, isDefaultImage],

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/types/orgUnit.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/types/orgUnit.ts
@@ -87,7 +87,7 @@ export type OrgUnit = {
     reference_instance_action?: string;
     opening_date?: Date;
     closed_date?: Date;
-    default_image?: File;
+    default_image_id?: number;
 };
 export interface PaginatedOrgUnits extends Pagination {
     orgunits: OrgUnit[];

--- a/iaso/api/org_units.py
+++ b/iaso/api/org_units.py
@@ -585,8 +585,8 @@ class OrgUnitViewSet(viewsets.ViewSet):
                     continue
                 new_groups.append(temp_group)
 
-        if "default_image" in request.data:
-            default_image_id = request.data["default_image"]
+        if "default_image_id" in request.data:
+            default_image_id = request.data["default_image_id"]
             if default_image_id is not None:
                 try:
                     default_image = InstanceFile.objects.get(id=default_image_id)

--- a/iaso/models/org_unit.py
+++ b/iaso/models/org_unit.py
@@ -480,7 +480,7 @@ class OrgUnit(TreeModel):
             "creator": get_creator_name(self.creator),
             "opening_date": self.opening_date.strftime("%d/%m/%Y") if self.opening_date else None,
             "closed_date": self.closed_date.strftime("%d/%m/%Y") if self.closed_date else None,
-            "default_image": self.default_image.as_dict() if self.default_image else None,
+            "default_image_id": self.default_image.id if self.default_image else None,
         }
         if not light:  # avoiding joins here
             res["groups"] = [group.as_dict(with_counts=False) for group in self.groups.all()]


### PR DESCRIPTION
Fix the 500 error when OrgUnits with default image are updated

Related JIRA tickets : IA-4111

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [x] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

/

## Changes

- Changed the OrgUnit serializer to return only the default image ID instead of a dict


## How to test

- Choose an OrgUnit that has a default image (click on the :star: button on the `Image` tab; if you don't have any image in OrgUnits, make a new submission with pictures or run the setuper)
- Update a field like opening/closing date, source ref...
- Notice that there was no 500 error

## Print screen / video
[Screencast from 2025-04-09 17-11-00.webm](https://github.com/user-attachments/assets/f2673397-7f22-406f-a5b4-8d5e2fb19d50)


## Notes

Since the `default_image` object in the payload was not used (except for the `id` field), I removed it and I am now sending `default_image_id` instead. 
I did not notice any issue in the frontend, but if something is broken, then we should revert this change and fetch, in the backend, the `id` from the `default_image` object when calling the OrgUnit `PATCH` endpoint

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
