### PR TITLE
IA-3962 Restrict change requests by projects

### DIFF
--- a/iaso/api/org_unit_change_requests/views.py
+++ b/iaso/api/org_unit_change_requests/views.py
@@ -97,7 +97,7 @@ class OrgUnitChangeRequestViewSet(viewsets.ModelViewSet):
                 "old_parent",
                 "new_org_unit_type",
                 "old_org_unit_type",
-                "org_unit__version",
+                "org_unit__version__data_source",
                 "data_source_synchronization",
             )
             .prefetch_related(
@@ -111,9 +111,11 @@ class OrgUnitChangeRequestViewSet(viewsets.ModelViewSet):
                 "org_unit__org_unit_type__projects",
             )
             .exclude_soft_deleted_new_reference_instances()
+            .filter(org_unit__in=org_units)
+            .filter_on_user_projects(self.request.user)
         )
 
-        return org_units_change_requests.filter(org_unit__in=org_units).filter_on_user_projects(self.request.user)
+        return org_units_change_requests
 
     def has_org_unit_permission(self, org_unit_to_change: OrgUnit) -> None:
         # The mobile adds `?app_id=.bar.baz` in the query params.

--- a/iaso/api/org_unit_change_requests/views.py
+++ b/iaso/api/org_unit_change_requests/views.py
@@ -113,7 +113,7 @@ class OrgUnitChangeRequestViewSet(viewsets.ModelViewSet):
             .exclude_soft_deleted_new_reference_instances()
         )
 
-        return org_units_change_requests.filter(org_unit__in=org_units)
+        return org_units_change_requests.filter(org_unit__in=org_units).filter_on_user_projects(self.request.user)
 
     def has_org_unit_permission(self, org_unit_to_change: OrgUnit) -> None:
         # The mobile adds `?app_id=.bar.baz` in the query params.

--- a/iaso/api/org_unit_change_requests/views.py
+++ b/iaso/api/org_unit_change_requests/views.py
@@ -114,7 +114,6 @@ class OrgUnitChangeRequestViewSet(viewsets.ModelViewSet):
             .filter(org_unit__in=org_units)
             .filter_on_user_projects(self.request.user)
         )
-
         return org_units_change_requests
 
     def has_org_unit_permission(self, org_unit_to_change: OrgUnit) -> None:

--- a/iaso/models/base.py
+++ b/iaso/models/base.py
@@ -28,6 +28,7 @@ from django.db.models import Count, Exists, FilteredRelation, OuterRef, Q
 from django.db.models.functions import Coalesce
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
+from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 from phonenumber_field.modelfields import PhoneNumberField
 from phonenumbers.phonenumberutil import region_code_for_number
@@ -1575,6 +1576,10 @@ class Profile(models.Model):
         if team:
             return True
         return False
+
+    @cached_property
+    def get_projects_ids(self) -> set[int]:
+        return list(self.projects.values_list("pk", flat=True))
 
     def get_editable_org_unit_type_ids(self) -> set[int]:
         ids_in_user_roles = set(

--- a/iaso/models/base.py
+++ b/iaso/models/base.py
@@ -1578,7 +1578,7 @@ class Profile(models.Model):
         return False
 
     @cached_property
-    def get_projects_ids(self) -> set[int]:
+    def projects_ids(self) -> set[int]:
         return list(self.projects.values_list("pk", flat=True))
 
     def get_editable_org_unit_type_ids(self) -> set[int]:

--- a/iaso/models/org_unit.py
+++ b/iaso/models/org_unit.py
@@ -657,7 +657,7 @@ class OrgUnitChangeRequestQuerySet(models.QuerySet):
     def filter_on_user_projects(self, user: User) -> models.QuerySet:
         if not hasattr(user, "iaso_profile"):
             return self
-        user_projects_ids = user.iaso_profile.get_projects_ids
+        user_projects_ids = user.iaso_profile.projects_ids
         if not user_projects_ids:
             return self
         return self.filter(org_unit__version__data_source__projects__in=user_projects_ids)

--- a/iaso/models/org_unit.py
+++ b/iaso/models/org_unit.py
@@ -654,6 +654,37 @@ class OrgUnitChangeRequestQuerySet(models.QuerySet):
             Q(requested_fields=["new_reference_instances"]) & Q(annotated_non_deleted_new_reference_instances_count=0)
         )
 
+    def filter_on_user_projects(self, user: User) -> models.QuerySet:
+        if not hasattr(user, "iaso_profile") or user.is_superuser:
+            return self
+        user_projects_ids = user.iaso_profile.projects.values_list("pk", flat=True)
+        if not user_projects_ids:
+            return self
+        return (
+            self.annotate(
+                annotated_authorized_new_reference_instances_count=Count(
+                    "new_reference_instances", filter=Q(new_reference_instances__project_id__in=user_projects_ids)
+                )
+            )
+            .annotate(
+                annotated_authorized_old_reference_instances_count=Count(
+                    "old_reference_instances", filter=Q(old_reference_instances__project_id__in=user_projects_ids)
+                )
+            )
+            .annotate(annotated_new_reference_instances_count=Count("new_reference_instances"))
+            .annotate(annotated_old_reference_instances_count=Count("old_reference_instances"))
+            .filter(
+                Q(
+                    annotated_new_reference_instances_count=0,
+                    annotated_old_reference_instances_count=0,
+                )
+                | Q(
+                    annotated_authorized_new_reference_instances_count__gt=0,
+                    annotated_authorized_old_reference_instances_count__gt=0,
+                )
+            )
+        )
+
 
 class OrgUnitChangeRequest(models.Model):
     """

--- a/iaso/tests/api/org_unit_change_requests/test_org_unit_change_requests.py
+++ b/iaso/tests/api/org_unit_change_requests/test_org_unit_change_requests.py
@@ -74,23 +74,24 @@ class OrgUnitChangeRequestAPITestCase(TaskAPITestCase):
 
         self.client.force_authenticate(self.user)
 
-        with self.assertNumQueries(12):
+        with self.assertNumQueries(13):
             # filter_for_user_and_app_id
-            #   1. SELECT OrgUnit
+            #   1. OrgUnit exists() => SELECT 1 AS "a"
             # get_queryset
-            #   2. COUNT(*)
-            #   3. SELECT OrgUnitChangeRequest
+            #   2. SELECT user Projects IDs
+            #   3. COUNT(*)
+            #   4. SELECT OrgUnitChangeRequest
             # prefetch
-            #   4. PREFETCH OrgUnit.groups
-            #   5. PREFETCH OrgUnit.reference_instances__form
-            #   6. PREFETCH OrgUnitChangeRequest.new_groups
-            #   7. PREFETCH OrgUnitChangeRequest.old_groups
-            #   8. PREFETCH OrgUnitChangeRequest.new_reference_instances__form
-            #   9. PREFETCH OrgUnitChangeRequest.old_reference_instances__form
-            #  10. PREFETCH OrgUnitChangeRequest.org_unit_type.projects
+            #   5. PREFETCH OrgUnit.groups
+            #   6. PREFETCH OrgUnit.reference_instances__form
+            #   7. PREFETCH OrgUnitChangeRequest.new_groups
+            #   8. PREFETCH OrgUnitChangeRequest.old_groups
+            #   9. PREFETCH OrgUnitChangeRequest.new_reference_instances__form
+            #  10. PREFETCH OrgUnitChangeRequest.old_reference_instances__form
+            #  11. PREFETCH OrgUnitChangeRequest.org_unit_type.projects
             # extra field `select_all_count` at the same level as `count` for pagination
-            #  11. COUNT(*) -> `self.get_queryset()` is called 2 times…
-            #  12. COUNT(status=new)
+            #  12. COUNT(*) -> `self.get_queryset()` is called 2 times…
+            #  13. COUNT(status=new)
             response = self.client.get("/api/orgunits/changes/")
             self.assertJSONResponse(response, 200)
 
@@ -105,7 +106,7 @@ class OrgUnitChangeRequestAPITestCase(TaskAPITestCase):
     def test_retrieve_ok(self):
         change_request = m.OrgUnitChangeRequest.objects.create(org_unit=self.org_unit, new_name="Foo")
         self.client.force_authenticate(self.user)
-        with self.assertNumQueries(9):
+        with self.assertNumQueries(10):
             response = self.client.get(f"/api/orgunits/changes/{change_request.pk}/")
         self.assertJSONResponse(response, 200)
         self.assertEqual(response.data["id"], change_request.pk)
@@ -120,7 +121,7 @@ class OrgUnitChangeRequestAPITestCase(TaskAPITestCase):
 
         self.client.force_authenticate(self.user)
 
-        with self.assertNumQueries(9):
+        with self.assertNumQueries(10):
             response = self.client.get(f"/api/orgunits/changes/{change_request.pk}/")
             self.assertJSONResponse(response, 200)
             self.assertEqual(response.data["id"], change_request.pk)
@@ -510,8 +511,7 @@ class OrgUnitChangeRequestAPITestCase(TaskAPITestCase):
         data_headers = data[0]
         self.assertEqual(data_headers, OrgUnitChangeRequestViewSet.CSV_HEADER_COLUMNS)
 
-        first_data_row = data[1]
-        expected_row_data = [
+        expected_csv_row = [
             str(change_request.id),
             str(change_request.org_unit_id),
             "112244",
@@ -525,7 +525,4 @@ class OrgUnitChangeRequestAPITestCase(TaskAPITestCase):
             datetime.datetime.strftime(change_request.updated_at, "%Y-%m-%d"),
             get_creator_name(change_request.updated_by) if change_request.updated_by else "",
         ]
-        self.assertEqual(
-            first_data_row,
-            expected_row_data,
-        )
+        self.assertIn(expected_csv_row, data)

--- a/iaso/tests/models/test_org_unit_change_request.py
+++ b/iaso/tests/models/test_org_unit_change_request.py
@@ -21,46 +21,41 @@ class OrgUnitChangeRequestModelTestCase(TestCase):
 
     @classmethod
     def setUpTestData(cls):
-        org_unit_type = m.OrgUnitType.objects.create(name="Org unit type")
-        parent = m.OrgUnit.objects.create(org_unit_type=org_unit_type)
-        org_unit = m.OrgUnit.objects.create(
-            org_unit_type=org_unit_type,
+        cls.account = m.Account.objects.create(name="Account")
+        cls.user = cls.create_user_with_profile(username="user", account=cls.account)
+
+        cls.project_1 = m.Project.objects.create(name="Project 1", app_id="org.ghi.p1", account=cls.account)
+        cls.project_2 = m.Project.objects.create(name="Project 2", app_id="org.ghi.p2", account=cls.account)
+
+        cls.data_source = m.DataSource.objects.create(name="Data source")
+        cls.data_source.projects.set([cls.project_1])
+
+        cls.version = m.SourceVersion.objects.create(number=1, data_source=cls.data_source)
+
+        cls.org_unit_type = m.OrgUnitType.objects.create(name="Org unit type")
+        cls.parent = m.OrgUnit.objects.create(org_unit_type=cls.org_unit_type)
+        cls.org_unit = m.OrgUnit.objects.create(
+            version=cls.version,
+            org_unit_type=cls.org_unit_type,
             name="Hôpital Général",
-            parent=parent,
+            parent=cls.parent,
             location=Point(-1.1111111, 1.1111111, 1.1111111),
             opening_date=datetime.date(2020, 1, 1),
             closed_date=datetime.date(2055, 1, 1),
         )
 
-        form = m.Form.objects.create(name="Vaccine form")
+        cls.form = m.Form.objects.create(name="Vaccine form")
 
-        account = m.Account.objects.create(name="Account")
-        user = cls.create_user_with_profile(username="user", account=account)
+        cls.new_parent = m.OrgUnit.objects.create(org_unit_type=cls.org_unit_type)
+        cls.new_org_unit_type = m.OrgUnitType.objects.create(name="New org unit type")
+        cls.new_group1 = m.Group.objects.create(name="Group 1")
+        cls.new_group2 = m.Group.objects.create(name="Group 2")
+        cls.org_unit.groups.set([cls.new_group1])
 
-        new_parent = m.OrgUnit.objects.create(org_unit_type=org_unit_type)
-        new_org_unit_type = m.OrgUnitType.objects.create(name="New org unit type")
-
-        new_group1 = m.Group.objects.create(name="Group 1")
-        new_group2 = m.Group.objects.create(name="Group 2")
-        org_unit.groups.set([new_group1])
-
-        other_form = m.Form.objects.create(name="Other form")
-        new_instance1 = m.Instance.objects.create(form=form, org_unit=org_unit)
-        new_instance2 = m.Instance.objects.create(form=other_form, org_unit=org_unit)
-        m.OrgUnitReferenceInstance.objects.create(org_unit=org_unit, form=form, instance=new_instance1)
-
-        cls.form = form
-        cls.org_unit = org_unit
-        cls.org_unit_type = org_unit_type
-        cls.user = user
-
-        cls.new_group1 = new_group1
-        cls.new_group2 = new_group2
-        cls.new_instance1 = new_instance1
-        cls.new_instance2 = new_instance2
-        cls.new_org_unit_type = new_org_unit_type
-        cls.parent = parent
-        cls.new_parent = new_parent
+        cls.other_form = m.Form.objects.create(name="Other form")
+        cls.new_instance1 = m.Instance.objects.create(form=cls.form, org_unit=cls.org_unit)
+        cls.new_instance2 = m.Instance.objects.create(form=cls.other_form, org_unit=cls.org_unit)
+        m.OrgUnitReferenceInstance.objects.create(org_unit=cls.org_unit, form=cls.form, instance=cls.new_instance1)
 
     @time_machine.travel(DT, tick=False)
     def test_create(self):
@@ -322,3 +317,31 @@ class OrgUnitChangeRequestModelTestCase(TestCase):
 
         change_requests = m.OrgUnitChangeRequest.objects.exclude_soft_deleted_new_reference_instances()
         self.assertEqual(change_requests.count(), 0)
+
+    def test_filter_on_user_projects(self):
+        # The data source should be linked to `project_1`.
+        self.assertEqual(self.data_source.projects.count(), 1)
+        self.assertEqual(self.data_source.projects.first(), self.project_1)
+
+        # The org unit should be linked to `project_1` (via the data source).
+        self.assertEqual(self.org_unit.version.data_source, self.data_source)
+
+        # Create a change request for this org unit.
+        m.OrgUnitChangeRequest.objects.create(org_unit=self.org_unit, new_name="Foo")
+
+        # No project restriction: the user should be able to see all change requests.
+        self.assertEqual(self.user.iaso_profile.projects_ids, [])
+        filtered_change_requests = m.OrgUnitChangeRequest.objects.filter_on_user_projects(self.user)
+        self.assertEqual(filtered_change_requests.count(), 1)
+
+        # Restriction on `project_2`: the user shouldn't be able to see change requests for `project_1`.
+        self.user.iaso_profile.projects.set([self.project_2])
+        del self.user.iaso_profile.projects_ids
+        filtered_change_requests = m.OrgUnitChangeRequest.objects.filter_on_user_projects(self.user)
+        self.assertEqual(filtered_change_requests.count(), 0)
+
+        # Restriction on `project_1` and `project_2`: the user should be able to see change requests for `project_1`.
+        self.user.iaso_profile.projects.set([self.project_1, self.project_2])
+        del self.user.iaso_profile.projects_ids
+        filtered_change_requests = m.OrgUnitChangeRequest.objects.filter_on_user_projects(self.user)
+        self.assertEqual(filtered_change_requests.count(), 1)


### PR DESCRIPTION
Restrict change requests by projects.

Related JIRA tickets : [IA-3962](https://bluesquare.atlassian.net/browse/IA-3962)

## Doc

A user restricted only to `project 1` should not be able to access change requests associated to `project 2`.

[IA-3962]: https://bluesquare.atlassian.net/browse/IA-3962?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ