### PR TITLE
IA-4047: show loading spinner when sorting forms

### DIFF
--- a/hat/assets/js/apps/Iaso/components/Buttons/FileUploadButtons.tsx
+++ b/hat/assets/js/apps/Iaso/components/Buttons/FileUploadButtons.tsx
@@ -1,8 +1,8 @@
-import { Button, Grid } from '@mui/material';
 import React, { FunctionComponent } from 'react';
+import { Button, Grid } from '@mui/material';
 import { CsvSvg, useSafeIntl } from 'bluesquare-components';
-import MESSAGES from './messages';
 import { useDownloadButtonStyles } from '../DownloadButtonsComponent';
+import MESSAGES from './messages';
 
 type Props = {
     closeDialog: () => void;

--- a/hat/assets/js/apps/Iaso/domains/forms/components/FormsTable.tsx
+++ b/hat/assets/js/apps/Iaso/domains/forms/components/FormsTable.tsx
@@ -1,9 +1,9 @@
 import React, { FunctionComponent } from 'react';
 import { Column } from 'bluesquare-components';
-import { useFormsTableColumns } from '../config';
 import { TableWithDeepLink } from '../../../components/tables/TableWithDeepLink';
-import { tableDefaults, useGetForms } from '../hooks/useGetForms';
 import { usePrefixedParams } from '../../../routing/hooks/usePrefixedParams';
+import { useFormsTableColumns } from '../config';
+import { tableDefaults, useGetForms } from '../hooks/useGetForms';
 
 type Props = {
     baseUrl: string;
@@ -29,7 +29,7 @@ export const FormsTable: FunctionComponent<Props> = ({
 
     const apiParams = usePrefixedParams(paramsPrefix, params);
 
-    const { data: forms, isLoading: isLoadingForms } = useGetForms(
+    const { data: forms, isFetching: isLoadingForms } = useGetForms(
         apiParams,
         tableDefaultsProp
             ? { ...tableDefaults, ...tableDefaultsProp }

--- a/hat/assets/js/apps/Iaso/domains/instances/index.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/index.js
@@ -1,3 +1,4 @@
+import React, { useCallback, useMemo, useState } from 'react';
 import { Box, Grid, Tooltip } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import {
@@ -8,7 +9,6 @@ import {
     useRedirectToReplace,
     useSafeIntl,
 } from 'bluesquare-components';
-import React, { useCallback, useMemo, useState } from 'react';
 import { useQueryClient } from 'react-query';
 import { DisplayIfUserHasPerm } from '../../components/DisplayIfUserHasPerm.tsx';
 import DownloadButtonsComponent from '../../components/DownloadButtonsComponent.tsx';


### PR DESCRIPTION
No spinner was showing when sorting forms, though the call is quite long

Related JIRA tickets : IA-4047

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

N/A

## Changes

- replace `isLoading` with `isFetching`

## How to test
Go to forms list, change sort order

## Print screen / video


https://github.com/user-attachments/assets/73dd7835-85c3-4167-8d70-6d803ba95bb2


## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
