### PR TITLE
IA-3961 Restrict user creation and profile edition by projects 

### DIFF
--- a/iaso/api/profiles/bulk_create_users.py
+++ b/iaso/api/profiles/bulk_create_users.py
@@ -345,29 +345,27 @@ class BulkCreateUserFromCsvViewSet(ModelViewSet):
                     except (IndexError, ValueError):
                         user_roles = None
                     if user_roles:
-                        user_roles = user_roles.split(value_splitter)
+                        user_roles = [role.strip() for role in user_roles.split(value_splitter) if role]
                         # check if the roles exists in the account of the request user
                         # and add it to user_roles_list
                         for role in user_roles:
-                            if role != "":
-                                role = role[1::] if role[:1] == " " else role
-                                try:
-                                    role_instance = UserRole.objects.get(
-                                        account=importer_account,
-                                        group__name=f"{importer_account.id}_{role}",
-                                    )
-                                    user_roles_list.append(role_instance)
-                                    # get the user group linked to the userrole
-                                    user_group_item = Group.objects.get(pk=role_instance.group.id)
-                                    user_groups_list.append(user_group_item)
+                            try:
+                                role_instance = UserRole.objects.get(
+                                    account=importer_account,
+                                    group__name=f"{importer_account.id}_{role}",
+                                )
+                                user_roles_list.append(role_instance)
+                                # get the user group linked to the userrole
+                                user_group_item = Group.objects.get(pk=role_instance.group.id)
+                                user_groups_list.append(user_group_item)
 
-                                except ObjectDoesNotExist:
-                                    raise serializers.ValidationError(
-                                        {
-                                            "error": f"Error. User Role: {role}, at row {i + 1} does not exists: Fix "
-                                            "the error and try again."
-                                        }
-                                    )
+                            except ObjectDoesNotExist:
+                                raise serializers.ValidationError(
+                                    {
+                                        "error": f"Error. User Role: {role}, at row {i + 1} does not exists: Fix "
+                                        "the error and try again."
+                                    }
+                                )
                     try:
                         projects = row[csv_indexes.index("projects")]
                     except (IndexError, ValueError):
@@ -391,12 +389,13 @@ class BulkCreateUserFromCsvViewSet(ModelViewSet):
                             )
 
                     try:
-                        user_permissions = row[csv_indexes.index("permissions")].split(value_splitter)
+                        user_permissions = [
+                            perm.strip() for perm in row[csv_indexes.index("permissions")].split(value_splitter) if perm
+                        ]
                         current_account = request.user.iaso_profile.account
                         module_permissions = self.module_permissions(current_account)
                         for perm in user_permissions:
-                            perm = perm[1::] if perm[:1] == " " else perm
-                            if perm and perm in module_permissions:
+                            if perm in module_permissions:
                                 try:
                                     perm = Permission.objects.get(codename=perm)
                                     user.user_permissions.add(perm)

--- a/iaso/api/profiles/bulk_create_users.py
+++ b/iaso/api/profiles/bulk_create_users.py
@@ -128,6 +128,10 @@ class BulkCreateUserFromCsvViewSet(ModelViewSet):
             user_editable_org_unit_type_ids = request.user.iaso_profile.get_editable_org_unit_type_ids()
             has_geo_limit = True
 
+        user_has_project_restrictions = hasattr(request.user, "iaso_profile") and bool(
+            request.user.iaso_profile.projects_ids
+        )
+
         if request.FILES:
             # Retrieve and check the validity and format of the CSV File
             try:
@@ -369,20 +373,18 @@ class BulkCreateUserFromCsvViewSet(ModelViewSet):
                     except (IndexError, ValueError):
                         projects = None
                     if projects:
-                        projects = projects.split(value_splitter)
-                        for project in projects:
-                            if project != "":
-                                project = project[1::] if project[:1] == " " else project
-                                try:
-                                    project_instance = Project.objects.get(account=importer_account, name=project)
-                                    projects_instance_list.append(project_instance)
-                                except ObjectDoesNotExist:
-                                    raise serializers.ValidationError(
-                                        {
-                                            "error": f"Error. User Project: {project}, at row {i + 1} does not exists: Fix "
-                                            "the error and try again."
-                                        }
-                                    )
+                        project_names = [name.strip() for name in projects.split(value_splitter) if name]
+                        if user_has_project_restrictions:
+                            projects_instance_list = Project.objects.filter(
+                                id__in=request.user.iaso_profile.projects_ids,
+                                name__in=project_names,
+                                account=importer_account,
+                            )
+                        else:
+                            projects_instance_list = Project.objects.filter(
+                                name__in=project_names, account=importer_account
+                            )
+
                     try:
                         user_permissions = row[csv_indexes.index("permissions")].split(value_splitter)
                         current_account = request.user.iaso_profile.account

--- a/iaso/api/profiles/bulk_create_users.py
+++ b/iaso/api/profiles/bulk_create_users.py
@@ -379,6 +379,12 @@ class BulkCreateUserFromCsvViewSet(ModelViewSet):
                                 name__in=project_names,
                                 account=importer_account,
                             ).filter_on_user_projects(request.user)
+                            # If none of the submitted projects is a subset of the user's project restrictions,
+                            # fallback to the same restrictions as the user.
+                            if not projects_instance_list.exists():
+                                projects_instance_list = Project.objects.filter(
+                                    account=importer_account
+                                ).filter_on_user_projects(request.user)
                         else:
                             projects_instance_list = Project.objects.filter(
                                 name__in=project_names, account=importer_account

--- a/iaso/api/profiles/bulk_create_users.py
+++ b/iaso/api/profiles/bulk_create_users.py
@@ -376,10 +376,9 @@ class BulkCreateUserFromCsvViewSet(ModelViewSet):
                         project_names = [name.strip() for name in projects.split(value_splitter) if name]
                         if user_has_project_restrictions:
                             projects_instance_list = Project.objects.filter(
-                                id__in=request.user.iaso_profile.projects_ids,
                                 name__in=project_names,
                                 account=importer_account,
-                            )
+                            ).filter_on_user_projects(request.user)
                         else:
                             projects_instance_list = Project.objects.filter(
                                 name__in=project_names, account=importer_account

--- a/iaso/api/profiles/profiles.py
+++ b/iaso/api/profiles/profiles.py
@@ -712,8 +712,7 @@ class ProfilesViewSet(viewsets.ViewSet):
 
         if not project_ids:
             if user_has_project_restrictions:
-                # Apply same project restrictions to the profile being edited
-                # otherwise it could have access to more projects.
+                # Apply the same project restrictions.
                 return list(Project.objects.filter(id__in=request.user.iaso_profile.projects_ids))
             # No project restrictions.
             return result

--- a/iaso/api/profiles/profiles.py
+++ b/iaso/api/profiles/profiles.py
@@ -713,7 +713,7 @@ class ProfilesViewSet(viewsets.ViewSet):
         if not project_ids:
             if user_has_project_restrictions:
                 # Apply the same project restrictions.
-                return list(Project.objects.filter(id__in=request.user.iaso_profile.projects_ids))
+                return list(Project.objects.filter_on_user_projects(request.user))
             # No project restrictions.
             return result
 

--- a/iaso/api/profiles/profiles.py
+++ b/iaso/api/profiles/profiles.py
@@ -705,7 +705,9 @@ class ProfilesViewSet(viewsets.ViewSet):
 
     def validate_projects(self, request, profile) -> list:
         project_ids = set([pk for pk in request.data.get("projects", []) if str(pk).isdigit()])
-        user_has_project_restrictions = request.user.iaso_profile and request.user.iaso_profile.projects_ids
+        user_has_project_restrictions = hasattr(request.user, "iaso_profile") and bool(
+            request.user.iaso_profile.projects_ids
+        )
         result = []
 
         if not project_ids:

--- a/iaso/api/projects/viewsets.py
+++ b/iaso/api/projects/viewsets.py
@@ -29,7 +29,9 @@ class ProjectsViewSet(ModelViewSet):
     def get_queryset(self):
         """Always filter the base queryset by account"""
 
-        return Project.objects.filter(account=self.request.user.iaso_profile.account)
+        return Project.objects.filter(account=self.request.user.iaso_profile.account).filter_on_user_projects(
+            self.request.user
+        )
 
     @action(detail=True, methods=["get"])
     def qr_code(self, request, *args, **kwargs):

--- a/iaso/locale/fr/LC_MESSAGES/django.po
+++ b/iaso/locale/fr/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-04-08 09:16+0000\n"
+"POT-Creation-Date: 2025-04-16 13:27+0000\n"
 "PO-Revision-Date: 2025-02-06 10:24+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -285,7 +285,11 @@ msgstr "Mot de passe requis"
 msgid "Both phone number and country code must be provided"
 msgstr "Le numéro de téléphone et le code pays doivent être fournis"
 
-#: iaso/api/profiles/profiles.py iaso/tests/api/test_profiles.py
+#: iaso/api/profiles/profiles.py
+msgid "Invalid phone number format"
+msgstr "Format de numéro de téléphone invalide"
+
+#: iaso/api/profiles/profiles.py
 msgid "Invalid phone number"
 msgstr "Numéro de téléphone invalide"
 

--- a/iaso/models/base.py
+++ b/iaso/models/base.py
@@ -1587,6 +1587,9 @@ class Profile(models.Model):
 
     @cached_property
     def projects_ids(self) -> set[int]:
+        """
+        Returns the list of project IDs authorized for this profile.
+        """
         return list(self.projects.values_list("pk", flat=True))
 
     def get_editable_org_unit_type_ids(self) -> set[int]:

--- a/iaso/models/base.py
+++ b/iaso/models/base.py
@@ -1589,6 +1589,12 @@ class Profile(models.Model):
     def projects_ids(self) -> set[int]:
         """
         Returns the list of project IDs authorized for this profile.
+
+        Note that this is implemented via a `@cached_property` for performance
+        reasons. You may have to manually delete it in unit tests, e.g.:
+
+            user.iaso_profile.projects.add(new_project)
+            del user.iaso_profile.projects_ids
         """
         return list(self.projects.values_list("pk", flat=True))
 

--- a/iaso/models/project.py
+++ b/iaso/models/project.py
@@ -38,6 +38,14 @@ class ProjectQuerySet(models.QuerySet):
 
         raise self.model.DoesNotExist(f"Could not find project for user {user} and app_id {app_id}")
 
+    def filter_on_user_projects(self, user: User) -> models.QuerySet:
+        if not hasattr(user, "iaso_profile"):
+            return self
+        user_projects_ids = user.iaso_profile.projects_ids
+        if not user_projects_ids:
+            return self
+        return self.filter(id__in=user_projects_ids)
+
 
 ProjectManager = models.Manager.from_queryset(ProjectQuerySet)
 

--- a/iaso/tasks/profiles_bulk_update.py
+++ b/iaso/tasks/profiles_bulk_update.py
@@ -51,9 +51,10 @@ def update_single_profile_from_bulk(
     org_units_to_be_added = []
     org_units_to_be_removed = []
 
-    has_perm_users_admin = user.has_perm(permission.USERS_ADMIN)
+    user_has_project_restrictions = hasattr(user, "iaso_profile") and bool(user.iaso_profile.projects_ids)
+    user_has_perm_users_admin = user.has_perm(permission.USERS_ADMIN)
     editable_org_unit_type_ids = (
-        user.iaso_profile.get_editable_org_unit_type_ids() if not has_perm_users_admin else set()
+        user.iaso_profile.get_editable_org_unit_type_ids() if not user_has_perm_users_admin else set()
     )
 
     if teams_id_added and not user.has_perm(permission.TEAMS):
@@ -66,7 +67,7 @@ def update_single_profile_from_bulk(
         for role_id in roles_id_added:
             role = get_object_or_404(UserRole, id=role_id, account_id=account_id)
             if role.account.id == account_id:
-                if not has_perm_users_admin:
+                if not user_has_perm_users_admin:
                     for p in role.group.permissions.all():
                         CustomPermissionSupport.assert_right_to_assign(user, p.codename)
                 roles_to_be_added.append(role)
@@ -75,41 +76,43 @@ def update_single_profile_from_bulk(
         for role_id in roles_id_removed:
             role = get_object_or_404(UserRole, id=role_id, account_id=account_id)
             if role.account.id == account_id:
-                if not has_perm_users_admin:
+                if not user_has_perm_users_admin:
                     for p in role.group.permissions.all():
                         CustomPermissionSupport.assert_right_to_assign(user, p.codename)
                 roles_to_be_removed.append(role)
 
     if projects_ids_added:
-        if not has_perm_users_admin:
+        if not user_has_perm_users_admin:
             raise PermissionDenied(
                 f"User with permission {permission.USERS_MANAGED} cannot changed project attributions"
             )
-        for project_id in projects_ids_added:
-            project = Project.objects.get(pk=project_id)
-            if project.account and project.account.id == account_id:
-                projects_to_be_added.append(project)
+        if user_has_project_restrictions:
+            authorized_projects_ids = [id_ for id_ in projects_ids_added if id_ in user.iaso_profile.projects_ids]
+            projects_to_be_added = Project.objects.filter(pk__in=authorized_projects_ids, account_id=account_id)
+        else:
+            projects_to_be_added = Project.objects.filter(pk__in=projects_ids_added, account_id=account_id)
 
     if projects_ids_removed:
-        if not has_perm_users_admin:
+        if not user_has_perm_users_admin:
             raise PermissionDenied(
                 f"User with permission {permission.USERS_MANAGED} cannot changed project attributions"
             )
-        for project_id in projects_ids_removed:
-            project = Project.objects.get(pk=project_id)
-            if project.account and project.account.id == account_id:
-                projects_to_be_removed.append(project)
+        if user_has_project_restrictions:
+            authorized_projects_ids = [id_ for id_ in projects_ids_removed if id_ in user.iaso_profile.projects_ids]
+            projects_to_be_removed = Project.objects.filter(pk__in=authorized_projects_ids, account_id=account_id)
+        else:
+            projects_to_be_removed = Project.objects.filter(pk__in=projects_ids_removed, account_id=account_id)
 
     if location_ids_added:
         for location_id in location_ids_added:
-            if managed_org_units and (not has_perm_users_admin) and (location_id not in managed_org_units):
+            if managed_org_units and (not user_has_perm_users_admin) and (location_id not in managed_org_units):
                 raise PermissionDenied(
                     f"User with permission {permission.USERS_MANAGED} cannot change OrgUnits outside of their own "
                     f"health pyramid"
                 )
             org_unit = OrgUnit.objects.select_related("org_unit_type").get(pk=location_id)
             if (
-                not has_perm_users_admin
+                not user_has_perm_users_admin
                 and org_unit.org_unit_type_id
                 and editable_org_unit_type_ids
                 and not user.iaso_profile.has_org_unit_write_permission(
@@ -124,14 +127,14 @@ def update_single_profile_from_bulk(
 
     if location_ids_removed:
         for location_id in location_ids_removed:
-            if managed_org_units and (not has_perm_users_admin) and (location_id not in managed_org_units):
+            if managed_org_units and (not user_has_perm_users_admin) and (location_id not in managed_org_units):
                 raise PermissionDenied(
                     f"User with permission {permission.USERS_MANAGED} cannot change OrgUnits outside of their own "
                     f"health pyramid"
                 )
             org_unit = OrgUnit.objects.select_related("org_unit_type").get(pk=location_id)
             if (
-                not has_perm_users_admin
+                not user_has_perm_users_admin
                 and org_unit.org_unit_type_id
                 and editable_org_unit_type_ids
                 and not user.iaso_profile.has_org_unit_write_permission(

--- a/iaso/tests/api/test_profiles.py
+++ b/iaso/tests/api/test_profiles.py
@@ -1383,6 +1383,20 @@ class ProfileAPITestCase(APITestCase):
             "You don't have access to the following projects: New project.",
         )
 
+        # Current project restrictions of the user should be applied to the edited profile
+        # when `projects` is not explicitly specified.
+        user.iaso_profile.projects.set([self.project])
+        del user.iaso_profile.projects_ids
+        self.assertEqual(user.iaso_profile.projects.count(), 1)
+        profile_to_edit.projects.clear()
+        self.assertEqual(profile_to_edit.projects.count(), 0)
+        data = {"user_name": "jum_new_user_name"}
+        response = self.client.patch(f"/api/profiles/{profile_to_edit.id}/", data=data, format="json")
+        self.assertEqual(response.status_code, 200)
+        profile_to_edit.refresh_from_db()
+        self.assertEqual(profile_to_edit.projects.count(), 1)
+        self.assertEqual(profile_to_edit.projects.first(), self.project)
+
     def get_new_user_data(self):
         user_name = "audit_user"
         pwd = "admin1234lol"

--- a/iaso/tests/api/test_profiles_bulk_update.py
+++ b/iaso/tests/api/test_profiles_bulk_update.py
@@ -25,10 +25,10 @@ class ProfileBulkUpdateAPITestCase(APITestCase):
         cls.account1 = m.Account.objects.create(name="Star Stuff")
         cls.account2 = m.Account.objects.create(name="Comic books")
         cls.account3 = m.Account.objects.create(name="Video game")
-        cls.project = m.Project.objects.create(name="Project 1", app_id="account1.app_id", account=cls.account1)
-        cls.project_1 = m.Project.objects.create(name="Project 2", app_id="account1.app_id", account=cls.account1)
-        cls.project_2 = m.Project.objects.create(name="Project 2", app_id="account1.app_id", account=cls.account1)
-        cls.project_3 = m.Project.objects.create(name="Project 3", app_id="account2.app_id", account=cls.account2)
+        cls.project_0 = m.Project.objects.create(name="Project 0", app_id="account1.foo", account=cls.account1)
+        cls.project_1 = m.Project.objects.create(name="Project 1", app_id="account1.bar", account=cls.account1)
+        cls.project_2 = m.Project.objects.create(name="Project 2", app_id="account1.baz", account=cls.account1)
+        cls.project_3 = m.Project.objects.create(name="Project 3", app_id="account2.qux", account=cls.account2)
 
         cls.group_1 = auth.models.Group.objects.create(name="group_1")
         cls.group_2 = auth.models.Group.objects.create(name="group_2")
@@ -43,7 +43,7 @@ class ProfileBulkUpdateAPITestCase(APITestCase):
         cls.user_role_different_account = m.UserRole.objects.create(group=cls.group_4, account=cls.account2)
 
         source1 = m.DataSource.objects.create(name="Evil Empire")
-        source1.projects.add(cls.project)
+        source1.projects.add(cls.project_0)
         cls.source1 = source1
         source1_version1 = m.SourceVersion.objects.create(data_source=source1, number=1)
         cls.account1.default_version = source1_version1
@@ -151,16 +151,16 @@ class ProfileBulkUpdateAPITestCase(APITestCase):
         saveUserProfile(cls.add_users_team_launcher_1)
 
         cls.team_1 = m.Team.objects.create(
-            name="Team 1", manager=cls.user_admin, project=cls.project, type=TeamType.TEAM_OF_USERS
+            name="Team 1", manager=cls.user_admin, project=cls.project_0, type=TeamType.TEAM_OF_USERS
         )
         cls.team_2 = m.Team.objects.create(
-            name="Team 2", manager=cls.user_admin, project=cls.project, type=TeamType.TEAM_OF_USERS
+            name="Team 2", manager=cls.user_admin, project=cls.project_0, type=TeamType.TEAM_OF_USERS
         )
         cls.team_3 = m.Team.objects.create(
-            name="Team 3", manager=cls.user_admin, project=cls.project, type=TeamType.TEAM_OF_USERS
+            name="Team 3", manager=cls.user_admin, project=cls.project_0, type=TeamType.TEAM_OF_USERS
         )
         cls.team_of_teams = m.Team.objects.create(
-            name="Team of Teams", manager=cls.user_admin, project=cls.project, type=TeamType.TEAM_OF_TEAMS
+            name="Team of Teams", manager=cls.user_admin, project=cls.project_0, type=TeamType.TEAM_OF_TEAMS
         )
 
     def refresh_all_users_from_db(self):
@@ -265,7 +265,7 @@ class ProfileBulkUpdateAPITestCase(APITestCase):
             "selected_ids": [self.user_admin_no_task.iaso_profile.pk, self.user_admin_no_task2.iaso_profile.pk],
             "unselected_ids": None,
             "projects_ids_added": [
-                self.project.pk,
+                self.project_0.pk,
                 self.project_3.pk,
             ],  # self.project_3 should not be saved, not from the same account
             "projects_ids_removed": [self.project_2.pk],
@@ -318,11 +318,11 @@ class ProfileBulkUpdateAPITestCase(APITestCase):
             self.user_admin_no_task2.iaso_profile.org_units.all(),
         )
         self.assertIn(
-            self.project,
+            self.project_0,
             self.user_admin_no_task.iaso_profile.projects.all(),
         )
         self.assertIn(
-            self.project,
+            self.project_0,
             self.user_admin_no_task2.iaso_profile.projects.all(),
         )
         self.assertNotIn(
@@ -428,11 +428,11 @@ class ProfileBulkUpdateAPITestCase(APITestCase):
             "selected_ids": [user_to_update.iaso_profile.pk],
             "unselected_ids": None,
             "projects_ids_added": [
-                self.project.pk,  # `user` has no rights on this project.
+                self.project_0.pk,  # `user` has no rights on this project.
                 self.project_1.pk,  # `user` should be able to add this project.
             ],
             "projects_ids_removed": [
-                self.project.pk,  # `user` has no rights on this project.
+                self.project_0.pk,  # `user` has no rights on this project.
                 self.project_2.pk,  # `user` should be able to remove this project.
             ],
             "roles_id_added": [],
@@ -471,7 +471,7 @@ class ProfileBulkUpdateAPITestCase(APITestCase):
         operation_payload = {
             "select_all": True,
             "projects_ids_added": [
-                self.project.pk,
+                self.project_0.pk,
                 self.project_3.pk,
             ],
         }
@@ -491,7 +491,7 @@ class ProfileBulkUpdateAPITestCase(APITestCase):
         operation_payload = {
             "select_all": True,
             "projects_ids_removed": [
-                self.project.pk,
+                self.project_0.pk,
                 self.project_3.pk,
             ],
         }
@@ -1074,7 +1074,7 @@ class ProfileBulkUpdateAPITestCase(APITestCase):
                 "location_ids_added": [self.org_unit1.pk],
                 "location_ids_removed": [self.org_unit2.pk],
                 "projects_ids_added": [
-                    self.project.pk,
+                    self.project_0.pk,
                 ],
                 "teams_id_added": [self.team_1.pk],
                 "projects_ids_removed": [self.project_2.pk],
@@ -1145,7 +1145,7 @@ class ProfileBulkUpdateAPITestCase(APITestCase):
         self.assertEqual(len(new_value["user_roles"]), 1)
         self.assertIn(self.user_role.id, new_value["user_roles"])
         self.assertEqual(len(new_value["projects"]), 1)
-        self.assertIn(self.project.id, new_value["projects"])
+        self.assertIn(self.project_0.id, new_value["projects"])
 
         # Check that user_admin_no_task2 profile is updated
         response = self.client.get(
@@ -1201,7 +1201,7 @@ class ProfileBulkUpdateAPITestCase(APITestCase):
         self.assertEqual(len(new_value["user_roles"]), 1)
         self.assertIn(self.user_role.id, new_value["user_roles"])
         self.assertEqual(len(new_value["projects"]), 1)
-        self.assertIn(self.project.id, new_value["projects"])
+        self.assertIn(self.project_0.id, new_value["projects"])
         # Check that team 1 is updated
         response = self.client.get(
             f"/api/logs/?contentType=iaso.team&fields=past_value,new_value&objectId={self.team_1.pk}"

--- a/iaso/tests/models/test_project.py
+++ b/iaso/tests/models/test_project.py
@@ -1,0 +1,37 @@
+from iaso import models as m
+from iaso.test import TestCase
+
+
+class ProjectModelTestCase(TestCase):
+    """
+    Test Project model.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.account = m.Account.objects.create(name="Account")
+        cls.user = cls.create_user_with_profile(username="user", account=cls.account)
+
+        cls.project_1 = m.Project.objects.create(name="Project 1", app_id="org.ghi.p1", account=cls.account)
+        cls.project_2 = m.Project.objects.create(name="Project 2", app_id="org.ghi.p2", account=cls.account)
+
+    def test_filter_on_user_projects(self):
+        self.assertEqual(self.account.project_set.count(), 2)
+
+        # No project restriction: the user should be able to see all projects.
+        self.assertEqual(self.user.iaso_profile.projects_ids, [])
+        filtered_projects = m.Project.objects.filter_on_user_projects(self.user)
+        self.assertEqual(filtered_projects.count(), 2)
+
+        # Restriction on `project_2`: the user shouldn't be able to see `project_1`.
+        self.user.iaso_profile.projects.set([self.project_2])
+        del self.user.iaso_profile.projects_ids
+        filtered_projects = m.Project.objects.filter_on_user_projects(self.user)
+        self.assertEqual(filtered_projects.count(), 1)
+        self.assertEqual(filtered_projects.first(), self.project_2)
+
+        # Restriction on `project_1` and `project_2`: the user should be able to see all projects.
+        self.user.iaso_profile.projects.set([self.project_1, self.project_2])
+        del self.user.iaso_profile.projects_ids
+        filtered_projects = m.Project.objects.filter_on_user_projects(self.user)
+        self.assertEqual(filtered_projects.count(), 2)

--- a/iaso/tests/models/test_project.py
+++ b/iaso/tests/models/test_project.py
@@ -14,23 +14,24 @@ class ProjectModelTestCase(TestCase):
 
         cls.project_1 = m.Project.objects.create(name="Project 1", app_id="org.ghi.p1", account=cls.account)
         cls.project_2 = m.Project.objects.create(name="Project 2", app_id="org.ghi.p2", account=cls.account)
+        cls.project_3 = m.Project.objects.create(name="Project 3", app_id="org.ghi.p3", account=cls.account)
 
     def test_filter_on_user_projects(self):
-        self.assertEqual(self.account.project_set.count(), 2)
+        self.assertEqual(self.account.project_set.count(), 3)
 
         # No project restriction: the user should be able to see all projects.
         self.assertEqual(self.user.iaso_profile.projects_ids, [])
         filtered_projects = m.Project.objects.filter_on_user_projects(self.user)
-        self.assertEqual(filtered_projects.count(), 2)
+        self.assertEqual(filtered_projects.count(), 3)
 
-        # Restriction on `project_2`: the user shouldn't be able to see `project_1`.
+        # Restriction on `project_2`: the user should be able to see only `project_2`.
         self.user.iaso_profile.projects.set([self.project_2])
         del self.user.iaso_profile.projects_ids
         filtered_projects = m.Project.objects.filter_on_user_projects(self.user)
         self.assertEqual(filtered_projects.count(), 1)
         self.assertEqual(filtered_projects.first(), self.project_2)
 
-        # Restriction on `project_1` and `project_2`: the user should be able to see all projects.
+        # Restriction on `project_1` and `project_2`: the user should be able to see only `project_1` and `project_2`.
         self.user.iaso_profile.projects.set([self.project_1, self.project_2])
         del self.user.iaso_profile.projects_ids
         filtered_projects = m.Project.objects.filter_on_user_projects(self.user)

--- a/iaso/tests/test_create_users_from_csv.py
+++ b/iaso/tests/test_create_users_from_csv.py
@@ -540,11 +540,14 @@ class BulkCreateCsvTestCase(APITestCase):
 
         self.assertEqual(response.status_code, 200)
 
-        # Because `user` is restricted to `project2`, `project` should've been skipped.
+        # Because `user` is restricted to `project2`, `project` should've been skipped
+        # and new profiles should end up having the same restrictions.
         profile_1 = Profile.objects.get(user__username=username_1)
-        self.assertEqual(0, profile_1.projects.count())
+        self.assertEqual(1, profile_1.projects.count())
+        self.assertEqual(profile_1.projects.first(), self.project2)
         profile_2 = Profile.objects.get(user__username=username_2)
-        self.assertEqual(0, profile_2.projects.count())
+        self.assertEqual(1, profile_2.projects.count())
+        self.assertEqual(profile_2.projects.first(), self.project2)
 
     def test_should_create_user_with_the_correct_org_unit_from_source_ref(self):
         """

--- a/iaso/tests/test_create_users_from_csv.py
+++ b/iaso/tests/test_create_users_from_csv.py
@@ -46,6 +46,7 @@ class BulkCreateCsvTestCase(APITestCase):
         cls.MODULES = [module["codename"] for module in MODULES]
         account1 = m.Account.objects.create(name="Account 1")
         cls.project = m.Project.objects.create(name="Project name", app_id="project.id", account=account1)
+        cls.project2 = m.Project.objects.create(name="Project 2", app_id="project.2", account=account1)
         account1.default_version = version1
         account1.save()
 
@@ -95,7 +96,7 @@ class BulkCreateCsvTestCase(APITestCase):
     def test_upload_valid_csv(self):
         self.client.force_authenticate(self.yoda)
         self.source.projects.set([self.project])
-        with self.assertNumQueries(82):
+        with self.assertNumQueries(83):
             with open("iaso/tests/fixtures/test_user_bulk_create_valid.csv") as csv_users:
                 response = self.client.post(f"{BASE_URL}", {"file": csv_users})
 
@@ -114,7 +115,7 @@ class BulkCreateCsvTestCase(APITestCase):
         self.assertEqual(org_unit_ids, [9999])
 
     def test_upload_valid_csv_with_perms(self):
-        with self.assertNumQueries(91):
+        with self.assertNumQueries(92):
             self.client.force_authenticate(self.yoda)
             self.source.projects.set([self.project])
 
@@ -509,6 +510,41 @@ class BulkCreateCsvTestCase(APITestCase):
         self.assertEqual(new_user_2.iaso_profile.dhis2_id, "dhis2_id_6")
         self.assertEqual(org_unit_ids, [9999])
         self.assertEqual(response.data, {"Accounts created": 2})
+
+    def test_create_user_with_project_restrictions(self):
+        self.source.projects.set([self.project, self.project2])
+
+        # The user is restricted to `project2`.
+        self.yoda.iaso_profile.projects.set([self.project2.id])
+
+        self.client.force_authenticate(self.yoda)
+
+        with open("iaso/tests/fixtures/test_user_bulk_create_valid_with_projects.csv") as csv_users:
+            csv_reader = list(csv.reader(csv_users))
+
+            csv_line_1 = csv_reader[1]
+            csv_line_2 = csv_reader[2]
+
+            username_index = 0
+            projects_index = 12
+
+            username_1 = csv_line_1[username_index]
+            username_2 = csv_line_2[username_index]
+
+            # Ensure the CSV tries to set `project` as an authorized project.
+            self.assertEqual(csv_line_1[projects_index], self.project.name)
+            self.assertEqual(csv_line_2[projects_index], self.project.name)
+
+        with open("iaso/tests/fixtures/test_user_bulk_create_valid_with_projects.csv") as csv_users:
+            response = self.client.post(f"{BASE_URL}", {"file": csv_users})
+
+        self.assertEqual(response.status_code, 200)
+
+        # Because `user` is restricted to `project2`, `project` should've been skipped.
+        profile_1 = Profile.objects.get(user__username=username_1)
+        self.assertEqual(0, profile_1.projects.count())
+        profile_2 = Profile.objects.get(user__username=username_2)
+        self.assertEqual(0, profile_2.projects.count())
 
     def test_should_create_user_with_the_correct_org_unit_from_source_ref(self):
         """

--- a/plugins/polio/locale/fr/LC_MESSAGES/django.po
+++ b/plugins/polio/locale/fr/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-04-02 08:35+0000\n"
+"POT-Creation-Date: 2025-04-16 13:27+0000\n"
 "PO-Revision-Date: 2025-02-05 14:43+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -379,10 +379,6 @@ msgstr "La VVM a atteint le point de rejet"
 #: plugins/polio/models/base.py
 msgid "Vaccine expired"
 msgstr "Vaccin expiré"
-
-#: plugins/polio/models/base.py
-msgid "Losses"
-msgstr "Pertes"
 
 #: plugins/polio/models/base.py
 msgid "Return"


### PR DESCRIPTION
Restrict user creation and profile edition by projects.

Related JIRA tickets : [IA-3961](https://bluesquare.atlassian.net/browse/IA-3961)

## Changes

This PR should fix the problem mentioned by Claire in the Jira issue.

It does the following things:

1. it filters the projects API by authorized projects (to limit choices in the UI's dropdowns)
2. it ensures that project restrictions of the current user are applied to edited profiles
3. it implements project restrictions in bulk profile update
4. it implements project restrictions in bulk user creation
5. bonus: it fixes `test_update_user_with_malformed_phone_number()`

[IA-3961]: https://bluesquare.atlassian.net/browse/IA-3961?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ