### PR TITLE
IA-4124 Exclude instances with `form_version_id`, `json`, `uuid` or `form_id` set to NULL from change requests

### DIFF
--- a/iaso/models/org_unit.py
+++ b/iaso/models/org_unit.py
@@ -645,13 +645,23 @@ class OrgUnitChangeRequestQuerySet(models.QuerySet):
         """
         Exclude change requests when `new_reference_instances` is the only
         requested change but instances have all been soft-deleted.
+
+        We consider instances with `form_version_id`, `json`, `uuid` or
+        `form_id` set to NULL as unusable for the mobile. See IA-4124.
         """
         return self.annotate(
             annotated_non_deleted_new_reference_instances_count=Count(
                 "new_reference_instances", filter=Q(new_reference_instances__deleted=False)
             )
         ).exclude(
-            Q(requested_fields=["new_reference_instances"]) & Q(annotated_non_deleted_new_reference_instances_count=0)
+            Q(requested_fields=["new_reference_instances"])
+            & (
+                Q(annotated_non_deleted_new_reference_instances_count=0)
+                | Q(new_reference_instances__json__isnull=True)
+                | Q(new_reference_instances__form_version_id__isnull=True)
+                | Q(new_reference_instances__uuid__isnull=True)
+                | Q(new_reference_instances__form_id__isnull=True)
+            )
         )
 
     def filter_on_user_projects(self, user: User) -> models.QuerySet:

--- a/iaso/tests/api/org_unit_change_requests/test_org_unit_change_requests_mobile.py
+++ b/iaso/tests/api/org_unit_change_requests/test_org_unit_change_requests_mobile.py
@@ -1,3 +1,5 @@
+import uuid
+
 from iaso import models as m
 from iaso.test import APITestCase
 
@@ -19,8 +21,25 @@ class MobileOrgUnitChangeRequestAPITestCase(APITestCase):
 
         form_1 = m.Form.objects.create(name="Form 1")
         form_2 = m.Form.objects.create(name="Form 2")
-        instance_1 = m.Instance.objects.create(form=form_1, org_unit=org_unit)
-        instance_2 = m.Instance.objects.create(form=form_2, org_unit=org_unit)
+
+        form_version_1 = m.FormVersion.objects.create(form=form_1, version_id=1)
+        form_version_2 = m.FormVersion.objects.create(form=form_2, version_id=1)
+
+        instance_1 = m.Instance.objects.create(
+            form=form_1,
+            org_unit=org_unit,
+            uuid=uuid.uuid4(),
+            json={"key": "value"},
+            form_version=form_version_1,
+        )
+        instance_2 = m.Instance.objects.create(
+            form=form_2,
+            org_unit=org_unit,
+            uuid=uuid.uuid4(),
+            json={"key": "value"},
+            form_version=form_version_2,
+        )
+
         m.OrgUnitReferenceInstance.objects.create(org_unit=org_unit, form=form_1, instance=instance_1)
         m.OrgUnitReferenceInstance.objects.create(org_unit=org_unit, form=form_2, instance=instance_2)
 

--- a/iaso/tests/models/test_org_unit_change_request.py
+++ b/iaso/tests/models/test_org_unit_change_request.py
@@ -1,4 +1,5 @@
 import datetime
+import uuid
 
 from decimal import Decimal
 
@@ -45,6 +46,10 @@ class OrgUnitChangeRequestModelTestCase(TestCase):
         )
 
         cls.form = m.Form.objects.create(name="Vaccine form")
+        cls.form_version = m.FormVersion.objects.create(form=cls.form, version_id=1)
+
+        cls.other_form = m.Form.objects.create(name="Other form")
+        cls.other_form_version = m.FormVersion.objects.create(form=cls.other_form, version_id=1)
 
         cls.new_parent = m.OrgUnit.objects.create(org_unit_type=cls.org_unit_type)
         cls.new_org_unit_type = m.OrgUnitType.objects.create(name="New org unit type")
@@ -52,9 +57,20 @@ class OrgUnitChangeRequestModelTestCase(TestCase):
         cls.new_group2 = m.Group.objects.create(name="Group 2")
         cls.org_unit.groups.set([cls.new_group1])
 
-        cls.other_form = m.Form.objects.create(name="Other form")
-        cls.new_instance1 = m.Instance.objects.create(form=cls.form, org_unit=cls.org_unit)
-        cls.new_instance2 = m.Instance.objects.create(form=cls.other_form, org_unit=cls.org_unit)
+        cls.new_instance1 = m.Instance.objects.create(
+            form=cls.form,
+            org_unit=cls.org_unit,
+            uuid=uuid.uuid4(),
+            json={"key": "value"},
+            form_version=cls.form_version,
+        )
+        cls.new_instance2 = m.Instance.objects.create(
+            form=cls.other_form,
+            org_unit=cls.org_unit,
+            uuid=uuid.uuid4(),
+            json={"key": "value"},
+            form_version=cls.other_form_version,
+        )
         m.OrgUnitReferenceInstance.objects.create(org_unit=cls.org_unit, form=cls.form, instance=cls.new_instance1)
 
     @time_machine.travel(DT, tick=False)
@@ -310,9 +326,54 @@ class OrgUnitChangeRequestModelTestCase(TestCase):
         change_requests = m.OrgUnitChangeRequest.objects.exclude_soft_deleted_new_reference_instances()
         self.assertEqual(change_requests.count(), 1)
 
+        # `deleted=True` should be excluded.
         self.new_instance1.deleted = True
         self.new_instance1.save()
         self.new_instance2.deleted = True
+        self.new_instance2.save()
+
+        change_requests = m.OrgUnitChangeRequest.objects.exclude_soft_deleted_new_reference_instances()
+        self.assertEqual(change_requests.count(), 0)
+
+        # `json=null` should be excluded.
+        self.new_instance1.deleted = False
+        self.new_instance1.json = None
+        self.new_instance1.save()
+        self.new_instance2.deleted = False
+        self.new_instance2.json = None
+        self.new_instance2.save()
+
+        change_requests = m.OrgUnitChangeRequest.objects.exclude_soft_deleted_new_reference_instances()
+        self.assertEqual(change_requests.count(), 0)
+
+        # `form_version_id=null` should be excluded.
+        self.new_instance1.json = {"key": "value"}
+        self.new_instance1.form_version = None
+        self.new_instance1.save()
+        self.new_instance2.json = {"key": "value"}
+        self.new_instance2.form_version = None
+        self.new_instance2.save()
+
+        change_requests = m.OrgUnitChangeRequest.objects.exclude_soft_deleted_new_reference_instances()
+        self.assertEqual(change_requests.count(), 0)
+
+        # `uuid=null` should be excluded.
+        self.new_instance1.form_version = self.form_version
+        self.new_instance1.uuid = None
+        self.new_instance1.save()
+        self.new_instance2.form_version = self.other_form_version
+        self.new_instance2.uuid = None
+        self.new_instance2.save()
+
+        change_requests = m.OrgUnitChangeRequest.objects.exclude_soft_deleted_new_reference_instances()
+        self.assertEqual(change_requests.count(), 0)
+
+        # `form_id=null` should be excluded.
+        self.new_instance1.uuid = uuid.uuid4()
+        self.new_instance1.form = None
+        self.new_instance1.save()
+        self.new_instance1.uuid = uuid.uuid4()
+        self.new_instance2.form = None
         self.new_instance2.save()
 
         change_requests = m.OrgUnitChangeRequest.objects.exclude_soft_deleted_new_reference_instances()


### PR DESCRIPTION
Exclude instances with `form_version_id`, `json`, `uuid` or `form_id` set to NULL from change requests

Related JIRA tickets : [IA-4124](https://bluesquare.atlassian.net/browse/IA-4124)


[IA-4124]: https://bluesquare.atlassian.net/browse/IA-4124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ