### PR TITLE
POLIO-1921: block VRF creation for round w/o scope (front-end)

### DIFF
--- a/plugins/polio/js/src/constants/translations/fr.json
+++ b/plugins/polio/js/src/constants/translations/fr.json
@@ -96,7 +96,7 @@
     "iaso.polio.campaign.seeLogDetail": "Voir plus de détails",
     "iaso.polio.campaign.typeNotSupported": "Ce type de valeur n'est pas encore supporté: {type}",
     "iaso.polio.campaign.value": "Valeur",
-    "iaso.polio.campaignSaved": "Campaign sauvegardée",
+    "iaso.polio.campaignSaved": "Campagne sauvegardée",
     "iaso.polio.campaignSaveError": "Erreur de sauvegarde de la campagne",
     "iaso.polio.chronogram.details.modal.add_title": "Ajouter une tâche",
     "iaso.polio.chronogram.details.modal.delete.confirm": "Voulez-vous vraiment supprimer cette tâche ?",

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/hooks/api/vrf.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/hooks/api/vrf.tsx
@@ -132,10 +132,14 @@ export const useCampaignDropDowns = (
     return useMemo(() => {
         const list = (data as Campaign[]) ?? [];
         const selectedCampaign = list.find(c => c.obr_name === campaign);
-        const campaigns = list.map(c => ({
-            label: c.obr_name,
-            value: c.obr_name,
-        }));
+        const campaigns = list
+            .filter(
+                c => c.separate_scopes_per_round || (c.scopes ?? []).length > 0,
+            )
+            .map(c => ({
+                label: c.obr_name,
+                value: c.obr_name,
+            }));
         const vaccines = selectedCampaign?.single_vaccines
             ? selectedCampaign.single_vaccines.split(',').map(vaccineName => ({
                   label: vaccineName.trim(),
@@ -148,12 +152,7 @@ export const useCampaignDropDowns = (
                   .filter(round =>
                       round.vaccine_names_extended.includes(vaccine),
                   )
-                  .filter(round => {
-                      if (selectedCampaign?.separate_scopes_per_round) {
-                          return (round.scopes ?? []).length > 0;
-                      }
-                      return (selectedCampaign?.scopes ?? []).length > 0;
-                  })
+                  .filter(round => (round?.scopes ?? []).length > 0)
                   .map(round => ({
                       label: `Round ${round.number}`,
                       value: `${round.number}`,

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/hooks/api/vrf.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/hooks/api/vrf.tsx
@@ -37,13 +37,10 @@ import { useGetCountries } from '../../../../../hooks/useGetCountries';
 import {
     CAMPAIGNS_ENDPOINT,
     CampaignCategory,
+    Options,
     useGetCampaigns,
 } from '../../../../Campaigns/hooks/api/useGetCampaigns';
-import {
-    apiUrl,
-    defaultVaccineOptions,
-    singleVaccinesList,
-} from '../../constants';
+import { apiUrl, singleVaccinesList } from '../../constants';
 import MESSAGES from '../../messages';
 import {
     CampaignDropdowns,
@@ -121,9 +118,9 @@ export const useCampaignDropDowns = (
     campaign?: string,
     vaccine?: string,
 ): CampaignDropdowns => {
-    const options = {
+    const options: Options = {
         enabled: Boolean(countryId),
-        countries: countryId ? [`${countryId}`] : undefined,
+        countries: Number.isSafeInteger(countryId) ? `${countryId}` : undefined,
         campaignCategory: 'regular' as CampaignCategory,
         campaignType: 'polio',
         on_hold: true,
@@ -145,11 +142,18 @@ export const useCampaignDropDowns = (
                   value: vaccineName.trim(),
               }))
             : singleVaccinesList;
+
         const rounds = vaccine
             ? (selectedCampaign?.rounds ?? [])
                   .filter(round =>
                       round.vaccine_names_extended.includes(vaccine),
                   )
+                  .filter(round => {
+                      if (selectedCampaign?.separate_scopes_per_round) {
+                          return (round.scopes ?? []).length > 0;
+                      }
+                      return (selectedCampaign?.scopes ?? []).length > 0;
+                  })
                   .map(round => ({
                       label: `Round ${round.number}`,
                       value: `${round.number}`,


### PR DESCRIPTION
What problem is this PR solving? Explain here in one sentence.

Related JIRA tickets : POLIO-1921, POLIO-1920

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

None

## Changes

- When generating campaign, vaccine and round dropdowns for VRF screen:
    - If scope is on campaign level, and there's no scope, the campaign will not appear in the dropdown
    - If the scope is at round level, the campaign can be selected, but the rounds without scope are filtered out of the dropdown options

## How to test

- create a campaign with an empty scope
- create a campaign with separate scopes per round and only one round with scope
- Go to VRF
- Try to create a VRF, check that the behaviour is as described

## Print screen / video


https://github.com/user-attachments/assets/57adefce-be3b-4a8d-a185-2c494cdef080



## Notes

Backend validation will be dealt with in POLIO-1920

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
