### PR TITLE
IA-4015: SETUPER: add planning data

### DIFF
--- a/iaso/api/setup_account.py
+++ b/iaso/api/setup_account.py
@@ -61,9 +61,12 @@ class SetupAccountSerializer(serializers.Serializer):
     def validate_feature_flags(self, feature_flags):
         default_account_feature_flags = AccountFeatureFlag.objects.all()
         account_feature_flags = [feature_flag.code for feature_flag in default_account_feature_flags]
-        for feature_flag in feature_flags:
-            if feature_flag not in account_feature_flags:
-                raise serializers.ValidationError("invalid_account_feature_flag")
+        if not feature_flags or len(feature_flags) == 0:
+            feature_flags = DEFAULT_ACCOUNT_FEATURE_FLAGS
+        else:
+            for feature_flag in feature_flags:
+                if feature_flag not in account_feature_flags:
+                    raise serializers.ValidationError("invalid_account_feature_flag")
         return feature_flags
 
     def create(self, validated_data):
@@ -91,10 +94,7 @@ class SetupAccountSerializer(serializers.Serializer):
             modules=account_modules,
             analytics_script=validated_data.get("analytics_script", ""),
         )
-        if validated_data.get("feature_flags") is not None and len(validated_data.get("feature_flags")) > 0:
-            account.feature_flags.set(validated_data.get("feature_flags"))
-        else:
-            account.feature_flags.set(DEFAULT_ACCOUNT_FEATURE_FLAGS)
+        account.feature_flags.set(validated_data.get("feature_flags", DEFAULT_ACCOUNT_FEATURE_FLAGS))
 
         # Create a setup_account project with an app_id represented by the account name
         app_id = validated_data["account_name"].replace(" ", ".").replace("-", ".")

--- a/iaso/api/setup_account.py
+++ b/iaso/api/setup_account.py
@@ -35,7 +35,9 @@ class SetupAccountSerializer(serializers.Serializer):
     user_manual_path = serializers.CharField(required=False)
     modules = serializers.JSONField(required=True, initial=["DEFAULT"])  # type: ignore
     analytics_script = serializers.CharField(required=False)
-    feature_flags = serializers.JSONField(required=False, default=DEFAULT_ACCOUNT_FEATURE_FLAGS, initial=DEFAULT_ACCOUNT_FEATURE_FLAGS)
+    feature_flags = serializers.JSONField(
+        required=False, default=DEFAULT_ACCOUNT_FEATURE_FLAGS, initial=DEFAULT_ACCOUNT_FEATURE_FLAGS
+    )
 
     def validate_account_name(self, value):
         if Account.objects.filter(name=value).exists():

--- a/iaso/tests/api/test_setup_account.py
+++ b/iaso/tests/api/test_setup_account.py
@@ -228,8 +228,6 @@ class SetupAccountApiTestCase(APITestCase):
             "modules": self.MODULES,
             "feature_flags": None,
         }
-        if not data["feature_flags"]:
-            data["feature_flags"] = []
         response = self.client.post("/api/setupaccount/", data=data, format="json")
         self.assertEqual(response.status_code, 201)
         created_account = m.Account.objects.filter(name="account with None feature flag test-featureappid")

--- a/iaso/tests/api/test_setup_account.py
+++ b/iaso/tests/api/test_setup_account.py
@@ -230,6 +230,7 @@ class SetupAccountApiTestCase(APITestCase):
         }
         response = self.client.post("/api/setupaccount/", data=data, format="json")
         self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["feature_flags"], ["This field may not be null."])
 
     def test_setup_account_with_empty_feature_flags(self):
         self.client.force_authenticate(self.admin)

--- a/iaso/tests/api/test_setup_account.py
+++ b/iaso/tests/api/test_setup_account.py
@@ -216,3 +216,22 @@ class SetupAccountApiTestCase(APITestCase):
         response = self.client.post("/api/setupaccount/", data=data, format="json")
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json()["feature_flags"], ["invalid_account_feature_flag"])
+
+    def test_setup_account_with_None_value_as_feature_flags(self):
+        self.client.force_authenticate(self.admin)
+        data = {
+            "account_name": "account with None feature flag test-featureappid",
+            "user_username": "username",
+            "user_first_name": "firstname",
+            "user_last_name": "lastname",
+            "password": "password",
+            "modules": self.MODULES,
+            "feature_flags": None,
+        }
+        if not data["feature_flags"]:
+            data["feature_flags"] = []
+        response = self.client.post("/api/setupaccount/", data=data, format="json")
+        self.assertEqual(response.status_code, 201)
+        created_account = m.Account.objects.filter(name="account with None feature flag test-featureappid")
+        feature_flags = created_account.first().feature_flags.values_list("code", flat=True)
+        self.assertEqual(sorted(feature_flags), sorted(DEFAULT_ACCOUNT_FEATURE_FLAGS))

--- a/iaso/tests/api/test_setup_account.py
+++ b/iaso/tests/api/test_setup_account.py
@@ -229,7 +229,19 @@ class SetupAccountApiTestCase(APITestCase):
             "feature_flags": None,
         }
         response = self.client.post("/api/setupaccount/", data=data, format="json")
-        self.assertEqual(response.status_code, 201)
-        created_account = m.Account.objects.filter(name="account with None feature flag test-featureappid")
-        feature_flags = created_account.first().feature_flags.values_list("code", flat=True)
-        self.assertEqual(sorted(feature_flags), sorted(DEFAULT_ACCOUNT_FEATURE_FLAGS))
+        self.assertEqual(response.status_code, 400)
+
+    def test_setup_account_with_empty_feature_flags(self):
+        self.client.force_authenticate(self.admin)
+        data = {
+            "account_name": "account empty feature flag test-featureappid",
+            "user_username": "username",
+            "user_first_name": "firstname",
+            "user_last_name": "lastname",
+            "password": "password",
+            "modules": self.MODULES,
+            "feature_flags": [],
+        }
+        response = self.client.post("/api/setupaccount/", data=data, format="json")
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["feature_flags"], ["feature_flags_empty"])

--- a/setuper/data_collection.py
+++ b/setuper/data_collection.py
@@ -16,9 +16,7 @@ def setup_instances(account_name, iaso_client):
     print("-- Setting up a form")
     project_id = iaso_client.get("/api/projects/")["projects"][0]["id"]
     org_unit_types = iaso_client.get("/api/v2/orgunittypes/?with_units_count=true")["orgUnitTypes"]
-    org_unit_type_ids = [
-        out["id"] for out in org_unit_types if out["name"] != "Health facility/Formation sanitaire - HF"
-    ]
+    org_unit_type_ids = [out["id"] for out in org_unit_types]
 
     # create a form
     data = {

--- a/setuper/micro_planning.py
+++ b/setuper/micro_planning.py
@@ -78,6 +78,7 @@ def setup_users_teams_micro_planning(account_name, iaso_client):
         },
     )
     forms = iaso_client.get("/api/forms")["forms"]
+    planning_form = [form for form in forms if form["form_id"] == "SAMPLE_FORM_new5"][0]
 
     source_id = manager["account"]["default_version"]["data_source"]["id"]
     country = iaso_client.get(
@@ -86,7 +87,14 @@ def setup_users_teams_micro_planning(account_name, iaso_client):
             "limit": 3000,
             "order": "id",
             "searches": json.dumps(
-                [{"validation_status": "VALID", "color": "f4511e", "source": str(source_id), "depth": 1}]
+                [
+                    {
+                        "validation_status": "VALID",
+                        "color": "f4511e",
+                        "source": str(source_id),
+                        "depth": 1,
+                    }
+                ]
             ),
         },
     )["orgunits"][0]
@@ -97,7 +105,7 @@ def setup_users_teams_micro_planning(account_name, iaso_client):
         "/api/microplanning/plannings/",
         {
             "name": "Campagne Carte Sanitaire",
-            "forms": [f["id"] for f in forms if f["form_id"] == "SAMPLE_FORM_new5"],
+            "forms": [planning_form["id"]],
             "project": project_id,
             "team": team["id"],
             "org_unit": country["id"],
@@ -121,11 +129,15 @@ def setup_users_teams_micro_planning(account_name, iaso_client):
     )["orgUnits"]
 
     for health_facitity in health_facitities:
-        print("assigning", health_facitity["name"], "to", team["name"])
+        print("assigning", health_facitity["name"], "to", campaign["name"])
 
         iaso_client.post(
             "/api/microplanning/assignments/",
-            json={"planning": campaign["id"], "org_unit": health_facitity["id"], "team": team["id"]},
+            json={
+                "planning": campaign["id"],
+                "org_unit": health_facitity["id"],
+                "user": manager["user_id"],
+            },
         )
 
     print(campaign)

--- a/setuper/micro_planning.py
+++ b/setuper/micro_planning.py
@@ -1,4 +1,5 @@
 import json
+import random
 
 from datetime import datetime, timedelta
 
@@ -118,15 +119,23 @@ def setup_users_teams_micro_planning(account_name, iaso_client):
     health_facitities = iaso_client.get(
         "/api/orgunits/",
         params={
-            "validation_status": "VALID",
-            "geography": "any",
-            "onlyDirectChildren": "false",
-            "page": 1,
-            "withParents": "true",
+            "limit": 70,
             "order": "name",
-            "depth": 5,
+            "page": 1,
+            "searches": json.dumps(
+                [
+                    {
+                        "validation_status": "VALID",
+                        "geography": "any",
+                        "depth": 5,
+                    }
+                ]
+            ),
+            "locationLimit": 100,
         },
-    )["orgUnits"]
+    )["orgunits"]
+
+    team_users = team["users"][:3]
 
     for health_facitity in health_facitities:
         print("assigning", health_facitity["name"], "to", campaign["name"])
@@ -136,7 +145,7 @@ def setup_users_teams_micro_planning(account_name, iaso_client):
             json={
                 "planning": campaign["id"],
                 "org_unit": health_facitity["id"],
-                "user": manager["user_id"],
+                "user": random.choice(team_users),
             },
         )
 


### PR DESCRIPTION
What problem is this PR solving? Explain here in one sentence.

Related JIRA tickets : [IA-4015](https://bluesquare.atlassian.net/browse/IA-4015)

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Changes

Assigned user to planning data through health facility.

## How to test

From setuper folder, launch setuper via `python3 setuper.py --additional_projects` to generate test data. Then login with created account and open planning list page, view the created planning. You should see the map with GPS: it's health facilities. In the [LIST tab](http://localhost:8081/dashboard/planning/assignments/accountId/2/planningId/2/team/8/baseOrgunitType/10/tab/list), you should see the user on the assignement column!

## Print screen / video

[iaso-planning-data.webm](https://github.com/user-attachments/assets/485a5628-9fcf-4aab-854f-c41a02145ac4)


[Capture vidéo du 16-04-2025 17:14:32.webm](https://github.com/user-attachments/assets/efabd624-c95c-4a62-897e-f0085a17df88)



## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.


[IA-4015]: https://bluesquare.atlassian.net/browse/IA-4015?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ