### PR TITLE
POLIO-1916: refresh button for VRF dashboard

### DIFF
--- a/iaso/utils/powerbi.py
+++ b/iaso/utils/powerbi.py
@@ -123,8 +123,8 @@ def launch_dataset_refresh(group_id, data_set_id):
         extra_sync_config = dataset_config.get("sync_refresh", None)
 
     if openhexa_config:
-        task = launch_external_task(dataset_config)
-        monitor_task_and_raise_if_fail(dataset_config, task)
+        task = launch_external_task(openhexa_config)
+        monitor_task_and_raise_if_fail(openhexa_config, task)
 
     sp_access_token = get_powerbi_service_principal_token(
         config["tenant_id"], config["client_id"], config["secret_value"]

--- a/plugins/polio/tests/test_refresh_powerbi.py
+++ b/plugins/polio/tests/test_refresh_powerbi.py
@@ -135,7 +135,7 @@ class RefreshPowerBITestCase(APITestCase):
 
     @patch("requests.post")
     @patch("iaso.utils.powerbi.get_powerbi_service_principal_token", mock_get_powerbi_service_principal_token)
-    @patch("iaso.utils.powerbu.launch_external_task", mock_launch_external_task)
+    @patch("iaso.utils.powerbi.launch_external_task", mock_launch_external_task)
     @patch.object(ExternalTaskModelViewSet, "launch_task", mock_openhexa_call_success)
     def test_powerbi_updates(self, mock_post):
         group_id = "some_group_id"

--- a/plugins/polio/tests/test_refresh_powerbi.py
+++ b/plugins/polio/tests/test_refresh_powerbi.py
@@ -99,6 +99,9 @@ class RefreshPowerBITestCase(APITestCase):
     def mock_launch_external_task(self, dataset_config=None):
         pass
 
+    def mock_monitor_task_and_raise_if_fail(self, dataset_config=None, task=None):
+        pass
+
     def test_get_extra_config_for_data_set_id(self):
         dataset_config = get_extra_config_for_data_set_id(self.dataset_id)
         self.assertDictEqual(dataset_config, self.dataset_json[self.dataset_id])
@@ -136,6 +139,7 @@ class RefreshPowerBITestCase(APITestCase):
     @patch("requests.post")
     @patch("iaso.utils.powerbi.get_powerbi_service_principal_token", mock_get_powerbi_service_principal_token)
     @patch("iaso.utils.powerbi.launch_external_task", mock_launch_external_task)
+    @patch("iaso.utils.powerbi.monitor_task_and_raise_if_fail", mock_launch_external_task)
     @patch.object(ExternalTaskModelViewSet, "launch_task", mock_openhexa_call_success)
     def test_powerbi_updates(self, mock_post):
         group_id = "some_group_id"

--- a/plugins/polio/tests/test_refresh_powerbi.py
+++ b/plugins/polio/tests/test_refresh_powerbi.py
@@ -96,6 +96,9 @@ class RefreshPowerBITestCase(APITestCase):
     def mock_get_powerbi_service_principal_token(self, tenant_id=None, client_id=None, secret_value=None):
         return "token"
 
+    def mock_launch_external_task(self, dataset_config=None):
+        pass
+
     def test_get_extra_config_for_data_set_id(self):
         dataset_config = get_extra_config_for_data_set_id(self.dataset_id)
         self.assertDictEqual(dataset_config, self.dataset_json[self.dataset_id])
@@ -132,6 +135,7 @@ class RefreshPowerBITestCase(APITestCase):
 
     @patch("requests.post")
     @patch("iaso.utils.powerbi.get_powerbi_service_principal_token", mock_get_powerbi_service_principal_token)
+    @patch("iaso.utils.powerbu.launch_external_task", mock_launch_external_task)
     @patch.object(ExternalTaskModelViewSet, "launch_task", mock_openhexa_call_success)
     def test_powerbi_updates(self, mock_post):
         group_id = "some_group_id"

--- a/plugins/polio/tests/test_refresh_powerbi.py
+++ b/plugins/polio/tests/test_refresh_powerbi.py
@@ -6,7 +6,12 @@ from iaso.api.tasks.views import ExternalTaskModelViewSet
 from iaso.models.base import RUNNING, SKIPPED, SUCCESS
 from iaso.models.json_config import Config
 from iaso.test import APITestCase
-from iaso.utils.powerbi import get_openhexa_config_for_data_set_id, launch_external_task, monitor_task_and_raise_if_fail
+from iaso.utils.powerbi import (
+    get_extra_config_for_data_set_id,
+    launch_dataset_refresh,
+    launch_external_task,
+    monitor_task_and_raise_if_fail,
+)
 from plugins.polio.tasks.api.refresh_lqas_data import LQAS_CONFIG_SLUG
 
 
@@ -64,15 +69,20 @@ class RefreshPowerBITestCase(APITestCase):
         cls.pipeline_config = Config.objects.create(slug=cls.slug, content=cls.pipeline_json)
         cls.dataset_json = {
             f"{cls.dataset_id}": {
-                "config": f"{cls.slug}",
-                "user_id": cls.user.pk,
-                "task_name": "Refresh dashboard",
-                "timeout_count": 2,
-                "expected_run_time": 1,
-                "additional_timeout": 1,
+                "openhexa": {
+                    "config": f"{cls.slug}",
+                    "user_id": cls.user.pk,
+                    "task_name": "Refresh dashboard",
+                    "timeout_count": 2,
+                    "expected_run_time": 1,
+                    "additional_timeout": 1,
+                },
+                "sync_refresh": ["some_dataset_id", "some_other_dataset_id"],
             }
         }
-        cls.openhexa_config = Config.objects.create(slug="openhexa_powerbi", content=cls.dataset_json)
+        cls.powerbi_config_json = {"client_id": "Who", "tenant_id": "David", "secret_value": "Victoria"}
+        cls.openhexa_config = Config.objects.create(slug="powerbi_dataset_configs", content=cls.dataset_json)
+        cls.powerbi_config = Config.objects.create(slug="powerbi_sp", content=cls.powerbi_config_json)
 
     def mock_openhexa_call_success(slug=None, config=None, id_field=None, task_id=None):
         return SUCCESS
@@ -83,13 +93,16 @@ class RefreshPowerBITestCase(APITestCase):
     def mock_openhexa_call_running(slug=None, config=None, id_field=None, task_id=None):
         return RUNNING
 
-    def test_get_openhexa_config_for_data_set_id(self):
-        dataset_config = get_openhexa_config_for_data_set_id(self.dataset_id)
+    def mock_get_powerbi_service_principal_token(self, tenant_id=None, client_id=None, secret_value=None):
+        return "token"
+
+    def test_get_extra_config_for_data_set_id(self):
+        dataset_config = get_extra_config_for_data_set_id(self.dataset_id)
         self.assertDictEqual(dataset_config, self.dataset_json[self.dataset_id])
 
     @patch.object(ExternalTaskModelViewSet, "launch_task", mock_openhexa_call_running)
     def test_launch_external_task(self):
-        dataset_config = self.dataset_json[self.dataset_id]
+        dataset_config = self.dataset_json[self.dataset_id]["openhexa"]
         task = launch_external_task(dataset_config)
         self.assertEqual(task.status, RUNNING)
         self.assertTrue(task.external)
@@ -99,7 +112,7 @@ class RefreshPowerBITestCase(APITestCase):
 
     @patch.object(ExternalTaskModelViewSet, "launch_task", mock_openhexa_call_running)
     def test_monitor_task_and_fail(self):
-        dataset_config = self.dataset_json[self.dataset_id]
+        dataset_config = self.dataset_json[self.dataset_id]["openhexa"]
         task = launch_external_task(dataset_config)
         with self.assertRaises(Exception) as raisedException:
             monitor_task_and_raise_if_fail(dataset_config, task)
@@ -108,7 +121,7 @@ class RefreshPowerBITestCase(APITestCase):
 
     @patch.object(ExternalTaskModelViewSet, "launch_task", mock_openhexa_call_success)
     def test_monitor_task_and_success(self):
-        dataset_config = self.dataset_json[self.dataset_id]
+        dataset_config = self.dataset_json[self.dataset_id]["openhexa"]
         task = launch_external_task(dataset_config)
         hasException = False
         try:
@@ -116,3 +129,27 @@ class RefreshPowerBITestCase(APITestCase):
         except:
             hasException = True
         self.assertFalse(hasException)
+
+    @patch("requests.post")
+    @patch("iaso.utils.powerbi.get_powerbi_service_principal_token", mock_get_powerbi_service_principal_token)
+    @patch.object(ExternalTaskModelViewSet, "launch_task", mock_openhexa_call_success)
+    def test_powerbi_updates(self, mock_post):
+        group_id = "some_group_id"
+        data_set_id = self.dataset_id
+        extra_dataset_ids = self.dataset_json[data_set_id]["sync_refresh"]
+
+        # Mock the PowerBI API responses for the main dataset and extra datasets
+        mock_post.return_value.status_code = 200
+        mock_post.return_value.json.return_value = {}
+
+        launch_dataset_refresh(group_id, data_set_id)
+
+        # Assert that the correct number of API calls were made
+        self.assertEqual(mock_post.call_count, 1 + len(extra_dataset_ids))
+        # Assert that the API calls were made with the correct URLs
+        expected_urls = [f"https://api.powerbi.com/v1.0/myorg/groups/{group_id}/datasets/{data_set_id}/refreshes"] + [
+            f"https://api.powerbi.com/v1.0/myorg/groups/{group_id}/datasets/{extra_dataset_id}/refreshes"
+            for extra_dataset_id in extra_dataset_ids
+        ]
+        actual_urls = [call[1]["url"] for call in mock_post.call_args_list]
+        self.assertEqual(actual_urls, expected_urls)


### PR DESCRIPTION
The refresh button should also refresh "children" dashboards

Related JIRA tickets :  POLIO-1916

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests?
- [x] Documentation has been included (for new feature)

## Doc

[Added a wiki entry](https://wiki.bluesquare.org/e/en/Dev-team/product-management/iaso/Polio/refresh-powerbi-reference)

## Changes

Explain the changes that were made.

- refactor "openhexa-config" as "powerbi_dataset_configs"
- store openhexa config under "openhexa" key in config dict
- store dataset ids to be synchronized together under "sync-refresh" key

Basically updated the existing config for powerBI updates so that it can take a list of dataset ids (that we retrieve manually from powerBi beforehand) and uses this list to trigger the refresh of the corresponding dashboards

## How to test

Unfortunately it needs to be deployed on prod (because powerBI)

## Print screen / video

N/A

## Notes

I added the new config in the django admin but left the old (=current) in place, so we can transition seamlessly from one to the other

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
