### PR TITLE
[IA-4159] Round accuracy when there are more than 2 decimal places

### DIFF
--- a/iaso/api/common.py
+++ b/iaso/api/common.py
@@ -510,13 +510,3 @@ class DropdownOptionsListViewSet(ViewSet):
         status_choices = self.get_status_choices()
         serializer = self.serializer(status_choices, many=True)
         return Response(serializer.data)
-
-
-class RoundingDecimalField(serializers.DecimalField):
-    """
-    As per the overridden method's documentation, this can be overridden to disable the validation.
-    The quantize method is called afterward and does the rounding.
-    """
-
-    def validate_precision(self, value):
-        return value

--- a/iaso/api/common.py
+++ b/iaso/api/common.py
@@ -510,3 +510,13 @@ class DropdownOptionsListViewSet(ViewSet):
         status_choices = self.get_status_choices()
         serializer = self.serializer(status_choices, many=True)
         return Response(serializer.data)
+
+
+class RoundingDecimalField(serializers.DecimalField):
+    """
+    As per the overridden method's documentation, this can be overridden to disable the validation.
+    The quantize method is called afterward and does the rounding.
+    """
+
+    def validate_precision(self, value):
+        return value

--- a/iaso/api/org_unit_change_requests/serializers.py
+++ b/iaso/api/org_unit_change_requests/serializers.py
@@ -7,12 +7,13 @@ from rest_framework import serializers
 
 from hat.audit.audit_logger import AuditLogger
 from hat.audit.models import ORG_UNIT_CHANGE_REQUEST_API
-from iaso.api.common import RoundingDecimalField, TimestampField
+from iaso.api.common import TimestampField
 from iaso.api.mobile.org_units import ReferenceInstancesSerializer
 from iaso.models import Instance, OrgUnit, OrgUnitChangeRequest, OrgUnitType
 from iaso.models.payments import PaymentStatuses
 from iaso.utils import geojson_queryset
 from iaso.utils.serializer.id_or_uuid_field import IdOrUuidRelatedField
+from iaso.utils.serializer.rounded_decimal_field import RoundedDecimalField
 from iaso.utils.serializer.three_dim_point_field import ThreeDimPointField
 
 
@@ -289,7 +290,7 @@ class OrgUnitChangeRequestWriteSerializer(serializers.ModelSerializer):
         required=False,
         allow_null=True,
     )
-    new_location_accuracy = RoundingDecimalField(
+    new_location_accuracy = RoundedDecimalField(
         max_digits=7,
         decimal_places=2,
         rounding=decimal.ROUND_HALF_UP,

--- a/iaso/api/org_unit_change_requests/serializers.py
+++ b/iaso/api/org_unit_change_requests/serializers.py
@@ -1,3 +1,4 @@
+import decimal
 import uuid
 
 from django.contrib.auth.models import User
@@ -6,7 +7,7 @@ from rest_framework import serializers
 
 from hat.audit.audit_logger import AuditLogger
 from hat.audit.models import ORG_UNIT_CHANGE_REQUEST_API
-from iaso.api.common import TimestampField
+from iaso.api.common import RoundingDecimalField, TimestampField
 from iaso.api.mobile.org_units import ReferenceInstancesSerializer
 from iaso.models import Instance, OrgUnit, OrgUnitChangeRequest, OrgUnitType
 from iaso.models.payments import PaymentStatuses
@@ -285,6 +286,13 @@ class OrgUnitChangeRequestWriteSerializer(serializers.ModelSerializer):
         allow_null=True,
     )
     new_location = ThreeDimPointField(
+        required=False,
+        allow_null=True,
+    )
+    new_location_accuracy = RoundingDecimalField(
+        max_digits=7,
+        decimal_places=2,
+        rounding=decimal.ROUND_HALF_UP,
         required=False,
         allow_null=True,
     )

--- a/iaso/tests/utils/test_rounded_decimal_field.py
+++ b/iaso/tests/utils/test_rounded_decimal_field.py
@@ -1,0 +1,31 @@
+import decimal
+
+from django.test import TestCase
+from rest_framework.exceptions import ValidationError
+
+from iaso.utils.serializer.rounded_decimal_field import RoundedDecimalField
+
+
+class RoundedDecimalFieldTestCase(TestCase):
+    def test_to_internal_value(self):
+        field = RoundedDecimalField(max_digits=6, decimal_places=4)
+        self.assertEqual(field.to_internal_value("1.12345"), decimal.Decimal("1.1234"))
+
+        field = RoundedDecimalField(max_digits=6, decimal_places=4)
+        self.assertEqual(field.to_internal_value("1.12346"), decimal.Decimal("1.1235"))
+
+        field = RoundedDecimalField(max_digits=4, decimal_places=2, rounding=decimal.ROUND_HALF_UP)
+        self.assertEqual(field.to_internal_value("1.234"), decimal.Decimal("1.23"))
+
+        field = RoundedDecimalField(max_digits=4, decimal_places=2, rounding=decimal.ROUND_HALF_UP)
+        self.assertEqual(field.to_internal_value("1.235"), decimal.Decimal("1.24"))
+
+        field = RoundedDecimalField(max_digits=2, decimal_places=1)
+        with self.assertRaises(ValidationError) as error:
+            field.to_internal_value("1.19")
+        self.assertIn("Ensure that there are no more than 2 digits in total.", error.exception.detail)
+
+        field = RoundedDecimalField(max_digits=4, decimal_places=2)
+        with self.assertRaises(ValidationError) as error:
+            field.to_internal_value("100.22")
+        self.assertIn("Ensure that there are no more than 2 digits before the decimal point.", error.exception.detail)

--- a/iaso/utils/serializer/rounded_decimal_field.py
+++ b/iaso/utils/serializer/rounded_decimal_field.py
@@ -1,0 +1,40 @@
+from rest_framework import serializers
+
+
+class RoundedDecimalField(serializers.DecimalField):
+    """
+    Some devices send accuracy with more than 2 decimals (IA-4159).
+
+    This field will round the value to the number specified in `decimal_places`.
+    """
+
+    def validate_precision(self, value):
+        """
+        Override of `validate_precision` to remove the `decimal_places` validation.
+        https://github.com/encode/django-rest-framework/blob/54399671/rest_framework/fields.py#L1049-L1082
+
+        The quantize method is called afterward and will do the rounding.
+        https://github.com/encode/django-rest-framework/blob/54399671/rest_framework/fields.py#L1047
+        """
+        sign, digittuple, exponent = value.as_tuple()
+
+        if exponent >= 0:
+            # 1234500.0
+            total_digits = len(digittuple) + exponent
+            whole_digits = total_digits
+        elif len(digittuple) > abs(exponent):
+            # 123.45
+            total_digits = len(digittuple)
+            whole_digits = total_digits - abs(exponent)
+        else:
+            # 0.001234
+            total_digits = abs(exponent)
+            whole_digits = 0
+
+        if self.max_whole_digits is not None and whole_digits > self.max_whole_digits:
+            self.fail("max_whole_digits", max_whole_digits=self.max_whole_digits)
+
+        if self.max_digits is not None and total_digits > self.max_digits:
+            self.fail("max_digits", max_digits=self.max_digits)
+
+        return value


### PR DESCRIPTION
When the backend receives an accuracy with more than 2 decimal places, it returns a 400 where it could just round it.

Related JIRA tickets : IA-4159

## Self proofreading checklist

- [X] Did I use eslint and ruff formatters?
- [X] Is my code clear enough and well documented?
- [X] Are there enough tests?
- [X] Documentation has been included (for new feature)

## Doc

Code comments

## Changes

I have added `RoundingDecimalField` and used it in the proper serializer.

## How to test

Send a `new_location_accuracy` with more than 2 decimal places.

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
