### PR TITLE
IA-4155 Fix sorting org units causes a 500 error

### DIFF
--- a/iaso/api/org_unit_search.py
+++ b/iaso/api/org_unit_search.py
@@ -90,7 +90,7 @@ def build_org_units_queryset(queryset, params, profile):
             group_ids = [group]
         else:
             group_ids = group
-        queryset = queryset.filter(groups__in=group_ids).distinct("id")
+        queryset = queryset.filter(groups__in=group_ids).distinct()
 
     if source:
         source = DataSource.objects.get(id=source)
@@ -115,7 +115,7 @@ def build_org_units_queryset(queryset, params, profile):
         queryset = queryset.filter(instance__created_at__lte=date_to)
 
     if date_from is not None and date_to is not None:
-        queryset = queryset.filter(instance__created_at__range=[date_from, date_to]).distinct("id")
+        queryset = queryset.filter(instance__created_at__range=[date_from, date_to]).distinct()
 
     if has_instances is not None:
         if has_instances == "true":

--- a/iaso/api/org_units.py
+++ b/iaso/api/org_units.py
@@ -166,18 +166,10 @@ class OrgUnitViewSet(viewsets.ViewSet):
 
         queryset = queryset.order_by(*order)
 
-        distinct_fields = [item.replace("-", "") for item in order]
-
         if not is_export:
             if limit and not as_location:
                 limit = int(limit)
                 page_offset = int(page_offset)
-
-                # Avoid a `SELECT DISTINCT ON expressions must match initial ORDER BY expressions` exception
-                # because `build_org_units_queryset()` can set `.distinct()` clauses.
-                if queryset.query.combinator != "union":  # `.distinct()` is not allowed with `.union()`.
-                    queryset = queryset.distinct(*distinct_fields)
-
                 paginator = Paginator(queryset, limit)
 
                 if page_offset > paginator.num_pages:
@@ -212,12 +204,6 @@ class OrgUnitViewSet(viewsets.ViewSet):
                 return Response({"orgUnits": org_units})
             if as_location:
                 limit = int(limit)
-
-                # Avoid a `SELECT DISTINCT ON expressions must match initial ORDER BY expressions` exception
-                # because `build_org_units_queryset()` can set `.distinct()` clauses.
-                if queryset.query.combinator != "union":  # `.distinct()` is not allowed with `.union()`.
-                    queryset = queryset.distinct(*distinct_fields)
-
                 paginator = Paginator(queryset, limit)
                 page = paginator.page(1)
                 org_units = []


### PR DESCRIPTION
Fix sorting org units causes a 500 error.

Related JIRA tickets : IA-4155

## Changes

We know that [using `distinct()` is slower](https://docs.djangoproject.com/en/5.0/ref/models/querysets/#django.db.models.query.QuerySet.distinct):

> For a normal `distinct()` call, the database compares each field in each row when determining which rows are distinct. For a `distinct()` call with specified field names, the database will only compare the specified field names.

But because of the way this endpoint is coded, [using `distinct("id")`](https://github.com/BLSQ/iaso/pull/2005/files#diff-a410d2a02a7ac632955a86a162e1e928dcfd747dd4587699e82da331f1a949ecR83) causes a lot more headaches, see:

- https://github.com/BLSQ/iaso/pull/2039
- https://github.com/BLSQ/iaso/pull/2041
- https://github.com/BLSQ/iaso/pull/2060

And now there are new problems:

- https://bluesquareorg.sentry.io/issues/6113446205
- https://bluesquareorg.sentry.io/issues/6559950873

So let's sacrifice a little bit of performance to reduce some of the complexity and use `.distinct()` instead of `.distinct("id")`.

## How to test?

You should be able to order the list of org units by "Number of submissions" without raising 500.

All the unit tests should be OK too.