### PR TITLE
IA-4117 Fix org unit with an empty `source_ref` causes the synchronization to fail

### DIFF
--- a/iaso/diffing/synchronizer.py
+++ b/iaso/diffing/synchronizer.py
@@ -103,7 +103,7 @@ class DataSourceVersionsSynchronizer:
 
     def _create_missing_org_units_and_prepare_missing_groups(self) -> None:
         """
-        Create missing `OrgUnit`s and groups prepare the list of missing `Group`s.
+        Create missing `OrgUnit`s and prepare the list of missing `Group`s.
 
         Because of the tree structure of the `OrgUnit` model, it's hard to bulk create them.
         So we sacrifice performance for the sake of simplicity by creating the missing `OrgUnit`s in a loop.
@@ -273,7 +273,12 @@ class DataSourceVersionsSynchronizer:
                             extra={"new_group": new_group, "data_source_sync": self.data_source_sync},
                         )
 
-        matching = self.org_units_matching[org_unit["source_ref"]]
+        try:
+            matching = self.org_units_matching[org_unit["source_ref"]]
+        except KeyError:
+            # This happens for org units skipped in `_create_missing_org_units_and_prepare_missing_groups`
+            # when they have no `source_ref` attribute.
+            return None, None
 
         org_unit_change_request = OrgUnitChangeRequest(
             # Data.

--- a/iaso/tests/api/data_source_versions_synchronization/test_views.py
+++ b/iaso/tests/api/data_source_versions_synchronization/test_views.py
@@ -178,7 +178,7 @@ class DataSourceVersionsSynchronizationViewSetTestCase(TaskAPITestCase):
     def test_synchronize_source_versions_async(self):
         # We use an empty `json_diff` here because `synchronize_source_versions()` (which
         # is called in the background task) is already fully tested in the model tests.
-        # We're just interested to check that the background task works as expected.
+        # We're just interested in checking that the background task works as expected.
         self.data_source_sync_1.json_diff = "[]"
         self.data_source_sync_1.save()
 


### PR DESCRIPTION
Fix org unit with an empty `source_ref` causes the synchronization to fail.

Related JIRA tickets : IA-4117

## How to test

Create a new org unit and let the `source_ref` empty.

Launch a versions synchronization.

Org units without `source_ref` should now be properly ignored without triggering an error.

