### PR TITLE
IA-4173 Fix payments loading takes forever (bis)

### DIFF
--- a/iaso/api/payments/serializers.py
+++ b/iaso/api/payments/serializers.py
@@ -37,8 +37,7 @@ class OrgChangeRequestNestedSerializer(serializers.ModelSerializer):
         user = self.context.get("request").user
         if user.is_superuser:
             return True
-        user_org_units = list(user.iaso_profile.get_hierarchy_for_user().values_list("id", flat=True))
-        return obj.org_unit.id in user_org_units
+        return obj.org_unit.id in self.context["user_org_units"]
 
 
 class AuditOrgChangeRequestNestedSerializer(serializers.ModelSerializer):
@@ -142,6 +141,8 @@ class PotentialPaymentSerializer(serializers.ModelSerializer):
             start_date = request.GET.get("change_requests__created_at_after", None)
             end_date = request.GET.get("change_requests__created_at_before", None)
             change_requests = filter_by_dates(request, change_requests, start_date, end_date)
+
+        self.context["user_org_units"] = obj.annotated_user_org_units
         return OrgChangeRequestNestedSerializer(change_requests, many=True, context=self.context).data
 
     def get_can_see_change_requests(self, obj):

--- a/iaso/api/payments/views.py
+++ b/iaso/api/payments/views.py
@@ -140,6 +140,9 @@ class PaymentLotsViewSet(ModelViewSet):
         )
         queryset = queryset.filter(created_by__iaso_profile__account=self.request.user.iaso_profile.account).distinct()
 
+        user_org_units_subquery = self.request.user.iaso_profile.get_hierarchy_for_user().values_list("id")
+        queryset = queryset.annotate(annotated_user_org_units=ArraySubquery(user_org_units_subquery))
+
         return queryset
 
     @swagger_auto_schema(

--- a/iaso/tests/api/payments/test_payment_lots.py
+++ b/iaso/tests/api/payments/test_payment_lots.py
@@ -174,7 +174,7 @@ class PaymentLotsViewSetAPITestCase(TaskAPITestCase):
         )
         extra_change_request.new_reference_instances.set([self.instance1, self.instance2, self.instance3])
 
-        with self.assertNumQueries(11):
+        with self.assertNumQueries(10):
             response = self.client.get(f"/api/payments/lots/{self.payment_lot.id}/?xlsx=true")
             self.assertEqual(response.status_code, 200)
             self.assertEqual(

--- a/iaso/tests/api/payments/test_payment_lots.py
+++ b/iaso/tests/api/payments/test_payment_lots.py
@@ -174,7 +174,7 @@ class PaymentLotsViewSetAPITestCase(TaskAPITestCase):
         )
         extra_change_request.new_reference_instances.set([self.instance1, self.instance2, self.instance3])
 
-        with self.assertNumQueries(10):
+        with self.assertNumQueries(11):
             response = self.client.get(f"/api/payments/lots/{self.payment_lot.id}/?xlsx=true")
             self.assertEqual(response.status_code, 200)
             self.assertEqual(

--- a/iaso/tests/api/payments/test_potential_payments.py
+++ b/iaso/tests/api/payments/test_potential_payments.py
@@ -76,7 +76,7 @@ class PotentialPaymentsViewSetAPITestCase(APITestCase):
 
         self.client.force_authenticate(self.user_with_perm)
 
-        with self.assertNumQueries(23):
+        with self.assertNumQueries(17):
             response = self.client.get("/api/potential_payments/")
             self.assertJSONResponse(response, 200)
 


### PR DESCRIPTION
Fix payments loading takes forever (bis).

Related JIRA tickets : IA-4173

## Notes

This fixes a performance problem in various payments API (see also https://github.com/BLSQ/iaso/pull/2124).

`get_hierarchy_for_user()` is now calculated only once in `get_serializer_context()` instead of evaluating it in a serializer method for each object in a queryset.

