### PR TITLE
IA-4168: duplicate columns on ou export 

### DIFF
--- a/iaso/api/org_units.py
+++ b/iaso/api/org_units.py
@@ -118,7 +118,9 @@ class OrgUnitViewSet(viewsets.ViewSet):
          These parameter can totally conflict and the result is undocumented
         """
         queryset = self.get_queryset().defer("geom").select_related("parent__org_unit_type")
-        forms = Form.objects.filter_for_user_and_app_id(self.request.user, self.request.query_params.get("app_id"))
+        forms = Form.objects.filter_for_user_and_app_id(
+            self.request.user, self.request.query_params.get("app_id")
+        ).distinct()
         limit = request.GET.get("limit", None)
         page_offset = request.GET.get("page", 1)
         order = request.GET.get("order", "name").split(",")


### PR DESCRIPTION
when downloading a list of OUs in xlsx format, the submission list now includes duplicated columns for the forms that are part of several projects simultaneously. 
This issue was observed on the IHP prod instance with user CHalleux.

Related JIRA tickets : IA-4168

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)



## Changes

use distinct while filtering forms

## How to test

Make a xlsx export of org units with submissions and make sure you don't have duplicates columns

