### PR TITLE
IA-4171 Org Unit Type restrictions shouldn't be used in user creation/modification

### DIFF
--- a/iaso/api/profiles/bulk_create_users.py
+++ b/iaso/api/profiles/bulk_create_users.py
@@ -123,9 +123,7 @@ class BulkCreateUserFromCsvViewSet(ModelViewSet):
         user_created_count = 0
 
         has_geo_limit = False
-        user_editable_org_unit_type_ids = set()
         if self.has_only_user_managed_permission(request):
-            user_editable_org_unit_type_ids = request.user.iaso_profile.get_editable_org_unit_type_ids()
             has_geo_limit = True
 
         user_has_project_restrictions = hasattr(request.user, "iaso_profile") and bool(
@@ -291,28 +289,6 @@ class BulkCreateUserFromCsvViewSet(ModelViewSet):
 
                     profile = Profile.objects.create(account=importer_account, user=user)
 
-                    if org_units_list and user_editable_org_unit_type_ids:
-                        invalid_ids = [
-                            org_unit.org_unit_type_id
-                            for org_unit in org_units_list
-                            if org_unit.org_unit_type_id
-                            and not profile.has_org_unit_write_permission(
-                                org_unit.org_unit_type_id, user_editable_org_unit_type_ids
-                            )
-                        ]
-                        if invalid_ids:
-                            invalid_names = ", ".join(
-                                name
-                                for name in OrgUnitType.objects.filter(pk__in=invalid_ids).values_list(
-                                    "name", flat=True
-                                )
-                            )
-                            raise serializers.ValidationError(
-                                {
-                                    "error": f"Operation aborted. You don't have rights on the following org unit types: {invalid_names}"
-                                }
-                            )
-
                     # Using try except for dhis2_id in case users are being created with an older version of the template
                     try:
                         dhis2_id = row[csv_indexes.index("dhis2_id")]
@@ -434,26 +410,6 @@ class BulkCreateUserFromCsvViewSet(ModelViewSet):
                             projects__account=importer_account, id__in=editable_org_unit_types_ids
                         )
                         if new_editable_org_unit_types:
-                            if user_editable_org_unit_type_ids:
-                                invalid_ids = [
-                                    out.pk
-                                    for out in new_editable_org_unit_types
-                                    if not profile.has_org_unit_write_permission(
-                                        out.pk, user_editable_org_unit_type_ids
-                                    )
-                                ]
-                                if invalid_ids:
-                                    invalid_names = ", ".join(
-                                        name
-                                        for name in OrgUnitType.objects.filter(pk__in=invalid_ids).values_list(
-                                            "name", flat=True
-                                        )
-                                    )
-                                    raise serializers.ValidationError(
-                                        {
-                                            "error": f"Operation aborted. You don't have rights on the following org unit types: {invalid_names}"
-                                        }
-                                    )
                             profile.editable_org_unit_types.set(new_editable_org_unit_types)
 
                     profile.org_units.set(org_units_list)

--- a/iaso/tasks/profiles_bulk_update.py
+++ b/iaso/tasks/profiles_bulk_update.py
@@ -53,9 +53,6 @@ def update_single_profile_from_bulk(
 
     user_has_project_restrictions = hasattr(user, "iaso_profile") and bool(user.iaso_profile.projects_ids)
     user_has_perm_users_admin = user.has_perm(permission.USERS_ADMIN)
-    editable_org_unit_type_ids = (
-        user.iaso_profile.get_editable_org_unit_type_ids() if not user_has_perm_users_admin else set()
-    )
 
     if teams_id_added and not user.has_perm(permission.TEAMS):
         raise PermissionDenied(f"User without the permission {permission.TEAMS} cannot add users to team")
@@ -111,18 +108,6 @@ def update_single_profile_from_bulk(
                     f"health pyramid"
                 )
             org_unit = OrgUnit.objects.select_related("org_unit_type").get(pk=location_id)
-            if (
-                not user_has_perm_users_admin
-                and org_unit.org_unit_type_id
-                and editable_org_unit_type_ids
-                and not user.iaso_profile.has_org_unit_write_permission(
-                    org_unit.org_unit_type_id, editable_org_unit_type_ids
-                )
-            ):
-                raise PermissionDenied(
-                    f"User with permission {permission.USERS_MANAGED} cannot change the org unit {org_unit.name} "
-                    f"because he does not have rights on the following org unit type: {org_unit.org_unit_type.name}"
-                )
             org_units_to_be_added.append(org_unit)
 
     if location_ids_removed:
@@ -133,18 +118,6 @@ def update_single_profile_from_bulk(
                     f"health pyramid"
                 )
             org_unit = OrgUnit.objects.select_related("org_unit_type").get(pk=location_id)
-            if (
-                not user_has_perm_users_admin
-                and org_unit.org_unit_type_id
-                and editable_org_unit_type_ids
-                and not user.iaso_profile.has_org_unit_write_permission(
-                    org_unit.org_unit_type_id, editable_org_unit_type_ids
-                )
-            ):
-                raise PermissionDenied(
-                    f"User with permission {permission.USERS_MANAGED} cannot change the org unit {org_unit.name} "
-                    f"because he does not have rights on the following org unit type: {org_unit.org_unit_type.name}"
-                )
             org_units_to_be_removed.append(org_unit)
 
     # Update


### PR DESCRIPTION
Org Unit Type restrictions shouldn't be used in user creation/modification.

Related JIRA tickets : IA-4171

## Changes

Remove Org Unit Type restrictions in:

- bulk create users (via CSV)
- `api/profiles` update and create
- profile bulk update

## How to test

Add Org Unit Type restrictions to a user. Then check that those restrictions never interfere with user creation or modification.
