### PR TITLE
IA-4186: exclude hidden path from redirections

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/users/utils.js
+++ b/hat/assets/js/apps/Iaso/domains/users/utils.js
@@ -97,7 +97,9 @@ export const getFirstAllowedUrl = (
             untestedPermissions.splice(i, 1);
         }
     });
-    const newPath = routes.find(p => p.permissions?.some(kp => kp === newRoot));
+    const newPath = routes
+        .filter(route => route.baseUrl !== 'secret')
+        .find(p => p.permissions?.some(kp => kp === newRoot));
     if (newPath) {
         return newPath.baseUrl;
     }


### PR DESCRIPTION
Plugin users w/o campaigns permission were redirected to blocked  url

Related JIRA tickets : IA-4186

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

- updated `getFirstAllowedUrl` to exclude `hidden` route

## How to test
 On a polio DB, with polio plugin active:

create a user without the campaigns permission
log in
user should not be redirected to `/secret` route


## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
