### PR TITLE
IA-4172 Project field shouldn't be greyed out in user creation/edition

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -1549,7 +1549,6 @@
     "iaso.users.selectAllHelperText": "Leave empty to select all",
     "iaso.users.selectedOrgUnits": "Org units selected",
     "iaso.users.update": "Update user",
-    "iaso.users.userAdminOnly": "Can only be edited by user admin",
     "iaso.users.userPermissions": "User permissions",
     "iaso.users.userRoleOrgUnitTypeRestrictionWarning": "Org Unit Type Write restrictions from User role apply to this user. Refer to the user role configuration for more details",
     "iaso.users.usersHistory": "Users history",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -1548,7 +1548,6 @@
     "iaso.users.selectAllHelperText": "Laisser vide pour tout sélectionner",
     "iaso.users.selectedOrgUnits": "Unité d'organisation sélectionnées",
     "iaso.users.update": "Mettre l'utilisateur à jour",
-    "iaso.users.userAdminOnly": "Edition pour les administrateurs uniquement",
     "iaso.users.userPermissions": "Permissions d'utilisateur",
     "iaso.users.userRoleOrgUnitTypeRestrictionWarning": "Des restrictions d'écriture de rôle d’utilisateur s’appliquent à cet utilisateur. Consulter le rôle d’utilisateur en question pour plus de détails",
     "iaso.users.usersHistory": "Historique des utilisateurs",

--- a/hat/assets/js/apps/Iaso/domains/users/components/UsersInfos.js
+++ b/hat/assets/js/apps/Iaso/domains/users/components/UsersInfos.js
@@ -6,14 +6,12 @@ import { useSafeIntl, InputWithInfos } from 'bluesquare-components';
 import isEmpty from 'lodash/isEmpty';
 import PropTypes from 'prop-types';
 import InputComponent from '../../../components/forms/InputComponent.tsx';
-import { USERS_ADMIN } from '../../../utils/permissions';
 import { useCurrentUser } from '../../../utils/usersUtils.ts';
 import { useAppLocales } from '../../app/constants';
 
 import { useGetProjectsDropdownOptions } from '../../projects/hooks/requests.ts';
 
 import MESSAGES from '../messages.ts';
-import { userHasPermission } from '../utils.js';
 
 const useStyles = makeStyles(theme => ({
     alert: {
@@ -28,7 +26,6 @@ const UsersInfos = ({
     allowSendEmailInvitation,
 }) => {
     const loggedUser = useCurrentUser();
-    const isLoggedUserAdmin = userHasPermission(USERS_ADMIN, loggedUser);
     const { formatMessage } = useSafeIntl();
     const classes = useStyles();
 
@@ -198,12 +195,6 @@ const UsersInfos = ({
                         label={MESSAGES.projects}
                         options={availableProjects}
                         loading={isFetchingProjects}
-                        disabled={!isLoggedUserAdmin}
-                        helperText={
-                            !isLoggedUserAdmin
-                                ? formatMessage(MESSAGES.userAdminOnly)
-                                : undefined
-                        }
                     />
                     <InputComponent
                         keyValue="language"

--- a/hat/assets/js/apps/Iaso/domains/users/messages.ts
+++ b/hat/assets/js/apps/Iaso/domains/users/messages.ts
@@ -510,10 +510,6 @@ const MESSAGES = defineMessages({
         id: 'iaso.users.selectAllHelperText',
         defaultMessage: 'Leave empty to select all',
     },
-    userAdminOnly: {
-        id: 'iaso.users.userAdminOnly',
-        defaultMessage: 'Can only be edited by user admin',
-    },
     OrgUnitTypeWriteDisableTooltip: {
         id: 'iaso.users.orgUnitTypeWriteDisableTooltip',
         defaultMessage:

--- a/iaso/api/profiles/profiles.py
+++ b/iaso/api/profiles/profiles.py
@@ -704,21 +704,23 @@ class ProfilesViewSet(viewsets.ViewSet):
 
     def validate_projects(self, request: HttpRequest, profile: Profile) -> list:
         new_project_ids = set([pk for pk in request.data.get("projects", []) if str(pk).isdigit()])
-        user_projects_ids = set(request.user.iaso_profile.projects_ids)
+        user_restricted_projects_ids = set(request.user.iaso_profile.projects_ids)
 
         if not new_project_ids:
-            if user_projects_ids:
+            if user_restricted_projects_ids:
                 # Apply the same project restrictions.
-                return Project.objects.filter(id__in=user_projects_ids, account=profile.account_id)
+                return Project.objects.filter(id__in=user_restricted_projects_ids, account=profile.account_id)
             # No project restrictions.
             return []
 
-        if not user_projects_ids:
-            # The current user has no project restrictions.
+        if not user_restricted_projects_ids:
             return Project.objects.filter(id__in=new_project_ids, account=profile.account_id)
 
-        if new_project_ids.issubset(user_projects_ids):
-            # The current user has project restrictions, ensure the new projects are within them.
+        profile_restricted_projects_ids = set(profile.projects_ids)
+        if profile_restricted_projects_ids.issuperset(user_restricted_projects_ids):
+            raise PermissionDenied("You cannot edit a user who has broader access to projects.")
+
+        if new_project_ids.issubset(user_restricted_projects_ids):
             return Project.objects.filter(id__in=new_project_ids, account=profile.account_id)
 
         raise PermissionDenied("Some projects are outside your scope.")

--- a/iaso/api/profiles/profiles.py
+++ b/iaso/api/profiles/profiles.py
@@ -6,11 +6,10 @@ from django.conf import settings
 from django.contrib.auth import login, models, update_session_auth_hash
 from django.contrib.auth.models import Permission, User
 from django.contrib.auth.tokens import PasswordResetTokenGenerator
-from django.core.exceptions import BadRequest
 from django.core.mail import send_mail
 from django.core.paginator import Paginator
 from django.db.models import Q, QuerySet
-from django.http import HttpResponse, JsonResponse, StreamingHttpResponse
+from django.http import HttpRequest, HttpResponse, JsonResponse, StreamingHttpResponse
 from django.shortcuts import get_object_or_404
 from django.template import Context, Template
 from django.urls import reverse
@@ -703,41 +702,26 @@ class ProfilesViewSet(viewsets.ViewSet):
             result["user_roles"].append(user_role_item)
         return result
 
-    def validate_projects(self, request, profile) -> list:
-        project_ids = set([pk for pk in request.data.get("projects", []) if str(pk).isdigit()])
-        user_has_project_restrictions = hasattr(request.user, "iaso_profile") and bool(
-            request.user.iaso_profile.projects_ids
-        )
-        result = []
+    def validate_projects(self, request: HttpRequest, profile: Profile) -> list:
+        new_project_ids = set([pk for pk in request.data.get("projects", []) if str(pk).isdigit()])
+        user_projects_ids = set(request.user.iaso_profile.projects_ids)
 
-        if not project_ids:
-            if user_has_project_restrictions:
+        if not new_project_ids:
+            if user_projects_ids:
                 # Apply the same project restrictions.
-                return list(Project.objects.filter_on_user_projects(request.user))
+                return Project.objects.filter(id__in=user_projects_ids, account=profile.account_id)
             # No project restrictions.
-            return result
+            return []
 
-        if not request.user.has_perm(permission.USERS_ADMIN):
-            raise PermissionDenied(
-                f"User without permission {permission.USERS_ADMIN} cannot change project attributions."
-            )
+        if not user_projects_ids:
+            # The current user has no project restrictions.
+            return Project.objects.filter(id__in=new_project_ids, account=profile.account_id)
 
-        if user_has_project_restrictions:
-            unauthorized_projects_ids = [p for p in project_ids if p not in request.user.iaso_profile.projects_ids]
-            unauthorized_projects_names = Project.objects.filter(id__in=unauthorized_projects_ids).values_list(
-                "name", flat=True
-            )
-            if unauthorized_projects_names:
-                raise PermissionDenied(
-                    f"You don't have access to the following projects: {','.join(unauthorized_projects_names)}."
-                )
+        if new_project_ids.issubset(user_projects_ids):
+            # The current user has project restrictions, ensure the new projects are within them.
+            return Project.objects.filter(id__in=new_project_ids, account=profile.account_id)
 
-        for project in Project.objects.filter(id__in=project_ids):
-            if profile.account_id != project.account_id:
-                raise BadRequest
-            result.append(project)
-
-        return result
+        raise PermissionDenied("Some projects are outside your scope.")
 
     def validate_editable_org_unit_types(self, request, profile: Profile) -> QuerySet[OrgUnitType]:
         editable_org_unit_type_ids = set(request.data.get("editable_org_unit_type_ids", []))

--- a/iaso/tests/api/test_profiles.py
+++ b/iaso/tests/api/test_profiles.py
@@ -1335,45 +1335,76 @@ class ProfileAPITestCase(APITestCase):
         self.assertEqual(response.data["phone_number"], None)
 
     def test_update_user_projects(self):
+        new_project_1 = m.Project.objects.create(name="New project 1", app_id="new.project.1", account=self.account)
+        new_project_2 = m.Project.objects.create(name="New project 2", app_id="new.project.2", account=self.account)
+        profile_to_edit = Profile.objects.get(user=self.jum)
+        profile_to_edit.projects.clear()
         user = self.jam
         self.client.force_authenticate(user)
-
-        self.assertTrue(user.has_perm(permission.USERS_MANAGED))
         self.assertEqual(user.iaso_profile.projects.count(), 0)
+        self.assertEqual(profile_to_edit.projects.count(), 0)
 
-        profile_to_edit = Profile.objects.get(user=self.jum)
-
-        # Changing `projects` is allowed for users without restrictions.
-        data = {
-            "user_name": "jum_new_user_name",
-            "projects": [self.project.id],
-        }
-        response = self.client.patch(f"/api/profiles/{profile_to_edit.id}/", data=data, format="json")
+        # A user without `projects` restrictions can set any project.
+        response = self.client.patch(
+            f"/api/profiles/{profile_to_edit.id}/",
+            data={
+                "user_name": "jum_new_user_name",
+                "projects": [self.project.id],
+            },
+            format="json",
+        )
         self.assertEqual(response.status_code, 200)
         profile_to_edit.refresh_from_db()
         self.assertEqual(profile_to_edit.projects.count(), 1)
         self.assertEqual(profile_to_edit.projects.first(), self.project)
         self.assertEqual(profile_to_edit.user.username, "jum_new_user_name")
 
-        # A user cannot assign a project outside his own scope.
-        user.iaso_profile.projects.set([self.project])
+        # A user with `projects` restrictions cannot edit a user who has broader access to projects.
+        user.iaso_profile.projects.clear()
+        profile_to_edit.projects.clear()
         del user.iaso_profile.projects_ids  # Refresh cached property.
-        new_project = m.Project.objects.create(name="New project", app_id="new.project", account=self.account)
-        data = {
-            "user_name": "jum_new_user_name",
-            "projects": [new_project.id],
-        }
-        response = self.client.patch(f"/api/profiles/{profile_to_edit.id}/", data=data, format="json")
+        user.iaso_profile.projects.set([self.project])
+        profile_to_edit.projects.set([self.project, new_project_1, new_project_2])
+        response = self.client.patch(
+            f"/api/profiles/{profile_to_edit.id}/",
+            data={
+                "user_name": "jum_new_user_name",
+                "projects": [self.project.id],
+            },
+            format="json",
+        )
         self.assertEqual(response.status_code, 403)
         self.assertEqual(
             response.data["detail"],
-            "Some projects are outside your scope.",
+            "You cannot edit a user who has broader access to projects.",
         )
+
+        # A user with `projects` restrictions can edit a user who has narrower access to projects.
+        user.iaso_profile.projects.clear()
+        profile_to_edit.projects.clear()
+        del user.iaso_profile.projects_ids  # Refresh cached property.
+        user.iaso_profile.projects.set([self.project, new_project_1])
+        profile_to_edit.projects.set([self.project])
+        response = self.client.patch(
+            f"/api/profiles/{profile_to_edit.id}/",
+            data={
+                "user_name": "jum_new_user_name",
+                "projects": [new_project_1.id],
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200)
+        profile_to_edit.refresh_from_db()
+        self.assertEqual(profile_to_edit.projects.count(), 1)
+        self.assertEqual(profile_to_edit.projects.first(), new_project_1)
+        self.assertEqual(profile_to_edit.user.username, "jum_new_user_name")
 
         # Current project restrictions of the user should be applied to the edited profile
         # when `projects` is not explicitly specified.
+        user.iaso_profile.projects.clear()
+        profile_to_edit.projects.clear()
+        del user.iaso_profile.projects_ids  # Refresh cached property.
         user.iaso_profile.projects.set([self.project])
-        del user.iaso_profile.projects_ids
         self.assertEqual(user.iaso_profile.projects.count(), 1)
         profile_to_edit.projects.clear()
         self.assertEqual(profile_to_edit.projects.count(), 0)
@@ -1383,6 +1414,25 @@ class ProfileAPITestCase(APITestCase):
         profile_to_edit.refresh_from_db()
         self.assertEqual(profile_to_edit.projects.count(), 1)
         self.assertEqual(profile_to_edit.projects.first(), self.project)
+
+        # A user with `projects` restrictions cannot assign projects outside his range.
+        user.iaso_profile.projects.clear()
+        profile_to_edit.projects.clear()
+        del user.iaso_profile.projects_ids  # Refresh cached property.
+        user.iaso_profile.projects.set([self.project])
+        response = self.client.patch(
+            f"/api/profiles/{profile_to_edit.id}/",
+            data={
+                "user_name": "jum_new_user_name",
+                "projects": [new_project_2.id],
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(
+            response.data["detail"],
+            "Some projects are outside your scope.",
+        )
 
     def get_new_user_data(self):
         user_name = "audit_user"


### PR DESCRIPTION
Project field shouldn't be greyed out in user creation/edition.

Related JIRA tickets : IA-4172

## Changes

Edition of the `project` field was restricted to admin users, see #1775.

We're changing that following the multi-projects restrictions (IA-2535) implemented in #2105 #2098 #097 #2096.

The project field isn't grayed out anymore in user creation/edition.

Behavior:

- if the `project` field is empty:
    - if the editing user has project restrictions, we set `project` with the same restrictions
    - otherwise we let `project` empty
- if the `project` field is not empty:
    - if the editing user has no project restrictions, we set `project` to the submitted values
    - if the editing user has project restrictions:
        - we set `project` to the submitted values if it's a subset of the user's project restrictions
    - else:
        - we prevent edition

Note that the choices in the project drowpdown are limited tot the project restrictions of the user.

## How to test

Try to reproduce all the scenarios above.

## Print screen

![1](https://github.com/user-attachments/assets/5fd8eee0-20e2-4215-a82d-a1192ee13bfd)

![2](https://github.com/user-attachments/assets/b01e6203-b94b-4acb-8243-b327c5ec3a74)


