### PR TITLE
[IA-4188] Fixed module federation files generation

### DIFF
--- a/hat/assets/js/apps/Iaso/bundle/generators.js
+++ b/hat/assets/js/apps/Iaso/bundle/generators.js
@@ -3,9 +3,22 @@ const path = require('path');
 const { getAvailableLanguages } = require('./languages.js');
 const { getPluginFolders } = require('./plugins.js');
 
+/**
+ * Checks if file content is the same to avoid rewriting the same file.
+ * The goal is to avoid having webpack generate a new bundle every time with the same content.
+ * @param filePath
+ * @param content
+ */
+function writeFileIfChanged(filePath, content) {
+    if (fs.existsSync(filePath)) {
+        const existing = fs.readFileSync(filePath, 'utf-8');
+        if (existing === content) return;
+    }
+    fs.writeFileSync(filePath, content);
+}
+
 /** @param {string} rootDir */
 /** @param {string[]} availableLanguages */
-
 const generateCombinedTranslations = rootDir => {
     const availableLanguages = getAvailableLanguages(rootDir);
     const combinedTranslationsPath = path.resolve(
@@ -103,7 +116,7 @@ export default translations;
     }
 
     // Write the file
-    fs.writeFileSync(combinedTranslationsPath, fileContent);
+    writeFileIfChanged(combinedTranslationsPath, fileContent);
     return combinedTranslationsPath;
 };
 
@@ -154,7 +167,7 @@ export default combinedConfigs;
     }
 
     // Write the file
-    fs.writeFileSync(combinedConfigPath, fileContent);
+    writeFileIfChanged(combinedConfigPath, fileContent);
     return combinedConfigPath;
 };
 
@@ -183,7 +196,7 @@ export default pluginKeys;
     }
 
     // Write the file
-    fs.writeFileSync(pluginKeysPath, fileContent);
+    writeFileIfChanged(pluginKeysPath, fileContent);
     return pluginKeysPath;
 };
 
@@ -279,7 +292,7 @@ export default LANGUAGE_CONFIGS;
     }
 
     // Write the file
-    fs.writeFileSync(languageConfigsPath, fileContent);
+    writeFileIfChanged(languageConfigsPath, fileContent);
     return languageConfigsPath;
 };
 

--- a/hat/webpack.dev.js
+++ b/hat/webpack.dev.js
@@ -85,6 +85,7 @@ module.exports = {
         publicPath: ``, // replace here with `${WEBPACK_URL}/` to use another url for webpack
         assetModuleFilename: 'assets/[name].[hash][ext][query]',
         scriptType: 'text/javascript',
+        compareBeforeEmit: true,
     },
     devtool: 'source-map',
 


### PR DESCRIPTION
Prevents module federation from recreating the same files every ~2 minutes.

Related JIRA tickets : IA-4188

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [x] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

/

## Changes

- Changed webpack config to generate a new bundle only if files changed
- Changed module federation to write files only if their content is different

## How to test

If you are on macOS and don't have this bug, it's impossible to test. Just make sure that your local frontend still works.

Otherwise:
- Start your local IASO environment
- Open IASO in your web browser and let it live its life
- Do something else for a while (more than 3 minutes)
- Check your backend logs: there shouldn't be new refreshes every ~2 minutes
- Check your webpack logs: there shouldn't be new refreshes every ~2 minutes
- Check file creation timestamp in `hat/assets/js/apps/Iaso/bundle/generated` - files should date from when you started your local frontend and not from ~2 minutes ago

## Print screen / video

/

## Notes
This PR simply prevents from overwriting files with the same content. But the underlying issue is still there: some code is triggered every ~2 minutes and tries to overwrite these files, which doesn't make sense. The best way to fix it would be to generate these files once when the local environment starts and no more.

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
