### PR TITLE
POLIO-1936 Fix for bug showing all formas in vaccine stock

### DIFF
--- a/plugins/polio/api/vaccines/stock_management.py
+++ b/plugins/polio/api/vaccines/stock_management.py
@@ -301,8 +301,17 @@ class OutgoingStockMovementViewSet(VaccineStockSubitemBase):
     ]
 
     def get_queryset(self):
-        return OutgoingStockMovement.objects.filter(
+        vaccine_stock_id = self.request.query_params.get("vaccine_stock")
+
+        base_queryset = OutgoingStockMovement.objects.filter(
             Q(round__isnull=True) | Q(round__isnull=False, round__on_hold=False)
+        )
+
+        if vaccine_stock_id is None:
+            return base_queryset.filter(vaccine_stock__account=self.request.user.iaso_profile.account)
+
+        return base_queryset.filter(
+            vaccine_stock=vaccine_stock_id, vaccine_stock__account=self.request.user.iaso_profile.account
         )
 
     def create(self, request, *args, **kwargs):

--- a/plugins/polio/tests/test_vaccine_stock_management.py
+++ b/plugins/polio/tests/test_vaccine_stock_management.py
@@ -65,6 +65,15 @@ class VaccineStockManagementAPITestCase(APITestCase):
             validation_status=m.OrgUnit.VALIDATION_VALID,
             source_ref="TestlandRef",
         )
+
+        cls.country_2 = m.OrgUnit.objects.create(
+            org_unit_type=cls.org_unit_type_country,
+            version=cls.source_version_1,
+            name="Testland 2",
+            validation_status=m.OrgUnit.VALIDATION_VALID,
+            source_ref="TestlandRef2",
+        )
+
         cls.campaign = pm.Campaign.objects.create(
             obr_name="Test Campaign",
             country=cls.country,
@@ -104,6 +113,13 @@ class VaccineStockManagementAPITestCase(APITestCase):
             country=cls.country,
             vaccine=pm.VACCINES[0][0],
         )
+
+        cls.vaccine_stock_2 = pm.VaccineStock.objects.create(
+            account=cls.account,
+            country=cls.country_2,
+            vaccine=pm.VACCINES[0][0],
+        )
+
         cls.outgoing_stock_movement = pm.OutgoingStockMovement.objects.create(
             campaign=cls.campaign,
             vaccine_stock=cls.vaccine_stock,
@@ -113,6 +129,15 @@ class VaccineStockManagementAPITestCase(APITestCase):
             lot_numbers=["LOT123"],
             comment="Hello world",
         )
+
+        cls.outgoing_stock_movement_2 = pm.OutgoingStockMovement.objects.create(
+            campaign=cls.campaign,
+            vaccine_stock=cls.vaccine_stock_2,
+            report_date=cls.now - datetime.timedelta(days=3),
+            form_a_reception_date=cls.now - datetime.timedelta(days=2),
+            usable_vials_used=10,
+        )
+
         cls.destruction_report = pm.DestructionReport.objects.create(
             vaccine_stock=cls.vaccine_stock,
             action="Destroyed due to expiration",
@@ -189,7 +214,7 @@ class VaccineStockManagementAPITestCase(APITestCase):
         response = self.client.get(BASE_URL)
         self.assertEqual(response.status_code, 200)
         results = response.json()["results"]
-        self.assertEqual(len(results), 1)
+        self.assertEqual(len(results), 2)
         stock = results[0]
         self.assertEqual(stock["country_name"], "Testland")
         self.assertEqual(stock["vaccine_type"], pm.VACCINES[0][0])
@@ -809,8 +834,6 @@ class VaccineStockManagementAPITestCase(APITestCase):
         for result in data["results"]:
             self.assertEqual(result["vaccine_stock"], self.vaccine_stock.pk)
 
-            # Add a new test which adds the order=date_of_incident_report and verify that the results are ordered by date_of_incident_report
-
     def test_outgoing_stock_movement_list_ordered_by_date(self):
         self.client.force_authenticate(self.user_rw_perms)
 
@@ -1148,7 +1171,7 @@ class VaccineStockManagementAPITestCase(APITestCase):
         response = self.client.get(BASE_URL)
         self.assertEqual(response.status_code, 200)
         results = response.json()["results"]
-        self.assertEqual(len(results), 1)
+        self.assertEqual(len(results), 2)
         stock = results[0]
         self.assertEqual(stock["country_name"], "Testland")
         self.assertEqual(stock["vaccine_type"], pm.VACCINES[0][0])


### PR DESCRIPTION
Client reported all Form As of countries are appearing within the stock page, instead of only the one linked to the current vaccine stock.

Related JIRA tickets : POLIO-1936

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?

## Changes

Somehow the filtering by vaccine_stock (id) was lost in the process.

## How to test

Go on  Vaccine Stock, Then choose a country, click on the eye, then click on the stock variation button, it should display only the Form A for the current country/vaccine (not all countries)


## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
