### PR TITLE
IA-4172 Ensure that a user with `projects` restrictions can edit a user with the same `projects` restrictions

### DIFF
--- a/iaso/api/profiles/profiles.py
+++ b/iaso/api/profiles/profiles.py
@@ -711,7 +711,7 @@ class ProfilesViewSet(viewsets.ViewSet):
             return Project.objects.filter(id__in=new_project_ids, account=profile.account_id)
 
         profile_restricted_projects_ids = set(profile.projects_ids)
-        if profile_restricted_projects_ids.issuperset(user_restricted_projects_ids):
+        if profile_restricted_projects_ids > user_restricted_projects_ids:
             raise PermissionDenied("You cannot edit a user who has broader access to projects.")
 
         if new_project_ids.issubset(user_restricted_projects_ids):

--- a/iaso/api/profiles/profiles.py
+++ b/iaso/api/profiles/profiles.py
@@ -704,10 +704,8 @@ class ProfilesViewSet(viewsets.ViewSet):
 
         if not new_project_ids:
             if user_restricted_projects_ids:
-                # Apply the same project restrictions.
-                return Project.objects.filter(id__in=user_restricted_projects_ids, account=profile.account_id)
-            # No project restrictions.
-            return []
+                raise PermissionDenied("You must specify which projects are authorized for this user.")
+            return []  # No project restrictions.
 
         if not user_restricted_projects_ids:
             return Project.objects.filter(id__in=new_project_ids, account=profile.account_id)


### PR DESCRIPTION
Ensure that a user with `projects` restrictions can edit a user with the same `projects` restrictions.

Related JIRA tickets : IA-4172

Related PR: https://github.com/BLSQ/iaso/pull/2148

## Changes

- ensure that a user with `projects` restrictions can edit a user with the same `projects` restrictions
- ensure that a user with `projects` restrictions cannot create a user without restrictions
   - this was previously done implicitly
   - now an error is triggered and shown in the API when a user with `projects` restrictions tries to create/edit a user without restrictions

