### PR TITLE
IA-4199 Make `ProfilesViewSet.create()` and `ProfilesViewSet.partial_update()` atomic

### DIFF
--- a/iaso/api/profiles/profiles.py
+++ b/iaso/api/profiles/profiles.py
@@ -9,6 +9,7 @@ from django.contrib.auth.tokens import PasswordResetTokenGenerator
 from django.core.mail import send_mail
 from django.core.paginator import Paginator
 from django.db.models import Q, QuerySet
+from django.db.transaction import atomic
 from django.http import HttpRequest, HttpResponse, JsonResponse, StreamingHttpResponse
 from django.shortcuts import get_object_or_404
 from django.template import Context, Template
@@ -334,6 +335,7 @@ class ProfilesViewSet(viewsets.ViewSet):
             return Response(res)
         return Response({"profiles": [profile.as_short_dict() for profile in queryset]})
 
+    @atomic
     def create(self, request):
         current_profile = request.user.iaso_profile
         current_account = current_profile.account
@@ -457,6 +459,7 @@ class ProfilesViewSet(viewsets.ViewSet):
 
         return Response(user.profile.as_dict())
 
+    @atomic
     def partial_update(self, request, pk=None):
         if pk == PK_ME:
             return self.update_user_own_profile(request)

--- a/iaso/tests/api/test_profiles.py
+++ b/iaso/tests/api/test_profiles.py
@@ -786,6 +786,37 @@ class ProfileAPITestCase(APITestCase):
 
         self.assertEqual(response.status_code, 403)
 
+    def test_create_user_is_atomic(self):
+        project_1 = m.Project.objects.create(name="Project 1", app_id="project.1", account=self.account)
+        project_2 = m.Project.objects.create(name="Project 2", app_id="project.2", account=self.account)
+
+        username = "john_doe"
+
+        user = self.jim
+        user.iaso_profile.projects.set([project_1])
+
+        self.client.force_authenticate(user)
+
+        self.assertEqual(get_user_model().objects.filter(username=username).count(), 0)
+
+        data = {
+            "user_name": username,
+            "password": "password",
+            "first_name": "John",
+            "last_name": "Doe",
+            "email": "john@doe.com",
+            "projects": [project_2.id],
+        }
+        response = self.client.post("/api/profiles/", data=data, format="json")
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(
+            response.data["detail"],
+            "Some projects are outside your scope.",
+        )
+
+        # If the creation is not successfully completed, no changes should be committed to the database.
+        self.assertEqual(get_user_model().objects.filter(username=username).count(), 0)
+
     def assertValidProfileData(self, project_data: typing.Mapping):
         self.assertHasField(project_data, "id", int)
         self.assertHasField(project_data, "first_name", str)
@@ -1229,7 +1260,7 @@ class ProfileAPITestCase(APITestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["phone_number"], None)
 
-    def test_update_user_projects(self):
+    def test_update_user_with_projects_restrictions(self):
         new_project_1 = m.Project.objects.create(name="New project 1", app_id="new.project.1", account=self.account)
         new_project_2 = m.Project.objects.create(name="New project 2", app_id="new.project.2", account=self.account)
         profile_to_edit = Profile.objects.get(user=self.jum)


### PR DESCRIPTION
Make `ProfilesViewSet.create()` and `ProfilesViewSet.partial_update()` atomic.

Related JIRA tickets : IA-4199

## How to test

Go to user management `/dashboard/settings/users/management/`.

Ensure you are connected with a user having project restrictions, then:

- try creating a user without any project
- you should get an error message telling you that you have to associate a project to it
- add a project to that user

In the past you would get an error message telling you that the user already exists.

This PR fixes this bug and you shouldn't see that message at all.