### PR TITLE
POLIO-1875 Add Created At column to differentiate if multiple VRFs

### DIFF
--- a/plugins/polio/js/src/constants/translations/en.json
+++ b/plugins/polio/js/src/constants/translations/en.json
@@ -742,6 +742,7 @@
     "iaso.polio.label.Volunteers": "Volunteers",
     "iaso.polio.label.VRF": "VRF",
     "iaso.polio.label.VRF_NOT_SIGNED": "VRF not signed",
+    "iaso.polio.label.vrfCreatedAt": "VRF created at",
     "iaso.polio.label.vrfTitle": "Vaccine request form",
     "iaso.polio.label.vrfType": "Vaccine request form Type",
     "iaso.polio.label.vrfTypeMissing": "Missing",

--- a/plugins/polio/js/src/constants/translations/en.json
+++ b/plugins/polio/js/src/constants/translations/en.json
@@ -742,7 +742,7 @@
     "iaso.polio.label.Volunteers": "Volunteers",
     "iaso.polio.label.VRF": "VRF",
     "iaso.polio.label.VRF_NOT_SIGNED": "VRF not signed",
-    "iaso.polio.label.vrfCreatedAt": "VRF created at",
+    "iaso.polio.label.vrfCreatedAt": "VRF created",
     "iaso.polio.label.vrfTitle": "Vaccine request form",
     "iaso.polio.label.vrfType": "Vaccine request form Type",
     "iaso.polio.label.vrfTypeMissing": "Missing",

--- a/plugins/polio/js/src/constants/translations/fr.json
+++ b/plugins/polio/js/src/constants/translations/fr.json
@@ -741,7 +741,7 @@
     "iaso.polio.label.Volunteers": "Volontaires",
     "iaso.polio.label.VRF": "VRF",
     "iaso.polio.label.VRF_NOT_SIGNED": "VRF non signée",
-    "iaso.polio.label.vrfCreatedAt": "VRF créé le",
+    "iaso.polio.label.vrfCreatedAt": "Création VRF",
     "iaso.polio.label.vrfTitle": "Formulaire de demande de vaccins",
     "iaso.polio.label.vrfType": "Type de Formulaire de demande de vaccins",
     "iaso.polio.label.vrfTypeMissing": "Manquant",

--- a/plugins/polio/js/src/constants/translations/fr.json
+++ b/plugins/polio/js/src/constants/translations/fr.json
@@ -741,6 +741,7 @@
     "iaso.polio.label.Volunteers": "Volontaires",
     "iaso.polio.label.VRF": "VRF",
     "iaso.polio.label.VRF_NOT_SIGNED": "VRF non signée",
+    "iaso.polio.label.vrfCreatedAt": "VRF créé le",
     "iaso.polio.label.vrfTitle": "Formulaire de demande de vaccins",
     "iaso.polio.label.vrfType": "Type de Formulaire de demande de vaccins",
     "iaso.polio.label.vrfTypeMissing": "Manquant",

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Table/useVaccineSupplyChainTableColumns.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Table/useVaccineSupplyChainTableColumns.tsx
@@ -54,6 +54,12 @@ export const useVaccineSupplyChainTableColumns = (): Column[] => {
                 },
             },
             {
+                Header: formatMessage(MESSAGES.vrfCreatedAt),
+                accessor: 'created_at',
+                sortable: true,
+                Cell: DateCell,
+            },
+            {
                 Header: formatMessage(MESSAGES.startDate),
                 accessor: 'start_date',
                 sortable: true,

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/messages.ts
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/messages.ts
@@ -356,7 +356,7 @@ const MESSAGES = defineMessages({
     },
     vrfCreatedAt: {
         id: 'iaso.polio.label.vrfCreatedAt',
-        defaultMessage: 'VRF created at',
+        defaultMessage: 'VRF created',
     },
 });
 

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/messages.ts
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/messages.ts
@@ -354,6 +354,10 @@ const MESSAGES = defineMessages({
         id: 'iaso.polio.label.PoNumberNoPrefix',
         defaultMessage: 'Please input PO number without prefix',
     },
+    vrfCreatedAt: {
+        id: 'iaso.polio.label.vrfCreatedAt',
+        defaultMessage: 'VRF created at',
+    },
 });
 
 export default MESSAGES;

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/types.ts
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/types.ts
@@ -18,6 +18,7 @@ export type VRF = {
     campaign: string; // obr_name
     obr_name: string;
     vaccine_type: Vaccine;
+    created_at: string; // date in string form
     rounds: { number: number }[];
     date_vrf_signature: string; // date in string form
     quantities_ordered_in_doses?: number;


### PR DESCRIPTION
The client wants to be able to create multiple VRFs

The backend is already working for it. We decided to just add a column on the supply chain page to be able to differentiate when there are multiple VRFs

Related JIRA tickets : POLIO-1875

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [x] Are my typescript files well typed?
- [x] New translations have been added or updated if new strings have been introduced in the frontend

## Changes

Add a column "vrf created at" to the Main Vaccine Supply Chain page.

## How to test

Go on the Vaccine Supply Chain Page and see if there is a "VRF created at" column. You can also try to create multiple VRFs for the same country/vaccine/round

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
