### PR TITLE
IA-4178 Users admin can bypass project restrictions in users management 

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/users/components/Filters.js
+++ b/hat/assets/js/apps/Iaso/domains/users/components/Filters.js
@@ -23,7 +23,7 @@ const useStyles = makeStyles(theme => ({
     ...commonStyles(theme),
 }));
 
-const Filters = ({ baseUrl, params }) => {
+const Filters = ({ baseUrl, params, canBypassProjectRestrictions }) => {
     const [filtersUpdated, setFiltersUpdated] = useState(false);
     const [textSearchError, setTextSearchError] = useState(false);
     const classes = useStyles();
@@ -53,7 +53,7 @@ const Filters = ({ baseUrl, params }) => {
     const { data: orgUnitTypes, isFetching: isFetchingOuTypes } =
         useGetOrgUnitTypesDropdownOptions();
     const { data: allProjects, isFetching: isFetchingProjects } =
-        useGetProjectsDropdownOptions();
+        useGetProjectsDropdownOptions(true, canBypassProjectRestrictions);
     const { data: teamsDropdown, isFetching: isFetchingTeams } =
         useGetTeamsDropdown();
 

--- a/hat/assets/js/apps/Iaso/domains/users/components/UsersDialog.tsx
+++ b/hat/assets/js/apps/Iaso/domains/users/components/UsersDialog.tsx
@@ -53,6 +53,7 @@ type Props = {
     allowSendEmailInvitation?: boolean;
     isOpen: boolean;
     closeDialog: () => void;
+    canBypassProjectRestrictions: boolean;
 };
 
 // Declaring defaultData here because using initialData={} in the props below will cause and infinite loop
@@ -64,6 +65,7 @@ const UserDialogComponent: FunctionComponent<Props> = ({
     saveProfile,
     allowSendEmailInvitation = false,
     closeDialog,
+    canBypassProjectRestrictions,
 }) => {
     const connectedUser = useCurrentUser();
     const { formatMessage } = useSafeIntl();
@@ -265,6 +267,9 @@ const UserDialogComponent: FunctionComponent<Props> = ({
                             initialData={initialData}
                             currentUser={user}
                             allowSendEmailInvitation={allowSendEmailInvitation}
+                            canBypassProjectRestrictions={
+                                canBypassProjectRestrictions
+                            }
                         />
                     </div>
                     {tab === 'permissions' && (

--- a/hat/assets/js/apps/Iaso/domains/users/components/UsersInfos.js
+++ b/hat/assets/js/apps/Iaso/domains/users/components/UsersInfos.js
@@ -24,6 +24,7 @@ const UsersInfos = ({
     currentUser,
     initialData,
     allowSendEmailInvitation,
+    canBypassProjectRestrictions,
 }) => {
     const loggedUser = useCurrentUser();
     const { formatMessage } = useSafeIntl();
@@ -48,7 +49,7 @@ const UsersInfos = ({
         }
     }
     const { data: allProjects, isFetching: isFetchingProjects } =
-        useGetProjectsDropdownOptions();
+        useGetProjectsDropdownOptions(true, canBypassProjectRestrictions);
 
     const availableProjects = useMemo(() => {
         if (!loggedUser || !loggedUser.projects) {

--- a/hat/assets/js/apps/Iaso/domains/users/components/UsersInfos.js
+++ b/hat/assets/js/apps/Iaso/domains/users/components/UsersInfos.js
@@ -55,13 +55,10 @@ const UsersInfos = ({
         if (!loggedUser || !loggedUser.projects) {
             return [];
         }
-        if (loggedUser.projects.length === 0) {
-            return allProjects;
-        }
-        return loggedUser.projects.map(project => {
+        return allProjects.map(project => {
             return {
-                value: project.id.toString(),
-                label: project.name,
+                value: project.value,
+                label: project.label,
             };
         });
     }, [allProjects, loggedUser]);

--- a/hat/assets/js/apps/Iaso/domains/users/components/UsersMultiActionsDialog.tsx
+++ b/hat/assets/js/apps/Iaso/domains/users/components/UsersMultiActionsDialog.tsx
@@ -49,6 +49,7 @@ type Props = {
     selection: Selection<Profile>;
     setSelection: Dispatch<SetStateAction<Selection<Profile>>>;
     saveMulti: UseMutateAsyncFunction<unknown, unknown, unknown, unknown>;
+    canBypassProjectRestrictions: boolean;
 };
 
 const useStyles = makeStyles(theme => ({
@@ -114,6 +115,7 @@ export const UsersMultiActionsDialog: FunctionComponent<Props> = ({
     selection,
     setSelection,
     saveMulti,
+    canBypassProjectRestrictions,
 }) => {
     const currentUser = useCurrentUser();
     const appLocales = useAppLocales();
@@ -121,7 +123,7 @@ export const UsersMultiActionsDialog: FunctionComponent<Props> = ({
     const { formatMessage } = useSafeIntl();
     const classes: Record<string, string> = useStyles();
     const { data: allProjects, isFetching: isFetchingProjects } =
-        useGetProjectsDropdownOptions();
+        useGetProjectsDropdownOptions(true, canBypassProjectRestrictions);
 
     const { data: userRoles, isFetching: isFetchingUserRoles } =
         useGetUserRolesDropDown();

--- a/hat/assets/js/apps/Iaso/domains/users/config.js
+++ b/hat/assets/js/apps/Iaso/domains/users/config.js
@@ -21,6 +21,7 @@ export const usersTableColumns = ({
     currentUser,
     saveProfile,
     exportMobileSetup,
+    canBypassProjectRestrictions,
 }) => [
     {
         Header: formatMessage(MESSAGES.projects),
@@ -78,6 +79,7 @@ export const usersTableColumns = ({
                     titleMessage={MESSAGES.updateUser}
                     params={params}
                     saveProfile={saveProfile}
+                    canBypassProjectRestrictions={canBypassProjectRestrictions}
                 />
                 {currentUser.id !== settings.row.original.id &&
                     userHasOneOfPermissions(

--- a/hat/assets/js/apps/Iaso/domains/users/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/users/index.tsx
@@ -43,6 +43,7 @@ import { Profile } from '../teams/types/profile';
 import { UsersMultiActionsDialog } from './components/UsersMultiActionsDialog';
 import { useBulkSaveProfiles } from './hooks/useBulkSaveProfiles';
 import * as Permission from '../../utils/permissions';
+import { userHasPermission } from '../users/utils';
 import { useParamsObject } from '../../routing/hooks/useParamsObject';
 import { DisplayIfUserHasPerm } from '../../components/DisplayIfUserHasPerm';
 
@@ -61,6 +62,10 @@ export const Users: FunctionComponent = () => {
     const params = useParamsObject(baseUrls.users) as unknown as Params;
     const classes: Record<string, string> = useStyles();
     const currentUser = useCurrentUser();
+    const canBypassProjectRestrictions = userHasPermission(
+        Permission.USERS_ADMIN,
+        currentUser,
+    );
     const { formatMessage } = useSafeIntl();
     const redirectTo = useRedirectTo();
 
@@ -121,6 +126,7 @@ export const Users: FunctionComponent = () => {
                 saveMulti={(saveData: Record<string, any>) =>
                     bulkSave({ ...saveData, ...params })
                 }
+                canBypassProjectRestrictions={canBypassProjectRestrictions}
             />
             <TopBar
                 title={formatMessage(MESSAGES.users)}
@@ -128,7 +134,11 @@ export const Users: FunctionComponent = () => {
             />
             <Box className={classes.containerFullHeightNoTabPadded}>
                 {multiActionPopupOpen && 'SHOW MODALE'}
-                <Filters baseUrl={baseUrl} params={params} />
+                <Filters
+                    baseUrl={baseUrl}
+                    params={params}
+                    canBypassProjectRestrictions={canBypassProjectRestrictions}
+                />
                 <DisplayIfUserHasPerm
                     permissions={[
                         Permission.USERS_ADMIN,
@@ -149,6 +159,9 @@ export const Users: FunctionComponent = () => {
                             iconProps={{
                                 dataTestId: 'add-user-button',
                             }}
+                            canBypassProjectRestrictions={
+                                canBypassProjectRestrictions
+                            }
                         />
                         <Box ml={2}>
                             {/* @ts-ignore */}
@@ -172,6 +185,7 @@ export const Users: FunctionComponent = () => {
                         currentUser,
                         saveProfile,
                         exportMobileSetup,
+                        canBypassProjectRestrictions,
                     })}
                     count={data?.count ?? 0}
                     baseUrl={baseUrl}

--- a/iaso/api/profiles/bulk_create_users.py
+++ b/iaso/api/profiles/bulk_create_users.py
@@ -225,13 +225,6 @@ class BulkCreateUserFromCsvViewSet(ModelViewSet):
                         if ou.isdigit():
                             try:
                                 ou = OrgUnit.objects.select_related("org_unit_type").get(id=int(ou))
-                                if has_geo_limit and ou not in importer_access_ou:
-                                    raise serializers.ValidationError(
-                                        {
-                                            "error": f"Operation aborted. A User with {permission.USERS_MANAGED} permission "
-                                            "has to create users with OrgUnits that are in the its controlled pyramid"
-                                        }
-                                    )
                                 if ou not in importer_access_ou:
                                     raise serializers.ValidationError(
                                         {

--- a/iaso/api/profiles/bulk_create_users.py
+++ b/iaso/api/profiles/bulk_create_users.py
@@ -348,7 +348,7 @@ class BulkCreateUserFromCsvViewSet(ModelViewSet):
                         projects = None
                     if projects:
                         project_names = [name.strip() for name in projects.split(value_splitter) if name]
-                        if user_has_project_restrictions:
+                        if user_has_project_restrictions and has_geo_limit:
                             projects_instance_list = Project.objects.filter(
                                 name__in=project_names,
                                 account=importer_account,

--- a/iaso/api/profiles/profiles.py
+++ b/iaso/api/profiles/profiles.py
@@ -703,6 +703,11 @@ class ProfilesViewSet(viewsets.ViewSet):
 
     def validate_projects(self, request: HttpRequest, profile: Profile) -> list:
         new_project_ids = set([pk for pk in request.data.get("projects", []) if str(pk).isdigit()])
+
+        if not request.user.has_perm(permission.USERS_MANAGED) and (request.user.iaso_profile.pk == profile.pk):
+            # An admin should be able to add himself to any project.
+            return Project.objects.filter(id__in=new_project_ids, account=profile.account_id)
+
         user_restricted_projects_ids = set(request.user.iaso_profile.projects_ids)
 
         if not new_project_ids:

--- a/iaso/api/profiles/profiles.py
+++ b/iaso/api/profiles/profiles.py
@@ -704,8 +704,7 @@ class ProfilesViewSet(viewsets.ViewSet):
     def validate_projects(self, request: HttpRequest, profile: Profile) -> list:
         new_project_ids = set([pk for pk in request.data.get("projects", []) if str(pk).isdigit()])
 
-        if not request.user.has_perm(permission.USERS_MANAGED) and (request.user.iaso_profile.pk == profile.pk):
-            # An admin should be able to add himself to any project.
+        if request.user.has_perm(permission.USERS_ADMIN):
             return Project.objects.filter(id__in=new_project_ids, account=profile.account_id)
 
         user_restricted_projects_ids = set(request.user.iaso_profile.projects_ids)

--- a/iaso/api/projects/viewsets.py
+++ b/iaso/api/projects/viewsets.py
@@ -1,16 +1,20 @@
+from django.db.models import QuerySet
 from django.http import HttpResponse
 from qr_code.qrcode.maker import make_qr_code_image
 from qr_code.qrcode.utils import QRCodeOptions
-from rest_framework import filters, permissions, status
+from rest_framework import filters, permissions, serializers, status
 from rest_framework.decorators import action
 from rest_framework.exceptions import PermissionDenied
-from rest_framework.response import Response
 
 from hat.menupermissions import models as permission
 from iaso.models import Project
 
 from ..common import ModelViewSet
 from .serializers import ProjectSerializer
+
+
+class ProjectsQuerystringSerializer(serializers.Serializer):
+    bypass_restrictions = serializers.BooleanField(default=False)
 
 
 class ProjectsViewSet(ModelViewSet):
@@ -20,7 +24,6 @@ class ProjectsViewSet(ModelViewSet):
 
     GET /api/projects/
     GET /api/projects/<id>
-    GET /api/projects/list_all/
     """
 
     permission_classes = [permissions.IsAuthenticated]
@@ -30,12 +33,21 @@ class ProjectsViewSet(ModelViewSet):
     results_key = "projects"
     http_method_names = ["get", "head", "options", "trace"]
 
-    def get_queryset(self, filter_on_user_projects=True):
-        # Always filter the base queryset by account.
+    def get_queryset(self) -> QuerySet[Project]:
+        querystring = self.request.query_params
+        querystring_serializer = ProjectsQuerystringSerializer(data=querystring)
+        querystring_serializer.is_valid(raise_exception=True)
+        bypass_restrictions = querystring_serializer.validated_data.get("bypass_restrictions")
+
         projects = Project.objects.filter(account=self.request.user.iaso_profile.account)
 
-        if filter_on_user_projects:
+        if not bypass_restrictions:
             projects = projects.filter_on_user_projects(self.request.user)
+        else:
+            # An admin should be able to bypass its own project restrictions in some cases,
+            # e.g., for users management.
+            if not self.request.user.has_perm(permission.USERS_ADMIN):
+                raise PermissionDenied(f"{permission.USERS_ADMIN} permission is required to access all projects.")
 
         return projects
 
@@ -51,21 +63,3 @@ class ProjectsViewSet(ModelViewSet):
                 qr_code_options=QRCodeOptions(size="S", image_format="png", error_correction="L"),
             ),
         )
-
-    @action(detail=False, methods=["get"])
-    def list_all(self, request):
-        """
-        List all projects by skipping restrictions.
-        """
-        if not request.user.has_perm(permission.USERS_ADMIN):
-            raise PermissionDenied(f"{permission.USERS_ADMIN} permission is required.")
-
-        projects = self.filter_queryset(self.get_queryset(filter_on_user_projects=False))
-
-        page = self.paginate_queryset(projects)
-        if page is not None:
-            serializer = self.get_serializer(page, many=True)
-            return self.get_paginated_response(serializer.data)
-
-        serializer = self.get_serializer(projects, many=True)
-        return Response(serializer.data)

--- a/iaso/api/projects/viewsets.py
+++ b/iaso/api/projects/viewsets.py
@@ -3,7 +3,10 @@ from qr_code.qrcode.maker import make_qr_code_image
 from qr_code.qrcode.utils import QRCodeOptions
 from rest_framework import filters, permissions, status
 from rest_framework.decorators import action
+from rest_framework.exceptions import PermissionDenied
+from rest_framework.response import Response
 
+from hat.menupermissions import models as permission
 from iaso.models import Project
 
 from ..common import ModelViewSet
@@ -17,6 +20,7 @@ class ProjectsViewSet(ModelViewSet):
 
     GET /api/projects/
     GET /api/projects/<id>
+    GET /api/projects/list_all/
     """
 
     permission_classes = [permissions.IsAuthenticated]
@@ -26,12 +30,14 @@ class ProjectsViewSet(ModelViewSet):
     results_key = "projects"
     http_method_names = ["get", "head", "options", "trace"]
 
-    def get_queryset(self):
-        """Always filter the base queryset by account"""
+    def get_queryset(self, filter_on_user_projects=True):
+        # Always filter the base queryset by account.
+        projects = Project.objects.filter(account=self.request.user.iaso_profile.account)
 
-        return Project.objects.filter(account=self.request.user.iaso_profile.account).filter_on_user_projects(
-            self.request.user
-        )
+        if filter_on_user_projects:
+            projects = projects.filter_on_user_projects(self.request.user)
+
+        return projects
 
     @action(detail=True, methods=["get"])
     def qr_code(self, request, *args, **kwargs):
@@ -45,3 +51,21 @@ class ProjectsViewSet(ModelViewSet):
                 qr_code_options=QRCodeOptions(size="S", image_format="png", error_correction="L"),
             ),
         )
+
+    @action(detail=False, methods=["get"])
+    def list_all(self, request):
+        """
+        List all projects by skipping restrictions.
+        """
+        if not request.user.has_perm(permission.USERS_ADMIN):
+            raise PermissionDenied(f"{permission.USERS_ADMIN} permission is required.")
+
+        projects = self.filter_queryset(self.get_queryset(filter_on_user_projects=False))
+
+        page = self.paginate_queryset(projects)
+        if page is not None:
+            serializer = self.get_serializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
+
+        serializer = self.get_serializer(projects, many=True)
+        return Response(serializer.data)

--- a/iaso/tests/api/test_profiles.py
+++ b/iaso/tests/api/test_profiles.py
@@ -1381,6 +1381,22 @@ class ProfileAPITestCase(APITestCase):
             "Some projects are outside your scope.",
         )
 
+        # An "admin" user with `projects` restrictions can assign projects outside his range.
+        user.user_permissions.add(Permission.objects.get(codename=permission._USERS_ADMIN))
+        del user._perm_cache
+        del user._user_perm_cache
+        self.assertTrue(user.has_perm(permission.USERS_ADMIN))
+        user.iaso_profile.projects.set([self.project])
+        response = self.client.patch(
+            f"/api/profiles/{profile_to_edit.id}/",
+            data={
+                "user_name": "jum_new_user_name",
+                "projects": [new_project_2.id],
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200)
+
     def test_admin_should_be_able_to_bypass_projects_restrictions_for_himself(self):
         """
         An admin with `projects` restrictions should be able to assign himself to any project.

--- a/iaso/tests/api/test_profiles.py
+++ b/iaso/tests/api/test_profiles.py
@@ -792,7 +792,7 @@ class ProfileAPITestCase(APITestCase):
 
         username = "john_doe"
 
-        user = self.jim
+        user = self.user_managed_geo_limit
         user.iaso_profile.projects.set([project_1])
 
         self.client.force_authenticate(user)
@@ -806,6 +806,7 @@ class ProfileAPITestCase(APITestCase):
             "last_name": "Doe",
             "email": "john@doe.com",
             "projects": [project_2.id],
+            "org_units": [{"id": self.org_unit_from_parent_type.id}],
         }
         response = self.client.post("/api/profiles/", data=data, format="json")
         self.assertEqual(response.status_code, 403)

--- a/iaso/tests/fixtures/test_user_bulk_create_managed_geo_limit.csv
+++ b/iaso/tests/fixtures/test_user_bulk_create_managed_geo_limit.csv
@@ -1,4 +1,4 @@
 username,password,email,first_name,last_name,orgunit,orgunit__source_ref,dhis2_id,organization,profile_language,permissions,user_roles,projects,phone_number,editable_org_unit_types
-broly,yOdnjdln8!,biobroly@bluesquarehub.com,broly,bio,1112,,,,fr,,,,,
-ferdinand,dEF80s:ghd,fdzepplin@bluesquarehub.com,ferdinand,von Zepplin,1112,,,,fr,,,,,
+broly,yOdnjdln8!,biobroly@bluesquarehub.com,broly,bio,1112,,,,fr,,,Project name,,
+ferdinand,dEF80s:ghd,fdzepplin@bluesquarehub.com,ferdinand,von Zepplin,1112,,,,fr,,,Project name,,
 rsfg,frdgEF73f9!,,feesf,dsfsf,1112,,,,FR,,,,,


### PR DESCRIPTION
Users with the `USERS_ADMIN` permission can bypass project restrictions in users management.

Related JIRA tickets : IA-4178

## Changes

Backend:

- add a new `bypass_restrictions` param to the `/api/projects/` endpoint
- bypass project restrictions in `/api/profiles/` for `USERS_ADMIN` permission
- bypass project restrictions in `/api/bulkcreateuser/` for `USERS_ADMIN` permission
- `/api/tasks/create/profilesbulkupdate/` is left unchanged because [it's already exclusive to admins](https://github.com/BLSQ/iaso/blob/cece49b7ae4ba136da4e9dbe769177fb635ebe5e/iaso/tasks/profiles_bulk_update.py#L82-L85)

Frontend:

- call the `/api/projects/` endpoint with the `bypass_restrictions` param when necessary

## How to test

Connect with a user having the `USERS_MANAGED` permission (which means "geo-restricted"):

- go to `/dashboard/settings/users/management/` 
- project restrictions should be enforced (if any)

Connect with a user having the `USERS_ADMIN` permission:

- go to `/dashboard/settings/users/management/` 
- admin should be able to access to all projects in the account and bypass any restrictions
