### PR TITLE
POLIO-1927: sub activities overlap calendar

### DIFF
--- a/plugins/polio/js/src/constants/messages.ts
+++ b/plugins/polio/js/src/constants/messages.ts
@@ -1234,6 +1234,10 @@ const MESSAGES = defineMessages({
         id: 'iaso.polio.label.subactivityName',
         defaultMessage: 'Sub-activity name',
     },
+    subactivity: {
+        id: 'iaso.polio.label.subactivity',
+        defaultMessage: 'Sub-activity',
+    },
     round: {
         id: 'iaso.polio.label.round',
         defaultMessage: 'Round',

--- a/plugins/polio/js/src/constants/translations/en.json
+++ b/plugins/polio/js/src/constants/translations/en.json
@@ -685,6 +685,7 @@
     "iaso.polio.label.stockToModify": "Stock to modify",
     "iaso.polio.label.stockVariation": "Stock variation",
     "iaso.polio.label.subactivities": "Sub-activities",
+    "iaso.polio.label.subactivity": "Sub-activity",
     "iaso.polio.label.subactivityName": "Sub-activity name",
     "iaso.polio.label.submission": "Submission",
     "iaso.polio.label.submitted": "Submitted",

--- a/plugins/polio/js/src/constants/translations/fr.json
+++ b/plugins/polio/js/src/constants/translations/fr.json
@@ -684,6 +684,7 @@
     "iaso.polio.label.stockToModify": "Stock à modifier",
     "iaso.polio.label.stockVariation": "Variation des stocks",
     "iaso.polio.label.subactivities": "Sous-activités",
+    "iaso.polio.label.subactivity": "Sous-activité",
     "iaso.polio.label.subactivityName": "Nom de la sous-activité",
     "iaso.polio.label.submission": "Soumission",
     "iaso.polio.label.submitted": "Soumis",

--- a/plugins/polio/js/src/domains/Calendar/campaignCalendar/CampaignRows.tsx
+++ b/plugins/polio/js/src/domains/Calendar/campaignCalendar/CampaignRows.tsx
@@ -1,13 +1,14 @@
 import React, { Fragment, FunctionComponent, useState } from 'react';
 
-import { TableRow } from '@mui/material';
+import { Box, TableCell, TableRow } from '@mui/material';
 
+import classnames from 'classnames';
 import { StaticFieldsCells } from './cells/StaticFields';
 import { StaticSubactivitiesFields } from './cells/StaticSubactivitiesFields';
 import { useStyles } from './Styles';
 import { CalendarData, CalendarParams, MappedCampaign } from './types';
 import { getRoundsCells } from './utils/rounds';
-import { getSubActivitiesCells } from './utils/subactivities';
+import { getSubActivitiesRow } from './utils/subactivities';
 
 type Props = {
     campaign: MappedCampaign;
@@ -27,7 +28,8 @@ export const CampaignRows: FunctionComponent<Props> = ({
     params,
 }) => {
     const classes = useStyles();
-    const [subActivitiesExpanded, setSubActivitiesExpanded] = useState(false);
+    const [subActivitiesExpanded, setSubActivitiesExpanded] = useState(true);
+    const defaultCellStyles = [classes.tableCell, classes.tableCellBordered];
     return (
         <Fragment key={`row-${campaign.id}`}>
             <TableRow className={classes.tableRow}>
@@ -48,24 +50,46 @@ export const CampaignRows: FunctionComponent<Props> = ({
             {subActivitiesExpanded &&
                 campaign.rounds
                     .filter(round => round.subActivities.length > 0)
-                    .map(round => (
-                        <TableRow
-                            className={classes.tableRowSmall}
-                            key={`round-${round.id}`}
-                        >
-                            <StaticSubactivitiesFields
-                                isPdf={isPdf}
-                                roundNumber={round.number}
-                            />
-                            {getSubActivitiesCells(
-                                campaign,
-                                round.subActivities,
-                                currentWeekIndex,
-                                firstMonday,
-                                lastSunday,
-                            )}
-                        </TableRow>
-                    ))}
+                    .map(round =>
+                        round.subActivities.map((subActivity, idx) => (
+                            <TableRow
+                                className={classes.tableRowSmall}
+                                key={`round-${round.id}-subactivity-${subActivity.id}`}
+                            >
+                                {idx === 0 && (
+                                    <TableCell
+                                        rowSpan={round.subActivities.length}
+                                        className={classnames(
+                                            defaultCellStyles,
+                                        )}
+                                        sx={{
+                                            fontSize: '9px',
+                                        }}
+                                    >
+                                        <Box
+                                            sx={{
+                                                display: 'flex',
+                                                justifyContent: 'center',
+                                            }}
+                                        >
+                                            R{round.number}
+                                        </Box>
+                                    </TableCell>
+                                )}
+                                <StaticSubactivitiesFields
+                                    isPdf={isPdf}
+                                    subActivity={subActivity}
+                                />
+                                {getSubActivitiesRow(
+                                    subActivity,
+                                    firstMonday,
+                                    lastSunday,
+                                    currentWeekIndex,
+                                    campaign,
+                                )}
+                            </TableRow>
+                        )),
+                    )}
         </Fragment>
     );
 };

--- a/plugins/polio/js/src/domains/Calendar/campaignCalendar/cells/StaticSubactivitiesFields.tsx
+++ b/plugins/polio/js/src/domains/Calendar/campaignCalendar/cells/StaticSubactivitiesFields.tsx
@@ -8,15 +8,16 @@ import MESSAGES from '../../../../constants/messages';
 import { useStaticFields } from '../../hooks/useStaticFields';
 import { colSpanTitle } from '../constants';
 import { useStyles } from '../Styles';
+import { SubActivity } from '../types';
 
 type Props = {
     isPdf: boolean;
-    roundNumber: number;
+    subActivity: SubActivity;
 };
 
 export const StaticSubactivitiesFields: FunctionComponent<Props> = ({
     isPdf,
-    roundNumber,
+    subActivity,
 }) => {
     const classes = useStyles();
     const { formatMessage } = useSafeIntl();
@@ -24,7 +25,7 @@ export const StaticSubactivitiesFields: FunctionComponent<Props> = ({
     const fields = useStaticFields(isPdf);
     return (
         <TableCell
-            colSpan={colSpanTitle * fields.length}
+            colSpan={colSpanTitle * fields.length - 1}
             className={classnames(defaultCellStyles)}
         >
             <Box
@@ -35,11 +36,9 @@ export const StaticSubactivitiesFields: FunctionComponent<Props> = ({
                 sx={{
                     display: 'flex',
                     justifyContent: 'center',
-                    textTransform: 'uppercase',
                 }}
             >
-                {formatMessage(MESSAGES.subactivities)}{' '}
-                {formatMessage(MESSAGES.round)} {roundNumber}
+                {formatMessage(MESSAGES.subactivity)}: {subActivity.name}
             </Box>
         </TableCell>
     );

--- a/plugins/polio/js/src/domains/Calendar/campaignCalendar/cells/StaticSubactivitiesFields.tsx
+++ b/plugins/polio/js/src/domains/Calendar/campaignCalendar/cells/StaticSubactivitiesFields.tsx
@@ -4,6 +4,7 @@ import { Box, TableCell } from '@mui/material';
 import { useSafeIntl } from 'bluesquare-components';
 import classnames from 'classnames';
 
+import { SxStyles } from 'Iaso/types/general';
 import MESSAGES from '../../../../constants/messages';
 import { useStaticFields } from '../../hooks/useStaticFields';
 import { colSpanTitle } from '../constants';
@@ -13,33 +14,57 @@ import { SubActivity } from '../types';
 type Props = {
     isPdf: boolean;
     subActivity: SubActivity;
+    displayRoundCell: boolean;
+    roundNumber: number;
+    subActivitiesCount: number;
+};
+const styles: SxStyles = {
+    roundCell: {
+        display: 'flex',
+        justifyContent: 'center',
+        fontSize: '9px',
+    },
+    subactivityCell: {
+        display: 'flex',
+        justifyContent: 'center',
+    },
 };
 
 export const StaticSubactivitiesFields: FunctionComponent<Props> = ({
     isPdf,
     subActivity,
+    displayRoundCell,
+    roundNumber,
+    subActivitiesCount,
 }) => {
     const classes = useStyles();
     const { formatMessage } = useSafeIntl();
     const defaultCellStyles = [classes.tableCell, classes.tableCellBordered];
     const fields = useStaticFields(isPdf);
     return (
-        <TableCell
-            colSpan={colSpanTitle * fields.length - 1}
-            className={classnames(defaultCellStyles)}
-        >
-            <Box
-                className={classnames(
-                    classes.tableCellSpan,
-                    classes.tableCellSpanRow,
-                )}
-                sx={{
-                    display: 'flex',
-                    justifyContent: 'center',
-                }}
+        <>
+            {displayRoundCell && (
+                <TableCell
+                    rowSpan={subActivitiesCount}
+                    className={classnames(defaultCellStyles)}
+                >
+                    <Box sx={styles.roundCell}>R{roundNumber}</Box>
+                </TableCell>
+            )}
+            <TableCell
+                colSpan={colSpanTitle * fields.length - 1}
+                className={classnames(defaultCellStyles)}
             >
-                {formatMessage(MESSAGES.subactivity)}: {subActivity.name}
-            </Box>
-        </TableCell>
+                <Box
+                    className={classnames(
+                        classes.tableCellSpan,
+                        classes.tableCellSpanRow,
+                    )}
+                    sx={styles.subactivityCell}
+                >
+                    {formatMessage(MESSAGES.subactivity)}: {subActivity.name}
+                </Box>
+            </TableCell>
+        </>
     );
 };

--- a/plugins/polio/js/src/domains/Calendar/campaignCalendar/types.ts
+++ b/plugins/polio/js/src/domains/Calendar/campaignCalendar/types.ts
@@ -21,7 +21,7 @@ export type CalendarRound = {
     end?: Moment;
     number: number;
     start?: Moment;
-    id?: number;
+    id: number;
     started_at?: string;
     ended_at?: string;
     daysCount?: number;

--- a/plugins/polio/js/src/domains/Calendar/campaignCalendar/utils/subactivities.tsx
+++ b/plugins/polio/js/src/domains/Calendar/campaignCalendar/utils/subactivities.tsx
@@ -5,7 +5,6 @@ import { SubactivityCell } from '../cells/SubactivityCell';
 import { MappedCampaign, SubActivity } from '../types';
 import {
     addRemainingEmptyCells,
-    getEmptyCellBetweenTwoDates,
     drawEmptyFirstCells,
     isDateInRange,
 } from './index';
@@ -70,98 +69,50 @@ const addSubactivityCell = ({
     return result;
 };
 
-const getSubActivitiesRow = (
-    originalCells: ReactElement[],
-    subActivities: SubActivity[],
+export const getSubActivitiesRow = (
+    subActivity: SubActivity,
     firstMonday: Moment,
     lastSunday: Moment,
     currentWeekIndex: number,
     campaign: MappedCampaign,
 ): ReactElement[] => {
     // First order subActivities by start date and filter out subActivities that are not in range
-    let cells = [...originalCells];
-    if (subActivities.length > 0) {
-        // Draw cells before first subActivity
-        const firstSubActivity = subActivities[0];
-        if (firstMonday.isBefore(firstSubActivity.start_date, 'day')) {
-            const emptyCells = drawEmptyFirstCells({
-                startDate: firstSubActivity.start_date.clone(),
-                firstMonday,
-                currentWeekIndex,
-                id: campaign.id,
-            });
-            cells.push(...emptyCells);
-        }
-        // loop into subActivities
-        subActivities.forEach((subActivity, index) => {
-            const startInRange = subActivity.start_date
-                ? isDateInRange(
-                      subActivity.start_date.clone(),
-                      firstMonday,
-                      lastSunday,
-                  )
-                : false;
-            const endInRange = subActivity.end_date
-                ? isDateInRange(
-                      subActivity.end_date.clone(),
-                      firstMonday,
-                      lastSunday,
-                  )
-                : false;
-            // Draw subactivity
-            cells = addSubactivityCell({
-                cells,
-                subActivity,
-                firstMonday,
-                lastSunday,
-                startInRange,
-                endInRange,
-                campaign,
-            });
-            // Draw cells after subActivity
-            const nextSubActivity = subActivities[index + 1];
-            if (nextSubActivity) {
-                const nextStartDate = nextSubActivity?.start_date.clone();
-                const emptyBetweenCells = getEmptyCellBetweenTwoDates(
-                    subActivity.end_date.clone(),
-                    nextStartDate,
-                    cells,
-                    currentWeekIndex,
-                );
-                cells.push(...emptyBetweenCells);
-            }
-        });
-
-        // Draw cells after last subActivity
-        cells = addRemainingEmptyCells({
-            cells,
-            dateUntilNextRound:
-                subActivities[subActivities.length - 1].end_date.clone(),
-            lastSunday,
-            campaign,
-            currentWeekIndex,
-        });
-    }
-
-    return cells;
-};
-
-export const getSubActivitiesCells = (
-    campaign: MappedCampaign,
-    subActivities: SubActivity[],
-    currentWeekIndex: number,
-    firstMonday: Moment,
-    lastSunday: Moment,
-): ReactElement[] => {
     let cells: ReactElement[] = [];
-
-    cells = getSubActivitiesRow(
+    // Draw cells before first subActivity
+    if (firstMonday.isBefore(subActivity.start_date, 'day')) {
+        const emptyCells = drawEmptyFirstCells({
+            startDate: subActivity.start_date.clone(),
+            firstMonday,
+            currentWeekIndex,
+            id: campaign.id,
+        });
+        cells.push(...emptyCells);
+    }
+    const startInRange = subActivity.start_date
+        ? isDateInRange(subActivity.start_date.clone(), firstMonday, lastSunday)
+        : false;
+    const endInRange = subActivity.end_date
+        ? isDateInRange(subActivity.end_date.clone(), firstMonday, lastSunday)
+        : false;
+    // Draw subactivity
+    cells = addSubactivityCell({
         cells,
-        subActivities,
+        subActivity,
         firstMonday,
         lastSunday,
-        currentWeekIndex,
+        startInRange,
+        endInRange,
         campaign,
-    );
+    });
+
+    // Draw cells after last subActivity
+    cells = addRemainingEmptyCells({
+        cells,
+        dateUntilNextRound: subActivity.end_date.clone(),
+        lastSunday,
+        campaign,
+        currentWeekIndex,
+    });
+
     return cells;
 };

--- a/plugins/polio/js/src/domains/Campaigns/SubActivities/SubActivityForm.tsx
+++ b/plugins/polio/js/src/domains/Campaigns/SubActivities/SubActivityForm.tsx
@@ -1,11 +1,11 @@
 import React, { FunctionComponent } from 'react';
-import { Table } from 'bluesquare-components';
 import { Box } from '@mui/material';
-import { Round } from '../../../constants/types';
+import { Table } from 'bluesquare-components';
 import { useTableState } from '../../../../../../../hat/assets/js/apps/Iaso/utils/table';
+import { Round } from '../../../constants/types';
+import { SubActivitiesInfos } from './components/SubActivitiesInfos';
 import { useGetSubActivities } from './hooks/api/useGetSubActivities';
 import { useSubActivitiesColumns } from './hooks/useSubActivitiesColumns';
-import { SubActivitiesInfos } from './components/SubActivitiesInfos';
 
 type Props = { round?: Round };
 

--- a/plugins/polio/js/src/domains/Campaigns/SubActivities/hooks/api/useDeleteSubActivity.ts
+++ b/plugins/polio/js/src/domains/Campaigns/SubActivities/hooks/api/useDeleteSubActivity.ts
@@ -11,7 +11,7 @@ const deleteActivity = (id: string) => {
 export const useDeleteSubActivity = (): UseMutationResult => {
     return useSnackMutation({
         mutationFn: deleteActivity,
-        invalidateQueryKey: 'subActivities',
+        invalidateQueryKey: ['subActivities', 'calendar-campaigns'],
         // TODO add success and error messages
     });
 };

--- a/plugins/polio/js/src/domains/Campaigns/SubActivities/hooks/useSubActivitiesColumns.tsx
+++ b/plugins/polio/js/src/domains/Campaigns/SubActivities/hooks/useSubActivitiesColumns.tsx
@@ -1,12 +1,12 @@
 import React, { useMemo } from 'react';
 import { Column, useSafeIntl } from 'bluesquare-components';
-import DeleteDialog from '../../../../../../../../hat/assets/js/apps/Iaso/components/dialogs/DeleteDialogComponent';
 import { DateCell } from '../../../../../../../../hat/assets/js/apps/Iaso/components/Cells/DateTimeCell';
-import { AgeRangeCell } from '../components/AgeRangeCell';
-import MESSAGES from '../messages';
-import { EditSubActivity } from '../components/Modal/CreateEditSubActivity';
-import { useDeleteSubActivity } from './api/useDeleteSubActivity';
+import DeleteDialog from '../../../../../../../../hat/assets/js/apps/Iaso/components/dialogs/DeleteDialogComponent';
 import { Round } from '../../../../constants/types';
+import { AgeRangeCell } from '../components/AgeRangeCell';
+import { EditSubActivity } from '../components/Modal/CreateEditSubActivity';
+import MESSAGES from '../messages';
+import { useDeleteSubActivity } from './api/useDeleteSubActivity';
 
 export const useSubActivitiesColumns = (round?: Round): Column[] => {
     const { formatMessage } = useSafeIntl();


### PR DESCRIPTION
Sub activiteis per round can be. on the same date, we should adapt the UI to display it correctly

Related JIRA tickets :POLIO-1927

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [x] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)


## Changes

- Use a row per subactivity allowing overlapping sub activities
- fix calendar refresh while deleting a sub activity

## How to test

Visit plain and public calendar and make sure you have sub activities with overlapping dates, expend the row and check everyting renders correctly 
try to delete a sub activity and check that calendar is refreshing

## Print screen / video

<img width="1134" alt="Screenshot 2025-05-15 at 12 17 17" src="https://github.com/user-attachments/assets/1ebf1a8f-1377-4a31-9135-5f8649acdfad" />

