### PR TITLE
[IA-4148] Fix PaymentLot creation select_all

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/payments/hooks/requests/useGetPotentialPayments.tsx
+++ b/hat/assets/js/apps/Iaso/domains/payments/hooks/requests/useGetPotentialPayments.tsx
@@ -1,9 +1,9 @@
 import { UseQueryResult } from 'react-query';
-import { makeUrlWithParams } from '../../../../libs/utils';
 import { getRequest } from '../../../../libs/Api';
 import { useSnackQuery } from '../../../../libs/apiHooks';
-import { PotentialPaymentParams, PotentialPaymentPaginated } from '../../types';
+import { makeUrlWithParams } from '../../../../libs/utils';
 import { apiDateFormat, formatDateString } from '../../../../utils/dates';
+import { PotentialPaymentParams, PotentialPaymentPaginated } from '../../types';
 
 const apiUrl = '/api/potential_payments/';
 

--- a/hat/assets/js/apps/Iaso/domains/payments/hooks/requests/useGetSelectedPotentialPayments.tsx
+++ b/hat/assets/js/apps/Iaso/domains/payments/hooks/requests/useGetSelectedPotentialPayments.tsx
@@ -1,7 +1,8 @@
 import { UseQueryResult } from 'react-query';
-import { makeUrlWithParams } from '../../../../libs/utils';
+import { apiDateFormat, formatDateString } from 'Iaso/utils/dates';
 import { getRequest } from '../../../../libs/Api';
 import { useSnackQuery } from '../../../../libs/apiHooks';
+import { makeUrlWithParams } from '../../../../libs/utils';
 import { Selection } from '../../../orgUnits/types/selection';
 import {
     PotentialPaymentParams,
@@ -26,8 +27,16 @@ const getSelectedPotentialPayments = (
     const { selectAll, selectedItems, unSelectedItems } = selection;
     const apiParams = {
         order: options.order || 'user__last_name',
-        change_requests__created_at_after,
-        change_requests__created_at_before,
+        change_requests__created_at_after: formatDateString(
+            change_requests__created_at_after,
+            'L',
+            apiDateFormat,
+        ),
+        change_requests__created_at_before: formatDateString(
+            change_requests__created_at_before,
+            'L',
+            apiDateFormat,
+        ),
         parent_id,
         forms,
         users,


### PR DESCRIPTION
Fixed wrong behavior with ` select_all` when making new payment lots. 

Related JIRA tickets : IA-4148

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [x] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

/

## Changes

- Changed date format passed to the backend 


## How to test

- Have multiple change requests, created by various users (and if possible on various parts of your pyramid, with various forms...)
- Edit the creation date of your change requests through the admin panel to have various dates
- Go to the potential payments page
- Fill out some fields (include either `Creation date from` or `Creation date to`) to filter out some of the potential payments
- Click on `Select all`
- Click on `+ Create a new lot of payments`
- The list in the modal window should match the list in the main window; before this PR, it wasn't the case
 
## Print screen / video
**setup**

![image](https://github.com/user-attachments/assets/8045b5b4-c2c3-405b-8a28-bad54927e77d)

**before**
![image](https://github.com/user-attachments/assets/036bc2b1-d310-4fb5-a9dc-0e93df296f58)

**after**
![image](https://github.com/user-attachments/assets/087bf720-b8df-4b42-bb28-8ef4869510cc)


## Notes

We thought this was an issue with `select_all` but it was actually a date format issue caused by the frontend

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
