### PR TITLE
POLIO-1922: prevent vrf creation for round without scope (backend)

### DIFF
--- a/plugins/polio/api/vaccines/supply_chain.py
+++ b/plugins/polio/api/vaccines/supply_chain.py
@@ -57,6 +57,8 @@ def validate_rounds_and_campaign(data, current_user=None, force_rounds=True, for
             if isinstance(round, dict) and "number" in round:
                 try:
                     round_obj = Round.objects.get(number=round["number"], campaign=new_campaign)
+                    if not round_obj.actual_scopes:
+                        raise forms.ValidationError("Rounds without scope are not allowed")
                     new_rounds.append(round_obj)
                 except Round.MultipleObjectsReturned:
                     raise forms.ValidationError(f"Multiple rounds with number {round['number']} found in the campaign.")
@@ -64,6 +66,8 @@ def validate_rounds_and_campaign(data, current_user=None, force_rounds=True, for
                     raise forms.ValidationError(f"No round with number {round['number']} found in the campaign.")
             elif hasattr(round, "campaign") and round.campaign != new_campaign:
                 raise forms.ValidationError("Each round's campaign must be the same as the form's campaign.")
+            elif not round.actual_scopes:
+                raise forms.ValidationError("Rounds without scope are not allowed")
         data["rounds"] = new_rounds
     else:
         try:
@@ -71,6 +75,8 @@ def validate_rounds_and_campaign(data, current_user=None, force_rounds=True, for
             for round in rounds_data.all():
                 if round.campaign != new_campaign:
                     raise forms.ValidationError("Each round's campaign must be the same as the form's campaign.")
+                if not round.actual_scopes:
+                    raise forms.ValidationError("Rounds without scope are not allowed")
                 new_rounds.append(round)
             data["rounds"] = new_rounds
         except AttributeError:

--- a/plugins/polio/tests/api/vaccine_supply_chain/base.py
+++ b/plugins/polio/tests/api/vaccine_supply_chain/base.py
@@ -67,6 +67,10 @@ class BaseVaccineSupplyChainAPITestCase(APITestCase):
 
         cls.org_unit_type_country.projects.set([cls.project, cls.project_2])
         cls.org_unit_type_country.save()
+        cls.org_unit_type_district = m.OrgUnitType.objects.create(name="DISTRICT", category="DISTRICT")
+
+        cls.org_unit_type_district.projects.set([cls.project, cls.project_2])
+        cls.org_unit_type_district.save()
 
         cls.org_unit_DRC = m.OrgUnit.objects.create(
             org_unit_type=cls.org_unit_type_country,

--- a/plugins/polio/tests/api/vaccine_supply_chain/test_vaccine_supply_chain.py
+++ b/plugins/polio/tests/api/vaccine_supply_chain/test_vaccine_supply_chain.py
@@ -6,10 +6,11 @@ from django.utils import timezone
 from iaso.utils.models.virus_scan import VirusScanStatus
 from plugins.polio import models as pm
 from plugins.polio.api.vaccines.supply_chain import AR_SET, PA_SET
+from plugins.polio.tests.api.test import PolioTestCaseMixin
 from plugins.polio.tests.api.vaccine_supply_chain.base import BaseVaccineSupplyChainAPITestCase
 
 
-class VaccineSupplyChainAPITestCase(BaseVaccineSupplyChainAPITestCase):
+class VaccineSupplyChainAPITestCase(BaseVaccineSupplyChainAPITestCase, PolioTestCaseMixin):
     def test_anonymous_user_cannot_see_list(self):
         self.client.force_authenticate(user=self.anon)
         response = self.client.get(self.BASE_URL)
@@ -631,3 +632,48 @@ class VaccineSupplyChainAPITestCase(BaseVaccineSupplyChainAPITestCase):
         # Check that the document name and size are the same as before
         self.assertEqual(updated_pre_alert.document.name, original_document_name)
         self.assertEqual(updated_pre_alert.document.size, original_document_size)
+
+    def test_vrf_cannot_be_created_for_round_without_scope(self):
+        campaign, rnd1, _, _, _, _ = self.create_campaign(
+            "NO_SCOPE_CAMPAIGN",
+            self.account,
+            self.source_version_1,
+            self.org_unit_type_country,
+            self.org_unit_type_district,
+        )
+        campaign.separate_scopes_per_round = True
+        campaign.save()
+        self.client.force_authenticate(user=self.user_rw_perm)
+        response = self.client.post(
+            self.BASE_URL,
+            data={
+                "campaign": campaign.id,
+                "rounds": [rnd1.id],
+                "vaccine_type": pm.VACCINES[0][0],
+                "date_vrf_reception": self.now - datetime.timedelta(days=1),
+                "date_vrf_signature": self.now,
+                "date_dg_approval": self.now,
+                "quantities_ordered_in_doses": 1000000,
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400)
+
+        campaign.separate_scopes_per_round = False
+        campaign.scopes.set([])
+        campaign.save()
+
+        response = self.client.post(
+            self.BASE_URL,
+            data={
+                "campaign": campaign.id,
+                "rounds": [rnd1.id],
+                "vaccine_type": pm.VACCINES[0][0],
+                "date_vrf_reception": self.now - datetime.timedelta(days=1),
+                "date_vrf_signature": self.now,
+                "date_dg_approval": self.now,
+                "quantities_ordered_in_doses": 1000000,
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400)


### PR DESCRIPTION
What problem is this PR solving? Explain here in one sentence.

Related JIRA tickets : POLIO-1922

## Self proofreading checklist

- [ ] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc
code

## Changes

- update round validation is supply chain to check for scope

## How to test

revert the changes of the front-end PR: https://github.com/BLSQ/iaso/pull/2112/files
Try to create a vrf for a round without scope



## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
