### PR TITLE
IA-4224 Ensure org units created in IASO have a `source_ref` value when exported to DHIS2

### DIFF
--- a/iaso/diffing/exporter.py
+++ b/iaso/diffing/exporter.py
@@ -30,7 +30,7 @@ def assign_dhis2_ids(to_create_diffs):
     # ideally should run on diff
     # assign source_ref for orgunits to avoid double creation
     for to_create in to_create_diffs:
-        if to_create.org_unit.source_ref is None:
+        if not to_create.org_unit.source_ref:
             to_create.org_unit.source_ref = generate_id_for_dhis_2()
             to_create.org_unit.save()
 
@@ -99,7 +99,7 @@ class Exporter:
             task.report_progress_and_stop_if_killed(
                 progress_message="Creating Orgunits", progress_value=0, end_value=len(to_create_diffs)
             )
-        # build the "minimal" payloads for creation, groups only done at later stage
+        # build the "minimal" payloads for creation, groups only done at a later stage
         index = 0
         for to_create in to_create_diffs:
             name_comparison = to_create.comparison("name")

--- a/iaso/tests/diffing/test_exporter.py
+++ b/iaso/tests/diffing/test_exporter.py
@@ -1,0 +1,47 @@
+import logging
+
+from iaso.diffing import Differ
+from iaso.diffing.exporter import assign_dhis2_ids
+from iaso.tests.diffing.utils import PyramidBaseTest
+
+
+test_logger = logging.getLogger(__name__)
+
+
+class ExporterTestCase(PyramidBaseTest):
+    """
+    Test Exporter.
+    """
+
+    def test_assign_dhis2_ids(self):
+        """
+        Test `assign_dhis2_ids()`.
+        """
+
+        # Simulate an org unit existing only in one pyramid.
+        self.angola_country_to_update.delete()
+
+        # Set `source_ref` to None or empty string (this is possible because of `blank=True` on the model field).
+        self.angola_country_to_compare_with.source_ref = None
+        self.angola_country_to_compare_with.save()
+        self.angola_region_to_compare_with.source_ref = ""
+        self.angola_region_to_compare_with.save()
+        self.angola_district_to_compare_with.source_ref = ""
+        self.angola_district_to_compare_with.save()
+
+        diffs, fields = Differ(test_logger).diff(
+            version=self.source_version_to_update,
+            version_ref=self.source_version_to_compare_with,
+        )
+
+        to_create_diffs = list(filter(lambda x: x.status == "new", diffs))
+        assign_dhis2_ids(to_create_diffs)
+
+        self.angola_country_to_compare_with.refresh_from_db()
+        self.angola_region_to_compare_with.refresh_from_db()
+        self.angola_district_to_compare_with.refresh_from_db()
+
+        # Ensure a `source_ref` has been generated (e.g. `KdPqb52qj79`).
+        self.assertEqual(11, len(self.angola_country_to_compare_with.source_ref))
+        self.assertEqual(11, len(self.angola_region_to_compare_with.source_ref))
+        self.assertEqual(11, len(self.angola_district_to_compare_with.source_ref))


### PR DESCRIPTION
Ensure org units created in IASO have a `source_ref` value when exported to DHIS2.

Related JIRA tickets : IA-4224

## Changes

Fix `assign_dhis2_ids` by considering `None` and "empty string" as no value.

## How to test

Ensure you have org units with `source_ref = ""` (empty string).

When exporting to DHIS2, a new `source_ref` should be generated.
