### PR TITLE
POLIO-1933: improve layout for read-only vaccine perm

### DIFF
--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/VaccineSupplyChainDetails.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/VaccineSupplyChainDetails.tsx
@@ -1,3 +1,4 @@
+import React, { FunctionComponent, useCallback } from 'react';
 import { Box, Grid } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import {
@@ -8,12 +9,16 @@ import {
 } from 'bluesquare-components';
 import classnames from 'classnames';
 import { FormikProvider, useFormik } from 'formik';
-import React, { FunctionComponent, useCallback } from 'react';
+import { DisplayIfUserHasPerm } from '../../../../../../../../hat/assets/js/apps/Iaso/components/DisplayIfUserHasPerm';
 import TopBar from '../../../../../../../../hat/assets/js/apps/Iaso/components/nav/TopBarComponent';
 import { useObjectState } from '../../../../../../../../hat/assets/js/apps/Iaso/hooks/useObjectState';
 import { useTabs } from '../../../../../../../../hat/assets/js/apps/Iaso/hooks/useTabs';
 import { useParamsObject } from '../../../../../../../../hat/assets/js/apps/Iaso/routing/hooks/useParamsObject';
 import { Optional } from '../../../../../../../../hat/assets/js/apps/Iaso/types/utils';
+import {
+    POLIO_SUPPLY_CHAIN_WRITE,
+    POLIO_SUPPLY_CHAIN_READ,
+} from '../../../../../../../../hat/assets/js/apps/Iaso/utils/permissions';
 import { baseUrls } from '../../../../constants/urls';
 import { PREALERT, VAR, VRF } from '../constants';
 import { useGetArrivalReportsDetails } from '../hooks/api/arrivalReports';
@@ -183,20 +188,33 @@ export const VaccineSupplyChainDetails: FunctionComponent = () => {
                                 items={values.arrival_reports}
                             />
                         )}
-                        <Grid container spacing={2} justifyContent="flex-end">
-                            <Box style={{ display: 'inline-flex' }} mr={3}>
-                                <VaccineSupplyChainConfirmButtons
-                                    className={classes.button}
-                                    tab={tab}
-                                    onSubmitTab={() => handleSubmit()}
-                                    onSubmitAll={() => handleSubmit(true)}
-                                    onCancel={onCancel}
-                                    allowSaveTab={allowSaveTab}
-                                    allowSaveAll={allowSaveAll}
-                                    showSaveAllButton={Boolean(values?.vrf?.id)}
-                                />
-                            </Box>
-                        </Grid>
+                        <DisplayIfUserHasPerm
+                            permissions={[
+                                POLIO_SUPPLY_CHAIN_WRITE,
+                                POLIO_SUPPLY_CHAIN_READ,
+                            ]}
+                        >
+                            <Grid
+                                container
+                                spacing={2}
+                                justifyContent="flex-end"
+                            >
+                                <Box style={{ display: 'inline-flex' }} mr={3}>
+                                    <VaccineSupplyChainConfirmButtons
+                                        className={classes.button}
+                                        tab={tab}
+                                        onSubmitTab={() => handleSubmit()}
+                                        onSubmitAll={() => handleSubmit(true)}
+                                        onCancel={onCancel}
+                                        allowSaveTab={allowSaveTab}
+                                        allowSaveAll={allowSaveAll}
+                                        showSaveAllButton={Boolean(
+                                            values?.vrf?.id,
+                                        )}
+                                    />
+                                </Box>
+                            </Grid>
+                        </DisplayIfUserHasPerm>
                     </>
                 )}
             </Box>

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Table/useVaccineSupplyChainTableColumns.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Table/useVaccineSupplyChainTableColumns.tsx
@@ -1,6 +1,6 @@
+import React, { ReactElement, useMemo } from 'react';
 import EditIcon from '@mui/icons-material/Edit';
 import { Column, IconButton, useSafeIntl } from 'bluesquare-components';
-import React, { ReactElement, useMemo } from 'react';
 import {
     DateCell,
     MultiDateCell,
@@ -8,7 +8,8 @@ import {
 import { NumberCell } from '../../../../../../../../hat/assets/js/apps/Iaso/components/Cells/NumberCell';
 import { SubTable } from '../../../../../../../../hat/assets/js/apps/Iaso/components/Cells/SubTable';
 import DeleteDialog from '../../../../../../../../hat/assets/js/apps/Iaso/components/dialogs/DeleteDialogComponent';
-import { userHasPermission } from '../../../../../../../../hat/assets/js/apps/Iaso/domains/users/utils';
+import { DisplayIfUserHasPerm } from '../../../../../../../../hat/assets/js/apps/Iaso/components/DisplayIfUserHasPerm';
+import { userHasOneOfPermissions } from '../../../../../../../../hat/assets/js/apps/Iaso/domains/users/utils';
 import { ColumnCell } from '../../../../../../../../hat/assets/js/apps/Iaso/types/general';
 import {
     POLIO_SUPPLY_CHAIN_WRITE,
@@ -20,7 +21,6 @@ import { baseUrls } from '../../../../constants/urls';
 import { useDeleteVrf } from '../hooks/api/vrf';
 import MESSAGES from '../messages';
 import { SupplyChainList } from '../types';
-import { DisplayIfUserHasPerm } from '../../../../../../../../hat/assets/js/apps/Iaso/components/DisplayIfUserHasPerm';
 
 export const useVaccineSupplyChainTableColumns = (): Column[] => {
     const { formatMessage } = useSafeIntl();
@@ -141,9 +141,30 @@ export const useVaccineSupplyChainTableColumns = (): Column[] => {
                                 ]}
                             >
                                 <IconButton
-                                    icon="edit"
-                                    overrideIcon={EditIcon}
-                                    tooltipMessage={MESSAGES.edit}
+                                    icon={
+                                        userHasOneOfPermissions(
+                                            [POLIO_SUPPLY_CHAIN_READ_ONLY],
+                                            currentUser,
+                                        )
+                                            ? 'remove-red-eye'
+                                            : 'edit'
+                                    }
+                                    overrideIcon={
+                                        !userHasOneOfPermissions(
+                                            [POLIO_SUPPLY_CHAIN_READ_ONLY],
+                                            currentUser,
+                                        )
+                                            ? EditIcon
+                                            : undefined
+                                    }
+                                    tooltipMessage={
+                                        userHasOneOfPermissions(
+                                            [POLIO_SUPPLY_CHAIN_READ_ONLY],
+                                            currentUser,
+                                        )
+                                            ? MESSAGES.see
+                                            : MESSAGES.edit
+                                    }
                                     url={`/${baseUrls.vaccineSupplyChainDetails}/id/${original.id}`}
                                 />
                             </DisplayIfUserHasPerm>

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/messages.ts
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/messages.ts
@@ -358,6 +358,10 @@ const MESSAGES = defineMessages({
         id: 'iaso.polio.label.vrfCreatedAt',
         defaultMessage: 'VRF created',
     },
+    see: {
+        defaultMessage: 'See',
+        id: 'iaso.label.see',
+    },
 });
 
 export default MESSAGES;


### PR DESCRIPTION
What problem is this PR solving? Explain here in one sentence.

Related JIRA tickets : POLIO-1933

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc
NA

## Changes

- hide save buttons from vaccine supply chain (vrfd, prealerts, VAR)
- change icon of vaccine stock for read only users

## How to test
 create a user with the vaccinemodule read-only permissions
go to supply chain and stock variation

## Print screen / video



![Screenshot 2025-05-23 at 17 47 26](https://github.com/user-attachments/assets/d4d82642-cf1b-41fa-91db-4f3b202a962d)

## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
