### PR TITLE
IA-4229- OU search count

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/TableList.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/TableList.tsx
@@ -124,6 +124,7 @@ export const TableList: FunctionComponent<Props> = ({
                     extraProps={{
                         columns,
                         data: orgUnitsData?.orgunits || [],
+                        count: orgUnitsData?.count,
                     }}
                     multiSelect
                     selection={selection}


### PR DESCRIPTION
Randomly, the total in "SEARCH" is different from the number of result(s)

Related JIRA tickets : IA-4229
[JamScreenRecording-IA-4229.webm](https://github.com/user-attachments/assets/eb9c6477-f844-4ea1-bac7-1683eabd6a5f)

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

-

## Changes

force table re render if count is changing

## How to test

You need to search org units like on the video, make sure count is correct 


## Print screen / video

- 

## Notes

-

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
