### PR TITLE
 IA-4249 limit pagination lower when shapes are requested

### DIFF
--- a/iaso/api/mobile/org_units.py
+++ b/iaso/api/mobile/org_units.py
@@ -25,6 +25,9 @@ from iaso.models import FeatureFlag, Instance, OrgUnit, Project
 from iaso.permissions import IsAuthenticatedOrReadOnlyWhenNoAuthenticationRequired
 
 
+SHAPE_RESULTS_MAX = 1000
+
+
 class MobileOrgUnitsSetPagination(Paginator):
     page_size_query_param = LIMIT
     page_query_param = PAGE
@@ -32,6 +35,11 @@ class MobileOrgUnitsSetPagination(Paginator):
 
     def get_iaso_page_number(self, request):
         return int(request.query_params.get(self.page_query_param, 1))
+
+    def get_page_size(self, request):
+        if request.query_params.get("shapes", "false").lower() == "true":
+            return SHAPE_RESULTS_MAX  # Max limit when shapes=true
+        return super().get_page_size(request)
 
 
 class ReferenceInstancesFilter(django_filters.rest_framework.FilterSet):
@@ -218,6 +226,7 @@ class MobileOrgUnitViewSet(ModelViewSet):
         include_geo_json = self.check_include_geo_json()
         if include_geo_json:
             queryset = queryset.annotate(geo_json=RawSQL("ST_AsGeoJson(COALESCE(simplified_geom, geom))::json", []))
+
         return queryset
 
     def get_serializer_context(self) -> Dict[str, Any]:

--- a/iaso/api/mobile/org_units.py
+++ b/iaso/api/mobile/org_units.py
@@ -37,8 +37,11 @@ class MobileOrgUnitsSetPagination(Paginator):
         return int(request.query_params.get(self.page_query_param, 1))
 
     def get_page_size(self, request):
+        page_size = super().get_page_size(request)
         if request.query_params.get("shapes", "false").lower() == "true":
-            return SHAPE_RESULTS_MAX  # Max limit when shapes=true
+            if page_size and page_size > SHAPE_RESULTS_MAX:
+                return SHAPE_RESULTS_MAX
+
         return super().get_page_size(request)
 
 

--- a/iaso/tests/api/test_mobile_orgunits.py
+++ b/iaso/tests/api/test_mobile_orgunits.py
@@ -3,6 +3,7 @@ import time_machine
 from django.contrib.gis.geos import MultiPolygon, Point, Polygon
 from django.core.cache import cache
 
+from iaso.api.mobile.org_units import SHAPE_RESULTS_MAX
 from iaso.api.query_params import APP_ID, IDS, LIMIT, PAGE
 from iaso.models import (
     Account,
@@ -133,6 +134,16 @@ class MobileOrgUnitAPITestCase(APITestCase):
         self.client.force_authenticate(user=self.user)
         response = self.client.get(BASE_URL, {APP_ID: self.project.app_id})
         self.assertJSONResponse(response, 200)
+
+    def test_org_unit_with_shapes_limited(self):
+        self.client.force_authenticate(self.user)
+
+        response = self.client.get(BASE_URL, data={APP_ID: BASE_APP_ID, "shapes": True, "limit": 25000, "page": 1})
+        self.assertEqual(response.json()["limit"], SHAPE_RESULTS_MAX)
+
+        response = self.client.get(BASE_URL, data={APP_ID: BASE_APP_ID, "limit": 25000, "page": 1})
+
+        self.assertEqual(response.json()["limit"], 25000)
 
     def test_org_unit_have_correct_parent_id_without_limit(self):
         self.client.force_authenticate(self.user)


### PR DESCRIPTION
Fix memory problems when a large number of org units is requested by the mobile with their shapes

Related JIRA tickets :  IA-4249 
## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [x] Are there enough tests?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
