### PR TITLE
IA-4232:  Is form a ref sublission not available in Submissions interface

### DIFF
--- a/hat/assets/js/apps/Iaso/components/Cells/YesNoCell.js
+++ b/hat/assets/js/apps/Iaso/components/Cells/YesNoCell.js
@@ -12,9 +12,11 @@ const MESSAGES = defineMessages({
     },
 });
 
-export const YesNoCell = cellInfo =>
-    cellInfo.value === true ? (
+export const YesNoCell = cellInfo => {
+    console.log('cellInfo', cellInfo);
+    return cellInfo.value === true ? (
         <FormattedMessage {...MESSAGES.yes} />
     ) : (
         <FormattedMessage {...MESSAGES.no} />
     );
+};

--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -611,6 +611,7 @@
     "iaso.label.instanceStatus.readyMulti": "Ready",
     "iaso.label.instanceStatus.readySingle": "ready",
     "iaso.label.invalidDate": "Invalid date",
+    "iaso.label.isReferenceInstance": "Reference submission",
     "iaso.label.key": "Key",
     "iaso.label.label": "Label",
     "iaso.label.lastName": "Last name",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -611,7 +611,7 @@
     "iaso.label.instanceStatus.readyMulti": "Ready",
     "iaso.label.instanceStatus.readySingle": "ready",
     "iaso.label.invalidDate": "Invalid date",
-    "iaso.label.isReferenceInstance": "Reference submission",
+    "iaso.label.orgunitreferenceinstance": "Reference submission",
     "iaso.label.key": "Key",
     "iaso.label.label": "Label",
     "iaso.label.lastName": "Last name",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -718,6 +718,7 @@
     "iaso.label.reAssignInstance": "Assigner la soumission",
     "iaso.label.reAssignInstanceAction": "Assigner",
     "iaso.label.refresh": "Actualiser",
+    "iaso.label.isReferenceInstance": "Soumission de référence",
     "iaso.label.rejected": "Refusé",
     "iaso.label.removeParameter": "Supprimer le paramètre",
     "iaso.label.renderError": "Erreur de rendu de la valeur",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -718,7 +718,7 @@
     "iaso.label.reAssignInstance": "Assigner la soumission",
     "iaso.label.reAssignInstanceAction": "Assigner",
     "iaso.label.refresh": "Actualiser",
-    "iaso.label.isReferenceInstance": "Soumission de référence",
+    "iaso.label.orgunitreferenceinstance": "Soumission de référence",
     "iaso.label.rejected": "Refusé",
     "iaso.label.removeParameter": "Supprimer le paramètre",
     "iaso.label.renderError": "Erreur de rendu de la valeur",

--- a/hat/assets/js/apps/Iaso/domains/instances/components/ColumnSelect.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/ColumnSelect.tsx
@@ -1,8 +1,3 @@
-import {
-    Column,
-    useRedirectToReplace,
-    useSafeIntl,
-} from 'bluesquare-components';
 import React, {
     FunctionComponent,
     ReactElement,
@@ -10,6 +5,11 @@ import React, {
     useEffect,
     useMemo,
 } from 'react';
+import {
+    Column,
+    useRedirectToReplace,
+    useSafeIntl,
+} from 'bluesquare-components';
 import { ColumnsSelectDrawer } from '../../../components/tables/ColumnSelectDrawer';
 import { useGetPossibleFields } from '../../forms/hooks/useGetPossibleFields';
 import { Form } from '../../forms/types/forms';

--- a/hat/assets/js/apps/Iaso/domains/instances/constants.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/constants.js
@@ -6,6 +6,7 @@ import {
 } from 'bluesquare-components';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
+import { YesNoCell } from '../../components/Cells/YesNoCell';
 import * as Permission from '../../utils/permissions.ts';
 import getDisplayName, { useCurrentUser } from '../../utils/usersUtils.ts';
 import { LinkToForm } from '../forms/components/LinkToForm.tsx';
@@ -154,6 +155,16 @@ export const INSTANCE_METAS_FIELDS = [
         },
     },
     {
+        key: 'is_reference_instance',
+        accessor: 'orgunitreferenceinstance',
+        id: 'orgunitreferenceinstance',
+        active: true,
+        tableOrder: 3,
+        type: 'info',
+        renderValue: data => <YesNoCell value={data.is_reference_instance} />,
+        Cell: YesNoCell,
+    },
+    {
         key: 'planning',
         type: 'info',
         renderValue: data => {
@@ -177,7 +188,7 @@ export const INSTANCE_METAS_FIELDS = [
         accessor: 'formVersion',
         active: false,
         sortable: false,
-        tableOrder: 3,
+        tableOrder: 4,
         type: 'info',
         renderValue: data => {
             return data.file_content?._version || textPlaceholder;
@@ -188,24 +199,42 @@ export const INSTANCE_METAS_FIELDS = [
         },
     },
     {
-        key: 'source_created_at',
-        active: false,
-        render: value => displayDateFromTimestamp(value),
-        tableOrder: 7,
-        type: 'info',
-    },
-    {
         key: 'updated_at',
         render: value => displayDateFromTimestamp(value),
         active: true,
-        tableOrder: 4,
+        tableOrder: 5,
+        type: 'info',
+    },
+    {
+        key: 'source_created_at',
+        active: false,
+        render: value => displayDateFromTimestamp(value),
+        tableOrder: 6,
+        type: 'info',
+    },
+    {
+        key: 'org_unit',
+        accessor: 'org_unit__name',
+        render: value => {
+            if (!value) return null;
+            return <OrgUnitLabelHyperLink value={value} />;
+        },
+        active: true,
+        tableOrder: 7,
+        type: 'location',
+    },
+    {
+        key: 'period',
+        render: value => <PrettyPeriod value={value} />,
+        tableOrder: 8,
+        active: true,
         type: 'info',
     },
     {
         key: 'created_at',
         active: false,
         render: value => displayDateFromTimestamp(value),
-        tableOrder: 6,
+        tableOrder: 9,
         type: 'info',
     },
     {
@@ -213,7 +242,7 @@ export const INSTANCE_METAS_FIELDS = [
         accessor: 'created_by__username',
         translationKey: 'created_by',
         active: false,
-        tableOrder: 7,
+        tableOrder: 10,
         type: 'info',
         Cell: settings => {
             const data = settings.row.original;
@@ -232,24 +261,6 @@ export const INSTANCE_METAS_FIELDS = [
         type: 'info',
     },
     {
-        key: 'org_unit',
-        accessor: 'org_unit__name',
-        render: value => {
-            if (!value) return null;
-            return <OrgUnitLabelHyperLink value={value} />;
-        },
-        active: true,
-        tableOrder: 5,
-        type: 'location',
-    },
-    {
-        key: 'period',
-        render: value => <PrettyPeriod value={value} />,
-        tableOrder: 6,
-        active: true,
-        type: 'info',
-    },
-    {
         key: 'status',
         render: value =>
             value && MESSAGES[value.toLowerCase()] ? (
@@ -258,7 +269,7 @@ export const INSTANCE_METAS_FIELDS = [
                 textPlaceholder
             ),
         active: true,
-        tableOrder: 7,
+        tableOrder: 9,
         type: 'info',
     },
     {

--- a/hat/assets/js/apps/Iaso/domains/instances/constants.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/constants.js
@@ -155,14 +155,16 @@ export const INSTANCE_METAS_FIELDS = [
         },
     },
     {
-        key: 'is_reference_instance',
+        key: 'orgunitreferenceinstance',
         accessor: 'orgunitreferenceinstance',
-        id: 'orgunitreferenceinstance',
         active: true,
         tableOrder: 3,
         type: 'info',
         renderValue: data => <YesNoCell value={data.is_reference_instance} />,
-        Cell: YesNoCell,
+        Cell: settings => {
+            const data = settings.row.original;
+            return <YesNoCell value={data.is_reference_instance} />;
+        },
     },
     {
         key: 'planning',

--- a/hat/assets/js/apps/Iaso/domains/instances/messages.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/messages.js
@@ -754,8 +754,8 @@ const MESSAGES = defineMessages({
             'Use prefix “ids:” for internal submissions ID search. You can also search multiple IDs at once, separated by a comma or a space. E.g. “ids: 123456, 654321” or “ids: 123456 654321”',
         id: 'iaso.instances.searchParams',
     },
-    isReferenceInstance: {
-        id: 'iaso.label.isReferenceInstance',
+    orgunitreferenceinstance: {
+        id: 'iaso.label.orgunitreferenceinstance',
         defaultMessage: 'Reference submission',
     },
 });

--- a/hat/assets/js/apps/Iaso/domains/instances/messages.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/messages.js
@@ -754,6 +754,10 @@ const MESSAGES = defineMessages({
             'Use prefix “ids:” for internal submissions ID search. You can also search multiple IDs at once, separated by a comma or a space. E.g. “ids: 123456, 654321” or “ids: 123456 654321”',
         id: 'iaso.instances.searchParams',
     },
+    isReferenceInstance: {
+        id: 'iaso.label.isReferenceInstance',
+        defaultMessage: 'Reference submission',
+    },
 });
 
 export default MESSAGES;

--- a/hat/assets/js/cypress/fixtures/submissions/list.json
+++ b/hat/assets/js/cypress/fixtures/submissions/list.json
@@ -47,7 +47,8 @@
             "altitude": 0.0,
             "period": "2021Q1",
             "status": "READY",
-            "correlation_id": null
+            "correlation_id": null,
+            "is_reference_instance": true
         },
         {
             "uuid": "uuid_2",
@@ -94,7 +95,9 @@
             "altitude": 0.0,
             "period": "2021Q1",
             "status": "READY",
-            "correlation_id": null
+            "correlation_id": null,
+            "is_reference_instance": false,
+            "project_name": "Main Project"
         },
         {
             "uuid": "uuid_3",
@@ -141,7 +144,9 @@
             "altitude": 0.0,
             "period": "2021Q1",
             "status": "READY",
-            "correlation_id": null
+            "correlation_id": null,
+            "is_reference_instance": false,
+            "project_name": "Main Project"
         },
         {
             "uuid": "uuid_4",
@@ -188,7 +193,9 @@
             "altitude": 0.0,
             "period": "2021Q1",
             "status": "READY",
-            "correlation_id": null
+            "correlation_id": null,
+            "is_reference_instance": false,
+            "project_name": "Main Project"
         },
         {
             "uuid": "uuid_5",
@@ -235,7 +242,9 @@
             "altitude": 0.0,
             "period": "2021Q1",
             "status": "READY",
-            "correlation_id": null
+            "correlation_id": null,
+            "is_reference_instance": false,
+            "project_name": "Main Project"
         },
         {
             "uuid": "uuid_5",
@@ -282,7 +291,9 @@
             "altitude": 0.0,
             "period": "2021Q1",
             "status": "READY",
-            "correlation_id": null
+            "correlation_id": null,
+            "is_reference_instance": false,
+            "project_name": "Main Project"
         },
         {
             "uuid": "uuid_6",
@@ -329,7 +340,9 @@
             "altitude": 0.0,
             "period": "2021Q1",
             "status": "READY",
-            "correlation_id": null
+            "correlation_id": null,
+            "is_reference_instance": false,
+            "project_name": "Main Project"
         },
         {
             "uuid": "uuid_7",
@@ -376,7 +389,9 @@
             "altitude": 0.0,
             "period": "2021Q1",
             "status": "READY",
-            "correlation_id": null
+            "correlation_id": null,
+            "is_reference_instance": false,
+            "project_name": "Main Project"
         },
         {
             "uuid": "uuid_8",
@@ -423,7 +438,9 @@
             "altitude": 0.0,
             "period": "2021Q1",
             "status": "READY",
-            "correlation_id": null
+            "correlation_id": null,
+            "is_reference_instance": false,
+            "project_name": "Main Project"
         },
         {
             "uuid": "uuid_9",
@@ -470,7 +487,9 @@
             "altitude": 0.0,
             "period": "2021Q1",
             "status": "READY",
-            "correlation_id": null
+            "correlation_id": null,
+            "is_reference_instance": false,
+            "project_name": "Main Project"
         },
         {
             "uuid": "uuid_10",
@@ -517,7 +536,9 @@
             "altitude": 0.0,
             "period": "2021Q1",
             "status": "READY",
-            "correlation_id": null
+            "correlation_id": null,
+            "is_reference_instance": false,
+            "project_name": "Main Project"
         }
     ],
     "has_next": true,

--- a/hat/assets/js/cypress/integration/11 - submissions/list.spec.js
+++ b/hat/assets/js/cypress/integration/11 - submissions/list.spec.js
@@ -141,7 +141,11 @@ const testRowContent = (index, p = listFixture.instances[index]) => {
     cy.get('table').as('table');
     cy.get('@table').find('tbody').find('tr').eq(index).as('row');
     cy.get('@row').find('td').eq(0).should('contain', p.project_name);
-    cy.get('@row').find('td').eq(3).should('contain', p.org_unit.name);
+    cy.get('@row').find('td').eq(4).should('contain', p.org_unit.name);
+    cy.get('@row')
+        .find('td')
+        .eq(2)
+        .should('contain', p.is_reference_instance ? 'Yes' : 'No');
 };
 
 const getActionCol = (index = 0) => {
@@ -214,8 +218,7 @@ describe('Submissions', () => {
                 permissions: [],
                 is_superuser: false,
             });
-            const errorCode = cy.get('#error-code');
-            errorCode.should('contain', '403');
+            cy.get('#error-code').should('contain', '403');
         });
         describe('Search field', () => {
             beforeEach(() => {
@@ -237,7 +240,7 @@ describe('Submissions', () => {
         testTablerender({
             baseUrl,
             rows: listFixture.instances.length,
-            columns: 8,
+            columns: 9,
             withVisit: false,
             apiKey: 'instances',
         });
@@ -251,13 +254,14 @@ describe('Submissions', () => {
         it('should render correct row infos', () => {
             cy.wait('@getSubmissions').then(() => {
                 testRowContent(0);
+                testRowContent(1);
             });
         });
 
         describe('Action columns', () => {
             it('should display correct amount of buttons', () => {
                 cy.wait('@getSubmissions').then(() => {
-                    getActionCol(6);
+                    getActionCol(7);
                     cy.get('@actionCol')
                         .find('button')
                         .should('have.length', 1);
@@ -266,7 +270,7 @@ describe('Submissions', () => {
             // This test is flakey
             it('buttons should link to submission', () => {
                 cy.wait('@getSubmissions').then(() => {
-                    getActionCol(6);
+                    getActionCol(7);
                     cy.get('@actionCol')
                         .find('button')
                         .eq(0)
@@ -297,15 +301,15 @@ describe('Submissions', () => {
             cy.wait('@getSubmissions').then(() => {
                 const sorts = [
                     {
-                        colIndex: 2,
+                        colIndex: 3,
                         order: 'updated_at',
                     },
                     {
-                        colIndex: 3,
+                        colIndex: 4,
                         order: 'org_unit__name',
                     },
                     {
-                        colIndex: 5,
+                        colIndex: 6,
                         order: 'status',
                     },
                 ];
@@ -364,8 +368,9 @@ describe('Submissions', () => {
         });
 
         cy.get('#userIds').type('lui');
-        cy.wait(800);
-        cy.get('#userIds').type('{downarrow}').type('{enter}');
+        cy.get('#userIds-option-0').should('be.visible');
+        cy.get('#userIds').type('{downarrow}');
+        cy.get('#userIds').type('{enter}');
         cy.get('[data-test="search-button"]').click();
         cy.wait('@Luigi').then(() => {
             cy.wrap(interceptFlag).should('eq', true);
@@ -390,8 +395,9 @@ describe('Submissions', () => {
         ).as('LuigiMario');
 
         cy.get('#userIds').type('mario');
-        cy.wait(800);
-        cy.get('#userIds').type('{downarrow}').type('{enter}');
+        cy.get('#userIds-option-0').should('be.visible');
+        cy.get('#userIds').type('{downarrow}');
+        cy.get('#userIds').type('{enter}');
         cy.get('[data-test="search-button"]').click();
         cy.wait('@LuigiMario').then(() => {
             cy.wrap(interceptFlag).should('eq', true);
@@ -468,26 +474,39 @@ describe('Submissions', () => {
     it('advanced settings should filter correctly', () => {
         goToPage();
         cy.get('[data-test="advanced-settings"]').click({ force: true });
-        cy.get('[data-test="modificationDate"]')
-            .find('[data-test="start-date"]')
-            .find('input.MuiInputBase-input')
-            .clear()
-            .type('14/07/2023');
-        cy.get('[data-test="modificationDate"]')
-            .find('[data-test="end-date"]')
-            .find('input.MuiInputBase-input')
-            .clear()
-            .type('15/07/2023');
-        cy.get('[data-test="sentDate"]')
-            .find('[data-test="start-date"]')
-            .find('input.MuiInputBase-input')
-            .clear()
-            .type('12/07/2023');
-        cy.get('[data-test="sentDate"]')
-            .find('[data-test="end-date"]')
-            .find('input.MuiInputBase-input')
-            .clear()
-            .type('13/07/2023');
+        cy.get('[data-test="modificationDate"]').find(
+            '[data-test="start-date"]',
+        );
+        cy.get(
+            '[data-test="modificationDate"] [data-test="start-date"] input.MuiInputBase-input',
+        ).clear();
+        cy.get(
+            '[data-test="modificationDate"] [data-test="start-date"] input.MuiInputBase-input',
+        ).type('14/07/2023');
+
+        cy.get('[data-test="modificationDate"]').find('[data-test="end-date"]');
+        cy.get(
+            '[data-test="modificationDate"] [data-test="end-date"] input.MuiInputBase-input',
+        ).clear();
+        cy.get(
+            '[data-test="modificationDate"] [data-test="end-date"] input.MuiInputBase-input',
+        ).type('15/07/2023');
+
+        cy.get('[data-test="sentDate"]').find('[data-test="start-date"]');
+        cy.get(
+            '[data-test="sentDate"] [data-test="start-date"] input.MuiInputBase-input',
+        ).clear();
+        cy.get(
+            '[data-test="sentDate"] [data-test="start-date"] input.MuiInputBase-input',
+        ).type('12/07/2023');
+
+        cy.get('[data-test="sentDate"]').find('[data-test="end-date"]');
+        cy.get(
+            '[data-test="sentDate"] [data-test="end-date"] input.MuiInputBase-input',
+        ).clear();
+        cy.get(
+            '[data-test="sentDate"] [data-test="end-date"] input.MuiInputBase-input',
+        ).type('13/07/2023');
         cy.wait('@getSubmissions')
             .then(() => {
                 interceptFlag = false;
@@ -545,7 +564,7 @@ describe('Submissions', () => {
             cy.get('#ColumnsSelectDrawer-search').type('form');
             cy.get('@selectColumnsList').find('li').should('have.length', 2);
             cy.get('#ColumnsSelectDrawer-search-empty').click();
-            cy.get('@selectColumnsList').find('li').should('have.length', 15);
+            cy.get('@selectColumnsList').find('li').should('have.length', 16);
             const testIsActive = (keyName, withUrl = true) => {
                 cy.get('table').as('table');
                 cy.get('@table').find('thead').find('th').as('thead');


### PR DESCRIPTION
In the CSV extraction, we recently added the column “is my form a reférence submission …” TRUE or FALSE….
I would like to be able to visualise this info in the tab view 
Minimum requirement : 

Sliding button on the right in “select visible columns”

If this column is activated, be able to sorte the submission by alphabetical order (True or False vs False then True)

Related JIRA tickets : IA-4232

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [x] Are my typescript files well typed?
- [x] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc
 -

## Changes

Adding column refe submission to default meta column of instance

## How to test

Open instances list page, make sure is reference submission is present in the table, that you can sort it and remove it with visible columns


## Print screen / video

https://github.com/user-attachments/assets/7ffa8431-0764-4f6c-a321-f5e7b5295c17


## Notes

-

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
