### PR TITLE
IA-4201 Replace `app_id=""` by `app_id=None`

### DIFF
--- a/iaso/migrations/0326_alter_project_app_id.py
+++ b/iaso/migrations/0326_alter_project_app_id.py
@@ -3,12 +3,18 @@
 from django.db import migrations, models
 
 
+def migrate_data_forward(apps, schema_editor):
+    Project = apps.get_model("iaso", "Project")
+    Project.objects.filter(app_id="").update(app_id=None)
+
+
 class Migration(migrations.Migration):
     dependencies = [
         ("iaso", "0325_merge_0324_auto_20250514_1244_0324_project_color"),
     ]
 
     operations = [
+        migrations.RunPython(migrate_data_forward, migrations.RunPython.noop, elidable=True),
         migrations.AlterField(
             model_name="project",
             name="app_id",


### PR DESCRIPTION
Replace `app_id=""` by `app_id=None`.

Related JIRA tickets : [IA-4201](https://bluesquare.atlassian.net/browse/IA-4201)

## Changes

Fix a problem where `app_id=""` (empty string) for multiple projects.

This would cause the migration to fail due to the unicity constraint added in #2170.

[IA-4201]: https://bluesquare.atlassian.net/browse/IA-4201?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ