### PR TITLE
IA-4252 Make the mobile bulk upload API public unless `REQUIRE_AUTHENTICATION` is enabled

### DIFF
--- a/beanstalk_worker/__init__.py
+++ b/beanstalk_worker/__init__.py
@@ -58,7 +58,10 @@ def task_decorator(task_name=""):
             # enqueue the task
             task = Task()
             user = kwargs.pop("user")
-            task.account = user.iaso_profile.account
+            if user:
+                task.account = user.iaso_profile.account
+            else:
+                task.account_id = kwargs.pop("account_id")
             task.created_by = user
             task.launcher = user
             task.name = task_name

--- a/iaso/api/mobile/org_units.py
+++ b/iaso/api/mobile/org_units.py
@@ -389,7 +389,7 @@ def import_data(org_units, user, app_id):
                 org_unit_db.updated_at = timestamp_to_utc_datetime(int(t))
             else:
                 org_unit_db.updated_at = org_unit.get("created_at", None)
-            if not user.is_anonymous:
+            if user and not user.is_anonymous:
                 org_unit_db.creator = user
             org_unit_db.source = "API"
             if org_unit_location:

--- a/iaso/models/project.py
+++ b/iaso/models/project.py
@@ -65,6 +65,8 @@ class Project(models.Model):
         null=True,
         unique=True,
     )
+    # The `needs_authentication` boolean field existed before the feature flags.
+    # Use feature flags instead.
     needs_authentication = models.BooleanField(default=False)
     feature_flags = models.ManyToManyField("FeatureFlag", related_name="+", blank=True)
     created_at = models.DateTimeField(auto_now_add=True)

--- a/iaso/tasks/process_mobile_bulk_upload.py
+++ b/iaso/tasks/process_mobile_bulk_upload.py
@@ -238,11 +238,17 @@ def duplicate_instance_files(new_instance_files):
 
 
 def result_message(user, project, start_date, start_time, stats):
-    return f"""
-Mobile bulk import successful for user {user.username} and project {project.name}.
-Started: {start_date!s}, time spent: {time.time() - start_time} sec
-Number of imported org units: {stats["new_org_units"]}
-Number of imported form submissions: {stats["new_instances"]}
-Number of imported submission attachments: {stats["new_instance_files"]}
-Number of imported org unit change requests: {stats["new_change_requests"]}
-    """
+    if user:
+        msg = f"Mobile bulk import successful for user {user.username} and project {project.name}."
+    else:
+        msg = f"Mobile bulk import successful for project {project.name}."
+
+    msg += f"""
+    Started: {start_date!s}, time spent: {time.time() - start_time} sec
+    Number of imported org units: {stats["new_org_units"]}
+    Number of imported form submissions: {stats["new_instances"]}
+    Number of imported submission attachments: {stats["new_instance_files"]}
+    Number of imported org unit change requests: {stats["new_change_requests"]}
+            """
+
+    return msg

--- a/iaso/tests/api/test_mobile_bulkuploads.py
+++ b/iaso/tests/api/test_mobile_bulkuploads.py
@@ -1,7 +1,7 @@
 from django.core.files.uploadedfile import SimpleUploadedFile
 
 from hat.api_import.models import APIImport
-from iaso.models import Account, Project
+from iaso.models import Account, FeatureFlag, Project, Task
 from iaso.test import APITestCase
 
 
@@ -19,8 +19,9 @@ class MobileBulkUploadsAPITestCase(APITestCase):
             account=cls.account,
         )
         cls.user = cls.create_user_with_profile(username="user", account=cls.account)
+        cls.require_authentication = FeatureFlag.objects.get(code=FeatureFlag.REQUIRE_AUTHENTICATION)
 
-    def test_success(self):
+    def test_success_authenticated(self):
         self.client.force_authenticate(self.user)
 
         self.assertEqual(APIImport.objects.count(), 0)
@@ -38,7 +39,38 @@ class MobileBulkUploadsAPITestCase(APITestCase):
         self.assertFalse(api_import.has_problem)
         self.assertIsNotNone(api_import.file)
 
+    def test_success_unauthenticated(self):
+        self.assertFalse(self.project.has_feature(FeatureFlag.REQUIRE_AUTHENTICATION))
+
+        self.assertEqual(APIImport.objects.count(), 0)
+        self.assertEqual(Task.objects.count(), 0)
+
+        response = self.client.post(
+            f"{BASE_URL}?app_id={APP_ID}",
+            {"zip_file": SimpleUploadedFile("file.zip", b"Some file content")},
+            format="multipart",
+        )
+        self.assertJSONResponse(response, 204)
+
+        self.assertEqual(APIImport.objects.count(), 1)
+        api_import = APIImport.objects.first()
+        self.assertEqual(api_import.import_type, "bulk")
+        self.assertFalse(api_import.has_problem)
+        self.assertIsNotNone(api_import.file)
+
+        task = Task.objects.last()
+        self.assertEqual(task.created_by, None)
+        self.assertEqual(task.launcher, None)
+        self.assertEqual(task.account, self.account)
+        self.assertEqual(task.name, "process_mobile_bulk_upload")
+
     def test_fail_unauthenticated(self):
+        """
+        If the project has the feature flag "REQUIRE_AUTHENTICATION" set to `True`,
+        authentication should be required.
+        """
+        self.project.feature_flags.add(self.require_authentication)
+
         response = self.client.post(f"{BASE_URL}?app_id={APP_ID}")
         self.assertJSONResponse(response, 401)
 

--- a/iaso/tests/tasks/test_process_mobile_bulk_upload.py
+++ b/iaso/tests/tasks/test_process_mobile_bulk_upload.py
@@ -127,7 +127,7 @@ class ProcessMobileBulkUploadTest(TestCase):
             id=1, name="Participant", reference_form=self.form_registration
         )
 
-    def test_success(self):
+    def _create_zip_file(self):
         # Create the zip file: we create it on the fly to be able to clearly
         # see the contents in our repo. We then mock the file download method
         # to return the filepath to this zip.
@@ -135,6 +135,75 @@ class ProcessMobileBulkUploadTest(TestCase):
         with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zipf:
             add_to_zip(zipf, zip_fixture_dir(CATT_TABLET_DIR), CORRECT_FILES_FOR_ZIP)
         save_file_to_api_import(self.api_import, zip_path)
+
+    def test_success(self):
+        self._create_zip_file()
+
+        self.assertEqual(m.Entity.objects.count(), 0)
+        self.assertEqual(m.Instance.objects.count(), 0)
+        self.assertEqual(m.InstanceFile.objects.count(), 0)
+
+        process_mobile_bulk_upload(
+            api_import_id=self.api_import.id,
+            project_id=self.project.id,
+            task=self.task,
+            _immediate=True,
+        )
+
+        # check Task status and result
+        self.task.refresh_from_db()
+        self.assertEqual(self.task.status, m.SUCCESS)
+
+        self.api_import.refresh_from_db()
+        self.assertEqual(self.api_import.import_type, "bulk")
+        self.assertFalse(self.api_import.has_problem)
+
+        # Org unit was created
+        ou = m.OrgUnit.objects.get(name="New Org Unit")
+        self.assertIsNotNone(ou)
+        self.assertEqual(ou.validation_status, m.OrgUnit.VALIDATION_NEW)
+
+        # Instances (Submissions) + Entity were created
+        self.assertEqual(m.Entity.objects.count(), 2)
+        ent_disasi = m.Entity.objects.get(uuid=DISASI_MAKULO_REGISTRATION)
+        entity_patrice = m.Entity.objects.get(uuid=PATRICE_AKAMBU_REGISTRATION)
+        self.assertEqual(m.Instance.objects.count(), 4)
+        self.assertEqual(m.InstanceFile.objects.count(), 2)
+
+        # Entity 1: Disasi Makulo
+        reg_instance = m.Instance.objects.get(uuid=DISASI_MAKULO_REGISTRATION)
+        self.assertEqual(reg_instance.json.get("_full_name"), "Disasi Makulo")
+        self.assertEqual(reg_instance.entity, ent_disasi)
+        self.assertEqual(reg_instance.instancefile_set.count(), 0)
+
+        catt_instance = m.Instance.objects.get(uuid=DISASI_MAKULO_CATT)
+        self.assertEqual(catt_instance.json.get("result"), "positive")
+        self.assertEqual(catt_instance.entity, ent_disasi)
+        self.assertEqual(catt_instance.instancefile_set.count(), 1)
+        image = catt_instance.instancefile_set.first()
+        self.assertEqual(image.name, "1712326156339.webp")
+
+        # Entity 2: Patrice Akambu
+        reg_instance = m.Instance.objects.get(uuid=PATRICE_AKAMBU_REGISTRATION)
+        self.assertEqual(reg_instance.json.get("_full_name"), "Patrice Akambu")
+        self.assertEqual(reg_instance.entity, entity_patrice)
+        self.assertEqual(reg_instance.instancefile_set.count(), 0)
+
+        catt_instance = m.Instance.objects.get(uuid=PATRICE_AKAMBU_CATT)
+        self.assertEqual(catt_instance.json.get("result"), "positive")
+        self.assertEqual(catt_instance.entity, entity_patrice)
+        self.assertEqual(catt_instance.instancefile_set.count(), 1)
+        # image from Disasi's CATT was duplicated to this test
+        image = catt_instance.instancefile_set.first()
+        self.assertEqual(image.name, "1712326156339.webp")
+
+    def test_success_when_user_is_none(self):
+        self.api_import.user = None
+        self.api_import.save()
+        self.task.launcher = None
+        self.task.save()
+
+        self._create_zip_file()
 
         self.assertEqual(m.Entity.objects.count(), 0)
         self.assertEqual(m.Instance.objects.count(), 0)
@@ -235,10 +304,8 @@ class ProcessMobileBulkUploadTest(TestCase):
     # on the already created instance)
     def test_reference_form_update(self):
         # Do an import with the CATT tablet first to already create Disasi Makulo
-        zip_path = f"/tmp/{CATT_TABLET_DIR}.zip"
-        with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zipf:
-            add_to_zip(zipf, zip_fixture_dir(CATT_TABLET_DIR), CORRECT_FILES_FOR_ZIP)
-        save_file_to_api_import(self.api_import, zip_path)
+
+        self._create_zip_file()
 
         process_mobile_bulk_upload(
             api_import_id=self.api_import.id,
@@ -322,10 +389,7 @@ class ProcessMobileBulkUploadTest(TestCase):
         )
         reg_disasi = ent_disasi.attributes
 
-        zip_path = f"/tmp/{CATT_TABLET_DIR}.zip"
-        with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zipf:
-            add_to_zip(zipf, zip_fixture_dir(CATT_TABLET_DIR), CORRECT_FILES_FOR_ZIP)
-        save_file_to_api_import(self.api_import, zip_path)
+        self._create_zip_file()
 
         self.assertEqual(m.Entity.objects.count(), 0)
         self.assertEqual(m.Instance.objects.exclude(deleted=True).count(), 0)


### PR DESCRIPTION
Make the mobile bulk upload API public unless `REQUIRE_AUTHENTICATION` is enabled.

Related JIRA tickets : IA-4252
