### PR TITLE
POLIO-1924: Earmarked vials  pre fill

### DIFF
--- a/plugins/polio/api/vaccines/supply_chain.py
+++ b/plugins/polio/api/vaccines/supply_chain.py
@@ -818,6 +818,14 @@ class NoFormDjangoFilterBackend(DjangoFilterBackend):
         return ""
 
 
+class RoundFilter(filters.BaseFilterBackend):
+    def filter_queryset(self, request, queryset, view):
+        round_id = request.query_params.get("round_id")
+        if round_id:
+            return queryset.filter(rounds=round_id)
+        return queryset
+
+
 class VaccineRequestFormViewSet(ModelViewSet):
     """
     GET /api/polio/vaccine/request_forms/ to get the list of all request_forms
@@ -827,6 +835,7 @@ class VaccineRequestFormViewSet(ModelViewSet):
     - vaccine_type : Use on of the VACCINES : mOPV2, nOPV2, bOPV
     - rounds__started_at : Use a date in the format YYYY-MM-DD
     - rounds__ended_at : Use a date in the format YYYY-MM-DD
+    - round_id : Filter by a specific round ID
 
     Available ordering:
     - country
@@ -879,6 +888,7 @@ class VaccineRequestFormViewSet(ModelViewSet):
         NoFormDjangoFilterBackend,
         VRFCustomOrderingFilter,
         VRFCustomFilter,
+        RoundFilter,
         filters.OrderingFilter,
     ]
     filterset_fields = {

--- a/plugins/polio/api/vaccines/supply_chain.py
+++ b/plugins/polio/api/vaccines/supply_chain.py
@@ -3,12 +3,15 @@ import os
 from logging import getLogger
 from typing import Any
 
+import django_filters
+
 from django import forms
 from django.db import IntegrityError
 from django.db.models import Max, Min, Sum
 from django.db.models.functions import Coalesce
 from django.utils import timezone
-from django_filters.rest_framework import DjangoFilterBackend  # type: ignore
+from django.utils.translation import gettext_lazy as _
+from django_filters.rest_framework import DjangoFilterBackend
 from nested_multipart_parser.drf import DrfNestedParser
 from rest_framework import filters, serializers, status
 from rest_framework.decorators import action
@@ -818,12 +821,12 @@ class NoFormDjangoFilterBackend(DjangoFilterBackend):
         return ""
 
 
-class RoundFilter(filters.BaseFilterBackend):
-    def filter_queryset(self, request, queryset, view):
-        round_id = request.query_params.get("round_id")
-        if round_id:
-            return queryset.filter(rounds=round_id)
-        return queryset
+class RoundFilterSet(django_filters.FilterSet):
+    round_id = django_filters.NumberFilter(field_name="rounds", label=_("Round ID"))
+
+    class Meta:
+        model = VaccineRequestForm
+        fields = ["round_id"]
 
 
 class VaccineRequestFormViewSet(ModelViewSet):
@@ -888,9 +891,10 @@ class VaccineRequestFormViewSet(ModelViewSet):
         NoFormDjangoFilterBackend,
         VRFCustomOrderingFilter,
         VRFCustomFilter,
-        RoundFilter,
+        DjangoFilterBackend,
         filters.OrderingFilter,
     ]
+    filterset_class = RoundFilterSet
     filterset_fields = {
         "campaign__obr_name": ["exact"],
         "campaign__country": ["exact"],

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/CreateEditEarmarked.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/CreateEditEarmarked.tsx
@@ -82,15 +82,17 @@ export const CreateEditEarmarked: FunctionComponent<Props> = ({
     const allowConfirm = formik.isValid && !isEqual(formik.touched, {});
     const { data: vrfList } = useGetVrfListByRound(selectedRound?.original?.id);
     const quantityOrdered = vrfList?.reduce(
-        (acc, vrf) => acc + vrf.quantities_ordered_in_doses,
+        (acc, vrf) => acc + (vrf.quantities_ordered_in_doses || 0),
         0,
     );
+    const isNewEarmark = !earmark?.id;
+    const hasQuantityOrdered = quantityOrdered && quantityOrdered > 0;
     // https://bluesquare.atlassian.net/browse/POLIO-1924
     useEffect(() => {
-        if (quantityOrdered && quantityOrdered > 0 && !earmark?.id) {
+        if (hasQuantityOrdered && isNewEarmark) {
             handleVialsChange(quantityOrdered);
         }
-    }, [quantityOrdered, earmark?.id, handleVialsChange]);
+    }, [hasQuantityOrdered, isNewEarmark, handleVialsChange, quantityOrdered]);
     return (
         <FormikProvider value={formik}>
             <ConfirmCancelModal

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/hooks/api.ts
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/hooks/api.ts
@@ -373,6 +373,7 @@ export const useCampaignOptions = (
                       return {
                           label: `${formatMessage(MESSAGES.round)} ${round.number}`,
                           value: round.number,
+                          original: round,
                       };
                   })
             : [];

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/hooks/api/vrf.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/hooks/api/vrf.tsx
@@ -54,7 +54,9 @@ const defaults = {
     pageSize: 20,
     page: 1,
 };
-const getVrfList = (params: FormattedApiParams): Promise<VRF[]> => {
+const getVrfList = (
+    params: FormattedApiParams,
+): Promise<{ results: VRF[] }> => {
     const queryString = new URLSearchParams(params).toString();
     return getRequest(`${apiUrl}?${queryString}`);
 };
@@ -81,6 +83,26 @@ export const useGetVrfList = (
             keepPreviousData: true,
             staleTime: 1000 * 60 * 15, // in MS
             cacheTime: 1000 * 60 * 5,
+        },
+    });
+};
+
+export const useGetVrfListByRound = (
+    roundId: string,
+): UseQueryResult<any, any> => {
+    const apiParams = useApiParams({ round_id: roundId });
+    return useSnackQuery({
+        queryKey: ['getVrfListByRound', roundId],
+        queryFn: () => getVrfList(apiParams),
+        options: {
+            select: data => {
+                if (!data) return [];
+                return data.results;
+            },
+            keepPreviousData: false,
+            staleTime: 1000 * 60 * 15, // in MS
+            cacheTime: 1000 * 60 * 5,
+            enabled: Boolean(roundId),
         },
     });
 };


### PR DESCRIPTION
When creating an earmarked, Gael has asked that as soon as a Round & OBR are entered, the vials requested  (created in the VRF) appear. 

Related JIRA tickets : POLIO-1924

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

-

## Changes

- custom backend filter to retrieve all VRF linked to a round
- while creating a VRF, fetch associated VRF's an pre fillvials with sum of requested doses

## How to test

- you need to enter VRF in supply chain for a specific country
- open stock management for the same country , click on variation stock and add a earmarked stock, vials doses should be prefilled with the sum of vrf entered for a specific round

## Print screen / video

https://github.com/user-attachments/assets/ecbe5a9d-7fbf-4c2e-bd2f-556a0bd4cb7b


## Notes
-
## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
