### PR TITLE
IA-4262: Org unit export missing ref

### DIFF
--- a/iaso/gpkg/export_gpkg.py
+++ b/iaso/gpkg/export_gpkg.py
@@ -85,7 +85,7 @@ def export_org_units_to_gpkg(filepath, orgunits: "QuerySet[OrgUnit]") -> None:
     )
     # fill parent ref with alternative if we don't have one.
     df["parent_ref"] = df["parent__source_ref"].fillna(df["alt_parent_ref"])
-    df["ref"] = df["source_ref"].fillna("iaso:" + df["id"].astype(str))
+    df["ref"] = df["source_ref"].fillna("").mask(df["source_ref"].fillna("") == "", "iaso:" + df["id"].astype(str))
     df["geography"] = df["geom"].fillna(df["simplified_geom"].fillna(df["location"]))
     df["depth"] = df["depth"].fillna(999)
     df["depth"] = df["depth"].astype(int)

--- a/iaso/tests/gpkg/test_export.py
+++ b/iaso/tests/gpkg/test_export.py
@@ -1,17 +1,26 @@
+import os
+import tempfile
+
 from django.contrib.gis.geos import MultiPolygon, Point, Polygon
 
 from iaso import models as m
 from iaso.gpkg import org_units_to_gpkg_bytes
+from iaso.gpkg.import_gpkg import import_gpkg_file
 from iaso.test import TestCase
 
 
 class ExportTestCase(TestCase):
     @classmethod
     def setUpTestData(cls):
+        cls.account = m.Account.objects.create(name="a")
+        cls.project = m.Project.objects.create(name="Project 1", account=cls.account, app_id="test_app_id")
+
         sw_source = m.DataSource.objects.create(name="Evil Empire")
         cls.sw_source = sw_source
         sw_version_1 = m.SourceVersion.objects.create(data_source=sw_source, number=1)
         sw_version_2 = m.SourceVersion.objects.create(data_source=sw_source, number=2)
+        cls.sw_version_1 = sw_version_1
+        cls.sw_version_2 = sw_version_2
 
         cls.jedi_squad = m.OrgUnitType.objects.create(name="Jedi Squad", short_name="Jds")
         cls.jedi_team = m.OrgUnitType.objects.create(name="Jedi Team", short_name="Jdt")
@@ -42,3 +51,118 @@ class ExportTestCase(TestCase):
         gpkg_content = org_units_to_gpkg_bytes(m.OrgUnit.objects.all())
         self.assertIsInstance(gpkg_content, bytes)
         self.assertGreater(len(gpkg_content), 200)
+
+    def test_org_units_source_ref_handling(self):
+        # Create org units with different source_ref scenarios
+        org_unit_none_ref = m.OrgUnit.objects.create(
+            org_unit_type=self.jedi_team,
+            version=self.sw_version_1,
+            name="None Ref Unit",
+            source_ref=None,
+            validated=True,
+        )
+
+        org_unit_empty_ref = m.OrgUnit.objects.create(
+            org_unit_type=self.jedi_team,
+            version=self.sw_version_1,
+            name="Empty Ref Unit",
+            source_ref="",
+            validated=True,
+        )
+
+        org_unit_with_ref = m.OrgUnit.objects.create(
+            org_unit_type=self.jedi_team,
+            version=self.sw_version_1,
+            name="With Ref Unit",
+            source_ref="test-ref-123",
+            validated=True,
+        )
+
+        # Export to gpkg
+        gpkg_content = org_units_to_gpkg_bytes(
+            m.OrgUnit.objects.filter(id__in=[org_unit_none_ref.id, org_unit_empty_ref.id, org_unit_with_ref.id])
+        )
+
+        # Import the gpkg content to verify the refs
+        import io
+
+        import geopandas as gpd
+
+        # Read the gpkg content
+        gdf = gpd.read_file(io.BytesIO(gpkg_content))
+
+        # Get the refs for our test org units
+        none_ref_row = gdf[gdf["name"] == "None Ref Unit"].iloc[0]
+        empty_ref_row = gdf[gdf["name"] == "Empty Ref Unit"].iloc[0]
+        with_ref_row = gdf[gdf["name"] == "With Ref Unit"].iloc[0]
+
+        # Verify the refs
+        self.assertEqual(none_ref_row["ref"], f"iaso:{org_unit_none_ref.id}")
+        self.assertEqual(empty_ref_row["ref"], f"iaso:{org_unit_empty_ref.id}")
+        self.assertEqual(with_ref_row["ref"], "test-ref-123")
+
+    def test_export_import_source_ref_edge_cases(self):
+        """Test end-to-end export and import of org units with edge cases for source_ref"""
+        # Create org units with different source_ref scenarios
+        org_unit_none_ref = m.OrgUnit.objects.create(
+            org_unit_type=self.jedi_team,
+            version=self.sw_version_1,
+            name="None Ref Unit",
+            source_ref=None,
+            validated=True,
+        )
+
+        org_unit_empty_ref = m.OrgUnit.objects.create(
+            org_unit_type=self.jedi_team,
+            version=self.sw_version_1,
+            name="Empty Ref Unit",
+            source_ref="",
+            validated=True,
+        )
+
+        org_unit_with_ref = m.OrgUnit.objects.create(
+            org_unit_type=self.jedi_team,
+            version=self.sw_version_1,
+            name="With Ref Unit",
+            source_ref="test-ref-123",
+            validated=True,
+        )
+
+        # Export to gpkg
+        gpkg_content = org_units_to_gpkg_bytes(
+            m.OrgUnit.objects.filter(id__in=[org_unit_none_ref.id, org_unit_empty_ref.id, org_unit_with_ref.id])
+        )
+
+        # Save the gpkg content to a temporary file
+
+        with tempfile.NamedTemporaryFile(suffix=".gpkg", delete=False) as temp_file:
+            temp_file.write(gpkg_content)
+            temp_file_path = temp_file.name
+
+        try:
+            # Create a new version for import
+            new_version = m.SourceVersion.objects.create(data_source=self.sw_source, number=3)
+
+            # Import the gpkg file
+            import_gpkg_file(
+                temp_file_path,
+                project_id=self.project.id,
+                source_name=self.sw_source.name,
+                version_number=3,
+                validation_status="new",
+                description="Testing source_ref edge cases",
+            )
+
+            # Verify the imported org units
+            imported_none_ref = m.OrgUnit.objects.get(version=new_version, name="None Ref Unit")
+            imported_empty_ref = m.OrgUnit.objects.get(version=new_version, name="Empty Ref Unit")
+            imported_with_ref = m.OrgUnit.objects.get(version=new_version, name="With Ref Unit")
+
+            # Verify source_refs
+            self.assertEqual(imported_none_ref.source_ref, f"iaso:{org_unit_none_ref.id}")
+            self.assertEqual(imported_empty_ref.source_ref, f"iaso:{org_unit_empty_ref.id}")
+            self.assertEqual(imported_with_ref.source_ref, "test-ref-123")
+
+        finally:
+            # Clean up the temporary file
+            os.unlink(temp_file_path)


### PR DESCRIPTION
As ref field is now mandatory to import org units, we are checking if an org unit has a ref , if None we are replacing it to `iaso:IASO_ID `
We should do the the same if we have an empty string to avoid crash while importing it
Related JIRA tickets : IA-4262

## Self proofreading checklist

- [ ] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

-

## Changes

Fix export to GPKG to replace org unit source_ref field with `iaso:IASO_ID` if the field contains an emtpy string

## How to test

Edit one org unit in the admin and remove the source_ref
Search this or unit using the dashboard, add a location to it , export it o GPKG.
Create a new data source and try to import this GPKG.
It should not fail

## Print screen / video
-

## Notes
-

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
