### PR TITLE
IA-4254: Last update by/Dernière mise à jour field in Data Source modal is not updated

### DIFF
--- a/iaso/gpkg/import_gpkg.py
+++ b/iaso/gpkg/import_gpkg.py
@@ -283,6 +283,9 @@ def import_gpkg_file2(
         source.default_version = version
         source.save()
 
+    if not created:
+        version.save()
+
     # TODO: check: what if the source has no projects? Or the project has no account?
     account = source.projects.first().account  # type: ignore
     if not account.default_version:  # type: ignore

--- a/iaso/tests/gpkg/test_import.py
+++ b/iaso/tests/gpkg/test_import.py
@@ -103,6 +103,10 @@ class GPKGImport(TestCase):
         self.assertEqual(ou2.groups.first().name, "Previous name of group B")
         self.assertEqual(ou2.groups.first().source_version, version)
 
+        # Store the version's updated_at before import
+        version.refresh_from_db()
+        updated_at_before = version.updated_at
+
         import_gpkg_file(
             "./iaso/tests/fixtures/gpkg/minimal.gpkg",
             project_id=self.project.id,
@@ -111,6 +115,10 @@ class GPKGImport(TestCase):
             validation_status="new",
             description="",
         )
+
+        # Verify that updated_at has been updated
+        version.refresh_from_db()
+        self.assertGreater(version.updated_at, updated_at_before)
 
         self.assertEqual(OrgUnit.objects.all().count(), 3)
         self.assertEqual(Group.objects.all().count(), 2)


### PR DESCRIPTION
The field “Dernière mise à jour/Last updated” in the data source modal version does not reflect the last update when updating the current version via Geopackage. 

Related JIRA tickets : IA-4254

## Self proofreading checklist

- [ ] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

-

## Changes

update version while import ou using gpkg + tests

## How to test

Create a new data source with this GPKG. 
[development-Setuptri-org_units-2025-06-02-09-40.gpkg.zip](https://github.com/user-attachments/files/20551909/development-Setuptri-org_units-2025-06-02-09-40.gpkg.zip)

try to update the version with the same gpkg, updated at should change

## Print screen / video

https://github.com/user-attachments/assets/6c047aa7-c875-43b3-b470-d79b46e31233


## Notes

-

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
