### PR TITLE
IA-4257: Display version number in orgunit details screen

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitCreationDetails.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitCreationDetails.tsx
@@ -51,9 +51,6 @@ export const OrgUnitCreationDetails: FunctionComponent<Props> = ({
         : '-';
     const isNewOrgunit = params.orgUnitId === '0';
     const { account } = useCurrentUser();
-    console.log('orgUnit', orgUnit);
-
-    console.log('account.default_version', account.default_version);
     return (
         <>
             {!orgUnit && <LoadingSpinner absolute />}

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitCreationDetails.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitCreationDetails.tsx
@@ -51,7 +51,9 @@ export const OrgUnitCreationDetails: FunctionComponent<Props> = ({
         : '-';
     const isNewOrgunit = params.orgUnitId === '0';
     const { account } = useCurrentUser();
+    console.log('orgUnit', orgUnit);
 
+    console.log('account.default_version', account.default_version);
     return (
         <>
             {!orgUnit && <LoadingSpinner absolute />}
@@ -64,6 +66,14 @@ export const OrgUnitCreationDetails: FunctionComponent<Props> = ({
                             value={
                                 orgUnit.source ??
                                 account.default_version?.data_source.name
+                            }
+                            dataTestId="source"
+                        />
+                        <Row
+                            label={formatMessage(MESSAGES.sourceVersion)}
+                            value={
+                                orgUnit.version ??
+                                account.default_version?.number
                             }
                             dataTestId="source"
                         />


### PR DESCRIPTION
Enhance the orgunit details screen to show the version number in addition to the source information.

Related JIRA tickets : IA-4257
## Self proofreading checklist

- [ ] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

-

## Changes

display ou version on detail page

## How to test

Open  details for an org unit, make sur source version number is displayed

## Print screen / video

![Screenshot 2025-06-04 at 15 56 50](https://github.com/user-attachments/assets/e35de26e-5254-45e8-a01c-34f5c841d8ef)


## Notes

-

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
