### PR TITLE
WC2-736: duplicate analysis on __int__ is failing

### DIFF
--- a/iaso/api/deduplication/algos/levenshtein.py
+++ b/iaso/api/deduplication/algos/levenshtein.py
@@ -62,19 +62,35 @@ def _build_query(params):
             # For numeric types, use the same comparison as numbers
             if cast_type in ["integer", "bigint", "double precision"]:
                 fc_arr.append(
-                    f"(1.0 - ( abs ( (instance1.json->>%s)::{cast_type} - (instance2.json->>%s)::{cast_type} ) / greatest( (instance1.json->>%s)::{cast_type}, (instance2.json->>%s)::{cast_type} )))"
+                    "(1.0 - ( abs ( (instance1.json->>%s)::"
+                    + cast_type
+                    + " - (instance2.json->>%s)::"
+                    + cast_type
+                    + " ) / greatest( (instance1.json->>%s)::"
+                    + cast_type
+                    + ", (instance2.json->>%s)::"
+                    + cast_type
+                    + " )))"
                 )
                 query_params.extend([f_name, f_name, f_name, f_name])
             # For boolean types, compare as 0/1
             elif cast_type == "boolean":
                 fc_arr.append(
-                    f"(1.0 - abs( (instance1.json->>%s)::{cast_type}::integer - (instance2.json->>%s)::{cast_type}::integer ))"
+                    "(1.0 - abs( (instance1.json->>%s)::"
+                    + cast_type
+                    + "::integer - (instance2.json->>%s)::"
+                    + cast_type
+                    + "::integer ))"
                 )
                 query_params.extend([f_name, f_name])
             # For date/time types, compare as timestamps
             elif cast_type in ["date", "time", "timestamp"]:
                 fc_arr.append(
-                    f"(1.0 - abs( extract(epoch from (instance1.json->>%s)::{cast_type} - (instance2.json->>%s)::{cast_type} ) / 86400.0 ))"
+                    "(1.0 - abs( extract(epoch from (instance1.json->>%s)::"
+                    + cast_type
+                    + " - (instance2.json->>%s)::"
+                    + cast_type
+                    + " ) / 86400.0 ))"
                 )
                 query_params.extend([f_name, f_name])
 


### PR DESCRIPTION
Launching Levensthein algo on __int__ fields is leading to an error:

The issue occurred because f-string interpolation of {cast_type} could lead to incorrect SQL type casting, causing PostgreSQL to try using the extract function on integer fields. String concatenation ensures proper type casting for numeric comparisons.

Related JIRA tickets WC2-736

## Self proofreading checklist

- [ ] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

-

## Changes

Changed numeric type casting in SQL query from f-string to string concatenation to ensure proper type handling for integer, bigint, and double precision fields.

## How to test

Launch a duplicate analysis on a entity type using this form as reference
[child_registration_2024082203 (2).xlsx](https://github.com/user-attachments/files/20628824/child_registration_2024082203.2.xlsx)
Make sur you select ages in month in the fields to analyse

## Print screen / video

-

## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
