### PR TITLE
IA-4273: Fix blank page when 'select-multiple' question is used in form module

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/forms/fields/hooks/useGetQueryBuildersFields.ts
+++ b/hat/assets/js/apps/Iaso/domains/forms/fields/hooks/useGetQueryBuildersFields.ts
@@ -113,11 +113,12 @@ export const getQueryBuildersFields = (
                         formDescriptor,
                     );
                     if (descriptor?.children) {
-                        const listValues =
-                            descriptor.children.map(child => ({
-                                value: child.name,
-                                title: formatLabel(child),
-                            })) || [];
+                        const listValues = Object.fromEntries(
+                            (descriptor.children || []).map(child => [
+                                child.name,
+                                formatLabel(child),
+                            ]),
+                        );
                         // @ts-ignore
                         fields[fieldCopy.fieldKey].fieldSettings = {
                             listValues,

--- a/hat/assets/js/apps/Iaso/domains/instances/components/InstancesFiltersComponent.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/InstancesFiltersComponent.js
@@ -24,11 +24,14 @@ import { useGetQueryBuilderListToReplace } from '../../forms/fields/hooks/useGet
 import { useGetQueryBuildersFields } from '../../forms/fields/hooks/useGetQueryBuildersFields.ts';
 import { OrgUnitTreeviewModal } from '../../orgUnits/components/TreeView/OrgUnitTreeviewModal.tsx';
 import { useGetOrgUnit } from '../../orgUnits/components/TreeView/requests.ts';
+import { useGetOrgUnitTypesDropdownOptions } from '../../orgUnits/orgUnitTypes/hooks/useGetOrgUnitTypesDropdownOptions';
 import PeriodPicker from '../../periods/components/PeriodPicker.tsx';
 import { periodTypeOptions } from '../../periods/constants';
 import { Period } from '../../periods/models.ts';
 import { isValidPeriod } from '../../periods/utils';
 
+import { useGetPlanningsOptions } from '../../plannings/hooks/requests/useGetPlannings.ts';
+import { useGetProjectsDropdownOptions } from '../../projects/hooks/requests.ts';
 import { INSTANCE_STATUSES } from '../constants';
 
 import { useGetForms } from '../hooks';
@@ -37,11 +40,7 @@ import { useGetProfilesDropdown } from '../hooks/useGetProfilesDropdown.tsx';
 import MESSAGES from '../messages';
 import { parseJson } from '../utils/jsonLogicParse.ts';
 
-
-import { useGetPlanningsOptions } from '../../plannings/hooks/requests/useGetPlannings.ts';
-import { useGetProjectsDropdownOptions } from '../../projects/hooks/requests.ts';
 import { ColumnSelect } from './ColumnSelect.tsx';
-import { useGetOrgUnitTypesDropdownOptions } from '../../orgUnits/orgUnitTypes/hooks/useGetOrgUnitTypesDropdownOptions';
 
 export const instanceStatusOptions = INSTANCE_STATUSES.map(status => ({
     value: status,

--- a/iaso/models/base.py
+++ b/iaso/models/base.py
@@ -41,7 +41,7 @@ from iaso.utils.file_utils import get_file_type
 
 from .. import periods
 from ..utils.emoji import fix_emoji
-from ..utils.jsonlogic import jsonlogic_to_q
+from ..utils.jsonlogic import instance_jsonlogic_to_q
 from .device import Device, DeviceOwnership
 from .forms import Form, FormVersion
 from .project import Project
@@ -941,7 +941,7 @@ class InstanceQuerySet(django_cte.CTEQuerySet):
             queryset = queryset.filter(created_by__id__in=user_ids.split(","))
 
         if json_content:
-            q = jsonlogic_to_q(jsonlogic=json_content, field_prefix="json__")
+            q = instance_jsonlogic_to_q(jsonlogic=json_content, field_prefix="json__")
             queryset = queryset.filter(q)
 
         return queryset

--- a/iaso/tests/utils/test_jsonlogic.py
+++ b/iaso/tests/utils/test_jsonlogic.py
@@ -57,3 +57,40 @@ class JsonLogicTests(TestCase):
             str(q),
             "(AND: ('var1__exact', 1), (NOT (AND: ('var2__exact', 1))), ('var3__gt', 1), ('var4__gte', 1), ('var5__lt', 1), ('var6__lte', 1))",
         )
+
+
+class JsonLogicSomeAllStringFieldTests(TestCase):
+    def test_some_operator_all_values_present(self):
+        filters = {"some": [{"var": "colors"}, {"in": [{"var": ""}, ["red", "blue"]]}]}
+        q = jsonlogic_to_q(filters)
+        self.assertEqual(str(q), "(AND: ('colors__icontains', 'red'), ('colors__icontains', 'blue'))")
+
+    def test_some_operator_three_values_present(self):
+        filters = {"some": [{"var": "colors"}, {"in": [{"var": ""}, ["red", "blue", "green"]]}]}
+        q = jsonlogic_to_q(filters)
+        self.assertEqual(
+            str(q), "(AND: ('colors__icontains', 'red'), ('colors__icontains', 'blue'), ('colors__icontains', 'green'))"
+        )
+
+    def test_some_operator_no_match(self):
+        filters = {"some": [{"var": "colors"}, {"in": [{"var": ""}, ["yellow", "green"]]}]}
+        q = jsonlogic_to_q(filters)
+        self.assertEqual(str(q), "(AND: ('colors__icontains', 'yellow'), ('colors__icontains', 'green'))")
+
+    def test_all_operator_exact_match(self):
+        filters = {"all": [{"var": "colors"}, {"in": [{"var": ""}, ["red", "blue", "orange"]]}]}
+        q = jsonlogic_to_q(filters)
+        pattern = r"^blue orange red$"
+        self.assertEqual(str(q), f"(AND: ('colors__regex', '{pattern}'))")
+
+    def test_all_operator_extra_value(self):
+        filters = {"all": [{"var": "colors"}, {"in": [{"var": ""}, ["red", "blue"]]}]}
+        q = jsonlogic_to_q(filters)
+        pattern = r"^blue red$"
+        self.assertEqual(str(q), f"(AND: ('colors__regex', '{pattern}'))")
+
+    def test_all_operator_single_value(self):
+        filters = {"all": [{"var": "colors"}, {"in": [{"var": ""}, ["red"]]}]}
+        q = jsonlogic_to_q(filters)
+        pattern = r"^red$"
+        self.assertEqual(str(q), f"(AND: ('colors__regex', '{pattern}'))")

--- a/iaso/tests/utils/test_jsonlogic.py
+++ b/iaso/tests/utils/test_jsonlogic.py
@@ -1,5 +1,5 @@
 from iaso.test import TestCase
-from iaso.utils.jsonlogic import jsonlogic_to_q
+from iaso.utils.jsonlogic import instance_jsonlogic_to_q, jsonlogic_to_q
 
 
 class JsonLogicTests(TestCase):
@@ -62,35 +62,35 @@ class JsonLogicTests(TestCase):
 class JsonLogicSomeAllStringFieldTests(TestCase):
     def test_some_operator_all_values_present(self):
         filters = {"some": [{"var": "colors"}, {"in": [{"var": ""}, ["red", "blue"]]}]}
-        q = jsonlogic_to_q(filters)
+        q = instance_jsonlogic_to_q(filters)
         self.assertEqual(str(q), "(AND: ('colors__icontains', 'red'), ('colors__icontains', 'blue'))")
 
     def test_some_operator_three_values_present(self):
         filters = {"some": [{"var": "colors"}, {"in": [{"var": ""}, ["red", "blue", "green"]]}]}
-        q = jsonlogic_to_q(filters)
+        q = instance_jsonlogic_to_q(filters)
         self.assertEqual(
             str(q), "(AND: ('colors__icontains', 'red'), ('colors__icontains', 'blue'), ('colors__icontains', 'green'))"
         )
 
     def test_some_operator_no_match(self):
         filters = {"some": [{"var": "colors"}, {"in": [{"var": ""}, ["yellow", "green"]]}]}
-        q = jsonlogic_to_q(filters)
+        q = instance_jsonlogic_to_q(filters)
         self.assertEqual(str(q), "(AND: ('colors__icontains', 'yellow'), ('colors__icontains', 'green'))")
 
     def test_all_operator_exact_match(self):
         filters = {"all": [{"var": "colors"}, {"in": [{"var": ""}, ["red", "blue", "orange"]]}]}
-        q = jsonlogic_to_q(filters)
+        q = instance_jsonlogic_to_q(filters)
         pattern = r"^blue orange red$"
         self.assertEqual(str(q), f"(AND: ('colors__regex', '{pattern}'))")
 
     def test_all_operator_extra_value(self):
         filters = {"all": [{"var": "colors"}, {"in": [{"var": ""}, ["red", "blue"]]}]}
-        q = jsonlogic_to_q(filters)
+        q = instance_jsonlogic_to_q(filters)
         pattern = r"^blue red$"
         self.assertEqual(str(q), f"(AND: ('colors__regex', '{pattern}'))")
 
     def test_all_operator_single_value(self):
         filters = {"all": [{"var": "colors"}, {"in": [{"var": ""}, ["red"]]}]}
-        q = jsonlogic_to_q(filters)
+        q = instance_jsonlogic_to_q(filters)
         pattern = r"^red$"
         self.assertEqual(str(q), f"(AND: ('colors__regex', '{pattern}'))")

--- a/iaso/utils/jsonlogic.py
+++ b/iaso/utils/jsonlogic.py
@@ -9,6 +9,24 @@ from django.db.models import Exists, OuterRef, Q, Transform
 from django.db.models.fields.json import JSONField, KeyTransformTextLookupMixin
 
 
+# JsonLogic operator to Django lookup mappings
+# These map JsonLogic operators to Django field lookup names
+COMPARISON_OPERATOR_LOOKUPS = {
+    "==": "exact",
+    "!=": "exact",
+    ">": "gt",
+    ">=": "gte",
+    "<": "lt",
+    "<=": "lte",
+}
+
+# Extended lookups that include the "in" operator for string containment
+EXTENDED_OPERATOR_LOOKUPS = {
+    **COMPARISON_OPERATOR_LOOKUPS,
+    "in": "icontains",
+}
+
+
 # This is used to cast a json value from string into a float.
 # Didn't find a simple way to do that.
 # Using `__forcefloat` in a json field's lookup will cast as a double precision, e.g:
@@ -75,19 +93,9 @@ def jsonlogic_to_q(
     if len(params) != 2:
         raise ValueError(f"Unsupported JsonLogic. Operator {op} take exactly two operands: {jsonlogic}")
 
-    lookups = {
-        "==": "exact",
-        "!=": "exact",
-        ">": "gt",
-        ">=": "gte",
-        "<": "lt",
-        "<=": "lte",
-        "in": "icontains",
-    }
-
-    if op not in lookups.keys():
+    if op not in EXTENDED_OPERATOR_LOOKUPS:
         raise ValueError(
-            f"Unsupported JsonLogic (unknown operator {op}): {jsonlogic}. Supported operators: f{lookups.keys()}"
+            f"Unsupported JsonLogic (unknown operator {op}): {jsonlogic}. Supported operators: {list(EXTENDED_OPERATOR_LOOKUPS.keys())}"
         )
 
     field_position = 1 if op == "in" else 0
@@ -105,7 +113,7 @@ def jsonlogic_to_q(
         # Since inside the json everything is cast as string we cast back as int
         extract = "__forcefloat"
 
-    lookup = lookups[op]
+    lookup = EXTENDED_OPERATOR_LOOKUPS[op]
 
     f = f"{field_prefix}{field_name}{extract}__{lookup}"
     q = Q(**{f: value})
@@ -121,106 +129,262 @@ def instance_jsonlogic_to_q(
     field_prefix: str = "",
     recursion_func: Callable = None,
 ) -> Q:
-    """Converts a JsonLogic query to a Django Q object."""
+    """Converts a JsonLogic query to a Django Q object for filtering Instance objects.
 
-    func = instance_jsonlogic_to_q if recursion_func is None else recursion_func
+    This function extends the basic jsonlogic_to_q() with support for array field operations
+    like "some" and "all" that work with space-separated string fields in JSON data.
 
-    # Handle group operators first
+    JsonLogic is a standardized way to express complex queries as JSON objects.
+    See https://jsonlogic.com/ for the specification.
+
+    Args:
+        jsonlogic: The JsonLogic query as a Python dict
+        field_prefix: Prefix to add to all field names (e.g., "json__" for JSONField lookups)
+        recursion_func: Function to use for recursion (defaults to self)
+
+    Returns:
+        Django Q object that can be used in queryset filters
+
+    Examples:
+        # Basic comparison operators
+        filters = {"==": [{"var": "gender"}, "F"]}
+        q = instance_jsonlogic_to_q(filters, field_prefix="json__")
+        # Result: Q(json__gender__exact="F")
+
+        # Logical operators (AND/OR/NOT)
+        filters = {
+            "and": [
+                {"==": [{"var": "gender"}, "F"]},
+                {"<": [{"var": "age"}, 25]}
+            ]
+        }
+        q = instance_jsonlogic_to_q(filters, field_prefix="json__")
+        # Result: Q(json__gender__exact="F") & Q(json__age__lt=25)
+
+        # Array field operations with space-separated strings
+        # "some": field contains ALL specified values
+        filters = {
+            "some": [
+                {"var": "colors"},  # field name
+                {"in": [{"var": ""}, ["red", "blue"]]}  # condition
+            ]
+        }
+        q = instance_jsonlogic_to_q(filters, field_prefix="json__")
+        # Result: Q(json__colors__icontains="red") & Q(json__colors__icontains="blue")
+
+        # "all": field contains EXACTLY the specified values (no extras)
+        filters = {
+            "all": [
+                {"var": "colors"},
+                {"in": [{"var": ""}, ["red", "blue"]]}
+            ]
+        }
+        q = instance_jsonlogic_to_q(filters, field_prefix="json__")
+        # Result: Q(json__colors__regex="^blue red$")  # sorted pattern
+
+        # "in" operator for field in array or string containment
+        filters = {"in": [{"var": "status"}, ["active", "pending"]]}
+        q = instance_jsonlogic_to_q(filters, field_prefix="json__")
+        # Result: Q(json__status__in=["active", "pending"])
+
+    Supported Operators:
+        - Comparison: ==, !=, >, >=, <, <=
+        - Logical: and, or, ! (not)
+        - Array: in, some, all
+        - Field prefix handling for JSONField lookups
+        - Automatic type casting for numeric values in JSON fields
+    """
+
+    recursion_function = instance_jsonlogic_to_q if recursion_func is None else recursion_func
+
+    # Handle logical group operators (AND/OR/NOT)
     if "and" in jsonlogic:
-        sub_query = Q()
-        for lookup in jsonlogic["and"]:
-            sub_query = operator.and_(sub_query, func(lookup, field_prefix))
-        return sub_query
+        return _handle_and_operator(jsonlogic["and"], field_prefix, recursion_function)
     if "or" in jsonlogic:
-        sub_query = Q()
-        for lookup in jsonlogic["or"]:
-            sub_query = operator.or_(sub_query, func(lookup, field_prefix))
-        return sub_query
+        return _handle_or_operator(jsonlogic["or"], field_prefix, recursion_function)
     if "!" in jsonlogic:
-        return ~func(jsonlogic["!"], field_prefix)
+        return ~recursion_function(jsonlogic["!"], field_prefix)
 
-    # Handle array field logic: "some", "all"
+    # Handle array field operations (some/all)
     if "some" in jsonlogic or "all" in jsonlogic:
-        operator_key = "some" if "some" in jsonlogic else "all"
-        var, condition = jsonlogic[operator_key]
-        field = var["var"]
-        # Only support: { "in": [ { "var": "" }, [array] ] }
-        if "in" in condition:
-            in_params = condition["in"]
-            if (
-                isinstance(in_params, list)
-                and len(in_params) == 2
-                and isinstance(in_params[0], dict)
-                and in_params[0].get("var") == ""
-            ):
-                value_list = in_params[1]
-                if operator_key == "some":
-                    # All values must be present
-                    q = Q()
-                    for v in value_list:
-                        q = q & Q(**{f"{field_prefix}{field}__icontains": v})
-                    return q
-                if operator_key == "all":
-                    # All values present AND no extra values
-                    # Sort the value list for consistent comparison
-                    sorted_values = sorted(value_list)
-                    # Create a pattern that matches the sorted string representation
-                    pattern = r"^" + r" ".join(re.escape(v) for v in sorted_values) + r"$"
-                    q = Q(**{f"{field_prefix}{field}__regex": pattern})
-                    return q
+        return _handle_array_operators(jsonlogic, field_prefix, recursion_function)
+
+    # Handle binary comparison operators
+    return _handle_binary_operators(jsonlogic, field_prefix)
+
+
+def _handle_and_operator(conditions: list, field_prefix: str, recursion_function: Callable) -> Q:
+    """Handle AND operator by combining all conditions with logical AND."""
+    sub_query = Q()
+    for condition in conditions:
+        sub_query = operator.and_(sub_query, recursion_function(condition, field_prefix))
+    return sub_query
+
+
+def _handle_or_operator(conditions: list, field_prefix: str, recursion_function: Callable) -> Q:
+    """Handle OR operator by combining all conditions with logical OR."""
+    sub_query = Q()
+    for condition in conditions:
+        sub_query = operator.or_(sub_query, recursion_function(condition, field_prefix))
+    return sub_query
+
+
+def _handle_array_operators(jsonlogic: Dict[str, Any], field_prefix: str, recursion_function: Callable) -> Q:
+    """Handle 'some' and 'all' operators for array-like string fields.
+
+    These operators work with space-separated string fields stored in JSON data.
+    For example, if a field contains "red blue green", it can be queried with
+    array operators to check for specific value combinations.
+
+    Args:
+        jsonlogic: JsonLogic dict containing 'some' or 'all' operator
+        field_prefix: Field prefix for JSONField lookups
+        recursion_function: Recursion function
+
+    Returns:
+        Django Q object for the array operation
+
+    Raises:
+        ValueError: If the JsonLogic structure is not supported
+    """
+    operator_key = "some" if "some" in jsonlogic else "all"
+    var, condition = jsonlogic[operator_key]
+    field = var["var"]
+
+    # Only support: { "in": [ { "var": "" }, [array] ] }
+    if "in" not in condition:
         raise ValueError(f"Unsupported JsonLogic for '{operator_key}': {jsonlogic}")
 
-    # Handle binary operators
+    in_params = condition["in"]
+    if not (
+        isinstance(in_params, list)
+        and len(in_params) == 2
+        and isinstance(in_params[0], dict)
+        and in_params[0].get("var") == ""
+    ):
+        raise ValueError(f"Unsupported JsonLogic for '{operator_key}': {jsonlogic}")
+
+    value_list = in_params[1]
+
+    if operator_key == "some":
+        # "some": field must contain ALL specified values
+        # Example: field="red blue" matches ["red", "blue"] but not ["red", "yellow"]
+        return _build_some_query(field, value_list, field_prefix)
+
+    if operator_key == "all":
+        # "all": field must contain EXACTLY the specified values (no extras)
+        # Example: field="red blue" matches ["red", "blue"] but not ["red", "blue", "green"]
+        return _build_all_query(field, value_list, field_prefix)
+
+    raise ValueError(f"Unsupported JsonLogic for '{operator_key}': {jsonlogic}")
+
+
+def _build_some_query(field: str, value_list: list, field_prefix: str) -> Q:
+    """Build query for 'some' operator: field must contain all specified values."""
+    q = Q()
+    for value in value_list:
+        q = q & Q(**{f"{field_prefix}{field}__icontains": value})
+    return q
+
+
+def _build_all_query(field: str, value_list: list, field_prefix: str) -> Q:
+    """Build query for 'all' operator: field must contain exactly the specified values.
+
+    Uses regex pattern matching to ensure the field contains only the specified values
+    in any order, with no extra values.
+    """
+    # Sort the value list for consistent comparison
+    sorted_values = sorted(value_list)
+    # Create a pattern that matches the sorted string representation
+    pattern = r"^" + r" ".join(re.escape(v) for v in sorted_values) + r"$"
+    return Q(**{f"{field_prefix}{field}__regex": pattern})
+
+
+def _handle_binary_operators(jsonlogic: Dict[str, Any], field_prefix: str) -> Q:
+    """Handle binary comparison operators (==, !=, >, >=, <, <=, in).
+
+    Args:
+        jsonlogic: JsonLogic dict containing a single binary operator
+        field_prefix: Field prefix for JSONField lookups
+
+    Returns:
+        Django Q object for the binary operation
+
+    Raises:
+        ValueError: If the JsonLogic structure is not supported
+    """
     if not jsonlogic.keys():
         return Q()
 
     op = list(jsonlogic.keys())[0]
     params = jsonlogic[op]
+
     if len(params) != 2:
-        raise ValueError(f"Unsupported JsonLogic. Operator {op} take exactly two operands: {jsonlogic}")
+        raise ValueError(f"Unsupported JsonLogic. Operator {op} takes exactly two operands: {jsonlogic}")
 
-    # True "in" operator (field in array)
+    # Handle "in" operator specially (field in array vs string containment)
     if op == "in":
-        field, value = params[0], params[1]
-        if "var" in field and isinstance(value, list):
-            field_name = field["var"]
-            return Q(**{f"{field_prefix}{field_name}__in": value})
-        # Fallback to string containment
-        if "var" in field and isinstance(value, str):
-            field_name = field["var"]
-            return Q(**{f"{field_prefix}{field_name}__icontains": value})
-        raise ValueError(f"Unsupported 'in' usage: {jsonlogic}")
+        return _handle_in_operator(params, field_prefix)
 
-    lookups = {
-        "==": "exact",
-        "!=": "exact",
-        ">": "gt",
-        ">=": "gte",
-        "<": "lt",
-        "<=": "lte",
-    }
+    # Handle standard comparison operators
+    return _handle_comparison_operators(op, params, field_prefix)
 
-    if op not in lookups.keys():
+
+def _handle_in_operator(params: list, field_prefix: str) -> Q:
+    """Handle 'in' operator for field in array or string containment.
+
+    Supports two patterns:
+    1. field in array: {"in": [{"var": "status"}, ["active", "pending"]]}
+    2. string containment: {"in": [{"var": "name"}, "john"]}
+    """
+    field, value = params[0], params[1]
+
+    if "var" not in field:
+        raise ValueError("Unsupported 'in' usage: field must be a variable")
+
+    field_name = field["var"]
+
+    if isinstance(value, list):
+        # Field in array: {"in": [{"var": "status"}, ["active", "pending"]]}
+        return Q(**{f"{field_prefix}{field_name}__in": value})
+
+    if isinstance(value, str):
+        # String containment: {"in": [{"var": "name"}, "john"]}
+        return Q(**{f"{field_prefix}{field_name}__icontains": value})
+
+    raise ValueError(f"Unsupported 'in' usage: {params}")
+
+
+def _handle_comparison_operators(op: str, params: list, field_prefix: str) -> Q:
+    """Handle standard comparison operators (==, !=, >, >=, <, <=)."""
+    if op not in COMPARISON_OPERATOR_LOOKUPS:
         raise ValueError(
-            f"Unsupported JsonLogic (unknown operator {op}): {jsonlogic}. Supported operators: {list(lookups.keys()) + ['in', 'some', 'all']}"
+            f"Unsupported JsonLogic (unknown operator {op}): {params}. "
+            f"Supported operators: {list(COMPARISON_OPERATOR_LOOKUPS.keys()) + ['in', 'some', 'all']}"
         )
 
     field = params[0]
     value = params[1]
+
     if "var" not in field:
-        raise ValueError(f"Unsupported JsonLogic. Argument[0] must contain a variable for given operator : {jsonlogic}")
+        raise ValueError(f"Unsupported JsonLogic. First argument must contain a variable: {params}")
+
     field_name = field["var"]
 
+    # Handle numeric type casting for JSON fields
     extract = ""
     if isinstance(value, (int, float)) and field_prefix:
+        # Since JSON fields store everything as strings, we need to cast back to numeric
         extract = "__forcefloat"
 
-    lookup = lookups[op]
-    f = f"{field_prefix}{field_name}{extract}__{lookup}"
-    q = Q(**{f: value})
+    lookup = COMPARISON_OPERATOR_LOOKUPS[op]
+    field_lookup = f"{field_prefix}{field_name}{extract}__{lookup}"
+    q = Q(**{field_lookup: value})
 
+    # Handle negation for != operator
     if op == "!=":
         q = ~q
+
     return q
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
                 "abortcontroller-polyfill": "^1.7.5",
                 "array-flat-polyfill": "^1.0.1",
                 "babel-plugin-formatjs": "^10.3.4",
-                "bluesquare-components": "github:BLSQ/bluesquare-components",
+                "bluesquare-components": "github:BLSQ/bluesquare-components#IA-4273-querybuilder-multiselect",
                 "classnames": "^2.2.6",
                 "color": "^3.1.2",
                 "dom-to-pdf": "^0.3.1",
@@ -6404,7 +6404,7 @@
         },
         "node_modules/bluesquare-components": {
             "version": "1.0.0",
-            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#09cd196b776c978cec60c828b21b6caf0dc60778",
+            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#9df15af9e791f793247ce1f9a5853c8453db1d1e",
             "dependencies": {
                 "@babel/plugin-transform-class-properties": "^7.24.6",
                 "@babel/plugin-transform-object-rest-spread": "^7.24.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6404,7 +6404,7 @@
         },
         "node_modules/bluesquare-components": {
             "version": "1.0.0",
-            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#9df15af9e791f793247ce1f9a5853c8453db1d1e",
+            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#ee525b45f50e0b024150f54e8c783d7b98b4e500",
             "dependencies": {
                 "@babel/plugin-transform-class-properties": "^7.24.6",
                 "@babel/plugin-transform-object-rest-spread": "^7.24.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6404,7 +6404,7 @@
         },
         "node_modules/bluesquare-components": {
             "version": "1.0.0",
-            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#ee525b45f50e0b024150f54e8c783d7b98b4e500",
+            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#97ec06adb46d9ef309f4a0ae54bc97b7232a930a",
             "dependencies": {
                 "@babel/plugin-transform-class-properties": "^7.24.6",
                 "@babel/plugin-transform-object-rest-spread": "^7.24.6",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
         "abortcontroller-polyfill": "^1.7.5",
         "array-flat-polyfill": "^1.0.1",
         "babel-plugin-formatjs": "^10.3.4",
-        "bluesquare-components": "github:BLSQ/bluesquare-components",
+        "bluesquare-components": "github:BLSQ/bluesquare-components#IA-4273-querybuilder-multiselect",
         "classnames": "^2.2.6",
         "color": "^3.1.2",
         "dom-to-pdf": "^0.3.1",


### PR DESCRIPTION
When a form contains a 'select-multiple' question, the request returns a blank page in the form module (specifically in the Advanced Search option on the submissions page). Investigate and resolve the issue so that multiple-choice questions do not cause the page to fail.

Related JIRA tickets : IA-4273

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [x] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

- fix mult iselect fiend in `[bluesquare-components](https://github.com/BLSQ/bluesquare-components/pull/182)` to use array of string instead of a pure string as values
- duplicate backend code to be use only with instances and support `some` and `all` operators 
- adding some test to cover those operators

## How to test

You need a form using multi select fields and submissions with this form.

go to instance page, select this form and perform some searches with the query builder on the multi select field 

## Print screen / video

https://github.com/user-attachments/assets/d411f195-79e6-4148-ab75-fcd1a5a12bb2


## Notes

⚠️ this depend on blsq-component [PR](https://github.com/BLSQ/bluesquare-components/pull/182)

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
