### PR TITLE
IA-4162 Allow to edit the geometric shape of an org unit

### DIFF
--- a/iaso/api/org_units.py
+++ b/iaso/api/org_units.py
@@ -474,6 +474,7 @@ class OrgUnitViewSet(viewsets.ViewSet):
         errors = []
         org_unit = get_object_or_404(self.get_queryset(), id=pk)
         profile = request.user.iaso_profile
+        can_edit_shape = profile.account.feature_flags.filter(code="ALLOW_SHAPE_EDITION").exists()
 
         self.check_object_permissions(request, org_unit)
 
@@ -527,11 +528,18 @@ class OrgUnitViewSet(viewsets.ViewSet):
         elif "simplified_geom" in request.data:
             org_unit.simplified_geom = request.data["simplified_geom"]
 
-        if "geo_json" in request.data and request.data["geo_json"]:
-            logger.warning(
-                "The `geo_json` field is deprecated. Use the `geom` field to modify the geometry.",
-                extra={"request_data": request.data},
-            )
+        geo_json = request.data.get("geo_json")
+        if geo_json and can_edit_shape:
+            try:
+                geometry = geo_json["features"][0]["geometry"] if geo_json else None
+                coordinates = geometry["coordinates"] if geometry else None
+                if coordinates:
+                    multi_polygon = MultiPolygon(*[Polygon(*coord) for coord in coordinates])
+                    # Keep geom and simplified geom consistent.
+                    org_unit.geom = multi_polygon
+                    org_unit.simplified_geom = simplify_geom(multi_polygon)
+            except Exception:
+                errors.append({"errorKey": "geo_json", "errorMessage": _("Can't parse geo_json")})
 
         if "catchment" in request.data:
             catchment = request.data["catchment"]
@@ -647,15 +655,21 @@ class OrgUnitViewSet(viewsets.ViewSet):
             res = org_unit.as_dict_with_parents()
             res["geo_json"] = None
             res["catchment"] = None
-            if org_unit.simplified_geom or org_unit.catchment:
-                queryset = self.get_queryset().filter(id=org_unit.id)
-                if org_unit.simplified_geom:
-                    res["geo_json"] = geojson_queryset(queryset, geometry_field="simplified_geom")
+
+            if org_unit.geom or org_unit.simplified_geom or org_unit.catchment:
+                geo_queryset = self.get_queryset().filter(id=org_unit.id)
+
+                if can_edit_shape and org_unit.geom:
+                    res["geo_json"] = geojson_queryset(geo_queryset, geometry_field="geom")
+                elif org_unit.simplified_geom:
+                    res["geo_json"] = geojson_queryset(geo_queryset, geometry_field="simplified_geom")
+
                 if org_unit.catchment:
-                    res["catchment"] = geojson_queryset(queryset, geometry_field="catchment")
+                    res["catchment"] = geojson_queryset(geo_queryset, geometry_field="catchment")
 
             res["reference_instances"] = org_unit.get_reference_instances_details_for_api()
             return Response(res)
+
         return Response(errors, status=400)
 
     def get_date(self, date: str) -> Union[datetime.date, None]:
@@ -840,21 +854,25 @@ class OrgUnitViewSet(viewsets.ViewSet):
             ancestor = ancestor.parent
             ancestor_dict = ancestor_dict["parent"]
 
-        geo_queryset = self.get_queryset().filter(id=org_unit.id)
-
-        can_edit_shape = False
-        if request.user.is_authenticated:
-            can_edit_shape = request.user.iaso_profile.account.feature_flags.filter(code="ALLOW_SHAPE_EDITION").exists()
-
         res["geo_json"] = None
-        if can_edit_shape and org_unit.geom:
-            res["geo_json"] = geojson_queryset(geo_queryset, geometry_field="geom")
-        elif org_unit.simplified_geom:
-            res["geo_json"] = geojson_queryset(geo_queryset, geometry_field="simplified_geom")
-
         res["catchment"] = None
-        if org_unit.catchment:
-            res["catchment"] = geojson_queryset(geo_queryset, geometry_field="catchment")
+
+        if org_unit.geom or org_unit.simplified_geom or org_unit.catchment:
+            can_edit_shape = False
+            if request.user.is_authenticated:
+                can_edit_shape = request.user.iaso_profile.account.feature_flags.filter(
+                    code="ALLOW_SHAPE_EDITION"
+                ).exists()
+
+            geo_queryset = self.get_queryset().filter(id=org_unit.id)
+
+            if can_edit_shape and org_unit.geom:
+                res["geo_json"] = geojson_queryset(geo_queryset, geometry_field="geom")
+            elif org_unit.simplified_geom:
+                res["geo_json"] = geojson_queryset(geo_queryset, geometry_field="simplified_geom")
+
+            if org_unit.catchment:
+                res["catchment"] = geojson_queryset(geo_queryset, geometry_field="catchment")
 
         res["reference_instances"] = org_unit.get_reference_instances_details_for_api()
         return Response(res)

--- a/iaso/locale/fr/LC_MESSAGES/django.po
+++ b/iaso/locale/fr/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-04 09:54+0000\n"
+"POT-Creation-Date: 2025-06-18 11:06+0000\n"
 "PO-Revision-Date: 2025-02-06 10:24+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -171,6 +171,10 @@ msgstr "Statut de validation invalide : {validation_status}"
 #: iaso/api/org_units.py
 msgid "Can't parse geom"
 msgstr "Impossible d'analyser la géométrie"
+
+#: iaso/api/org_units.py
+msgid "Can't parse geo_json"
+msgstr "Impossible d'analyser le champ geo_json"
 
 #: iaso/api/org_units.py
 msgid "You cannot create an Org Unit without a parent"


### PR DESCRIPTION
Allow to edit the geometric shape of an org unit.

Related JIRA tickets : IA-4162

---

This PR cancels and replaces #2218.

To restore shape edition as quickly as possible, we decided to rely on the existing API instead of adding a new endpoint.
