### PR TITLE
[IA-4295] Fix enketo manifest with auth feature flag

### DIFF
--- a/iaso/api/enketo.py
+++ b/iaso/api/enketo.py
@@ -306,7 +306,7 @@ def enketo_form_list(request):
         # pass the app_id so it can be accessed anonymously from Enketo
         project = i.form.projects.first()
         app_id = project.app_id if project else ""
-        url = f"/api/forms/{i.form_id}/manifest/"
+        url = f"/api/forms/{i.form_id}/manifest_enketo/"
         secret = enketo_settings("ENKETO_SIGNING_SECRET")
         url_with_secret = generate_signed_url(path=url, secret=secret, extra_params={APP_ID: app_id})
         manifest_url = public_url_for_enketo(request, url_with_secret)

--- a/iaso/api/forms.py
+++ b/iaso/api/forms.py
@@ -24,7 +24,7 @@ from ..permissions import IsAuthenticatedOrReadOnlyWhenNoAuthenticationRequired,
 from .common import CONTENT_TYPE_CSV, CONTENT_TYPE_XLSX, DynamicFieldsModelSerializer, ModelViewSet, TimestampField
 from .enketo import public_url_for_enketo
 from .projects import ProjectSerializer
-from .query_params import APP_ID
+from .serializers import AppIdSerializer
 
 
 class HasFormPermission(IsAuthenticatedOrReadOnlyWhenNoAuthenticationRequired):
@@ -442,7 +442,7 @@ class FormsViewSet(ModelViewSet):
         """
         enketo_secret = enketo_settings("ENKETO_SIGNING_SECRET")
         if verify_signed_url(request, enketo_secret):
-            app_id = request.query_params.get(APP_ID, None)
+            app_id = AppIdSerializer(data=request.query_params).get_app_id(raise_exception=True)
             queryset = Form.objects.filter(
                 projects__app_id=app_id
             )  # Not using the default queryset because there's no auth

--- a/iaso/api/forms.py
+++ b/iaso/api/forms.py
@@ -15,15 +15,16 @@ from rest_framework.request import Request
 from hat.api.export_utils import Echo, generate_xlsx, iter_items
 from hat.audit.models import FORM_API, log_modification
 from hat.menupermissions import models as permission
-from iaso.models import Form, FormPredefinedFilter, OrgUnit, OrgUnitType, Project
+from iaso.models import Form, FormAttachment, FormPredefinedFilter, OrgUnit, OrgUnitType, Project
 from iaso.utils.date_and_time import timestamp_to_datetime
 
 from ..enketo import enketo_settings
 from ..enketo.enketo_url import verify_signed_url
-from ..permissions import IsAuthenticatedOrReadOnlyWhenNoAuthenticationRequired
+from ..permissions import IsAuthenticatedOrReadOnlyWhenNoAuthenticationRequired, ReadOnly
 from .common import CONTENT_TYPE_CSV, CONTENT_TYPE_XLSX, DynamicFieldsModelSerializer, ModelViewSet, TimestampField
 from .enketo import public_url_for_enketo
 from .projects import ProjectSerializer
+from .query_params import APP_ID
 
 
 class HasFormPermission(IsAuthenticatedOrReadOnlyWhenNoAuthenticationRequired):
@@ -41,15 +42,6 @@ class HasFormPermission(IsAuthenticatedOrReadOnlyWhenNoAuthenticationRequired):
             .filter(id=obj.id)
             .exists()
         )
-
-
-class HasFormPermissionOrSignedURL(HasFormPermission):
-    def has_permission(self, request, view):
-        if super().has_permission(request, view):
-            return True
-
-        enketo_secret = enketo_settings("ENKETO_SIGNING_SECRET")
-        return verify_signed_url(request, enketo_secret)
 
 
 class FormPredefinedFilterSerializer(serializers.ModelSerializer):
@@ -431,42 +423,79 @@ class FormsViewSet(ModelViewSet):
         log_modification(original, destroyed_form, FORM_API, user=request.user)
         return response
 
-    @action(detail=True, methods=["get"], permission_classes=[HasFormPermissionOrSignedURL])
+    @action(detail=True, methods=["get"])
     def manifest(self, request, *args, **kwargs):
         """Returns a xml manifest file in the openrosa format for the Form
 
-        This is used for the mobile app and Enketo to fetch the list of file attached to the Form
+        This is used for the mobile app to fetch the list of files attached to the Form
         see https://docs.getodk.org/openrosa-form-list/#the-manifest-document
         """
         form = self.get_object()
-        attachments = form.attachments.all()
-        media_files = []
-        for attachment in attachments:
-            attachment_file_url: str = attachment.file.url
-            if not attachment_file_url.startswith("http"):
-                # Needed for local dev
-                attachment_file_url = public_url_for_enketo(request, attachment_file_url)
+        return generate_manifest_for_form(form, request)
 
-            media_files.append(
-                f"""<mediaFile>
-                        <filename>{escape(attachment.name)}</filename>
-                        <hash>md5:{attachment.md5}</hash>
-                        <downloadUrl>{escape(attachment_file_url)}</downloadUrl>
-                    </mediaFile>"""
-            )
+    @action(detail=True, methods=["get"], permission_classes=[ReadOnly])
+    def manifest_enketo(self, request, pk, *args, **kwargs):
+        """Returns a xml manifest file in the openrosa format for the Form
 
-        nl = "\n"  # Backslashes are not allowed in f-string ¯\_(ツ)_/¯
+        This is used by enketo to fetch the list of files attached to the Form
+        see https://docs.getodk.org/openrosa-form-list/#the-manifest-document
+        """
+        enketo_secret = enketo_settings("ENKETO_SIGNING_SECRET")
+        if verify_signed_url(request, enketo_secret):
+            app_id = request.query_params.get(APP_ID, None)
+            queryset = Form.objects.filter(
+                projects__app_id=app_id
+            )  # Not using the default queryset because there's no auth
+            form = get_object_or_404(queryset, pk=pk)
+            return generate_manifest_for_form(form, request)
+
         return HttpResponse(
-            status=status.HTTP_200_OK,
+            status=status.HTTP_400_BAD_REQUEST,
             content_type="text/xml",
             headers={
                 "X-OpenRosa-Version": "1.0",
             },
-            content=f"""<?xml version="1.0" encoding="UTF-8"?>
-                        <manifest xmlns="http://openrosa.org/xforms/xformsManifest">
-                            {nl.join(media_files)}
-                        </manifest>""",
+            content="<error>Invalid URL signature</error>",
         )
+
+
+def generate_manifest_for_form(form: Form, request: Request) -> HttpResponse:
+    attachments = form.attachments.all()
+    media_files = []
+    for attachment in attachments:
+        attachment_file_url: str = attachment.file.url
+        if not attachment_file_url.startswith("http"):
+            # Needed for local dev
+            attachment_file_url = public_url_for_enketo(request, attachment_file_url)
+        media_files.append(generate_manifest_media_file(attachment, attachment_file_url))
+
+    manifest = generate_manifest_structure(media_files)
+    return HttpResponse(
+        status=status.HTTP_200_OK,
+        content_type="text/xml",
+        headers={
+            "X-OpenRosa-Version": "1.0",
+        },
+        content=manifest,
+    )
+
+
+def generate_manifest_media_file(attachment: FormAttachment, url: str) -> str:
+    return f"""<mediaFile>
+        <filename>{escape(attachment.name)}</filename>
+        <hash>md5:{attachment.md5}</hash>
+        <downloadUrl>{escape(url)}</downloadUrl>
+    </mediaFile>"""
+
+
+def generate_manifest_structure(content: list[str]) -> str:
+    nl = "\n"  # Backslashes are not allowed in f-string ¯\_(ツ)_/¯
+    return (
+        f"""<?xml version="1.0" encoding="UTF-8"?>
+<manifest xmlns="http://openrosa.org/xforms/xformsManifest">
+    {nl.join(content)}
+</manifest>""",
+    )
 
 
 class MobileFormViewSet(FormsViewSet):

--- a/iaso/tests/fixtures/form_attachments/manifest_empty.xml
+++ b/iaso/tests/fixtures/form_attachments/manifest_empty.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-                        <manifest xmlns="http://openrosa.org/xforms/xformsManifest">
-                            
-                        </manifest>
+<manifest xmlns="http://openrosa.org/xforms/xformsManifest">
+    
+</manifest>

--- a/iaso/tests/fixtures/form_attachments/manifest_invalid_character.xml
+++ b/iaso/tests/fixtures/form_attachments/manifest_invalid_character.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-                        <manifest xmlns="http://openrosa.org/xforms/xformsManifest">
-                            <mediaFile>
-                        <filename>&lt;&amp;&gt;.png</filename>
-                        <hash>md5:test1</hash>
-                        <downloadUrl>http://testserver{{ attachment_url }}</downloadUrl>
-                    </mediaFile>
-                        </manifest>
+<manifest xmlns="http://openrosa.org/xforms/xformsManifest">
+    <mediaFile>
+        <filename>&lt;&amp;&gt;.png</filename>
+        <hash>md5:test1</hash>
+        <downloadUrl>http://testserver{{ attachment_url }}</downloadUrl>
+    </mediaFile>
+</manifest>

--- a/iaso/tests/fixtures/form_attachments/manifest_multiple_attachments.xml
+++ b/iaso/tests/fixtures/form_attachments/manifest_multiple_attachments.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-                        <manifest xmlns="http://openrosa.org/xforms/xformsManifest">
-                            <mediaFile>
-                        <filename>{{ attachment_1_name }}</filename>
-                        <hash>md5:{{ attachment_1_hash }}</hash>
-                        <downloadUrl>http://testserver{{ attachment_1_url }}</downloadUrl>
-                    </mediaFile>
+<manifest xmlns="http://openrosa.org/xforms/xformsManifest">
+    <mediaFile>
+        <filename>{{ attachment_1_name }}</filename>
+        <hash>md5:{{ attachment_1_hash }}</hash>
+        <downloadUrl>http://testserver{{ attachment_1_url }}</downloadUrl>
+    </mediaFile>
 <mediaFile>
-                        <filename>{{ attachment_2_name }}</filename>
-                        <hash>md5:{{ attachment_2_hash }}</hash>
-                        <downloadUrl>http://testserver{{ attachment_2_url }}</downloadUrl>
-                    </mediaFile>
-                        </manifest>
+        <filename>{{ attachment_2_name }}</filename>
+        <hash>md5:{{ attachment_2_hash }}</hash>
+        <downloadUrl>http://testserver{{ attachment_2_url }}</downloadUrl>
+    </mediaFile>
+</manifest>


### PR DESCRIPTION
Let enketo download a form manifest even when the auth feature flag is enabled.

Related JIRA tickets : IA-4295

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

/

## Changes

- Split manifest endpoints into 2:
   - one for mobile (already existing) -> revert changes from previous PR back to its original state
   - one for enketo (new one)

## How to test

- Choose a form that has attachments
- Make sure it's linked to a project that has the auth feature flag enabled
- Start enketo
- Make a new submission for your form using enketo - there's shouldn't be any error

## Print screen / video

![image](https://github.com/user-attachments/assets/9ae458c9-946a-475c-afae-cbe2c21057c6)


## Notes

The endpoint was split because we need to use a different queryset from the one used in the mobile endpoint (no filtering for forms/projects for anonymous user; direct filtering on `app_id`). 

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
