### PR TITLE
Snt 49 metrics query builder

### DIFF
--- a/iaso/api/metrics/serializers.py
+++ b/iaso/api/metrics/serializers.py
@@ -28,9 +28,14 @@ class MetricTypeSerializer(serializers.ModelSerializer):
             "updated_at",
         ]
 
-
 class MetricValueSerializer(serializers.ModelSerializer):
     class Meta:
         model = MetricValue
         fields = ["id", "metric_type", "org_unit", "year", "value"]
         read_only_fields = fields
+
+class OrgUnitIdSerializer(serializers.Serializer):
+    org_unit_id = serializers.IntegerField()
+
+    def to_representation(self, instance):
+        return {"org_unit_id": instance}

--- a/iaso/api/metrics/serializers.py
+++ b/iaso/api/metrics/serializers.py
@@ -28,11 +28,13 @@ class MetricTypeSerializer(serializers.ModelSerializer):
             "updated_at",
         ]
 
+
 class MetricValueSerializer(serializers.ModelSerializer):
     class Meta:
         model = MetricValue
         fields = ["id", "metric_type", "org_unit", "year", "value"]
         read_only_fields = fields
+
 
 class OrgUnitIdSerializer(serializers.Serializer):
     org_unit_id = serializers.IntegerField()

--- a/iaso/api/metrics/views.py
+++ b/iaso/api/metrics/views.py
@@ -4,7 +4,7 @@ from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import filters, viewsets
 
 from iaso.models import MetricType, MetricValue
-from iaso.utils.jsonlogic import jsonlogic_to_q
+from iaso.utils.jsonlogic import jsonlogic_to_q, keyvalue_jsonlogic_to_q
 
 from .serializers import MetricTypeSerializer, MetricValueSerializer
 
@@ -31,11 +31,30 @@ class ValueFilterBackend(filters.BaseFilterBackend):
 
         return queryset
 
+class ValueAndTypeFilterBackend(filters.BaseFilterBackend):
+    def filter_queryset(self, request, queryset, view):
+        json_filter = request.query_params.get("json_filter")
+        print("json_filter", json_filter)
+        if not json_filter:
+            return queryset
+
+        q, annotations, filters = keyvalue_jsonlogic_to_q(json.loads(json_filter), "metric_type", "value")
+        filteredOrgUnitIds = queryset.values('org_unit_id')\
+            .annotate(**annotations).filter(filters)\
+            .values_list('org_unit_id', flat=True)
+        print("q", q)
+        print("annotations", annotations)
+        print("filters", filters)
+        print("queryset", filteredOrgUnitIds)
+
+        rows = queryset.filter(org_unit_id__in=filteredOrgUnitIds)
+        print("rows", rows)
+        return rows
 
 class MetricValueViewSet(viewsets.ModelViewSet):
     serializer_class = MetricValueSerializer
     queryset = MetricValue.objects.all()
-    filter_backends = [DjangoFilterBackend, ValueFilterBackend]
+    filter_backends = [DjangoFilterBackend, ValueAndTypeFilterBackend]
     filterset_fields = ["metric_type_id", "org_unit_id"]
 
     def get_queryset(self):

--- a/iaso/api/metrics/views.py
+++ b/iaso/api/metrics/views.py
@@ -41,11 +41,11 @@ class ValueAndTypeFilterBackend(filters.BaseFilterBackend):
             return queryset.values(group_by_field_name).distinct().values_list(group_by_field_name, flat=True)
 
         q = jsonlogic_to_exists_q_clauses(
-            jsonlogic=json.loads(json_filter), 
-            entities=MetricValue.objects, 
-            id_field_name="metric_type_id", 
-            value_field_name="value", 
-            group_by_field_name=group_by_field_name
+            json.loads(json_filter), 
+            MetricValue.objects, 
+            "metric_type_id", 
+            "value", 
+            group_by_field_name
         )
 
         qs = queryset.filter(q).values_list(group_by_field_name, flat=True).distinct()

--- a/iaso/api/metrics/views.py
+++ b/iaso/api/metrics/views.py
@@ -4,7 +4,7 @@ from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import filters, viewsets
 
 from iaso.models import MetricType, MetricValue
-from iaso.utils.jsonlogic import jsonlogic_to_q, keyvalue_jsonlogic_to_q
+from iaso.utils.jsonlogic import jsonlogic_to_q, annotation_jsonlogic_to_q
 
 from .serializers import MetricTypeSerializer, MetricValueSerializer
 
@@ -38,11 +38,10 @@ class ValueAndTypeFilterBackend(filters.BaseFilterBackend):
         if not json_filter:
             return queryset
 
-        q, annotations, filters = keyvalue_jsonlogic_to_q(json.loads(json_filter), "metric_type", "value")
+        annotations, filters = annotation_jsonlogic_to_q(json.loads(json_filter), "metric_type", "value")
         filteredOrgUnitIds = queryset.values('org_unit_id')\
             .annotate(**annotations).filter(filters)\
             .values_list('org_unit_id', flat=True)
-        print("q", q)
         print("annotations", annotations)
         print("filters", filters)
         print("queryset", filteredOrgUnitIds)

--- a/iaso/api/metrics/views.py
+++ b/iaso/api/metrics/views.py
@@ -4,7 +4,7 @@ from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import filters, viewsets
 
 from iaso.models import MetricType, MetricValue
-from iaso.utils.jsonlogic import LOOKUPS, jsonlogic_to_exists_q_clauses, jsonlogic_to_q
+from iaso.utils.jsonlogic import jsonlogic_to_exists_q_clauses, jsonlogic_to_q
 
 from .serializers import MetricTypeSerializer, MetricValueSerializer, OrgUnitIdSerializer
 
@@ -41,11 +41,7 @@ class ValueAndTypeFilterBackend(filters.BaseFilterBackend):
             return queryset.values(group_by_field_name).distinct().values_list(group_by_field_name, flat=True)
 
         q = jsonlogic_to_exists_q_clauses(
-            json.loads(json_filter), 
-            MetricValue.objects, 
-            "metric_type_id", 
-            "value", 
-            group_by_field_name
+            json.loads(json_filter), MetricValue.objects, "metric_type_id", "value", group_by_field_name
         )
 
         qs = queryset.filter(q).values_list(group_by_field_name, flat=True).distinct()

--- a/iaso/api/metrics/views.py
+++ b/iaso/api/metrics/views.py
@@ -35,12 +35,12 @@ class ValueAndTypeFilterBackend(filters.BaseFilterBackend):
     def filter_queryset(self, request, queryset, view):
         json_filter = request.query_params.get("json_filter")
         if not json_filter:
-            return queryset.values('org_unit_id').distinct().values_list('org_unit_id', flat=True)
+            return queryset.values("org_unit_id").distinct().values_list("org_unit_id", flat=True)
 
         annotations, filters = annotation_jsonlogic_to_q(json.loads(json_filter), "metric_type", "value")
-        filteredOrgUnitIds = queryset.values('org_unit_id')\
+        filteredOrgUnitIds = queryset.values("org_unit_id")\
             .annotate(**annotations).filter(filters)\
-            .values_list('org_unit_id', flat=True)
+            .values_list("org_unit_id", flat=True)
 
         # rows = queryset.filter(org_unit_id__in=filteredOrgUnitIds)
         return filteredOrgUnitIds

--- a/iaso/api/metrics/views.py
+++ b/iaso/api/metrics/views.py
@@ -1,10 +1,12 @@
 import json
+import operator
 
+from django.db.models import Exists, OuterRef, Q
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import filters, viewsets
 
 from iaso.models import MetricType, MetricValue
-from iaso.utils.jsonlogic import jsonlogic_to_q, annotation_jsonlogic_to_q
+from iaso.utils.jsonlogic import LOOKUPS, annotation_jsonlogic_to_q, jsonlogic_to_q
 
 from .serializers import MetricTypeSerializer, MetricValueSerializer, OrgUnitIdSerializer
 
@@ -31,19 +33,72 @@ class ValueFilterBackend(filters.BaseFilterBackend):
 
         return queryset
 
+
 class ValueAndTypeFilterBackend(filters.BaseFilterBackend):
     def filter_queryset(self, request, queryset, view):
         json_filter = request.query_params.get("json_filter")
+
         if not json_filter:
             return queryset.values("org_unit_id").distinct().values_list("org_unit_id", flat=True)
 
         annotations, filters = annotation_jsonlogic_to_q(json.loads(json_filter), "metric_type", "value")
-        filteredOrgUnitIds = queryset.values("org_unit_id")\
-            .annotate(**annotations).filter(filters)\
-            .values_list("org_unit_id", flat=True)
+        print(queryset.values("org_unit_id").annotate(**annotations).filter(filters).query)
+        print(queryset.values("org_unit_id").annotate(**annotations).filter(filters).count())
+
+        filteredOrgUnitIds = (
+            queryset.values("org_unit_id").annotate(**annotations).filter(filters).values_list("org_unit_id", flat=True)
+        )
+
+        print("%" * 20)
+
+        q = self._jsonlogic_to_exists_q_clauses(jsonlogic=json.loads(json_filter))
+        qs = queryset.filter(q).values("org_unit_id").distinct()
+        print(qs.query)
+        print(qs.count())
+
+        print("EQUALS", sorted(list(filteredOrgUnitIds)) == sorted(list(qs.values_list("org_unit_id", flat=True))))
 
         # rows = queryset.filter(org_unit_id__in=filteredOrgUnitIds)
         return filteredOrgUnitIds
+
+    def _jsonlogic_to_exists_q_clauses(self, jsonlogic):
+        if "and" in jsonlogic:
+            sub_query = Q()
+            for lookup in jsonlogic["and"]:
+                sub_query = operator.and_(sub_query, self._jsonlogic_to_exists_q_clauses(lookup))
+            return sub_query
+        if "or" in jsonlogic:
+            sub_query = Q()
+            for lookup in jsonlogic["or"]:
+                sub_query = operator.or_(sub_query, self._jsonlogic_to_exists_q_clauses(lookup))
+            return sub_query
+        if "!" in jsonlogic:
+            return ~self._jsonlogic_to_exists_q_clauses(jsonlogic["!"])
+
+        if not jsonlogic.keys():
+            return Q()
+
+        op = list(jsonlogic.keys())[0]
+        params = jsonlogic[op]
+
+        field_position = 1 if op == "in" else 0
+        field = params[field_position]
+        value = params[0] if op == "in" else params[1]
+
+        q = Q(
+            Exists(
+                MetricValue.objects.filter(
+                    org_unit_id=OuterRef("org_unit_id"),
+                    metric_type_id=field["var"],
+                ).filter(Q(**{f"value__{LOOKUPS[op]}": value}))
+            )
+        )
+
+        if op == "!=":
+            # invert the filter
+            q = ~q
+        return q
+
 
 class MetricValueViewSet(viewsets.ModelViewSet):
     serializer_class = MetricValueSerializer
@@ -54,11 +109,13 @@ class MetricValueViewSet(viewsets.ModelViewSet):
     def get_queryset(self):
         return MetricValue.objects.filter(metric_type__account=self.request.user.iaso_profile.account)
 
+
 class MetricOrgUnitsViewSet(viewsets.ModelViewSet):
     """
     This viewset is used to retrieve the org units for a given metric type.
     It is used in the frontend to display the org units for a given metric type.
     """
+
     serializer_class = OrgUnitIdSerializer
     queryset = MetricValue.objects.all()
     filter_backends = [DjangoFilterBackend, ValueAndTypeFilterBackend]

--- a/iaso/migrations/0326_merge_20250416_1317.py
+++ b/iaso/migrations/0326_merge_20250416_1317.py
@@ -4,11 +4,9 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("iaso", "0321_formattachment_file_last_scan_and_more"),
         ("iaso", "0325_alter_metrictype_options"),
     ]
 
-    operations = [
-    ]
+    operations = []

--- a/iaso/migrations/0327_merge_20250424_0829.py
+++ b/iaso/migrations/0327_merge_20250424_0829.py
@@ -4,11 +4,9 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("iaso", "0322_alter_orgunit_org_unit_type_and_more"),
         ("iaso", "0326_merge_20250416_1317"),
     ]
 
-    operations = [
-    ]
+    operations = []

--- a/iaso/migrations/0328_merge_20250613_1308.py
+++ b/iaso/migrations/0328_merge_20250613_1308.py
@@ -4,11 +4,9 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("iaso", "0326_alter_project_app_id"),
         ("iaso", "0327_merge_20250424_0829"),
     ]
 
-    operations = [
-    ]
+    operations = []

--- a/iaso/tests/utils/test_jsonlogic.py
+++ b/iaso/tests/utils/test_jsonlogic.py
@@ -1,8 +1,147 @@
 from iaso.test import TestCase
-from iaso.utils.jsonlogic import jsonlogic_to_q
+from iaso.utils.jsonlogic import jsonlogic_to_q, keyvalue_jsonlogic_to_q
 
 
 class JsonLogicTests(TestCase):
+    def test_keyvalut_jsonlogic_to_q__simple_and(self) -> None:
+        filters = { "and": [{">=":[ {"var":"23"}, 900]}, {"==":[{"var":"22"}, 700]}]}
+        q, annotations, annotationFilters = keyvalue_jsonlogic_to_q(filters, "metric_type", "value", "org_unit_id")
+        self.assertEqual(str(q), "(OR: (AND: ('metric_type__exact', '23'), ('value__gte', 900)), (AND: ('metric_type__exact', '22'), ('value__exact', 700)))")
+        
+        annotationKey = "23__gte__900"
+        self.assertIn(annotationKey, annotations.keys())
+        firstConditionCases = annotations[annotationKey].cases
+        firstConditionCase = firstConditionCases[0]
+        self.assertEqual(str(firstConditionCase.condition), "(AND: ('metric_type__exact', '23'), ('value__gte', 900))")
+        self.assertEqual(str(firstConditionCase.result), "Value(True)")
+
+        annotationKey = "22__exact__700"
+        self.assertIn(annotationKey, annotations.keys())
+        firstConditionCases = annotations[annotationKey].cases
+        firstConditionCase = firstConditionCases[0]
+        self.assertEqual(str(firstConditionCase.condition), "(AND: ('metric_type__exact', '22'), ('value__exact', 700))")
+        self.assertEqual(str(firstConditionCase.result), "Value(True)")
+
+
+        self.assertNotIn("or", annotationFilters.keys())
+        self.assertIn("and", annotationFilters.keys())
+
+        andAnnotationFilters = annotationFilters["and"]
+        self.assertEqual(2, len(andAnnotationFilters))
+        expectedAnnotationFilters = [
+            "(AND: {'23__gte__900': True})",
+            "(AND: {'22__exact__700': True})"
+        ]
+        for query in andAnnotationFilters:
+            self.assertIn(str(query), expectedAnnotationFilters)
+
+    def test_keyvalut_jsonlogic_to_q__simple_or(self) -> None:
+        filters = { "or": [{">=":[ {"var":"23"}, 900]}, {"==":[{"var":"22"}, 700]}]}
+        q, annotations, annotationFilters = keyvalue_jsonlogic_to_q(filters, "metric_type", "value", "org_unit_id")
+        self.assertEqual(str(q), "(OR: (AND: ('metric_type__exact', '23'), ('value__gte', 900)), (AND: ('metric_type__exact', '22'), ('value__exact', 700)))")
+        
+        annotationKey = "23__gte__900"
+        self.assertIn(annotationKey, annotations.keys())
+        firstConditionCases = annotations[annotationKey].cases
+        firstConditionCase = firstConditionCases[0]
+        self.assertEqual(str(firstConditionCase.condition), "(AND: ('metric_type__exact', '23'), ('value__gte', 900))")
+        self.assertEqual(str(firstConditionCase.result), "Value(True)")
+
+        annotationKey = "22__exact__700"
+        self.assertIn(annotationKey, annotations.keys())
+        firstConditionCases = annotations[annotationKey].cases
+        firstConditionCase = firstConditionCases[0]
+        self.assertEqual(str(firstConditionCase.condition), "(AND: ('metric_type__exact', '22'), ('value__exact', 700))")
+        self.assertEqual(str(firstConditionCase.result), "Value(True)")
+
+
+        self.assertIn("or", annotationFilters.keys())
+        self.assertNotIn("and", annotationFilters.keys())
+
+        andAnnotationFilters = annotationFilters["or"]
+        self.assertEqual(2, len(andAnnotationFilters))
+        expectedAnnotationFilters = [
+            "(AND: {'23__gte__900': True})",
+            "(AND: {'22__exact__700': True})"
+        ]
+        for query in andAnnotationFilters:
+            self.assertIn(str(query), expectedAnnotationFilters)
+
+
+    def test_keyvalut_jsonlogic_to_q__simple_and_or(self) -> None:
+        filters = { 
+            "or":[
+                {">=":[{"var":"23"},900]},
+                {"==":[{"var":"22"},700]},
+                {"and":[
+                    {"<=":[{"var":"23"},1500]},
+                    {"==":[{"var":"24"},1000]}
+                ]}
+            ]
+                  
+        }
+        q, annotations, annotationFilters = keyvalue_jsonlogic_to_q(filters, "metric_type", "value", "org_unit_id")
+        
+        self.assertEqual(str(q), (""
+        "(OR: "
+            "(AND: ('metric_type__exact', '23'), ('value__gte', 900)), "
+            "(AND: ('metric_type__exact', '22'), ('value__exact', 700)), "
+            "(AND: ('metric_type__exact', '23'), ('value__lte', 1500)), "
+            "(AND: ('metric_type__exact', '24'), ('value__exact', 1000))"
+        ")"))
+        
+        annotationKey = "23__gte__900"
+        self.assertIn(annotationKey, annotations.keys())
+        firstConditionCases = annotations[annotationKey].cases
+        firstConditionCase = firstConditionCases[0]
+        self.assertEqual(str(firstConditionCase.condition), "(AND: ('metric_type__exact', '23'), ('value__gte', 900))")
+        self.assertEqual(str(firstConditionCase.result), "Value(True)")
+
+        annotationKey = "23__lte__1500"
+        self.assertIn(annotationKey, annotations.keys())
+        firstConditionCases = annotations[annotationKey].cases
+        firstConditionCase = firstConditionCases[0]
+        self.assertEqual(str(firstConditionCase.condition), "(AND: ('metric_type__exact', '23'), ('value__lte', 1500))")
+        self.assertEqual(str(firstConditionCase.result), "Value(True)")
+
+        annotationKey = "24__exact__1000"
+        self.assertIn(annotationKey, annotations.keys())
+        firstConditionCases = annotations[annotationKey].cases
+        firstConditionCase = firstConditionCases[0]
+        self.assertEqual(str(firstConditionCase.condition), "(AND: ('metric_type__exact', '24'), ('value__exact', 1000))")
+        self.assertEqual(str(firstConditionCase.result), "Value(True)")
+
+
+        self.assertIn("or", annotationFilters.keys())
+        self.assertNotIn("and", annotationFilters.keys())
+
+        print(annotationFilters)
+
+        orAnnotationFilters = annotationFilters["or"]
+        self.assertEqual(3, len(orAnnotationFilters))
+        expectedAnnotationFilters = [
+            "(AND: {'23__gte__900': True})",
+            "(AND: {'22__exact__700': True})"
+        ]
+
+        andSubAnnotationFilters = []
+        for query in orAnnotationFilters:
+            if (type(query) is dict):
+                self.assertTrue('and' in query)
+                andSubAnnotationFilters = query['and']
+                continue
+            self.assertIn(str(query), expectedAnnotationFilters)
+
+        print(andSubAnnotationFilters)
+
+        expectedSubAnnotationFilters = [
+            "(AND: {'23__lte__1500': True})",
+            "(AND: {'24__exact__1000': True})"
+        ]
+
+        for query in andSubAnnotationFilters:
+            self.assertIn(str(query), expectedSubAnnotationFilters)
+
     def test_jsonlogic_to_q_filters_base(self) -> None:
         """The base case of jsonlogic_to_q works as expected."""
         filters = {"and": [{"==": [{"var": "gender"}, "F"]}, {"<": [{"var": "age"}, "25"]}]}

--- a/iaso/tests/utils/test_jsonlogic.py
+++ b/iaso/tests/utils/test_jsonlogic.py
@@ -1,89 +1,92 @@
-from unittest.mock import Mock
+from django.db.models import Q
+
 from iaso.models.metric import MetricValue
 from iaso.test import TestCase
-from iaso.utils.jsonlogic import jsonlogic_to_q, jsonlogic_to_exists_q_clauses
-from django.db.models import Exists, Q
+from iaso.utils.jsonlogic import jsonlogic_to_exists_q_clauses, jsonlogic_to_q
+
 
 class JsonLogicTests(TestCase):
-
     def setUp(self):
-        self.id_field_name = 'metric_type_id'
-        self.value_field_name = 'value'
-        self.group_by_field_name = 'org_unit_id'
+        self.id_field_name = "metric_type_id"
+        self.value_field_name = "value"
+        self.group_by_field_name = "org_unit_id"
 
     def test_jsonlogic_to_exists_q_clauses__simple(self) -> None:
         """Test a simple JsonLogic query to ensure it returns a Q object."""
-        filters = {"==": [{"var":22}, 1]}
-        expectedQuerySet = '' \
-        'SELECT "iaso_metricvalue"."id", "iaso_metricvalue"."metric_type_id", "iaso_metricvalue"."org_unit_id", ' \
-            '"iaso_metricvalue"."year", "iaso_metricvalue"."value" ' \
-        'FROM "iaso_metricvalue" ' \
-        'WHERE EXISTS(' \
+        filters = {"==": [{"var": 22}, 1]}
+        expectedQuerySet = (
+            'SELECT "iaso_metricvalue"."id", "iaso_metricvalue"."metric_type_id", "iaso_metricvalue"."org_unit_id", '
+            '"iaso_metricvalue"."year", "iaso_metricvalue"."value" '
+            'FROM "iaso_metricvalue" '
+            "WHERE EXISTS("
             'SELECT 1 AS "a" FROM "iaso_metricvalue" U0 WHERE (U0."metric_type_id" = 22 AND U0."org_unit_id" = ("iaso_metricvalue"."org_unit_id") AND U0."value" = 1.0) LIMIT 1)'
-        q = jsonlogic_to_exists_q_clauses(filters, MetricValue.objects, self.id_field_name, self.value_field_name, self.group_by_field_name)
-        
+        )
+        q = jsonlogic_to_exists_q_clauses(
+            filters, MetricValue.objects, self.id_field_name, self.value_field_name, self.group_by_field_name
+        )
+
         querySet = MetricValue.objects.filter(q)
         self.assertEqual(str(querySet.query), expectedQuerySet)
 
-
     def test_jsonlogic_to_exists_q_clauses__simple_and(self) -> None:
-        filters = { "and": [{">=":[ {"var":"23"}, 900]}, {"==":[{"var":"22"}, 700]}]}
-        expectedQuerySet = '' \
-        'SELECT "iaso_metricvalue"."id", "iaso_metricvalue"."metric_type_id", "iaso_metricvalue"."org_unit_id", ' \
-        '"iaso_metricvalue"."year", "iaso_metricvalue"."value" ' \
-        'FROM "iaso_metricvalue" ' \
-        'WHERE (' \
-            'EXISTS(SELECT 1 AS "a" FROM "iaso_metricvalue" U0 WHERE (U0."metric_type_id" = 23 AND U0."org_unit_id" = ("iaso_metricvalue"."org_unit_id") AND U0."value" >= 900.0) LIMIT 1) ' \
-            'AND ' \
-            'EXISTS(SELECT 1 AS "a" FROM "iaso_metricvalue" U0 WHERE (U0."metric_type_id" = 22 AND U0."org_unit_id" = ("iaso_metricvalue"."org_unit_id") AND U0."value" = 700.0) LIMIT 1)' \
-        ')'
+        filters = {"and": [{">=": [{"var": "23"}, 900]}, {"==": [{"var": "22"}, 700]}]}
+        expectedQuerySet = (
+            'SELECT "iaso_metricvalue"."id", "iaso_metricvalue"."metric_type_id", "iaso_metricvalue"."org_unit_id", '
+            '"iaso_metricvalue"."year", "iaso_metricvalue"."value" '
+            'FROM "iaso_metricvalue" '
+            "WHERE ("
+            'EXISTS(SELECT 1 AS "a" FROM "iaso_metricvalue" U0 WHERE (U0."metric_type_id" = 23 AND U0."org_unit_id" = ("iaso_metricvalue"."org_unit_id") AND U0."value" >= 900.0) LIMIT 1) '
+            "AND "
+            'EXISTS(SELECT 1 AS "a" FROM "iaso_metricvalue" U0 WHERE (U0."metric_type_id" = 22 AND U0."org_unit_id" = ("iaso_metricvalue"."org_unit_id") AND U0."value" = 700.0) LIMIT 1)'
+            ")"
+        )
         q = jsonlogic_to_exists_q_clauses(filters, MetricValue.objects, "metric_type_id", "value", "org_unit_id")
         querySet = MetricValue.objects.filter(q)
         self.assertEqual(str(querySet.query), expectedQuerySet)
 
     def test_jsonlogic_to_exists_q_clauses__simple_or(self) -> None:
-        filters = { "or": [{">=":[ {"var":"23"}, 900]}, {"==":[{"var":"22"}, 700]}]}
-        expectedQuerySet = '' \
-        'SELECT "iaso_metricvalue"."id", "iaso_metricvalue"."metric_type_id", "iaso_metricvalue"."org_unit_id", ' \
-            '"iaso_metricvalue"."year", "iaso_metricvalue"."value" ' \
-        'FROM "iaso_metricvalue" ' \
-        'WHERE (' \
-            'EXISTS(SELECT 1 AS "a" FROM "iaso_metricvalue" U0 WHERE (U0."metric_type_id" = 23 AND U0."org_unit_id" = ("iaso_metricvalue"."org_unit_id") AND U0."value" >= 900.0) LIMIT 1) ' \
-            'OR ' \
-            'EXISTS(SELECT 1 AS "a" FROM "iaso_metricvalue" U0 WHERE (U0."metric_type_id" = 22 AND U0."org_unit_id" = ("iaso_metricvalue"."org_unit_id") AND U0."value" = 700.0) LIMIT 1)' \
-        ')'
+        filters = {"or": [{">=": [{"var": "23"}, 900]}, {"==": [{"var": "22"}, 700]}]}
+        expectedQuerySet = (
+            'SELECT "iaso_metricvalue"."id", "iaso_metricvalue"."metric_type_id", "iaso_metricvalue"."org_unit_id", '
+            '"iaso_metricvalue"."year", "iaso_metricvalue"."value" '
+            'FROM "iaso_metricvalue" '
+            "WHERE ("
+            'EXISTS(SELECT 1 AS "a" FROM "iaso_metricvalue" U0 WHERE (U0."metric_type_id" = 23 AND U0."org_unit_id" = ("iaso_metricvalue"."org_unit_id") AND U0."value" >= 900.0) LIMIT 1) '
+            "OR "
+            'EXISTS(SELECT 1 AS "a" FROM "iaso_metricvalue" U0 WHERE (U0."metric_type_id" = 22 AND U0."org_unit_id" = ("iaso_metricvalue"."org_unit_id") AND U0."value" = 700.0) LIMIT 1)'
+            ")"
+        )
         q = jsonlogic_to_exists_q_clauses(filters, MetricValue.objects, "metric_type_id", "value", "org_unit_id")
         self.assertIsInstance(q, Q)
         querySet = MetricValue.objects.filter(q)
         self.assertEqual(str(querySet.query), expectedQuerySet)
 
     def test_jsonlogic_to_exists_q_clauses__complex(self) -> None:
-        filters = { "or":[
-            {">=":[{"var":"23"},900]},
-            {"==":[{"var":"22"},700]},
-            {"and":[
-                {"<=":[{"var":"23"},1500]},
-                {"==":[{"var":"24"},1000]}
-            ]}
-        ]}
-        expectedQuerySet = '' \
-        'SELECT "iaso_metricvalue"."id", "iaso_metricvalue"."metric_type_id", ' \
-        '"iaso_metricvalue"."org_unit_id", "iaso_metricvalue"."year", "iaso_metricvalue"."value" ' \
-        'FROM "iaso_metricvalue" ' \
-        'WHERE (' \
-            'EXISTS(SELECT 1 AS "a" FROM "iaso_metricvalue" U0 WHERE (U0."metric_type_id" = 23 AND U0."org_unit_id" = ("iaso_metricvalue"."org_unit_id") AND U0."value" >= 900.0) LIMIT 1) ' \
-            'OR ' \
-            'EXISTS(SELECT 1 AS "a" FROM "iaso_metricvalue" U0 WHERE (U0."metric_type_id" = 22 AND U0."org_unit_id" = ("iaso_metricvalue"."org_unit_id") AND U0."value" = 700.0) LIMIT 1) ' \
-            'OR (' \
-                'EXISTS(SELECT 1 AS "a" FROM "iaso_metricvalue" U0 WHERE (U0."metric_type_id" = 23 AND U0."org_unit_id" = ("iaso_metricvalue"."org_unit_id") AND U0."value" <= 1500.0) LIMIT 1) ' \
-                'AND ' \
-                'EXISTS(SELECT 1 AS "a" FROM "iaso_metricvalue" U0 WHERE (U0."metric_type_id" = 24 AND U0."org_unit_id" = ("iaso_metricvalue"."org_unit_id") AND U0."value" = 1000.0) LIMIT 1)' \
-            ')' \
-        ')' 
+        filters = {
+            "or": [
+                {">=": [{"var": "23"}, 900]},
+                {"==": [{"var": "22"}, 700]},
+                {"and": [{"<=": [{"var": "23"}, 1500]}, {"==": [{"var": "24"}, 1000]}]},
+            ]
+        }
+        expectedQuerySet = (
+            'SELECT "iaso_metricvalue"."id", "iaso_metricvalue"."metric_type_id", '
+            '"iaso_metricvalue"."org_unit_id", "iaso_metricvalue"."year", "iaso_metricvalue"."value" '
+            'FROM "iaso_metricvalue" '
+            "WHERE ("
+            'EXISTS(SELECT 1 AS "a" FROM "iaso_metricvalue" U0 WHERE (U0."metric_type_id" = 23 AND U0."org_unit_id" = ("iaso_metricvalue"."org_unit_id") AND U0."value" >= 900.0) LIMIT 1) '
+            "OR "
+            'EXISTS(SELECT 1 AS "a" FROM "iaso_metricvalue" U0 WHERE (U0."metric_type_id" = 22 AND U0."org_unit_id" = ("iaso_metricvalue"."org_unit_id") AND U0."value" = 700.0) LIMIT 1) '
+            "OR ("
+            'EXISTS(SELECT 1 AS "a" FROM "iaso_metricvalue" U0 WHERE (U0."metric_type_id" = 23 AND U0."org_unit_id" = ("iaso_metricvalue"."org_unit_id") AND U0."value" <= 1500.0) LIMIT 1) '
+            "AND "
+            'EXISTS(SELECT 1 AS "a" FROM "iaso_metricvalue" U0 WHERE (U0."metric_type_id" = 24 AND U0."org_unit_id" = ("iaso_metricvalue"."org_unit_id") AND U0."value" = 1000.0) LIMIT 1)'
+            ")"
+            ")"
+        )
         q = jsonlogic_to_exists_q_clauses(filters, MetricValue.objects, "metric_type_id", "value", "org_unit_id")
         querySet = MetricValue.objects.filter(q)
         self.assertEqual(str(querySet.query), expectedQuerySet)
-
 
     def test_jsonlogic_to_q_filters_base(self) -> None:
         """The base case of jsonlogic_to_q works as expected."""

--- a/iaso/tests/utils/test_jsonlogic.py
+++ b/iaso/tests/utils/test_jsonlogic.py
@@ -1,52 +1,46 @@
 from iaso.test import TestCase
-from iaso.utils.jsonlogic import jsonlogic_to_q, keyvalue_jsonlogic_to_q
+from iaso.utils.jsonlogic import jsonlogic_to_q, annotation_jsonlogic_to_q
 
 
 class JsonLogicTests(TestCase):
     def test_keyvalut_jsonlogic_to_q__simple_and(self) -> None:
         filters = { "and": [{">=":[ {"var":"23"}, 900]}, {"==":[{"var":"22"}, 700]}]}
-        q, annotations, annotationFilters = keyvalue_jsonlogic_to_q(filters, "metric_type", "value")
-        self.assertEqual(str(q), "(OR: (AND: ('metric_type__exact', '23'), ('value__gte', 900)), (AND: ('metric_type__exact', '22'), ('value__exact', 700)))")
+        annotations, annotationFilters = annotation_jsonlogic_to_q(filters, "metric_type", "value")
         
         annotationKey = "23__gte__900"
         self.assertIn(annotationKey, annotations.keys())
-        firstConditionCases = annotations[annotationKey].cases
-        firstConditionCase = firstConditionCases[0]
-        self.assertEqual(str(firstConditionCase.condition), "(AND: ('metric_type__exact', '23'), ('value__gte', 900))")
-        self.assertEqual(str(firstConditionCase.result), "Value(True)")
+        self.assertEqual(
+            str(annotations[annotationKey]),
+            "Sum(CASE WHEN <Q: (AND: ('metric_type__exact', '23'), ('value__gte', 900))> THEN Value(1), ELSE Value(0))")
 
         annotationKey = "22__exact__700"
         self.assertIn(annotationKey, annotations.keys())
-        firstConditionCases = annotations[annotationKey].cases
-        firstConditionCase = firstConditionCases[0]
-        self.assertEqual(str(firstConditionCase.condition), "(AND: ('metric_type__exact', '22'), ('value__exact', 700))")
-        self.assertEqual(str(firstConditionCase.result), "Value(True)")
+        self.assertEqual(
+            str(annotations[annotationKey]),
+            "Sum(CASE WHEN <Q: (AND: ('metric_type__exact', '22'), ('value__exact', 700))> THEN Value(1), ELSE Value(0))")
 
         self.assertEqual(
-            "(AND: ('23__gte__900', True), ('22__exact__700', True))",
+            "(AND: ('23__gte__900__gte', 1), ('22__exact__700__gte', 1))",
             str(annotationFilters))
 
     def test_keyvalut_jsonlogic_to_q__simple_or(self) -> None:
         filters = { "or": [{">=":[ {"var":"23"}, 900]}, {"==":[{"var":"22"}, 700]}]}
-        q, annotations, annotationFilters = keyvalue_jsonlogic_to_q(filters, "metric_type", "value")
-        self.assertEqual(str(q), "(OR: (AND: ('metric_type__exact', '23'), ('value__gte', 900)), (AND: ('metric_type__exact', '22'), ('value__exact', 700)))")
+        annotations, annotationFilters = annotation_jsonlogic_to_q(filters, "metric_type", "value")
         
         annotationKey = "23__gte__900"
         self.assertIn(annotationKey, annotations.keys())
-        firstConditionCases = annotations[annotationKey].cases
-        firstConditionCase = firstConditionCases[0]
-        self.assertEqual(str(firstConditionCase.condition), "(AND: ('metric_type__exact', '23'), ('value__gte', 900))")
-        self.assertEqual(str(firstConditionCase.result), "Value(True)")
+        self.assertEqual(
+            str(annotations[annotationKey]),
+            "Sum(CASE WHEN <Q: (AND: ('metric_type__exact', '23'), ('value__gte', 900))> THEN Value(1), ELSE Value(0))")
 
         annotationKey = "22__exact__700"
         self.assertIn(annotationKey, annotations.keys())
-        firstConditionCases = annotations[annotationKey].cases
-        firstConditionCase = firstConditionCases[0]
-        self.assertEqual(str(firstConditionCase.condition), "(AND: ('metric_type__exact', '22'), ('value__exact', 700))")
-        self.assertEqual(str(firstConditionCase.result), "Value(True)")
+        self.assertEqual(
+            str(annotations[annotationKey]),
+            "Sum(CASE WHEN <Q: (AND: ('metric_type__exact', '22'), ('value__exact', 700))> THEN Value(1), ELSE Value(0))")
 
         self.assertEqual(
-            "(OR: ('23__gte__900', True), ('22__exact__700', True))",
+            "(OR: ('23__gte__900__gte', 1), ('22__exact__700__gte', 1))",
             str(annotationFilters))
 
     def test_keyvalut_jsonlogic_to_q__simple_and_or(self) -> None:
@@ -60,41 +54,30 @@ class JsonLogicTests(TestCase):
                 ]}
             ]
         }
-        q, annotations, annotationFilters = keyvalue_jsonlogic_to_q(filters, "metric_type", "value")
-        
-        self.assertEqual(str(q), (""
-        "(OR: "
-            "(AND: ('metric_type__exact', '23'), ('value__gte', 900)), "
-            "(AND: ('metric_type__exact', '22'), ('value__exact', 700)), "
-            "(AND: ('metric_type__exact', '23'), ('value__lte', 1500)), "
-            "(AND: ('metric_type__exact', '24'), ('value__exact', 1000))"
-        ")"))
+        annotations, annotationFilters = annotation_jsonlogic_to_q(filters, "metric_type", "value")
         
         annotationKey = "23__gte__900"
         self.assertIn(annotationKey, annotations.keys())
-        firstConditionCases = annotations[annotationKey].cases
-        firstConditionCase = firstConditionCases[0]
-        self.assertEqual(str(firstConditionCase.condition), "(AND: ('metric_type__exact', '23'), ('value__gte', 900))")
-        self.assertEqual(str(firstConditionCase.result), "Value(True)")
+        self.assertEqual(
+            str(annotations[annotationKey]),
+            "Sum(CASE WHEN <Q: (AND: ('metric_type__exact', '23'), ('value__gte', 900))> THEN Value(1), ELSE Value(0))")
 
         annotationKey = "23__lte__1500"
         self.assertIn(annotationKey, annotations.keys())
-        firstConditionCases = annotations[annotationKey].cases
-        firstConditionCase = firstConditionCases[0]
-        self.assertEqual(str(firstConditionCase.condition), "(AND: ('metric_type__exact', '23'), ('value__lte', 1500))")
-        self.assertEqual(str(firstConditionCase.result), "Value(True)")
+        self.assertEqual(
+            str(annotations[annotationKey]),
+            "Sum(CASE WHEN <Q: (AND: ('metric_type__exact', '23'), ('value__lte', 1500))> THEN Value(1), ELSE Value(0))")
 
         annotationKey = "24__exact__1000"
         self.assertIn(annotationKey, annotations.keys())
-        firstConditionCases = annotations[annotationKey].cases
-        firstConditionCase = firstConditionCases[0]
-        self.assertEqual(str(firstConditionCase.condition), "(AND: ('metric_type__exact', '24'), ('value__exact', 1000))")
-        self.assertEqual(str(firstConditionCase.result), "Value(True)")
+        self.assertEqual(
+            str(annotations[annotationKey]),
+            "Sum(CASE WHEN <Q: (AND: ('metric_type__exact', '24'), ('value__exact', 1000))> THEN Value(1), ELSE Value(0))")
 
-        print(annotationFilters)
+        self.assertEqual(
+            "(OR: ('23__gte__900__gte', 1), ('22__exact__700__gte', 1), (AND: ('23__lte__1500__gte', 1), ('24__exact__1000__gte', 1)))",
+            str(annotationFilters))
 
-        self.assertEqual("(OR: ('23__gte__900', True), ('22__exact__700', True), (AND: ('23__lte__1500', True), ('24__exact__1000', True)))", str(annotationFilters))
-        
 
     def test_jsonlogic_to_q_filters_base(self) -> None:
         """The base case of jsonlogic_to_q works as expected."""

--- a/iaso/urls.py
+++ b/iaso/urls.py
@@ -64,7 +64,7 @@ from .api.instances.instances import InstancesViewSet
 from .api.links import LinkViewSet
 from .api.logs import LogsViewSet
 from .api.mapping_versions import MappingVersionsViewSet
-from .api.metrics.views import MetricTypeViewSet, MetricValueViewSet
+from .api.metrics.views import MetricTypeViewSet, MetricValueViewSet, MetricOrgUnitsViewSet
 from .api.microplanning import AssignmentViewSet, MobilePlanningViewSet, PlanningViewSet, TeamViewSet
 from .api.mobile.bulk_uploads import MobileBulkUploadsViewSet
 from .api.mobile.entity import MobileEntityDeletedViewSet, MobileEntityViewSet
@@ -219,6 +219,7 @@ router.register(r"mobile/bulkupload", MobileBulkUploadsViewSet, basename="mobile
 router.register(r"superset/token", SupersetTokenViewSet, basename="supersettoken")
 router.register(r"metrictypes", MetricTypeViewSet, basename="metrictypes")
 router.register(r"metricvalues", MetricValueViewSet, basename="metricvalues")
+router.register(r"metricorgunits", MetricOrgUnitsViewSet, basename="metricorgunits")
 router.registry.extend(plugins_router.registry)
 
 urlpatterns: URLList = [

--- a/iaso/urls.py
+++ b/iaso/urls.py
@@ -64,7 +64,7 @@ from .api.instances.instances import InstancesViewSet
 from .api.links import LinkViewSet
 from .api.logs import LogsViewSet
 from .api.mapping_versions import MappingVersionsViewSet
-from .api.metrics.views import MetricTypeViewSet, MetricValueViewSet, MetricOrgUnitsViewSet
+from .api.metrics.views import MetricOrgUnitsViewSet, MetricTypeViewSet, MetricValueViewSet
 from .api.microplanning import AssignmentViewSet, MobilePlanningViewSet, PlanningViewSet, TeamViewSet
 from .api.mobile.bulk_uploads import MobileBulkUploadsViewSet
 from .api.mobile.entity import MobileEntityDeletedViewSet, MobileEntityViewSet

--- a/iaso/utils/jsonlogic.py
+++ b/iaso/utils/jsonlogic.py
@@ -20,7 +20,7 @@ from django.db.models.fields.json import JSONField, KeyTransformTextLookupMixin
 # would have to annotate every field we are casting for.
 # Instance.objects.annotate(b=Cast(KeyTextTransform('usable_vials_physical', "json"), FloatField())).filter(b__gte=2)
 
-lookups = {
+LOOKUPS = {
     "==": "exact",
     "!=": "exact",
     ">": "gt",
@@ -83,10 +83,9 @@ def jsonlogic_to_q(
     if len(params) != 2:
         raise ValueError(f"Unsupported JsonLogic. Operator {op} take exactly two operands: {jsonlogic}")
 
-
-    if op not in lookups.keys():
+    if op not in LOOKUPS.keys():
         raise ValueError(
-            f"Unsupported JsonLogic (unknown operator {op}): {jsonlogic}. Supported operators: f{lookups.keys()}"
+            f"Unsupported JsonLogic (unknown operator {op}): {jsonlogic}. Supported operators: f{LOOKUPS.keys()}"
         )
 
     field_position = 1 if op == "in" else 0
@@ -104,7 +103,7 @@ def jsonlogic_to_q(
         # Since inside the json everything is cast as string we cast back as int
         extract = "__forcefloat"
 
-    lookup = lookups[op]
+    lookup = LOOKUPS[op]
 
     f = f"{field_prefix}{field_name}{extract}__{lookup}"
     q = Q(**{f: value})
@@ -194,7 +193,7 @@ def annotation_jsonlogic_to_q(jsonlogic: Dict[str, Any], id_field_name: str= "",
         value_field_value = next((arg for arg in params if arg != var_obj), None)
         # Create query object 
         # TODO Check for extract and field_prefix on other functions
-        lookup = lookups[op]
+        lookup = LOOKUPS[op]
         value_f = f"{value_field_name}__{lookup}"
         # Add ID filter
         id_f = f"{id_field_name}__exact"

--- a/iaso/utils/jsonlogic.py
+++ b/iaso/utils/jsonlogic.py
@@ -30,6 +30,7 @@ LOOKUPS = {
     "in": "icontains",
 }
 
+
 class ExtractForceFloat(KeyTransformTextLookupMixin, Transform):
     lookup_name = "forcefloat"
 
@@ -113,10 +114,10 @@ def jsonlogic_to_q(
         q = ~q
     return q
 
+
 def jsonlogic_to_exists_q_clauses(
-        jsonlogic: Dict[str, Any], queryset: Any, id_field_name: str, 
-        value_field_name: str, group_by_field_name: str
-        ) -> Q:
+    jsonlogic: Dict[str, Any], queryset: Any, id_field_name: str, value_field_name: str, group_by_field_name: str
+) -> Q:
     """Converts a JsonLogic query to a Django Q object for use in Exists clauses.
     This is used to filter entities based on the existence of certain conditions
     in their related instances.
@@ -140,20 +141,16 @@ def jsonlogic_to_exists_q_clauses(
         sub_query = Q()
         for lookup in jsonlogic["and"]:
             sub_query = operator.and_(
-                sub_query, 
-                jsonlogic_to_exists_q_clauses(
-                    lookup, queryset, id_field_name, value_field_name, group_by_field_name
-                )
+                sub_query,
+                jsonlogic_to_exists_q_clauses(lookup, queryset, id_field_name, value_field_name, group_by_field_name),
             )
         return sub_query
     if "or" in jsonlogic:
         sub_query = Q()
         for lookup in jsonlogic["or"]:
             sub_query = operator.or_(
-                sub_query, 
-                jsonlogic_to_exists_q_clauses(
-                    lookup, queryset, id_field_name, value_field_name, group_by_field_name
-                )
+                sub_query,
+                jsonlogic_to_exists_q_clauses(lookup, queryset, id_field_name, value_field_name, group_by_field_name),
             )
         return sub_query
     if "!" in jsonlogic:
@@ -172,10 +169,12 @@ def jsonlogic_to_exists_q_clauses(
     value = params[0] if op == "in" else params[1]
     q = Q(
         Exists(
-            queryset.filter(**{
-                group_by_field_name: OuterRef(group_by_field_name),
-                id_field_name: field["var"],
-            }).filter(Q(**{f"{value_field_name}__{LOOKUPS[op]}": value}))
+            queryset.filter(
+                **{
+                    group_by_field_name: OuterRef(group_by_field_name),
+                    id_field_name: field["var"],
+                }
+            ).filter(Q(**{f"{value_field_name}__{LOOKUPS[op]}": value}))
         )
     )
 

--- a/iaso/utils/jsonlogic.py
+++ b/iaso/utils/jsonlogic.py
@@ -114,7 +114,7 @@ def jsonlogic_to_q(
     return q
 
 def jsonlogic_to_exists_q_clauses(
-        jsonlogic: Dict[str, Any], entities: Any, id_field_name: str, 
+        jsonlogic: Dict[str, Any], queryset: Any, id_field_name: str, 
         value_field_name: str, group_by_field_name: str
         ) -> Q:
     """Converts a JsonLogic query to a Django Q object for use in Exists clauses.
@@ -142,7 +142,7 @@ def jsonlogic_to_exists_q_clauses(
             sub_query = operator.and_(
                 sub_query, 
                 jsonlogic_to_exists_q_clauses(
-                    lookup, entities, id_field_name, value_field_name, group_by_field_name
+                    lookup, queryset, id_field_name, value_field_name, group_by_field_name
                 )
             )
         return sub_query
@@ -152,13 +152,13 @@ def jsonlogic_to_exists_q_clauses(
             sub_query = operator.or_(
                 sub_query, 
                 jsonlogic_to_exists_q_clauses(
-                    lookup, entities, id_field_name, value_field_name, group_by_field_name
+                    lookup, queryset, id_field_name, value_field_name, group_by_field_name
                 )
             )
         return sub_query
     if "!" in jsonlogic:
         return ~jsonlogic_to_exists_q_clauses(
-            jsonlogic["!"], entities, id_field_name, value_field_name, group_by_field_name
+            jsonlogic["!"], queryset, id_field_name, value_field_name, group_by_field_name
         )
 
     if not jsonlogic.keys():
@@ -172,7 +172,7 @@ def jsonlogic_to_exists_q_clauses(
     value = params[0] if op == "in" else params[1]
     q = Q(
         Exists(
-            entities.filter(**{
+            queryset.filter(**{
                 group_by_field_name: OuterRef(group_by_field_name),
                 id_field_name: field["var"],
             }).filter(Q(**{f"{value_field_name}__{LOOKUPS[op]}": value}))

--- a/iaso/utils/jsonlogic.py
+++ b/iaso/utils/jsonlogic.py
@@ -20,6 +20,15 @@ from django.db.models.fields.json import JSONField, KeyTransformTextLookupMixin
 # would have to annotate every field we are casting for.
 # Instance.objects.annotate(b=Cast(KeyTextTransform('usable_vials_physical', "json"), FloatField())).filter(b__gte=2)
 
+lookups = {
+    "==": "exact",
+    "!=": "exact",
+    ">": "gt",
+    ">=": "gte",
+    "<": "lt",
+    "<=": "lte",
+    "in": "icontains",
+}
 
 class ExtractForceFloat(KeyTransformTextLookupMixin, Transform):
     lookup_name = "forcefloat"
@@ -74,15 +83,6 @@ def jsonlogic_to_q(
     if len(params) != 2:
         raise ValueError(f"Unsupported JsonLogic. Operator {op} take exactly two operands: {jsonlogic}")
 
-    lookups = {
-        "==": "exact",
-        "!=": "exact",
-        ">": "gt",
-        ">=": "gte",
-        "<": "lt",
-        "<=": "lte",
-        "in": "icontains",
-    }
 
     if op not in lookups.keys():
         raise ValueError(
@@ -114,11 +114,17 @@ def jsonlogic_to_q(
         q = ~q
     return q
 
-def keyvalue_jsonlogic_to_q(jsonlogic: Dict[str, Any], id_field_name: str= "", value_field_name: str = "") -> tuple[Q, dict[str, Case], dict[str, list]]:
+def annotation_jsonlogic_to_q(jsonlogic: Dict[str, Any], id_field_name: str= "", value_field_name: str = "") -> tuple[dict[str, Sum], dict[str, list]]:
     """This enhances the jsonlogic_to_q() method to allow filtering entities on
     multiple criteria for same properties.
-    It will convert a JsonLogic query to a Django Q object
+    It will convert a JsonLogic query to a Django annotation and Q object to apply on annotations.
     It only accept one level deep.
+
+    Exemple of usage: 
+    annotations, filters = annotation_jsonlogic_to_q(json.loads(json_filter), "metric_type", "value")
+    filteredOrgUnitIds = queryset.values('org_unit_id')
+        .annotate(**annotations).filter(filters)
+        .values_list('org_unit_id', flat=True)
 
     :param id_field_name: the identifier field name for "var" of json logic to target
     :value_field_name: the value field name to target
@@ -132,25 +138,16 @@ def keyvalue_jsonlogic_to_q(jsonlogic: Dict[str, Any], id_field_name: str= "", v
         ]}
     ]
     :return: 
-    A Django Q Object that return all records matching single criteria.
-    As we need to have all records matching any criteria, we use OR to compose the query.
-    This is used to compose HAVING later on which will be used to filter the results.
-    (OR:
-            (AND: ('metric_type__exact', '23'), ('value__gte', 900)),
-            (AND: ('metric_type__exact', '22'), ('value__exact', 700)),
-            (AND: ('metric_type__exact', '23'), ('value__lte', 1500)),
-            (AND: ('metric_type__exact', '24'), ('value__exact', 1000))
-    )
     Annotations:
     {
         '23__gte__900': 
-            <Case: CASE WHEN <Q: (AND: ('metric_type__exact', '23'), ('value__gte', 900))> THEN Value(True), ELSE Value(False)>, 
+            Sum(CASE WHEN <Q: (AND: ('metric_type__exact', '23'), ('value__gte', 900))> THEN Value(1), ELSE Value(0)), 
         '22__exact__700': 
-            <Case: CASE WHEN <Q: (AND: ('metric_type__exact', '22'), ('value__exact', 700))> THEN Value(True), ELSE Value(False)>, 
+            Sum(CASE WHEN <Q: (AND: ('metric_type__exact', '22'), ('value__exact', 700))> THEN Value(1), ELSE Value(0)),
         '23__lte__1500': 
-            <Case: CASE WHEN <Q: (AND: ('metric_type__exact', '23'), ('value__lte', 1500))> THEN Value(True), ELSE Value(False)>, 
+            Sum(CASE WHEN <Q: (AND: ('metric_type__exact', '23'), ('value__lte', 1500))> THEN Value(1), ELSE Value(0)),
         '24__exact__1000': 
-             <Case: CASE WHEN <Q: (AND: ('metric_type__exact', '24'), ('value__exact', 1000))> THEN Value(True), ELSE Value(False)>
+            Sum(CASE WHEN <Q: (AND: ('metric_type__exact', '24'), ('value__exact', 1000))> THEN Value(1), ELSE Value(0))
     }
     Annotation filters: {
     'or': [
@@ -162,30 +159,17 @@ def keyvalue_jsonlogic_to_q(jsonlogic: Dict[str, Any], id_field_name: str= "", v
         ]}
     ]}
     """
-    from iaso.models import Instance
     # TODO Bullet proof this function, it is used in the API and it is not well tested.
-    # TODO Share this
-    lookups = {
-        "==": "exact",
-        "!=": "exact",
-        ">": "gt",
-        ">=": "gte",
-        "<": "lt",
-        "<=": "lte",
-        "in": "icontains",
-    }
 
     if "and" in jsonlogic or "or" in jsonlogic or "!" in jsonlogic:
         key = "and" if "and" in jsonlogic else "or" if "or" in jsonlogic else "!"
         operation = operator.and_ if key == "and" else operator.or_ if key == "or" else operator.not_
-        sub_query = Q()
         # This will hold all the annotations, which are used to compose the HAVING statement.
         allAnnotations: dict[str, Case] = {}
         # Used to construct the HAVING statement, this is delegated to the caller.
-        # allFilters = { key: [] }
         annotation_query = Q()
         for lookup in jsonlogic[key]:
-            jsonToQ, annotations, annotation_sub_query = keyvalue_jsonlogic_to_q(lookup, id_field_name, value_field_name)
+            annotations, annotation_sub_query = annotation_jsonlogic_to_q(lookup, id_field_name, value_field_name)
             if annotation_sub_query:
                 # If we have a sub query, we need to add it to the annotation query.
                 annotation_query = operation(annotation_query, annotation_sub_query)
@@ -195,13 +179,7 @@ def keyvalue_jsonlogic_to_q(jsonlogic: Dict[str, Any], id_field_name: str= "", v
                     akey= next(iter(annotations))
                     annotation_query = operation(annotation_query, Q(**{f"{akey}__gte": 1}))
 
-            # if filters:
-                # We need to keep nesting here, otherwise the rule will be flatten and will loose their purpose.
-                # allFilters[key].append(filters)
-            # OR is forced is by purpose, we want all records matching any query to compose HAVING later on
-            # TODO Not sure this is needed, as we are using AND in the sub_query
-            sub_query = operator.or_(sub_query, jsonToQ)
-        return sub_query, allAnnotations, annotation_query            
+        return allAnnotations, annotation_query            
 
     elif len(jsonlogic) == 1:
         # binary operator # >= and such
@@ -217,10 +195,8 @@ def keyvalue_jsonlogic_to_q(jsonlogic: Dict[str, Any], id_field_name: str= "", v
         # TODO Check for extract and field_prefix on other functions
         lookup = lookups[op]
         value_f = f"{value_field_name}__{lookup}"
-        simple_query = Q(**{value_f: value_field_value})
         # Add ID filter
         id_f = f"{id_field_name}__exact"
-        id_query = Q(**{id_f: id_field_value})
 
         annotation = {
             f"{id_field_value}__{lookup}__{value_field_value}": Sum(Case(
@@ -230,7 +206,7 @@ def keyvalue_jsonlogic_to_q(jsonlogic: Dict[str, Any], id_field_name: str= "", v
             ))
         }
 
-        return operator.and_(id_query, simple_query), annotation, None
+        return annotation, None
 
         # TODO use OR instead of AND in where clause.
         # TODO Add Having statement


### PR DESCRIPTION
What problem is this PR solving? Explain here in one sentence.

Related JIRA tickets : [SNT-49](https://bluesquare.atlassian.net/browse/SNT-49?atlOrigin=eyJpIjoiZGJiMDYzMjU4NmZhNDVkZTgxYzZkNzgxMGJkMmFkYTIiLCJwIjoiaiJ9)

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

Added a new endpoint into metric views.
Point is to be able to get a list of OrgUnit ids related to Metrics based on a query.
That query will filter on metric type id and value.
It can get quite complexe with a lot of OR, AND. 

Nested level for the query will not exceed two level (this is defined in the FE).

## How to test

You need to setup nst malaria for this.
Go and check the repo. 
For this specific case, you'll need changes part of branch SNT-49-Metrics-query-builder (there is a [PR](https://github.com/BLSQ/snt-malaria/pull/34) for this)

Then you can use this endpoint: 
 http://localhost:8081/api/metricorgunits 
 
 If you don't specify any query string, it will return all org unit ids.
 But you can specify a json_filter query string.
 
 Here are few query you can test with: 
 {"and":[{">=":[{"var":"23"},670]},{">=":[{"var":"22"},193777]}]}
{"and":[{">=":[{"var":"22"},300000]}]}
{"or":[{">=":[{"var":"23"},910]},{"and":[{">=":[{"var":"23"},700]},{">=":[{"var":"22"},300000]}]}]}

If you want to find other cases, you can check this endpoint to have all metric values: 
http://localhost:8081/api/metricvalues/
And compose your own json_query from there.

## Print screen / video

Upload here print screens or videos showing the changes.

## Notes

Things that the reviewers should know:

This PR is related to this PR (https://github.com/BLSQ/snt-malaria/pull/34)

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.


[SNT-49]: https://bluesquare.atlassian.net/browse/SNT-49?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ