### PR TITLE
IA-4293 notif email bug

### DIFF
--- a/iaso/models/base.py
+++ b/iaso/models/base.py
@@ -365,6 +365,14 @@ class Task(models.Model):
         self.result = {"result": SUCCESS, "message": message}
         self.save()
 
+    def terminate_with_error(self, message=None):
+        self.refresh_from_db()
+        logger.error(f"Task {self} ended in error")
+        self.status = ERRORED
+        self.ended_at = timezone.now()
+        self.result = {"result": ERRORED, "message": message if message else "Error"}
+        self.save()
+
 
 class Link(models.Model):
     destination = models.ForeignKey(

--- a/plugins/polio/tasks/vaccine_authorizations_mail_alerts.py
+++ b/plugins/polio/tasks/vaccine_authorizations_mail_alerts.py
@@ -161,7 +161,7 @@ def send_email_expired_vaccine_authorizations_alert(task=None):
     past_date = dt.date.today() - timedelta(days=1)
     team = get_object_or_404(Team, name=NOPV2_VACCINE_TEAM_NAME)
     vaccine_auths = VaccineAuthorization.objects.filter(expiration_date=past_date)
-    mailing_list = team.users.values_list("pk", flat=True)
+    mailing_list = team.users.values_list("email", flat=True)
     total = vaccine_auths.count()
 
     email_sent = 0

--- a/plugins/polio/tasks/vaccine_authorizations_mail_alerts.py
+++ b/plugins/polio/tasks/vaccine_authorizations_mail_alerts.py
@@ -85,8 +85,8 @@ def send_email_vaccine_authorizations_60_days_expiration_alert(task=None):
     total = vaccine_auths.count()
 
     team = get_object_or_404(Team, name=NOPV2_VACCINE_TEAM_NAME)
-
-    mailing_list = User.objects.filter(pk__in=team.users.all()).values_list("email", flat=True)
+    # Convert to list so we can append the GPEI coordinator email later
+    mailing_list = list(User.objects.filter(pk__in=team.users.all()).values_list("email", flat=True))
     email_sent = 0
 
     for i, vacc_auth in enumerate(vaccine_auths):
@@ -104,10 +104,11 @@ def send_email_vaccine_authorizations_60_days_expiration_alert(task=None):
         logger.info(f"Email for {vacc_auth}")
         try:
             status = vaccine_authorizations_60_days_expiration_email_alert(vaccine_auths, mailing_list)
+            if not status:
+                logger.info("... skipped")
         except Exception as e:
             task.terminate_with_error(message=str(e))
-        if not status:
-            logger.info("... skipped")
+            raise e
         else:
             email_sent += 1
 
@@ -115,8 +116,6 @@ def send_email_vaccine_authorizations_60_days_expiration_alert(task=None):
 
 
 def expired_vaccine_authorizations_email_alert(vaccine_auths, mailing_list):
-    mail_sent = False
-
     for obj in vaccine_auths:
         account_id = obj.account.id
         next_vaccine_auth = (
@@ -128,39 +127,45 @@ def expired_vaccine_authorizations_email_alert(vaccine_auths, mailing_list):
         )
 
         if next_vaccine_auth and obj.expiration_date < next_vaccine_auth.expiration_date:
-            send_mail(
-                f"ALERT: Vaccine Authorization {obj} has expired.",
-                f"""
-                ALERT, 
+            try:
+                send_mail(
+                    f"ALERT: Vaccine Authorization {obj} has expired.",
+                    f"""
+                    ALERT, 
 
-                {obj.country} nOPV2 vaccines authorization has expired expired on {obj.expiration_date}.
-                A new authorization is ongoing {next_vaccine_auth}, with an expiry date on {next_vaccine_auth.expiration_date}.
-                Please take appropriate action as needed. 
-                Link to the platform vaccine authorization page : {vaccine_dashboard_link}/dashboard/polio/vaccinemodule/nopv2authorisation/accountId/{account_id}/order/-current_expiration_date/pageSize/20/page/1"
-                RRT team
-                """,
-                settings.DEFAULT_FROM_EMAIL,
-                mailing_list,
-            )
-            mail_sent = True
+                    {obj.country} nOPV2 vaccines authorization has expired expired on {obj.expiration_date}.
+                    A new authorization is ongoing {next_vaccine_auth}, with an expiry date on {next_vaccine_auth.expiration_date}.
+                    Please take appropriate action as needed. 
+                    Link to the platform vaccine authorization page : {vaccine_dashboard_link}/dashboard/polio/vaccinemodule/nopv2authorisation/accountId/{account_id}/order/-current_expiration_date/pageSize/20/page/1"
+                    RRT team
+                    """,
+                    settings.DEFAULT_FROM_EMAIL,
+                    mailing_list,
+                )
+            except Exception as e:
+                logger.error(f"Could not send emails for {obj}")
+                raise e
         else:
-            send_mail(
-                f"ALERT: Vaccine Authorization {obj} has expired.",
-                f"""
-                            ALERT
+            try:
+                send_mail(
+                    f"ALERT: Vaccine Authorization {obj} has expired.",
+                    f"""
+                                ALERT
 
-                            {obj.country} nOPV2 vaccines authorization has expired on {obj.expiration_date}.
-                            No new authorization pending.
-                            Please take appropriate action as needed. 
-                            Link to the platform vaccine authorization page : {vaccine_dashboard_link}/dashboard/polio/vaccinemodule/nopv2authorisation/accountId/{account_id}/order/-current_expiration_date/pageSize/20/page/1"
-                            RRT team
-                            """,
-                settings.DEFAULT_FROM_EMAIL,
-                mailing_list,
-            )
-            mail_sent = True
+                                {obj.country} nOPV2 vaccines authorization has expired on {obj.expiration_date}.
+                                No new authorization pending.
+                                Please take appropriate action as needed. 
+                                Link to the platform vaccine authorization page : {vaccine_dashboard_link}/dashboard/polio/vaccinemodule/nopv2authorisation/accountId/{account_id}/order/-current_expiration_date/pageSize/20/page/1"
+                                RRT team
+                                """,
+                    settings.DEFAULT_FROM_EMAIL,
+                    mailing_list,
+                )
+            except Exception as e:
+                logger.error(f"Could not send emails for {obj}")
+                raise e
 
-    return {"vacc_auth_mail_sent_to": mailing_list} if mail_sent else "no_vacc_auth_mail_sent"
+    return {"vacc_auth_mail_sent_to": mailing_list}
 
 
 @task_decorator(task_name="expired_vaccine_authorizations_email_alert")
@@ -168,7 +173,8 @@ def send_email_expired_vaccine_authorizations_alert(task=None):
     past_date = dt.date.today() - timedelta(days=1)
     team = get_object_or_404(Team, name=NOPV2_VACCINE_TEAM_NAME)
     vaccine_auths = VaccineAuthorization.objects.filter(expiration_date=past_date)
-    mailing_list = team.users.values_list("email", flat=True)
+    # Convert to list so we can append the GPEI coordinator email later
+    mailing_list = list(team.users.values_list("email", flat=True))
     total = vaccine_auths.count()
 
     email_sent = 0
@@ -187,11 +193,12 @@ def send_email_expired_vaccine_authorizations_alert(task=None):
 
         logger.info(f"Email for {vacc_auth}")
         try:
-            status = vaccine_authorizations_60_days_expiration_email_alert(vaccine_auths, mailing_list)
+            status = expired_vaccine_authorizations_email_alert(vaccine_auths, mailing_list)
+            if not status:
+                logger.info("... skipped")
         except Exception as e:
             task.terminate_with_error(message=str(e))
-        if not status:
-            logger.info("... skipped")
+            raise e
         else:
             email_sent += 1
 

--- a/plugins/polio/tests/test_vaccine_authorizations.py
+++ b/plugins/polio/tests/test_vaccine_authorizations.py
@@ -614,7 +614,7 @@ class VaccineAuthorizationAPITestCase(APITestCase):
 
         team = get_object_or_404(Team, name=NOPV2_VACCINE_TEAM_NAME)
 
-        mailing_list = [user.email for user in User.objects.filter(pk__in=team.users.all())]
+        mailing_list = list(User.objects.filter(pk__in=team.users.all()).values_list("email", flat=True))
 
         for i, vacc_auth in enumerate(vaccine_auths):
             try:
@@ -661,16 +661,13 @@ class VaccineAuthorizationAPITestCase(APITestCase):
         response = expired_vaccine_authorizations_email_alert(vaccine_auths, mailing_list)
         domain = settings.DNS_DOMAIN
         page_url = f"{domain}/dashboard/polio/vaccinemodule/nopv2authorisation/accountId/{self.team.project.account.id}/order/-current_expiration_date/pageSize/20/page/1"
-        url_is_correct = False
-        if page_url in mail.outbox[0].body:
-            url_is_correct = True
 
         self.assertEqual(response, {"vacc_auth_mail_sent_to": ["XlfeeekfdpppZ@somemailzz.io"]})
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].subject, f"ALERT: Vaccine Authorization {past_vacc_auth} has expired.")
         self.assertEqual(mail.outbox[0].from_email, from_email)
         self.assertEqual(mail.outbox[0].to, ["XlfeeekfdpppZ@somemailzz.io"])
-        self.assertEqual(url_is_correct, True)
+        self.assertTrue(page_url in mail.outbox[0].body)
 
         # test the Task
 
@@ -1127,3 +1124,93 @@ class VaccineAuthorizationAPITestCase(APITestCase):
 
         self.assertEqual(response.status_code, 403)
         self.assertEqual(response.data["error"], "A vaccine authorization is already validated for this country")
+
+    # Mock send_mail to raise an exception when receiving invalid recipients
+    def mock_send_mail(self, subject, message, from_email, recipient_list, **kwargs):
+        print("---------------------------------")
+        print("recipients list", recipient_list)
+        print("---------------------------------")
+        if not all(isinstance(r, str) and "@" in r for r in recipient_list):
+            raise ValueError("Invalid email recipients")
+        return 1  # Django's send_mail returns the number of successfully sent messages
+
+    def test_failing_to_send_raises(self):
+        from unittest.mock import patch
+
+        self.client.force_authenticate(self.user_1)
+        self.user_1.iaso_profile.org_units.set([self.org_unit_DRC.pk])
+
+        # Create a user with invalid email using the helper
+        invalid_user = self.create_user_with_profile(
+            username="invalid_email_user",
+            email="123",  # Invalid email without @
+            password="password",
+            account=self.account,
+        )
+        self.team.users.set([self.user_1, invalid_user])
+
+        past_date = datetime.date.today() - datetime.timedelta(days=1)
+
+        # Create a vaccine auth that expired yesterday
+        past_vacc_auth = VaccineAuthorization.objects.create(
+            account=self.user_1.iaso_profile.account,
+            country=self.org_unit_DRC,
+            status="VALIDATED",
+            quantity=1000000,
+            comment="Validated for 1M",
+            expiration_date=past_date,
+        )
+
+        # Create an ongoing auth to test the "next auth" logic
+        VaccineAuthorization.objects.create(
+            account=self.user_1.iaso_profile.account,
+            country=self.org_unit_DRC,
+            status="ONGOING",
+            quantity=1000000,
+            comment="Validated for 1M",
+            expiration_date=datetime.date.today() + datetime.timedelta(days=100),
+        )
+
+        # Mock send_mail to validate recipients
+        with patch("plugins.polio.tasks.vaccine_authorizations_mail_alerts.send_mail", side_effect=self.mock_send_mail):
+            task_service = TestTaskService()
+            task = send_email_expired_vaccine_authorizations_alert(user=self.user_1)
+            task_service.run_all()  # Actually execute the task
+            task.refresh_from_db()
+            self.assertEqual(task.status, "ERRORED")
+            self.assertEqual(task.result["message"], "Invalid email recipients")
+
+    def test_failing_to_send_raises_60_days(self):
+        from unittest.mock import patch
+
+        self.client.force_authenticate(self.user_1)
+        self.user_1.iaso_profile.org_units.set([self.org_unit_DRC.pk])
+
+        # Create a user with invalid email using the helper
+        invalid_user = self.create_user_with_profile(
+            username="invalid_email_user_60",
+            email="notanemail60",  # Invalid email without @
+            password="password",
+            account=self.account,
+        )
+        self.team.users.set([self.user_1, invalid_user])
+
+        # Create a vaccine auth that expires in 60 days
+        future_date = datetime.date.today() + datetime.timedelta(days=60)
+        VaccineAuthorization.objects.create(
+            account=self.user_1.iaso_profile.account,
+            country=self.org_unit_DRC,
+            status="VALIDATED",
+            quantity=1000000,
+            comment="Validated for 1M",
+            expiration_date=future_date,
+        )
+
+        # Mock send_mail to validate recipients
+        with patch("plugins.polio.tasks.vaccine_authorizations_mail_alerts.send_mail", side_effect=self.mock_send_mail):
+            task_service = TestTaskService()
+            task = send_email_vaccine_authorizations_60_days_expiration_alert(user=self.user_1)
+            task_service.run_all()  # Actually execute the task
+            task.refresh_from_db()
+            self.assertEqual(task.status, "ERRORED")
+            self.assertEqual(task.result["message"], "Invalid email recipients")

--- a/plugins/polio/tests/test_vaccine_authorizations.py
+++ b/plugins/polio/tests/test_vaccine_authorizations.py
@@ -1127,9 +1127,6 @@ class VaccineAuthorizationAPITestCase(APITestCase):
 
     # Mock send_mail to raise an exception when receiving invalid recipients
     def mock_send_mail(self, subject, message, from_email, recipient_list, **kwargs):
-        print("---------------------------------")
-        print("recipients list", recipient_list)
-        print("---------------------------------")
         if not all(isinstance(r, str) and "@" in r for r in recipient_list):
             raise ValueError("Invalid email recipients")
         return 1  # Django's send_mail returns the number of successfully sent messages


### PR DESCRIPTION
What problem is this PR solving? Explain here in one sentence.

Related JIRA tickets : IA-4293

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [x] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc
NA
## Changes

- Modify code generating mailing list so that it generates a list of emails i.o a list of ids
- Add `try...except` statements to have the task fail when an email fails to be sent
- Add `terminate_with_error_ method on `Task` model for convenience
- Add tests

## How to test

Manually trigger `send_email_vaccine_authorizations_60_days_expiration_alert` and `send_email_expired_vaccine_authorizations_alert` (needs worker). The tasks should not fail.

To further test that exceptions are raised, run  `expired_vaccine_authorizations_email_alert` and `vaccine_authorizations_60_days_expiration_email_alert` with a badly formatted mailing list. It's dubious this will error on localhost though due to the django config in that env. On the other hand this cases are covered by tests

## Print screen / video
NA

## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
