### PR TITLE
POLIO-1958 bis exclude wsheets in config

### DIFF
--- a/plugins/polio/api/campaigns/campaigns.py
+++ b/plugins/polio/api/campaigns/campaigns.py
@@ -742,7 +742,7 @@ def get_current_preparedness(campaign, roundNumber):
     if not round.preparedness_spreadsheet_url:
         return {}
     spreadsheet_url = round.preparedness_spreadsheet_url
-    return preparedness_from_url(spreadsheet_url, campaign.country)
+    return preparedness_from_url(spreadsheet_url, campaign.country.id)
 
 
 class CampaignPreparednessSpreadsheetSerializer(serializers.Serializer):
@@ -902,7 +902,10 @@ class CampaignViewSet(ModelViewSet):
     def preview_preparedness(self, request, **kwargs):
         campaign = self.get_object()
         country = campaign.country
-        serializer = PreparednessPreviewSerializer(data={**request.data, "country_id": country.id})
+        # Create a mutable copy of the data
+        data = request.data.copy()
+        data["country_id"] = country.id
+        serializer = PreparednessPreviewSerializer(data=data)
         serializer.is_valid(raise_exception=True)
         return Response(serializer.data)
 

--- a/plugins/polio/api/campaigns/campaigns.py
+++ b/plugins/polio/api/campaigns/campaigns.py
@@ -726,7 +726,8 @@ class PreparednessPreviewSerializer(serializers.Serializer):
 
     def validate(self, attrs):
         spreadsheet_url = attrs.get("google_sheet_url")
-        return preparedness_from_url(spreadsheet_url, force_refresh=True)
+        country_id = attrs.get("country_id")
+        return preparedness_from_url(spreadsheet_url, country_id=country_id, force_refresh=True)
 
     def to_representation(self, instance):
         return instance
@@ -897,7 +898,7 @@ class CampaignViewSet(ModelViewSet):
         serializer = CampaignTypeSerializer(campaign_types, many=True)
         return Response(serializer.data)
 
-    @action(methods=["POST"], detail=False, serializer_class=PreparednessPreviewSerializer)
+    @action(methods=["POST"], detail=True, serializer_class=PreparednessPreviewSerializer)
     def preview_preparedness(self, request, **kwargs):
         campaign = self.get_object()
         country = campaign.country

--- a/plugins/polio/js/src/domains/Campaigns/Preparedness/PreparednessConfig.tsx
+++ b/plugins/polio/js/src/domains/Campaigns/Preparedness/PreparednessConfig.tsx
@@ -90,7 +90,11 @@ export const PreparednessConfig: FunctionComponent<Props> = ({
 
     const refreshData = () => {
         previewMutation.mutate(
-            { googleSheetUrl: preparedness_spreadsheet_url, campaignName },
+            {
+                googleSheetUrl: preparedness_spreadsheet_url,
+                campaignName,
+                campaignId,
+            },
             {
                 onSuccess: data => {
                     setFieldValue(lastKey, data);

--- a/plugins/polio/js/src/domains/Campaigns/Preparedness/hooks/useGetPreparednessData.tsx
+++ b/plugins/polio/js/src/domains/Campaigns/Preparedness/hooks/useGetPreparednessData.tsx
@@ -26,19 +26,24 @@ export const useGetPreparednessData = (
 type RefreshPreparednessArgs = {
     googleSheetUrl?: Url | null;
     campaignName?: ObrName;
+    campaignId?: UuidAsString;
 };
 
 const refreshPreparedness = ({
     googleSheetUrl,
     campaignName,
+    campaignId,
 }: RefreshPreparednessArgs): Promise<RefreshPreparednessResponse> => {
     // launch task to refresh endpoint for preparedness dashboard
-    postRequest('/api/tasks/create/refreshpreparedness/', {
+    postRequest(`/api/tasks/create/refreshpreparedness/`, {
         obr_name: campaignName,
     });
-    return postRequest('/api/polio/campaigns/preview_preparedness/', {
-        google_sheet_url: googleSheetUrl,
-    });
+    return postRequest(
+        `/api/polio/campaigns/${campaignId}/preview_preparedness/`,
+        {
+            google_sheet_url: googleSheetUrl,
+        },
+    );
 };
 
 // This retrieve data but since it contact data from an external service this is

--- a/plugins/polio/preparedness/parser.py
+++ b/plugins/polio/preparedness/parser.py
@@ -1,5 +1,6 @@
+import logging
+
 from enum import Enum
-from logging import getLogger
 from typing import Any, Dict, Optional
 
 from gspread.utils import absolute_range_name, rowcol_to_a1
@@ -8,10 +9,9 @@ from plugins.polio.preparedness.calculator import get_preparedness_score
 from plugins.polio.preparedness.client import get_client
 from plugins.polio.preparedness.exceptions import InvalidFormatError
 from plugins.polio.preparedness.spread_cache import CachedSheet, CachedSpread
-from plugins.polio.preparedness.spreadsheet_manager import TEMPLATE_VERSION, get_config_for_country
 
 
-logger = getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def parse_value(value: str):
@@ -388,6 +388,10 @@ def get_national_level_preparedness_v2(spread: CachedSpread):
 
 
 def parse_prepardness_v2(spread: CachedSpread, ignore_list=None):
+    # Import inside function to avoid circular import:
+    # models/__init__.py -> models/base.py -> parser.py -> spreadsheet_manager.py -> models
+    from plugins.polio.preparedness.spreadsheet_manager import TEMPLATE_VERSION
+
     preparedness_data = {
         "national": get_national_level_preparedness_v2(spread),
         **get_regional_level_preparedness_v2(spread, ignore_list),
@@ -400,6 +404,10 @@ def parse_prepardness_v2(spread: CachedSpread, ignore_list=None):
 def get_preparedness(spread: CachedSpread, country_id=None):
     ignore_list = None
     if country_id is not None:
+        # Import inside function to avoid circular import:
+        # models/__init__.py -> models/base.py -> parser.py -> spreadsheet_manager.py -> models
+        from plugins.polio.preparedness.spreadsheet_manager import get_config_for_country
+
         config, _ = get_config_for_country(country_id)
         ignore_list = config["ignore_worksheets"]
     #  use New system with named range

--- a/plugins/polio/preparedness/parser.py
+++ b/plugins/polio/preparedness/parser.py
@@ -409,7 +409,7 @@ def get_preparedness(spread: CachedSpread, country_id=None):
         from plugins.polio.preparedness.spreadsheet_manager import get_config_for_country
 
         config, _ = get_config_for_country(country_id)
-        ignore_list = config["ignore_worksheets"]
+        ignore_list = config.get("ignore_worksheets", None)
     #  use New system with named range
     if "national_status_score" in spread.range_dict:
         return parse_prepardness_v2(spread, ignore_list)

--- a/plugins/polio/preparedness/spreadsheet_manager.py
+++ b/plugins/polio/preparedness/spreadsheet_manager.py
@@ -29,13 +29,13 @@ logger = getLogger(__name__)
 
 # you need to create a polio.Config object with this key in the DB
 PREPAREDNESS_TEMPLATE_CONFIG_KEY = "preparedness_template_id"
-TEMPLATE_VERSION = "v3.3"
+TEMPLATE_VERSION = "v3.4"
 
 
-def get_config_for_country(config, country):
+def get_config_for_country(country_id):
     config = get_google_config(PREPAREDNESS_TEMPLATE_CONFIG_KEY)
-    if str(country.id) in config:
-        return config[str(country.id)], str(country.id)
+    if str(country_id) in config:
+        return config[str(country_id)], str(country_id)
     if TEMPLATE_VERSION not in config:
         raise Exception(f"Template config for {TEMPLATE_VERSION} not found")
     return config[TEMPLATE_VERSION], TEMPLATE_VERSION
@@ -204,8 +204,7 @@ def generate_spreadsheet_for_campaign(campaign: Campaign, round_number: Optional
     except Exception as e:
         logger.exception(e)
         logger.error(f"Could not find template language for {campaign}")
-    config = get_google_config(PREPAREDNESS_TEMPLATE_CONFIG_KEY)
-    config_for_country, template_version = get_config_for_country(config=config, country=country)
+    config_for_country, template_version = get_config_for_country(country_id=country.id)
     spreadsheet = create_spreadsheet(campaign.obr_name, lang, config_for_country)
 
     alt_sheets, alt_regions, alt_names, alt_regions_list = setup_multilingual_sheets(config_for_country, campaign)


### PR DESCRIPTION
What problem is this PR solving? Explain here in one sentence.

Related JIRA tickets :POLIO-1958

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

commented the code

## Changes

1. The feature
    - refactor `get_preparedness` so it receives a `country_id`
    - use this id to get the preparedness config for the country
    - use the config to get a list of `worksheet.title` to ignore when calculating regional scores
    - update the preparedness template version (unrelated, but cleaner)
2. Side effects
    - Change `preview_preparedness` method in CampainViewSet so `details=True` in order to be able to access the country id from the campaign
    - Add `country_id` field to `PreparednessPreviewSerializer` so it can pass it to `preparedness_from_url` (who calls `get_preparedness` down the line
    - Adapt the front-end to call the `preview_preparedness` endpoint as a details endpoint and pass the country id in the request body
    - Adapt `get_config_for_country` to make it easier to reuse
    - Update preparedness summary code to pass country_id to ge_preparedness
    - Update existing test
    
## How to test

Explain how to test your PR.

If a specific config is required explain it here: dataset, account, profile, etc.

## Print screen / video

Upload here print screens or videos showing the changes.

## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
