### PR TITLE
IA-4323 improve-forms-performance for picklist

### DIFF
--- a/iaso/api/forms.py
+++ b/iaso/api/forms.py
@@ -295,7 +295,20 @@ class FormsViewSet(ModelViewSet):
             profile = self.request.user.iaso_profile
         else:
             profile = False
-        if not mobile:
+
+        # empty fields then do the count assume it's give me all the fields like the forms page list (except for mobile)
+        # if specified fields contains :all or instances_count then do the count
+        requested_fields = self.request.query_params.get("fields")
+        enable_count = False
+        if (
+            not requested_fields
+            or ":all" in requested_fields.split(",")
+            or "instances_count" in requested_fields.split(",")
+        ):
+            enable_count = True
+        # TODO do the same thing to remove instance_updated_at if not in order or fields ?
+
+        if not mobile and enable_count:
             if profile and profile.org_units.exists():
                 orgunits = OrgUnit.objects.hierarchy(profile.org_units.all())
                 queryset = queryset.annotate(

--- a/iaso/tests/api/test_forms.py
+++ b/iaso/tests/api/test_forms.py
@@ -50,7 +50,11 @@ class FormsAPITestCase(APITestCase):
         )
 
         cls.form_1 = m.Form.objects.create(name="Hydroponics study", created_at=cls.now)
-
+        form_version = cls.form_1.form_versions.create(
+            file=cls.create_file_mock(name="testf1.xml"), version_id="2020022401"
+        )
+        form_version.possible_fields = {}
+        form_version.save()
         cls.project_3 = m.Project.objects.create(name="Kotor", app_id="knights.of.the.old.republic", account=star_wars)
 
         cls.jedi_council_corruscant = m.OrgUnit.objects.create(
@@ -69,7 +73,11 @@ class FormsAPITestCase(APITestCase):
             single_per_period=True,
             created_at=cls.now,
         )
-        cls.form_2.form_versions.create(file=cls.create_file_mock(name="testf1.xml"), version_id="2020022401")
+        form_version = cls.form_2.form_versions.create(
+            file=cls.create_file_mock(name="testf1.xml"), version_id="2020022401"
+        )
+        form_version.possible_fields = {}
+        form_version.save()
         cls.form_2.org_unit_types.add(cls.jedi_council)
         cls.form_2.org_unit_types.add(cls.jedi_academy)
 
@@ -737,3 +745,34 @@ class FormsAPITestCase(APITestCase):
         self.assertJSONResponse(response, 200)
         self.assertValidFormListData(response.json(), 2)
         self.assertEqual(response.json()["forms"][0]["instances_count"], 2)
+
+    def test_instance_count_computation_removed_when_not_requested(self):
+        """
+        Test that instance_count computation is removed when not in requested fields.
+        This test verifies the optimization added in iaso/api/forms.py:299-311.
+        """
+        self.client.force_authenticate(self.yoda)
+
+        # Test with specific fields that don't include instances_count or :all
+        response = self.client.get("/api/forms/?fields=id,name,form_id", headers={"Content-Type": "application/json"})
+        self.assertJSONResponse(response, 200)
+
+        # The response should not include instances_count field when not requested
+        for form_data in response.json()["forms"]:
+            self.assertNotIn("instances_count", form_data)
+
+        # Test that instances_count is included when explicitly requested
+        response = self.client.get(
+            "/api/forms/?fields=id,name,instances_count", headers={"Content-Type": "application/json"}
+        )
+        self.assertJSONResponse(response, 200)
+
+        for form_data in response.json()["forms"]:
+            self.assertIn("instances_count", form_data)
+
+        # Test that instances_count is included when no fields parameter is provided (default behavior)
+        response = self.client.get("/api/forms/", headers={"Content-Type": "application/json"})
+        self.assertJSONResponse(response, 200)
+
+        for form_data in response.json()["forms"]:
+            self.assertIn("instances_count", form_data)


### PR DESCRIPTION
avoid instance_count when fields are specified (like the picklist)
ex : `/api/forms/?all=true&order=name&fields=name,period_type,label_keys,id,latest_form_version`

if someone knows how to add test/assert on that he is welcomed 

Related JIRA tickets : IA-4323

## Self proofreading checklist

- [ ] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

Don't issue instances_count

## How to test

1. change your docker-compose.yml : DEBUG_SQL : 'true'
2. launch the seed command or setuper
3. go in the form list check the instance_count is displayed
4. access the api by specifying fields (not all) http://localhost:8081/api/forms/?all=true&order=name&fields=name%2Cperiod_type%2Clabel_keys%2Cid%2Clatest_form_version&format=js
5. access completeness screen verify the instance count is not issued
6. use the mobile to sync forms and verify the count is not issued
7. the export of the forms seem to work (they don't specify fields query param)

## Print screen / video

Upload here print screens or videos showing the changes.

## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
