### PR TITLE
[IA-4303] Add OrgUnit.code to XLSX/CSV exports

### DIFF
--- a/iaso/api/org_units.py
+++ b/iaso/api/org_units.py
@@ -295,6 +295,7 @@ class OrgUnitViewSet(viewsets.ViewSet):
             {"title": "Type", "width": 15},
             {"title": "Latitude", "width": 15},
             {"title": "Longitude", "width": 15},
+            {"title": "Code", "width": 15},
             {"title": "Date d'ouverture", "width": 20},
             {"title": "Date de fermeture", "width": 20},
             {"title": "Date de création", "width": 20},
@@ -346,6 +347,7 @@ class OrgUnitViewSet(viewsets.ViewSet):
             "instances_count",
             "opening_date",
             "closed_date",
+            "code",
         )
 
         user_account_name = profile.account.name if profile else ""
@@ -368,12 +370,15 @@ class OrgUnitViewSet(viewsets.ViewSet):
                 for field_name in parent_source_ref_name
             ]
 
+            code = org_unit.get("code") if org_unit.get("code") != "" else None
+
             org_unit_values = [
                 org_unit.get("id"),
                 org_unit.get("name"),
                 org_unit.get("org_unit_type__name"),
                 location.y if location else None,
                 location.x if location else None,
+                code,
                 (
                     org_unit.get("opening_date").strftime("%Y-%m-%d")
                     if org_unit.get("opening_date") is not None

--- a/iaso/tests/api/payments/test_payment_lots.py
+++ b/iaso/tests/api/payments/test_payment_lots.py
@@ -1,6 +1,3 @@
-import numpy as np
-import pandas as pd
-
 from hat.audit import models as am
 from iaso import models as m
 from iaso.models.payments import PaymentStatuses
@@ -176,14 +173,8 @@ class PaymentLotsViewSetAPITestCase(TaskAPITestCase):
 
         with self.assertNumQueries(10):
             response = self.client.get(f"/api/payments/lots/{self.payment_lot.id}/?xlsx=true")
-            self.assertEqual(response.status_code, 200)
-            self.assertEqual(
-                response["Content-Type"], "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-            )
+            excel_columns, excel_data = self.assertXlsxFileResponse(response)
 
-        excel_data = pd.read_excel(response.content, engine="openpyxl")
-
-        excel_columns = list(excel_data.columns.ravel())
         self.assertEqual(
             excel_columns,
             [
@@ -205,9 +196,8 @@ class PaymentLotsViewSetAPITestCase(TaskAPITestCase):
             ],
         )
 
-        data_dict = excel_data.replace({np.nan: None}).to_dict()
         self.assertDictEqual(
-            data_dict,
+            excel_data,
             {
                 "ID": {
                     0: self.second_payment.id,

--- a/iaso/tests/api/test_orgunits.py
+++ b/iaso/tests/api/test_orgunits.py
@@ -4,6 +4,9 @@ import io
 import json
 import typing
 
+import numpy as np
+import pandas as pd
+
 from django.contrib.gis.geos import GEOSGeometry, MultiPolygon, Point, Polygon
 from django.db import connection
 from django.test import SimpleTestCase
@@ -83,6 +86,7 @@ class OrgUnitAPITestCase(APITestCase):
             catchment=mock_multipolygon,
             validation_status=m.OrgUnit.VALIDATION_VALID,
             source_ref="PvtAI4RUMkr",
+            code="code1",
         )
 
         cls.instance_related_to_reference_form = cls.create_form_instance(
@@ -109,6 +113,7 @@ class OrgUnitAPITestCase(APITestCase):
             simplified_geom=mock_multipolygon_empty,
             catchment=mock_multipolygon_empty,
             validation_status=m.OrgUnit.VALIDATION_VALID,
+            code="code2",
         )
 
         # I am really sorry to have to rely on this ugly hack to set the location field to an empty point, but
@@ -131,6 +136,7 @@ class OrgUnitAPITestCase(APITestCase):
             location=mock_point,
             validation_status=m.OrgUnit.VALIDATION_VALID,
             source_ref="F9w3VW1cQmb",
+            code="code3",
         )
         cls.jedi_squad_endor_2 = m.OrgUnit.objects.create(
             parent=jedi_council_endor,
@@ -141,6 +147,7 @@ class OrgUnitAPITestCase(APITestCase):
             simplified_geom=mock_multipolygon,
             catchment=mock_multipolygon,
             validation_status=m.OrgUnit.VALIDATION_VALID,
+            code="code4",
         )
 
         cls.jedi_council_brussels = m.OrgUnit.objects.create(
@@ -152,6 +159,7 @@ class OrgUnitAPITestCase(APITestCase):
             catchment=mock_multipolygon,
             location=mock_point,
             validation_status=m.OrgUnit.VALIDATION_VALID,
+            code="code5",
         )
 
         cls.yoda = cls.create_user_with_profile(username="yoda", account=star_wars, permissions=["iaso_org_units"])
@@ -735,7 +743,7 @@ class OrgUnitAPITestCase(APITestCase):
 
         self.client.force_authenticate(self.yoda)
 
-        response = self.client.get("/api/orgunits/?csv=true")
+        response = self.client.get("/api/orgunits/?order=id&csv=true")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response["Content-Type"], "text/csv")
 
@@ -744,9 +752,110 @@ class OrgUnitAPITestCase(APITestCase):
         response_string = "".join(s for s in response_csv)
         reader = csv.reader(io.StringIO(response_string), delimiter=",")
         data = list(reader)
+
+        headers = data[0]
+        self.assertEqual(
+            headers,
+            [
+                "ID",
+                "Nom",
+                "Type",
+                "Latitude",
+                "Longitude",
+                "Code",
+                "Date d'ouverture",
+                "Date de fermeture",
+                "Date de création",
+                "Date de modification",
+                "Créé par",
+                "Source",
+                "Validé",
+                "Référence externe",
+                "parent 1",
+                "parent 2",
+                "parent 3",
+                "parent 4",
+                "Ref Ext parent 1",
+                "Ref Ext parent 2",
+                "Ref Ext parent 3",
+                "Ref Ext parent 4",
+                "Total de soumissions",
+                self.elite_group.name,
+            ],
+        )
+
         first_row = data[1]
         first_row_name = first_row[1]
-        self.assertEqual(first_row_name, self.jedi_council_brussels.name)
+        self.assertEqual(first_row_name, self.jedi_council_corruscant.name)
+
+        first_row_code = first_row[5]
+        self.assertEqual(first_row_code, self.jedi_council_corruscant.code)
+
+    def test_can_retrieve_org_units_list_in_xlsx_format(self):
+        self.client.force_authenticate(self.yoda)
+        response = self.client.get("/api/orgunits/?&order=id&xlsx=true")
+        self.assertFileResponse(
+            response, status.HTTP_200_OK, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        )
+
+        excel_data = pd.read_excel(response.content, engine="openpyxl")
+
+        excel_columns = list(excel_data.columns.ravel())
+        self.assertEqual(
+            excel_columns,
+            [
+                "ID",
+                "Nom",
+                "Type",
+                "Latitude",
+                "Longitude",
+                "Code",
+                "Date d'ouverture",
+                "Date de fermeture",
+                "Date de création",
+                "Date de modification",
+                "Créé par",
+                "Source",
+                "Validé",
+                "Référence externe",
+                "parent 1",
+                "parent 2",
+                "parent 3",
+                "parent 4",
+                "Ref Ext parent 1",
+                "Ref Ext parent 2",
+                "Ref Ext parent 3",
+                "Ref Ext parent 4",
+                "Total de soumissions",
+                self.elite_group.name,
+            ],
+        )
+
+        data_dict = excel_data.replace({np.nan: None}).to_dict()
+
+        ids = data_dict["ID"]
+        self.assertEqual(
+            ids,
+            {
+                0: self.jedi_council_corruscant.id,
+                1: self.jedi_council_endor.id,
+                2: self.jedi_squad_endor.id,
+                3: self.jedi_squad_endor_2.id,
+                4: self.jedi_council_brussels.id,
+            },
+        )
+
+        codes = data_dict["Code"]
+        self.assertEqual(
+            codes,
+            {
+                0: self.jedi_council_corruscant.code,
+                1: self.jedi_council_endor.code,
+                2: self.jedi_squad_endor.code,
+                3: self.jedi_squad_endor_2.code,
+                4: self.jedi_council_brussels.code,
+            },
+        )
 
     def assertValidOrgUnitListData(self, *, list_data: typing.Mapping, expected_length: int):
         self.assertValidListData(list_data=list_data, results_key="orgUnits", expected_length=expected_length)

--- a/iaso/tests/api/test_orgunits.py
+++ b/iaso/tests/api/test_orgunits.py
@@ -4,9 +4,6 @@ import io
 import json
 import typing
 
-import numpy as np
-import pandas as pd
-
 from django.contrib.gis.geos import GEOSGeometry, MultiPolygon, Point, Polygon
 from django.db import connection
 from django.test import SimpleTestCase
@@ -794,15 +791,10 @@ class OrgUnitAPITestCase(APITestCase):
     def test_can_retrieve_org_units_list_in_xlsx_format(self):
         self.client.force_authenticate(self.yoda)
         response = self.client.get("/api/orgunits/?&order=id&xlsx=true")
-        self.assertFileResponse(
-            response, status.HTTP_200_OK, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-        )
+        columns, excel_data = self.assertXlsxFileResponse(response)
 
-        excel_data = pd.read_excel(response.content, engine="openpyxl")
-
-        excel_columns = list(excel_data.columns.ravel())
         self.assertEqual(
-            excel_columns,
+            columns,
             [
                 "ID",
                 "Nom",
@@ -831,9 +823,7 @@ class OrgUnitAPITestCase(APITestCase):
             ],
         )
 
-        data_dict = excel_data.replace({np.nan: None}).to_dict()
-
-        ids = data_dict["ID"]
+        ids = excel_data["ID"]
         self.assertEqual(
             ids,
             {
@@ -845,7 +835,7 @@ class OrgUnitAPITestCase(APITestCase):
             },
         )
 
-        codes = data_dict["Code"]
+        codes = excel_data["Code"]
         self.assertEqual(
             codes,
             {

--- a/iaso/tests/api/test_profiles.py
+++ b/iaso/tests/api/test_profiles.py
@@ -1,8 +1,6 @@
 import typing
 
 import jsonschema
-import numpy as np
-import pandas as pd
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, Permission
@@ -382,12 +380,8 @@ class ProfileAPITestCase(APITestCase):
 
         self.client.force_authenticate(self.jane)
         response = self.client.get("/api/profiles/?xlsx=true")
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response["Content-Type"], "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
+        excel_columns, excel_data = self.assertXlsxFileResponse(response)
 
-        excel_data = pd.read_excel(response.content, engine="openpyxl")
-
-        excel_columns = list(excel_data.columns.ravel())
         self.assertEqual(
             excel_columns,
             [
@@ -409,10 +403,8 @@ class ProfileAPITestCase(APITestCase):
             ],
         )
 
-        data_dict = excel_data.replace({np.nan: None}).to_dict()
-
         self.assertDictEqual(
-            data_dict,
+            excel_data,
             {
                 "username": {0: "janedoe", 1: "johndoe", 2: "jim", 3: "jam", 4: "jom", 5: "jum", 6: "managedGeoLimit"},
                 "password": {0: None, 1: None, 2: None, 3: None, 4: None, 5: None, 6: None},

--- a/iaso/tests/api/test_storage.py
+++ b/iaso/tests/api/test_storage.py
@@ -6,8 +6,6 @@ from io import StringIO
 from typing import List
 from unittest import mock
 
-import numpy as np
-import pandas as pd
 import pytz
 
 from django.http import StreamingHttpResponse
@@ -1605,14 +1603,9 @@ class StorageAPITestCase(APITestCase):
 
         # 1. Check the response status and content type
         response = self.client.get("/api/storages/?xlsx=true")
-        self.assertEqual(response.status_code, 200)
-
-        self.assertEqual(response["Content-Type"], "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
-
-        excel_data = pd.read_excel(response.content, engine="openpyxl")
+        excel_columns, excel_data = self.assertXlsxFileResponse(response)
 
         # 2. Check the headers
-        excel_columns = list(excel_data.columns.ravel())
         self.assertEqual(
             excel_columns,
             [
@@ -1630,9 +1623,8 @@ class StorageAPITestCase(APITestCase):
         )
 
         # 3. Check the data
-        data_dict = excel_data.replace({np.nan: None}).to_dict()
         self.assertDictEqual(
-            data_dict,
+            excel_data,
             {
                 "Storage ID": {
                     0: "EXISTING_STORAGE",
@@ -1755,14 +1747,11 @@ class StorageAPITestCase(APITestCase):
         self.client.force_authenticate(self.yoda)
 
         response = self.client.get("/api/storages/NFC/EXISTING_STORAGE/logs?xlsx=true")
-        excel_data = pd.read_excel(response.content, engine="openpyxl")
 
         # 1. Check the response status and content type
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response["Content-Type"], "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
+        excel_columns, excel_data = self.assertXlsxFileResponse(response)
 
         # 2. Check the headers
-        excel_columns = list(excel_data.columns.ravel())
         self.assertEqual(
             excel_columns,
             [
@@ -1782,9 +1771,8 @@ class StorageAPITestCase(APITestCase):
         )
 
         # 3. Check the data
-        data_dict = excel_data.replace({np.nan: None}).to_dict()
         self.assertEqual(
-            data_dict,
+            excel_data,
             {
                 "id": {0: "e4200710-bf82-4d29-a29b-6a042f79ef25"},
                 "storage_id": {0: "EXISTING_STORAGE"},


### PR DESCRIPTION
Add OrgUnit.code to XLSX/CSV exports

Related JIRA tickets : IA-4303, IA-4030 (epic)

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

/

## Changes

- Added the `Code` column to OrgUnit XLSX/CSV exports
- Added a utility test method `assertXlsxFileResponse` + refactor

## How to test
- Have some OrgUnit that have a code (for instance by importing a pyramid from DHIS2)
- Go to the OrgUnit page
- Click on the XLSX/CSV export button
- You should see the `Code` column and its data

## Print screen / video
![image](https://github.com/user-attachments/assets/a4b95980-b6a5-4d31-a874-13e90681496e)



## Notes

See Jira epic for further developments on codes


## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
