### PR TITLE
[WC2-778] Try to fix CIAM login for Ethiopia

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -144,7 +144,7 @@ jobs:
                   RDS_USERNAME: postgres
                   CACHE: false
                   DEV_SERVER: true
-                  PLUGINS: polio,wfp
+                  PLUGINS: polio,wfp,wfp_auth
             - name: Django tests
               run: |
                   . ./venv/bin/activate &&  python manage.py migrate
@@ -164,7 +164,7 @@ jobs:
                   RDS_USERNAME: postgres
                   CACHE: false
                   DEV_SERVER: true
-                  PLUGINS: polio,wfp
+                  PLUGINS: polio,wfp,wfp_auth
                   AWS_STORAGE_BUCKET_NAME: iaso-dev
                   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
                   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@
 # make test
 # make test TARGET=iaso.tests.api.test_profiles.ProfileAPITestCase
 test:
-	docker compose exec iaso ./manage.py test \
-	--noinput --keepdb --failfast --settings=hat.settings_test --verbosity 3 \
+	docker compose exec -e PLUGINS=polio,wfp,wfp_auth iaso ./manage.py test \
+	--noinput --keepdb --failfast --settings=hat.settings --verbosity 3 \
 	$(TARGET)
 
 # When the migration history is changed, we need to drop the DB before running the tests suite with `--keepdb`.

--- a/hat/settings_test.py
+++ b/hat/settings_test.py
@@ -1,8 +1,4 @@
-from .settings import *
+from .settings import *  # Import base settings.
 
 
-# Disable Database Serialization to speed up tests (Django < 4.0).
-# Django serializes the whole database into a SQL string at the start of a test run, which can take a few seconds.
-# https://docs.djangoproject.com/en/3.2/topics/testing/overview/#test-case-serialized-rollback
-# Fixed in Django 4.0 https://code.djangoproject.com/ticket/32446
-DATABASES["default"]["TEST"] = {"SERIALIZE": False}  # type: ignore
+PLUGINS = ["polio", "wfp", "wfp_auth"]

--- a/hat/settings_test.py
+++ b/hat/settings_test.py
@@ -1,4 +1,0 @@
-from .settings import *  # Import base settings.
-
-
-PLUGINS = ["polio", "wfp", "wfp_auth"]

--- a/iaso/admin/base.py
+++ b/iaso/admin/base.py
@@ -458,7 +458,7 @@ class ProfileAdmin(admin.GeoModelAdmin):
     list_select_related = ("user", "account")
     list_filter = ("account",)
     list_display = ("id", "user", "account", "language")
-    autocomplete_fields = ["account"]
+    autocomplete_fields = ["account", "user"]
 
 
 @admin.register(ExportRequest)

--- a/iaso/admin/user_admin.py
+++ b/iaso/admin/user_admin.py
@@ -85,7 +85,7 @@ class UserAdmin(AuthUserAdmin):
         ordering="annotated_is_account_user",
     )
     def is_account_user(self, obj):
-        return obj.annotated_is_account_user
+        return bool(obj.annotated_is_account_user)
 
     @admin.display(
         boolean=True,
@@ -93,7 +93,7 @@ class UserAdmin(AuthUserAdmin):
         ordering="annotated_is_account_main_user",
     )
     def is_account_main_user(self, obj):
-        return obj.annotated_is_account_main_user
+        return bool(obj.annotated_is_account_main_user)
 
     def accounts(self, user):
         if user.tenant_users.exists():  # Multi-account user

--- a/iaso/admin/user_admin.py
+++ b/iaso/admin/user_admin.py
@@ -66,6 +66,7 @@ class UserAdmin(AuthUserAdmin):
     list_display = ("id",) + AuthUserAdmin.list_display + ("is_account_user", "is_account_main_user", "accounts")
     list_filter = (IsMultiAccountUserFilter, IsMultiAccountMainUserFilter) + AuthUserAdmin.list_filter
     list_display_links = ("id", "username")
+    ordering = ("-id",)
 
     def get_queryset(self, request):
         is_main_user = TenantUser.objects.filter(main_user_id=OuterRef("pk"))

--- a/iaso/admin/user_admin.py
+++ b/iaso/admin/user_admin.py
@@ -79,19 +79,21 @@ class UserAdmin(AuthUserAdmin):
             .annotate(annotated_is_account_main_user=Exists(is_main_user))
         )
 
+    @admin.display(
+        boolean=True,
+        description="multi-account user",
+        ordering="annotated_is_account_user",
+    )
     def is_account_user(self, obj):
         return obj.annotated_is_account_user
 
-    is_account_user.boolean = True
-    is_account_user.short_description = "multi-account user"
-    is_account_user.admin_order_field = "annotated_is_account_user"
-
+    @admin.display(
+        boolean=True,
+        description="multi-account main user",
+        ordering="annotated_is_account_main_user",
+    )
     def is_account_main_user(self, obj):
         return obj.annotated_is_account_main_user
-
-    is_account_main_user.boolean = True
-    is_account_main_user.short_description = "multi-account main user"
-    is_account_main_user.admin_order_field = "annotated_is_account_main_user"
 
     def accounts(self, user):
         if user.tenant_users.exists():  # Multi-account user

--- a/iaso/api/profiles/profiles.py
+++ b/iaso/api/profiles/profiles.py
@@ -353,7 +353,7 @@ class ProfilesViewSet(viewsets.ViewSet):
             return JsonResponse({"errorKey": "password", "errorMessage": _("Mot de passe requis")}, status=400)
 
         try:
-            user = TenantUser.objects.create_user_or_tenant_user(
+            new_user, tenant_main_user, tenant_account_user = TenantUser.objects.create_user_or_tenant_user(
                 data=UserCreationData(
                     username=username,
                     email=email,
@@ -365,7 +365,9 @@ class ProfilesViewSet(viewsets.ViewSet):
         except UsernameAlreadyExistsError as e:
             return JsonResponse({"errorKey": "user_name", "errorMessage": e.message}, status=400)
 
-        if password != "":
+        user = new_user or tenant_account_user
+
+        if new_user and password != "":
             user.set_password(password)
             user.save()
 

--- a/iaso/api/profiles/profiles.py
+++ b/iaso/api/profiles/profiles.py
@@ -362,8 +362,8 @@ class ProfilesViewSet(viewsets.ViewSet):
                     account=current_account,
                 )
             )
-        except UsernameAlreadyExistsError:
-            return JsonResponse({"errorKey": "user_name", "errorMessage": _("Nom d'utilisateur existant")}, status=400)
+        except UsernameAlreadyExistsError as e:
+            return JsonResponse({"errorKey": "user_name", "errorMessage": e.message}, status=400)
 
         if password != "":
             user.set_password(password)

--- a/iaso/api/profiles/profiles.py
+++ b/iaso/api/profiles/profiles.py
@@ -1,5 +1,3 @@
-import copy
-
 from typing import Any, List, Optional, Union
 
 from django.conf import settings
@@ -31,6 +29,7 @@ from iaso.api.common import CONTENT_TYPE_CSV, CONTENT_TYPE_XLSX, FileFormatEnum
 from iaso.api.profiles.audit import ProfileAuditLogger
 from iaso.api.profiles.bulk_create_users import BULK_CREATE_USER_COLUMNS_LIST
 from iaso.models import OrgUnit, OrgUnitType, Profile, Project, TenantUser, UserRole
+from iaso.models.tenant_users import UserCreationData, UsernameAlreadyExistsError
 from iaso.utils import is_mobile_request, is_multi_account_user
 from iaso.utils.module_permissions import account_module_permissions
 
@@ -340,63 +339,35 @@ class ProfilesViewSet(viewsets.ViewSet):
         current_profile = request.user.iaso_profile
         current_account = current_profile.account
 
-        username = request.data.get("user_name")
+        email = request.data.get("email", "")
+        first_name = request.data.get("first_name", "")
+        last_name = request.data.get("last_name", "")
         password = request.data.get("password", "")
         send_email_invitation = request.data.get("send_email_invitation")
+        username = request.data.get("user_name")
 
         if not username:
             return JsonResponse({"errorKey": "user_name", "errorMessage": _("Nom d'utilisateur requis")}, status=400)
-        existing_user = User.objects.filter(username__iexact=username)
-        if existing_user:
-            return JsonResponse({"errorKey": "user_name", "errorMessage": _("Nom d'utilisateur existant")}, status=400)
+
         if not password and not send_email_invitation:
             return JsonResponse({"errorKey": "password", "errorMessage": _("Mot de passe requis")}, status=400)
-        main_user = None
+
         try:
-            existing_user = User.objects.get(username__iexact=username)
-            user_in_same_account = False
-            try:
-                if existing_user.iaso_profile and existing_user.iaso_profile.account == current_account:
-                    user_in_same_account = True
-            except User.iaso_profile.RelatedObjectDoesNotExist:
-                # User doesn't have an iaso_profile, so they're not in the same account
-                pass
-
-            if user_in_same_account:
-                return JsonResponse(
-                    {"errorKey": "user_name", "errorMessage": _("Nom d'utilisateur existant")}, status=400
+            user = TenantUser.objects.create_user_or_tenant_user(
+                data=UserCreationData(
+                    username=username,
+                    email=email,
+                    first_name=first_name,
+                    last_name=last_name,
+                    account=current_account,
                 )
-            # TODO: invitation
-            # TODO what if already main user?
-            old_username = username
-            username = f"{username}_{current_account.name.lower().replace(' ', '_')}"
-
-            # duplicate existing_user into main user and account user
-            main_user = copy.copy(existing_user)
-
-            existing_user.username = f"{old_username}_{'unknown' if not hasattr(existing_user, 'iaso_profile') else existing_user.iaso_profile.account.name.lower().replace(' ', '_')}"
-            existing_user.set_unusable_password()
-            existing_user.save()
-
-            main_user.pk = None
-            main_user.save()
-
-            TenantUser.objects.create(main_user=main_user, account_user=existing_user)
-        except User.DoesNotExist:
-            pass  # no existing user, simply create a new user
-
-        user = User()
-        user.first_name = request.data.get("first_name", "")
-        user.last_name = request.data.get("last_name", "")
-        user.username = username
-        user.email = request.data.get("email", "")
+            )
+        except UsernameAlreadyExistsError:
+            return JsonResponse({"errorKey": "user_name", "errorMessage": _("Nom d'utilisateur existant")}, status=400)
 
         if password != "":
             user.set_password(password)
-        user.save()
-
-        if main_user:
-            TenantUser.objects.create(main_user=main_user, account_user=user)
+            user.save()
 
         # Create an Iaso profile for the new user and attach it to the same account
         # as the currently authenticated user

--- a/iaso/models/tenant_users.py
+++ b/iaso/models/tenant_users.py
@@ -89,6 +89,22 @@ class TenantUserManager(models.Manager):
 
 
 class TenantUser(models.Model):
+    """
+    Multi tenant (or multiple accounts).
+
+    `main_user` is the user who logs in with `username/password` (or with `email` with the WFP CIAM OAuth protocol).
+
+    There can be a bunch of `account_user` for a given `main_user`.
+
+    When `main_user` logs in, an "under the hood" login is performed so that
+    `main_user` is switched to one of its `account_user`.
+
+    Ideally:
+
+    - `main_user` shouldn't have any profile
+    - `account_user` should have an unusable password to avoid a "direct" login
+    """
+
     main_user = models.ForeignKey(User, on_delete=models.CASCADE, related_name="tenant_users")
     account_user = models.OneToOneField(User, on_delete=models.CASCADE, related_name="tenant_user")
     created_at = models.DateTimeField(auto_now_add=True)

--- a/iaso/models/tenant_users.py
+++ b/iaso/models/tenant_users.py
@@ -23,7 +23,8 @@ class UsernameAlreadyExistsError(ValidationError):
 
 def get_unique_username(username: str, account_name: str) -> str:
     account_name_slug = account_name.lower().replace(" ", "_")
-    return f"{username}_{account_name_slug}"
+    max_length = User._meta.get_field("username").max_length
+    return f"{username}_{account_name_slug}"[0:max_length]
 
 
 class TenantUserManager(models.Manager):

--- a/iaso/models/tenant_users.py
+++ b/iaso/models/tenant_users.py
@@ -21,8 +21,9 @@ class UsernameAlreadyExistsError(ValidationError):
     pass
 
 
-def slugify_account(name: str) -> str:
-    return name.lower().replace(" ", "_")
+def get_unique_username(username: str, account_name: str) -> str:
+    account_name_slug = account_name.lower().replace(" ", "_")
+    return f"{username}_{account_name_slug}"
 
 
 class TenantUserManager(models.Manager):
@@ -51,7 +52,7 @@ class TenantUserManager(models.Manager):
         # 3) The user doesn't have multiple accounts.
         elif hasattr(existing_user, "iaso_profile"):
             existing_account = existing_user.iaso_profile.account
-            new_username = f"{data.username}_{slugify_account(existing_account.name)}"
+            new_username = get_unique_username(data.username, existing_account.name)
             existing_user.username = new_username
             existing_user.save()
             main_user = User.objects.create(
@@ -66,7 +67,7 @@ class TenantUserManager(models.Manager):
         else:
             main_user = existing_user
 
-        new_username = f"{data.username}_{slugify_account(data.account.name)}"
+        new_username = get_unique_username(data.username, data.account.name)
         user = User.objects.create(
             username=new_username,
             email=data.email,

--- a/iaso/models/tenant_users.py
+++ b/iaso/models/tenant_users.py
@@ -1,5 +1,64 @@
 from django.contrib.auth.models import User
+from django.core.exceptions import ValidationError
 from django.db import models
+from django.db.models import Q
+
+from iaso.models import Account
+
+
+def slugify_account(name: str) -> str:
+    return name.lower().replace(" ", "_")
+
+
+class TenantUserManager(models.Manager):
+    def create_user_or_tenant_user(
+        self, username: str, email: str, first_name: str, last_name: str, account: Account
+    ) -> User:
+        existing_user = User.objects.filter(username=username).first()
+
+        if not existing_user:
+            user = User.objects.create(
+                username=username,
+                email=email,
+                first_name=first_name,
+                last_name=last_name,
+            )
+            return user
+
+        if hasattr(existing_user, "iaso_profile") and existing_user.iaso_profile.account == account:
+            raise ValidationError("Username already exists for this account.")
+
+        existing_tenant_user = self.filter(Q(main_user=existing_user) | Q(account_user=existing_user)).first()
+
+        if existing_tenant_user:
+            main_user = existing_tenant_user.main_user
+
+        elif hasattr(existing_user, "iaso_profile"):  # Insert `existing_user` and its profile into `TenantUser`.
+            existing_account = existing_user.iaso_profile.account
+            new_username = f"{username}_{slugify_account(existing_account.name)}"
+            existing_user.username = new_username
+            existing_user.save()
+            main_user = User.objects.create(
+                username=username,
+                email=existing_user.email,
+                first_name=existing_user.first_name,
+                last_name=existing_user.last_name,
+            )
+            self.create(main_user=main_user, account_user=existing_user)
+
+        else:
+            main_user = existing_user
+
+        new_username = f"{username}_{slugify_account(account.name)}"
+        user = User.objects.create(
+            username=new_username,
+            email=email,
+            first_name=first_name,
+            last_name=last_name,
+        )
+        self.create(main_user=main_user, account_user=user)
+
+        return user
 
 
 class TenantUser(models.Model):
@@ -7,6 +66,8 @@ class TenantUser(models.Model):
     account_user = models.OneToOneField(User, on_delete=models.CASCADE, related_name="tenant_user")
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
+
+    objects = TenantUserManager()
 
     class Meta:
         constraints = [
@@ -16,6 +77,15 @@ class TenantUser(models.Model):
             models.Index(fields=["created_at"]),
             models.Index(fields=["updated_at"]),
         ]
+
+    def __str__(self):
+        account_name = "Unknown"
+        try:
+            if self.account_user.iaso_profile:
+                account_name = self.account_user.iaso_profile.account
+        except User.iaso_profile.RelatedObjectDoesNotExist:
+            pass
+        return f"{self.main_user} -- {self.account_user} ({account_name})"
 
     @property
     def account(self):
@@ -29,15 +99,6 @@ class TenantUser(models.Model):
 
     def get_other_accounts(self):
         return [tu.account for tu in self.main_user.tenant_users.exclude(pk=self.pk) if tu.account]
-
-    def __str__(self):
-        account_name = "Unknown"
-        try:
-            if self.account_user.iaso_profile:
-                account_name = self.account_user.iaso_profile.account
-        except User.iaso_profile.RelatedObjectDoesNotExist:
-            pass
-        return f"{self.main_user} -- {self.account_user} ({account_name})"
 
     def as_dict(self):
         account_dict = None

--- a/iaso/test.py
+++ b/iaso/test.py
@@ -125,12 +125,13 @@ class IasoTestCaseMixin:
         return [user, anon, user_no_perms]
 
     @staticmethod
-    def create_account_datasource_version_project(source_name, account_name, project_name):
+    def create_account_datasource_version_project(source_name, account_name, project_name, app_id=None):
         """Create a project and all related data: account, data source, source version"""
         data_source = m.DataSource.objects.create(name=source_name)
         source_version = m.SourceVersion.objects.create(data_source=data_source, number=1)
         account = m.Account.objects.create(name=account_name, default_version=source_version)
-        project = m.Project.objects.create(name=project_name, app_id=f"{project_name}.app", account=account)
+        app_id = app_id or f"{project_name}.app"
+        project = m.Project.objects.create(name=project_name, app_id=app_id, account=account)
         data_source.projects.set([project])
 
         return [account, data_source, source_version, project]

--- a/iaso/tests/models/test_tenant_users.py
+++ b/iaso/tests/models/test_tenant_users.py
@@ -19,6 +19,17 @@ class TenantUserModelTestCase(TestCase):
             account=cls.account,
         )
 
+    def test_get_unique_username(self):
+        username = "user"
+        account_name = "account foo"
+        unique_username = get_unique_username(username, account_name)
+        self.assertEqual(unique_username, "user_account_foo")
+
+        username = "x" * m.User._meta.get_field("username").max_length
+        account_name = "too_long"
+        unique_username = get_unique_username(username, account_name)
+        self.assertEqual(len(unique_username), 150)
+
     def test_create_user_or_tenant_user_with_no_preexisting_user(self):
         """
         No preexisting user.

--- a/iaso/tests/models/test_tenant_users.py
+++ b/iaso/tests/models/test_tenant_users.py
@@ -1,0 +1,144 @@
+from iaso import models as m
+from iaso.models.tenant_users import UserCreationData, UsernameAlreadyExistsError, get_unique_username
+from iaso.test import TestCase
+
+
+class TenantUserModelTestCase(TestCase):
+    """
+    Test `TenantUser` model.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.account = m.Account.objects.create(name="Account")
+        cls.user_creation_data = UserCreationData(
+            username="john_doe",
+            email="john@doe.com",
+            first_name="John",
+            last_name="Doe",
+            account=cls.account,
+        )
+
+    def test_create_user_or_tenant_user_with_no_preexisting_user(self):
+        """
+        No preexisting user.
+        """
+        m.TenantUser.objects.create_user_or_tenant_user(data=self.user_creation_data)
+
+        # Users.
+        self.assertEqual(m.User.objects.count(), 1)
+        user = m.User.objects.get(username=self.user_creation_data.username)
+        self.assertEqual(user.email, self.user_creation_data.email)
+        self.assertEqual(user.first_name, self.user_creation_data.first_name)
+        self.assertEqual(user.last_name, self.user_creation_data.last_name)
+
+        # Tenant Users.
+        self.assertEqual(m.TenantUser.objects.count(), 0)
+
+        # Iaso Profiles.
+        self.assertFalse(hasattr(user, "iaso_profile"))
+
+    def test_create_user_or_tenant_user_with_preexisting_user_for_same_account(self):
+        self.create_user_with_profile(
+            username=self.user_creation_data.username, email=self.user_creation_data.email, account=self.account
+        )
+        with self.assertRaises(UsernameAlreadyExistsError):
+            m.TenantUser.objects.create_user_or_tenant_user(data=self.user_creation_data)
+
+    def test_create_user_or_tenant_user_for_preexisting_user_with_multiple_account(self):
+        """
+        The user already exists and has multiple accounts: add an account.
+        """
+        main_user = m.User.objects.create(username=self.user_creation_data.username, email="john@doe.com")
+
+        other_account_1 = m.Account.objects.create(name="Other Account 1")
+        other_account_user_1 = self.create_user_with_profile(
+            username="john_doe_other_account_1", email="john@doe.com", account=other_account_1
+        )
+        m.TenantUser.objects.create(main_user=main_user, account_user=other_account_user_1)
+
+        other_account_2 = m.Account.objects.create(name="Other Account 2")
+        other_account_user_2 = self.create_user_with_profile(
+            username="john_doe_other_account_2", email="john@doe.com", account=other_account_2
+        )
+        m.TenantUser.objects.create(main_user=main_user, account_user=other_account_user_2)
+
+        self.assertEqual(m.User.objects.count(), 3)
+        self.assertEqual(m.TenantUser.objects.count(), 2)
+
+        m.TenantUser.objects.create_user_or_tenant_user(data=self.user_creation_data)
+
+        # Users.
+        self.assertEqual(m.User.objects.count(), 4)
+        new_user = m.User.objects.get(
+            username=get_unique_username(self.user_creation_data.username, self.user_creation_data.account.name)
+        )
+        self.assertEqual(new_user.email, self.user_creation_data.email)
+        self.assertEqual(new_user.first_name, self.user_creation_data.first_name)
+        self.assertEqual(new_user.last_name, self.user_creation_data.last_name)
+
+        # Tenant Users.
+        self.assertEqual(m.TenantUser.objects.count(), 3)
+        self.assertEqual(main_user.tenant_users.count(), 3)
+        self.assertEqual(new_user.tenant_user.main_user, main_user)
+
+        # Iaso Profiles.
+        self.assertFalse(hasattr(new_user, "iaso_profile"))
+
+    def test_create_user_or_tenant_user_for_preexisting_user_without_multiple_account(self):
+        """
+        The user already exists and doesn't have multiple accounts.
+        """
+        other_account = m.Account.objects.create(name="Other Account")
+        other_account_user = self.create_user_with_profile(
+            username=self.user_creation_data.username, email="john@doe.com", account=other_account
+        )
+
+        self.assertEqual(m.User.objects.count(), 1)
+        self.assertEqual(m.TenantUser.objects.count(), 0)
+
+        m.TenantUser.objects.create_user_or_tenant_user(data=self.user_creation_data)
+
+        # Users.
+        self.assertEqual(m.User.objects.count(), 3)
+        new_user = m.User.objects.get(
+            username=get_unique_username(self.user_creation_data.username, self.user_creation_data.account.name)
+        )
+        self.assertEqual(new_user.email, self.user_creation_data.email)
+        self.assertEqual(new_user.first_name, self.user_creation_data.first_name)
+        self.assertEqual(new_user.last_name, self.user_creation_data.last_name)
+
+        # Tenant Users.
+        self.assertEqual(m.TenantUser.objects.count(), 2)
+        tenant_user_1 = m.TenantUser.objects.get(account_user=other_account_user)
+        tenant_user_2 = m.TenantUser.objects.get(account_user=new_user)
+        self.assertEqual(tenant_user_1.main_user, tenant_user_2.main_user)
+
+        # Iaso Profiles.
+        self.assertFalse(hasattr(new_user, "iaso_profile"))
+        self.assertFalse(hasattr(tenant_user_1.main_user, "iaso_profile"))
+
+    def test_create_user_or_tenant_user_for_preexisting_user_without_profile(self):
+        """
+        The user already exists and doesn't have a profile.
+        """
+        user = m.User.objects.create(username=self.user_creation_data.username, email="john@doe.com")
+
+        m.TenantUser.objects.create_user_or_tenant_user(data=self.user_creation_data)
+
+        # Users.
+        self.assertEqual(m.User.objects.count(), 2)
+        new_user = m.User.objects.get(
+            username=get_unique_username(self.user_creation_data.username, self.user_creation_data.account.name)
+        )
+        self.assertEqual(new_user.email, self.user_creation_data.email)
+        self.assertEqual(new_user.first_name, self.user_creation_data.first_name)
+        self.assertEqual(new_user.last_name, self.user_creation_data.last_name)
+
+        # Tenant Users.
+        self.assertEqual(m.TenantUser.objects.count(), 1)
+        self.assertEqual(user.tenant_users.count(), 1)
+        self.assertEqual(new_user.tenant_user.main_user, user)
+
+        # Iaso Profiles.
+        self.assertFalse(hasattr(new_user, "iaso_profile"))

--- a/iaso/tests/models/test_tenant_users.py
+++ b/iaso/tests/models/test_tenant_users.py
@@ -34,20 +34,25 @@ class TenantUserModelTestCase(TestCase):
         """
         No preexisting user.
         """
-        m.TenantUser.objects.create_user_or_tenant_user(data=self.user_creation_data)
+        new_user, tenant_main_user, tenant_account_user = m.TenantUser.objects.create_user_or_tenant_user(
+            data=self.user_creation_data
+        )
+        self.assertIsNotNone(new_user)
+        self.assertIsNone(tenant_main_user)
+        self.assertIsNone(tenant_account_user)
 
         # Users.
         self.assertEqual(m.User.objects.count(), 1)
-        user = m.User.objects.get(username=self.user_creation_data.username)
-        self.assertEqual(user.email, self.user_creation_data.email)
-        self.assertEqual(user.first_name, self.user_creation_data.first_name)
-        self.assertEqual(user.last_name, self.user_creation_data.last_name)
+        self.assertEqual(new_user.username, self.user_creation_data.username)
+        self.assertEqual(new_user.email, self.user_creation_data.email)
+        self.assertEqual(new_user.first_name, self.user_creation_data.first_name)
+        self.assertEqual(new_user.last_name, self.user_creation_data.last_name)
 
         # Tenant Users.
         self.assertEqual(m.TenantUser.objects.count(), 0)
 
         # Iaso Profiles.
-        self.assertFalse(hasattr(user, "iaso_profile"))
+        self.assertFalse(hasattr(new_user, "iaso_profile"))
 
     def test_create_user_or_tenant_user_with_preexisting_user_for_same_account(self):
         self.create_user_with_profile(
@@ -79,7 +84,12 @@ class TenantUserModelTestCase(TestCase):
         self.assertEqual(m.User.objects.count(), 3)
         self.assertEqual(m.TenantUser.objects.count(), 2)
 
-        m.TenantUser.objects.create_user_or_tenant_user(data=self.user_creation_data)
+        new_user, tenant_main_user, tenant_account_user = m.TenantUser.objects.create_user_or_tenant_user(
+            data=self.user_creation_data
+        )
+        self.assertIsNone(new_user)
+        self.assertIsNotNone(tenant_main_user)
+        self.assertIsNotNone(tenant_account_user)
 
         # Users.
         self.assertEqual(m.User.objects.count(), 4)
@@ -127,7 +137,12 @@ class TenantUserModelTestCase(TestCase):
         self.assertEqual(m.User.objects.count(), 1)
         self.assertEqual(m.TenantUser.objects.count(), 0)
 
-        m.TenantUser.objects.create_user_or_tenant_user(data=self.user_creation_data)
+        new_user, tenant_main_user, tenant_account_user = m.TenantUser.objects.create_user_or_tenant_user(
+            data=self.user_creation_data
+        )
+        self.assertIsNone(new_user)
+        self.assertIsNotNone(tenant_main_user)
+        self.assertIsNotNone(tenant_account_user)
 
         # Users.
         self.assertEqual(m.User.objects.count(), 3)
@@ -165,7 +180,12 @@ class TenantUserModelTestCase(TestCase):
         user.set_password("p4ssword")
         user.save()
 
-        m.TenantUser.objects.create_user_or_tenant_user(data=self.user_creation_data)
+        new_user, tenant_main_user, tenant_account_user = m.TenantUser.objects.create_user_or_tenant_user(
+            data=self.user_creation_data
+        )
+        self.assertIsNone(new_user)
+        self.assertIsNotNone(tenant_main_user)
+        self.assertIsNotNone(tenant_account_user)
 
         # Users.
         self.assertEqual(m.User.objects.count(), 2)

--- a/plugins/wfp_auth/tests/test_auth.py
+++ b/plugins/wfp_auth/tests/test_auth.py
@@ -42,6 +42,7 @@ class WFPAuthTestCase(APITestCase):
 
         self.assertEqual(response.status_code, 200)
 
+        self.assertEqual(m.User.objects.count(), 1)
         new_user = m.User.objects.get(email="john@doe.com")
         self.assertEqual(new_user.username, "john@doe.com")
         self.assertEqual(new_user.first_name, "John")
@@ -58,8 +59,8 @@ class WFPAuthTestCase(APITestCase):
     @patch("requests.get")
     def test_complete_login_ok_with_existing_username(self, mock_get):
         """
-        TODO.
         Avoid an IntegrityError when another user already has the same username.
+        Create an entry in `TenantUser` instead.
         """
         other_account = m.Account.objects.create(name="Other account")
         self.create_user_with_profile(username="john@doe.com", email="foo@bar.com", account=other_account)

--- a/plugins/wfp_auth/tests/test_auth.py
+++ b/plugins/wfp_auth/tests/test_auth.py
@@ -11,7 +11,8 @@ class WFPAuthTestCase(APITestCase):
     @classmethod
     def setUpTestData(cls):
         cls.account, cls.data_source, cls.version, cls.project = cls.create_account_datasource_version_project(
-            source_name="Data source", account_name="Account", project_name="Project")
+            source_name="Data source", account_name="Account", project_name="Project"
+        )
 
     @patch("requests.get")
     def test_complete_login_ok(self, mock_get):

--- a/plugins/wfp_auth/tests/test_auth.py
+++ b/plugins/wfp_auth/tests/test_auth.py
@@ -11,7 +11,7 @@ class WFPAuthTestCase(APITestCase):
     @classmethod
     def setUpTestData(cls):
         cls.account, cls.data_source, cls.version, cls.project = cls.create_account_datasource_version_project(
-            source_name="Data source", account_name="Account", project_name="Project"
+            source_name="Data source", account_name="Account", project_name="Project", app_id="test_app_id"
         )
 
     @patch("requests.get")

--- a/plugins/wfp_auth/tests/test_auth.py
+++ b/plugins/wfp_auth/tests/test_auth.py
@@ -10,10 +10,8 @@ from plugins.wfp_auth.views import ExtraData
 class WFPAuthTestCase(APITestCase):
     @classmethod
     def setUpTestData(cls):
-        cls.data_source = m.DataSource.objects.create(name="Data source")
-        cls.version = m.SourceVersion.objects.create(number=1, data_source=cls.data_source)
-        cls.account = m.Account.objects.create(name="Account", default_version=cls.version)
-        cls.project = m.Project.objects.create(name="Project", account=cls.account, app_id="test_app_id")
+        cls.account, cls.data_source, cls.version, cls.project = cls.create_account_datasource_version_project(
+            source_name="Data source", account_name="Account", project_name="Project")
 
     @patch("requests.get")
     def test_complete_login_ok(self, mock_get):

--- a/plugins/wfp_auth/tests/test_auth.py
+++ b/plugins/wfp_auth/tests/test_auth.py
@@ -1,0 +1,88 @@
+from unittest.mock import patch
+
+from allauth.socialaccount.models import SocialAccount
+
+from iaso import models as m
+from iaso.test import APITestCase
+from plugins.wfp_auth.views import ExtraData
+
+
+class WFPAuthTestCase(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.data_source = m.DataSource.objects.create(name="Data source")
+        cls.version = m.SourceVersion.objects.create(number=1, data_source=cls.data_source)
+        cls.account = m.Account.objects.create(name="Account", default_version=cls.version)
+        cls.project = m.Project.objects.create(name="Project", account=cls.account, app_id="test_app_id")
+
+    @patch("requests.get")
+    def test_complete_login_ok(self, mock_get):
+        self.assertEqual(m.User.objects.count(), 0)
+        self.assertEqual(m.Profile.objects.count(), 0)
+        self.assertEqual(SocialAccount.objects.count(), 0)
+
+        # Mock `requests.get()` response.
+        extra_data: ExtraData = {
+            "email": "john@doe.com",
+            "sub": "john@doe.com",
+            "given_name": "John",
+            "family_name": "Doe",
+        }
+        mock_response = mock_get.return_value
+        mock_response.json.return_value = extra_data
+
+        with patch("plugins.wfp_auth.views.WFP2Adapter.settings", new={"IASO_ACCOUNT_NAME": "foo"}):
+            response = self.client.post(
+                f"/wfp_auth/wfp/token/?app_id={self.project.app_id}&app_version=2501",
+                format="json",
+                data={
+                    "token": "f4k3-t0k3n",
+                },
+            )
+
+        self.assertEqual(response.status_code, 200)
+
+        new_user = m.User.objects.get(email="john@doe.com")
+        self.assertEqual(new_user.username, "test_app_id_john@doe.com")
+        self.assertEqual(new_user.first_name, "John")
+        self.assertEqual(new_user.last_name, "Doe")
+
+        new_profile = m.Profile.objects.get(user=new_user)
+        self.assertEqual(new_profile.account, self.account)
+
+        new_social_account = SocialAccount.objects.get(uid="test_app_id_john@doe.com")
+        self.assertEqual(new_social_account.provider, "wfp")
+        self.assertEqual(new_social_account.extra_data, extra_data)
+        self.assertEqual(new_social_account.user, new_user)
+
+    @patch("requests.get")
+    def test_complete_login_ok_with_existing_username(self, mock_get):
+        """
+        Avoid an IntegrityError when another user already has the same username.
+        """
+        self.create_user_with_profile(username="john@doe.com", email="foo@bar.com", account=self.account)
+
+        # Mock `requests.get()` response.
+        extra_data: ExtraData = {
+            "email": "john@doe.com",
+            "sub": "john@doe.com",
+            "given_name": "John",
+            "family_name": "Doe",
+        }
+        mock_response = mock_get.return_value
+        mock_response.json.return_value = extra_data
+
+        with patch("plugins.wfp_auth.views.WFP2Adapter.settings", new={"IASO_ACCOUNT_NAME": "foo"}):
+            response = self.client.post(
+                f"/wfp_auth/wfp/token/?app_id={self.project.app_id}&app_version=2501",
+                format="json",
+                data={
+                    "token": "f4k3-t0k3n",
+                },
+            )
+
+        self.assertEqual(response.status_code, 200)
+
+        self.assertEqual(m.User.objects.count(), 2)
+        new_user = m.User.objects.get(email="john@doe.com")
+        self.assertEqual(new_user.username, "test_app_id_john@doe.com")

--- a/plugins/wfp_auth/views.py
+++ b/plugins/wfp_auth/views.py
@@ -145,7 +145,7 @@ class WFP2Adapter(Auth0OAuth2Adapter):
             user = User.objects.filter(iaso_profile__account=account, email=email).first()
 
             if not user:
-                user = TenantUser.objects.create_user_or_tenant_user(
+                new_user, tenant_main_user, tenant_account_user = TenantUser.objects.create_user_or_tenant_user(
                     data=UserCreationData(
                         username=email,
                         email=email,
@@ -154,6 +154,7 @@ class WFP2Adapter(Auth0OAuth2Adapter):
                         account=account,
                     )
                 )
+                user = new_user or tenant_account_user
                 user.set_unusable_password()
                 Profile.objects.create(account=account, user=user)
                 self.send_new_account_email(request, user)

--- a/plugins/wfp_auth/views.py
+++ b/plugins/wfp_auth/views.py
@@ -29,6 +29,7 @@ from rest_framework_simplejwt.tokens import RefreshToken  # type: ignore
 
 from iaso.api.query_params import APP_ID
 from iaso.models import Account, Profile, Project, TenantUser
+from iaso.models.tenant_users import UserCreationData
 
 from .provider import WFPProvider
 
@@ -145,11 +146,13 @@ class WFP2Adapter(Auth0OAuth2Adapter):
 
             if not user:
                 user = TenantUser.objects.create_user_or_tenant_user(
-                    username=email,
-                    email=email,
-                    first_name=extra_data.get("given_name"),
-                    last_name=extra_data.get("family_name"),
-                    account=account,
+                    data=UserCreationData(
+                        username=email,
+                        email=email,
+                        first_name=extra_data.get("given_name"),
+                        last_name=extra_data.get("family_name"),
+                        account=account,
+                    )
                 )
                 user.set_unusable_password()
                 Profile.objects.create(account=account, user=user)

--- a/plugins/wfp_auth/views.py
+++ b/plugins/wfp_auth/views.py
@@ -29,7 +29,7 @@ from rest_framework_simplejwt.tokens import RefreshToken  # type: ignore
 
 from iaso.api.query_params import APP_ID
 from iaso.models import Account, Profile, Project, TenantUser
-from iaso.models.tenant_users import UserCreationData
+from iaso.models.tenant_users import UserCreationData, UsernameAlreadyExistsError
 
 from .provider import WFPProvider
 
@@ -238,14 +238,16 @@ def token_view(request):
                 {"message": "Access token validation failed", "result": "error", "error": "invalid_token"}, status=401
             )
         return JsonResponse(
-            {"result": "error", "message": "error login to auth server", "details": e.response.text}, status=500
+            {"result": "error", "message": "Error login to auth server", "details": e.response.text}, status=500
         )
+    except UsernameAlreadyExistsError as e:
+        return JsonResponse({"result": "error", "message": e.message, "details": e.message}, status=409)
     except Exception as e:
         logger.exception(str(e))
         return JsonResponse(
             {
                 "result": "error",
-                "message": "error login account",
+                "message": "Error login account",
                 "details": str(e),
             },
             status=500,


### PR DESCRIPTION
Related JIRA tickets : WC2-778

## Changes

When creating a new user for SocialAccount, add a prefix to avoid unique constraint clashes.

## Notes

This PR was initially an attempt to quick fix the bug by @bmonjoie.

The scope has been extended after @madewulf asked to create a `TenantUser` instead of just hacking the username.

In doing so, I found a bug. The part [where we create a `TenantUser`](https://github.com/BLSQ/iaso/blob/48da9a9f1093a6c4dc74d5c8e6798bf611c3b4c4/iaso/api/profiles/profiles.py#L355-L386) was never reached because of [this condition](https://github.com/BLSQ/iaso/blob/48da9a9f1093a6c4dc74d5c8e6798bf611c3b4c4/iaso/api/profiles/profiles.py#L349-L351).

I fixed that and factorized the code that create a `User` or a `TenantUser`. This should be used every time we put a user in the system.

That PR should fix the CIAM login for Ethiopia in an elegant way.

The code is fully tested and the logic was approved by @bramj.

I also changed the behavior of the admin because we struggled with @beygorghor to understand why we weren't able to see all users.

Now we default on listing all the users and there are new filters:

![admin](https://github.com/user-attachments/assets/53895208-9d66-4c83-ab1c-1a645012f4b8)
