### PR TITLE
POLIO-1914: add endpoint to refresh prep from PowerBI

### DIFF
--- a/iaso/utils/powerbi.py
+++ b/iaso/utils/powerbi.py
@@ -110,10 +110,14 @@ def launch_dataset_refresh(group_id, data_set_id):
     # FIXME : import is not extra but will do till we move this model
     from iaso.models.json_config import Config
 
+    # Get the config for the powerBI refresh
     conf = get_object_or_404(Config, slug="powerbi_sp")
     config = conf.content
+    # Get configs to launch associated OH pipelines if any
     dataset_config = get_extra_config_for_data_set_id(data_set_id)
+    # OpenHexa config, used to launch an external task
     openhexa_config = None
+    # Config used to refresh other dashboards that should be refreshed together with the selected one
     extra_sync_config = None
 
     if dataset_config:

--- a/plugins/polio/api/urls.py
+++ b/plugins/polio/api/urls.py
@@ -61,6 +61,7 @@ from plugins.polio.tasks.api.refresh_im_data import (
     RefreshIMOutOfHouseholdDataViewset,
 )
 from plugins.polio.tasks.api.refresh_lqas_data import RefreshLQASDataViewset
+from plugins.polio.tasks.api.refresh_preparedness_dashboard_data import RefreshPreparednessDataViewset
 from plugins.polio.tasks.api.refresh_vrf_dashboard_data import RefreshVrfDataViewset
 
 
@@ -98,6 +99,7 @@ router.register(r"polio/powerbirefresh", LaunchPowerBIRefreshViewSet, basename="
 router.register(r"polio/rounds", RoundViewSet, basename="rounds")
 router.register(r"polio/reasonsfordelay", ReasonForDelayViewSet, basename="reasonsfordelay")
 router.register(r"polio/tasks/refreshvrf", RefreshVrfDataViewset, basename="refreshvrf")
+router.register(r"polio/tasks/refreshpreparedness", RefreshPreparednessDataViewset, basename="refreshpreparedness")
 router.register(r"polio/tasks/refreshlqas", RefreshLQASDataViewset, basename="refreshlqas")
 router.register(r"polio/tasks/refreshim/hh", RefreshIMHouseholdDataViewset, basename="refreshimhh")
 router.register(r"polio/tasks/refreshim/ohh", RefreshIMOutOfHouseholdDataViewset, basename="refreshimohh")

--- a/plugins/polio/tasks/api/refresh_preparedness_dashboard_data.py
+++ b/plugins/polio/tasks/api/refresh_preparedness_dashboard_data.py
@@ -1,0 +1,44 @@
+from datetime import datetime
+
+from rest_framework.response import Response
+
+from iaso.api.tasks.serializers import TaskSerializer
+from iaso.api.tasks.views import ExternalTaskModelViewSet
+from iaso.models.base import RUNNING, Task
+
+
+PREPAREDNESS_TASK_NAME = "Refresh Preparedness dashboard data"
+PREPAREDNESS_CONFIG_SLUG = "preparedness-pipeline-config"
+
+
+class RefreshPreparednessDataViewset(ExternalTaskModelViewSet):
+    http_method_names = ["get", "patch"]
+    model = Task
+    task_name = PREPAREDNESS_TASK_NAME
+    config_slug = PREPAREDNESS_CONFIG_SLUG
+
+    # Overriding the list method because powerBI sends a GET request
+    # So we have to have a GET that behaves like a POST
+    def list(self, request):
+        user = request.user
+        slug = PREPAREDNESS_CONFIG_SLUG
+        task = Task.objects.create(
+            created_by=user,
+            launcher=user,
+            account=user.iaso_profile.account,
+            name=PREPAREDNESS_TASK_NAME,
+            status=RUNNING,
+            external=True,
+            started_at=datetime.now(),
+            should_be_killed=False,
+        )
+        status = self.launch_task(slug=slug, task_id=task.pk)
+        task.status = status
+        task.save()
+        return Response({"task": TaskSerializer(instance=task).data})
+
+    def get_queryset(self):
+        user = self.request.user
+        account = user.iaso_profile.account
+        queryset = Task.objects.filter(account=account).filter(external=True)
+        return queryset

--- a/plugins/polio/tests/test_refresh_preparedness_data.py
+++ b/plugins/polio/tests/test_refresh_preparedness_data.py
@@ -1,6 +1,16 @@
+from datetime import datetime
+from unittest.mock import patch
+
 from iaso import models as m
+from iaso.models.base import KILLED, RUNNING, SKIPPED, SUCCESS
+from iaso.models.json_config import Config
 from iaso.test import APITestCase
 from plugins.polio.models import Campaign
+from plugins.polio.tasks.api.refresh_preparedness_dashboard_data import (
+    PREPAREDNESS_CONFIG_SLUG,
+    PREPAREDNESS_TASK_NAME,
+    RefreshPreparednessDataViewset,
+)
 
 
 class RefreshPreparednessTestCase(APITestCase):
@@ -55,3 +65,134 @@ class RefreshPreparednessTestCase(APITestCase):
         task = self.assertValidTaskAndInDB(jr)
         self.assertEqual(task.launcher, self.user)
         self.assertEqual(task.params["kwargs"]["campaigns"], [self.campaign.obr_name])
+
+
+class RefreshPreparednessDataTestCase(APITestCase):
+    @classmethod
+    def setUp(cls):
+        cls.url = "/api/polio/tasks/refreshpreparedness/"
+        cls.account = account = m.Account.objects.create(name="test account")
+        cls.user = cls.create_user_with_profile(username="test user", account=account, permissions=["iaso_polio"])
+
+        cls.external_task1 = m.Task.objects.create(
+            status=RUNNING, account=account, launcher=cls.user, name="external task 1", external=True
+        )
+        cls.external_task2 = m.Task.objects.create(
+            status=RUNNING, account=account, launcher=cls.user, name="external task 2", external=True
+        )
+        cls.project = m.Project.objects.create(name="Polio", app_id="polio.rapid.outbreak.taskforce", account=account)
+        cls.data_source = m.DataSource.objects.create(name="Default source")
+        cls.data_source.projects.add(cls.project)
+        cls.data_source.save()
+        cls.source_version = m.SourceVersion.objects.create(data_source=cls.data_source, number=1)
+        cls.account.default_version = cls.source_version
+        cls.account.save()
+
+        cls.task1 = m.Task.objects.create(
+            status=RUNNING,
+            account=account,
+            launcher=cls.user,
+            name=PREPAREDNESS_CONFIG_SLUG,
+            started_at=datetime.now(),
+            external=True,
+        )
+        cls.task2 = m.Task.objects.create(
+            status=RUNNING, account=account, launcher=cls.user, name="task 2", external=True
+        )
+
+        cls.json_config = {
+            "pipeline": "pipeline",
+            "openhexa_url": "https://yippie.openhexa.xyz/",
+            "openhexa_token": "token",
+            "pipeline_version": 1,
+            "oh_pipeline_target": "staging",
+        }
+        cls.preparedness_config = Config.objects.create(slug=PREPAREDNESS_CONFIG_SLUG, content=cls.json_config)
+
+    def mock_openhexa_call_success(self, slug=None, config=None, id_field=None, task_id=None):
+        return SUCCESS
+
+    def mock_openhexa_call_skipped(self, slug=None, config=None, id_field=None, task_id=None):
+        return SKIPPED
+
+    def mock_openhexa_call_running(self, slug=None, config=None, id_field=None, task_id=None):
+        return RUNNING
+
+    def test_no_auth_needed(self):
+        user_no_perm = self.create_user_with_profile(username="test user2", account=self.account, permissions=[])
+        self.client.force_authenticate(user_no_perm)
+        response = self.client.get(
+            self.url,
+            format="json",
+        )
+        self.assertJSONResponse(response, 200)
+
+    @patch.object(RefreshPreparednessDataViewset, "launch_task", mock_openhexa_call_running)
+    def test_create_external_task(self):
+        self.client.force_authenticate(self.user)
+        response = self.client.get(
+            self.url,
+        )
+        response = self.assertJSONResponse(response, 200)
+        task = response["task"]
+        self.assertEqual(task["status"], RUNNING)
+        self.assertEqual(task["launcher"]["username"], self.user.username)
+        self.assertEqual(task["name"], PREPAREDNESS_TASK_NAME)
+
+    @patch.object(RefreshPreparednessDataViewset, "launch_task", mock_openhexa_call_skipped)
+    def test_create_external_task_pipeline_already_running(self):
+        self.client.force_authenticate(self.user)
+        response = self.client.get(
+            self.url,
+        )
+        response = self.assertJSONResponse(response, 200)
+        task = response["task"]
+        self.assertEqual(task["status"], SKIPPED)
+        self.assertEqual(task["launcher"]["username"], self.user.username)
+        self.assertEqual(task["name"], PREPAREDNESS_TASK_NAME)
+
+    @patch.object(RefreshPreparednessDataViewset, "launch_task", mock_openhexa_call_running)
+    def test_patch_external_task(self):
+        self.client.force_authenticate(self.user)
+        response = self.client.get(
+            self.url,
+        )
+        response = self.assertJSONResponse(response, 200)
+        task = response["task"]
+        task_id = task["id"]
+        self.assertEqual(task["status"], RUNNING)
+        self.assertEqual(task["progress_value"], 0)
+        self.assertEqual(task["end_value"], 0)
+
+        response = self.client.patch(
+            f"{self.url}{task_id}/", format="json", data={"status": SUCCESS, "progress_value": 21}
+        )
+        response = self.assertJSONResponse(response, 200)
+        task = response
+        self.assertEqual(task["id"], task_id)
+        self.assertEqual(task["status"], SUCCESS)
+        self.assertEqual(task["progress_value"], 21)
+        self.assertEqual(task["end_value"], 0)
+
+    @patch.object(RefreshPreparednessDataViewset, "launch_task", mock_openhexa_call_running)
+    def test_kill_external_task(self):
+        self.client.force_authenticate(self.user)
+        response = self.client.get(
+            self.url,
+        )
+        response = self.assertJSONResponse(response, 200)
+        task = response["task"]
+        task_id = task["id"]
+        self.assertEqual(task["status"], RUNNING)
+
+        response = self.client.patch(
+            f"{self.url}{task_id}/",
+            format="json",
+            data={
+                "should_be_killed": True,
+            },
+        )
+        response = self.assertJSONResponse(response, 200)
+        task = response
+        self.assertEqual(task["id"], task_id)
+        self.assertEqual(task["status"], KILLED)


### PR DESCRIPTION
Add an endpoint to launch preparedness dashboard refresh from powerBI

Related JIRA tickets : POLIO-1914

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Added comments in the code.
Also , the wiki: https://wiki.bluesquare.org/en/Dev-team/product-management/iaso/Polio/refresh-powerbi-reference

## Changes

- Add an endpoint to update preparedness dashboard, based on the architecture used for the refresh vrf dashboard (see wiki)

## How to test

Untestable, sorry. We need all the configs in the backend, access to OH and access to the prod or staging dashboards

## Print screen / video
N/A

## Notes

Before deploying on prod, the apprpriate configs should be updated:
- Add preparedness-pipeline-config
- update powerbi-dataset-config

Examples can be found on polio staging


