### PR TITLE
[IA-4304] Added OrgUnit.code in frontend - details page

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -928,6 +928,7 @@
     "iaso.orgUnits.addToGroups": "Add to group(s)",
     "iaso.orgUnits.bulkChangeCount": "You are about to change {count} Org units",
     "iaso.orgUnits.closingDate": "Closing date",
+    "iaso.orgUnits.code": "Code",
     "iaso.orgUnits.confirmMultiChange": "Confirm bulk changes ?",
     "iaso.orgUnits.createdBy": "Created By",
     "iaso.orgUnits.createSubUnitTypes": "Sub org units types to create",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -927,6 +927,7 @@
     "iaso.orgUnits.addToGroups": "Ajouter au(x) groupe(s)",
     "iaso.orgUnits.bulkChangeCount": "Vous allez modifier {count} unités d'org.",
     "iaso.orgUnits.closingDate": "Date de fermeture",
+    "iaso.orgUnits.code": "Code",
     "iaso.orgUnits.confirmMultiChange": "Confirmer les modifications multiples ?",
     "iaso.orgUnits.createdBy": "Créé par",
     "iaso.orgUnits.createSubUnitTypes": "Sous-type d'unités d'org. pour la création",

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitForm.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitForm.tsx
@@ -36,6 +36,7 @@ const initialFormState = (
     source_id: orgUnit?.source_id,
     parent: orgUnit?.parent,
     source_ref: orgUnit?.source_ref,
+    code: orgUnit?.code,
     reference_instance_id: orgUnit?.reference_instance_id,
     opening_date: orgUnit?.opening_date ? orgUnit.opening_date : undefined,
     closed_date: orgUnit?.closed_date ? orgUnit.closed_date : undefined,

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitInfos.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitInfos.tsx
@@ -161,6 +161,15 @@ export const OrgUnitInfos: FunctionComponent<Props> = ({
                     label={MESSAGES.groups}
                     disabled={disabled}
                 />
+                <InputComponent
+                    keyValue="code"
+                    type="text"
+                    onChange={onChangeInfo}
+                    value={orgUnitState.code.value}
+                    errors={orgUnitState.code.errors}
+                    label={MESSAGES.code}
+                    disabled={disabled}
+                />
                 <div className={classes.divAliasWrapper}>
                     <InputComponent
                         keyValue="aliases"

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/messages.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/messages.ts
@@ -149,6 +149,10 @@ const MESSAGES = defineMessages({
         defaultMessage: 'Name',
         id: 'iaso.orgUnits.name',
     },
+    code: {
+        defaultMessage: 'Code',
+        id: 'iaso.orgUnits.code',
+    },
     groups: {
         defaultMessage: 'Groups',
         id: 'iaso.label.groups',

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/types/orgUnit.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/types/orgUnit.ts
@@ -31,6 +31,7 @@ export type OrgunitInititialState = {
     source_id?: number;
     parent?: ParentOrgUnit;
     source_ref?: string;
+    code?: string;
     reference_instance_id?: Nullable<number>;
     opening_date?: Date;
     closed_date?: Date;
@@ -54,6 +55,7 @@ export type OrgUnit = {
     name: string;
     short_name: string;
     id: number;
+    code?: string;
     sub_source: string;
     sub_source_id: string | undefined;
     source_ref: string;
@@ -123,6 +125,7 @@ export type OrgUnitState = {
     aliases: FormState<string>;
     source_id: FormState<number>;
     source: FormState<string>;
+    code: FormState<string>;
     parent: FormState<OrgUnit>;
     source_ref: FormState<string>;
     creator: FormStateRequired<Record<string, any>>;

--- a/iaso/api/org_units.py
+++ b/iaso/api/org_units.py
@@ -10,6 +10,7 @@ from django.conf import settings
 from django.contrib.gis.geos import GEOSGeometry, MultiPolygon, Point, Polygon
 from django.core.exceptions import ValidationError
 from django.core.paginator import Paginator
+from django.db import IntegrityError
 from django.db.models import Count, IntegerField, Q, Value
 from django.http import HttpResponse, StreamingHttpResponse
 from django.shortcuts import get_object_or_404
@@ -517,6 +518,10 @@ class OrgUnitViewSet(viewsets.ViewSet):
                     }
                 )
 
+        if "code" in request.data:
+            # Warning: this could cause an error with the model constraint when saving below
+            org_unit.code = request.data["code"]
+
         if "geom" in request.data:
             geom = request.data["geom"]
             if geom:
@@ -651,29 +656,41 @@ class OrgUnitViewSet(viewsets.ViewSet):
         org_unit.closed_date = self.get_date(request.data.get("closed_date"))
 
         if not errors:
-            org_unit.save()
-            if new_groups is not None:
-                org_unit.groups.set(new_groups)
+            try:
+                org_unit.save()
+                if new_groups is not None:
+                    org_unit.groups.set(new_groups)
 
-            audit_models.log_modification(original_copy, org_unit, source=audit_models.ORG_UNIT_API, user=request.user)
+                audit_models.log_modification(
+                    original_copy, org_unit, source=audit_models.ORG_UNIT_API, user=request.user
+                )
 
-            res = org_unit.as_dict_with_parents()
-            res["geo_json"] = None
-            res["catchment"] = None
+                res = org_unit.as_dict_with_parents()
+                res["geo_json"] = None
+                res["catchment"] = None
 
-            if org_unit.geom or org_unit.simplified_geom or org_unit.catchment:
-                geo_queryset = self.get_queryset().filter(id=org_unit.id)
+                if org_unit.geom or org_unit.simplified_geom or org_unit.catchment:
+                    geo_queryset = self.get_queryset().filter(id=org_unit.id)
 
-                if can_edit_shape and org_unit.geom:
-                    res["geo_json"] = geojson_queryset(geo_queryset, geometry_field="geom")
-                elif org_unit.simplified_geom:
-                    res["geo_json"] = geojson_queryset(geo_queryset, geometry_field="simplified_geom")
+                    if can_edit_shape and org_unit.geom:
+                        res["geo_json"] = geojson_queryset(geo_queryset, geometry_field="geom")
+                    elif org_unit.simplified_geom:
+                        res["geo_json"] = geojson_queryset(geo_queryset, geometry_field="simplified_geom")
 
-                if org_unit.catchment:
-                    res["catchment"] = geojson_queryset(geo_queryset, geometry_field="catchment")
+                    if org_unit.catchment:
+                        res["catchment"] = geojson_queryset(geo_queryset, geometry_field="catchment")
 
-            res["reference_instances"] = org_unit.get_reference_instances_details_for_api()
-            return Response(res)
+                res["reference_instances"] = org_unit.get_reference_instances_details_for_api()
+                return Response(res)
+            except IntegrityError:
+                errors.append(
+                    {
+                        "errorKey": "code",
+                        "errorMessage": _(
+                            "Another valid OrgUnit already exists with the code '{}' in this version"
+                        ).format(request.data["code"]),
+                    }
+                )
 
         return Response(errors, status=400)
 
@@ -736,6 +753,7 @@ class OrgUnitViewSet(viewsets.ViewSet):
 
         org_unit.short_name = request.data.get("short_name", "")
         org_unit.source = request.data.get("source", "")
+        org_unit.code = request.data.get("code", "")  # This could raise an IntegrityError if not unique
 
         opening_date = request.data.get("opening_date", None)
         closed_date = request.data.get("closed_date", None)
@@ -817,7 +835,19 @@ class OrgUnitViewSet(viewsets.ViewSet):
         org_unit_type = get_object_or_404(OrgUnitType, id=org_unit_type_id)
         org_unit.org_unit_type = org_unit_type
 
-        org_unit.save()
+        try:
+            org_unit.save()
+        except IntegrityError:
+            errors.append(
+                {
+                    "errorKey": "code",
+                    "errorMessage": _("Another valid OrgUnit already exists with the code '{}' in this version").format(
+                        org_unit.code
+                    ),
+                }
+            )
+            return Response(errors, status=400)
+
         org_unit.groups.set(new_groups)
 
         if reference_instance_id and org_unit_type:

--- a/iaso/locale/fr/LC_MESSAGES/django.po
+++ b/iaso/locale/fr/LC_MESSAGES/django.po
@@ -190,7 +190,7 @@ msgstr "Le fichier d'instance avec l'id {} n'existe pas"
 
 #: iaso/api/org_units.py
 msgid "Another valid OrgUnit already exists with the code '{}' in this version"
-msgstr "Une autre unité organisationnelle valide existe déjà avec le code '{}' dans cette version"
+msgstr "Une autre unité d'organisation valide existe déjà avec le code '{}' dans cette version"
 
 #: iaso/api/org_units.py
 msgid "Unauthorized version id"

--- a/iaso/locale/fr/LC_MESSAGES/django.po
+++ b/iaso/locale/fr/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-18 11:06+0000\n"
+"POT-Creation-Date: 2025-06-26 09:39+0000\n"
 "PO-Revision-Date: 2025-02-06 10:24+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -187,6 +187,10 @@ msgstr "Le groupe doit être dans la même version source"
 #: iaso/api/org_units.py
 msgid "InstanceFile with id {} does not exist"
 msgstr "Le fichier d'instance avec l'id {} n'existe pas"
+
+#: iaso/api/org_units.py
+msgid "Another valid OrgUnit already exists with the code '{}' in this version"
+msgstr "Une autre unité organisationnelle valide existe déjà avec le code '{}' dans cette version"
 
 #: iaso/api/org_units.py
 msgid "Unauthorized version id"

--- a/iaso/models/org_unit.py
+++ b/iaso/models/org_unit.py
@@ -481,6 +481,7 @@ class OrgUnit(TreeModel):
             "name": self.name,
             "short_name": self.name,
             "id": self.id,
+            "code": self.code,
             "sub_source": self.sub_source,
             "sub_source_id": self.sub_source,
             "source_ref": self.source_ref,

--- a/iaso/tests/api/test_orgunits.py
+++ b/iaso/tests/api/test_orgunits.py
@@ -31,6 +31,8 @@ class OrgUnitAPIUtilsTestCase(SimpleTestCase):
 
 
 class OrgUnitAPITestCase(APITestCase):
+    ORG_UNIT_CREATE_URL = "/api/orgunits/create_org_unit/"
+
     @classmethod
     def setUpTestData(cls):
         cls.star_wars = star_wars = m.Account.objects.create(name="Star Wars")
@@ -197,6 +199,37 @@ class OrgUnitAPITestCase(APITestCase):
             org_unit=jedi_council_corruscant,
             project=project,
         )
+
+    def setUp(self):
+        self.old_counts = self.counts()
+
+    def counts(self) -> dict:
+        return {
+            m.OrgUnit: m.OrgUnit.objects.count(),
+            m.OrgUnitType: m.OrgUnitType.objects.count(),
+            Modification: Modification.objects.count(),
+        }
+
+    def assertValidOrgUnitListData(self, *, list_data: typing.Mapping, expected_length: int):
+        self.assertValidListData(list_data=list_data, results_key="orgUnits", expected_length=expected_length)
+        for org_unit_data in list_data["orgUnits"]:
+            self.assertValidOrgUnitData(org_unit_data)
+
+    def assertValidOrgUnitData(self, org_unit_data: typing.Mapping):
+        self.assertHasField(org_unit_data, "id", int)
+        self.assertHasField(org_unit_data, "name", str)
+
+    def assertNoCreation(self):
+        self.assertEqual(self.old_counts, self.counts())
+
+    def assertCreated(self, createds: dict):
+        new_counts = self.counts()
+        diff = {}
+
+        for model in new_counts.keys():
+            diff[model] = new_counts[model] - self.old_counts[model]
+
+        self.assertTrue(set(createds.items()).issubset(set(diff.items())))
 
     def test_org_unit_search_with_ids(self):
         """GET /orgunits/ with a search based on refs"""
@@ -847,40 +880,9 @@ class OrgUnitAPITestCase(APITestCase):
             },
         )
 
-    def assertValidOrgUnitListData(self, *, list_data: typing.Mapping, expected_length: int):
-        self.assertValidListData(list_data=list_data, results_key="orgUnits", expected_length=expected_length)
-        for org_unit_data in list_data["orgUnits"]:
-            self.assertValidOrgUnitData(org_unit_data)
-
-    def assertValidOrgUnitData(self, org_unit_data: typing.Mapping):
-        self.assertHasField(org_unit_data, "id", int)
-        self.assertHasField(org_unit_data, "name", str)
-
-    def setUp(self):
-        self.old_counts = self.counts()
-
-    def counts(self) -> dict:
-        return {
-            m.OrgUnit: m.OrgUnit.objects.count(),
-            m.OrgUnitType: m.OrgUnitType.objects.count(),
-            Modification: Modification.objects.count(),
-        }
-
-    def assertNoCreation(self):
-        self.assertEqual(self.old_counts, self.counts())
-
-    def assertCreated(self, createds: dict):
-        new_counts = self.counts()
-        diff = {}
-
-        for model in new_counts.keys():
-            diff[model] = new_counts[model] - self.old_counts[model]
-
-        self.assertTrue(set(createds.items()).issubset(set(diff.items())))
-
     def set_up_org_unit_creation(self):
         return self.client.post(
-            "/api/orgunits/create_org_unit/",
+            self.ORG_UNIT_CREATE_URL,
             format="json",
             data={
                 "id": None,
@@ -895,6 +897,7 @@ class OrgUnitAPITestCase(APITestCase):
                 "source_ref": "",
                 "creation_source": "dashboard",
                 "opening_date": "01-01-2024",
+                "code": "very-nice",
             },
         )
 
@@ -939,7 +942,7 @@ class OrgUnitAPITestCase(APITestCase):
     def test_create_org_unit_opening_date_not_anterior_to_closed_date(self):
         self.client.force_authenticate(self.yoda)
         response = self.client.post(
-            "/api/orgunits/create_org_unit/",
+            self.ORG_UNIT_CREATE_URL,
             format="json",
             data={
                 "id": None,
@@ -962,7 +965,7 @@ class OrgUnitAPITestCase(APITestCase):
     def test_create_org_unit_minimal(self):
         self.client.force_authenticate(self.yoda)
         response = self.client.post(
-            "/api/orgunits/create_org_unit/",
+            self.ORG_UNIT_CREATE_URL,
             format="json",
             data={
                 "name": "Test ou",
@@ -987,7 +990,7 @@ class OrgUnitAPITestCase(APITestCase):
         # returning a 404 is strange, but it was the current behaviour
         self.client.force_authenticate(self.yoda)
         response = self.client.post(
-            "/api/orgunits/create_org_unit/",
+            self.ORG_UNIT_CREATE_URL,
             format="json",
             data={
                 "name": "Test ou",
@@ -1003,7 +1006,7 @@ class OrgUnitAPITestCase(APITestCase):
         # returning a 404 is strange, but it was the current behaviour
         self.client.force_authenticate(self.yoda)
         response = self.client.post(
-            "/api/orgunits/create_org_unit/",
+            self.ORG_UNIT_CREATE_URL,
             format="json",
             data={
                 "name": "Test ou",
@@ -1019,7 +1022,7 @@ class OrgUnitAPITestCase(APITestCase):
         group = m.Group.objects.create(name="bla")
         self.client.force_authenticate(self.yoda)
         response = self.client.post(
-            "/api/orgunits/create_org_unit/",
+            self.ORG_UNIT_CREATE_URL,
             format="json",
             data={
                 "name": "Test ou",
@@ -1038,7 +1041,7 @@ class OrgUnitAPITestCase(APITestCase):
         group = m.Group.objects.create(name="bla")
         self.client.force_authenticate(self.yoda)
         response = self.client.post(
-            "/api/orgunits/create_org_unit/",
+            self.ORG_UNIT_CREATE_URL,
             format="json",
             data={
                 "name": "Test ou",
@@ -1058,7 +1061,7 @@ class OrgUnitAPITestCase(APITestCase):
         group_2 = m.Group.objects.create(name="bla2", source_version=self.star_wars.default_version)
         self.client.force_authenticate(self.yoda)
         response = self.client.post(
-            "/api/orgunits/create_org_unit/",
+            self.ORG_UNIT_CREATE_URL,
             format="json",
             data={
                 "name": "Test ou",
@@ -1084,7 +1087,7 @@ class OrgUnitAPITestCase(APITestCase):
     def test_create_org_unit_with_reference_instance(self):
         self.client.force_authenticate(self.yoda)
         response = self.client.post(
-            "/api/orgunits/create_org_unit/",
+            self.ORG_UNIT_CREATE_URL,
             format="json",
             data={
                 "id": None,
@@ -1110,7 +1113,7 @@ class OrgUnitAPITestCase(APITestCase):
     def test_create_org_unit_with_not_linked_reference_instance(self):
         self.client.force_authenticate(self.yoda)
         response = self.client.post(
-            "/api/orgunits/create_org_unit/",
+            self.ORG_UNIT_CREATE_URL,
             format="json",
             data={
                 "id": None,
@@ -1132,6 +1135,239 @@ class OrgUnitAPITestCase(APITestCase):
         self.assertValidOrgUnitData(jr)
         ou = m.OrgUnit.objects.get(id=jr["id"])
         self.assertEqual(ou.reference_instances.count(), 0)
+
+    def test_create_org_unit_with_blank_code_valid_status(self):
+        blank_code = ""
+        existing_org_unit = m.OrgUnit.objects.create(
+            name="Existing org unit",
+            org_unit_type=self.jedi_council,
+            version=self.sw_version_1,
+            validation_status=m.OrgUnit.VALIDATION_VALID,
+            code=blank_code,
+        )
+
+        self.client.force_authenticate(self.yoda)
+        response = self.client.post(
+            self.ORG_UNIT_CREATE_URL,
+            format="json",
+            data={
+                "name": "New org unit",
+                "org_unit_type_id": self.jedi_council.pk,
+                "validation_status": m.OrgUnit.VALIDATION_VALID,
+                "parent_id": "",
+                "source_ref": "",
+                "opening_date": "01-01-2024",
+            },
+        )
+        jr = self.assertJSONResponse(response, status.HTTP_200_OK)
+        self.assertValidOrgUnitData(jr)
+        new_org_unit = m.OrgUnit.objects.get(id=jr["id"])
+
+        self.assertEqual(new_org_unit.validation_status, existing_org_unit.validation_status)
+        self.assertEqual(new_org_unit.code, existing_org_unit.code)
+        self.assertEqual(new_org_unit.code, blank_code)
+        self.assertEqual(m.OrgUnit.objects.count(), 7)  # 5 in setup + 1 existing + 1 new
+
+    def test_create_org_unit_with_blank_code_other_status(self):
+        blank_code = ""
+        existing_org_unit = m.OrgUnit.objects.create(
+            name="Existing org unit",
+            org_unit_type=self.jedi_council,
+            version=self.sw_version_1,
+            validation_status=m.OrgUnit.VALIDATION_VALID,
+            code=blank_code,
+        )
+
+        self.client.force_authenticate(self.yoda)
+        response = self.client.post(
+            self.ORG_UNIT_CREATE_URL,
+            format="json",
+            data={
+                "name": "New org unit",
+                "org_unit_type_id": self.jedi_council.pk,
+                "validation_status": m.OrgUnit.VALIDATION_NEW,  # Change here - status does not create any conflict
+                "parent_id": "",
+                "source_ref": "",
+                "opening_date": "01-01-2024",
+            },
+        )
+        jr = self.assertJSONResponse(response, status.HTTP_200_OK)
+        self.assertValidOrgUnitData(jr)
+        new_org_unit = m.OrgUnit.objects.get(id=jr["id"])
+
+        self.assertNotEqual(new_org_unit.validation_status, existing_org_unit.validation_status)
+        self.assertEqual(new_org_unit.code, existing_org_unit.code)
+        self.assertEqual(new_org_unit.code, blank_code)
+        self.assertEqual(m.OrgUnit.objects.count(), 7)  # 5 in setup + 1 existing + 1 new
+
+    def test_create_org_unit_with_new_code_valid_status(self):
+        code = "code"
+        new_code = "new code"
+
+        existing_org_unit = m.OrgUnit.objects.create(
+            name="Existing org unit",
+            org_unit_type=self.jedi_council,
+            version=self.sw_version_1,
+            validation_status=m.OrgUnit.VALIDATION_VALID,
+            code=code,
+        )
+
+        self.client.force_authenticate(self.yoda)
+        response = self.client.post(
+            self.ORG_UNIT_CREATE_URL,
+            format="json",
+            data={
+                "name": "New org unit",
+                "org_unit_type_id": self.jedi_council.pk,
+                "validation_status": m.OrgUnit.VALIDATION_VALID,
+                "parent_id": "",
+                "source_ref": "",
+                "opening_date": "01-01-2024",
+                "code": new_code,  # Change here - code does not create any conflict
+            },
+        )
+        jr = self.assertJSONResponse(response, status.HTTP_200_OK)
+        self.assertValidOrgUnitData(jr)
+        new_org_unit = m.OrgUnit.objects.get(id=jr["id"])
+
+        self.assertEqual(new_org_unit.validation_status, existing_org_unit.validation_status)
+        self.assertNotEqual(new_org_unit.code, existing_org_unit.code)
+        self.assertEqual(new_org_unit.code, new_code)
+        self.assertEqual(m.OrgUnit.objects.count(), 7)  # 5 in setup + 1 existing + 1 new
+
+    def test_create_org_unit_with_new_code_other_status(self):
+        old_code = "old code"
+        new_code = "new code"
+
+        existing_org_unit = m.OrgUnit.objects.create(
+            name="Existing org unit",
+            org_unit_type=self.jedi_council,
+            version=self.sw_version_1,
+            validation_status=m.OrgUnit.VALIDATION_VALID,
+            code=old_code,
+        )
+
+        self.client.force_authenticate(self.yoda)
+        response = self.client.post(
+            self.ORG_UNIT_CREATE_URL,
+            format="json",
+            data={
+                "name": "New org unit",
+                "org_unit_type_id": self.jedi_council.pk,
+                "validation_status": m.OrgUnit.VALIDATION_NEW,  # Change here - status does not create any conflict
+                "parent_id": "",
+                "source_ref": "",
+                "opening_date": "01-01-2024",
+                "code": new_code,  # Change here - code does not create any conflict
+            },
+        )
+        jr = self.assertJSONResponse(response, status.HTTP_200_OK)
+        self.assertValidOrgUnitData(jr)
+        new_org_unit = m.OrgUnit.objects.get(id=jr["id"])
+
+        self.assertNotEqual(new_org_unit.validation_status, existing_org_unit.validation_status)
+        self.assertNotEqual(new_org_unit.code, existing_org_unit.code)
+        self.assertEqual(new_org_unit.code, new_code)
+        self.assertEqual(m.OrgUnit.objects.count(), 7)  # 5 in setup + 1 existing + 1 new
+
+    def test_create_org_unit_with_existing_code_valid_status(self):
+        existing_code = "*Gandalf vibing while listening to epic sax guy*"
+        m.OrgUnit.objects.create(
+            name="Existing org unit",
+            org_unit_type=self.jedi_council,
+            version=self.sw_version_1,
+            validation_status=m.OrgUnit.VALIDATION_VALID,
+            code=existing_code,
+        )
+
+        self.client.force_authenticate(self.yoda)
+        response = self.client.post(
+            self.ORG_UNIT_CREATE_URL,
+            format="json",
+            data={
+                "name": "New org unit",
+                "org_unit_type_id": self.jedi_council.pk,
+                "validation_status": m.OrgUnit.VALIDATION_VALID,
+                "parent_id": "",
+                "source_ref": "",
+                "opening_date": "01-01-2024",
+                "code": existing_code,  # Change here - this will create a conflict
+            },
+        )
+        json = self.assertJSONResponse(response, status.HTTP_400_BAD_REQUEST)[0]
+        self.assertEqual(json["errorKey"], "code")
+        self.assertEqual(
+            json["errorMessage"],
+            f"Another valid OrgUnit already exists with the code '{existing_code}' in this version",
+        )
+        self.assertEqual(m.OrgUnit.objects.count(), 6)  # 5 in setup + 1 existing (no new org unit created)
+
+    def test_create_org_unit_with_existing_code_other_status(self):
+        existing_code = "*Gandalf vibing while listening to epic sax guy*"
+        existing_org_unit = m.OrgUnit.objects.create(
+            name="Existing org unit",
+            org_unit_type=self.jedi_council,
+            version=self.sw_version_1,
+            validation_status=m.OrgUnit.VALIDATION_VALID,
+            code=existing_code,
+        )
+
+        self.client.force_authenticate(self.yoda)
+        response = self.client.post(
+            self.ORG_UNIT_CREATE_URL,
+            format="json",
+            data={
+                "name": "New org unit",
+                "org_unit_type_id": self.jedi_council.pk,
+                "validation_status": m.OrgUnit.VALIDATION_NEW,  # Change here - status does not create any conflict
+                "parent_id": "",
+                "source_ref": "",
+                "opening_date": "01-01-2024",
+                "code": existing_code,
+            },
+        )
+        jr = self.assertJSONResponse(response, status.HTTP_200_OK)
+        self.assertValidOrgUnitData(jr)
+        new_org_unit = m.OrgUnit.objects.get(id=jr["id"])
+
+        self.assertNotEqual(new_org_unit.validation_status, existing_org_unit.validation_status)
+        self.assertEqual(new_org_unit.code, existing_org_unit.code)
+        self.assertEqual(new_org_unit.code, existing_code)
+        self.assertEqual(m.OrgUnit.objects.count(), 7)  # 5 in setup + 1 existing + 1 new
+
+    def test_create_org_unit_with_existing_code_from_another_version_valid_status(self):
+        existing_code = "*Gandalf vibing while listening to epic sax guy*"
+        other_org_unit = m.OrgUnit.objects.create(
+            name="Existing org unit",
+            org_unit_type=self.jedi_council,
+            version=self.sw_version_2,  # version 2
+            validation_status=m.OrgUnit.VALIDATION_VALID,
+            code=existing_code,
+        )
+
+        self.client.force_authenticate(self.yoda)
+        response = self.client.post(  # this will create in version 1 (default version)
+            self.ORG_UNIT_CREATE_URL,
+            format="json",
+            data={
+                "name": "New org unit",
+                "org_unit_type_id": self.jedi_council.pk,
+                "validation_status": m.OrgUnit.VALIDATION_VALID,
+                "parent_id": "",
+                "source_ref": "",
+                "opening_date": "01-01-2024",
+                "code": existing_code,  # Change here - this will create a conflict
+            },
+        )
+        jr = self.assertJSONResponse(response, status.HTTP_200_OK)
+        self.assertValidOrgUnitData(jr)
+        new_org_unit = m.OrgUnit.objects.get(id=jr["id"])
+
+        self.assertEqual(new_org_unit.validation_status, other_org_unit.validation_status)
+        self.assertEqual(new_org_unit.code, other_org_unit.code)
+        self.assertEqual(new_org_unit.code, existing_code)
+        self.assertNotEqual(new_org_unit.version_id, other_org_unit.version_id)
+        self.assertEqual(m.OrgUnit.objects.count(), 7)  # 5 in setup + 1 other + 1 new
 
     def test_edit_org_unit_retrieve_put(self):
         """Retrieve an orgunit data and then resend back mostly unmodified and ensure that nothing burn
@@ -1613,6 +1849,240 @@ class OrgUnitAPITestCase(APITestCase):
         self.assertEqual(ou.as_dict()["latitude"], form_latitude)
         self.assertEqual(ou.as_dict()["longitude"], form_longitude)
         self.assertEqual(ou.as_dict()["altitude"], form_altitude)
+
+    def test_partial_update_org_unit_with_blank_code_valid_status(self):
+        blank_code = ""
+        existing_org_unit = m.OrgUnit.objects.create(
+            name="Existing org unit",
+            org_unit_type=self.jedi_council,
+            version=self.sw_version_1,
+            validation_status=m.OrgUnit.VALIDATION_VALID,
+            code=blank_code,
+        )
+
+        org_unit = self.jedi_squad_endor
+        org_unit.code = "old code"
+        org_unit.save()
+
+        new_name = "new name"
+        data = {
+            "code": blank_code,
+            "name": new_name,
+        }
+
+        self.client.force_authenticate(self.yoda)
+        response = self.client.patch(
+            f"/api/orgunits/{org_unit.id}/",
+            format="json",
+            data=data,
+        )
+        jr = self.assertJSONResponse(response, status.HTTP_200_OK)
+        self.assertValidOrgUnitData(jr)
+
+        org_unit.refresh_from_db()
+        self.assertEqual(org_unit.code, blank_code)
+        self.assertEqual(org_unit.name, new_name)
+        self.assertEqual(existing_org_unit.code, org_unit.code)
+        self.assertEqual(existing_org_unit.version_id, org_unit.version_id)
+
+    def test_partial_update_org_unit_with_blank_code_other_status(self):
+        blank_code = ""
+        existing_org_unit = m.OrgUnit.objects.create(
+            name="Existing org unit",
+            org_unit_type=self.jedi_council,
+            version=self.sw_version_1,
+            validation_status=m.OrgUnit.VALIDATION_VALID,
+            code=blank_code,
+        )
+
+        org_unit = self.jedi_squad_endor
+        org_unit.code = "old code"
+        org_unit.save()
+
+        new_name = "new name"
+        data = {
+            "code": blank_code,
+            "name": new_name,
+            "validation_status": m.OrgUnit.VALIDATION_NEW,
+        }
+
+        self.client.force_authenticate(self.yoda)
+        response = self.client.patch(
+            f"/api/orgunits/{org_unit.id}/",
+            format="json",
+            data=data,
+        )
+        jr = self.assertJSONResponse(response, status.HTTP_200_OK)
+        self.assertValidOrgUnitData(jr)
+
+        org_unit.refresh_from_db()
+        self.assertEqual(org_unit.code, blank_code)
+        self.assertEqual(org_unit.name, new_name)
+        self.assertEqual(org_unit.validation_status, m.OrgUnit.VALIDATION_NEW)
+        self.assertEqual(existing_org_unit.code, org_unit.code)
+        self.assertNotEqual(existing_org_unit.validation_status, org_unit.validation_status)
+        self.assertEqual(existing_org_unit.version_id, org_unit.version_id)
+
+    def test_partial_update_org_unit_with_new_code_valid_status(self):
+        old_code = "old code"
+        org_unit = self.jedi_squad_endor
+        org_unit.code = old_code
+        org_unit.save()
+
+        new_name = "new name"
+        new_code = "new code"
+        data = {
+            "code": new_code,
+            "name": new_name,
+            "validation_status": m.OrgUnit.VALIDATION_VALID,
+        }
+
+        self.client.force_authenticate(self.yoda)
+        response = self.client.patch(
+            f"/api/orgunits/{org_unit.id}/",
+            format="json",
+            data=data,
+        )
+        jr = self.assertJSONResponse(response, status.HTTP_200_OK)
+        self.assertValidOrgUnitData(jr)
+
+        org_unit.refresh_from_db()
+        self.assertEqual(org_unit.code, new_code)
+        self.assertEqual(org_unit.name, new_name)
+        self.assertEqual(org_unit.validation_status, m.OrgUnit.VALIDATION_VALID)
+
+    def test_partial_update_org_unit_with_new_code_other_status(self):
+        old_code = "old code"
+        org_unit = self.jedi_squad_endor
+        org_unit.code = old_code
+        org_unit.save()
+
+        new_name = "new name"
+        new_code = "new code"
+        data = {
+            "code": new_code,
+            "name": new_name,
+            "validation_status": m.OrgUnit.VALIDATION_NEW,
+        }
+
+        self.jedi_council_corruscant.code = new_code
+        self.jedi_council_corruscant.save()
+        self.jedi_council_corruscant.refresh_from_db()
+
+        self.client.force_authenticate(self.yoda)
+        response = self.client.patch(
+            f"/api/orgunits/{org_unit.id}/",
+            format="json",
+            data=data,
+        )
+        jr = self.assertJSONResponse(response, status.HTTP_200_OK)
+        self.assertValidOrgUnitData(jr)
+
+        org_unit.refresh_from_db()
+        self.assertEqual(org_unit.code, new_code)
+        self.assertEqual(org_unit.name, new_name)
+        self.assertEqual(org_unit.validation_status, m.OrgUnit.VALIDATION_NEW)
+        self.assertEqual(self.jedi_council_corruscant.code, org_unit.code)
+        self.assertNotEqual(self.jedi_council_corruscant.validation_status, org_unit.validation_status)
+        self.assertEqual(self.jedi_council_corruscant.version_id, org_unit.version_id)
+
+    def test_partial_update_org_unit_with_existing_code_valid_status(self):
+        new_name = "new name"
+        new_code = "new code"
+        data = {
+            "code": new_code,
+            "name": new_name,
+        }
+
+        self.jedi_council_corruscant.code = new_code
+        self.jedi_council_corruscant.save()
+        self.jedi_council_corruscant.refresh_from_db()
+
+        self.client.force_authenticate(self.yoda)
+        org_unit = self.jedi_squad_endor
+        response = self.client.patch(
+            f"/api/orgunits/{org_unit.id}/",
+            format="json",
+            data=data,
+        )
+
+        json = self.assertJSONResponse(response, status.HTTP_400_BAD_REQUEST)[0]
+        self.assertEqual(json["errorKey"], "code")
+        self.assertEqual(
+            json["errorMessage"], f"Another valid OrgUnit already exists with the code '{new_code}' in this version"
+        )
+        self.assertNotEqual(org_unit.name, new_name)
+        self.assertNotEqual(org_unit.code, new_code)
+        self.assertEqual(org_unit.validation_status, m.OrgUnit.VALIDATION_VALID)
+        self.assertEqual(org_unit.validation_status, self.jedi_council_corruscant.validation_status)
+        self.assertEqual(org_unit.version_id, self.jedi_council_corruscant.version_id)
+        self.assertNotEqual(org_unit.code, self.jedi_council_corruscant.code)
+
+    def test_partial_update_org_unit_with_existing_code_other_status(self):
+        new_name = "new name"
+        new_code = "new code"
+        data = {
+            "code": new_code,
+            "name": new_name,
+            "validation_status": m.OrgUnit.VALIDATION_NEW,
+        }
+
+        self.jedi_council_corruscant.code = new_code
+        self.jedi_council_corruscant.save()
+        self.jedi_council_corruscant.refresh_from_db()
+
+        self.client.force_authenticate(self.yoda)
+        org_unit = self.jedi_squad_endor
+        response = self.client.patch(
+            f"/api/orgunits/{org_unit.id}/",
+            format="json",
+            data=data,
+        )
+
+        jr = self.assertJSONResponse(response, status.HTTP_200_OK)
+        self.assertValidOrgUnitData(jr)
+
+        org_unit.refresh_from_db()
+        self.assertEqual(org_unit.name, new_name)
+        self.assertEqual(org_unit.code, new_code)
+        self.assertEqual(org_unit.validation_status, m.OrgUnit.VALIDATION_NEW)
+        self.assertNotEqual(org_unit.validation_status, self.jedi_council_corruscant.validation_status)
+        self.assertEqual(org_unit.code, self.jedi_council_corruscant.code)
+        self.assertEqual(org_unit.version_id, self.jedi_council_corruscant.version_id)
+
+    def test_partial_update_org_unit_with_existing_code_from_other_version_valid_status(self):
+        existing_code = "*Gandalf vibing while listening to epic sax guy*"
+        other_org_unit = m.OrgUnit.objects.create(
+            name="Existing org unit",
+            org_unit_type=self.jedi_council,
+            version=self.sw_version_2,  # version 2
+            validation_status=m.OrgUnit.VALIDATION_VALID,
+            code=existing_code,
+        )
+
+        new_name = "new name"
+        data = {
+            "code": existing_code,
+            "name": new_name,
+            "validation_status": m.OrgUnit.VALIDATION_VALID,
+        }
+        self.client.force_authenticate(self.yoda)
+        org_unit = self.jedi_squad_endor
+        response = self.client.patch(
+            f"/api/orgunits/{org_unit.id}/",
+            format="json",
+            data=data,
+        )
+        jr = self.assertJSONResponse(response, status.HTTP_200_OK)
+        self.assertValidOrgUnitData(jr)
+
+        org_unit.refresh_from_db()
+        self.assertEqual(org_unit.name, new_name)
+        self.assertEqual(org_unit.code, existing_code)
+        self.assertEqual(org_unit.validation_status, m.OrgUnit.VALIDATION_VALID)
+        self.assertEqual(org_unit.validation_status, other_org_unit.validation_status)
+        self.assertEqual(org_unit.code, other_org_unit.code)
+        self.assertNotEqual(org_unit.version_id, other_org_unit.version_id)
 
     def test_create_org_unit_from_different_level_from_mobile(self):
         self.client.force_authenticate(self.yoda)


### PR DESCRIPTION
Added OrgUnit.code in frontend - details page

Related JIRA tickets : IA-4304, IA-4030 (epic)

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [x] Are my typescript files well typed?
- [x] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

/

## Changes

Added the `code` field in the OrgUnit detail page


## How to test

- Go to the OrgUnits page
- Check the details of an OrgUnit
- Edit the code field and save
- Create a new OrgUnit with that field
- Create or update an OrgUnit with an existing code to trigger an error


## Print screen / video
![image](https://github.com/user-attachments/assets/56ca7ca3-12e1-4729-8c19-a8e07318b007)


**Error when using an invalid code:**
![image](https://github.com/user-attachments/assets/3de22cc5-734e-4732-9f04-29cb6e6fd0f4)


## Notes

See Jira epic for further developments on codes

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
