### PR TITLE
[IA-4305] Search OrgUnits by code

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -967,7 +967,7 @@
     "iaso.orgUnits.search": "Search org unit",
     "iaso.orgUnits.searchByIds": "Search by multiple IDs",
     "iaso.orgUnits.searchByIdsInfo": "Search by ID or multiple IDs at once, separated by a comma or a space. E.g. “132,654”",
-    "iaso.orgUnits.searchParams": "Use prefix “refs:” for external org unit ID search. Use prefix “ids:” for internal org unit ID search. You can also search multiple IDs at once, separated by a comma or a space. E.g. “ids: 123456, 654321” or “refs: O6uvpzGd5pu, ImspTQPwCqd”",
+    "iaso.orgUnits.searchParams": "Use prefix “refs:” for external org unit ID search, “ids:” for internal org unit ID search or “codes:” for org unit code search. You can also search multiple IDs at once, separated by a comma or a space. E.g. “ids: 123456, 654321”, “refs: O6uvpzGd5pu, ImspTQPwCqd” or “codes: OU420, OU69”",
     "iaso.orgUnits.selectionAction": "With selected org unit",
     "iaso.orgUnits.selectOrgUnit": "Please select an org Unit",
     "iaso.orgUnits.selectProjects": "Select a project",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -966,7 +966,7 @@
     "iaso.orgUnits.search": "Rechercher une unité d'org.",
     "iaso.orgUnits.searchByIds": "Recherche par ID multiples",
     "iaso.orgUnits.searchByIdsInfo": "Recherche par un ou plusieurs ID à la fois, séparés par une virgule ou un espace. Par exemple, ”132,654”",
-    "iaso.orgUnits.searchParams": "Utilisez le préfixe “refs:” pour la recherche d'ID externe d'unité d’organisation. Utilisez le préfixe “ids:” pour la recherche d'ID interne d'unité d’organisation. Vous pouvez également rechercher plusieurs ID à la fois, séparés par une virgule ou un espace. Par exemple: “ids: 123456, 654321” ou “refs: O6uvpzGd5pu, ImspTQPwCqd”",
+    "iaso.orgUnits.searchParams": "Utilisez les préfixes “refs:” pour la recherche d'ID externe d'unité d’organisation, “ids:” pour la recherche d'ID interne d'unité d’organisation ou “codes:”, pour la recherche de codes d'unité d'organisation. Vous pouvez également rechercher plusieurs ID à la fois, séparés par une virgule ou un espace. Par exemple: “ids: 123456, 654321”, “refs: O6uvpzGd5pu, ImspTQPwCqd” ou “codes: OU420, OU69”",
     "iaso.orgUnits.selectionAction": "Avec la sélection d'unités d'organisation",
     "iaso.orgUnits.selectOrgUnit": "Merci de sélectionner une unité d'organisation",
     "iaso.orgUnits.selectProjects": "Selectionner un projet",

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/messages.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/messages.ts
@@ -575,7 +575,7 @@ const MESSAGES = defineMessages({
         id: 'iaso.orgUnits.searchParams',
         defaultMessage:
             // eslint-disable-next-line max-len
-            'Use prefix “refs:” for external org unit ID search. Use prefix “ids:” for internal org unit ID search. You can also search multiple IDs at once, separated by a comma or a space. E.g. “ids: 123456, 654321” or “refs: O6uvpzGd5pu, ImspTQPwCqd”',
+            'Use prefix “refs:” for external org unit ID search, “ids:” for internal org unit ID search or “codes:” for org unit code search. You can also search multiple IDs at once, separated by a comma or a space. E.g. “ids: 123456, 654321”, “refs: O6uvpzGd5pu, ImspTQPwCqd” or “codes: OU420, OU69”',
     },
     textSearch: {
         id: 'iaso.forms.textSearch',

--- a/iaso/api/org_unit_search.py
+++ b/iaso/api/org_unit_search.py
@@ -80,6 +80,14 @@ def build_org_units_queryset(queryset, params, profile):
             except:
                 queryset = queryset.filter(source_ref__in=[])
                 print("Failed parsing refs in search", search)
+        elif search.startswith("codes:"):
+            s = search.replace("codes:", "")
+            try:
+                codes = re.findall("[A-Za-z0-9_-]+", s)
+                queryset = queryset.filter(code__in=codes)
+            except:
+                queryset = queryset.filter(code__in=[])
+                print("Failed parsing codes in search", search)
         else:
             queryset = queryset.filter(Q(name__icontains=search) | Q(aliases__contains=[search]))
 

--- a/iaso/api/org_units.py
+++ b/iaso/api/org_units.py
@@ -152,6 +152,7 @@ class OrgUnitViewSet(viewsets.ViewSet):
         Special Search Formats:
         - ids:search: Search by IDs (e.g. "ids:1,2,3")
         - refs:search: Search by references (e.g. "refs:ref1,ref2")
+        - codes:search: Search by codes (e.g. "codes:code1,code2")
 
         Example Response Formats:
         * Simple JSON (default) -> as_dict_for_mobile

--- a/iaso/tests/api/test_orgunits.py
+++ b/iaso/tests/api/test_orgunits.py
@@ -333,6 +333,26 @@ class OrgUnitAPITestCase(APITestCase):
         self.assertEqual(org_units[1]["source_ref"], jedi_counsil_endor_source_ref)
         self.assertEqual(org_units[2]["id"], self.jedi_squad_endor.id)
 
+    def test_org_unit_search_with_code(self):
+        """GET /orgunits/ with a search based on codes"""
+        search_criteria = {
+            "validation_status": "all",
+            "version": self.sw_version_1.id,
+            "search": f"codes: {self.jedi_council_endor.code} {self.jedi_council_corruscant.code} unknown_code",
+        }
+        search_criteria_str = json.dumps(search_criteria)
+
+        self.client.force_authenticate(self.yoda)
+        response = self.client.get(
+            f"/api/orgunits/?&order=id&page=1&searchTabIndex=0&searches=[{search_criteria_str}]&limit=50"
+        )
+        response_json = self.assertJSONResponse(response, 200)
+
+        self.assertEqual(response_json["count"], 2)
+        org_units = response_json["orgunits"]
+        self.assertEqual(org_units[0]["id"], self.jedi_council_corruscant.id)
+        self.assertEqual(org_units[1]["id"], self.jedi_council_endor.id)
+
     def test_org_unit_search(self):
         """GET /orgunits/ with a search based on name"""
 


### PR DESCRIPTION
Search OrgUnits by code

Related JIRA tickets : IA-4305, IA-4030 (epic)

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [x] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc
/

## Changes

Added the keyword `codes:` in OrgUnit searches

## How to test
- Go to the OrgUnits page
- Use the `search` field with `codes: <some codes>`
- Run the search, the list should be filtered out based on your codes

## Print screen / video

![image](https://github.com/user-attachments/assets/9c269e1e-12e0-4cd5-9c75-bda19318b583)

## Notes

See Jira epic for further developments on codes

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
