### PR TITLE
IA-4336 Fix: Bulk upload fails when updating an instance without entity

### DIFF
--- a/iaso/tasks/process_mobile_bulk_upload.py
+++ b/iaso/tasks/process_mobile_bulk_upload.py
@@ -183,7 +183,12 @@ def update_merged_entity_ref_form_if_needed(instance, incoming_updated_at, file,
     IF the incoming timestamp is more recent.
     """
     entity = instance.entity
-    if not (entity.deleted_at and entity.merged_to):
+
+    if entity is None:
+        return
+
+    is_soft_deleted_merged_entity = entity.deleted_at and entity.merged_to
+    if not is_soft_deleted_merged_entity:
         return
 
     active_entity = entity.merged_to


### PR DESCRIPTION
- Add fix for edge case of updating an instance when there's no entity attached
- Add 2 tests for missing scenarios of creating/updating instances without entities

Related JIRA tickets : https://bluesquare.atlassian.net/browse/IA-4336