### PR TITLE
[IA-4340] Fixing n+1 query problem for `is_reference_instance`

### DIFF
--- a/iaso/api/instances/instances.py
+++ b/iaso/api/instances/instances.py
@@ -280,7 +280,7 @@ class InstancesViewSet(viewsets.ViewSet):
 
         filename = "%s-%s" % (filename, strftime("%Y-%m-%d-%H-%M", gmtime()))
 
-        def get_row(instance, **kwargs):
+        def get_row(instance, reference_instances=set(), **kwargs):
             created_at_timestamp = instance.source_created_at_with_fallback.timestamp()
             updated_at_timestamp = instance.source_updated_at_with_fallback.timestamp()
             org_unit = instance.org_unit
@@ -288,7 +288,7 @@ class InstancesViewSet(viewsets.ViewSet):
 
             instance_values = [
                 instance.id,
-                str(instance.is_reference_instance),
+                str(instance.id in reference_instances),
                 file_content.get("_version") if file_content else None,
                 instance.export_id,
                 instance.location.y if instance.location else None,
@@ -357,6 +357,11 @@ class InstancesViewSet(viewsets.ViewSet):
                 queryset=OrgUnit.objects.only("name", "parent_id", "source_ref"),
             )
         )
+
+        reference_instances = OrgUnit.objects.filter(reference_instances__form=form).values_list(
+            "reference_instances__id", flat=True
+        )
+        reference_instances = set(reference_instances)
 
         if file_format == FileFormatEnum.XLSX:
             filename = filename + ".xlsx"

--- a/iaso/api/instances/instances.py
+++ b/iaso/api/instances/instances.py
@@ -219,8 +219,7 @@ class InstancesViewSet(viewsets.ViewSet):
         serializer = InstanceFileSerializer(queryset, many=True)
         return Response(serializer.data)
 
-    @staticmethod
-    def list_file_export(filters: Dict[str, Any], queryset: "QuerySet[Instance]", file_format: FileFormatEnum):
+    def list_file_export(self, filters: Dict[str, Any], queryset: "QuerySet[Instance]", file_format: FileFormatEnum):
         """WIP: Helper function to divide the huge list method"""
         columns = [
             {"title": "ID du formulaire", "width": 20},
@@ -280,7 +279,7 @@ class InstancesViewSet(viewsets.ViewSet):
 
         filename = "%s-%s" % (filename, strftime("%Y-%m-%d-%H-%M", gmtime()))
 
-        def get_row(instance, reference_instances=set(), **kwargs):
+        def get_row(instance, **kwargs):
             created_at_timestamp = instance.source_created_at_with_fallback.timestamp()
             updated_at_timestamp = instance.source_updated_at_with_fallback.timestamp()
             org_unit = instance.org_unit
@@ -288,7 +287,7 @@ class InstancesViewSet(viewsets.ViewSet):
 
             instance_values = [
                 instance.id,
-                str(instance.id in reference_instances),
+                str(instance.id in self.reference_instances),
                 file_content.get("_version") if file_content else None,
                 instance.export_id,
                 instance.location.y if instance.location else None,
@@ -358,10 +357,9 @@ class InstancesViewSet(viewsets.ViewSet):
             )
         )
 
-        reference_instances = OrgUnit.objects.filter(reference_instances__form=form).values_list(
-            "reference_instances__id", flat=True
+        self.reference_instances = set(
+            OrgUnit.objects.filter(reference_instances__form=form).values_list("reference_instances__id", flat=True)
         )
-        reference_instances = set(reference_instances)
 
         if file_format == FileFormatEnum.XLSX:
             filename = filename + ".xlsx"

--- a/iaso/tests/api/instances/test_instances.py
+++ b/iaso/tests/api/instances/test_instances.py
@@ -1032,7 +1032,7 @@ class InstancesAPITestCase(TaskAPITestCase):
             org_unit=self.jedi_council_corruscant, instance=self.instance_1, form=self.form_1
         )
 
-        with self.assertNumQueries(11):
+        with self.assertNumQueries(12):
             response = self.client.get(
                 f"/api/instances/?form_ids={self.instance_1.form.id}&csv=true", headers={"Content-Type": "text/csv"}
             )


### PR DESCRIPTION
Fixing the n+1 query problem we had on CSV export for the property `is_reference_instance`

Related JIRA tickets: IA-4340

It did not appear in the query count because it's a streaming API, which explains why we missed it. I was not able to fix this using a prefetch, so I took another approach that is similar in terms of logic (prefetching) but using a separate query The value of the field was tested in an existing test, I didn't have to add one.

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [x] Are there enough tests?



[IA-4340]: https://bluesquare.atlassian.net/browse/IA-4340?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ