### PR TITLE
[IA-4337] Filter out mobile entities with deleted reference instances

### DIFF
--- a/iaso/api/mobile/entity.py
+++ b/iaso/api/mobile/entity.py
@@ -17,7 +17,6 @@ def filter_for_mobile_entity(queryset, request):
             queryset = queryset.filter_for_mobile_entity(
                 request.query_params.get("limit_date"), request.query_params.get("json_content")
             )
-            queryset = queryset.filter(attributes__deleted=False)
         except InvalidLimitDateError as e:
             raise ParseError(e.message)
         except InvalidJsonContentError as e:

--- a/iaso/api/mobile/entity.py
+++ b/iaso/api/mobile/entity.py
@@ -17,6 +17,7 @@ def filter_for_mobile_entity(queryset, request):
             queryset = queryset.filter_for_mobile_entity(
                 request.query_params.get("limit_date"), request.query_params.get("json_content")
             )
+            queryset = queryset.filter(attributes__deleted=False)
         except InvalidLimitDateError as e:
             raise ParseError(e.message)
         except InvalidJsonContentError as e:

--- a/iaso/models/entity.py
+++ b/iaso/models/entity.py
@@ -122,7 +122,7 @@ class EntityQuerySet(models.QuerySet):
             ).exclude(file=""),
         )
 
-        self = self.filter(attributes_id__isnull=False)
+        self = self.filter(attributes_id__isnull=False, attributes__deleted=False)
 
         self = self.prefetch_related(p).prefetch_related("instances__form")
 

--- a/iaso/tests/api/entities/common_base_with_setup.py
+++ b/iaso/tests/api/entities/common_base_with_setup.py
@@ -1,0 +1,53 @@
+import uuid
+
+from django.contrib.auth.models import AnonymousUser
+
+from iaso import models as m
+from iaso.test import APITestCase
+
+
+class EntityAPITestCase(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.account = m.Account.objects.create(name="Account")
+        sw_source = m.DataSource.objects.create(name="Source")
+        cls.sw_source = sw_source
+        sw_version = m.SourceVersion.objects.create(data_source=sw_source, number=1)
+        cls.account.default_version = sw_version
+        cls.account.save()
+        cls.sw_version = sw_version
+
+        cls.anon = AnonymousUser()
+
+        cls.project = m.Project.objects.create(name="Project", app_id="project", account=cls.account)
+
+        cls.yop_solo = cls.create_user_with_profile(
+            username="yop solo", account=m.Account.objects.create(name="Account 2"), permissions=["iaso_entities"]
+        )
+
+        cls.ou_country = m.OrgUnit.objects.create(
+            name="Burkina Faso (validated)", validation_status=m.OrgUnit.VALIDATION_VALID
+        )
+        cls.ou_country_unvalidated = m.OrgUnit.objects.create(name="Burkina Faso (unvalidated)")
+
+        cls.yoda = cls.create_user_with_profile(username="yoda", account=cls.account, permissions=["iaso_entities"])
+
+        cls.user_without_ou = cls.create_user_with_profile(
+            username="user_without_ou", account=cls.account, permissions=["iaso_entities"]
+        )
+
+        cls.form_1 = m.Form.objects.create(
+            name="Hydroponics study",
+            period_type=m.MONTH,
+            single_per_period=True,
+            form_id="form_1",
+        )
+
+        cls.create_form_instance(form=cls.form_1, org_unit=cls.ou_country, project=cls.project, uuid=uuid.uuid4)
+        cls.create_form_instance(form=cls.form_1, org_unit=cls.ou_country, project=cls.project, uuid=uuid.uuid4)
+        cls.create_form_instance(form=cls.form_1, org_unit=cls.ou_country, project=cls.project, uuid=uuid.uuid4)
+        cls.create_form_instance(form=cls.form_1, org_unit=cls.ou_country, project=cls.project, uuid=uuid.uuid4)
+
+        cls.form_1.projects.add(cls.project)
+
+        cls.entity_type = m.EntityType.objects.create(name="Type 1", reference_form=cls.form_1, account=cls.account)

--- a/iaso/tests/api/entities/test_entities.py
+++ b/iaso/tests/api/entities/test_entities.py
@@ -9,62 +9,16 @@ from unittest import mock
 
 import pytz
 
-from django.contrib.auth.models import AnonymousUser
 from django.core.files import File
 
 from iaso import models as m
 from iaso.api.common import EXPORTS_DATETIME_FORMAT
 from iaso.models import Entity, EntityType, FormVersion, Instance, Project
 from iaso.models.deduplication import ValidationStatus
-from iaso.test import APITestCase
+from iaso.tests.api.entities.common_base_with_setup import EntityAPITestCase
 
 
-class EntityAPITestCase(APITestCase):
-    @classmethod
-    def setUpTestData(cls):
-        cls.account = m.Account.objects.create(name="Account")
-        sw_source = m.DataSource.objects.create(name="Source")
-        cls.sw_source = sw_source
-        sw_version = m.SourceVersion.objects.create(data_source=sw_source, number=1)
-        cls.account.default_version = sw_version
-        cls.account.save()
-        cls.sw_version = sw_version
-
-        cls.anon = AnonymousUser()
-
-        cls.project = m.Project.objects.create(name="Project", app_id="project", account=cls.account)
-
-        cls.yop_solo = cls.create_user_with_profile(
-            username="yop solo", account=m.Account.objects.create(name="Account 2"), permissions=["iaso_entities"]
-        )
-
-        cls.ou_country = m.OrgUnit.objects.create(
-            name="Burkina Faso (validated)", validation_status=m.OrgUnit.VALIDATION_VALID
-        )
-        cls.ou_country_unvalidated = m.OrgUnit.objects.create(name="Burkina Faso (unvalidated)")
-
-        cls.yoda = cls.create_user_with_profile(username="yoda", account=cls.account, permissions=["iaso_entities"])
-
-        cls.user_without_ou = cls.create_user_with_profile(
-            username="user_without_ou", account=cls.account, permissions=["iaso_entities"]
-        )
-
-        cls.form_1 = m.Form.objects.create(
-            name="Hydroponics study",
-            period_type=m.MONTH,
-            single_per_period=True,
-            form_id="form_1",
-        )
-
-        cls.create_form_instance(form=cls.form_1, org_unit=cls.ou_country, project=cls.project, uuid=uuid.uuid4)
-        cls.create_form_instance(form=cls.form_1, org_unit=cls.ou_country, project=cls.project, uuid=uuid.uuid4)
-        cls.create_form_instance(form=cls.form_1, org_unit=cls.ou_country, project=cls.project, uuid=uuid.uuid4)
-        cls.create_form_instance(form=cls.form_1, org_unit=cls.ou_country, project=cls.project, uuid=uuid.uuid4)
-
-        cls.form_1.projects.add(cls.project)
-
-        cls.entity_type = EntityType.objects.create(name="Type 1", reference_form=cls.form_1, account=cls.account)
-
+class WebEntityAPITestCase(EntityAPITestCase):
     def test_create_single_entity(self):
         self.client.force_authenticate(self.yoda)
 

--- a/iaso/tests/api/entities/test_entities_mobile.py
+++ b/iaso/tests/api/entities/test_entities_mobile.py
@@ -1,0 +1,53 @@
+import uuid
+
+from rest_framework import status
+
+from iaso import models as m
+from iaso.tests.api.entities.common_base_with_setup import EntityAPITestCase
+
+
+class MobileEntityAPITestCase(EntityAPITestCase):
+    BASE_URL = "/api/mobile/entities/"
+
+    def test_list_entities_with_filtered_out_entities_with_soft_deleted_instances(self):
+        uuid_valid_instance = uuid.uuid4()
+        valid_instance = self.create_form_instance(
+            project=self.project,
+            org_unit=self.ou_country,
+            form=self.form_1,
+            uuid=uuid_valid_instance,
+        )
+        entity_with_valid_instance = m.Entity.objects.create(
+            name="valid",
+            entity_type=self.entity_type,
+            attributes=valid_instance,
+            account=self.account,
+        )
+        valid_instance.entity = entity_with_valid_instance
+        valid_instance.save()
+
+        uuid_deleted_instance = uuid.uuid4()
+        deleted_instance = self.create_form_instance(
+            project=self.project,
+            org_unit=self.ou_country,
+            form=self.form_1,
+            deleted=True,
+            uuid=uuid_deleted_instance,
+        )
+        entity_with_deleted_instance = m.Entity.objects.create(
+            name="deleted",
+            entity_type=self.entity_type,
+            attributes=deleted_instance,
+            account=self.account,
+        )
+        deleted_instance.entity = entity_with_deleted_instance
+        deleted_instance.save()
+
+        self.client.force_authenticate(self.yoda)
+        response = self.client.get(self.BASE_URL, {"app_id": self.project.app_id})
+        response_json = self.assertJSONResponse(response, status.HTTP_200_OK)
+
+        self.assertEqual(response_json["count"], 1)  # Only the entity with the valid instance should be returned
+
+        entity = response_json["results"][0]
+        self.assertEqual(entity["defining_instance_id"], str(uuid_valid_instance))


### PR DESCRIPTION
Entities whose reference instance is soft deleted are no longer returned to the mobile API endpoints.

Related JIRA tickets : IA-4337

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

/

## Changes

- Filtered out queryset used in mobile endpoints
- Refactored some tests + added some new ones

## How to test

This might be a bit tricky to manually test, but the tests explain what to do:
- Define a project, a reference form, an entity type that uses the reference form
- Fill out the form and create entities with these submissions
- Soft delete the instances
- The mobile endpoints should no longer return the entities because their reference instances were deleted
    - `/api/mobile/entitytypes/{entity_type.pk}/entities/?app_id={app_id}`
    - `/api/mobile/entities/`

## Print screen / video

/

## Notes
/

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
