### PR TITLE
Cypress: Add color property on project on save

### DIFF
--- a/hat/assets/js/cypress/integration/05 - orgUnits/list.spec.js
+++ b/hat/assets/js/cypress/integration/05 - orgUnits/list.spec.js
@@ -1,12 +1,10 @@
 /// <reference types="cypress" />
 import { search, searchWithForbiddenChars } from '../../constants/search';
-import orgUnits from '../../fixtures/orgunits/list.json';
 import superUser from '../../fixtures/profiles/me/superuser.json';
 import {
     makeDataSourcesFromSeed,
     makeSourceVersionsFromSeed,
 } from '../../support/dummyData';
-import { testPagination } from '../../support/testPagination';
 import { testSearchField } from '../../support/testSearchField';
 
 const siteBaseUrl = Cypress.env('siteBaseUrl');

--- a/hat/assets/js/cypress/integration/09 - projects/list.spec.js
+++ b/hat/assets/js/cypress/integration/09 - projects/list.spec.js
@@ -220,13 +220,14 @@ describe('Projects', () => {
                 openDialogForIndex(theIndex);
                 const newProject = {
                     id: listFixture.projects[theIndex].app_id,
-                    name: 'superman',
-                    app_id: 'pacman',
                     feature_flags: [
                         listfeatureFlags.featureflags[2],
                         listfeatureFlags.featureflags[3],
                     ],
+                    app_id: 'pacman',
+                    name: 'superman',
                     old_app_id: listFixture.projects[theIndex].app_id,
+                    color: '#1976D2',
                 };
                 const newProjects = [...listFixture.projects];
                 newProjects[theIndex] = {
@@ -286,6 +287,7 @@ describe('Projects', () => {
                         listfeatureFlags.featureflags[0],
                         listfeatureFlags.featureflags[1],
                     ],
+                    color: '#1976D2',
                 };
                 const newList = {
                     ...listFixture,


### PR DESCRIPTION
What problem is this PR solving? Explain here in one sentence.

Related JIRA tickets : IA-XXX, WC2-XXX, POLIO-XXX

## Self proofreading checklist

- [ ] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

/

## Changes

Fix one cypress error, a new property color was added to a model and break the tests.

## How to test

Run Cypress, you should not have a model structure error anymore.

 Projects
       Dialog
         should create correctly:
AssertionError: expected { Object (feature_flags, app_id, ...) } to deeply equal { Object (name, app_id, ...) }

and

 Projects
       Dialog
         should save correctly:

      AssertionError: expected { Object (id, feature_flags, ...) } to deeply equal { Object (id, name, ...) }

## Print screen / video

Upload here print screens or videos showing the changes.

## Notes

/

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
