### PR TITLE
IA-4332: support field value for barcode on entities page

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/entities/hooks/useGetFieldValue.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/hooks/useGetFieldValue.tsx
@@ -45,6 +45,7 @@ export const useGetFieldValue = (
             case 'calculate':
             case 'integer':
             case 'decimal':
+            case 'barcode':
             case 'note': {
                 return fileContent[fieldKey] || textPlaceholder;
             }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/31161bc8-cac8-4155-9b09-1d9013d19fbd)
Barcode should be visible, it's only a string

Related JIRA tickets : IA-4332

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc
-

## Changes

 Added support for barcode to display it like  a text

## How to test

- create an entity type using this form  
[enregistrement_cps_2025_2025062002.xlsx](https://github.com/user-attachments/files/21038294/enregistrement_cps_2025_2025062002.xlsx)
- make sur qr code is selected in details info fields
- create an entity via the mobile app using this form
- visit entities page and make sure qrcode is displayed


## Print screen / video
-

## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
