### PR TITLE
WC2-776: WHO Guidelines ETL

### DIFF
--- a/plugins/wfp/common.py
+++ b/plugins/wfp/common.py
@@ -263,9 +263,11 @@ class ETL:
         if visit["form_id"] in [
             "child_assistance_2nd_visit_tsfp",
             "child_assistance_follow_up",
+            "child_assistance_follow_up_2",
             "assistance_admission_otp",
             "assistance_admission_2nd_visit_otp",
             "child_assistance_admission",
+            "child_assistance_admission_2",
             "ethiopia_child_assistance_follow_up",
             "wfp_coda_pbwg_assistance",
             "wfp_coda_pbwg_assistance_followup",


### PR DESCRIPTION
What problem is this PR solving? Explain here in one sentence.

Related JIRA tickets : [WC2-776](https://bluesquare.atlassian.net/browse/WC2-776)

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Changes

Adapted Children Under 5 South Sudan script to integrate the new WHO Guideline!

## How to test

From the local instance with wfp coda database having South Sudan data with new forms linked to new Guidelines, run ETL script to generate data with `docker compose run iaso manage etl_ssd`

Then login on [django admin](http://localhost:8081/admin/login/?next=/admin/) and check on analytics tables by filtering to South Sudan account and  U5 program type:

- [Beneficiary](http://localhost:8081/admin/wfp/beneficiary/?account__id__exact=1)
- [Journey](http://localhost:8081/admin/wfp/beneficiary/?account__id__exact=1)
- [Visits](http://localhost:8081/admin/wfp/visit/?journey__beneficiary__account__id__exact=1&journey__programme_type__exact=U5)
- [Steps](http://localhost:8081/admin/wfp/step/?visit__journey__beneficiary__account__id__exact=1&visit__journey__programme_type__exact=U5)
- [Monthly Statistics](http://localhost:8081/admin/wfp/monthlystatistics/?account__id__exact=1&programme_type__exact=U5)

 You should see data.

You can then try to access to debug page for entities [TSFP](http://localhost:8081/wfp/debug/1625/) and [OTP](http://localhost:8081/wfp/debug/1624) which is linked to new guideline.

## Print screen / video

[Wfp-administration-Iaso.webm](https://github.com/user-attachments/assets/df936793-d230-494e-9e37-13565e008bf8)


## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.


[WC2-776]: https://bluesquare.atlassian.net/browse/WC2-776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ