### PR TITLE
IA 4313: Mobile API - Filter out planning without started_date null

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -250,6 +250,7 @@
     "iaso.error.label.planningAndOrgUnit": "Planning and org unit must be in the same project",
     "iaso.error.label.planningAndTeams": "Planning and teams must be in the same project",
     "iaso.error.label.startDateAfterEndDate": "Start date can't after end date",
+    "iaso.error.label.publishedWithoutStartDate": "Start date must be set when publishing",
     "iaso.errors.label": "An error occurred",
     "iaso.errors.noPermissions": "There is no permission associated to this user. Please contact an administrator to request permission(s). Thank you!",
     "iaso.errors.noPermissionsTitle": "Awaiting Access Permissions",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/es.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/es.json
@@ -233,6 +233,8 @@
     "iaso.error.label.planningAndForms": "La planificación y los formularios deben estar en el mismo proyecto",
     "iaso.error.label.planningAndOrgUnit": "La planificación y la unidad organizativa deben estar en el mismo proyecto",
     "iaso.error.label.planningAndTeams": "La planificación y los equipos deben estar en el mismo proyecto",
+    "iaso.error.label.publishedWithoutStartDate": "La fecha de inicio debe establecerse al publicar",
+
     "iaso.error.label.startDateAfterEndDate": "La fecha de inicio no puede ser posterior a la fecha de fin",
     "iaso.errors.label": "Ocurrió un error",
     "iaso.errors.noPermissions": "No hay permisos asociados a este usuario. Por favor contacte a un administrador para solicitar permiso(s). ¡Gracias!",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -249,6 +249,7 @@
     "iaso.error.label.planningAndForms": "Planning et formulaires doivent faire partie du même projet",
     "iaso.error.label.planningAndOrgUnit": "Planning et unité d'org. doivent faire partie du même projet",
     "iaso.error.label.planningAndTeams": "Planning et équipes doivent faire partie du même projet",
+    "iaso.error.label.publishedWithoutStartDate": "La date de début doit être définie lors de la publication",
     "iaso.error.label.startDateAfterEndDate": "La date de début ne peut être après la date de fin",
     "iaso.errors.label": "Une erreur est survenue.",
     "iaso.errors.noPermissions": "Aucune permission n'est associée à cet utilisateur. Veuillez contacter un administrateur pour demander la(les) permission(s). Merci !",

--- a/hat/assets/js/apps/Iaso/domains/plannings/CreateEditPlanning/CreateEditPlanning.tsx
+++ b/hat/assets/js/apps/Iaso/domains/plannings/CreateEditPlanning/CreateEditPlanning.tsx
@@ -1,3 +1,4 @@
+import React, { FunctionComponent, useEffect, useMemo, useState } from 'react';
 import FileCopyIcon from '@mui/icons-material/FileCopy';
 import { Box, Grid } from '@mui/material';
 import {
@@ -8,14 +9,11 @@ import {
 } from 'bluesquare-components';
 import { Field, FormikProvider, useFormik } from 'formik';
 import { isEqual } from 'lodash';
-import React, { FunctionComponent, useEffect, useMemo, useState } from 'react';
-import ConfirmCancelDialogComponent from '../../../components/dialogs/ConfirmCancelDialogComponent';
-import InputComponent from '../../../components/forms/InputComponent';
-
-import MESSAGES from '../messages';
 
 import { OrgUnitsLevels as OrgUnitSelect } from '../../../../../../../../plugins/polio/js/src/components/Inputs/OrgUnitsSelect';
+import ConfirmCancelDialogComponent from '../../../components/dialogs/ConfirmCancelDialogComponent';
 import DatesRange from '../../../components/filters/DatesRange';
+import InputComponent from '../../../components/forms/InputComponent';
 import {
     useApiErrorValidation,
     useTranslatedErrors,
@@ -30,6 +28,7 @@ import {
     useSavePlanning,
 } from '../hooks/requests/useSavePlanning';
 import { usePlanningValidation } from '../hooks/validation';
+import MESSAGES from '../messages';
 
 type ModalMode = 'create' | 'edit' | 'copy';
 
@@ -155,6 +154,7 @@ export const CreateEditPlanning: FunctionComponent<Props> = ({
         isValid,
         handleSubmit,
         resetForm,
+        validateField,
     } = formik;
 
     const { data: formsDropdown, isFetching: isFetchingForms } = useGetForms(
@@ -172,6 +172,9 @@ export const CreateEditPlanning: FunctionComponent<Props> = ({
     const onChange = (keyValue, value) => {
         setFieldTouched(keyValue, true);
         setFieldValue(keyValue, value);
+        // Reset validation from server to not block the user.
+        // If this is not called, even changing a field won't mark the form as valid.
+        validateField(keyValue);
     };
     // converting undefined to null for the API
     const onChangeDate = (keyValue, value) => {

--- a/hat/assets/js/apps/Iaso/domains/plannings/messages.ts
+++ b/hat/assets/js/apps/Iaso/domains/plannings/messages.ts
@@ -149,6 +149,10 @@ const MESSAGES = defineMessages({
         id: 'iaso.error.label.startDateAfterEndDate',
         defaultMessage: "Start date can't after end date",
     },
+    publishedWithoutStartDate: {
+        id: 'iaso.error.label.publishedWithoutStartDate',
+        defaultMessage: 'Start date must be set when publishing',
+    },
     formSelectHelperText: {
         id: 'iaso.label.formSelectHelperText',
         defaultMessage: 'You must select a project before selecting a form',

--- a/iaso/api/microplanning.py
+++ b/iaso/api/microplanning.py
@@ -301,6 +301,10 @@ class PlanningSerializer(serializers.ModelSerializer):
         ):
             validation_errors["started_at"] = "startDateAfterEndDate"
             validation_errors["ended_at"] = "EndDateBeforeStartDate"
+
+        if validated_data.get("published_at") and validated_data.get("started_at") is None:
+            validation_errors["started_at"] = "publishedWithoutStartDate"
+
         project = validated_data.get("project", self.instance.project if self.instance else None)
 
         team = validated_data.get("team", self.instance.team if self.instance else None)

--- a/iaso/api/microplanning.py
+++ b/iaso/api/microplanning.py
@@ -591,6 +591,7 @@ class MobilePlanningViewSet(ModelViewSet):
         return (
             Planning.objects.filter(assignment__user=user)
             .exclude(published_at__isnull=True)
+            .exclude(started_at__isnull=True)
             .filter(deleted_at__isnull=True)
             .distinct()
         )


### PR DESCRIPTION
What problem is this PR solving? Explain here in one sentence.

Related JIRA tickets : [IA-4313](https://bluesquare.atlassian.net/browse/IA-4313)

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Mobile api for planning: Filter out planning where started_at date is null to prevent failure in mobile app.

Display an error message when start date is not defined and publish is.
<img width="901" alt="image" src="https://github.com/user-attachments/assets/a8ef443a-a850-41b6-8fab-2fc5b535c62b" />


## Changes

Filter out Plannings from MobilePlanningViewSet when started_at is null

## How to test

You can create a new planning and publish it (without start date).
http://localhost:8081/dashboard/planning/list/accountId/1/publishingStatus/all/order/name/pageSize/20/page/1

Go api and check if item is returned (note that it could be filtered out if you are not part of the team it is attached to).
 http://localhost:8081/api/mobile/plannings/
 
 Then go and modify the planning to have a start date.
 Go back through the api and it should now appear.

## Print screen / video
 /

## Notes

 /

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.


[IA-4313]: https://bluesquare.atlassian.net/browse/IA-4313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ