### PR TITLE
IA-4331: Dropdown of the FORM field show duplicate forms by the number of project associated to the form

### DIFF
--- a/iaso/api/forms.py
+++ b/iaso/api/forms.py
@@ -392,6 +392,9 @@ class FormsViewSet(ModelViewSet):
 
         queryset = queryset.order_by(*order)
 
+        # Ensure duplicates are removed after all joins and annotations
+        queryset = queryset.distinct()
+
         return queryset
 
     def list(self, request: Request, *args, **kwargs):

--- a/iaso/tests/api/test_forms.py
+++ b/iaso/tests/api/test_forms.py
@@ -776,3 +776,18 @@ class FormsAPITestCase(APITestCase):
 
         for form_data in response.json()["forms"]:
             self.assertIn("instances_count", form_data)
+
+    def test_forms_list_no_duplicates_when_linked_to_multiple_projects(self):
+        """
+        Ensure that a form linked to multiple projects appears only once in the forms list API response.
+        """
+        self.client.force_authenticate(self.yoda)
+        # Link form_1 to both project_1 and project_2
+        self.project_2.forms.add(self.form_1)
+        self.project_2.save()
+
+        response = self.client.get("/api/forms/", headers={"Content-Type": "application/json"})
+        self.assertJSONResponse(response, 200)
+        form_ids = [form["id"] for form in response.json()["forms"]]
+        # Assert that each form id appears only once
+        self.assertEqual(len(form_ids), len(set(form_ids)), "Duplicate forms found in API response!")


### PR DESCRIPTION
Every form that is associated to multiple projects appears in duplicate (by the number of the projects associated to the form.
![image](https://github.com/user-attachments/assets/c4ee3e9e-8db6-4081-8b0d-57cdf8689e05)

Related JIRA tickets : IA-4331

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc
/

## Changes

Added distinct on get_queryset, added a test

## How to test

Link form to multiple project, 
open submissions page, make sure this form is present only once in the dropdown result

## Print screen / video

![Screenshot 2025-07-04 at 12 07 13](https://github.com/user-attachments/assets/e9eb53f4-a1cf-4fa4-a1e2-5f02df1ac0f5)
![Screenshot 2025-07-04 at 12 07 03](https://github.com/user-attachments/assets/04d615b8-9ba4-4d35-9485-2a863692627e)

## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
