### PR TITLE
[IA-3801] Invalid change requests are returned to the mobile

### DIFF
--- a/iaso/api/instances/instances.py
+++ b/iaso/api/instances/instances.py
@@ -927,11 +927,9 @@ def import_data(instances, user, app_id):
                 oucr.org_unit = instance.org_unit
                 if user and not user.is_anonymous:
                     oucr.created_by = user
-                previous_reference_instances = list(instance.org_unit.reference_instances.all())
-                new_reference_instances = list(filter(lambda i: i.form != instance.form, previous_reference_instances))
-                new_reference_instances.append(instance)
                 oucr.save()
-                oucr.new_reference_instances.set(new_reference_instances)
+                # Change request should reference only changed instances
+                oucr.new_reference_instances.set([instance])
                 oucr.requested_fields = ["new_reference_instances"]
                 oucr.save()
 

--- a/iaso/api/instances/instances.py
+++ b/iaso/api/instances/instances.py
@@ -927,9 +927,11 @@ def import_data(instances, user, app_id):
                 oucr.org_unit = instance.org_unit
                 if user and not user.is_anonymous:
                     oucr.created_by = user
+                previous_reference_instances = list(instance.org_unit.reference_instances.all())
+                new_reference_instances = list(filter(lambda i: i.form != instance.form, previous_reference_instances))
+                new_reference_instances.append(instance)
                 oucr.save()
-                # Change request should reference only changed instances
-                oucr.new_reference_instances.set([instance])
+                oucr.new_reference_instances.set(new_reference_instances)
                 oucr.requested_fields = ["new_reference_instances"]
                 oucr.save()
 

--- a/iaso/api/org_unit_change_requests/views_mobile.py
+++ b/iaso/api/org_unit_change_requests/views_mobile.py
@@ -1,6 +1,6 @@
 import django_filters
 
-from django.db.models import Count, Prefetch, Q
+from django.db.models import Count, F, Prefetch, Q
 from rest_framework import filters, viewsets
 from rest_framework.mixins import ListModelMixin
 
@@ -33,7 +33,20 @@ class MobileOrgUnitChangeRequestViewSet(ListModelMixin, viewsets.GenericViewSet)
                 # Change requests liked to a `data_source_synchronization` are limited to the web.
                 data_source_synchronization__isnull=True,
             )
-            .filter(Q(new_reference_instances__isnull=True) | Q(new_reference_instances__project__app_id=app_id))
+            .annotate(
+                total_new_reference_instances=Count("new_reference_instances", distinct=True),
+                total_new_reference_instances_in_project=Count(
+                    "new_reference_instances", Q(new_reference_instances__project__app_id=app_id), distinct=True
+                ),
+                total_new_reference_instances__form_in_project=Count(
+                    "new_reference_instances", Q(new_reference_instances__form__projects__app_id=app_id), distinct=True
+                ),
+            )
+            .filter(
+                Q(new_reference_instances__isnull=True)
+                | Q(total_new_reference_instances=F("total_new_reference_instances_in_project"))
+                & Q(total_new_reference_instances=F("total_new_reference_instances__form_in_project"))
+            )
             .select_related("org_unit")
             .prefetch_related(
                 "new_groups",

--- a/iaso/tests/api/org_unit_change_requests/test_change_request_on_new_reference_form.py
+++ b/iaso/tests/api/org_unit_change_requests/test_change_request_on_new_reference_form.py
@@ -48,7 +48,7 @@ class AutoChangeRequestForInstanceFormTestCase(APITestCase):
             "name": name,
         }
 
-        response = c.post("/api/orgunits/?app_id=com.example.testproject", data=[unit_body], format="json")
+        response = c.post(f"/api/orgunits/?app_id={self.project.app_id}", data=[unit_body], format="json")
         self.assertJSONResponse(response, 200)
         org_unit_model = OrgUnit.objects.get(uuid=uuid)
         uuid = "4b7c3954-f69a-4b99-83b1-db73957b32b8"
@@ -71,7 +71,7 @@ class AutoChangeRequestForInstanceFormTestCase(APITestCase):
             }
         ]
 
-        response = c.post("/api/instances/?app_id=com.example.testproject", data=instance_body, format="json")
+        response = c.post(f"/api/instances/?app_id={self.project.app_id}", data=instance_body, format="json")
         self.assertEqual(response.status_code, 200)
 
         instance = Instance.objects.get(uuid=uuid)
@@ -109,7 +109,7 @@ class AutoChangeRequestForInstanceFormTestCase(APITestCase):
             }
         ]
 
-        response = c.post("/api/instances/?app_id=com.example.testproject", data=instance_body, format="json")
+        response = c.post(f"/api/instances/?app_id={self.project.app_id}", data=instance_body, format="json")
 
         self.assertEqual(response.status_code, 200)
 


### PR DESCRIPTION
Change requests returned to mobile could contain invalid instances

Related JIRA tickets : IA-3801

## Self proofreading checklist

- [X] Did I use eslint and ruff formatters?
- [X] Is my code clear enough and well documented?
- [X] Are there enough tests?


## Changes

Filtering change requests where  **all** `new_reference_instances` match the predicate. 
Fix auto change request creation is adding existing reference instances.

## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
