### PR TITLE
IA-4333; change request zoom level

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/hooks/useNewFields.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/hooks/useNewFields.tsx
@@ -98,7 +98,7 @@ const getLocationValue = (
         <MarkerMap
             longitude={location.longitude}
             latitude={location.latitude}
-            maxZoom={8}
+            maxZoom={16}
             mapHeight={300}
             parent={parent}
         />


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/53ab7b9f-fa84-44af-82eb-33c2bc098786)
Zoom level should be increased
Related JIRA tickets : IA-4333
## Self proofreading checklist

- [ ] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

/

## Changes

Increase max zoom level on marker map

## How to test

You need change request with a n org unit having a geolocation. Check thaht the zoom level is closer
## Print screen / video

![Screenshot 2025-07-07 at 13 23 54](https://github.com/user-attachments/assets/b9ede83b-5d41-4d13-890a-682e0fc715bf)
![Screenshot 2025-07-07 at 13 23 22](https://github.com/user-attachments/assets/15f87376-9644-4128-81ea-40790ead725a)

## Notes

Bounds are calculate using parent shape too, so behaviour will a bit different with or without a parent

