### PR TITLE
[IA-3801] Fix auto-OUCR creates invalid OUCR

### DIFF
--- a/iaso/api/instances/instances.py
+++ b/iaso/api/instances/instances.py
@@ -985,11 +985,8 @@ def import_data(instances, user, app_id):
                 oucr.org_unit = instance.org_unit
                 if user and not user.is_anonymous:
                     oucr.created_by = user
-                previous_reference_instances = list(instance.org_unit.reference_instances.all())
-                new_reference_instances = list(filter(lambda i: i.form != instance.form, previous_reference_instances))
-                new_reference_instances.append(instance)
                 oucr.save()
-                oucr.new_reference_instances.set(new_reference_instances)
+                oucr.new_reference_instances.set([instance])
                 oucr.requested_fields = ["new_reference_instances"]
                 oucr.save()
 

--- a/iaso/models/org_unit.py
+++ b/iaso/models/org_unit.py
@@ -873,19 +873,20 @@ class OrgUnitChangeRequest(SoftDeletableModel):
                 self.org_unit.groups.clear()
                 self.org_unit.groups.add(*self.new_groups.all())
             elif field_name == "new_reference_instances":
-                previous_reference_instances = list(self.org_unit.reference_instances.all())
                 self.org_unit.reference_instances.clear()
-                new_reference_instances = self.new_reference_instances.all()
-                # We need to merge the old reference instances with the new ones. To do so, we need to check which
-                # forms do the new reference instances point to, to filter out the old ones that point to the same forms.
-                new_reference_forms = list(map(lambda i: i.form, new_reference_instances))
-                new_reference_forms.append(
-                    list(filter(lambda i: i.form not in new_reference_forms, previous_reference_instances))
-                )
+
+                new_reference_instances = list(self.new_reference_instances.all())
+                new_reference_forms_ids = self.new_reference_instances.values_list("form_id", flat=True)
+
+                for instance in self.old_reference_instances.all():
+                    if instance.form_id not in new_reference_forms_ids:
+                        new_reference_instances.append(instance)
+
                 new_ou_reference_instances = [
                     OrgUnitReferenceInstance(org_unit_id=self.org_unit.pk, form_id=instance.form_id, instance=instance)
                     for instance in new_reference_instances
                 ]
+
                 OrgUnitReferenceInstance.objects.bulk_create(new_ou_reference_instances)
             # Handle non m2m fields.
             else:

--- a/iaso/models/org_unit.py
+++ b/iaso/models/org_unit.py
@@ -873,12 +873,14 @@ class OrgUnitChangeRequest(SoftDeletableModel):
                 self.org_unit.groups.clear()
                 self.org_unit.groups.add(*self.new_groups.all())
             elif field_name == "new_reference_instances":
+                current_reference_instances = list(self.org_unit.reference_instances.all())
+
                 self.org_unit.reference_instances.clear()
 
                 new_reference_instances = list(self.new_reference_instances.all())
                 new_reference_forms_ids = self.new_reference_instances.values_list("form_id", flat=True)
 
-                for instance in self.old_reference_instances.all():
+                for instance in current_reference_instances:
                     if instance.form_id not in new_reference_forms_ids:
                         new_reference_instances.append(instance)
 

--- a/iaso/tests/models/test_org_unit_change_request.py
+++ b/iaso/tests/models/test_org_unit_change_request.py
@@ -338,6 +338,68 @@ class OrgUnitChangeRequestModelTestCase(TestCase):
         self.assertEqual(diff["modified"]["closed_date"]["before"], "2055-01-01")
         self.assertIsNone(diff["modified"]["closed_date"]["after"])
 
+    @time_machine.travel(DT, tick=False)
+    def test_approve_for_new_reference_instances(self):
+        org_unit = self.org_unit
+        org_unit.reference_instances.clear()
+
+        form_1 = m.Form.objects.create(name="1")
+        form_2 = m.Form.objects.create(name="2")
+        form_3 = m.Form.objects.create(name="3")
+
+        form_v1 = m.FormVersion.objects.create(form=form_1, version_id=1)
+        form_v2 = m.FormVersion.objects.create(form=form_2, version_id=1)
+        form_v3 = m.FormVersion.objects.create(form=form_3, version_id=1)
+
+        instance_1 = m.Instance.objects.create(form=form_1, org_unit=org_unit, json={"k": "v"}, form_version=form_v1)
+        instance_2 = m.Instance.objects.create(form=form_2, org_unit=org_unit, json={"k": "v"}, form_version=form_v2)
+        instance_3 = m.Instance.objects.create(form=form_3, org_unit=org_unit, json={"k": "v"}, form_version=form_v3)
+
+        m.OrgUnitReferenceInstance.objects.create(org_unit=org_unit, form=form_1, instance=instance_1)
+        m.OrgUnitReferenceInstance.objects.create(org_unit=org_unit, form=form_2, instance=instance_2)
+        m.OrgUnitReferenceInstance.objects.create(org_unit=org_unit, form=form_3, instance=instance_3)
+
+        self.assertEqual(org_unit.reference_instances.count(), 3)
+        self.assertCountEqual(org_unit.reference_instances.all(), [instance_1, instance_2, instance_3])
+
+        # Change the reference instance of `form_1` from `instance_1` to `instance_1_bis`.
+
+        instance_1_bis = m.Instance.objects.create(
+            form=form_1, org_unit=org_unit, json={"k": "v"}, form_version=form_v1
+        )
+        self.assertEqual(form_1.instances.count(), 2)
+
+        change_request = m.OrgUnitChangeRequest.objects.create(
+            org_unit=org_unit,
+            requested_fields=["new_reference_instances"],
+        )
+        change_request.new_groups.set([self.new_group1, self.new_group2])
+        change_request.new_reference_instances.set([instance_1_bis])
+        change_request.approve(user=self.user, approved_fields=["new_reference_instances"])
+
+        org_unit.refresh_from_db()
+        expected_new_reference_instances = [instance_1_bis, instance_2, instance_3]
+        self.assertCountEqual(org_unit.reference_instances.all(), expected_new_reference_instances)
+
+        # Change the reference instance of `form_2` from `instance_2` to `instance_2_bis`.
+
+        instance_2_bis = m.Instance.objects.create(
+            form=form_2, org_unit=org_unit, json={"k": "v"}, form_version=form_v1
+        )
+        self.assertEqual(form_2.instances.count(), 2)
+
+        change_request = m.OrgUnitChangeRequest.objects.create(
+            org_unit=org_unit,
+            requested_fields=["new_reference_instances"],
+        )
+        change_request.new_groups.set([self.new_group1, self.new_group2])
+        change_request.new_reference_instances.set([instance_2_bis])
+        change_request.approve(user=self.user, approved_fields=["new_reference_instances"])
+
+        org_unit.refresh_from_db()
+        expected_new_reference_instances = [instance_1_bis, instance_2_bis, instance_3]
+        self.assertCountEqual(org_unit.reference_instances.all(), expected_new_reference_instances)
+
     def test_exclude_soft_deleted_new_reference_instances(self):
         change_request = m.OrgUnitChangeRequest.objects.create(
             org_unit=self.org_unit, requested_fields=["new_reference_instances"]

--- a/iaso/tests/models/test_org_unit_change_request.py
+++ b/iaso/tests/models/test_org_unit_change_request.py
@@ -359,8 +359,8 @@ class OrgUnitChangeRequestModelTestCase(TestCase):
         m.OrgUnitReferenceInstance.objects.create(org_unit=org_unit, form=form_2, instance=instance_2)
         m.OrgUnitReferenceInstance.objects.create(org_unit=org_unit, form=form_3, instance=instance_3)
 
-        self.assertEqual(org_unit.reference_instances.count(), 3)
-        self.assertCountEqual(org_unit.reference_instances.all(), [instance_1, instance_2, instance_3])
+        expected_reference_instances = [instance_1, instance_2, instance_3]
+        self.assertCountEqual(org_unit.reference_instances.all(), expected_reference_instances)
 
         # Change the reference instance of `form_1` from `instance_1` to `instance_1_bis`.
 
@@ -373,7 +373,6 @@ class OrgUnitChangeRequestModelTestCase(TestCase):
             org_unit=org_unit,
             requested_fields=["new_reference_instances"],
         )
-        change_request.new_groups.set([self.new_group1, self.new_group2])
         change_request.new_reference_instances.set([instance_1_bis])
         change_request.approve(user=self.user, approved_fields=["new_reference_instances"])
 
@@ -392,7 +391,6 @@ class OrgUnitChangeRequestModelTestCase(TestCase):
             org_unit=org_unit,
             requested_fields=["new_reference_instances"],
         )
-        change_request.new_groups.set([self.new_group1, self.new_group2])
         change_request.new_reference_instances.set([instance_2_bis])
         change_request.approve(user=self.user, approved_fields=["new_reference_instances"])
 


### PR DESCRIPTION
When an OUCR is created automatically, it adds all existing reference instances. This is not supposed to happen.

Related JIRA tickets: IA-3801

## Self proofreading checklist

- [X] Did I use eslint and ruff formatters?
- [X] Is my code clear enough and well documented?
- [ ] Are there enough tests?

## Changes

Only add the newly created instance to the automatically created OUCR

## How to test

Submit an instance of a reference form with the auto-OUCR flag activated.
This needs to be submitted to an OU with several validated reference instances.
Check that the change request contains only the newly created submission.

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
