### PR TITLE
SLEEP 1506: Mail alert when iaso data synced

### DIFF
--- a/iaso/tasks/process_mobile_bulk_upload.py
+++ b/iaso/tasks/process_mobile_bulk_upload.py
@@ -38,6 +38,7 @@ from plugins.trypelim.common.form_utils import (
     get_population_form,
     get_population_instances,
 )
+from plugins.trypelim.common.utils import sns_notify
 
 INSTANCES_JSON = "instances.json"
 ORG_UNITS_JSON = "orgUnits.json"
@@ -117,9 +118,16 @@ def process_mobile_bulk_upload(api_import_id, project_id, task=None):
     api_import.has_problem = False
     api_import.exception = ""
     api_import.save()
-    the_task.report_success_with_result(
-        message=result_message(user, project, start_date, start_time, stats),
-    )
+
+    message = result_message(user, project, start_date, start_time, stats)
+    the_task.report_success_with_result(message=message)
+
+    # Trypelim-specific
+    try:
+        logger.info("Notifying SNS topic of new bulk upload.")
+        sns_notify(message)
+    except Exception as e:
+        logger.exception("Failed to publish to SNS" + str(e))
 
 
 def read_json_file_from_zip(zip_ref, filename):


### PR DESCRIPTION
Notify a SNS topic when a mobile client syncs data. 

Related JIRA tickets : [SLEEP-1506](https://bluesquare.atlassian.net/browse/SLEEP-1506)

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Users subscribed to the SNS topic will receive a message with some information about the data sync: 
```
Mobile bulk import successful for user tablet259 and project Trypelim.
Started: 2025-07-08 10:40:34.251498, time spent: 1898.7377276420593 sec
Number of imported org units: 0
Number of imported form submissions: 829
Number of imported submission attachments: 19
```

## Changes

A very minimal implementation that uses the existing SNS notification feature from the trypelim plugin in the IASO mobile bulk upload task. 

## How to test

Make sure `SNS_NOTIFICATION_TOPIC` is set and send an import payload to the `/api/mobile/bulkupload` endpoint. 

## Print screen / video

/

## Notes

Areas of future improvement (also depending on how much time you’d like me to spend on this): 
- Testing: If we keep using the SNS notification in the future, we could add some testing utility (mock notification) and perhaps include it in IASO?
- Exception handling: I’m using a catch-all at the moment, perhaps the SNS notification utility could be fleshed out for more granular error handling? 
- Having a more general and decoupled way of letting plugins hook into the bulk upload process.
- i18n 

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.


[SLEEP-1506]: https://bluesquare.atlassian.net/browse/SLEEP-1506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ