### PR TITLE
IA-4291: Completeness stats CSV export

### DIFF
--- a/iaso/tests/api/test_completeness_stats.py
+++ b/iaso/tests/api/test_completeness_stats.py
@@ -906,12 +906,20 @@ class CompletenessStatsAPITestCase(APITestCase):
         # Use multiple forms to check column generation
         form_ids = f"{self.form_hs_1.id},{self.form_hs_2.id},{self.form_hs_4.id}"
         response = self.client.get(f"/api/v2/completeness_stats.csv?form_id={form_ids}&limit=10")
+
         self.assertEqual(response.status_code, 200)
         content = response.content.decode("utf-8")
         reader = csv.reader(StringIO(content))
-        header = next(reader)
-        # Check that the header contains the expected columns
+        csv_data = list(reader)
+
+        # Check that the header contains the expected columns in the correct order
+        header = csv_data[0]
         expected_columns = [
+            "id",
+            "org_unit_name",
+            "org_unit_type_name",
+            "parent_org_unit_name",
+            "has_children",
             f"{self.form_hs_1.name} - Descendants Numerator",
             f"{self.form_hs_1.name} - Descendants Denominator",
             f"{self.form_hs_1.name} - Descendants Percentage",
@@ -921,15 +929,8 @@ class CompletenessStatsAPITestCase(APITestCase):
             f"{self.form_hs_4.name} - Descendants Numerator",
             f"{self.form_hs_4.name} - Descendants Denominator",
             f"{self.form_hs_4.name} - Descendants Percentage",
-            "has_children",
-            "id",
-            "name",
-            "org_unit_name",
-            "org_unit_type_name",
-            "parent_org_unit_name",
         ]
-        for col in expected_columns:
-            self.assertIn(col, header)
+        self.assertEqual(header, expected_columns)
         # Optionally, check the data rows for expected values
-        for row in reader:
+        for row in csv_data[1:]:  # Skip header row
             self.assertEqual(len(row), len(header))


### PR DESCRIPTION
Exporting the following completeness statistics in CSV (see attached file) provides a file with numerous useless columns in an illogical (alphabetical?) order. This comes to the point that our MoH users end up copying completeness numbers manually instead of using the existing exported file.

Ideally, to improve the user experience, the exported file should have maximum the triple amount of “descending” columns => In our example, while the web table has 14 columns, the expected exported table should have (14-1+5*2) 23 columns (in order to include numerator / denominator / percentage in separate fields), while it currently contains 1529 columns.

Related JIRA tickets : IA-4291

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

Explain the changes that were made.

Custom renderer for csv export + tests

## How to test

Go to completeness stats, try to export a CSV, we should have same data as on the table, not hundred of columns

## Print screen / video
[completeness_stats (15).csv](https://github.com/user-attachments/files/21120657/completeness_stats.15.csv)


## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
