### PR TITLE
IA-3605: Display field of type 'file' on instance detail page

### DIFF
--- a/hat/assets/js/apps/Iaso/components/files/DocumentsItemComponent.tsx
+++ b/hat/assets/js/apps/Iaso/components/files/DocumentsItemComponent.tsx
@@ -1,11 +1,9 @@
 import React, { FunctionComponent } from 'react';
 
+import AttachFile from '@mui/icons-material/AttachFile';
 import { Paper, Box } from '@mui/material';
 
-import AttachFile from '@mui/icons-material/AttachFile';
-
 import {
-    displayDateFromTimestamp,
     PdfSvg,
     TextSvg,
     WordSvg,
@@ -13,7 +11,7 @@ import {
     CsvSvg,
 } from 'bluesquare-components';
 import { getFileName } from '../../utils/filesUtils';
-import { ShortFile } from '../../domains/instances/types/instance';
+import { PdfPreview } from './pdf/PdfPreview';
 
 const styles = {
     paper: {
@@ -50,6 +48,7 @@ const styles = {
         width: '100%',
         height: '20px',
         whiteSpace: 'nowrap',
+        fontSize: 10,
     },
 };
 type IconProps = {
@@ -76,24 +75,65 @@ const ExtensionIcon: FunctionComponent<IconProps> = ({ fileExtension }) => {
 };
 
 type Props = {
-    file: ShortFile;
+    filePath: string;
+    fileInfo?: string;
+};
+export const OpenButtonComponent = ({ onClick, disabled, ...buttonProps }) => (
+    <Box
+        role="button"
+        onClick={disabled ? undefined : onClick}
+        sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            opacity: disabled ? 0.5 : 1,
+            cursor: disabled ? 'not-allowed' : 'pointer',
+        }}
+    >
+        <Paper sx={styles.paper}>
+            <PdfSvg color="secondary" sx={styles.icon} />
+            <Box sx={styles.fileInfo}>{buttonProps.label}</Box>
+        </Paper>
+    </Box>
+);
+
+const PdfItem: FunctionComponent<Props> = ({ filePath, fileInfo }) => {
+    return (
+        <PdfPreview
+            fileInfo={fileInfo}
+            pdfUrl={filePath}
+            OpenButtonComponent={OpenButtonComponent}
+            buttonProps={{
+                label: fileInfo,
+            }}
+        />
+    );
 };
 
-const DocumentsItemComponent: FunctionComponent<Props> = ({ file }) => {
-    const fileName = getFileName(file.path);
+const DocumentsItemComponent: FunctionComponent<Props> = ({
+    filePath,
+    fileInfo,
+}) => {
+    const fileName = getFileName(filePath);
+    if (fileName.extension === 'pdf') {
+        return (
+            <PdfItem
+                filePath={filePath}
+                fileInfo={`${fileName.name}.${fileName.extension}`}
+            />
+        );
+    }
     return (
         <Box
             component="a"
-            href={file.path}
+            href={filePath}
             target="_blank"
             sx={styles.link}
             rel="noreferrer"
         >
             <Paper sx={styles.paper}>
                 <ExtensionIcon fileExtension={fileName.extension} />
-                <Box sx={styles.fileInfo}>
-                    {displayDateFromTimestamp(file.createdAt)}
-                </Box>
+                {fileInfo && <Box sx={styles.fileInfo}>{fileInfo}</Box>}
                 <Box sx={styles.fileInfo}>
                     {`${fileName.name}.${fileName.extension}`}
                 </Box>

--- a/hat/assets/js/apps/Iaso/components/files/DocumentsListComponent.tsx
+++ b/hat/assets/js/apps/Iaso/components/files/DocumentsListComponent.tsx
@@ -1,9 +1,10 @@
 import React, { FunctionComponent } from 'react';
 import { Grid } from '@mui/material';
+import { displayDateFromTimestamp } from 'bluesquare-components';
 
+import { ShortFile } from '../../domains/instances/types/instance';
 import { getFileName } from '../../utils/filesUtils';
 import DocumentsItem from './DocumentsItemComponent';
-import { ShortFile } from '../../domains/instances/types/instance';
 
 const styles = {
     root: {
@@ -26,7 +27,10 @@ const DocumentsListComponent: FunctionComponent<Props> = ({ docsList }) => {
                     md={1}
                     key={`${file.itemId}-${getFileName(file.path).name}`}
                 >
-                    <DocumentsItem file={file} />
+                    <DocumentsItem
+                        filePath={file.path}
+                        fileInfo={displayDateFromTimestamp(file.createdAt)}
+                    />
                 </Grid>
             ))}
         </Grid>

--- a/hat/assets/js/apps/Iaso/components/files/VideoItemComponent.tsx
+++ b/hat/assets/js/apps/Iaso/components/files/VideoItemComponent.tsx
@@ -1,12 +1,11 @@
 import React, { useState, useEffect, useRef, FunctionComponent } from 'react';
-import videojs from 'video.js';
-import moment from 'moment';
-import { Box, IconButton } from '@mui/material';
-import PlayIcon from '@mui/icons-material/PlayCircleFilled';
 import PauseIcon from '@mui/icons-material/PauseCircleFilled';
+import PlayIcon from '@mui/icons-material/PlayCircleFilled';
+import { Box, IconButton } from '@mui/material';
+import moment from 'moment';
+import videojs from 'video.js';
 
 import 'video.js/dist/video-js.min.css';
-import { ShortFile } from '../../domains/instances/types/instance';
 import { getFileName } from '../../utils/filesUtils';
 
 const styles = {
@@ -86,20 +85,24 @@ const styles = {
 };
 
 type Props = {
-    videoItem: ShortFile;
+    videoPath: string;
+    fileInfo?: string;
 };
 
-const VideoItemComponent: FunctionComponent<Props> = ({ videoItem }) => {
+const VideoItemComponent: FunctionComponent<Props> = ({
+    videoPath,
+    fileInfo,
+}) => {
     const [playerPaused, setPlayerPaused] = useState(true);
     const playerRef = useRef<videojs.Player | null>(null);
     const videoNodeRef = useRef<HTMLVideoElement | null>(null);
-    const fileName = getFileName(videoItem.path);
+    const fileName = getFileName(videoPath);
 
     useEffect(() => {
         if (!playerRef.current) {
             playerRef.current = videojs(videoNodeRef.current, {}, () => {
                 if (playerRef.current) {
-                    playerRef.current.src({ src: videoItem.path });
+                    playerRef.current.src({ src: videoPath });
                 }
             });
         }
@@ -109,7 +112,7 @@ const VideoItemComponent: FunctionComponent<Props> = ({ videoItem }) => {
                 playerRef.current.dispose();
             }
         };
-    }, [videoItem.path]);
+    }, [videoPath]);
 
     const togglePlayback = () => {
         if (playerRef.current) {
@@ -145,11 +148,13 @@ const VideoItemComponent: FunctionComponent<Props> = ({ videoItem }) => {
                     <PauseIcon sx={styles.icon} />
                 )}
             </IconButton>
-            <Box sx={playerPaused ? styles.fileInfo : styles.fileInfoHidden}>
-                {`${moment.unix(videoItem.createdAt).format('LTS')} - ${
-                    fileName.name
-                }.${fileName.extension}`}
-            </Box>
+            {fileInfo && (
+                <Box
+                    sx={playerPaused ? styles.fileInfo : styles.fileInfoHidden}
+                >
+                    {fileInfo}
+                </Box>
+            )}
         </Box>
     );
 };

--- a/hat/assets/js/apps/Iaso/components/files/VideosListComponent.tsx
+++ b/hat/assets/js/apps/Iaso/components/files/VideosListComponent.tsx
@@ -1,8 +1,10 @@
 import React, { FunctionComponent, useRef, useState, useEffect } from 'react';
-import { Box } from '@mui/material';
 import { Masonry } from '@mui/lab';
-import VideoItem from './VideoItemComponent';
+import { Box } from '@mui/material';
+import moment from 'moment';
+import { getFileName } from 'Iaso/utils/filesUtils';
 import { ShortFile } from '../../domains/instances/types/instance';
+import VideoItem from './VideoItemComponent';
 
 type Props = {
     videoList: ShortFile[];
@@ -20,11 +22,19 @@ const VideosListComponent: FunctionComponent<Props> = ({ videoList }) => {
         <Box ref={containerRef} overflow="hidden">
             {width > 0 && (
                 <Masonry columns={width < 500 ? 1 : 3} spacing={2}>
-                    {videoList.map(file => (
-                        <Box key={file.itemId}>
-                            <VideoItem videoItem={file} />
-                        </Box>
-                    ))}
+                    {videoList.map(file => {
+                        const fileName = getFileName(file.path);
+                        return (
+                            <Box key={file.itemId}>
+                                <VideoItem
+                                    videoPath={file.path}
+                                    fileInfo={`${moment.unix(file.createdAt).format('LTS')} - ${
+                                        fileName.name
+                                    }.${fileName.extension}`}
+                                />
+                            </Box>
+                        );
+                    })}
                 </Masonry>
             )}
         </Box>

--- a/hat/assets/js/apps/Iaso/components/files/pdf/PdfPreview.tsx
+++ b/hat/assets/js/apps/Iaso/components/files/pdf/PdfPreview.tsx
@@ -12,6 +12,7 @@ import {
     Dialog,
     DialogActions,
     DialogContent,
+    DialogTitle,
     IconButton,
 } from '@mui/material';
 import { LoadingSpinner, useSafeIntl } from 'bluesquare-components';
@@ -41,6 +42,7 @@ type PdfPreviewProps = {
     scanResult?: string | undefined;
     scanTimestamp?: number | undefined;
     coloredScanResultIcon?: boolean;
+    fileInfo?: string;
 };
 
 const styles: SxStyles = {
@@ -85,6 +87,7 @@ export const PdfPreview: FunctionComponent<PdfPreviewProps> = ({
     scanResult,
     scanTimestamp,
     coloredScanResultIcon,
+    fileInfo,
 }) => {
     const [open, setOpen] = useState(false);
     const [numPages, setNumPages] = useState<number | null>(null);
@@ -148,6 +151,7 @@ export const PdfPreview: FunctionComponent<PdfPreviewProps> = ({
                     onClose={handleClose}
                 >
                     <DialogContent sx={styles.dialogContent}>
+                        {fileInfo && <DialogTitle>{fileInfo}</DialogTitle>}
                         <FileScanHeader
                             scanResult={scanResult}
                             scanTimestamp={scanTimestamp}

--- a/hat/assets/js/apps/Iaso/domains/instances/components/InstanceFileContentRich.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/InstanceFileContentRich.tsx
@@ -2,10 +2,20 @@
 import React, { useMemo, FunctionComponent, JSX } from 'react';
 import CommentIcon from '@mui/icons-material/Comment';
 import FunctionsIcon from '@mui/icons-material/Functions';
-import { Table, TableBody, TableCell, TableRow, Tooltip } from '@mui/material';
+import {
+    Box,
+    Table,
+    TableBody,
+    TableCell,
+    TableRow,
+    Tooltip,
+} from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import { textPlaceholder } from 'bluesquare-components';
 import isPlainObject from 'lodash/isPlainObject';
+import DocumentsItemComponent from 'Iaso/components/files/DocumentsItemComponent';
+import VideoItemComponent from 'Iaso/components/files/VideoItemComponent';
+import { getFileName, getFileType } from 'Iaso/utils/filesUtils';
 import { useLocale } from '../../app/contexts/LocaleContext';
 import { InstanceImagePreview } from './InstanceImagePreview';
 
@@ -43,6 +53,13 @@ type FormNoteFieldProps = {
 };
 
 type PhotoFieldProps = {
+    descriptor: Descriptor;
+    data: Data;
+    showQuestionKey?: boolean;
+    files?: string[];
+};
+
+type FileFieldProps = {
     descriptor: Descriptor;
     data: Data;
     showQuestionKey?: boolean;
@@ -274,6 +291,66 @@ const PhotoField: FunctionComponent<PhotoFieldProps> = ({
     );
 };
 
+const FileField: FunctionComponent<FileFieldProps> = ({
+    descriptor,
+    data,
+    showQuestionKey = true,
+    files = [],
+}) => {
+    const classes = useStyles();
+    const value = data[descriptor.name];
+    const fileUrl = useMemo(() => {
+        if (value && files.length > 0) {
+            const slugifiedValue = value.replace(/\s/g, '_'); // Replace spaces with underscores
+            return files.find(f => f.includes(slugifiedValue));
+        }
+        return null;
+    }, [value, files]);
+    const fileName = value ? getFileName(value) : undefined;
+    const fileType = fileName ? getFileType(fileName) : undefined;
+
+    return (
+        <TableRow>
+            <TableCell className={classes.tableCell}>
+                <Label
+                    descriptor={descriptor}
+                    showQuestionKey={showQuestionKey}
+                />
+            </TableCell>
+            <TableCell
+                className={classes.tableCell}
+                align="right"
+                title={getRawValue(descriptor, data)}
+            >
+                {value && fileUrl && fileName && (
+                    <>
+                        {fileType === 'image' && (
+                            <InstanceImagePreview
+                                imageUrl={fileUrl}
+                                altText={descriptor.name}
+                            />
+                        )}
+                        {fileType === 'video' && (
+                            <Box sx={{ height: '200px' }}>
+                                <VideoItemComponent
+                                    videoPath={fileUrl}
+                                    fileInfo={fileName.name}
+                                />
+                            </Box>
+                        )}
+                        {(fileType === 'document' || fileType === 'other') && (
+                            <Box sx={{ float: 'right', width: '150px' }}>
+                                <DocumentsItemComponent filePath={fileUrl} />
+                            </Box>
+                        )}
+                    </>
+                )}
+                {(!value || !fileUrl) && textPlaceholder}
+            </TableCell>
+        </TableRow>
+    );
+};
+
 const FormChild = ({
     descriptor,
     data,
@@ -291,6 +368,7 @@ const FormChild = ({
                             descriptor={descriptor}
                             data={subdata}
                             showQuestionKey={showQuestionKey}
+                            files={files}
                         />
                     ))}
                 </>
@@ -326,6 +404,15 @@ const FormChild = ({
         case 'image':
             return (
                 <PhotoField
+                    descriptor={descriptor}
+                    data={data}
+                    showQuestionKey={showQuestionKey}
+                    files={files}
+                />
+            );
+        case 'file':
+            return (
+                <FileField
                     descriptor={descriptor}
                     data={data}
                     showQuestionKey={showQuestionKey}

--- a/hat/assets/js/apps/Iaso/domains/instances/components/InstanceFileContentRich.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/InstanceFileContentRich.tsx
@@ -133,7 +133,7 @@ const useStyles = makeStyles(theme => ({
 
 /**
  * Slugification function that matches Django's slugify_underscore behavior
- * Replaces spaces with underscores and converts accented characters to ASCII
+ * Replaces spaces with underscores, converts accented characters to ASCII, and removes parentheses and commas
  * @param value - The string to slugify
  * @returns The slugified string
  */
@@ -141,6 +141,7 @@ const slugifyValue = (value: string): string => {
     return value
         .normalize('NFD') // Decompose characters into base + accent
         .replace(/[\u0300-\u036f]/g, '') // Remove diacritics (accents)
+        .replace(/[(),]/g, '') // Remove parentheses and commas
         .replace(/\s+/g, '_'); // Replace spaces with underscores
 };
 

--- a/hat/assets/js/apps/Iaso/domains/instances/components/InstanceFileContentRich.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/InstanceFileContentRich.tsx
@@ -132,6 +132,23 @@ const useStyles = makeStyles(theme => ({
 }));
 
 /**
+ * Slugification function that matches Django's slugify_underscore behavior
+ * Converts to lowercase, removes special characters, and replaces spaces with underscores
+ * @param value - The string to slugify
+ * @returns The slugified string
+ */
+const slugifyValue = (value: string): string => {
+    return value
+        .normalize('NFD') // Decompose characters into base + accent (matches Django's Unicode handling)
+        .replace(/[\u0300-\u036f]/g, '') // Remove diacritics (accents)
+        .toLowerCase() // Convert to lowercase
+        .replace(/[^a-z0-9\s]/g, '') // Remove special characters except spaces
+        .replace(/\s+/g, '_') // Replace spaces with underscores
+        .replace(/_+/g, '_') // Replace multiple underscores with single underscore
+        .replace(/^_|_$/g, ''); // Remove leading/trailing underscores
+};
+
+/**
  * Translate the provided label if it is translatable
  * If the locale language matches the user language, we display it
  * if not, we display it in English by default
@@ -261,7 +278,7 @@ const PhotoField: FunctionComponent<PhotoFieldProps> = ({
     const value = data[descriptor.name];
     const fileUrl = useMemo(() => {
         if (value && files.length > 0) {
-            const slugifiedValue = value.replace(/\s/g, '_'); // Replace spaces with underscores
+            const slugifiedValue = slugifyValue(value);
             return files.find(f => f.includes(slugifiedValue));
         }
         return null;
@@ -301,7 +318,7 @@ const FileField: FunctionComponent<FileFieldProps> = ({
     const value = data[descriptor.name];
     const fileUrl = useMemo(() => {
         if (value && files.length > 0) {
-            const slugifiedValue = value.replace(/\s/g, '_'); // Replace spaces with underscores
+            const slugifiedValue = slugifyValue(value);
             return files.find(f => f.includes(slugifiedValue));
         }
         return null;

--- a/hat/assets/js/apps/Iaso/domains/instances/components/InstanceFileContentRich.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/InstanceFileContentRich.tsx
@@ -133,19 +133,15 @@ const useStyles = makeStyles(theme => ({
 
 /**
  * Slugification function that matches Django's slugify_underscore behavior
- * Converts to lowercase, removes special characters, and replaces spaces with underscores
+ * Replaces spaces with underscores and converts accented characters to ASCII
  * @param value - The string to slugify
  * @returns The slugified string
  */
 const slugifyValue = (value: string): string => {
     return value
-        .normalize('NFD') // Decompose characters into base + accent (matches Django's Unicode handling)
+        .normalize('NFD') // Decompose characters into base + accent
         .replace(/[\u0300-\u036f]/g, '') // Remove diacritics (accents)
-        .toLowerCase() // Convert to lowercase
-        .replace(/[^a-z0-9\s]/g, '') // Remove special characters except spaces
-        .replace(/\s+/g, '_') // Replace spaces with underscores
-        .replace(/_+/g, '_') // Replace multiple underscores with single underscore
-        .replace(/^_|_$/g, ''); // Remove leading/trailing underscores
+        .replace(/\s+/g, '_'); // Replace spaces with underscores
 };
 
 /**
@@ -316,6 +312,7 @@ const FileField: FunctionComponent<FileFieldProps> = ({
 }) => {
     const classes = useStyles();
     const value = data[descriptor.name];
+
     const fileUrl = useMemo(() => {
         if (value && files.length > 0) {
             const slugifiedValue = slugifyValue(value);

--- a/hat/assets/js/apps/Iaso/domains/instances/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/index.tsx
@@ -196,10 +196,9 @@ const Instances = () => {
                                             id: params.formIds,
                                         }}
                                         orgUnitTypes={orgUnitTypes}
-                                        onCreateOrReAssign={(
-                                            _currentForm,
-                                            payload,
-                                        ) => createInstance(payload)}
+                                        onCreateOrReAssign={payload =>
+                                            createInstance(payload)
+                                        }
                                     />
                                 </Box>
                             </DisplayIfUserHasPerm>

--- a/hat/assets/js/apps/Iaso/utils/filesUtils.ts
+++ b/hat/assets/js/apps/Iaso/utils/filesUtils.ts
@@ -1,6 +1,6 @@
 import { ShortFile } from '../domains/instances/types/instance';
 
-const imgExtensions: string[] = [
+export const imgExtensions: string[] = [
     'jpg',
     'jpeg',
     'png',
@@ -9,8 +9,8 @@ const imgExtensions: string[] = [
     'tiff',
     'webp',
 ];
-const videoExtensions: string[] = ['mp4', 'mov'];
-const documentExtensions: string[] = [
+export const videoExtensions: string[] = ['mp4', 'mov'];
+export const documentExtensions: string[] = [
     'pdf',
     'doc',
     'docx',
@@ -52,6 +52,19 @@ export type SortedFiles = {
     videos: ShortFile[];
     docs: ShortFile[];
     others: ShortFile[];
+};
+
+export const getFileType = (fileName: FileName): string => {
+    if (imgExtensions.includes(fileName.extension)) {
+        return 'image';
+    }
+    if (videoExtensions.includes(fileName.extension)) {
+        return 'video';
+    }
+    if (documentExtensions.includes(fileName.extension)) {
+        return 'document';
+    }
+    return 'other';
 };
 
 export const sortFilesType = (files: ShortFile[]): SortedFiles => {


### PR DESCRIPTION
Currently, the filename in a submission on Iaso web for question of type file is just a filename as text. It would be easier if it could a link to the file and make the UX of user reviewing submissions containing file attachment more simpler.
Related JIRA tickets : IA-3605

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [x] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

-

## Changes

Manage type 'file' and use specific component using the extension

## How to test

You need a form using `file` type fields like this:
[demonstration_remontee_des_pieces_justificatives_2025070401.xlsx](https://github.com/user-attachments/files/21144847/demonstration_remontee_des_pieces_justificatives_2025070401.xlsx)

And you need an instance using this form and files attached to this instance (doc, pdf, png, mp4)
Check the render of the instance detail page 

## Print screen / video
<img width="1331" alt="Screenshot 2025-07-09 at 16 28 30" src="https://github.com/user-attachments/assets/13465f2c-a81c-47ac-8151-b1fbac6185b0" />


https://github.com/user-attachments/assets/e0e9db14-2cfd-411c-807b-83533b5c2dc8


## Notes
- 