### PR TITLE
IA-4255: Hide MOBILE_NO_ORG_UNIT project feature flag

### DIFF
--- a/iaso/api/feature_flags.py
+++ b/iaso/api/feature_flags.py
@@ -66,10 +66,5 @@ class FeatureFlagViewSet(ModelViewSet):
         if featureflags_to_exclude:
             featureflags = featureflags.exclude(code__in=featureflags_to_exclude)
 
-        # Additional filtering: Remove MOBILE_NO_ORG_UNIT if account doesn't have SHOW_MOBILE_NO_ORGUNIT_PROJECT_FEATURE_FLAG
-        account_feature_flags = current_account.feature_flags.values_list("code", flat=True)
-        if "SHOW_MOBILE_NO_ORGUNIT_PROJECT_FEATURE_FLAG" not in account_feature_flags:
-            featureflags = featureflags.exclude(code="MOBILE_NO_ORG_UNIT")
-
         serializer = FeatureFlagsSerializer(featureflags, many=True)
         return Response({self.get_results_key(): serializer.data})

--- a/iaso/api/feature_flags.py
+++ b/iaso/api/feature_flags.py
@@ -39,6 +39,16 @@ class FeatureFlagViewSet(ModelViewSet):
 
     def get_queryset(self):
         featureflags = FeatureFlag.objects.all()
+
+        # Filter out MOBILE_NO_ORG_UNIT if account doesn't have SHOW_MOBILE_NO_ORGUNIT_PROJECT_FEATURE_FLAG
+        request = self.request
+        if request and request.user.is_authenticated:
+            user_account = request.user.iaso_profile.account
+            account_feature_flags = user_account.feature_flags.values_list("code", flat=True)
+
+            if "SHOW_MOBILE_NO_ORGUNIT_PROJECT_FEATURE_FLAG" not in account_feature_flags:
+                featureflags = featureflags.exclude(code="MOBILE_NO_ORG_UNIT")
+
         return featureflags.order_by("name")
 
     @action(methods=["GET"], detail=False)
@@ -55,6 +65,11 @@ class FeatureFlagViewSet(ModelViewSet):
 
         if featureflags_to_exclude:
             featureflags = featureflags.exclude(code__in=featureflags_to_exclude)
+
+        # Additional filtering: Remove MOBILE_NO_ORG_UNIT if account doesn't have SHOW_MOBILE_NO_ORGUNIT_PROJECT_FEATURE_FLAG
+        account_feature_flags = current_account.feature_flags.values_list("code", flat=True)
+        if "SHOW_MOBILE_NO_ORGUNIT_PROJECT_FEATURE_FLAG" not in account_feature_flags:
+            featureflags = featureflags.exclude(code="MOBILE_NO_ORG_UNIT")
 
         serializer = FeatureFlagsSerializer(featureflags, many=True)
         return Response({self.get_results_key(): serializer.data})

--- a/iaso/migrations/0331_add_account_feature_flag_and_auto_assign.py
+++ b/iaso/migrations/0331_add_account_feature_flag_and_auto_assign.py
@@ -1,0 +1,61 @@
+from django.db import migrations
+
+
+def create_and_assign_account_flag(apps, schema_editor):
+    """Create SHOW_MOBILE_NO_ORGUNIT_PROJECT_FEATURE_FLAG and assign it to accounts with MOBILE_NO_ORG_UNIT projects"""
+    Account = apps.get_model("iaso", "Account")
+    AccountFeatureFlag = apps.get_model("iaso", "AccountFeatureFlag")
+    FeatureFlag = apps.get_model("iaso", "FeatureFlag")
+
+    # Create the account feature flag
+    account_flag, created = AccountFeatureFlag.objects.get_or_create(
+        code="SHOW_MOBILE_NO_ORGUNIT_PROJECT_FEATURE_FLAG",
+        defaults={"name": "Display no org units project feature flag"},
+    )
+
+    if created:
+        print(f"Created account feature flag: {account_flag.code}")
+
+    # Get the project feature flag (it should exist from previous migrations)
+    try:
+        project_flag = FeatureFlag.objects.get(code="MOBILE_NO_ORG_UNIT")
+    except FeatureFlag.DoesNotExist:
+        print("MOBILE_NO_ORG_UNIT feature flag not found, skipping auto-assignment")
+        return
+
+    # Find accounts that have projects with MOBILE_NO_ORG_UNIT feature flag
+    accounts_with_mobile_no_org_unit = Account.objects.filter(project__feature_flags=project_flag).distinct()
+
+    # Add the account feature flag to these accounts
+    for account in accounts_with_mobile_no_org_unit:
+        if account_flag not in account.feature_flags.all():
+            account.feature_flags.add(account_flag)
+            print(f"Added SHOW_MOBILE_NO_ORGUNIT_PROJECT_FEATURE_FLAG to account: {account.name}")
+        else:
+            print(f"Account {account.name} already has SHOW_MOBILE_NO_ORGUNIT_PROJECT_FEATURE_FLAG")
+
+
+def reverse_create_and_assign_account_flag(apps, schema_editor):
+    """Remove SHOW_MOBILE_NO_ORGUNIT_PROJECT_FEATURE_FLAG from all accounts and delete the flag"""
+    Account = apps.get_model("iaso", "Account")
+    AccountFeatureFlag = apps.get_model("iaso", "AccountFeatureFlag")
+
+    # Remove the flag from all accounts
+    try:
+        account_flag = AccountFeatureFlag.objects.get(code="SHOW_MOBILE_NO_ORGUNIT_PROJECT_FEATURE_FLAG")
+        for account in Account.objects.all():
+            account.feature_flags.remove(account_flag)
+        account_flag.delete()
+        print("Removed SHOW_MOBILE_NO_ORGUNIT_PROJECT_FEATURE_FLAG from all accounts and deleted the flag")
+    except AccountFeatureFlag.DoesNotExist:
+        print("SHOW_MOBILE_NO_ORGUNIT_PROJECT_FEATURE_FLAG not found, nothing to remove")
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("iaso", "0330_formversion_md5"),
+    ]
+
+    operations = [
+        migrations.RunPython(create_and_assign_account_flag, reverse_create_and_assign_account_flag),
+    ]


### PR DESCRIPTION
MOBILE_NO_ORG_UNIT feature flag is a bit dangerous to activate like that and leads to mobile app misconfiguration

Related JIRA tickets : IA-4255

## Self proofreading checklist

- [ ] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

-

## Changes

- added a new account feature flag named `SHOW_MOBILE_NO_ORGUNIT_PROJECT_FEATURE_FLAG`
- migrate all account where a project has already `MOBILE_NO_ORG_UNIT` activated to add the `SHOW_MOBILE_NO_ORGUNIT_PROJECT_FEATURE_FLAG` 
- modify endpoint feature_flags to filter out `MOBILE_NO_ORG_UNIT` if `SHOW_MOBILE_NO_ORGUNIT_PROJECT_FEATURE_FLAG` is prenset or not
- wrote some test 

## How to test

**BEFORE** running the migration

- make sure you have a project with MOBILE_NO_ORG_UNIT activated
- make sure you have two active accounts on your env
- run the migration `0331_add_account_feature_flag_and_auto_assign`
- make sure that the account with a project with `MOBILE_NO_ORG_UNIT` has `SHOW_MOBILE_NO_ORGUNIT_PROJECT_FEATURE_FLAG`
- visit a project, make sure MOBILE_NO_ORG_UNIT is present on the first account and not the second

## Print screen / video

-

## Notes

-

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
