### PR TITLE
IA-4367: Setuper data is badly formatted

### DIFF
--- a/setuper/submissions.py
+++ b/setuper/submissions.py
@@ -2,7 +2,7 @@ import os
 import random
 import uuid
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from dict2xml import dict2xml
 from fake import fake_person
@@ -69,7 +69,7 @@ def instance_by_LLIN_campaign_form(form, instance_id, orgunit=None):
     random_year = random.randint(1, 5)
     random_date = (datetime.now() - timedelta(days=(random_year * 365.25))).date()
     beneficiary_name = generate_name(style="capital")
-    registration_date = datetime.now()
+    registration_date = datetime.now(timezone(timedelta(hours=2))).isoformat()
     code = random.randint(1000000000, 9999999999)
     ticket_number = random.randint(10000, 99999)
     instance_json = None


### PR DESCRIPTION
What problem is this PR solving? Explain here in one sentence.

Related JIRA tickets : [IA-4367](https://bluesquare.atlassian.net/browse/IA-4367)

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

Fix registration date for PBWG entity

## How to test

From setuper folder, launch `python3 setuper.py --additional_projects` to create data and login with the created account. Then open any Registration Vaccination Pregnant Women submission linked to check the submissions linked **Pregnant women**, check the format of **Date of Registration**, it should be formatted like `2025-07-10T17:03:46.130192+02:00`


## Print screen / video

<img width="1183" height="486" alt="Iaso-Registration-Vaccination-Pregnant-Women-example_32890bfb-8ca0-466c-8064-e35c94aedcb6-07-10-2025_05_12_PM" src="https://github.com/user-attachments/assets/e555aa15-3834-4752-b289-bc9c2914a044" />


[Uploading Capture vidéo du 10-07-2025 17:15:42.webm…]()



## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.


[IA-4367]: https://bluesquare.atlassian.net/browse/IA-4367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ