### PR TITLE
IA-3828: OU batch updates groups

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitFiltersContainer.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitFiltersContainer.tsx
@@ -1,4 +1,10 @@
 /* eslint-disable react/no-array-index-key */
+import React, {
+    FunctionComponent,
+    useCallback,
+    useMemo,
+    useState,
+} from 'react';
 import Add from '@mui/icons-material/Add';
 import { AppBar, Box, Button } from '@mui/material';
 import { makeStyles } from '@mui/styles';
@@ -11,32 +17,22 @@ import {
     useSkipEffectOnMount,
 } from 'bluesquare-components';
 import classnames from 'classnames';
-import React, {
-    FunctionComponent,
-    useCallback,
-    useMemo,
-    useState,
-} from 'react';
 
 import { isEqual } from 'lodash';
-import { useCurrentUser } from '../../../utils/usersUtils';
-
+import { DisplayIfUserHasPerm } from '../../../components/DisplayIfUserHasPerm';
 import { SearchButton } from '../../../components/SearchButton';
-import { OrgUnitFilters as Filters } from './OrgUnitsFilters';
-
-import { OrgUnitParams } from '../types/orgUnit';
 
 import { getChipColors } from '../../../constants/chipColors';
 import { baseUrls } from '../../../constants/urls';
 
-import { Count } from '../hooks/requests/useGetOrgUnits';
-import { Search } from '../types/search';
-
-import { decodeSearch } from '../utils';
-
-import { DisplayIfUserHasPerm } from '../../../components/DisplayIfUserHasPerm';
 import { ORG_UNITS } from '../../../utils/permissions';
+import { useCurrentUser } from '../../../utils/usersUtils';
+import { Count } from '../hooks/requests/useGetOrgUnits';
 import MESSAGES from '../messages';
+import { OrgUnitParams } from '../types/orgUnit';
+import { Search } from '../types/search';
+import { decodeSearch } from '../utils';
+import { OrgUnitFilters as Filters } from './OrgUnitsFilters';
 
 type Props = {
     params: OrgUnitParams;
@@ -86,9 +82,13 @@ export const OrgUnitFiltersContainer: FunctionComponent<Props> = ({
     const { formatMessage }: { formatMessage: IntlFormatMessage } =
         useSafeIntl();
     const classes: Record<string, string> = useStyles();
-    const defaultSource = useMemo(
-        () => currentUser?.account?.default_version?.data_source,
+    const defaultVersion = useMemo(
+        () => currentUser?.account?.default_version,
         [currentUser],
+    );
+    const defaultSource = useMemo(
+        () => defaultVersion?.data_source,
+        [defaultVersion],
     );
     const [hasLocationLimitError, setHasLocationLimitError] =
         useState<boolean>(false);
@@ -100,11 +100,21 @@ export const OrgUnitFiltersContainer: FunctionComponent<Props> = ({
     const currentSearchIndex = parseInt(params.searchTabIndex, 10);
 
     const handleSearch = useCallback(() => {
+        const tempSearches = [...searches].map(s => {
+            const newSearch = { ...s };
+            // isAdded is added while creating a new search,
+            // it is removed while clicking on search,
+            // this avoid to launch a search if we add a new tab without clicking on search
+            if (s.isAdded) {
+                delete newSearch.isAdded;
+            }
+            return newSearch;
+        });
         const tempParams = {
             ...params,
             locationLimit,
             page: 1,
-            searches,
+            searches: tempSearches,
         };
         onSearch(tempParams);
     }, [params, locationLimit, searches, onSearch]);
@@ -141,7 +151,6 @@ export const OrgUnitFiltersContainer: FunctionComponent<Props> = ({
         },
         [redirectTo],
     );
-
     // update filter state if search changed in the url
     useSkipEffectOnMount(() => {
         if (!isEqual(decodeSearch(decodeURI(params.searches)), searches)) {
@@ -149,6 +158,20 @@ export const OrgUnitFiltersContainer: FunctionComponent<Props> = ({
         }
     }, [params.searches]);
 
+    const defaultItem = useMemo(
+        () => ({
+            validation_status: 'all',
+            color: getChipColors(
+                searches.length + 1,
+                false,
+                searches.map(search => `#${search.color}`),
+            ).replace('#', ''),
+            source: defaultSource && defaultSource.id,
+            version: defaultVersion?.id,
+            isAdded: true,
+        }),
+        [searches, defaultSource, defaultVersion],
+    );
     return (
         <>
             <AppBar
@@ -165,15 +188,7 @@ export const OrgUnitFiltersContainer: FunctionComponent<Props> = ({
                         ...params,
                         searches: JSON.stringify(searches),
                     }}
-                    defaultItem={{
-                        validation_status: 'all',
-                        color: getChipColors(
-                            searches.length + 1,
-                            false,
-                            searches.map(search => `#${search.color}`),
-                        ).replace('#', ''),
-                        source: defaultSource && defaultSource.id,
-                    }}
+                    defaultItem={defaultItem}
                     paramKey="searches"
                     tabParamKey="searchTabIndex"
                     onTabChange={newParams => {

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/hooks/requests/useGetGroups.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/hooks/requests/useGetGroups.ts
@@ -1,7 +1,7 @@
 import { UseQueryResult } from 'react-query';
 // @ts-ignore
 import { getRequest } from 'Iaso/libs/Api';
-import { useSnackQuery } from 'Iaso/libs/apiHooks.ts';
+import { useSnackQuery } from 'Iaso/libs/apiHooks';
 // @ts-ignore
 import { DropdownOptionsWithOriginal } from '../../../../types/utils';
 
@@ -16,6 +16,8 @@ import MESSAGES from '../../messages';
 const queryParamsMap = new Map([
     ['dataSourceId', 'dataSource'],
     ['sourceVersionId', 'version'],
+    ['dataSourceIds', 'dataSourceIds'],
+    ['sourceVersionIds', 'versionIds'],
     ['blockOfCountries', 'blockOfCountries'],
     ['appId', 'app_id'],
     ['projectIds', 'projectIds'],
@@ -25,6 +27,8 @@ const queryParamsMap = new Map([
 type ApiParams = {
     dataSource?: number;
     version?: number;
+    dataSourceIds?: string;
+    versionIds?: string;
     blockOfCountries?: string;
     app_id?: string;
     defaultVersion?: string;
@@ -32,7 +36,9 @@ type ApiParams = {
 };
 type Params = {
     dataSourceId?: number;
+    dataSourceIds?: string;
     sourceVersionId?: number;
+    sourceVersionIds?: string;
     blockOfCountries?: string | boolean;
     appId?: string;
     defaultVersion?: string;
@@ -57,6 +63,8 @@ export const useGetGroupDropdown = (
     if (
         !queryParams.version &&
         !queryParams.dataSource &&
+        !queryParams.dataSourceIds &&
+        !queryParams.versionIds &&
         !queryParams.defaultVersion
     ) {
         queryParams.defaultVersion = 'true';

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/hooks/useGetApiParams.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/hooks/useGetApiParams.ts
@@ -25,13 +25,14 @@ export const useGetApiParams = (
     params: OrgUnitParams,
     asLocation = false,
 ): Result => {
-    const tempSearches = [...searches];
-    searches.forEach((s, i) => {
-        tempSearches[i].orgUnitParentId = searches[i].levels;
+    const activeSearches = searches.filter(s => !s.isAdded);
+    const tempSearches = [...activeSearches];
+    activeSearches.forEach((s, i) => {
+        tempSearches[i].orgUnitParentId = activeSearches[i].levels;
         tempSearches[i].dateFrom =
-            getFromDateString(searches[i].dateFrom) || undefined;
+            getFromDateString(activeSearches[i].dateFrom) || undefined;
         tempSearches[i].dateTo =
-            getToDateString(searches[i].dateTo) || undefined;
+            getToDateString(activeSearches[i].dateTo) || undefined;
     });
 
     const apiParams: ApiParams = {

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/hooks/utils/useSourceVersionIds.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/hooks/utils/useSourceVersionIds.tsx
@@ -1,0 +1,27 @@
+import { useMemo } from 'react';
+import { DefaultVersion } from 'Iaso/utils/usersUtils';
+import { Search } from '../../types/search';
+
+/**
+ * Returns the source version ids for the given searches and default version
+ * @param searches - The searches to get the source version ids for
+ * @param defaultVersion - The default version to use if no version is provided in the searches
+ * @returns The source version ids
+ */
+export const useSourceVersionIds = (
+    searches: Search[],
+    defaultVersion?: DefaultVersion,
+): string | undefined => {
+    return useMemo(() => {
+        let versions: number[] = [];
+        const searchesWithVersion = searches.filter(s => s.version);
+        if (searchesWithVersion.length > 0) {
+            versions = searchesWithVersion.flatMap(s =>
+                parseInt(s.version!, 10),
+            );
+        } else {
+            versions = defaultVersion?.id ? [defaultVersion?.id] : [];
+        }
+        return versions.length > 0 ? versions.join(',') : undefined;
+    }, [defaultVersion, searches]);
+};

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/types/search.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/types/search.ts
@@ -14,4 +14,5 @@ export type Search = {
     dateFrom?: string;
     dateTo?: string;
     color?: string;
+    isAdded?: boolean;
 };

--- a/iaso/tests/api/test_groups.py
+++ b/iaso/tests/api/test_groups.py
@@ -208,6 +208,234 @@ class GroupsAPITestCase(APITestCase):
         response = self.client.delete(f"/api/groups/{self.group_1.id}/", format="json")
         self.assertJSONResponse(response, 204)
 
+    # Dropdown tests
+    def test_dropdown_authenticated_user_ok(self):
+        """GET /groups/dropdown/ with authenticated user - happy path"""
+
+        self.client.force_authenticate(self.yoda)
+        response = self.client.get("/api/groups/dropdown/")
+        self.assertJSONResponse(response, 200)
+
+        data = response.json()
+        self.assertIsInstance(data, list)
+        self.assertGreater(len(data), 0)
+
+        # Check first item structure
+        first_item = data[0]
+        self.assertHasField(first_item, "id", int)
+        self.assertHasField(first_item, "name", str)
+        self.assertHasField(first_item, "label", str)
+
+        # Check label format: "name (datasource - version)"
+        self.assertIn("(", first_item["label"])
+        self.assertIn(")", first_item["label"])
+
+    def test_dropdown_anonymous_user_with_app_id_ok(self):
+        """GET /groups/dropdown/ with anonymous user and valid app_id - happy path"""
+
+        response = self.client.get(f"/api/groups/dropdown/?app_id={self.project_1.app_id}")
+        self.assertJSONResponse(response, 200)
+
+        data = response.json()
+        self.assertIsInstance(data, list)
+        self.assertGreater(len(data), 0)
+
+    def test_dropdown_anonymous_user_without_app_id_fails(self):
+        """GET /groups/dropdown/ with anonymous user without app_id - should fail"""
+
+        response = self.client.get("/api/groups/dropdown/")
+        self.assertJSONResponse(response, 400)
+
+        data = response.json()
+        self.assertIn("Parameter app_id is missing", str(data))
+
+    def test_dropdown_with_default_version_filter(self):
+        """GET /groups/dropdown/ with defaultVersion=true filter"""
+
+        self.client.force_authenticate(self.yoda)
+        response = self.client.get("/api/groups/dropdown/?defaultVersion=true")
+        self.assertJSONResponse(response, 200)
+
+        data = response.json()
+        self.assertIsInstance(data, list)
+
+        # Should only return groups from the default version (source_version_2)
+        for item in data:
+            # The label should contain the default version number
+            self.assertIn("Default source - 2", item["label"])
+
+    def test_dropdown_with_version_filter(self):
+        """GET /groups/dropdown/ with specific version filter"""
+
+        self.client.force_authenticate(self.yoda)
+        response = self.client.get(f"/api/groups/dropdown/?version={self.source_version_1.id}")
+        self.assertJSONResponse(response, 200)
+
+        data = response.json()
+        self.assertIsInstance(data, list)
+
+        # Should only return groups from the specified version
+        for item in data:
+            self.assertIn("Default source - 1", item["label"])
+
+    def test_dropdown_with_data_source_filter(self):
+        """GET /groups/dropdown/ with dataSource filter"""
+
+        self.client.force_authenticate(self.yoda)
+        response = self.client.get(f"/api/groups/dropdown/?dataSource={self.data_source.id}")
+        self.assertJSONResponse(response, 200)
+
+        data = response.json()
+        self.assertIsInstance(data, list)
+
+        # Should only return groups from the specified data source
+        for item in data:
+            self.assertIn("Default source", item["label"])
+
+    def test_dropdown_with_data_source_ids_filter(self):
+        """GET /groups/dropdown/ with dataSourceIds filter"""
+
+        # Create a second data source for testing
+        second_data_source = m.DataSource.objects.create(name="Second source")
+        second_version = m.SourceVersion.objects.create(data_source=second_data_source, number=1)
+        second_group = m.Group.objects.create(name="Second Group", source_version=second_version)
+
+        # Add second data source to the project
+        self.project_1.data_sources.add(second_data_source)
+        self.project_1.save()
+
+        self.client.force_authenticate(self.yoda)
+        response = self.client.get(f"/api/groups/dropdown/?dataSourceIds={self.data_source.id},{second_data_source.id}")
+        self.assertJSONResponse(response, 200)
+
+        data = response.json()
+        self.assertIsInstance(data, list)
+
+        # Should return groups from both specified data sources
+        data_source_names = ["Default source", "Second source"]
+        for item in data:
+            self.assertTrue(any(name in item["label"] for name in data_source_names))
+
+    def test_dropdown_with_search_filter(self):
+        """GET /groups/dropdown/ with search filter"""
+
+        self.client.force_authenticate(self.yoda)
+        response = self.client.get("/api/groups/dropdown/?search=Councils")
+        self.assertJSONResponse(response, 200)
+
+        data = response.json()
+        self.assertIsInstance(data, list)
+
+        # Should only return groups matching the search term
+        for item in data:
+            self.assertIn("Councils", item["name"])
+
+    def test_dropdown_with_block_of_countries_filter(self):
+        """GET /groups/dropdown/ with blockOfCountries filter"""
+
+        # Create a group with block_of_countries=True
+        block_group = m.Group.objects.create(
+            name="Countries Block", source_version=self.source_version_1, block_of_countries=True
+        )
+
+        self.client.force_authenticate(self.yoda)
+        response = self.client.get("/api/groups/dropdown/?blockOfCountries=true")
+        self.assertJSONResponse(response, 200)
+
+        data = response.json()
+        self.assertIsInstance(data, list)
+
+        # Should only return groups with block_of_countries=True
+        for item in data:
+            self.assertEqual("Countries Block", item["name"])
+
+    def test_dropdown_with_order_parameter(self):
+        """GET /groups/dropdown/ with order parameter"""
+
+        self.client.force_authenticate(self.yoda)
+        response = self.client.get("/api/groups/dropdown/?order=name")
+        self.assertJSONResponse(response, 200)
+
+        data = response.json()
+        self.assertIsInstance(data, list)
+        self.assertGreater(len(data), 1)
+
+        # Check that items are ordered by name
+        names = [item["name"] for item in data]
+        self.assertEqual(names, sorted(names))
+
+    def test_dropdown_pagination(self):
+        """GET /groups/dropdown/ with pagination"""
+
+        self.client.force_authenticate(self.yoda)
+        response = self.client.get("/api/groups/dropdown/?limit=1&page=1")
+        self.assertJSONResponse(response, 200)
+
+        data = response.json()
+        # Should return paginated response structure
+        self.assertHasField(data, "groups", list)
+        self.assertHasField(data, "page", int)
+        self.assertHasField(data, "pages", int)
+        self.assertHasField(data, "limit", int)
+        self.assertHasField(data, "count", int)
+
+        self.assertEqual(len(data["groups"]), 1)
+        self.assertEqual(data["page"], 1)
+        self.assertEqual(data["limit"], 1)
+
+    def test_dropdown_invalid_app_id_fails(self):
+        """GET /groups/dropdown/ with invalid app_id - should fail"""
+
+        response = self.client.get("/api/groups/dropdown/?app_id=invalid_app_id")
+        self.assertJSONResponse(response, 400)
+
+        data = response.json()
+        self.assertIn("No project found", str(data))
+
+    def test_dropdown_user_from_different_account(self):
+        """GET /groups/dropdown/ with user from different account - should only see their groups"""
+
+        # Create a group for the marvel account
+        marvel_data_source = m.DataSource.objects.create(name="Marvel source")
+        marvel_version = m.SourceVersion.objects.create(data_source=marvel_data_source, number=1)
+        marvel_group = m.Group.objects.create(name="Marvel Group", source_version=marvel_version)
+
+        # Add marvel data source to marvel project
+        marvel_project = m.Project.objects.create(
+            name="Marvel Project", app_id="marvel.project", account=self.raccoon.iaso_profile.account
+        )
+        marvel_project.data_sources.add(marvel_data_source)
+        marvel_project.save()
+
+        # Set default version for marvel account
+        marvel_account = self.raccoon.iaso_profile.account
+        marvel_account.default_version = marvel_version
+        marvel_account.save()
+
+        self.client.force_authenticate(self.raccoon)
+        response = self.client.get("/api/groups/dropdown/")
+        self.assertJSONResponse(response, 200)
+
+        data = response.json()
+        self.assertIsInstance(data, list)
+
+        # Should only see groups from their account
+        for item in data:
+            self.assertIn("Marvel source", item["label"])
+
+    def test_dropdown_anonymous_user_different_project(self):
+        """GET /groups/dropdown/ with anonymous user and different project app_id"""
+
+        response = self.client.get(f"/api/groups/dropdown/?app_id={self.project_2.app_id}")
+        self.assertJSONResponse(response, 200)
+
+        data = response.json()
+        self.assertIsInstance(data, list)
+
+        # Should only see groups from the specified project
+        for item in data:
+            self.assertIn("Default source", item["label"])
+
     def assertValidGroupListData(self, list_data: typing.Mapping, expected_length: int, paginated: bool = False):
         self.assertValidListData(
             list_data=list_data, expected_length=expected_length, results_key="groups", paginated=paginated


### PR DESCRIPTION
- When working on another source than main - Batch update of groups doesn't work as still linked to main source
- adding a ne search is triggering the search and should not
- adding a search is not using default version



https://github.com/user-attachments/assets/c400521d-b2bf-4730-a61f-51f0eac6d097


Related JIRA tickets : IA-3828

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [x] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

/

## Changes

- adapt group dropdown api to receive multiple versions or datasources ids + tests
- adapt frontend to use version from org unit searches and if not use default version
- adding default version to default search
- use `isAdded` in the search to filter out searches and avoid to trigger the search while adding a new search

## How to test

Make sure you have multiple groups on different datasource and/or versions
Perform a search whit those multiple version, select all, try to adapt the groups, you should see all the groups from the selected versions
Make sure search in not launched while adding a new search (you need to click on search to see the results)

## Print screen / video

Uploading Screen Recording 2025-07-14 at 13.14.37.mov…


## Notes

/

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
