### PR TITLE
IA-4221: Create payment lot button not disabled

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/payments/PotentialPayments.tsx
+++ b/hat/assets/js/apps/Iaso/domains/payments/PotentialPayments.tsx
@@ -1,22 +1,22 @@
 import React, { FunctionComponent, useState, useCallback } from 'react';
+import { Box, useTheme } from '@mui/material';
 import {
     commonStyles,
     selectionInitialState,
     useSafeIntl,
     setTableSelection,
 } from 'bluesquare-components';
-import { Box, useTheme } from '@mui/material';
 import TopBar from '../../components/nav/TopBarComponent';
-import MESSAGES from './messages';
-import { PotentialPaymentParams, PotentialPayment } from './types';
-import { useGetPotentialPayments } from './hooks/requests/useGetPotentialPayments';
 import { TableWithDeepLink } from '../../components/tables/TableWithDeepLink';
 import { baseUrls } from '../../constants/urls';
-import { PotentialPaymentsFilters } from './components/CreatePaymentLot/PotentialPaymentsFilters';
-import { usePaymentColumns } from './hooks/config/usePaymentColumns';
+import { useParamsObject } from '../../routing/hooks/useParamsObject';
 import { Selection } from '../orgUnits/types/selection';
 import { AddPaymentLotDialog } from './components/CreatePaymentLot/PaymentLotDialog';
-import { useParamsObject } from '../../routing/hooks/useParamsObject';
+import { PotentialPaymentsFilters } from './components/CreatePaymentLot/PotentialPaymentsFilters';
+import { usePaymentColumns } from './hooks/config/usePaymentColumns';
+import { useGetPotentialPayments } from './hooks/requests/useGetPotentialPayments';
+import MESSAGES from './messages';
+import { PotentialPaymentParams, PotentialPayment } from './types';
 
 const baseUrl = baseUrls.potentialPayments;
 export const PotentialPayments: FunctionComponent = () => {
@@ -52,10 +52,16 @@ export const PotentialPayments: FunctionComponent = () => {
                 displayBackButton={false}
             />
             <Box sx={commonStyles(theme).containerFullHeightNoTabPadded}>
-                <PotentialPaymentsFilters params={params} />
+                <PotentialPaymentsFilters
+                    params={params}
+                    setSelection={setSelection}
+                />
                 <Box display="flex" justifyContent="flex-end">
                     <AddPaymentLotDialog
-                        iconProps={{ disabled: multiEditDisabled }}
+                        iconProps={{
+                            disabled:
+                                multiEditDisabled || data?.results.length === 0,
+                        }}
                         selection={selection}
                         titleMessage={formatMessage(MESSAGES.createLot)}
                         params={params}

--- a/hat/assets/js/apps/Iaso/domains/payments/components/CreatePaymentLot/PotentialPaymentsFilters.tsx
+++ b/hat/assets/js/apps/Iaso/domains/payments/components/CreatePaymentLot/PotentialPaymentsFilters.tsx
@@ -1,27 +1,38 @@
-import React, { FunctionComponent, useCallback, useMemo } from 'react';
+import React, {
+    Dispatch,
+    FunctionComponent,
+    SetStateAction,
+    useCallback,
+    useMemo,
+} from 'react';
 import { Box, Grid } from '@mui/material';
-import { useSafeIntl } from 'bluesquare-components';
+import { selectionInitialState, useSafeIntl } from 'bluesquare-components';
 import { FilterButton } from '../../../../components/FilterButton';
-import { useFilterState } from '../../../../hooks/useFilterState';
-import InputComponent from '../../../../components/forms/InputComponent';
-import { baseUrls } from '../../../../constants/urls';
-import MESSAGES from '../../messages';
-import { OrgUnitTreeviewModal } from '../../../orgUnits/components/TreeView/OrgUnitTreeviewModal';
-import { useGetOrgUnit } from '../../../orgUnits/components/TreeView/requests';
 
 import DatesRange from '../../../../components/filters/DatesRange';
-import { useGetForms } from '../../../workflows/hooks/requests/useGetForms';
-import { PotentialPaymentParams } from '../../types';
 import { AsyncSelect } from '../../../../components/forms/AsyncSelect';
+import InputComponent from '../../../../components/forms/InputComponent';
+import { baseUrls } from '../../../../constants/urls';
+import { useFilterState } from '../../../../hooks/useFilterState';
 import { getUsersDropDown } from '../../../instances/hooks/requests/getUsersDropDown';
 import { useGetProfilesDropdown } from '../../../instances/hooks/useGetProfilesDropdown';
+import { OrgUnitTreeviewModal } from '../../../orgUnits/components/TreeView/OrgUnitTreeviewModal';
+import { useGetOrgUnit } from '../../../orgUnits/components/TreeView/requests';
+import { Selection } from '../../../orgUnits/types/selection';
 import { useGetUserRolesDropDown } from '../../../userRoles/hooks/requests/useGetUserRoles';
+import { useGetForms } from '../../../workflows/hooks/requests/useGetForms';
+import MESSAGES from '../../messages';
+import { PotentialPaymentParams, PotentialPayment } from '../../types';
 
 const baseUrl = baseUrls.potentialPayments;
-type Props = { params: PotentialPaymentParams };
+type Props = {
+    params: PotentialPaymentParams;
+    setSelection: Dispatch<SetStateAction<Selection<PotentialPayment>>>;
+};
 
 export const PotentialPaymentsFilters: FunctionComponent<Props> = ({
     params,
+    setSelection,
 }) => {
     const { formatMessage } = useSafeIntl();
     const { filters, handleSearch, handleChange, filtersUpdated } =
@@ -46,6 +57,10 @@ export const PotentialPaymentsFilters: FunctionComponent<Props> = ({
         },
         [handleChange],
     );
+    const onSearch = useCallback(() => {
+        setSelection(selectionInitialState);
+        handleSearch();
+    }, [handleSearch, setSelection]);
 
     return (
         <Grid container spacing={2}>
@@ -114,7 +129,7 @@ export const PotentialPaymentsFilters: FunctionComponent<Props> = ({
                 <Box mt={2} display="flex" justifyContent="flex-end">
                     <FilterButton
                         disabled={!filtersUpdated}
-                        onFilter={handleSearch}
+                        onFilter={onSearch}
                     />
                 </Box>
             </Grid>


### PR DESCRIPTION
If you:

- go to the potential payments page
- select all available potential payments
- change filters in order to not have any results and hit the “filter” button

You will see that the “create new payment lot” button is not disabled

Related JIRA tickets : IA-4221

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [x] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

- reset selection if filters are changing
- disable button if result is empty

## How to test

 repeat the initial process, button should be disabled

## Print screen / video

https://github.com/user-attachments/assets/79199487-5b35-46e6-8ef3-7d6d8e786bff


## Notes

-

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
