### PR TITLE
IA-4291: Completeness stats CSV feed-back

### DIFF
--- a/iaso/api/completeness_stats.py
+++ b/iaso/api/completeness_stats.py
@@ -81,7 +81,7 @@ class CompletenessStatsCSVRenderer(rest_framework_csv.renderers.CSVRenderer):
             return super().render(data, accepted_media_type, renderer_context)
 
         # Build the header in the desired order
-        header = ["id", "org_unit_name", "org_unit_type_name", "parent_org_unit_name", "has_children"]
+        header = ["id", "org_unit_name", "org_unit_type_name", "parent_org_unit_name"]
 
         # Add form-specific columns to the header
         for form in forms:
@@ -91,6 +91,7 @@ class CompletenessStatsCSVRenderer(rest_framework_csv.renderers.CSVRenderer):
                     f"{form_name} - Descendants Numerator",
                     f"{form_name} - Descendants Denominator",
                     f"{form_name} - Descendants Percentage",
+                    f"{form_name} - Itself Target",
                 ]
             )
 
@@ -110,7 +111,6 @@ class CompletenessStatsCSVRenderer(rest_framework_csv.renderers.CSVRenderer):
                         "parent_org_unit_name",
                         row.get("parent_org_unit", {}).get("name", "") if row.get("parent_org_unit") else "",
                     ),
-                    ("has_children", row.get("has_children", False)),
                 ]
             )
 
@@ -121,9 +121,36 @@ class CompletenessStatsCSVRenderer(rest_framework_csv.renderers.CSVRenderer):
                 form_name = form.get("name", "")
                 form_stats_data = form_stats.get(form_slug, {})
 
-                transformed_row[f"{form_name} - Descendants Numerator"] = form_stats_data.get("descendants_ok", 0)
-                transformed_row[f"{form_name} - Descendants Denominator"] = form_stats_data.get("descendants", 0)
-                transformed_row[f"{form_name} - Descendants Percentage"] = form_stats_data.get("percent", 0)
+                descendants = form_stats_data.get("descendants", 0)
+                descendants_ok = form_stats_data.get("descendants_ok", 0)
+                itself_target = form_stats_data.get("itself_target", 0)
+                itself_has_instances = form_stats_data.get("itself_has_instances", 0)
+                percent = form_stats_data.get("percent", 0)
+
+                # If the form doesn't apply to this org unit (no descendants and not itself targeted), show N/A
+                if descendants == 0 and itself_target == 0:
+                    transformed_row[f"{form_name} - Descendants Numerator"] = "N/A"
+                    transformed_row[f"{form_name} - Descendants Denominator"] = "N/A"
+                    transformed_row[f"{form_name} - Descendants Percentage"] = "N/A"
+                    transformed_row[f"{form_name} - Itself Target"] = "N/A"
+                else:
+                    transformed_row[f"{form_name} - Descendants Numerator"] = descendants_ok
+                    transformed_row[f"{form_name} - Descendants Denominator"] = descendants
+                    transformed_row[f"{form_name} - Descendants Percentage"] = percent
+
+                    # Itself Target logic:
+                    # - itself_target = 0 => N/A
+                    # - itself_target = 1 and itself_has_instances = 0 => false
+                    # - itself_target = 1 and itself_has_instances = 1 => true
+                    if itself_target == 0:
+                        transformed_row[f"{form_name} - Itself Target"] = "N/A"
+                    elif itself_target == 1 and itself_has_instances == 0:
+                        transformed_row[f"{form_name} - Itself Target"] = "false"
+                    elif itself_target == 1 and itself_has_instances == 1:
+                        transformed_row[f"{form_name} - Itself Target"] = "true"
+                    else:
+                        # Fallback for unexpected values
+                        transformed_row[f"{form_name} - Itself Target"] = "N/A"
 
             transformed_data.append(transformed_row)
 

--- a/iaso/tests/api/test_completeness_stats.py
+++ b/iaso/tests/api/test_completeness_stats.py
@@ -919,18 +919,63 @@ class CompletenessStatsAPITestCase(APITestCase):
             "org_unit_name",
             "org_unit_type_name",
             "parent_org_unit_name",
-            "has_children",
             f"{self.form_hs_1.name} - Descendants Numerator",
             f"{self.form_hs_1.name} - Descendants Denominator",
             f"{self.form_hs_1.name} - Descendants Percentage",
+            f"{self.form_hs_1.name} - Itself Target",
             f"{self.form_hs_2.name} - Descendants Numerator",
             f"{self.form_hs_2.name} - Descendants Denominator",
             f"{self.form_hs_2.name} - Descendants Percentage",
+            f"{self.form_hs_2.name} - Itself Target",
             f"{self.form_hs_4.name} - Descendants Numerator",
             f"{self.form_hs_4.name} - Descendants Denominator",
             f"{self.form_hs_4.name} - Descendants Percentage",
+            f"{self.form_hs_4.name} - Itself Target",
         ]
         self.assertEqual(header, expected_columns)
-        # Optionally, check the data rows for expected values
+
+        # Check the data rows for expected values
         for row in csv_data[1:]:  # Skip header row
             self.assertEqual(len(row), len(header))
+
+            org_unit_id = int(row[0])  # First column is id
+
+            # For "Not yet validated country" (id=9), form_hs_2 should show N/A
+            # because it has descendants=0 and itself_target=0 (form doesn't apply)
+            if org_unit_id == 9:
+                # Find the index of form_hs_2 columns
+                form_hs_2_numerator_idx = header.index(f"{self.form_hs_2.name} - Descendants Numerator")
+                form_hs_2_denominator_idx = header.index(f"{self.form_hs_2.name} - Descendants Denominator")
+                form_hs_2_percentage_idx = header.index(f"{self.form_hs_2.name} - Descendants Percentage")
+                form_hs_2_itself_idx = header.index(f"{self.form_hs_2.name} - Itself Target")
+
+                # Check that these columns show N/A for org unit 9 (form doesn't apply)
+                self.assertEqual(row[form_hs_2_numerator_idx], "N/A")
+                self.assertEqual(row[form_hs_2_denominator_idx], "N/A")
+                self.assertEqual(row[form_hs_2_percentage_idx], "N/A")
+                self.assertEqual(row[form_hs_2_itself_idx], "N/A")
+
+                # Check form_hs_4 for org unit 9 - it should show itself_target as "false"
+                # because form_hs_4 has itself_target=1 but itself_has_instances=0
+                form_hs_4_itself_idx = header.index(f"{self.form_hs_4.name} - Itself Target")
+                self.assertEqual(row[form_hs_4_itself_idx], "false")
+
+            # For "LaLaland" (id=1), form_hs_2 should show 0 values
+            # because it has descendants=1 and itself_target=0 (form applies but no submissions)
+            elif org_unit_id == 1:
+                # Find the index of form_hs_2 columns
+                form_hs_2_numerator_idx = header.index(f"{self.form_hs_2.name} - Descendants Numerator")
+                form_hs_2_denominator_idx = header.index(f"{self.form_hs_2.name} - Descendants Denominator")
+                form_hs_2_percentage_idx = header.index(f"{self.form_hs_2.name} - Descendants Percentage")
+                form_hs_2_itself_idx = header.index(f"{self.form_hs_2.name} - Itself Target")
+
+                # Check that these columns show 0 for org unit 1 (form applies but no submissions)
+                self.assertEqual(row[form_hs_2_numerator_idx], "0")
+                self.assertEqual(row[form_hs_2_denominator_idx], "1")
+                self.assertEqual(row[form_hs_2_percentage_idx], "0")
+                self.assertEqual(row[form_hs_2_itself_idx], "N/A")
+
+                # Check form_hs_4 for org unit 1 - it should show itself_target as "false"
+                # because form_hs_4 has itself_target=1 but itself_has_instances=0
+                form_hs_4_itself_idx = header.index(f"{self.form_hs_4.name} - Itself Target")
+                self.assertEqual(row[form_hs_4_itself_idx], "false")


### PR DESCRIPTION
It seems to me that the value of the “Direct” field still isn’t part of the csv even when there is data

Numerator, denominator and percentage display 0 in the csv when the online table shows NA

Is it necessary that the “has children” column appears in the csv? 



Related JIRA tickets : IA-4291

## Self proofreading checklist

- [ ] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

- added itself column
- remove has children column
- display N/A if non applicable
- adapt tests

## How to test

Go to completeness stats page and select a form with data entry, export CSV, check that itself column is present, that has children is removed and that is display N/A if not applicable instead of ZERO

## Print screen / video


## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
