### PR TITLE
IA-4313: Set microplanning ended_date required on mobile endpoint

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -253,6 +253,7 @@
     "iaso.error.label.planningAndTeams": "Planning and teams must be in the same project",
     "iaso.error.label.startDateAfterEndDate": "Start date can't after end date",
     "iaso.error.label.publishedWithoutStartDate": "Start date must be set when publishing",
+    "iaso.error.label.publishedWithoutEndDate": "End date must be set when publishing",
     "iaso.errors.label": "An error occurred",
     "iaso.errors.noPermissions": "There is no permission associated to this user. Please contact an administrator to request permission(s). Thank you!",
     "iaso.errors.noPermissionsTitle": "Awaiting Access Permissions",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/es.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/es.json
@@ -234,7 +234,7 @@
     "iaso.error.label.planningAndOrgUnit": "La planificación y la unidad organizativa deben estar en el mismo proyecto",
     "iaso.error.label.planningAndTeams": "La planificación y los equipos deben estar en el mismo proyecto",
     "iaso.error.label.publishedWithoutStartDate": "La fecha de inicio debe establecerse al publicar",
-    "iaso.error.label.publishedWithoutEndDate": "End date must be set when publishing",
+    "iaso.error.label.publishedWithoutEndDate": "La fecha de finalización debe establecerse al publicar",
     "iaso.error.label.startDateAfterEndDate": "La fecha de inicio no puede ser posterior a la fecha de fin",
     "iaso.errors.label": "Ocurrió un error",
     "iaso.errors.noPermissions": "No hay permisos asociados a este usuario. Por favor contacte a un administrador para solicitar permiso(s). ¡Gracias!",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/es.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/es.json
@@ -234,7 +234,7 @@
     "iaso.error.label.planningAndOrgUnit": "La planificación y la unidad organizativa deben estar en el mismo proyecto",
     "iaso.error.label.planningAndTeams": "La planificación y los equipos deben estar en el mismo proyecto",
     "iaso.error.label.publishedWithoutStartDate": "La fecha de inicio debe establecerse al publicar",
-
+    "iaso.error.label.publishedWithoutEndDate": "End date must be set when publishing",
     "iaso.error.label.startDateAfterEndDate": "La fecha de inicio no puede ser posterior a la fecha de fin",
     "iaso.errors.label": "Ocurrió un error",
     "iaso.errors.noPermissions": "No hay permisos asociados a este usuario. Por favor contacte a un administrador para solicitar permiso(s). ¡Gracias!",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -253,7 +253,7 @@
     "iaso.error.label.planningAndOrgUnit": "Planning et unité d'org. doivent faire partie du même projet",
     "iaso.error.label.planningAndTeams": "Planning et équipes doivent faire partie du même projet",
     "iaso.error.label.publishedWithoutStartDate": "La date de début doit être définie lors de la publication",
-    "iaso.error.label.publishedWithoutEndDate": "End date must be set when publishing",
+    "iaso.error.label.publishedWithoutEndDate": "La date de fin doit être définie lors de la publication",
     "iaso.error.label.startDateAfterEndDate": "La date de début ne peut être après la date de fin",
     "iaso.errors.label": "Une erreur est survenue.",
     "iaso.errors.noPermissions": "Aucune permission n'est associée à cet utilisateur. Veuillez contacter un administrateur pour demander la(les) permission(s). Merci !",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -253,6 +253,7 @@
     "iaso.error.label.planningAndOrgUnit": "Planning et unité d'org. doivent faire partie du même projet",
     "iaso.error.label.planningAndTeams": "Planning et équipes doivent faire partie du même projet",
     "iaso.error.label.publishedWithoutStartDate": "La date de début doit être définie lors de la publication",
+    "iaso.error.label.publishedWithoutEndDate": "End date must be set when publishing",
     "iaso.error.label.startDateAfterEndDate": "La date de début ne peut être après la date de fin",
     "iaso.errors.label": "Une erreur est survenue.",
     "iaso.errors.noPermissions": "Aucune permission n'est associée à cet utilisateur. Veuillez contacter un administrateur pour demander la(les) permission(s). Merci !",

--- a/hat/assets/js/apps/Iaso/domains/plannings/messages.ts
+++ b/hat/assets/js/apps/Iaso/domains/plannings/messages.ts
@@ -153,6 +153,10 @@ const MESSAGES = defineMessages({
         id: 'iaso.error.label.publishedWithoutStartDate',
         defaultMessage: 'Start date must be set when publishing',
     },
+    publishedWithoutEndDate: {
+        id: 'iaso.error.label.publishedWithoutEndDate',
+        defaultMessage: 'End date must be set when publishing',
+    },
     formSelectHelperText: {
         id: 'iaso.label.formSelectHelperText',
         defaultMessage: 'You must select a project before selecting a form',

--- a/iaso/api/microplanning.py
+++ b/iaso/api/microplanning.py
@@ -304,6 +304,8 @@ class PlanningSerializer(serializers.ModelSerializer):
 
         if validated_data.get("published_at") and validated_data.get("started_at") is None:
             validation_errors["started_at"] = "publishedWithoutStartDate"
+        if validated_data.get("published_at") and validated_data.get("ended_at") is None:
+            validation_errors["ended_at"] = "publishedWithoutEndDate"
 
         project = validated_data.get("project", self.instance.project if self.instance else None)
 
@@ -596,6 +598,7 @@ class MobilePlanningViewSet(ModelViewSet):
             Planning.objects.filter(assignment__user=user)
             .exclude(published_at__isnull=True)
             .exclude(started_at__isnull=True)
+            .exclude(ended_at__isnull=True)
             .filter(deleted_at__isnull=True)
             .distinct()
         )

--- a/iaso/tests/test_microplanning.py
+++ b/iaso/tests/test_microplanning.py
@@ -587,7 +587,12 @@ class PlanningTestCase(APITestCase):
         cls.form1.projects.add(project1)
         cls.form2.projects.add(project1)
         cls.planning = Planning.objects.create(
-            project=project1, name="planning1", team=cls.team1, org_unit=org_unit, started_at="2025-01-01"
+            project=project1,
+            name="planning1",
+            team=cls.team1,
+            org_unit=org_unit,
+            started_at="2025-01-01",
+            ended_at="2025-01-10",
         )
 
     def test_query_happy_path(self):
@@ -624,7 +629,7 @@ class PlanningTestCase(APITestCase):
                 "description": "",
                 "published_at": None,
                 "started_at": "2025-01-01",
-                "ended_at": None,
+                "ended_at": "2025-01-10",
             },
             r,
         )
@@ -735,6 +740,31 @@ class PlanningTestCase(APITestCase):
         self.assertIsNotNone(r["started_at"])
         self.assertEqual(r["started_at"][0], "publishedWithoutStartDate")
 
+    def test_patch_api__throw_error_if_published_and_no_ended_date(self):
+        planning = Planning.objects.create(
+            name="Planning to modify",
+            project=self.project1,
+            org_unit=self.org_unit,
+            team=self.team1,
+        )
+        user_with_perms = self.create_user_with_profile(
+            username="user_with_perms", account=self.account, permissions=["iaso_planning_write"]
+        )
+        self.client.force_authenticate(user_with_perms)
+        data = {
+            "name": "My Planning",
+            "forms": [self.form1.id, self.form2.id],
+            "team": self.team1.id,
+            "team_details": {"id": self.team1.id, "name": self.team1.name},
+            "published_at": "2022-02-02",
+            "started_at": "2022-03-03",
+        }
+        response = self.client.patch(f"/api/microplanning/plannings/{planning.id}/", data=data, format="json")
+        r = self.assertJSONResponse(response, 400)
+        print(r)
+        self.assertIsNotNone(r["ended_at"])
+        self.assertEqual(r["ended_at"][0], "publishedWithoutEndDate")
+
     def test_create_api(self):
         user_with_perms = self.create_user_with_profile(
             username="user_with_perms", account=self.account, permissions=["iaso_planning_write"]
@@ -793,7 +823,12 @@ class AssignmentAPITestCase(APITestCase):
         OrgUnit.objects.create(version=version, parent=root_org_unit, name="child2")
 
         cls.planning = Planning.objects.create(
-            project=project1, name="planning1", team=cls.team1, org_unit=root_org_unit, started_at="2025-01-01"
+            project=project1,
+            name="planning1",
+            team=cls.team1,
+            org_unit=root_org_unit,
+            started_at="2025-01-01",
+            ended_at="2025-01-10",
         )
         Assignment.objects.create(
             planning=cls.planning,
@@ -985,28 +1020,39 @@ class AssignmentAPITestCase(APITestCase):
             team=self.team1,
             org_unit=self.root_org_unit,
             started_at="2025-01-01",
+            ended_at="2025-01-10",
+            published_at="2025-01-01",
         )
         p.assignment_set.create(org_unit=self.child1, user=self.user)
         p.assignment_set.create(org_unit=self.child2, user=self.user)
 
         # This one should not be returned because started_at is None
         p4 = Planning.objects.create(
-            project=self.project1, name="planning4", team=self.team1, org_unit=self.root_org_unit
+            project=self.project1,
+            name="planning4",
+            team=self.team1,
+            org_unit=self.root_org_unit,
+            started_at=None,
+            ended_at="2025-01-10",
         )
         p4.assignment_set.create(org_unit=self.child3, user=self.user)
         p4.assignment_set.create(org_unit=self.child4, user=self.user)
 
-        Planning.objects.create(
+        # This one should not be returned because ended_at is None
+        p5 = Planning.objects.create(
             project=self.project1,
-            name="planning3",
+            name="planning5",
             team=self.team1,
             org_unit=self.root_org_unit,
-            started_at="2025-01-01",
+            started_at="2025-01-10",
+            ended_at=None,
         )
+        p5.assignment_set.create(org_unit=self.child3, user=self.user)
+        p5.assignment_set.create(org_unit=self.child4, user=self.user)
 
         plannings = Planning.objects.filter(assignment__user=self.user).distinct()
         Planning.objects.update(published_at=now())
-        self.assertEqual(plannings.count(), 3)
+        self.assertEqual(plannings.count(), 4)
 
         self.client.force_authenticate(self.user)
 


### PR DESCRIPTION
What problem is this PR solving? Explain here in one sentence.

Related JIRA tickets : [IA-4313](https://bluesquare.atlassian.net/browse/IA-4313)

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Mobile api for planning: Filter out planning where ended_at date is null to prevent failure in mobile app.

Display an error message when start date is not defined and publish is.
<img width="923" height="574" alt="image" src="https://github.com/user-attachments/assets/f82da1cc-2e38-4bef-8ec7-25f4b3e0e729" />



## Changes

Filter out Plannings from MobilePlanningViewSet when ended_at is null

## How to test

You can create a new planning and publish it (without end date).
http://localhost:8081/dashboard/planning/list/accountId/1/publishingStatus/all/order/name/pageSize/20/page/1

Go api and check if item is returned (note that it could be filtered out if you are not part of the team it is attached to).
 http://localhost:8081/api/mobile/plannings/
 
 Then go and modify the planning to have a start date.
 Go back through the api and it should now appear.

## Print screen / video
 /

## Notes

 /

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.


[IA-4313]: https://bluesquare.atlassian.net/browse/IA-4313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ