### PR TITLE
IA-4291: completeness stats, rename an change order

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -92,7 +92,7 @@
     "iaso.completenessStats.descendantsNoSubmissionExpected": "No descendant OrgUnit is expected to fill that form. Check the Form config if this is unexpected",
     "iaso.completenessStats.directCompleteness": "Form filled at org unit",
     "iaso.completenessStats.formsInfos": "Please select one form to enable completeness map view",
-    "iaso.completenessStats.itselfColumnLabel": "Itself",
+    "iaso.completenessStats.itselfColumnLabel": "Direct",
     "iaso.completenessStats.itselfColumnTitle": "Submissions on this org unit",
     "iaso.completenessStats.itselfNoSubmissionExcepted": "No submission is expected on this level for this form",
     "iaso.completenessStats.itselfSubmissionCount": "Total submissions: {value}",

--- a/hat/assets/js/apps/Iaso/domains/completenessStats/messages.ts
+++ b/hat/assets/js/apps/Iaso/domains/completenessStats/messages.ts
@@ -62,7 +62,7 @@ const MESSAGES = defineMessages({
         id: 'iaso.completenessStats.itselfColumnTitle',
     },
     itselfColumnLabel: {
-        defaultMessage: 'Itself',
+        defaultMessage: 'Direct',
         id: 'iaso.completenessStats.itselfColumnLabel',
     },
     itselfSubmissionCount: {

--- a/iaso/api/completeness_stats.py
+++ b/iaso/api/completeness_stats.py
@@ -88,10 +88,10 @@ class CompletenessStatsCSVRenderer(rest_framework_csv.renderers.CSVRenderer):
             form_name = form.get("name", "")
             header.extend(
                 [
+                    f"{form_name} - Direct",
                     f"{form_name} - Descendants Numerator",
                     f"{form_name} - Descendants Denominator",
                     f"{form_name} - Descendants Percentage",
-                    f"{form_name} - Itself Target",
                 ]
             )
 
@@ -129,28 +129,28 @@ class CompletenessStatsCSVRenderer(rest_framework_csv.renderers.CSVRenderer):
 
                 # If the form doesn't apply to this org unit (no descendants and not itself targeted), show N/A
                 if descendants == 0 and itself_target == 0:
+                    transformed_row[f"{form_name} - Direct"] = "N/A"
                     transformed_row[f"{form_name} - Descendants Numerator"] = "N/A"
                     transformed_row[f"{form_name} - Descendants Denominator"] = "N/A"
                     transformed_row[f"{form_name} - Descendants Percentage"] = "N/A"
-                    transformed_row[f"{form_name} - Itself Target"] = "N/A"
                 else:
-                    transformed_row[f"{form_name} - Descendants Numerator"] = descendants_ok
-                    transformed_row[f"{form_name} - Descendants Denominator"] = descendants
-                    transformed_row[f"{form_name} - Descendants Percentage"] = percent
-
-                    # Itself Target logic:
+                    # Direct logic:
                     # - itself_target = 0 => N/A
                     # - itself_target = 1 and itself_has_instances = 0 => false
                     # - itself_target = 1 and itself_has_instances = 1 => true
                     if itself_target == 0:
-                        transformed_row[f"{form_name} - Itself Target"] = "N/A"
+                        transformed_row[f"{form_name} - Direct"] = "N/A"
                     elif itself_target == 1 and itself_has_instances == 0:
-                        transformed_row[f"{form_name} - Itself Target"] = "false"
+                        transformed_row[f"{form_name} - Direct"] = "false"
                     elif itself_target == 1 and itself_has_instances == 1:
-                        transformed_row[f"{form_name} - Itself Target"] = "true"
+                        transformed_row[f"{form_name} - Direct"] = "true"
                     else:
                         # Fallback for unexpected values
-                        transformed_row[f"{form_name} - Itself Target"] = "N/A"
+                        transformed_row[f"{form_name} - Direct"] = "N/A"
+
+                    transformed_row[f"{form_name} - Descendants Numerator"] = descendants_ok
+                    transformed_row[f"{form_name} - Descendants Denominator"] = descendants
+                    transformed_row[f"{form_name} - Descendants Percentage"] = percent
 
             transformed_data.append(transformed_row)
 

--- a/iaso/tests/api/test_completeness_stats.py
+++ b/iaso/tests/api/test_completeness_stats.py
@@ -919,18 +919,18 @@ class CompletenessStatsAPITestCase(APITestCase):
             "org_unit_name",
             "org_unit_type_name",
             "parent_org_unit_name",
+            f"{self.form_hs_1.name} - Direct",
             f"{self.form_hs_1.name} - Descendants Numerator",
             f"{self.form_hs_1.name} - Descendants Denominator",
             f"{self.form_hs_1.name} - Descendants Percentage",
-            f"{self.form_hs_1.name} - Itself Target",
+            f"{self.form_hs_2.name} - Direct",
             f"{self.form_hs_2.name} - Descendants Numerator",
             f"{self.form_hs_2.name} - Descendants Denominator",
             f"{self.form_hs_2.name} - Descendants Percentage",
-            f"{self.form_hs_2.name} - Itself Target",
+            f"{self.form_hs_4.name} - Direct",
             f"{self.form_hs_4.name} - Descendants Numerator",
             f"{self.form_hs_4.name} - Descendants Denominator",
             f"{self.form_hs_4.name} - Descendants Percentage",
-            f"{self.form_hs_4.name} - Itself Target",
         ]
         self.assertEqual(header, expected_columns)
 
@@ -944,38 +944,38 @@ class CompletenessStatsAPITestCase(APITestCase):
             # because it has descendants=0 and itself_target=0 (form doesn't apply)
             if org_unit_id == 9:
                 # Find the index of form_hs_2 columns
+                form_hs_2_direct_idx = header.index(f"{self.form_hs_2.name} - Direct")
                 form_hs_2_numerator_idx = header.index(f"{self.form_hs_2.name} - Descendants Numerator")
                 form_hs_2_denominator_idx = header.index(f"{self.form_hs_2.name} - Descendants Denominator")
                 form_hs_2_percentage_idx = header.index(f"{self.form_hs_2.name} - Descendants Percentage")
-                form_hs_2_itself_idx = header.index(f"{self.form_hs_2.name} - Itself Target")
 
                 # Check that these columns show N/A for org unit 9 (form doesn't apply)
+                self.assertEqual(row[form_hs_2_direct_idx], "N/A")
                 self.assertEqual(row[form_hs_2_numerator_idx], "N/A")
                 self.assertEqual(row[form_hs_2_denominator_idx], "N/A")
                 self.assertEqual(row[form_hs_2_percentage_idx], "N/A")
-                self.assertEqual(row[form_hs_2_itself_idx], "N/A")
 
-                # Check form_hs_4 for org unit 9 - it should show itself_target as "false"
+                # Check form_hs_4 for org unit 9 - it should show direct as "false"
                 # because form_hs_4 has itself_target=1 but itself_has_instances=0
-                form_hs_4_itself_idx = header.index(f"{self.form_hs_4.name} - Itself Target")
-                self.assertEqual(row[form_hs_4_itself_idx], "false")
+                form_hs_4_direct_idx = header.index(f"{self.form_hs_4.name} - Direct")
+                self.assertEqual(row[form_hs_4_direct_idx], "false")
 
             # For "LaLaland" (id=1), form_hs_2 should show 0 values
             # because it has descendants=1 and itself_target=0 (form applies but no submissions)
             elif org_unit_id == 1:
                 # Find the index of form_hs_2 columns
+                form_hs_2_direct_idx = header.index(f"{self.form_hs_2.name} - Direct")
                 form_hs_2_numerator_idx = header.index(f"{self.form_hs_2.name} - Descendants Numerator")
                 form_hs_2_denominator_idx = header.index(f"{self.form_hs_2.name} - Descendants Denominator")
                 form_hs_2_percentage_idx = header.index(f"{self.form_hs_2.name} - Descendants Percentage")
-                form_hs_2_itself_idx = header.index(f"{self.form_hs_2.name} - Itself Target")
 
                 # Check that these columns show 0 for org unit 1 (form applies but no submissions)
+                self.assertEqual(row[form_hs_2_direct_idx], "N/A")
                 self.assertEqual(row[form_hs_2_numerator_idx], "0")
                 self.assertEqual(row[form_hs_2_denominator_idx], "1")
                 self.assertEqual(row[form_hs_2_percentage_idx], "0")
-                self.assertEqual(row[form_hs_2_itself_idx], "N/A")
 
-                # Check form_hs_4 for org unit 1 - it should show itself_target as "false"
+                # Check form_hs_4 for org unit 1 - it should show direct as "false"
                 # because form_hs_4 has itself_target=1 but itself_has_instances=0
-                form_hs_4_itself_idx = header.index(f"{self.form_hs_4.name} - Itself Target")
-                self.assertEqual(row[form_hs_4_itself_idx], "false")
+                form_hs_4_direct_idx = header.index(f"{self.form_hs_4.name} - Direct")
+                self.assertEqual(row[form_hs_4_direct_idx], "false")


### PR DESCRIPTION
Use the same denomination as on the completeness stat page, i.e. “Direct” (instead of “Itself Target”) or at least align both?
Put that column before the numerator/denominator/% ones as on the completeness stat page (instead of after)?

Related JIRA tickets : IA-4291

## Self proofreading checklist

- [ ] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

-

## Changes

 rename itself to direct an change order of columns

## How to test

download a csv file for the completeness stats, check order columns and the naming of itself should be replace by  direct

## Print screen / video

-

## Notes

-

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
