### PR TITLE
[POLIO-1974] Fix polio permissions in OrgUnits

### DIFF
--- a/iaso/api/org_units.py
+++ b/iaso/api/org_units.py
@@ -63,10 +63,17 @@ class HasOrgUnitPermission(permissions.BasePermission):
                 or request.user.has_perm(permission.SUBMISSIONS)
                 or request.user.has_perm(permission.REGISTRY_WRITE)
                 or request.user.has_perm(permission.REGISTRY_READ)
-                or request.user.has_perm(permission.POLIO)
             )
         ):
             return False
+
+        # Split polio checks from previous block - run only if polio plugin is enabled
+        if "polio" in settings.PLUGINS:
+            from plugins.polio import permissions as polio_permissions
+
+            has_polio_perm = request.user.has_perm(polio_permissions.POLIO)
+            if not (request.user.is_authenticated and has_polio_perm):
+                return False
 
         read_only = request.user.has_perm(permission.ORG_UNITS_READ) and not request.user.has_perm(permission.ORG_UNITS)
         if (read_only or obj.version.data_source.read_only) and request.method != "GET":


### PR DESCRIPTION
Fix the polio permission import in OrgUnits API

Related JIRA tickets : POLIO-1974

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

/

## Changes

/

## How to test

- Have a polio pyramid stored in a private (non-public) data source
- Login with a user that doesn't have any of the following permissions
<img width="445" height="164" alt="image" src="https://github.com/user-attachments/assets/d5e02ed8-9dfb-47ab-a18f-2225a044ce9f" />

- Go to `/api/orgunits/<id-of-one-of-your-polio-org-units>`
- Depending on whether your user has the `POLIO` permission, you will see the data (or not). The backend should not crash



## Print screen / video

/

## Notes
/

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
