### PR TITLE
fix: bulk uploads remove error from APIImport on successfull run

### DIFF
--- a/iaso/tasks/process_mobile_bulk_upload.py
+++ b/iaso/tasks/process_mobile_bulk_upload.py
@@ -112,6 +112,9 @@ def process_mobile_bulk_upload(api_import_id, project_id, task=None):
         api_import.save()
         raise e
 
+    api_import.has_problem = False
+    api_import.exception = ""
+    api_import.save()
     the_task.report_success_with_result(
         message=result_message(user, project, start_date, start_time, stats),
     )


### PR DESCRIPTION
Small fix: When an errored task is relaunched, we want the corresponding `api_import` to no longer show up as errored in the Django admin.