### PR TITLE
[IA-4386] Fix api/modules endpoint

### DIFF
--- a/iaso/api/modules.py
+++ b/iaso/api/modules.py
@@ -70,7 +70,7 @@ class ModulesViewSet(ModelViewSet):
     def get_queryset(self):
         queryset = []
         for module in MODULES:
-            permissions = MODULE_PERMISSIONS[module["codename"]]
+            permissions = MODULE_PERMISSIONS.get(module["codename"], [])
             name = module["name"]
             codename = module["codename"]
             fr_name = module["fr_name"]


### PR DESCRIPTION
Fix `api/modules/` endpoint

Related JIRA tickets : IA-4386

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

/

## Changes

Added a default empty permissions list when a module is not installed.

## How to test

- Have a setup without the polio plugin installed
- Login and go to `api/modules/`
- The page shouldn't crash

## Print screen / video

<img width="318" height="228" alt="image" src="https://github.com/user-attachments/assets/c2617db9-b300-4b9d-a066-41484ffd0ab2" />


## Notes

There's no test because:
- the polio plugin is always active in the CI, and disabling it with `@override_settings()` in the test does not work (it's probably executed after permissions are already loaded)
- modules are going to be redone soon (with permissions) and tests will need to be changed anyway at that point

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
