### PR TITLE
IA-4377 Form versions speedup

### DIFF
--- a/iaso/tests/api/test_forms_attachment.py
+++ b/iaso/tests/api/test_forms_attachment.py
@@ -29,7 +29,16 @@ from django.conf import settings
 from django.test import override_settings
 
 
-@override_settings(ENKETO_SIGNING_SECRET="supersecret")
+enketo_test_settings = {
+    "ENKETO_API_TOKEN": "ENKETO_API_TOKEN_TEST",
+    "ENKETO_URL": "https://enketo_url.host.test",
+    "ENKETO_API_SURVEY_PATH": "/api_v2/survey",
+    "ENKETO_API_INSTANCE_PATH": "/api_v2/instance",
+    "ENKETO_SIGNING_SECRET": "supersecret",
+}
+
+
+@override_settings(ENKETO=enketo_test_settings)
 class FormAttachmentsAPITestCase(APITestCase):
     project_1: m.Project
     DT = datetime.datetime(2024, 10, 9, 16, 45, 27, tzinfo=datetime.timezone.utc)
@@ -395,7 +404,7 @@ class FormAttachmentsAPITestCase(APITestCase):
         """Test that signed anonymous URLs can be used to fetch manifests (enketo use case)"""
         path = MANIFEST_ENKETO_URL.format(form_id=self.form_2.id)
         signed_url = generate_signed_url(
-            path, settings.ENKETO_SIGNING_SECRET, extra_params={APP_ID: self.project_1.app_id}
+            path, settings.ENKETO.get("ENKETO_SIGNING_SECRET"), extra_params={APP_ID: self.project_1.app_id}
         )
 
         response = self.client.get(signed_url)
@@ -430,7 +439,7 @@ class FormAttachmentsAPITestCase(APITestCase):
         # Rebuilding the signed URL with the app_id
         path = MANIFEST_ENKETO_URL.format(form_id=self.form_2.id)
         signed_url = generate_signed_url(
-            path, settings.ENKETO_SIGNING_SECRET, extra_params={APP_ID: self.project_1.app_id}
+            path, settings.ENKETO.get("ENKETO_SIGNING_SECRET"), extra_params={APP_ID: self.project_1.app_id}
         )
 
         response = self.client.get(signed_url)
@@ -457,7 +466,7 @@ class FormAttachmentsAPITestCase(APITestCase):
         """Test that an invalid signed anonymous URL generates an error"""
         path = MANIFEST_ENKETO_URL.format(form_id=self.form_2.id)
         signed_url = generate_signed_url(
-            path, settings.ENKETO_SIGNING_SECRET, extra_params={APP_ID: self.project_1.app_id}
+            path, settings.ENKETO.get("ENKETO_SIGNING_SECRET"), extra_params={APP_ID: self.project_1.app_id}
         )
 
         response = self.client.get(f"{signed_url}error")
@@ -470,7 +479,7 @@ class FormAttachmentsAPITestCase(APITestCase):
         """Test that a signed anonymous URL generates an error when querying an unknown form"""
         path = MANIFEST_ENKETO_URL.format(form_id=123456789)
         signed_url = generate_signed_url(
-            path, settings.ENKETO_SIGNING_SECRET, extra_params={APP_ID: self.project_1.app_id}
+            path, settings.ENKETO.get("ENKETO_SIGNING_SECRET"), extra_params={APP_ID: self.project_1.app_id}
         )
 
         response = self.client.get(signed_url)

--- a/iaso/tests/api/test_forms_attachment.py
+++ b/iaso/tests/api/test_forms_attachment.py
@@ -376,7 +376,10 @@ class FormAttachmentsAPITestCase(APITestCase):
 
         return response.content
 
-    @override_settings(DEBUG=True)
+    @override_settings(
+        MIDDLEWARE=[mw for mw in settings.MIDDLEWARE if "querycount.middleware.QueryCountMiddleware" not in mw],
+        DEBUG=True,
+    )
     def test_manifest_anonymous_app_id(self):
         f"""GET {BASE_URL} via app id"""
         reset_queries()


### PR DESCRIPTION
the load of the "self.get_objects" trigger the whole get_queryset with heavy count and max(instance_updated_at)

Related JIRA tickets : IA-4377
## Self proofreading checklist

- [ ] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

I fixed the test that didn't work in docker (known issue by thibault)

I tried various way to skip the get_object but the http status behaviour was never the one expected by the test. So I ended up check if is_request_from_manifest to skip all the heavy queries.

## How to test

seed a project
login
edit the PCA form 
  - add an attachement

then test by accessing the url (change the id with your seed form)

`view-source:http://localhost:8081/api/forms/7/manifest/`

it should display an xml like this one
```
<?xml version="1.0" encoding="UTF-8"?>
<manifest xmlns="http://openrosa.org/xforms/xformsManifest">
    <mediaFile>
        <filename>annif.jpeg</filename>
        <hash>md5:f2da2c4d60f2ec309accf178f785a852</hash>
        <downloadUrl>http://iaso:8081/media/form_attachments/7/annif.jpeg</downloadUrl>
    </mediaFile>
</manifest>
```
and the logs should says 

```
iaso-1     | http://localhost:8081/api/forms/7/manifest/
iaso-1     | |------|-----------|----------|----------|----------|------------|
iaso-1     | | Type | Database  |   Reads  |  Writes  |  Totals  | Duplicates |
iaso-1     | |------|-----------|----------|----------|----------|------------|
iaso-1     | | RESP |  default  |    9     |    0     |    9     |     0      |
iaso-1     | |------|-----------|----------|----------|----------|------------|
iaso-1     | Total queries: 9 in 0.1167s 
```

previous it was 17 and the main sql was with condition like
```
  MAX("iaso_instance"."updated_at") AS "instance_updated_at",
                COUNT(DISTINCT "iaso_instance"."id") FILTER (
                                                             WHERE (NOT ("iaso_instance"."file" = ''
                                                                         AND "iaso_instance"."file" IS NOT NULL)
                                                                    AND NOT ("iaso_device"."test_device"
                                                                             AND "iaso_device"."test_device" IS NOT NULL)
                                                                    AND NOT ("iaso_instance"."deleted"
                                                                             AND "iaso_instance"."deleted" IS NOT NULL))) AS "instances_count",
```

now there's no more joins on iaso_instance.


## Print screen / video


## Notes


## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
