### PR TITLE
IA-4363 Fix flaky tests (bis)

### DIFF
--- a/hat/audit/tests.py
+++ b/hat/audit/tests.py
@@ -10,7 +10,7 @@ from iaso import models as m
 from iaso.test import TestCase
 
 
-class ModelTestCase(TestCase):
+class ModificationModelTestCase(TestCase):
     """
     Test the `Modification` model.
     """
@@ -71,7 +71,7 @@ class ModelTestCase(TestCase):
             "object_id": self.org_unit.pk,
             "source": "org_unit_change_request",
             "user": {
-                "id": self.user.pk,
+                "id": self.user.iaso_profile.pk,
                 "first_name": "",
                 "user_name": "user",
                 "last_name": "",

--- a/hat/settings.py
+++ b/hat/settings.py
@@ -429,7 +429,6 @@ REST_FRAMEWORK = {
         "rest_framework.renderers.BrowsableAPIRenderer",
         "rest_framework_csv.renderers.CSVRenderer",
     ),
-    "TEST_REQUEST_DEFAULT_FORMAT": "json",
 }
 
 SIMPLE_JWT = {

--- a/hat/settings.py
+++ b/hat/settings.py
@@ -429,6 +429,7 @@ REST_FRAMEWORK = {
         "rest_framework.renderers.BrowsableAPIRenderer",
         "rest_framework_csv.renderers.CSVRenderer",
     ),
+    "TEST_REQUEST_DEFAULT_FORMAT": "json",
 }
 
 SIMPLE_JWT = {

--- a/iaso/api/payments/views.py
+++ b/iaso/api/payments/views.py
@@ -230,7 +230,7 @@ class PaymentLotsViewSet(ModelViewSet):
         user = self.request.user
         name = request.data.get("name")
         comment = request.data.get("comment")
-        potential_payment_ids = request.POST.getlist("potential_payments")  # Expecting a list of IDs
+        potential_payment_ids = request.data.get("potential_payments", [])  # Expecting a list of IDs
 
         try:
             potential_payment_ids = [int(pp_id) for pp_id in potential_payment_ids]

--- a/iaso/api/payments/views.py
+++ b/iaso/api/payments/views.py
@@ -230,7 +230,7 @@ class PaymentLotsViewSet(ModelViewSet):
         user = self.request.user
         name = request.data.get("name")
         comment = request.data.get("comment")
-        potential_payment_ids = request.data.getlist("potential_payments")  # Expecting a list of IDs
+        potential_payment_ids = request.POST.getlist("potential_payments")  # Expecting a list of IDs
 
         try:
             potential_payment_ids = [int(pp_id) for pp_id in potential_payment_ids]

--- a/iaso/tests/api/payments/test_payment_lots.py
+++ b/iaso/tests/api/payments/test_payment_lots.py
@@ -155,7 +155,9 @@ class PaymentLotsViewSetAPITestCase(TaskAPITestCase):
 
     def test_update_payment_lot_mark_payments_as_sent(self):
         self.client.force_authenticate(self.user)
-        response = self.client.patch(f"/api/payments/lots/{self.payment_lot.id}/?mark_payments_as_sent=true")
+        response = self.client.patch(
+            f"/api/payments/lots/{self.payment_lot.id}/?mark_payments_as_sent=true", format="json"
+        )
         self.assertJSONResponse(response, 201)
         data = response.json()
         task = self.assertValidTaskAndInDB(data["task"], status="QUEUED", name="mark_payments_as_read")
@@ -174,13 +176,13 @@ class PaymentLotsViewSetAPITestCase(TaskAPITestCase):
 
     def test_retrieve_payment_lot(self):
         self.client.force_authenticate(self.user)
-        response = self.client.get(f"/api/payments/lots/{self.payment_lot.id}/")
+        response = self.client.get(f"/api/payments/lots/{self.payment_lot.id}/", format="json")
         self.assertJSONResponse(response, 200)
         self.assertEqual(response.data["name"], self.payment_lot.name)
 
     def test_retrieve_payment_lot_to_csv(self):
         self.client.force_authenticate(self.user)
-        response = self.client.get(f"/api/payments/lots/{self.payment_lot.id}/?csv=true")
+        response = self.client.get(f"/api/payments/lots/{self.payment_lot.id}/?csv=true", format="json")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response["Content-Type"], "text/csv")
         response_csv = response.getvalue().decode("utf-8")
@@ -197,7 +199,7 @@ class PaymentLotsViewSetAPITestCase(TaskAPITestCase):
         extra_change_request.new_reference_instances.set([self.instance1, self.instance2, self.instance3])
 
         with self.assertNumQueries(10):
-            response = self.client.get(f"/api/payments/lots/{self.payment_lot.id}/?xlsx=true")
+            response = self.client.get(f"/api/payments/lots/{self.payment_lot.id}/?xlsx=true", format="json")
             excel_columns, excel_data = self.assertXlsxFileResponse(response)
 
         self.assertEqual(
@@ -296,6 +298,7 @@ class PaymentLotsViewSetAPITestCase(TaskAPITestCase):
                 "name": "New Payment Lot",
                 "potential_payments": [self.potential_payment.pk, self.potential_payment_with_task.pk],
             },
+            format="json",
         )
 
         self.assertJSONResponse(response, 201)
@@ -316,6 +319,7 @@ class PaymentLotsViewSetAPITestCase(TaskAPITestCase):
                 "name": "New Payment Lot",
                 "potential_payments": [self.potential_payment.pk, self.potential_payment_with_task.pk + 100],
             },
+            format="json",
         )
 
         self.assertJSONResponse(response, 201)
@@ -330,7 +334,7 @@ class PaymentLotsViewSetAPITestCase(TaskAPITestCase):
 
     def test_geo_limited_user_cannot_see_change_requests_not_in_org_units(self):
         self.client.force_authenticate(self.geo_limited_user)
-        response = self.client.get("/api/payments/lots/")
+        response = self.client.get("/api/payments/lots/", format="json")
         self.assertJSONResponse(response, 200)
         data = response.json()
         results = data["results"]

--- a/iaso/tests/api/payments/test_payment_lots.py
+++ b/iaso/tests/api/payments/test_payment_lots.py
@@ -95,20 +95,20 @@ class PaymentLotsViewSetAPITestCase(TaskAPITestCase):
 
         # Invalid format for `potential_payments`.
         data = {"name": "New Payment Lot", "potential_payments": "foo"}
-        response = self.client.post("/api/payments/lots/", data)
+        response = self.client.post("/api/payments/lots/", data, format="json")
         self.assertJSONResponse(response, 400)
         self.assertEqual(response.json(), ["Expecting `potential_payments` to be a list of IDs."])
 
         # No `potential_payments`.
         data = {"name": "New Payment Lot"}
-        response = self.client.post("/api/payments/lots/", data)
+        response = self.client.post("/api/payments/lots/", data, format="json")
         self.assertJSONResponse(response, 400)
         self.assertEqual(response.json(), ["At least one potential payment required."])
 
         # `potential_payments` is a list of multiple IDs.
         potential_payment_ids = [self.potential_payment.pk, self.potential_payment_with_task.pk]
         data = {"name": "New Payment Lot", "potential_payments": potential_payment_ids}
-        response = self.client.post("/api/payments/lots/", data)
+        response = self.client.post("/api/payments/lots/", data, format="json")
         self.assertJSONResponse(response, 201)
         data = response.json()
         task = self.assertValidTaskAndInDB(data["task"], status="QUEUED", name="create_payment_lot")
@@ -119,7 +119,7 @@ class PaymentLotsViewSetAPITestCase(TaskAPITestCase):
         # `potential_payments` is a list containing only one ID.
         potential_payment_ids = [self.potential_payment.pk]
         data = {"name": "New Payment Lot", "potential_payments": potential_payment_ids}
-        response = self.client.post("/api/payments/lots/", data)
+        response = self.client.post("/api/payments/lots/", data, format="json")
         self.assertJSONResponse(response, 201)
         data = response.json()
         task = self.assertValidTaskAndInDB(data["task"], status="QUEUED", name="create_payment_lot")

--- a/iaso/tests/api/payments/test_payment_lots.py
+++ b/iaso/tests/api/payments/test_payment_lots.py
@@ -95,20 +95,20 @@ class PaymentLotsViewSetAPITestCase(TaskAPITestCase):
 
         # Invalid format for `potential_payments`.
         data = {"name": "New Payment Lot", "potential_payments": "foo"}
-        response = self.client.post("/api/payments/lots/", data, format="json")
+        response = self.client.post("/api/payments/lots/", data)
         self.assertJSONResponse(response, 400)
         self.assertEqual(response.json(), ["Expecting `potential_payments` to be a list of IDs."])
 
         # No `potential_payments`.
         data = {"name": "New Payment Lot"}
-        response = self.client.post("/api/payments/lots/", data, format="json")
+        response = self.client.post("/api/payments/lots/", data)
         self.assertJSONResponse(response, 400)
         self.assertEqual(response.json(), ["At least one potential payment required."])
 
         # `potential_payments` is a list of multiple IDs.
         potential_payment_ids = [self.potential_payment.pk, self.potential_payment_with_task.pk]
         data = {"name": "New Payment Lot", "potential_payments": potential_payment_ids}
-        response = self.client.post("/api/payments/lots/", data, format="json")
+        response = self.client.post("/api/payments/lots/", data)
         self.assertJSONResponse(response, 201)
         data = response.json()
         task = self.assertValidTaskAndInDB(data["task"], status="QUEUED", name="create_payment_lot")
@@ -119,7 +119,7 @@ class PaymentLotsViewSetAPITestCase(TaskAPITestCase):
         # `potential_payments` is a list containing only one ID.
         potential_payment_ids = [self.potential_payment.pk]
         data = {"name": "New Payment Lot", "potential_payments": potential_payment_ids}
-        response = self.client.post("/api/payments/lots/", data, format="json")
+        response = self.client.post("/api/payments/lots/", data)
         self.assertJSONResponse(response, 201)
         data = response.json()
         task = self.assertValidTaskAndInDB(data["task"], status="QUEUED", name="create_payment_lot")
@@ -155,9 +155,7 @@ class PaymentLotsViewSetAPITestCase(TaskAPITestCase):
 
     def test_update_payment_lot_mark_payments_as_sent(self):
         self.client.force_authenticate(self.user)
-        response = self.client.patch(
-            f"/api/payments/lots/{self.payment_lot.id}/?mark_payments_as_sent=true", format="json"
-        )
+        response = self.client.patch(f"/api/payments/lots/{self.payment_lot.id}/?mark_payments_as_sent=true")
         self.assertJSONResponse(response, 201)
         data = response.json()
         task = self.assertValidTaskAndInDB(data["task"], status="QUEUED", name="mark_payments_as_read")
@@ -176,13 +174,13 @@ class PaymentLotsViewSetAPITestCase(TaskAPITestCase):
 
     def test_retrieve_payment_lot(self):
         self.client.force_authenticate(self.user)
-        response = self.client.get(f"/api/payments/lots/{self.payment_lot.id}/", format="json")
+        response = self.client.get(f"/api/payments/lots/{self.payment_lot.id}/")
         self.assertJSONResponse(response, 200)
         self.assertEqual(response.data["name"], self.payment_lot.name)
 
     def test_retrieve_payment_lot_to_csv(self):
         self.client.force_authenticate(self.user)
-        response = self.client.get(f"/api/payments/lots/{self.payment_lot.id}/?csv=true", format="json")
+        response = self.client.get(f"/api/payments/lots/{self.payment_lot.id}/?csv=true")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response["Content-Type"], "text/csv")
         response_csv = response.getvalue().decode("utf-8")
@@ -199,7 +197,7 @@ class PaymentLotsViewSetAPITestCase(TaskAPITestCase):
         extra_change_request.new_reference_instances.set([self.instance1, self.instance2, self.instance3])
 
         with self.assertNumQueries(10):
-            response = self.client.get(f"/api/payments/lots/{self.payment_lot.id}/?xlsx=true", format="json")
+            response = self.client.get(f"/api/payments/lots/{self.payment_lot.id}/?xlsx=true")
             excel_columns, excel_data = self.assertXlsxFileResponse(response)
 
         self.assertEqual(
@@ -298,7 +296,6 @@ class PaymentLotsViewSetAPITestCase(TaskAPITestCase):
                 "name": "New Payment Lot",
                 "potential_payments": [self.potential_payment.pk, self.potential_payment_with_task.pk],
             },
-            format="json",
         )
 
         self.assertJSONResponse(response, 201)
@@ -319,7 +316,6 @@ class PaymentLotsViewSetAPITestCase(TaskAPITestCase):
                 "name": "New Payment Lot",
                 "potential_payments": [self.potential_payment.pk, self.potential_payment_with_task.pk + 100],
             },
-            format="json",
         )
 
         self.assertJSONResponse(response, 201)
@@ -334,7 +330,7 @@ class PaymentLotsViewSetAPITestCase(TaskAPITestCase):
 
     def test_geo_limited_user_cannot_see_change_requests_not_in_org_units(self):
         self.client.force_authenticate(self.geo_limited_user)
-        response = self.client.get("/api/payments/lots/", format="json")
+        response = self.client.get("/api/payments/lots/")
         self.assertJSONResponse(response, 200)
         data = response.json()
         results = data["results"]


### PR DESCRIPTION
Fix flaky tests.

Related JIRA tickets : [IA-4363](https://bluesquare.atlassian.net/browse/IA-4363)

## Changes

- Fix `ModificationModelTestCase.test_create()`
    - there was an error and we were just lucky that the test succeeded with a fresh DB
- Fix `PaymentLotsViewSet.create()`
    - there was a bug where a number made up of multiple digits was parsed as multiple integers
    - e.g., `56` was parsed as `5` and `6`
    - this bug was just real in tests since `format="json"` was missing from the HTTP requests



[IA-4363]: https://bluesquare.atlassian.net/browse/IA-4363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ