### PR TITLE
SNT-84: Update json logic to handle string values

### DIFF
--- a/iaso/api/metrics/views.py
+++ b/iaso/api/metrics/views.py
@@ -36,12 +36,11 @@ class ValueAndTypeFilterBackend(filters.BaseFilterBackend):
     def filter_queryset(self, request, queryset, view):
         json_filter = request.query_params.get("json_filter")
         group_by_field_name = "org_unit_id"
-
         if not json_filter:
             return queryset.values(group_by_field_name).distinct().values_list(group_by_field_name, flat=True)
 
         q = jsonlogic_to_exists_q_clauses(
-            json.loads(json_filter), MetricValue.objects, "metric_type_id", "value", group_by_field_name
+            json.loads(json_filter), MetricValue.objects, "metric_type_id", group_by_field_name
         )
 
         qs = queryset.filter(q).values_list(group_by_field_name, flat=True).distinct()


### PR DESCRIPTION
Accept string values when filtering org units for SNT Malaria

Related JIRA tickets : [SNT-84](https://bluesquare.atlassian.net/browse/SNT-84)

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [x] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

## Changes

Metrics can have one or other value type: value:float or string_value: string.
Previous version of json logic was only looking at value field.
Making it a little bit smarter so it checks if value is a float or not, if it is, filter is applied on value property.
If not, filter is applied on string_value property

## How to test

Go to snt malaria and try to filter on an ordinal filter.
Such as seasonal by rainfall (ERA5)

## Print screen / video

Upload here print screens or videos showing the changes.

## Notes

This PR depends on another one in SNT-Malaria repo: [PR55](https://github.com/BLSQ/snt-malaria/pull/55)

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.


[SNT-84]: https://bluesquare.atlassian.net/browse/SNT-84?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ