### PR TITLE
IA-4399 : load less related relationships, avoid full form versions load

### DIFF
--- a/iaso/api/mobile/entity.py
+++ b/iaso/api/mobile/entity.py
@@ -63,9 +63,9 @@ class MobileEntityAttributesSerializer(serializers.ModelSerializer):
             "json",
         ]
 
-    form_id = serializers.IntegerField(read_only=True, source="form.id")
+    form_id = serializers.IntegerField(read_only=True)
     id = serializers.CharField(read_only=True, source="uuid")
-    org_unit_id = serializers.CharField(read_only=True, source="org_unit.id")
+    org_unit_id = serializers.CharField(read_only=True)
     form_version_id = serializers.SerializerMethodField()
     created_at = TimestampField(read_only=True, source="source_created_at_with_fallback")
     updated_at = TimestampField(read_only=True, source="source_updated_at_with_fallback")
@@ -161,14 +161,14 @@ class MobileEntityViewSet(ModelViewSet):
     def get_serializer_context(self):
         context = super().get_serializer_context()
         user = self.request.user
-        possible_form_versions = FormVersion.objects.filter(
-            form__projects__account=user.iaso_profile.account
-        ).distinct()
-        possible_form_versions_dict = {}
-        for version in possible_form_versions:
-            key = "%s|%s" % (version.version_id, str(version.form_id))
-            possible_form_versions_dict[key] = version.id
-        context["possible_form_versions"] = possible_form_versions_dict
+
+        qs = FormVersion.objects.filter(form__projects__account=user.iaso_profile.account).values_list(
+            "version_id", "form_id", "id"
+        )
+
+        context["possible_form_versions"] = {
+            f"{version_id}|{form_id}": version_pk for version_id, form_id, version_pk in qs
+        }
 
         return context
 
@@ -185,12 +185,8 @@ class MobileEntityViewSet(ModelViewSet):
         queryset = filter_on_user_and_app_id(queryset, user, app_id)
         queryset = filter_for_mobile_entity(queryset, self.request)
 
-        queryset = queryset.select_related("entity_type").prefetch_related(
-            "instances__org_unit",
-            "attributes__org_unit",
-            "instances__form__form_versions",
-            "attributes__form__form_versions",
-        )
+        queryset = queryset.select_related("entity_type", "attributes").prefetch_related("instances")
+
         return queryset.order_by("id")
 
 


### PR DESCRIPTION
Load less things
- join on attributes instead of related
- pick only ids needed for form_version
- don't load orgunits and forms/form versions

Related JIRA tickets : IA-4399

## Self proofreading checklist

- [ ] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

https://gist.github.com/mestachs/565233794e08c1bdc874ab32bcae483d

IMO the main issues isn't solved but remove some load on the db server.

see https://bluesquare.slack.com/archives/C032F8GFAUD/p1752837730874539?thread_ts=1752675699.592859&cid=C032F8GFAUD

I would try to stop doing the "count" ask a page with + 1 size and deduce if there's another page. But verify with mobile if it's ok to do it like that.

## How to test

Explain how to test your PR.

If a specific config is required explain it here: dataset, account, profile, etc.

## Print screen / video

Upload here print screens or videos showing the changes.

## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: mobile entity load less related relationships, avoid full form versions load

Refs: IA-4399
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
