### PR TITLE
HOT-FIX: v2025.07.15c 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6809,9 +6809,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001690",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001690.tgz",
-            "integrity": "sha512-5ExiE3qQN6oF8Clf8ifIDcMRCRE/dMGcETG/XGMD8/XiXm6HXQgQTh1yZYLXXpSOsEUlJm1Xr7kGULZTuGtP/w==",
+            "version": "1.0.30001727",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001727.tgz",
+            "integrity": "sha512-pB68nIHmbN6L/4C6MH1DokyR3bYqFwjaSs/sWDHGj4CTcFtQUQMuJftVwWkXq7mNWOybD3KhUv3oWHoGxgP14Q==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -6843,40 +6843,20 @@
             }
         },
         "node_modules/canvg": {
-            "version": "3.0.10",
-            "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.10.tgz",
-            "integrity": "sha512-qwR2FRNO9NlzTeKIPIKpnTY6fqwuYSequ8Ru8c0YkYU7U0oW+hLUvWadLvAu1Rl72OMNiFhoLu4f8eUjQ7l/+Q==",
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/canvg/-/canvg-4.0.3.tgz",
+            "integrity": "sha512-fKzMoMBwus3CWo1Uy8XJc4tqqn98RoRrGV6CsIkaNiQT5lOeHuMh4fOt+LXLzn2Wqtr4p/c2TOLz4xtu4oBlFA==",
             "optional": true,
             "dependencies": {
-                "@babel/runtime": "^7.12.5",
                 "@types/raf": "^3.4.0",
-                "core-js": "^3.8.3",
                 "raf": "^3.4.1",
-                "regenerator-runtime": "^0.13.7",
                 "rgbcolor": "^1.0.1",
                 "stackblur-canvas": "^2.0.0",
                 "svg-pathdata": "^6.0.3"
             },
             "engines": {
-                "node": ">=10.0.0"
+                "node": ">=12.0.0"
             }
-        },
-        "node_modules/canvg/node_modules/core-js": {
-            "version": "3.39.0",
-            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.39.0.tgz",
-            "integrity": "sha512-raM0ew0/jJUqkJ0E6e8UDtl+y/7ktFivgWvqw8dNSQeNWoSDLvQ1H/RN3aPXB9tBd4/FhyR4RDPGhsNIMsAn7g==",
-            "hasInstallScript": true,
-            "optional": true,
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/core-js"
-            }
-        },
-        "node_modules/canvg/node_modules/regenerator-runtime": {
-            "version": "0.13.11",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-            "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
-            "optional": true
         },
         "node_modules/caseless": {
             "version": "0.12.0",

--- a/package.json
+++ b/package.json
@@ -165,5 +165,8 @@
         "webpack-bundle-tracker": "^1.0.0-alpha.1",
         "webpack-cli": "^4.10.0",
         "webpack-dev-server": "^4.15.1"
+    },
+    "overrides": {
+        "canvg": "4.0.3"
     }
 }


### PR DESCRIPTION
An issue in canvg v.4.0.2 allows an attacker to execute arbitrary code via the Constructor of the class StyleElement.
canvg is used by dom-to-pdf


## Self proofreading checklist

- [ ] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

-

## Changes

- override canvg package
- upgrade browser list definition

## How to test

Make sure calendar esport to pdf feature is still working


## Print screen / video

-

## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
