### PR TITLE
POLIO-1975: remove test campaigns from lqas options

### DIFF
--- a/plugins/polio/api/lqas_im/lqas_im_dropdowns.py
+++ b/plugins/polio/api/lqas_im/lqas_im_dropdowns.py
@@ -57,6 +57,7 @@ class LqasImCountryOptionsFilter(django_filters.rest_framework.FilterSet):
         )
         countries_with_lqas = (
             Round.objects.filter(campaign__country__in=queryset)
+            .filter(campaign__is_test=False)
             .filter(with_lqas_end_date | without_lqas_end_date)
             .values_list("campaign__country__id")
         )

--- a/plugins/polio/api/lqas_im/lqas_im_dropdowns.py
+++ b/plugins/polio/api/lqas_im/lqas_im_dropdowns.py
@@ -133,7 +133,7 @@ class LqasImCampaignOptionsViewset(ModelViewSet):
 
     def get_queryset(self):
         user = self.request.user
-        campaigns = Campaign.objects.filter_for_user(user)
+        campaigns = Campaign.objects.filter_for_user(user).filter(is_test=False)
         return campaigns
 
 

--- a/plugins/polio/js/src/domains/Campaigns/hooks/api/useSaveCampaign.ts
+++ b/plugins/polio/js/src/domains/Campaigns/hooks/api/useSaveCampaign.ts
@@ -94,6 +94,7 @@ export const useSaveCampaign = (): UseMutationResult<any, any, any> => {
             queryClient.invalidateQueries('campaigns');
             queryClient.invalidateQueries(['subActivities']);
             queryClient.invalidateQueries(['calendar-campaigns']);
+            queryClient.invalidateQueries(['lqasCountries']);
         },
     });
 };

--- a/plugins/polio/js/src/domains/Campaigns/hooks/api/useSaveCampaign.ts
+++ b/plugins/polio/js/src/domains/Campaigns/hooks/api/useSaveCampaign.ts
@@ -94,8 +94,8 @@ export const useSaveCampaign = (): UseMutationResult<any, any, any> => {
             queryClient.invalidateQueries('campaigns');
             queryClient.invalidateQueries(['subActivities']);
             queryClient.invalidateQueries(['calendar-campaigns']);
-            queryClient.invalidateQueries(['lqasCountries']);
-            queryClient.invalidateQueries(['lqasCampaigns']);
+            queryClient.invalidateQueries('lqasCountries');
+            queryClient.invalidateQueries('lqasCampaigns');
         },
     });
 };

--- a/plugins/polio/js/src/domains/Campaigns/hooks/api/useSaveCampaign.ts
+++ b/plugins/polio/js/src/domains/Campaigns/hooks/api/useSaveCampaign.ts
@@ -95,6 +95,7 @@ export const useSaveCampaign = (): UseMutationResult<any, any, any> => {
             queryClient.invalidateQueries(['subActivities']);
             queryClient.invalidateQueries(['calendar-campaigns']);
             queryClient.invalidateQueries(['lqasCountries']);
+            queryClient.invalidateQueries(['lqasCampaigns']);
         },
     });
 };

--- a/plugins/polio/js/src/domains/LQAS-IM/LQAS/hooks/useGetLqasCountriesOptions.tsx
+++ b/plugins/polio/js/src/domains/LQAS-IM/LQAS/hooks/useGetLqasCountriesOptions.tsx
@@ -50,7 +50,7 @@ export const useGetLqasCountriesOptions = ({
             enabled: Boolean(monthYear),
             staleTime: 1000 * 60 * 15, // in MS
             cacheTime: 1000 * 60 * 5,
-            keepPreviousData: true,
+            keepPreviousData: false,
             select: data => data?.results ?? [],
         },
     });
@@ -80,7 +80,7 @@ export const useGetLqasCampaignsOptions = ({
             enabled: Boolean(monthYear) && Boolean(country),
             staleTime: 1000 * 60 * 15, // in MS
             cacheTime: 1000 * 60 * 5,
-            keepPreviousData: true,
+            keepPreviousData: false,
             select: data => data?.results ?? [],
         },
     });
@@ -112,7 +112,7 @@ export const useGetLqasRoundOptions = ({
             enabled: Boolean(monthYear) && Boolean(campaign),
             staleTime: 1000 * 60 * 15, // in MS
             cacheTime: 1000 * 60 * 5,
-            keepPreviousData: true,
+            keepPreviousData: false,
             select: data => data?.results ?? [],
         },
     });

--- a/plugins/polio/tests/api/lqas_im/test_lqas_im_options.py
+++ b/plugins/polio/tests/api/lqas_im/test_lqas_im_options.py
@@ -181,6 +181,48 @@ class PolioLqasImCountriesOptionsTestCase(LqasImOptionsTestCase):
         results = json_response["results"]
         self.assertEqual(len(results), 0)
 
+    def test_ignore_countries_with_only_test_campaigns(self):
+        test_campaign, test_rnd1, test_rnd2, test_rnd3, cameroon, north_east = self.create_campaign(
+            "Test Campaign",
+            self.account,
+            self.source_version_1,
+            self.ou_type_country,
+            self.ou_type_district,
+            "CAMEROON",
+            "NORTH EAST",
+        )
+        test_rnd2.lqas_ended_at = self.rdc_round_2.lqas_ended_at
+        test_rnd2.save()
+        test_rnd3.lqas_ended_at = self.rdc_round_3.lqas_ended_at
+        test_rnd3.save()
+
+        self.client.force_authenticate(self.user)
+
+        response = self.client.get(f"{self.endpoint}?month=04-2021")  # expecting rdc in result
+        json_response = self.assertJSONResponse(response, 200)
+        results = json_response["results"]
+        self.assertEqual(len(results), 2)
+        labels = [result["label"] for result in results]
+        values = [result["value"] for result in results]
+        self.assertTrue(cameroon.name in labels)
+        self.assertTrue(cameroon.id in values)
+        self.assertTrue(self.rdc.name in labels)
+        self.assertTrue(self.rdc.id in values)
+
+        test_campaign.is_test = True
+        test_campaign.save()
+
+        #  test when lqas end = last day of month
+        response = self.client.get(f"{self.endpoint}?month=04-2021")  # expecting rdc in result
+        json_response = self.assertJSONResponse(response, 200)
+        results = json_response["results"]
+        self.assertEqual(len(results), 1)
+        result = results[0]
+        self.assertNotEqual(result["label"], cameroon.name)
+        self.assertNotEqual(result["value"], cameroon.id)
+        self.assertEqual(result["label"], self.rdc.name)
+        self.assertEqual(result["value"], self.rdc.id)
+
     def test_use_date_fallback_if_no_lqas_end_date(self):
         self.client.force_authenticate(self.user)
 


### PR DESCRIPTION
Test campaigns should not be available in lqas country dropdown

Related JIRA tickets : POLIO-1975

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

NA

## Changes
- filter out test campaigns at viewset level
- filter out countries with only test campaigns at viewset level
- add query key invalidation on the front-end side
- Add and fix tests in backend

## How to test

- Go to lqas
- Choose a month+year that includes a test campaign
- Choose the test campaign's country
- Check the campaigns dropdown: the campaign should not appear
- Alternately: if the country has no other campaign for the selected period, it will not appear at the country level

## Print screen / video


https://github.com/user-attachments/assets/0d94f992-5b43-4d8f-89a5-be222fa2bfb0




