### PR TITLE
SNT-90: Accept more styling on deleteModal button

### DIFF
--- a/hat/assets/js/apps/Iaso/components/DeleteRestoreModals/DeleteButton.tsx
+++ b/hat/assets/js/apps/Iaso/components/DeleteRestoreModals/DeleteButton.tsx
@@ -13,15 +13,27 @@ const messages = defineMessages({
 type Props = {
     onClick: () => void;
     message?: IntlMessage;
+    variant?: 'text' | 'outlined' | 'contained';
+    size?: 'small' | 'medium' | 'large';
+    sx?: object;
 };
 
 export const DeleteButton: FunctionComponent<Props> = ({
     onClick,
     message,
+    variant = 'contained',
+    size = 'medium',
+    sx = {},
 }) => {
     const { formatMessage } = useSafeIntl();
     return (
-        <Button onClick={onClick} variant="contained" color="primary">
+        <Button
+            onClick={onClick}
+            variant={variant}
+            color="primary"
+            size={size}
+            sx={sx}
+        >
             {message ?? formatMessage(messages.delete)}
         </Button>
     );


### PR DESCRIPTION
Delete modal button is not customizable and we need to make it so

Related JIRA tickets : SNT-90

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [x] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc


## Changes

Added more accepted props on DeleteButton component:
 - size
 - type
 - sx
 
 Set default to what it was before so it doesn't break existing usage

## How to test

Verify existing delete modal button usage in Iaso.
Verify that if you modify one of those props, it is properly applied.
You can change this through the DeleteModal

## Print screen / video

<img width="184" height="76" alt="image" src="https://github.com/user-attachments/assets/d6751dca-de86-40db-9912-7effd519afb2" />


## Notes

This will be used in SNT Malaria but is still work in progress

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
