### PR TITLE
POLIO-1979: fix duplicate obr_names

### DIFF
--- a/plugins/polio/api/lqas_im/lqas_im_dropdowns.py
+++ b/plugins/polio/api/lqas_im/lqas_im_dropdowns.py
@@ -134,7 +134,8 @@ class LqasImCampaignOptionsViewset(ModelViewSet):
 
     def get_queryset(self):
         user = self.request.user
-        campaigns = Campaign.objects.filter_for_user(user).filter(is_test=False)
+        # Sometimes filter_for_user will return duplicate campaigns but fixing this at the queryset manager level introduces a whole loit of new bugs
+        campaigns = Campaign.objects.filter_for_user(user).filter(is_test=False).distinct("obr_name")
         return campaigns
 
 


### PR DESCRIPTION
Duplicated items in lqas camapign dropdown

Related JIRA tickets : POLIO-1979

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

In the code


## Changes

Explain the changes that were made.

The idea is not to list exhaustively all the changes made (GitHub already provides a full diff), but to help the reviewers better understand:

- which specific file changes go together, e.g: when creating a table in the front-end, there usually is a config file that goes with it
- the reasoning behind some changes, e.g: deleted files because they are now redundant
- the behaviour to expect, e.g: tooltip has purple background color because the client likes it so, changed a key in the API response to be consistent with other endpoints

## How to test

- Duplicate the campaign in the screenshot on your local DB
- Get lqas data from JsonDatastore
- Select dates and campaign to show the campaign data on lqas page
- When selecting the campaign, the obr name should not be duplicated

## Print screen / video

Before

<img width="3194" height="1410" alt="Screenshot 2025-07-23 at 14 29 01" src="https://github.com/user-attachments/assets/2bd3a925-98fa-481f-b31e-e3f0fc940e57" />

After

<img width="1484" height="1410" alt="Screenshot 2025-07-23 at 15 35 45" src="https://github.com/user-attachments/assets/a10c37f2-74e4-4c65-9a65-7d1e557f421d" />



