### PR TITLE
IA-4393: Code is not a valid choice for data source synchronization

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -182,7 +182,7 @@
     "iaso.datasources.title.export": "Org units to export",
     "iaso.datasources.title.exportTitle": "Are you sure?",
     "iaso.datasources.title.origin": "Origin",
-    "iaso.datasources.title.syncMessage": "This might create a lot of changes requests to align the two versions. This dialog will stay frozen until the preview is done. Geometry will not be synchronized.",
+    "iaso.datasources.title.syncMessage": "This might create a lot of changes requests to align the two versions. This dialog will stay frozen until the preview is done. Geometry and code will not be synchronized.",
     "iaso.datasources.title.syncTitle": "Synchronize data sources",
     "iaso.datasources.title.target": "Target",
     "iaso.datasources.tooltip.compare": "Compare/Synchronize data sources",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -182,7 +182,7 @@
     "iaso.datasources.title.export": "Unités d'org. à exporter",
     "iaso.datasources.title.exportTitle": "Êtes vous sûr?",
     "iaso.datasources.title.origin": "Origine",
-    "iaso.datasources.title.syncMessage": "Cela pourrait créer beaucoup de demandes de changement pour aligner les deux versions. Cette fenêtre restera figée jusqu'à ce que la prévisualisation soit terminée. Les données géométriques ne seront pas synchronisées.",
+    "iaso.datasources.title.syncMessage": "Cela pourrait créer beaucoup de demandes de changement pour aligner les deux versions. Cette fenêtre restera figée jusqu'à ce que la prévisualisation soit terminée. Les données géométriques et les codes ne seront pas synchronisés.",
     "iaso.datasources.title.syncTitle": "Synchroniser les sources de données",
     "iaso.datasources.title.target": "Cible",
     "iaso.datasources.tooltip.compare": "Comparer/Synchroniser des sources",

--- a/hat/assets/js/apps/Iaso/domains/dataSources/hooks/useCreateJsonDiffAsync.ts
+++ b/hat/assets/js/apps/Iaso/domains/dataSources/hooks/useCreateJsonDiffAsync.ts
@@ -72,7 +72,7 @@ const createJsonDiffAsync = async ({
 
     // Options
     const nonEmptyFields = fieldsToExport.filter(
-        field => field !== 'geometry' && field !== 'groups',
+        field => field !== 'geometry' && field !== 'groups' && field !== 'code',
     );
     if (nonEmptyFields.length > 0) {
         params.field_names = nonEmptyFields;
@@ -80,7 +80,6 @@ const createJsonDiffAsync = async ({
 
     params.ignore_groups = !fieldsToExport.includes('groups');
     params.show_deleted_org_units = false;
-
     return patchRequest(
         `/api/datasources/sync/${id}/create_json_diff/`,
         params,

--- a/hat/assets/js/apps/Iaso/domains/dataSources/messages.js
+++ b/hat/assets/js/apps/Iaso/domains/dataSources/messages.js
@@ -208,7 +208,7 @@ const MESSAGES = defineMessages({
     syncMessage: {
         id: 'iaso.datasources.title.syncMessage',
         defaultMessage:
-            'This might create a lot of changes requests to align the two versions. This dialog will stay frozen until the preview is done. Geometry will not be synchronized.',
+            'This might create a lot of changes requests to align the two versions. This dialog will stay frozen until the preview is done. Geometry and code will not be synchronized.',
     },
     default: {
         id: 'iaso.datasources.options.label.default',


### PR DESCRIPTION
Despite that the data source comparison preview works, the change requests preview fails.

Related JIRA tickets : IA-4393

## Self proofreading checklist

- [ ] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

-

## Changes

remove code from fields + adapt message

## How to test

Try to launch a data source comparaison using code field, preview should not use the code fields at all

## Print screen / video

-

## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
