### PR TITLE
IA-4299: Reflect Project colors in the dropdowns

### DIFF
--- a/hat/assets/js/apps/Iaso/components/forms/InputComponent.tsx
+++ b/hat/assets/js/apps/Iaso/components/forms/InputComponent.tsx
@@ -1,3 +1,4 @@
+import React, { FocusEventHandler, ReactNode, useMemo, useState } from 'react';
 import { Box } from '@mui/material';
 import {
     ArrayFieldInput,
@@ -16,7 +17,6 @@ import {
     translateOptions,
     useSafeIntl,
 } from 'bluesquare-components';
-import React, { FocusEventHandler, ReactNode, useMemo, useState } from 'react';
 import { useLocale } from '../../domains/app/contexts/LocaleContext';
 import MESSAGES from '../../domains/forms/messages';
 import {

--- a/hat/assets/js/apps/Iaso/domains/projects/hooks/requests.ts
+++ b/hat/assets/js/apps/Iaso/domains/projects/hooks/requests.ts
@@ -44,6 +44,7 @@ export const useGetProjectsDropdownOptions = (
                     return {
                         value: asString ? project.id?.toString() : project.id,
                         label: project.name,
+                        color: project.color,
                     };
                 });
             },


### PR DESCRIPTION
Reflect project colors in the dropdowns

Related JIRA tickets : [IA-4299](https://bluesquare.atlassian.net/browse/IA-4299)

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [x] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

## Changes

Added color property when getting projects dropdown options

## How to test

Go to any filter containing project input such as: DHIS mappings or Forms
When selecting project, colors of the chip should reflect the color defined on project.

## Print screen / video

<img width="584" height="130" alt="image" src="https://github.com/user-attachments/assets/4e377e53-622a-4f65-a51d-23601ea6dde1" />


<img width="584" height="437" alt="image" src="https://github.com/user-attachments/assets/42effcc8-7d33-40be-9ead-14bf36a3f205" />


## Notes

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.


[IA-4299]: https://bluesquare.atlassian.net/browse/IA-4299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ