### PR TITLE
IA-4387 Fix n+1 query on `/api/formversions`

### DIFF
--- a/iaso/api/form_versions.py
+++ b/iaso/api/form_versions.py
@@ -224,6 +224,8 @@ class FormVersionsViewSet(ModelViewSet):
         if mapped_filter:
             queryset = queryset.filter(mapped=(mapped_filter == "true"))
 
+        queryset = queryset.select_related("form").prefetch_related("mapping_versions")
+
         queryset = queryset.order_by(*orders)
 
         return queryset

--- a/iaso/tests/api/test_form_versions.py
+++ b/iaso/tests/api/test_form_versions.py
@@ -152,7 +152,8 @@ class FormsVersionAPITestCase(APITestCase):
         """GET /formversions/: allowed"""
 
         self.client.force_authenticate(self.yoda)
-        response = self.client.get("/api/formversions/")
+        with self.assertNumQueries(2):
+            response = self.client.get("/api/formversions/")
         self.assertJSONResponse(response, 200)
         form_versions_data = response.json()["form_versions"]
 


### PR DESCRIPTION
Fix n+1 query on `api/formversions`.

Related JIRA tickets : IA-4387

[Sentry issue](https://bluesquareorg.sentry.io/issues/6748364928/?project=5530884).