### PR TITLE
IA-4388 Fix n+1 query on `/api/microplanning/plannings`

### DIFF
--- a/iaso/api/microplanning.py
+++ b/iaso/api/microplanning.py
@@ -381,7 +381,9 @@ class PlanningViewSet(AuditMixin, ModelViewSet):
 
     def get_queryset(self):
         user = self.request.user
-        return self.queryset.filter_for_user(user)
+        return (
+            self.queryset.filter_for_user(user).select_related("project", "org_unit", "team").prefetch_related("forms")
+        )
 
 
 class AssignmentSerializer(serializers.ModelSerializer):

--- a/iaso/tests/test_microplanning.py
+++ b/iaso/tests/test_microplanning.py
@@ -597,7 +597,8 @@ class PlanningTestCase(APITestCase):
 
     def test_query_happy_path(self):
         self.client.force_authenticate(self.user)
-        response = self.client.get("/api/microplanning/plannings/", format="json")
+        with self.assertNumQueries(5):
+            response = self.client.get("/api/microplanning/plannings/", format="json")
         r = self.assertJSONResponse(response, 200)
         self.assertEqual(len(r), 1)
 


### PR DESCRIPTION
Fix n+1 query on `/api/microplanning/plannings`.

Related JIRA tickets : IA-4388

[Jira issue](https://bluesquareorg.sentry.io/issues/6746773431/?project=5530884).
