### PR TITLE
IA-4389 Fix n+1 query on `/api/microplanning/teams`

### DIFF
--- a/iaso/api/microplanning.py
+++ b/iaso/api/microplanning.py
@@ -253,7 +253,7 @@ class TeamViewSet(AuditMixin, ModelViewSet):
 
     def get_queryset(self):
         user = self.request.user
-        return self.queryset.filter_for_user(user)
+        return self.queryset.filter_for_user(user).select_related("project").prefetch_related("users", "sub_teams")
 
 
 class PlanningSerializer(serializers.ModelSerializer):

--- a/iaso/tests/test_microplanning.py
+++ b/iaso/tests/test_microplanning.py
@@ -270,7 +270,8 @@ class TeamAPITestCase(APITestCase):
 
     def test_query_happy_path(self):
         self.client.force_authenticate(self.user)
-        response = self.client.get("/api/microplanning/teams/", format="json")
+        with self.assertNumQueries(5):
+            response = self.client.get("/api/microplanning/teams/", format="json")
         r = self.assertJSONResponse(response, 200)
         self.assertEqual(len(r), 2)
 


### PR DESCRIPTION
Fix n+1 query on `/api/microplanning/teams`.

Related JIRA tickets : IA-4389

[Jira issue](https://bluesquareorg.sentry.io/issues/6741054317/?project=5530884&referrer=sentry-issues-glance).
