### PR TITLE
IA-4390 Fix n+1 query on `/api/instances`

### DIFF
--- a/iaso/api/instances/instances.py
+++ b/iaso/api/instances/instances.py
@@ -193,8 +193,12 @@ class InstancesViewSet(viewsets.ViewSet):
 
     def get_queryset(self):
         request = self.request
-        queryset: InstanceQuerySet = Instance.objects.order_by("-id")
-        queryset = queryset.filter_for_user(request.user).filter_on_user_projects(user=request.user)
+        queryset: InstanceQuerySet = (
+            Instance.objects.order_by("-id")
+            .filter_for_user(request.user)
+            .filter_on_user_projects(user=request.user)
+            .select_related("form", "created_by", "last_modified_by")
+        )
         return queryset
 
     def _get_filtered_attachments_queryset(self, request):

--- a/iaso/tests/api/instances/test_instances.py
+++ b/iaso/tests/api/instances/test_instances.py
@@ -730,7 +730,8 @@ class InstancesAPITestCase(TaskAPITestCase):
 
         self.client.force_authenticate(self.yoda)
         json_filters = json.dumps({"and": [{"==": [{"var": "gender"}, "F"]}, {"<": [{"var": "age"}, 25]}]})
-        response = self.client.get("/api/instances/", {"jsonContent": json_filters})
+        with self.assertNumQueries(6):
+            response = self.client.get("/api/instances/", {"jsonContent": json_filters})
         self.assertJSONResponse(response, 200)
         response_json = response.json()
         self.assertValidInstanceListData(response_json, expected_length=1)

--- a/iaso/tests/api/instances/test_instances.py
+++ b/iaso/tests/api/instances/test_instances.py
@@ -1033,7 +1033,7 @@ class InstancesAPITestCase(TaskAPITestCase):
             org_unit=self.jedi_council_corruscant, instance=self.instance_1, form=self.form_1
         )
 
-        with self.assertNumQueries(12):
+        with self.assertNumQueries(10):
             response = self.client.get(
                 f"/api/instances/?form_ids={self.instance_1.form.id}&csv=true", headers={"Content-Type": "text/csv"}
             )


### PR DESCRIPTION
Fix n+1 query on `/api/instances`.

Related JIRA tickets : IA-4390

[Jira issue](https://bluesquareorg.sentry.io/issues/6748372064/?project=5530884).
