### PR TITLE
IA-4391 Fix n+1 query on `/api/datasources`

### DIFF
--- a/iaso/models/data_source.py
+++ b/iaso/models/data_source.py
@@ -143,14 +143,14 @@ class SourceVersion(models.Model):
             "id": self.id,
         }
 
-    def as_dict_without_data_source(self):
+    def as_dict_without_data_source(self, org_units_count=None):
         return {
             "number": self.number,
             "description": self.description,
             "id": self.id,
             "created_at": self.created_at.timestamp() if self.created_at else None,
             "updated_at": self.updated_at.timestamp() if self.updated_at else None,
-            "org_units_count": self.orgunit_set.count(),
+            "org_units_count": org_units_count or self.orgunit_set.count(),
         }
 
     def as_report_dict(self):

--- a/iaso/tests/api/test_data_sources.py
+++ b/iaso/tests/api/test_data_sources.py
@@ -46,7 +46,8 @@ class DataSourcesAPITestCase(APITestCase):
         # if the user has one perms
         self.client.force_authenticate(self.jane)
 
-        response = self.client.get("/api/datasources/")
+        with self.assertNumQueries(7):
+            response = self.client.get("/api/datasources/")
         self.assertJSONResponse(response, 200)
 
     def test_datasource_post_with_all_params(self):


### PR DESCRIPTION
Fix n+1 query on `/api/datasources`.

Related JIRA tickets : IA-4391

[Jira issue](https://bluesquareorg.sentry.io/issues/6745902036/?project=5530884&referrer=sentry-issues-glance).
