### PR TITLE
[IA-4414] Allow multiple models in plugin permissions

### DIFF
--- a/hat/menupermissions/models.py
+++ b/hat/menupermissions/models.py
@@ -193,12 +193,15 @@ class CustomPermissionSupport(models.Model):
     @staticmethod
     def filter_permissions(permissions, modules_permissions, settings: LazySettings):
         content_types = [ContentType.objects.get_for_model(CustomPermissionSupport)]
-        content_types.append(ContentType.objects.get_for_model(core_permissions.CorePermissionSupport))
+        core_permission_models = core_permissions.permission_models
+        for model in core_permission_models:
+            content_types.append(ContentType.objects.get_for_model(model))
 
         for plugin in settings.PLUGINS:
             try:
-                permission_model = import_module(f"plugins.{plugin}.permissions").permission_model
-                content_types.append(ContentType.objects.get_for_model(permission_model))
+                plugin_permission_models = import_module(f"plugins.{plugin}.permissions").permission_models
+                for model in plugin_permission_models:
+                    content_types.append(ContentType.objects.get_for_model(model))
             except ImportError:
                 print(f"{plugin} plugin has no permission support")
 

--- a/iaso/permissions.py
+++ b/iaso/permissions.py
@@ -275,3 +275,6 @@ class CorePermissionSupport(models.Model):
             (_PAYMENTS, _("Payments page")),
             (_MOBILE_APP_OFFLINE_SETUP, ("Mobile app offline setup")),
         )
+
+
+permission_models = [CorePermissionSupport]

--- a/iaso/test.py
+++ b/iaso/test.py
@@ -21,10 +21,11 @@ from django.utils import timezone
 from jinja2 import Environment, FileSystemLoader
 from rest_framework.test import APIClient, APITestCase as BaseAPITestCase
 
+import iaso.permissions as core_permissions
+
 from hat.api_import.models import APIImport
 from hat.menupermissions.models import CustomPermissionSupport
 from iaso import models as m
-from iaso.permissions import CorePermissionSupport
 
 
 class IasoTestCaseMixin:
@@ -47,12 +48,15 @@ class IasoTestCaseMixin:
 
         if permissions is not None:
             content_types = [ContentType.objects.get_for_model(CustomPermissionSupport)]
-            content_types.append(ContentType.objects.get_for_model(CorePermissionSupport))
+            core_permission_models = core_permissions.permission_models
+            for model in core_permission_models:
+                content_types.append(ContentType.objects.get_for_model(model))
 
             for plugin in settings.PLUGINS:
                 try:
-                    permission_model = import_module(f"plugins.{plugin}.permissions").permission_model
-                    content_types.append(ContentType.objects.get_for_model(permission_model))
+                    plugin_permission_models = import_module(f"plugins.{plugin}.permissions").permission_models
+                    for model in plugin_permission_models:
+                        content_types.append(ContentType.objects.get_for_model(model))
                 except ImportError:
                     pass
 

--- a/plugins/polio/permissions.py
+++ b/plugins/polio/permissions.py
@@ -154,4 +154,4 @@ class PolioPermissionSupport(models.Model):
         )
 
 
-permission_model = PolioPermissionSupport
+permission_models = [PolioPermissionSupport]


### PR DESCRIPTION
Allow multiple models in plugin permissions.

This is required for Trypelim, as each Trypelim app handles its own permissions.

Related JIRA tickets : IA-4414

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

/

## Changes

Transformed each `permission_model` value in `permissions.py` as a list (`permission_models`)

## How to test

Run the app, nothing should change nor be broken


## Print screen / video

/

## Notes

This is required for splitting Trypelim permissions from `hat.menupermissions`

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
