### PR TITLE
IA-4397 Set `TEST_REQUEST_DEFAULT_FORMAT` to `json`

### DIFF
--- a/beanstalk_worker/views.py
+++ b/beanstalk_worker/views.py
@@ -1,4 +1,5 @@
 import http
+import json
 
 from datetime import timedelta
 from logging import getLogger
@@ -107,11 +108,16 @@ def task_launcher(request, task_name: str, user_name: str):
 
     call_args = {"user": the_user}
     try:
-        if len(request.POST) > 0:
-            call_args = {**call_args, **request.POST}
+        if request.content_type == "application/json" and request.body:
+            # https://docs.djangoproject.com/en/dev/releases/1.5/#non-form-data-in-http-requests
+            call_args = {**call_args, **json.loads(request.body)}
 
-        if len(request.GET) > 0:
-            call_args = {**call_args, **request.GET}
+        else:
+            if len(request.POST) > 0:
+                call_args = {**call_args, **request.POST}
+
+            if len(request.GET) > 0:
+                call_args = {**call_args, **request.GET}
 
         the_task = the_task_fn(**call_args)
         return JsonResponse({"status": "success", "task": the_task.as_dict()}, status=http.HTTPStatus.OK)

--- a/hat/settings.py
+++ b/hat/settings.py
@@ -429,6 +429,7 @@ REST_FRAMEWORK = {
         "rest_framework.renderers.BrowsableAPIRenderer",
         "rest_framework_csv.renderers.CSVRenderer",
     ),
+    "TEST_REQUEST_DEFAULT_FORMAT": "json",  # The default format that should be used when making test requests.
 }
 
 SIMPLE_JWT = {

--- a/iaso/tests/api/test_account.py
+++ b/iaso/tests/api/test_account.py
@@ -50,7 +50,7 @@ class AccountAPITestCase(APITestCase):
         """POST /account/ with auth should result in a 405 as method is not allowed"""
         self.client.force_authenticate(self.jane)
 
-        response = self.client.post("/api/accounts/", {"default_version": self.ghi_version})
+        response = self.client.post("/api/accounts/", {"default_version": self.ghi_version.pk})
         self.assertJSONResponse(response, 405)
 
     def test_account_detail_forbidden(self):

--- a/iaso/tests/api/test_correlation.py
+++ b/iaso/tests/api/test_correlation.py
@@ -54,7 +54,7 @@ class CorrelationAPITestCase(APITestCase):
         self.assertEqual(response.status_code, 200)
 
         with open("iaso/tests/fixtures/land_speeder.xml") as fp:
-            self.client.post("/sync/form_upload/", {"xml_submission_file": fp})
+            self.client.post("/sync/form_upload/", {"xml_submission_file": fp}, format="multipart")
         self.assertEqual(response.status_code, 200)
         instance = m.Instance.objects.get(uuid=uuid)
         self.assertTrue(str(instance.correlation_id).startswith(str(instance.id)))
@@ -93,7 +93,7 @@ class CorrelationAPITestCase(APITestCase):
         self.assertEqual(response.status_code, 200)
 
         with open("iaso/tests/fixtures/%s" % file_name) as fp:
-            self.client.post("/sync/form_upload/", {"xml_submission_file": fp})
+            self.client.post("/sync/form_upload/", {"xml_submission_file": fp}, format="multipart")
 
         instance = m.Instance.objects.get(uuid=uuid)
 
@@ -145,7 +145,7 @@ class CorrelationAPITestCase(APITestCase):
         self.client.credentials(HTTP_AUTHORIZATION="Token: {0}".format(jwt_token.json()["access"]))
 
         with open("iaso/tests/fixtures/%s" % file_name) as fp:
-            response_form = self.client.post("/sync/form_upload/", {"xml_submission_file": fp})
+            response_form = self.client.post("/sync/form_upload/", {"xml_submission_file": fp}, format="multipart")
 
         updated_instance = Instance.objects.get(uuid=anonymous_uploaded_instance.uuid)
 

--- a/iaso/tests/api/test_enketo.py
+++ b/iaso/tests/api/test_enketo.py
@@ -281,7 +281,9 @@ class EnketoAPITestCase(APITestCase):
                 .replace("REPLACEuserID", str(self.yoda.id))
                 .encode(),
             )
-            self.client.post("/api/enketo/submission", {"name": "xml_submission_file", "xml_submission_file": f})
+            self.client.post(
+                "/api/enketo/submission", {"name": "xml_submission_file", "xml_submission_file": f}, format="multipart"
+            )
 
             instance = self.form_1.instances.first()
 
@@ -310,7 +312,7 @@ class EnketoAPITestCase(APITestCase):
                 .encode(),
             )
             response = self.client.post(
-                "/api/enketo/submission", {"name": "xml_submission_file", "xml_submission_file": f}
+                "/api/enketo/submission", {"name": "xml_submission_file", "xml_submission_file": f}, format="multipart"
             )
 
             instance = self.form_1.instances.first()

--- a/iaso/tests/api/test_json_data_store.py
+++ b/iaso/tests/api/test_json_data_store.py
@@ -133,7 +133,9 @@ class JsonDataStoreAPITestCase(APITestCase):
         new_slug = "new_slug"
         self.client.force_authenticate(self.authorized_user_write)
         response = self.client.put(
-            f"{api_url}{self.data_store1.slug}/", {"key": f"{new_slug}", "data": data_store_content2}
+            f"{api_url}{self.data_store1.slug}/",
+            {"key": f"{new_slug}", "data": data_store_content2},
+            format="multipart",
         )
         response_body = self.assertJSONResponse(response, 200)
         self.assertEqual(response_body["key"], new_slug)

--- a/iaso/tests/test_create_users_from_csv.py
+++ b/iaso/tests/test_create_users_from_csv.py
@@ -99,7 +99,7 @@ class BulkCreateCsvTestCase(APITestCase):
         self.source.projects.set([self.project])
         with self.assertNumQueries(83):
             with open("iaso/tests/fixtures/test_user_bulk_create_valid.csv") as csv_users:
-                response = self.client.post(f"{BASE_URL}", {"file": csv_users})
+                response = self.client.post(f"{BASE_URL}", {"file": csv_users}, format="multipart")
 
         users = User.objects.all()
         profiles = Profile.objects.all()
@@ -128,7 +128,7 @@ class BulkCreateCsvTestCase(APITestCase):
 
             self.account1.refresh_from_db()
             with open("iaso/tests/fixtures/test_user_bulk_create_valid_with_perm.csv") as csv_users:
-                response = self.client.post(f"{BASE_URL}", {"file": csv_users})
+                response = self.client.post(f"{BASE_URL}", {"file": csv_users}, format="multipart")
 
             pollux = User.objects.get(username="pollux")
             pollux_perms = pollux.user_permissions.all()
@@ -144,7 +144,7 @@ class BulkCreateCsvTestCase(APITestCase):
         self.source.projects.set([self.project])
 
         with open("iaso/tests/fixtures/test_user_bulk_create_invalid_mail.csv") as csv_users:
-            response = self.client.post(f"{BASE_URL}", {"file": csv_users})
+            response = self.client.post(f"{BASE_URL}", {"file": csv_users}, format="multipart")
 
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
@@ -156,7 +156,7 @@ class BulkCreateCsvTestCase(APITestCase):
         self.source.projects.set([self.project])
 
         with open("iaso/tests/fixtures/test_user_bulk_create_no_mail.csv") as csv_users:
-            response = self.client.post(f"{BASE_URL}", {"file": csv_users})
+            response = self.client.post(f"{BASE_URL}", {"file": csv_users}, format="multipart")
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["Accounts created"], 3)
@@ -166,7 +166,7 @@ class BulkCreateCsvTestCase(APITestCase):
         self.source.projects.set([self.project])
 
         with open("iaso/tests/fixtures/test_user_bulk_create_invalid_orgunit.csv") as csv_users:
-            response = self.client.post(f"{BASE_URL}", {"file": csv_users})
+            response = self.client.post(f"{BASE_URL}", {"file": csv_users}, format="multipart")
 
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
@@ -184,7 +184,7 @@ class BulkCreateCsvTestCase(APITestCase):
         user.save()
 
         with open("iaso/tests/fixtures/test_user_bulk_create_invalid_orgunit.csv") as csv_users:
-            response = self.client.post(f"{BASE_URL}", {"file": csv_users})
+            response = self.client.post(f"{BASE_URL}", {"file": csv_users}, format="multipart")
 
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
@@ -197,7 +197,7 @@ class BulkCreateCsvTestCase(APITestCase):
         self.source.projects.set([self.project])
 
         with open("iaso/tests/fixtures/test_user_bulk_create_invalid_orgunit.csv") as csv_users:
-            response = self.client.post(f"{BASE_URL}", {"file": csv_users})
+            response = self.client.post(f"{BASE_URL}", {"file": csv_users}, format="multipart")
 
         users = User.objects.all()
         profiles = Profile.objects.all()
@@ -215,7 +215,7 @@ class BulkCreateCsvTestCase(APITestCase):
         self.source.projects.set([self.project])
 
         with open("iaso/tests/fixtures/test_user_bulk_create_managed_geo_limit.csv") as csv_users:
-            response = self.client.post(f"{BASE_URL}", {"file": csv_users})
+            response = self.client.post(f"{BASE_URL}", {"file": csv_users}, format="multipart")
 
         self.assertEqual(response.status_code, 200)
 
@@ -226,7 +226,7 @@ class BulkCreateCsvTestCase(APITestCase):
         self.user_managed_geo_limit.save()
 
         with open("iaso/tests/fixtures/test_user_bulk_create_managed_geo_limit.csv") as csv_users:
-            response = self.client.post(f"{BASE_URL}", {"file": csv_users})
+            response = self.client.post(f"{BASE_URL}", {"file": csv_users}, format="multipart")
 
         self.assertEqual(response.status_code, 400)
 
@@ -253,7 +253,7 @@ class BulkCreateCsvTestCase(APITestCase):
         pswd_deleted = True
 
         with open("iaso/tests/fixtures/test_user_bulk_create_valid.csv") as csv_users:
-            response = self.client.post(f"{BASE_URL}", {"file": csv_users})
+            response = self.client.post(f"{BASE_URL}", {"file": csv_users}, format="multipart")
 
         csv_file = BulkCreateUserCsvFile.objects.last()
 
@@ -276,7 +276,7 @@ class BulkCreateCsvTestCase(APITestCase):
         self.source.projects.set([self.project])
 
         with open("iaso/tests/fixtures/test_user_bulk_create_invalid_password.csv") as csv_users:
-            response = self.client.post(f"{BASE_URL}", {"file": csv_users})
+            response = self.client.post(f"{BASE_URL}", {"file": csv_users}, format="multipart")
 
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
@@ -289,7 +289,7 @@ class BulkCreateCsvTestCase(APITestCase):
         self.source.projects.set([self.project])
 
         with open("iaso/tests/fixtures/test_user_bulk_create_valid.csv") as csv_users:
-            response = self.client.post(f"{BASE_URL}", {"file": csv_users})
+            response = self.client.post(f"{BASE_URL}", {"file": csv_users}, format="multipart")
 
         self.assertEqual(response.status_code, 200)
 
@@ -304,7 +304,7 @@ class BulkCreateCsvTestCase(APITestCase):
         self.source.projects.set([self.project])
 
         with open("iaso/tests/fixtures/test_user_bulk_create_invalid_ou_name.csv") as csv_users:
-            response = self.client.post(f"{BASE_URL}", {"file": csv_users})
+            response = self.client.post(f"{BASE_URL}", {"file": csv_users}, format="multipart")
 
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
@@ -320,7 +320,7 @@ class BulkCreateCsvTestCase(APITestCase):
         self.source.projects.set([self.project])
 
         with open("iaso/tests/fixtures/test_user_bulk_create_valid.csv") as csv_users:
-            response = self.client.post(f"{BASE_URL}", {"file": csv_users})
+            response = self.client.post(f"{BASE_URL}", {"file": csv_users}, format="multipart")
 
         broly_ou = Profile.objects.get(user=User.objects.get(username="broly").id).org_units.all()
         ou_list = []
@@ -342,7 +342,7 @@ class BulkCreateCsvTestCase(APITestCase):
         self.client.force_authenticate(self.yoda)
 
         with open("iaso/tests/fixtures/test_user_bulk_create_valid.csv") as csv_users:
-            response = self.client.post(f"{BASE_URL}", {"file": csv_users})
+            response = self.client.post(f"{BASE_URL}", {"file": csv_users}, format="multipart")
 
         self.assertEqual(response.status_code, 400)
 
@@ -350,7 +350,7 @@ class BulkCreateCsvTestCase(APITestCase):
         self.client.force_authenticate(self.yoda)
 
         with open("iaso/tests/fixtures/test_user_bulk_create_creator_no_access_to_ou.csv") as csv_users:
-            response = self.client.post(f"{BASE_URL}", {"file": csv_users})
+            response = self.client.post(f"{BASE_URL}", {"file": csv_users}, format="multipart")
 
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
@@ -366,7 +366,7 @@ class BulkCreateCsvTestCase(APITestCase):
         self.source.projects.set([self.project])
 
         with open("iaso/tests/fixtures/test_user_bulk_create_user_duplicate_ou_names.csv") as csv_users:
-            response = self.client.post(f"{BASE_URL}", {"file": csv_users})
+            response = self.client.post(f"{BASE_URL}", {"file": csv_users}, format="multipart")
 
         self.assertEqual(User.objects.filter(username="jan").exists(), True)
 
@@ -384,7 +384,7 @@ class BulkCreateCsvTestCase(APITestCase):
         self.source.projects.set([self.project])
 
         with open("iaso/tests/fixtures/test_user_bulk_create_user_access_to_child_ou.csv") as csv_users:
-            response = self.client.post(f"{BASE_URL}", {"file": csv_users})
+            response = self.client.post(f"{BASE_URL}", {"file": csv_users}, format="multipart")
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(User.objects.filter(username="jan").exists(), True)
@@ -400,7 +400,7 @@ class BulkCreateCsvTestCase(APITestCase):
         self.source.projects.set([self.project])
 
         with open("iaso/tests/fixtures/test_user_bulk_create_semicolon.csv") as csv_users:
-            response = self.client.post(f"{BASE_URL}", {"file": csv_users})
+            response = self.client.post(f"{BASE_URL}", {"file": csv_users}, format="multipart")
 
         users = User.objects.all()
         profiles = Profile.objects.all()
@@ -428,7 +428,7 @@ class BulkCreateCsvTestCase(APITestCase):
         self.client.force_authenticate(self.yoda)
 
         with open("iaso/tests/fixtures/test_user_bulk_missing_columns.csv") as csv_users:
-            response = self.client.post(f"{BASE_URL}", {"file": csv_users})
+            response = self.client.post(f"{BASE_URL}", {"file": csv_users}, format="multipart")
 
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
@@ -447,7 +447,7 @@ class BulkCreateCsvTestCase(APITestCase):
         self.client.post("/api/userroles/", data=area_manager)
 
         with open("iaso/tests/fixtures/test_user_bulk_create_valid_with_roles.csv") as csv_users:
-            response = self.client.post(f"{BASE_URL}", {"file": csv_users})
+            response = self.client.post(f"{BASE_URL}", {"file": csv_users}, format="multipart")
 
         users = User.objects.all()
         profiles = Profile.objects.all()
@@ -486,7 +486,7 @@ class BulkCreateCsvTestCase(APITestCase):
         self.source.projects.set([self.project])
 
         with open("iaso/tests/fixtures/test_user_bulk_create_valid_with_projects.csv") as csv_users:
-            response = self.client.post(f"{BASE_URL}", {"file": csv_users})
+            response = self.client.post(f"{BASE_URL}", {"file": csv_users}, format="multipart")
         users = User.objects.all()
         profiles = Profile.objects.all()
         profile_1 = Profile.objects.get(user__username="broly")
@@ -539,7 +539,7 @@ class BulkCreateCsvTestCase(APITestCase):
 
         self.client.force_authenticate(self.user_managed_geo_limit)
         with open("iaso/tests/fixtures/test_user_bulk_create_managed_geo_limit.csv") as csv_users:
-            response = self.client.post(f"{BASE_URL}", {"file": csv_users})
+            response = self.client.post(f"{BASE_URL}", {"file": csv_users}, format="multipart")
             self.assertEqual(response.status_code, 200)
 
         # The current project restrictions of a `user` without the admin perm should be applied.
@@ -562,7 +562,7 @@ class BulkCreateCsvTestCase(APITestCase):
 
         self.client.force_authenticate(self.yoda)
         with open("iaso/tests/fixtures/test_user_bulk_create_managed_geo_limit.csv") as csv_users:
-            response = self.client.post(f"{BASE_URL}", {"file": csv_users})
+            response = self.client.post(f"{BASE_URL}", {"file": csv_users}, format="multipart")
             self.assertEqual(response.status_code, 200)
 
         # A `user` with the admin perm should be able to bypass project restrictions.
@@ -616,7 +616,7 @@ class BulkCreateCsvTestCase(APITestCase):
         csv_bytes = csv_str.getvalue().encode()
         csv_file = SimpleUploadedFile("users.csv", csv_bytes)
 
-        response = self.client.post(f"{BASE_URL}", {"file": csv_file})
+        response = self.client.post(f"{BASE_URL}", {"file": csv_file}, format="multipart")
         self.assertEqual(response.status_code, 200)
 
         new_user = User.objects.get(email="john@foo.com")
@@ -663,7 +663,7 @@ class BulkCreateCsvTestCase(APITestCase):
         self.client.post("/api/userroles/", data=area_manager)
 
         with open("iaso/tests/fixtures/test_user_bulk_create_all_fields.csv") as csv_users:
-            response = self.client.post(f"{BASE_URL}", {"file": csv_users})
+            response = self.client.post(f"{BASE_URL}", {"file": csv_users}, format="multipart")
         self.assertJSONResponse(response, 200)
 
         self.client.force_authenticate(self.john)

--- a/iaso/tests/test_multi_tenant.py
+++ b/iaso/tests/test_multi_tenant.py
@@ -153,7 +153,11 @@ class MultiTenantTestCase(APITestCase):
 
         # now uploading the file content, so that it will appear in /instances/ for the Star Wars account
         with open("iaso/tests/fixtures/hydroponics_test_upload.xml") as fp:
-            c.post("/sync/form_upload/", {"name": "hydroponics_test_upload.xml", "xml_submission_file": fp})
+            c.post(
+                "/sync/form_upload/",
+                {"name": "hydroponics_test_upload.xml", "xml_submission_file": fp},
+                format="multipart",
+            )
 
         response = yoda_client.get("/api/instances/", accept="application/json")
         self.assertEqual(response.status_code, 200)  # yoda authorized to see Star Wars data

--- a/plugins/polio/tests/api/test_budget.py
+++ b/plugins/polio/tests/api/test_budget.py
@@ -390,6 +390,7 @@ class BudgetProcessViewSetTestCase(APITestCase):
                 "comment": "hello world2",
                 "files": [fake_file],
             },
+            format="multipart",
         )
         response_data = self.assertJSONResponse(response, 201)
         self.assertEqual(response_data["result"], "success")
@@ -454,6 +455,7 @@ class BudgetProcessViewSetTestCase(APITestCase):
                     ]
                 ),
             },
+            format="multipart",
         )
         response_data = self.assertJSONResponse(response, 201)
         self.assertEqual(response_data["result"], "success")
@@ -692,6 +694,7 @@ class BudgetProcessViewSetTestCase(APITestCase):
                 "comment": "override me",
                 "files": [fake_file],
             },
+            format="multipart",
         )
         response_data = self.assertJSONResponse(response, 201)
         self.assertEqual(response_data["result"], "success")


### PR DESCRIPTION
Set `TEST_REQUEST_DEFAULT_FORMAT` to `json`.

Related JIRA tickets : IA-4397

## Notes

About [File upload fields](https://www.django-rest-framework.org/api-guide/fields/#file-upload-fields):

> The `FileField` and `ImageField` classes are only suitable for use with `MultiPartParser` or `FileUploadParser`. Most parsers, such as e.g. JSON don't support file uploads. Django's regular `FILE_UPLOAD_HANDLERS` are used for handling uploaded files.

This is why we need to force `format="multipart"` for uploads.