### PR TITLE
[IA-4416] Add utility functions is_plugin_active

### DIFF
--- a/iaso/api/logs.py
+++ b/iaso/api/logs.py
@@ -1,6 +1,5 @@
 from typing import Union
 
-from django.conf import settings
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 from django.core.paginator import Paginator
@@ -19,6 +18,7 @@ from iaso.models import Form, Instance, OrgUnit
 from iaso.models.base import Profile
 from iaso.models.org_unit import OrgUnitChangeRequest
 from iaso.models.payments import Payment, PaymentLot
+from iaso.plugins import is_polio_plugin_active
 
 
 def has_access_to(user: User, obj: Union[OrgUnit, Instance, models.Model]):
@@ -49,8 +49,7 @@ def has_access_to(user: User, obj: Union[OrgUnit, Instance, models.Model]):
         return profiles.filter(id=obj.id).exists() and user.has_perm(core_permissions.USERS_ADMIN)
 
     # Now checking models that are part of plugins
-    plugins = settings.PLUGINS
-    if "polio" in plugins:
+    if is_polio_plugin_active():
         from plugins.polio import permissions as polio_permissions
         from plugins.polio.models import Campaign
 

--- a/iaso/api/org_units.py
+++ b/iaso/api/org_units.py
@@ -31,6 +31,7 @@ from iaso.models import DataSource, Form, Group, Instance, InstanceFile, OrgUnit
 from iaso.utils import geojson_queryset
 from iaso.utils.gis import simplify_geom
 
+from ..plugins import is_polio_plugin_active
 from ..utils.models.common import get_creator_name, get_org_unit_parents_ref
 
 
@@ -63,7 +64,7 @@ class HasOrgUnitPermission(permissions.BasePermission):
             request.user.has_perm(core_permissions.REGISTRY_WRITE),
             request.user.has_perm(core_permissions.REGISTRY_READ),
         ]
-        if "polio" in settings.PLUGINS:
+        if is_polio_plugin_active():
             from plugins.polio import permissions as polio_permissions
 
             required_perms.append(request.user.has_perm(polio_permissions.POLIO))

--- a/iaso/plugins.py
+++ b/iaso/plugins.py
@@ -1,0 +1,25 @@
+from django.conf import settings
+
+
+def is_polio_plugin_active():
+    return "polio" in settings.PLUGINS
+
+
+def is_trypelim_plugin_active():
+    return "trypelim" in settings.PLUGINS
+
+
+def is_wfp_plugin_active():
+    return "wfp" in settings.PLUGINS
+
+
+def is_saas_plugin_active():
+    return "saas" in settings.PLUGINS
+
+
+def is_snt_malaria_plugin_active():
+    return "snt_malaria" in settings.PLUGINS
+
+
+def is_registry_plugin_active():
+    return "registry" in settings.PLUGINS


### PR DESCRIPTION
Add utility functions is_plugin_active

Related JIRA tickets : IA-4416

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

/

## Changes

Add utility functions is_plugin_xxx_active

## How to test

Can't really test it, except using an endpoint that somehow calls one of these functions

## Print screen / video

/

## Notes

- This is going to be useful for Trypelim & SaaS later on
- I'm not quite sure if there should be one for `wfp_auth` - I guess it's never used without `wfp`  active


## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
