### PR TITLE
[IA-3801] Display current OU values in OUCR by default

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -80,6 +80,7 @@
     "iaso.completeness.generateDerivedInstances": "Generate derived instances",
     "iaso.completeness.orgUnitHasMultipleSubmissions": "This org unit has multiple direct submissions",
     "iaso.completeness.orgUnitTypeGroupBy": "Group by type",
+    "iaso.changeRequest.showValuesAtCreation": "Show values at creation",
     "iaso.completeness.title": "Completeness",
     "iaso.completeness.titleDescendants": "Completeness (with descendants)",
     "iaso.completeness.titleDirect": "Completeness (direct)",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/es.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/es.json
@@ -64,6 +64,7 @@
     "iaso.changeRequest.reject": "Rechazar todo",
     "iaso.changeRequest.seeApprovedChanges": "Ver cambio(s) aprobado(s)",
     "iaso.changeRequest.seeRejectedChanges": "Ver cambio(s) rechazado(s)",
+    "iaso.changeRequest.showValuesAtCreation": "Mostrar valores al crear",
     "iaso.completeness.chooseParent": "Seleccione un formulario o una unidad organizativa padre para habilitar",
     "iaso.completeness.formsFilledDirect": "# Formularios completados (directo)",
     "iaso.completeness.formsFilledWithDescendants": "# Formularios completados (con descendientes)",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -74,6 +74,7 @@
     "iaso.changeRequest.restoreOrgUnitChangesCount": "Restaurer {count} demande(s) de changement",
     "iaso.changeRequest.seeApprovedChanges": "Voir le(s) changement(s) approuvé(s)",
     "iaso.changeRequest.seeRejectedChanges": "Voir le(s) changement(s) rejeté(s)",
+    "iaso.changeRequest.showValuesAtCreation": "Montrer les valeurs à la création",
     "iaso.completeness.chooseParent": "Selectionnez un formulaire ou une unité d'org parente pour activer",
     "iaso.completeness.formsFilledDirect": "# Formulaires remplis (direct)",
     "iaso.completeness.formsFilledWithDescendants": "# Formulaires remplis (avec niv. inf.)",

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/Components/ReviewOrgUnitFieldChanges.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/Components/ReviewOrgUnitFieldChanges.tsx
@@ -1,9 +1,9 @@
 import React, { FunctionComponent } from 'react';
 import { Table, TableBody, TableCell, TableRow } from '@mui/material';
 import { useSafeIntl } from 'bluesquare-components';
-import { Accordion } from '../../../../components/Accordion/Accordion';
-import { AccordionDetails } from '../../../../components/Accordion/AccordionDetails';
-import { AccordionSummary } from '../../../../components/Accordion/AccordionSummary';
+import { Accordion } from 'Iaso/components/Accordion/Accordion';
+import { AccordionDetails } from 'Iaso/components/Accordion/AccordionDetails';
+import { AccordionSummary } from 'Iaso/components/Accordion/AccordionSummary';
 import { NewOrgUnitField } from '../hooks/useNewFields';
 import MESSAGES from '../messages';
 import { ExtendedNestedGroup, OrgUnitChangeRequestDetails } from '../types';
@@ -59,7 +59,7 @@ export const ReviewOrgUnitFieldChanges: FunctionComponent<Props> = ({
                                             color: isHighlighted,
                                         }}
                                     >
-                                        {(value.left === true && name) || '--'}
+                                        {(value.left && name) || '--'}
                                     </TableCell>
                                     <TableCell
                                         sx={{
@@ -71,7 +71,7 @@ export const ReviewOrgUnitFieldChanges: FunctionComponent<Props> = ({
                                                 isHighlighted,
                                         }}
                                     >
-                                        {(value.right === true && name) || '--'}
+                                        {(value.right && name) || '--'}
                                     </TableCell>
                                 </TableRow>
                             );

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/messages.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/messages.ts
@@ -330,6 +330,10 @@ const MESSAGES = defineMessages({
         id: 'iaso.changeRequest.isSoftDeleted',
         defaultMessage: 'Show only deleted',
     },
+    showValuesAtCreation: {
+        id: 'iaso.changeRequest.showValuesAtCreation',
+        defaultMessage: 'Show values at creation',
+    },
 });
 
 export default MESSAGES;


### PR DESCRIPTION
Display current OU values in OUCR by default

Related JIRA tickets : IA-3801

## Self proofreading checklist

- [X] Did I use eslint and ruff formatters?
- [X] Is my code clear enough and well documented?
- [X] Are my typescript files well typed?
- [X] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] Are there enough tests?

## Doc

The code is the truth

## Changes

I added a toggle for new OUCRs that allows to switch between current OU values and the one at creation.

## How to test

1. Create a new OUCR,
2. Change some value on the OU
3. Open the OUCR and toggle the switch

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
