### PR TITLE
HOT-fix: avoid duplicate pages link

### DIFF
--- a/hat/assets/js/apps/Iaso/constants/menu.tsx
+++ b/hat/assets/js/apps/Iaso/constants/menu.tsx
@@ -416,7 +416,10 @@ export const useMenuItems = (): MenuItems => {
     }
 
     // add feature flags
-    if (hasFeatureFlag(currentUser, SHOW_PAGES)) {
+    if (
+        hasFeatureFlag(currentUser, SHOW_PAGES) &&
+        !basicItems.find(item => item.key === 'pages')
+    ) {
         basicItems.push({
             label: formatMessage(MESSAGES.pages),
             key: 'pages',


### PR DESCRIPTION
Embedded links entry in the menu are duplicates

<img width="462" height="1153" alt="Screenshot 2025-08-12 at 17 01 35" src="https://github.com/user-attachments/assets/d8144221-3f8b-449e-a469-22340b3727ee" />
