### PR TITLE
IA-4422 Fix n+1 query on `/api/mobile/forms`

### DIFF
--- a/iaso/api/forms.py
+++ b/iaso/api/forms.py
@@ -540,4 +540,9 @@ def generate_manifest_structure(content: list[str]) -> str:
 class MobileFormViewSet(FormsViewSet):
     # Filtering out forms without form versions to prevent mobile app from crashing
     def get_queryset(self):
-        return super().get_queryset(mobile=True).exclude(form_versions=None)
+        return (
+            super()
+            .get_queryset(mobile=True)
+            .exclude(form_versions=None)
+            .prefetch_related("predefined_filters", "attachments", "reference_of_org_unit_types__sub_unit_types")
+        )


### PR DESCRIPTION
Fix n+1 query on `/api/mobile/forms`.

Related JIRA tickets : IA-4422

[Jira issue](https://bluesquareorg.sentry.io/issues/6749687187/?project=5530884).

This one was triggered when calling relations via the `fields` parameter, e.g.:

```
http://localhost:8081/api/mobile/forms/?fields=id,name,form_id,org_unit_types,period_type,single_per_period,periods_before_allowed,periods_after_allowed,latest_form_version,label_keys,possible_fields,predefined_filters,has_attachments,created_at,updated_at,reference_form_of_org_unit_types
```
