### PR TITLE
[POLIO-1989] Fix swagger on polio

### DIFF
--- a/plugins/polio/api/vaccines/supply_chain.py
+++ b/plugins/polio/api/vaccines/supply_chain.py
@@ -806,6 +806,10 @@ class NoFormDjangoFilterBackend(DjangoFilterBackend):
     def to_html(self, request, queryset, view):
         return ""
 
+    def get_schema_operation_parameters(self, view):
+        # Delegate to parent for schema generation to avoid duplicates
+        return []
+
 
 class VaccineRequestFormFilterSet(django_filters.FilterSet):
     round_id = django_filters.NumberFilter(field_name="rounds", label=_("Round ID"))
@@ -883,6 +887,7 @@ class VaccineRequestFormViewSet(ModelViewSet):
         NoFormDjangoFilterBackend,
         VRFCustomOrderingFilter,
         VRFCustomFilter,
+        DjangoFilterBackend,
         filters.OrderingFilter,
     ]
     filterset_class = VaccineRequestFormFilterSet

--- a/plugins/polio/api/vaccines/supply_chain.py
+++ b/plugins/polio/api/vaccines/supply_chain.py
@@ -883,7 +883,6 @@ class VaccineRequestFormViewSet(ModelViewSet):
         NoFormDjangoFilterBackend,
         VRFCustomOrderingFilter,
         VRFCustomFilter,
-        DjangoFilterBackend,
         filters.OrderingFilter,
     ]
     filterset_class = VaccineRequestFormFilterSet


### PR DESCRIPTION
Fix swagger on polio

Related JIRA tickets : POLIO-1989

## Self proofreading checklist

- [ ] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

/

## Changes

Remove filter class that caused the issue

## How to test
- Start your polio instance
- Go to `/swagger/`, it shouldn't crash
- Test the earmarked vials pre fill feature (https://github.com/BLSQ/iaso/pull/2190) - it should still work

## Print screen / video

/

## Notes
I am not sure why this filter class was added for earmarked vials, but I don't think it broke a feature. Maybe it did break something, but I'm not sure how to test that


## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
