### PR TITLE
[POLIO-1990] Fix group creation with blank source ref

### DIFF
--- a/iaso/api/groups/serializers.py
+++ b/iaso/api/groups/serializers.py
@@ -44,7 +44,7 @@ class GroupSerializer(serializers.ModelSerializer):
 
     def validate(self, attrs):
         default_version = self._fetch_user_default_source_version()
-        if "source_ref" in attrs:
+        if "source_ref" in attrs and attrs["source_ref"]:
             # Check if the source_ref is already used by another group
             potential_group = Group.objects.filter(source_ref=attrs["source_ref"], source_version=default_version)
             if potential_group.exists():

--- a/iaso/tests/api/groups/test_views.py
+++ b/iaso/tests/api/groups/test_views.py
@@ -1,6 +1,5 @@
 import typing
 
-from django.db.models import Q
 from django.utils.timezone import now
 from rest_framework import status
 
@@ -166,8 +165,10 @@ class GroupsAPITestCase(APITestCase):
 
     def test_groups_create_multiple_with_blank_source_ref(self):
         """POST /groups/ another group with blank source ref"""
-        source_ref_filter = Q(source_ref="") | Q(source_ref__isnull=True)
-        count_before = m.Group.objects.filter(source_ref_filter, source_version=self.source_version_2).count()
+        self.group_2.source_ref = ""
+        self.group_2.save()
+
+        count_before = m.Group.objects.filter(source_ref="", source_version=self.source_version_2).count()
         self.assertEqual(count_before, 1)  # we already have a group with blank source_ref
 
         self.client.force_authenticate(self.yoda)
@@ -178,14 +179,14 @@ class GroupsAPITestCase(APITestCase):
         response = self.client.post("/api/groups/", data=data, format="json")
         self.assertJSONResponse(response, status.HTTP_201_CREATED)
 
-        count_after = m.Group.objects.filter(source_ref_filter, source_version=self.source_version_2).count()
+        count_after = m.Group.objects.filter(source_ref="", source_version=self.source_version_2).count()
         self.assertEqual(count_before + 1, count_after)
 
         # Multiple groups can be created with blank source_ref
         response = self.client.post("/api/groups/", data=data, format="json")  # posting the same thing again
         self.assertJSONResponse(response, status.HTTP_201_CREATED)
 
-        last_count = m.Group.objects.filter(source_ref_filter, source_version=self.source_version_2).count()
+        last_count = m.Group.objects.filter(source_ref="", source_version=self.source_version_2).count()
         self.assertEqual(count_after + 1, last_count)
 
     def test_groups_partial_update_ok(self):
@@ -203,6 +204,34 @@ class GroupsAPITestCase(APITestCase):
         self.group_1.refresh_from_db()
         self.assertEqual("test group (updated)", self.group_1.name)
         self.assertEqual(1, self.group_1.source_version.number)
+
+    def test_groups_partial_update_with_blank_source_ref(self):
+        """PATCH /groups/<group_id>: removing a source_ref doesn't crash"""
+        self.group_2.source_ref = ""
+        self.group_2.save()
+
+        count_before = m.Group.objects.filter(source_ref="", source_version=self.source_version_2).count()
+        self.assertEqual(count_before, 1)  # we already have a group with blank source_ref
+
+        # Preparing a new group with a source ref
+        new_group = m.Group.objects.create(
+            name="new group",
+            source_version=self.source_version_2,  # default version
+            source_ref="some_source_ref",
+        )
+
+        self.client.force_authenticate(self.yoda)
+        response = self.client.patch(f"/api/groups/{new_group.id}/", data={"source_ref": ""}, format="json")
+        self.assertJSONResponse(response, status.HTTP_200_OK)
+
+        response_data = response.json()
+        self.assertValidGroupData(response_data)
+
+        new_group.refresh_from_db()
+        self.assertEqual(new_group.source_ref, "")
+
+        count_blank_source_refs = m.Group.objects.filter(source_ref="", source_version=self.source_version_2).count()
+        self.assertEqual(count_blank_source_refs, 2)
 
     def test_groups_update_not_implemented(self):
         """PUT /groups/<group_id>: 405"""


### PR DESCRIPTION
Fix group creation with blank source ref

Related JIRA tickets : POLIO-1990

## Self proofreading checklist

- [ ] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

/

## Changes

Now checking if `source_ref` is not blank before checking for unicity

## How to test

- Have a group with a blank/null `source_ref` in your default version
- Create another one through the web interface - leave the `source_ref` field blank :arrow_right: there shouldn't be any error
- Create a new group with a `source_ref`
- Update that new group and remove the `source_ref` :arrow_right: updating shouldn't cause any error either

## Print screen / video

<img width="850" height="606" alt="image" src="https://github.com/user-attachments/assets/d01ac669-9c64-42a7-99eb-4c1a560d440c" />


## Notes

/

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
