### PR TITLE
IA-4424 Fix n+1 query on `/api/mobile/group_sets`

### DIFF
--- a/iaso/api/mobile/group_sets.py
+++ b/iaso/api/mobile/group_sets.py
@@ -77,5 +77,6 @@ class MobileGroupSetsViewSet(ListModelMixin, GenericViewSet):
         qs = qs.annotate(
             annotated_erased=ExpressionWrapper(~Q(source_version=default_version), output_field=BooleanField())
         )
+        qs = qs.prefetch_related("groups")
 
         return qs

--- a/iaso/tests/api/test_mobile_groupsets.py
+++ b/iaso/tests/api/test_mobile_groupsets.py
@@ -114,7 +114,8 @@ class MobileGroupSetsAPITestCase(APITestCase):
         }
 
         # Groups with `source_version_1`.
-        response = self.client.get("/api/mobile/group_sets/", {APP_ID: self.project_cameroon.app_id})
+        with self.assertNumQueries(3):
+            response = self.client.get("/api/mobile/group_sets/", {APP_ID: self.project_cameroon.app_id})
         self.assertJSONResponse(response, 200)
         self.assertEqual(json.dumps(response.data), json.dumps([record_cameroon]))
 
@@ -136,7 +137,8 @@ class MobileGroupSetsAPITestCase(APITestCase):
 
         # Groups with `source_version_2`.
         ## Without all versions
-        response = self.client.get("/api/mobile/group_sets/", {APP_ID: self.project_nigeria.app_id})
+        with self.assertNumQueries(3):
+            response = self.client.get("/api/mobile/group_sets/", {APP_ID: self.project_nigeria.app_id})
         self.assertEqual(json.dumps(response.data), json.dumps([record_nigeria, record_nigeria_2]))
 
     def test_api_mobile_groupsets_list_with_app_id_and_authenticated(self):


### PR DESCRIPTION
Fix n+1 query on `/api/mobile/group_sets`.

Related JIRA tickets: IA-4424

[Jira issue](https://bluesquareorg.sentry.io/issues/6748360164/?project=5530884).

This one was triggered when calling e.g.:

```
/api/mobile/group_sets/?app_id=my_app_id&showDeleted=true
```
