### PR TITLE
[POLIO-1994] Fix flaky test

### DIFF
--- a/plugins/polio/api/dashboards/supply_chain.py
+++ b/plugins/polio/api/dashboards/supply_chain.py
@@ -159,9 +159,11 @@ class VaccineRequestFormDashboardViewSet(ModelViewSet):
         return super().list(request, *args, **kwargs)
 
     def get_queryset(self):
-        return VaccineRequestForm.objects.filter(
-            campaign__account=self.request.user.iaso_profile.account
-        ).select_related("campaign__country")
+        return (
+            VaccineRequestForm.objects.filter(campaign__account=self.request.user.iaso_profile.account)
+            .select_related("campaign__country")
+            .order_by("id")
+        )
 
 
 class VaccinePreAlertDashboardSerializer(serializers.ModelSerializer):

--- a/plugins/polio/tests/test_supply_chain_dashboards.py
+++ b/plugins/polio/tests/test_supply_chain_dashboards.py
@@ -257,6 +257,7 @@ class SupplyChainDashboardsAPITestCase(APITestCase):
         vrf1 = results[0]
 
         # Check if the latest dates are returned
+        self.assertEqual(vrf1["id"], self.vrf.id)
         self.assertEqual(vrf1["form_a_reception_date"], str(self.form_a.form_a_reception_date))
         self.assertEqual(
             vrf1["destruction_report_reception_date"],
@@ -266,5 +267,6 @@ class SupplyChainDashboardsAPITestCase(APITestCase):
         vrf2 = results[1]
 
         # Check if the latest dates are returned
+        self.assertEqual(vrf2["id"], new_vrf.id)
         self.assertEqual(vrf2["form_a_reception_date"], str(new_forma.form_a_reception_date))
         self.assertEqual(vrf2["destruction_report_reception_date"], str(last_dr.rrt_destruction_report_reception_date))


### PR DESCRIPTION
Fix flaky test

Related JIRA tickets : POLIO-1994

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

/

## Changes

- Added default ordering on the queryset that was generated
- Added more checks in the unit test to make it easier to understand if it fails again

## How to test

- Run `SupplyChainDashboardsAPITestCase.test_vrf_correct_dates_with_multiple_entries` as many times as you want - it should no longer fail

## Print screen / video

/

## Notes
/

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
