### PR TITLE
IA-4426 Fix n+1 query on `/api/orgunittypes`

### DIFF
--- a/iaso/api/org_unit_types/serializers.py
+++ b/iaso/api/org_unit_types/serializers.py
@@ -92,10 +92,13 @@ class OrgUnitTypeSerializerV1(DynamicFieldsModelSerializer):
 
     def get_sub_unit_types(self, obj: OrgUnitType):
         # Filter sub unit types to show only visible items for the current app id
-        unit_types = obj.allow_creating_sub_unit_types.all()
-        app_id = self.context["request"].query_params.get("app_id")
-        if app_id is not None:
-            unit_types = unit_types.filter(projects__app_id=app_id)
+        if hasattr(obj, "filtered_allow_creating_sub_unit_types"):
+            unit_types = obj.filtered_allow_creating_sub_unit_types
+        else:
+            unit_types = obj.allow_creating_sub_unit_types.all()
+            app_id = self.context["request"].query_params.get("app_id")
+            if app_id is not None:
+                unit_types = unit_types.filter(projects__app_id=app_id)
 
         return OrgUnitTypeSerializerV1(
             unit_types,

--- a/iaso/tests/test_api.py
+++ b/iaso/tests/test_api.py
@@ -355,9 +355,10 @@ class BasicAPITestCase(APITestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(json_response["orgUnitTypes"]), 0)
 
-        response = c.get(
-            "/api/orgunittypes/?app_id=org.inconnus.spectacle", accept="application/json"
-        )  # this should have 2 results
+        with self.assertNumQueries(10):
+            response = c.get(
+                "/api/orgunittypes/?app_id=org.inconnus.spectacle", accept="application/json"
+            )  # this should have 2 results
         json_response = json.loads(response.content)
         org_unit_types = json_response["orgUnitTypes"]
         self.assertEqual(len(org_unit_types), 2)


### PR DESCRIPTION
Fix n+1 query on `/api/orgunittypes`.

Related JIRA tickets: IA-4426

[Jira issue](https://bluesquareorg.sentry.io/issues/6748465481/?project=5530884).

This one was triggered when calling e.g.:

```
/api/orgunittypes/?app_id=my_app_id&fields=id,name,short_name,sub_unit_types,created_at,updated_at
```

Note that this will not completely fix the problem because the serializer method is operating on a recursive data structure.
