### PR TITLE
IA-4339 plausible

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,7 @@ services:
             DISABLE_PASSWORD_LOGINS:
             DNS_DOMAIN:
             EMAIL_BACKEND: 'django.core.mail.backends.console.EmailBackend'
+            ENABLE_ANALYTICS:
             ENKETO_API_TOKEN: AZE78974654azeAZE
             ENKETO_DEV: 'true'
             ENKETO_SIGNING_SECRET: supersecret
@@ -87,7 +88,6 @@ services:
             WFP_AUTH_ACCOUNT:
             WFP_AUTH_CLIENT_ID:
             WFP_EMAIL_RECIPIENTS_NEW_ACCOUNT:
-            ENABLE_ANALYTICS:
         logging: &iaso_logging
             driver: 'json-file'
             options:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,6 +87,7 @@ services:
             WFP_AUTH_ACCOUNT:
             WFP_AUTH_CLIENT_ID:
             WFP_EMAIL_RECIPIENTS_NEW_ACCOUNT:
+            ENABLE_ANALYTICS:
         logging: &iaso_logging
             driver: 'json-file'
             options:

--- a/docs/pages/dev/reference/analytics/plausible-setup.en.md
+++ b/docs/pages/dev/reference/analytics/plausible-setup.en.md
@@ -6,6 +6,14 @@ This guide explains how to set up and configure Plausible analytics in Iaso.
 
 Iaso supports Plausible analytics integration for tracking user activity and account usage. The system automatically generates analytics scripts and tracks custom events with user and account information.
 
+### Analytics Levels
+
+The system provides different levels of analytics tracking:
+
+1. **Basic Tracking**: Page views for all users (domain only)
+2. **Enhanced Tracking**: Custom events with user/account data for authenticated users
+3. **Future**: Custom analytics scripts for specific customer requirements
+
 ## Prerequisites
 
 - A Plausible account and subscription
@@ -114,7 +122,7 @@ You can create custom views to analyze:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `ENABLE_ANALYTICS` | `false` | Enable/disable analytics globally |
+| `ENABLE_ANALYTICS` | `true` | Enable/disable analytics globally |
 
 ### Analytics Data Tracked
 
@@ -122,13 +130,19 @@ You can create custom views to analyze:
 - All page visits are automatically tracked
 - Domain is automatically detected from the request
 
-#### Custom Events
+#### Custom Events (Authenticated Users Only)
 - **Event**: "User Login"
 - **Properties**:
   - `username`: User's username
   - `user_id`: User's unique ID
   - `account_name`: Account/organization name
   - `account_id`: Account's unique ID
+
+#### Non-Connected Pages
+For pages without user authentication (embeddable pages, public pages, etc.):
+- **Only domain tracking**: Basic page views are tracked
+- **No user data**: No custom events or user properties
+- **Privacy-focused**: Minimal data collection for anonymous users
 
 ## Privacy and Security
 
@@ -218,6 +232,17 @@ The system is designed to support multiple analytics providers. Future versions 
 - Google Analytics
 - Matomo
 - Custom analytics solutions
+
+### Custom Analytics Scripts (Future Feature)
+
+The `analytics_script` field in the Account model is preserved for future use:
+
+- **Current**: Not used in the new analytics system
+- **Future**: Will allow customers to specify custom analytics scripts
+- **Implementation**: Will be added in a future version
+- **Use Case**: For customers who need specific analytics providers or configurations
+
+**Note**: The current system uses automatic Plausible script generation. Custom scripts will be implemented as an additional feature.
 
 ## Support
 

--- a/docs/pages/dev/reference/analytics/plausible-setup.en.md
+++ b/docs/pages/dev/reference/analytics/plausible-setup.en.md
@@ -296,7 +296,7 @@ For pages without user authentication (embeddable pages, public pages, etc.):
    - Verify Plausible script is loading
 
 4. **Check network requests**:
-   - Ensure requests to `plausible.io` are not blocked
+   - Ensure requests to `plausible.io` are not blocked (i.e. by your ad blocker)
    - Check for CORS issues
 
 ### Custom Properties Not Showing

--- a/docs/pages/dev/reference/analytics/plausible-setup.en.md
+++ b/docs/pages/dev/reference/analytics/plausible-setup.en.md
@@ -1,0 +1,234 @@
+# Plausible Analytics Setup
+
+This guide explains how to set up and configure Plausible analytics in Iaso.
+
+## Overview
+
+Iaso supports Plausible analytics integration for tracking user activity and account usage. The system automatically generates analytics scripts and tracks custom events with user and account information.
+
+## Prerequisites
+
+- A Plausible account and subscription
+- Access to your Iaso instance
+- Domain name for your Iaso instance
+
+## Step 1: Enable Analytics
+
+### Environment Variable
+
+Add the following environment variable to enable analytics:
+
+```bash
+ENABLE_ANALYTICS=true
+```
+
+**Docker Compose:**
+```yaml
+# docker-compose.yml
+services:
+  iaso:
+    environment:
+      ENABLE_ANALYTICS: "true"
+```
+
+**Environment File:**
+```bash
+# .env
+ENABLE_ANALYTICS=true
+```
+
+## Step 2: Add Your Domain to Plausible
+
+1. **Log into your Plausible dashboard**
+2. **Add a new site** with your Iaso domain
+3. **Enter your domain** (e.g., `your-iaso-instance.com`)
+4. **Save the site**
+
+## Step 3: Configure Custom Properties
+
+To see user and account data in your Plausible dashboard, you need to add custom properties:
+
+### Required Custom Properties
+
+| Property Name | Type | Description |
+|---------------|------|-------------|
+| `username` | String | User's username |
+| `user_id` | Number | User's unique ID |
+| `account_name` | String | Account/organization name |
+| `account_id` | Number | Account's unique ID |
+
+### How to Add Custom Properties
+
+1. **Go to your site in Plausible**
+2. **Navigate to Settings** → **Custom Properties**
+3. **Click "Add custom property"**
+4. **Enter the property details:**
+   - **Name**: `username`
+   - **Type**: String
+5. **Repeat for all properties**
+6. **Save each property**
+
+## Step 4: Verify Setup
+
+### Check Analytics Script
+
+1. **Enable analytics**: `ENABLE_ANALYTICS=true`
+2. **Access your Iaso instance**
+3. **Log in as a user**
+4. **Open browser developer tools**
+5. **Check the page source** for the Plausible script:
+   ```html
+   <script defer data-domain="your-domain.com" src="https://plausible.io/js/script.js"></script>
+   ```
+
+### Check Network Requests
+
+1. **Open browser developer tools**
+2. **Go to Network tab**
+3. **Refresh the page**
+4. **Look for requests to `plausible.io`**
+5. **Verify custom events are being sent**
+
+## Step 5: View Analytics Data
+
+### Custom Events
+
+In your Plausible dashboard, you'll see:
+
+- **Event Name**: "User Login"
+- **Properties**: All user and account details
+- **Timing**: When users log in and access pages
+
+### Dashboard Views
+
+You can create custom views to analyze:
+
+- **User Activity**: Most active users
+- **Account Usage**: Usage per account/organization
+- **Feature Usage**: Which features are used most
+- **User Journeys**: Individual user behavior patterns
+
+## Configuration Options
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ENABLE_ANALYTICS` | `false` | Enable/disable analytics globally |
+
+### Analytics Data Tracked
+
+#### Page Views
+- All page visits are automatically tracked
+- Domain is automatically detected from the request
+
+#### Custom Events
+- **Event**: "User Login"
+- **Properties**:
+  - `username`: User's username
+  - `user_id`: User's unique ID
+  - `account_name`: Account/organization name
+  - `account_id`: Account's unique ID
+
+## Privacy and Security
+
+### Data Privacy
+- **No PII**: Usernames are typically not personally identifiable
+- **Account Level**: Focuses on organizational usage patterns
+- **GDPR Compliant**: Plausible is privacy-focused by design
+- **No Cookies**: Plausible doesn't use cookies
+
+### Security Considerations
+- **HTTPS Only**: Analytics only works over HTTPS in production
+- **Domain Validation**: Only tracks on the configured domain
+- **User Consent**: Consider implementing user consent if required
+
+## Troubleshooting
+
+### Analytics Not Working
+
+1. **Check environment variable**:
+   ```bash
+   echo $ENABLE_ANALYTICS
+   ```
+
+2. **Verify domain in Plausible**:
+   - Ensure your domain is added to Plausible
+   - Check for typos in the domain name
+
+3. **Check browser console**:
+   - Look for JavaScript errors
+   - Verify Plausible script is loading
+
+4. **Check network requests**:
+   - Ensure requests to `plausible.io` are not blocked
+   - Check for CORS issues
+
+### Custom Properties Not Showing
+
+1. **Verify property names**: Must match exactly (case-sensitive)
+2. **Check property types**: Ensure correct data types
+3. **Wait for data**: Custom properties may take time to appear
+4. **Check event data**: Verify events are being sent with properties
+
+### Development Testing
+
+For local development:
+
+1. **Use a test domain**:
+   ```bash
+   # In /etc/hosts
+   127.0.0.1 test-iaso.local
+   ```
+
+2. **Add test domain to Plausible**:
+   - Add `test-iaso.local` as a site in Plausible
+
+3. **Enable analytics locally**:
+   ```bash
+   ENABLE_ANALYTICS=true
+   ```
+
+4. **Access via test domain**:
+   ```
+   http://test-iaso.local:8081
+   ```
+
+## Advanced Configuration
+
+### Custom Event Tracking
+
+You can extend the analytics system to track additional events:
+
+```javascript
+// Example: Track feature usage
+window.plausible('Feature Used', {
+    props: {
+        feature: 'data_export',
+        username: 'user123',
+        account_name: 'WHO'
+    }
+});
+```
+
+### Multiple Analytics Providers
+
+The system is designed to support multiple analytics providers. Future versions may include:
+
+- Google Analytics
+- Matomo
+- Custom analytics solutions
+
+## Support
+
+For issues with:
+
+- **Iaso Analytics Integration**: Check this documentation
+- **Plausible Service**: Contact Plausible support
+- **Custom Properties**: Refer to Plausible documentation
+
+## Related Documentation
+
+- [Environment Variables](../env_variables/env_variables.en.md)
+- [Docker Configuration](../../deployment/docker.md)
+- [Privacy Policy](../../legal/privacy.md)

--- a/docs/pages/dev/reference/analytics/plausible-setup.en.md
+++ b/docs/pages/dev/reference/analytics/plausible-setup.en.md
@@ -72,7 +72,6 @@ To see user and account data in your Plausible dashboard, you need to add custom
 3. **Click "Add custom property"**
 4. **Enter the property details:**
    - **Name**: `username`
-   - **Type**: String
 5. **Repeat for all properties**
 6. **Save each property**
 
@@ -115,6 +114,128 @@ You can create custom views to analyze:
 - **Account Usage**: Usage per account/organization
 - **Feature Usage**: Which features are used most
 - **User Journeys**: Individual user behavior patterns
+
+## Plausible Filters and Iaso Pages
+
+Iaso supports creating pages with raw HTML, Superset dashboards, or embedded Plausible dashboards. You can use Plausible's filtering capabilities to create targeted analytics views.
+
+### Filtering by User Properties
+
+Plausible allows filtering results using URL parameters. You can create Iaso pages that show filtered analytics data:
+
+#### Filter for Non-Connected Pages
+To show only analytics for non-authenticated users (pages without user data):
+```
+https://plausible.io/your-domain.com?f=is,props:username,(none)
+```
+
+#### Filter by Account
+To show analytics for a specific account:
+```
+https://plausible.io/your-domain.com?f=is,props:account_id,123
+```
+
+#### Filter by Username
+To show analytics for a specific user:
+```
+https://plausible.io/your-domain.com?f=is,props:username,john_doe
+```
+
+### Creating Iaso Pages with Filtered Analytics
+
+#### 1. Raw HTML Page
+Create a page with embedded Plausible dashboard:
+
+```html
+<iframe 
+    src="https://plausible.io/your-domain.com?f=is,props:account_id,123" 
+    width="100%" 
+    height="600px"
+    frameborder="0">
+</iframe>
+```
+
+
+#### 2. Plausible Dashboard Page
+Create a dedicated analytics page:
+
+```html
+<!-- Full analytics dashboard -->
+<iframe 
+    src="https://plausible.io/your-domain.com?f=is,props:username,(none)&period=30d" 
+    width="100%" 
+    height="800px">
+</iframe>
+```
+
+### Common Filter Patterns
+
+#### Account-Specific Dashboards
+```
+# Dashboard for specific account
+https://plausible.io/your-domain.com?f=is,props:account_id,678&period=30d
+
+# Dashboard for account by name
+https://plausible.io/your-domain.com?f=is,props:account_name,WHO%20Country%20Office
+```
+
+#### User-Specific Views
+```
+# Analytics for specific user
+https://plausible.io/your-domain.com?f=is,props:username,john_doe&period=7d
+
+# Analytics for users in specific account
+https://plausible.io/your-domain.com?f=is,props:account_id,678&f=is,props:username,(not%20none)
+```
+
+#### Anonymous vs Authenticated Users
+```
+# Only anonymous users (non-connected pages)
+https://plausible.io/your-domain.com?f=is,props:username,(none)
+
+# Only authenticated users
+https://plausible.io/your-domain.com?f=is,props:username,(not%20none)
+```
+
+### Filter URL Parameters
+
+| Parameter | Description | Example |
+|-----------|-------------|---------|
+| `f=is,props:username,(none)` | Filter for anonymous users | Non-connected pages |
+| `f=is,props:account_id,123` | Filter by account ID | Account-specific dashboard |
+| `f=is,props:account_name,WHO` | Filter by account name | Organization dashboard |
+| `f=is,props:user_id,456` | Filter by user ID | User-specific analytics |
+| `period=30d` | Time period | Last 30 days |
+| `period=7d` | Time period | Last 7 days |
+| `period=1m` | Time period | Last month |
+
+### Creating Multi-Account Dashboards
+
+For organizations managing multiple accounts, you can create comparison dashboards:
+
+```html
+<!-- Compare multiple accounts -->
+<iframe 
+    src="https://plausible.io/your-domain.com?f=is,props:account_id,123&f=is,props:account_id,456&period=30d" 
+    width="100%" 
+    height="600px">
+</iframe>
+```
+
+### Using Plausible Dashboards in Iaso Pages
+
+To create analytics dashboards in Iaso pages, use the **iframe option** with a specific Plausible URL:
+
+```html
+<iframe 
+    src="https://plausible.io/your-domain.com?f=is,props:account_id,123&period=30d" 
+    width="100%" 
+    height="600px"
+    frameborder="0">
+</iframe>
+```
+
+This allows you to embed filtered Plausible analytics directly into your Iaso pages.
 
 ## Configuration Options
 

--- a/docs/pages/dev/reference/analytics/plausible-setup.fr.md
+++ b/docs/pages/dev/reference/analytics/plausible-setup.fr.md
@@ -1,0 +1,1 @@
+## Traduction française bientôt disponible

--- a/docs/pages/dev/reference/env_variables/env_variables.en.md
+++ b/docs/pages/dev/reference/env_variables/env_variables.en.md
@@ -147,6 +147,26 @@ PRODUCT_FRUITS_WORKSPACE_CODE=YOUR_CODE
 
 When this variable is set, Product Fruits will be enabled and only the account name and ID will be sent to the service. This allows for user onboarding and feature discovery.
 
+## Analytics Integration
+
+### Plausible Analytics
+
+To enable Plausible analytics tracking, set the following environment variable:
+
+```
+ENABLE_ANALYTICS=true
+```
+
+When enabled, Iaso will automatically generate and include Plausible analytics scripts on all pages for authenticated users. The system tracks:
+
+- **Page views**: All page visits
+- **Custom events**: User login events with account details
+- **User information**: Username, user ID, account name, and account ID
+
+**Note**: Analytics is disabled by default and only works when explicitly enabled via the environment variable.
+
+For detailed setup instructions, see [Plausible Analytics Setup](../analytics/plausible-setup.md).
+
 ## Frontend Configuration
 
 ### Development Settings

--- a/hat/dashboard/views.py
+++ b/hat/dashboard/views.py
@@ -7,10 +7,18 @@ from django.shortcuts import render
 from django.views.decorators.http import require_http_methods
 
 from hat.__version__ import VERSION
-from iaso.models.base import Account
 
 
-def _base_iaso(request: HttpRequest, analytics_scripts: list[str] = None, analytics_data: dict = None) -> HttpResponse:
+def _should_enable_analytics(request: HttpRequest) -> bool:
+    """Check if analytics should be enabled based on environment variable"""
+    return getattr(settings, "ENABLE_ANALYTICS", False)
+
+
+def _get_domain_from_request(request: HttpRequest) -> str:
+    return request.get_host().split(":")[0]
+
+
+def _base_iaso(request: HttpRequest, analytics_data: dict = None) -> HttpResponse:
     try:
         USER_HOME_PAGE = request.user.iaso_profile.home_page if request.user.is_authenticated else ""
     except ObjectDoesNotExist:
@@ -21,9 +29,6 @@ def _base_iaso(request: HttpRequest, analytics_scripts: list[str] = None, analyt
         "USER_HOME_PAGE": USER_HOME_PAGE,
         "VERSION": VERSION,
     }
-
-    if analytics_scripts:
-        variables_to_render["ANALYTICS_SCRIPTS"] = list(analytics_scripts)
 
     if analytics_data:
         variables_to_render["ANALYTICS_DATA"] = analytics_data
@@ -40,10 +45,8 @@ def _base_iaso(request: HttpRequest, analytics_scripts: list[str] = None, analyt
 def iaso(request: HttpRequest) -> HttpResponse:
     analytics_data = None
 
-    # Check if analytics should be enabled
     if _should_enable_analytics(request):
-        # Pass analytics data to template
-        domain = request.get_host().split(":")[0]  # Remove port if present
+        domain = _get_domain_from_request(request)
         user_account = request.user.iaso_profile.account
         analytics_data = {
             "domain": domain,
@@ -56,21 +59,18 @@ def iaso(request: HttpRequest) -> HttpResponse:
     return _base_iaso(request, analytics_data=analytics_data)
 
 
-def _should_enable_analytics(request: HttpRequest) -> bool:
-    """Check if analytics should be enabled based on environment variable"""
-    from django.conf import settings
-
-    # Only enable analytics if explicitly enabled via environment variable
-    return getattr(settings, "ENABLE_ANALYTICS", False)
-
-
 @require_http_methods(["GET"])
 def embeddable_iaso(request: HttpRequest) -> HttpResponse:
     """Embeddable iaso page without login requirement and with correct header"""
-    all_analytics_scripts = set(
-        [account.analytics_script for account in Account.objects.all() if account.analytics_script]
-    )
-    response = _base_iaso(request, all_analytics_scripts)
+    analytics_data = None
+
+    if _should_enable_analytics(request):
+        domain = _get_domain_from_request(request)
+        analytics_data = {
+            "domain": domain,
+        }
+
+    response = _base_iaso(request, analytics_data=analytics_data)
     response["X-Frame-Options"] = "ALLOW"
     return response
 

--- a/hat/settings.py
+++ b/hat/settings.py
@@ -103,6 +103,7 @@ DISABLE_PASSWORD_LOGINS = os.environ.get("DISABLE_PASSWORD_LOGINS", "").lower() 
 CACHE_BACKEND = os.environ.get("CACHE_BACKEND", "django.core.cache.backends.db.DatabaseCache")
 CACHE_LOCATION = os.environ.get("CACHE_LOCATION", "django_cache_table")
 CACHE_MAX_ENTRIES = os.environ.get("CACHE_MAX_ENTRIES", 300)
+ENABLE_ANALYTICS = os.environ.get("ENABLE_ANALYTICS", "false").lower() == "true"
 
 ALLOWED_HOSTS = ["*"]
 

--- a/hat/templates/iaso/analytics/plausible.html
+++ b/hat/templates/iaso/analytics/plausible.html
@@ -1,0 +1,18 @@
+{% if ANALYTICS_DATA %}
+<script defer data-domain="{{ ANALYTICS_DATA.domain }}" src="https://plausible.io/js/script.js"></script>
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    if (window.plausible) {
+        // Track user login event with account details
+        window.plausible('User Login', {
+            props: {
+                username: '{{ ANALYTICS_DATA.username }}',
+                user_id: {{ ANALYTICS_DATA.user_id }},
+                account_name: '{{ ANALYTICS_DATA.account_name }}',
+                account_id: {{ ANALYTICS_DATA.account_id }}
+            }
+        });
+    }
+});
+</script>
+{% endif %}

--- a/hat/templates/iaso/analytics/plausible.html
+++ b/hat/templates/iaso/analytics/plausible.html
@@ -1,18 +1,24 @@
 {% if ANALYTICS_DATA %}
-<script defer data-domain="{{ ANALYTICS_DATA.domain }}" src="https://plausible.io/js/script.js"></script>
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-    if (window.plausible) {
-        // Track user login event with account details
-        window.plausible('User Login', {
-            props: {
-                username: '{{ ANALYTICS_DATA.username }}',
-                user_id: {{ ANALYTICS_DATA.user_id }},
-                account_name: '{{ ANALYTICS_DATA.account_name }}',
-                account_id: {{ ANALYTICS_DATA.account_id }}
-            }
-        });
-    }
-});
-</script>
+    <script
+        defer
+        data-domain="{{ ANALYTICS_DATA.domain }}"
+        src="https://plausible.io/js/script.js"
+    ></script>
+    {% if user.is_authenticated and ANALYTICS_DATA.username %}
+        <script>
+            document.addEventListener('DOMContentLoaded', function() {
+                if (window.plausible) {
+                    // Track user login event with account details
+                    window.plausible('User Login', {
+                        props: {
+                            username: '{{ ANALYTICS_DATA.username }}',
+                            user_id: {{ ANALYTICS_DATA.user_id }},
+                            account_name: '{{ ANALYTICS_DATA.account_name }}',
+                            account_id: {{ ANALYTICS_DATA.account_id }}
+                        }
+                    });
+                }
+            });
+        </script>
+    {% endif %}
 {% endif %}

--- a/hat/templates/iaso/base.html
+++ b/hat/templates/iaso/base.html
@@ -31,6 +31,9 @@
       {{ analytic_script | safe }}
     {% endfor %} 
   {% endif %}
+  {% if ANALYTICS_DATA %}
+    {% include "iaso/analytics/plausible.html" %}
+  {% endif %}
 </head>
 
 <body class="iaso">

--- a/hat/templates/iaso/base.html
+++ b/hat/templates/iaso/base.html
@@ -26,11 +26,6 @@
   <meta property="og:image" content="" />
   <meta property="og:url" content="{{ request.build_absolute_uri }} " />
   {% endif %}
-  {% if ANALYTICS_SCRIPTS %}
-    {% for analytic_script in ANALYTICS_SCRIPTS %}
-      {{ analytic_script | safe }}
-    {% endfor %} 
-  {% endif %}
   {% if ANALYTICS_DATA %}
     {% include "iaso/analytics/plausible.html" %}
   {% endif %}

--- a/hat/templates/iaso/language_picker.html
+++ b/hat/templates/iaso/language_picker.html
@@ -1,7 +1,6 @@
 {% load i18n %}
 <script type="text/javascript">
   function handleLanguageChange(e) {
-    console.log(e.value)
     document.getElementById('lang-form').submit();
   }
 </script>

--- a/iaso/models/base.py
+++ b/iaso/models/base.py
@@ -145,6 +145,8 @@ class Account(models.Model):
     modules = ChoiceArrayField(
         models.CharField(max_length=100, choices=MODULE_CHOICES), blank=True, null=True, default=list
     )
+    # analytics_script is no longer used (replaced by the plausible setup) - it's kept in case we need another
+    # specific analytics setup for a specific account
     analytics_script = models.TextField(blank=True, null=True)
     custom_translations = models.JSONField(null=True, blank=True)
 


### PR DESCRIPTION
Add plausible on all accounts on IASO 

Related JIRA tickets : IA-4339

## Self proofreading checklist

- [ ] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

[docs/pages/dev/reference/analytics/plausible-setup.en.md](/docs/pages/dev/reference/analytics/plausible-setup.en.md)

## Changes

- specific template for plausible script
- change iaso connected and not connected view to use plausible script if env variable  `ENABLE_ANALYTICS` is true
- adding some doc

## How to test

- you need to access plausible account using 1 password
- ideally deploy this PR on staging (env variable is already set)
- check plausible dashboard on staging and play with it 

## Print screen / video

-

## Notes

- ⚠️  We need to enable analytics on prod, playground and polio while releasing  ⚠️  
- analytics_script field on account is still present for further implementations with other analytics services

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
