### PR TITLE
IA-3648: Unexpected behavior - Cancel Button on form creation

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/forms/detail.tsx
+++ b/hat/assets/js/apps/Iaso/domains/forms/detail.tsx
@@ -254,7 +254,7 @@ const FormDetail: FunctionComponent = () => {
                         <Button
                             data-id="form-detail-cancel"
                             className={classes.marginLeft}
-                            disabled={isNew ? false : !isFormModified}
+                            disabled={!isNew && !isFormModified}
                             variant="contained"
                             onClick={handleCancel}
                         >

--- a/hat/assets/js/apps/Iaso/domains/forms/detail.tsx
+++ b/hat/assets/js/apps/Iaso/domains/forms/detail.tsx
@@ -206,11 +206,7 @@ const FormDetail: FunctionComponent = () => {
     );
 
     const handleCancel = useCallback(() => {
-        if (isNew) {
-            goBack();
-        } else {
-            handleReset();
-        }
+        isNew ? goBack() : handleReset();
     }, [goBack, handleReset, isNew]);
 
     const handleChangeTab = (newTab: string) => {

--- a/hat/assets/js/apps/Iaso/domains/forms/detail.tsx
+++ b/hat/assets/js/apps/Iaso/domains/forms/detail.tsx
@@ -204,6 +204,15 @@ const FormDetail: FunctionComponent = () => {
             formatMessage,
         ],
     );
+
+    const handleCancel = useCallback(() => {
+        if (isNew) {
+            goBack();
+        } else {
+            handleReset();
+        }
+    }, [goBack, handleReset, isNew]);
+
     const handleChangeTab = (newTab: string) => {
         setTab(newTab);
         const newParams = {
@@ -249,9 +258,9 @@ const FormDetail: FunctionComponent = () => {
                         <Button
                             data-id="form-detail-cancel"
                             className={classes.marginLeft}
-                            disabled={!isFormModified}
+                            disabled={isNew ? false : !isFormModified}
                             variant="contained"
-                            onClick={() => handleReset()}
+                            onClick={handleCancel}
                         >
                             {formatMessage(MESSAGES.cancel)}
                         </Button>


### PR DESCRIPTION
When I’m on the form creation page and click on cancel, I’d expect to return to the previous screen. Instead of that, clicking on the button only clears the fields…
Related JIRA tickets : IA-3648

## Self proofreading checklist

- [ ] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

-

## Changes

- go back while clicking on cancel if creating new form

## How to test

- edit a form, change the name, click on cancel, it should reset the form
- create a form, change the name, click on cancel, it should come back to forms list

## Print screen / video


https://github.com/user-attachments/assets/6ae0a82e-4804-48e8-97f9-26d3bb512a5e



## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
