### PR TITLE
IA-4434 User modal not closing when clicking outside

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/users/components/UsersDialog.tsx
+++ b/hat/assets/js/apps/Iaso/domains/users/components/UsersDialog.tsx
@@ -194,7 +194,7 @@ const UserDialogComponent: FunctionComponent<Props> = ({
                 confirmMessage={MESSAGES.save}
                 maxWidth="md"
                 open={isOpen}
-                closeDialog={() => null}
+                closeDialog={closeDialog}
                 allowConfirm={
                     !(
                         user.user_name.value === '' ||
@@ -202,9 +202,7 @@ const UserDialogComponent: FunctionComponent<Props> = ({
                     )
                 }
                 onClose={() => null}
-                onCancel={() => {
-                    closeDialog();
-                }}
+                onCancel={closeDialog}
                 id="user-dialog"
                 dataTestId="user-dialog"
             >


### PR DESCRIPTION
Usually in iaso, when there’s a modal window, you can click outside of it to close it (instead of clicking on the “close” button). This does not work when interacting with users, which is quite cumbersome when you need to go through many users

Related JIRA tickets : IA-4434
## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

-

## Changes

just use the `closeDialog` function

## How to test

edit a user , try to click outside of the dialog, it should close the dialog

## Print screen / video

https://github.com/user-attachments/assets/3d93f4a6-e879-4df2-bfb6-4048a385f650


## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
