### PR TITLE
IA-4437 Fix n+1 query on `/api/orgunits/{pk}/`

### DIFF
--- a/iaso/api/org_units.py
+++ b/iaso/api/org_units.py
@@ -900,7 +900,7 @@ class OrgUnitViewSet(viewsets.ViewSet):
                 geo_queryset = self.get_queryset().filter(id=ancestor.id)
                 ancestor_dict["geo_json"] = geojson_queryset(geo_queryset, geometry_field="simplified_geom")
                 break
-            ancestor = ancestor.parent
+            ancestor = ancestors_dict.get(ancestor.parent_id) if ancestor.parent_id else None
             ancestor_dict = ancestor_dict["parent"]
 
         res["geo_json"] = None

--- a/iaso/api/org_units.py
+++ b/iaso/api/org_units.py
@@ -873,15 +873,22 @@ class OrgUnitViewSet(viewsets.ViewSet):
         return Response([org_unit.as_dict() for org_unit in new_org_units])
 
     def retrieve(self, request, pk=None):
+        prefetch_args = ["reference_instances", "org_unit_type__sub_unit_types", "groups"]
+        related_args = ["parent", "org_unit_type", "version__data_source__credentials"]
+
         org_unit: OrgUnit = get_object_or_404(
-            self.get_queryset().prefetch_related("reference_instances"),
+            self.get_queryset().select_related(*related_args).prefetch_related(*prefetch_args),
             pk=pk,
         )
-
         # Count instances for the Org unit and its descendants.
         org_unit.instances_count = org_unit.descendants().aggregate(Count("instance"))["instance__count"]
 
         self.check_object_permissions(request, org_unit)
+
+        # Fetch all ancestors in a single query to avoid N+1 problems.
+        ancestors = list(org_unit.ancestors().select_related(*related_args).prefetch_related(*prefetch_args))
+        ancestors_dict = {ancestor.id: ancestor for ancestor in ancestors}
+        org_unit._prefetched_ancestors = ancestors_dict
 
         res = org_unit.as_dict_with_parents(light=False, light_parents=False)
 

--- a/iaso/models/org_unit.py
+++ b/iaso/models/org_unit.py
@@ -511,7 +511,9 @@ class OrgUnit(TreeModel):
             "default_image_id": self.default_image.id if self.default_image else None,
         }
         if not light:  # avoiding joins here
-            res["groups"] = [group.as_dict(with_counts=False) for group in self.groups.all()]
+            res["groups"] = sorted(
+                [group.as_dict(with_counts=False) for group in self.groups.all()], key=lambda x: x["id"]
+            )
             res["org_unit_type_name"] = self.org_unit_type.name if self.org_unit_type else None
             res["org_unit_type"] = self.org_unit_type.as_dict() if self.org_unit_type else None
             res["source"] = self.version.data_source.name if self.version else None

--- a/iaso/tests/api/test_orgunits.py
+++ b/iaso/tests/api/test_orgunits.py
@@ -699,13 +699,13 @@ class OrgUnitAPITestCase(APITestCase):
         self.client.force_authenticate(self.yoda)
 
         parent = self.jedi_council_corruscant
-        for i in range(3):
+        for i in range(6):
             child = m.OrgUnit.objects.create(
                 name=f"Deep Level {i + 1}", version=parent.version, validation_status="VALID", parent=parent
             )
             parent = child
 
-        with self.assertNumQueries(15):
+        with self.assertNumQueries(13):
             response = self.client.get(f"/api/orgunits/{parent.id}/")
 
         self.assertEqual(response.status_code, 200)

--- a/iaso/tests/api/test_user_roles.py
+++ b/iaso/tests/api/test_user_roles.py
@@ -146,7 +146,7 @@ class UserRoleAPITestCase(APITestCase):
 
         r = self.assertJSONResponse(response, 200)
         self.assertEqual(r["name"], payload["name"])
-        self.assertEqual(r["editable_org_unit_type_ids"], [self.org_unit_type.id, new_org_unit_type.id])
+        self.assertCountEqual(r["editable_org_unit_type_ids"], [self.org_unit_type.id, new_org_unit_type.id])
 
     def test_partial_update_no_permission(self):
         self.client.force_authenticate(self.user_with_no_permissions)


### PR DESCRIPTION
Fix n+1 query on `/api/orgunits/{pk}/`.

Related JIRA tickets : IA-4437

[Jira issue](https://bluesquareorg.sentry.io/issues/6749129513/?project=5530884).

This one was triggered when calling the detail of an org unit, especially when there are a lot of ancestors:

```
/api/orgunits/{pk}/
```
