### PR TITLE
IA-4438 Fix n+1 query on `/api/instances/{pk}/`

### DIFF
--- a/iaso/api/instances/instances.py
+++ b/iaso/api/instances/instances.py
@@ -568,14 +568,32 @@ class InstancesViewSet(viewsets.ViewSet):
                 "instancelock_set__top_org_unit",
                 "instancelock_set__locked_by",
                 "instancelock_set__unlocked_by",
+                "org_unit__groups",
+                "org_unit__org_unit_type__sub_unit_types",
                 "org_unit__reference_instances",
-                "org_unit__org_unit_type__reference_forms",
+            )
+            .select_related(
+                "org_unit",
+                "org_unit__parent",
+                "org_unit__org_unit_type",
+                "org_unit__version__data_source__credentials",
             )
             .with_status()
         )
         instance: Instance = get_object_or_404(queryset, pk=pk)
         self.check_object_permissions(request, instance)
         all_instance_locks = instance.instancelock_set.all()
+
+        if instance.org_unit:
+            # Fetch all ancestors in a single query to avoid N+1 problems
+            # because `as_full_model()` will call `org_unit.as_dict_with_parents()`.
+            ancestors = list(
+                instance.org_unit.ancestors()
+                .select_related("version__data_source__credentials", "org_unit_type")
+                .prefetch_related("reference_instances", "org_unit_type__sub_unit_types", "groups")
+            )
+            ancestors_dict = {ancestor.id: ancestor for ancestor in ancestors}
+            instance.org_unit._prefetched_ancestors = ancestors_dict
 
         response = instance.as_full_model(with_entity=True)
 

--- a/iaso/models/org_unit.py
+++ b/iaso/models/org_unit.py
@@ -495,8 +495,12 @@ class OrgUnit(TreeModel):
             ),
             "parent_id": self.parent_id,
             "validation_status": self.validation_status,
-            "parent_name": self.parent.name if self.parent else None,
-            "parent": (self._get_parent_dict(light_parents, light_parents) if self.parent else None),
+            "parent_name": (
+                self._prefetched_ancestors[self.parent_id].name
+                if hasattr(self, "_prefetched_ancestors") and self.parent_id in self._prefetched_ancestors
+                else (self.parent.name if self.parent_id else None)
+            ),
+            "parent": (self._get_parent_dict(light_parents, light_parents) if self.parent_id else None),
             "org_unit_type_id": self.org_unit_type_id,
             "created_at": self.source_created_at_with_fallback.timestamp(),
             "updated_at": self.updated_at.timestamp() if self.updated_at else None,

--- a/iaso/tests/api/instances/test_instances.py
+++ b/iaso/tests/api/instances/test_instances.py
@@ -619,7 +619,7 @@ class InstancesAPITestCase(TaskAPITestCase):
         self.client.force_authenticate(self.yoda)
 
         parent = m.OrgUnit.objects.create(name="Country", version=self.sw_version, validation_status="VALID")
-        for i in range(3):
+        for i in range(6):
             child = m.OrgUnit.objects.create(
                 name=f"Level {i + 1}", version=self.sw_version, validation_status="VALID", parent=parent
             )
@@ -627,7 +627,7 @@ class InstancesAPITestCase(TaskAPITestCase):
 
         instance = self.create_form_instance(form=self.form_1, org_unit=parent, project=self.project)
 
-        with self.assertNumQueries(20):
+        with self.assertNumQueries(18):
             response = self.client.get(f"/api/instances/{instance.id}/")
         self.assertEqual(response.status_code, 200)
 


### PR DESCRIPTION
Fix n+1 query on `/api/instances/{pk}/`.

Related JIRA tickets : IA-4438

[Jira issue](https://bluesquareorg.sentry.io/issues/6748906815/?project=5530884).

This one was triggered when calling the detail of an instances, especially when its org unit has a lot of ancestors:

```
/api/instances/{pk}/
```

## Note

This should be reviewed and merged after https://github.com/BLSQ/iaso/pull/2387 or directly merged into https://github.com/BLSQ/iaso/pull/2387.