### PR TITLE
SNT-103 DeleteDialog: Add possibility to provide a custom trigger

### DIFF
--- a/hat/assets/js/apps/Iaso/components/dialogs/DeleteDialogComponent.js
+++ b/hat/assets/js/apps/Iaso/components/dialogs/DeleteDialogComponent.js
@@ -15,6 +15,8 @@ export default function DeleteDialog({
     disabled,
     keyName,
     iconColor,
+    Trigger,
+    triggerProps,
 }) {
     const closeThenOnConfirm = useCallback(
         closeDialog => {
@@ -33,17 +35,21 @@ export default function DeleteDialog({
             titleMessage={titleMessage}
             dataTestId={`delete-dialog-${keyName}`}
             onConfirm={closeThenOnConfirm}
-            renderTrigger={({ openDialog }) => (
-                <IconButtonComponent
-                    onClick={openDialog}
-                    dataTestId={`delete-dialog-button-${keyName}`}
-                    disabled={disabled}
-                    icon="delete"
-                    tooltipMessage={MESSAGES.delete}
-                    color={iconColor}
-                    {...iconButtonExtraProps}
-                />
-            )}
+            renderTrigger={({ openDialog }) =>
+                Trigger ? (
+                    <Trigger onClick={openDialog} {...triggerProps} />
+                ) : (
+                    <IconButtonComponent
+                        onClick={openDialog}
+                        dataTestId={`delete-dialog-button-${keyName}`}
+                        disabled={disabled}
+                        icon="delete"
+                        tooltipMessage={MESSAGES.delete}
+                        color={iconColor}
+                        {...iconButtonExtraProps}
+                    />
+                )
+            }
         >
             <div id={`delete-dialog-${keyName}`}>
                 {message && (
@@ -61,6 +67,8 @@ DeleteDialog.defaultProps = {
     keyName: 'key',
     message: null,
     iconColor: 'action',
+    Trigger: null,
+    triggerProps: {},
 };
 DeleteDialog.propTypes = {
     titleMessage: PropTypes.object.isRequired,
@@ -69,4 +77,6 @@ DeleteDialog.propTypes = {
     disabled: PropTypes.bool,
     keyName: PropTypes.string,
     iconColor: PropTypes.string,
+    Trigger: PropTypes.elementType,
+    triggerProps: PropTypes.object,
 };


### PR DESCRIPTION
DeleteDialog doesn't allow anything else than an Icon as trigger.

Related JIRA tickets : SNT-103

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [x] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

DeleteDialog is using Icon as a trigger and there is no way to change this.
Added a Trigger prop that can override the default icon.

## How to test

It should work ASIS in Iaso.
For SNT-Malaria, refer to associated PR for test scenario.

## Print screen / video

Upload here print screens or videos showing the changes.

## Notes

Related PR: https://github.com/BLSQ/snt-malaria/pull/73

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
