### PR TITLE
IA-4432 Add sortable user roles column in user management

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/users/config.js
+++ b/hat/assets/js/apps/Iaso/domains/users/config.js
@@ -73,9 +73,8 @@ export const useUsersTableColumns = ({
             },
             {
                 Header: formatMessage(MESSAGES.userRoles),
-                id: 'user_roles',
+                id: 'annotated_first_user_role',
                 accessor: 'user_roles_permissions',
-                sortable: false,
                 Cell: settings =>
                     settings.value
                         ?.map(user_role => user_role.name)

--- a/iaso/api/profiles/profiles.py
+++ b/iaso/api/profiles/profiles.py
@@ -6,7 +6,7 @@ from django.contrib.auth.models import Permission, User
 from django.contrib.auth.tokens import PasswordResetTokenGenerator
 from django.core.mail import send_mail
 from django.core.paginator import Paginator
-from django.db.models import Q, QuerySet
+from django.db.models import Min, Q, QuerySet
 from django.db.transaction import atomic
 from django.http import HttpRequest, HttpResponse, JsonResponse, StreamingHttpResponse
 from django.shortcuts import get_object_or_404
@@ -274,26 +274,33 @@ class ProfilesViewSet(viewsets.ViewSet):
         user_roles = request.GET.get("userRoles", None)
         if user_roles:
             user_roles = user_roles.split(",")
-        managed_users_only = request.GET.get("managedUsersOnly", None) == "true"
         teams = request.GET.get("teams", None)
         if teams:
             teams = teams.split(",")
         managed_users_only = request.GET.get("managedUsersOnly", None) == "true"
-        queryset = get_filtered_profiles(
-            queryset=self.get_queryset(),
-            user=request.user,
-            search=search,
-            perms=perms,
-            location=location,
-            org_unit_type=org_unit_type,
-            parent_ou=parent_ou,
-            children_ou=children_ou,
-            projects=projects,
-            user_roles=user_roles,
-            teams=teams,
-            managed_users_only=managed_users_only,
-            ids=ids,
-        ).order_by("id")
+        queryset = (
+            get_filtered_profiles(
+                queryset=self.get_queryset(),
+                user=request.user,
+                search=search,
+                perms=perms,
+                location=location,
+                org_unit_type=org_unit_type,
+                parent_ou=parent_ou,
+                children_ou=children_ou,
+                projects=projects,
+                user_roles=user_roles,
+                teams=teams,
+                managed_users_only=managed_users_only,
+                ids=ids,
+            )
+            .annotate(
+                # Adds a sortable field containing each user's alphabetically first role name,
+                # enabling consistent frontend sorting of users with multiple roles.
+                annotated_first_user_role=Min("user_roles__group__name")
+            )
+            .order_by("id")
+        )
 
         queryset = queryset.prefetch_related(
             "user",

--- a/iaso/models/base.py
+++ b/iaso/models/base.py
@@ -1573,7 +1573,7 @@ class Profile(models.Model):
             )
 
     def as_dict(self, small=False):
-        user_roles = self.user_roles.all()
+        user_roles = self.user_roles.all().order_by("group__name")
         user_group_permissions = list(
             map(lambda permission: permission.split(".")[1], list(self.user.get_group_permissions()))
         )


### PR DESCRIPTION
Add sortable user roles column in user management.

Related JIRA tickets : IA-4432

## Changes

Implement sortable user roles functionality.

  - add `annotated_first_user_role` field for consistent sorting of users with multiple roles
  - enable sorting on user roles column in frontend
  - order user roles alphabetically in profile serialization
  - add a test

## How to test

Go to `/dashboard/settings/users/management/`.

Sort the "User roles" column.

## Video

https://github.com/user-attachments/assets/d316010f-fdf6-4f19-b538-80bfda90592d


