### PR TITLE
IA-4144 Translate the payments XLS/CSV file

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/payments/components/PaymentLotActionCell.tsx
+++ b/hat/assets/js/apps/Iaso/domains/payments/components/PaymentLotActionCell.tsx
@@ -3,11 +3,12 @@ import SendIcon from '@mui/icons-material/Send';
 import { ExternalLinkIconButton, IconButton } from 'bluesquare-components';
 import React, { ReactElement, useCallback } from 'react';
 import { PaymentLot } from '../types';
+import { useLocale } from '../../app/contexts/LocaleContext';
 
 import { useMarkPaymentsAsSent } from '../hooks/requests/useSavePaymentLot';
 import MESSAGES from '../messages';
 import { EditPaymentLotDialog } from './EditPaymentLot/EditPaymentLotDialog';
-import { baseUrls } from '../../../constants/urls';
+import { baseUrls } from 'Iaso/constants/urls';
 
 interface ActionCellProps<T> {
     row: {
@@ -18,6 +19,7 @@ export const PaymentLotActionCell = ({
     row: { original: paymentLot },
 }: ActionCellProps<PaymentLot>): ReactElement => {
     const { mutateAsync: markAsSent } = useMarkPaymentsAsSent();
+    const { locale } = useLocale();
 
     const handleSend = useCallback(() => {
         markAsSent({
@@ -60,7 +62,7 @@ export const PaymentLotActionCell = ({
                 <ExternalLinkIconButton
                     tooltipMessage={MESSAGES.download_payments}
                     overrideIcon={FileDownloadIcon}
-                    url={`/api/payments/lots/${paymentLot.id}/?xlsx=true`}
+                    url={`/api/payments/lots/${paymentLot.id}/?xlsx=true&lang=${locale}`}
                 />
             )}
         </>

--- a/iaso/admin/base.py
+++ b/iaso/admin/base.py
@@ -994,6 +994,7 @@ class PotentialPaymentAdmin(admin.ModelAdmin):
 class PaymentAdmin(admin.ModelAdmin):
     formfield_overrides = {models.JSONField: {"widget": IasoJSONEditorWidget}}
     list_display = ("id", "status", "created_at", "updated_at", "change_request_ids")
+    autocomplete_fields = ("user", "created_by", "updated_by", "payment_lot")
 
     def change_request_ids(self, obj):
         change_requests = obj.change_requests.all()
@@ -1013,6 +1014,7 @@ class PaymentLotAdmin(admin.ModelAdmin):
     formfield_overrides = {models.JSONField: {"widget": IasoJSONEditorWidget}}
     list_display = ("id", "status", "created_at", "updated_at", "payment_ids")
     search_fields = ("id",)
+    autocomplete_fields = ("created_by", "updated_by", "task")
 
     def payment_ids(self, obj):
         payments = obj.payments.all()


### PR DESCRIPTION
Translate the payments XLS/CSV file.

Related JIRA tickets : IA-4144

## Changes

The frontend is using `ExternalLinkIconButton` which creates a direct browser link, thus bypassing the API client in `Api.ts` that adds the `Accept-Language` header.

So the Django backend receives a request **without** the `Accept-Language` header, and `get_language_from_request()` defaults to the `LANGUAGE_CODE = "en"` from `settings.py`.

The implemented solution passes the language as a query parameter.

## How to test

- you need some payment lots
- then go to `/dashboard/payments/lots/`
- then download the XLS file once in EN and once in FR, it should be translated

## Print screen / video

https://github.com/user-attachments/assets/5a45ad10-dbf0-4b2c-81a3-bd4473babf73
