### PR TITLE
IA-4444 Exclude unsupported fields types from the duplicates detection

### DIFF
--- a/iaso/api/deduplication/entity_duplicate_analyzis.py
+++ b/iaso/api/deduplication/entity_duplicate_analyzis.py
@@ -30,10 +30,8 @@ class AnalyzePostBodySerializer(serializers.Serializer):
         possible_fields = e_type.reference_form.possible_fields
 
         for f_name in data["fields"]:
-            try:
-                field = [f for f in possible_fields if f["name"] == f_name]
-                field = field[0]
-            except IndexError:
+            field = next((f for f in possible_fields if f["name"] == f_name), None)
+            if not field:
                 raise serializers.ValidationError(f"Field `{f_name}` does not exist on reference form.")
 
             if field["type"] not in EntityDuplicateAnalyzis.SUPPORTED_FIELD_TYPES:

--- a/iaso/api/deduplication/entity_duplicate_analyzis.py
+++ b/iaso/api/deduplication/entity_duplicate_analyzis.py
@@ -30,22 +30,13 @@ class AnalyzePostBodySerializer(serializers.Serializer):
         possible_fields = e_type.reference_form.possible_fields
 
         for f_name in data["fields"]:
-            # Ensure the field exists on the reference form.
             try:
                 field = [f for f in possible_fields if f["name"] == f_name]
                 field = field[0]
             except IndexError:
                 raise serializers.ValidationError(f"Field `{f_name}` does not exist on reference form.")
 
-            # Ensure the field type is supported by the Levenshtein algorithm.
-            if field["type"] not in [
-                "number",
-                "integer",
-                "decimal",
-                "text",
-                "calculate",
-                None,
-            ]:
+            if field["type"] not in EntityDuplicateAnalyzis.SUPPORTED_FIELD_TYPES:
                 raise serializers.ValidationError(f"Field `{f_name}` has an unsupported type `{field['type']}`.")
 
         return data

--- a/iaso/models/deduplication.py
+++ b/iaso/models/deduplication.py
@@ -19,6 +19,8 @@ class TypeOfRelation(models.TextChoices):
 
 
 class EntityDuplicateAnalyzis(models.Model):
+    SUPPORTED_FIELD_TYPES = ["number", "integer", "decimal", "text", "calculate", None]
+
     algorithm = models.CharField(
         max_length=20, choices=PossibleAlgorithms.choices, default=PossibleAlgorithms.LEVENSHTEIN
     )

--- a/iaso/tests/api/test_forms_serializers.py
+++ b/iaso/tests/api/test_forms_serializers.py
@@ -1,3 +1,5 @@
+from unittest.mock import Mock
+
 from django.test import TestCase
 from rest_framework.test import APIRequestFactory
 
@@ -72,3 +74,28 @@ class FormsSerializerTestCase(TestCase):
 
         with self.assertNumQueries(8):
             self.assertEqual(serializer.data, expected_data)
+
+    def test_get_possible_fields_with_latest_version_filters_by_supported_types(self):
+        """
+        Test that `get_possible_fields_with_latest_version()` only returns fields with supported types.
+        """
+        mock_form = Mock()
+        mock_form.possible_fields = [
+            {"name": "field1", "type": "text"},  # supported
+            {"name": "field2", "type": "number"},  # supported
+            {"name": "field3", "type": "photo"},  # not supported
+            {"name": "field4", "type": "select"},  # not supported
+            {"name": "field5", "type": "integer"},  # supported
+            {"name": "field6", "type": None},  # supported
+        ]
+        mock_form.latest_version = None  # No latest version to keep the test simple.
+
+        result = FormSerializer.get_possible_fields_with_latest_version(mock_form)
+
+        expected_fields = [
+            {"name": "field1", "type": "text"},
+            {"name": "field2", "type": "number"},
+            {"name": "field5", "type": "integer"},
+            {"name": "field6", "type": None},
+        ]
+        self.assertEqual(result, expected_fields)


### PR DESCRIPTION
Exclude unsupported fields types from the duplicates detection.

Related JIRA tickets : IA-4444

## Changes

- add field type validation in both:
    - the duplicates analysis serializer
    - the form API
- use a centralized constant for the validation logic
- fix `EntityType.DoesNotExist` exception handling (was using `Entity.DoesNotExist`)

## How to test

The first thing you can do is look at the unit tests.

To test the endpoint used by the frontend:

- look at the details of a form in the same way that the UI is calling the endpoint
- any field that has a type not compatible with the duplicates detection should not be listed in the result

```
http://localhost:8081/api/forms/{ID}/?fields=possible_fields_with_latest_version,name,latest_form_version
```

The backend code double checks that rule.