### PR TITLE
Product fruit is crashing on pages without account

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/app/components/ProductFruits.tsx
+++ b/hat/assets/js/apps/Iaso/domains/app/components/ProductFruits.tsx
@@ -5,11 +5,10 @@ import { useCurrentUser } from '../../../utils/usersUtils';
 const ProductFruitsComponent = () => {
     const currentUser = useCurrentUser();
 
-    if (!window.PRODUCT_FRUITS_WORKSPACE_CODE || !currentUser) {
-        return null;
-    }
-
     const userInfo = useMemo(() => {
+        if (!currentUser || !currentUser.account) {
+            return null;
+        }
         return {
             username: `${currentUser.account.name}-${currentUser.id}`,
             props: {
@@ -18,6 +17,10 @@ const ProductFruitsComponent = () => {
             },
         };
     }, [currentUser]);
+
+    if (!window.PRODUCT_FRUITS_WORKSPACE_CODE || !currentUser || !userInfo) {
+        return null;
+    }
 
     return (
         <ProductFruits

--- a/hat/assets/js/apps/Iaso/utils/usersUtils.ts
+++ b/hat/assets/js/apps/Iaso/utils/usersUtils.ts
@@ -70,7 +70,7 @@ export type User = {
     username: string;
     user_name?: string;
     email: string;
-    account: Account;
+    account?: Account;
     other_accounts: Account[];
     permissions: string[];
     is_staff?: boolean;


### PR DESCRIPTION
The page setup account is not accessible on instances with product fruit activated. 

Related JIRA tickets : IA-4459

## Self proofreading checklist

- [ ] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

-

## Changes

disable product fruit if no account

## How to test

Enable product fruit with PRODUCT_FRUITS_WORKSPACE_CODE (enabled on staging)
Take an admin user not linked to an account and log in to the dashboard

## Print screen / video

-
## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
