### PR TITLE
IA-4195 Fix multi-tenant authentication bug

### DIFF
--- a/hat/settings.py
+++ b/hat/settings.py
@@ -711,6 +711,7 @@ HIDE_BASIC_NAV_ITEMS = os.environ.get("HIDE_BASIC_NAV_ITEMS", "no")
 # Django tries the second one, and so on…
 AUTHENTICATION_BACKENDS = [
     "iaso.auth.backends.MultiTenantAuthBackend",
+    "django.contrib.auth.backends.ModelBackend",  # ModelBackend is explicitly required in DHIS2 and token authentication.
     "allauth.account.auth_backends.AuthenticationBackend",
 ]
 

--- a/iaso/api/profiles/profiles.py
+++ b/iaso/api/profiles/profiles.py
@@ -1,7 +1,7 @@
 from typing import Any, List, Optional, Union
 
 from django.conf import settings
-from django.contrib.auth import login, models, update_session_auth_hash
+from django.contrib.auth import models, update_session_auth_hash
 from django.contrib.auth.models import Permission, User
 from django.contrib.auth.tokens import PasswordResetTokenGenerator
 from django.core.mail import send_mail
@@ -226,12 +226,6 @@ class ProfilesViewSet(viewsets.ViewSet):
     def retrieve(self, request, *args, **kwargs):
         pk = kwargs.get("pk")
         if pk == PK_ME:
-            # if the user is a main_user, login as an account user
-            # TODO: This is not a clean side-effect and should be improved.
-            if request.user.tenant_users.exists():
-                account_user = request.user.tenant_users.first().account_user
-                account_user.backend = "django.contrib.auth.backends.ModelBackend"
-                login(request, account_user)
             try:
                 queryset = self.get_queryset()
                 profile = queryset.get(user=request.user)

--- a/iaso/auth/backends.py
+++ b/iaso/auth/backends.py
@@ -22,6 +22,8 @@ class MultiTenantAuthBackend(ModelBackend):
             # When users switch accounts, `login()` is called and automatically updates `last_login`.
             tenant_user = UserModel.objects.filter(tenant_user__main_user=user).order_by("-last_login").first()
             if tenant_user:
+                if not hasattr(tenant_user, "iaso_profile"):
+                    raise ValueError(f"Tenant user `{tenant_user.username}` is missing a `iaso_profile`.")
                 return tenant_user
 
             return user


### PR DESCRIPTION
Fix multi-tenant authentication bug.

Related JIRA tickets: IA-4195

## Changes

This bug was introduced in #2404 

The bug was caused by redundant authentication logic.

The `MultiTenantAuthBackend` already switches from `main_user` to `account_user` during login, but the `profiles.py` was trying to do this again, creating session conflicts.

## How to test?

Just like in #2404 

- login with a multi-accounts user
- switch to another project
- logout
- login again
- you should be connected to the most recently used account
