### PR TITLE
WC2-818 Optimise entities list for large datasets

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/entities/config.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/config.tsx
@@ -144,21 +144,23 @@ export const useColumns = (
                             icon="remove-red-eye"
                             tooltipMessage={MESSAGES.see}
                         />
-                        {settings.row.original.duplicates.length === 1 && (
-                            <IconButtonComponent
-                                url={`/${baseUrls.entityDuplicateDetails}/entities/${settings.row.original.id},${settings.row.original.duplicates[0]}/`}
-                                overrideIcon={FileCopyIcon}
-                                tooltipMessage={MESSAGES.seeDuplicate}
-                            />
-                        )}
+                        {settings.row.original.has_duplicates &&
+                            settings.row.original.duplicate_count === 1 && (
+                                <IconButtonComponent
+                                    url={`/${baseUrls.entityDuplicates}/entity_id/${settings.row.original.id}/order/id/pageSize/50/page/1/`}
+                                    overrideIcon={FileCopyIcon}
+                                    tooltipMessage={MESSAGES.seeDuplicate}
+                                />
+                            )}
                         {/* When there's more than one dupe for the entity */}
-                        {settings.row.original.duplicates.length > 1 && (
-                            <IconButtonComponent
-                                url={`/${baseUrls.entityDuplicates}/entity_id/${settings.row.original.id}/order/id/pageSize/50/page/1/`}
-                                overrideIcon={FileCopyIcon}
-                                tooltipMessage={MESSAGES.seeDuplicates}
-                            />
-                        )}
+                        {settings.row.original.has_duplicates &&
+                            settings.row.original.duplicate_count > 1 && (
+                                <IconButtonComponent
+                                    url={`/${baseUrls.entityDuplicates}/entity_id/${settings.row.original.id}/order/id/pageSize/50/page/1/`}
+                                    overrideIcon={FileCopyIcon}
+                                    tooltipMessage={MESSAGES.seeDuplicates}
+                                />
+                            )}
                     </>
                 );
             },

--- a/hat/assets/js/apps/Iaso/domains/entities/types/entity.ts
+++ b/hat/assets/js/apps/Iaso/domains/entities/types/entity.ts
@@ -32,7 +32,9 @@ export type Entity = {
     submitter: string;
     instances: Record<string, any>[];
     program?: string;
-    duplicates: number[];
+    duplicates?: number[];
+    has_duplicates?: boolean;
+    duplicate_count?: number;
     latitude?: number;
     longitude?: number;
     nfc_cards?: number;

--- a/iaso/api/entity.py
+++ b/iaso/api/entity.py
@@ -370,10 +370,11 @@ class EntityViewSet(ModelViewSet):
                 name = None
                 if file_content is not None:
                     name = file_content.get("name")
-                duplicates = []
-                # not needed for map display or exports
+                has_duplicates = False
+                duplicate_count = 0
                 if fetch_duplicates:
-                    duplicates.extend(entity.duplicate_ids)
+                    has_duplicates = getattr(entity, "has_duplicates", False)
+                    duplicate_count = getattr(entity, "duplicate_count", 0)
 
                 result = {
                     "id": entity.id,
@@ -385,7 +386,8 @@ class EntityViewSet(ModelViewSet):
                     "entity_type": entity.entity_type.name,
                     "last_saved_instance": entity.last_saved_instance,
                     "org_unit": attributes_ou,
-                    "duplicates": duplicates,
+                    "has_duplicates": has_duplicates,
+                    "duplicate_count": duplicate_count,
                     "latitude": attributes_latitude,
                     "longitude": attributes_longitude,
                 }

--- a/iaso/models/entity.py
+++ b/iaso/models/entity.py
@@ -20,15 +20,14 @@ import uuid
 from copy import copy
 
 from django.contrib.auth.models import AnonymousUser, User
-from django.contrib.postgres.aggregates import ArrayAgg
 from django.contrib.postgres.fields import ArrayField
 from django.core.exceptions import ValidationError
 from django.db import models
-from django.db.models import Case, F, Prefetch, Q, When
+from django.db.models import Count, Exists, OuterRef, Prefetch, Q
 
 from hat.audit.models import log_modification
 from iaso.models import Account, Instance, OrgUnit, Project
-from iaso.models.deduplication import ValidationStatus
+from iaso.models.deduplication import EntityDuplicate, ValidationStatus
 from iaso.utils.jsonlogic import jsonlogic_to_q
 from iaso.utils.models.soft_deletable import (
     DefaultSoftDeletableManager,
@@ -167,22 +166,15 @@ class EntityQuerySet(models.QuerySet):
 
     def with_duplicates(self):
         return self.annotate(
-            duplicate_ids=ArrayAgg(
-                Case(
-                    When(
-                        Q(duplicates1__validation_status=ValidationStatus.PENDING),
-                        then=F("duplicates1__entity2__id"),
-                    ),
-                    When(
-                        Q(duplicates2__validation_status=ValidationStatus.PENDING),
-                        then=F("duplicates2__entity1__id"),
-                    ),
-                    output_field=models.IntegerField(),
-                ),
-                distinct=True,
-                filter=Q(duplicates1__validation_status=ValidationStatus.PENDING)
-                | Q(duplicates2__validation_status=ValidationStatus.PENDING),
+            has_duplicates=Exists(
+                EntityDuplicate.objects.filter(
+                    Q(entity1=OuterRef("pk")) | Q(entity2=OuterRef("pk")), validation_status=ValidationStatus.PENDING
+                )
+            ),
+            duplicate_count=Count(
+                "duplicates1", filter=Q(duplicates1__validation_status=ValidationStatus.PENDING), distinct=True
             )
+            + Count("duplicates2", filter=Q(duplicates2__validation_status=ValidationStatus.PENDING), distinct=True),
         )
 
 

--- a/iaso/tests/api/entities/test_entities.py
+++ b/iaso/tests/api/entities/test_entities.py
@@ -212,7 +212,7 @@ class WebEntityAPITestCase(EntityAPITestCase):
 
     def test_list_entities_annotate_duplicates(self):
         """
-        Test that the list of entities at /api/entities includes duplicate ids annotations
+        Test that the list of entities at /api/entities includes duplicate annotations.
 
         This shouldn't result in n+1 queries.
         """
@@ -237,7 +237,8 @@ class WebEntityAPITestCase(EntityAPITestCase):
         result = response.json()["result"]
         self.assertEqual(len(result), 3)
         self.assertEqual(result[0]["id"], entities[0].id)
-        self.assertEqual(result[0]["duplicates"], [entities[1].id])
+        self.assertTrue(result[0]["has_duplicates"])
+        self.assertEqual(result[0]["duplicate_count"], 1)
 
     @time_machine.travel(datetime.datetime(2021, 7, 18, 14, 57, 0, 1), tick=False)
     def test_list_entities_single_entity_type(self):

--- a/iaso/tests/models/test_entity.py
+++ b/iaso/tests/models/test_entity.py
@@ -67,13 +67,22 @@ class EntityTestCase(TestCase):
 
         annotated = list(m.Entity.objects.with_duplicates().all())
 
-        self.assertEqual(sorted(annotated[0].duplicate_ids), [annotated[1].id, annotated[2].id])
+        # Entity 0 has 2 duplicates
+        self.assertTrue(annotated[0].has_duplicates)
+        self.assertEqual(annotated[0].duplicate_count, 2)
 
-        self.assertEqual(sorted(annotated[1].duplicate_ids), [annotated[0].id])
-        self.assertEqual(sorted(annotated[2].duplicate_ids), [annotated[0].id])
+        # Entities 1 and 2 each have 1 duplicate (entity 0)
+        self.assertTrue(annotated[1].has_duplicates)
+        self.assertEqual(annotated[1].duplicate_count, 1)
+        self.assertTrue(annotated[2].has_duplicates)
+        self.assertEqual(annotated[2].duplicate_count, 1)
 
-        self.assertEqual(sorted(annotated[3].duplicate_ids), [annotated[4].id])
-        self.assertEqual(sorted(annotated[4].duplicate_ids), [annotated[3].id])
+        # Entities 3 and 4 are duplicates of each other
+        self.assertTrue(annotated[3].has_duplicates)
+        self.assertEqual(annotated[3].duplicate_count, 1)
+        self.assertTrue(annotated[4].has_duplicates)
+        self.assertEqual(annotated[4].duplicate_count, 1)
 
-        # Entity 6 has no duplicates
-        self.assertEqual(sorted(annotated[5].duplicate_ids), [])
+        # Entity 5 has no duplicates
+        self.assertFalse(annotated[5].has_duplicates)
+        self.assertEqual(annotated[5].duplicate_count, 0)


### PR DESCRIPTION
Optimise entities list for large datasets.

Related JIRA tickets: WC2-818

## Changes

- replace expensive `ArrayAgg` operations with `boolean` + `count` in `EntityQuerySet.with_duplicates()`
- entity list API fields:
    - add `has_duplicates` and `duplicate_count`
    - remove `duplicates`
- update frontend to use boolean flags instead of array operations

This should reduce memory usage and database load as well as network transfer (boolean + int vs large arrays of integers).