### PR TITLE
IA-4351: Include default fields to display to instance popup 

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/entities/entityTypes/hooks/requests/forms.ts
+++ b/hat/assets/js/apps/Iaso/domains/entities/entityTypes/hooks/requests/forms.ts
@@ -4,35 +4,8 @@ import { getRequest } from '../../../../../libs/Api';
 import { useSnackQuery } from '../../../../../libs/apiHooks';
 
 import { usePossibleFields } from '../../../../forms/hooks/useGetPossibleFields';
+import { useGetForm } from '../../../../forms/requests';
 import { Form, PossibleField } from '../../../../forms/types/forms';
-
-export const useGetForm = (
-    formId: number | undefined,
-    enabled: boolean,
-    fields?: string | undefined,
-    appId?: string,
-): UseQueryResult<Form, Error> => {
-    const queryKey: any[] = ['form', formId];
-    let url = `/api/forms/${formId}`;
-    if (fields) {
-        url += `/?fields=${fields}`;
-        if (appId) {
-            url += `&app_id=${appId}`;
-        }
-    } else if (appId) {
-        url += `/?app_id=${appId}`;
-    }
-    return useSnackQuery({
-        queryKey,
-        queryFn: () => getRequest(url),
-        options: {
-            retry: false,
-            enabled,
-            staleTime: 60000,
-            cacheTime: 1000 * 60 * 5,
-        },
-    });
-};
 
 export const useGetForms = (
     enabled: boolean,

--- a/hat/assets/js/apps/Iaso/domains/forms/detail.tsx
+++ b/hat/assets/js/apps/Iaso/domains/forms/detail.tsx
@@ -100,7 +100,11 @@ const FormDetail: FunctionComponent = () => {
     ) as unknown as FormParams;
     const goBack = useGoBack(baseUrls.forms);
     const queryClient = useQueryClient();
-    const { data: form, isLoading: isFormLoading } = useGetForm(params.formId);
+    const { data: form, isLoading: isFormLoading } = useGetForm(
+        params.formId,
+        Boolean(params.formId),
+        'id,name,org_unit_types,projects,period_type,derived,single_per_period,periods_before_allowed,periods_after_allowed,device_field,location_field,label_keys,possible_fields,legend_threshold,change_request_mode',
+    );
     const [isLoading, setIsLoading] = useState(false);
     const [isSaved, setIsSaved] = useState(false);
     const [tab, setTab] = useState(params.tab || 'versions');

--- a/hat/assets/js/apps/Iaso/domains/forms/hooks/useGetPossibleFields.ts
+++ b/hat/assets/js/apps/Iaso/domains/forms/hooks/useGetPossibleFields.ts
@@ -5,9 +5,9 @@ import { FormState } from 'Iaso/domains/entities/components/EntitiesQuerybuilder
 import { getRequest } from '../../../libs/Api';
 import { useSnackQueries, useSnackQuery } from '../../../libs/apiHooks';
 import { DropdownOptions } from '../../../types/utils';
-import { useGetForm } from '../../entities/entityTypes/hooks/requests/forms';
 
 import MESSAGES from '../messages';
+import { useGetForm } from '../requests';
 import { Form, PossibleField } from '../types/forms';
 
 type Result = {

--- a/hat/assets/js/apps/Iaso/domains/instances/components/InstancePopUp/InstancePopUp.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/InstancePopUp/InstancePopUp.tsx
@@ -1,9 +1,7 @@
-import { Theme } from '@mui/material/styles';
-import L from 'leaflet';
 import React, { createRef, FunctionComponent, useCallback } from 'react';
-import { Popup, useMap } from 'react-leaflet';
 
 import { Box, Card, CardContent, CardMedia, Grid } from '@mui/material';
+import { Theme } from '@mui/material/styles';
 import { makeStyles } from '@mui/styles';
 
 import {
@@ -13,15 +11,18 @@ import {
     mapPopupStyles,
     useSafeIntl,
 } from 'bluesquare-components';
+import L from 'leaflet';
+import { Popup, useMap } from 'react-leaflet';
 import ConfirmDialog from '../../../../components/dialogs/ConfirmDialogComponent';
-import InstanceDetailsInfos from '../InstanceDetailsInfos';
 
 import { baseUrls } from '../../../../constants/urls';
 import { usePopupState } from '../../../../utils/map/usePopupState';
 import { useGetInstance } from '../../../registry/hooks/useGetInstances';
+import { INSTANCE_MAP_METAS_FIELDS } from '../../constants';
 import MESSAGES from '../../messages';
 import { Instance } from '../../types/instance';
-import { INSTANCE_MAP_METAS_FIELDS } from '../../constants';
+import InstanceDetailsInfos from '../InstanceDetailsInfos';
+import { InstancesLabelKeys } from '../InstancesLabelKeys';
 
 const useStyles = makeStyles((theme: Theme) => ({
     ...(commonStyles(theme) as Record<string, any>),
@@ -64,8 +65,8 @@ export const InstancePopup: FunctionComponent<Props> = ({
     }, [currentInstance, map, popup, replaceLocation]);
 
     const hasHero = (currentInstance?.files?.length ?? 0) > 0;
-
     return (
+        // @ts-ignore - Popup className prop type issue with react-leaflet
         <Popup className={classes.popup} ref={popup} pane="popupPane">
             {isLoading && <LoadingSpinner />}
             {currentInstance && (
@@ -86,6 +87,7 @@ export const InstancePopup: FunctionComponent<Props> = ({
                             currentInstance={currentInstance}
                             fieldsToHide={['device_id']}
                         />
+                        <InstancesLabelKeys currentInstance={currentInstance} />
 
                         <Box className={classes.actionBox}>
                             <Grid
@@ -111,6 +113,7 @@ export const InstancePopup: FunctionComponent<Props> = ({
                                         confirm={confirmDialog}
                                     />
                                 )}
+                                {/* This is leading to warning in the console due to the use of unstable_viewTransition prop in Bluesquare Components */}
                                 <LinkButton
                                     variant="outlined"
                                     color="primary"

--- a/hat/assets/js/apps/Iaso/domains/instances/components/InstancesLabelKeys.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/InstancesLabelKeys.tsx
@@ -34,7 +34,7 @@ export const InstancesLabelKeys: FunctionComponent<Props> = ({
     );
     return (
         <>
-            {currentForm?.label_keys.map((labelKey: string) => (
+            {currentForm?.label_keys.slice(0, 10).map((labelKey: string) => (
                 <InstanceDetailsField
                     key={labelKey}
                     label={getLabelKeyLabel(labelKey)}

--- a/hat/assets/js/apps/Iaso/domains/instances/components/InstancesLabelKeys.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/InstancesLabelKeys.tsx
@@ -1,0 +1,46 @@
+import React, { FunctionComponent, useCallback } from 'react';
+import { useGetForm } from 'Iaso/domains/forms/requests';
+import { PossibleField } from 'Iaso/domains/forms/types/forms';
+import { Instance } from '../types/instance';
+import { formatLabel } from '../utils';
+import InstanceDetailsField from './InstanceDetailsField';
+
+type Props = {
+    currentInstance?: Instance;
+};
+
+export const InstancesLabelKeys: FunctionComponent<Props> = ({
+    currentInstance,
+}) => {
+    const { data: currentForm, isFetching: isFetchingForm } = useGetForm(
+        currentInstance?.form_id,
+        undefined,
+        'name,label_keys,id,possible_fields',
+    );
+    const getLabelKeyLabel = useCallback(
+        (labelKey: string) => {
+            if (isFetchingForm) {
+                return '';
+            }
+            const possibleField = currentForm?.possible_fields.find(
+                (field: PossibleField) => field.name === labelKey,
+            );
+            if (possibleField) {
+                return formatLabel(possibleField);
+            }
+            return labelKey;
+        },
+        [currentForm, isFetchingForm],
+    );
+    return (
+        <>
+            {currentForm?.label_keys.map((labelKey: string) => (
+                <InstanceDetailsField
+                    key={labelKey}
+                    label={getLabelKeyLabel(labelKey)}
+                    value={currentInstance?.file_content[labelKey]}
+                />
+            ))}
+        </>
+    );
+};


### PR DESCRIPTION
What problem is this PR solving? Explain here in one sentence.

Related JIRA tickets : IA-4351
## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

-

## Changes

- only use one useGetForm
- component to disply value of label_key fields on popup

## How to test

- make sure you selected default fields to disply while editing a form in advanced mode
- find a submission with location, find it on the instances map and open the details, you should see the result of label_key

## Print screen / video
<img width="943" height="596" alt="Screenshot 2025-09-03 at 13 32 50" src="https://github.com/user-attachments/assets/5c9bb446-8ccd-4547-8765-7f54e720c525" />



## Notes
-

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
