### PR TITLE
IA-4467: When creating an Org Unit, have Status "Valid" selected as default

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitForm.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitForm.tsx
@@ -30,7 +30,7 @@ const initialFormState = (
         : undefined,
     groups: orgUnit?.groups?.map(g => g.id) ?? [],
     sub_source: orgUnit?.sub_source,
-    validation_status: orgUnit?.validation_status,
+    validation_status: orgUnit?.id ? orgUnit?.validation_status : 'VALID',
     aliases: orgUnit?.aliases ?? ([] as string[]),
     source_id: orgUnit?.source_id,
     parent: orgUnit?.parent,


### PR DESCRIPTION
When creating an Org Unit, have Status "Valid" selected as default

Related JIRA tickets : IA-4467

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

-

## Changes

- set initial value of the org unit to `'VALID' `if new

## How to test

Create an org unit, status should be valid by deafault

## Print screen / video

<img width="1697" height="621" alt="Screenshot 2025-09-04 at 10 11 52" src="https://github.com/user-attachments/assets/9744c8ed-2f36-498a-ab0f-49853bb48ad3" />


## Notes
-

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
