### PR TITLE
WC2-818 Optimise entities list for large datasets (bis)

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/entities/config.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/config.tsx
@@ -151,14 +151,6 @@ export const useColumns = (
                                 tooltipMessage={MESSAGES.seeDuplicate}
                             />
                         )}
-                        {/* When there's more than one dupe for the entity */}
-                        {settings.row.original.has_duplicates && (
-                            <IconButtonComponent
-                                url={`/${baseUrls.entityDuplicates}/entity_id/${settings.row.original.id}/order/id/pageSize/50/page/1/`}
-                                overrideIcon={FileCopyIcon}
-                                tooltipMessage={MESSAGES.seeDuplicates}
-                            />
-                        )}
                     </>
                 );
             },

--- a/hat/assets/js/apps/Iaso/domains/entities/config.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/config.tsx
@@ -144,23 +144,21 @@ export const useColumns = (
                             icon="remove-red-eye"
                             tooltipMessage={MESSAGES.see}
                         />
-                        {settings.row.original.has_duplicates &&
-                            settings.row.original.duplicate_count === 1 && (
-                                <IconButtonComponent
-                                    url={`/${baseUrls.entityDuplicates}/entity_id/${settings.row.original.id}/order/id/pageSize/50/page/1/`}
-                                    overrideIcon={FileCopyIcon}
-                                    tooltipMessage={MESSAGES.seeDuplicate}
-                                />
-                            )}
+                        {settings.row.original.has_duplicates && (
+                            <IconButtonComponent
+                                url={`/${baseUrls.entityDuplicates}/entity_id/${settings.row.original.id}/order/id/pageSize/50/page/1/`}
+                                overrideIcon={FileCopyIcon}
+                                tooltipMessage={MESSAGES.seeDuplicate}
+                            />
+                        )}
                         {/* When there's more than one dupe for the entity */}
-                        {settings.row.original.has_duplicates &&
-                            settings.row.original.duplicate_count > 1 && (
-                                <IconButtonComponent
-                                    url={`/${baseUrls.entityDuplicates}/entity_id/${settings.row.original.id}/order/id/pageSize/50/page/1/`}
-                                    overrideIcon={FileCopyIcon}
-                                    tooltipMessage={MESSAGES.seeDuplicates}
-                                />
-                            )}
+                        {settings.row.original.has_duplicates && (
+                            <IconButtonComponent
+                                url={`/${baseUrls.entityDuplicates}/entity_id/${settings.row.original.id}/order/id/pageSize/50/page/1/`}
+                                overrideIcon={FileCopyIcon}
+                                tooltipMessage={MESSAGES.seeDuplicates}
+                            />
+                        )}
                     </>
                 );
             },

--- a/hat/assets/js/apps/Iaso/domains/entities/types/entity.ts
+++ b/hat/assets/js/apps/Iaso/domains/entities/types/entity.ts
@@ -34,7 +34,6 @@ export type Entity = {
     program?: string;
     duplicates?: number[];
     has_duplicates?: boolean;
-    duplicate_count?: number;
     latitude?: number;
     longitude?: number;
     nfc_cards?: number;

--- a/iaso/api/entity.py
+++ b/iaso/api/entity.py
@@ -150,16 +150,22 @@ class EntityViewSet(ModelViewSet):
         groups = self.request.query_params.get("groups", None)
         fields_search = self.request.GET.get("fields_search", None)
 
-        queryset = Entity.objects.filter_for_user(self.request.user)
-
-        queryset = queryset.prefetch_related(
-            "attributes__created_by__teams",
-            "attributes__form",
-            "attributes__org_unit__groups",
-            "attributes__org_unit__org_unit_type",
-            "attributes__org_unit__parent",
-            "attributes__org_unit__version__data_source",
-            "entity_type",
+        queryset = (
+            Entity.objects.filter_for_user(self.request.user)
+            .select_related(
+                "attributes__org_unit",
+                "attributes__created_by",
+                "entity_type",
+            )
+            .prefetch_related(
+                "attributes__created_by__teams",
+                "attributes__form",
+                "attributes__org_unit__groups",
+                "attributes__org_unit__org_unit_type",
+                "attributes__org_unit__parent",
+                "attributes__org_unit__version__data_source",
+                "instances",
+            )
         )
 
         if form_name:

--- a/iaso/api/entity.py
+++ b/iaso/api/entity.py
@@ -371,10 +371,8 @@ class EntityViewSet(ModelViewSet):
                 if file_content is not None:
                     name = file_content.get("name")
                 has_duplicates = False
-                duplicate_count = 0
                 if fetch_duplicates:
                     has_duplicates = getattr(entity, "has_duplicates", False)
-                    duplicate_count = getattr(entity, "duplicate_count", 0)
 
                 result = {
                     "id": entity.id,
@@ -387,7 +385,6 @@ class EntityViewSet(ModelViewSet):
                     "last_saved_instance": entity.last_saved_instance,
                     "org_unit": attributes_ou,
                     "has_duplicates": has_duplicates,
-                    "duplicate_count": duplicate_count,
                     "latitude": attributes_latitude,
                     "longitude": attributes_longitude,
                 }

--- a/iaso/models/entity.py
+++ b/iaso/models/entity.py
@@ -23,7 +23,7 @@ from django.contrib.auth.models import AnonymousUser, User
 from django.contrib.postgres.fields import ArrayField
 from django.core.exceptions import ValidationError
 from django.db import models
-from django.db.models import Count, Exists, OuterRef, Prefetch, Q
+from django.db.models import Exists, OuterRef, Prefetch, Q
 
 from hat.audit.models import log_modification
 from iaso.models import Account, Instance, OrgUnit, Project
@@ -170,11 +170,7 @@ class EntityQuerySet(models.QuerySet):
                 EntityDuplicate.objects.filter(
                     Q(entity1=OuterRef("pk")) | Q(entity2=OuterRef("pk")), validation_status=ValidationStatus.PENDING
                 )
-            ),
-            duplicate_count=Count(
-                "duplicates1", filter=Q(duplicates1__validation_status=ValidationStatus.PENDING), distinct=True
             )
-            + Count("duplicates2", filter=Q(duplicates2__validation_status=ValidationStatus.PENDING), distinct=True),
         )
 
 

--- a/iaso/tests/api/entities/test_entities.py
+++ b/iaso/tests/api/entities/test_entities.py
@@ -238,7 +238,6 @@ class WebEntityAPITestCase(EntityAPITestCase):
         self.assertEqual(len(result), 3)
         self.assertEqual(result[0]["id"], entities[0].id)
         self.assertTrue(result[0]["has_duplicates"])
-        self.assertEqual(result[0]["duplicate_count"], 1)
 
     @time_machine.travel(datetime.datetime(2021, 7, 18, 14, 57, 0, 1), tick=False)
     def test_list_entities_single_entity_type(self):

--- a/iaso/tests/api/entities/test_entities.py
+++ b/iaso/tests/api/entities/test_entities.py
@@ -231,7 +231,7 @@ class WebEntityAPITestCase(EntityAPITestCase):
         m.EntityDuplicate.objects.create(
             entity1=entities[0], entity2=entities[1], validation_status=ValidationStatus.PENDING
         )
-        with self.assertNumQueries(9):
+        with self.assertNumQueries(7):
             response = self.client.get("/api/entities/", format="json")
         self.assertEqual(response.status_code, 200)
         result = response.json()["result"]

--- a/iaso/tests/models/test_entity.py
+++ b/iaso/tests/models/test_entity.py
@@ -67,22 +67,9 @@ class EntityTestCase(TestCase):
 
         annotated = list(m.Entity.objects.with_duplicates().all())
 
-        # Entity 0 has 2 duplicates
         self.assertTrue(annotated[0].has_duplicates)
-        self.assertEqual(annotated[0].duplicate_count, 2)
-
-        # Entities 1 and 2 each have 1 duplicate (entity 0)
         self.assertTrue(annotated[1].has_duplicates)
-        self.assertEqual(annotated[1].duplicate_count, 1)
         self.assertTrue(annotated[2].has_duplicates)
-        self.assertEqual(annotated[2].duplicate_count, 1)
-
-        # Entities 3 and 4 are duplicates of each other
         self.assertTrue(annotated[3].has_duplicates)
-        self.assertEqual(annotated[3].duplicate_count, 1)
         self.assertTrue(annotated[4].has_duplicates)
-        self.assertEqual(annotated[4].duplicate_count, 1)
-
-        # Entity 5 has no duplicates
         self.assertFalse(annotated[5].has_duplicates)
-        self.assertEqual(annotated[5].duplicate_count, 0)


### PR DESCRIPTION
Optimise entities list for large datasets (bis).

Related JIRA tickets: WC2-818

See also: #2413 

## Changes

- removed the multiple `duplicate_count annotation`
- add `select_related` for frequently accessed FKs
- add instances to `prefetch_related` to ensure the `last_saved_instance` annotation works efficiently
