### PR TITLE
IA-3219: UserDialog validation

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -1573,6 +1573,7 @@
     "iaso.users.history.labels.newLocation": "New location",
     "iaso.users.history.labels.pastLocation": "Past location",
     "iaso.users.homePageInfos": "Copy/paste the url after \"dashboard/\"",
+    "iaso.users.invalidEmailFormat": "Invalid email format",
     "iaso.users.isSuperUser": "User is a super admin and has all rights",
     "iaso.users.label.english": "English",
     "iaso.users.label.french": "French",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -18,6 +18,7 @@
     "blsq.treeview.search.confirm": "Confirmer",
     "blsq.treeview.search.inputLabelObject": "Rechercher",
     "blsq.treeview.search.options.label.clear": "Effacer",
+    "iaso.users.invalidEmailFormat": "Format d'email invalide",
     "blsq.treeview.search.options.label.noOptions": "Aucun résultat trouvé",
     "blsq.treeview.search.results.label.display": "Afficher",
     "blsq.treeview.search.results.label.resultsLower": "résultat(s)",

--- a/hat/assets/js/apps/Iaso/domains/users/components/UsersDialog.tsx
+++ b/hat/assets/js/apps/Iaso/domains/users/components/UsersDialog.tsx
@@ -26,7 +26,7 @@ import PermissionsAttribution from './PermissionsAttribution';
 import { useInitialUser } from './useInitialUser';
 import { UserOrgUnitWriteTypes } from './UserOrgUnitWriteTypes';
 import UsersDialogTabDisabled from './UsersDialogTabDisabled';
-import UsersInfos from './UsersInfos';
+import { UsersInfos } from './UsersInfos';
 import UsersLocations from './UsersLocations';
 import { WarningModal } from './WarningModal/WarningModal';
 
@@ -73,7 +73,14 @@ const UserDialogComponent: FunctionComponent<Props> = ({
     const queryClient = useQueryClient();
     const classes: Record<string, string> = useStyles();
 
-    const { user, setFieldValue, setFieldErrors } = useInitialUser(initialData);
+    const {
+        user,
+        setFieldValue,
+        setFieldErrors,
+        setPhoneNumber,
+        hasErrors,
+        setEmail,
+    } = useInitialUser(initialData);
     const [tab, setTab] = useState('infos');
     const [openWarning, setOpenWarning] = useState<boolean>(false);
     const [hasNoOrgUnitManagementWrite, setHasNoOrgUnitManagementWrite] =
@@ -176,6 +183,17 @@ const UserDialogComponent: FunctionComponent<Props> = ({
             !allUserUserRolesPermissions.includes(Permissions.ORG_UNITS),
         );
     }, [allUserRolesPermissions.length, allUserUserRolesPermissions]);
+    const isNewUser = !user.id?.value;
+    const allowConfirm =
+        !hasErrors &&
+        !(
+            user.user_name.value === '' ||
+            (isNewUser &&
+                (((!user.password.value || user.password.value === '') &&
+                    !user.send_email_invitation.value) ||
+                    (user.send_email_invitation.value &&
+                        user.email?.value === '')))
+        );
     return (
         <>
             <WarningModal
@@ -194,12 +212,7 @@ const UserDialogComponent: FunctionComponent<Props> = ({
                 maxWidth="md"
                 open={isOpen}
                 closeDialog={closeDialog}
-                allowConfirm={
-                    !(
-                        user.user_name.value === '' ||
-                        (!user.id?.value && user.password.value === '')
-                    )
-                }
+                allowConfirm={allowConfirm}
                 onClose={() => null}
                 onCancel={closeDialog}
                 id="user-dialog"
@@ -268,6 +281,8 @@ const UserDialogComponent: FunctionComponent<Props> = ({
                             canBypassProjectRestrictions={
                                 canBypassProjectRestrictions
                             }
+                            setPhoneNumber={setPhoneNumber}
+                            setEmail={setEmail}
                         />
                     </div>
                     {tab === 'permissions' && (

--- a/hat/assets/js/apps/Iaso/domains/users/messages.ts
+++ b/hat/assets/js/apps/Iaso/domains/users/messages.ts
@@ -529,6 +529,10 @@ const MESSAGES = defineMessages({
         defaultMessage:
             'This user is a multi-account user. For this user, you can only edit settings specific to this account, such as their permissions.',
     },
+    invalidEmailFormat: {
+        id: 'iaso.users.invalidEmailFormat',
+        defaultMessage: 'Invalid email format',
+    },
 });
 
 export default MESSAGES;

--- a/hat/assets/js/apps/Iaso/domains/users/types.ts
+++ b/hat/assets/js/apps/Iaso/domains/users/types.ts
@@ -23,11 +23,12 @@ export type UserDialogData = {
     language: ValueAndErrors<string | null>;
     password: ValueAndErrors<string | null>;
     phone_number: ValueAndErrors<string | null>;
-    country_code: ValueAndErrors<string | null>;
+    country_code: ValueAndErrors<string | number | null>;
     projects: ValueAndErrors<Project[] | null>;
     editable_org_unit_type_ids: ValueAndErrors<number[] | null>;
     user_roles_editable_org_unit_type_ids: ValueAndErrors<number[] | []>;
     has_multiple_accounts: ValueAndErrors<boolean>;
+    organization: ValueAndErrors<string | undefined>;
 };
 
 export type InitialUserData = Partial<Profile> & { is_superuser?: boolean };


### PR DESCRIPTION
As soon as there is a user name, an email and that the invitation checkbox is checked, the save button should activate, but that’s not what we have
Related JIRA tickets : IA-3219

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [x] Are my typescript files well typed?
- [x] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

Review, refactor user dialog a bit to improve validation

## How to test

Try to create / edit one user, check that the validation is ok and save button is correctly disabled

## Print screen / video

https://github.com/user-attachments/assets/12776b23-cf47-40d8-8362-e98580296aba


## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
