### PR TITLE
IA-4466: Setup account improvements

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/setup/hooks/useGetModulesDropDown.ts
+++ b/hat/assets/js/apps/Iaso/domains/setup/hooks/useGetModulesDropDown.ts
@@ -1,14 +1,14 @@
-import { UseQueryResult } from 'react-query';
 import { IntlFormatMessage, useSafeIntl } from 'bluesquare-components';
+import { UseQueryResult } from 'react-query';
 import { getRequest } from '../../../libs/Api';
 import { useSnackQuery } from '../../../libs/apiHooks';
 import { DropdownOptions } from '../../../types/utils';
-import { Module } from '../types/account';
-import { MESSAGES } from '../messages';
 import { MESSAGES as MODULE_MESSAGES } from '../../modules/messages';
+import { MESSAGES } from '../messages';
+import { Module } from '../types/account';
 
 export const useGetModulesDropDown = (): UseQueryResult<
-    DropdownOptions<number>[],
+    DropdownOptions<string>[],
     Error
 > => {
     const { formatMessage }: { formatMessage: IntlFormatMessage } =

--- a/hat/assets/js/apps/Iaso/domains/setup/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/setup/index.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useState } from 'react';
+import React, { FunctionComponent, useState, useMemo } from 'react';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import ContactSupportIcon from '@mui/icons-material/ContactSupport';
 import ExitIcon from '@mui/icons-material/ExitToApp';
@@ -14,6 +14,7 @@ import {
     useApiErrorValidation,
     useTranslatedErrors,
 } from '../../libs/validation';
+import { DropdownOptions } from '../../types/utils';
 import { commaSeparatedIdsToStringArray } from '../../utils/forms';
 import getDisplayName, { useCurrentUser } from '../../utils/usersUtils';
 import { useGetModulesDropDown } from './hooks/useGetModulesDropDown';
@@ -76,7 +77,7 @@ export const SetupAccount: FunctionComponent = () => {
             password: undefined,
             email_invitation: false,
             language: 'en',
-            modules: ['DATA_COLLECTION_FORMS', 'DEFAULT'],
+            modules: ['DATA_COLLECTION_FORMS'],
         },
         enableReinitialize: true,
         validateOnBlur: true,
@@ -114,6 +115,13 @@ export const SetupAccount: FunctionComponent = () => {
     const { data: modules, isFetching: isFetchingModules } =
         useGetModulesDropDown();
 
+    const filteredModules: DropdownOptions<string>[] = useMemo(
+        () =>
+            modules?.filter(
+                (module: DropdownOptions<string>) => module.value !== 'DEFAULT',
+            ) ?? [],
+        [modules],
+    );
     const allowConfirm = isValid && !isEqual(values, initialValues);
     const hasAccount = Boolean(currentUser.account);
     return (
@@ -266,7 +274,7 @@ export const SetupAccount: FunctionComponent = () => {
                                         onChange={onChange}
                                         errors={getErrors('modules')}
                                         loading={isFetchingModules}
-                                        options={modules ?? []}
+                                        options={filteredModules}
                                     />
                                     <Box
                                         mt={2}

--- a/iaso/api/setup_account.py
+++ b/iaso/api/setup_account.py
@@ -52,7 +52,7 @@ class SetupAccountSerializer(serializers.Serializer):
         default="en",
         help_text="Language for the user interface and email invitations",
     )
-    modules = serializers.JSONField(required=True, initial=["DEFAULT", "DATA_COLLECTION_FORMS"])  # type: ignore
+    modules = serializers.JSONField(required=True, initial=["DATA_COLLECTION_FORMS"])  # type: ignore
     feature_flags = serializers.JSONField(
         required=False, default=DEFAULT_ACCOUNT_FEATURE_FLAGS, initial=DEFAULT_ACCOUNT_FEATURE_FLAGS
     )
@@ -148,6 +148,9 @@ class SetupAccountSerializer(serializers.Serializer):
         for module in validated_data.get("modules"):
             if module in module_codenames and module not in account_modules:
                 account_modules.append(module)
+
+        if "DEFAULT" not in account_modules:
+            account_modules.append("DEFAULT")
 
         account = Account.objects.create(
             name=validated_data["account_name"],

--- a/iaso/api/setup_account.py
+++ b/iaso/api/setup_account.py
@@ -51,7 +51,6 @@ class SetupAccountSerializer(serializers.Serializer):
         help_text="Language for the user interface and email invitations",
     )
     modules = serializers.JSONField(required=True, initial=["DEFAULT", "DATA_COLLECTION_FORMS"])  # type: ignore
-    analytics_script = serializers.CharField(required=False)
     feature_flags = serializers.JSONField(
         required=False, default=DEFAULT_ACCOUNT_FEATURE_FLAGS, initial=DEFAULT_ACCOUNT_FEATURE_FLAGS
     )
@@ -153,7 +152,6 @@ class SetupAccountSerializer(serializers.Serializer):
             default_version=source_version,
             user_manual_path=validated_data.get("user_manual_path"),
             modules=account_modules,
-            analytics_script=validated_data.get("analytics_script", ""),
         )
         account.feature_flags.set(validated_data.get("feature_flags"))
 

--- a/iaso/tests/api/test_setup_account.py
+++ b/iaso/tests/api/test_setup_account.py
@@ -1067,3 +1067,178 @@ class SetupAccountApiTestCase(APITestCase):
         # Verify the account was properly created with expected properties
         self.assertEqual(created_account.name, data["account_name"])
         self.assertEqual(created_account.modules, data["modules"])
+
+    def test_setup_account_creates_project_feature_flags(self):
+        """Test that setup account creates project feature flags for REQUIRE_AUTHENTICATION and FORMS_AUTO_UPLOAD"""
+        self.client.force_authenticate(self.admin)
+        data = {
+            "account_name": "unittest_account",
+            "user_username": "unittest_username",
+            "password": "unittest_password",
+            "email_invitation": False,
+            "modules": self.MODULES,
+        }
+        response = self.client.post("/api/setupaccount/", data=data, format="json")
+        self.assertEqual(response.status_code, 201)
+
+        # Get the created project
+        project = m.Project.objects.filter(name="Main Project").first()
+        self.assertIsNotNone(project)
+
+        # Check that the project has the required feature flags
+        self.assertTrue(project.has_feature(m.FeatureFlag.REQUIRE_AUTHENTICATION))
+        self.assertTrue(project.has_feature(m.FeatureFlag.FORMS_AUTO_UPLOAD))
+
+        # Verify ProjectFeatureFlags entries exist
+        require_auth_pff = m.ProjectFeatureFlags.objects.filter(
+            project=project, featureflag__code=m.FeatureFlag.REQUIRE_AUTHENTICATION
+        ).first()
+        self.assertIsNotNone(require_auth_pff)
+
+        forms_auto_upload_pff = m.ProjectFeatureFlags.objects.filter(
+            project=project, featureflag__code=m.FeatureFlag.FORMS_AUTO_UPLOAD
+        ).first()
+        self.assertIsNotNone(forms_auto_upload_pff)
+
+        # Verify the feature flags are properly linked
+        self.assertEqual(require_auth_pff.featureflag.code, m.FeatureFlag.REQUIRE_AUTHENTICATION)
+        self.assertEqual(forms_auto_upload_pff.featureflag.code, m.FeatureFlag.FORMS_AUTO_UPLOAD)
+
+    def test_setup_account_project_feature_flags_audit_logging(self):
+        """Test that project feature flags are included in audit logs"""
+        self.client.force_authenticate(self.admin)
+        data = {
+            "account_name": "unittest_account",
+            "user_username": "unittest_username",
+            "password": "unittest_password",
+            "email_invitation": False,
+            "modules": self.MODULES,
+        }
+
+        # Count audit logs before
+        initial_count = Modification.objects.filter(source=SETUP_ACCOUNT_API).count()
+
+        response = self.client.post("/api/setupaccount/", data=data, format="json")
+        self.assertEqual(response.status_code, 201)
+
+        # Check that an audit log was created
+        audit_logs = Modification.objects.filter(source=SETUP_ACCOUNT_API)
+        self.assertEqual(audit_logs.count(), initial_count + 1)
+
+        # Get the latest audit log
+        latest_log = audit_logs.latest("id")
+        audit_data = latest_log.new_value[0]
+
+        # Check that project feature flags are included in audit data
+        self.assertIn("project_feature_flags", audit_data)
+        self.assertEqual(
+            audit_data["project_feature_flags"], [m.FeatureFlag.REQUIRE_AUTHENTICATION, m.FeatureFlag.FORMS_AUTO_UPLOAD]
+        )
+
+    def test_setup_account_feature_flags_exist_in_database(self):
+        """Test that the required feature flags exist in the database"""
+        # Verify that the feature flags exist
+        require_auth_flag = m.FeatureFlag.objects.filter(code=m.FeatureFlag.REQUIRE_AUTHENTICATION).first()
+        self.assertIsNotNone(require_auth_flag)
+        self.assertEqual(require_auth_flag.code, m.FeatureFlag.REQUIRE_AUTHENTICATION)
+
+        forms_auto_upload_flag = m.FeatureFlag.objects.filter(code=m.FeatureFlag.FORMS_AUTO_UPLOAD).first()
+        self.assertIsNotNone(forms_auto_upload_flag)
+        self.assertEqual(forms_auto_upload_flag.code, m.FeatureFlag.FORMS_AUTO_UPLOAD)
+
+    def test_setup_account_project_feature_flags_configuration(self):
+        """Test that project feature flags are created with proper configuration"""
+        self.client.force_authenticate(self.admin)
+        data = {
+            "account_name": "unittest_account",
+            "user_username": "unittest_username",
+            "password": "unittest_password",
+            "email_invitation": False,
+            "modules": self.MODULES,
+        }
+        response = self.client.post("/api/setupaccount/", data=data, format="json")
+        self.assertEqual(response.status_code, 201)
+
+        # Get the created project
+        project = m.Project.objects.filter(name="Main Project").first()
+        self.assertIsNotNone(project)
+
+        # Check ProjectFeatureFlags configuration
+        project_feature_flags = m.ProjectFeatureFlags.objects.filter(project=project)
+        self.assertEqual(project_feature_flags.count(), 2)
+
+        for pff in project_feature_flags:
+            # Configuration should be None for these feature flags
+            self.assertIsNone(pff.configuration)
+            # Feature flag should be one of the expected ones
+            self.assertIn(pff.featureflag.code, [m.FeatureFlag.REQUIRE_AUTHENTICATION, m.FeatureFlag.FORMS_AUTO_UPLOAD])
+
+    def test_setup_account_project_feature_flags_multiple_accounts(self):
+        """Test that multiple accounts get the same project feature flags"""
+        self.client.force_authenticate(self.admin)
+
+        # Create first account
+        data1 = {
+            "account_name": "unittest_account_1",
+            "user_username": "unittest_username_1",
+            "password": "unittest_password",
+            "email_invitation": False,
+            "modules": self.MODULES,
+        }
+        response1 = self.client.post("/api/setupaccount/", data=data1, format="json")
+        self.assertEqual(response1.status_code, 201)
+
+        # Create second account
+        data2 = {
+            "account_name": "unittest_account_2",
+            "user_username": "unittest_username_2",
+            "password": "unittest_password",
+            "email_invitation": False,
+            "modules": self.MODULES,
+        }
+        response2 = self.client.post("/api/setupaccount/", data=data2, format="json")
+        self.assertEqual(response2.status_code, 201)
+
+        # Get both projects
+        project1 = m.Project.objects.filter(name="Main Project", account__name="unittest_account_1").first()
+        project2 = m.Project.objects.filter(name="Main Project", account__name="unittest_account_2").first()
+
+        self.assertIsNotNone(project1)
+        self.assertIsNotNone(project2)
+
+        # Both projects should have the same feature flags
+        for project in [project1, project2]:
+            self.assertTrue(project.has_feature(m.FeatureFlag.REQUIRE_AUTHENTICATION))
+            self.assertTrue(project.has_feature(m.FeatureFlag.FORMS_AUTO_UPLOAD))
+
+            # Check ProjectFeatureFlags entries
+            pff_count = m.ProjectFeatureFlags.objects.filter(project=project).count()
+            self.assertEqual(pff_count, 2)
+
+    def test_setup_account_project_feature_flags_integration(self):
+        """Test that project feature flags work with the complete setup account flow"""
+        self.client.force_authenticate(self.admin)
+        data = {
+            "account_name": "unittest_account",
+            "user_username": "unittest_username",
+            "password": "unittest_password",
+            "email_invitation": False,
+            "modules": self.MODULES,
+        }
+        response = self.client.post("/api/setupaccount/", data=data, format="json")
+        self.assertEqual(response.status_code, 201)
+
+        # Verify complete integration
+        account = m.Account.objects.get(name="unittest_account")
+        project = m.Project.objects.get(name="Main Project", account=account)
+
+        # Project should have feature flags
+        self.assertTrue(project.has_feature(m.FeatureFlag.REQUIRE_AUTHENTICATION))
+        self.assertTrue(project.has_feature(m.FeatureFlag.FORMS_AUTO_UPLOAD))
+
+        # Project should be linked to account
+        self.assertEqual(project.account, account)
+
+        # Project should have proper app_id
+        expected_app_id = "unittest_account"
+        self.assertEqual(project.app_id, expected_app_id)


### PR DESCRIPTION
- We should remove project from profile creation
- We need to hide default module and make sure it’s always used
- We need authentication and automatic upload (project Feature flag) on the mobile app
- Remove analytics script from the setup (keep model)

Related JIRA tickets : IA-4466

## Self proofreading checklist

- [ ] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

-

## Changes

- remove DEFAUT module and make sure it's automatically added
- remove analytic script form setup
- activate project feature flag REQUIRE_AUTHENTICATION and FORMS_AUTO_UPLOAD
- remove project from main user

## How to test

- Connect to the dashboard using admin account 
- Go to Settings/Setup a new account
- Create a new account
- Connect to the account using the user you just created. 
- Make sure the user has no project
- Make sure Default module is activated
- Make sure project has REQUIRE_AUTHENTICATION and FORMS_AUTO_UPLOAD feature flag activated
- Navigate to `/api/setupaccount/ `and make sure analytic script is removed 


## Print screen / video
<img width="1707" height="638" alt="Screenshot 2025-09-10 at 11 37 51" src="https://github.com/user-attachments/assets/901d399e-7d1e-45e7-8136-068b2420d346" />
<img width="1698" height="824" alt="Screenshot 2025-09-10 at 11 36 44" src="https://github.com/user-attachments/assets/b5447f16-5905-449a-af68-0581d4f48bc6" />
<img width="1330" height="996" alt="Screenshot 2025-09-10 at 11 34 55" src="https://github.com/user-attachments/assets/3f09d978-382a-4da5-9e41-aee252fe9bbc" />
<img width="845" height="1212" alt="Screenshot 2025-09-10 at 11 34 36" src="https://github.com/user-attachments/assets/8c766c22-da87-4c17-a284-bc4183452b3d" />



## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
