### PR TITLE
IA-4476: Hide logo when no path is set

### DIFF
--- a/hat/templates/iaso/login.html
+++ b/hat/templates/iaso/login.html
@@ -5,17 +5,19 @@
 {% block body %}
 <div class="auth__container iasologin">
   <div class="auth__content">
-    <header class="auth__header">
-      <h1 class="auth__heading">
-        {% if LEARN_MORE_URL %}
-          <a href="{{ LEARN_MORE_URL }}" target="_blank">
+    {% if logo_path %}
+      <header class="auth__header">
+        <h1 class="auth__heading">
+          {% if LEARN_MORE_URL %}
+            <a href="{{ LEARN_MORE_URL }}" target="_blank">
+              <img alt="logo" src="{% static logo_path %}" />
+            </a>
+          {% else %}
             <img alt="logo" src="{% static logo_path %}" />
-          </a>
-        {% else %}
-          <img alt="logo" src="{% static logo_path %}" />
-        {% endif %}
-      </h1>
-    </header>
+          {% endif %}
+        </h1>
+      </header>
+    {% endif %}
     <div>
       {% get_providers as socialaccount_providers %}
       {% for provider in socialaccount_providers %}


### PR DESCRIPTION
Hide logo on login page if no logo path is provided

Related JIRA tickets : IA-4476

## Self proofreading checklist

- [ ] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

Don't display logo if no logo path is provided

## How to test

Run IASO as usual, the logo should be shown.
Now, set LOGO_PATH environment variable to nothing.
(I did it for a plugin, so in snt_malaria, plugin_settings.py: CONSTANTS = {"LOGO_PATH": "", ... })

## Print screen / video

<img width="1506" height="502" alt="image" src="https://github.com/user-attachments/assets/63ca3cea-449a-436a-af23-469701eec8ba" />


## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
