### PR TITLE
IA-4478 Disable the password field only when `send_email_invitation` is checked

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/users/components/UsersInfos.tsx
+++ b/hat/assets/js/apps/Iaso/domains/users/components/UsersInfos.tsx
@@ -49,9 +49,7 @@ export const UsersInfos: FunctionComponent<Props> = ({
         ? MESSAGES.sentEmailInvitationWhenAdresseExist
         : MESSAGES.sentEmailInvitation;
     const isMultiAccountUser = currentUser.has_multiple_accounts.value;
-    const passwordDisabled =
-        currentUser.send_email_invitation.value ||
-        (isMultiAccountUser && loggedUser.id !== currentUser.id?.value);
+    const passwordDisabled = currentUser.send_email_invitation.value;
 
     const { data: allProjects, isFetching: isFetchingProjects } =
         useGetProjectsDropdownOptions(true, canBypassProjectRestrictions);


### PR DESCRIPTION
Disable the password field only when `send_email_invitation` is checked.

Related JIRA tickets: IA-4478

## Changes

The password field is now only disabled when `send_email_invitation` is checked.

This allows multi-account users to have their passwords edited by admins or themselves.

The other user fields (`username`, `first_name`, `last_name`, `email`) remain properly disabled for multi-account users.

This is basically just changing a little part introduced here https://github.com/BLSQ/iaso/pull/2423

## How to test

- you need a multi-tenant user with the permission to change users
- go to `/dashboard/settings/users/management`
- edit a user
- you should see the info message:
    - > This user is a multi-account user. For this user, you can only edit settings specific to this Iaso account "polio", such as their permissions.
- but you should still be able to change the `password`
