### PR TITLE
IA-4482 Fix search field in users list not working with some checkboxes

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/users/components/Filters.js
+++ b/hat/assets/js/apps/Iaso/domains/users/components/Filters.js
@@ -85,13 +85,21 @@ const Filters = ({ baseUrl, params, canBypassProjectRestrictions }) => {
     const handleChange = useCallback(
         (key, value) => {
             setFiltersUpdated(true);
-            if (key === 'location') {
-                setInitialOrgUnitId(value);
-            }
-            setFilters({
+            let updatedFilters = {
                 ...filters,
                 [key]: value,
-            });
+            };
+            if (key === 'location') {
+                setInitialOrgUnitId(value);
+                // Reset checkboxes when the `location` field is cleared.
+                if (!value) {
+                    setOuParent(false);
+                    setOuChildren(false);
+                    updatedFilters.ouParent = false;
+                    updatedFilters.ouChildren = false;
+                }
+            }
+            setFilters(updatedFilters);
         },
         [filters],
     );
@@ -203,7 +211,7 @@ const Filters = ({ baseUrl, params, canBypassProjectRestrictions }) => {
                         handleChange('ouChildren', !ouChildren);
                         setOuChildren(value);
                     }}
-                    disabled={!initialOrgUnit}
+                    disabled={!initialOrgUnitId || !initialOrgUnit}
                     value={ouChildren}
                     label={MESSAGES.ouChildrenCheckbox}
                 />
@@ -230,7 +238,7 @@ const Filters = ({ baseUrl, params, canBypassProjectRestrictions }) => {
                         handleChange('ouParent', value);
                         setOuParent(value);
                     }}
-                    disabled={!initialOrgUnit}
+                    disabled={!initialOrgUnitId || !initialOrgUnit}
                     value={ouParent}
                     label={MESSAGES.ouParentCheckbox}
                 />

--- a/iaso/api/profiles/profiles.py
+++ b/iaso/api/profiles/profiles.py
@@ -116,24 +116,24 @@ def get_filtered_profiles(
         if parent_ou and ou.parent is not None:
             parent = ou.parent
 
+        org_unit_filter = Q(user__iaso_profile__org_units__pk=location)
+
         if parent_ou and not children_ou:
-            org_unit_filter = Q(user__iaso_profile__org_units__pk=location)
             if parent:
-                org_unit_filter |= Q(user__iaso_profile__org_units__pk=parent.id)
+                org_unit_filter |= Q(user__iaso_profile__org_units__pk=parent.pk)
             queryset = queryset.filter(org_unit_filter).distinct()
 
         if children_ou and not parent_ou:
             descendant_ous = OrgUnit.objects.hierarchy(ou)
-            queryset = queryset.filter(user__iaso_profile__org_units__in=descendant_ous)
+            org_unit_filter |= Q(user__iaso_profile__org_units__in=descendant_ous)
+            queryset = queryset.filter(org_unit_filter).distinct()
 
         if parent_ou and children_ou:
-            descendant_ous = OrgUnit.objects.hierarchy(ou).exclude(id=ou.id)
-            org_unit_filter = Q(user__iaso_profile__org_units__pk=location) | Q(
-                user__iaso_profile__org_units__in=descendant_ous
-            )
+            descendant_ous = OrgUnit.objects.hierarchy(ou)
+            org_unit_filter |= Q(user__iaso_profile__org_units__in=descendant_ous)
             if parent:
                 org_unit_filter |= Q(user__iaso_profile__org_units__pk=parent.pk)
-            queryset = queryset.filter(org_unit_filter)
+            queryset = queryset.filter(org_unit_filter).distinct()
 
     if org_unit_type:
         if org_unit_type == "unassigned":

--- a/iaso/api/profiles/profiles.py
+++ b/iaso/api/profiles/profiles.py
@@ -123,12 +123,12 @@ def get_filtered_profiles(
                 org_unit_filter |= Q(user__iaso_profile__org_units__pk=parent.pk)
             queryset = queryset.filter(org_unit_filter).distinct()
 
-        if children_ou and not parent_ou:
+        elif children_ou and not parent_ou:
             descendant_ous = OrgUnit.objects.hierarchy(ou)
             org_unit_filter |= Q(user__iaso_profile__org_units__in=descendant_ous)
             queryset = queryset.filter(org_unit_filter).distinct()
 
-        if parent_ou and children_ou:
+        elif parent_ou and children_ou:
             descendant_ous = OrgUnit.objects.hierarchy(ou)
             org_unit_filter |= Q(user__iaso_profile__org_units__in=descendant_ous)
             if parent:

--- a/iaso/api/profiles/profiles.py
+++ b/iaso/api/profiles/profiles.py
@@ -94,7 +94,6 @@ def get_filtered_profiles(
     managed_users_only: Optional[bool] = False,
     ids: Optional[str] = None,
 ) -> QuerySet[Profile]:
-    original_queryset = queryset
     if search:
         queryset = queryset.filter(
             Q(user__username__icontains=search)
@@ -118,19 +117,16 @@ def get_filtered_profiles(
             parent = ou.parent
 
         if parent_ou and not children_ou:
-            queryset = queryset if search else original_queryset
             org_unit_filter = Q(user__iaso_profile__org_units__pk=location)
             if parent:
                 org_unit_filter |= Q(user__iaso_profile__org_units__pk=parent.id)
             queryset = queryset.filter(org_unit_filter).distinct()
 
         if children_ou and not parent_ou:
-            queryset = queryset if search else original_queryset
             descendant_ous = OrgUnit.objects.hierarchy(ou)
             queryset = queryset.filter(user__iaso_profile__org_units__in=descendant_ous)
 
         if parent_ou and children_ou:
-            queryset = queryset if search else original_queryset
             descendant_ous = OrgUnit.objects.hierarchy(ou).exclude(id=ou.id)
             org_unit_filter = Q(user__iaso_profile__org_units__pk=location) | Q(
                 user__iaso_profile__org_units__in=descendant_ous


### PR DESCRIPTION
When the `ouChildren` checkbox was checked, the backend code was using `original_queryset` instead of the already-filtered `queryset`.

Related JIRA tickets: IA-4482

## Changes

- fix backend issue where search results were overridden when `ouChildren`/`ouParent` checkboxes were checked
- prevent `location` filtering from interfering with parent/children organizational unit filtering
- simplify filtering logic using `Q` objects
- add unit test

## How to test

See the attached video:

https://github.com/user-attachments/assets/b131d891-402c-440d-834f-ef5b5fd7dbc0

