### PR TITLE
IA-4461: Add isSearchActive url param to entities list page

### DIFF
--- a/hat/assets/js/apps/Iaso/constants/menu.tsx
+++ b/hat/assets/js/apps/Iaso/constants/menu.tsx
@@ -81,7 +81,9 @@ const menuItems = (
             isActive: pathname =>
                 pathname?.includes(`/entityTypeIds/${entityType.value}/`) &&
                 pathname?.includes(`entities/list/`),
-            extraPath: `/entityTypeIds/${entityType.value}/locationLimit/1000/order/-last_saved_instance/pageSize/20/page/1`,
+            extraPath:
+                `/entityTypeIds/${entityType.value}/locationLimit/1000/order/-last_saved_instance/pageSize/20/page/1` +
+                `/isSearchActive/true`,
         }));
     }
     const settingsSubMenu = [

--- a/hat/assets/js/apps/Iaso/constants/urls.ts
+++ b/hat/assets/js/apps/Iaso/constants/urls.ts
@@ -398,6 +398,7 @@ export const baseRouteConfigs: Record<string, RouteConfig> = {
             'groups',
             'fieldsSearch',
             ...paginationPathParams,
+            'isSearchActive',
         ],
     },
     entityDetails: {

--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -232,6 +232,7 @@
     "iaso.entities.typeNotSupported": "Type not supported yet: {type}",
     "iaso.entities.types": "Types",
     "iaso.entities.update": "Update entity",
+    "iaso.entities.searchToSeeEntities": "Click \"Search\" button to see entities",
     "iaso.entities.vaccinationNumber": "Vaccination number",
     "iaso.entity.label.noSubmissionFound": "No submission found",
     "iaso.entity.label.submissionsForEntity": "Submissions for Entity {entity}",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -234,6 +234,7 @@
     "iaso.entities.typeNotSupported": "Type non supporté: {type}",
     "iaso.entities.types": "Types",
     "iaso.entities.update": "Mettre l'entité à jour",
+    "iaso.entities.searchToSeeEntities": "Cliquez sur  \"Rechercher\" pour voir les entités",
     "iaso.entities.vaccinationNumber": "Numéro de vaccination",
     "iaso.entity.label.noSubmissionFound": "Aucune soumission trouvée",
     "iaso.entity.label.submissionsForEntity": "Soumissions Entité {entity}",

--- a/hat/assets/js/apps/Iaso/domains/entities/components/Filters.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/components/Filters.tsx
@@ -52,9 +52,14 @@ const useStyles = makeStyles(theme => ({
 type Props = {
     params: Params;
     isFetching: boolean;
+    isSearchActive: boolean;
 };
 
-const Filters: FunctionComponent<Props> = ({ params, isFetching }) => {
+const Filters: FunctionComponent<Props> = ({
+    params,
+    isFetching,
+    isSearchActive,
+}) => {
     const getParams = useFiltersParams();
     const currentUser = useCurrentUser();
     const classes: Record<string, string> = useStyles();
@@ -114,13 +119,15 @@ const Filters: FunctionComponent<Props> = ({ params, isFetching }) => {
         ? JSON.parse(filters.fieldsSearch)
         : undefined;
 
+    const searchEnabled = filtersUpdated || !isSearchActive;
     const handleSearch = useCallback(() => {
-        if (filtersUpdated) {
+        if (searchEnabled) {
             setFiltersUpdated(false);
             const tempParams: Params = getParams(params, filters);
+            tempParams.isSearchActive = 'true';
             redirectTo(baseUrl, tempParams);
         }
-    }, [filtersUpdated, getParams, params, filters, redirectTo]);
+    }, [searchEnabled, getParams, params, filters, redirectTo]);
 
     const handleChange = useCallback(
         (key, value) => {
@@ -287,9 +294,7 @@ const Filters: FunctionComponent<Props> = ({ params, isFetching }) => {
                             <Box mb={2}>
                                 <Button
                                     data-test="search-button"
-                                    disabled={
-                                        textSearchError || !filtersUpdated
-                                    }
+                                    disabled={textSearchError || !searchEnabled}
                                     variant="contained"
                                     color="primary"
                                     onClick={() => handleSearch()}
@@ -300,11 +305,13 @@ const Filters: FunctionComponent<Props> = ({ params, isFetching }) => {
                                     {formatMessage(MESSAGES.search)}
                                 </Button>
                             </Box>
-                            <DownloadButtonsComponent
-                                csvUrl={`${apiUrl}&csv=true`}
-                                xlsxUrl={`${apiUrl}&xlsx=true`}
-                                disabled={isFetching}
-                            />
+                            {isSearchActive && (
+                                <DownloadButtonsComponent
+                                    csvUrl={`${apiUrl}&csv=true`}
+                                    xlsxUrl={`${apiUrl}&xlsx=true`}
+                                    disabled={isFetching}
+                                />
+                            )}
                         </Box>
                     </Grid>
                 </Grid>

--- a/hat/assets/js/apps/Iaso/domains/entities/entityTypes/config.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/entityTypes/config.tsx
@@ -77,7 +77,7 @@ export const useColumns = ({
                             )}
                             <IconButtonComponent
                                 id={`entities-link-${type.id}`}
-                                url={`/${baseUrls.entities}/entityTypeIds/${type.id}/locationLimit/1000/order/-last_saved_instance/pageSize/20/page/1`}
+                                url={`/${baseUrls.entities}/entityTypeIds/${type.id}/locationLimit/1000/order/-last_saved_instance/pageSize/20/page/1/isSearchActive/true`}
                                 icon="remove-red-eye"
                                 tooltipMessage={MESSAGES.entities}
                                 disabled={type.entities_count === 0}

--- a/hat/assets/js/apps/Iaso/domains/entities/hooks/requests.ts
+++ b/hat/assets/js/apps/Iaso/domains/entities/hooks/requests.ts
@@ -88,14 +88,14 @@ export const useGetEntitiesApiParams = (
 
 export const useGetEntitiesPaginated = (
     params: Params,
-    isSearchActive: boolean,
+    isEnabled: boolean,
 ): UseQueryResult<PaginatedEntities, Error> => {
     const { url, apiParams } = useGetEntitiesApiParams(params);
     return useSnackQuery({
         queryKey: ['entities', apiParams],
         queryFn: () => getRequest(url),
         options: {
-            enabled: apiParams.tab === 'list' && isSearchActive,
+            enabled: apiParams.tab === 'list' && isEnabled,
             staleTime: 60000,
             cacheTime: 1000 * 60 * 5,
             keepPreviousData: true,

--- a/hat/assets/js/apps/Iaso/domains/entities/hooks/requests.ts
+++ b/hat/assets/js/apps/Iaso/domains/entities/hooks/requests.ts
@@ -88,13 +88,14 @@ export const useGetEntitiesApiParams = (
 
 export const useGetEntitiesPaginated = (
     params: Params,
+    isSearchActive: boolean,
 ): UseQueryResult<PaginatedEntities, Error> => {
     const { url, apiParams } = useGetEntitiesApiParams(params);
     return useSnackQuery({
         queryKey: ['entities', apiParams],
         queryFn: () => getRequest(url),
         options: {
-            enabled: apiParams.tab === 'list',
+            enabled: apiParams.tab === 'list' && isSearchActive,
             staleTime: 60000,
             cacheTime: 1000 * 60 * 5,
             keepPreviousData: true,

--- a/hat/assets/js/apps/Iaso/domains/entities/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/index.tsx
@@ -49,6 +49,7 @@ type Params = {
     locationLimit?: string;
     groups?: string;
     fieldsSearch?: string;
+    isSearchActive?: string;
 };
 
 export const Entities: FunctionComponent = () => {
@@ -58,8 +59,12 @@ export const Entities: FunctionComponent = () => {
         useState<DisplayedLocation>('submissions');
     const { formatMessage } = useSafeIntl();
     const redirectTo = useRedirectTo();
+    const isSearchActive = params?.isSearchActive === 'true';
 
-    const { data, isFetching } = useGetEntitiesPaginated(params);
+    const { data, isFetching } = useGetEntitiesPaginated(
+        params,
+        isSearchActive,
+    );
     const [tab, setTab] = useState(params.tab ?? 'list');
 
     const isLoading = isFetching;
@@ -132,7 +137,11 @@ export const Entities: FunctionComponent = () => {
                 </Tabs>
             </TopBar>
             <Box p={4} className={classes.container}>
-                <Filters params={params} isFetching={isFetching} />
+                <Filters
+                    params={params}
+                    isFetching={isFetching}
+                    isSearchActive={isSearchActive}
+                />
                 <Box position="relative" width="100%" mt={2}>
                     <Box
                         width="100%"

--- a/hat/assets/js/apps/Iaso/domains/entities/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/index.tsx
@@ -169,6 +169,11 @@ export const Entities: FunctionComponent = () => {
                                 baseUrl={baseUrl}
                                 params={params}
                                 extraProps={{ loading: isFetching }}
+                                noDataMessage={
+                                    !isSearchActive
+                                        ? MESSAGES.searchToSeeEntities
+                                        : undefined
+                                }
                             />
                         </Box>
                     )}

--- a/hat/assets/js/apps/Iaso/domains/entities/messages.ts
+++ b/hat/assets/js/apps/Iaso/domains/entities/messages.ts
@@ -277,6 +277,10 @@ const MESSAGES = defineMessages({
         id: 'iaso.entities.addForm',
         defaultMessage: 'Add a form',
     },
+    searchToSeeEntities: {
+        id: 'iaso.entities.searchToSeeEntities',
+        defaultMessage: 'Click "Search" button to see entities',
+    },
 });
 
 export default MESSAGES;

--- a/hat/assets/js/apps/Iaso/domains/entities/types/filters.ts
+++ b/hat/assets/js/apps/Iaso/domains/entities/types/filters.ts
@@ -16,4 +16,5 @@ export type Params = Filters & {
     page: string;
     pageSize: string;
     tab: string;
+    isSearchActive: string;
 };

--- a/hat/assets/js/apps/Iaso/routing/hooks/useRedirections.tsx
+++ b/hat/assets/js/apps/Iaso/routing/hooks/useRedirections.tsx
@@ -56,7 +56,7 @@ const baseRedirections = [
         path: `/${baseUrls.entities}`,
         to: `/${baseUrls.entities}${getPaginationParams(
             'last_saved_instance',
-        )}`,
+        )}/isSearchActive/true`,
     },
     {
         path: `/${baseUrls.entityTypes}`,

--- a/hat/assets/js/cypress/integration/07 - entities/list.spec.js
+++ b/hat/assets/js/cypress/integration/07 - entities/list.spec.js
@@ -132,7 +132,7 @@ describe('Entities', () => {
             cy.wait('@getEntities').then(() => {
                 cy.url().should(
                     'eq',
-                    `${baseUrl}/accountId/1/order/last_saved_instance/pageSize/20/page/1`,
+                    `${baseUrl}/accountId/1/order/last_saved_instance/pageSize/20/page/1/isSearchActive/true`,
                 );
             });
         });


### PR DESCRIPTION
Add `isSearchActive` URL parameter to the Entity list page to fetch entities on initial page load or not.

The parameter is enabled by default in the menu entry to preserve the current behavior of loading the entities immediately.

refs: IA-4461

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [x] Are my typescript files well typed?
- [ ] ~New translations have been added or updated if new strings have been introduced in the frontend~
- [ ] ~My migrations file are included~
- [x] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

/

## Changes

- Added support for `isSearchActive` URL param to Entity list page.
- Added `/isSearchActive/true` to existing links to the page.
- Adjusted the search button behavior accordingly (enabled when no data has been loaded yet).

## How to test

- Browse to the entity list page `/dashboard/entities/list/`
- Check that the entity data is loaded by default, as before.
- Test the menu with the SHOW_BENEFICIARY_TYPES_IN_LIST_MENU feature flag turned on and off. 
- Test the isSearchActive url parameter and search button behavior. 

## Print screen / video

/

## Notes

/

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
