### PR TITLE
IA-4466: Setup account adding TAKE_GPS_ON_FORM

### DIFF
--- a/iaso/api/setup_account.py
+++ b/iaso/api/setup_account.py
@@ -166,7 +166,7 @@ class SetupAccountSerializer(serializers.Serializer):
         initial_project = Project.objects.create(name="Main Project", account=account, app_id=app_id)
 
         # Add project feature flags
-        codes = [FeatureFlag.REQUIRE_AUTHENTICATION, FeatureFlag.FORMS_AUTO_UPLOAD]
+        codes = [FeatureFlag.REQUIRE_AUTHENTICATION, FeatureFlag.FORMS_AUTO_UPLOAD, FeatureFlag.TAKE_GPS_ON_FORM]
         feature_flags = FeatureFlag.objects.filter(code__in=codes)
 
         found_codes = [ff.code for ff in feature_flags]

--- a/iaso/tests/api/test_setup_account.py
+++ b/iaso/tests/api/test_setup_account.py
@@ -1107,7 +1107,7 @@ class SetupAccountApiTestCase(APITestCase):
         self.assertEqual(created_account.modules, data["modules"])
 
     def test_setup_account_creates_project_feature_flags(self):
-        """Test that setup account creates project feature flags for REQUIRE_AUTHENTICATION and FORMS_AUTO_UPLOAD"""
+        """Test that setup account creates project feature flags for REQUIRE_AUTHENTICATION and FORMS_AUTO_UPLOAD and TAKE_GPS_ON_FORM"""
         self.client.force_authenticate(self.admin)
         data = {
             "account_name": "unittest_account",
@@ -1126,6 +1126,7 @@ class SetupAccountApiTestCase(APITestCase):
         # Check that the project has the required feature flags
         self.assertTrue(project.has_feature(m.FeatureFlag.REQUIRE_AUTHENTICATION))
         self.assertTrue(project.has_feature(m.FeatureFlag.FORMS_AUTO_UPLOAD))
+        self.assertTrue(project.has_feature(m.FeatureFlag.TAKE_GPS_ON_FORM))
 
         # Verify ProjectFeatureFlags entries exist
         require_auth_pff = m.ProjectFeatureFlags.objects.filter(
@@ -1203,13 +1204,16 @@ class SetupAccountApiTestCase(APITestCase):
 
         # Check ProjectFeatureFlags configuration
         project_feature_flags = m.ProjectFeatureFlags.objects.filter(project=project)
-        self.assertEqual(project_feature_flags.count(), 2)
+        self.assertEqual(project_feature_flags.count(), 3)
 
         for pff in project_feature_flags:
             # Configuration should be None for these feature flags
             self.assertIsNone(pff.configuration)
             # Feature flag should be one of the expected ones
-            self.assertIn(pff.featureflag.code, [m.FeatureFlag.REQUIRE_AUTHENTICATION, m.FeatureFlag.FORMS_AUTO_UPLOAD])
+            self.assertIn(
+                pff.featureflag.code,
+                [m.FeatureFlag.REQUIRE_AUTHENTICATION, m.FeatureFlag.FORMS_AUTO_UPLOAD, m.FeatureFlag.TAKE_GPS_ON_FORM],
+            )
 
     def test_setup_account_project_feature_flags_multiple_accounts(self):
         """Test that multiple accounts get the same project feature flags"""
@@ -1251,7 +1255,7 @@ class SetupAccountApiTestCase(APITestCase):
 
             # Check ProjectFeatureFlags entries
             pff_count = m.ProjectFeatureFlags.objects.filter(project=project).count()
-            self.assertEqual(pff_count, 2)
+            self.assertEqual(pff_count, 3)
 
     def test_setup_account_project_feature_flags_integration(self):
         """Test that project feature flags work with the complete setup account flow"""


### PR DESCRIPTION
What problem is this PR solving? Explain here in one sentence.

Related JIRA tickets : IA-4466

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

-

## Changes

- adding TAKE_GPS_ON_FORM to setup account script and tests

## How to test

Uase admin account to setup a new account, make sure the project has TAKE_GPS_ON_FORM feature flag

## Print screen / video

-

## Notes

-

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
