### PR TITLE
IA-4462 - Delete parquet file on response complete

### DIFF
--- a/iaso/api/instances/instances.py
+++ b/iaso/api/instances/instances.py
@@ -14,7 +14,7 @@ from django.contrib.gis.geos import Point
 from django.core.paginator import Paginator
 from django.db import connection, transaction
 from django.db.models import Count, Prefetch, Q, QuerySet
-from django.http import FileResponse, Http404, HttpResponse, JsonResponse, StreamingHttpResponse
+from django.http import Http404, HttpResponse, JsonResponse, StreamingHttpResponse
 from django.utils.timezone import now
 from rest_framework import permissions, serializers, status, viewsets
 from rest_framework.decorators import action
@@ -43,7 +43,7 @@ from iaso.api.instances.instance_filters import get_form_from_instance_filters, 
 from iaso.api.instances.serializers import FileTypeSerializer
 from iaso.api.org_units import HasCreateOrgUnitPermission
 from iaso.api.serializers import OrgUnitSerializer
-from iaso.exports import parquet
+from iaso.exports import CleaningFileResponse, parquet
 from iaso.models import (
     Entity,
     Form,
@@ -561,7 +561,7 @@ class InstancesViewSet(viewsets.ViewSet):
 
         parquet.export_django_query_to_parquet_via_duckdb(export_queryset, tmp.name)
 
-        response = FileResponse(open(tmp.name, "rb"), as_attachment=True, filename="submissions.parquet")
+        response = CleaningFileResponse(tmp.name, as_attachment=True, filename="submissions.parquet")
 
         return response
 

--- a/iaso/api/org_units.py
+++ b/iaso/api/org_units.py
@@ -13,7 +13,7 @@ from django.core.exceptions import ValidationError
 from django.core.paginator import Paginator
 from django.db import IntegrityError
 from django.db.models import Count, IntegerField, Q, Value
-from django.http import FileResponse, HttpResponse, JsonResponse, StreamingHttpResponse
+from django.http import HttpResponse, JsonResponse, StreamingHttpResponse
 from django.shortcuts import get_object_or_404
 from django.utils.translation import gettext as _
 from rest_framework import permissions, status, viewsets
@@ -27,7 +27,7 @@ from hat.audit import models as audit_models
 from iaso.api.common import CONTENT_TYPE_CSV, CONTENT_TYPE_XLSX, safe_api_import
 from iaso.api.org_unit_search import annotate_query, build_org_units_queryset
 from iaso.api.serializers import OrgUnitSearchSerializer, OrgUnitSmallSearchSerializer, OrgUnitTreeSearchSerializer
-from iaso.exports import parquet
+from iaso.exports import CleaningFileResponse, parquet
 from iaso.gpkg import org_units_to_gpkg_bytes
 from iaso.models import DataSource, Form, Group, Instance, InstanceFile, OrgUnit, OrgUnitType, Project, SourceVersion
 from iaso.utils import geojson_queryset
@@ -479,7 +479,7 @@ class OrgUnitViewSet(viewsets.ViewSet):
 
         parquet.export_django_query_to_parquet_via_duckdb(export_queryset, tmp.name)
 
-        response = FileResponse(open(tmp.name, "rb"), as_attachment=True, filename=filename + ".parquet")
+        response = CleaningFileResponse(tmp.name, as_attachment=True, filename=filename + ".parquet")
 
         return response
 

--- a/iaso/exports/__init__.py
+++ b/iaso/exports/__init__.py
@@ -1,0 +1,4 @@
+from .cleaning_file_response import CleaningFileResponse
+
+
+__all__ = ["CleaningFileResponse"]

--- a/iaso/exports/cleaning_file_response.py
+++ b/iaso/exports/cleaning_file_response.py
@@ -1,0 +1,25 @@
+import os
+
+from django.http import FileResponse
+
+
+# Since we are on a hold python and django version
+# cleaning the tmp file once served, seem to be the only way
+class CleaningFileResponse(FileResponse):
+    def __init__(self, path, *args, **kwargs):
+        self._path = path
+        self._file = open(path, "rb")
+        super().__init__(self._file, *args, **kwargs)
+
+    def close(self):
+        try:
+            super().close()
+        finally:
+            try:
+                self._file.close()
+            except Exception:
+                pass
+            try:
+                os.remove(self._path)
+            except FileNotFoundError:
+                pass

--- a/iaso/exports/duckdb_util.py
+++ b/iaso/exports/duckdb_util.py
@@ -22,20 +22,28 @@ def export_django_query_to_parquet_via_duckdb(qs: QuerySet, output_file_path: st
     # initially was full_sql = sql % tuple(map(adapt_param, params)) but supporting all types is complicated
     dsn = connection.get_connection_params()
 
+    tmpdir = "/tmp/duckdb_tmp"
+    os.makedirs(tmpdir, exist_ok=True)
+
     with duckdb.connect() as duckdb_connection:
+        duckdb_connection.execute(f"PRAGMA temp_directory='{tmpdir}'")
+        duckdb_connection.execute(
+            "PRAGMA memory_limit='1500MB'"
+        )  # reasonable but should work even if you don't have that memory available
+
         attach_sql = f"""
             INSTALL postgres;
             LOAD postgres;
             ATTACH 'dbname={dsn["dbname"]} host={dsn["host"]} user={dsn["user"]} password={dsn["password"]} port={dsn["port"]}' AS pg (TYPE postgres, READ_ONLY);
-
         """
         duckdb_connection.execute(attach_sql)
 
         logger.info(f"exporting parquet : {output_file_path} \n\n {full_sql}")
+        # had to specify ROW_GROUP_SIZE when exporting large rows like several geojson on the same row
         parquet_export_sql = f"""
             COPY (
                 SELECT * FROM postgres_query('pg', $$ {full_sql} $$)
-            ) TO '{output_file_path}' (FORMAT PARQUET)
+            ) TO '{output_file_path}' (FORMAT PARQUET, ROW_GROUP_SIZE 10000)
         """
 
         duckdb_connection.execute(parquet_export_sql)

--- a/iaso/exports/submissions.py
+++ b/iaso/exports/submissions.py
@@ -21,10 +21,15 @@ def build_submissions_queryset(qs: QuerySet[m.Instance], form_id: str) -> QueryS
 
     possible_fields = form.possible_fields
 
+    def fix_field_name(name):
+        if name == "id":
+            return "answer_id"
+        return name
+
     json_annotations = {}
     for field in possible_fields:
         field_name = field["name"]
-        json_annotations[field_name] = KeyTextTransform(field_name, "json")
+        json_annotations[fix_field_name(field_name)] = KeyTextTransform(field_name, "json")
     prefixed_fields = build_submission_annotations()
 
     qs = (

--- a/iaso/tests/exports/test_submissions_export.py
+++ b/iaso/tests/exports/test_submissions_export.py
@@ -7,6 +7,35 @@ from iaso.test import TestCase
 from .parquet_helper import get_columns_from_parquet
 
 
+STANDARD_COLUMNS = [
+    ["iaso_subm_id", "INTEGER"],
+    ["iaso_subm_form_id", "INTEGER"],
+    ["iaso_subm_period", "VARCHAR"],
+    ["iaso_subm_uuid", "VARCHAR"],
+    ["iaso_subm_org_unit_id", "INTEGER"],
+    ["iaso_subm_org_unit_name", "VARCHAR"],
+    ["iaso_subm_org_unit_source_ref", "VARCHAR"],
+    ["iaso_subm_entity_id", "INTEGER"],
+    ["iaso_subm_created_at", "TIMESTAMP WITH TIME ZONE"],
+    ["iaso_subm_source_created_at", "TIMESTAMP WITH TIME ZONE"],
+    ["iaso_subm_created_by_username", "VARCHAR"],
+    ["iaso_subm_created_by_id", "INTEGER"],
+    ["iaso_subm_updated_at", "TIMESTAMP WITH TIME ZONE"],
+    ["iaso_subm_source_updated_at", "TIMESTAMP WITH TIME ZONE"],
+    ["iaso_subm_last_modified_by_username", "VARCHAR"],
+    ["iaso_subm_last_modified_by_id", "INTEGER"],
+    ["iaso_subm_deleted", "BOOLEAN"],
+    ["iaso_subm_export_id", "VARCHAR"],
+    ["iaso_subm_correlation_id", "BIGINT"],
+    ["iaso_subm_is_reference", "BOOLEAN"],
+    ["iaso_subm_form_version_id", "VARCHAR"],
+    ["iaso_subm_longitude", "DOUBLE"],
+    ["iaso_subm_latitude", "DOUBLE"],
+    ["iaso_subm_altitude", "DOUBLE"],
+    ["iaso_subm_accuracy", "DECIMAL(7,2)"],
+]
+
+
 class SubmissionsExportTest(TestCase):
     @classmethod
     def setUpTestData(cls):
@@ -25,32 +54,21 @@ class SubmissionsExportTest(TestCase):
             actual_columns = get_columns_from_parquet(tmpfile)
 
         expected = [
-            ["iaso_subm_id", "INTEGER"],
-            ["iaso_subm_form_id", "INTEGER"],
-            ["iaso_subm_period", "VARCHAR"],
-            ["iaso_subm_uuid", "VARCHAR"],
-            ["iaso_subm_org_unit_id", "INTEGER"],
-            ["iaso_subm_org_unit_name", "VARCHAR"],
-            ["iaso_subm_org_unit_source_ref", "VARCHAR"],
-            ["iaso_subm_entity_id", "INTEGER"],
-            ["iaso_subm_created_at", "TIMESTAMP WITH TIME ZONE"],
-            ["iaso_subm_source_created_at", "TIMESTAMP WITH TIME ZONE"],
-            ["iaso_subm_created_by_username", "VARCHAR"],
-            ["iaso_subm_created_by_id", "INTEGER"],
-            ["iaso_subm_updated_at", "TIMESTAMP WITH TIME ZONE"],
-            ["iaso_subm_source_updated_at", "TIMESTAMP WITH TIME ZONE"],
-            ["iaso_subm_last_modified_by_username", "VARCHAR"],
-            ["iaso_subm_last_modified_by_id", "INTEGER"],
-            ["iaso_subm_deleted", "BOOLEAN"],
-            ["iaso_subm_export_id", "VARCHAR"],
-            ["iaso_subm_correlation_id", "BIGINT"],
-            ["iaso_subm_is_reference", "BOOLEAN"],
-            ["iaso_subm_form_version_id", "VARCHAR"],
-            ["iaso_subm_longitude", "DOUBLE"],
-            ["iaso_subm_latitude", "DOUBLE"],
-            ["iaso_subm_altitude", "DOUBLE"],
-            ["iaso_subm_accuracy", "DECIMAL(7,2)"],
+            *STANDARD_COLUMNS,
             ["answer_A", "VARCHAR"],
             ["answer_B", "VARCHAR"],
         ]
+        self.assertEqual(actual_columns, expected)
+
+    def test_expected_columns_all_fields_even_if_some_answers_collide_with_model_field(self):
+        self.form_to_export.possible_fields = [{"name": "answer_A"}, {"name": "id"}, {"name": "created_at"}]
+        self.form_to_export.save()
+
+        qs = parquet.build_submissions_queryset(Instance.objects, self.form_to_export.id)
+
+        with tempfile.NamedTemporaryFile(suffix=".parquet") as tmpfile:
+            parquet.export_django_query_to_parquet_via_duckdb(qs, tmpfile.name)
+            actual_columns = get_columns_from_parquet(tmpfile)
+
+        expected = [*STANDARD_COLUMNS, ["answer_A", "VARCHAR"], ["answer_id", "VARCHAR"], ["created_at", "VARCHAR"]]
         self.assertEqual(actual_columns, expected)


### PR DESCRIPTION
During user testing I noticed 
- the file were not deleted from /tmp.
- Also tuned a bit duckdb to overflow to /tmp and decent limit for memory (instead of being Killed by oomkiller) when the pyramid has huge geojson
- if a form contains a question called `id` then you get a 500 error

Related JIRA tickets : IA-4462

## Self proofreading checklist

- [ ] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

share the same solution with both endpoints
once the close on the response is called the file will be deleted
since we are in a old python/django there is no delete_on_close 

Also tuned a bit duckdb to overflow to /tmp and decent limit for memory
and row_group_size when the rows are quite large (like multiple columns with geo_json)

## How to test

seed and export instances/orgunits but change `csv=true` to `parquet=true` (remove extra params like offset/limit/page)

## Print screen / video

Upload here print screens or videos showing the changes.

## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: delete temp parquet files once the response is answered

Refs: IA-4462
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
