### PR TITLE
IA-4462 improve compression of parquet file with zstd

### DIFF
--- a/iaso/exports/duckdb_util.py
+++ b/iaso/exports/duckdb_util.py
@@ -43,7 +43,7 @@ def export_django_query_to_parquet_via_duckdb(qs: QuerySet, output_file_path: st
         parquet_export_sql = f"""
             COPY (
                 SELECT * FROM postgres_query('pg', $$ {full_sql} $$)
-            ) TO '{output_file_path}' (FORMAT PARQUET, ROW_GROUP_SIZE 10000)
+            ) TO '{output_file_path}' (FORMAT PARQUET, COMPRESSION 'ZSTD', ROW_GROUP_SIZE 10000)
         """
 
         duckdb_connection.execute(parquet_export_sql)


### PR DESCRIPTION
Iterate on IA-4462 to enable better compression (cpu tradeoff)

Related JIRA tickets : IA-4462

## Self proofreading checklist

- [ ] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

Explain the changes that were made.

The idea is not to list exhaustively all the changes made (GitHub already provides a full diff), but to help the reviewers better understand:

- which specific file changes go together, e.g: when creating a table in the front-end, there usually is a config file that goes with it
- the reasoning behind some changes, e.g: deleted files because they are now redundant
- the behaviour to expect, e.g: tooltip has purple background color because the client likes it so, changed a key in the API response to be consistent with other endpoints

## How to test

export existing submissions (take the csv url and replace `csv=true` by `parquet=true`
ex : http://localhost:8081/api/instances/?showDeleted=false&form_ids=2&parquet=true


## Print screen / video

comparison on a "small" parquet

<img width="747" height="82" alt="image" src="https://github.com/user-attachments/assets/0255f55c-0d61-4725-b892-276c5e58eec1" />

## Notes


## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: enable compression via ztsd for parquet files

Refs: IA-4462
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
