### PR TITLE
Fix the pagination calculation in chronogram details table

### DIFF
--- a/plugins/polio/js/src/domains/Chronogram/ChronogramDetails/Table/ChronogramDetailsTable.tsx
+++ b/plugins/polio/js/src/domains/Chronogram/ChronogramDetails/Table/ChronogramDetailsTable.tsx
@@ -35,7 +35,10 @@ export const ChronogramDetailsTable: FunctionComponent<Props> = ({
             columns={columns}
             count={data?.count ?? 0}
             params={params}
-            extraProps={{ loading: isFetching }}
+            extraProps={{
+                loading: isFetching,
+                defaultPageSize: data?.limit ?? 20,
+            }}
             columnSelectorEnabled
             columnSelectorButtonType="button"
         />


### PR DESCRIPTION
What problem is this PR solving? Explain here in one sentence.

Related JIRA tickets: N/A

Sentry issue: https://bluesquareorg.sentry.io/issues/6894979283/

## Changes

The "_go to last page_" button was navigating to incorrect page numbers due to missing `defaultPageSize` in `TableWithDeepLink.extraProps`.

The bluesquare-components Table was calculating pages using a different page size than the API, causing a frontend/backend pagination mismatch.

## Print screen / video

https://github.com/user-attachments/assets/6992534e-6621-47f8-99ed-1d37a32788b5

