### PR TITLE
IA-4502 show api error translated message in snackbar

### DIFF
--- a/hat/assets/js/apps/Iaso/libs/apiHooks.ts
+++ b/hat/assets/js/apps/Iaso/libs/apiHooks.ts
@@ -70,6 +70,7 @@ type SnackMutationDict<Data, Error, Variables, Context> = {
           >
         | undefined;
     ignoreErrorCodes?: number[];
+    useApiErrorMessage?: boolean;
     showSuccessSnackBar?: boolean;
     successSnackBar?: (
         msg: IntlMessage,
@@ -84,6 +85,37 @@ type SnackMutationDict<Data, Error, Variables, Context> = {
     };
 };
 
+const getErrorFromDetails = (details: any) => {
+    if (typeof details === 'string') {
+        return details;
+    }
+    if (Array.isArray(details)) {
+        return details.join('\n');
+    }
+};
+
+const getApiErrorMessage = (error: any) => {
+    let errorMsg = '';
+
+    if (typeof error === 'string') {
+        return error;
+    }
+
+    if (!error.details) {
+        return error.message;
+    }
+
+    const keys = Object.keys(error.details);
+    if (keys.length === 1) {
+        return getErrorFromDetails(error.details[keys[0]]);
+    } else {
+        errorMsg = Object.keys(error.details)
+            .map(key => `${key}: ${getErrorFromDetails(error.details[key])}`)
+            .join('\n');
+    }
+    return errorMsg;
+};
+
 const useBaseSnackMutation = <
     Data = unknown,
     Error = unknown,
@@ -92,7 +124,7 @@ const useBaseSnackMutation = <
 >(
     mutationFn: MutationFunction<Data, any>,
     snackSuccessMessage: IntlMessage = MESSAGES.defaultMutationApiSuccess,
-    snackErrorMsg: IntlMessage = MESSAGES.defaultMutationApiError,
+    snackErrorMsg: IntlMessage | string = MESSAGES.defaultMutationApiError,
     invalidateQueryKey: QueryKey | undefined = undefined,
     options:
         | Omit<
@@ -113,6 +145,7 @@ const useBaseSnackMutation = <
             persist: boolean;
         };
     } = msg => succesfullSnackBar(undefined, msg),
+    useApiErrorMessage = false,
 ): UseMutationResult<Data, Error, Variables, Context> => {
     const queryClient = useQueryClient();
     const { formatMessage } = useSafeIntl();
@@ -124,13 +157,17 @@ const useBaseSnackMutation = <
         onError: (error, variables, context) => {
             if (!ignoreErrorCodes.includes(error.status)) {
                 let errorMsg = snackErrorMsg;
+
                 if (error.status === 403) {
                     if (error.details.detail) {
                         errorMsg = error.details.detail;
                     } else if (!errorMsg) {
                         errorMsg = formatMessage(MESSAGES.permissionError);
                     }
+                } else if (useApiErrorMessage && error.details) {
+                    errorMsg = getApiErrorMessage(error) as any;
                 }
+
                 openSnackBar(errorSnackBar(undefined, errorMsg, error));
             }
             if (options.onError) {
@@ -192,6 +229,7 @@ export const useSnackMutation = <
             persist: boolean;
         };
     } = msg => succesfullSnackBar(undefined, msg),
+    useApiErrorMessage = false,
 ): UseMutationResult<Data, Error, Variables, Context> => {
     let arg1;
     let arg2;
@@ -201,6 +239,7 @@ export const useSnackMutation = <
     let arg6;
     let arg7;
     let arg8;
+    let arg9;
     // Checking if the first argument passed is a dictionary
     const keys = Object.keys(mutationArg) ?? [];
     if (keys.length > 0 && keys.includes('mutationFn')) {
@@ -228,6 +267,9 @@ export const useSnackMutation = <
         arg8 = (
             mutationArg as SnackMutationDict<Data, Error, Variables, Context>
         ).successSnackBar;
+        arg9 = (
+            mutationArg as SnackMutationDict<Data, Error, Variables, Context>
+        ).useApiErrorMessage;
     } else {
         arg1 = mutationArg;
         arg2 = snackSuccessMessage;
@@ -237,6 +279,7 @@ export const useSnackMutation = <
         arg6 = showSuccessSnackBar;
         arg7 = ignoreErrorCodes;
         arg8 = successSnackBar;
+        arg9 = useApiErrorMessage;
     }
     return useBaseSnackMutation<Data, Error, Variables, Context>(
         arg1,
@@ -247,6 +290,7 @@ export const useSnackMutation = <
         arg6,
         arg7,
         arg8,
+        arg9,
     );
 };
 


### PR DESCRIPTION
Display error message provided by the API in snackbar

Related JIRA tickets : IA-4502

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [x] Are my typescript files well typed?
- [x] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

Added a flag on useSnackbarMutation to display error message returned by the API if any.

## How to test

Make sure nothing is broken :D

## Print screen / video

Upload here print screens or videos showing the changes.

## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
