### PR TITLE
[IA-4364] Add missing requirement for permissions 2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ django-storages==1.14.2  # https://github.com/jschneier/django-storages/tags
 django-translated-fields==0.12.0  # https://github.com/matthiask/django-translated-fields/tags
 django-phonenumber-field[phonenumberslite]==7.3.0 # https://django-phonenumber-field.readthedocs.io/en/latest/
 django-qr-code==4.0.1 # https://django-qr-code.readthedocs.io/en/latest/
+django-stubs-ext==4.2.7  # https://github.com/typeddjango/django-stubs/tags
 
 # Django REST Framework.
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Add missing requirement for permissions 2.0

Related JIRA tickets : IA-4364

## Self proofreading checklist

- [ ] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

/

## Changes

- Added `django-stubs-ext` 4.2.7 to requirements


## How to test

- Run the app, everything should work fine

## Print screen / video

/

## Notes

- This was missing from the [permissions & modules 2.0 PR](https://github.com/BLSQ/iaso/pull/2433) - I'm not sure why it didn't cause an issue earlier

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
