### PR TITLE
IA-4498 fix parquet export when too long column name based on submissions json keys

### DIFF
--- a/iaso/api/instances/instances.py
+++ b/iaso/api/instances/instances.py
@@ -560,11 +560,11 @@ class InstancesViewSet(viewsets.ViewSet):
         # actually return parquet file
         form_ids = filters["form_ids"]
         form = Form.objects.get(pk=form_ids)
-        export_queryset = parquet.build_submissions_queryset(queryset, form.id)
+        export_queryset, mapping = parquet.build_submissions_queryset(queryset, form.id)
 
         tmp = tempfile.NamedTemporaryFile(suffix=".parquet", delete=False)
 
-        parquet.export_django_query_to_parquet_via_duckdb(export_queryset, tmp.name)
+        parquet.export_django_query_to_parquet_via_duckdb(export_queryset, tmp.name, mapping)
 
         response = CleaningFileResponse(tmp.name, as_attachment=True, filename="submissions.parquet")
 

--- a/iaso/exports/mapping.py
+++ b/iaso/exports/mapping.py
@@ -1,0 +1,47 @@
+import re
+
+from typing import Dict, Iterable
+
+
+MAX_COL_LEN = 63
+SAFE_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def fix_field_name(name):
+    if name == "id":
+        return "answer_id"
+    return name
+
+
+def _sanitize(name: str) -> str:
+    name = fix_field_name(name)
+    s = re.sub(r"[^A-Za-z0-9_]", "_", name).strip("_")
+    if not s:
+        return ""
+    if not re.match(r"^[A-Za-z_]", s):
+        s = "_" + s
+    return s
+
+
+def make_safe_name(orig: str, idx: int, used_lower: set) -> str:
+    base = _sanitize(orig) or f"c{idx}"
+    if len(base) > MAX_COL_LEN:
+        base = base[:MAX_COL_LEN]
+    candidate = base
+    i = 1
+    while candidate.lower() in used_lower:
+        suffix = f"_{i}"
+        cut = MAX_COL_LEN - len(suffix)
+        candidate = (base[:cut] + suffix) if cut > 0 else f"c{idx}{suffix}"
+        i += 1
+    used_lower.add(candidate.lower())
+    return candidate
+
+
+def generate_safe_mapping(keys: Iterable[str]) -> Dict[str, str]:
+    used_lower = set()
+    mapping: Dict[str, str] = {}
+    for idx, k in enumerate(keys, start=1):
+        safe = make_safe_name(k, idx, used_lower)
+        mapping[k] = safe
+    return mapping

--- a/iaso/exports/submissions.py
+++ b/iaso/exports/submissions.py
@@ -6,6 +6,7 @@ from django.db.models.fields.json import KeyTextTransform
 
 import iaso.models as m
 
+from .mapping import generate_safe_mapping
 from .utils import normalize_field_name
 
 
@@ -19,18 +20,16 @@ def build_submissions_queryset(qs: QuerySet[m.Instance], form_id: str) -> QueryS
 
     qs = qs.filter(form_id=form_id)
 
+    prefixed_fields = build_submission_annotations()
+
     possible_fields = form.possible_fields
 
-    def fix_field_name(name):
-        if name == "id":
-            return "answer_id"
-        return name
+    answer_mappings = generate_safe_mapping(list(prefixed_fields.keys()) + [f["name"] for f in possible_fields])
 
     json_annotations = {}
     for field in possible_fields:
         field_name = field["name"]
-        json_annotations[fix_field_name(field_name)] = KeyTextTransform(field_name, "json")
-    prefixed_fields = build_submission_annotations()
+        json_annotations[answer_mappings[field_name]] = KeyTextTransform(field_name, "json")
 
     qs = (
         qs.values("id")
@@ -39,7 +38,7 @@ def build_submissions_queryset(qs: QuerySet[m.Instance], form_id: str) -> QueryS
         .values(*prefixed_fields.keys(), *json_annotations.keys())
     )
 
-    return qs
+    return qs, answer_mappings
 
 
 class ST_X(Func):

--- a/iaso/tests/exports/test_submissions_export.py
+++ b/iaso/tests/exports/test_submissions_export.py
@@ -45,12 +45,13 @@ class SubmissionsExportTest(TestCase):
             single_per_period=True,
             possible_fields=[{"name": "answer_A"}, {"name": "answer_B"}],
         )
+        cls.maxDiff = None
 
     def test_expected_columns_all_fields_even_if_no_records(self):
-        qs = parquet.build_submissions_queryset(Instance.objects, self.form_to_export.id)
+        qs, mapping = parquet.build_submissions_queryset(Instance.objects, self.form_to_export.id)
 
         with tempfile.NamedTemporaryFile(suffix=".parquet") as tmpfile:
-            parquet.export_django_query_to_parquet_via_duckdb(qs, tmpfile.name)
+            parquet.export_django_query_to_parquet_via_duckdb(qs, tmpfile.name, mapping)
             actual_columns = get_columns_from_parquet(tmpfile)
 
         expected = [
@@ -60,15 +61,63 @@ class SubmissionsExportTest(TestCase):
         ]
         self.assertEqual(actual_columns, expected)
 
-    def test_expected_columns_all_fields_even_if_some_answers_collide_with_model_field(self):
-        self.form_to_export.possible_fields = [{"name": "answer_A"}, {"name": "id"}, {"name": "created_at"}]
+    def test_expected_columns_all_fields_even_if_some_answers_collide_with_model_field(
+        self,
+    ):
+        self.form_to_export.possible_fields = [
+            {"name": "answer_A"},
+            {"name": "id"},
+            {"name": "created_at"},
+        ]
         self.form_to_export.save()
 
-        qs = parquet.build_submissions_queryset(Instance.objects, self.form_to_export.id)
+        qs, mapping = parquet.build_submissions_queryset(Instance.objects, self.form_to_export.id)
 
         with tempfile.NamedTemporaryFile(suffix=".parquet") as tmpfile:
-            parquet.export_django_query_to_parquet_via_duckdb(qs, tmpfile.name)
+            parquet.export_django_query_to_parquet_via_duckdb(qs, tmpfile.name, mapping)
             actual_columns = get_columns_from_parquet(tmpfile)
 
-        expected = [*STANDARD_COLUMNS, ["answer_A", "VARCHAR"], ["answer_id", "VARCHAR"], ["created_at", "VARCHAR"]]
+        expected = [
+            *STANDARD_COLUMNS,
+            ["answer_A", "VARCHAR"],
+            ["id", "VARCHAR"],
+            ["created_at", "VARCHAR"],
+        ]
+        self.assertEqual(actual_columns, expected)
+
+    def test_expected_columns_all_fields_even_if_some_answers_collide_with_same_name_case(
+        self,
+    ):
+        self.form_to_export.possible_fields = [
+            {
+                "name": "Prise_en_charge_des_survivantes_de_violences_sexuelles_Au_cours_de_2_dernieres_annees",
+                "type": "integer",
+                "label": "Au cours de 2 dernieres annees",
+            },
+            {
+                "name": "Prise_en_charge_des_survivantes_de_violences_sexuelles_au_cours_de_annee_de_rapportage",
+                "type": "integer",
+                "label": "Au cours de l'annee de rapportage",
+            },
+        ]
+
+        self.form_to_export.save()
+
+        qs, mapping = parquet.build_submissions_queryset(Instance.objects, self.form_to_export.id)
+
+        with tempfile.NamedTemporaryFile(suffix=".parquet") as tmpfile:
+            parquet.export_django_query_to_parquet_via_duckdb(qs, tmpfile.name, mapping)
+            actual_columns = get_columns_from_parquet(tmpfile)
+
+        expected = [
+            *STANDARD_COLUMNS,
+            [
+                "Prise_en_charge_des_survivantes_de_violences_sexuelles_Au_cours_de_2_dernieres_annees",
+                "VARCHAR",
+            ],
+            [
+                "Prise_en_charge_des_survivantes_de_violences_sexuelles_au_cours_de_annee_de_rapportage",
+                "VARCHAR",
+            ],
+        ]
         self.assertEqual(actual_columns, expected)


### PR DESCRIPTION

Postgres is limited to 64 chars identifier.

Related JIRA tickets : IA-4498 

## Self proofreading checklist

- [ ] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

The problem comes from postgres and postgres_query that limits the number of chars and just truncate them without really a warning. the only solution is generating shorter unique alias while in postgres space then rename to longer names when in duckdb space.

So instead of 
```sql
 COPY (
   SELECT * FROM postgres_query('pg', $$ 
    select 
json->>'Gestion_des_projets_et_suivi_des_activites_internes_sur_5_derniers_mois_2025_4564654654654654' as Gestion_des_projets_et_suivi_des_activites_internes_sur_5_derniers_mois_2025_4564654654654654
  ...
)

```

it will generate a "safe mapping" with shorter column names and once in duckdb layer change to the longer column name

```sql
 COPY (
   SELECT 
   c2 as 'Gestion_des_projets_et_suivi_des_activites_internes_sur_5_derniers_mois_2025_4564654654654654'

FROM postgres_query('pg', $$ 
    select 
json->>'Gestion_des_projets_et_suivi_des_activites_internes_sur_5_derniers_mois_2025_4564654654654654' as c2
  ...
)
```



## How to test

1. create a form
2. upload a form version xlsx : https://docs.google.com/spreadsheets/d/1g3kI7lSNOKiDJjw_XhX72qY_feF5diqXKZBn6DiisVk/edit?gid=0#gid=0
3. go submission screen, select the form, copy the "csv" url, replace `csv=true` by `parquet=true`
  - it should work (was failing before the fix)
5. look at the generated columns with duckdb cli (adapt the file name)
```
describe select * from 'submissions.parquet'
```

## Print screen / video

<img width="1489" height="967" alt="image" src="https://github.com/user-attachments/assets/0c357d07-c3ac-49f6-a92c-d7ab208e4913" />


## Notes


## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: failing export when 2 question names starts with same 63 chars

Refs: IA-4498
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
