### PR TITLE
IA-4503 Fix parent assignment bug in data source synchronization

### DIFF
--- a/iaso/diffing/synchronizer.py
+++ b/iaso/diffing/synchronizer.py
@@ -318,13 +318,22 @@ class DataSourceVersionsSynchronizer:
 
         org_unit = diff["orgunit_dhis2"]
         requested_fields = []
-        new_parent = None
+        new_parent_id = None
         new_name = ""
         new_opening_date = None
         new_closed_date = None
 
         if changes.get("parent"):
-            new_parent = changes["parent"]
+            parent_source_ref = changes["parent"]
+            parent_org_unit = (
+                OrgUnit.objects.filter(
+                    source_ref=parent_source_ref, version=self.data_source_sync.source_version_to_update
+                )
+                .only("pk")
+                .first()
+            )
+            if parent_org_unit:
+                new_parent_id = parent_org_unit.pk
             requested_fields.append("new_parent")
 
         if changes.get("name"):
@@ -361,7 +370,7 @@ class DataSourceVersionsSynchronizer:
             old_opening_date=org_unit.get("opening_date"),
             old_closed_date=org_unit.get("closed_date"),
             # New values.
-            new_parent=new_parent,
+            new_parent_id=new_parent_id,
             new_name=new_name,
             new_opening_date=new_opening_date,
             new_closed_date=new_closed_date,

--- a/iaso/tests/models/test_data_source_versions_synchronization.py
+++ b/iaso/tests/models/test_data_source_versions_synchronization.py
@@ -561,3 +561,25 @@ class DataSourceVersionsSynchronizationModelTestCase(TestCase):
                 org_unit=self.angola_facility_without_source_ref_to_compare_with
             ).count(),
         )
+
+    def test_parent_modification(self):
+        # Simulate a parent modification.
+        self.angola_facility_to_compare_with.parent = self.angola_country_to_compare_with
+        self.angola_facility_to_compare_with.save()
+
+        data_source_sync = m.DataSourceVersionsSynchronization.objects.create(
+            name="Parent modification test",
+            source_version_to_update=self.source_version_to_update,
+            source_version_to_compare_with=self.source_version_to_compare_with,
+            json_diff=None,
+            account=self.account,
+            created_by=self.user,
+        )
+
+        data_source_sync.create_json_diff()
+        data_source_sync.synchronize_source_versions()
+
+        angola_facility_change_request = m.OrgUnitChangeRequest.objects.get(
+            org_unit__source_ref="id-4", data_source_synchronization=data_source_sync
+        )
+        self.assertEqual(angola_facility_change_request.new_parent, self.angola_country_to_update)


### PR DESCRIPTION
Fix parent assignment bug in data source synchronization.

Related JIRA tickets: IA-4503

## Changes

When modifying an org unit's parent during synchronization, the code was attempting to assign a string source reference directly to the `new_parent` ForeignKey field, causing a `ValueError`.

```
Cannot assign "'QywkxFudXrC'": "OrgUnitChangeRequest.new_parent" must be a "OrgUnit" instance.
```

The fix resolves the parent source reference to the actual OrgUnit ID in the target version before assignment, matching the  pattern used in the creation case.

## How to test

Look at the unit test.