### PR TITLE
IA-4511 fix admin forms to limit to user scope

### DIFF
--- a/iaso/api/data_source_versions_synchronization/filters.py
+++ b/iaso/api/data_source_versions_synchronization/filters.py
@@ -1,13 +1,21 @@
 import django_filters
 
+from django.contrib.auth import get_user_model
 from django.utils.translation import gettext_lazy as _
 
+from iaso.api.filters import ScopedModelChoiceFilter, get_users_for_user
 from iaso.models import DataSourceVersionsSynchronization
 
 
 class DataSourceVersionsSynchronizationFilter(django_filters.rest_framework.FilterSet):
     created_at__gte = django_filters.IsoDateTimeFilter(
         field_name="created_at", lookup_expr="gte", label=_("Created at greater than or equal to")
+    )
+
+    created_by = ScopedModelChoiceFilter(
+        field_name="created_by",
+        queryset=get_user_model().objects.none(),  # safe default nothing visible
+        scope_queryset=lambda request: get_users_for_user(request.user),
     )
 
     class Meta:

--- a/iaso/api/filters.py
+++ b/iaso/api/filters.py
@@ -1,5 +1,9 @@
 import django_filters
 
+from django.contrib.auth import get_user_model
+
+from iaso.models import Profile
+
 
 def get_users_for_user(user):
     return get_user_model().objects.filter(iaso_profile__in=Profile.objects.filter(account=user.iaso_profile.account))

--- a/iaso/api/filters.py
+++ b/iaso/api/filters.py
@@ -1,0 +1,29 @@
+import django_filters
+
+
+def get_users_for_user(user):
+    return get_user_model().objects.filter(iaso_profile__in=Profile.objects.filter(account=user.iaso_profile.account))
+
+
+class ScopedModelChoiceFilter(django_filters.ModelChoiceFilter):
+    """
+    ModelChoiceFilter that dynamically scopes its queryset using the request.
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.scope_queryset = kwargs.pop("scope_queryset", None)
+        super().__init__(*args, **kwargs)
+
+    def get_queryset(self, request):
+        if self.scope_queryset and request is not None and request.user.is_authenticated:
+            return self.scope_queryset(request)
+        return super().get_queryset(request)
+
+    @property
+    def field(self):
+        field = super().field
+        if self.parent and hasattr(self.parent, "request"):
+            qs = self.get_queryset(self.parent.request)
+            if qs is not None:
+                field.queryset = qs
+        return field

--- a/iaso/api/org_unit_tree/filters.py
+++ b/iaso/api/org_unit_tree/filters.py
@@ -5,7 +5,8 @@ from django.db.models.query import QuerySet
 from django.utils.translation import gettext_lazy as _
 from rest_framework.exceptions import ValidationError
 
-from iaso.models import DataSource, OrgUnit
+from iaso.api.filters import ScopedModelChoiceFilter
+from iaso.models import DataSource, OrgUnit, SourceVersion
 
 
 class OrgUnitTreeFilter(django_filters.rest_framework.FilterSet):
@@ -16,6 +17,12 @@ class OrgUnitTreeFilter(django_filters.rest_framework.FilterSet):
         choices=OrgUnit.VALIDATION_STATUS_CHOICES, label=_("Validation status"), widget=forms.CheckboxSelectMultiple
     )
     search = django_filters.CharFilter(field_name="name", lookup_expr="icontains")
+
+    version = ScopedModelChoiceFilter(
+        field_name="version",
+        queryset=SourceVersion.objects.none(),  # safe default nothing visible
+        scope_queryset=lambda request: SourceVersion.objects.filter_for_user(request.user),
+    )
 
     class Meta:
         model = OrgUnit

--- a/iaso/management/commands/review_queryset_filters.py
+++ b/iaso/management/commands/review_queryset_filters.py
@@ -1,0 +1,56 @@
+# myapp/management/commands/check_unrestricted_filters.py
+import django_filters
+
+from django.core.management.base import BaseCommand
+from django.urls import get_resolver
+from rest_framework.viewsets import ViewSetMixin
+
+
+def is_unrestricted_queryset(qs):
+    """
+    Return True if the queryset has no filtering (i.e., pure .all()).
+    """
+    if qs is None:
+        return False
+    try:
+        return not qs.query.where  # no WHERE clause = unrestricted
+    except:
+        print("failed to review", qs)
+        return False
+
+
+class Command(BaseCommand):
+    help = "Flag endpoints with ModelChoiceFilters that use unrestricted querysets (possible data leaks)"
+
+    def handle(self, *args, **options):
+        resolver = get_resolver()
+        for pattern in resolver.url_patterns:
+            self.inspect_pattern(pattern)
+
+    def inspect_pattern(self, pattern, prefix=""):
+        if hasattr(pattern, "url_patterns"):  # include patterns
+            for p in pattern.url_patterns:
+                self.inspect_pattern(p, prefix + str(pattern.pattern))
+        else:
+            callback = getattr(pattern, "callback", None)
+            if not callback:
+                return
+
+            view_cls = getattr(callback, "cls", None)
+            if not view_cls or not issubclass(view_cls, ViewSetMixin):
+                return
+
+            fs = getattr(view_cls, "filterset_class", None)
+            if not fs:
+                return
+
+            for name, flt in fs.base_filters.items():
+                if isinstance(flt, django_filters.ModelChoiceFilter):
+                    qs = getattr(flt, "queryset", None)
+                    if is_unrestricted_queryset(qs):
+                        self.stdout.write(
+                            f"Endpoint: {prefix}{pattern.pattern}"
+                            + self.style.ERROR(
+                                f"  ⚠ {name}: ModelChoiceFilter with unrestricted queryset ({qs.model.__name__})"
+                            )
+                        )


### PR DESCRIPTION
The default scope return every objects. When it's user or source version this become really big.

Related JIRA tickets : IA-4511

## Self proofreading checklist

- [ ] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

I've also added a command to see if some filter are a bit too open

```
docker compose exec iaso coverage run ./manage.py review_queryset_filters
```

May be we should put as item to review when adding a new endpoint or modifying an existing one.

## Changes

Introduce a  ScopedModelChoiceFilter that will limit via a lambda based on the request and can be reused in other places.

```
    created_by = ScopedModelChoiceFilter(
        field_name="created_by",
        queryset=get_user_model().objects.none(),  # safe default nothing visible
        scope_queryset=lambda request: get_users_for_user(request.user),
    )
```
## How to test

in your dev environnment if you have several accounts

login and go to the
 - /api/orgunits/tree 
 - /api/datasources/sync/?fields=id,name

click on filters

<img width="1872" height="257" alt="image" src="https://github.com/user-attachments/assets/a43f8ac0-66c1-4c80-8050-99edea5cd38d" />

then check form proposed, you should only see data (users, datasource versions) from your current account.


## Print screen / video



## Notes

another solution would have been to only ask for ids textfield

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: admin forms to limit to user scope

Refs: IA-4511
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
