### PR TITLE
IA-4508 Add org_unit_parent_id to parquet of pyramid export

### DIFF
--- a/iaso/exports/pyramid.py
+++ b/iaso/exports/pyramid.py
@@ -58,6 +58,7 @@ def build_org_unit_annotations(model_prefix: str):
         "path",
         "org_unit_type_id",
         "org_unit_type__name",
+        "parent_id",
     ]
 
     # sad to not be aligned with submission : created_by__username, created_by_id

--- a/iaso/tests/exports/test_pyramid_export.py
+++ b/iaso/tests/exports/test_pyramid_export.py
@@ -10,7 +10,7 @@ from .parquet_helper import get_columns_from_parquet
 class PyramidExportTest(TestCase):
     def test_expected_columns_all_fields_even_if_no_records(self):
         qs = parquet.build_pyramid_queryset(OrgUnit.objects, extra_fields=[":all"])
-
+        self.maxDiff = None
         with tempfile.NamedTemporaryFile(suffix=".parquet") as tmpfile:
             parquet.export_django_query_to_parquet_via_duckdb(qs, tmpfile.name)
             actual_columns = get_columns_from_parquet(tmpfile)
@@ -32,6 +32,7 @@ class PyramidExportTest(TestCase):
             ["org_unit_path", "VARCHAR"],
             ["org_unit_type_id", "INTEGER"],
             ["org_unit_type_name", "VARCHAR"],
+            ["org_unit_parent_id", "INTEGER"],
             ["org_unit_level", "INTEGER"],
             ["org_unit_longitude", "DOUBLE"],
             ["org_unit_latitude", "DOUBLE"],


### PR DESCRIPTION
Add org_unit_parent_id to parquet of pyramid export so we can "self join" the parquet file

Related JIRA tickets : IA-4508

## Self proofreading checklist

- [ ] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes


## How to test

in your dev environment, seed some data (orgunits)

1. go in the orgunit search, 
2. launch the search
3. copy the csv url and return the page= , limit= and replace csv=true by parquet=true
   - ex url : http://localhost:8081/api/orgunits/?&order=id&searches=[{%22validation_status%22:%22all%22,%22color%22:%22f4511e%22,%22version%22:1}]&parquet=true

5. check the downloaded parquet (adapt the parquet sql filename below)

```
describe select * from 'development-Organisation Namestable-2-40-9-org_units-2025-10-02-13-51.parquet';
```

you can then join

```
select ou.org_unit_id as id, ou.org_unit_name as name, ou.org_unit_parent_id as parent_id, parent.org_unit_name as parent_name
from 'development-Organisation Namestable-2-40-9-org_units-2025-10-02-13-51.parquet' as ou 
left join  'development-Organisation Namestable-2-40-9-org_units-2025-10-02-13-51.parquet'
  as parent on parent.org_unit_id=ou.org_unit_parent_id;
```

## Print screen / video

<img width="1453" height="1201" alt="image" src="https://github.com/user-attachments/assets/08f983b0-ea8b-4fb5-acc1-6ad6d9734831" />

```
┌───────┬─────────────────────────┬───────────┬───────────────────┐
│  id   │          name           │ parent_id │    parent_name    │
│ int32 │         varchar         │   int32   │      varchar      │
├───────┼─────────────────────────┼───────────┼───────────────────┤
│     2 │ Bo                      │         1 │ Sierra Leone      │
│     3 │ Wonde                   │         2 │ Bo                │
│     4 │ Kambawama MCHP          │         3 │ Wonde             │
│     5 │ Fanima (Wonde) MCHP     │         3 │ Wonde             │
│     6 │ Bathurst MCHP           │         3 │ Wonde             │
│     7 │ Gboyama CHC             │         3 │ Wonde             │
│     8 │ Bumpe Ngao              │         2 │ Bo                │
│     9 │ Buma MCHP               │         8 │ Bumpe Ngao        │
│    10 │ Kaniya MCHP             │         8 │ Bumpe Ngao        │
│    11 │ Bumpe CHC               │         8 │ Bumpe Ngao        │
 
```


## Notes


## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: add org_unit_parent_id to parquet of pyramid export

Refs: IA-4508
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
