### PR TITLE
WC2-817  Reducing the number of SQL queries per page of entity in WFP ETL

### DIFF
--- a/plugins/wfp/common.py
+++ b/plugins/wfp/common.py
@@ -68,7 +68,7 @@ class ETL:
                 "source_created_at",
             )
         )
-        return Paginator(beneficiaries, 200)
+        return Paginator(beneficiaries, 5000)
 
     def existing_beneficiaries(self):
         existing_beneficiaries = Beneficiary.objects.exclude(entity_id=None).values("entity_id")
@@ -575,25 +575,21 @@ class ETL:
                             sub_step["instance_id"],
                         )
                         all_steps.append(current_step)
-        save_steps = Step.objects.bulk_create(all_steps)
-        return save_steps
+        return all_steps
 
     def save_visit(self, visits, journey):
         saved_visits = []
-        created_visits = None
         visit_number = 0
         for current_visit in visits:
             visit = Visit()
             visit.date = current_visit.get("date", None)
             visit.number = visit_number
             visit.journey = journey
-            orgUnit = OrgUnit.objects.get(id=current_visit["org_unit_id"])
-            visit.org_unit = orgUnit
+            visit.org_unit_id = current_visit["org_unit_id"]
             visit.instance_id = current_visit.get("instance_id", None)
             saved_visits.append(visit)
             visit_number += 1
-        created_visits = Visit.objects.bulk_create(saved_visits)
-        return created_visits
+        return saved_visits
 
     def followup_visits_at_next_visit_date(self, visits, formIds, next_visit__date__, secondNextVisitDate):
         followup_visits_in_period = []
@@ -717,15 +713,12 @@ class ETL:
         journey.end_date = record.get("end_date", None)
         journey.duration = record.get("duration", None)
 
-        journey.save()
-
         return journey
 
     def save_monthly_journey(self, monthly_journey, account):
         monthly_Statistic = MonthlyStatistics()
-        orgUnit = OrgUnit.objects.get(id=monthly_journey.get("org_unit"))
-
-        monthly_Statistic.org_unit = orgUnit
+        org_unit_id = monthly_journey.get("org_unit")
+        monthly_Statistic.org_unit_id = org_unit_id
         monthly_Statistic.gender = monthly_journey.get("gender")
         monthly_Statistic.month = monthly_journey.get("month")
         monthly_Statistic.year = monthly_journey.get("year")

--- a/plugins/wfp/management/commands/ethiopia/Under5.py
+++ b/plugins/wfp/management/commands/ethiopia/Under5.py
@@ -141,7 +141,10 @@ class ET_Under5:
             entities = sorted(list(beneficiaries.page(page).object_list), key=itemgetter("entity_id"))
             existing_beneficiaries = ETL().existing_beneficiaries()
             instances = self.group_visit_by_entity(entities)
-
+            all_steps = []
+            all_visits = []
+            all_journeys = []
+            all_beneficiaries = []
             for index, instance in enumerate(instances):
                 logger.info(
                     f"---------------------------------------- Beneficiary N° {(index + 1)} {instance['entity_id']}-----------------------------------"
@@ -157,7 +160,7 @@ class ET_Under5:
                     beneficiary.birth_date = instance["birth_date"]
                     beneficiary.entity_id = instance["entity_id"]
                     beneficiary.account = account
-                    beneficiary.save()
+                    all_beneficiaries.append(beneficiary)
                     logger.info("Created new beneficiary")
                 else:
                     beneficiary = Beneficiary.objects.filter(entity_id=instance["entity_id"]).first()
@@ -167,14 +170,16 @@ class ET_Under5:
                     for journey_instance in instance["journey"]:
                         if len(journey_instance["visits"]) > 0:
                             journey = self.save_journey(beneficiary, journey_instance)
+                            all_journeys.append(journey)
                             visits = ETL().save_visit(journey_instance["visits"], journey)
+                            all_visits.extend(visits)
                             logger.info(f"Inserted {len(visits)} Visits")
                             grouped_steps = ETL().get_admission_steps(journey_instance["steps"])
                             admission_step = grouped_steps[0]
 
                             followUpVisits = ETL().group_followup_steps(grouped_steps, admission_step)
                             steps = ETL().save_steps(visits, followUpVisits)
-
+                            all_steps.extend(steps)
                             logger.info(f"Inserted {len(steps)} Steps")
                             # exit()
                         else:
@@ -182,6 +187,10 @@ class ET_Under5:
                     logger.info(
                         "---------------------------------------------------------------------------------------------\n\n"
                     )
+            Beneficiary.objects.bulk_create(all_beneficiaries)
+            Journey.objects.bulk_create(all_journeys)
+            Visit.objects.bulk_create(all_visits)
+            Step.objects.bulk_create(all_steps)
 
     def journeyMapper(self, visits, admission_form):
         current_journey = {"visits": [], "steps": []}

--- a/plugins/wfp/management/commands/nigeria/Under5.py
+++ b/plugins/wfp/management/commands/nigeria/Under5.py
@@ -136,7 +136,10 @@ class NG_Under5:
             entities = sorted(list(beneficiaries.page(page).object_list), key=itemgetter("entity_id"))
             existing_beneficiaries = ETL().existing_beneficiaries()
             instances = self.group_visit_by_entity(entities)
-
+            all_steps = []
+            all_visits = []
+            all_journeys = []
+            all_beneficiaries = []
             for index, instance in enumerate(instances):
                 logger.info(
                     f"---------------------------------------- Beneficiary N° {(index + 1)} {instance['entity_id']}-----------------------------------"
@@ -151,7 +154,7 @@ class NG_Under5:
                     beneficiary.birth_date = instance["birth_date"]
                     beneficiary.entity_id = instance["entity_id"]
                     beneficiary.account = account
-                    beneficiary.save()
+                    all_beneficiaries.append(beneficiary)
                     logger.info("Created new beneficiary")
                 else:
                     beneficiary = Beneficiary.objects.filter(entity_id=instance["entity_id"]).first()
@@ -161,7 +164,9 @@ class NG_Under5:
                 for journey_instance in instance["journey"]:
                     if journey_instance.get("nutrition_programme") is not None and len(journey_instance["visits"]) > 0:
                         journey = self.save_journey(beneficiary, journey_instance)
+                        all_journeys.append(journey)
                         visits = ETL().save_visit(journey_instance["visits"], journey)
+                        all_visits.extend(visits)
                         logger.info(f"Inserted {len(visits)} Visits")
                         grouped_steps = ETL().get_admission_steps(journey_instance["steps"])
                         admission_step = grouped_steps[0]
@@ -169,12 +174,17 @@ class NG_Under5:
                         followUpVisits = ETL().group_followup_steps(grouped_steps, admission_step)
 
                         steps = ETL().save_steps(visits, followUpVisits)
+                        all_steps.extend(steps)
                         logger.info(f"Inserted {len(steps)} Steps")
                     else:
                         logger.info("No new journey")
                 logger.info(
                     "---------------------------------------------------------------------------------------------\n\n"
                 )
+            Beneficiary.objects.bulk_create(all_beneficiaries)
+            Journey.objects.bulk_create(all_journeys)
+            Visit.objects.bulk_create(all_visits)
+            Step.objects.bulk_create(all_steps)
 
     def journeyMapper(self, visits, admission_form):
         current_journey = {"visits": [], "steps": []}

--- a/plugins/wfp/management/commands/south_sudan/Pbwg.py
+++ b/plugins/wfp/management/commands/south_sudan/Pbwg.py
@@ -28,7 +28,10 @@ class PBWG:
             )
             existing_beneficiaries = ETL().existing_beneficiaries()
             instances = self.group_visit_by_entity(entities)
-
+            all_steps = []
+            all_visits = []
+            all_journeys = []
+            all_beneficiaries = []
             for index, instance in enumerate(instances):
                 logger.info(
                     f"---------------------------------------- Beneficiary N° {(index + 1)} {instance['entity_id']}-----------------------------------"
@@ -41,7 +44,7 @@ class PBWG:
                     beneficiary.account = account
                     if instance.get("birth_date") is not None:
                         beneficiary.birth_date = instance["birth_date"]
-                        beneficiary.save()
+                        all_beneficiaries.append(beneficiary)
                         logger.info("Created new beneficiary")
                 else:
                     beneficiary = Beneficiary.objects.filter(entity_id=instance["entity_id"]).first()
@@ -51,7 +54,9 @@ class PBWG:
                 for journey_instance in instance["journey"]:
                     if len(journey_instance["visits"]) > 0:
                         journey = self.save_journey(beneficiary, journey_instance)
+                        all_journeys.append(journey)
                         visits = ETL().save_visit(journey_instance["visits"], journey)
+                        all_visits.extend(visits)
                         logger.info(f"Inserted {len(visits)} Visits")
 
                         grouped_steps = ETL().get_admission_steps(journey_instance["steps"])
@@ -59,12 +64,17 @@ class PBWG:
                         followUpVisits = ETL().group_followup_steps(grouped_steps, admission_step)
 
                         steps = ETL().save_steps(visits, followUpVisits)
+                        all_steps.extend(steps)
                         logger.info(f"Inserted {len(steps)} Steps")
                     else:
                         logger.info("No new journey")
                 logger.info(
                     "---------------------------------------------------------------------------------------------\n\n"
                 )
+            Beneficiary.objects.bulk_create(all_beneficiaries)
+            Journey.objects.bulk_create(all_journeys)
+            Visit.objects.bulk_create(all_visits)
+            Step.objects.bulk_create(all_steps)
 
     def save_journey(self, beneficiary, record):
         journey = Journey()

--- a/plugins/wfp/tasks.py
+++ b/plugins/wfp/tasks.py
@@ -41,6 +41,8 @@ def etl_ng():
 
 @shared_task()
 def etl_ssd():
+    # from django.db import connection # For debugging purposes only, to see the SQL queries executed
+
     logger.info("Starting ETL for South Sudan")
     entity_type_U5_code = "ssd_under5"
     child_account = ETL([entity_type_U5_code]).account_related_to_entity_type()
@@ -60,6 +62,8 @@ def etl_ssd():
     )
     MonthlyStatistics.objects.filter(account=pbwg_account, programme_type="PLW").delete()
     ETL().journey_with_visit_and_steps_per_visit(pbwg_account, "PLW")
+    # print("len(connection.queries)", len(connection.queries))  # Uncomment this line to see the number of SQL queries executed
+    # print(connection.queries) # Uncomment this line to see the SQL queries executed
 
 
 @shared_task()


### PR DESCRIPTION
Reducing the number of SQL queries per page of entity in WFP ETL

[WC2-817] 

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?


## Changes

Two main changes: 
- prevent the fetching of org_unit while you already have the id and can use juste that to save the foreign key. 
- batching a lot more the insert queries (only one batch insert for beneficiary, visits, steps and journeys per page of entity)



[WC2-817]: https://bluesquare.atlassian.net/browse/WC2-817?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ