### PR TITLE
IA-4509: Falsy loading message

### DIFF
--- a/hat/assets/js/apps/Iaso/components/forms/AsyncSelect.tsx
+++ b/hat/assets/js/apps/Iaso/components/forms/AsyncSelect.tsx
@@ -1,3 +1,4 @@
+import React, { FunctionComponent, useEffect, useMemo, useState } from 'react';
 import { Box, TextField } from '@mui/material';
 import Autocomplete from '@mui/material/Autocomplete';
 import { AutocompleteRenderGetTagProps } from '@mui/material/Autocomplete/Autocomplete';
@@ -8,7 +9,6 @@ import {
     useSafeIntl,
 } from 'bluesquare-components';
 import { isArray } from 'lodash';
-import React, { FunctionComponent, useEffect, useMemo, useState } from 'react';
 import { defineMessages } from 'react-intl';
 
 const MESSAGES = defineMessages({
@@ -146,6 +146,11 @@ export const AsyncSelect: FunctionComponent<Props> = ({
                         label={formatMessage(label)}
                         required={required}
                         helperText={helperText}
+                        placeholder={
+                            inputValue.length < minCharBeforeQuery
+                                ? formatMessage(MESSAGES.noOptionsText)
+                                : undefined
+                        }
                     />
                 )}
                 renderTags={renderTags}

--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -333,6 +333,7 @@
     "iaso.forms.new": "new",
     "iaso.forms.newCap": "New",
     "iaso.forms.no": "No",
+    "iaso.forms.noResultsFound": "No results found",
     "iaso.forms.notValidated": "Not validated",
     "iaso.forms.org_unit_type": "Organisation unit type",
     "iaso.forms.org_unit_type_id": "Org unit type",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -360,6 +360,7 @@
     "iaso.forms.status": "Statut",
     "iaso.forms.sub_source": "Sous-source",
     "iaso.forms.subSource": "Sous-source",
+    "iaso.forms.noResultsFound": "Aucun résultat trouvé",
     "iaso.forms.textSearch": "Recherche textuelle",
     "iaso.forms.title": "Formulaires",
     "iaso.forms.type": "Type",

--- a/hat/assets/js/apps/Iaso/domains/dataSources/hooks/useGetDataSourceVersionsSynchronizationDropdown.ts
+++ b/hat/assets/js/apps/Iaso/domains/dataSources/hooks/useGetDataSourceVersionsSynchronizationDropdown.ts
@@ -18,13 +18,6 @@ const searchOptions = {
 };
 export const useSearchDataSourceVersionsSynchronization = () => {
     const queryClient = useQueryClient();
-    const query = useSnackQuery({
-        queryKey: ['searchDataSourceVersionsSynchronization', ''],
-        queryFn: () => [],
-        snackErrorMsg: MESSAGES.error,
-        options: searchOptions,
-    });
-
     const searchWithInput = useCallback(
         async (input: string) => {
             const newQueryKey = [
@@ -42,7 +35,7 @@ export const useSearchDataSourceVersionsSynchronization = () => {
         [queryClient],
     );
 
-    return { ...query, searchWithInput };
+    return { searchWithInput };
 };
 
 export const useGetDataSourceVersionsSynchronizationDropdown = (
@@ -56,6 +49,7 @@ export const useGetDataSourceVersionsSynchronizationDropdown = (
         },
         snackErrorMsg: MESSAGES.error,
         options: {
+            enabled: Boolean(id),
             select: data => {
                 if (data === undefined || (Array.isArray(data) && !data.length))
                     return [];


### PR DESCRIPTION
On change request page, searching for sync version is displaying loading message and shouldn't

Related JIRA tickets : IA-4509

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

-

## Changes

- remove useless query
- disable dropdown option call if no version id
- - handle free solo to display no option text

## How to test

Visit change request page and click in Data source version input, loading should not be displayed


https://github.com/user-attachments/assets/05c1ab13-8d5b-4233-b1a5-d1793b01500a



## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
