### PR TITLE
IA-4490 create children from parent should we filter out based on out hierarchies

### DIFF
--- a/hat/assets/js/apps/Iaso/components/MainWrapper.tsx
+++ b/hat/assets/js/apps/Iaso/components/MainWrapper.tsx
@@ -39,27 +39,19 @@ export const MainWrapper: FC<MainWrapperProps> = ({
     embedded = false,
 }) => {
     const wrapperStyle = useMemo(() => {
+        let style = styles.standalone;
         if (embedded) {
-            return styles.embedded;
+            style = styles.embedded;
         }
         if (navHasTabs) {
-            return styles.standaloneTabbed;
+            style = styles.standaloneTabbed;
         }
 
-        return styles.standalone;
-    }, [embedded, navHasTabs]);
-
-    return (
-        <Box
-            sx={{
-                ...styles.base,
-                ...(Array.isArray(wrapperStyle)
-                    ? wrapperStyle
-                    : [wrapperStyle]),
-                ...(Array.isArray(sx) ? sx : [sx]),
-            }}
-        >
-            {children}
-        </Box>
-    );
+        return {
+            ...styles.base,
+            ...style,
+            ...sx,
+        };
+    }, [embedded, navHasTabs, sx]);
+    return <Box sx={wrapperStyle}>{children}</Box>;
 };

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitInfos.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitInfos.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, useEffect, useMemo } from 'react';
 
 import { Box, Button, Grid } from '@mui/material';
 
@@ -107,6 +107,26 @@ export const OrgUnitInfos: FunctionComponent<Props> = ({
     const { data: parentOrgunit } = useGetOrgUnit(
         parentId ? `${parentId}` : undefined,
     );
+
+    useEffect(() => {
+        if (
+            !orgUnitState.org_unit_type_id?.value &&
+            isNewOrgunit &&
+            !orgUnitModified &&
+            parentOrgunit?.org_unit_type.sub_unit_types?.[0]?.id
+        ) {
+            onChangeInfo(
+                'org_unit_type_id',
+                parentOrgunit.org_unit_type.sub_unit_types?.[0]?.id,
+            );
+        }
+    }, [
+        parentOrgunit,
+        isNewOrgunit,
+        orgUnitState,
+        orgUnitModified,
+        onChangeInfo,
+    ]);
 
     const hasManagementPermission = useCheckUserHasWritePermissionOnOrgunit(
         orgUnit?.org_unit_type_id,


### PR DESCRIPTION
When creating a child OU no default org unit type is selected by default

Related JIRA tickets : IA-4490

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [x] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

When creating an OU, if a parent was loaded and nothing has changed on org unit yet,
Use parent OU type first sub unit type to select in form by default.

## How to test

Go to OrgUnits, search for some, preview one then on child tab, create a new one.
An org unit type should be selected by default, it should be the next sub level compared to the parent.
If it is the smallest type possible, nothing is selected.

## Print screen / video

Upload here print screens or videos showing the changes.

## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
