### PR TITLE
IA-4520 export parquet parse error when reserved keyword in the question names

### DIFF
--- a/iaso/exports/duckdb_util.py
+++ b/iaso/exports/duckdb_util.py
@@ -63,4 +63,4 @@ def export_django_query_to_parquet_via_duckdb(qs: QuerySet, output_file_path: st
 
 
 def dict_to_projection(mapping):
-    return ",\n    ".join(f'{safe} as "{orig}"' for orig, safe in mapping.items())
+    return ",\n    ".join(f'"{safe}" as "{orig}"' for orig, safe in mapping.items())


### PR DESCRIPTION
When there's a reserved keyword (specific to duckdb) there's a parser error
now the column will be quoted. As end is often in the forms it's perhaps a good idea to do a hotfix

Related JIRA tickets : IA-4520

## Self proofreading checklist

- [ ] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc


## Changes



## How to test

create a new form, create a new form version : upload the xlsform in the jira
then http://localhost:8081/api/instances/?showDeleted=false&form_ids=19&parquet=true
(adapt the id to match the new form)

## Print screen / video



## Notes



## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: export parquet parse error when reserved keyword in the question names

Refs: IA-4520
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
