### PR TITLE
IA-3777: Display OUT name in OU History tab

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/history/LogValue.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/history/LogValue.tsx
@@ -1,20 +1,20 @@
 import React, { FunctionComponent, useState } from 'react';
+import { makeStyles } from '@mui/styles';
 import { wktToGeoJSON as terraformer } from '@terraformer/wkt';
 import { textPlaceholder, useSafeIntl } from 'bluesquare-components';
 import moment from 'moment';
-import { makeStyles } from '@mui/styles';
 
-import { GeoJsonMap } from '../../../components/maps/GeoJsonMapComponent';
-import { MarkerMap } from '../../../components/maps/MarkerMapComponent';
-import { GeoJson } from '../../../components/maps/types';
+import { GeoJsonMap } from 'Iaso/components/maps/GeoJsonMapComponent';
+import { MarkerMap } from 'Iaso/components/maps/MarkerMapComponent';
+import { GeoJson } from 'Iaso/components/maps/types';
 import { LinkToOrgUnit } from '../components/LinkToOrgUnit';
 import { useGetOrgUnitDetail } from '../hooks/requests/useGetOrgUnitDetail';
 
-import MESSAGES from './messages';
+import { MESSAGES } from './messages';
 
 type Props = {
     fieldKey: string;
-    value?: string | number;
+    value?: any;
 };
 
 export const wktToGeoJSON = (value: string | number): GeoJson | undefined => {
@@ -81,11 +81,12 @@ export const LogValue: FunctionComponent<Props> = ({ fieldKey, value }) => {
                     </div>
                 );
             }
+            case 'org_unit_type':
+                return `${value.name} (id: ${value.id})`;
             default:
                 return value.toString();
         }
     } catch (e) {
-        // eslint-disable-next-line no-console
         console.error('Could not parse', e);
         throw new Error(value.toString());
     }

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/history/LogsDetails.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/history/LogsDetails.tsx
@@ -1,17 +1,17 @@
 import React, { FunctionComponent } from 'react';
+import Alert from '@mui/lab/Alert';
+import { Container, Grid } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 import {
     LoadingSpinner,
     LinkWithLocation,
     commonStyles,
     useSafeIntl,
 } from 'bluesquare-components';
-import { Container, Grid } from '@mui/material';
-import Alert from '@mui/lab/Alert';
-import { makeStyles } from '@mui/styles';
+import { baseUrls } from 'Iaso/constants/urls';
+import { useGetLogDetails } from 'Iaso/hooks/useGetLogDetails';
 import LogCompareComponent from './LogCompareComponent';
-import MESSAGES from './messages';
-import { useGetLogDetails } from '../../../hooks/useGetLogDetails';
-import { baseUrls } from '../../../constants/urls';
+import { MESSAGES } from './messages';
 
 const useStyles = makeStyles(theme => ({
     ...commonStyles(theme),

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/history/ValueWithErrorBoundary.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/history/ValueWithErrorBoundary.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { injectIntl } from 'bluesquare-components';
 import { Typography, Box } from '@mui/material';
 import { withStyles } from '@mui/styles';
+import { injectIntl } from 'bluesquare-components';
+import PropTypes from 'prop-types';
 
 import { LogValue } from './LogValue.tsx';
-import MESSAGES from './messages';
+import { MESSAGES } from './messages';
 
 const styles = theme => ({
     errorContainer: {

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/history/messages.js
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/history/messages.js
@@ -74,5 +74,3 @@ export const MESSAGES = defineMessages({
         defaultMessage: `These changes originated from Change Request #{change_request_id}`,
     },
 });
-
-export default MESSAGES;

--- a/hat/audit/models.py
+++ b/hat/audit/models.py
@@ -10,6 +10,8 @@ from django.contrib.contenttypes.models import ContentType
 from django.core import serializers
 from django.db import models
 
+from hat.audit.modifications import get_values_serializer
+
 
 logger = logging.getLogger(__name__)
 
@@ -99,12 +101,13 @@ class Modification(models.Model):
         )
 
     def as_dict(self):
+        values_serializer = get_values_serializer(self.content_object)
         return {
             "id": self.id,
             "content_type": self.content_type.app_label,
             "object_id": self.object_id,
-            "past_value": self.past_value,
-            "new_value": self.new_value,
+            "past_value": values_serializer.serialize(self.past_value),
+            "new_value": values_serializer.serialize(self.new_value),
             "source": self.source,
             "user": self.user.iaso_profile.as_dict() if self.user else None,
             "created_at": self.created_at,

--- a/hat/audit/modifications/__init__.py
+++ b/hat/audit/modifications/__init__.py
@@ -1,0 +1,7 @@
+from hat.audit.modifications.values_serializer import ValuesSerializer, get_values_serializer
+
+
+__all__ = [
+    "get_values_serializer",
+    "ValuesSerializer",
+]

--- a/hat/audit/modifications/values_serializer.py
+++ b/hat/audit/modifications/values_serializer.py
@@ -1,0 +1,40 @@
+from typing import Any, Union
+
+from django.db import models
+from django.forms import JSONField
+
+from iaso.models import OrgUnit, OrgUnitType
+
+
+class ValuesSerializer:
+    def serialize(self, values: Union[JSONField, Any]) -> Union[JSONField, list[dict]]:
+        return values
+
+
+class OrgUnitValuesSerializer(ValuesSerializer):
+    @staticmethod
+    def map_field(field: str, value: str) -> Union[str, dict]:
+        if field == "org_unit_type":
+            return {"id": value, "name": OrgUnitType.objects.get(pk=value).name}
+        return value
+
+    def serialize(self, values: Union[JSONField, Any]) -> Union[JSONField, list[dict]]:
+        dict = []
+        for value in values:
+            fields = value["fields"]
+            for field in fields:
+                fields[field] = self.map_field(field, fields[field])
+            dict.append(
+                {
+                    "pk": value["pk"],
+                    "model": value["model"],
+                    "fields": fields,
+                }
+            )
+        return dict
+
+
+def get_values_serializer(content_object: models.Model) -> ValuesSerializer:
+    if isinstance(content_object, OrgUnit):
+        return OrgUnitValuesSerializer()
+    return ValuesSerializer()


### PR DESCRIPTION
OrgUnit's history tab would display the types as their IDs. This displays them as their names and IDs.

Related JIRA tickets : IA-3777

## Self proofreading checklist

- [X] Did I use eslint and ruff formatters?
- [X] Is my code clear enough and well documented?
- [X] Are my typescript files well typed?
- [ ] Are there enough tests?

## Changes

I have added a `ValuesSerializer` class which acts as an interface for a [Strategy Pattern](https://en.wikipedia.org/wiki/Strategy_pattern).

The serializer is responsible of mapping fields to add missing information before returning them to the client.

## How to test

Go in an OrgUnit history tab.

## Print screen / video

<img width="3896" height="885" alt="image" src="https://github.com/user-attachments/assets/af160c6d-0452-4df6-b1fc-d11c853dade2" />

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
