### PR TITLE
WC2-806: Remove "OrgUnit" as admin `list_filter` as it is too slow in production

### DIFF
--- a/iaso/admin/base.py
+++ b/iaso/admin/base.py
@@ -763,7 +763,7 @@ class StockItemAdmin(admin.ModelAdmin):
     fields = ("org_unit", "sku", "value", "created_at", "updated_at")
     readonly_fields = ("created_at", "updated_at")
     list_display = ("org_unit", "sku", "value")
-    list_filter = ("org_unit", "sku")
+    list_filter = ["sku"]
 
 
 @admin.register(StockItemRule)
@@ -809,7 +809,7 @@ class StockLedgerItemAdmin(admin.ModelAdmin):
     fields = ("rule", "sku", "org_unit", "submission", "question", "impact", "value", "created_at", "created_by")
     readonly_fields = ("created_at", "created_by")
     list_display = ("rule", "sku", "org_unit", "question", "impact", "value", "created_at")
-    list_filter = ("sku", "org_unit", "impact", "rule")
+    list_filter = ("sku", "impact", "rule")
 
 
 @admin.register(StockRulesVersion)


### PR DESCRIPTION
Putting "OrgUnit" as a `list_filter` in the admin is too heavy for the servers in production.

Related JIRA tickets : WC2-806

## Self proofreading checklist

- [X] Did I use eslint and ruff formatters?
- [X] Is my code clear enough and well documented?

## Changes

Remove problematic filters

## How to test

Go in the admin for `StockItem` and `StockLedgerItem`

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
