### PR TITLE
IA-4525: Allow to filter OUs that are open on a specific date

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -1010,6 +1010,7 @@
     "iaso.orgUnits.name": "Name",
     "iaso.orgUnits.new": "Create an org unit",
     "iaso.orgUnits.onlyDirectChildren": "Only Direct children",
+    "iaso.orgUnits.openDate": "Open on",
     "iaso.orgUnits.openingDate": "Opening date",
     "iaso.orgUnits.orgUnitsTypes": "Organisation unit type",
     "iaso.orgUnits.ouTypesHelperText": "Children org units",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/es.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/es.json
@@ -948,6 +948,7 @@
     "iaso.orgUnits.name": "Nombre",
     "iaso.orgUnits.new": "Crear una unidad organizativa",
     "iaso.orgUnits.onlyDirectChildren": "Solo hijos directos",
+    "iaso.orgUnits.openDate": "Abierto el",
     "iaso.orgUnits.openingDate": "Fecha de apertura",
     "iaso.orgUnits.orgUnitsTypes": "Tipo de unidad organizativa",
     "iaso.orgUnits.ouTypesHelperText": "Unidades organizativas hijas",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -1011,6 +1011,7 @@
     "iaso.orgUnits.name": "Nom",
     "iaso.orgUnits.new": "Créer une unité d'org.",
     "iaso.orgUnits.onlyDirectChildren": "Seulement les enfants directs",
+    "iaso.orgUnits.openDate": "Ouverte le",
     "iaso.orgUnits.openingDate": "Date d'ouverture",
     "iaso.orgUnits.orgUnitsTypes": "Type d'unité d'org.",
     "iaso.orgUnits.ouTypesHelperText": "Unité d'organisation enfants",

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/messages.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/messages.ts
@@ -205,6 +205,10 @@ const MESSAGES = defineMessages({
         defaultMessage: 'Details',
         id: 'iaso.label.details',
     },
+    clear: {
+        id: 'iaso.label.clear',
+        defaultMessage: 'Clear',
+    },
     date: {
         defaultMessage: 'Date',
         id: 'iaso.label.date',
@@ -562,6 +566,10 @@ const MESSAGES = defineMessages({
     multiReferenceInstancesLabel: {
         id: 'iaso.orgUnits.MultiReferenceInstancesLabel',
         defaultMessage: 'Reference submissions',
+    },
+    openDate: {
+        id: 'iaso.orgUnits.openDate',
+        defaultMessage: 'Open on',
     },
     openingDate: {
         id: 'iaso.orgUnits.openingDate',

--- a/iaso/api/org_unit_search.py
+++ b/iaso/api/org_unit_search.py
@@ -45,6 +45,7 @@ def build_org_units_queryset(queryset, params, profile):
     org_unit_type_category = params.get("orgUnitTypeCategory", None)
     path_depth = params.get("depth", None)
 
+    date_open = params.get("date_open", None)
     opening_date = params.get("opening_date", None)
     closed_date = params.get("closed_date", None)
 
@@ -244,6 +245,11 @@ def build_org_units_queryset(queryset, params, profile):
 
     if path_depth is not None:
         queryset = queryset.filter(path__depth=path_depth)
+    if date_open is not None:
+        date = datetime.strptime(date_open, "%d-%m-%Y").date()
+        queryset = queryset.filter(Q(opening_date__isnull=True) | Q(opening_date__lte=date)).filter(
+            Q(closed_date__isnull=True) | Q(closed_date__gt=date)
+        )
     if opening_date:
         queryset = queryset.filter(opening_date=datetime.strptime(opening_date, "%d-%m-%Y").date())
     if closed_date:


### PR DESCRIPTION
Adding a way to filter OU that are open on a specific date

Related JIRA tickets : IA-4525

## Self proofreading checklist

- [X] Did I use eslint and ruff formatters?
- [X] Is my code clear enough and well documented?
- [X] Are my typescript files well typed?
- [X] New translations have been added or updated if new strings have been introduced in the frontend
- [X] Are there enough tests?

## Changes

I have added a `open_date` parameter to the `OrgUnit` search which filters based on the following logic:

**Opening date** : Either null or lower or equal to the given date
**Closed date**: Either null or greater (but not equal to) the given date 

## How to test

Go to the OrgUnit list and filter on a specific date.

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
