### PR TITLE
[SLEEP] Entities list page: attempt to solve performance issues

### DIFF
--- a/iaso/api/entities/serializers.py
+++ b/iaso/api/entities/serializers.py
@@ -1,0 +1,85 @@
+from rest_framework import serializers
+
+from iaso.models import Entity
+from iaso.models.deduplication import ValidationStatus
+from iaso.models.storage import StorageDevice
+
+
+class EntitySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Entity
+        fields = [
+            "id",
+            "name",
+            "uuid",
+            "created_at",
+            "updated_at",
+            "attributes",
+            "entity_type",
+            "entity_type_name",
+            "instances",
+            "submitter",
+            "org_unit",
+            "duplicates",
+            "nfc_cards",
+            "migration_source",
+        ]
+
+    entity_type_name = serializers.SerializerMethodField()
+    attributes = serializers.SerializerMethodField()
+    submitter = serializers.SerializerMethodField()
+    org_unit = serializers.SerializerMethodField()
+    duplicates = serializers.SerializerMethodField()
+    nfc_cards = serializers.SerializerMethodField()
+    migration_source = serializers.SerializerMethodField()
+
+    def get_attributes(self, entity: Entity):
+        if entity.attributes:
+            return entity.attributes.as_dict()
+        return None
+
+    def get_org_unit(self, entity: Entity):
+        if entity.attributes and entity.attributes.org_unit:
+            return entity.attributes.org_unit.as_dict_for_entity()
+        return None
+
+    def get_submitter(self, entity: Entity):
+        try:
+            # TODO: investigate type issue on next line
+            submitter = entity.attributes.created_by.username  # type: ignore
+        except AttributeError:
+            submitter = None
+        return submitter
+
+    def get_duplicates(self, entity: Entity):
+        return _get_duplicates(entity)
+
+    def get_nfc_cards(self, entity: Entity):
+        nfc_count = StorageDevice.objects.filter(entity=entity, type=StorageDevice.NFC).count()
+        return nfc_count
+
+    @staticmethod
+    def get_entity_type_name(obj: Entity):
+        return obj.entity_type.name if obj.entity_type else None
+
+    def get_migration_source(self, obj: Entity):
+        if not obj.attributes:
+            return None
+
+        if obj.attributes.patient_set.exists():
+            patient = obj.attributes.patient_set.first()
+            if patient:
+                return patient.id
+
+        return None
+
+
+def _get_duplicates(entity):
+    results = []
+    e1qs = entity.duplicates1.filter(validation_status=ValidationStatus.PENDING)
+    e2qs = entity.duplicates2.filter(validation_status=ValidationStatus.PENDING)
+    if e1qs.count() > 0:
+        results = results + list(map(lambda x: x.entity2.id, e1qs.all()))
+    elif e2qs.count() > 0:
+        results = results + list(map(lambda x: x.entity1.id, e2qs.all()))
+    return results

--- a/iaso/api/entities/views.py
+++ b/iaso/api/entities/views.py
@@ -33,89 +33,9 @@ from iaso.api.common import (
     ModelViewSet,
 )
 from iaso.models import Entity, EntityType, Instance, OrgUnit
-from iaso.models.deduplication import ValidationStatus
-from iaso.models.storage import StorageDevice
 from iaso.utils.jsonlogic import entities_jsonlogic_to_q
 
-
-class EntitySerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Entity
-        fields = [
-            "id",
-            "name",
-            "uuid",
-            "created_at",
-            "updated_at",
-            "attributes",
-            "entity_type",
-            "entity_type_name",
-            "instances",
-            "submitter",
-            "org_unit",
-            "duplicates",
-            "nfc_cards",
-            "migration_source",
-        ]
-
-    entity_type_name = serializers.SerializerMethodField()
-    attributes = serializers.SerializerMethodField()
-    submitter = serializers.SerializerMethodField()
-    org_unit = serializers.SerializerMethodField()
-    duplicates = serializers.SerializerMethodField()
-    nfc_cards = serializers.SerializerMethodField()
-    migration_source = serializers.SerializerMethodField()
-
-    def get_attributes(self, entity: Entity):
-        if entity.attributes:
-            return entity.attributes.as_dict()
-        return None
-
-    def get_org_unit(self, entity: Entity):
-        if entity.attributes and entity.attributes.org_unit:
-            return entity.attributes.org_unit.as_dict_for_entity()
-        return None
-
-    def get_submitter(self, entity: Entity):
-        try:
-            # TODO: investigate type issue on next line
-            submitter = entity.attributes.created_by.username  # type: ignore
-        except AttributeError:
-            submitter = None
-        return submitter
-
-    def get_duplicates(self, entity: Entity):
-        return _get_duplicates(entity)
-
-    def get_nfc_cards(self, entity: Entity):
-        nfc_count = StorageDevice.objects.filter(entity=entity, type=StorageDevice.NFC).count()
-        return nfc_count
-
-    @staticmethod
-    def get_entity_type_name(obj: Entity):
-        return obj.entity_type.name if obj.entity_type else None
-
-    def get_migration_source(self, obj: Entity):
-        if not obj.attributes:
-            return None
-
-        if obj.attributes.patient_set.exists():
-            patient = obj.attributes.patient_set.first()
-            if patient:
-                return patient.id
-
-        return None
-
-
-def _get_duplicates(entity):
-    results = []
-    e1qs = entity.duplicates1.filter(validation_status=ValidationStatus.PENDING)
-    e2qs = entity.duplicates2.filter(validation_status=ValidationStatus.PENDING)
-    if e1qs.count() > 0:
-        results = results + list(map(lambda x: x.entity2.id, e1qs.all()))
-    elif e2qs.count() > 0:
-        results = results + list(map(lambda x: x.entity1.id, e2qs.all()))
-    return results
+from .serializers import EntitySerializer
 
 
 class EntityViewSet(ModelViewSet):

--- a/iaso/api/storage.py
+++ b/iaso/api/storage.py
@@ -16,7 +16,7 @@ from rest_framework.response import Response
 import iaso.permissions as core_permissions
 
 from hat.api.export_utils import Echo, generate_xlsx, iter_items, timestamp_to_utc_datetime
-from iaso.api.entity import EntitySerializer
+from iaso.api.entities.serializers import EntitySerializer
 from iaso.api.serializers import OrgUnitSerializer
 from iaso.models import Entity, Instance, OrgUnit, StorageDevice, StorageLogEntry
 

--- a/iaso/urls.py
+++ b/iaso/urls.py
@@ -50,7 +50,7 @@ from .api.enketo import (
     enketo_public_create_url,
     enketo_public_launch,
 )
-from .api.entity import EntityViewSet
+from .api.entities.views import EntityViewSet
 from .api.entity_types import EntityTypeViewSet
 from .api.export_requests import ExportRequestsViewSet
 from .api.feature_flags import FeatureFlagViewSet


### PR DESCRIPTION
This PR attempts to address perf issues in the Entities list page (mega-slow for Trypelim with > 1M entities)

- Refactoring: Format entities API to IASO structure
- Improve performance of the entities list page
  - TEMP: Ignore the duplicates, they're not used now
  - Remove 2 problematic `select_related` clauses: this gives the biggest
  gain I think, since it adds SQL joins on massive tables.
  - Use minimal dict for org units when possible
  - Only fetch fields we need for instances

Helpful article about `select_related` vs `prefetch_related`: https://medium.com/@akhilvp/optimizing-django-queries-select-related-vs-prefetch-related-for-large-databases-724da5c743a4

I think the next step could be to add a `last_synced_at` to the `iaso_entities` table, that we maintain synced with the newest instance. This would mean we could avoid the join on the `iaso_instances` table, I think that would be a huge gain.