### PR TITLE
IA-4506: workflows operators < and >

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/workflows/config/followUps.tsx
+++ b/hat/assets/js/apps/Iaso/domains/workflows/config/followUps.tsx
@@ -1,3 +1,4 @@
+import React, { ReactNode } from 'react';
 import { Box } from '@mui/material';
 import {
     Column,
@@ -5,15 +6,14 @@ import {
     QueryBuilderFields,
     useSafeIntl,
 } from 'bluesquare-components';
-import React, { ReactNode } from 'react';
 
 import { DateCell } from '../../../components/Cells/DateTimeCell';
 import { getLocaleDateFormat } from '../../../utils/dates';
 import { LinkToForm } from '../../forms/components/LinkToForm';
-import MESSAGES from '../messages';
-
 import { Field } from '../../forms/fields/constants';
 import { FollowUpActionCell } from '../components/followUps/ActionCell';
+import MESSAGES from '../messages';
+
 import { WorkflowVersionDetail } from '../types';
 
 interface FollowUpsColumns extends Column {
@@ -57,6 +57,8 @@ export const iasoFields: Field[] = [
             operators: [
                 'equal',
                 'not_equal',
+                'greater',
+                'less',
                 'greater_or_equal',
                 'less_or_equal',
                 'is_null',
@@ -72,6 +74,8 @@ export const iasoFields: Field[] = [
             operators: [
                 'equal',
                 'not_equal',
+                'greater',
+                'less',
                 'greater_or_equal',
                 'less_or_equal',
                 'is_null',
@@ -101,6 +105,8 @@ export const iasoFields: Field[] = [
             operators: [
                 'equal',
                 'not_equal',
+                'greater',
+                'less',
                 'greater_or_equal',
                 'less_or_equal',
                 'is_null',
@@ -115,6 +121,8 @@ export const iasoFields: Field[] = [
             operators: [
                 'equal',
                 'not_equal',
+                'greater',
+                'less',
                 'greater_or_equal',
                 'less_or_equal',
                 'is_null',
@@ -144,6 +152,8 @@ export const iasoFields: Field[] = [
             operators: [
                 'equal',
                 'not_equal',
+                'greater',
+                'less',
                 'greater_or_equal',
                 'less_or_equal',
                 'is_null',
@@ -225,6 +235,8 @@ export const iasoFields: Field[] = [
             operators: [
                 'equal',
                 'not_equal',
+                'greater',
+                'less',
                 'greater_or_equal',
                 'less_or_equal',
                 'is_null',

--- a/hat/assets/js/apps/Iaso/domains/workflows/details.tsx
+++ b/hat/assets/js/apps/Iaso/domains/workflows/details.tsx
@@ -30,24 +30,24 @@ import { useParamsObject } from '../../routing/hooks/useParamsObject';
 import { useGetFormDescriptor } from '../forms/fields/hooks/useGetFormDescriptor';
 import { useGetQueryBuilderListToReplace } from '../forms/fields/hooks/useGetQueryBuilderListToReplace';
 import { useGetQueryBuildersFields } from '../forms/fields/hooks/useGetQueryBuildersFields';
+import { useGetPossibleFieldsByFormVersion } from '../forms/hooks/useGetPossibleFields';
+import { PossibleField } from '../forms/types/forms';
+import { AddChangeModal } from './components/changes/Modal';
+import { AddFollowUpsModal } from './components/followUps/Modal';
+import { FollowUpsTable } from './components/followUps/Table';
+import { WorkflowBaseInfo } from './components/WorkflowBaseInfo';
+import { useGetChangesColumns } from './config/changes';
+import { useGetFollowUpsColumns, iasoFields } from './config/followUps';
+import { useBulkUpdateWorkflowFollowUp } from './hooks/requests/useBulkUpdateWorkflowFollowUp';
 import { useGetWorkflowVersionChanges } from './hooks/requests/useGetWorkflowVersionChanges';
 import { useGetWorkflowVersion } from './hooks/requests/useGetWorkflowVersions';
 import MESSAGES from './messages';
-import { useBulkUpdateWorkflowFollowUp } from './hooks/requests/useBulkUpdateWorkflowFollowUp';
 import {
     WorkflowVersionDetail,
     WorkflowParams,
     FollowUps,
     Change,
 } from './types';
-import { WorkflowBaseInfo } from './components/WorkflowBaseInfo';
-import { FollowUpsTable } from './components/followUps/Table';
-import { AddFollowUpsModal } from './components/followUps/Modal';
-import { AddChangeModal } from './components/changes/Modal';
-import { useGetChangesColumns } from './config/changes';
-import { useGetFollowUpsColumns, iasoFields } from './config/followUps';
-import { useGetPossibleFieldsByFormVersion } from '../forms/hooks/useGetPossibleFields';
-import { PossibleField } from '../forms/types/forms';
 
 const useStyles = makeStyles(theme => ({
     ...commonStyles(theme),

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
                 "abortcontroller-polyfill": "^1.7.5",
                 "array-flat-polyfill": "^1.0.1",
                 "babel-plugin-formatjs": "^10.3.4",
-                "bluesquare-components": "github:BLSQ/bluesquare-components#IA-4506-worflows-operators",
+                "bluesquare-components": "github:BLSQ/bluesquare-components",
                 "classnames": "^2.2.6",
                 "color": "^3.1.2",
                 "dom-to-pdf": "^0.3.1",
@@ -7226,7 +7226,7 @@
         },
         "node_modules/bluesquare-components": {
             "version": "1.0.0",
-            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#2ded30776e38dfcfc89714ed2382be8862975d99",
+            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#13839a63cf6313b30b3142cb4c2b1c156ea1922a",
             "license": "Apache-2.0",
             "dependencies": {
                 "@babel/plugin-transform-class-properties": "^7.24.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
                 "abortcontroller-polyfill": "^1.7.5",
                 "array-flat-polyfill": "^1.0.1",
                 "babel-plugin-formatjs": "^10.3.4",
-                "bluesquare-components": "github:BLSQ/bluesquare-components",
+                "bluesquare-components": "github:BLSQ/bluesquare-components#IA-4506-worflows-operators",
                 "classnames": "^2.2.6",
                 "color": "^3.1.2",
                 "dom-to-pdf": "^0.3.1",
@@ -7226,7 +7226,7 @@
         },
         "node_modules/bluesquare-components": {
             "version": "1.0.0",
-            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#c7b59501a7e810b3c8df7223fadfacd7a20e2418",
+            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#2ded30776e38dfcfc89714ed2382be8862975d99",
             "license": "Apache-2.0",
             "dependencies": {
                 "@babel/plugin-transform-class-properties": "^7.24.6",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
         "abortcontroller-polyfill": "^1.7.5",
         "array-flat-polyfill": "^1.0.1",
         "babel-plugin-formatjs": "^10.3.4",
-        "bluesquare-components": "github:BLSQ/bluesquare-components#IA-4506-worflows-operators",
+        "bluesquare-components": "github:BLSQ/bluesquare-components",
         "classnames": "^2.2.6",
         "color": "^3.1.2",
         "dom-to-pdf": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
         "abortcontroller-polyfill": "^1.7.5",
         "array-flat-polyfill": "^1.0.1",
         "babel-plugin-formatjs": "^10.3.4",
-        "bluesquare-components": "github:BLSQ/bluesquare-components",
+        "bluesquare-components": "github:BLSQ/bluesquare-components#IA-4506-worflows-operators",
         "classnames": "^2.2.6",
         "color": "^3.1.2",
         "dom-to-pdf": "^0.3.1",


### PR DESCRIPTION
Request to add greater than (>) and less than (<) operators in the workflow logic formulations as discussed in the chat.

Related JIRA tickets : IA-4506

- [ ] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

- 

## Changes

- adding operators to follow up config
- did the same on bluesquare components

## How to test

Edit / create a follow up on a workflow, select  a field (date, number, datetime) make sure the < and > operators are present in the dropdown 

## Print screen / video

<img width="910" height="609" alt="Screenshot 2025-10-14 at 11 13 39" src="https://github.com/user-attachments/assets/9eb2a5d8-0382-4b51-91d9-a68a3d48eee9" />


## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
