### PR TITLE
IA-4510: change request multi select count is wrong

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/Tables/ReviewOrgUnitChangesTable.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/Tables/ReviewOrgUnitChangesTable.tsx
@@ -220,7 +220,7 @@ export const ReviewOrgUnitChangesTable: FunctionComponent<Props> = ({
     const isRestoreAction = params.is_soft_deleted === 'true';
 
     const { selection, handleTableSelection, handleUnselectAll } =
-        useTableSelection<OrgUnitChangeRequest>(data?.results?.length ?? 0);
+        useTableSelection<OrgUnitChangeRequest>(data?.count ?? 0);
 
     const [multiActionPopupOpen, setMultiActionPopupOpen] =
         useState<boolean>(false);
@@ -298,11 +298,7 @@ export const ReviewOrgUnitChangesTable: FunctionComponent<Props> = ({
                 selection={selection}
                 selectionActions={selectionActions}
                 setTableSelection={(selectionType, items) =>
-                    handleTableSelection(
-                        selectionType,
-                        items,
-                        data?.results?.length,
-                    )
+                    handleTableSelection(selectionType, items, data?.count)
                 }
             />
         </>


### PR DESCRIPTION
Select "all changerequest" count is incoherent and misleading

Related JIRA tickets : IA-4510

## Self proofreading checklist

- [ ] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

-

## Changes

- use count instead of result length

## How to test

Make sure you have more change request than pagination, select all, make sure count is correct

## Print screen / video

<img width="1124" height="877" alt="Screenshot 2025-10-14 at 11 34 15" src="https://github.com/user-attachments/assets/af47f1b7-7826-487c-a4da-c64f6875137e" />


## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
