### PR TITLE
IA-4486: restore org unit doesn't restore org unit type

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/details.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/details.tsx
@@ -276,11 +276,10 @@ const OrgUnitDetail: FunctionComponent = () => {
             mappedRevision.groups = group_ids;
             saveOu(mappedRevision).then(res => {
                 refreshOrgUnitQueryCache(res);
-                queryClient.invalidateQueries('currentOrgUnit');
                 onSuccess();
             });
         },
-        [currentOrgUnit, refreshOrgUnitQueryCache, saveOu, queryClient],
+        [currentOrgUnit, refreshOrgUnitQueryCache, saveOu],
     );
     const handleSaveOrgUnit = useCallback(
         (newOrgUnit = {}, onSuccess = () => {}, onError = () => {}) => {
@@ -305,7 +304,6 @@ const OrgUnitDetail: FunctionComponent = () => {
                         });
                     }
                     refreshOrgUnitQueryCache(ou);
-                    queryClient.invalidateQueries('logs');
                     onSuccess(ou);
                 })
                 .catch(onError);

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/details.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/details.tsx
@@ -257,6 +257,7 @@ const OrgUnitDetail: FunctionComponent = () => {
             const mappedRevision = {
                 ...currentOrgUnit,
                 ...revision,
+                org_unit_type_id: revision.org_unit_type?.id,
                 location,
                 geo_json: null, // this line to prevent overwriting the geo_json with a simplified shape/ Disables restoring a previous version of a single shape
                 aliases,
@@ -275,10 +276,11 @@ const OrgUnitDetail: FunctionComponent = () => {
             mappedRevision.groups = group_ids;
             saveOu(mappedRevision).then(res => {
                 refreshOrgUnitQueryCache(res);
+                queryClient.invalidateQueries('currentOrgUnit');
                 onSuccess();
             });
         },
-        [currentOrgUnit, refreshOrgUnitQueryCache, saveOu],
+        [currentOrgUnit, refreshOrgUnitQueryCache, saveOu, queryClient],
     );
     const handleSaveOrgUnit = useCallback(
         (newOrgUnit = {}, onSuccess = () => {}, onError = () => {}) => {
@@ -303,6 +305,7 @@ const OrgUnitDetail: FunctionComponent = () => {
                         });
                     }
                     refreshOrgUnitQueryCache(ou);
+                    queryClient.invalidateQueries('logs');
                     onSuccess(ou);
                 })
                 .catch(onError);
@@ -314,6 +317,7 @@ const OrgUnitDetail: FunctionComponent = () => {
             redirectToReplace,
             refreshOrgUnitQueryCache,
             saveOu,
+            queryClient,
         ],
     );
 

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/hooks.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/hooks.ts
@@ -230,7 +230,11 @@ export const useSaveOrgUnit = (
 
 export const useRefreshOrgUnit = () => {
     const queryClient = useQueryClient();
-    return data => queryClient.setQueryData(['forms', data.id], data);
+    return data => {
+        queryClient.invalidateQueries('currentOrgUnit');
+        queryClient.invalidateQueries('logs');
+        return queryClient.setQueryData(['forms', data.id], data);
+    };
 };
 
 export const useOrgUnitTabParams = (params, paramsPrefix) => {


### PR DESCRIPTION
Restoring version of OU through the historical change is not complete

Related JIRA tickets : IA-4486
## Self proofreading checklist

- [ ] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

use org_unit_type_id and invalidate data

## How to test

Edit an org unit and change the type, go to history tab. restore previous value, org unit types should ba back to initial value

## Print screen / video

https://github.com/user-attachments/assets/dd5b5bbd-aff4-42eb-91f7-97b4306872f4


## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
