### PR TITLE
WC2-831: Fix cannot load storage details of truncated id

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/storages/config.tsx
+++ b/hat/assets/js/apps/Iaso/domains/storages/config.tsx
@@ -1,23 +1,22 @@
 import React from 'react';
 import {
+    Column,
+    IntlFormatMessage,
     useSafeIntl,
     IconButton as IconButtonComponent,
-    IntlFormatMessage,
-    Column,
 } from 'bluesquare-components';
-
-import { LinkToOrgUnit } from '../orgUnits/components/LinkToOrgUnit';
-import { DateTimeCell } from '../../components/Cells/DateTimeCell';
-import { StatusCell } from './components/StatusCell';
-import { LinkToEntity } from './components/LinkToEntity';
-import { LinkToInstance } from '../instances/components/LinkToInstance';
-import { baseUrls } from '../../constants/urls';
-import { StorageParams } from './types/storages';
+import { DateTimeCell } from 'Iaso/components/Cells/DateTimeCell';
+import { baseUrls } from 'Iaso/constants/urls';
 import getDisplayName from '../../utils/usersUtils';
+import { LinkToInstance } from '../instances/components/LinkToInstance';
+import { LinkToOrgUnit } from '../orgUnits/components/LinkToOrgUnit';
+import { LinkToEntity } from './components/LinkToEntity';
+import { StatusCell } from './components/StatusCell';
 import { useGetOperationsTypesLabel } from './hooks/useGetOperationsTypes';
 import { useGetReasons } from './hooks/useGetReasons';
 import { useGetStatus } from './hooks/useGetStatus';
 import MESSAGES from './messages';
+import { Storage, StorageParams } from './types/storages';
 
 export const defaultSorted = [{ id: 'updated_at', desc: false }];
 
@@ -74,9 +73,11 @@ export const useGetColumns = (params: StorageParams): Array<Column> => {
             sortable: false,
             accessor: 'actions',
             Cell: settings => {
+                const storage = settings.row.original as Storage;
+                const url = `/${baseUrls.storageDetail}/type/${settings.row.original.storage_type}/storageId/${storage.id}`;
                 return (
                     <IconButtonComponent
-                        url={`/${baseUrls.storageDetail}/type/${settings.row.original.storage_type}/storageId/${settings.row.original.storage_id}`}
+                        url={url}
                         icon="remove-red-eye"
                         tooltipMessage={MESSAGES.see}
                     />
@@ -101,7 +102,7 @@ export const useGetColumns = (params: StorageParams): Array<Column> => {
 export const useGetDetailsColumns = (): Array<Column> => {
     const { formatMessage }: { formatMessage: IntlFormatMessage } =
         useSafeIntl();
-    const getOparationTypeLabel = useGetOperationsTypesLabel();
+    const getOperationTypeLabel = useGetOperationsTypesLabel();
     const reasons = useGetReasons();
     const statusList = useGetStatus();
     return [
@@ -123,7 +124,7 @@ export const useGetDetailsColumns = (): Array<Column> => {
             accessor: 'operation_type',
             id: 'operation_type',
             Cell: settings =>
-                getOparationTypeLabel(settings.row.original.operation_type),
+                getOperationTypeLabel(settings.row.original.operation_type),
         },
         {
             Header: formatMessage(MESSAGES.status),
@@ -179,7 +180,7 @@ export const useGetDetailsColumns = (): Array<Column> => {
             Cell: settings => {
                 const { instances } = settings.row.original;
                 if (instances.length === 0) return '-';
-                return instances.map((instanceId, index) => (
+                return instances.map((instanceId: string, index: number) => (
                     <span key={instanceId}>
                         <LinkToInstance instanceId={instanceId} />
                         {index + 1 < instances.length && ', '}
@@ -205,5 +206,3 @@ export const useGetDetailsColumns = (): Array<Column> => {
         },
     ];
 };
-
-useGetOperationsTypesLabel;

--- a/hat/assets/js/apps/Iaso/domains/storages/hooks/requests/useGetStorageLogs.ts
+++ b/hat/assets/js/apps/Iaso/domains/storages/hooks/requests/useGetStorageLogs.ts
@@ -1,7 +1,7 @@
 import { UseQueryResult } from 'react-query';
-import { getRequest } from '../../../../libs/Api';
-import { useSnackQuery } from '../../../../libs/apiHooks';
-import { makeUrlWithParams } from '../../../../libs/utils';
+import { getRequest } from 'Iaso/libs/Api';
+import { useSnackQuery } from 'Iaso/libs/apiHooks';
+import { makeUrlWithParams } from 'Iaso/libs/utils';
 import { PaginatedStorage, StorageDetailsParams } from '../../types/storages';
 
 type ApiParams = {
@@ -10,8 +10,6 @@ type ApiParams = {
     page: string;
     types?: string;
     performed_at?: string;
-    type: string;
-    storageId: string;
 };
 type GetAPiParams = {
     url: string;
@@ -24,8 +22,6 @@ export const useGetApiParams = (params: StorageDetailsParams): GetAPiParams => {
         performedAt,
         order,
         page,
-        type,
-        storageId,
     }: StorageDetailsParams = params;
     const apiParams: ApiParams = {
         limit: pageSize || '20',
@@ -33,13 +29,10 @@ export const useGetApiParams = (params: StorageDetailsParams): GetAPiParams => {
         performed_at: performedAt,
         order,
         page,
-        type,
-        storageId,
     };
-    const baseUrl = `/api/storages/${type}/${storageId}/logs`;
-    const url = makeUrlWithParams(baseUrl, apiParams);
+    const baseUrl = `/api/storages/${params.type}/${params.storageId}/logs`;
     return {
-        url,
+        url: baseUrl,
         apiParams,
     };
 };
@@ -48,7 +41,7 @@ const getStorageLogs = async (
     baseUrl: string,
 ): Promise<PaginatedStorage> => {
     const url = makeUrlWithParams(baseUrl, apiParams);
-    return getRequest(url) as Promise<PaginatedStorage>;
+    return await getRequest(url);
 };
 
 export const useGetStorageLogs = (

--- a/hat/assets/js/apps/Iaso/domains/storages/types/storages.ts
+++ b/hat/assets/js/apps/Iaso/domains/storages/types/storages.ts
@@ -33,6 +33,7 @@ type Log = {
 };
 
 export type Storage = {
+    id: number;
     storage_id: string;
     updated_at: number;
     created_at: number;

--- a/hat/assets/js/apps/Iaso/domains/storages/types/storages.ts
+++ b/hat/assets/js/apps/Iaso/domains/storages/types/storages.ts
@@ -1,5 +1,5 @@
 import { Pagination, UrlParams } from 'bluesquare-components';
-import { Profile } from '../../../utils/usersUtils';
+import { Profile } from 'Iaso/utils/usersUtils';
 import { ShortOrgUnit } from '../../orgUnits/types/orgUnit';
 
 export type StorageFilterParams = {
@@ -22,10 +22,18 @@ export type StorageStatus = {
     comment?: string;
 };
 
-type Log = {
-    operation_type: 'OK' | 'BLACKLISTED';
+export type Log = {
+    operation_type:
+        | 'WRITE_PROFILE'
+        | 'RESET'
+        | 'READ'
+        | 'WRITE_RECORD'
+        | 'CHANGE_STATUS';
+    status?: 'OK' | 'BLACKLISTED';
+    status_reason?: string;
+    status_comment?: string;
     storage_status: StorageStatus;
-    forms: Array<number>; // array of instances ids
+    instances: Array<number>; // array of instances ids
     org_unit: ShortOrgUnit;
     entity: any;
     performed_at: number;

--- a/iaso/api/storage.py
+++ b/iaso/api/storage.py
@@ -4,9 +4,9 @@ import datetime
 from typing import Any, List, Tuple, Union
 
 from django.core.paginator import Paginator
-from django.db.models import Prefetch, Q, QuerySet
+from django.db.models import Q, QuerySet
 from django.http import HttpResponse, StreamingHttpResponse
-from rest_framework import permissions, serializers, status, viewsets
+from rest_framework import exceptions, permissions, serializers, status, viewsets
 from rest_framework.decorators import action, api_view, permission_classes
 from rest_framework.fields import Field
 from rest_framework.mixins import CreateModelMixin, ListModelMixin
@@ -15,8 +15,8 @@ from rest_framework.response import Response
 
 from hat.api.export_utils import Echo, generate_xlsx, iter_items, timestamp_to_utc_datetime
 from iaso.api.entity import EntitySerializer
-from iaso.api.serializers import OrgUnitSerializer
-from iaso.models import Entity, Instance, OrgUnit, StorageDevice, StorageLogEntry
+from iaso.api.serializers import AppIdSerializer, OrgUnitSerializer
+from iaso.models import Entity, Instance, OrgUnit, Project, StorageDevice, StorageLogEntry
 from iaso.permissions.core_permissions import CORE_STORAGE_PERMISSION
 
 from .common import (
@@ -123,6 +123,7 @@ class StorageSerializer(serializers.ModelSerializer):
         fields: Tuple[str, ...] = (
             "updated_at",
             "created_at",
+            "id",
             "storage_id",
             "storage_type",
             "storage_status",
@@ -480,7 +481,7 @@ def logs_for_device_generate_export(
 
 @api_view()
 @permission_classes([IsAuthenticated, HasPermission(CORE_STORAGE_PERMISSION)])
-def logs_per_device(request, storage_customer_chosen_id: str, storage_type: str):
+def logs_per_device(request, storage_id: str, storage_type: str):
     """Return a list of log entries for a given device"""
 
     # 1. Retrieve data from request
@@ -509,15 +510,14 @@ def logs_per_device(request, storage_customer_chosen_id: str, storage_type: str)
 
     performed_at_str = request.GET.get("performed_at", None)
 
-    device_identity_fields = {
-        "customer_chosen_id": storage_customer_chosen_id,
-        "type": storage_type,
-        "account": user_account,
-    }
-
     # We need to filter the log entries early or the paginator (count, ...) will have inconsistent values with the
     # prefetched log entries later
-    device = StorageDevice.objects.get(**device_identity_fields)
+    device = (
+        StorageDevice.objects.filter(Q(id=storage_id) | Q(customer_chosen_id=storage_id))
+        .filter(type=storage_type)
+        .filter(account=user_account)
+        .get()
+    )
     log_entries_queryset = StorageLogEntry.objects.filter(device=device).order_by(*order)
 
     if org_unit_id is not None:
@@ -534,15 +534,9 @@ def logs_per_device(request, storage_customer_chosen_id: str, storage_type: str)
             performed_at__date=datetime.datetime.strptime(performed_at_str, "%Y-%m-%d").date()
         )
 
-    if not file_export:
-        device_with_logs = StorageDevice.objects.prefetch_related(
-            Prefetch(
-                "log_entries",
-                log_entries_queryset,
-                to_attr="filtered_log_entries",
-            )
-        ).get(**device_identity_fields)
+    device.filtered_log_entries = log_entries_queryset
 
+    if not file_export:
         if limit_str:
             # Pagination as requested: each page contains the device metadata + a subset of log entries
             limit = int(limit_str)
@@ -553,7 +547,7 @@ def logs_per_device(request, storage_customer_chosen_id: str, storage_type: str)
                 page_offset = paginator.num_pages
             page = paginator.page(page_offset)
             res["results"] = StorageSerializerWithPaginatedLogs(  # type: ignore
-                device_with_logs, context={"limit": limit, "offset": page.start_index() - 1}
+                device, context={"limit": limit, "offset": max(page.start_index() - 1, 0)}
             ).data
             res["has_next"] = page.has_next()
             res["has_previous"] = page.has_previous()
@@ -561,7 +555,7 @@ def logs_per_device(request, storage_customer_chosen_id: str, storage_type: str)
             res["pages"] = paginator.num_pages
             res["limit"] = limit
             return Response(res)
-        return Response(StorageSerializerWithLogs(device_with_logs).data)
+        return Response(StorageSerializerWithLogs(device).data)
     # File export requested
     return logs_for_device_generate_export(queryset=log_entries_queryset, file_format=file_format_export)
 
@@ -595,5 +589,15 @@ class StorageBlacklistedViewSet(ListModelMixin, viewsets.GenericViewSet):
         Returns a list of blacklisted devices
         """
         queryset = self.get_queryset()
+        app_id = AppIdSerializer(data=self.request.query_params).get_app_id(raise_exception=False)
+        if app_id is not None:
+            try:
+                project = Project.objects.get_for_user_and_app_id(user=self.request.user, app_id=app_id)
+                queryset = queryset.filter(account=project.account)
+            except Project.DoesNotExist:
+                if self.request.user.is_anonymous:
+                    raise exceptions.NotAuthenticated
+                raise exceptions.NotFound(f"Project not found for {app_id}")
+
         serializer = self.get_serializer(queryset, many=True)
         return Response({"storages": serializer.data})

--- a/iaso/tests/api/test_storage.py
+++ b/iaso/tests/api/test_storage.py
@@ -546,6 +546,7 @@ class StorageAPITestCase(APITestCase):
                 {
                     "updated_at": 1580608922.0,
                     "created_at": 1580608922.0,
+                    "id": self.existing_storage_device.id,
                     "storage_id": "EXISTING_STORAGE",
                     "storage_type": "NFC",
                     "storage_status": {"status": "OK", "updated_at": "2020-02-02T02:02:02Z"},
@@ -555,6 +556,7 @@ class StorageAPITestCase(APITestCase):
                 {
                     "updated_at": 1580608922.0,
                     "created_at": 1580608922.0,
+                    "id": self.existing_storage_device_2.id,
                     "storage_id": "ANOTHER_EXISTING_STORAGE_BLACKLISTED_STOLEN",
                     "storage_type": "NFC",
                     "storage_status": {
@@ -569,6 +571,7 @@ class StorageAPITestCase(APITestCase):
                 {
                     "updated_at": 1580608922.0,
                     "created_at": 1580608922.0,
+                    "id": self.existing_storage_device_3.id,
                     "storage_id": "ANOTHER_EXISTING_STORAGE_BLACKLISTED_ABUSE",
                     "storage_type": "SD",
                     "storage_status": {
@@ -594,6 +597,7 @@ class StorageAPITestCase(APITestCase):
                 {
                     "updated_at": 1580608922.0,
                     "created_at": 1580608922.0,
+                    "id": self.existing_storage_device_2.id,
                     "storage_id": "ANOTHER_EXISTING_STORAGE_BLACKLISTED_STOLEN",
                     "storage_type": "NFC",
                     "storage_status": {
@@ -608,6 +612,7 @@ class StorageAPITestCase(APITestCase):
                 {
                     "updated_at": 1580608922.0,
                     "created_at": 1580608922.0,
+                    "id": self.existing_storage_device_3.id,
                     "storage_id": "ANOTHER_EXISTING_STORAGE_BLACKLISTED_ABUSE",
                     "storage_type": "SD",
                     "storage_status": {
@@ -635,6 +640,7 @@ class StorageAPITestCase(APITestCase):
                 {
                     "updated_at": 1580608922.0,
                     "created_at": 1580608922.0,
+                    "id": self.existing_storage_device_2.id,
                     "storage_id": "ANOTHER_EXISTING_STORAGE_BLACKLISTED_STOLEN",
                     "storage_type": "NFC",
                     "storage_status": {
@@ -660,6 +666,7 @@ class StorageAPITestCase(APITestCase):
                 {
                     "updated_at": 1580608922.0,
                     "created_at": 1580608922.0,
+                    "id": self.existing_storage_device.id,
                     "storage_id": "EXISTING_STORAGE",
                     "storage_type": "NFC",
                     "storage_status": {"status": "OK", "updated_at": "2020-02-02T02:02:02Z"},
@@ -669,6 +676,7 @@ class StorageAPITestCase(APITestCase):
                 {
                     "updated_at": 1580608922.0,
                     "created_at": 1580608922.0,
+                    "id": self.existing_storage_device_2.id,
                     "storage_id": "ANOTHER_EXISTING_STORAGE_BLACKLISTED_STOLEN",
                     "storage_type": "NFC",
                     "storage_status": {
@@ -709,6 +717,7 @@ class StorageAPITestCase(APITestCase):
                 {
                     "updated_at": 1580608922.0,
                     "created_at": 1580608922.0,
+                    "id": self.existing_storage_device.id,
                     "storage_id": "EXISTING_STORAGE",
                     "storage_type": "NFC",
                     "storage_status": {"status": "OK", "updated_at": "2020-02-02T02:02:02Z"},
@@ -718,6 +727,7 @@ class StorageAPITestCase(APITestCase):
                 {
                     "updated_at": 1580608922.0,
                     "created_at": 1580608922.0,
+                    "id": self.existing_storage_device_3.id,
                     "storage_id": "ANOTHER_EXISTING_STORAGE_BLACKLISTED_ABUSE",
                     "storage_type": "SD",
                     "storage_status": {
@@ -868,19 +878,19 @@ class StorageAPITestCase(APITestCase):
 
     def test_get_logs_for_device_unauthenticated(self):
         """A non authenticated user should receive a 401"""
-        response = self.client.get("/api/storages/NFC/EXISTING_STORAGE/logs")
+        response = self.client.get(f"/api/storages/NFC/{self.existing_storage_device.id}/logs")
         self.assertEqual(response.status_code, 401)
 
     def test_get_logs_for_device_insufficient_permissions(self):
         """A user without the "iaso_storages" permission should receive a 403"""
         self.client.force_authenticate(self.another_user)
-        response = self.client.get("/api/storages/NFC/EXISTING_STORAGE/logs")
+        response = self.client.get(f"/api/storages/NFC/{self.existing_storage_device.id}/logs")
         self.assertEqual(response.status_code, 403)
 
     def test_get_logs_for_device_base(self):
         """Test the basics of the logs per device endpoint"""
         self.client.force_authenticate(self.yoda)
-        response = self.client.get("/api/storages/NFC/EXISTING_STORAGE/logs")
+        response = self.client.get(f"/api/storages/NFC/{self.existing_storage_device.id}/logs")
         self.assertEqual(response.status_code, 200)
         received_json = response.json()
         self.assertDictEqual(
@@ -888,6 +898,7 @@ class StorageAPITestCase(APITestCase):
             {
                 "updated_at": 1580608922.0,
                 "created_at": 1580608922.0,
+                "id": self.existing_storage_device.id,
                 "storage_id": "EXISTING_STORAGE",
                 "storage_type": "NFC",
                 "storage_status": {"status": "OK", "updated_at": "2020-02-02T02:02:02Z"},
@@ -922,7 +933,9 @@ class StorageAPITestCase(APITestCase):
         """The logs per device endpoint can be filtered by org_unit_id"""
         self.client.force_authenticate(self.yoda)
         # 1. Case one: no logs because no log entries for this device refer to the given OU
-        response = self.client.get(f"/api/storages/NFC/EXISTING_STORAGE/logs?org_unit_id={self.org_unit.id}")
+        response = self.client.get(
+            f"/api/storages/NFC/{self.existing_storage_device.id}/logs?org_unit_id={self.org_unit.id}"
+        )
 
         self.assertEqual(response.status_code, 200)
         received_json = response.json()
@@ -931,6 +944,7 @@ class StorageAPITestCase(APITestCase):
             {
                 "updated_at": 1580608922.0,
                 "created_at": 1580608922.0,
+                "id": self.existing_storage_device.id,
                 "storage_id": "EXISTING_STORAGE",
                 "storage_type": "NFC",
                 "storage_status": {"status": "OK", "updated_at": "2020-02-02T02:02:02Z"},
@@ -954,7 +968,9 @@ class StorageAPITestCase(APITestCase):
         )
 
         # This time, it should be returned
-        response = self.client.get(f"/api/storages/NFC/EXISTING_STORAGE/logs?org_unit_id={self.org_unit.id}")
+        response = self.client.get(
+            f"/api/storages/NFC/{self.existing_storage_device.id}/logs?org_unit_id={self.org_unit.id}"
+        )
         received_json = response.json()
         self.assertEqual(response.status_code, 200)
         self.assertDictEqual(
@@ -962,6 +978,7 @@ class StorageAPITestCase(APITestCase):
             {
                 "updated_at": 1580608922.0,
                 "created_at": 1580608922.0,
+                "id": self.existing_storage_device.id,
                 "storage_id": "EXISTING_STORAGE",
                 "storage_type": "NFC",
                 "storage_status": {"status": "OK", "updated_at": "2020-02-02T02:02:02Z"},
@@ -997,7 +1014,7 @@ class StorageAPITestCase(APITestCase):
         self.client.force_authenticate(self.yoda)
 
         # Case 1: we request WRITE_PROFILE, there is one from setupTestData
-        response = self.client.get("/api/storages/NFC/EXISTING_STORAGE/logs?types=WRITE_PROFILE")
+        response = self.client.get(f"/api/storages/NFC/{self.existing_storage_device.id}/logs?types=WRITE_PROFILE")
         received_json = response.json()
         self.assertEqual(response.status_code, 200)
         self.assertDictEqual(
@@ -1005,6 +1022,7 @@ class StorageAPITestCase(APITestCase):
             {
                 "updated_at": 1580608922.0,
                 "created_at": 1580608922.0,
+                "id": self.existing_storage_device.id,
                 "storage_id": "EXISTING_STORAGE",
                 "storage_type": "NFC",
                 "storage_status": {"status": "OK", "updated_at": "2020-02-02T02:02:02Z"},
@@ -1036,7 +1054,7 @@ class StorageAPITestCase(APITestCase):
         )
 
         # Case 2: we request WRITE_RECORD, there's currently none
-        response = self.client.get("/api/storages/NFC/EXISTING_STORAGE/logs?types=WRITE_RECORD")
+        response = self.client.get(f"/api/storages/NFC/{self.existing_storage_device.id}/logs?types=WRITE_RECORD")
         self.assertEqual(response.status_code, 200)
         received_json = response.json()
         self.assertDictEqual(
@@ -1044,6 +1062,7 @@ class StorageAPITestCase(APITestCase):
             {
                 "updated_at": 1580608922.0,
                 "created_at": 1580608922.0,
+                "id": self.existing_storage_device.id,
                 "storage_id": "EXISTING_STORAGE",
                 "storage_type": "NFC",
                 "storage_status": {"status": "OK", "updated_at": "2020-02-02T02:02:02Z"},
@@ -1054,7 +1073,9 @@ class StorageAPITestCase(APITestCase):
         )
 
         # Case 3: we request both, there's currently only one WRITE_PROFILE
-        response = self.client.get("/api/storages/NFC/EXISTING_STORAGE/logs?types=WRITE_PROFILE,WRITE_RECORD")
+        response = self.client.get(
+            f"/api/storages/NFC/{self.existing_storage_device.id}/logs?types=WRITE_PROFILE,WRITE_RECORD"
+        )
         self.assertEqual(response.status_code, 200)
         received_json = response.json()
         self.assertDictEqual(
@@ -1062,6 +1083,7 @@ class StorageAPITestCase(APITestCase):
             {
                 "updated_at": 1580608922.0,
                 "created_at": 1580608922.0,
+                "id": self.existing_storage_device.id,
                 "storage_id": "EXISTING_STORAGE",
                 "storage_type": "NFC",
                 "storage_status": {"status": "OK", "updated_at": "2020-02-02T02:02:02Z"},
@@ -1102,7 +1124,9 @@ class StorageAPITestCase(APITestCase):
             org_unit=self.org_unit,
         )
 
-        response = self.client.get("/api/storages/NFC/EXISTING_STORAGE/logs?types=WRITE_PROFILE,WRITE_RECORD&order=id")
+        response = self.client.get(
+            f"/api/storages/NFC/{self.existing_storage_device.id}/logs?types=WRITE_PROFILE,WRITE_RECORD&order=id"
+        )
         self.assertEqual(response.status_code, 200)
         received_json = response.json()
         self.assertEqual(
@@ -1110,6 +1134,7 @@ class StorageAPITestCase(APITestCase):
             {
                 "updated_at": 1580608922.0,
                 "created_at": 1580608922.0,
+                "id": self.existing_storage_device.id,
                 "storage_id": "EXISTING_STORAGE",
                 "storage_type": "NFC",
                 "storage_status": {"status": "OK", "updated_at": "2020-02-02T02:02:02Z"},
@@ -1165,7 +1190,7 @@ class StorageAPITestCase(APITestCase):
         self.client.force_authenticate(self.yoda)
 
         # Case 1: we request the OK status, there is one from setupTestData
-        response = self.client.get("/api/storages/NFC/EXISTING_STORAGE/logs?status=OK")
+        response = self.client.get(f"/api/storages/NFC/{self.existing_storage_device.id}/logs?status=OK")
         self.assertEqual(response.status_code, 200)
         received_json = response.json()
         self.assertDictEqual(
@@ -1173,6 +1198,7 @@ class StorageAPITestCase(APITestCase):
             {
                 "updated_at": 1580608922.0,
                 "created_at": 1580608922.0,
+                "id": self.existing_storage_device.id,
                 "storage_id": "EXISTING_STORAGE",
                 "storage_type": "NFC",
                 "storage_status": {"status": "OK", "updated_at": "2020-02-02T02:02:02Z"},
@@ -1204,7 +1230,7 @@ class StorageAPITestCase(APITestCase):
         )
 
         # Case 2: we request the blacklisted status, there is none
-        response = self.client.get("/api/storages/NFC/EXISTING_STORAGE/logs?status=BLACKLISTED")
+        response = self.client.get(f"/api/storages/NFC/{self.existing_storage_device.id}/logs?status=BLACKLISTED")
         self.assertEqual(response.status_code, 200)
         received_json = response.json()
         self.assertEqual(
@@ -1212,6 +1238,7 @@ class StorageAPITestCase(APITestCase):
             {
                 "updated_at": 1580608922.0,
                 "created_at": 1580608922.0,
+                "id": self.existing_storage_device.id,
                 "storage_id": "EXISTING_STORAGE",
                 "storage_type": "NFC",
                 "storage_status": {"status": "OK", "updated_at": "2020-02-02T02:02:02Z"},
@@ -1225,7 +1252,7 @@ class StorageAPITestCase(APITestCase):
         """The logs per device endpoint can be filtered by (status) reason"""
         self.client.force_authenticate(self.yoda)
 
-        response = self.client.get("/api/storages/NFC/EXISTING_STORAGE/logs?reason=STOLEN")
+        response = self.client.get(f"/api/storages/NFC/{self.existing_storage_device.id}/logs?reason=STOLEN")
         self.assertEqual(response.status_code, 200)
         received_json = response.json()
         self.assertDictEqual(
@@ -1233,6 +1260,7 @@ class StorageAPITestCase(APITestCase):
             {
                 "updated_at": 1580608922.0,
                 "created_at": 1580608922.0,
+                "id": self.existing_storage_device.id,
                 "storage_id": "EXISTING_STORAGE",
                 "storage_type": "NFC",
                 "storage_status": {"status": "OK", "updated_at": "2020-02-02T02:02:02Z"},
@@ -1256,7 +1284,7 @@ class StorageAPITestCase(APITestCase):
             org_unit=self.org_unit,
         )
 
-        response = self.client.get("/api/storages/NFC/EXISTING_STORAGE/logs?performed_at=2022-11-03")
+        response = self.client.get(f"/api/storages/NFC/{self.existing_storage_device.id}/logs?performed_at=2022-11-03")
         self.assertEqual(response.status_code, 200)
         received_json = response.json()
         # if the filter didn't worked, we would also receive the log from setupTestData
@@ -1277,7 +1305,7 @@ class StorageAPITestCase(APITestCase):
         )
 
         # We request the first page
-        response = self.client.get("/api/storages/NFC/EXISTING_STORAGE/logs?limit=1&page=1&order=id")
+        response = self.client.get(f"/api/storages/NFC/{self.existing_storage_device.id}/logs?limit=1&page=1&order=id")
         received_json = response.json()
         self.assertEqual(
             received_json,
@@ -1286,6 +1314,7 @@ class StorageAPITestCase(APITestCase):
                 "results": {
                     "updated_at": 1580608922.0,
                     "created_at": 1580608922.0,
+                    "id": self.existing_storage_device.id,
                     "storage_id": "EXISTING_STORAGE",
                     "storage_type": "NFC",
                     "storage_status": {"status": "OK", "updated_at": "2020-02-02T02:02:02Z"},
@@ -1323,7 +1352,7 @@ class StorageAPITestCase(APITestCase):
         )
 
         # Then the second
-        response = self.client.get("/api/storages/NFC/EXISTING_STORAGE/logs?limit=1&page=2&order=id")
+        response = self.client.get(f"/api/storages/NFC/{self.existing_storage_device.id}/logs?limit=1&page=2&order=id")
         received_json = response.json()
         self.assertDictEqual(
             received_json,
@@ -1332,6 +1361,7 @@ class StorageAPITestCase(APITestCase):
                 "results": {
                     "updated_at": 1580608922.0,
                     "created_at": 1580608922.0,
+                    "id": self.existing_storage_device.id,
                     "storage_id": "EXISTING_STORAGE",
                     "storage_type": "NFC",
                     "storage_status": {"status": "OK", "updated_at": "2020-02-02T02:02:02Z"},
@@ -1369,7 +1399,7 @@ class StorageAPITestCase(APITestCase):
         )
 
         # Then both records on the same page
-        response = self.client.get("/api/storages/NFC/EXISTING_STORAGE/logs?limit=10&page=1&order=id")
+        response = self.client.get(f"/api/storages/NFC/{self.existing_storage_device.id}/logs?limit=10&page=1&order=id")
         received_json = response.json()
         self.assertEqual(
             received_json,
@@ -1378,6 +1408,7 @@ class StorageAPITestCase(APITestCase):
                 "results": {
                     "updated_at": 1580608922.0,
                     "created_at": 1580608922.0,
+                    "id": self.existing_storage_device.id,
                     "storage_id": "EXISTING_STORAGE",
                     "storage_type": "NFC",
                     "storage_status": {"status": "OK", "updated_at": "2020-02-02T02:02:02Z"},
@@ -1448,7 +1479,7 @@ class StorageAPITestCase(APITestCase):
         )
 
         # We request the first page
-        response = self.client.get("/api/storages/NFC/EXISTING_STORAGE/logs?limit=1&page=1&order=id")
+        response = self.client.get(f"/api/storages/NFC/{self.existing_storage_device.id}/logs?limit=1&page=1&order=id")
         received_json = response.json()
         self.assertEqual(received_json["count"], 1)
 
@@ -1467,37 +1498,37 @@ class StorageAPITestCase(APITestCase):
         )
 
         # Ordering by "id"
-        response = self.client.get("/api/storages/NFC/EXISTING_STORAGE/logs?order=id")
+        response = self.client.get(f"/api/storages/NFC/{self.existing_storage_device.id}/logs?order=id")
         received_json = response.json()
         received_data = [e["id"] for e in received_json["logs"]]
         self.assertEqual(received_data, sorted(received_data))
 
         # Ordering by reverse "id"
-        response = self.client.get("/api/storages/NFC/EXISTING_STORAGE/logs?order=-id")
+        response = self.client.get(f"/api/storages/NFC/{self.existing_storage_device.id}/logs?order=-id")
         received_json = response.json()
         received_data = [e["id"] for e in received_json["logs"]]
         self.assertEqual(received_data[::-1], sorted(received_data))
 
         # Ordering by "operation_type"
-        response = self.client.get("/api/storages/NFC/EXISTING_STORAGE/logs?order=operation_type")
+        response = self.client.get(f"/api/storages/NFC/{self.existing_storage_device.id}/logs?order=operation_type")
         received_json = response.json()
         received_data = [e["operation_type"] for e in received_json["logs"]]
         self.assertEqual(received_data, sorted(received_data))
 
         # Ordering by reverse "operation_type"
-        response = self.client.get("/api/storages/NFC/EXISTING_STORAGE/logs?order=-operation_type")
+        response = self.client.get(f"/api/storages/NFC/{self.existing_storage_device.id}/logs?order=-operation_type")
         received_json = response.json()
         received_data = [e["operation_type"] for e in received_json["logs"]]
         self.assertEqual(received_data[::-1], sorted(received_data))
 
         # Ordering by "performed_at"
-        response = self.client.get("/api/storages/NFC/EXISTING_STORAGE/logs?order=performed_at")
+        response = self.client.get(f"/api/storages/NFC/{self.existing_storage_device.id}/logs?order=performed_at")
         received_json = response.json()
         received_data = [e["performed_at"] for e in received_json["logs"]]
         self.assertEqual(received_data, sorted(received_data))
 
         # Ordering by reverse "performed_at"
-        response = self.client.get("/api/storages/NFC/EXISTING_STORAGE/logs?order=-performed_at")
+        response = self.client.get(f"/api/storages/NFC/{self.existing_storage_device.id}/logs?order=-performed_at")
         received_json = response.json()
         received_data = [e["performed_at"] for e in received_json["logs"]]
         self.assertEqual(received_data[::-1], sorted(received_data))
@@ -1698,7 +1729,7 @@ class StorageAPITestCase(APITestCase):
         """A CSV download with decent content is returned"""
         self.client.force_authenticate(self.yoda)
 
-        response = self.client.get("/api/storages/NFC/EXISTING_STORAGE/logs?csv=true")
+        response = self.client.get(f"/api/storages/NFC/{self.existing_storage_device.id}/logs?csv=true")
 
         # 1. Check the response status and content type
         self.assertEqual(response.status_code, 200)
@@ -1749,7 +1780,7 @@ class StorageAPITestCase(APITestCase):
         """A XLSX download with decent content is returned"""
         self.client.force_authenticate(self.yoda)
 
-        response = self.client.get("/api/storages/NFC/EXISTING_STORAGE/logs?xlsx=true")
+        response = self.client.get(f"/api/storages/NFC/{self.existing_storage_device.id}/logs?xlsx=true")
 
         # 1. Check the response status and content type
         excel_columns, excel_data = self.assertXlsxFileResponse(response)
@@ -1806,7 +1837,9 @@ class StorageAPITestCase(APITestCase):
             org_unit=self.org_unit,
         )
 
-        response = self.client.get("/api/storages/NFC/EXISTING_STORAGE/logs?csv=true&types=WRITE_RECORD")
+        response = self.client.get(
+            f"/api/storages/NFC/{self.existing_storage_device.id}/logs?csv=true&types=WRITE_RECORD"
+        )
         data = self._csv_response_to_list(response)
         # We check that only the new one is found, the one from setUpTestData is filtered out
         self.assertEqual(len(data), 2)  # 1 header, 1 data row
@@ -1842,7 +1875,7 @@ class StorageAPITestCase(APITestCase):
             org_unit=self.org_unit,
         )
 
-        response = self.client.get("/api/storages/NFC/EXISTING_STORAGE/logs?csv=true&order=-id")
+        response = self.client.get(f"/api/storages/NFC/{self.existing_storage_device.id}/logs?csv=true&order=-id")
         data = self._csv_response_to_list(response)
         self.assertEqual(data[1][0], "e4200710-bf82-4d29-a29b-6a042f79ef26")
         self.assertEqual(data[2][0], "e4200710-bf82-4d29-a29b-6a042f79ef25")

--- a/iaso/urls.py
+++ b/iaso/urls.py
@@ -286,7 +286,7 @@ if not settings.DISABLE_PASSWORD_LOGINS:
     ]
 
 urlpatterns = urlpatterns + [
-    path("storages/<str:storage_type>/<str:storage_customer_chosen_id>/logs", logs_per_device),
+    path("storages/<str:storage_type>/<str:storage_id>/logs", logs_per_device),
     path("workflows/export/<workflow_id>/", export_workflow, name="export_workflow"),
     path("workflows/import/", import_workflow, name="import_workflow"),
     path("", include(router.urls)),


### PR DESCRIPTION
When a storage id has a `/` in its value, it is truncated and doesn't work.

Related JIRA tickets : WC2-831

## Self proofreading checklist

- [X] Did I use eslint and ruff formatters?
- [X] Is my code clear enough and well documented?
- [X] Are my typescript files well typed?
- [X] Are there enough tests?

## Changes

I have reverted from using `Customer chosen id` in favor of `id` 

Also, I have added a filter based on the app_id for `blacklisted` storage.

## How to test

Create a storage with a customer chosen id containing a `/` and go into its details page.

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
