### PR TITLE
[SLEEP-1648] Add missing postgres extension

### DIFF
--- a/iaso/migrations/0001_squashed_0343_importgpkg_default_valid.py
+++ b/iaso/migrations/0001_squashed_0343_importgpkg_default_valid.py
@@ -9,7 +9,7 @@ import django_ltree.fields
 import phonenumber_field.modelfields
 
 from django.conf import settings
-from django.contrib.postgres.operations import CreateExtension
+from django.contrib.postgres.operations import CITextExtension, CreateExtension, TrigramExtension
 from django.db import migrations, models
 
 import iaso.models.base
@@ -730,7 +730,8 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        CreateExtension("citext"),
+        TrigramExtension(),
+        CITextExtension(),
         CreateExtension("ltree"),
         # Now create the collation
         migrations.RunSQL(


### PR DESCRIPTION
Add missing postgres extension

Related JIRA tickets : SLEEP-1648

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

/

## Changes

- Added missing postgres extension in squashed migration

## How to test

- run this on a fresh DB with trypelim active - all migrations and features should work fine

## Print screen / video

/

## Notes

- this was done while rebasing `develop` on the `trypelim` branch - see [PR here](https://github.com/BLSQ/iaso/pull/2484)
- there's another extension that exists in a previous migration file but is missing from the squashed migration - `CreateExtension("postgis")` - but somehow postgis is already active even without this call, so I did not add it

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
