### PR TITLE
SLEEP-1598: export mobile app setup performance

### DIFF
--- a/iaso/tasks/utils/mobile_app_setup_api_calls.py
+++ b/iaso/tasks/utils/mobile_app_setup_api_calls.py
@@ -59,10 +59,11 @@ API_CALLS = [
         "filename": "storage-blacklisted",
     },
     {
-        "path": "/api/mobile/entities/",
+        "path": "/api/internal/entities/",
         "required_feature_flag": "ENTITY",
         "filename": "entities",
         "paginated": True,
+        "cursor_pagination": {"shim": True, "legacy_url": "/api/mobile/entities/"},
     },
     {
         "path": "/api/mobile/entities/deleted/",

--- a/iaso/tests/tasks/test_export_mobile_app_setup_for_user.py
+++ b/iaso/tests/tasks/test_export_mobile_app_setup_for_user.py
@@ -7,7 +7,11 @@ from django.contrib.auth.models import User
 from django.test import TestCase
 
 from iaso.models import SUCCESS, Account, Project, Task
-from iaso.tasks.export_mobile_app_setup_for_user import export_mobile_app_setup_for_user
+from iaso.tasks.export_mobile_app_setup_for_user import (
+    _call_cursor_pagination_page,
+    _get_cursor_pagination_metadata,
+    export_mobile_app_setup_for_user,
+)
 from iaso.utils.encryption import decrypt_file
 
 
@@ -25,6 +29,22 @@ def mocked_iaso_client_get(*args, **kwargs):
         return {"form_versions": []}
     if url.startswith("/api/formattachments/"):
         return {"results": []}
+    if url.startswith("/api/internal/entities/"):
+        return {
+            "next": None,
+            "previous": None,
+            "results": [],
+        }
+    if url.startswith("/api/mobile/entities/"):
+        return {
+            "count": 1,
+            "results": [],
+            "has_next": False,
+            "has_previous": False,
+            "page": 1,
+            "pages": 1,
+            "limit": 1000,
+        }
     # for all other calls, return an empty array
     return []
 
@@ -71,12 +91,12 @@ class ExportMobileAppSetupForUserTest(TestCase):
             _immediate=True,
         )
 
-        s3_client_mock.upload_file.assert_called_once()
-
         # check Task status and result
         self.task.refresh_from_db()
         self.assertEqual(self.task.status, SUCCESS)
         self.assertIn("file:export-files/mobile-app-export-", self.task.result["data"])
+
+        s3_client_mock.upload_file.assert_called_once()
 
         # check zip file contents
         zip_name = self.task.result["data"].replace("file:export-files/", "")
@@ -96,3 +116,94 @@ class ExportMobileAppSetupForUserTest(TestCase):
         self.assertIn("storage-blacklisted.json", created_files)
         self.assertIn("storage-passwords.json", created_files)
         self.assertIn("workflows.json", created_files)
+
+
+class CursorPaginationShimTest(TestCase):
+    def setUp(self):
+        self.iaso_client = mock.MagicMock()
+        self.call = {
+            "path": "/api/internal/entities/",
+            "filename": "entities",
+            "required_feature_flag": "ENTITY",
+            "filename": "entities",
+            "paginated": True,
+            "cursor_pagination": {
+                "shim": True,
+                "legacy_url": "/api/mobile/entities/"
+            },
+        }
+        self.app_id = "org.test.app"
+
+    @mock.patch("iaso.tasks.export_mobile_app_setup_for_user._call_endpoint")
+    def test_cursor_pagination_single_page(self, mock_call_endpoint):
+        """Verify that the cursor shim returns offset-style metadata for a single-page cursor response."""
+
+        #  Mock the legacy count endpoint 
+        mock_call_endpoint.side_effect = [
+            {"count": 3},  # called by _get_cursor_pagination_metadata
+            {
+                "next": None,
+                "previous": None,
+                "results": [{"id": 1}, {"id": 2}, {"id": 3}],
+            },  # called by _call_cursor_pagination_page
+        ]
+
+        # Retrieve total count and pages
+        cursor_state = _get_cursor_pagination_metadata(self.iaso_client, self.call, self.app_id)
+
+        self.assertEqual(cursor_state.total_count, 3)
+        self.assertEqual(cursor_state.page_size, 1000)
+        self.assertEqual(cursor_state.total_pages, 1)
+
+        # Simulate page 1 call
+        result, filename = _call_cursor_pagination_page(
+            self.iaso_client, self.call, self.app_id, page=1, cursor_state=cursor_state
+        )
+
+        # Verify transformation to offset-like metadata
+        self.assertEqual(filename, "entities-1.json")
+        self.assertIn("count", result)
+        self.assertIn("page", result)
+        self.assertIn("pages", result)
+        self.assertIn("limit", result)
+        self.assertFalse(result["has_next"])
+        self.assertFalse(result["has_previous"])
+        self.assertEqual(result["count"], 3)
+        self.assertEqual(result["page"], 1)
+        self.assertEqual(result["pages"], 1)
+        self.assertEqual(len(result["results"]), 3)
+
+        # Verify _call_endpoint calls
+        self.assertEqual(mock_call_endpoint.call_count, 2)
+
+    @mock.patch("iaso.tasks.export_mobile_app_setup_for_user._call_endpoint")
+    def test_cursor_pagination_multiple_pages(self, mock_call_endpoint):
+        """Simulate two cursor pages and verify has_next flips correctly."""
+
+        # First call: legacy count endpoint
+        # Second call: first page (has next)
+        # Third call: second page (no next)
+        mock_call_endpoint.side_effect = [
+            {"count": 2},
+            {"next": "/api/internal/entities/?cursor=abc123", "previous": None, "results": [{"id": 1}]},
+            {"next": None, "previous": "/api/internal/entities/?cursor=abc123", "results": [{"id": 2}]},
+        ]
+
+        cursor_state = _get_cursor_pagination_metadata(self.iaso_client, self.call, self.app_id)
+
+        # Page 1
+        result1, filename1 = _call_cursor_pagination_page(
+            self.iaso_client, self.call, self.app_id, page=1, cursor_state=cursor_state
+        )
+        self.assertTrue(result1["has_next"])
+        self.assertFalse(result1["has_previous"])
+
+        # Page 2 (using the updated next_url)
+        result2, filename2 = _call_cursor_pagination_page(
+            self.iaso_client, self.call, self.app_id, page=2, cursor_state=cursor_state
+        )
+        self.assertFalse(result2["has_next"])
+        self.assertTrue(result2["has_previous"])
+
+        self.assertEqual(mock_call_endpoint.call_count, 3)
+

--- a/iaso/urls.py
+++ b/iaso/urls.py
@@ -66,7 +66,7 @@ from .api.metrics.views import MetricOrgUnitsViewSet, MetricTypeViewSet, MetricV
 from .api.microplanning.views import AssignmentViewSet, PlanningViewSet, TeamViewSet
 from .api.microplanning.views_mobile import MobilePlanningViewSet
 from .api.mobile.bulk_uploads import MobileBulkUploadsViewSet
-from .api.mobile.entity import MobileEntityDeletedViewSet, MobileEntityViewSet
+from .api.mobile.entity import MobileEntityDeletedViewSet, MobileEntityViewSet, InternalMobileEntityViewSet
 from .api.mobile.entity_type import MobileEntityTypesViewSet
 from .api.mobile.group_sets import MobileGroupSetsViewSet
 from .api.mobile.groups import MobileGroupsViewSet
@@ -199,6 +199,7 @@ router.register(r"comments", CommentViewSet, basename="comments")
 router.register(r"entities", EntityViewSet, basename="entity")
 router.register(r"mobile/entities/deleted", MobileEntityDeletedViewSet, basename="entitiesdeleted")
 router.register(r"mobile/entities", MobileEntityViewSet, basename="entities")
+router.register(r"internal/entities", InternalMobileEntityViewSet, basename="entities")
 router.register(r"entitytypes", EntityTypeViewSet, basename="entitytype")
 router.register(r"mobile/entitytypes?", MobileEntityTypesViewSet, basename="entitytype")
 router.register(r"entityduplicates", EntityDuplicateViewSet, basename="entityduplicates")


### PR DESCRIPTION
Speeds up the retrieval of entities for the `export_mobile_app_setup` task by optimizing the database query and using cursor pagination. 

This is Trypelim-only but I'd like to bring these optimisations to IASO and have a more thorough refactor/review at that point. 

Related JIRA tickets : [SLEEP-1598](https://bluesquare.atlassian.net/browse/SLEEP-1598)

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [x] Are there enough tests?

## Changes

- Optimized the mobile entity viewpoint database query
- Broke off the optimization to a separate endpoint to keep everything else unaffected for now (but don't want to keep it that way, as there is some duplicated functionality).
- Used cursor-based pagination for an additional substantial speed-up
- Adapted the task to preserve the existing json schema for the entities.

## Notes

Another approach that was considered, after talking with Benjamin, is to adapt the task to do straight-up database calls in the task instead of going through the api. This might be a better approach, as well as perhaps calling the viewsets directly instead of using http. 



[SLEEP-1598]: https://bluesquare.atlassian.net/browse/SLEEP-1598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ