### PR TITLE
WC2-832: [HOT-FIX] Add boolean support on follow up querybuilder 

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/workflows/config/followUps.tsx
+++ b/hat/assets/js/apps/Iaso/domains/workflows/config/followUps.tsx
@@ -1,3 +1,4 @@
+import React, { ReactNode } from 'react';
 import { Box } from '@mui/material';
 import {
     Column,
@@ -5,15 +6,14 @@ import {
     QueryBuilderFields,
     useSafeIntl,
 } from 'bluesquare-components';
-import React, { ReactNode } from 'react';
 
 import { DateCell } from '../../../components/Cells/DateTimeCell';
 import { getLocaleDateFormat } from '../../../utils/dates';
 import { LinkToForm } from '../../forms/components/LinkToForm';
-import MESSAGES from '../messages';
-
 import { Field } from '../../forms/fields/constants';
 import { FollowUpActionCell } from '../components/followUps/ActionCell';
+import MESSAGES from '../messages';
+
 import { WorkflowVersionDetail } from '../types';
 
 interface FollowUpsColumns extends Column {
@@ -106,6 +106,12 @@ export const iasoFields: Field[] = [
                 'is_null',
                 'is_not_null',
             ],
+        },
+    },
+    {
+        type: 'boolean',
+        queryBuilder: {
+            type: 'boolean',
         },
     },
     {


### PR DESCRIPTION
For now boolean fields are not displayed in the query builder while editing /creating a follow up  in a workflow.

Related JIRA tickets WC2-832

## Self proofreading checklist

- [ ] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

-

## Changes

map ODK field to query builder field

## How to test

- Create / use  a form with a bool field type
- Create a entity type with this form, 
- Create a workflow for this entity type. 
- create a follow up and try to select your boolean field



## Print screen / video

<img width="1386" height="507" alt="Screenshot 2025-10-17 at 12 05 24" src="https://github.com/user-attachments/assets/f297d3d5-d188-4913-b75b-94a1c369c96a" />


## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
