### PR TITLE
IA-4532 IA-4533 [PLANNING] Error message in fr and org unit type pre selection

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -38,7 +38,7 @@
     "iaso.assignment.count": "Assignments count",
     "iaso.assignment.deleteAssignments": "Delete assignments for planning : {name}",
     "iaso.assignment.deleteAssignmentsInfos": "Please delete all assignments first",
-    "iaso.assignment.deleteAssignmentsWarning": "Are you sure you want to delete {name} assignments?",
+    "iaso.assignment.deleteAssignmentsWarning": "Are you sure you want to delete {count} assignments?",
     "iaso.assignment.inAnotherTeam": "in another team",
     "iaso.assignment.label": "Assignment",
     "iaso.assignment.map.disabled": "Already assigned",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -39,7 +39,7 @@
     "iaso.assignment.count": "Nombre d'assignations",
     "iaso.assignment.deleteAssignments": "Supprimer les assignations pour le planning : {name}",
     "iaso.assignment.deleteAssignmentsInfos": "Veuillez supprimer toutes les assignations d'abord",
-    "iaso.assignment.deleteAssignmentsWarning": "Êtes-vous sûr de vouloir supprimer les assignations pour le planning {name}?",
+    "iaso.assignment.deleteAssignmentsWarning": "Êtes-vous sûr de vouloir supprimer {count} assignations?",
     "iaso.assignment.inAnotherTeam": "dans une autre équipe",
     "iaso.assignment.label": "Affectation",
     "iaso.assignment.map.disabled": "Déjà assigné",

--- a/hat/assets/js/apps/Iaso/domains/assignments/components/AssignmentsFilters.tsx
+++ b/hat/assets/js/apps/Iaso/domains/assignments/components/AssignmentsFilters.tsx
@@ -2,10 +2,10 @@ import React, { FunctionComponent, useState } from 'react';
 import FiltersIcon from '@mui/icons-material/FilterList';
 import { Grid, Button, Box } from '@mui/material';
 import { useSafeIntl, IntlFormatMessage } from 'bluesquare-components';
+import { OrgUnitTypeHierarchyDropdownValues } from 'Iaso/domains/orgUnits/orgUnitTypes/hooks/useGetOrgUnitTypesHierarchy';
 import InputComponent from '../../../components/forms/InputComponent';
 import { baseUrls } from '../../../constants/urls';
 import { useFilterState } from '../../../hooks/useFilterState';
-import { DropdownOptions } from '../../../types/utils';
 
 import MESSAGES from '../messages';
 import { AssignmentParams } from '../types/assigment';
@@ -15,8 +15,8 @@ type Props = {
     params: AssignmentParams;
     teams: Array<DropdownTeamsOptions>;
     isFetchingTeams: boolean;
-    orgunitTypes: Array<DropdownOptions<string>>;
-    isFetchingOrgUnitTypes: boolean;
+    orgunitTypes: OrgUnitTypeHierarchyDropdownValues;
+    isFetchingOrgunitTypes: boolean;
 };
 
 const baseUrl = baseUrls.assignments;
@@ -25,7 +25,7 @@ export const AssignmentsFilters: FunctionComponent<Props> = ({
     teams,
     isFetchingTeams,
     orgunitTypes,
-    isFetchingOrgUnitTypes,
+    isFetchingOrgunitTypes,
 }) => {
     const { formatMessage }: { formatMessage: IntlFormatMessage } =
         useSafeIntl();
@@ -55,17 +55,17 @@ export const AssignmentsFilters: FunctionComponent<Props> = ({
             <Grid item xs={12} lg={3}>
                 <InputComponent
                     type="select"
-                    disabled={isFetchingOrgUnitTypes}
+                    disabled={isFetchingOrgunitTypes}
                     keyValue="baseOrgunitType"
                     onChange={handleChange}
                     value={
-                        isFetchingOrgUnitTypes
+                        isFetchingOrgunitTypes
                             ? undefined
                             : filters.baseOrgunitType
                     }
                     label={MESSAGES.baseOrgUnitsType}
                     options={orgunitTypes}
-                    loading={isFetchingOrgUnitTypes}
+                    loading={isFetchingOrgunitTypes}
                     clearable={false}
                 />
             </Grid>

--- a/hat/assets/js/apps/Iaso/domains/assignments/components/AssignmentsMap.tsx
+++ b/hat/assets/js/apps/Iaso/domains/assignments/components/AssignmentsMap.tsx
@@ -1,4 +1,6 @@
 import React, { FunctionComponent, useMemo, useRef, useState } from 'react';
+import { Box } from '@mui/material';
+import { LoadingSpinner } from 'bluesquare-components';
 import {
     GeoJSON,
     MapContainer,
@@ -7,23 +9,14 @@ import {
     Tooltip,
 } from 'react-leaflet';
 
-import { Box } from '@mui/material';
-import { LoadingSpinner } from 'bluesquare-components';
-
-import { Locations, OrgUnitMarker, OrgUnitShape } from '../types/locations';
-
+import { OrgUnitTypeHierarchyDropdownValues } from 'Iaso/domains/orgUnits/orgUnitTypes/hooks/useGetOrgUnitTypesHierarchy';
 import MarkersListComponent from '../../../components/maps/markers/MarkersListComponent';
+
+import { CustomTileLayer } from '../../../components/maps/tools/CustomTileLayer';
+import { CustomZoomControl } from '../../../components/maps/tools/CustomZoomControl';
 import { Tile } from '../../../components/maps/tools/TilesSwitchControl';
-import { MapLegend } from './MapLegend';
-import { OrgUnitPopup } from './OrgUnitPopup';
-
+import { GeoJson } from '../../../components/maps/types';
 import tiles from '../../../constants/mapTiles';
-import {
-    disabledColor,
-    parentColor,
-    unSelectedColor,
-} from '../constants/colors';
-
 import {
     Bounds,
     circleColorMarkerOptions,
@@ -31,13 +24,17 @@ import {
     getShapesBounds,
 } from '../../../utils/map/mapUtils';
 import { Profile } from '../../../utils/usersUtils';
-
-import { CustomTileLayer } from '../../../components/maps/tools/CustomTileLayer';
-import { CustomZoomControl } from '../../../components/maps/tools/CustomZoomControl';
-import { DropdownOptions } from '../../../types/utils';
+import {
+    disabledColor,
+    parentColor,
+    unSelectedColor,
+} from '../constants/colors';
 import { AssignmentParams, AssignmentsApi } from '../types/assigment';
+import { Locations, OrgUnitMarker, OrgUnitShape } from '../types/locations';
 import { DropdownTeamsOptions } from '../types/team';
 import { AssignmentsMapSelectors } from './AssignmentsMapSelectors';
+import { MapLegend } from './MapLegend';
+import { OrgUnitPopup } from './OrgUnitPopup';
 
 const defaultViewport = {
     center: [1, 20],
@@ -56,8 +53,8 @@ type Props = {
     isFetchingParentLocations: boolean;
     assignments: AssignmentsApi;
     profiles: Profile[];
-    orgunitTypes: Array<DropdownOptions<string>>;
-    isFetchingOrgUnitTypes: boolean;
+    orgunitTypes: OrgUnitTypeHierarchyDropdownValues;
+    isFetchingOrgunitTypes: boolean;
     params: AssignmentParams;
 };
 
@@ -104,7 +101,7 @@ export const AssignmentsMap: FunctionComponent<Props> = ({
     assignments,
     profiles,
     orgunitTypes,
-    isFetchingOrgUnitTypes,
+    isFetchingOrgunitTypes,
     params,
 }) => {
     const mapContainer: any = useRef();
@@ -184,7 +181,7 @@ export const AssignmentsMap: FunctionComponent<Props> = ({
                 <AssignmentsMapSelectors
                     params={params}
                     orgunitTypes={orgunitTypes}
-                    isFetchingOrgUnitTypes={isFetchingOrgUnitTypes}
+                    isFetchingOrgunitTypes={isFetchingOrgunitTypes}
                 />
                 <MapLegend />
                 {/* TODO uncomment when feature is reinstated */}
@@ -252,7 +249,9 @@ export const AssignmentsMap: FunctionComponent<Props> = ({
                                                     )
                                                 }
                                                 key={shape.id}
-                                                data={shape.geoJson}
+                                                data={
+                                                    shape.geoJson as unknown as GeoJson
+                                                }
                                                 style={() => ({
                                                     color: disabledColor,
                                                     fillOpacity: 0.5,
@@ -276,7 +275,9 @@ export const AssignmentsMap: FunctionComponent<Props> = ({
                                                 click: () => onClick(shape),
                                             }}
                                             key={shape.id}
-                                            data={shape.geoJson}
+                                            data={
+                                                shape.geoJson as unknown as GeoJson
+                                            }
                                             style={() => ({
                                                 color: unSelectedColor,
                                             })}
@@ -293,7 +294,9 @@ export const AssignmentsMap: FunctionComponent<Props> = ({
                                         eventHandlers={{
                                             click: () => onClick(shape),
                                         }}
-                                        data={shape.geoJson}
+                                        data={
+                                            shape.geoJson as unknown as GeoJson
+                                        }
                                         style={() => ({
                                             color: shape.color,
                                             fillOpacity: 0.4,
@@ -368,7 +371,9 @@ export const AssignmentsMap: FunctionComponent<Props> = ({
                                                 click: () =>
                                                     onParentClick(shape),
                                             }}
-                                            data={shape.geoJson}
+                                            data={
+                                                shape.geoJson as unknown as GeoJson
+                                            }
                                             style={{
                                                 color: parentColor,
                                                 fillOpacity: '0',

--- a/hat/assets/js/apps/Iaso/domains/assignments/components/AssignmentsMapSelectors.tsx
+++ b/hat/assets/js/apps/Iaso/domains/assignments/components/AssignmentsMapSelectors.tsx
@@ -1,17 +1,17 @@
 import React, { FunctionComponent, useCallback } from 'react';
 import { Paper, Box } from '@mui/material';
 import { useRedirectTo } from 'bluesquare-components';
-import { baseUrls } from '../../../constants/urls';
+import { OrgUnitTypeHierarchyDropdownValues } from 'Iaso/domains/orgUnits/orgUnitTypes/hooks/useGetOrgUnitTypesHierarchy';
 import InputComponent from '../../../components/forms/InputComponent';
-import { DropdownOptions } from '../../../types/utils';
-import { AssignmentParams } from '../types/assigment';
+import { baseUrls } from '../../../constants/urls';
 import { SxStyles } from '../../../types/general';
 import MESSAGES from '../messages';
+import { AssignmentParams } from '../types/assigment';
 
 type Props = {
     params: AssignmentParams;
-    orgunitTypes: Array<DropdownOptions<string>>;
-    isFetchingOrgUnitTypes: boolean;
+    orgunitTypes: OrgUnitTypeHierarchyDropdownValues;
+    isFetchingOrgunitTypes: boolean;
 };
 
 const styles: SxStyles = {
@@ -53,7 +53,7 @@ const baseUrl = baseUrls.assignments;
 export const AssignmentsMapSelectors: FunctionComponent<Props> = ({
     params,
     orgunitTypes,
-    isFetchingOrgUnitTypes,
+    isFetchingOrgunitTypes,
 }) => {
     const redirectTo = useRedirectTo();
 
@@ -72,17 +72,17 @@ export const AssignmentsMapSelectors: FunctionComponent<Props> = ({
             <Box sx={styles.dropdown}>
                 <InputComponent
                     type="select"
-                    disabled={isFetchingOrgUnitTypes}
+                    disabled={isFetchingOrgunitTypes}
                     keyValue="parentOrgunitType"
                     onChange={handleChange}
                     value={
-                        isFetchingOrgUnitTypes
+                        isFetchingOrgunitTypes
                             ? undefined
                             : params.parentOrgunitType
                     }
                     label={MESSAGES.parentOrgunitType}
                     options={orgunitTypes}
-                    loading={isFetchingOrgUnitTypes}
+                    loading={isFetchingOrgunitTypes}
                     clearable
                     withMarginTop={false}
                 />

--- a/hat/assets/js/apps/Iaso/domains/assignments/components/AssignmentsMapTab.tsx
+++ b/hat/assets/js/apps/Iaso/domains/assignments/components/AssignmentsMapTab.tsx
@@ -1,17 +1,18 @@
 import React, { FunctionComponent } from 'react';
 
-import { AssignmentsMap } from './AssignmentsMap';
+import { OrgUnitTypeHierarchyDropdownValues } from 'Iaso/domains/orgUnits/orgUnitTypes/hooks/useGetOrgUnitTypesHierarchy';
 
 import { Profile } from '../../../utils/usersUtils';
+
+import { ParentOrgUnit } from '../../orgUnits/types/orgUnit';
+import { useGetOrgUnitParentLocations } from '../hooks/requests/useGetOrgUnitParentLocations';
+import { useGetOrgUnitParentIds } from '../hooks/useGetOrgUnitParentIds';
 import { AssignmentParams, AssignmentsApi } from '../types/assigment';
 import { Locations, OrgUnitMarker, OrgUnitShape } from '../types/locations';
 import { Planning } from '../types/planning';
 import { DropdownTeamsOptions, Team } from '../types/team';
 
-import { DropdownOptions } from '../../../types/utils';
-import { ParentOrgUnit } from '../../orgUnits/types/orgUnit';
-import { useGetOrgUnitParentLocations } from '../hooks/requests/useGetOrgUnitParentLocations';
-import { useGetOrgUnitParentIds } from '../hooks/useGetOrgUnitParentIds';
+import { AssignmentsMap } from './AssignmentsMap';
 
 type Props = {
     allAssignments: AssignmentsApi;
@@ -27,8 +28,8 @@ type Props = {
     handleSaveAssignment: (
         selectedOrgUnit: OrgUnitShape | OrgUnitMarker,
     ) => void;
-    orgunitTypes: Array<DropdownOptions<string>>;
-    isFetchingOrgUnitTypes: boolean;
+    orgunitTypes: OrgUnitTypeHierarchyDropdownValues;
+    isFetchingOrgunitTypes: boolean;
 };
 
 export const AssignmentsMapTab: FunctionComponent<Props> = ({
@@ -44,7 +45,7 @@ export const AssignmentsMapTab: FunctionComponent<Props> = ({
     isFetchingLocations,
     isLoadingAssignments,
     orgunitTypes,
-    isFetchingOrgUnitTypes,
+    isFetchingOrgunitTypes,
 }) => {
     const { parentOrgunitType } = params;
 
@@ -70,7 +71,7 @@ export const AssignmentsMapTab: FunctionComponent<Props> = ({
             profiles={profiles}
             assignments={allAssignments}
             orgunitTypes={orgunitTypes}
-            isFetchingOrgUnitTypes={isFetchingOrgUnitTypes}
+            isFetchingOrgunitTypes={isFetchingOrgunitTypes}
             params={params}
         />
     );

--- a/hat/assets/js/apps/Iaso/domains/assignments/components/DeleteAssignments.tsx
+++ b/hat/assets/js/apps/Iaso/domains/assignments/components/DeleteAssignments.tsx
@@ -48,7 +48,7 @@ export const DeleteAssignments: FunctionComponent<Props> = ({
         return {
             ...MESSAGES.deleteAssignmentsWarning,
             values: {
-                name: formatThousand(count),
+                count: formatThousand(count),
             },
         };
     }, [count]);

--- a/hat/assets/js/apps/Iaso/domains/assignments/hooks/useGetAssignmentData.ts
+++ b/hat/assets/js/apps/Iaso/domains/assignments/hooks/useGetAssignmentData.ts
@@ -107,7 +107,7 @@ export const useGetAssignmentData = ({
             planning?.org_unit_details.org_unit_type || 0,
         );
     const orgunitTypes = useMemo(
-        () => flattenHierarchy(orgUnitTypeHierarchy?.sub_unit_types || [], 0),
+        () => flattenHierarchy(orgUnitTypeHierarchy?.sub_unit_types || []),
         [orgUnitTypeHierarchy],
     );
     const { data: childrenOrgunits, isFetching: isFetchingChildrenOrgunits } =

--- a/hat/assets/js/apps/Iaso/domains/assignments/hooks/useGetAssignmentData.ts
+++ b/hat/assets/js/apps/Iaso/domains/assignments/hooks/useGetAssignmentData.ts
@@ -1,8 +1,11 @@
 import { useMemo } from 'react';
 
+import {
+    OrgUnitTypeHierarchyDropdownValues,
+    useGetOrgUnitTypesHierarchy,
+} from 'Iaso/domains/orgUnits/orgUnitTypes/hooks/useGetOrgUnitTypesHierarchy';
+import { flattenHierarchy } from 'Iaso/domains/orgUnits/orgUnitTypes/hooks/useGetOrgUnitTypesHierarchy';
 import { useBoundState } from '../../../hooks/useBoundState';
-import { DropdownOptions } from '../../../types/utils';
-import { useGetOrgUnitTypesDropdownOptions } from '../../orgUnits/orgUnitTypes/hooks/useGetOrgUnitTypesDropdownOptions';
 import { OrgUnit, ParentOrgUnit } from '../../orgUnits/types/orgUnit';
 import { AssignmentApi, SaveAssignmentQuery } from '../types/assigment';
 import { Locations } from '../types/locations';
@@ -43,7 +46,7 @@ type Result = {
     saveMultiAssignments: (params: SaveAssignmentQuery) => void;
     teams: DropdownTeamsOptions[] | undefined;
     profiles: ProfileWithColor[];
-    orgunitTypes: DropdownOptions<string>[] | undefined;
+    orgunitTypes: OrgUnitTypeHierarchyDropdownValues;
     childrenOrgunits: ChildrenOrgUnits | undefined;
     orgUnits: Locations | undefined;
     orgUnitsList: OrgUnit[] | undefined;
@@ -99,8 +102,14 @@ export const useGetAssignmentData = ({
         () => (data ? data.allAssignments : []),
         [data],
     );
-    const { data: orgunitTypes, isFetching: isFetchingOrgunitTypes } =
-        useGetOrgUnitTypesDropdownOptions();
+    const { data: orgUnitTypeHierarchy, isFetching: isFetchingOrgunitTypes } =
+        useGetOrgUnitTypesHierarchy(
+            planning?.org_unit_details.org_unit_type || 0,
+        );
+    const orgunitTypes = useMemo(
+        () => flattenHierarchy(orgUnitTypeHierarchy?.sub_unit_types || [], 0),
+        [orgUnitTypeHierarchy],
+    );
     const { data: childrenOrgunits, isFetching: isFetchingChildrenOrgunits } =
         useGetOrgUnitsByParent({
             orgUnitParentId: parentSelected?.id,
@@ -200,7 +209,8 @@ export const useGetAssignmentData = ({
             isFetchingOrgUnitsList,
             isLoadingPlanning,
             isSaving: isBulkSaving || isSaving,
-            isFetchingOrgunitTypes,
+            isFetchingOrgunitTypes:
+                !orgUnitTypeHierarchy || isFetchingOrgunitTypes,
             isFetchingChildrenOrgunits,
             isLoadingAssignments,
             isTeamsFetched,
@@ -232,5 +242,6 @@ export const useGetAssignmentData = ({
         setTeams,
         sidebarData,
         teams,
+        orgUnitTypeHierarchy,
     ]);
 };

--- a/hat/assets/js/apps/Iaso/domains/assignments/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/assignments/index.tsx
@@ -47,7 +47,6 @@ const useStyles = makeStyles(theme => ({
 const baseUrl = baseUrls.assignments;
 
 export const Assignments: FunctionComponent = () => {
-    const [groupId, setGroupId] = useState<number | undefined>(undefined);
     const params: AssignmentParams = useParamsObject(
         baseUrls.assignments,
     ) as unknown as AssignmentParams;
@@ -90,9 +89,9 @@ export const Assignments: FunctionComponent = () => {
         sidebarData,
         isFetchingOrgUnits,
         isFetchingOrgUnitsList,
+        isFetchingOrgunitTypes,
         isLoadingPlanning,
         isSaving,
-        isFetchingOrgunitTypes,
         isFetchingChildrenOrgunits,
         isLoadingAssignments,
         isTeamsFetched,
@@ -105,7 +104,6 @@ export const Assignments: FunctionComponent = () => {
         order: params.order || 'name',
         search: params.search,
         selectedItem,
-        groupId,
     });
     const isLoading = isLoadingPlanning || isSaving;
 
@@ -278,7 +276,8 @@ export const Assignments: FunctionComponent = () => {
                                 disabledMessage={formatMessage(
                                     MESSAGES.deleteAssignmentsInfos,
                                 )}
-                                setGroupId={setGroupId}
+                                orgunitTypes={orgunitTypes}
+                                isFetchingOrgunitTypes={isFetchingOrgunitTypes}
                             />
                         )}
                 </Box>
@@ -287,7 +286,7 @@ export const Assignments: FunctionComponent = () => {
                     teams={teams || []}
                     isFetchingTeams={!isTeamsFetched}
                     orgunitTypes={orgunitTypes || []}
-                    isFetchingOrgUnitTypes={isFetchingOrgunitTypes}
+                    isFetchingOrgunitTypes={isFetchingOrgunitTypes}
                 />
                 <Box mt={2}>
                     <Grid container spacing={2}>
@@ -330,7 +329,7 @@ export const Assignments: FunctionComponent = () => {
                                                 orgunitTypes={
                                                     orgunitTypes || []
                                                 }
-                                                isFetchingOrgUnitTypes={
+                                                isFetchingOrgunitTypes={
                                                     isFetchingOrgunitTypes
                                                 }
                                                 planning={planning}

--- a/hat/assets/js/apps/Iaso/domains/assignments/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/assignments/index.tsx
@@ -47,6 +47,7 @@ const useStyles = makeStyles(theme => ({
 const baseUrl = baseUrls.assignments;
 
 export const Assignments: FunctionComponent = () => {
+    const [groupId, setGroupId] = useState<number | undefined>(undefined);
     const params: AssignmentParams = useParamsObject(
         baseUrls.assignments,
     ) as unknown as AssignmentParams;
@@ -104,6 +105,7 @@ export const Assignments: FunctionComponent = () => {
         order: params.order || 'name',
         search: params.search,
         selectedItem,
+        groupId,
     });
     const isLoading = isLoadingPlanning || isSaving;
 
@@ -276,6 +278,7 @@ export const Assignments: FunctionComponent = () => {
                                 disabledMessage={formatMessage(
                                     MESSAGES.deleteAssignmentsInfos,
                                 )}
+                                setGroupId={setGroupId}
                             />
                         )}
                 </Box>
@@ -288,23 +291,6 @@ export const Assignments: FunctionComponent = () => {
                 />
                 <Box mt={2}>
                     <Grid container spacing={2}>
-                        <Grid item xs={12} lg={5}>
-                            <Sidebar
-                                data={sidebarData || []}
-                                assignments={assignments}
-                                selectedItem={selectedItem}
-                                orgUnits={orgUnitsList || []}
-                                setSelectedItem={setSelectedItem}
-                                currentTeam={currentTeam}
-                                setItemColor={setItemColor}
-                                teams={teams || []}
-                                profiles={profiles}
-                                isLoadingAssignments={
-                                    isLoadingAssignments ||
-                                    isFetchingOrgUnitsList
-                                }
-                            />
-                        </Grid>
                         <Grid item xs={12} lg={7}>
                             <Paper>
                                 <Box ml={-4}>
@@ -392,6 +378,23 @@ export const Assignments: FunctionComponent = () => {
                                     )}
                                 </Box>
                             </Paper>
+                        </Grid>
+                        <Grid item xs={12} lg={5}>
+                            <Sidebar
+                                data={sidebarData || []}
+                                assignments={assignments}
+                                selectedItem={selectedItem}
+                                orgUnits={orgUnitsList || []}
+                                setSelectedItem={setSelectedItem}
+                                currentTeam={currentTeam}
+                                setItemColor={setItemColor}
+                                teams={teams || []}
+                                profiles={profiles}
+                                isLoadingAssignments={
+                                    isLoadingAssignments ||
+                                    isFetchingOrgUnitsList
+                                }
+                            />
                         </Grid>
                     </Grid>
                 </Box>

--- a/hat/assets/js/apps/Iaso/domains/assignments/messages.ts
+++ b/hat/assets/js/apps/Iaso/domains/assignments/messages.ts
@@ -212,7 +212,7 @@ const MESSAGES = defineMessages({
     },
     deleteAssignmentsWarning: {
         id: 'iaso.assignment.deleteAssignmentsWarning',
-        defaultMessage: 'Are you sure you want to delete {name} assignments?',
+        defaultMessage: 'Are you sure you want to delete {count} assignments?',
     },
     deleteAssignmentsInfos: {
         id: 'iaso.assignment.deleteAssignmentsInfos',

--- a/hat/assets/js/apps/Iaso/domains/assignments/sampling/OpenhexaIntegrationDrawer.tsx
+++ b/hat/assets/js/apps/Iaso/domains/assignments/sampling/OpenhexaIntegrationDrawer.tsx
@@ -29,6 +29,7 @@ import { useGetPipelinesDropdown } from 'Iaso/domains/openHexa/hooks/useGetPipel
 import { useLaunchTask } from 'Iaso/domains/openHexa/hooks/useLaunchTask';
 import { ParameterValues } from 'Iaso/domains/openHexa/types/pipeline';
 
+import { OrgUnitTypeHierarchyDropdownValues } from 'Iaso/domains/orgUnits/orgUnitTypes/hooks/useGetOrgUnitTypesHierarchy';
 import { TaskLogMessages } from 'Iaso/domains/tasks/components/TaskLogMessages';
 import { useGetLogs } from 'Iaso/domains/tasks/hooks/api';
 
@@ -42,6 +43,8 @@ type Props = {
     planning: Planning;
     disabled?: boolean;
     disabledMessage?: string;
+    orgunitTypes: OrgUnitTypeHierarchyDropdownValues;
+    isFetchingOrgunitTypes: boolean;
 };
 
 const styles: SxStyles = {
@@ -85,6 +88,8 @@ export const OpenhexaIntegrationDrawer: FunctionComponent<Props> = ({
     planning,
     disabled = false,
     disabledMessage,
+    orgunitTypes,
+    isFetchingOrgunitTypes,
 }) => {
     const [isSubmitting, setIsSubmitting] = useState(false);
     const queryClient = useQueryClient();
@@ -325,6 +330,10 @@ export const OpenhexaIntegrationDrawer: FunctionComponent<Props> = ({
                                             parameterValues={parameterValues}
                                             handleParameterChange={
                                                 handleParameterChange
+                                            }
+                                            orgunitTypes={orgunitTypes}
+                                            isFetchingOrgunitTypes={
+                                                isFetchingOrgunitTypes
                                             }
                                         />
                                     )}

--- a/hat/assets/js/apps/Iaso/domains/assignments/sampling/customForms/LQASForm.tsx
+++ b/hat/assets/js/apps/Iaso/domains/assignments/sampling/customForms/LQASForm.tsx
@@ -10,6 +10,7 @@ import { Box, Button, Paper } from '@mui/material';
 import { grey } from '@mui/material/colors';
 import { useSafeIntl } from 'bluesquare-components';
 import { useGetOrgUnitTypesDropdownOptions } from 'Iaso/domains/orgUnits/orgUnitTypes/hooks/useGetOrgUnitTypesDropdownOptions';
+import { useGetOrgUnitTypesHierarchy } from 'Iaso/domains/orgUnits/orgUnitTypes/hooks/useGetOrgUnitTypesHierarchy';
 import { SxStyles } from 'Iaso/types/general';
 import {
     addToArray,
@@ -94,7 +95,11 @@ export const LQASForm: FunctionComponent<Props> = ({
         useGetOrgUnitTypesDropdownOptions({
             projectId: planning.project,
         });
-
+    const { data: orgUnitTypeHierarchy } = useGetOrgUnitTypesHierarchy(
+        planning.org_unit_details.org_unit_type || 0,
+    );
+    console.log('orgUnitTypes', orgUnitTypes);
+    console.log('orgUnitTypeHierarchy', orgUnitTypeHierarchy);
     const update = useCallback(
         (arrayName: string, index: number, value: any) => {
             const currentArray = parameterValues?.[arrayName] || [];

--- a/hat/assets/js/apps/Iaso/domains/assignments/sampling/customForms/Level.tsx
+++ b/hat/assets/js/apps/Iaso/domains/assignments/sampling/customForms/Level.tsx
@@ -105,7 +105,6 @@ export const Level: FunctionComponent<Props> = ({
 
         options = flattenHierarchy(
             orgUnitTypeHierarchy.sub_unit_types,
-            0,
             orgUnitTypeId,
             parameterValues?.org_unit_type_sequence_identifiers,
         );

--- a/hat/assets/js/apps/Iaso/domains/assignments/sampling/customForms/Level.tsx
+++ b/hat/assets/js/apps/Iaso/domains/assignments/sampling/customForms/Level.tsx
@@ -5,8 +5,12 @@ import { Grid, Collapse, Box } from '@mui/material';
 import { grey } from '@mui/material/colors';
 import { IconButton, useSafeIntl } from 'bluesquare-components';
 import InputComponent from 'Iaso/components/forms/InputComponent';
-import { OriginalOrgUnitType } from 'Iaso/domains/orgUnits/orgUnitTypes/hooks/useGetOrgUnitTypesDropdownOptions';
-import { useGetOrgUnitTypesHierarchy } from 'Iaso/domains/orgUnits/orgUnitTypes/hooks/useGetOrgUnitTypesHierarchy';
+import {
+    OrgUnitTypeHierarchy,
+    OrgUnitTypeHierarchyDropdownValues,
+    useGetOrgUnitTypesHierarchy,
+} from 'Iaso/domains/orgUnits/orgUnitTypes/hooks/useGetOrgUnitTypesHierarchy';
+import { flattenHierarchy } from 'Iaso/domains/orgUnits/orgUnitTypes/hooks/useGetOrgUnitTypesHierarchy';
 import { SxStyles } from 'Iaso/types/general';
 import { DropdownOptionsWithOriginal } from 'Iaso/types/utils';
 import MESSAGES from '../../messages';
@@ -31,8 +35,8 @@ const styles: SxStyles = {
 
 type Props = {
     parameterValues?: ParameterValues;
-    orgUnitTypes: DropdownOptionsWithOriginal<string, OriginalOrgUnitType>[];
-    isFetchingOrgUnitTypes: boolean;
+    orgunitTypes: OrgUnitTypeHierarchyDropdownValues;
+    isFetchingOrgunitTypes: boolean;
     index: number;
     levels: number[] | undefined[];
     handleOrgUnitTypeChange: (value: any, index: number) => void;
@@ -46,43 +50,10 @@ type Props = {
     setExpandedLevels: (expandedLevels: boolean[]) => void;
 };
 
-const flattenHierarchy = (
-    items: any[],
-    level = 0,
-    parameterValues: ParameterValues,
-    orgUnitTypeId: number,
-): any[] => {
-    return items.flatMap(item => {
-        if (
-            parameterValues?.org_unit_type_sequence_identifiers?.includes(
-                item.id,
-            ) &&
-            item.id !== orgUnitTypeId
-        ) {
-            return [];
-        }
-        const currentItem = {
-            value: item.id,
-            label: item.name,
-            original: item,
-        };
-        const children =
-            item.sub_unit_types && item.sub_unit_types.length > 0
-                ? flattenHierarchy(
-                      item.sub_unit_types,
-                      level + 1,
-                      parameterValues,
-                      orgUnitTypeId,
-                  )
-                : [];
-
-        return [currentItem, ...children];
-    });
-};
 export const Level: FunctionComponent<Props> = ({
     parameterValues,
-    orgUnitTypes,
-    isFetchingOrgUnitTypes,
+    orgunitTypes,
+    isFetchingOrgunitTypes,
     index,
     levels,
     handleOrgUnitTypeChange,
@@ -99,16 +70,16 @@ export const Level: FunctionComponent<Props> = ({
     const criteriaOptions = useGetCriteriaOptions();
 
     const previousLevel:
-        | DropdownOptionsWithOriginal<string, OriginalOrgUnitType>
+        | DropdownOptionsWithOriginal<number, OrgUnitTypeHierarchy>
         | undefined = useMemo(
         () =>
-            orgUnitTypes?.find(
-                orgUnitType => orgUnitType.value === `${levels[index - 1]}`,
+            orgunitTypes?.find(
+                orgUnitType => orgUnitType.value === levels[index - 1],
             ),
-        [orgUnitTypes, levels, index],
+        [orgunitTypes, levels, index],
     );
     const { data: orgUnitTypeHierarchy } = useGetOrgUnitTypesHierarchy(
-        previousLevel?.value ? parseInt(previousLevel.value, 10) : 0,
+        previousLevel?.value ? previousLevel.value : 0,
     );
     const isExpanded = expandedLevels[index];
     const handleSetIsExpanded = useCallback(
@@ -123,11 +94,11 @@ export const Level: FunctionComponent<Props> = ({
     );
     const orgUnitTypesOptions = useMemo(() => {
         let options: DropdownOptionsWithOriginal<
-            string,
-            OriginalOrgUnitType
+            number,
+            OrgUnitTypeHierarchy
         >[] = [];
         if (!previousLevel) {
-            options = orgUnitTypes;
+            options = orgunitTypes;
         }
 
         if (!orgUnitTypeHierarchy?.sub_unit_types) return options;
@@ -135,8 +106,8 @@ export const Level: FunctionComponent<Props> = ({
         options = flattenHierarchy(
             orgUnitTypeHierarchy.sub_unit_types,
             0,
-            parameterValues,
             orgUnitTypeId,
+            parameterValues?.org_unit_type_sequence_identifiers,
         );
         return options;
     }, [
@@ -144,7 +115,7 @@ export const Level: FunctionComponent<Props> = ({
         orgUnitTypeHierarchy?.sub_unit_types,
         parameterValues,
         orgUnitTypeId,
-        orgUnitTypes,
+        orgunitTypes,
     ]);
     const selectedOrgUnitTypeId = useMemo(
         () =>
@@ -169,7 +140,7 @@ export const Level: FunctionComponent<Props> = ({
                         labelString={`${formatMessage(MESSAGES.level)} ${index + 1}`}
                         value={orgUnitTypeId}
                         options={orgUnitTypesOptions}
-                        loading={isFetchingOrgUnitTypes}
+                        loading={isFetchingOrgunitTypes}
                     />
                 </Grid>
                 {index !== 0 && (

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/orgUnitTypes/hooks/useGetOrgUnitTypesHierarchy.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/orgUnitTypes/hooks/useGetOrgUnitTypesHierarchy.ts
@@ -18,7 +18,6 @@ export type OrgUnitTypeHierarchyDropdownValues = DropdownOptionsWithOriginal<
 
 export const flattenHierarchy = (
     items: any[],
-    level = 0,
     orgUnitTypeId?: number,
     selectedOrgUnitTypeIds?: number[],
 ): any[] => {
@@ -35,15 +34,11 @@ export const flattenHierarchy = (
             label: item.name,
             original: item,
         };
-        const children =
-            item.sub_unit_types && item.sub_unit_types.length > 0
-                ? flattenHierarchy(
-                      item.sub_unit_types,
-                      level + 1,
-                      orgUnitTypeId,
-                  )
-                : [];
-
+        const children = flattenHierarchy(
+            item.sub_unit_types ?? [],
+            orgUnitTypeId,
+            selectedOrgUnitTypeIds,
+        );
         return [currentItem, ...children];
     });
 };

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/orgUnitTypes/hooks/useGetOrgUnitTypesHierarchy.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/orgUnitTypes/hooks/useGetOrgUnitTypesHierarchy.ts
@@ -1,6 +1,7 @@
 import { UseQueryResult } from 'react-query';
 import { getRequest } from 'Iaso/libs/Api';
 import { useSnackQuery } from 'Iaso/libs/apiHooks';
+import { DropdownOptionsWithOriginal } from 'Iaso/types/utils';
 
 export type OrgUnitTypeHierarchy = {
     id: number;
@@ -9,6 +10,42 @@ export type OrgUnitTypeHierarchy = {
     depth: number;
     category: string;
     sub_unit_types: OrgUnitTypeHierarchy[];
+};
+export type OrgUnitTypeHierarchyDropdownValues = DropdownOptionsWithOriginal<
+    number,
+    OrgUnitTypeHierarchy
+>[];
+
+export const flattenHierarchy = (
+    items: any[],
+    level = 0,
+    orgUnitTypeId?: number,
+    selectedOrgUnitTypeIds?: number[],
+): any[] => {
+    return items.flatMap(item => {
+        if (
+            selectedOrgUnitTypeIds?.includes(item.id) &&
+            orgUnitTypeId &&
+            item.id !== orgUnitTypeId
+        ) {
+            return [];
+        }
+        const currentItem = {
+            value: item.id,
+            label: item.name,
+            original: item,
+        };
+        const children =
+            item.sub_unit_types && item.sub_unit_types.length > 0
+                ? flattenHierarchy(
+                      item.sub_unit_types,
+                      level + 1,
+                      orgUnitTypeId,
+                  )
+                : [];
+
+        return [currentItem, ...children];
+    });
 };
 
 export const useGetOrgUnitTypesHierarchy = (


### PR DESCRIPTION
- Preselect children org unit type of root parent org unit
- Delete assigments message in french is wrong

Related JIRA tickets : IA-4532  IA-4533

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [x] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

-

## Changes

-  fixed message in french
- Use hierarchy on org unit types to list org unit types based on the org unit type of the org unit in the planning

## How to test

Select a country as starting point of a planning.
Click on view planning.
Base org unit type list should only contain children org unit types of the country
same while clicking on sampling, first level should be the same list
Assign some org units to some users or  teams. Try to delete those, french message should be correct

## Print screen / video


https://github.com/user-attachments/assets/e79e0a70-1731-419a-be33-039a21c088fd



## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
