### PR TITLE
IA-4528 ensure path are re-calculated after geopackage import

### DIFF
--- a/iaso/gpkg/import_gpkg.py
+++ b/iaso/gpkg/import_gpkg.py
@@ -10,6 +10,7 @@ import fiona  # type: ignore
 from django.contrib.auth.models import User
 from django.contrib.gis.geos import MultiPolygon, Point, Polygon
 from django.db import transaction
+from django.db.models import Q
 
 from hat.audit import models as audit_models
 from iaso.models import DataSource, Group, OrgUnit, OrgUnitType, SourceVersion
@@ -404,6 +405,9 @@ def import_gpkg_file2(
         ou.parent = parent_ou
         ou.source_ref = ou.source_ref.replace(OLD_INTERNAL_REF, NEW_INTERNAL_REF)
         ou.save()
+
+    recalculate_missing_paths(version, task)
+
     if task:
         task.report_progress_and_stop_if_killed(
             progress_message=f"storing log_modifications total_org_unit : {total_org_unit}"
@@ -412,3 +416,20 @@ def import_gpkg_file2(
         # Possible optimisation, crate a bulk update
         audit_models.log_modification(old_ou, new_ou, source=audit_models.GPKG_IMPORT, user=user)
     return total_org_unit
+
+
+def recalculate_missing_paths(version, task):
+    top_parents = OrgUnit.objects.filter(version=version).filter(parent_id__isnull=True)
+    empty_paths_before = OrgUnit.objects.filter(version=version).filter(Q(path__isnull=True) | Q(path=[])).count()
+    if task:
+        task.report_progress_and_stop_if_killed(progress_message=f"updating path from {top_parents.count()} parents")
+
+    for top_parent in top_parents:
+        # normally this will trigger the children too, so probably a bit excessive at least the whole pyramid will be consistent
+        top_parent.save(force_recalculate=True)
+
+    empty_paths_after = OrgUnit.objects.filter(version=version).filter(Q(path__isnull=True) | Q(path=[])).count()
+    if task:
+        task.report_progress_and_stop_if_killed(
+            progress_message=f"update path complete : empty_paths_before {empty_paths_before} empty_paths_after {empty_paths_after}"
+        )

--- a/iaso/tests/api/test_import_gpkg.py
+++ b/iaso/tests/api/test_import_gpkg.py
@@ -1,3 +1,4 @@
+from django.db.models import Q
 from rest_framework import status
 
 from iaso.models import ImportGPKG
@@ -59,3 +60,5 @@ class ImportGpkgAPITestCase(TaskAPITestCase):
 
         for ou in orgUnits:
             self.assertEqual(ou.validation_status, OrgUnit.VALIDATION_VALID)
+
+        self.assertEqual(orgUnits.filter(Q(path__isnull=True) | Q(path=[])).count(), 0)


### PR DESCRIPTION
Some orgunits don't have a path after geopackage import making a lot feature not functional

Related JIRA tickets : IA-4528

## Self proofreading checklist

- [ ] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

it recalculates the path starting from the "top" parents after all orgunits have been imported.

## How to test

1. create a new account will most modules

2. start the worker : `docker compose run iaso manage tasks_worker`

3. create a datasource version based on the geopackage in the jira

<img width="1463" height="547" alt="image" src="https://github.com/user-attachments/assets/66f79dec-7091-41bd-b505-cebc13b7a13a" />

create a new version (or update V1)

<img width="1097" height="949" alt="image" src="https://github.com/user-attachments/assets/4e03b6bc-a0c4-4d02-8e2f-8e56f507a83e" />


4. afterwards all path should be computed, you can verify in django shell or trust the logs in the task

## Print screen / video

<img width="1016" height="1077" alt="image" src="https://github.com/user-attachments/assets/8908ce14-7fb2-48b7-b251-892c4a25f6ee" />


## Notes

I've modified the test but the path was already filled for every orgunit
I suspect that the geopackage order processing in the test is too simple ( p1 -> p2-> leaf1) but I haven't been able to locate which pattern trigger this behavior;

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: ensure path are re-calculated after geopackage import

Refs: IA-4528
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
