### PR TITLE
WC2-838: Add base info to StockRulesVersion details page

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/stock/messages.ts
+++ b/hat/assets/js/apps/Iaso/domains/stock/messages.ts
@@ -201,6 +201,10 @@ const MESSAGES = defineMessages({
         defaultMessage: 'Direct Stock Manipulation Forms Explanation',
         id: 'iaso.stock.direct_stock_manipulation_forms_explanation',
     },
+    infos: {
+        defaultMessage: 'Informations',
+        id: 'iaso.instance.infos',
+    },
 });
 
 export default MESSAGES;

--- a/hat/assets/js/apps/Iaso/domains/stock/versions/components/DetailsForm.tsx
+++ b/hat/assets/js/apps/Iaso/domains/stock/versions/components/DetailsForm.tsx
@@ -1,0 +1,61 @@
+import React, { FunctionComponent, useState, useCallback } from 'react';
+import { Box, Button } from '@mui/material';
+import { makeStyles } from '@mui/styles';
+import { useSafeIntl } from 'bluesquare-components';
+
+import InputComponent from 'Iaso/components/forms/InputComponent';
+import { StockRulesVersion } from 'Iaso/domains/stock/types/stocks';
+
+import { useUpdateStockRulesVersion } from 'Iaso/domains/stock/versions/hooks/requests';
+import MESSAGES from '../../messages';
+
+type Props = {
+    version: StockRulesVersion;
+};
+// @ts-ignore
+const useStyles = makeStyles(theme => ({
+    root: {
+        position: 'relative',
+        '& #input-text-name': {
+            paddingRight: theme.spacing(15),
+        },
+    },
+    button: {
+        position: 'absolute !important',
+        right: theme.spacing(3),
+        top: 26,
+    },
+}));
+export const DetailsForm: FunctionComponent<Props> = ({ version }) => {
+    const classes = useStyles();
+    const [name, setName] = useState<string>(version.name);
+    const { formatMessage } = useSafeIntl();
+    const { mutate: updateVersion } = useUpdateStockRulesVersion();
+    const handleSave = useCallback(() => {
+        updateVersion({ name, id: version.id });
+    }, [name, updateVersion, version.id]);
+    const saveDisabled = name === version.name || name === '';
+    return (
+        <Box p={2} className={classes.root}>
+            <InputComponent
+                withMarginTop={false}
+                keyValue="name"
+                onChange={(_, value) => setName(value)}
+                value={name}
+                type="text"
+                label={MESSAGES.name}
+                required
+            />
+            <Button
+                className={classes.button}
+                disabled={saveDisabled}
+                color="primary"
+                data-test="save-name-button"
+                onClick={handleSave}
+                variant="contained"
+            >
+                {formatMessage(MESSAGES.save)}
+            </Button>
+        </Box>
+    );
+};

--- a/hat/assets/js/apps/Iaso/domains/stock/versions/components/DetailsForm.tsx
+++ b/hat/assets/js/apps/Iaso/domains/stock/versions/components/DetailsForm.tsx
@@ -1,33 +1,33 @@
 import React, { FunctionComponent, useState, useCallback } from 'react';
 import { Box, Button } from '@mui/material';
-import { makeStyles } from '@mui/styles';
+import { Theme } from '@mui/system';
 import { useSafeIntl } from 'bluesquare-components';
 
 import InputComponent from 'Iaso/components/forms/InputComponent';
 import { StockRulesVersion } from 'Iaso/domains/stock/types/stocks';
 
 import { useUpdateStockRulesVersion } from 'Iaso/domains/stock/versions/hooks/requests';
+import { SxStyles } from 'Iaso/types/general';
 import MESSAGES from '../../messages';
 
 type Props = {
     version: StockRulesVersion;
 };
 // @ts-ignore
-const useStyles = makeStyles(theme => ({
+const styles: SxStyles = {
     root: {
         position: 'relative',
         '& #input-text-name': {
-            paddingRight: theme.spacing(15),
+            paddingRight: (theme: Theme) => theme.spacing(15),
         },
     },
     button: {
         position: 'absolute !important',
-        right: theme.spacing(3),
+        right: (theme: Theme) => theme.spacing(3),
         top: 26,
     },
-}));
+};
 export const DetailsForm: FunctionComponent<Props> = ({ version }) => {
-    const classes = useStyles();
     const [name, setName] = useState<string>(version.name);
     const { formatMessage } = useSafeIntl();
     const { mutate: updateVersion } = useUpdateStockRulesVersion();
@@ -36,7 +36,7 @@ export const DetailsForm: FunctionComponent<Props> = ({ version }) => {
     }, [name, updateVersion, version.id]);
     const saveDisabled = name === version.name || name === '';
     return (
-        <Box p={2} className={classes.root}>
+        <Box p={2} sx={styles.root}>
             <InputComponent
                 withMarginTop={false}
                 keyValue="name"
@@ -47,7 +47,7 @@ export const DetailsForm: FunctionComponent<Props> = ({ version }) => {
                 required
             />
             <Button
-                className={classes.button}
+                sx={styles.button}
                 disabled={saveDisabled}
                 color="primary"
                 data-test="save-name-button"

--- a/hat/assets/js/apps/Iaso/domains/stock/versions/components/VersionBaseInfo.tsx
+++ b/hat/assets/js/apps/Iaso/domains/stock/versions/components/VersionBaseInfo.tsx
@@ -7,10 +7,12 @@ import {
     Divider,
     Box,
 } from '@mui/material';
-import { makeStyles } from '@mui/styles';
+import { Theme } from '@mui/system';
 import { useSafeIntl } from 'bluesquare-components';
 
+import { textPlaceholder } from 'Iaso/constants/uiConstants';
 import { DetailsForm } from 'Iaso/domains/stock/versions/components/DetailsForm';
+import { SxStyles } from 'Iaso/types/general';
 import MESSAGES from '../../messages';
 
 import { StockRulesVersion } from '../../types/stocks';
@@ -18,13 +20,14 @@ import { StockRulesVersion } from '../../types/stocks';
 import { PublishVersionModal } from './PublishVersionModal';
 import { StatusCell } from './StatusCell';
 
-const useStyles = makeStyles(theme => ({
+const styles: SxStyles = {
     leftCell: {
         // @ts-ignore
-        borderRight: `1px solid ${theme.palette.ligthGray.border}`,
+        borderRight: (theme: Theme) =>
+            `1px solid ${theme.palette.ligthGray.border}`,
         fontWeight: 'bold',
     },
-}));
+};
 
 type RowProps = {
     label: string;
@@ -32,10 +35,9 @@ type RowProps = {
 };
 
 const Row: FunctionComponent<RowProps> = ({ label, value }) => {
-    const classes = useStyles();
     return (
         <TableRow>
-            <TableCell className={classes.leftCell}>{label}</TableCell>
+            <TableCell sx={styles.leftCell}>{label}</TableCell>
             <TableCell>{value}</TableCell>
         </TableRow>
     );
@@ -58,7 +60,7 @@ export const VersionBaseInfo: FunctionComponent<Props> = ({ version }) => {
                             version ? (
                                 <StatusCell status={version.status} />
                             ) : (
-                                ''
+                                textPlaceholder
                             )
                         }
                     />

--- a/hat/assets/js/apps/Iaso/domains/stock/versions/components/VersionBaseInfo.tsx
+++ b/hat/assets/js/apps/Iaso/domains/stock/versions/components/VersionBaseInfo.tsx
@@ -1,0 +1,82 @@
+import React, { FunctionComponent, ReactNode } from 'react';
+import {
+    Table,
+    TableBody,
+    TableRow,
+    TableCell,
+    Divider,
+    Box,
+} from '@mui/material';
+import { makeStyles } from '@mui/styles';
+import { useSafeIntl } from 'bluesquare-components';
+
+import { DetailsForm } from 'Iaso/domains/stock/versions/components/DetailsForm';
+import MESSAGES from '../../messages';
+
+import { StockRulesVersion } from '../../types/stocks';
+
+import { PublishVersionModal } from './PublishVersionModal';
+import { StatusCell } from './StatusCell';
+
+const useStyles = makeStyles(theme => ({
+    leftCell: {
+        // @ts-ignore
+        borderRight: `1px solid ${theme.palette.ligthGray.border}`,
+        fontWeight: 'bold',
+    },
+}));
+
+type RowProps = {
+    label: string;
+    value?: string | ReactNode;
+};
+
+const Row: FunctionComponent<RowProps> = ({ label, value }) => {
+    const classes = useStyles();
+    return (
+        <TableRow>
+            <TableCell className={classes.leftCell}>{label}</TableCell>
+            <TableCell>{value}</TableCell>
+        </TableRow>
+    );
+};
+
+type Props = {
+    version: StockRulesVersion;
+};
+export const VersionBaseInfo: FunctionComponent<Props> = ({ version }) => {
+    const { formatMessage } = useSafeIntl();
+    return (
+        <>
+            <DetailsForm version={version} />
+            <Divider />
+            <Table size="small" data-test="workflow-base-info">
+                <TableBody>
+                    <Row
+                        label={formatMessage(MESSAGES.status)}
+                        value={
+                            version ? (
+                                <StatusCell status={version.status} />
+                            ) : (
+                                ''
+                            )
+                        }
+                    />
+                </TableBody>
+            </Table>
+            {version?.status !== 'PUBLISHED' && (
+                <>
+                    <Divider />
+                    <Box p={2} display="flex" justifyContent="flex-end">
+                        <PublishVersionModal
+                            version={version}
+                            iconProps={{
+                                dataTestId: 'publish-workflow-button',
+                            }}
+                        />
+                    </Box>
+                </>
+            )}
+        </>
+    );
+};

--- a/hat/assets/js/apps/Iaso/domains/stock/versions/hooks/requests.ts
+++ b/hat/assets/js/apps/Iaso/domains/stock/versions/hooks/requests.ts
@@ -35,7 +35,7 @@ export const useGetStockRulesVersionsApiParams = (
     params: Params,
 ): GetAPiParams => {
     const apiParams: ApiParams = {
-        order: params.order || 'id',
+        order: params.order || '-id',
         name: params.search,
         status: params.status,
         limit: params.pageSize || '20',

--- a/hat/assets/js/apps/Iaso/domains/stock/versions/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/stock/versions/index.tsx
@@ -9,6 +9,7 @@ import {
     useSafeIntl,
 } from 'bluesquare-components';
 import TopBar from 'Iaso/components/nav/TopBarComponent';
+import WidgetPaper from 'Iaso/components/papers/WidgetPaperComponent';
 import { baseUrls } from 'Iaso/constants/urls';
 import MESSAGES from 'Iaso/domains/stock/messages';
 import { AddVersionModal } from 'Iaso/domains/stock/versions/components/AddVersionModal';
@@ -17,6 +18,7 @@ import {
     VersionFilters,
 } from 'Iaso/domains/stock/versions/components/Filters';
 import { AddRuleDialog } from 'Iaso/domains/stock/versions/components/RuleDialog';
+import { VersionBaseInfo } from 'Iaso/domains/stock/versions/components/VersionBaseInfo';
 import { Params } from 'Iaso/domains/stock/versions/types/filters';
 import { useParamsObject } from 'Iaso/routing/hooks/useParamsObject';
 import { useVersionsColumns, baseUrl, useRulesColumns } from './config';
@@ -30,6 +32,8 @@ import {
 
 const useStyles = makeStyles(theme => ({
     ...commonStyles(theme),
+    infoPaper: { width: '100%', position: 'relative' },
+    infoPaperBox: { minHeight: '100px' },
 }));
 
 export const StockRulesVersions: FunctionComponent = () => {
@@ -80,7 +84,7 @@ const StockRulesVersionsList: FunctionComponent<Props> = ({ params }) => {
                     getObjectId={obj => obj.id}
                     data={data?.results ?? []}
                     pages={data?.pages ?? 1}
-                    defaultSorted={[{ id: 'name', desc: false }]}
+                    defaultSorted={[{ id: 'id', desc: true }]}
                     columns={columns}
                     count={data?.count ?? 0}
                     baseUrl={baseUrl}
@@ -122,7 +126,24 @@ const StockRulesList: FunctionComponent<RulesProps> = ({
                 goBack={() => redirectTo(baseUrl)}
             />
             <Box className={classes.containerFullHeightNoTabPadded}>
-                <RulesFilters params={params} />
+                <Grid container spacing={2}>
+                    <Grid container item xs={3}>
+                        <WidgetPaper
+                            className={classes.infoPaper}
+                            title={formatMessage(MESSAGES.infos)}
+                        >
+                            <Box className={classes.infoPaperBox}>
+                                {!version && <LoadingSpinner absolute />}
+                                {version && (
+                                    <VersionBaseInfo version={version} />
+                                )}
+                            </Box>
+                        </WidgetPaper>
+                    </Grid>
+                </Grid>
+                <Box mt={2}>
+                    <RulesFilters params={params} />
+                </Box>
                 <Grid
                     container
                     spacing={0}

--- a/iaso/api/stocks/serializers.py
+++ b/iaso/api/stocks/serializers.py
@@ -391,6 +391,7 @@ class StockRulesVersionSerializer(serializers.ModelSerializer):
     class Meta:
         model = StockRulesVersion
         fields = [
+            "id",
             "name",
             "status",
             "rules",

--- a/iaso/tests/api/stocks/test_serializers.py
+++ b/iaso/tests/api/stocks/test_serializers.py
@@ -658,6 +658,7 @@ class StockRulesVersionSerializerTestCase(TestCase):
         self.assertEqual(
             serializer.data,
             {
+                "id": self.version_1.pk,
                 "name": "Version 1",
                 "status": m.StockRulesVersionsStatus.DRAFT.value,
                 "rules": [


### PR DESCRIPTION
The StockRulesVersion details page was missing a way to edit the name and publish from there.

Related JIRA tickets : WC2-838

## Self proofreading checklist

- [X] Did I use eslint and ruff formatters?
- [X] Is my code clear enough and well documented?
- [X] Are my typescript files well typed?

## Changes

Adding the info at the top of the page
Fixing the default sort order on the list page.

## How to test

Go into the details of one of the version and change the name or publish it.

## Print screen / video

<img width="2050" height="690" alt="image" src="https://github.com/user-attachments/assets/6ae4bd4a-4cef-4343-b0da-aef83be59b38" />

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
