### PR TITLE
IA-4546: Disallow Creation and Edition of `StockItem`

### DIFF
--- a/iaso/admin/base.py
+++ b/iaso/admin/base.py
@@ -761,9 +761,12 @@ class StorageLogEntryInline(admin.TabularInline):
 @admin.register(StockItem)
 class StockItemAdmin(admin.ModelAdmin):
     fields = ("org_unit", "sku", "value", "created_at", "updated_at")
-    readonly_fields = ("created_at", "updated_at")
+    readonly_fields = ("org_unit", "sku", "value", "created_at", "updated_at")
     list_display = ("org_unit", "sku", "value")
     list_filter = ["sku"]
+
+    def has_add_permission(self, request, obj=None):
+        return False
 
 
 @admin.register(StockItemRule)

--- a/iaso/admin/base.py
+++ b/iaso/admin/base.py
@@ -810,9 +810,22 @@ class StockKeepingUnitChildrenAdmin(admin.ModelAdmin):
 @admin.register(StockLedgerItem)
 class StockLedgerItemAdmin(admin.ModelAdmin):
     fields = ("rule", "sku", "org_unit", "submission", "question", "impact", "value", "created_at", "created_by")
-    readonly_fields = ("created_at", "created_by")
+    readonly_fields = (
+        "rule",
+        "sku",
+        "org_unit",
+        "submission",
+        "question",
+        "impact",
+        "value",
+        "created_at",
+        "created_by",
+    )
     list_display = ("rule", "sku", "org_unit", "question", "impact", "value", "created_at")
     list_filter = ("sku", "impact", "rule")
+
+    def has_add_permission(self, request, obj=None):
+        return False
 
 
 @admin.register(StockRulesVersion)


### PR DESCRIPTION
In Staging and Production, there are too many OrgUnits. When editing/adding a StockItem, the admin tries to load all the OrgUnit which results in a 502. Since it's not possible to create or edit fully, the edition and creation functionalities have been removed.

Related JIRA tickets : IA-4546

## Self proofreading checklist

- [X] Did I use eslint and ruff formatters?
- [X] Is my code clear enough and well documented?

## Changes

The edition and creation of `StockItem`, through the admin, functionalities have been removed.

## How to test

Go to the StockItem admin page.


## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
