### PR TITLE
IA-4544: Fix bulk ignore duplicates ignores filters

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/entities/duplicates/hooks/api/useBulkIgnoreDuplicate.ts
+++ b/hat/assets/js/apps/Iaso/domains/entities/duplicates/hooks/api/useBulkIgnoreDuplicate.ts
@@ -1,14 +1,20 @@
 import { UseMutationResult } from 'react-query';
+import { DuplicatesGETParams } from 'Iaso/domains/entities/duplicates/hooks/api/useGetDuplicates';
 import { DuplicateEntity } from 'Iaso/domains/entities/duplicates/types';
 import { Selection } from 'Iaso/domains/orgUnits/types/selection';
 import { postRequest } from 'Iaso/libs/Api';
 import { useSnackMutation } from 'Iaso/libs/apiHooks';
+import { formatParams } from 'Iaso/utils/requests';
 
 const apiUrl = '/api/entityduplicates/bulk_ignore/';
 
-const ignoreDuplicate = (selection: Selection<DuplicateEntity>) => {
+const ignoreDuplicate = (
+    params: DuplicatesGETParams,
+    selection: Selection<DuplicateEntity>,
+) => {
+    const queryString = new URLSearchParams(formatParams(params)).toString();
     return postRequest({
-        url: apiUrl,
+        url: `${apiUrl}?${queryString}`,
         data: {
             select_all: selection.selectAll,
             selected_ids: selection.selectedItems.map(it => it.id),
@@ -18,11 +24,12 @@ const ignoreDuplicate = (selection: Selection<DuplicateEntity>) => {
 };
 
 export const useBulkIgnoreDuplicate = (
+    filters: DuplicatesGETParams,
     onSuccess: (data: any) => void = _data => null,
 ): UseMutationResult => {
     return useSnackMutation({
         mutationFn: (selection: Selection<DuplicateEntity>) =>
-            ignoreDuplicate(selection),
+            ignoreDuplicate(filters, selection),
         invalidateQueryKey: 'entityDuplicates',
         options: {
             retry: false,

--- a/hat/assets/js/apps/Iaso/domains/entities/duplicates/list/Duplicates.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/duplicates/list/Duplicates.tsx
@@ -108,7 +108,7 @@ export const Duplicates: FunctionComponent = () => {
         pages: 1,
         count: 0,
     };
-    const { mutate: bulkIgnore } = useBulkIgnoreDuplicate(() =>
+    const { mutate: bulkIgnore } = useBulkIgnoreDuplicate(params, () =>
         setSelection(selectionInitialState),
     );
 

--- a/iaso/api/deduplication/entity_duplicate.py
+++ b/iaso/api/deduplication/entity_duplicate.py
@@ -597,7 +597,7 @@ class EntityDuplicateViewSet(ModelViewSet):
     def bulk_ignore(self, request, pk=None, *args, **kwargs):
         serializer = BulkIgnoreRequestSerializer(data=request.data, context=self.get_serializer_context())
         serializer.is_valid(raise_exception=True)
-        queryset = self.get_queryset().filter(validation_status=ValidationStatus.PENDING)
+        queryset = self.filter_queryset(self.get_queryset()).filter(validation_status=ValidationStatus.PENDING)
         if serializer.validated_data["select_all"]:
             queryset = queryset.exclude(id__in=request.data.get("unselected_ids"))
         else:


### PR DESCRIPTION
Bulk ignore didn't take into account the current filters

Related JIRA tickets : IA-4544

## Self proofreading checklist

- [X] Did I use eslint and ruff formatters?
- [X] Is my code clear enough and well documented?
- [X] Are my typescript files well typed?
- [X] Are there enough tests?

## Changes

Make use of `self.filter_queryset` and pass the filters to the endpoint.

## How to test

- Go to the duplicates list page
- Filter the list in a way that you don't see them all
- Click on the "+" to select them all
- Validate ignore them all
- Remove the filter, check that there are still pending duplicates.

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
