### PR TITLE
POLIO-2017: fix param passed to send_mail

### DIFF
--- a/plugins/polio/api/campaigns/vaccine_authorization_missing_email.py
+++ b/plugins/polio/api/campaigns/vaccine_authorization_missing_email.py
@@ -11,7 +11,6 @@ def missing_vaccine_authorization_for_campaign_email_alert(obr_name, org_unit, a
         users = [user for user in Team.objects.get(name=NOPV2_VACCINE_TEAM_NAME).users.all()]
         recipient_list = [user.email for user in users]
         subject = f"Vaccine Authorization missing for campaign OBR Name {obr_name}"
-        from_email = (settings.DEFAULT_FROM_EMAIL,)
         message = f"""
         Dear team,
 
@@ -26,6 +25,6 @@ def missing_vaccine_authorization_for_campaign_email_alert(obr_name, org_unit, a
         This is an automated message from the poliooutbreaks platform.
             """
 
-        send_mail(subject, message, from_email, recipient_list)
+        send_mail(subject, message, settings.DEFAULT_FROM_EMAIL, recipient_list)
     except ObjectDoesNotExist:
         pass


### PR DESCRIPTION
Vaccine authorization emails were not sent

Related JIRA tickets :  POLIO-2017

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc
NA

## Changes

Explain the changes that were made.

The django method [sanitise_address](https://github.com/django/django/blob/stable/5.2.x/django/core/mail/message.py#L79) expects either a string or a tuple, but our [missing_vaccine_authorization_for_campaign_email_alert](https://github.com/BLSQ/iaso/blob/develop/plugins/polio/api/campaigns/vaccine_authorization_missing_email.py) was passing a tuple with only one value. That was the source of the error.

## How to test

deploy on staging

## Print screen / video
N/A

