### PR TITLE
WC2-837: Allow to re-run ETL on the whole data when necessary

### DIFF
--- a/plugins/wfp/tasks.py
+++ b/plugins/wfp/tasks.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 
 @shared_task()
-def etl_ng(all_data):
+def etl_ng(all_data=None):
     """Extract beneficiary data from Iaso tables and store them in the format expected by existing tableau dashboards"""
     last_success_task = TaskResult.objects.filter(task_name="plugins.wfp.tasks.etl_ng", status="SUCCESS").first()
 
@@ -59,7 +59,7 @@ def etl_ng(all_data):
 
 
 @shared_task()
-def etl_ssd(all_data):
+def etl_ssd(all_data=None):
     """Extract beneficiary data from Iaso tables and store them in the format expected by existing tableau dashboards"""
     last_success_task = TaskResult.objects.filter(task_name="plugins.wfp.tasks.etl_ssd", status="SUCCESS").first()
 
@@ -101,7 +101,7 @@ def etl_ssd(all_data):
 
 
 @shared_task()
-def etl_ethiopia(all_data):
+def etl_ethiopia(all_data=None):
     """Extract beneficiary data from Iaso tables and store them in the format expected by existing tableau dashboards"""
     last_success_task = TaskResult.objects.filter(task_name="plugins.wfp.tasks.etl_ethiopia", status="SUCCESS").first()
 


### PR DESCRIPTION
Forgot the set the argument `all_data` optional, it crashed the periodic tasks on QA.

e.g: 
<img width="1462" height="539" alt="image" src="https://github.com/user-attachments/assets/5b0a77c2-5c45-47d6-b290-8e9108e36dac" />

But tested by setting up a new task with the argument `all_data` on QA, it worked with: https://qa.coda.go.wfp.org/admin/django_celery_beat/periodictask/9/change/



Related JIRA tickets : [WC2-837](https://bluesquare.atlassian.net/browse/WC2-837)

## Self proofreading checklist

- [ ] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

Set optional the argument to allow run ETL on the whole data.

## How to test

Explain how to test your PR.

If a specific config is required explain it here: dataset, account, profile, etc.

## Print screen / video

Upload here print screens or videos showing the changes.

## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.


[WC2-837]: https://bluesquare.atlassian.net/browse/WC2-837?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ