### PR TITLE
POLIO-2022: add translation

### DIFF
--- a/plugins/polio/js/src/constants/messages.ts
+++ b/plugins/polio/js/src/constants/messages.ts
@@ -2493,6 +2493,10 @@ const MESSAGES = defineMessages({
         id: 'iaso.polio.label.plannedCampaign',
         defaultMessage: 'Planned campaign',
     },
+    planned: {
+        id: 'iaso.polio.label.planned',
+        defaultMessage: 'Planned',
+    },
     plannedRound: {
         id: 'iaso.polio.label.plannedRound',
         defaultMessage: 'Planned round',

--- a/plugins/polio/js/src/constants/translations/en.json
+++ b/plugins/polio/js/src/constants/translations/en.json
@@ -582,6 +582,7 @@
     "iaso.polio.label.PENDING_LIQUIDATION_OF_PREVIOUS_SIA_FUNDING": "Pending liquidation of previous SIA funding",
     "iaso.polio.label.physical_inventory_add": "Add to Physical inventory",
     "iaso.polio.label.physical_inventory_remove": "Remove from Physical inventory",
+    "iaso.polio.label.planned": "Planned",
     "iaso.polio.label.plannedCampaign": "Planned campaign",
     "iaso.polio.label.plannedRound": "Planned round",
     "iaso.polio.label.playground": "At playground",

--- a/plugins/polio/js/src/constants/translations/fr.json
+++ b/plugins/polio/js/src/constants/translations/fr.json
@@ -581,6 +581,7 @@
     "iaso.polio.label.PENDING_LIQUIDATION_OF_PREVIOUS_SIA_FUNDING": "Liquidation des fonds de la SIA précédente en attente",
     "iaso.polio.label.physical_inventory_add": "Ajouter à l'inventaire physique",
     "iaso.polio.label.physical_inventory_remove": "Retirer de l'inventaire physique",
+    "iaso.polio.label.planned": "Planifiée",
     "iaso.polio.label.plannedCampaign": "Campagne planifiée",
     "iaso.polio.label.plannedRound": "Round planifié",
     "iaso.polio.label.playground": "À la plaine de jeux",


### PR DESCRIPTION
What problem is this PR solving? Explain here in one sentence.

Related JIRA tickets : POLIO-2022, POLIO-1998

## Self proofreading checklist

- [ ] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc
NA

## Changes

Add missing translation for dropdown option

## How to test

Go to main polio page: it shouldn't crash. 
Try the campaign category filter, you should see "planned" in the options

## Print screen / video

<img width="1676" height="812" alt="Screenshot 2025-10-27 at 16 28 17" src="https://github.com/user-attachments/assets/42f8c730-9cfd-4615-9ba6-36e2eaf7810f" />

