### PR TITLE
POLIO-2021: remove vial numbers from summary API

### DIFF
--- a/plugins/polio/api/vaccines/stock_management.py
+++ b/plugins/polio/api/vaccines/stock_management.py
@@ -745,7 +745,7 @@ class VaccineStockManagementViewSet(ModelViewSet):
         return Response({"error": serializer.errors}, status=status.HTTP_400_BAD_REQUEST)
 
     @action(detail=True, methods=["get"])
-    def summary(self, request, pk=None):
+    def summary(self, _, pk=None):
         """
         Retrieve a summary of vaccine stock for a given VaccineStock ID.
 
@@ -768,13 +768,13 @@ class VaccineStockManagementViewSet(ModelViewSet):
 
         calculator = VaccineStockCalculator(vaccine_stock)
 
-        total_usable_vials, total_usable_doses = calculator.get_total_of_usable_vials()
+        _, total_usable_doses = calculator.get_total_of_usable_vials()
         (
-            total_unusable_vials,
+            _,
             total_unusable_doses,
         ) = calculator.get_total_of_unusable_vials()
         (
-            total_earmarked_vials,
+            _,
             total_earmarked_doses,
         ) = calculator.get_total_of_earmarked()
 
@@ -782,10 +782,7 @@ class VaccineStockManagementViewSet(ModelViewSet):
             "country_id": vaccine_stock.country.id,
             "country_name": vaccine_stock.country.name,
             "vaccine_type": vaccine_stock.vaccine,
-            "total_usable_vials": total_usable_vials,
-            "total_unusable_vials": total_unusable_vials,
             "total_usable_doses": total_usable_doses,
-            "total_earmarked_vials": total_earmarked_vials,
             "total_earmarked_doses": total_earmarked_doses,
             "total_unusable_doses": total_unusable_doses,
         }

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/Details/Summary/VaccineStockManagementSummary.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/Details/Summary/VaccineStockManagementSummary.tsx
@@ -39,18 +39,6 @@ export const VaccineStockManagementSummary: FunctionComponent<Props> = ({
             <Table size="small">
                 <TableBody>
                     <PaperTableRow
-                        label={formatMessage(MESSAGES.usableVials)}
-                        value={data?.total_usable_vials}
-                        isLoading={isLoading}
-                    />
-                    {!isBopv && (
-                        <PaperTableRow
-                            label={formatMessage(MESSAGES.unusableVials)}
-                            value={data?.total_unusable_vials}
-                            isLoading={isLoading}
-                        />
-                    )}
-                    <PaperTableRow
                         label={formatMessage(MESSAGES.usableDoses)}
                         value={data?.total_usable_doses}
                         isLoading={isLoading}
@@ -62,11 +50,6 @@ export const VaccineStockManagementSummary: FunctionComponent<Props> = ({
                             isLoading={isLoading}
                         />
                     )}
-                    <PaperTableRow
-                        label={formatMessage(MESSAGES.earmarked_vials)}
-                        value={data?.total_earmarked_vials}
-                        isLoading={isLoading}
-                    />
                     <PaperTableRow
                         label={formatMessage(MESSAGES.earmarked_doses)}
                         value={data?.total_earmarked_doses}

--- a/plugins/polio/tests/test_vaccine_stock_management.py
+++ b/plugins/polio/tests/test_vaccine_stock_management.py
@@ -670,21 +670,15 @@ class VaccineStockManagementAPITestCase(APITestCase):
             "properties": {
                 "country_name": {"type": "string"},
                 "vaccine_type": {"type": "string"},
-                "total_usable_vials": {"type": "integer"},
-                "total_unusable_vials": {"type": "integer"},
                 "total_usable_doses": {"type": "integer"},
                 "total_unusable_doses": {"type": "integer"},
-                "total_earmarked_vials": {"type": "integer"},
                 "total_earmarked_doses": {"type": "integer"},
             },
             "required": [
                 "country_name",
                 "vaccine_type",
-                "total_usable_vials",
-                "total_unusable_vials",
                 "total_usable_doses",
                 "total_unusable_doses",
-                "total_earmarked_vials",
                 "total_earmarked_doses",
             ],
         }
@@ -698,11 +692,8 @@ class VaccineStockManagementAPITestCase(APITestCase):
         # Check that the values match what is expected
         self.assertEqual(data["country_name"], self.vaccine_stock.country.name)
         self.assertEqual(data["vaccine_type"], self.vaccine_stock.vaccine)
-        self.assertEqual(data["total_usable_vials"], 23)
-        self.assertEqual(data["total_unusable_vials"], 27)
         self.assertEqual(data["total_usable_doses"], 460)
         self.assertEqual(data["total_unusable_doses"], 540)
-        self.assertEqual(data["total_earmarked_vials"], 0)  # No earmarked stock in test data
         self.assertEqual(data["total_earmarked_doses"], 0)  # No earmarked stock in test data
 
     def test_delete(self):
@@ -1341,11 +1332,8 @@ class VaccineStockManagementAPITestCase(APITestCase):
         data = response.json()
         self.assertEqual(data["country_name"], self.vaccine_stock.country.name)
         self.assertEqual(data["vaccine_type"], self.vaccine_stock.vaccine)
-        self.assertIsInstance(data["total_usable_vials"], int)
-        self.assertIsInstance(data["total_unusable_vials"], int)
         self.assertIsInstance(data["total_usable_doses"], int)
         self.assertIsInstance(data["total_unusable_doses"], int)
-        self.assertIsInstance(data["total_earmarked_vials"], int)
         self.assertIsInstance(data["total_earmarked_doses"], int)
 
     def test_user_with_read_only_can_see_usable_vials(self):
@@ -1814,7 +1802,7 @@ class VaccineStockManagementAPITestCase(APITestCase):
             quantities_ordered_in_doses=500,
         )
 
-        other_vaccine_arrival_report = pm.VaccineArrivalReport.objects.create(
+        _ = pm.VaccineArrivalReport.objects.create(
             request_form=other_vaccine_request_form,
             arrival_report_date=self.now - datetime.timedelta(days=5),
             doses_received=400,
@@ -1929,7 +1917,7 @@ class VaccineStockManagementAPITestCase(APITestCase):
         self.client.force_authenticate(user=self.user_ro_perms)
 
         # Create multiple arrival reports with the same doses_per_vial
-        vaccine_arrival_report_2 = pm.VaccineArrivalReport.objects.create(
+        _ = pm.VaccineArrivalReport.objects.create(
             request_form=self.vaccine_request_form,
             arrival_report_date=self.now - datetime.timedelta(days=3),
             doses_received=300,
@@ -1940,7 +1928,7 @@ class VaccineStockManagementAPITestCase(APITestCase):
             expiration_date=self.now + datetime.timedelta(days=180),
         )
 
-        vaccine_arrival_report_3 = pm.VaccineArrivalReport.objects.create(
+        _ = pm.VaccineArrivalReport.objects.create(
             request_form=self.vaccine_request_form,
             arrival_report_date=self.now - datetime.timedelta(days=2),
             doses_received=200,


### PR DESCRIPTION
Remove vial counts from vaccine stock summary since the amount of doses per vial is now variable

Related JIRA tickets : POLIO-2021, POLIO-1998

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [x] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

N/A

## Changes

- Remove vial numbers from summary front-end
- Remove unnecessary fields from API response
- Fix tests

## How to test
Go to polio> vaccine module> stock managment> details of any stock: the upper left summary should only display counts in doses

## Print screen / video

<img width="1670" height="784" alt="Screenshot 2025-10-27 at 17 46 19" src="https://github.com/user-attachments/assets/a5d39e70-db2d-4676-b605-65260bbeb713" />

