### PR TITLE
IA-4557: Use same searchButton component for forms as in other places

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/forms/components/Filters.tsx
+++ b/hat/assets/js/apps/Iaso/domains/forms/components/Filters.tsx
@@ -1,7 +1,6 @@
 import React, { useState, FunctionComponent, useCallback } from 'react';
 
 import Add from '@mui/icons-material/Add';
-import SearchIcon from '@mui/icons-material/Search';
 import { Grid, Button, Box, useMediaQuery, useTheme } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import {
@@ -10,6 +9,7 @@ import {
     useSafeIntl,
 } from 'bluesquare-components';
 
+import { SearchButton } from 'Iaso/components/SearchButton';
 import { baseUrls } from 'Iaso/constants/urls';
 import * as Permission from 'Iaso/utils/permissions';
 import { DisplayIfUserHasPerm } from '../../../components/DisplayIfUserHasPerm';
@@ -166,21 +166,14 @@ const Filters: FunctionComponent<Props> = ({ params }) => {
                                 {formatMessage(MESSAGES.addForm)}
                             </Button>
                         </DisplayIfUserHasPerm>
-                        <Button
-                            data-test="search-button"
+                        <SearchButton
                             disabled={
                                 (!filtersUpdated &&
                                     params?.isSearchActive === 'true') ||
                                 textSearchError
                             }
-                            variant="contained"
-                            className={classes.button}
-                            color="primary"
-                            onClick={handleSearch}
-                        >
-                            <SearchIcon className={classes.buttonIcon} />
-                            {formatMessage(MESSAGES.search)}
-                        </Button>
+                            onSearch={handleSearch}
+                        />
                     </Box>
                 </Grid>
             </Grid>


### PR DESCRIPTION
Wording doesn't match between the action and the message displayed in the table for forms

Related JIRA tickets : IA-4557

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [x] Are my typescript files well typed?
- [x] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

N/A

## Changes

Use SearchButton in form filters to align style and label with other filters in IASO

## How to test

Go to forms, change language to FRENCH and verify that label shown when table is empty matches with the search button.
Both should be "Rechercher".

## Print screen / video

Upload here print screens or videos showing the changes.

## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
