### PR TITLE
POLIO-2019 doses per vial

### DIFF
--- a/hat/assets/js/apps/Iaso/components/forms/InputComponent.tsx
+++ b/hat/assets/js/apps/Iaso/components/forms/InputComponent.tsx
@@ -285,7 +285,6 @@ const InputComponent: React.FC<InputComponentProps> = ({
                         dataTestId={dataTestId}
                         placeholder={placeholder}
                         onBlur={onBlur}
-                        // onFocus={onFocus}
                     />
                 );
             case 'arrayInput':

--- a/hat/assets/js/apps/Iaso/components/forms/InputComponent.tsx
+++ b/hat/assets/js/apps/Iaso/components/forms/InputComponent.tsx
@@ -284,6 +284,8 @@ const InputComponent: React.FC<InputComponentProps> = ({
                         returnFullObject={returnFullObject}
                         dataTestId={dataTestId}
                         placeholder={placeholder}
+                        onBlur={onBlur}
+                        // onFocus={onFocus}
                     />
                 );
             case 'arrayInput':

--- a/package-lock.json
+++ b/package-lock.json
@@ -7226,7 +7226,7 @@
         },
         "node_modules/bluesquare-components": {
             "version": "1.0.0",
-            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#13839a63cf6313b30b3142cb4c2b1c156ea1922a",
+            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#987dae14d2aea4568142f5c089664d9fffd6ae28",
             "license": "Apache-2.0",
             "dependencies": {
                 "@babel/plugin-transform-class-properties": "^7.24.6",

--- a/plugins/polio/api/urls.py
+++ b/plugins/polio/api/urls.py
@@ -41,7 +41,7 @@ from plugins.polio.api.polio_org_units import PolioOrgunitViewSet
 from plugins.polio.api.rounds.reasons_for_delay import ReasonForDelayViewSet
 from plugins.polio.api.rounds.round import RoundViewSet
 from plugins.polio.api.rounds.round_date_history import RoundDateHistoryEntryViewset
-from plugins.polio.api.vaccines.doses_per_vaccine import DosesPerVaccineViewset
+from plugins.polio.api.vaccines.doses_per_vaccine import DosesPerVialViewset
 from plugins.polio.api.vaccines.public_vaccine_stock import PublicVaccineStockViewset
 from plugins.polio.api.vaccines.repository_forms import VaccineRepositoryFormsViewSet
 from plugins.polio.api.vaccines.repository_reports import VaccineRepositoryReportsViewSet
@@ -111,7 +111,7 @@ router.register(r"polio/tasks/refreshim/ohh", RefreshIMOutOfHouseholdDataViewset
 router.register(r"polio/tasks/refreshim/hh_ohh", RefreshIMAllDataViewset, basename="refreshimhhohh")
 router.register(r"polio/vaccine/request_forms", VaccineRequestFormViewSet, basename="vaccine_request_forms")
 router.register(r"polio/vaccine/vaccine_stock", VaccineStockManagementViewSet, basename="vaccine_stocks")
-router.register(r"polio/vaccine/doses_per_vial", DosesPerVaccineViewset, basename="doses_per_vial")
+router.register(r"polio/vaccine/doses_per_vial", DosesPerVialViewset, basename="doses_per_vial")
 router.register(r"polio/vaccine/repository", VaccineRepositoryFormsViewSet, basename="vaccine_repository")
 router.register(
     r"polio/vaccine/repository_reports", VaccineRepositoryReportsViewSet, basename="vaccine_repository_reports"

--- a/plugins/polio/api/urls.py
+++ b/plugins/polio/api/urls.py
@@ -41,6 +41,7 @@ from plugins.polio.api.polio_org_units import PolioOrgunitViewSet
 from plugins.polio.api.rounds.reasons_for_delay import ReasonForDelayViewSet
 from plugins.polio.api.rounds.round import RoundViewSet
 from plugins.polio.api.rounds.round_date_history import RoundDateHistoryEntryViewset
+from plugins.polio.api.vaccines.doses_per_vaccine import DosesPerVaccineViewset
 from plugins.polio.api.vaccines.public_vaccine_stock import PublicVaccineStockViewset
 from plugins.polio.api.vaccines.repository_forms import VaccineRepositoryFormsViewSet
 from plugins.polio.api.vaccines.repository_reports import VaccineRepositoryReportsViewSet
@@ -110,6 +111,7 @@ router.register(r"polio/tasks/refreshim/ohh", RefreshIMOutOfHouseholdDataViewset
 router.register(r"polio/tasks/refreshim/hh_ohh", RefreshIMAllDataViewset, basename="refreshimhhohh")
 router.register(r"polio/vaccine/request_forms", VaccineRequestFormViewSet, basename="vaccine_request_forms")
 router.register(r"polio/vaccine/vaccine_stock", VaccineStockManagementViewSet, basename="vaccine_stocks")
+router.register(r"polio/vaccine/doses_per_vial", DosesPerVaccineViewset, basename="doses_per_vial")
 router.register(r"polio/vaccine/repository", VaccineRepositoryFormsViewSet, basename="vaccine_repository")
 router.register(
     r"polio/vaccine/repository_reports", VaccineRepositoryReportsViewSet, basename="vaccine_repository_reports"

--- a/plugins/polio/api/vaccines/doses_per_vaccine.py
+++ b/plugins/polio/api/vaccines/doses_per_vaccine.py
@@ -1,0 +1,53 @@
+from rest_framework import permissions
+from rest_framework.mixins import ListModelMixin
+from rest_framework.viewsets import GenericViewSet
+
+from iaso.api.common import HasPermission
+from iaso.api.config import ConfigSerializer
+from iaso.models.json_config import Config
+from plugins.polio.permissions import (
+    POLIO_CONFIG_PERMISSION,
+    POLIO_PERMISSION,
+    POLIO_VACCINE_STOCK_EARMARKS_ADMIN_PERMISSION,
+    POLIO_VACCINE_STOCK_EARMARKS_NONADMIN_PERMISSION,
+    POLIO_VACCINE_STOCK_EARMARKS_READ_ONLY_PERMISSION,
+    POLIO_VACCINE_STOCK_MANAGEMENT_READ_ONLY_PERMISSION,
+    POLIO_VACCINE_STOCK_MANAGEMENT_READ_PERMISSION,
+    POLIO_VACCINE_STOCK_MANAGEMENT_WRITE_PERMISSION,
+    POLIO_VACCINE_SUPPLY_CHAIN_READ_ONLY_PERMISSION,
+    POLIO_VACCINE_SUPPLY_CHAIN_READ_PERMISSION,
+    POLIO_VACCINE_SUPPLY_CHAIN_WRITE_PERMISSION,
+)
+
+
+class DosesPerVaccineViewset(ListModelMixin, GenericViewSet):
+    """
+    Super custom endpoint to send the possible vaccine presentation (doses per vial) to the front end
+
+    A config with a slug == self.CONFIG_SLUG  is required (create it via the django admin)
+
+    The config data should have 1 key per available vaccine, and the value should be a list of positive integers, eg: 'bOPV':[10,20]
+
+    """
+
+    permission_classes = [
+        permissions.IsAuthenticated,
+        HasPermission(
+            POLIO_CONFIG_PERMISSION,
+            POLIO_PERMISSION,
+            POLIO_VACCINE_SUPPLY_CHAIN_READ_ONLY_PERMISSION,
+            POLIO_VACCINE_SUPPLY_CHAIN_READ_PERMISSION,
+            POLIO_VACCINE_SUPPLY_CHAIN_WRITE_PERMISSION,
+            POLIO_VACCINE_STOCK_MANAGEMENT_READ_ONLY_PERMISSION,
+            POLIO_VACCINE_STOCK_MANAGEMENT_READ_PERMISSION,
+            POLIO_VACCINE_STOCK_MANAGEMENT_WRITE_PERMISSION,
+            POLIO_VACCINE_STOCK_EARMARKS_READ_ONLY_PERMISSION,
+            POLIO_VACCINE_STOCK_EARMARKS_NONADMIN_PERMISSION,
+            POLIO_VACCINE_STOCK_EARMARKS_ADMIN_PERMISSION,
+        ),
+    ]
+    serializer_class = ConfigSerializer
+    CONFIG_SLUG = "vaccine_doses_per_vial"
+
+    def get_queryset(self):
+        return Config.objects.filter(slug=self.CONFIG_SLUG)

--- a/plugins/polio/api/vaccines/doses_per_vaccine.py
+++ b/plugins/polio/api/vaccines/doses_per_vaccine.py
@@ -21,7 +21,7 @@ from plugins.polio.permissions import (
 )
 
 
-class DosesPerVaccineViewset(ListModelMixin, GenericViewSet):
+class DosesPerVialViewset(ListModelMixin, GenericViewSet):
     """
     Super custom endpoint to send the possible vaccine presentation (doses per vial) to the front end
 

--- a/plugins/polio/api/vaccines/doses_per_vaccine.py
+++ b/plugins/polio/api/vaccines/doses_per_vaccine.py
@@ -25,7 +25,7 @@ class DosesPerVialViewset(ListModelMixin, GenericViewSet):
     """
     Super custom endpoint to send the possible vaccine presentation (doses per vial) to the front end
 
-    A config with a slug == self.CONFIG_SLUG  is required (create it via the django admin)
+    A config with a slug == DOSES_PER_VIAL_CONFIG_SLUG  is required (create it via the django admin)
 
     The config data should have 1 key per available vaccine, and the value should be a list of positive integers, eg: 'bOPV':[10,20]
 
@@ -48,7 +48,6 @@ class DosesPerVialViewset(ListModelMixin, GenericViewSet):
         ),
     ]
     serializer_class = ConfigSerializer
-    CONFIG_SLUG = DOSES_PER_VIAL_CONFIG_SLUG
 
     def get_queryset(self):
-        return Config.objects.filter(slug=self.CONFIG_SLUG)
+        return Config.objects.filter(slug=DOSES_PER_VIAL_CONFIG_SLUG)

--- a/plugins/polio/api/vaccines/doses_per_vaccine.py
+++ b/plugins/polio/api/vaccines/doses_per_vaccine.py
@@ -5,6 +5,7 @@ from rest_framework.viewsets import GenericViewSet
 from iaso.api.common import HasPermission
 from iaso.api.config import ConfigSerializer
 from iaso.models.json_config import Config
+from plugins.polio.models.base import DOSES_PER_VIAL_CONFIG_SLUG
 from plugins.polio.permissions import (
     POLIO_CONFIG_PERMISSION,
     POLIO_PERMISSION,
@@ -47,7 +48,7 @@ class DosesPerVaccineViewset(ListModelMixin, GenericViewSet):
         ),
     ]
     serializer_class = ConfigSerializer
-    CONFIG_SLUG = "vaccine_doses_per_vial"
+    CONFIG_SLUG = DOSES_PER_VIAL_CONFIG_SLUG
 
     def get_queryset(self):
         return Config.objects.filter(slug=self.CONFIG_SLUG)

--- a/plugins/polio/api/vaccines/stock_management.py
+++ b/plugins/polio/api/vaccines/stock_management.py
@@ -984,20 +984,6 @@ class VaccineStockManagementViewSet(ModelViewSet):
                 }
             )
         return Response({"results": results}, status=status.HTTP_200_OK)
-        # country = vaccine_stock.country
-        # vaccine = vaccine_stock.vaccine
-        # values = (
-        #     VaccineArrivalReport.objects.filter(
-        #         request_form__campaign__account=request.user.iaso_profile.account,  # filter by account
-        #         request_form__campaign__country=country,
-        #         request_form__vaccine_type=vaccine,
-        #     )
-        #     .values_list("doses_per_vial", flat=True)
-        #     .distinct()
-        # )
-        # return Response(
-        #     {"results": [{"label": f"{value}", "value": value} for value in values]}, status=status.HTTP_200_OK
-        # )
 
 
 class EmbeddedVaccineStockManagementViewset(VaccineStockManagementViewSet):

--- a/plugins/polio/api/vaccines/stock_management.py
+++ b/plugins/polio/api/vaccines/stock_management.py
@@ -17,6 +17,7 @@ from rest_framework.response import Response
 
 from iaso.api.common import CONTENT_TYPE_XLSX, ModelViewSet, Paginator
 from iaso.models import OrgUnit
+from iaso.models.json_config import Config
 from iaso.utils.virus_scan.serializers import ModelWithFileSerializer
 from plugins.polio.api.vaccines.common import sort_results
 from plugins.polio.api.vaccines.export_utils import download_xlsx_stock_variants
@@ -33,7 +34,7 @@ from plugins.polio.models import (
     OutgoingStockMovement,
     VaccineStock,
 )
-from plugins.polio.models.base import Round, VaccineArrivalReport, VaccineStockCalculator
+from plugins.polio.models.base import DOSES_PER_VIAL_CONFIG_SLUG, Round, VaccineStockCalculator
 from plugins.polio.permissions import (
     POLIO_VACCINE_STOCK_EARMARKS_ADMIN_PERMISSION,
     POLIO_VACCINE_STOCK_EARMARKS_NONADMIN_PERMISSION,
@@ -965,20 +966,38 @@ class VaccineStockManagementViewSet(ModelViewSet):
         if not vaccine_stock:
             return Response(status=status.HTTP_404_NOT_FOUND)
 
-        country = vaccine_stock.country
         vaccine = vaccine_stock.vaccine
-        values = (
-            VaccineArrivalReport.objects.filter(
-                request_form__campaign__account=request.user.iaso_profile.account,  # filter by account
-                request_form__campaign__country=country,
-                request_form__vaccine_type=vaccine,
+        try:
+            config = Config.objects.get(slug=DOSES_PER_VIAL_CONFIG_SLUG)
+        except Config.DoesNotExist:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+        options = config.content[vaccine]
+        calculator = VaccineStockCalculator(vaccine_stock)
+        doses_available = calculator.get_stock_by_vaccine_presentation()
+        results = []
+        for option in options:
+            results.append(
+                {
+                    "label": str(option),
+                    "value": option,
+                    "doses_available": doses_available[str(option)],
+                }
             )
-            .values_list("doses_per_vial", flat=True)
-            .distinct()
-        )
-        return Response(
-            {"results": [{"label": f"{value}", "value": value} for value in values]}, status=status.HTTP_200_OK
-        )
+        return Response({"results": results}, status=status.HTTP_200_OK)
+        # country = vaccine_stock.country
+        # vaccine = vaccine_stock.vaccine
+        # values = (
+        #     VaccineArrivalReport.objects.filter(
+        #         request_form__campaign__account=request.user.iaso_profile.account,  # filter by account
+        #         request_form__campaign__country=country,
+        #         request_form__vaccine_type=vaccine,
+        #     )
+        #     .values_list("doses_per_vial", flat=True)
+        #     .distinct()
+        # )
+        # return Response(
+        #     {"results": [{"label": f"{value}", "value": value} for value in values]}, status=status.HTTP_200_OK
+        # )
 
 
 class EmbeddedVaccineStockManagementViewset(VaccineStockManagementViewSet):

--- a/plugins/polio/api/vaccines/stock_management.py
+++ b/plugins/polio/api/vaccines/stock_management.py
@@ -973,7 +973,8 @@ class VaccineStockManagementViewSet(ModelViewSet):
             return Response(status=status.HTTP_404_NOT_FOUND)
         options = config.content[vaccine]
         calculator = VaccineStockCalculator(vaccine_stock)
-        doses_available = calculator.get_stock_by_vaccine_presentation()
+        doses_available = calculator.get_usable_stock_by_vaccine_presentation()
+        unusable_doses = calculator.get_unusable_stock_by_vaccine_presentation()
         results = []
         for option in options:
             results.append(
@@ -981,6 +982,7 @@ class VaccineStockManagementViewSet(ModelViewSet):
                     "label": str(option),
                     "value": option,
                     "doses_available": doses_available[str(option)],
+                    "unusable_doses": unusable_doses[str(option)],
                 }
             )
         return Response({"results": results}, status=status.HTTP_200_OK)

--- a/plugins/polio/js/src/components/Inputs/SingleSelect.tsx
+++ b/plugins/polio/js/src/components/Inputs/SingleSelect.tsx
@@ -14,6 +14,8 @@ type Props = {
     disabled?: boolean;
     onChange?: (_keyValue: string, value: any) => void;
     isLoading?: boolean;
+    onBlur?: () => void;
+    onFocus?: () => void;
 };
 
 export const SingleSelect: FunctionComponent<Props> = ({
@@ -22,6 +24,8 @@ export const SingleSelect: FunctionComponent<Props> = ({
     field,
     form,
     onChange,
+    onFocus,
+    onBlur,
     disabled = false,
     clearable = true,
     withMarginTop = false,
@@ -53,6 +57,8 @@ export const SingleSelect: FunctionComponent<Props> = ({
             }}
             errors={hasError ? [get(form.errors, field.name)] : []}
             loading={isLoading}
+            onFocus={onFocus}
+            onBlur={onBlur}
         />
     );
 };

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/CreateEditDestruction.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/CreateEditDestruction.tsx
@@ -26,6 +26,7 @@ import {
 import MESSAGES from '../../messages';
 import { useDestructionValidation } from './validation';
 import { DropdownOptions } from 'Iaso/types/utils';
+import { DosesPerVialDropdown } from '../../types';
 
 type Props = {
     destruction?: any;
@@ -35,12 +36,7 @@ type Props = {
     countryName: string;
     vaccine: Vaccine;
     vaccineStockId: string;
-    dosesOptions?: {
-        label: string;
-        value: number;
-        doses_available: number;
-        unusable_doses: number;
-    }[];
+    dosesOptions?: DosesPerVialDropdown;
 };
 
 export const CreateEditDestruction: FunctionComponent<Props> = ({

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/CreateEditDestruction.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/CreateEditDestruction.tsx
@@ -25,8 +25,8 @@ import {
 } from '../../hooks/api';
 import MESSAGES from '../../messages';
 import { useDestructionValidation } from './validation';
-import { DropdownOptions } from 'Iaso/types/utils';
 import { DosesPerVialDropdown } from '../../types';
+import { useAvailablePresentations } from './dropdownOptions';
 
 type Props = {
     destruction?: any;
@@ -70,24 +70,11 @@ export const CreateEditDestruction: FunctionComponent<Props> = ({
         onSubmit: values => save(values),
         validationSchema,
     });
-    const availableDosesPresentations: DropdownOptions<number>[] =
-        useMemo(() => {
-            const availableOptions: DropdownOptions<number>[] = dosesOptions
-                ? dosesOptions.filter(option => option.unusable_doses > 0)
-                : [];
-            const availableValues = availableOptions.map(o => o.value);
-            // If the form A has already been encoded, we add the value to avoid putting the form in error
-            if (
-                destruction?.doses_per_vial &&
-                !availableValues.includes(destruction.doses_per_vial)
-            ) {
-                availableOptions.push({
-                    label: `${destruction.doses_per_vial}`,
-                    value: destruction.doses_per_vial,
-                });
-            }
-            return availableOptions;
-        }, [dosesOptions, destruction?.doses_per_vial]);
+    const availableDosesPresentations = useAvailablePresentations(
+        dosesOptions,
+        destruction,
+        false,
+    );
 
     const [debouncedDate] = useDebounce(
         formik.values.destruction_report_date,

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/CreateEditDestruction.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/CreateEditDestruction.tsx
@@ -37,6 +37,7 @@ type Props = {
     vaccine: Vaccine;
     vaccineStockId: string;
     dosesOptions?: DosesPerVialDropdown;
+    defaultDosesPerVial: number | undefined;
 };
 
 export const CreateEditDestruction: FunctionComponent<Props> = ({
@@ -47,14 +48,12 @@ export const CreateEditDestruction: FunctionComponent<Props> = ({
     vaccine,
     vaccineStockId,
     dosesOptions,
+    defaultDosesPerVial,
 }) => {
     const { formatMessage } = useSafeIntl();
     const { mutateAsync: save } = useSaveDestruction();
+    const hasFixedDosesPerVial = Boolean(defaultDosesPerVial);
     const validationSchema = useDestructionValidation();
-
-    const defaultDosesPerVial =
-        //@ts-ignore
-        (dosesOptions ?? []).length === 1 ? dosesOptions[0].value : undefined;
     const formik = useFormik<any>({
         initialValues: {
             id: destruction?.id,
@@ -168,6 +167,8 @@ export const CreateEditDestruction: FunctionComponent<Props> = ({
                         name="doses_per_vial"
                         component={SingleSelect}
                         options={availableDosesPresentations}
+                        disabled={hasFixedDosesPerVial}
+                        required
                     />
                 </Box>
                 <Box mb={2}>

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/CreateEditEarmarked.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/CreateEditEarmarked.tsx
@@ -34,6 +34,7 @@ type Props = {
     vaccine: VaccineForStock;
     vaccineStockId: string;
     dosesOptions?: DosesPerVialDropdown;
+    defaultDosesPerVial: number | undefined;
 };
 
 export const CreateEditEarmarked: FunctionComponent<Props> = ({
@@ -44,12 +45,12 @@ export const CreateEditEarmarked: FunctionComponent<Props> = ({
     vaccine,
     vaccineStockId,
     dosesOptions,
+    defaultDosesPerVial,
 }) => {
     const { formatMessage } = useSafeIntl();
     const { mutateAsync: save } = useSaveEarmarked();
-    const defaultDosesPerVial =
-        //@ts-ignore
-        (dosesOptions ?? []).length === 1 ? dosesOptions[0].value : undefined;
+
+    const hasFixedDosesPerVial = Boolean(defaultDosesPerVial);
     const validationSchema = useEarmarkValidation();
     const formik = useFormik<any>({
         initialValues: {
@@ -189,6 +190,8 @@ export const CreateEditEarmarked: FunctionComponent<Props> = ({
                         name="doses_per_vial"
                         component={SingleSelect}
                         options={availableDosesPresentations}
+                        disabled={hasFixedDosesPerVial}
+                        required
                     />
                 </Box>
                 <Box mb={2}>

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/CreateEditEarmarked.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/CreateEditEarmarked.tsx
@@ -1,9 +1,4 @@
-import React, {
-    FunctionComponent,
-    useCallback,
-    useEffect,
-    useMemo,
-} from 'react';
+import React, { FunctionComponent, useCallback, useEffect } from 'react';
 import { Box } from '@mui/material';
 import {
     AddButton,
@@ -20,9 +15,11 @@ import { VaccineForStock } from '../../../../../constants/types';
 import { useGetVrfListByRound } from '../../../SupplyChain/hooks/api/vrf';
 import { useCampaignOptions, useSaveEarmarked } from '../../hooks/api';
 import MESSAGES from '../../messages';
-import { useEarmarkOptions } from './dropdownOptions';
+import {
+    useAvailablePresentations,
+    useEarmarkOptions,
+} from './dropdownOptions';
 import { useEarmarkValidation } from './validation';
-import { DropdownOptions } from 'Iaso/types/utils';
 import { DosesPerVialDropdown } from '../../types';
 
 type Props = {
@@ -82,24 +79,11 @@ export const CreateEditEarmarked: FunctionComponent<Props> = ({
         round => round.value === formik.values.round_number,
     );
     const earmarkTypeOptions = useEarmarkOptions();
-    const availableDosesPresentations: DropdownOptions<number>[] =
-        useMemo(() => {
-            const availableOptions: DropdownOptions<number>[] = dosesOptions
-                ? dosesOptions.filter(option => option.doses_available > 0)
-                : [];
-            const availableValues = availableOptions.map(o => o.value);
-            // If the form A has already been encoded, we add the value to avoid putting the form in error
-            if (
-                earmark?.doses_per_vial &&
-                !availableValues.includes(earmark.doses_per_vial)
-            ) {
-                availableOptions.push({
-                    label: `${earmark.doses_per_vial}`,
-                    value: earmark.doses_per_vial,
-                });
-            }
-            return availableOptions;
-        }, [dosesOptions, earmark?.doses_per_vial]);
+    const availableDosesPresentations = useAvailablePresentations(
+        dosesOptions,
+        earmark,
+    );
+
     const handleVialsChange = useCallback(
         value => {
             setFieldValue('vials_earmarked', value);

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/CreateEditEarmarked.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/CreateEditEarmarked.tsx
@@ -23,6 +23,7 @@ import MESSAGES from '../../messages';
 import { useEarmarkOptions } from './dropdownOptions';
 import { useEarmarkValidation } from './validation';
 import { DropdownOptions } from 'Iaso/types/utils';
+import { DosesPerVialDropdown } from '../../types';
 
 type Props = {
     earmark?: any;
@@ -32,12 +33,7 @@ type Props = {
     countryName: string;
     vaccine: VaccineForStock;
     vaccineStockId: string;
-    dosesOptions?: {
-        label: string;
-        value: number;
-        doses_available: number;
-        unusable_doses: number;
-    }[];
+    dosesOptions?: DosesPerVialDropdown;
 };
 
 export const CreateEditEarmarked: FunctionComponent<Props> = ({

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/CreateEditFormA.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/CreateEditFormA.tsx
@@ -41,6 +41,7 @@ type Props = {
     vaccine: Vaccine;
     vaccineStockId: string;
     dosesOptions?: DosesPerVialDropdown;
+    defaultDosesPerVial: number | undefined;
 };
 
 export type FormAFormValues = {
@@ -67,13 +68,11 @@ export const CreateEditFormA: FunctionComponent<Props> = ({
     vaccine,
     vaccineStockId,
     dosesOptions,
+    defaultDosesPerVial,
 }) => {
     const { formatMessage } = useSafeIntl();
     const { mutateAsync: save } = useSaveFormA();
-
-    const defaultDosesPerVial =
-        //@ts-ignore
-        (dosesOptions ?? []).length === 1 ? dosesOptions[0].value : undefined;
+    const hasFixedDosesPerVial = Boolean(defaultDosesPerVial);
     const validationSchema = useFormAValidation();
     const formik = useFormik<FormAFormValues>({
         initialValues: {
@@ -257,6 +256,8 @@ export const CreateEditFormA: FunctionComponent<Props> = ({
                         name="doses_per_vial"
                         component={SingleSelect}
                         options={availableDosesPresentations}
+                        disabled={hasFixedDosesPerVial}
+                        required
                     />
                 </Box>
                 <Box mb={2}>

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/CreateEditFormA.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/CreateEditFormA.tsx
@@ -30,6 +30,7 @@ import MESSAGES from '../../messages';
 import { useFormAValidation } from './validation';
 import InputComponent from 'Iaso/components/forms/InputComponent';
 import { DropdownOptions } from 'Iaso/types/utils';
+import { DosesPerVialDropdown } from '../../types';
 
 type Props = {
     formA?: any;
@@ -39,12 +40,7 @@ type Props = {
     countryName: string;
     vaccine: Vaccine;
     vaccineStockId: string;
-    dosesOptions?: {
-        label: string;
-        value: number;
-        doses_available: number;
-        unusable_doses: number;
-    }[];
+    dosesOptions?: DosesPerVialDropdown;
 };
 
 export type FormAFormValues = {

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/CreateEditFormA.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/CreateEditFormA.tsx
@@ -31,6 +31,7 @@ import { useFormAValidation } from './validation';
 import InputComponent from 'Iaso/components/forms/InputComponent';
 import { DropdownOptions } from 'Iaso/types/utils';
 import { DosesPerVialDropdown } from '../../types';
+import { useAvailablePresentations } from './dropdownOptions';
 
 type Props = {
     formA?: any;
@@ -96,24 +97,10 @@ export const CreateEditFormA: FunctionComponent<Props> = ({
         Boolean(formA?.alternative_campaign),
     );
 
-    const availableDosesPresentations: DropdownOptions<number>[] =
-        useMemo(() => {
-            const availableOptions: DropdownOptions<number>[] = dosesOptions
-                ? dosesOptions.filter(option => option.doses_available > 0)
-                : [];
-            const availableValues = availableOptions.map(o => o.value);
-            // If the form A has already been encoded, we add the value to avoid putting the form in error
-            if (
-                formA?.doses_per_vial &&
-                !availableValues.includes(formA.doses_per_vial)
-            ) {
-                availableOptions.push({
-                    label: `${formA.doses_per_vial}`,
-                    value: formA.doses_per_vial,
-                });
-            }
-            return availableOptions;
-        }, [dosesOptions, formA?.doses_per_vial]);
+    const availableDosesPresentations = useAvailablePresentations(
+        dosesOptions,
+        formA,
+    );
     const { campaignOptions, isFetching, roundOptions } = useCampaignOptions(
         countryName,
         formik.values.campaign,

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/CreateEditIncident.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/CreateEditIncident.tsx
@@ -44,6 +44,7 @@ type Props = {
     dosesOptions?: DosesPerVialDropdown;
     hasUsableStock: boolean;
     hasUnusableStock: boolean;
+    defaultDosesPerVial: number | undefined;
 };
 
 /**
@@ -137,6 +138,7 @@ export const CreateEditIncident: FunctionComponent<Props> = ({
     dosesOptions,
     hasUsableStock,
     hasUnusableStock,
+    defaultDosesPerVial,
 }) => {
     const { formatMessage } = useSafeIntl();
     const { mutateAsync: save } = useSaveIncident();
@@ -215,9 +217,7 @@ export const CreateEditIncident: FunctionComponent<Props> = ({
         [incidentConfig, inventoryType, save],
     );
 
-    const defaultDosesPerVial =
-        //@ts-ignore
-        (dosesOptions ?? []).length === 1 ? dosesOptions[0].value : undefined;
+    const hasFixedDosesPerVial = Boolean(defaultDosesPerVial);
     const formik = useFormik<any>({
         initialValues: {
             id: incident?.id,
@@ -417,6 +417,8 @@ export const CreateEditIncident: FunctionComponent<Props> = ({
                                 name="doses_per_vial"
                                 component={SingleSelect}
                                 options={dosesOptions}
+                                disabled={hasFixedDosesPerVial}
+                                required
                             />
                         </Box>
                     </>

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/CreateEditIncident.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/CreateEditIncident.tsx
@@ -29,7 +29,10 @@ import { Vaccine } from '../../../../../constants/types';
 import { useSaveIncident } from '../../hooks/api';
 import { useGetMovementDescription } from '../../hooks/useGetMovementDescription';
 import MESSAGES from '../../messages';
-import { useIncidentOptions } from './dropdownOptions';
+import {
+    useAvailablePresentations,
+    useIncidentOptions,
+} from './dropdownOptions';
 import { useIncidentValidation } from './validation';
 import { DosesPerVialDropdown } from '../../types';
 
@@ -136,8 +139,8 @@ export const CreateEditIncident: FunctionComponent<Props> = ({
     vaccine,
     vaccineStockId,
     dosesOptions,
-    hasUsableStock,
-    hasUnusableStock,
+    hasUsableStock = true, // set default to true for editing mode
+    hasUnusableStock = true, // set default to true for editing mode
     defaultDosesPerVial,
 }) => {
     const { formatMessage } = useSafeIntl();
@@ -162,6 +165,10 @@ export const CreateEditIncident: FunctionComponent<Props> = ({
             return movementType === 'inventoryAdd' ? 0 : i.usable_vials;
         },
         [incidentConfig],
+    );
+    const availableDosesPresentations = useAvailablePresentations(
+        dosesOptions,
+        incident,
     );
 
     const handleInventoryTypeChange = (
@@ -411,18 +418,18 @@ export const CreateEditIncident: FunctionComponent<Props> = ({
                                 required
                             />
                         </Box>
-                        <Box mb={2}>
-                            <Field
-                                label={formatMessage(MESSAGES.doses_per_vial)}
-                                name="doses_per_vial"
-                                component={SingleSelect}
-                                options={dosesOptions}
-                                disabled={hasFixedDosesPerVial}
-                                required
-                            />
-                        </Box>
                     </>
                 )}
+                <Box mb={2}>
+                    <Field
+                        label={formatMessage(MESSAGES.doses_per_vial)}
+                        name="doses_per_vial"
+                        component={SingleSelect}
+                        options={availableDosesPresentations}
+                        disabled={hasFixedDosesPerVial}
+                        required
+                    />
+                </Box>
                 <Box mb={2}>
                     <Field
                         label={formatMessage(MESSAGES.comment)}

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/CreateEditIncident.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/CreateEditIncident.tsx
@@ -31,7 +31,7 @@ import { useGetMovementDescription } from '../../hooks/useGetMovementDescription
 import MESSAGES from '../../messages';
 import { useIncidentOptions } from './dropdownOptions';
 import { useIncidentValidation } from './validation';
-import { dosesPerVial } from '../../../SupplyChain/hooks/utils';
+import { DosesPerVialDropdown } from '../../types';
 
 type Props = {
     incident?: any;
@@ -41,12 +41,7 @@ type Props = {
     countryName: string;
     vaccine: Vaccine;
     vaccineStockId: string;
-    dosesOptions?: {
-        label: string;
-        value: number;
-        doses_available: number;
-        unusable_doses: number;
-    }[];
+    dosesOptions?: DosesPerVialDropdown;
     hasUsableStock: boolean;
     hasUnusableStock: boolean;
 };
@@ -219,6 +214,10 @@ export const CreateEditIncident: FunctionComponent<Props> = ({
         },
         [incidentConfig, inventoryType, save],
     );
+
+    const defaultDosesPerVial =
+        //@ts-ignore
+        (dosesOptions ?? []).length === 1 ? dosesOptions[0].value : undefined;
     const formik = useFormik<any>({
         initialValues: {
             id: incident?.id,
@@ -230,7 +229,7 @@ export const CreateEditIncident: FunctionComponent<Props> = ({
             date_of_incident_report: incident?.date_of_incident_report,
             usable_vials: incident?.usable_vials || 0,
             unusable_vials: incident?.unusable_vials || 0,
-            doses_per_vial: incident?.doses_per_vial || dosesPerVial[vaccine],
+            doses_per_vial: incident?.doses_per_vial || defaultDosesPerVial,
             movement: getInitialMovement(incident),
             vaccine_stock: vaccineStockId,
             file: incident?.file,

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/dropdownOptions.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/dropdownOptions.tsx
@@ -3,6 +3,7 @@ import { useSafeIntl } from 'bluesquare-components';
 import { DropdownOptions } from '../../../../../../../../../hat/assets/js/apps/Iaso/types/utils';
 import { CREATED, RETURNED } from '../../constants';
 import MESSAGES from '../../messages';
+import { DosesPerVialDropdown } from '../../types';
 
 export const VM_REACHED_DISCARD_POINT = 'vvm_reached_discard_point';
 export const VACCINE_EXPIRED = 'vaccine_expired';
@@ -84,13 +85,16 @@ export const useIncidentOptions = (
         if (hasUsableStock) {
             inventoryOptions.concat(optionsForUsable);
         }
-        return inventoryOptions.sort(
+        const results = hasUsableStock
+            ? [...inventoryOptions, ...optionsForUsable]
+            : inventoryOptions;
+        return results.sort(
             (
                 option1: DropdownOptions<IncidentType>,
                 option2: DropdownOptions<IncidentType>,
             ) => option1.label.localeCompare(option2.label),
         ) as DropdownOptions<IncidentType>[];
-    }, [formatMessage]);
+    }, [formatMessage, hasUsableStock]);
 };
 
 type EarmarkType = 'created' | 'returned' | 'used';
@@ -115,4 +119,32 @@ export const useEarmarkOptions = (): DropdownOptions<EarmarkType>[] => {
             ) => option1.label.localeCompare(option2.label),
         ) as DropdownOptions<EarmarkType>[];
     }, [formatMessage]);
+};
+
+export const useAvailablePresentations = (
+    dosesOptions: DosesPerVialDropdown | undefined,
+    formData: { doses_per_vial?: number },
+    usable = true,
+): DropdownOptions<number>[] => {
+    return useMemo(() => {
+        const availableOptions: DropdownOptions<number>[] = dosesOptions
+            ? dosesOptions.filter(option =>
+                  usable
+                      ? option.doses_available > 0
+                      : option.unusable_doses > 0,
+              )
+            : [];
+        const availableValues = availableOptions.map(o => o.value);
+        // If the form has already been encoded, we add the value to avoid putting the form in error
+        if (
+            formData?.doses_per_vial &&
+            !availableValues.includes(formData.doses_per_vial)
+        ) {
+            availableOptions.push({
+                label: `${formData.doses_per_vial}`,
+                value: formData.doses_per_vial,
+            });
+        }
+        return availableOptions;
+    }, [dosesOptions, formData?.doses_per_vial]);
 };

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/dropdownOptions.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/dropdownOptions.tsx
@@ -29,14 +29,18 @@ type IncidentType =
     | 'missing'
     | 'stealing'
     | 'physical_inventory'
+    | 'physical_inventory_add'
+    | 'physical_inventory_remove'
     | 'broken'
     | 'unreadable_label'
     | 'return';
 
-export const useIncidentOptions = (): DropdownOptions<IncidentType>[] => {
+export const useIncidentOptions = (
+    hasUsableStock: boolean,
+): DropdownOptions<IncidentType>[] => {
     const { formatMessage } = useSafeIntl();
     return useMemo(() => {
-        return [
+        const optionsForUsable: DropdownOptions<IncidentType>[] = [
             {
                 label: formatMessage(MESSAGES[VM_REACHED_DISCARD_POINT]),
                 value: VM_REACHED_DISCARD_POINT,
@@ -58,14 +62,6 @@ export const useIncidentOptions = (): DropdownOptions<IncidentType>[] => {
                 value: STEALING,
             },
             {
-                label: formatMessage(MESSAGES[PHYSICAL_INVENTORY_ADD]),
-                value: PHYSICAL_INVENTORY_ADD,
-            },
-            {
-                label: formatMessage(MESSAGES[PHYSICAL_INVENTORY_REMOVE]),
-                value: PHYSICAL_INVENTORY_REMOVE,
-            },
-            {
                 label: formatMessage(MESSAGES[BROKEN]),
                 value: BROKEN,
             },
@@ -73,7 +69,22 @@ export const useIncidentOptions = (): DropdownOptions<IncidentType>[] => {
                 label: formatMessage(MESSAGES[UNREADABLE_LABEL]),
                 value: UNREADABLE_LABEL,
             },
-        ].sort(
+        ];
+        const inventoryOptions: DropdownOptions<IncidentType>[] = [
+            {
+                label: formatMessage(MESSAGES[PHYSICAL_INVENTORY_ADD]),
+                value: PHYSICAL_INVENTORY_ADD,
+            },
+            {
+                label: formatMessage(MESSAGES[PHYSICAL_INVENTORY_REMOVE]),
+                value: PHYSICAL_INVENTORY_REMOVE,
+            },
+        ];
+
+        if (hasUsableStock) {
+            inventoryOptions.concat(optionsForUsable);
+        }
+        return inventoryOptions.sort(
             (
                 option1: DropdownOptions<IncidentType>,
                 option2: DropdownOptions<IncidentType>,

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/VaccineStockVariation.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/VaccineStockVariation.tsx
@@ -78,6 +78,9 @@ export const VaccineStockVariation: FunctionComponent = () => {
         dosesOptions?.some(option => option.doses_available > 0) ?? false;
     const hasUnusableStock =
         dosesOptions?.some(option => option.unusable_doses > 0) ?? false;
+    const defaultDosesPerVial =
+        //@ts-ignore
+        (dosesOptions ?? []).length === 1 ? dosesOptions[0].value : undefined;
     const { data: formA, isFetching: isFetchingFormA } = useGetFormAList(
         params,
         tab === FORM_A,
@@ -167,6 +170,9 @@ export const VaccineStockVariation: FunctionComponent = () => {
                                         vaccine={summary?.vaccine_type}
                                         vaccineStockId={params.id as string}
                                         dosesOptions={dosesOptions}
+                                        defaultDosesPerVial={
+                                            defaultDosesPerVial
+                                        }
                                     />
                                 )}
                             </DisplayIfUserHasPerm>
@@ -185,6 +191,9 @@ export const VaccineStockVariation: FunctionComponent = () => {
                                         vaccine={summary?.vaccine_type}
                                         vaccineStockId={params.id as string}
                                         dosesOptions={dosesOptions}
+                                        defaultDosesPerVial={
+                                            defaultDosesPerVial
+                                        }
                                     />
                                 )}
                             </DisplayIfUserHasPerm>
@@ -203,6 +212,9 @@ export const VaccineStockVariation: FunctionComponent = () => {
                                         dosesOptions={dosesOptions}
                                         hasUsableStock={hasUsableStock}
                                         hasUnusableStock={hasUnusableStock}
+                                        defaultDosesPerVial={
+                                            defaultDosesPerVial
+                                        }
                                     />
                                 )}
                             </DisplayIfUserHasPerm>
@@ -221,6 +233,9 @@ export const VaccineStockVariation: FunctionComponent = () => {
                                         vaccine={summary?.vaccine_type}
                                         vaccineStockId={params.id as string}
                                         dosesOptions={dosesOptions}
+                                        defaultDosesPerVial={
+                                            defaultDosesPerVial
+                                        }
                                     />
                                 )}
                             </DisplayIfUserHasPerm>

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/VaccineStockVariation.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/VaccineStockVariation.tsx
@@ -112,7 +112,7 @@ export const VaccineStockVariation: FunctionComponent = () => {
         summary?.country_name,
         summary?.vaccine_type,
     );
-
+    console.log('HAS USABLE', hasUsableStock, dosesOptions, tab);
     return (
         <>
             <TopBar title={title} displayBackButton goBack={goBack}>

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/VaccineStockVariation.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/VaccineStockVariation.tsx
@@ -22,6 +22,7 @@ import { baseUrls } from '../../../../constants/urls';
 import { DESTRUCTION, EARMARKED, FORM_A, INCIDENT } from '../constants';
 import {
     useGetDestructionList,
+    useGetDosesOptions,
     useGetEarmarkedList,
     useGetFormAList,
     useGetIncidentList,
@@ -72,6 +73,11 @@ export const VaccineStockVariation: FunctionComponent = () => {
         baseUrl,
     });
 
+    const { data: dosesOptions } = useGetDosesOptions(parseInt(params.id, 10));
+    const hasUsableStock =
+        dosesOptions?.some(option => option.doses_available > 0) ?? false;
+    const hasUnusableStock =
+        dosesOptions?.some(option => option.unusable_doses > 0) ?? false;
     const { data: formA, isFetching: isFetchingFormA } = useGetFormAList(
         params,
         tab === FORM_A,
@@ -154,10 +160,13 @@ export const VaccineStockVariation: FunctionComponent = () => {
                             >
                                 {tab === FORM_A && (
                                     <CreateFormA
-                                        iconProps={{}}
+                                        iconProps={{
+                                            disabled: !hasUsableStock,
+                                        }}
                                         countryName={summary?.country_name}
                                         vaccine={summary?.vaccine_type}
                                         vaccineStockId={params.id as string}
+                                        dosesOptions={dosesOptions}
                                     />
                                 )}
                             </DisplayIfUserHasPerm>
@@ -169,10 +178,13 @@ export const VaccineStockVariation: FunctionComponent = () => {
                             >
                                 {tab === DESTRUCTION && (
                                     <CreateDestruction
-                                        iconProps={{}}
+                                        iconProps={{
+                                            disabled: !hasUnusableStock,
+                                        }}
                                         countryName={summary?.country_name}
                                         vaccine={summary?.vaccine_type}
                                         vaccineStockId={params.id as string}
+                                        dosesOptions={dosesOptions}
                                     />
                                 )}
                             </DisplayIfUserHasPerm>
@@ -188,6 +200,9 @@ export const VaccineStockVariation: FunctionComponent = () => {
                                         countryName={summary?.country_name}
                                         vaccine={summary?.vaccine_type}
                                         vaccineStockId={params.id as string}
+                                        dosesOptions={dosesOptions}
+                                        hasUsableStock={hasUsableStock}
+                                        hasUnusableStock={hasUnusableStock}
                                     />
                                 )}
                             </DisplayIfUserHasPerm>
@@ -199,10 +214,13 @@ export const VaccineStockVariation: FunctionComponent = () => {
                             >
                                 {tab === EARMARKED && (
                                     <CreateEarmarked
-                                        iconProps={{}}
+                                        iconProps={{
+                                            disabled: !hasUsableStock,
+                                        }}
                                         countryName={summary?.country_name}
                                         vaccine={summary?.vaccine_type}
                                         vaccineStockId={params.id as string}
+                                        dosesOptions={dosesOptions}
                                     />
                                 )}
                             </DisplayIfUserHasPerm>

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/VaccineStockVariation.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/VaccineStockVariation.tsx
@@ -112,7 +112,7 @@ export const VaccineStockVariation: FunctionComponent = () => {
         summary?.country_name,
         summary?.vaccine_type,
     );
-    console.log('HAS USABLE', hasUsableStock, dosesOptions, tab);
+
     return (
         <>
             <TopBar title={title} displayBackButton goBack={goBack}>

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/hooks/api.ts
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/hooks/api.ts
@@ -253,9 +253,18 @@ export const useGetEarmarkedList = (
     });
 };
 
-export const useGetDosesOptions = (stockId: number) => {
+export const useGetDosesOptions = (
+    stockId: number,
+): UseQueryResult<
+    {
+        label: string;
+        value: number;
+        doses_available: number;
+        unusable_doses: number;
+    }[]
+> => {
     return useSnackQuery({
-        queryKey: ['earmarked-list', 'options'],
+        queryKey: ['doses_options', stockId],
         queryFn: () => getRequest(`${apiUrl}doses_options/?stockId=${stockId}`),
         options: {
             ...options,

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/hooks/api.ts
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/hooks/api.ts
@@ -417,6 +417,7 @@ export const useSaveFormA = (): UseMutationResult<
             'file',
             'earmarked',
             'earmarked-list',
+            'doses_options',
         ],
     });
 };
@@ -467,6 +468,7 @@ export const useSaveDestruction = () => {
             'stock-management-summary',
             'unusable-vials',
             'file',
+            'doses_options',
         ],
     });
 };
@@ -518,6 +520,7 @@ export const useSaveIncident = () => {
             'file',
             'earmarked',
             'earmarked-list',
+            'doses_options',
         ],
     });
 };
@@ -557,6 +560,7 @@ export const useSaveEarmarked = () => {
             'unusable-vials',
             'earmarked',
             'earmarked-list',
+            'doses_options',
         ],
     });
 };
@@ -587,6 +591,7 @@ export const useDeleteIncident = (): UseMutationResult => {
             'unusable-vials',
             'earmarked',
             'earmarked-list',
+            'doses_options',
         ],
     });
 };
@@ -604,6 +609,7 @@ export const useDeleteDestruction = (): UseMutationResult => {
             'usable-vials',
             'stock-management-summary',
             'unusable-vials',
+            'doses_options',
         ],
     });
 };
@@ -623,6 +629,7 @@ export const useDeleteFormA = (): UseMutationResult => {
             'unusable-vials',
             'earmarked',
             'earmarked-list',
+            'doses_options',
         ],
     });
 };
@@ -640,6 +647,7 @@ export const useDeleteEarmarked = (): UseMutationResult => {
             'unusable-vials',
             'earmarked',
             'earmarked-list',
+            'doses_options',
         ],
     });
 };

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/hooks/api.ts
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/hooks/api.ts
@@ -26,6 +26,7 @@ import {
 import { patchRequest2, postRequest2 } from '../../SupplyChain/hooks/api/vrf';
 import MESSAGES from '../messages';
 import {
+    DosesPerVialDropdown,
     StockManagementDetailsParams,
     StockManagementListParams,
     StockVariationParams,
@@ -255,14 +256,7 @@ export const useGetEarmarkedList = (
 
 export const useGetDosesOptions = (
     stockId: number,
-): UseQueryResult<
-    {
-        label: string;
-        value: number;
-        doses_available: number;
-        unusable_doses: number;
-    }[]
-> => {
+): UseQueryResult<DosesPerVialDropdown> => {
     return useSnackQuery({
         queryKey: ['doses_options', stockId],
         queryFn: () => getRequest(`${apiUrl}doses_options/?stockId=${stockId}`),

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/types.ts
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/types.ts
@@ -52,3 +52,12 @@ export type StockVariationParams = {
     earmarkedPage?: string; // number as string
     earmarkedOrder?: string;
 };
+
+export type DosesPerVialDropdownItem = {
+    label: string;
+    value: number;
+    doses_available: number;
+    unusable_doses: number;
+};
+
+export type DosesPerVialDropdown = DosesPerVialDropdownItem[];

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/PreAlerts/PreAlerts.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/PreAlerts/PreAlerts.tsx
@@ -8,7 +8,6 @@ import {
     useEmptyPreAlert,
 } from '../shared';
 import { PREALERT } from '../../constants';
-import { createEmptyPreAlert } from '../../hooks/utils';
 import { useCurrentUser } from '../../../../../../../../../hat/assets/js/apps/Iaso/utils/usersUtils';
 
 import { userHasOneOfPermissions } from '../../../../../../../../../hat/assets/js/apps/Iaso/domains/users/utils';

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/PreAlerts/PreAlerts.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/PreAlerts/PreAlerts.tsx
@@ -2,7 +2,11 @@ import React, { FunctionComponent, useCallback } from 'react';
 import { useFormikContext } from 'formik';
 import { PreAlert } from './PreAlert';
 import MESSAGES from '../../messages';
-import { MultiFormTab } from '../shared';
+import {
+    MultiFormTab,
+    useDosesPerVialDropDownForVaccine,
+    useEmptyPreAlert,
+} from '../shared';
 import { PREALERT } from '../../constants';
 import { createEmptyPreAlert } from '../../hooks/utils';
 import { useCurrentUser } from '../../../../../../../../../hat/assets/js/apps/Iaso/utils/usersUtils';
@@ -23,13 +27,11 @@ export const PreAlerts: FunctionComponent<Props> = ({
     // TODO manage errors
     const { values, setFieldValue } = useFormikContext<any>();
     const vaccine = values.vrf?.vaccine_type;
-
+    const dosesPerVaccineOptions = useDosesPerVialDropDownForVaccine(vaccine);
+    const emptyPreAlert = useEmptyPreAlert(dosesPerVaccineOptions);
     const onClick = useCallback(() => {
-        setFieldValue(PREALERT, [
-            ...values[PREALERT],
-            createEmptyPreAlert(vaccine),
-        ]);
-    }, [setFieldValue, values, vaccine]);
+        setFieldValue(PREALERT, [...values[PREALERT], emptyPreAlert]);
+    }, [setFieldValue, values, vaccine, emptyPreAlert]);
 
     const currentUser = useCurrentUser();
 
@@ -48,7 +50,13 @@ export const PreAlerts: FunctionComponent<Props> = ({
             onClick={onClick}
         >
             {items.map((_, index) => {
-                return <PreAlert index={index} vaccine={vaccine} key={index} />;
+                return (
+                    <PreAlert
+                        index={index}
+                        key={index}
+                        dosesForVaccineOptions={dosesPerVaccineOptions}
+                    />
+                );
             })}
         </MultiFormTab>
     );

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/VAR/VaccineArrivalReport.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/VAR/VaccineArrivalReport.tsx
@@ -5,21 +5,26 @@ import classNames from 'classnames';
 import { Field, useFormikContext } from 'formik';
 import React, { FunctionComponent, useCallback, useMemo, useRef } from 'react';
 import { DeleteIconButton } from '../../../../../../../../../hat/assets/js/apps/Iaso/components/Buttons/DeleteIconButton';
-import { NumberCell } from '../../../../../../../../../hat/assets/js/apps/Iaso/components/Cells/NumberCell';
-import { Optional } from '../../../../../../../../../hat/assets/js/apps/Iaso/types/utils';
+import {
+    DropdownOptions,
+    Optional,
+} from '../../../../../../../../../hat/assets/js/apps/Iaso/types/utils';
 import { NumberInput, Select } from '../../../../../components/Inputs';
 import { DateInput } from '../../../../../components/Inputs/DateInput';
 import { VAR } from '../../constants';
-import { dosesPerVial } from '../../hooks/utils';
 import MESSAGES from '../../messages';
 import { SupplyChainFormData } from '../../types';
-import { grayText, usePaperStyles } from '../shared';
+import { usePaperStyles } from '../shared';
+import { SingleSelect } from '../../../../../components/Inputs/SingleSelect';
 
-type Props = { index: number; vaccine?: string };
+type Props = {
+    index: number;
+    dosesForVaccineOptions: DropdownOptions<number>[];
+};
 
 export const VaccineArrivalReport: FunctionComponent<Props> = ({
     index,
-    vaccine,
+    dosesForVaccineOptions,
 }) => {
     const classes: Record<string, string> = usePaperStyles();
     const { formatMessage } = useSafeIntl();
@@ -27,17 +32,19 @@ export const VaccineArrivalReport: FunctionComponent<Props> = ({
         useFormikContext<SupplyChainFormData>();
     const { arrival_reports } = values as SupplyChainFormData;
     const markedForDeletion = arrival_reports?.[index].to_delete ?? false;
-    const uneditableTextStyling = markedForDeletion ? grayText : undefined;
+
     // Use refs to track focused state to reduce renders and avoid sluggish UI
     const dosesReceivedRef = useRef<boolean>(false);
     const vialsReceivedRef = useRef<boolean>(false);
     const dosesShippedRef = useRef<boolean>(false);
     const vialsShippedRef = useRef<boolean>(false);
-    const dosesPerVialsRef = useRef<boolean>(false);
 
-    const doses_per_vial_default = vaccine ? dosesPerVial[vaccine] : undefined;
+    const defaultDosesPerVial =
+        dosesForVaccineOptions.length === 1
+            ? dosesForVaccineOptions[0].value
+            : undefined;
     const doses_per_vial =
-        arrival_reports?.[index].doses_per_vial ?? doses_per_vial_default;
+        arrival_reports?.[index].doses_per_vial ?? defaultDosesPerVial;
     const poNumberOptions = useMemo(() => {
         return (
             (
@@ -71,6 +78,10 @@ export const VaccineArrivalReport: FunctionComponent<Props> = ({
             );
             if (preAlert) {
                 setFieldValue(
+                    `${VAR}[${index}].doses_per_vial`,
+                    preAlert.doses_per_vial,
+                );
+                setFieldValue(
                     `${VAR}[${index}].doses_shipped`,
                     preAlert.doses_shipped,
                 );
@@ -81,10 +92,7 @@ export const VaccineArrivalReport: FunctionComponent<Props> = ({
                         : parseInt(dosesShipped ?? '0', 10);
                 setFieldValue(
                     `${VAR}[${index}].vials_shipped`,
-                    Math.ceil(
-                        dosesShippedAsNumber /
-                            parseInt(doses_per_vial ?? 1, 10),
-                    ),
+                    Math.ceil(dosesShippedAsNumber / (doses_per_vial ?? 1)),
                 );
             }
             // Call setFieldTouched before setFieldValue to avoid validation bug
@@ -178,28 +186,24 @@ export const VaccineArrivalReport: FunctionComponent<Props> = ({
 
     const handleDosesPerVialUpdate = useCallback(
         (value: number) => {
-            if (dosesPerVialsRef.current) {
-                const vialsShipped = Math.ceil(
-                    parseInt(
-                        (arrival_reports?.[index].doses_shipped ??
-                            '0') as string,
-                        10,
-                    ) / value,
-                );
-                const vialsReceived = Math.ceil(
-                    parseInt(
-                        (arrival_reports?.[index].doses_received ??
-                            '0') as string,
-                        10,
-                    ) / value,
-                );
+            const vialsShipped = Math.ceil(
+                parseInt(
+                    (arrival_reports?.[index].doses_shipped ?? '0') as string,
+                    10,
+                ) / value,
+            );
+            const vialsReceived = Math.ceil(
+                parseInt(
+                    (arrival_reports?.[index].doses_received ?? '0') as string,
+                    10,
+                ) / value,
+            );
 
-                handleSetValues({
-                    vials_shipped: vialsShipped,
-                    doses_per_vial: value,
-                    vials_received: vialsReceived,
-                });
-            }
+            handleSetValues({
+                vials_shipped: vialsShipped,
+                doses_per_vial: value,
+                vials_received: vialsReceived,
+            });
         },
         [index, setFieldValue, arrival_reports],
     );
@@ -227,12 +231,6 @@ export const VaccineArrivalReport: FunctionComponent<Props> = ({
     };
     const onVialsReceivedBlur = () => {
         vialsReceivedRef.current = false;
-    };
-    const onDosesPerVialFocus = () => {
-        dosesPerVialsRef.current = true;
-    };
-    const onDosesPerVialBlur = () => {
-        dosesPerVialsRef.current = false;
     };
 
     return (
@@ -324,14 +322,15 @@ export const VaccineArrivalReport: FunctionComponent<Props> = ({
                                         MESSAGES.doses_per_vial,
                                     )}
                                     name={`arrival_reports[${index}].doses_per_vial`}
-                                    component={NumberInput}
+                                    component={SingleSelect}
                                     disabled={
                                         markedForDeletion ||
-                                        !arrival_reports?.[index].can_edit
+                                        !arrival_reports?.[index].can_edit ||
+                                        dosesForVaccineOptions.length === 1
                                     }
                                     onChange={handleDosesPerVialUpdate}
-                                    onFocus={onDosesPerVialFocus}
-                                    onBlur={onDosesPerVialBlur}
+                                    options={dosesForVaccineOptions}
+                                    clearable={false}
                                     required
                                 />
                             </Box>

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/VAR/VaccineArrivalReport.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/VAR/VaccineArrivalReport.tsx
@@ -185,7 +185,7 @@ export const VaccineArrivalReport: FunctionComponent<Props> = ({
     );
 
     const handleDosesPerVialUpdate = useCallback(
-        (value: number) => {
+        (_, value: number) => {
             const vialsShipped = Math.ceil(
                 parseInt(
                     (arrival_reports?.[index].doses_shipped ?? '0') as string,

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/VAR/VaccineArrivalReport.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/VAR/VaccineArrivalReport.tsx
@@ -77,10 +77,13 @@ export const VaccineArrivalReport: FunctionComponent<Props> = ({
                 pre => pre.po_number === value,
             );
             if (preAlert) {
-                setFieldValue(
-                    `${VAR}[${index}].doses_per_vial`,
-                    preAlert.doses_per_vial,
-                );
+                // Only set doses per vial if the arrival report doesn't already have a value for it
+                if (!doses_per_vial) {
+                    setFieldValue(
+                        `${VAR}[${index}].doses_per_vial`,
+                        preAlert.doses_per_vial,
+                    );
+                }
                 setFieldValue(
                     `${VAR}[${index}].doses_shipped`,
                     preAlert.doses_shipped,
@@ -92,7 +95,9 @@ export const VaccineArrivalReport: FunctionComponent<Props> = ({
                         : parseInt(dosesShipped ?? '0', 10);
                 setFieldValue(
                     `${VAR}[${index}].vials_shipped`,
-                    Math.ceil(dosesShippedAsNumber / (doses_per_vial ?? 1)),
+                    Math.ceil(
+                        dosesShippedAsNumber / (preAlert.doses_per_vial ?? 1),
+                    ),
                 );
             }
             // Call setFieldTouched before setFieldValue to avoid validation bug
@@ -198,7 +203,6 @@ export const VaccineArrivalReport: FunctionComponent<Props> = ({
                     10,
                 ) / value,
             );
-
             handleSetValues({
                 vials_shipped: vialsShipped,
                 doses_per_vial: value,

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/VAR/VaccineArrivalReports.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/VAR/VaccineArrivalReports.tsx
@@ -2,9 +2,12 @@ import React, { FunctionComponent, useCallback } from 'react';
 import { useFormikContext } from 'formik';
 import { VaccineArrivalReport } from './VaccineArrivalReport';
 import MESSAGES from '../../messages';
-import { MultiFormTab } from '../shared';
+import {
+    MultiFormTab,
+    useDosesPerVialDropDownForVaccine,
+    useEmptyArrivalReport,
+} from '../shared';
 import { VAR } from '../../constants';
-import { createEmptyArrivalReport } from '../../hooks/utils';
 import { useCurrentUser } from '../../../../../../../../../hat/assets/js/apps/Iaso/utils/usersUtils';
 import {
     POLIO_SUPPLY_CHAIN_READ,
@@ -20,9 +23,10 @@ export const VaccineArrivalReports: FunctionComponent<Props> = ({
 }) => {
     const { values, setFieldValue } = useFormikContext<any>();
     const vaccine = values.vrf?.vaccine_type;
-
+    const dosesPerVaccineOptions = useDosesPerVialDropDownForVaccine(vaccine);
+    const emptyArrivalReport = useEmptyArrivalReport(dosesPerVaccineOptions);
     const onClick = useCallback(() => {
-        setFieldValue(VAR, [...values[VAR], createEmptyArrivalReport(vaccine)]);
+        setFieldValue(VAR, [...values[VAR], emptyArrivalReport]);
     }, [setFieldValue, values, vaccine]);
 
     const currentUser = useCurrentUser();
@@ -44,8 +48,8 @@ export const VaccineArrivalReports: FunctionComponent<Props> = ({
                 return (
                     <VaccineArrivalReport
                         index={index}
-                        vaccine={vaccine}
                         key={index}
+                        dosesForVaccineOptions={dosesPerVaccineOptions}
                     />
                 );
             })}

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/shared.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/shared.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, ReactNode } from 'react';
+import React, { FunctionComponent, ReactNode, useMemo } from 'react';
 import { Box, Grid, Theme, Typography } from '@mui/material';
 import { grey } from '@mui/material/colors';
 import { makeStyles } from '@mui/styles';
@@ -8,6 +8,8 @@ import {
     MENU_HEIGHT_WITH_TABS,
     useSafeIntl,
 } from 'bluesquare-components';
+import { useGetDosesPerVial } from '../hooks/api/useGetDosesPerVial';
+import { DropdownOptions } from 'Iaso/types/utils';
 
 export const useSharedStyles = makeStyles({
     scrollableForm: {
@@ -74,3 +76,61 @@ export const usePaperStyles = makeStyles((theme: Theme) => ({
     container: { display: 'inline-flex', width: '100%' },
 }));
 export const grayText = { color: grey[500] };
+
+export const useDosesPerVialDropDownForVaccine = (
+    vaccine?: 'bOPV' | 'nOPV2' | 'mOPV2',
+): DropdownOptions<number>[] => {
+    const { data: dosesPerVialReference } = useGetDosesPerVial();
+    return useMemo(() => {
+        const options =
+            vaccine && dosesPerVialReference
+                ? dosesPerVialReference[vaccine]
+                : [];
+        return options.map((option: number) => ({
+            label: `${option}`,
+            value: option,
+        }));
+    }, [dosesPerVialReference, vaccine]);
+};
+
+export const useEmptyPreAlert = (
+    dosesPerVaccineOptions: DropdownOptions<number>[],
+) => {
+    return useMemo(() => {
+        return {
+            date_pre_alert_reception: undefined,
+            po_number: undefined,
+            estimated_arrival_time: undefined,
+            expiration_date: undefined,
+            doses_shipped: undefined,
+            doses_per_vial:
+                dosesPerVaccineOptions.length === 1
+                    ? dosesPerVaccineOptions[0].value
+                    : undefined,
+            lot_numbers: undefined,
+            to_delete: false,
+            id: undefined,
+            can_edit: true,
+        };
+    }, [dosesPerVaccineOptions]);
+};
+export const useEmptyArrivalReport = (
+    dosesPerVaccineOptions: DropdownOptions<number>[],
+) => {
+    return useMemo(() => {
+        return {
+            report_date: undefined,
+            po_number: undefined,
+            lot_numbers: undefined,
+            expiration_date: undefined,
+            doses_shipped: undefined,
+            doses_received: undefined,
+            to_delete: false,
+            can_edit: true,
+            doses_per_vial:
+                dosesPerVaccineOptions.length === 1
+                    ? dosesPerVaccineOptions[0].value
+                    : undefined,
+        };
+    }, [dosesPerVaccineOptions]);
+};

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/hooks/api/useGetDosesPerVial.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/hooks/api/useGetDosesPerVial.tsx
@@ -1,0 +1,15 @@
+import { getRequest } from 'Iaso/libs/Api';
+import { useSnackQuery } from 'Iaso/libs/apiHooks';
+
+export const useGetDosesPerVial = () => {
+    return useSnackQuery({
+        queryKey: ['doses_per_vial'],
+        queryFn: () => getRequest('/api/polio/vaccine/doses_per_vial/'),
+        options: {
+            select: data => (data ?? [{}])[0].data,
+            keepPreviousData: true,
+            staleTime: 1000 * 60 * 15, // in MS
+            cacheTime: 1000 * 60 * 5,
+        },
+    });
+};

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/hooks/utils.ts
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/hooks/utils.ts
@@ -44,7 +44,7 @@ export const createEmptyPreAlert = (vaccineType?: string) => {
         estimated_arrival_time: undefined,
         expiration_date: undefined,
         doses_shipped: undefined,
-        doses_per_vial,
+        doses_per_vial: undefined,
         lot_numbers: undefined,
         to_delete: false,
         id: undefined,

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/hooks/utils.ts
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/hooks/utils.ts
@@ -19,39 +19,6 @@ export const dosesPerVial = {
     mOPV2: 20,
 };
 
-export const createEmptyArrivalReport = (vaccineType?: string) => {
-    const doses_per_vial = vaccineType ? dosesPerVial[vaccineType] : undefined;
-
-    return {
-        report_date: undefined,
-        po_number: undefined,
-        lot_numbers: undefined,
-        expiration_date: undefined,
-        doses_shipped: undefined,
-        doses_received: undefined,
-        to_delete: false,
-        doses_per_vial,
-        can_edit: true,
-    };
-};
-
-export const createEmptyPreAlert = (vaccineType?: string) => {
-    const doses_per_vial = vaccineType ? dosesPerVial[vaccineType] : undefined;
-
-    return {
-        date_pre_alert_reception: undefined,
-        po_number: undefined,
-        estimated_arrival_time: undefined,
-        expiration_date: undefined,
-        doses_shipped: undefined,
-        doses_per_vial: undefined,
-        lot_numbers: undefined,
-        to_delete: false,
-        id: undefined,
-        can_edit: true,
-    };
-};
-
 const areArrayElementsChanged = (
     newElements: Array<Partial<PreAlert>> | Array<Partial<VARType>>,
 ): boolean => {

--- a/plugins/polio/models/base.py
+++ b/plugins/polio/models/base.py
@@ -34,6 +34,7 @@ from beanstalk_worker import task_decorator
 from iaso.models import Group, OrgUnit
 from iaso.models.base import Account
 from iaso.models.entity import UserNotAuthError
+from iaso.models.json_config import Config
 from iaso.models.microplanning import Team
 from iaso.models.project import Project
 from iaso.models.task import Task
@@ -46,6 +47,8 @@ from iaso.utils.virus_scan.model import ModelWithFile
 from plugins.polio.preparedness.parser import open_sheet_by_url
 from plugins.polio.preparedness.spread_cache import CachedSpread
 
+
+DOSES_PER_VIAL_CONFIG_SLUG = "vaccine_doses_per_vial"
 
 VIRUSES = [
     ("PV1", _("PV1")),
@@ -2792,3 +2795,32 @@ class VaccineStockCalculator:
             self.list_of_earmarked = results
 
         return results
+
+    def get_stock_by_vaccine_presentation(self):
+        presentation_config = Config.objects.filter(slug=DOSES_PER_VIAL_CONFIG_SLUG).first()
+        if not presentation_config:
+            return None
+
+        options = presentation_config.content[self.vaccine_stock.vaccine]
+        if not options:
+            return None
+        results = {}
+        for option in options:
+            results[str(option)] = self._get_stock_for_presentation(option)[1]
+        return results
+
+    def _get_stock_for_presentation(self, option: str):
+        usable_vials = self.get_list_of_usable_vials()
+        total_usable_vials = 0
+        total_usable_doses = 0
+        for vial in usable_vials:
+            if vial["doses_per_vial"] == option:
+                if vial["vials_in"]:
+                    total_usable_vials += vial["vials_in"]
+                if vial["doses_in"]:
+                    total_usable_doses += vial["doses_in"]
+                if vial["vials_out"]:
+                    total_usable_vials -= vial["vials_out"]
+                if vial["doses_out"]:
+                    total_usable_doses -= vial["doses_out"]
+        return total_usable_vials, total_usable_doses

--- a/plugins/polio/tests/api/vaccine_stock_management/test_doses_per_vaccine_endpoint.py
+++ b/plugins/polio/tests/api/vaccine_stock_management/test_doses_per_vaccine_endpoint.py
@@ -1,5 +1,6 @@
 from iaso.models.json_config import Config
 from iaso.test import APITestCase
+from plugins.polio.models.base import DOSES_PER_VIAL_CONFIG_SLUG
 from plugins.polio.permissions import POLIO_PERMISSION
 
 
@@ -18,7 +19,7 @@ class DosesPerVaccineEndpointTestCase(APITestCase):
 
         # Relevant config for the endpoint
         cls.content = {"mOPV2": [50], "nOPV2": [20, 50], "bOPV": [10, 20]}
-        Config.objects.create(slug="vaccine_doses_per_vial", content=cls.content)
+        Config.objects.create(slug=DOSES_PER_VIAL_CONFIG_SLUG, content=cls.content)
 
         # Irrelevant config should be ignored by the queryset filter
         Config.objects.create(slug="unrelated_config", content={"foo": "bar"})
@@ -44,5 +45,5 @@ class DosesPerVaccineEndpointTestCase(APITestCase):
         # ConfigSerializer fields: created_at, updated_at, key (slug), data (content)
         self.assertIn("created_at", item)
         self.assertIn("updated_at", item)
-        self.assertEqual(item["key"], "vaccine_doses_per_vial")
+        self.assertEqual(item["key"], DOSES_PER_VIAL_CONFIG_SLUG)
         self.assertEqual(item["data"], self.content)

--- a/plugins/polio/tests/api/vaccine_stock_management/test_doses_per_vaccine_endpoint.py
+++ b/plugins/polio/tests/api/vaccine_stock_management/test_doses_per_vaccine_endpoint.py
@@ -1,0 +1,48 @@
+from iaso.models.json_config import Config
+from iaso.test import APITestCase
+from plugins.polio.permissions import POLIO_PERMISSION
+
+
+BASE_URL = "/api/polio/vaccine/doses_per_vial/"
+
+
+class DosesPerVaccineEndpointTestCase(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        # Minimal account/project setup
+        cls.account, cls.datasource, cls.source_version, cls.project = cls.create_account_datasource_version_project(
+            "Default source", "Default account", "Default project"
+        )
+        # Users: one with required permission, one without, and an anonymous user
+        cls.user, cls.anon, cls.user_no_perms = cls.create_base_users(cls.account, [POLIO_PERMISSION])
+
+        # Relevant config for the endpoint
+        cls.content = {"mOPV2": [50], "nOPV2": [20, 50], "bOPV": [10, 20]}
+        Config.objects.create(slug="vaccine_doses_per_vial", content=cls.content)
+
+        # Irrelevant config should be ignored by the queryset filter
+        Config.objects.create(slug="unrelated_config", content={"foo": "bar"})
+
+    def test_anonymous_user_cannot_list(self):
+        self.client.force_authenticate(self.anon)
+        response = self.client.get(BASE_URL)
+        self.assertEqual(response.status_code, 403)
+
+    def test_user_without_perms_cannot_list(self):
+        self.client.force_authenticate(self.user_no_perms)
+        response = self.client.get(BASE_URL)
+        self.assertEqual(response.status_code, 403)
+
+    def test_user_with_perm_can_list(self):
+        self.client.force_authenticate(self.user)
+        response = self.client.get(BASE_URL)
+        data = self.assertJSONResponse(response, 200)
+
+        self.assertEqual(len(data), 1)
+
+        item = data[0]
+        # ConfigSerializer fields: created_at, updated_at, key (slug), data (content)
+        self.assertIn("created_at", item)
+        self.assertIn("updated_at", item)
+        self.assertEqual(item["key"], "vaccine_doses_per_vial")
+        self.assertEqual(item["data"], self.content)

--- a/plugins/polio/tests/test_vaccine_stock_management.py
+++ b/plugins/polio/tests/test_vaccine_stock_management.py
@@ -8,9 +8,11 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.utils import timezone
 
 from iaso import models as m
+from iaso.models.json_config import Config
 from iaso.test import APITestCase
 from plugins.polio import models as pm
 from plugins.polio.models import OutgoingStockMovement
+from plugins.polio.models.base import DOSES_PER_VIAL_CONFIG_SLUG
 from plugins.polio.permissions import (
     POLIO_VACCINE_STOCK_EARMARKS_ADMIN_PERMISSION,
     POLIO_VACCINE_STOCK_MANAGEMENT_READ_ONLY_PERMISSION,
@@ -218,6 +220,10 @@ class VaccineStockManagementAPITestCase(APITestCase):
             unusable_vials=1,
             usable_vials=0,
             doses_per_vial=20,
+        )
+
+        cls.config = Config.objects.create(
+            slug=DOSES_PER_VIAL_CONFIG_SLUG, content={"bOPV": [10, 20], "mOPV2": [20, 50], "nOPV2": [50]}
         )
 
     def test_anonymous_user_cannot_see_list(self):
@@ -1701,23 +1707,18 @@ class VaccineStockManagementAPITestCase(APITestCase):
         # Test with valid stock ID
         response = self.client.get(f"{BASE_URL}doses_options/?stockId={self.vaccine_stock.id}")
 
-        self.assertEqual(response.status_code, 200)
-        data = response.json()
+        data = self.assertJSONResponse(response, 200)
 
-        # Check response structure
-        self.assertIn("results", data)
-        self.assertIsInstance(data["results"], list)
+        results = data["results"]
+        self.assertEqual(len(results), 2)
 
-        # Check that we have the expected doses_per_vial value from our test data
-        expected_doses = [20]  # From vaccine_arrival_report.doses_per_vial = 20
-        result_values = [item["value"] for item in data["results"]]
-        self.assertEqual(set(result_values), set(expected_doses))
-
-        # Check that each result has the correct structure
-        for item in data["results"]:
+        for item in results:
             self.assertIn("label", item)
             self.assertIn("value", item)
-            self.assertEqual(item["label"], str(item["value"]))
+            self.assertIn("doses_available", item)
+
+        self.assertIn({"label": "20", "value": 20, "doses_available": 460}, results)
+        self.assertIn({"label": "50", "value": 50, "doses_available": 0}, results)
 
     def test_doses_options_endpoint_missing_stock_id(self):
         """Test the doses_options endpoint returns 400 when stockId is missing"""
@@ -1735,144 +1736,6 @@ class VaccineStockManagementAPITestCase(APITestCase):
         response = self.client.get(f"{BASE_URL}doses_options/?stockId=99999")
 
         self.assertEqual(response.status_code, 404)
-
-    def test_doses_options_endpoint_multiple_doses_per_vial(self):
-        """Test the doses_options endpoint with multiple different doses_per_vial values"""
-        self.client.force_authenticate(user=self.user_ro_perms)
-
-        # Create additional vaccine arrival reports with different doses_per_vial
-        vaccine_arrival_report_2 = pm.VaccineArrivalReport.objects.create(
-            request_form=self.vaccine_request_form,
-            arrival_report_date=self.now - datetime.timedelta(days=3),
-            doses_received=300,
-            doses_shipped=300,
-            po_number="PO456",
-            doses_per_vial=50,  # Different from the existing 20
-            lot_numbers=["LOT789"],
-            expiration_date=self.now + datetime.timedelta(days=180),
-        )
-
-        vaccine_arrival_report_3 = pm.VaccineArrivalReport.objects.create(
-            request_form=self.vaccine_request_form,
-            arrival_report_date=self.now - datetime.timedelta(days=2),
-            doses_received=200,
-            doses_shipped=200,
-            po_number="PO789",
-            doses_per_vial=10,  # Another different value
-            lot_numbers=["LOT101"],
-            expiration_date=self.now + datetime.timedelta(days=180),
-        )
-
-        response = self.client.get(f"{BASE_URL}doses_options/?stockId={self.vaccine_stock.id}")
-
-        self.assertEqual(response.status_code, 200)
-        data = response.json()
-
-        # Should have 3 unique doses_per_vial values: 20, 50, 10
-        expected_doses = [20, 50, 10]
-        result_values = [item["value"] for item in data["results"]]
-        self.assertEqual(set(result_values), set(expected_doses))
-        self.assertEqual(len(data["results"]), 3)
-
-    def test_doses_options_endpoint_filters_by_account(self):
-        """Test that doses_options only returns data for the user's account"""
-        # Create a different account and vaccine stock
-        other_account = m.Account.objects.create(name="other_account")
-        other_project = m.Project.objects.create(name="Other Project", app_id="other.projects", account=other_account)
-        other_country = m.OrgUnit.objects.create(
-            org_unit_type=self.org_unit_type_country,
-            version=self.source_version_1,
-            name="Other Country",
-            validation_status=m.OrgUnit.VALIDATION_VALID,
-            source_ref="OtherCountryRef",
-        )
-
-        other_campaign = pm.Campaign.objects.create(
-            obr_name="Other Campaign",
-            country=other_country,
-            account=other_account,
-        )
-
-        other_vaccine_request_form = pm.VaccineRequestForm.objects.create(
-            campaign=other_campaign,
-            vaccine_type=pm.VACCINES[0][0],
-            date_vrf_reception=self.now - datetime.timedelta(days=30),
-            date_vrf_signature=self.now - datetime.timedelta(days=20),
-            date_dg_approval=self.now - datetime.timedelta(days=10),
-            quantities_ordered_in_doses=500,
-        )
-
-        _ = pm.VaccineArrivalReport.objects.create(
-            request_form=other_vaccine_request_form,
-            arrival_report_date=self.now - datetime.timedelta(days=5),
-            doses_received=400,
-            doses_shipped=400,
-            po_number="OTHER_PO123",
-            doses_per_vial=30,  # Different value that shouldn't appear in our results
-            lot_numbers=["OTHER_LOT123"],
-            expiration_date=self.now + datetime.timedelta(days=180),
-        )
-
-        self.client.force_authenticate(user=self.user_ro_perms)
-
-        response = self.client.get(f"{BASE_URL}doses_options/?stockId={self.vaccine_stock.id}")
-
-        self.assertEqual(response.status_code, 200)
-        data = response.json()
-
-        # Should only contain doses_per_vial from our account's data (20), not the other account's (30)
-        result_values = [item["value"] for item in data["results"]]
-        self.assertIn(20, result_values)
-        self.assertNotIn(30, result_values)
-
-    def test_doses_options_endpoint_filters_by_country_and_vaccine(self):
-        """Test that doses_options filters by country and vaccine type"""
-        # Create vaccine arrival report for different country
-        other_country = m.OrgUnit.objects.create(
-            org_unit_type=self.org_unit_type_country,
-            version=self.source_version_1,
-            name="Other Country",
-            validation_status=m.OrgUnit.VALIDATION_VALID,
-            source_ref="OtherCountryRef",
-        )
-
-        other_campaign = pm.Campaign.objects.create(
-            obr_name="Other Campaign",
-            country=other_country,
-            account=self.account,  # Same account
-        )
-
-        other_vaccine_request_form = pm.VaccineRequestForm.objects.create(
-            campaign=other_campaign,
-            vaccine_type=pm.VACCINES[0][0],  # Same vaccine type
-            date_vrf_reception=self.now - datetime.timedelta(days=30),
-            date_vrf_signature=self.now - datetime.timedelta(days=20),
-            date_dg_approval=self.now - datetime.timedelta(days=10),
-            quantities_ordered_in_doses=500,
-        )
-
-        other_vaccine_arrival_report = pm.VaccineArrivalReport.objects.create(
-            request_form=other_vaccine_request_form,
-            arrival_report_date=self.now - datetime.timedelta(days=5),
-            doses_received=400,
-            doses_shipped=400,
-            po_number="OTHER_PO123",
-            doses_per_vial=30,  # Different value that shouldn't appear in our results
-            lot_numbers=["OTHER_LOT123"],
-            expiration_date=self.now + datetime.timedelta(days=180),
-        )
-
-        self.client.force_authenticate(user=self.user_ro_perms)
-
-        response = self.client.get(f"{BASE_URL}doses_options/?stockId={self.vaccine_stock.id}")
-
-        self.assertEqual(response.status_code, 200)
-        data = response.json()
-
-        # Should only contain doses_per_vial from our country's data (20), not the other country's (30)
-        result_values = [item["value"] for item in data["results"]]
-        self.assertIn(20, result_values)
-        self.assertNotIn(30, result_values)
 
     def test_doses_options_endpoint_anonymous_user(self):
         """Test that anonymous users cannot access doses_options endpoint"""
@@ -1899,55 +1762,6 @@ class VaccineStockManagementAPITestCase(APITestCase):
         self.assertEqual(response.status_code, 200)
         data = response.json()
         self.assertIn("results", data)
-
-    def test_doses_options_endpoint_empty_results(self):
-        """Test doses_options endpoint when no vaccine arrival reports exist"""
-        # Create a vaccine stock without any arrival reports
-
-        self.client.force_authenticate(user=self.user_ro_perms)
-
-        response = self.client.get(f"{BASE_URL}doses_options/?stockId={self.empty_vaccine_stock.id}")
-
-        self.assertEqual(response.status_code, 200)
-        data = response.json()
-        self.assertEqual(data["results"], [])
-
-    def test_doses_options_endpoint_duplicate_doses_per_vial(self):
-        """Test that doses_options endpoint returns unique doses_per_vial values"""
-        self.client.force_authenticate(user=self.user_ro_perms)
-
-        # Create multiple arrival reports with the same doses_per_vial
-        _ = pm.VaccineArrivalReport.objects.create(
-            request_form=self.vaccine_request_form,
-            arrival_report_date=self.now - datetime.timedelta(days=3),
-            doses_received=300,
-            doses_shipped=300,
-            po_number="PO456",
-            doses_per_vial=20,  # Same as existing
-            lot_numbers=["LOT789"],
-            expiration_date=self.now + datetime.timedelta(days=180),
-        )
-
-        _ = pm.VaccineArrivalReport.objects.create(
-            request_form=self.vaccine_request_form,
-            arrival_report_date=self.now - datetime.timedelta(days=2),
-            doses_received=200,
-            doses_shipped=200,
-            po_number="PO789",
-            doses_per_vial=20,  # Same as existing
-            lot_numbers=["LOT101"],
-            expiration_date=self.now + datetime.timedelta(days=180),
-        )
-
-        response = self.client.get(f"{BASE_URL}doses_options/?stockId={self.vaccine_stock.id}")
-
-        self.assertEqual(response.status_code, 200)
-        data = response.json()
-
-        # Should only have one unique value (20) despite multiple reports
-        self.assertEqual(len(data["results"]), 1)
-        self.assertEqual(data["results"][0]["value"], 20)
-        self.assertEqual(data["results"][0]["label"], "20")
 
     def test_doses_options_endpoint_invalid_stock_id_format(self):
         """Test the doses_options endpoint with invalid stockId format"""

--- a/plugins/polio/tests/test_vaccine_stock_management.py
+++ b/plugins/polio/tests/test_vaccine_stock_management.py
@@ -1723,7 +1723,7 @@ class VaccineStockManagementAPITestCase(APITestCase):
         self.assertIsNotNone(item_20)
         self.assertEqual(item_20["label"], "20")
         self.assertEqual(item_20["doses_available"], 460)
-        self.assertIsInstance(item_20["unusable_doses"], int)
+        self.assertEqual(item_20["unusable_doses"], 540)
 
         item_50 = next((item for item in results if item["value"] == 50), None)
         self.assertIsNotNone(item_50)
@@ -1828,46 +1828,6 @@ class VaccineStockManagementAPITestCase(APITestCase):
         result_empty = calculator_empty.get_unusable_stock_by_vaccine_presentation()
         self.assertEqual({"10": 0, "20": 0}, result_empty)
 
-    def test_vaccine_stock_calculator_get_usable_stock_for_presentation(self):
-        """Test VaccineStockCalculator._get_usable_stock_for_presentation method"""
-        from plugins.polio.models.base import VaccineStockCalculator
-
-        calculator = VaccineStockCalculator(self.vaccine_stock)
-
-        # Test with 20 doses per vial (which exists in our test data)
-        vials, doses = calculator._get_usable_stock_for_presentation(20)
-
-        # Should return tuple of (vials, doses)
-        self.assertIsInstance(vials, int)
-        self.assertIsInstance(doses, int)
-
-        # Test with 50 doses per vial (which doesn't exist in our test data)
-        vials_50, doses_50 = calculator._get_usable_stock_for_presentation(50)
-
-        # Should return 0 for both since we don't have 50-dose vials in test data
-        self.assertEqual(vials_50, 0)
-        self.assertEqual(doses_50, 0)
-
-    def test_vaccine_stock_calculator_get_unusable_stock_for_presentation(self):
-        """Test VaccineStockCalculator._get_unusable_stock_for_presentation method"""
-        from plugins.polio.models.base import VaccineStockCalculator
-
-        calculator = VaccineStockCalculator(self.vaccine_stock)
-
-        # Test with 20 doses per vial (which exists in our test data)
-        vials, doses = calculator._get_unusable_stock_for_presentation(20)
-
-        # Should return tuple of (vials, doses)
-        self.assertIsInstance(vials, int)
-        self.assertIsInstance(doses, int)
-
-        # Test with 50 doses per vial (which doesn't exist in our test data)
-        vials_50, doses_50 = calculator._get_unusable_stock_for_presentation(50)
-
-        # Should return 0 for both since we don't have 50-dose vials in test data
-        self.assertEqual(vials_50, 0)
-        self.assertEqual(doses_50, 0)
-
     def test_doses_options_endpoint_includes_unusable_doses(self):
         """Test that the doses_options endpoint includes unusable_doses field"""
         self.client.force_authenticate(user=self.user_ro_perms)
@@ -1886,7 +1846,7 @@ class VaccineStockManagementAPITestCase(APITestCase):
         # We expect some unusable doses for 20-dose vials based on our test data
         item_20 = next((item for item in results if item["value"] == 20), None)
         self.assertIsNotNone(item_20)
-        self.assertGreaterEqual(item_20["unusable_doses"], 0)
+        self.assertEqual(item_20["unusable_doses"], 540)
 
         item_50 = next((item for item in results if item["value"] == 50), None)
         self.assertIsNotNone(item_50)


### PR DESCRIPTION
What problem is this PR solving? Explain here in one sentence.

Related JIRA tickets :  POLIO-2019, POLIO-1998

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [x] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [x] My migrations file are included
- [x] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

[Will edit this section when doc is written](https://github.com/BLSQ/polio-doc/pull/4)

## Changes

- Backend:
    - Add an endpoint returning the possible presentations (doses_per_vial) based on a `Config` object. The slug of the config is hard coded/stored in a constant. For use in Supply chain, where we need to show all possible options
    - Add an endpoint returning the possible presentations and the number of usable doses and unusable doses for each presentation. For use in vaccine stock, where some actions are disabled if there's no stock available
    - Add methods to `VaccineStockCalculator` to compute the totals needed for the new API

- Front-end
    - SupplyChain:
        -  PreAlert: 
            - Replace `NumberInput` with `SingleSelect`
            - Set a `defaultDosesPerVial` only if there's only 1 possible presentation
            - Make doses per vial uneditable if there's only one presentation
        - Arrival Report: same as PreAlert, plus:
            - auto-fill `doses_per_vial` when user picks a PO number from the auto-generated list (from pre-alerts)
     - Vaccine Stock:
         - FormA, Earmarked:
             - disable creation if there's no stock of usable doses
              - Replace `NumberInput` with `SingleSelect`
              - Only show presentations for which stock of usable doses > 0 in the dropdown options
              - Edition: add the saved value for presentation/doses per vial to the dropdown to avoid having an errored UI
          - Destruction reports:
              - Same as FormA and Earmarked, but based on stock of unusable doses
          - Incident reports:
              - Never disable Creation, to allow for encoding of Physical Inventory
              - Disable movements from usable stock to unusable if usable stock <= 0
              - Physical Inventory: disable some options based on usable/unusable stock being available 
              
## How to test

With a DB setup for polio, go to the django admin and add a `Config` with the following:
slug=vaccine_doses_per_vial
content=
```json
{
  "bOPV": [
    10,
    20
  ],
  "mOPV2": [
    20,
    50
  ],
  "nOPV2": [
    50
  ]
}
```

Then go to supply chain:
- Try adding a PreAlert: change the values --> the doses and vial values should update. Saving should work OK
- Try adding a vaccine arrival report: select a PO number from the dropdown --> The doses per vial should auto fill

Go to vaccine stock:
- Try adding/editing each type of report for every vaccine. nOPV2 should have a different behaviour: the dropdowns should be (pre)filled with 50 and not be editable

## Print screen / video

https://github.com/user-attachments/assets/80d23082-999c-4d8f-9164-aa41717f8711

https://github.com/user-attachments/assets/7ab8affd-3905-459d-a9ff-429efb23a1e8



