### PR TITLE
POLIO-1958: add exclusion list for prep worksheets

### DIFF
--- a/plugins/polio/preparedness/parser.py
+++ b/plugins/polio/preparedness/parser.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, Optional
 
 from gspread.utils import absolute_range_name, rowcol_to_a1
 
+from iaso.models.json_config import Config
 from plugins.polio.preparedness.calculator import get_preparedness_score
 from plugins.polio.preparedness.client import get_client
 from plugins.polio.preparedness.exceptions import InvalidFormatError
@@ -13,6 +14,8 @@ from plugins.polio.preparedness.spread_cache import CachedSheet, CachedSpread
 logger = getLogger(__name__)
 
 TEMPLATE_VERSION = "v3.5"
+WORKSHEET_EXCLUSION_LIST = ["synth_scores"]
+WORKSHEET_EXCLUSION_SLUG = "preparedness_sheetnames_blacklist"
 
 
 def parse_value(value: str):
@@ -133,9 +136,14 @@ class RoundNumber(str, Enum):
     unknown = "Unknown"
 
 
-def get_national_level_preparedness(spread: CachedSpread):
+def get_national_level_preparedness(spread: CachedSpread, exclusions):
     for worksheet in spread.worksheets():
-        if worksheet.is_hidden:
+        if (
+            worksheet.is_hidden
+            or worksheet.title.lower() in WORKSHEET_EXCLUSION_LIST
+            or worksheet.title.lower().startswith("sheet")
+            or (exclusions and worksheet.title in exclusions)
+        ):
             continue
         cell = worksheet.find_one_of(
             "Summary of National Level Preparedness",
@@ -167,7 +175,7 @@ def get_national_level_preparedness(spread: CachedSpread):
     )
 
 
-def get_regional_level_preparedness(spread: CachedSpread):
+def get_regional_level_preparedness(spread: CachedSpread, exclusions):
     """Parse the region sheet
     There is two section we parse the General table, and the score table. They are not aligned.
     for the first table we assume it's always in the same place only the number of district change
@@ -181,7 +189,12 @@ def get_regional_level_preparedness(spread: CachedSpread):
 
     sheet: CachedSheet
     for sheet in spread.worksheets():
-        if sheet.is_hidden:
+        if (
+            sheet.is_hidden
+            or sheet.title.lower() in WORKSHEET_EXCLUSION_LIST
+            or sheet.title.lower().startswith("sheet")
+            or (exclusions and sheet.title in exclusions)
+        ):
             continue
         # detect if we are in a Regional Spreadsheet form the title
         # and find position of the total score box
@@ -214,7 +227,7 @@ def get_regional_level_preparedness(spread: CachedSpread):
         districts_indicators: Dict[str, Any] = {}
 
         # noinspection SpellCheckingInspection
-        for rownum, colnum, name in region_districts:
+        for _rownum, colnum, name in region_districts:
             if not name:
                 continue
             districts_indicators[name] = {}
@@ -256,7 +269,7 @@ def get_regional_level_preparedness(spread: CachedSpread):
     return {"regions": regions, "districts": districts, "warnings": warnings}
 
 
-def get_regional_level_preparedness_v2(spread: CachedSpread):
+def get_regional_level_preparedness_v2(spread: CachedSpread, exclusions):
     """Parse the region sheet
     There is two section we parse the General table, and the score table. They are not aligned.
     for the first table we assume it's always in the same place only the number of district change
@@ -269,7 +282,12 @@ def get_regional_level_preparedness_v2(spread: CachedSpread):
 
     sheet: CachedSheet
     for sheet in spread.worksheets():
-        if sheet.is_hidden:
+        if (
+            sheet.is_hidden
+            or sheet.title.lower() in WORKSHEET_EXCLUSION_LIST
+            or sheet.title.lower().startswith("sheet")
+            or (exclusions and sheet.title in exclusions)
+        ):
             continue
         # detect if we are in a Regional Spreadsheet form the title
         # and find position of the total score box
@@ -351,9 +369,14 @@ def get_regional_level_preparedness_v2(spread: CachedSpread):
     return {"regions": regions, "districts": districts}
 
 
-def get_national_level_preparedness_v2(spread: CachedSpread):
+def get_national_level_preparedness_v2(spread: CachedSpread, exclusions):
     for worksheet in spread.worksheets():
-        if worksheet.is_hidden:
+        if (
+            worksheet.is_hidden
+            or worksheet.title.lower() in WORKSHEET_EXCLUSION_LIST
+            or worksheet.title.lower().startswith("sheet")
+            or (exclusions and worksheet.title in exclusions)
+        ):
             continue
         cell = worksheet.find_one_of(
             "Summary of National Level Preparedness",
@@ -375,31 +398,40 @@ def get_national_level_preparedness_v2(spread: CachedSpread):
             kv[indicator_key] = value
             print(indicator_key, value, rowcol_to_a1(*rc))
 
-        kv["round"] = RoundNumber.unknown
+        round_name = worksheet.get_a1("C8")  # Temp fix using hard coded cell position to avoid round mismatch errors
+        if round_name == "Tour 1 / Rnd 1":
+            round = RoundNumber.round1
+        elif round_name == "Tour 2 / Rnd 2":
+            round = RoundNumber.round2
+        else:
+            round = RoundNumber.unknown
+
+        kv["round"] = round
         return kv
     raise Exception(
         "Summary of National Level Preparedness or Summary of Regional Level Preparedness was not found in this document"
     )
 
 
-def parse_prepardness_v2(spread: CachedSpread):
+def parse_prepardness_v2(spread: CachedSpread, exclusions=None):
     preparedness_data = {
-        "national": get_national_level_preparedness_v2(spread),
-        **get_regional_level_preparedness_v2(spread),
+        "national": get_national_level_preparedness_v2(spread, exclusions),
+        **get_regional_level_preparedness_v2(spread, exclusions),
         "format": TEMPLATE_VERSION,
     }
     preparedness_data["totals"] = get_preparedness_score(preparedness_data)
     return preparedness_data
 
 
-def get_preparedness(spread: CachedSpread):
+def get_preparedness(spread: CachedSpread, exclusions=None):
+    exclusions = Config.objects.filter(slug=WORKSHEET_EXCLUSION_SLUG).first()
     #  use New system with named range
     if "national_status_score" in spread.range_dict:
-        return parse_prepardness_v2(spread)
+        return parse_prepardness_v2(spread, exclusions)
     # old system with hard code emplacement
     preparedness_data = {
-        "national": get_national_level_preparedness(spread),
-        **get_regional_level_preparedness(spread),
+        "national": get_national_level_preparedness(spread, exclusions),
+        **get_regional_level_preparedness(spread, exclusions),
     }
     preparedness_data["totals"] = get_preparedness_score(preparedness_data)
     return preparedness_data

--- a/plugins/polio/preparedness/parser.py
+++ b/plugins/polio/preparedness/parser.py
@@ -424,7 +424,7 @@ def parse_prepardness_v2(spread: CachedSpread, exclusions=None):
 
 
 def get_preparedness(spread: CachedSpread, exclusions=None):
-    exclusions = Config.objects.filter(slug=WORKSHEET_EXCLUSION_SLUG).first()
+    exclusions = Config.objects.filter(slug=WORKSHEET_EXCLUSION_SLUG).first().content
     #  use New system with named range
     if "national_status_score" in spread.range_dict:
         return parse_prepardness_v2(spread, exclusions)


### PR DESCRIPTION
Client adds worksheets to the preparedness google sheet, and it breaks everyting

Related JIRA tickets :  POLIO-1958

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

[Tell us where the doc can be found (docs folder, wiki, in the code...).](https://github.com/BLSQ/polio-doc/pull/3/files)

## Changes

- Hard coded an exclusion on common sheet names
- Added a config for additional exclusions
- Fixed small bug with round number in the preparedness parser

## How to test
- Generate a preparedness sheet (needs a round with a scope and a future start date)
- Add empty worksheets to the generated sheets
- rename at least 1.
- Add the custom worksheet name to the `preparedness_sheetnames_blacklist`config (add it if necessary: it just a list of strings). In the new sheet, add (in any cell) the string: `"Summary of Regional Level Preparedness"`(this will circumvent the exclusion mechanism already in place)
- From the preparedness tab, launch a refresh: the additional sheets should not trigger errors

## Note

This should go in the next release one way or another since it would solve refresh problems with an actual upcoming campaign
