### PR TITLE
IA-4561: fix query key invalidation bug

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/orgUnitTypes/components/OrgUnitsTypesDialog.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/orgUnitTypes/components/OrgUnitsTypesDialog.tsx
@@ -245,10 +245,17 @@ export const OrgUnitsTypesDialog: FunctionComponent<Props> = ({
     );
 
     const onConfirm = useCallback(
-        async (closeDialog: () => void) => {
+        (closeDialog: () => void) => {
             try {
-                await saveType(mapValues(formState, v => v.value));
-                closeDialog();
+                saveType(
+                    mapValues(formState, v => v.value),
+                    {
+                        onSuccess: () => {
+                            closeDialog();
+                            resetForm();
+                        },
+                    },
+                );
             } catch (error) {
                 if (error.status === 400) {
                     Object.entries(error.details).forEach(entry => {

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/orgUnitTypes/hooks/useDeleteOrgUnitType.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/orgUnitTypes/hooks/useDeleteOrgUnitType.ts
@@ -8,6 +8,9 @@ const deleteOrgUnitType = (id: number) =>
 export const useDeleteOrgUnitType = (): UseMutationResult => {
     return useSnackMutation({
         mutationFn: deleteOrgUnitType,
-        invalidateQueryKey: ['paginated-orgunit-types'],
+        invalidateQueryKey: [
+            'paginated-orgunit-types',
+            'orgunittypes-dropdown',
+        ],
     });
 };

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/orgUnitTypes/hooks/useSaveOrgUnitType.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/orgUnitTypes/hooks/useSaveOrgUnitType.ts
@@ -24,7 +24,10 @@ export const useSaveOrgUnitType = (): UseMutationResult => {
             data.id
                 ? patchOrgUniType(data)
                 : postOrgUnitType(data as OrgunitType),
-        invalidateQueryKey: ['paginated-orgunit-types'],
+        invalidateQueryKey: [
+            'paginated-orgunit-types',
+            'orgunittypes-dropdown',
+        ],
         ignoreErrorCodes,
     });
 };


### PR DESCRIPTION


New OU types were not added to the dropdown lists on the OU page

Related JIRA tickets : IA-4561

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

N/A

## Changes

- Add missing query keys to save and delete hook invalidation lists
- Call resetForm() on successful save (unrelated bug)

## How to test

- Go to org unit ypes
- create a type
- Save
- click "create again": the form fields should be empty
- open another type: the new type should appear in the form's dropdowns
- now delete the newly created type
- open another type: the deleted type should be gone

## Print screen / video


https://github.com/user-attachments/assets/ce51cd4d-6eda-497d-8577-20dcb9b7ae7b



## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
