### PR TITLE
POLIO-2026: fix incident report presentation list

### DIFF
--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/CreateEditIncident.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/CreateEditIncident.tsx
@@ -166,6 +166,8 @@ export const CreateEditIncident: FunctionComponent<Props> = ({
         },
         [incidentConfig],
     );
+
+    // TODO fix this when physical Inventory
     const availableDosesPresentations = useAvailablePresentations(
         dosesOptions,
         incident,
@@ -257,6 +259,9 @@ export const CreateEditIncident: FunctionComponent<Props> = ({
     const allowConfirm = formik.isValid && !isEqual(formik.touched, {});
 
     const currentMovementType = incidentConfig[formik.values.stock_correction];
+    const isInventoryMovement =
+        currentMovementType === 'inventoryAdd' ||
+        currentMovementType === 'inventoryRemove';
 
     return (
         <FormikProvider value={formik}>
@@ -425,7 +430,11 @@ export const CreateEditIncident: FunctionComponent<Props> = ({
                         label={formatMessage(MESSAGES.doses_per_vial)}
                         name="doses_per_vial"
                         component={SingleSelect}
-                        options={availableDosesPresentations}
+                        options={
+                            isInventoryMovement
+                                ? dosesOptions // We want to allow all possible presentation for physical inventory operations
+                                : availableDosesPresentations
+                        }
                         disabled={hasFixedDosesPerVial}
                         required
                     />


### PR DESCRIPTION
- show all presentations regardless of stock for incident reports of type physical inventory

What problem is this PR solving? Explain here in one sentence.

Related JIRA tickets :  POLIO-1998, POLIO-2026

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

NA

## Changes

- Added check on report type to determine which dropdown to display

## How to test

pre-requisite: cf https://github.com/BLSQ/iaso/pull/2524


- Go to an empty stock for a vaccine with 2+ presentations
- Add an Incident report:
   - there shoud only be 2 options
   - choose add physical inventory
   - when selecting doses per vial, there should be all options available 
   - Save
- Add another incident report:
     -  All type options should be available
     - iin the doses per vial select, only the presentation just saved should be available

## Print screen / video


https://github.com/user-attachments/assets/7ce9f616-074f-4abf-817c-0612ca8359a2


