### PR TITLE
IA-4565 : make simple events exportable to 2.42 and keep backward compatibility

### DIFF
--- a/iaso/api/data_sources.py
+++ b/iaso/api/data_sources.py
@@ -207,7 +207,7 @@ class TestCredentialSerializer(serializers.Serializer):
             if err.code == 401:
                 self.raise_exception("dhis2_password")
             self.raise_exception("dhis2_url", err.description)
-        except requests.exceptions.ConnectionError:
+        except requests.exceptions.ConnectionError as err2:
             self.raise_exception("dhis2_url")
         except Exception as err:
             logging.exception(err)
@@ -217,9 +217,10 @@ class TestCredentialSerializer(serializers.Serializer):
         try:
             response = requests.get(dhis2_system_info_api, auth=(dhis2_login, password)).json()
             # dependending on the version the field url is not always the same
-            if "instanceBaseUrl" in response and response["instanceBaseUrl"] != dhis2_url:
-                self.raise_exception("dhis2_url")
-            if "contextPath" in response and response["contextPath"] != dhis2_url:
+            if "contextPath" in response:
+                if response["contextPath"] != dhis2_url:
+                    self.raise_exception("dhis2_url")
+            elif "instanceBaseUrl" in response and response["instanceBaseUrl"] != dhis2_url:
                 self.raise_exception("dhis2_url")
             # just in case both fields are empty, at least verify that we have a version field
             if "version" not in response:

--- a/iaso/management/commands/seed_test_data.py
+++ b/iaso/management/commands/seed_test_data.py
@@ -62,7 +62,8 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         dhis2_version = options.get("dhis2version")
-        dhis2_version = "stable-" + dhis2_version.replace(".", "-")
+        prefix = "stable-" if dhis2_version.startswith("2") else ""
+        dhis2_version = prefix + dhis2_version.replace(".", "-")
         dhis2_url = f"https://play.im.dhis2.org/{dhis2_version}"
         print(dhis2_url)
         response = requests.get(dhis2_url)


### PR DESCRIPTION
A longtime ago deprecated api is now removed since 2.42 so we need to adapt the url/payload.

Related JIRA tickets : IA-4565

## Self proofreading checklist

- [ ] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

event export is evolving on the side of dhis2
  - new endpoint /api/tracker
  - it's async by default so to keep the code as is : /api/tracker?async=false
  - evenDate is now occurredAt

so I modified the export code to check the version and change the behavior
sadly it's easier to be done per page with the existing code and didn't dare to change it.
but it's a call that isn't too expensive. So I guess it's ok.

## How to test

- launch the seed command for a 2.42 : `docker compose run --rm iaso manage seed_test_data --mode=seed --dhis2version=2.42.2`
- launch the worker : `docker compose run iaso manage tasks_worker`
- export submissions of the form "Community Verification Satisfaction form ..."
- to make the export work adapt the dhis2 program : 
   - grant access to the admin user to read and encode data in the program 
      - in the [maintenance program page](https://play.im.dhis2.org/stable-2-42-2/apps/maintenance#/list/programSection/program) search for : `Inpatient morbidity and mortality`
      - then pick the Sharing settings menu item 
<img width="1089" height="759" alt="image" src="https://github.com/user-attachments/assets/99f44010-9f1c-4a6b-95bf-29e7dfe10535" />
       - add `John Traore` and grant RW access       
<img width="1162" height="866" alt="image" src="https://github.com/user-attachments/assets/bd436513-e373-43ea-b1b6-d4bb118cb5b7" />

   - make the data elements not mandatory (our mapping is 100% ok with this)
      - do the search and click on the program
      - then go in the "tab/wizzard" (Assign data elements)
      - don't forget to click on Save at the bottom
<img width="2477" height="1321" alt="image" src="https://github.com/user-attachments/assets/98e5a44b-ec81-45c6-8bd4-16caf8dce39f" />

- check the submissions are sent there (the task, the export status on details page)
- check the export logs to see which api has been called with with params
- check in dhis2 : https://play.im.dhis2.org/stable-2-42-2/api/tracker/events/w5gg8HdFUHr.json (substitute the dhis2 id with the export_id of the submission)

do the same thing a 2.41 or 2.40


## Print screen / video

Upload here print screens or videos showing the changes.

## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
