### PR TITLE
WC2-840: ETL change of programme update

### DIFF
--- a/plugins/wfp/common.py
+++ b/plugins/wfp/common.py
@@ -663,6 +663,7 @@ class ETL:
 
     def entity_journey_mapper(self, visits, anthropometric_visit_forms, admission_form, current_journey):
         journey = []
+        new_journey_after_transfer = {}
         for index, visit in enumerate(visits):
             if visit:
                 current_journey["weight_gain"] = visit.get("weight_gain", None)
@@ -679,7 +680,24 @@ class ETL:
                     index,
                 )
             current_journey["steps"].append(visit)
+            if current_journey.get("exit_type") == "transfer_to_tsfp":
+                new_journey_after_transfer["programme_type"] = "TSFP"
+                new_journey_after_transfer["nutrition_programme"] = "TSFP"
+                new_journey_after_transfer["admission_type"] = "referred_from_otp_sam"
+                new_journey_after_transfer["admission_criteria"] = current_journey.get("admission_criteria")
+            elif current_journey.get("exit_type") == "transfer_to_otp":
+                new_journey_after_transfer["programme_type"] = "OTP"
+                new_journey_after_transfer["nutrition_programme"] = "OTP"
+                new_journey_after_transfer["admission_type"] = "referred_from_tsfp_mam"
+                new_journey_after_transfer["admission_criteria"] = current_journey.get("admission_criteria")
+
+            new_journey_after_transfer["steps"] = [visit]
+            new_journey_after_transfer["visits"] = [visit]
+            new_journey_after_transfer["start_date"] = current_journey.get("end_date")
+            new_journey_after_transfer["initial_weight"] = current_journey.get("discharge_weight")
         journey.append(current_journey)
+        if new_journey_after_transfer.get("programme_type") is not None:
+            journey.append(new_journey_after_transfer)
         return journey
 
     def compute_gained_weight(self, initial_weight, current_weight, duration):

--- a/plugins/wfp/common.py
+++ b/plugins/wfp/common.py
@@ -684,13 +684,11 @@ class ETL:
                 new_journey_after_transfer["programme_type"] = "TSFP"
                 new_journey_after_transfer["nutrition_programme"] = "TSFP"
                 new_journey_after_transfer["admission_type"] = "referred_from_otp_sam"
-                new_journey_after_transfer["admission_criteria"] = current_journey.get("admission_criteria")
             elif current_journey.get("exit_type") == "transfer_to_otp":
                 new_journey_after_transfer["programme_type"] = "OTP"
                 new_journey_after_transfer["nutrition_programme"] = "OTP"
                 new_journey_after_transfer["admission_type"] = "referred_from_tsfp_mam"
-                new_journey_after_transfer["admission_criteria"] = current_journey.get("admission_criteria")
-
+            new_journey_after_transfer["admission_criteria"] = current_journey.get("admission_criteria")
             new_journey_after_transfer["steps"] = [visit]
             new_journey_after_transfer["visits"] = [visit]
             new_journey_after_transfer["start_date"] = current_journey.get("end_date")


### PR DESCRIPTION
What problem is this PR solving? Explain here in one sentence.

Related JIRA tickets : [WC2-840](https://bluesquare.atlassian.net/browse/WC2-840)

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

For U5 when a beneficiary move from OTP to TSFP or TSFP to OTP , it's ending the OTP journey and starting a new TSFP journey and vice-versa.

## How to test

From the local instance with wfp coda database, launch with docker compose run iaso manage etl_ssd all_data the ETL script in order to generate data for tableau dashboard.
Then open the debug page for the following beneficiary: http://localhost:8081/wfp/debug/2959/

You should see 2 journeys:
- First one starting on 01/09/2025 and ending on 15/09/2025
- Second one starting on 15/09/2025, the date the beneficiary changed the program

## Print screen / video

[Tab-1762242879545.webm](https://github.com/user-attachments/assets/346a55fb-3829-46ed-919f-5c4216d6fd3e)


## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.


[WC2-840]: https://bluesquare.atlassian.net/browse/WC2-840?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ