### PR TITLE
[IA-4568] Add default value for ENCRYPTED_TEXT_FIELD_KEY

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -161,7 +161,6 @@ jobs:
                   DEFAULT_FILE_STORAGE: storages.backends.s3boto3.S3Boto3Storage
                   DEV_SERVER: true
                   DJANGO_SETTINGS_MODULE: hat.settings
-                  ENCRYPTED_TEXT_FIELD_KEY: bNqPWD4KdouaH-yxfl7PPdJLbbNt31mnJDwg9IHoGDM=
                   IASO_ENVIRONMENT: development
                   PLUGINS: polio,wfp,wfp_auth
                   RDS_DB_NAME: github_actions

--- a/hat/settings.py
+++ b/hat/settings.py
@@ -58,7 +58,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SECRET_KEY = os.environ.get("SECRET_KEY")
 
 # SECURITY WARNING: keep the encryption key used in production secret!
-ENCRYPTED_TEXT_FIELD_KEY = os.environ.get("ENCRYPTED_TEXT_FIELD_KEY")
+ENCRYPTED_TEXT_FIELD_KEY = os.environ.get("ENCRYPTED_TEXT_FIELD_KEY", "71Eax4PGazWNj7vaXrucAD1bYUzjI-Fxubv8MZzcSyk=")
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.environ.get("DEBUG", "").lower() == "true"

--- a/hat/settings.py
+++ b/hat/settings.py
@@ -58,7 +58,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SECRET_KEY = os.environ.get("SECRET_KEY")
 
 # SECURITY WARNING: keep the encryption key used in production secret!
-ENCRYPTED_TEXT_FIELD_KEY = os.environ.get("ENCRYPTED_TEXT_FIELD_KEY", "71Eax4PGazWNj7vaXrucAD1bYUzjI-Fxubv8MZzcSyk=")
+ENCRYPTED_TEXT_FIELD_KEY = os.environ.get("ENCRYPTED_TEXT_FIELD_KEY")
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.environ.get("DEBUG", "").lower() == "true"
@@ -822,3 +822,5 @@ if IN_TESTS:
             "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",  # Default option
         },
     }
+    if not ENCRYPTED_TEXT_FIELD_KEY:
+        ENCRYPTED_TEXT_FIELD_KEY = "71Eax4PGazWNj7vaXrucAD1bYUzjI-Fxubv8MZzcSyk="


### PR DESCRIPTION
Add default value for `ENCRYPTED_TEXT_FIELD_KEY` when running tests

Related JIRA tickets : IA-4568

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

/

## Changes
- Add default value for ENCRYPTED_TEXT_FIELD_KEY in tests

## How to test

- Don't set `ENCRYPTED_TEXT_FIELD_KEY` in your env variables
- Run tests :arrow_right: all of them should pass
- Go to the admin panel :arrow_right: `OpenHEXAServers` :arrow_right: create a new one :arrow_right: it should crash
- If you do the same, with the env variable set, it should work fine
  - the password should be ciphered in your DB


## Print screen / video

/

## Notes
/

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
