### PR TITLE
IA-3772: Skip existing org units when importing data (hotfix)

### DIFF
--- a/iaso/api/org_units.py
+++ b/iaso/api/org_units.py
@@ -1018,20 +1018,21 @@ def import_org_units(org_units: List[Dict], user, app_id):
     """Import a list of org units."""
     new_org_units = []
     project = Project.objects.get_for_user_and_app_id(user, app_id)
-    if project.account.default_version.data_source.read_only:
+    version = project.account.default_version
+    if version.data_source.read_only:
         raise ValidationError("Creation of org unit not authorized on default data source")
 
     # common values to all new org units
     extra_save_kwargs = {
         "custom": True,
         "validation_status": OrgUnit.VALIDATION_NEW,
-        "version": project.account.default_version,
+        "version": version,
         "creator": user if (user and not user.is_anonymous) else None,
     }
 
     for org_unit_data in org_units:
         uuid = org_unit_data.get("id")
-        if OrgUnit.objects.filter(uuid=uuid).exists():
+        if OrgUnit.objects.filter(uuid=uuid, version=version).exists():
             continue  # skip existing org units
 
         serializer = OrgUnitImportSerializer(data=org_unit_data)

--- a/iaso/api/org_units.py
+++ b/iaso/api/org_units.py
@@ -1025,18 +1025,18 @@ def import_org_units(org_units: List[Dict], user, app_id):
     extra_save_kwargs = {
         "custom": True,
         "validation_status": OrgUnit.VALIDATION_NEW,
-        "source": "API",
         "version": project.account.default_version,
         "creator": user if (user and not user.is_anonymous) else None,
     }
 
     for org_unit_data in org_units:
+        uuid = org_unit_data.get("id")
+        if OrgUnit.objects.filter(uuid=uuid).exists():
+            continue  # skip existing org units
+
         serializer = OrgUnitImportSerializer(data=org_unit_data)
         serializer.is_valid(raise_exception=True)
-
         new_org_unit = serializer.save(**extra_save_kwargs)
-
-        if new_org_unit:
-            new_org_units.append(new_org_unit)
+        new_org_units.append(new_org_unit)
 
     return new_org_units


### PR DESCRIPTION
refs: IA-3772

**Hotfix** for exceptions raised by PR #2522

When attempting to create an OrgUnit that already exists, an AssertionError is thrown:
`AssertionError: `create()` did not return an object instance.`

This PR fixes the error and replicates the original behavior of ignoring the existing OrgUnits.

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [ ] ~~Are my typescript files well typed?~~
- [ ] ~~New translations have been added or updated if new strings have been introduced in the frontend~~
- [ ] ~~My migrations file are included~~
- [x] Are there enough tests?
- [ ] ~~Documentation has been included (for new feature)~~

## Doc

- 

## Changes

- Added tests that replicate the issue.
- Fixed the issue by checking for existing OrgUnits and ignoring them. 


## How to test

1. Testing the regular upload:
- Create an org unit on mobile (note: you need to configure "sub org unit types to create" on the parent org unit type in the dashboard to allow the creation of org units on mobile).
- Upload the new org unit
- Find the payload in the api imports in the django admin.
- Query the api manually with the same payload, it should be something like this:
```
curl --request POST \
  --url 'http://localhost:8081/api/mobile/orgunits/?app_id=hwbewoz&app_version=2600' \
  --header 'Authorization: Bearer <token>' \
  --header 'content-type: application/json' \
  --data '[
  {
    "id": "2740df90-5307-4bd9-aa5c-be9e6b144ffc",
    "name": "Test Areea Duplicated",
    "validation_status": "",
    "org_unit_type_id": "5",
    "parent_id": "4",
    "time": 0,
    "created_at": 1.762433961328E9,
    "updated_at": 1.762433961328E9
  }
]
```
- The backend should return an empty response as the org unit is already saved and will be ignored.
- You may try further queries with a mix of old and new UUIDs. 

2. Testing the bulk upload.
- You need 2 project feature flags:
   -  Entities > Mobile: Show entities screen
   -  Data Validation > Mobile: Change requests
- Create and upload an org unit with the mobile app
- In the django admin, find the task associated with the upload and check that it's succesfull
- Manually set its status to error
- Restart the task in the dashboard
- Check that it completes again without error. 

You may want to test the features of the original PR #2522 as well 


## Print screen / video

/

## Notes

Didn't want to change anything else, however, in removing the `create()` method on the serializer, I realized that both the code introduced by my PR and the original code set attributes on the OrgUnits that don't exist on the model and were silently ignored. I had to remove them when getting rid of the custom create logic as `source` and `accuracy` were passed to the OrgUnit's constructor and trigger TypeError. 

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
