### PR TITLE
IA-3772: Skip existing org units when importing data (develop)

### DIFF
--- a/iaso/api/org_units.py
+++ b/iaso/api/org_units.py
@@ -1018,20 +1018,21 @@ def import_org_units(org_units: List[Dict], user, app_id):
     """Import a list of org units."""
     new_org_units = []
     project = Project.objects.get_for_user_and_app_id(user, app_id)
-    if project.account.default_version.data_source.read_only:
+    version = project.account.default_version
+    if version.data_source.read_only:
         raise ValidationError("Creation of org unit not authorized on default data source")
 
     # common values to all new org units
     extra_save_kwargs = {
         "custom": True,
         "validation_status": OrgUnit.VALIDATION_NEW,
-        "version": project.account.default_version,
+        "version": version,
         "creator": user if (user and not user.is_anonymous) else None,
     }
 
     for org_unit_data in org_units:
         uuid = org_unit_data.get("id")
-        if OrgUnit.objects.filter(uuid=uuid).exists():
+        if OrgUnit.objects.filter(uuid=uuid, version=version).exists():
             continue  # skip existing org units
 
         serializer = OrgUnitImportSerializer(data=org_unit_data)

--- a/iaso/api/org_units.py
+++ b/iaso/api/org_units.py
@@ -1025,18 +1025,18 @@ def import_org_units(org_units: List[Dict], user, app_id):
     extra_save_kwargs = {
         "custom": True,
         "validation_status": OrgUnit.VALIDATION_NEW,
-        "source": "API",
         "version": project.account.default_version,
         "creator": user if (user and not user.is_anonymous) else None,
     }
 
     for org_unit_data in org_units:
+        uuid = org_unit_data.get("id")
+        if OrgUnit.objects.filter(uuid=uuid).exists():
+            continue  # skip existing org units
+
         serializer = OrgUnitImportSerializer(data=org_unit_data)
         serializer.is_valid(raise_exception=True)
-
         new_org_unit = serializer.save(**extra_save_kwargs)
-
-        if new_org_unit:
-            new_org_units.append(new_org_unit)
+        new_org_units.append(new_org_unit)
 
     return new_org_units


### PR DESCRIPTION
( Copy of the hotfix PR #2532 )