### PR TITLE
IA-4582 fix docker compose build webpack

### DIFF
--- a/docker/webpack/Dockerfile
+++ b/docker/webpack/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && apt-get install -y \
     python3-pip \
     git \
     build-essential \
+    libcogl-pango-dev \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Set Python 3 as the default python


### PR DESCRIPTION
A native build error, here installing the package upfront helps.

Related JIRA tickets : IA-4582

## Self proofreading checklist

- [ ] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

still haven't understood why I'm alone to have this problem

## How to test

`docker compose build webpack --no-cache`

## Print screen / video


## Notes


## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: docker compose build webpack

Refs: IA-4582
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
