### PR TITLE
fix: POLIO-2028 Planned Campaigns: indicate correct status in table column 'campaign category'

### DIFF
--- a/plugins/polio/api/campaigns/campaigns.py
+++ b/plugins/polio/api/campaigns/campaigns.py
@@ -542,58 +542,6 @@ class AnonymousCampaignSerializer(CampaignSerializer):
         read_only_fields = fields
 
 
-class SmallCampaignSerializer(CampaignSerializer):
-    campaign_types = CampaignTypeSerializer(many=True, required=False)
-
-    class Meta:
-        model = Campaign
-        # TODO: refactor to avoid duplication with AnonymousCampaignSerializer?
-        fields = [
-            "id",
-            "epid",
-            "obr_name",
-            "gpei_coordinator",
-            "gpei_email",
-            "description",
-            "initial_org_unit",
-            "creation_email_send_at",
-            "onset_at",
-            "cvdpv2_notified_at",
-            "pv_notified_at",
-            "pv2_notified_at",
-            "virus",
-            "vaccines",
-            "detection_status",
-            "detection_responsible",
-            "detection_first_draft_submitted_at",
-            "risk_assessment_status",
-            "risk_assessment_responsible",
-            "investigation_at",
-            "risk_assessment_first_draft_submitted_at",
-            "risk_assessment_rrt_oprtt_approval_at",
-            "ag_nopv_group_met_at",
-            "dg_authorized_at",
-            "verification_score",
-            "budget_status",
-            "who_disbursed_to_co_at",
-            "who_disbursed_to_moh_at",
-            "unicef_disbursed_to_co_at",
-            "unicef_disbursed_to_moh_at",
-            "no_regret_fund_amount",
-            "payment_mode",
-            "created_at",
-            "updated_at",
-            "district_count",
-            "top_level_org_unit_name",
-            "top_level_org_unit_id",
-            "is_preventive",
-            "account",
-            "outbreak_declaration_date",
-            "campaign_types",
-        ]
-        read_only_fields = fields
-
-
 class CalendarCampaignSerializer(CampaignSerializer):
     """This serializer contains juste enough data for the Calendar view in the web ui. Read only.
     Used by both anonymous and non-anonymous user"""

--- a/plugins/polio/api/campaigns/campaigns.py
+++ b/plugins/polio/api/campaigns/campaigns.py
@@ -484,6 +484,7 @@ class ListCampaignSerializer(CampaignSerializer):
             "is_test",
             "is_preventive",
             "on_hold",
+            "is_planned",
         ]
         read_only_fields = fields
 

--- a/plugins/polio/js/src/constants/types.ts
+++ b/plugins/polio/js/src/constants/types.ts
@@ -455,6 +455,7 @@ export type CampaignListItem = {
     is_test: boolean;
     on_hold?: boolean;
     is_preventive: boolean;
+    is_planned: boolean;
 };
 
 export type DefaultCampaignValues = {

--- a/plugins/polio/js/src/domains/Campaigns/CampaignsList/CampaignCategoryCell.tsx
+++ b/plugins/polio/js/src/domains/Campaigns/CampaignsList/CampaignCategoryCell.tsx
@@ -1,0 +1,38 @@
+import React, { FunctionComponent } from 'react';
+import { useSafeIntl } from 'bluesquare-components';
+import MESSAGES from '../../../constants/messages';
+import { CampaignListItem } from '../../../constants/types';
+
+type Props = {
+    row: {
+        original: CampaignListItem;
+    };
+};
+
+export const CampaignCategoryCell: FunctionComponent<Props> = ({
+    row: { original: campaign },
+}) => {
+    const { formatMessage } = useSafeIntl();
+    const categories: string[] = [];
+
+    if (campaign.on_hold) {
+        categories.push(formatMessage(MESSAGES.campaignOnHold));
+    } else if (campaign.is_test) {
+        categories.push(formatMessage(MESSAGES.testCampaign));
+    } else if (campaign.is_planned) {
+        categories.push(formatMessage(MESSAGES.planned));
+    } else if (campaign.is_preventive) {
+        categories.push(formatMessage(MESSAGES.preventiveShort));
+    } else {
+        categories.push(formatMessage(MESSAGES.regular));
+    }
+
+    if (
+        campaign.is_preventive &&
+        !categories.includes(formatMessage(MESSAGES.preventiveShort))
+    ) {
+        categories.push(formatMessage(MESSAGES.preventiveShort));
+    }
+
+    return <>{categories.join(' - ')}</>;
+};

--- a/plugins/polio/js/src/domains/Campaigns/CampaignsList/useCampaignsTableColumns.tsx
+++ b/plugins/polio/js/src/domains/Campaigns/CampaignsList/useCampaignsTableColumns.tsx
@@ -7,6 +7,7 @@ import { RestoreModal } from '../../../../../../../hat/assets/js/apps/Iaso/compo
 import MESSAGES from '../../../constants/messages';
 import { CampaignListItem } from '../../../constants/types';
 import { EditCampaignModal } from '../MainDialog/EditCampaignModal';
+import { CampaignCategoryCell } from './CampaignCategoryCell';
 
 type Args = {
     showOnlyDeleted: boolean;
@@ -80,27 +81,7 @@ export const useCampaignsTableColumns = ({
                 Header: formatMessage(MESSAGES.campaignCategory),
                 accessor: 'campaign_category',
                 sortable: false,
-                Cell: ({
-                    row: { original },
-                }: {
-                    row: { original: CampaignListItem };
-                }): string => {
-                    let campaignCategory;
-                    if (original.on_hold) {
-                        campaignCategory = original.is_preventive
-                            ? `${formatMessage(MESSAGES.campaignOnHold)} - ${formatMessage(MESSAGES.preventiveShort)}`
-                            : formatMessage(MESSAGES.campaignOnHold);
-                    } else if (original.is_test) {
-                        campaignCategory = original.is_preventive
-                            ? `${formatMessage(MESSAGES.testCampaign)} - ${formatMessage(MESSAGES.preventiveShort)}`
-                            : formatMessage(MESSAGES.testCampaign);
-                    } else {
-                        campaignCategory = original.is_preventive
-                            ? formatMessage(MESSAGES.preventiveShort)
-                            : formatMessage(MESSAGES.regular);
-                    }
-                    return campaignCategory;
-                },
+                Cell: CampaignCategoryCell,
             },
             {
                 Header: formatMessage(MESSAGES.status),


### PR DESCRIPTION
Planned Campaigns: indicate correct status in table column 'campaign category'

Related JIRA tickets POLIO-2028

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc
-

## Changes

- removed unused serializer
- adding `is_planned` to campaigns list api 
- adapt front

## How to test

Make sure you have at least one campaigns planned 
Filter list of campaigns to see only planned campaigns, cell should display planned

## Print screen / video

<img width="1687" height="664" alt="Screenshot 2025-11-10 at 14 08 37" src="https://github.com/user-attachments/assets/114b64dd-5470-49e6-acfd-f16a4bc9baf1" />
<img width="1693" height="774" alt="Screenshot 2025-11-10 at 14 08 31" src="https://github.com/user-attachments/assets/c64ac651-7a8f-4dfa-a1cb-75dd95be942b" />


## Notes

-

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
