### PR TITLE
IA-4517 make attachements visible even if s3 is used

### DIFF
--- a/iaso/enketo/enketo_url.py
+++ b/iaso/enketo/enketo_url.py
@@ -71,12 +71,10 @@ def enketo_url_for_edition(
                 # posting form data it's
                 #   'instance_attachments[image-10_43_8.png]': 'https://...image-10_43_8.png'
                 # just don't know what will happen if there's a [ or ] in the file name
-
-                path = "/api/enketo/instance_files/{instance_file.id}/{file.name}"
+                path = f"/api/enketo/instance_files/{instance_file.id}/{instance_file.name}"
                 safe_filename = instance_file.name.replace("[", "%5B").replace("]", "%5D")
                 key = f"instance_attachments[{safe_filename}]"
-                data[key] = generate_url_for_enketo(instance_file.file.url)
-
+                data[key] = generate_url_for_enketo(path)
     return get_url_from_enketo(url, data)
 
 

--- a/iaso/urls.py
+++ b/iaso/urls.py
@@ -43,6 +43,7 @@ from .api.enketo import (
     enketo_edit_url,
     enketo_form_download,
     enketo_form_list,
+    enketo_instance_files,
     enketo_public_create_url,
     enketo_public_launch,
 )
@@ -259,6 +260,9 @@ urlpatterns: URLList = [
     path("enketo/formList", view=enketo_form_list, name="enketo-form-list"),
     path("enketo/formDownload/", view=enketo_form_download, name="enketo_form_download"),
     path("enketo/submission", view=EnketoSubmissionAPIView.as_view(), name="enketo-submission"),
+    path(
+        "enketo/instance_files/<instance_file_id>/<file_name>", view=enketo_instance_files, name="enketo-instance-files"
+    ),
     path("logout-iaso", auth.views.LogoutView.as_view(next_page="login"), name="logout-iaso"),
 ]
 


### PR DESCRIPTION
s3 urls are not supported by enketo, so enketo will fetch them via a new iaso endpoint

Related JIRA tickets : IA-4517

## Self proofreading checklist

- [ ] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

Explain the changes that were made.

The idea is not to list exhaustively all the changes made (GitHub already provides a full diff), but to help the reviewers better understand:

- which specific file changes go together, e.g: when creating a table in the front-end, there usually is a config file that goes with it
- the reasoning behind some changes, e.g: deleted files because they are now redundant
- the behaviour to expect, e.g: tooltip has purple background color because the client likes it so, changed a key in the API response to be consistent with other endpoints

## How to test

Explain how to test your PR.

If a specific config is required explain it here: dataset, account, profile, etc.

## Print screen / video

Upload here print screens or videos showing the changes.

## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-4517
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
