### PR TITLE
IA-4543: Allow pyramid synchronization between different sources

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/dataSources/components/sync/SyncDialog.tsx
+++ b/hat/assets/js/apps/Iaso/domains/dataSources/components/sync/SyncDialog.tsx
@@ -127,15 +127,13 @@ export const SyncDialog: FunctionComponent<Props> = ({ dataSource }) => {
         handleClose();
     }, [exportData, exportToDHIS2, handleClose]);
 
-    const areVersionsFromSameDataSource =
-        sourceVersion?.data_source === dataSource.id;
     const allowPreview =
         Boolean(exportData.source_version_id?.value) &&
         (Boolean(exportData.ref_status?.value) ||
             exportData.ref_status?.value === '') &&
         exportData.fields_to_export?.value.length > 0 &&
         Boolean(exportData.ref_version_id?.value);
-    const allowSync = allowPreview && areVersionsFromSameDataSource;
+    // const allowSync = allowPreview && areVersionsFromSameDataSource;
     const allowConfirmExport = allowPreview && credentials?.is_valid;
 
     // Reset Treeview when changing source datasource
@@ -249,7 +247,7 @@ export const SyncDialog: FunctionComponent<Props> = ({ dataSource }) => {
                     </Button>
                     <ConfirmSyncButton
                         closeMainDialog={handleClose}
-                        allowConfirm={allowSync}
+                        allowConfirm={allowPreview}
                         toUpdateSourceVersion={sourceVersion}
                         toCompareWithSourceVersion={refVersion}
                         toUpdateFields={toUpdateFields}

--- a/iaso/api/data_source_versions_synchronization/serializers.py
+++ b/iaso/api/data_source_versions_synchronization/serializers.py
@@ -96,8 +96,6 @@ class DataSourceVersionsSynchronizationSerializer(DynamicFieldsModelSerializer):
         source_version_to_update = validated_data["source_version_to_update"]
         source_version_to_compare_with = validated_data["source_version_to_compare_with"]
 
-        if source_version_to_update.data_source_id != source_version_to_compare_with.data_source_id:
-            raise serializers.ValidationError("The two versions to compare must be linked to the same data source.")
         if source_version_to_update.pk == source_version_to_compare_with.pk:
             raise serializers.ValidationError("The two versions to compare must be different.")
 

--- a/iaso/models/data_source.py
+++ b/iaso/models/data_source.py
@@ -267,8 +267,6 @@ class DataSourceVersionsSynchronization(models.Model):
         self.clean_data_source_versions()
 
     def clean_data_source_versions(self) -> None:
-        if self.source_version_to_update.data_source_id != self.source_version_to_compare_with.data_source_id:
-            raise ValidationError("The two versions to compare must be linked to the same data source.")
         if self.source_version_to_update.pk == self.source_version_to_compare_with.pk:
             raise ValidationError("The two versions to compare must be different.")
 

--- a/iaso/tests/api/data_source_versions_synchronization/test_serializers.py
+++ b/iaso/tests/api/data_source_versions_synchronization/test_serializers.py
@@ -113,10 +113,6 @@ class DataSourceVersionsSynchronizationSerializerTestCase(TestCase):
         }
         serializer = DataSourceVersionsSynchronizationSerializer(data=data)
         self.assertFalse(serializer.is_valid())
-        self.assertIn(
-            "The two versions to compare must be linked to the same data source.",
-            serializer.errors["non_field_errors"][0],
-        )
 
     def test_validate_that_versions_to_compare_are_different(self):
         data = {

--- a/iaso/tests/models/test_data_source_versions_synchronization.py
+++ b/iaso/tests/models/test_data_source_versions_synchronization.py
@@ -208,10 +208,6 @@ class DataSourceVersionsSynchronizationModelTestCase(TestCase):
         }
         data_source_sync = m.DataSourceVersionsSynchronization(**kwargs)
 
-        with self.assertRaises(ValidationError) as error:
-            data_source_sync.clean_data_source_versions()
-        self.assertIn("The two versions to compare must be linked to the same data source.", error.exception.messages)
-
         kwargs = {
             "name": "Foo",
             "source_version_to_update": self.source_version_to_update,


### PR DESCRIPTION
After taking some time since the implementation of the synchronization tool between pyramid versions, I want to confirm that there are sufficient use cases requiring synchronization between source versions.

Related JIRA tickets : IA-4543

## Self proofreading checklist

- [ ] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

-

## Changes

Remove front and back constraints

## How to test

Take 

## Print screen / video

Upload here print screens or videos showing the changes.

## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
