### PR TITLE
feat: SNT-186 Allow text variant on DownloadButtonComponent

### DIFF
--- a/hat/assets/js/apps/Iaso/components/DownloadButtonsComponent.tsx
+++ b/hat/assets/js/apps/Iaso/components/DownloadButtonsComponent.tsx
@@ -23,7 +23,7 @@ type Props = {
     xlsxUrl?: string;
     gpkgUrl?: string;
     disabled?: boolean;
-    variant?: 'contained' | 'outlined';
+    variant?: 'contained' | 'outlined' | 'text';
 };
 
 const DownloadButtonsComponent: FunctionComponent<Props> = ({


### PR DESCRIPTION
Allow text variant on DownloadButtonComponent

Related JIRA tickets : SNT-186

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [x] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

Add "text" in allowed variant of the component

## How to test

Nothing to test in IASO, in SNT it is required for related PR

## Print screen / video

Upload here print screens or videos showing the changes.

## Notes

Related SNT PR: https://github.com/BLSQ/snt-malaria/pull/122

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
