### PR TITLE
POLIO-2031: unhide planned campaigns

### DIFF
--- a/plugins/polio/api/campaigns/campaigns.py
+++ b/plugins/polio/api/campaigns/campaigns.py
@@ -786,10 +786,8 @@ class CampaignViewSet(ModelViewSet):
         on_hold = self.request.query_params.get("on_hold", "false")
         org_unit_groups = self.request.query_params.get("org_unit_groups")
         campaign_types = self.request.query_params.get("campaign_types")
-        is_embedded = self.request.query_params.get("is_embedded", "false")
         campaigns = queryset
-        if is_embedded == "true":
-            campaigns = campaigns.filter(is_planned=False)
+
         if show_test == "false":
             campaigns = campaigns.filter(is_test=False)
         if on_hold == "false":
@@ -798,7 +796,7 @@ class CampaignViewSet(ModelViewSet):
             campaigns = campaigns.filter(is_preventive=True).filter(is_planned=False)
         if campaign_category == "on_hold":
             campaigns = campaigns.filter(on_hold=True).filter(is_planned=False)
-        if campaign_category == "is_planned" and is_embedded == "false":
+        if campaign_category == "is_planned":
             campaigns = campaigns.filter(is_planned=True)
         if campaign_category == "regular" and on_hold == "true":
             campaigns = campaigns.filter(is_preventive=False).filter(is_test=False).filter(is_planned=False)

--- a/plugins/polio/js/src/domains/Calendar/campaignCalendar/CampaignsFilters.tsx
+++ b/plugins/polio/js/src/domains/Calendar/campaignCalendar/CampaignsFilters.tsx
@@ -157,7 +157,7 @@ export const CampaignsFilters: FunctionComponent<Props> = ({
     const theme = useTheme();
     const isLargeLayout = useMediaQuery(theme.breakpoints.up('md'));
     const [textSearchError, setTextSearchError] = useState(false);
-    const campaignCategoryOptions = useCampaignCategoryOptions(isEmbedded);
+    const campaignCategoryOptions = useCampaignCategoryOptions();
 
     useEffect(() => {
         setFiltersUpdated(true);

--- a/plugins/polio/js/src/domains/Campaigns/hooks/useCampaignCategoryOptions.ts
+++ b/plugins/polio/js/src/domains/Campaigns/hooks/useCampaignCategoryOptions.ts
@@ -1,20 +1,21 @@
+import { useMemo } from 'react';
 import { useSafeIntl } from 'bluesquare-components';
 import { DropdownOptions } from '../../../../../../../hat/assets/js/apps/Iaso/types/utils';
 import MESSAGES from '../../../constants/messages';
 
-export const useCampaignCategoryOptions = (
-    isEmbedded: boolean,
-): DropdownOptions<string>[] => {
+export const useCampaignCategoryOptions = (): DropdownOptions<string>[] => {
     const { formatMessage } = useSafeIntl();
-    const baseOptions = [
-        { label: formatMessage(MESSAGES.all), value: 'all' },
-        { label: formatMessage(MESSAGES.preventiveShort), value: 'preventive' },
-        { label: formatMessage(MESSAGES.regular), value: 'regular' },
-        { label: formatMessage(MESSAGES.campaignOnHold), value: 'on_hold' },
-    ];
-    if (isEmbedded) return baseOptions;
-    return [
-        ...baseOptions,
-        { label: formatMessage(MESSAGES.planned), value: 'is_planned' },
-    ];
+    return useMemo(
+        () => [
+            { label: formatMessage(MESSAGES.all), value: 'all' },
+            {
+                label: formatMessage(MESSAGES.preventiveShort),
+                value: 'preventive',
+            },
+            { label: formatMessage(MESSAGES.regular), value: 'regular' },
+            { label: formatMessage(MESSAGES.campaignOnHold), value: 'on_hold' },
+            { label: formatMessage(MESSAGES.planned), value: 'is_planned' },
+        ],
+        [formatMessage],
+    );
 };


### PR DESCRIPTION
unhide planned campaigns from polio calendar

Related JIRA tickets : POLIO-2031

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

N/A

## Changes

Remove front and back end code excluding planned campaigns from calendar

## How to test

- Use a Db with planned campaigns or create one
- Go to calendar: the planned campaigns should be visible
- use filter: user should be able to select planned campaigns in filter

## Print screen / video


<img width="1651" height="1367" alt="Screenshot 2025-11-17 at 11 55 52" src="https://github.com/user-attachments/assets/6320dff7-b2d3-4a0c-9c34-ee609bebeb60" />
