### PR TITLE
POLIO-2032: remove reason for delay for planned round/campaign

### DIFF
--- a/plugins/polio/api/campaigns/campaigns.py
+++ b/plugins/polio/api/campaigns/campaigns.py
@@ -312,7 +312,7 @@ class CampaignSerializer(serializers.ModelSerializer):
             for scope in campaign_scopes:
                 vaccine = scope.get("vaccine", "")
                 org_units = scope.get("group", {}).get("org_units")
-                scope, created = instance.scopes.get_or_create(vaccine=vaccine)
+                scope, _ = instance.scopes.get_or_create(vaccine=vaccine)
                 source_version_id = None
                 name = f"scope for campaign {instance.obr_name} - {vaccine or ''}"
                 if org_units:

--- a/plugins/polio/js/src/domains/Campaigns/Rounds/RoundDates/RoundDates.tsx
+++ b/plugins/polio/js/src/domains/Campaigns/Rounds/RoundDates/RoundDates.tsx
@@ -33,6 +33,7 @@ export const RoundDates: FunctionComponent<Props> = ({
     const { formatMessage } = useSafeIntl();
     const {
         values: { rounds = [] },
+        values,
         initialValues,
     } = useFormikContext<CampaignFormValues>();
     const currentStartDate = rounds?.[roundIndex]?.started_at;
@@ -45,6 +46,9 @@ export const RoundDates: FunctionComponent<Props> = ({
             initialValues?.rounds?.find(round => round.number === roundNumber)
                 ?.ended_at,
     );
+    const isPlanned =
+        values?.is_planned ||
+        rounds.some(rnd => rnd.number === roundNumber && rnd.is_planned);
     const save = ({ startDate, endDate, reason_for_delay }, helpers) => {
         setParentFieldValue(`rounds[${roundIndex}]`, {
             ...rounds[roundIndex],
@@ -86,7 +90,7 @@ export const RoundDates: FunctionComponent<Props> = ({
 
     return (
         <>
-            {!hasInitialData && (
+            {(!hasInitialData || isPlanned) && (
                 <>
                     <Field
                         label={formatMessage(MESSAGES.startDate)}
@@ -105,7 +109,7 @@ export const RoundDates: FunctionComponent<Props> = ({
                     />
                 </>
             )}
-            {hasInitialData && (
+            {hasInitialData && !isPlanned && (
                 <FormikProvider value={formik}>
                     <Box mb={2}>
                         <Divider />


### PR DESCRIPTION


Related JIRA tickets :  POLIO-2032

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

NA

## Changes

- Add a check in the front end to not display reasons for delay interface if campaign is planned

## How to test

- With a polio Db and a planned campaign:
    - Go to round tab: dates should be editable without reasons for delay
    - Try with regular campaign: reason for delay should be mandatory 

## Print screen / video


https://github.com/user-attachments/assets/ade9f33e-76dc-4e26-9949-ca0d5305c04b



## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
