### PR TITLE
IA-4610: Openhexa raise Sentry error

### DIFF
--- a/iaso/api/openhexa/views.py
+++ b/iaso/api/openhexa/views.py
@@ -313,7 +313,7 @@ class OpenHexaPipelinesViewSet(ViewSet):
                 return Response({"configured": False})
 
             account = request.user.iaso_profile.account
-            *_, workspace = get_openhexa_config(account, silent=True)
+            *_, workspace = get_openhexa_config(account)
 
             # If we reach here, config is valid
             response_data = {"configured": True}

--- a/iaso/api/openhexa/views.py
+++ b/iaso/api/openhexa/views.py
@@ -324,9 +324,5 @@ class OpenHexaPipelinesViewSet(ViewSet):
 
             return Response(response_data)
 
-        except ValidationError:
-            # Configuration not properly set up - this is expected, not an error
-            return Response({"configured": False})
-        except Exception:
-            # Any other unexpected error - still return False without logging to Sentry
+        except (ValidationError, Exception):
             return Response({"configured": False})

--- a/iaso/api/openhexa/views.py
+++ b/iaso/api/openhexa/views.py
@@ -313,7 +313,7 @@ class OpenHexaPipelinesViewSet(ViewSet):
                 return Response({"configured": False})
 
             account = request.user.iaso_profile.account
-            *_, workspace = get_openhexa_config(account)
+            *_, workspace = get_openhexa_config(account, silent=True)
 
             # If we reach here, config is valid
             response_data = {"configured": True}
@@ -325,8 +325,8 @@ class OpenHexaPipelinesViewSet(ViewSet):
             return Response(response_data)
 
         except ValidationError:
-            # Configuration not properly set up
+            # Configuration not properly set up - this is expected, not an error
             return Response({"configured": False})
-        except Exception as e:
-            logger.exception(f"Error checking OpenHexa config: {str(e)}")
+        except Exception:
+            # Any other unexpected error - still return False without logging to Sentry
             return Response({"configured": False})

--- a/iaso/utils/openhexa.py
+++ b/iaso/utils/openhexa.py
@@ -19,13 +19,12 @@ from iaso.models.openhexa import OpenHEXAWorkspace
 logger = logging.getLogger(__name__)
 
 
-def get_openhexa_config(account, silent=False):
+def get_openhexa_config(account):
     """
     Retrieve OpenHexa configuration from OpenHEXAWorkspace and OpenHEXAInstance models.
 
     Args:
         account: The account to retrieve OpenHEXA configuration for
-        silent: If True, don't log errors (for checking config existence)
 
     Returns:
         tuple: (openhexa_url, openhexa_token, workspace_slug, workspace)
@@ -38,19 +37,16 @@ def get_openhexa_config(account, silent=False):
         try:
             workspace = OpenHEXAWorkspace.objects.select_related("openhexa_instance").get(account=account)
         except OpenHEXAWorkspace.DoesNotExist:
-            if not silent:
-                logger.error(f"No OpenHEXA workspace configured for account '{account.name}' (ID: {account.id})")
+            logger.warning(f"No OpenHEXA workspace configured for account '{account.name}' (ID: {account.id})")
             raise ValidationError(_("No OpenHEXA workspace configured for your account"))
         except OpenHEXAWorkspace.MultipleObjectsReturned:
-            if not silent:
-                logger.error(f"Multiple OpenHEXA workspaces found for account '{account.name}' (ID: {account.id})")
+            logger.warning(f"Multiple OpenHEXA workspaces found for account '{account.name}' (ID: {account.id})")
             raise ValidationError(_("Multiple OpenHEXA workspaces configured for your account"))
 
         # Get workspace slug
         workspace_slug = workspace.slug
         if not workspace_slug:
-            if not silent:
-                logger.error(f"OpenHEXA workspace for account '{account.name}' has no slug configured")
+            logger.warning(f"OpenHEXA workspace for account '{account.name}' has no slug configured")
             raise ValidationError(_("OpenHEXA workspace has no slug configured"))
 
         # Get OpenHEXA instance configuration
@@ -59,19 +55,16 @@ def get_openhexa_config(account, silent=False):
         openhexa_token = openhexa_instance.token
 
         if not openhexa_url:
-            if not silent:
-                logger.error(f"OpenHEXA instance '{openhexa_instance.name}' has no URL configured")
+            logger.warning(f"OpenHEXA instance '{openhexa_instance.name}' has no URL configured")
             raise ValidationError(_("OpenHEXA instance has no URL configured"))
 
         if not openhexa_token:
-            if not silent:
-                logger.error(f"OpenHEXA instance '{openhexa_instance.name}' has no token configured")
+            logger.warning(f"OpenHEXA instance '{openhexa_instance.name}' has no token configured")
             raise ValidationError(_("OpenHEXA instance has no token configured"))
 
         # Validate that the URL contains 'graphql'
         if "graphql" not in openhexa_url.lower():
-            if not silent:
-                logger.error(f"OpenHexa URL does not contain 'graphql': {openhexa_url}")
+            logger.warning(f"OpenHexa URL does not contain 'graphql': {openhexa_url}")
             raise ValidationError(_("OpenHEXA URL must contain 'graphql'"))
 
         return openhexa_url, openhexa_token, workspace_slug, workspace
@@ -79,9 +72,8 @@ def get_openhexa_config(account, silent=False):
     except ValidationError:
         # Re-raise ValidationErrors from inner try block
         raise
-    except Exception:
-        if not silent:
-            logger.exception(f"Could not fetch OpenHEXA config for account {account.id}")
+    except Exception as e:
+        logger.warning(f"Could not fetch OpenHEXA config for account {account.id}: {str(e)}")
         raise ValidationError(_("OpenHexa configuration not found"))
 
 


### PR DESCRIPTION
While fetching the OpenHexa configuration during planning editing, if the account does not have an associated OpenHexa config, the backend API throws an error and triggers Sentry. For this specific endpoint, the absence of a configuration should fail silently—without affecting error reporting for other usages (trying to fetch pipelines, launch metrics command).

Related JIRA tickets : IA-4610

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

- 

## Changes

- `get_openhexa_config` option to fail silently

## How to test

First edit a planning without those changes, make sure you have an error in the terminal:
`
ERROR    2025-11-19 08:27:22,103 iaso.utils.openhexa -- No OpenHEXA workspace configured for account ...
`
Apply those changes, error should disappear

## Print screen / video

-

## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
