### PR TITLE
POLIO-2035 fix embedded pages

### DIFF
--- a/iaso/api/colors.py
+++ b/iaso/api/colors.py
@@ -1,6 +1,5 @@
 from rest_framework import serializers, status
 from rest_framework.decorators import api_view, permission_classes
-from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
 from iaso.utils.colors import COLOR_CHOICES, DISPERSED_COLOR_ORDER
@@ -15,7 +14,8 @@ class ColorsQueryParamsSerializer(serializers.Serializer):
 
 
 @api_view(["GET"])
-@permission_classes([IsAuthenticated])
+# public API to avoid breaking embedded pages
+@permission_classes([])
 def colors_list(request):
     """Return the list of available colors for the application
 

--- a/iaso/tests/api/test_colors.py
+++ b/iaso/tests/api/test_colors.py
@@ -12,9 +12,9 @@ class ColorsApiTestCase(APITestCase):
         cls.user = cls.create_user_with_profile(username="user", account=account)
 
     def test_colors_unauth(self):
-        """Test that unauthenticated users cannot access colors API"""
+        """Test that unauthenticated users can access colors API"""
         response = self.client.get("/api/colors/", format="json")
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, 200)
 
     def test_colors_rainbow_order(self):
         """Test colors API returns rainbow order by default"""


### PR DESCRIPTION
Colors API need to be public to avoid breaking embedded pages

Related JIRA tickets : POLIO-2035

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

  Added comment in the code on why the API is public

## Changes

 - removed permission check
 - updated access control test for endpoint

## How to test

Go to `dashboards/polio/embeddedCalendar` while not logged. The page should load properly



## Notes

Deployed as hotfix with tag `v2025.11.18b`
