### PR TITLE
WC2-852: Fix imports fails due to storage logs

### DIFF
--- a/iaso/api/storage.py
+++ b/iaso/api/storage.py
@@ -28,7 +28,7 @@ from .common import (
     UserSerializer,
     safe_api_import,
 )
-from .instances.instances import FileFormatEnum
+from .instances.instances import FileFormatEnum, find_entity
 
 
 class EntityNestedSerializer(EntitySerializer):
@@ -393,12 +393,11 @@ def import_storage_logs(data, user):
             if "org_unit_id" in log_data and log_data["org_unit_id"] is not None:
                 concerned_orgunit = OrgUnit.objects.get(id=log_data["org_unit_id"])
 
+            account = user.iaso_profile.account
             concerned_entity = None
             entity_id = log_data.get("entity_id") or log_data.get("entity_uuid")
             if entity_id:
-                concerned_entity = Entity.objects.get(uuid=entity_id)
-
-            account = user.iaso_profile.account
+                concerned_entity = find_entity(account, entity_id)
 
             # 1. Create the storage device, if needed
             device, _ = StorageDevice.objects.get_or_create(

--- a/iaso/tasks/process_mobile_bulk_upload.py
+++ b/iaso/tasks/process_mobile_bulk_upload.py
@@ -33,7 +33,7 @@ from iaso.api.org_unit_change_requests.serializers import OrgUnitChangeRequestWr
 from iaso.api.org_units import import_org_units
 from iaso.api.stocks.utils import import_stock_ledger_items
 from iaso.api.storage import import_storage_logs
-from iaso.models import Instance, Project, StockLedgerItem
+from iaso.models import Instance, Project, StockLedgerItem, Task
 
 
 INSTANCES_JSON = "instances.json"
@@ -45,11 +45,16 @@ STOCK_LEDGER_ITEMS_JSON = "stockLedgerItems.json"
 logger = logging.getLogger(__name__)
 
 
+def log_progress(task: Task, progress: int, message: str) -> None:
+    logger.info(message)
+    task.report_progress_and_stop_if_killed(progress_value=progress, progress_message=message, end_value=100)
+
+
 @task_decorator(task_name="process_mobile_bulk_upload")
 def process_mobile_bulk_upload(api_import_id, project_id, task=None):
     start_date = datetime.now()
     start_time = time.time()
-    the_task = task
+    the_task: Task = task
     the_task.report_progress_and_stop_if_killed(
         progress_value=0,
         progress_message=_("Starting"),
@@ -62,17 +67,19 @@ def process_mobile_bulk_upload(api_import_id, project_id, task=None):
     try:
         stats = {"new_org_units": 0, "new_instances": 0, "new_instance_files": 0, "new_change_requests": 0}
 
-        with transaction.atomic():
-            with zipfile.ZipFile(api_import.file, "r") as zip_ref:
+        with zipfile.ZipFile(api_import.file, "r") as zip_ref:
+            with transaction.atomic():
                 if ORG_UNITS_JSON in zip_ref.namelist():
+                    log_progress(the_task, 0, "Importing OrgUnits")
                     org_units_data = read_json_file_from_zip(zip_ref, ORG_UNITS_JSON)
                     new_org_units = import_org_units(org_units_data, user, project.app_id)
                     stats["new_org_units"] = len(new_org_units)
                 else:
-                    logger.info(f"The file {ORG_UNITS_JSON} does not exist in the zip file.")
+                    log_progress(the_task, 0, f"The file {ORG_UNITS_JSON} does not exist in the zip file.")
 
+            with transaction.atomic():
                 if INSTANCES_JSON in zip_ref.namelist():
-                    logger.info("Processing forms and files")
+                    log_progress(the_task, 20, "Processing forms and files")
                     instances_data = read_json_file_from_zip(zip_ref, INSTANCES_JSON)
                     import_instances(instances_data, user, project.app_id)
                     new_instance_files = []
@@ -87,15 +94,17 @@ def process_mobile_bulk_upload(api_import_id, project_id, task=None):
                     duplicated_count = duplicate_instance_files(new_instance_files)
                     stats["new_instance_files"] = len(new_instance_files) + duplicated_count
                 else:
-                    logger.info(f"The file {INSTANCES_JSON} does not exist in the zip file.")
+                    log_progress(the_task, 20, f"The file {INSTANCES_JSON} does not exist in the zip file.")
 
+            with transaction.atomic():
                 if STORAGE_LOGS_JSON in zip_ref.namelist():
-                    logger.info("Processing storage logs")
+                    log_progress(the_task, 40, "Processing storage logs")
                     storage_logs_data = read_json_file_from_zip(zip_ref, STORAGE_LOGS_JSON)
                     import_storage_logs(storage_logs_data, user)
 
+            with transaction.atomic():
                 if STOCK_LEDGER_ITEMS_JSON in zip_ref.namelist():
-                    logger.info("Processing stock ledger items")
+                    log_progress(the_task, 60, "Processing stock ledger items")
                     stock_ledger_items_data = read_json_file_from_zip(zip_ref, STOCK_LEDGER_ITEMS_JSON)
                     import_stock_ledger_items(
                         user,
@@ -104,8 +113,9 @@ def process_mobile_bulk_upload(api_import_id, project_id, task=None):
                         StockLedgerItem.objects.filter_for_project(project),
                     )
 
+            with transaction.atomic():
                 if CHANGE_REQUESTS_JSON in zip_ref.namelist():
-                    logger.info("Processing change requests")
+                    log_progress(the_task, 80, "Processing change requests")
                     change_requests_data = read_json_file_from_zip(zip_ref, CHANGE_REQUESTS_JSON)
                     for change_request in change_requests_data:
                         serializer = OrgUnitChangeRequestWriteSerializer(data=change_request)
@@ -118,7 +128,7 @@ def process_mobile_bulk_upload(api_import_id, project_id, task=None):
                         stats["new_change_requests"] += 1
 
     except Exception as e:
-        logger.exception("Exception! Rolling back import: " + str(e))
+        logger.exception("Exception! Rolling back import that failed: " + str(e))
         api_import.has_problem = True
         api_import.exception = format_exc()
         api_import.save()


### PR DESCRIPTION
`process_mobile_bulk_upload` was wrapped into one giant transaction. This was problematic because we can have multiple zips each with the **full** storage logs. The storage logs could point on entities that are created in one of the zips. If we have entities created in at least two zips, the storage logs can never succeed and therefore the import of all the zips is blocked.

Also, I extracted the logic of finding an entity to attach the storage logs to the proper entity even when there are duplicates.

Related JIRA tickets : WC2-852

## Self proofreading checklist

- [X] Did I use eslint and ruff formatters?
- [X] Is my code clear enough and well documented?
- [X] Are there enough tests?

## Changes

See top of the PR

## How to test

It's quite hard to test because you need to send two zips with some entities created in each zips and have storage logs to point to those new entities.

The best is to test that synchronizing using zip is still working fine.

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
