### PR TITLE
SNT-189 Users can see the cost breakdown per org unit

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
             # Optional Used to load dev bluesquare-components JS. See `Live Bluesquare components` in doc
             - ../bluesquare-components:/opt/bluesquare-components
             # Optional Used to load dev snt-malaria-budgeting Python package.
-            - ../snt-malaria-budgeting:/opt/snt_malaria_budgeting
+            - ../snt-malaria-budgeting:/opt/snt-malaria-budgeting
         links: &hat_links
             - db
         environment: &hat_environment

--- a/docker/django/Dockerfile
+++ b/docker/django/Dockerfile
@@ -2,12 +2,12 @@
 FROM python:3.9
 
 RUN apt-get update && apt-get --yes install \
-		curl \
-		gettext \
-		gettext-base \
-		postgresql-client \
-		libgdal-dev \
-    &&  apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+	curl \
+	gettext \
+	gettext-base \
+	postgresql-client \
+	libgdal-dev \
+	&&  apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 WORKDIR /opt/app
 
@@ -17,8 +17,9 @@ COPY requirements-dev.txt /opt/app/requirements-dev.txt
 RUN pip install -r requirements-dev.txt
 
 # Uncomment to debug snt-malaria budgeting
-# RUN pip uninstall -y snt-malaria-budgeting || true
+# ENV PYTHONPATH="/opt/snt-malaria-budgeting:${PYTHONPATH}"
 
+# RUN pip uninstall -y snt-malaria-budgeting || true
 
 # don't copy app we mount everything afterwards for hot reloading anyway
 #COPY . /opt/app

--- a/requirements.txt
+++ b/requirements.txt
@@ -156,4 +156,4 @@ azure-storage-blob==12.19.0
 
 # SNT Malaria plugin.
 # ------------------------------------------------------------------------------
-snt-malaria-budgeting==0.4.1
+snt-malaria-budgeting==0.4.2


### PR DESCRIPTION
Update snt-malaria-budgeting package version 

Related JIRA tickets :  SNT-189

## Self proofreading checklist

- [ ] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

N/A

## Changes

Update snt-malaria-budgeting package version 
Add config to be able to live edit it in docker.

## How to test

Just check that everything runs and package is installed.
Usage is on snt-malaria repo.

## Print screen / video

N/A

## Notes

Related to snt-malaria PR: https://github.com/BLSQ/snt-malaria/pull/127

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
