### PR TITLE
[IA-4534] Change modal title on Change Request rejection

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/Components/ReviewOrgUnitChangesButtons.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/Components/ReviewOrgUnitChangesButtons.tsx
@@ -36,7 +36,6 @@ export const ApproveOrgUnitChangesButtons: FunctionComponent<Props> = ({
             : selectedFields.map(field => `new_${field.key}`);
     }, [isNewOrgUnit, changeRequest, selectedFields]);
 
-    const [isApproved, setIsApproved] = useState<boolean>(false);
     const [isRejected, setIsRejected] = useState<boolean>(false);
     const isPartiallyApproved = Boolean(
         changeRequest?.requested_fields &&
@@ -52,7 +51,6 @@ export const ApproveOrgUnitChangesButtons: FunctionComponent<Props> = ({
                 open={isConfirmDialogOpen}
                 onClose={() => setIsConfirmDialogOpen(false)}
                 isPartiallyApproved={isPartiallyApproved}
-                isApproved={isApproved}
                 approvedFields={approvedFields}
                 isNewOrgUnit={isNewOrgUnit}
                 isRejected={isRejected}
@@ -64,7 +62,6 @@ export const ApproveOrgUnitChangesButtons: FunctionComponent<Props> = ({
                             <Button
                                 data-test="reject-button"
                                 onClick={() => {
-                                    setIsApproved(false);
                                     setIsRejected(true);
                                     setIsConfirmDialogOpen(true);
                                 }}
@@ -79,7 +76,6 @@ export const ApproveOrgUnitChangesButtons: FunctionComponent<Props> = ({
                             <Button
                                 data-test="confirm-button"
                                 onClick={() => {
-                                    setIsApproved(true);
                                     setIsRejected(false);
                                     setIsConfirmDialogOpen(true);
                                 }}

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/Components/ReviewOrgUnitChangesButtons.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/Components/ReviewOrgUnitChangesButtons.tsx
@@ -37,6 +37,7 @@ export const ApproveOrgUnitChangesButtons: FunctionComponent<Props> = ({
     }, [isNewOrgUnit, changeRequest, selectedFields]);
 
     const [isApproved, setIsApproved] = useState<boolean>(false);
+    const [isRejected, setIsRejected] = useState<boolean>(false);
     const isPartiallyApproved = Boolean(
         changeRequest?.requested_fields &&
             changeRequest?.requested_fields.length > approvedFields.length &&
@@ -54,6 +55,7 @@ export const ApproveOrgUnitChangesButtons: FunctionComponent<Props> = ({
                 isApproved={isApproved}
                 approvedFields={approvedFields}
                 isNewOrgUnit={isNewOrgUnit}
+                isRejected={isRejected}
             />
             <Box display="flex" justifyContent="flex-end" m={2}>
                 {isNew && (
@@ -63,6 +65,7 @@ export const ApproveOrgUnitChangesButtons: FunctionComponent<Props> = ({
                                 data-test="reject-button"
                                 onClick={() => {
                                     setIsApproved(false);
+                                    setIsRejected(true);
                                     setIsConfirmDialogOpen(true);
                                 }}
                                 variant="contained"
@@ -77,6 +80,7 @@ export const ApproveOrgUnitChangesButtons: FunctionComponent<Props> = ({
                                 data-test="confirm-button"
                                 onClick={() => {
                                     setIsApproved(true);
+                                    setIsRejected(false);
                                     setIsConfirmDialogOpen(true);
                                 }}
                                 variant="contained"

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/Components/ReviewOrgUnitChangesConfirmDialog.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/Components/ReviewOrgUnitChangesConfirmDialog.tsx
@@ -42,6 +42,7 @@ type Props = {
     onClose: () => void;
     isApproved: boolean;
     isPartiallyApproved: boolean;
+    isRejected: boolean;
     approvedFields: string[];
     isNewOrgUnit: boolean;
 };
@@ -52,20 +53,21 @@ export const ReviewOrgUnitChangesConfirmDialog: FunctionComponent<Props> = ({
     onClose,
     isApproved,
     isPartiallyApproved,
+    isRejected,
     approvedFields,
     isNewOrgUnit,
 }) => {
     const [comment, setComment] = useState<string | undefined>();
     const { formatMessage } = useSafeIntl();
     const titleMessage = useMemo(() => {
+        if (isRejected) {
+            return formatMessage(MESSAGES.addRejectionComment);
+        }
         if (isPartiallyApproved) {
             return formatMessage(MESSAGES.addPartiallyApprovedComment);
         }
-        if (isApproved) {
-            return '';
-        }
-        return formatMessage(MESSAGES.addRejectionComment);
-    }, [isApproved, isPartiallyApproved, formatMessage]);
+        return '';
+    }, [isPartiallyApproved, isRejected, formatMessage]);
 
     const reviewOrgUnitChangesCommentDialogButtons = useMemo(() => {
         return createChangesConfirmDialogButtons({

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/Components/ReviewOrgUnitChangesConfirmDialog.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/reviewChanges/Components/ReviewOrgUnitChangesConfirmDialog.tsx
@@ -40,7 +40,6 @@ type Props = {
     submitChangeRequest: SubmitChangeRequest;
     open: boolean;
     onClose: () => void;
-    isApproved: boolean;
     isPartiallyApproved: boolean;
     isRejected: boolean;
     approvedFields: string[];
@@ -51,7 +50,6 @@ export const ReviewOrgUnitChangesConfirmDialog: FunctionComponent<Props> = ({
     submitChangeRequest,
     open,
     onClose,
-    isApproved,
     isPartiallyApproved,
     isRejected,
     approvedFields,
@@ -74,7 +72,7 @@ export const ReviewOrgUnitChangesConfirmDialog: FunctionComponent<Props> = ({
             comment,
             onClose,
             submitChangeRequest,
-            isApproved,
+            isApproved: !isRejected,
             isPartiallyApproved,
             approvedFields,
         });
@@ -82,7 +80,7 @@ export const ReviewOrgUnitChangesConfirmDialog: FunctionComponent<Props> = ({
         approvedFields,
         comment,
         onClose,
-        isApproved,
+        isRejected,
         isPartiallyApproved,
         submitChangeRequest,
     ]);
@@ -97,7 +95,7 @@ export const ReviewOrgUnitChangesConfirmDialog: FunctionComponent<Props> = ({
             closeDialog={onClose}
             buttons={() => reviewOrgUnitChangesCommentDialogButtons}
         >
-            {(!isApproved || isPartiallyApproved) && (
+            {(isRejected || isPartiallyApproved) && (
                 <InputComponent
                     type="textarea"
                     keyValue=""
@@ -107,7 +105,7 @@ export const ReviewOrgUnitChangesConfirmDialog: FunctionComponent<Props> = ({
                     withMarginTop={false}
                 />
             )}
-            {isApproved && !isPartiallyApproved && (
+            {!isRejected && !isPartiallyApproved && (
                 <>
                     <p>
                         {formatMessage(


### PR DESCRIPTION
Change modal title on CR rejection

Related JIRA tickets : IA-4534

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [x] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

/

## Changes

- Changed the logic that displays change request modal titles


## How to test

- Have a PR that has multiple fields to approve/reject
- Tick some of the fields, but not all
- Click on `REJECT ALL`
- The modal title now says that the change request is going to get rejected (before, it said that it would be approved)

## Print screen / video

<img width="1260" height="852" alt="image" src="https://github.com/user-attachments/assets/0d76b84d-c918-48e3-b4e3-095c2ed2b126" />

## Notes

/

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
