### PR TITLE
[IA-4481] Store user when deleting instances

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -403,6 +403,8 @@
     "iaso.instance.coordinate": "Coordinates",
     "iaso.instance.created_at": "Created in Iaso",
     "iaso.instance.delete": "Delete instance(s)",
+    "iaso.instance.deleted_at": "Deleted at",
+    "iaso.instance.deleted_by": "Deleted by",
     "iaso.instance.deleteCount": "Delete {count} instance(s)",
     "iaso.instance.deleteInstanceWarning": "This operation can still be undone",
     "iaso.instance.deleteText": "Undelete is possible on submission detail page",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -404,6 +404,8 @@
     "iaso.instance.coordinate": "Coordonnées",
     "iaso.instance.created_at": "Création dans Iaso",
     "iaso.instance.delete": "Effacer une(des) soumission(s)",
+    "iaso.instance.deleted_at": "Deleted at",
+    "iaso.instance.deleted_by": "Deleted by",
     "iaso.instance.deleteCount": "Effacer {count} soumission(s)",
     "iaso.instance.deleteInstanceWarning": "Cette opération peut toujours être annulée.",
     "iaso.instance.deleteText": "Restaurer la soumission est possible sur la page detail",

--- a/hat/assets/js/apps/Iaso/domains/instances/compare/components/CompareInstanceLogs.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/compare/components/CompareInstanceLogs.tsx
@@ -176,7 +176,7 @@ export const CompareInstanceLogs: FunctionComponent = () => {
                                         logAInitialValue),
                             )}
                             loading={isFetchingInstanceLogs}
-                            user={instanceLogA?.user}
+                            user={instanceLogB?.user}
                             infos={instanceLogContent.logB}
                             dropDownLoading={isInstanceLogBFetching}
                         />

--- a/hat/assets/js/apps/Iaso/domains/instances/components/InstanceDetailsInfos.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/InstanceDetailsInfos.js
@@ -33,8 +33,8 @@ const InstanceDetailsInfos = ({
                         }
                         label={formatMessage(
                             MESSAGES[
-                                'labelKey' in f
-                                    ? f.labelKey
+                                'getLabelKey' in f
+                                    ? f.getLabelKey(currentInstance)
                                     : f.translationKey ?? f.key
                             ],
                         )}

--- a/hat/assets/js/apps/Iaso/domains/instances/constants.js
+++ b/hat/assets/js/apps/Iaso/domains/instances/constants.js
@@ -189,7 +189,6 @@ export const INSTANCE_METAS_FIELDS = [
             return textPlaceholder;
         },
     },
-
     {
         key: 'version',
         accessor: 'formVersion',
@@ -204,13 +203,6 @@ export const INSTANCE_METAS_FIELDS = [
             const data = settings.row.original;
             return data.file_content?._version || textPlaceholder;
         },
-    },
-    {
-        key: 'updated_at',
-        render: value => displayDateFromTimestamp(value),
-        active: true,
-        tableOrder: 5,
-        type: 'info',
     },
     {
         key: 'source_created_at',
@@ -282,6 +274,17 @@ export const INSTANCE_METAS_FIELDS = [
     {
         key: 'last_modified_by',
         type: 'info',
+        getLabelKey: data => {
+            return data.deleted? 'deleted_by' : 'last_modified_by';
+        },
+    },
+    {
+        key: 'updated_at',
+        render: value => displayDateFromTimestamp(value),
+        type: 'info',
+        getLabelKey: data => {
+            return data.deleted? 'deleted_at' : 'updated_at';
+        },
     },
 ];
 

--- a/hat/assets/js/apps/Iaso/domains/instances/messages.ts
+++ b/hat/assets/js/apps/Iaso/domains/instances/messages.ts
@@ -123,8 +123,12 @@ const MESSAGES = defineMessages({
         defaultMessage: 'Created in Iaso',
     },
     updated_at: {
-        id: 'iaso.instance.last_sync_at',
+        id: 'iaso.instance.updated_at',
         defaultMessage: 'Updated',
+    },
+    deleted_at: {
+        id: 'iaso.instance.deleted_at',
+        defaultMessage: 'Deleted',
     },
     source_created_at: {
         id: 'iaso.instance.source_created_at',
@@ -133,6 +137,10 @@ const MESSAGES = defineMessages({
     last_modified_by: {
         id: 'iaso.instance.last_modified_by',
         defaultMessage: 'Modified by',
+    },
+    deleted_by: {
+        id: 'iaso.instance.deleted_by',
+        defaultMessage: 'Deleted by',
     },
     files: {
         id: 'iaso.instance.files',

--- a/iaso/api/instances/instances.py
+++ b/iaso/api/instances/instances.py
@@ -672,8 +672,10 @@ class InstancesViewSet(viewsets.ViewSet):
 
     def delete(self, request, pk=None):
         original = get_object_or_404(self.get_queryset(), pk=pk)
-        instance = get_object_or_404(self.get_queryset(), pk=pk)
+        instance: Instance = get_object_or_404(self.get_queryset(), pk=pk)
         self.check_object_permissions(request, instance)
+        user = request.user
+        instance.last_modified_by = user
         instance.soft_delete()
         log_modification(original, instance, INSTANCE_API, user=request.user)
         return Response(instance.as_full_model())

--- a/iaso/models/instances.py
+++ b/iaso/models/instances.py
@@ -820,10 +820,12 @@ class Instance(models.Model):
 
     def soft_delete(self):
         self.deleted = True
+        self.updated_at = timezone.now()
         self.save()
 
     def restore(self):
         self.deleted = False
+        self.updated_at = timezone.now()
         self.save()
 
     def can_user_modify(self, user):

--- a/iaso/tests/api/instances/test_instances.py
+++ b/iaso/tests/api/instances/test_instances.py
@@ -655,21 +655,30 @@ class InstancesAPITestCase(TaskAPITestCase):
 
     def test_soft_delete_an_instance(self):
         """DELETE /instances/{instanceid}/"""
-
+        # setting up some fields first
+        updated_at_before = timezone.now()
         soft_deleted_instance = self.form_1.instances.first()
+        soft_deleted_instance.updated_at = updated_at_before
+        soft_deleted_instance.last_modified_by = self.guest
+        soft_deleted_instance.save()
 
         self.client.force_authenticate(self.yoda)
 
         response = self.client.get(f"/api/instances/{soft_deleted_instance.id}/")
-        self.assertJSONResponse(response, 200)
+        self.assertJSONResponse(response, status.HTTP_200_OK)
         self.assertFalse(response.json()["deleted"])
 
         response = self.client.delete(f"/api/instances/{soft_deleted_instance.id}/")
-        self.assertJSONResponse(response, 200)
+        self.assertJSONResponse(response, status.HTTP_200_OK)
 
         response = self.client.get(f"/api/instances/{soft_deleted_instance.id}/")
-        self.assertJSONResponse(response, 200)
-        self.assertTrue(response.json()["deleted"])
+        result = self.assertJSONResponse(response, status.HTTP_200_OK)
+        self.assertTrue(result["deleted"])
+
+        soft_deleted_instance.refresh_from_db()
+        self.assertGreater(soft_deleted_instance.updated_at, updated_at_before)
+        self.assertNotEqual(soft_deleted_instance.last_modified_by_id, self.guest.id)
+        self.assertEqual(soft_deleted_instance.last_modified_by_id, self.yoda.id)
 
         self.assertEqual(1, Modification.objects.count())
         modification = Modification.objects.first()


### PR DESCRIPTION
Store user when deleting instances

Related JIRA tickets : IA-4481

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [x] Are my typescript files well typed?
- [x] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

/

## Changes

- Store user + timestamp in `updated_xx` fields when deleting instances
- Fix bug in instances comparison (the history always displayed the same user in both instances, even when the value was a different user)
- Display who deleted the instance in instance detail view

## How to test

- Log into IASO with user A
- Soft delete an instance
- Log out
- Log into IASO with user B
- Check the soft deleted instance: you should now see that it has been deleted by user A
- Restore the instance
- The 2 fields related to deletion now display information about updating the instance and display user B
- Check the instance history
- Compare the initial version with the latest version: you should see different users


## Print screen / video

Details when the instance is not deleted:
<img width="594" height="482" alt="image" src="https://github.com/user-attachments/assets/99bf0bb5-b6dd-4462-875f-0a43f76cfb01" />


Details when the instance is deleted:
<img width="611" height="677" alt="image" src="https://github.com/user-attachments/assets/06fb435d-da84-4ea0-bb49-ad5b1a8bd529" />

The comparison now displays the proper users:
<img width="1823" height="730" alt="image" src="https://github.com/user-attachments/assets/16779499-acdc-4f15-8bd9-22861949fb22" />


## Notes

/

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
