### PR TITLE
IA-4593 search users by ids or refs

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -1671,6 +1671,7 @@
     "iaso.users.removeProjects": "Remove from project(s)",
     "iaso.users.removeRoles": "Remove user role(s)",
     "iaso.users.removeTeams": "Remove from team(s)",
+    "iaso.users.searchParams": "Use prefix “refs:” for dhis2 ID search, “ids:” for internal profile ID. You can also search multiple IDs at once, separated by a comma or a space. E.g. “ids: 123456, 654321”, “refs: O6uvpzGd5pu, ImspTQPwCqd”",
     "iaso.users.selectAllHelperText": "Leave empty to select all",
     "iaso.users.selectedOrgUnits": "Org units selected",
     "iaso.users.update": "Update user",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -1671,6 +1671,7 @@
     "iaso.users.removeProjects": "Retirer du(des) projet(s)",
     "iaso.users.removeRoles": "Retirer le(s) rôle(s)",
     "iaso.users.removeTeams": "Enlever de l'/des équipe(s)",
+    "iaso.users.searchParams": "Utilisez les préfixes “refs:” pour la recherche d'ID dhis2 d'un user, “ids:” pour la recherche d'ID interne d'un user. Vous pouvez également rechercher plusieurs ID à la fois, séparés par une virgule ou un espace. Par exemple: “ids: 123456, 654321”, “refs: O6uvpzGd5pu, ImspTQPwCqd”",
     "iaso.users.selectAllHelperText": "Laisser vide pour tout sélectionner",
     "iaso.users.selectedOrgUnits": "Unité d'organisation sélectionnées",
     "iaso.users.update": "Mettre l'utilisateur à jour",

--- a/hat/assets/js/apps/Iaso/domains/users/components/Filters.js
+++ b/hat/assets/js/apps/Iaso/domains/users/components/Filters.js
@@ -6,6 +6,7 @@ import {
     commonStyles,
     useRedirectTo,
     useSafeIntl,
+    InputWithInfos
 } from 'bluesquare-components';
 import PropTypes from 'prop-types';
 import React, { useCallback, useMemo, useState } from 'react';
@@ -131,16 +132,18 @@ const Filters = ({ baseUrl, params, canBypassProjectRestrictions }) => {
     return (
         <Grid container spacing={2}>
             <Grid item xs={12} md={3}>
-                <InputComponent
-                    keyValue="search"
-                    onChange={handleChange}
-                    value={filters.search}
-                    type="search"
-                    label={MESSAGES.search}
-                    onEnterPressed={handleSearch}
-                    onErrorChange={setTextSearchError}
-                    blockForbiddenChars
-                />
+                <InputWithInfos infos={formatMessage(MESSAGES.searchParams)}>
+                    <InputComponent
+                        keyValue="search"
+                        onChange={handleChange}
+                        value={filters.search}
+                        type="search"
+                        label={MESSAGES.search}
+                        onEnterPressed={handleSearch}
+                        onErrorChange={setTextSearchError}
+                        blockForbiddenChars
+                    />
+                </InputWithInfos>
                 <InputComponent
                     keyValue="projectsIds"
                     onChange={handleChange}

--- a/hat/assets/js/apps/Iaso/domains/users/messages.ts
+++ b/hat/assets/js/apps/Iaso/domains/users/messages.ts
@@ -61,6 +61,13 @@ const MESSAGES = defineMessages({
         defaultMessage: 'Search',
         id: 'iaso.search',
     },
+
+    searchParams: {
+        id: 'iaso.users.searchParams',
+        defaultMessage:
+            // eslint-disable-next-line max-len
+            'Use prefix “refs:” for dhis2 ID search, “ids:” for internal profile ID. You can also search multiple IDs at once, separated by a comma or a space. E.g. “ids: 123456, 654321”, “refs: O6uvpzGd5pu, ImspTQPwCqd”',
+    },    
     infos: {
         defaultMessage: 'Infos',
         id: 'iaso.orgUnits.infos',

--- a/iaso/api/org_unit_search.py
+++ b/iaso/api/org_unit_search.py
@@ -8,18 +8,12 @@ from django.db.models import Case, Count, IntegerField, Q, QuerySet, Sum, When
 from django.db.models.functions import Cast
 
 from iaso.models import DataSource, Instance, OrgUnit
+from iaso.utils import search_by_ids_refs
 
 
 def apply_org_unit_search(queryset: QuerySet, value: str, prefix: str = "") -> QuerySet:
     if value.startswith("ids:"):
-        s = value.replace("ids:", "")
-
-        try:
-            ids = re.findall("[A-Za-z0-9_-]+", s)
-            queryset = queryset.filter(**{f"{prefix}id__in": ids})
-        except:
-            queryset = queryset.filter(**{f"{prefix}id__in": []})
-            print("Failed parsing ids in search", value)
+        queryset = queryset.filter(**{f"{prefix}id__in": search_by_ids_refs.parse_ids("ids:", value)})
     elif value.startswith("refs:"):
         s = value.replace("refs:", "")
         try:
@@ -42,13 +36,7 @@ def apply_org_unit_search(queryset: QuerySet, value: str, prefix: str = "") -> Q
             queryset = queryset.filter(**{f"{prefix}source_ref__in": []})
             print("Failed parsing refs in search", value)
     elif value.startswith("codes:"):
-        s = value.replace("codes:", "")
-        try:
-            codes = re.findall("[A-Za-z0-9_-]+", s)
-            queryset = queryset.filter(**{f"{prefix}code__in": codes})
-        except:
-            queryset = queryset.filter(**{f"{prefix}code__in": []})
-            print("Failed parsing codes in search", value)
+        queryset = queryset.filter(**{f"{prefix}code__in": search_by_ids_refs.parse_ids("codes:", value)})
     else:
         queryset = queryset.filter(
             Q(**{f"{prefix}name__icontains": value}) | Q(**{f"{prefix}aliases__contains": [value]})

--- a/iaso/api/profiles/profiles.py
+++ b/iaso/api/profiles/profiles.py
@@ -1,5 +1,3 @@
-import re
-
 from typing import Any, List, Optional, Union
 
 from django.conf import settings
@@ -32,20 +30,10 @@ from iaso.models import OrgUnit, OrgUnitType, Profile, Project, TenantUser, User
 from iaso.models.tenant_users import UserCreationData, UsernameAlreadyExistsError
 from iaso.permissions.core_permissions import CORE_USERS_ADMIN_PERMISSION, CORE_USERS_MANAGED_PERMISSION
 from iaso.permissions.utils import raise_error_if_user_lacks_admin_permission
-from iaso.utils import is_mobile_request
+from iaso.utils import is_mobile_request, search_by_ids_refs
 
 
 PK_ME = "me"
-
-
-def _parse_ids(prefix, search):
-    s = search.replace(prefix, "")
-    try:
-        parsed_ids = re.findall("[A-Za-z0-9_-]+", s)
-    except:
-        print("Failed parsing ids in search", search)
-        parsed_ids = []
-    return parsed_ids
 
 
 class HasProfilePermission(permissions.BasePermission):
@@ -106,9 +94,9 @@ def get_filtered_profiles(
 ) -> QuerySet[Profile]:
     if search:
         if search.startswith("ids:"):
-            queryset = queryset.filter(id__in=_parse_ids("ids:", search))
+            queryset = queryset.filter(id__in=search_by_ids_refs.parse_ids("ids:", search))
         elif search.startswith("refs:"):
-            queryset = queryset.filter(dhis2_id__in=_parse_ids("refs:", search))
+            queryset = queryset.filter(dhis2_id__in=search_by_ids_refs.parse_ids("refs:", search))
         else:
             queryset = queryset.filter(
                 Q(user__username__icontains=search)

--- a/iaso/models/instances.py
+++ b/iaso/models/instances.py
@@ -1,7 +1,6 @@
 import operator
 import os
 import random
-import re
 import time
 import typing
 
@@ -40,6 +39,7 @@ from .org_unit import OrgUnit, OrgUnitReferenceInstance
 
 
 logger = getLogger(__name__)
+from iaso.utils import search_by_ids_refs
 from iaso.utils.dates import get_beginning_of_day, get_end_of_day
 
 
@@ -302,20 +302,9 @@ class InstanceQuerySet(django_cte.CTEQuerySet):
 
         if search:
             if search.startswith("ids:"):
-                ids_str = search.replace("ids:", "")
-                try:
-                    ids = re.findall("[A-Za-z0-9_-]+", ids_str)
-                    queryset = queryset.filter(id__in=ids)
-                except:
-                    queryset = queryset.filter(id__in=[])
-                    print("Failed parsing ids in search", search)
+                queryset = queryset.filter(id__in=search_by_ids_refs.parse_ids("ids:", search))
             elif search.startswith("refs:"):
-                s = search.replace("refs:", "")
-                try:
-                    refs = re.findall("[A-Za-z0-9_-]+", s)
-                    queryset = queryset.filter(org_unit__source_ref__in=refs)
-                except:
-                    print("Failed parsing refs in search", search)
+                queryset = queryset.filter(org_unit__source_ref__in=search_by_ids_refs.parse_ids("refs:", search))
             else:
                 queryset = queryset.filter(
                     Q(org_unit__name__icontains=search) | Q(org_unit__aliases__contains=[search])

--- a/iaso/tests/api/test_profiles.py
+++ b/iaso/tests/api/test_profiles.py
@@ -424,7 +424,7 @@ class ProfileAPITestCase(APITestCase):
                     3: self.jam.iaso_profile.id,
                     4: self.jom.iaso_profile.id,
                     5: self.jum.iaso_profile.id,
-                    6: self.user_managed_geo_limit.id,
+                    6: self.user_managed_geo_limit.iaso_profile.id,
                 },
                 "username": {0: "janedoe", 1: "johndoe", 2: "jim", 3: "jam", 4: "jom", 5: "jum", 6: "managedGeoLimit"},
                 "password": {0: None, 1: None, 2: None, 3: None, 4: None, 5: None, 6: None},

--- a/iaso/tests/api/test_profiles.py
+++ b/iaso/tests/api/test_profiles.py
@@ -351,33 +351,34 @@ class ProfileAPITestCase(APITestCase):
 
         response_csv = response.getvalue().decode("utf-8")
 
-        expected_csv = (
-            "username,"
-            "password,"
-            "email,"
-            "first_name,"
-            "last_name,"
-            "orgunit,"
-            "orgunit__source_ref,"
-            "profile_language,"
-            "dhis2_id,"
-            "organization,"
-            "permissions,"
-            "user_roles,"
-            "projects,"
-            "phone_number,"
-            "editable_org_unit_types\r\n"
+        expected_csv = "".join(
+            [
+                "user_profile_id,",
+                "username,"
+                "password,"
+                "email,"
+                "first_name,"
+                "last_name,"
+                "orgunit,"
+                "orgunit__source_ref,"
+                "profile_language,"
+                "dhis2_id,"
+                "organization,"
+                "permissions,"
+                "user_roles,"
+                "projects,"
+                "phone_number,"
+                "editable_org_unit_types\r\n",
+            ]
         )
 
-        expected_csv += "janedoe,,,,,,,,,,iaso_forms,,,,\r\n"
-        expected_csv += f'johndoe,,,,,"{self.org_unit_from_sub_type.pk},{self.org_unit_from_parent_type.pk}",{self.org_unit_from_parent_type.source_ref},,,,,,,,\r\n'
-        expected_csv += (
-            f'jim,,,,,,,,,,"{CORE_FORMS_PERMISSION.codename},{CORE_USERS_ADMIN_PERMISSION.codename}",,,,\r\n'
-        )
-        expected_csv += f"jam,,,,,,,en,,,{CORE_USERS_MANAGED_PERMISSION.codename},,,,\r\n"
-        expected_csv += "jom,,,,,,,fr,,,,,,,\r\n"
-        expected_csv += f"jum,,,,,,,,,,,,{self.project.name},,{self.sub_unit_type.pk}\r\n"
-        expected_csv += f'managedGeoLimit,,,,,{self.org_unit_from_parent_type.id},{self.org_unit_from_parent_type.source_ref},,,,{CORE_USERS_MANAGED_PERMISSION.codename},"{self.user_role_name},{self.user_role_another_account_name}",,,\r\n'
+        expected_csv += f"{self.jane.id},janedoe,,,,,,,,,,iaso_forms,,,,\r\n"
+        expected_csv += f'{self.john.id},johndoe,,,,,"{self.org_unit_from_sub_type.pk},{self.org_unit_from_parent_type.pk}",{self.org_unit_from_parent_type.source_ref},,,,,,,,\r\n'
+        expected_csv += f'{self.jim.id},jim,,,,,,,,,,"{CORE_FORMS_PERMISSION.codename},{CORE_USERS_ADMIN_PERMISSION.codename}",,,,\r\n'
+        expected_csv += f"{self.jam.id},jam,,,,,,,en,,,{CORE_USERS_MANAGED_PERMISSION.codename},,,,\r\n"
+        expected_csv += f"{self.jom.id},jom,,,,,,,fr,,,,,,,\r\n"
+        expected_csv += f"{self.jum.id},jum,,,,,,,,,,,,{self.project.name},,{self.sub_unit_type.pk}\r\n"
+        expected_csv += f'{self.user_managed_geo_limit.id},managedGeoLimit,,,,,{self.org_unit_from_parent_type.id},{self.org_unit_from_parent_type.source_ref},,,,{CORE_USERS_MANAGED_PERMISSION.codename},"{self.user_role_name},{self.user_role_another_account_name}",,,\r\n'
 
         self.assertEqual(response_csv, expected_csv)
 
@@ -392,6 +393,7 @@ class ProfileAPITestCase(APITestCase):
         self.assertEqual(
             excel_columns,
             [
+                "user_profile_id",
                 "username",
                 "password",
                 "email",
@@ -413,6 +415,15 @@ class ProfileAPITestCase(APITestCase):
         self.assertDictEqual(
             excel_data,
             {
+                "user_profile_id": {
+                    0: self.jane.id,
+                    1: self.john.id,
+                    2: self.jim.id,
+                    3: self.jam.id,
+                    4: self.jom.id,
+                    5: self.jum.id,
+                    6: self.user_managed_geo_limit.id,
+                },
                 "username": {0: "janedoe", 1: "johndoe", 2: "jim", 3: "jam", 4: "jom", 5: "jum", 6: "managedGeoLimit"},
                 "password": {0: None, 1: None, 2: None, 3: None, 4: None, 5: None, 6: None},
                 "email": {0: None, 1: None, 2: None, 3: None, 4: None, 5: None, 6: None},

--- a/iaso/tests/api/test_profiles.py
+++ b/iaso/tests/api/test_profiles.py
@@ -341,6 +341,7 @@ class ProfileAPITestCase(APITestCase):
         self.assertValidProfileListData(response.json(), 7)
 
     def test_profile_list_export_as_csv(self):
+        self.maxDiff = None
         self.john.iaso_profile.org_units.set([self.org_unit_from_sub_type, self.org_unit_from_parent_type])
         self.jum.iaso_profile.editable_org_unit_types.set([self.sub_unit_type])
 
@@ -372,17 +373,18 @@ class ProfileAPITestCase(APITestCase):
             ]
         )
 
-        expected_csv += f"{self.jane.id},janedoe,,,,,,,,,,iaso_forms,,,,\r\n"
-        expected_csv += f'{self.john.id},johndoe,,,,,"{self.org_unit_from_sub_type.pk},{self.org_unit_from_parent_type.pk}",{self.org_unit_from_parent_type.source_ref},,,,,,,,\r\n'
-        expected_csv += f'{self.jim.id},jim,,,,,,,,,,"{CORE_FORMS_PERMISSION.codename},{CORE_USERS_ADMIN_PERMISSION.codename}",,,,\r\n'
-        expected_csv += f"{self.jam.id},jam,,,,,,,en,,,{CORE_USERS_MANAGED_PERMISSION.codename},,,,\r\n"
-        expected_csv += f"{self.jom.id},jom,,,,,,,fr,,,,,,,\r\n"
-        expected_csv += f"{self.jum.id},jum,,,,,,,,,,,,{self.project.name},,{self.sub_unit_type.pk}\r\n"
-        expected_csv += f'{self.user_managed_geo_limit.id},managedGeoLimit,,,,,{self.org_unit_from_parent_type.id},{self.org_unit_from_parent_type.source_ref},,,,{CORE_USERS_MANAGED_PERMISSION.codename},"{self.user_role_name},{self.user_role_another_account_name}",,,\r\n'
+        expected_csv += f"{self.jane.iaso_profile.id},janedoe,,,,,,,,,,iaso_forms,,,,\r\n"
+        expected_csv += f'{self.john.iaso_profile.id},johndoe,,,,,"{self.org_unit_from_sub_type.pk},{self.org_unit_from_parent_type.pk}",{self.org_unit_from_parent_type.source_ref},,,,,,,,\r\n'
+        expected_csv += f'{self.jim.iaso_profile.id},jim,,,,,,,,,,"{CORE_FORMS_PERMISSION.codename},{CORE_USERS_ADMIN_PERMISSION.codename}",,,,\r\n'
+        expected_csv += f"{self.jam.iaso_profile.id},jam,,,,,,,en,,,{CORE_USERS_MANAGED_PERMISSION.codename},,,,\r\n"
+        expected_csv += f"{self.jom.iaso_profile.id},jom,,,,,,,fr,,,,,,,\r\n"
+        expected_csv += f"{self.jum.iaso_profile.id},jum,,,,,,,,,,,,{self.project.name},,{self.sub_unit_type.pk}\r\n"
+        expected_csv += f'{self.user_managed_geo_limit.iaso_profile.id},managedGeoLimit,,,,,{self.org_unit_from_parent_type.id},{self.org_unit_from_parent_type.source_ref},,,,{CORE_USERS_MANAGED_PERMISSION.codename},"{self.user_role_name},{self.user_role_another_account_name}",,,\r\n'
 
         self.assertEqual(response_csv, expected_csv)
 
     def test_profile_list_export_as_xlsx(self):
+        self.maxDiff = None
         self.john.iaso_profile.org_units.set([self.org_unit_from_sub_type, self.org_unit_from_parent_type])
         self.jum.iaso_profile.editable_org_unit_types.set([self.sub_unit_type])
 
@@ -416,12 +418,12 @@ class ProfileAPITestCase(APITestCase):
             excel_data,
             {
                 "user_profile_id": {
-                    0: self.jane.id,
-                    1: self.john.id,
-                    2: self.jim.id,
-                    3: self.jam.id,
-                    4: self.jom.id,
-                    5: self.jum.id,
+                    0: self.jane.iaso_profile.id,
+                    1: self.john.iaso_profile.id,
+                    2: self.jim.iaso_profile.id,
+                    3: self.jam.iaso_profile.id,
+                    4: self.jom.iaso_profile.id,
+                    5: self.jum.iaso_profile.id,
                     6: self.user_managed_geo_limit.id,
                 },
                 "username": {0: "janedoe", 1: "johndoe", 2: "jim", 3: "jam", 4: "jom", 5: "jum", 6: "managedGeoLimit"},

--- a/iaso/tests/api/test_profiles.py
+++ b/iaso/tests/api/test_profiles.py
@@ -953,13 +953,35 @@ class ProfileAPITestCase(APITestCase):
         self.assertEqual(response.json()["profiles"][0]["user_name"], "janedoe")
         self.assertEqual(len(response.json()["profiles"]), 2)
 
-    def test_search_by_ids(self):
+    def test_list_by_ids(self):
         self.client.force_authenticate(self.jane)
         response = self.client.get("/api/profiles/", {"ids": f"{self.jane.id},{self.jim.id}"})
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.json()["profiles"]), 2)
         self.assertEqual(response.json()["profiles"][0]["user_name"], "janedoe")
         self.assertEqual(response.json()["profiles"][1]["user_name"], "jim")
+
+    def test_search_by_profile_ids(self):
+        self.client.force_authenticate(self.jane)
+        response = self.client.get(
+            "/api/profiles/", {"search": f"ids:{self.jane.iaso_profile.id},{self.jim.iaso_profile.id}", "order": "id"}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json()["profiles"]), 2)
+        self.assertEqual(response.json()["profiles"][0]["user_name"], "janedoe")
+        self.assertEqual(response.json()["profiles"][1]["user_name"], "jim")
+
+    def test_search_by_dhis2_id(self):
+        self.client.force_authenticate(self.jane)
+        mydhis2_id = "mydhis2id"
+
+        self.jim.iaso_profile.dhis2_id = mydhis2_id
+        self.jim.iaso_profile.save()
+
+        response = self.client.get("/api/profiles/", {"search": f"refs:{mydhis2_id}"})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json()["profiles"]), 1)
+        self.assertEqual(response.json()["profiles"][0]["user_name"], "jim")
 
     def test_search_by_teams(self):
         self.client.force_authenticate(self.jane)

--- a/iaso/utils/search_by_ids_refs.py
+++ b/iaso/utils/search_by_ids_refs.py
@@ -1,0 +1,16 @@
+import re
+
+from logging import getLogger
+
+
+logger = getLogger(__name__)
+
+
+def parse_ids(prefix, search):
+    s = search.replace(prefix, "")
+    try:
+        parsed_ids = re.findall("[A-Za-z0-9_-]+", s)
+    except Exception as err:
+        logger.warn("Failed parsing ids in search '%s': %s", search, err)
+        parsed_ids = []
+    return parsed_ids


### PR DESCRIPTION
Allow advanced users to search by ids/dhis2_ids users, add the id in the excel/csv export.

Related JIRA tickets : IA-4593

## Self proofreading checklist

- [ ] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

Explain the changes that were made.

- add the user profile's id in the csv and excel export
- allows to search with ids:34, 35
- add a info icon near the search field with helper text

## How to test

- seed a new environnement (via seed command or setuper)
- create users if needed
- export the xlsx and csv
- use the search feature

## Print screen / video

<img width="2559" height="1348" alt="image" src="https://github.com/user-attachments/assets/88d7957f-db83-40e9-b9fa-6a16f06453f7" />


## Notes



## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
feat: search users by ids or refs

Refs: IA-4593
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
