### PR TITLE
[IA-4569] Prevent users from updating instances from another account

### DIFF
--- a/hat/sync/views.py
+++ b/hat/sync/views.py
@@ -59,6 +59,11 @@ def create_instance_file(instance, file_name, file):
 @authentication_classes([])
 @permission_classes([])
 def form_upload(request: HttpRequest) -> HttpResponse:
+    """
+    This endpoint is called when uploading instances "manually" (not in bulk).
+    It should be the second call (after POST /api/instances/) but sometimes, it is not (network error...).
+    This endpoint takes the empty instance (no actual files) created by the previous call and fills it with missing data.
+    """
     main_file = request.FILES["xml_submission_file"]
     instances = Instance.objects.filter(file_name=main_file.name)
     i: Instance

--- a/iaso/api/instances/instances.py
+++ b/iaso/api/instances/instances.py
@@ -933,6 +933,11 @@ class InstancesViewSet(viewsets.ViewSet):
 
 
 def import_data(instances, user, app_id):
+    """
+    This function creates empty instances (without files) and should be called first when uploading new instances.
+    Sometimes, due to some network issues, this function might not properly be called and the instances are created by
+    the second endpoint (POST /sync/form_upload/).
+    """
     project = Project.objects.get_for_user_and_app_id(user, app_id)
 
     for instance_data in instances:
@@ -943,7 +948,7 @@ def import_data(instances, user, app_id):
 
         # Get or create instance based on file_name - this "get or create" logic is important:
         # it is possible (although it won't happen often) that the instance has already been created by the
-        # POST /sync/ endpoint.
+        # POST /sync/form_upload/ endpoint.
         file_name = ntpath.basename(instance_data.get("file", None))
         instance, _ = Instance.objects.get_or_create(file_name=file_name)
 


### PR DESCRIPTION
Prevent users from updating instances from another account

Related JIRA tickets : IA-4569

## Self proofreading checklist

- [ ] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

/

## Changes

- Added some comments about instance creation through the mobile app

## How to test
/

## Print screen / video

/

## Notes

/

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
