### PR TITLE
[IA-4558] Add a button for the Django admin panel

### DIFF
--- a/hat/assets/js/apps/Iaso/components/nav/DjangoAdminPanelButton.tsx
+++ b/hat/assets/js/apps/Iaso/components/nav/DjangoAdminPanelButton.tsx
@@ -1,0 +1,38 @@
+import React, { FunctionComponent } from 'react';
+import { IconButton as MuiIconButton, Tooltip } from '@mui/material';
+import { makeStyles } from '@mui/styles';
+import { useSafeIntl } from 'bluesquare-components';
+
+import MESSAGES from '../../domains/app/components/messages';
+import { AdminPanelSettings } from '@mui/icons-material';
+
+const useStyles = makeStyles(theme => ({
+    djangoAdminPanelButton: {
+        padding: theme.spacing(0),
+    },
+}));
+
+type Props = {
+    color?: 'inherit' | 'primary' | 'secondary';
+};
+
+export const DjangoAdminPanelButton: FunctionComponent<Props> = ({
+    color = 'inherit',
+}) => {
+    const classes = useStyles();
+    const { formatMessage } = useSafeIntl();
+    return (
+        <Tooltip arrow title={formatMessage(MESSAGES.djangoAdmin)}>
+            <MuiIconButton
+                className={classes.djangoAdminPanelButton}
+                color={color}
+                href="/admin/"
+                id="top-bar-admin-panel-button"
+                target="_blank"
+                rel="noreferrer"
+            >
+                <AdminPanelSettings />
+            </MuiIconButton>
+        </Tooltip>
+    );
+};

--- a/hat/assets/js/apps/Iaso/components/nav/TopBarComponent.js
+++ b/hat/assets/js/apps/Iaso/components/nav/TopBarComponent.js
@@ -15,6 +15,7 @@ import { useCurrentUser } from '../../utils/usersUtils.ts';
 import { CurrentUserInfos } from './CurrentUser/index.tsx';
 import { HomePageButton } from './HomePageButton.tsx';
 import { LogoutButton } from './LogoutButton.tsx';
+import { DjangoAdminPanelButton } from 'Iaso/components/nav/DjangoAdminPanelButton';
 
 const styles = theme => ({
     menuButton: {
@@ -149,6 +150,12 @@ function TopBar(props) {
                             <Box display="flex" justifyContent="center" pl={2}>
                                 <HomePageButton />
                             </Box>
+
+                            {(currentUser.is_staff === true || currentUser.is_superuser === true) && (
+                                <Box display="flex" justifyContent="center" pl={1}>
+                                    <DjangoAdminPanelButton />
+                                </Box>
+                            )}
 
                             <Box display="flex" justifyContent="center" pl={1}>
                                 <LogoutButton />

--- a/hat/assets/js/apps/Iaso/components/nav/TopBarComponent.js
+++ b/hat/assets/js/apps/Iaso/components/nav/TopBarComponent.js
@@ -151,7 +151,7 @@ function TopBar(props) {
                                 <HomePageButton />
                             </Box>
 
-                            {(currentUser.is_staff === true || currentUser.is_superuser === true) && (
+                            { currentUser.is_staff === true && (
                                 <Box display="flex" justifyContent="center" pl={1}>
                                     <DjangoAdminPanelButton />
                                 </Box>

--- a/hat/assets/js/apps/Iaso/components/nav/TopBarComponent.js
+++ b/hat/assets/js/apps/Iaso/components/nav/TopBarComponent.js
@@ -151,7 +151,7 @@ function TopBar(props) {
                                 <HomePageButton />
                             </Box>
 
-                            { currentUser.is_staff === true && (
+                            {(currentUser.is_staff === true && currentUser.is_superuser === true) && (
                                 <Box display="flex" justifyContent="center" pl={1}>
                                     <DjangoAdminPanelButton />
                                 </Box>

--- a/hat/assets/js/apps/Iaso/domains/app/components/messages.js
+++ b/hat/assets/js/apps/Iaso/domains/app/components/messages.js
@@ -21,6 +21,10 @@ const MESSAGES = defineMessages({
         defaultMessage: 'View user manual',
         id: 'iaso.tooltip.viewUserManual',
     },
+    djangoAdmin: {
+        defaultMessage: 'Django Admin Panel',
+        id: 'iaso.label.djangoAdmin',
+    },
     iasoVersion: {
         defaultMessage: 'App version',
         id: 'iaso.label.iasoVersion',

--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -583,6 +583,7 @@
     "iaso.label.dhis2Mappings": "DHIS mappings",
     "iaso.label.display": "Display",
     "iaso.label.displayPassword": "Display the password",
+    "iaso.label.djangoAdmin": "Django Admin Panel",
     "iaso.label.docs": "Docs",
     "iaso.label.document": "Document",
     "iaso.label.documents": "Documents",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/es.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/es.json
@@ -532,6 +532,7 @@
     "iaso.label.dhis2Mappings": "Mapeos de DHIS",
     "iaso.label.display": "Mostrar",
     "iaso.label.displayPassword": "Mostrar la contraseña",
+    "iaso.label.djangoAdmin": "Administración de Django",
     "iaso.label.docs": "Documentación",
     "iaso.label.document": "Documento",
     "iaso.label.documents": "Documentos",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -584,6 +584,7 @@
     "iaso.label.dhis2Mappings": "Correspondances avec DHIS2",
     "iaso.label.display": "Afficher",
     "iaso.label.displayPassword": "Afficher le mot de passe",
+    "iaso.label.djangoAdmin": "Panneau d'administraton Django",
     "iaso.label.docs": "Docs",
     "iaso.label.document": "Document",
     "iaso.label.documents": "Documents",


### PR DESCRIPTION
Add a button for the Django admin panel

Related JIRA tickets : IA-4558

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [x] Are my typescript files well typed?
- [x] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

/

## Changes

- Added a new button to the top bar

## How to test

- Log into IASO as a staff member and superuser :arrow_right: you should see the new button on the top bar
- Click on the button :arrow_right: a new tab opens with the Django admin panel
- Log out from IASO
- Log into IASO as a standard user :arrow_right: you should not see the new button on the top bar


## Print screen / video

<img width="508" height="199" alt="image" src="https://github.com/user-attachments/assets/f6a3e734-9f06-45b0-bda6-512c6191e732" />

## Notes

- I initially wanted to add this to the side bar menu, but it's impossible to add a new entry that does not go to `/dashboard/something...`, so I added it there

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
