### PR TITLE
POLIO-2038: make polio LQAS country view embeddable

### DIFF
--- a/hat/dashboard/urls.py
+++ b/hat/dashboard/urls.py
@@ -8,6 +8,8 @@ urlpatterns = [
     re_path(r"^polio/embeddedCalendar/.*$", views.embeddable_iaso, name="embedded_calendar"),
     re_path(r"^polio/embeddedVaccineRepository/.*$", views.embeddable_iaso, name="embedded_vaccine_repository"),
     re_path(r"^polio/embeddedVaccineStock/.*$", views.embeddable_iaso, name="embedded_vaccine_stock"),
+    re_path(r"^polio/embeddedLqasCountry/.*$", views.embeddable_iaso, name="embedded_lqas_country"),
+    re_path(r"^polio/embeddedLqasMap/.*$", views.embeddable_iaso, name="embedded_lqas_map"),
     path("home/", views.home_iaso, name="home_iaso"),
     re_path(r"^.*$", views.iaso, name="iaso"),
 ]

--- a/plugins/polio/api/campaigns/campaigns.py
+++ b/plugins/polio/api/campaigns/campaigns.py
@@ -539,6 +539,7 @@ class AnonymousCampaignSerializer(CampaignSerializer):
             "account",
             "outbreak_declaration_date",
             "campaign_types",
+            "separate_scopes_per_round",
         ]
         read_only_fields = fields
 

--- a/plugins/polio/api/lqas_im/lqas_im_country.py
+++ b/plugins/polio/api/lqas_im/lqas_im_country.py
@@ -1,3 +1,6 @@
+from django.http import Http404
+from rest_framework.exceptions import ValidationError
+
 from iaso.api.common import ModelViewSet, ReadOnlyOrHasPermission
 from iaso.api.data_store import DataStoreSerializer
 from iaso.models.data_store import JsonDataStore
@@ -21,7 +24,7 @@ class LQASIMCountryViewset(ModelViewSet):
         app_id = self.request.query_params.get("app_id", None)
         user = self.request.user
         if slug is None:
-            return JsonDataStore.objects.none()
+            raise ValidationError("No slug provided")
 
         queryset = JsonDataStore.objects.filter(slug=slug)
         if not user.is_anonymous:
@@ -31,7 +34,7 @@ class LQASIMCountryViewset(ModelViewSet):
                 project = Project.objects.get_for_user_and_app_id(user, app_id)
                 queryset = queryset.filter(account=project.account)
             except Project.DoesNotExist:
-                pass
+                raise Http404("No project matching app_id")
         else:
             queryset = JsonDataStore.objects.none()
         return queryset

--- a/plugins/polio/api/lqas_im/lqas_im_country.py
+++ b/plugins/polio/api/lqas_im/lqas_im_country.py
@@ -1,15 +1,37 @@
-from iaso.api.data_store import DataStoreViewSet
+from iaso.api.common import ModelViewSet, ReadOnlyOrHasPermission
+from iaso.api.data_store import DataStoreSerializer
 from iaso.models.data_store import JsonDataStore
-from plugins.polio.api.permission_classes import PolioReadPermission
+from iaso.models.project import Project
+from plugins.polio.permissions import POLIO_CONFIG_PERMISSION, POLIO_PERMISSION
 
 
 # Extending DataStore Viewset to give users with polio and polio config permissions access to lqas endpoints in datastore
-class LQASIMCountryViewset(DataStoreViewSet):
+class LQASIMCountryViewset(ModelViewSet):
     http_method_names = ["get"]
-    permission_classes = [PolioReadPermission]
+    permission_classes = [ReadOnlyOrHasPermission(POLIO_PERMISSION, POLIO_CONFIG_PERMISSION)]
+    serializer_class = DataStoreSerializer
+    lookup_field = "slug"
+
+    class Meta:
+        model = JsonDataStore
+        fields = ["created_at", "updated_at", "key", "data"]
 
     def get_queryset(self):
         slug = self.kwargs.get("slug", None)
-        if slug:
-            return JsonDataStore.objects.filter(account=self.request.user.iaso_profile.account, slug=slug)
-        return JsonDataStore.objects.none()
+        app_id = self.request.query_params.get("app_id", None)
+        user = self.request.user
+        if slug is None:
+            return JsonDataStore.objects.none()
+
+        queryset = JsonDataStore.objects.filter(slug=slug)
+        if not user.is_anonymous:
+            queryset = queryset.filter(account=user.iaso_profile.account)
+        elif app_id:
+            try:
+                project = Project.objects.get_for_user_and_app_id(user, app_id)
+                queryset = queryset.filter(account=project.account)
+            except Project.DoesNotExist:
+                pass
+        else:
+            queryset = JsonDataStore.objects.none()
+        return queryset

--- a/plugins/polio/api/lqas_im/lqas_im_dropdowns.py
+++ b/plugins/polio/api/lqas_im/lqas_im_dropdowns.py
@@ -8,14 +8,14 @@ from django.db.models import Q, QuerySet
 from rest_framework import permissions, serializers
 from rest_framework.exceptions import ValidationError
 
-from iaso.api.common import ModelViewSet
+from iaso.api.common import ModelViewSet, ReadOnlyOrHasPermission
 from iaso.api.serializers import OrgUnitDropdownSerializer
 from iaso.models.base import Group
 from iaso.models.org_unit import OrgUnit
 from plugins.polio.api.polio_org_units import PolioOrgunitViewSet
 from plugins.polio.models import Campaign, Round
 from plugins.polio.models.base import SubActivity
-from plugins.polio.permissions import POLIO_PERMISSION
+from plugins.polio.permissions import POLIO_CONFIG_PERMISSION, POLIO_PERMISSION
 
 
 class HasPolioPermission(permissions.BasePermission):
@@ -71,7 +71,7 @@ class LqasImCountryOptionsFilter(django_filters.rest_framework.FilterSet):
 
 class LqasImCountriesOptionsViewset(PolioOrgunitViewSet):
     http_method_names = ["get"]
-    permission_classes = [HasPolioPermission | HasPolioAdminPermission]
+    permission_classes = [ReadOnlyOrHasPermission(POLIO_PERMISSION, POLIO_CONFIG_PERMISSION)]
     filterset_class = LqasImCountryOptionsFilter
     remove_results_key_if_paginated = False
     results_key = "results"
@@ -82,7 +82,7 @@ class LqasImCountriesOptionsViewset(PolioOrgunitViewSet):
 
     def get_queryset(self):
         queryset = super().get_queryset()
-        queryset = queryset.filter(org_unit_type__category="COUNTRY")
+        queryset = queryset.filter(org_unit_type__category="COUNTRY")  # TODO add filter by user and app id
         return queryset
 
 
@@ -130,7 +130,7 @@ class CampaignDropDownSerializer(serializers.ModelSerializer):
 
 class LqasImCampaignOptionsViewset(ModelViewSet):
     http_method_names = ["get"]
-    permission_classes = [HasPolioPermission | HasPolioAdminPermission]
+    permission_classes = [ReadOnlyOrHasPermission(POLIO_PERMISSION, POLIO_CONFIG_PERMISSION)]
     filterset_class = LqasImCampaignOptionsFilter
     remove_results_key_if_paginated = False
     results_key = "results"
@@ -188,7 +188,7 @@ class LqasImRoundOptionsFilter(django_filters.rest_framework.FilterSet):
 
 class LqasImRoundOptionsViewset(ModelViewSet):
     http_method_names = ["get"]
-    permission_classes = [HasPolioPermission | HasPolioAdminPermission]
+    permission_classes = [ReadOnlyOrHasPermission(POLIO_PERMISSION, POLIO_CONFIG_PERMISSION)]
     filterset_class = LqasImRoundOptionsFilter
     remove_results_key_if_paginated = False
     results_key = "results"

--- a/plugins/polio/js/src/constants/routes.tsx
+++ b/plugins/polio/js/src/constants/routes.tsx
@@ -44,6 +44,7 @@ import {
 } from './permissions';
 import {
     EMBEDDED_CALENDAR_URL,
+    EMBEDDED_LQAS_COUNTRY_URL,
     EMBEDDED_VACCINE_REPOSITORY_URL,
     EMBEDDED_VACCINE_STOCK_URL,
     baseUrls,
@@ -108,6 +109,13 @@ export const embeddedVaccineStockPath: AnonymousRoutePath = {
     isRootUrl: false,
 };
 
+export const embeddedLqasCountryPath: AnonymousRoutePath = {
+    allowAnonymous: true,
+    baseUrl: baseUrls.embeddedLqasCountry,
+    routerUrl: `${EMBEDDED_LQAS_COUNTRY_URL}/*`,
+    element: <Lqas />,
+    isRootUrl: false,
+};
 export const lqasCountryPath: RoutePath = {
     baseUrl: baseUrls.lqasCountry,
     routerUrl: `${baseUrls.lqasCountry}/*`,
@@ -287,4 +295,5 @@ export const routes: (RoutePath | AnonymousRoutePath)[] = [
     chronogramPath,
     chronogramTemplateTaskPath,
     chronogramDetailsPath,
+    embeddedLqasCountryPath,
 ];

--- a/plugins/polio/js/src/constants/urls.ts
+++ b/plugins/polio/js/src/constants/urls.ts
@@ -25,6 +25,7 @@ export const EMBEDDED_VACCINE_STOCK_URL = 'polio/embeddedVaccineStock';
 export const CONFIG_BASE_URL = 'polio/config';
 export const CONFIG_COUNTRY_URL = `${CONFIG_BASE_URL}/country`;
 export const CONFIG_REASONS_FOR_DELAY_URL = `${CONFIG_BASE_URL}/reasonsfordelay`;
+export const EMBEDDED_LQAS_COUNTRY_URL = 'polio/embeddedLqasCountry';
 export const LQAS_BASE_URL = 'polio/lqas/lqas';
 export const LQAS_AFRO_MAP_URL = 'polio/lqas/lqas-map';
 export const IM_GLOBAL = 'polio/im/global';
@@ -150,6 +151,23 @@ export const polioRouteConfigs: Record<string, RouteConfig> = {
     },
     lqasCountry: {
         url: LQAS_BASE_URL,
+        params: [
+            'leftCountry',
+            'leftCampaign',
+            'leftRound',
+            'leftMonth',
+            'leftYear',
+            'leftTab',
+            'rightCampaign',
+            'rightCountry',
+            'rightRound',
+            'rightMonth',
+            'rightYear',
+            'rightTab',
+        ],
+    },
+    embeddedLqasCountry: {
+        url: EMBEDDED_LQAS_COUNTRY_URL,
         params: [
             'leftCountry',
             'leftCampaign',
@@ -361,6 +379,7 @@ export type PolioBaseUrls = {
     embeddedCalendar: string;
     embeddedVaccineRepository: string;
     embeddedVaccineStock: string;
+    embeddedLqasCountry: string;
     notification: string;
     chronogram: string;
     chronogramTemplateTask: string;

--- a/plugins/polio/js/src/domains/Campaigns/Scope/ScopeForm.tsx
+++ b/plugins/polio/js/src/domains/Campaigns/Scope/ScopeForm.tsx
@@ -54,10 +54,12 @@ export const ScopeForm: FunctionComponent = () => {
     const parentCountryId =
         country?.country_parent?.id || country?.root?.id || country?.id;
     const { data: districtShapes, isFetching: isFetchingDistrictsShapes } =
-        useGetGeoJson(parentCountryId, 'DISTRICT');
+        useGetGeoJson({
+            topParentId: parentCountryId,
+            orgUnitCategory: 'DISTRICT',
+        });
     const { data: regionShapes, isFetching: isFetchingRegions } = useGetGeoJson(
-        parentCountryId,
-        'REGION',
+        { topParentId: parentCountryId, orgUnitCategory: 'REGION' },
     );
 
     const scopes = useMemo(() => {

--- a/plugins/polio/js/src/domains/Campaigns/Scope/hooks/useGetGeoJson.ts
+++ b/plugins/polio/js/src/domains/Campaigns/Scope/hooks/useGetGeoJson.ts
@@ -1,10 +1,9 @@
-// @ts-ignore
 import _ from 'lodash';
 import { UseQueryResult } from 'react-query';
 import { OrgUnit } from 'Iaso/domains/orgUnits/types/orgUnit';
 import { getRequest } from 'Iaso/libs/Api';
-// @ts-ignore
 import { useSnackQuery } from 'Iaso/libs/apiHooks';
+import { cleanupParams } from 'bluesquare-components';
 
 type Params = {
     // eslint-disable-next-line camelcase
@@ -15,24 +14,33 @@ type Params = {
     orgUnitParentId?: string;
     asLocation?: 'true' | 'false';
     limit?: string;
+    app_id?: string;
 };
 
-export const useGetGeoJson = (
-    topParentId: number | undefined,
-    orgUnitCategory: string,
-    validationStatus: string | undefined = 'all',
-): UseQueryResult<OrgUnit[]> => {
+type Args = {
+    topParentId: number | undefined;
+    orgUnitCategory: string;
+    validationStatus?: string;
+    appId?: string;
+};
+export const useGetGeoJson = ({
+    topParentId,
+    orgUnitCategory,
+    validationStatus = 'all',
+    appId,
+}: Args): UseQueryResult<OrgUnit[]> => {
     const params: Params = {
         validation_status: validationStatus,
         withShapes: 'true',
         order: 'id',
         orgUnitTypeCategory: orgUnitCategory,
+        app_id: appId,
     };
     if (_.isNumber(topParentId)) {
         params.orgUnitParentId = `${topParentId}`;
     }
 
-    const urlParams = new URLSearchParams(params);
+    const urlParams = new URLSearchParams(cleanupParams(params));
 
     return useSnackQuery(
         ['geo_json', params],

--- a/plugins/polio/js/src/domains/Campaigns/SubActivities/hooks/api/subActivityShapes.tsx
+++ b/plugins/polio/js/src/domains/Campaigns/SubActivities/hooks/api/subActivityShapes.tsx
@@ -23,10 +23,12 @@ export const useGetSubActivityShapes = (
         country?.country_parent?.id || country?.root?.id || country?.id;
 
     const { data: districtShapes, isFetching: isFetchingDistricts } =
-        useGetGeoJson(parentCountryId, 'DISTRICT');
+        useGetGeoJson({
+            topParentId: parentCountryId,
+            orgUnitCategory: 'DISTRICT',
+        });
     const { data: regionShapes, isFetching: isFetchingRegions } = useGetGeoJson(
-        parentCountryId,
-        'REGION',
+        { topParentId: parentCountryId, orgUnitCategory: 'REGION' },
     );
 
     const districtShapesForSubActivity = districtShapes?.filter(shape =>

--- a/plugins/polio/js/src/domains/LQAS-IM/LQAS/CountryOverview/LqasCountryCharts.tsx
+++ b/plugins/polio/js/src/domains/LQAS-IM/LQAS/CountryOverview/LqasCountryCharts.tsx
@@ -25,6 +25,7 @@ type Props = {
     campaignObrName?: string;
     convertedData: Record<string, ConvertedLqasImData>;
     countryId?: NumberAsString;
+    isEmbedded?: boolean;
 };
 
 export const LqasCountryCharts: FunctionComponent<Props> = ({
@@ -37,6 +38,7 @@ export const LqasCountryCharts: FunctionComponent<Props> = ({
     convertedData,
     countryId,
     isFetchingCampaign,
+    isEmbedded = false,
 }) => {
     const { formatMessage } = useSafeIntl();
     return (
@@ -57,6 +59,7 @@ export const LqasCountryCharts: FunctionComponent<Props> = ({
                     countryId={countryId ? parseInt(countryId, 10) : undefined}
                     data={convertedData}
                     isLoading={isFetching}
+                    isEmbedded={isEmbedded}
                 />
             </Paper>
 

--- a/plugins/polio/js/src/domains/LQAS-IM/LQAS/CountryOverview/LqasCountryDataView.tsx
+++ b/plugins/polio/js/src/domains/LQAS-IM/LQAS/CountryOverview/LqasCountryDataView.tsx
@@ -1,7 +1,6 @@
-import { Campaign, MapShapes, Side } from '../../../../constants/types';
 import React, { FunctionComponent, useMemo } from 'react';
+import { Campaign, MapShapes, Side } from '../../../../constants/types';
 import { ConvertedLqasImData, LqasImMapLayer } from '../../types';
-import { baseUrls } from '../../../../constants/urls';
 import { useLqasImTabState } from '../../shared/Tabs/useLqasImTabState';
 import { useMapShapes } from '../../shared/hooks/api/useMapShapes';
 import { getLqasMapLayer, useLqasMapHeaderData } from './utils';
@@ -26,9 +25,10 @@ type Props = {
     params: Record<string, string | undefined>;
     isFetching: boolean;
     roundOptions?: DropdownOptions<string>[];
+    currentUrl: string;
+    isEmbedded: boolean;
 };
 
-const baseUrl = baseUrls.lqasCountry;
 export const LqasCountryDataView: FunctionComponent<Props> = ({
     params,
     side,
@@ -40,10 +40,12 @@ export const LqasCountryDataView: FunctionComponent<Props> = ({
     debugData,
     roundOptions,
     onRoundChange,
+    currentUrl,
+    isEmbedded,
 }) => {
     const campaignObrName = campaign?.obr_name;
     const { tab, handleChangeTab } = useLqasImTabState({
-        baseUrl,
+        baseUrl: currentUrl,
         params,
         side,
     });
@@ -52,7 +54,7 @@ export const LqasCountryDataView: FunctionComponent<Props> = ({
         isFetchingGeoJson,
         regionShapes,
         isFetchingRegions,
-    }: MapShapes = useMapShapes(countryId);
+    }: MapShapes = useMapShapes(countryId, isEmbedded);
 
     const mainLayer: LqasImMapLayer[] = useMemo(() => {
         return getLqasMapLayer({ data, campaign, roundNumber, shapes });

--- a/plugins/polio/js/src/domains/LQAS-IM/LQAS/CountryOverview/LqasCountryFilter.tsx
+++ b/plugins/polio/js/src/domains/LQAS-IM/LQAS/CountryOverview/LqasCountryFilter.tsx
@@ -7,7 +7,6 @@ import {
 import { LqasUrlParams } from '..';
 import { Box, Grid } from '@mui/material';
 import MESSAGES from '../../../../constants/messages';
-import { baseUrls } from '../../../../constants/urls';
 import {
     useGetLqasCampaignsOptions,
     useGetLqasCountriesOptions,
@@ -19,6 +18,8 @@ import moment from 'moment';
 type Props = {
     params: LqasUrlParams;
     side: Side;
+    currentUrl: string;
+    isEmbedded: boolean;
 };
 
 const monthOptions = [
@@ -53,19 +54,19 @@ const generateYearOptions = (
 };
 const yearOptions = generateYearOptions();
 
-const baseUrl = baseUrls.lqasCountry;
-
 export const LqasCountryFilter: FunctionComponent<Props> = ({
     params,
     side,
+    currentUrl,
+    isEmbedded,
 }) => {
     const { formatMessage } = useSafeIntl();
     const redirectToReplace = useRedirectToReplace();
 
     const { data: countriesOptions, isFetching: isFetchingCountriesOptions } =
-        useGetLqasCountriesOptions({ side, params });
+        useGetLqasCountriesOptions({ side, params, isEmbedded });
     const { data: campaignsOptions, isFetching: isFetchingCampaignsOptions } =
-        useGetLqasCampaignsOptions({ side, params });
+        useGetLqasCampaignsOptions({ side, params, isEmbedded });
 
     const onChange = useCallback(
         (key, value) => {
@@ -88,7 +89,7 @@ export const LqasCountryFilter: FunctionComponent<Props> = ({
             }
 
             // setFilters(newFilters);
-            redirectToReplace(baseUrl, newParams);
+            redirectToReplace(currentUrl, newParams);
         },
         [redirectToReplace, ...Object.values(params), side],
     );

--- a/plugins/polio/js/src/domains/LQAS-IM/LQAS/CountryOverview/LqasCountryMapView.tsx
+++ b/plugins/polio/js/src/domains/LQAS-IM/LQAS/CountryOverview/LqasCountryMapView.tsx
@@ -69,7 +69,6 @@ export const LqasCountryMapView: FunctionComponent<Props> = ({
             roundNumber,
         });
     }, [campaign, roundNumber]);
-    console.log('SCOPE IDS', scopeIds, campaign, roundNumber);
     const title = formatMessage(MESSAGES.lqasResults);
     const name = `LQASIMMap${roundNumber}-LQAS-${countryId}-${side}-${campaign?.obr_name}`;
     return (

--- a/plugins/polio/js/src/domains/LQAS-IM/LQAS/CountryOverview/LqasCountryMapView.tsx
+++ b/plugins/polio/js/src/domains/LQAS-IM/LQAS/CountryOverview/LqasCountryMapView.tsx
@@ -69,6 +69,7 @@ export const LqasCountryMapView: FunctionComponent<Props> = ({
             roundNumber,
         });
     }, [campaign, roundNumber]);
+    console.log('SCOPE IDS', scopeIds, campaign, roundNumber);
     const title = formatMessage(MESSAGES.lqasResults);
     const name = `LQASIMMap${roundNumber}-LQAS-${countryId}-${side}-${campaign?.obr_name}`;
     return (

--- a/plugins/polio/js/src/domains/LQAS-IM/LQAS/CountryOverview/LqasCountryView.tsx
+++ b/plugins/polio/js/src/domains/LQAS-IM/LQAS/CountryOverview/LqasCountryView.tsx
@@ -20,24 +20,30 @@ import { LqasCountryCharts } from './LqasCountryCharts';
 type Props = {
     side: Side;
     params: LqasUrlParams;
+    isEmbedded: boolean;
 };
 
 const baseUrl = baseUrls.lqasCountry;
+const embeddedUrl = baseUrls.embeddedLqasCountry;
 
-export const LqasCountryView: FunctionComponent<Props> = ({ side, params }) => {
+export const LqasCountryView: FunctionComponent<Props> = ({
+    side,
+    params,
+    isEmbedded,
+}) => {
     const countryId = params[`${side}Country`];
     const campaignId = params[`${side}Campaign`];
     const redirectToReplace = useRedirectToReplace();
+    const currentUrl = isEmbedded ? embeddedUrl : baseUrl;
     const { data: lqasData, isFetching }: UseQueryResult<LqasImData> =
-        useLqasIm('lqas', countryId);
+        useLqasIm('lqas', countryId, isEmbedded);
     const { data: campaign, isFetching: isFetchingCampaign } =
         useGetCampaign(campaignId);
     const campaignObrName = campaign?.obr_name;
     const roundNumber = params[`${side}Round`]
         ? parseInt(params[`${side}Round`] as string, 10)
         : undefined;
-    const { data: roundOptions, isFetching: isFetchingRoundOptions } =
-        useGetLqasRoundOptions({ side, params });
+    const { data: roundOptions } = useGetLqasRoundOptions({ side, params });
 
     const {
         convertedData,
@@ -53,18 +59,23 @@ export const LqasCountryView: FunctionComponent<Props> = ({ side, params }) => {
 
     const onRoundChange = useCallback(
         (value: number | NumberAsString) => {
-            redirectToReplace(baseUrl, {
+            redirectToReplace(currentUrl, {
                 ...params,
                 [`${side}Round`]: value,
             });
         },
-        [params, side, redirectToReplace],
+        [params, side, redirectToReplace, currentUrl],
     );
     const hasRoundNumber = Number.isSafeInteger(roundNumber);
     return (
         <>
             <Box>
-                <LqasCountryFilter side={side} params={params} />
+                <LqasCountryFilter
+                    side={side}
+                    params={params}
+                    currentUrl={currentUrl}
+                    isEmbedded={isEmbedded}
+                />
                 <LqasCountryDataView
                     params={params}
                     side={side}
@@ -76,6 +87,8 @@ export const LqasCountryView: FunctionComponent<Props> = ({ side, params }) => {
                     debugData={debugData}
                     roundOptions={roundOptions}
                     onRoundChange={onRoundChange}
+                    isEmbedded={isEmbedded}
+                    currentUrl={currentUrl}
                 />
                 {!isFetchingCampaign && !isFetching && hasRoundNumber && (
                     <LqasCountryCharts
@@ -88,6 +101,7 @@ export const LqasCountryView: FunctionComponent<Props> = ({ side, params }) => {
                         campaignObrName={campaignObrName}
                         convertedData={convertedData}
                         countryId={countryId}
+                        isEmbedded={isEmbedded}
                     />
                 )}
             </Box>

--- a/plugins/polio/js/src/domains/LQAS-IM/LQAS/hooks/useGetLqasCountriesOptions.tsx
+++ b/plugins/polio/js/src/domains/LQAS-IM/LQAS/hooks/useGetLqasCountriesOptions.tsx
@@ -19,7 +19,7 @@ const getLqasCountriesOptions = (monthYear?: MonthYear, isEmbedded = false) => {
     if (isEmbedded) {
         return getRequest(`${url}&app_id=${appId}`);
     }
-    return getRequest(`${endpoint}/?month=${monthYear}`);
+    return getRequest(url);
 };
 
 type UseGetLqasCountriesOptionsArgs = {

--- a/plugins/polio/js/src/domains/LQAS-IM/LQAS/hooks/useGetLqasCountriesOptions.tsx
+++ b/plugins/polio/js/src/domains/LQAS-IM/LQAS/hooks/useGetLqasCountriesOptions.tsx
@@ -11,15 +11,21 @@ import moment from 'moment';
 import { useSnackQuery } from 'Iaso/libs/apiHooks';
 import { getRequest } from 'Iaso/libs/Api';
 import { DropdownOptions } from 'Iaso/types/utils';
+import { appId } from '../../../../constants/app';
 
-const getLqasCountriesOptions = (monthYear?: MonthYear) => {
+const getLqasCountriesOptions = (monthYear?: MonthYear, isEmbedded = false) => {
     const endpoint = '/api/polio/lqasim/countriesoptions';
+    const url = `${endpoint}/?month=${monthYear}`;
+    if (isEmbedded) {
+        return getRequest(`${url}&app_id=${appId}`);
+    }
     return getRequest(`${endpoint}/?month=${monthYear}`);
 };
 
 type UseGetLqasCountriesOptionsArgs = {
     side: Side;
     params: LqasUrlParams;
+    isEmbedded?: boolean;
 };
 
 const useMonthYear = ({
@@ -39,13 +45,14 @@ const useMonthYear = ({
 export const useGetLqasCountriesOptions = ({
     side,
     params,
+    isEmbedded = false,
 }: UseGetLqasCountriesOptionsArgs): UseQueryResult<
     DropdownOptions<number>[]
 > => {
     const monthYear: MonthYear | undefined = useMonthYear({ side, params });
     return useSnackQuery({
-        queryKey: ['lqasCountries', monthYear],
-        queryFn: () => getLqasCountriesOptions(monthYear),
+        queryKey: ['lqasCountries', monthYear], // not including isEmbedded to the queryKey since it has no impact on the result
+        queryFn: () => getLqasCountriesOptions(monthYear, isEmbedded),
         options: {
             enabled: Boolean(monthYear),
             staleTime: 1000 * 60 * 15, // in MS

--- a/plugins/polio/js/src/domains/LQAS-IM/LQAS/index.tsx
+++ b/plugins/polio/js/src/domains/LQAS-IM/LQAS/index.tsx
@@ -9,6 +9,8 @@ import { Box, Grid } from '@mui/material';
 import { NumberAsString, UuidAsString } from '../../../constants/types';
 import { LqasTabValue } from '../types';
 import { LqasCountryView } from './CountryOverview/LqasCountryView';
+import { useLocation } from 'react-router-dom';
+import { MainWrapper } from 'Iaso/components/MainWrapper';
 
 export type LqasUrlParams = {
     accountId: string;
@@ -27,11 +29,15 @@ export type LqasUrlParams = {
 };
 
 const baseUrl = baseUrls.lqasCountry;
+const embeddedUrl = baseUrls.embeddedLqasCountry;
 
 export const Lqas = () => {
+    const location = useLocation();
+    const isEmbedded = location.pathname.includes(embeddedUrl);
+    const currentUrl = isEmbedded ? embeddedUrl : baseUrl;
     const { formatMessage } = useSafeIntl();
     const classes: Record<string, string> = useStyles();
-    const params = useParamsObject(baseUrl) as LqasUrlParams;
+    const params = useParamsObject(currentUrl) as LqasUrlParams;
     const {
         leftCountry,
         rightCountry,
@@ -51,24 +57,34 @@ export const Lqas = () => {
                 title={formatMessage(MESSAGES.lqas)}
                 displayBackButton={false}
             />
-            <Box className={classes.containerFullHeightNoTabPadded}>
-                <Grid container spacing={2} direction="row">
-                    <Grid
-                        item
-                        xs={6}
-                        key={`left-${leftCountry}-${leftCampaign}-${leftMonth}-${leftRound}-${leftTab}`}
-                    >
-                        <LqasCountryView side="left" params={params} />
+            <MainWrapper embedded={isEmbedded}>
+                <Box className={classes.containerFullHeightNoTabPadded}>
+                    <Grid container spacing={2} direction="row">
+                        <Grid
+                            item
+                            xs={6}
+                            key={`left-${leftCountry}-${leftCampaign}-${leftMonth}-${leftRound}-${leftTab}`}
+                        >
+                            <LqasCountryView
+                                side="left"
+                                params={params}
+                                isEmbedded={isEmbedded}
+                            />
+                        </Grid>
+                        <Grid
+                            item
+                            xs={6}
+                            key={`right-${rightCountry}-${rightCampaign}-${rightMonth}-${rightRound}-${rightTab}`}
+                        >
+                            <LqasCountryView
+                                side="right"
+                                params={params}
+                                isEmbedded={isEmbedded}
+                            />
+                        </Grid>
                     </Grid>
-                    <Grid
-                        item
-                        xs={6}
-                        key={`right-${rightCountry}-${rightCampaign}-${rightMonth}-${rightRound}-${rightTab}`}
-                    >
-                        <LqasCountryView side="right" params={params} />
-                    </Grid>
-                </Grid>
-            </Box>
+                </Box>
+            </MainWrapper>
         </>
     );
 };

--- a/plugins/polio/js/src/domains/LQAS-IM/shared/charts/LqasImHorizontalChart.tsx
+++ b/plugins/polio/js/src/domains/LQAS-IM/shared/charts/LqasImHorizontalChart.tsx
@@ -23,6 +23,7 @@ type Props = {
     countryId?: number;
     data: Record<string, ConvertedLqasImData>;
     isLoading: boolean;
+    isEmbedded?: boolean;
 };
 
 export const LqasImHorizontalChart: FunctionComponent<Props> = ({
@@ -32,6 +33,7 @@ export const LqasImHorizontalChart: FunctionComponent<Props> = ({
     countryId,
     data,
     isLoading,
+    isEmbedded = false,
 }) => {
     // TODO: add consition on scope
     const { formatMessage } = useSafeIntl();
@@ -40,8 +42,10 @@ export const LqasImHorizontalChart: FunctionComponent<Props> = ({
     const {
         data: regions,
         isLoading: isLoadingRegions,
-    }: UseQueryResult<{ name: string; id: number }[]> =
-        useGetRegions(countryId);
+    }: UseQueryResult<{ name: string; id: number }[]> = useGetRegions(
+        countryId,
+        isEmbedded,
+    );
 
     const chartData = useMemo(() => {
         if (type === 'lqas') {

--- a/plugins/polio/js/src/domains/LQAS-IM/shared/hooks/api/useGetRegions.tsx
+++ b/plugins/polio/js/src/domains/LQAS-IM/shared/hooks/api/useGetRegions.tsx
@@ -1,17 +1,22 @@
 import { UseQueryResult } from 'react-query';
 import { getRequest } from 'Iaso/libs/Api';
 import { useSnackQuery } from 'Iaso/libs/apiHooks';
+import { appId } from '../../../../../constants/app';
 
 export const useGetRegions = (
     country?: number,
+    isEmbedded = false,
 ): UseQueryResult<{ name: string; id: number }[]> => {
-    const params = {
+    const params: Record<string, string> = {
         validation_status: 'all',
         limit: '3000',
         order: 'id',
         orgUnitParentId: `${country}`,
         orgUnitTypeCategory: 'REGION',
     };
+    if (isEmbedded) {
+        params.app_id = appId;
+    }
 
     const queryString = new URLSearchParams(params).toString();
 

--- a/plugins/polio/js/src/domains/LQAS-IM/shared/hooks/api/useLqasIm.ts
+++ b/plugins/polio/js/src/domains/LQAS-IM/shared/hooks/api/useLqasIm.ts
@@ -10,10 +10,12 @@ import {
 } from '../../../IM/constants';
 import { LQAS_COUNTRY_URL } from '../../../LQAS/constants';
 import { LqasImData, LqasIMType } from '../../../types';
+import { appId } from '../../../../../constants/app';
 
 export const getLqasIm = (
     type: LqasIMType,
     countryId?: string,
+    isEmbedded = false,
 ): Promise<any> => {
     switch (type) {
         case 'imOHH':
@@ -25,6 +27,11 @@ export const getLqasIm = (
                 `${IM_COUNTRY_URL}${IM_GLOBAL_SLUG}_${countryId}`,
             );
         case 'lqas':
+            if (isEmbedded) {
+                return getRequest(
+                    `${LQAS_COUNTRY_URL}${countryId}/?app_id=${appId}`,
+                );
+            }
             return getRequest(`${LQAS_COUNTRY_URL}${countryId}/`);
         default:
             throw new Error(
@@ -36,10 +43,11 @@ export const getLqasIm = (
 export const useLqasIm = (
     type: LqasIMType,
     countryId?: string,
+    isEmbedded = false,
 ): UseQueryResult<LqasImData> => {
     return useSnackQuery({
         queryKey: [type, countryId, getLqasIm],
-        queryFn: async () => getLqasIm(type, countryId),
+        queryFn: async () => getLqasIm(type, countryId, isEmbedded),
         dispatchOnError: false,
         options: {
             select: data => {

--- a/plugins/polio/js/src/domains/LQAS-IM/shared/hooks/api/useMapShapes.tsx
+++ b/plugins/polio/js/src/domains/LQAS-IM/shared/hooks/api/useMapShapes.tsx
@@ -2,15 +2,27 @@ import { useMemo } from 'react';
 import { OrgUnit } from 'Iaso/domains/orgUnits/types/orgUnit';
 import { MapShapes } from '../../../../../constants/types';
 import { useGetGeoJson } from '../../../../Campaigns/Scope/hooks/useGetGeoJson';
+import { appId } from '../../../../../constants/app';
 
 const defaultShapes: OrgUnit[] = [];
-export const useMapShapes = (countryId?: number): MapShapes => {
+export const useMapShapes = (
+    countryId?: number,
+    isEmbedded = false,
+): MapShapes => {
     const { data: shapes = defaultShapes, isFetching: isFetchingGeoJson } =
-        useGetGeoJson(countryId, 'DISTRICT');
+        useGetGeoJson({
+            topParentId: countryId,
+            orgUnitCategory: 'DISTRICT',
+            appId: isEmbedded ? appId : undefined,
+        });
     const {
         data: regionShapes = defaultShapes,
         isFetching: isFetchingRegions,
-    } = useGetGeoJson(countryId, 'REGION');
+    } = useGetGeoJson({
+        topParentId: countryId,
+        orgUnitCategory: 'REGION',
+        appId: isEmbedded ? appId : undefined,
+    });
 
     return useMemo(() => {
         return {

--- a/plugins/polio/tests/api/campaigns/test_campaigns_1.py
+++ b/plugins/polio/tests/api/campaigns/test_campaigns_1.py
@@ -7,6 +7,7 @@ from iaso import models as m
 from iaso.models import Account
 from iaso.permissions.core_permissions import CORE_FORMS_PERMISSION
 from iaso.test import APITestCase
+from plugins.polio.api.campaigns.campaigns import AnonymousCampaignSerializer
 from plugins.polio.models import (
     CampaignScope,
     CampaignType,
@@ -149,7 +150,7 @@ class PolioAPITestCase(APITestCase, PolioTestCaseMixin):
         json_response = self.client.get("/api/polio/campaigns/").json()
         self.assertEqual(len(json_response), 3)
 
-    def test_campaings_list_authenticated_account_id_ignored(self):
+    def test_campaigns_list_authenticated_account_id_ignored(self):
         """Campaigns list endpoint: authenticated users cannot make use of the account_id parameter
 
         Notes:
@@ -183,16 +184,15 @@ class PolioAPITestCase(APITestCase, PolioTestCaseMixin):
         """
         Campaign.objects.create(account=self.account, obr_name="obr_name", detection_status="PENDING")
         Campaign.objects.create(account=self.account, obr_name="obr_name2", detection_status="PENDING")
-
         response = self.client.get("/api/polio/campaigns/")
         self.assertEqual(response.status_code, 200)
         json_response = response.json()
         self.assertEqual(len(json_response), 2)
-
+        fields = AnonymousCampaignSerializer.Meta.fields
         for campaign_data in json_response:
             # Both are part of the same account
             self.assertEqual(campaign_data["account"], self.account.pk)
-            # TODO: test other fields (all that's needed for anonymous access) here
+            self.assertEqual(list(campaign_data.keys()), list(fields))
 
     def test_create_campaign_account_not_mandatory(self):
         """Campaigns ca be created without an account"""

--- a/plugins/polio/tests/api/lqas_im/test_lqas_im_campaign_options.py
+++ b/plugins/polio/tests/api/lqas_im/test_lqas_im_campaign_options.py
@@ -18,8 +18,6 @@ class PolioLqasImCampaignOptionsTestCase(LqasImOptionsTestCase):
     @override
     def test_get_without_perm(self):
         """GET - Read-only access  for page embedding"""
-        if not self.endpoint:
-            return
         self.client.force_authenticate(self.anon)
         response = self.client.get(self.endpoint)
         self.assertJSONResponse(response, 200)

--- a/plugins/polio/tests/api/lqas_im/test_lqas_im_campaign_options.py
+++ b/plugins/polio/tests/api/lqas_im/test_lqas_im_campaign_options.py
@@ -12,8 +12,6 @@ class PolioLqasImCampaignOptionsTestCase(LqasImOptionsTestCase):
     @override
     def test_get_without_auth(self):
         """GET - Read-only access to anonymous users for page embedding"""
-        if not self.endpoint:
-            return
         response = self.client.get(self.endpoint)
         self.assertJSONResponse(response, 200)
 

--- a/plugins/polio/tests/api/lqas_im/test_lqas_im_campaign_options.py
+++ b/plugins/polio/tests/api/lqas_im/test_lqas_im_campaign_options.py
@@ -1,11 +1,33 @@
 import datetime
 
+from typing_extensions import override
+
 from plugins.polio.models import Round
 from plugins.polio.tests.api.lqas_im.test_lqas_im_options import LqasImOptionsTestCase
 
 
 class PolioLqasImCampaignOptionsTestCase(LqasImOptionsTestCase):
     endpoint = "/api/polio/lqasim/campaignoptions/"
+
+    @override
+    def test_get_without_auth(self):
+        """GET - Read-only access to anonymous users for page embedding"""
+        if not self.endpoint:
+            return
+        response = self.client.get(self.endpoint)
+        self.assertJSONResponse(response, 200)
+
+    @override
+    def test_get_without_perm(self):
+        """GET - Read-only access  for page embedding"""
+        if not self.endpoint:
+            return
+        self.client.force_authenticate(self.anon)
+        response = self.client.get(self.endpoint)
+        self.assertJSONResponse(response, 200)
+        self.client.force_authenticate(self.user_no_perms)
+        response = self.client.get(self.endpoint)
+        self.assertJSONResponse(response, 200)
 
     def test_filter_campaigns_for_user(self):
         self.client.force_authenticate(self.user)

--- a/plugins/polio/tests/api/lqas_im/test_lqas_im_country_options.py
+++ b/plugins/polio/tests/api/lqas_im/test_lqas_im_country_options.py
@@ -12,8 +12,6 @@ class PolioLqasImCountriesOptionsTestCase(LqasImOptionsTestCase):
     @override
     def test_get_without_auth(self):
         """GET - Read-only access to anonymous users for page embedding"""
-        if not self.endpoint:
-            return
         response = self.client.get(self.endpoint)
         self.assertJSONResponse(response, 200)
 

--- a/plugins/polio/tests/api/lqas_im/test_lqas_im_country_options.py
+++ b/plugins/polio/tests/api/lqas_im/test_lqas_im_country_options.py
@@ -18,8 +18,6 @@ class PolioLqasImCountriesOptionsTestCase(LqasImOptionsTestCase):
     @override
     def test_get_without_perm(self):
         """GET - Read-only access  for page embedding"""
-        if not self.endpoint:
-            return
         self.client.force_authenticate(self.anon)
         response = self.client.get(self.endpoint)
         self.assertJSONResponse(response, 200)

--- a/plugins/polio/tests/api/lqas_im/test_lqas_im_round_options.py
+++ b/plugins/polio/tests/api/lqas_im/test_lqas_im_round_options.py
@@ -12,8 +12,6 @@ class PolioLqasImRoundOptionsTestCase(LqasImOptionsTestCase):
     @override
     def test_get_without_auth(self):
         """GET - Read-only access to anonymous users for page embedding"""
-        if not self.endpoint:
-            return
         response = self.client.get(self.endpoint)
         self.assertJSONResponse(response, 200)
 

--- a/plugins/polio/tests/api/lqas_im/test_lqas_im_round_options.py
+++ b/plugins/polio/tests/api/lqas_im/test_lqas_im_round_options.py
@@ -1,11 +1,33 @@
 import datetime
 
+from typing_extensions import override
+
 from plugins.polio.models import Round
 from plugins.polio.tests.api.lqas_im.test_lqas_im_options import LqasImOptionsTestCase
 
 
 class PolioLqasImRoundOptionsTestCase(LqasImOptionsTestCase):
     endpoint = "/api/polio/lqasim/roundoptions/"
+
+    @override
+    def test_get_without_auth(self):
+        """GET - Read-only access to anonymous users for page embedding"""
+        if not self.endpoint:
+            return
+        response = self.client.get(self.endpoint)
+        self.assertJSONResponse(response, 200)
+
+    @override
+    def test_get_without_perm(self):
+        """GET - Read-only access  for page embedding"""
+        if not self.endpoint:
+            return
+        self.client.force_authenticate(self.anon)
+        response = self.client.get(self.endpoint)
+        self.assertJSONResponse(response, 200)
+        self.client.force_authenticate(self.user_no_perms)
+        response = self.client.get(self.endpoint)
+        self.assertJSONResponse(response, 200)
 
     def test_filter_rounds_for_user(self):
         # Add a rnd 4 to the India campaign to test it's not returned in the results

--- a/plugins/polio/tests/api/lqas_im/test_lqas_im_round_options.py
+++ b/plugins/polio/tests/api/lqas_im/test_lqas_im_round_options.py
@@ -18,8 +18,6 @@ class PolioLqasImRoundOptionsTestCase(LqasImOptionsTestCase):
     @override
     def test_get_without_perm(self):
         """GET - Read-only access  for page embedding"""
-        if not self.endpoint:
-            return
         self.client.force_authenticate(self.anon)
         response = self.client.get(self.endpoint)
         self.assertJSONResponse(response, 200)

--- a/plugins/polio/tests/test_lqas_im_country.py
+++ b/plugins/polio/tests/test_lqas_im_country.py
@@ -1,5 +1,6 @@
 import json
 
+from iaso.models import Project
 from iaso.models.base import Account
 from iaso.models.data_store import JsonDataStore
 from iaso.test import APITestCase
@@ -19,6 +20,7 @@ class LQASCountryAPITestCase(APITestCase):
     def setUpTestData(cls):
         cls.account1 = Account.objects.create(name="Account 1")
         cls.account2 = Account.objects.create(name="Account 2")
+        cls.account1_project = Project.objects.create(name="Project1", app_id="com.app_id.app", account=cls.account1)
         cls.authorized_user_regular = cls.create_user_with_profile(
             username="authorized_polio", account=cls.account1, permissions=[POLIO_PERMISSION]
         )
@@ -38,46 +40,56 @@ class LQASCountryAPITestCase(APITestCase):
         )
 
     def test_datastore_list_without_auth(self):
-        """GET /polio/lqasimmap/country/ without auth should result in a 401"""
+        """GET /polio/lqasimmap/country/ Read-only API publicly available for embedding page"""
 
-        response = self.client.get(api_url)
-        self.assertJSONResponse(response, 401)
+        response = self.client.get(f"{api_url}{self.data_store1.slug}/?app_id={self.account1_project.app_id}")
+        self.assertJSONResponse(response, 200)
 
-    def test_datastore_list_permissions(self):
-        """GET /polio/lqasimmap/country/ with auth but without the proper permission should return a 403"""
+    def test_no_slug_returns_400(self):
+        """GET /polio/lqasimmap/country/ - Returns 400. Slug is mandatory for this endppoint"""
+
+        response = self.client.get(f"{api_url}")
+        self.assertJSONResponse(response, 400)
 
         self.client.force_authenticate(self.unauthorized)
         response = self.client.get(api_url)
-        self.assertJSONResponse(response, 403)
+        self.assertJSONResponse(response, 400)
         self.client.force_authenticate(self.authorized_user_admin)
         response = self.client.get(api_url)
-        self.assertJSONResponse(response, 200)
+        self.assertJSONResponse(response, 400)
         self.client.force_authenticate(self.authorized_user_regular)
         response = self.client.get(api_url)
-        self.assertJSONResponse(response, 200)
-
-    def test_datastore_detail_without_auth(self):
-        """GET /polio/lqasimmap/country/{slug} without auth should result in a 401"""
-
-        response = self.client.get(f"{api_url}{self.data_store1.slug}/")
-        self.assertJSONResponse(response, 401)
+        self.assertJSONResponse(response, 400)
 
     def test_datastore_detail_permissions(self):
-        """GET /polio/lqasimmap/country/{slug} with auth but without the proper permission should return a 403. Wrong account should return a 404"""
+        """GET /polio/lqasimmap/country/<slug> Read-only API publicly available for embedding page"""
 
+        # Anon user can see data if app_id is provided
+        response = self.client.get(f"{api_url}{self.data_store1.slug}/?app_id={self.account1_project.app_id}")
+        self.assertJSONResponse(response, 200)
         self.client.force_authenticate(self.unauthorized)
         response = self.client.get(f"{api_url}{self.data_store1.slug}/")
-        self.assertJSONResponse(response, 403)
-
+        self.assertJSONResponse(response, 200)
         self.client.force_authenticate(self.authorized_user_admin)
         response = self.client.get(f"{api_url}{self.data_store1.slug}/")
         self.assertJSONResponse(response, 200)
+        self.client.force_authenticate(self.authorized_user_regular)
+        response = self.client.get(f"{api_url}{self.data_store1.slug}/")
+        response_body = self.assertJSONResponse(response, 200)
+        self.assertEqual(response_body["data"], data_store_content1)
 
         self.client.force_authenticate(self.user_with_perm_but_wrong_account)
         response = self.client.get(f"{api_url}{self.data_store2.slug}/")
         self.assertJSONResponse(response, 404)
 
-        self.client.force_authenticate(self.authorized_user_regular)
+    def test_datastore_detail_without_auth(self):
+        """GET /polio/lqasimmap/country/{slug} without auth and app_id should result in a 404.
+        Anon user with app_id should result in 200 if Project is correctly configured
+        """
+
         response = self.client.get(f"{api_url}{self.data_store1.slug}/")
-        response_body = self.assertJSONResponse(response, 200)
-        self.assertEqual(response_body["data"], data_store_content1)
+        self.assertJSONResponse(response, 404)
+        response = self.client.get(f"{api_url}{self.data_store1.slug}/?app_id={self.account1_project.app_id}")
+        self.assertJSONResponse(response, 200)
+        response = self.client.get(f"{api_url}{self.data_store1.slug}/?app_id=unknown_app_id")
+        self.assertJSONResponse(response, 404)


### PR DESCRIPTION
 The page needs to be publicly accessible

Related JIRA tickets : POLIO-2038

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [x] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

- Country map
    - Add route (front and backend)
    - Adapt endpoints and API calls: mainly pass app_id to endpoints filtering by account
    - Update tests


## How to test

Pre-requisite: a polio table with lqas data, i.e `JsonDataStore` with the relevant data. It can be copied from staging

- when not logged go to `/dashboard/polio/embeddedLqasCountry/` and select date + campaign
- compare to the behaviour of `dashboard/polio/lqas/lqas/` which is the same page but requires auth

Same procedure with `/dashboard/polio/embeddableLqasMap`



## Print screen / video

Country map

<img width="1673" height="1360" alt="Screenshot 2025-12-01 at 13 50 28" src="https://github.com/user-attachments/assets/34265260-c145-41ef-8bd9-16e83f5506a3" />


