### PR TITLE
IA-4595: Sort users profiles per projects

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/users/config.js
+++ b/hat/assets/js/apps/Iaso/domains/users/config.js
@@ -27,9 +27,8 @@ export const useUsersTableColumns = ({
         () => [
             {
                 Header: formatMessage(MESSAGES.projects),
-                id: 'projects',
+                id: 'projects__name',
                 accessor: 'projects',
-                sortable: false,
                 Cell: settings => <ProjectChips projects={settings.value} />,
             },
             {


### PR DESCRIPTION
What problem is this PR solving? Explain here in one sentence.

Related JIRA tickets : IA-4595

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

-

## Changes

use correct key to enable sort

## How to test

Go to user profiles page, try to order users per projects

## Print screen / video

https://github.com/user-attachments/assets/7db70d84-c8f4-4adb-b9fb-4ab35acc9752


## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
