### PR TITLE
IA-4643: Groups api count of org units is wrong

### DIFF
--- a/iaso/api/groups/serializers.py
+++ b/iaso/api/groups/serializers.py
@@ -55,6 +55,9 @@ class GroupSerializer(serializers.ModelSerializer):
 
     def get_org_units(self, obj):
         """Return list of org unit IDs for read operations."""
+        cache = getattr(obj, "_prefetched_objects_cache", None)
+        if cache and "org_units" in cache:
+            return [org_unit.id for org_unit in cache["org_units"]]
         return list(obj.org_units.values_list("id", flat=True))
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Count of org units is wrong on groups list page.
Also this endpoint is quiet slow in production.

<img width="515" height="103" alt="Screenshot 2025-12-04 at 10 25 36" src="https://github.com/user-attachments/assets/4cd87833-4585-49ec-8366-11e1ba272279" />
<img width="1712" height="803" alt="Screenshot 2025-12-04 at 10 03 01" src="https://github.com/user-attachments/assets/4b93e3a4-ac53-4cc7-9b18-8e9b67097293" />
<img width="1702" height="646" alt="Screenshot 2025-12-04 at 10 02 54" src="https://github.com/user-attachments/assets/5619dc45-e5ac-4bed-9b90-04dba9f69b42" />

Related JIRA tickets : IA-4643

## Self proofreading checklist

- [ ] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

-

## Changes

use distinct + prefetch/select to avoid n+1

## How to test

Visit groups list page, count of org units should correspond with number of org units.
Make sure fetching groups is not anymore create duplicates queries in the python console.

If a specific config is required explain it here: dataset, account, profile, etc.

## Print screen / video
<img width="1720" height="796" alt="Screenshot 2025-12-04 at 10 28 48" src="https://github.com/user-attachments/assets/82cffa49-da88-4605-a24c-571a5c73e9a6" />
<img width="1705" height="473" alt="Screenshot 2025-12-04 at 10 28 36" src="https://github.com/user-attachments/assets/72018b05-a505-4c98-876b-2c8710cffdbe" />
<img width="531" height="116" alt="Screenshot 2025-12-04 at 10 25 25" src="https://github.com/user-attachments/assets/ed1335bb-5bf4-444d-a74b-5d7859afbe0f" />


## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
