### PR TITLE
IA-4644: Small n+1 on projects api

### DIFF
--- a/iaso/api/projects/viewsets.py
+++ b/iaso/api/projects/viewsets.py
@@ -1,4 +1,4 @@
-from django.db.models import QuerySet
+from django.db.models import Prefetch, QuerySet
 from django.http import HttpResponse
 from qr_code.qrcode.maker import make_qr_code_image
 from qr_code.qrcode.utils import QRCodeOptions
@@ -6,7 +6,7 @@ from rest_framework import filters, permissions, serializers, status
 from rest_framework.decorators import action
 from rest_framework.exceptions import PermissionDenied
 
-from iaso.models import Project
+from iaso.models import Project, ProjectFeatureFlags
 
 from ...permissions.core_permissions import CORE_USERS_ADMIN_PERMISSION
 from ..common import ModelViewSet
@@ -39,7 +39,12 @@ class ProjectsViewSet(ModelViewSet):
         querystring_serializer.is_valid(raise_exception=True)
         bypass_restrictions = querystring_serializer.validated_data.get("bypass_restrictions")
 
-        projects = Project.objects.filter(account=self.request.user.iaso_profile.account)
+        projects = Project.objects.filter(account=self.request.user.iaso_profile.account).prefetch_related(
+            Prefetch(
+                "projectfeatureflags_set",
+                queryset=ProjectFeatureFlags.objects.select_related("featureflag"),
+            )
+        )
 
         if not bypass_restrictions:
             projects = projects.filter_on_user_projects(self.request.user)

--- a/iaso/tests/api/test_projects.py
+++ b/iaso/tests/api/test_projects.py
@@ -69,6 +69,17 @@ class ProjectsAPITestCase(APITestCase):
         self.assertIn("color", response.json()["projects"][0])
         self.assertEqual(response.json()["projects"][0]["color"], "#FF5733")
 
+    def test_projects_list_query_count(self):
+        """
+        Ensure projects list query count is controlled (prefetch feature flags, etc.).
+        Note: Count set deliberately to refine during debugging.
+        """
+        self.client.force_authenticate(self.jane)
+        with self.assertNumQueries(3):
+            response = self.client.get("/api/projects/", headers={"Content-Type": "application/json"})
+        self.assertJSONResponse(response, 200)
+        self.assertValidProjectListData(response.json(), 2)
+
     def test_projects_list_paginated(self):
         """GET /projects/ paginated happy path"""
 


### PR DESCRIPTION

<img width="776" height="146" alt="Screenshot 2025-12-04 at 10 37 00" src="https://github.com/user-attachments/assets/b81d6513-b8ef-45a1-8419-4fece67d420e" />


Related JIRA tickets : IA-4644

## Self proofreading checklist

- [ ] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

-

## Changes

Prefetch feature flags

## How to test

Visit http://localhost:8081/api/projects/?limit=20&order=name&page=1, you should not have duplicates anymore

## Print screen / video
<img width="546" height="127" alt="Screenshot 2025-12-04 at 10 39 46" src="https://github.com/user-attachments/assets/2c2eeaa8-824b-44d5-88db-961e49223a92" />


## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
