### PR TITLE
IA-4645: Forms api n+1

### DIFF
--- a/iaso/api/forms.py
+++ b/iaso/api/forms.py
@@ -4,7 +4,7 @@ from copy import copy
 from datetime import timedelta
 from xml.sax.saxutils import escape
 
-from django.db.models import BooleanField, Case, Count, Max, Q, When
+from django.db.models import BooleanField, Case, Count, Exists, Max, OuterRef, Prefetch, Q, When
 from django.http import HttpResponse, StreamingHttpResponse
 from django.utils.dateparse import parse_date
 from rest_framework import permissions, serializers, status
@@ -15,7 +15,16 @@ from rest_framework.request import Request
 from hat.api.export_utils import Echo, generate_xlsx, iter_items
 from hat.audit.models import FORM_API, log_modification
 from iaso.api.permission_checks import IsAuthenticatedOrReadOnlyWhenNoAuthenticationRequired, ReadOnly
-from iaso.models import EntityDuplicateAnalyzis, Form, FormAttachment, FormVersion, OrgUnit, OrgUnitType, Project
+from iaso.models import (
+    EntityDuplicateAnalyzis,
+    Form,
+    FormAttachment,
+    FormVersion,
+    OrgUnit,
+    OrgUnitType,
+    Project,
+    ProjectFeatureFlags,
+)
 from iaso.permissions.core_permissions import CORE_FORMS_PERMISSION
 from iaso.utils.date_and_time import timestamp_to_datetime
 
@@ -162,7 +171,9 @@ class FormSerializer(DynamicFieldsModelSerializer):
 
     @staticmethod
     def get_has_attachments(obj: Form):
-        return len(obj.attachments.all()) > 0
+        if hasattr(obj, "has_attachments"):
+            return obj.has_attachments
+        return obj.attachments.exists()
 
     @staticmethod
     def get_possible_fields_with_latest_version(obj: Form):
@@ -315,6 +326,10 @@ class FormsViewSet(ModelViewSet):
                 ),
             )
 
+        if is_field_referenced("has_attachments", requested_fields, order) and not is_request_from_manifest:
+            attachment_exists = FormAttachment.objects.filter(form_id=OuterRef("pk"))
+            queryset = queryset.annotate(has_attachments=Exists(attachment_exists))
+
         if not self.request.user.is_anonymous:
             profile = self.request.user.iaso_profile
         else:
@@ -386,6 +401,10 @@ class FormsViewSet(ModelViewSet):
                 "form_versions",
                 "projects",
                 "projects__feature_flags",
+                Prefetch(
+                    "projects__projectfeatureflags_set",
+                    queryset=ProjectFeatureFlags.objects.select_related("featureflag"),
+                ),
                 "reference_of_org_unit_types",
                 "org_unit_types",
                 "org_unit_types__reference_forms",


### PR DESCRIPTION

<img width="1499" height="140" alt="Screenshot 2025-12-04 at 11 00 52" src="https://github.com/user-attachments/assets/941d338c-0215-48e9-b328-b576234db686" />


Related JIRA tickets : IA-4645
## Self proofreading checklist

- [ ] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc
-
## Changes

Prefetch feature flags and use has_attachments if requested

## How to test

Visit forms dashboard page and check that we don't have duplicate anymore on forms call

## Print screen / video

<img width="1500" height="145" alt="Screenshot 2025-12-04 at 11 00 59" src="https://github.com/user-attachments/assets/74de476d-bc79-452a-b4fd-04012a782bdc" />

## Notes

-

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
