### PR TITLE
POLIO-2046:  Fix pdf preview

### DIFF
--- a/hat/assets/js/apps/Iaso/components/files/pdf/PdfPreview.tsx
+++ b/hat/assets/js/apps/Iaso/components/files/pdf/PdfPreview.tsx
@@ -29,7 +29,7 @@ import MESSAGES from './messages';
 // Note: The PDF file itself is not transferred to the worker; only the processing is offloaded.
 // This is necessary for the react-pdf library to function correctly.
 if (!pdfjs.GlobalWorkerOptions.workerSrc) {
-    pdfjs.GlobalWorkerOptions.workerSrc = `//unpkg.com/pdfjs-dist@5.3.31/build/pdf.worker.min.mjs`;
+    pdfjs.GlobalWorkerOptions.workerSrc = `//unpkg.com/pdfjs-dist@${pdfjs.version}/build/pdf.worker.min.mjs`;
 }
 
 type PdfPreviewProps = {


### PR DESCRIPTION
Preview of pdf is not working

Related JIRA tickets :POLIO-2046

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

use correct version of pdf preview

## How to test

Try to preview a pdf from submissions or vaccine repository in Polio

## Print screen / video

<img width="1119" height="869" alt="Screenshot 2025-12-08 at 15 08 27" src="https://github.com/user-attachments/assets/643ed2d8-b8fd-432f-9e4e-0c0dee3cef03" />


## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
