### PR TITLE
IA-4530: Make main org unit and demo form optional

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -1394,6 +1394,8 @@
     "iaso.setup.accountNameAlreadyExist": "This account name is already taken",
     "iaso.setup.accountSetup": "Setup a new account",
     "iaso.setup.confirmMessage": "Account and profile created successfully, please logout and login again with the new profile.",
+    "iaso.setup.createDemoForm": "Create demo form",
+    "iaso.setup.createMainOrgUnit": "Create main organization unit",
     "iaso.setup.dataSourceNameAlreadyExist": "Data source name already exists",
     "iaso.setup.modulesEmpty": "Modules should not be empty",
     "iaso.setup.modulesNotExist": "Modules do not exist",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -1395,6 +1395,8 @@
     "iaso.setup.accountNameAlreadyExist": "Un compte avec ce nom existe déjà",
     "iaso.setup.accountSetup": "Configuration d'un nouveau compte",
     "iaso.setup.confirmMessage": "Compte et profil créés avec succès, veuillez vous déconnecter et vous reconnecter avec le nouveau profil.",
+    "iaso.setup.createDemoForm": "Créer un formulaire de démo",
+    "iaso.setup.createMainOrgUnit": "Créer l'unité d'organisation principale",
     "iaso.setup.dataSourceNameAlreadyExist": "Une source avec ce nom existe déjà",
     "iaso.setup.modulesEmpty": "Les modules ne doivent pas être vides.",
     "iaso.setup.modulesNotExist": "Les modules n'existent pas",

--- a/hat/assets/js/apps/Iaso/domains/setup/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/setup/index.tsx
@@ -82,6 +82,8 @@ export const SetupAccount: FunctionComponent = () => {
             email_invitation: false,
             language: 'en',
             modules: ['DATA_COLLECTION_FORMS'],
+            create_main_org_unit: true,
+            create_demo_form: true,
         },
         enableReinitialize: true,
         validateOnBlur: true,
@@ -288,6 +290,30 @@ export const SetupAccount: FunctionComponent = () => {
                                             errors={getErrors('modules')}
                                             loading={isFetchingModules}
                                             options={filteredModules}
+                                        />
+                                        <InputComponent
+                                            type="checkbox"
+                                            keyValue="create_main_org_unit"
+                                            labelString={formatMessage(
+                                                MESSAGES.createMainOrgUnit,
+                                            )}
+                                            value={values.create_main_org_unit}
+                                            onChange={onChange}
+                                            helperText={formatMessage(
+                                                MESSAGES.createMainOrgUnitHint,
+                                            )}
+                                        />
+                                        <InputComponent
+                                            type="checkbox"
+                                            keyValue="create_demo_form"
+                                            labelString={formatMessage(
+                                                MESSAGES.createDemoForm,
+                                            )}
+                                            value={values.create_demo_form}
+                                            onChange={onChange}
+                                            helperText={formatMessage(
+                                                MESSAGES.createDemoFormHint,
+                                            )}
                                         />
                                         <Box
                                             mt={2}

--- a/hat/assets/js/apps/Iaso/domains/setup/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/setup/index.tsx
@@ -299,9 +299,6 @@ export const SetupAccount: FunctionComponent = () => {
                                             )}
                                             value={values.create_main_org_unit}
                                             onChange={onChange}
-                                            helperText={formatMessage(
-                                                MESSAGES.createMainOrgUnitHint,
-                                            )}
                                         />
                                         <InputComponent
                                             type="checkbox"
@@ -311,9 +308,6 @@ export const SetupAccount: FunctionComponent = () => {
                                             )}
                                             value={values.create_demo_form}
                                             onChange={onChange}
-                                            helperText={formatMessage(
-                                                MESSAGES.createDemoFormHint,
-                                            )}
                                         />
                                         <Box
                                             mt={2}

--- a/hat/assets/js/apps/Iaso/domains/setup/messages.ts
+++ b/hat/assets/js/apps/Iaso/domains/setup/messages.ts
@@ -94,4 +94,20 @@ export const MESSAGES = defineMessages({
         defaultMessage: 'An error occurred while fetching modules',
         id: 'iaso.snackBar.fetchModules',
     },
+    createMainOrgUnit: {
+        defaultMessage: 'Create main organization unit',
+        id: 'iaso.setup.createMainOrgUnit',
+    },
+    createMainOrgUnitHint: {
+        defaultMessage: 'Automatically create a main organization unit for the account',
+        id: 'iaso.setup.createMainOrgUnitHint',
+    },
+    createDemoForm: {
+        defaultMessage: 'Create demo form',
+        id: 'iaso.setup.createDemoForm',
+    },
+    createDemoFormHint: {
+        defaultMessage: 'Automatically create a demo form for testing',
+        id: 'iaso.setup.createDemoFormHint',
+    },
 });

--- a/hat/assets/js/apps/Iaso/domains/setup/messages.ts
+++ b/hat/assets/js/apps/Iaso/domains/setup/messages.ts
@@ -98,16 +98,8 @@ export const MESSAGES = defineMessages({
         defaultMessage: 'Create main organization unit',
         id: 'iaso.setup.createMainOrgUnit',
     },
-    createMainOrgUnitHint: {
-        defaultMessage: 'Automatically create a main organization unit for the account',
-        id: 'iaso.setup.createMainOrgUnitHint',
-    },
     createDemoForm: {
         defaultMessage: 'Create demo form',
         id: 'iaso.setup.createDemoForm',
-    },
-    createDemoFormHint: {
-        defaultMessage: 'Automatically create a demo form for testing',
-        id: 'iaso.setup.createDemoFormHint',
     },
 });

--- a/hat/assets/js/apps/Iaso/domains/setup/types/account.ts
+++ b/hat/assets/js/apps/Iaso/domains/setup/types/account.ts
@@ -8,6 +8,8 @@ export type SaveAccountQuery = {
     email_invitation: boolean;
     language: string;
     modules: string[];
+    create_main_org_unit: boolean;
+    create_demo_form: boolean;
 };
 
 export type Module = {

--- a/hat/assets/js/apps/Iaso/domains/setup/validation.ts
+++ b/hat/assets/js/apps/Iaso/domains/setup/validation.ts
@@ -44,6 +44,8 @@ export const useAccountValidation = (
                 })
                 .test(apiValidator('password')),
             modules: array().of(string()).nullable().required('requiredField'),
+            create_main_org_unit: boolean().nullable(),
+            create_demo_form: boolean().nullable(),
         });
     }, [apiValidator]);
     return schema;

--- a/iaso/tests/api/test_setup_account.py
+++ b/iaso/tests/api/test_setup_account.py
@@ -1284,3 +1284,43 @@ class SetupAccountApiTestCase(APITestCase):
         # Project should have proper app_id
         expected_app_id = "unittest_account"
         self.assertEqual(project.app_id, expected_app_id)
+
+    def test_setup_account_create_main_org_unit_false(self):
+        """Test that setting create_main_org_unit to False skips org unit creation"""
+        self.client.force_authenticate(self.admin)
+        data = {
+            "account_name": "unittest_account",
+            "user_username": "unittest_username",
+            "password": "unittest_password",
+            "email_invitation": False,
+            "modules": self.MODULES,
+            "create_main_org_unit": False,
+        }
+        response = self.client.post("/api/setupaccount/", data=data, format="json")
+        self.assertEqual(response.status_code, 201)
+
+        # Check that main org unit was NOT created
+        org_unit = m.OrgUnit.objects.filter(name="Main org unit").first()
+        self.assertIsNone(org_unit)
+
+        # Check that main org unit type was NOT created
+        org_unit_type = m.OrgUnitType.objects.filter(name="Main org unit type").first()
+        self.assertIsNone(org_unit_type)
+
+    def test_setup_account_create_demo_form_false(self):
+        """Test that setting create_demo_form to False skips demo form creation"""
+        self.client.force_authenticate(self.admin)
+        data = {
+            "account_name": "unittest_account",
+            "user_username": "unittest_username",
+            "password": "unittest_password",
+            "email_invitation": False,
+            "modules": self.MODULES,
+            "create_demo_form": False,
+        }
+        response = self.client.post("/api/setupaccount/", data=data, format="json")
+        self.assertEqual(response.status_code, 201)
+
+        # Check that demo form was NOT created
+        form = m.Form.objects.filter(name="Demo Form").first()
+        self.assertIsNone(form)

--- a/setuper/setuper.py
+++ b/setuper/setuper.py
@@ -73,6 +73,8 @@ def setup_account(account_name, server_url, username, password):
             "SHOW_LINK_INSTANCE_REFERENCE",
             "ALLOW_CATCHMENT_EDITION",
         ],
+        "create_main_org_unit": True,
+        "create_demo_form": True,
     }
     iaso_admin_client = admin_login(server_url, username, password)
     iaso_admin_client.post("/api/setupaccount/", json=data)


### PR DESCRIPTION
This commit introduces the option to skip the creation of the main organization unit and the demo form when setting up a new account. This provides more flexibility for users who may not need these default items.

- Added checkboxes to the setup form to control the creation of the main org unit and demo form.
- Updated the backend to conditionally create these resources based on the user's selection.
- Added tests to verify the new functionality.
- Updated the setuper script to include the new options.

  Related JIRA Tickets

  - IA-4530 - Make main org unit optional when launching new account

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [x] Are my typescript files well typed?
- [x] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

  Frontend (TypeScript/React):
  - hat/assets/js/apps/Iaso/domains/setup/index.tsx - Added two checkbox inputs to the setup form for controlling main org unit and demo form creation
  - hat/assets/js/apps/Iaso/domains/setup/messages.ts - Added 4 new i18n messages with labels and hints for the new checkboxes
  - hat/assets/js/apps/Iaso/domains/setup/types/account.ts - Extended SaveAccountQuery type with create_main_org_unit and create_demo_form boolean fields
  - hat/assets/js/apps/Iaso/domains/setup/validation.ts - Added validation rules for the new boolean fields

  Backend (Python/Django):
  - iaso/api/setup_account.py - Updated SetupAccountSerializer to accept the new boolean fields with defaults (True), and modified the account setup logic to conditionally create the main org unit type/unit and demo form based on user selection
  - iaso/tests/api/test_setup_account.py - Added 2 new test cases to verify that org units and forms are not created when the flags are set to False

  Scripts:
  - setuper/setuper.py - Updated the setup script to include the new options with default values

## How to test
connect as an admin
go to: http://localhost:8081/dashboard/setupAccount
create an user with checkbox unchecked for org_unit and  demo_form
check in the database than org_unit and demo_form was not created

## Print screen / video

Upload here print screens or videos showing the changes.

## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
