### PR TITLE
IA-4649: Fix `Open on` filter is not working

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitsFilters.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitsFilters.tsx
@@ -21,7 +21,7 @@ import { ColorPicker } from 'Iaso/components/forms/ColorPicker';
 
 import { getColor } from 'Iaso/hooks/useGetColors';
 import { DropdownOptionsWithOriginal } from 'Iaso/types/utils';
-import { apiDateFormat } from 'Iaso/utils/dates';
+import { dateFormat } from 'Iaso/utils/dates';
 import { LocationLimit } from 'Iaso/utils/map/LocationLimit';
 import DatesRange from '../../../components/filters/DatesRange';
 import InputComponent from '../../../components/forms/InputComponent';
@@ -299,7 +299,7 @@ export const OrgUnitFilters: FunctionComponent<Props> = ({
                         onChange={date => {
                             handleChange(
                                 'open_date',
-                                date ? date.format(apiDateFormat) : null,
+                                date ? date.format(dateFormat) : null,
                             );
                         }}
                     />

--- a/iaso/api/org_unit_search.py
+++ b/iaso/api/org_unit_search.py
@@ -80,7 +80,7 @@ def build_org_units_queryset(queryset, params, profile):
     org_unit_type_category = params.get("orgUnitTypeCategory", None)
     path_depth = params.get("depth", None)
 
-    date_open = params.get("date_open", None)
+    open_date = params.get("open_date", None)
     opening_date = params.get("opening_date", None)
     closed_date = params.get("closed_date", None)
 
@@ -243,8 +243,8 @@ def build_org_units_queryset(queryset, params, profile):
 
     if path_depth is not None:
         queryset = queryset.filter(path__depth=path_depth)
-    if date_open is not None:
-        date = datetime.strptime(date_open, "%d-%m-%Y").date()
+    if open_date is not None:
+        date = datetime.strptime(open_date, "%d-%m-%Y").date()
         queryset = queryset.filter(Q(opening_date__isnull=True) | Q(opening_date__lte=date)).filter(
             Q(closed_date__isnull=True) | Q(closed_date__gt=date)
         )

--- a/iaso/tests/api/test_orgunits.py
+++ b/iaso/tests/api/test_orgunits.py
@@ -544,7 +544,7 @@ class OrgUnitAPITestCase(APITestCase):
 
         def get_at_date(date: str):
             return self.client.get(
-                '/api/orgunits/?&order=id&page=1&searchTabIndex=0&searches=[{"validation_status":"all","color":"4dd0e1", "date_open": "'
+                '/api/orgunits/?&order=id&page=1&searchTabIndex=0&searches=[{"validation_status":"all","color":"4dd0e1", "open_date": "'
                 + date
                 + '"}]&limit=50'
             )


### PR DESCRIPTION
`Open on` filter was never taken into account and date format was wrong

Related JIRA tickets : IA-4649

## Self proofreading checklist

- [X] Did I use eslint and ruff formatters?
- [X] Is my code clear enough and well documented?
- [X] Are my typescript files well typed?
- [X] Are there enough tests?

## Changes

I have changed the query parameter from `date_open` to `open_date` to match the frontend.
I changed the frontend to send the date in `DD-MM-YYYY` format as it is for the other parameters.

## How to test

Go in the OrgUnit's list and enter a date in the `Open on` filter.

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
