### PR TITLE
[IA-4374] Fix setuper sandbox task

### DIFF
--- a/iaso/tasks/setuper_sandbox.py
+++ b/iaso/tasks/setuper_sandbox.py
@@ -117,7 +117,7 @@ def reset_superuser_password() -> str:
 
 def run_setuper(account_name: str, password: str):
     server_url = f"https://{settings.DNS_DOMAIN}"
-    command = [
+    command_for_logging = [
         "python3",
         "setuper/setuper.py",
         "--additional_projects",
@@ -125,12 +125,15 @@ def run_setuper(account_name: str, password: str):
         account_name,
         "-u",
         "cron_task_sandbox_user",
-        "-p",
-        password,
         "-s",
         server_url,
     ]
-    logger.info(f"Executing command: {' '.join(command)}")
+    logger.info(f"Executing command: {' '.join(command_for_logging)}")
+    command = [
+        *command_for_logging,
+        "-p",
+        password,
+    ]
     try:
         process = subprocess.run(command, capture_output=True, text=True, check=True)
         logger.info(f"Stdout:\n{process.stdout}")

--- a/iaso/tasks/setuper_sandbox.py
+++ b/iaso/tasks/setuper_sandbox.py
@@ -1,10 +1,12 @@
 import logging
+import secrets
 import subprocess
 
 from datetime import datetime
 
 from django.conf import settings
-from django.db.models import Q
+from django.contrib.auth.models import User
+from django.core.exceptions import ImproperlyConfigured
 
 from beanstalk_worker import task_decorator
 from iaso.models import Account, DataSource, Profile, Project, Task
@@ -13,27 +15,124 @@ from iaso.models import Account, DataSource, Profile, Project, Task
 logger = logging.getLogger(__name__)
 
 
-def update_users_profiles(profiles, account_name, new_account_name):
+def prepare_account_name_str(name):
+    """
+    If this task is triggered by a web call (e.g. if you curl your server), the name parameter is passed as a list instead of a str.
+    If this task is triggered by code inside IASO, the name parameter is passed as a str.
+    """
+    if isinstance(name, list):
+        return name[0]
+    return name
+
+
+def log_and_progress_task(task: Task, message: str, progress: int):
+    logger.info(message)
+    task.report_progress_and_stop_if_killed(progress, message, 100)
+
+
+def reset_account(account: Account, task: Task):
+    current_timestamp = int(datetime.now().timestamp())
+    old_name = account.name
+    new_name = f"{old_name}{current_timestamp}"
+
+    log_and_progress_task(task, f"Renaming current account {old_name} to {new_name}", 5)
+    account.name = new_name
+    account.save()
+
+    profiles = Profile.objects.filter(account=account)
+    log_and_progress_task(
+        task, f"Renaming and deactivating all {len(profiles)} users that belong to account {old_name}", 10
+    )
+    update_user_profiles(profiles, old_name, new_name)
+    log_and_progress_task(task, f"Disabled {len(profiles)} users", 30)
+
+    projects = Project.objects.filter(account=account)
+    log_and_progress_task(
+        task, f"Renaming app_id for all {len(projects)} projects that belong to account {old_name}", 35
+    )
+    logger.info(f"Renaming app id for all {len(projects)} projects belong to account {old_name}")
+    update_projects_app_id(projects, old_name, new_name)
+    log_and_progress_task(task, f"Renamed app_id for all {len(projects)} projects", 55)
+
+    data_sources = DataSource.objects.filter(projects__account=account).distinct()
+    log_and_progress_task(task, f"Renaming all {len(data_sources)} data_sources that belong to account {old_name}", 60)
+    update_data_sources(data_sources, current_timestamp)
+    log_and_progress_task(task, f"Renamed all {len(data_sources)} data_sources", 70)
+
+    log_and_progress_task(task, f"Finished reseting {old_name} account!", 70)
+
+
+def update_user_profiles(profiles, account_name, new_account_name):
+    """
+    Users in a setuper account have usernames like: "admin", "admin.user01", "admin.user02"...
+    """
     for profile in profiles:
-        new_user_name = profile.user.username.replace(account_name, new_account_name)
-        profile.user.username = new_user_name
-        profile.user.is_active = False
-        profile.user.save()
-    return profiles
+        user: User = profile.user
+        new_username = user.username.replace(account_name, new_account_name)
+        user.username = new_username
+        user.is_active = False
+        user.save()
 
 
-def change_projects_app_id(projects, account_name, new_account_name):
+def update_projects_app_id(projects, account_name, new_account_name):
+    """
+    Projects in a setuper account have app_ids like: "project.children", "project.georegistry", "project"...
+    """
     for project in projects:
         project.app_id = project.app_id.replace(account_name, new_account_name)
         project.save()
-    return projects
 
 
-def recreate_account(account_name):
-    command = ["python3", "setuper/setuper.py", "--additional_projects", "-n", account_name]
+def update_data_sources(data_sources, timestamp):
+    for data_source in data_sources:
+        data_source.name = f"{data_source.name}{timestamp}"
+        data_source.save()
+
+
+def recreate_account(account_name: str, task: Task):
+    log_and_progress_task(task, "Recreating the cron_task_sandbox_user superuser", 75)
+    new_password = reset_superuser_password()
+    log_and_progress_task(task, "Superuser password reset", 80)
+    log_and_progress_task(task, "Launching setuper...", 80)
+    success = run_setuper(account_name, new_password)
+    if success:
+        message = "admin account recreated successfully"
+        task.report_success(message)
+    else:
+        message = "admin account recreation failed"
+        task.terminate_with_error(message)
+    logger.info(message)
+
+
+def reset_superuser_password() -> str:
+    user = User.objects.filter(username="cron_task_sandbox_user")
+    if not user:
+        raise ImproperlyConfigured("Can't find the cron_task_sandbox_user user")
+    new_password = secrets.token_urlsafe(32)
+    superuser = user.first()
+    superuser.set_password(new_password)
+    superuser.save()
+    return new_password
+
+
+def run_setuper(account_name: str, password: str):
+    server_url = f"https://{settings.DNS_DOMAIN}"
+    command = [
+        "python3",
+        "setuper/setuper.py",
+        "--additional_projects",
+        "-n",
+        account_name,
+        "-u",
+        "cron_task_sandbox_user",
+        "-p",
+        password,
+        "-s",
+        server_url,
+    ]
     logger.info(f"Executing command: {' '.join(command)}")
     try:
-        process = subprocess.run(command, capture_output=True, text=True)
+        process = subprocess.run(command, capture_output=True, text=True, check=True)
         logger.info(f"Stdout:\n{process.stdout}")
         return True
     except subprocess.CalledProcessError as e:
@@ -49,43 +148,16 @@ def recreate_account(account_name):
 @task_decorator(task_name="setuper_sandbox")
 def setuper_sandbox(name="admin", task=Task):
     if settings.ENABLE_SETUPER_SANDBOX:
-        logger.warning(f" .... Resetting {name} account and its data! ...")
-        current_timestamp = int(datetime.now().timestamp())
-        account_name = name
-        if isinstance(name, list):
-            account_name = name[0]
-        new_name = f"{account_name}{current_timestamp}"
-        logger.info(f"Renaming current account {account_name} to {new_name}")
-        account = Account.objects.filter(name=account_name).first()
+        account_name = prepare_account_name_str(name)
+        log_and_progress_task(task, f" .... trying to reset account {name} account and its data! ...", 0)
+        account = Account.objects.filter(name__exact=account_name).first()
         if account is not None:
-            account.name = new_name
-            account.save()
-
-        profiles = Profile.objects.filter(Q(account=account) | Q(user__username=account_name))
-        logger.info(f"Renaming and deactivating all {len(profiles)} users belong to account {account_name}")
-
-        updated_users = update_users_profiles(profiles, account_name, new_name)
-        logger.info(f"Disabled {len(updated_users)} users")
-
-        projects = Project.objects.filter(account=account)
-        logger.info(f"Renaming app id for all {len(projects)} projects belong to account {account_name}")
-        projects_to_updated = change_projects_app_id(projects, account_name, new_name)
-        updated_projects = Project.objects.bulk_update(projects_to_updated, ["app_id"])
-        logger.info(f"Renamed app id for all {updated_projects} projects")
-
-        data_sources = DataSource.objects.filter(projects__account=account).distinct()
-        logger.info(f"Renaming all {len(data_sources)} data_sources belong to account {account_name}")
-        for data_source in data_sources:
-            data_source.name = f"{data_source.name}{current_timestamp}"
-            data_source.save()
-        logger.info(f"Renamed all {len(data_sources)} data_sources")
-
-        logger.info(f"Reset {account_name} account!")
-        result = recreate_account(account_name)
-        message = f"Sandbox {account_name} account"
-        if result:
-            task.report_success(f"{message} created")
+            reset_account(account, task)
         else:
-            task.terminate_with_error(f"{message} task failed")
+            message = f"Account {account_name} does not exist. Simply calling the setuper."
+            logger.warning(message)
+            task.report_progress_and_stop_if_killed(progress_value=50, progress_message=message, end_value=100)
+
+        recreate_account(account_name, task)
     else:
         logger.info("No setuper sandbox task")


### PR DESCRIPTION
Fix setuper sandbox task

Related JIRA tickets : IA-4374

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

/

## Changes

- Prevented the task from updating any data if the account is not found
- Refactored the code and added more logging and task progress
- Made the task fail if the setuper is not successful

## How to test

You can't really test that locally, as this needs to be tested on a deployed server
On a deployed server:
- make sure that there's a superuser called `cron_task_sandbox_user`
- check that the `admin` account has been archived (elements have a new name, users can no longer login)
- make sure that there's a new fresh `admin` account
- make sure that `ENABLE_SETUPER_SANDBOX=True`

Or check the server's logs to check what happened


## Print screen / video

/

## Notes

/

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
