### PR TITLE
POLIO-2047: Added Performance threshold in the django admin panel

### DIFF
--- a/plugins/polio/admin.py
+++ b/plugins/polio/admin.py
@@ -446,7 +446,7 @@ class ChronogramTemplateTaskAdmin(TranslatedFieldAdmin, admin.ModelAdmin):
 
 @admin.register(PerformanceThresholds)
 class PerformanceThresholdsAdmin(admin.ModelAdmin):
-    list_display = ("indicator", "account", "updated_at")
+    list_display = ("indicator", "account", "updated_at", "deleted_at")
     list_filter = ("account",)
     search_fields = ("indicator",)
     readonly_fields = ("created_at", "updated_at")
@@ -454,6 +454,9 @@ class PerformanceThresholdsAdmin(admin.ModelAdmin):
     formfield_overrides = {
         models.JSONField: {"widget": IasoJSONEditorWidget},
     }
+
+    def get_queryset(self, request):
+        return PerformanceThresholds.objects_include_deleted.all()
 
 
 admin.site.register(RoundDateHistoryEntry)

--- a/plugins/polio/admin.py
+++ b/plugins/polio/admin.py
@@ -42,6 +42,7 @@ from .models import (
     VaccineStock,
     create_polio_notifications_async,
 )
+from .models.performance_thresholds import PerformanceThresholds
 
 
 @admin.register(Campaign)
@@ -441,6 +442,18 @@ class ChronogramTemplateTaskAdmin(TranslatedFieldAdmin, admin.ModelAdmin):
         else:
             obj.updated_by = request.user
         super().save_model(request, obj, form, change)
+
+
+@admin.register(PerformanceThresholds)
+class PerformanceThresholdsAdmin(admin.ModelAdmin):
+    list_display = ("indicator", "account", "updated_at")
+    list_filter = ("account",)
+    search_fields = ("indicator",)
+    readonly_fields = ("created_at", "updated_at")
+    raw_id_fields = ("account",)
+    formfield_overrides = {
+        models.JSONField: {"widget": IasoJSONEditorWidget},
+    }
 
 
 admin.site.register(RoundDateHistoryEntry)


### PR DESCRIPTION
What problem is this PR solving? Explain here in one sentence.

Related JIRA tickets : https://bluesquare.atlassian.net/browse/POLIO-2047

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)


## Changes

Added the admin panel to perform CRUD operations for the Performance thresholds module



## How to test

Go to `http://localhost:8081/admin/polio/performancethresholds/`
You can add, modify and Delete

## Print screen / video

Upload here print screens or videos showing the changes.


## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: POLIO-2047
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
