### PR TITLE
POLIO-2051: fix OR condition display

### DIFF
--- a/plugins/polio/js/src/domains/VaccineModule/PerformanceThresholds/hooks/useGetJsonLogicToString.ts
+++ b/plugins/polio/js/src/domains/VaccineModule/PerformanceThresholds/hooks/useGetJsonLogicToString.ts
@@ -9,7 +9,8 @@ export const useGetJSonLogicConverter = () => {
             if (!json) return '';
 
             const parsed = typeof json === 'string' ? JSON.parse(json) : json;
-            const value = parsed['and'];
+            const value = parsed['and'] ?? parsed['or'];
+            const connector = parsed['and'] ? 'AND' : 'OR';
             return value
                 ?.map((rule, index) => {
                     const operator = Object.keys(rule)[0];
@@ -21,7 +22,7 @@ export const useGetJSonLogicConverter = () => {
                     if (index === 0) {
                         return `value ${operator} ${rightHandValue}`;
                     }
-                    return ` & value ${operator} ${rightHandValue}`;
+                    return ` ${connector} value ${operator} ${rightHandValue}`;
                 })
                 .join('');
         },

--- a/plugins/polio/js/src/domains/VaccineModule/PerformanceThresholds/hooks/useGetJsonLogicToString.ts
+++ b/plugins/polio/js/src/domains/VaccineModule/PerformanceThresholds/hooks/useGetJsonLogicToString.ts
@@ -7,7 +7,6 @@ export const useGetJSonLogicConverter = () => {
     return useCallback(
         (json: string) => {
             if (!json) return '';
-
             const parsed = typeof json === 'string' ? JSON.parse(json) : json;
             const value = parsed['and'] ?? parsed['or'];
             const connector = parsed['and'] ? 'AND' : 'OR';


### PR DESCRIPTION
Conditions joined by OR were  not displayed

Related JIRA tickets : POLIO-2051

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes
- The code parsing the json value to convert it to readable string did not account for the `OR` operator (only handled ÀND`)

## How to test
- Go to polio> vaccine module> performance threshold
- create a threshold with the shape `condition1 OR condition2`
- it should be correctly displayed in the list and in the querybuilder

## Print screen / video

<img width="1708" height="1366" alt="Screenshot 2025-12-15 at 15 00 28" src="https://github.com/user-attachments/assets/12567b90-4675-4def-80be-755dc66facd3" />



