### PR TITLE
IA-4658: django admin show account name for form orgunit

### DIFF
--- a/iaso/admin/base.py
+++ b/iaso/admin/base.py
@@ -219,10 +219,6 @@ class OrgUnitAdmin(admin.GeoModelAdmin):
                 return first_project.account.name
             return "-"
 
-        # self.get_account_name.admin_order_field = "version__data_source__project_set__account__name"
-
-
-
     def get_queryset(self, request):
         queryset = super().get_queryset(request)
         queryset = queryset.prefetch_related("org_unit_type",
@@ -257,6 +253,7 @@ class FormAdmin(admin.GeoModelAdmin):
         "periods_before_allowed",
         "periods_after_allowed",
         "derived",
+        "get_account_names",
         "created_at",
         "updated_at",
         "deleted_at",
@@ -266,8 +263,14 @@ class FormAdmin(admin.GeoModelAdmin):
 
     list_filter = ["projects__account"]
 
+    @admin.display(description="Accounts")
+    def get_account_names(self, obj):
+        accounts = set(project.account.name for project in obj.projects.all())
+        return ",".join(sorted(accounts)) if accounts else "-"
+
+
     def get_queryset(self, request):
-        return Form.objects_include_deleted.all()
+        return Form.objects_include_deleted.all().prefetch_related("projects__account")
 
 
 @admin.register(FormVersion)

--- a/iaso/admin/base.py
+++ b/iaso/admin/base.py
@@ -196,7 +196,13 @@ class OrgUnitReferenceInstanceInline(admin.TabularInline):
 class OrgUnitAdmin(admin.GeoModelAdmin):
     raw_id_fields = ("parent", "reference_instances", "default_image")
     autocomplete_fields = ("creator", "org_unit_type", "version")
-    list_filter = ("org_unit_type", "custom", "validation_status", "sub_source", "version__data_source__projects__account")
+    list_filter = (
+        "org_unit_type",
+        "custom",
+        "validation_status",
+        "sub_source",
+        "version__data_source__projects__account",
+    )
     search_fields = ("name", "source_ref", "uuid")
     readonly_fields = ("path",)
     inlines = [
@@ -221,9 +227,9 @@ class OrgUnitAdmin(admin.GeoModelAdmin):
 
     def get_queryset(self, request):
         queryset = super().get_queryset(request)
-        queryset = queryset.prefetch_related("org_unit_type",
-                                             "parent__org_unit_type",
-                                             "version__data_source__projects__account")
+        queryset = queryset.prefetch_related(
+            "org_unit_type", "parent__org_unit_type", "version__data_source__projects__account"
+        )
         return queryset
 
 
@@ -267,7 +273,6 @@ class FormAdmin(admin.GeoModelAdmin):
     def get_account_names(self, obj):
         accounts = set(project.account.name for project in obj.projects.all())
         return ",".join(sorted(accounts)) if accounts else "-"
-
 
     def get_queryset(self, request):
         return Form.objects_include_deleted.all().prefetch_related("projects__account")


### PR DESCRIPTION
With the creation of demo accounts, we can have several “demo form” and/or “main org unit”  (cf screenshot of staging).  Adding the account would remove ambiguity

Related JIRA tickets : https://bluesquare.atlassian.net/browse/IA-4658


## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

For the OrgUnit model, I created a custom method `get_account_name` to display the account name by traversing the relationships OrgUnit -> SourceVersion -> DataSource -> Project -> Account and listed that method into the list_display

For Form, I also created a custom method `get_account_names` to display a set of account names associated with the forms
## How to test

Explain how to test your PR.

Go to `http://localhost:8081/admin/iaso/orgunit/` for OrgUnit
and `http://localhost:8081/admin/iaso/form/` for Form

## Print screen / video

Upload here print screens or videos showing the changes.

## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
