### PR TITLE
IA-4652: Fix looking up instances using JSONLogic with suffixed questions

### DIFF
--- a/iaso/models/instances.py
+++ b/iaso/models/instances.py
@@ -29,7 +29,7 @@ from django.utils.translation import gettext_lazy as _
 from iaso.utils import extract_form_version_id, flat_parse_xml_soup
 from iaso.utils.emoji import fix_emoji
 from iaso.utils.file_utils import get_file_type
-from iaso.utils.jsonlogic import instance_jsonlogic_to_q
+from iaso.utils.jsonlogic import annotate_suffixed_json_fields, instance_jsonlogic_to_q
 from iaso.utils.models.upload_to import get_account_name_based_on_user
 
 from ..utils.dhis2 import generate_id_for_dhis_2
@@ -331,7 +331,7 @@ class InstanceQuerySet(django_cte.CTEQuerySet):
 
         if json_content:
             q = instance_jsonlogic_to_q(jsonlogic=json_content, field_prefix="json__")
-            queryset = queryset.filter(q)
+            queryset = annotate_suffixed_json_fields(queryset, json_content, "json").filter(q)
 
         return queryset
 

--- a/iaso/tests/api/entities/test_entities.py
+++ b/iaso/tests/api/entities/test_entities.py
@@ -559,7 +559,7 @@ class WebEntityAPITestCase(EntityAPITestCase):
         ent1_instance1 = Instance.objects.create(
             org_unit=self.ou_country,
             form=self.form_1,
-            json={"gender": "F"},
+            json={"gender": "F", "age__int__": "28"},
         )
         ent1 = Entity.objects.create(
             name="Ent 1",
@@ -580,7 +580,7 @@ class WebEntityAPITestCase(EntityAPITestCase):
         ent2_instance1 = Instance.objects.create(
             org_unit=self.ou_country,
             form=self.form_1,
-            json={"gender": "M"},
+            json={"gender": "M", "age__int__": "56"},
         )
         ent2 = Entity.objects.create(
             name="Ent 1",
@@ -648,6 +648,25 @@ class WebEntityAPITestCase(EntityAPITestCase):
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.json()["result"]), 0)
+
+        # age is 56
+        response = self.client.get(
+            "/api/entities/",
+            {
+                "fields_search": json.dumps(
+                    {
+                        "some": [
+                            {"var": self.form_1.form_id},
+                            {"==": [{"var": "age__int__"}, 56]},
+                        ]
+                    }
+                )
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json()["result"]), 1)
+        the_result = response.json()["result"][0]
+        self.assertEqual(the_result["id"], ent2.id)
 
     def _generate_json_filter(self, operator, some_or_all, gender, residence):
         return json.dumps(

--- a/iaso/tests/api/entities/test_entity_types.py
+++ b/iaso/tests/api/entities/test_entity_types.py
@@ -457,6 +457,7 @@ class EntityTypeAPITestCase(APITestCase):
             "father_name": "Don Alejandro de la Vega",
             "age_type": 0,
             "birth_date": "1919-08-09",
+            "age__int__": 6,
             "gender": "male",
             "hc": "hc_C",
             "_version": "2022090601",
@@ -481,6 +482,7 @@ class EntityTypeAPITestCase(APITestCase):
             "father_name": "Professor Procyon",
             "age_type": 0,
             "birth_date": "1978-07-03",
+            "age__int__": 47,
             "gender": "male",
             "hc": "hc_C",
             "_version": "2022090601",
@@ -509,6 +511,19 @@ class EntityTypeAPITestCase(APITestCase):
 
         self.assertEqual(response_entity_instance[0]["id"], instance2.uuid)
         self.assertEqual(response_entity_instance[0]["json"], instance2.json)
+
+        json_content = json.dumps({"==": [{"var": "age__int__"}, 6]})
+        response = self.client.get(
+            f"/api/mobile/entitytypes/{entity_type.pk}/entities/",
+            {"json_content": json_content, "app_id": self.project.app_id},
+            format="json",
+        )
+        self.assertEqual(response.json()["count"], 1)
+
+        response_entity_instance = response.json()["results"][0]["instances"]
+
+        self.assertEqual(response_entity_instance[0]["id"], instance.uuid)
+        self.assertEqual(response_entity_instance[0]["json"], instance.json)
 
     def test_get_entities_by_entity_type_empty_list_deleted_instances(self):
         entity_type = EntityType.objects.create(

--- a/iaso/tests/api/instances/test_instances.py
+++ b/iaso/tests/api/instances/test_instances.py
@@ -747,7 +747,7 @@ class InstancesAPITestCase(TaskAPITestCase):
             period="202001",
             org_unit=self.jedi_council_corruscant,
             project=self.project,
-            json={"name": "a", "age": "18", "gender": "M"},
+            json={"name": "a", "age__int__": "18", "gender": "M"},
         )
 
         b = self.create_form_instance(
@@ -755,7 +755,7 @@ class InstancesAPITestCase(TaskAPITestCase):
             period="202001",
             org_unit=self.jedi_council_corruscant,
             project=self.project,
-            json={"name": "b", "age": "19", "gender": "F"},
+            json={"name": "b", "age__int__": "19", "gender": "F"},
         )
 
         self.create_form_instance(
@@ -763,11 +763,11 @@ class InstancesAPITestCase(TaskAPITestCase):
             period="202001",
             org_unit=self.jedi_council_corruscant,
             project=self.project,
-            json={"name": "c", "age": "30", "gender": "F"},
+            json={"name": "c", "age__int__": "30", "gender": "F"},
         )
 
         self.client.force_authenticate(self.yoda)
-        json_filters = json.dumps({"and": [{"==": [{"var": "gender"}, "F"]}, {"<": [{"var": "age"}, 25]}]})
+        json_filters = json.dumps({"and": [{"==": [{"var": "gender"}, "F"]}, {"<": [{"var": "age__int__"}, 25]}]})
         with self.assertNumQueries(6):
             response = self.client.get("/api/instances/", {"jsonContent": json_filters})
         self.assertJSONResponse(response, 200)


### PR DESCRIPTION
Due to the mobile application's need to assign a type to some calculated questions, the JSONField `Instance.json` might contain keys with a suffix like this: `__int__`. This collides with DRF's way to declare accessing sub-objects properties or even casting.


Related JIRA tickets : IA-4652

## Self proofreading checklist

- [X] Did I use eslint and ruff formatters?
- [X] Is my code clear enough and well documented?
- [X] Are there enough tests?

## Changes

The cleanest solution is to annotate the queryset to give those keys a name not containing `__`. 
After the query has been annotated, we can refer to that name and avoid any collisions.

I have added a method to annotate a queryset and I have changed how we access fields with `__` in their names.

## How to test

Search for an instance (or an entity) through a form which contains a suffixed question.

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
