### PR TITLE
IA-4665: N+1 on api/app/{app_id}

### DIFF
--- a/iaso/tests/api/test_apps.py
+++ b/iaso/tests/api/test_apps.py
@@ -176,6 +176,16 @@ class AppsAPITestCase(APITestCase):
         self.assertValidAppData(response_data)
         self.assertEqual(2, len(response_data["feature_flags"]))
 
+    def test_apps_retrieve_ok_queries_capped(self):
+        """Ensure app detail does not trigger N+1 on feature flags/forms."""
+
+        with self.assertNumQueries(3):
+            response = self.client.get(f"/api/apps/{self.project_2.app_id}/")
+            self.assertJSONResponse(response, 200)
+            response_data = response.json()
+            self.assertValidAppData(response_data)
+            self.assertEqual(2, len(response_data["feature_flags"]))
+
     def test_app_create_ok_with_auth(self):
         candidate_app = {
             "name": "This is a new app",


### PR DESCRIPTION
We have more than 5k event in sentry for this n+1 issue
Related JIRA tickets : IA-4665

## Self proofreading checklist

- [ ] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [x] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

-

## Changes

- fix the n+1
- test it

## How to test

Run the tests

## Print screen / video

Before:
<img width="561" height="116" alt="Screenshot 2025-12-18 at 10 35 29" src="https://github.com/user-attachments/assets/4afb8bed-f1e8-4bff-9003-f44eb7484524" />

After:
<img width="519" height="117" alt="Screenshot 2025-12-18 at 10 35 16" src="https://github.com/user-attachments/assets/896088de-0139-48e3-abf6-938f056c2a96" />


## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
