### PR TITLE
IA-4666: registry pop-up not open by default

### DIFF
--- a/hat/assets/js/apps/Iaso/components/dialogs/ConfirmCancelDialogComponent.tsx
+++ b/hat/assets/js/apps/Iaso/components/dialogs/ConfirmCancelDialogComponent.tsx
@@ -1,10 +1,10 @@
 import React, { FunctionComponent } from 'react';
 import { Button, DialogActions } from '@mui/material';
 import { makeStyles } from '@mui/styles';
+import { IntlMessage } from 'bluesquare-components';
 import { FormattedMessage } from 'react-intl';
 import DialogComponent from './DialogComponent';
 import MESSAGES from './messages';
-import { IntlMessage } from 'bluesquare-components';
 
 const useActionStyles = makeStyles(theme => ({
     action: {
@@ -100,6 +100,7 @@ type Props = {
         openDialog: () => void;
     }) => React.JSX.Element;
     children?: React.JSX.Element;
+    defaultOpen?: boolean;
 };
 
 /** @deprecated */
@@ -122,6 +123,7 @@ const ConfirmCancelDialogComponent: FunctionComponent<Props> = ({
     onOpen = () => {},
     children,
     titleMessage,
+    defaultOpen = false,
 }) => {
     return (
         <DialogComponent
@@ -145,9 +147,11 @@ const ConfirmCancelDialogComponent: FunctionComponent<Props> = ({
             onOpen={onOpen}
             onClosed={onClosed}
             renderTrigger={renderTrigger}
-            children={children}
             titleMessage={titleMessage}
-        />
+            defaultOpen={defaultOpen}
+        >
+            {children}
+        </DialogComponent>
     );
 };
 


### PR DESCRIPTION
When visit registry root url, org unit tree dialog should be opened by default if no org unit is selected
Related JIRA tickets : IA-4666

## Self proofreading checklist

- [ ] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

-

## Changes

Side effect of remove prop types PR, `defaultOpen`prop was missing

## How to test

Visit registry page, org unit selection popup should be opened

## Print screen / video

<img width="1583" height="890" alt="Screenshot 2025-12-19 at 15 38 58" src="https://github.com/user-attachments/assets/5d5c6a42-da8b-4f4f-8c6d-0966d2b1d516" />


## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
