### PR TITLE
IA-4652: Fix looking up instances using JSONLogic with suffixed questions

### DIFF
--- a/iaso/api/enketo.py
+++ b/iaso/api/enketo.py
@@ -52,6 +52,7 @@ def public_url_for_enketo(request: HttpRequest, path):
     # network are not the same that in the inside.
     if enketo_settings().get("ENKETO_DEV"):
         resolved_path = resolved_path.replace("localhost:8081", "iaso:8081")
+        resolved_path = resolved_path.replace("127.0.0.1:8081", "iaso:8081")
     return resolved_path
 
 

--- a/iaso/api/entity.py
+++ b/iaso/api/entity.py
@@ -224,7 +224,7 @@ class EntityViewSet(ModelViewSet):
             queryset = queryset.filter(attributes__org_unit__groups__in=groups.split(","))
 
         if fields_search:
-            q = entities_jsonlogic_to_q(json.loads(fields_search))
+            q, _ = entities_jsonlogic_to_q(json.loads(fields_search))
             queryset = queryset.filter(q)
 
         # location

--- a/iaso/models/instances.py
+++ b/iaso/models/instances.py
@@ -330,8 +330,9 @@ class InstanceQuerySet(django_cte.CTEQuerySet):
             queryset = queryset.filter(created_by__id__in=user_ids.split(","))
 
         if json_content:
-            q = instance_jsonlogic_to_q(jsonlogic=json_content, field_prefix="json__")
-            queryset = annotate_suffixed_json_fields(queryset, json_content, "json").filter(q)
+            q, _ = instance_jsonlogic_to_q(jsonlogic=json_content, field_prefix="json__")
+            queryset, _ = annotate_suffixed_json_fields(queryset, json_content, "json")
+            queryset = queryset.filter(q)
 
         return queryset
 

--- a/iaso/tests/api/instances/test_instances.py
+++ b/iaso/tests/api/instances/test_instances.py
@@ -767,7 +767,15 @@ class InstancesAPITestCase(TaskAPITestCase):
         )
 
         self.client.force_authenticate(self.yoda)
-        json_filters = json.dumps({"and": [{"==": [{"var": "gender"}, "F"]}, {"<": [{"var": "age__int__"}, 25]}]})
+        json_filters = json.dumps(
+            {
+                "and": [
+                    {"==": [{"var": "gender"}, "F"]},
+                    {">": [{"var": "age__int__"}, 15]},
+                    {"<": [{"var": "age__int__"}, 29]},
+                ]
+            }
+        )
         with self.assertNumQueries(6):
             response = self.client.get("/api/instances/", {"jsonContent": json_filters})
         self.assertJSONResponse(response, 200)
@@ -811,6 +819,43 @@ class InstancesAPITestCase(TaskAPITestCase):
         self.assertIn(a.id, received_instances_ids)
         self.assertIn(c.id, received_instances_ids)
         self.assertNotIn(b.id, received_instances_ids)
+
+    def test_instance_list_by_json_content_all_in(self):
+        """Check the particular check in logic for multiple answers"""
+        a = self.create_form_instance(
+            form=self.form_1,
+            period="202001",
+            org_unit=self.jedi_council_corruscant,
+            project=self.project,
+            json={"name": "a", "age": "18", "gender": "M", "list__test__": "1 2"},
+        )
+
+        b = self.create_form_instance(
+            form=self.form_1,
+            period="202001",
+            org_unit=self.jedi_council_corruscant,
+            project=self.project,
+            json={"name": "b", "age": "19", "gender": "F", "list__test__": "2 3"},
+        )
+
+        c = self.create_form_instance(
+            form=self.form_1,
+            period="202001",
+            org_unit=self.jedi_council_corruscant,
+            project=self.project,
+            json={"name": "c", "age": 30, "gender": "F", "list__test__": "3 4"},
+        )
+
+        self.client.force_authenticate(self.yoda)
+        json_filters = json.dumps({"some": [{"var": "list__test__"}, {"in": [{"var": ""}, ["2"]]}]})
+        response = self.client.get("/api/instances/", {"jsonContent": json_filters})
+
+        response_json = response.json()
+        # We should receive the a and b, but not the c (because it doesn't contain 2)
+        received_instances_ids = [instance["id"] for instance in response_json["instances"]]
+        self.assertIn(a.id, received_instances_ids)
+        self.assertIn(b.id, received_instances_ids)
+        self.assertNotIn(c.id, received_instances_ids)
 
     def test_instance_list_by_json_content_nested(self):
         """Search using the instance content (in JSON field) with nested and/or operators"""

--- a/iaso/tests/utils/test_jsonlogic.py
+++ b/iaso/tests/utils/test_jsonlogic.py
@@ -119,19 +119,19 @@ class JsonLogicTests(TestCase):
     def test_jsonlogic_to_q_filters_base(self) -> None:
         """The base case of jsonlogic_to_q works as expected."""
         filters = {"and": [{"==": [{"var": "gender"}, "F"]}, {"<": [{"var": "age"}, "25"]}]}
-        q = jsonlogic_to_q(filters)
+        q, _ = jsonlogic_to_q(filters)
         self.assertEqual(str(q), "(AND: ('gender__exact', 'F'), ('age__lt', '25'))")
 
     def test_jsonlogic_to_q_filters_not(self) -> None:
         """The not operator works as expected"""
         filters = {"!": {"and": [{"==": [{"var": "gender"}, "F"]}, {"<": [{"var": "age"}, "25"]}]}}
-        q = jsonlogic_to_q(filters)
+        q, _ = jsonlogic_to_q(filters)
         self.assertEqual(str(q), "(NOT (AND: ('gender__exact', 'F'), ('age__lt', '25')))")
 
     def test_jsonlogic_to_q_filters_field_prefix(self) -> None:
         """The field_prefix argument is taken into account."""
         filters = {"and": [{"==": [{"var": "gender"}, "F"]}, {"<": [{"var": "age"}, "25"]}]}
-        q = jsonlogic_to_q(filters, field_prefix="content__")
+        q, _ = jsonlogic_to_q(filters, field_prefix="content__")
         self.assertEqual(str(q), "(AND: ('content__gender__exact', 'F'), ('content__age__lt', '25'))")
 
     def test_jsonlogic_to_q_filters_field_recursive(self) -> None:
@@ -143,7 +143,7 @@ class JsonLogicTests(TestCase):
             ],
         }
 
-        q = jsonlogic_to_q(filters)
+        q, _ = jsonlogic_to_q(filters)
         self.assertEqual(str(q), "(AND: ('gender__exact', 'F'), (OR: ('age__exact', '20'), ('age__exact', '30')))")
 
     def test_jsonlogic_to_q_filters_field_valueerror(self) -> None:
@@ -165,7 +165,7 @@ class JsonLogicTests(TestCase):
             ],
         }
 
-        q = jsonlogic_to_q(filters)
+        q, _ = jsonlogic_to_q(filters)
         self.assertEqual(
             str(q),
             "(AND: ('var1__exact', 1), (NOT (AND: ('var2__exact', 1))), ('var3__gt', 1), ('var4__gte', 1), ('var5__lt', 1), ('var6__lte', 1))",
@@ -175,35 +175,35 @@ class JsonLogicTests(TestCase):
 class JsonLogicSomeAllStringFieldTests(TestCase):
     def test_some_operator_all_values_present(self):
         filters = {"some": [{"var": "colors"}, {"in": [{"var": ""}, ["red", "blue"]]}]}
-        q = instance_jsonlogic_to_q(filters)
+        q, _ = instance_jsonlogic_to_q(filters)
         self.assertEqual(str(q), "(AND: ('colors__icontains', 'red'), ('colors__icontains', 'blue'))")
 
     def test_some_operator_three_values_present(self):
         filters = {"some": [{"var": "colors"}, {"in": [{"var": ""}, ["red", "blue", "green"]]}]}
-        q = instance_jsonlogic_to_q(filters)
+        q, _ = instance_jsonlogic_to_q(filters)
         self.assertEqual(
             str(q), "(AND: ('colors__icontains', 'red'), ('colors__icontains', 'blue'), ('colors__icontains', 'green'))"
         )
 
     def test_some_operator_no_match(self):
         filters = {"some": [{"var": "colors"}, {"in": [{"var": ""}, ["yellow", "green"]]}]}
-        q = instance_jsonlogic_to_q(filters)
+        q, _ = instance_jsonlogic_to_q(filters)
         self.assertEqual(str(q), "(AND: ('colors__icontains', 'yellow'), ('colors__icontains', 'green'))")
 
     def test_all_operator_exact_match(self):
         filters = {"all": [{"var": "colors"}, {"in": [{"var": ""}, ["red", "blue", "orange"]]}]}
-        q = instance_jsonlogic_to_q(filters)
+        q, _ = instance_jsonlogic_to_q(filters)
         pattern = r"^blue orange red$"
         self.assertEqual(str(q), f"(AND: ('colors__regex', '{pattern}'))")
 
     def test_all_operator_extra_value(self):
         filters = {"all": [{"var": "colors"}, {"in": [{"var": ""}, ["red", "blue"]]}]}
-        q = instance_jsonlogic_to_q(filters)
+        q, _ = instance_jsonlogic_to_q(filters)
         pattern = r"^blue red$"
         self.assertEqual(str(q), f"(AND: ('colors__regex', '{pattern}'))")
 
     def test_all_operator_single_value(self):
         filters = {"all": [{"var": "colors"}, {"in": [{"var": ""}, ["red"]]}]}
-        q = instance_jsonlogic_to_q(filters)
+        q, _ = instance_jsonlogic_to_q(filters)
         pattern = r"^red$"
         self.assertEqual(str(q), f"(AND: ('colors__regex', '{pattern}'))")


### PR DESCRIPTION
Due to the mobile application's need to assign a type to some calculated questions, the JSONField `Instance.json` might contain keys with a suffix like this: `__int__`. This collides with DRF's way to declare accessing sub-objects properties or even casting.

The cleanest solution is to annotate the queryset to give those keys a name not containing `__`. After the query has been annotated, we can refer to that name and avoid any collisions.

IA-4652

What problem is this PR solving? Explain here in one sentence.

Related JIRA tickets : IA-4652

## Self proofreading checklist

- [ ] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

Explain the changes that were made.

The idea is not to list exhaustively all the changes made (GitHub already provides a full diff), but to help the reviewers better understand:

- which specific file changes go together, e.g: when creating a table in the front-end, there usually is a config file that goes with it
- the reasoning behind some changes, e.g: deleted files because they are now redundant
- the behaviour to expect, e.g: tooltip has purple background color because the client likes it so, changed a key in the API response to be consistent with other endpoints

## How to test

Explain how to test your PR.

If a specific config is required explain it here: dataset, account, profile, etc.

## Print screen / video

Upload here print screens or videos showing the changes.

## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
