### PR TITLE
IA-4677: Fix unnecessary annotations with form possible_fields

### DIFF
--- a/iaso/api/forms.py
+++ b/iaso/api/forms.py
@@ -316,7 +316,7 @@ class FormsViewSet(ModelViewSet):
         requested_fields = self.request.query_params.get("fields")
 
         is_request_from_manifest = self.request.path.endswith("/manifest/")
-        default_order = "id" if is_request_from_manifest else "instance_updated_at"
+        default_order = "id" if is_request_from_manifest or self.action == "retrieve" else "instance_updated_at"
 
         order = self.request.query_params.get("order", default_order).split(",")
 


### PR DESCRIPTION

refs: IA-4677

This fixes a performance issue with the `/api/forms/20/?fields=possible_fields` endpoint, where unnecessary annotations (last instance and instance count) were performed but not used in the response. 


## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [ ] ~~Are my typescript files well typed?~~
- [ ] ~~New translations have been added or updated if new strings have been introduced in the frontend~~
- [ ] ~~My migrations file are included~~
- [ ] Are there enough tests?
- [ ] ~~Documentation has been included (for new feature)~~

## Doc

/ 

## Changes

- Set the default ordering to `id` for the details action, avoiding the more expensive annotations.

## How to test

Try pages related to the form endpoint to see if they don't throw exceptions: 
- Test the Entity details page
- Test the Form list page
    - Test the csv/xlsx exports 
- Test the Form details page
- Test the Form Submissions page, and check that the form dropdown is not broken

If a specific config is required explain it here: dataset, account, profile, etc.

## Print screen / video

/ 

## Notes

I'm not 100% sure about the /manifest/ or /manifest_enketo/ endpoints, that could be affected by this change but I couldn't test with real data.

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
