### PR TITLE
SNT-182: Hide logo from template if url not set

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/app/components/LogoAndTitle.tsx
+++ b/hat/assets/js/apps/Iaso/domains/app/components/LogoAndTitle.tsx
@@ -1,8 +1,7 @@
-import React, { FunctionComponent, useContext, useMemo } from 'react';
+import React, { FunctionComponent, useContext } from 'react';
 import { Box, Theme } from '@mui/material';
 
 import { ThemeConfigContext } from '../contexts/ThemeConfigContext';
-import { LogoSvg } from './LogoSvg';
 import { Logo } from './Logo';
 
 const styles = {

--- a/hat/templates/iaso/disabled_password_login.html
+++ b/hat/templates/iaso/disabled_password_login.html
@@ -5,9 +5,11 @@
 {% block body %}
 <div class="auth__container iasologin">
   <div class="auth__content">
-    <header class="auth__header">
-      <h1 class="auth__heading"> <img alt="logo" src="{% static logo_path %}" /></h1>
-    </header>
+    {% if logo_path %}
+      <header class="auth__header">
+        <h1 class="auth__heading"> <img alt="logo" src="{% static logo_path %}" /></h1>
+      </header>
+    {% endif %}
     <div>
       {% get_providers as socialaccount_providers %}
       {% for provider in socialaccount_providers %}

--- a/hat/templates/iaso/forgot_password.html
+++ b/hat/templates/iaso/forgot_password.html
@@ -3,9 +3,11 @@
 {% load static %}
 {% block body %}
   <div class="auth__container">
-    <header class="auth__header">
-      <h1 class="auth__heading"> <img alt="logo" src="{% static logo_path %}" /></h1>
-    </header>
+    {% if logo_path %}
+      <header class="auth__header">
+        <h1 class="auth__heading"> <img alt="logo" src="{% static logo_path %}" /></h1>
+      </header>
+    {% endif %}
     <div class="auth__content">
       <form method="post" class="auth__form">
         {% csrf_token %}

--- a/hat/templates/iaso/forgot_password_confirmation.html
+++ b/hat/templates/iaso/forgot_password_confirmation.html
@@ -3,9 +3,11 @@
 {% load static %}
 {% block body %}
   <div class="auth__container">
-    <header class="auth__header">
-      <h1 class="auth__heading"> <img alt="logo" src="{% static logo_path %}" /></h1>
-    </header>
+    {% if logo_path %}
+      <header class="auth__header">
+        <h1 class="auth__heading"> <img alt="logo" src="{% static logo_path %}" /></h1>
+      </header>
+    {% endif %}
     <div class="auth__content">
       <div class="auth__message">
         <p>{% trans "We've emailed you instructions for setting your password, if an account exists with the email you entered. You should receive them shortly." %}</p>

--- a/hat/templates/iaso/reset_password_complete.html
+++ b/hat/templates/iaso/reset_password_complete.html
@@ -3,9 +3,11 @@
 {% load static %}
 {% block body %}
 <div class="auth__container">
-  <header class="auth__header">
-    <h1 class="auth__heading"> <img alt="logo" src="{% static logo_path %}" /></h1>
-  </header>
+  {% if logo_path %}
+    <header class="auth__header">
+      <h1 class="auth__heading"> <img alt="logo" src="{% static logo_path %}" /></h1>
+    </header>
+  {% endif %}
   <div class="auth__content">
     <div class="auth__message">
       <p>

--- a/hat/templates/iaso/reset_password_confirmation.html
+++ b/hat/templates/iaso/reset_password_confirmation.html
@@ -3,9 +3,11 @@
 {% load static %}
 {% block body %}
   <div class="auth__container">
-      <header class="auth__header">
-        <h1 class="auth__heading"> <img alt="logo" src="{% static logo_path %}" /></h1>
-      </header>
+      {% if logo_path %}
+        <header class="auth__header">
+          <h1 class="auth__heading"> <img alt="logo" src="{% static logo_path %}" /></h1>
+        </header>
+      {% endif %}
       {% if form %}
         <div class="auth__content">
           


### PR DESCRIPTION
Logo should not be displayed if no logo url is set.

Related JIRA tickets : SNT-182

## Self proofreading checklist

- [ ] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

N/A

## Changes

Display logo on template pages (login, reset password, etc...) only if we have a logo URL to prevent ugly place older to be shown.

## How to test

Easiest way is to activate snt_malaria config (no logo url is defined yet) and do the reset password flow.
No logo should be shown and not place holder neither.

## Print screen / video

<img width="376" height="294" alt="image" src="https://github.com/user-attachments/assets/fa7b5cc9-cc41-483c-905c-3635ea8a78c4" />

## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
