### PR TITLE
SNT-179: Lock a scenario - accept icon button on Confirmation modal

### DIFF
--- a/hat/assets/js/apps/Iaso/components/dialogs/ConfirmDialogComponent.tsx
+++ b/hat/assets/js/apps/Iaso/components/dialogs/ConfirmDialogComponent.tsx
@@ -1,6 +1,6 @@
 import React, { Fragment, FunctionComponent, ReactNode } from 'react';
 
-import { Box, Button, Tooltip } from '@mui/material';
+import { Box, Button, IconButton, Tooltip } from '@mui/material';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
@@ -13,6 +13,7 @@ import MESSAGES from './messages';
 
 type Props = {
     btnMessage: string;
+    BtnIcon?: React.ElementType;
     message: string | ReactNode;
     question: string | ReactNode;
     confirm: () => void;
@@ -27,6 +28,7 @@ type Props = {
 
 const ConfirmDialog: FunctionComponent<Props> = ({
     btnMessage,
+    BtnIcon,
     message,
     question,
     confirm,
@@ -56,15 +58,27 @@ const ConfirmDialog: FunctionComponent<Props> = ({
         <>
             <Tooltip title={tooltipMessage}>
                 <Box>
-                    <Button
-                        variant={btnVariant}
-                        size={btnSize}
-                        color="primary"
-                        disabled={btnDisabled}
-                        onClick={() => handleClickOpen()}
-                    >
-                        {btnMessage}
-                    </Button>
+                    {BtnIcon ? (
+                        <Tooltip title={tooltipMessage}>
+                            <IconButton
+                                disabled={btnDisabled}
+                                color="primary"
+                                onClick={() => handleClickOpen()}
+                            >
+                                <BtnIcon></BtnIcon>
+                            </IconButton>
+                        </Tooltip>
+                    ) : (
+                        <Button
+                            variant={btnVariant}
+                            size={btnSize}
+                            color="primary"
+                            disabled={btnDisabled}
+                            onClick={() => handleClickOpen()}
+                        >
+                            {btnMessage}
+                        </Button>
+                    )}
                 </Box>
             </Tooltip>
             <Dialog

--- a/requirements.txt
+++ b/requirements.txt
@@ -156,4 +156,4 @@ azure-storage-blob==12.19.0
 
 # SNT Malaria plugin.
 # ------------------------------------------------------------------------------
-snt-malaria-budgeting==0.5.0
+snt-malaria-budgeting==0.5.1


### PR DESCRIPTION
Accept icon button on ConfirmationModal

Related JIRA tickets : SNT-179

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [x] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

N/A

## Changes

Add a new property on ConfirmationModal that will render an icon button instead of a button.

## How to test

It should not impact default behavior.
Check related PR for SNT malaria which uses this new property and verify that the icon button behaves properly.

## Print screen / video

/

## Notes

Related SNT Malaria PR: https://github.com/BLSQ/snt-malaria/pull/158

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
