### PR TITLE
POLIO-2068: ensure lqas api returns campaign_id

### DIFF
--- a/plugins/polio/api/lqas_im/lqasim_global_map.py
+++ b/plugins/polio/api/lqas_im/lqasim_global_map.py
@@ -89,6 +89,7 @@ class LQASIMGlobalMapViewSet(LqasAfroViewset):
                     "id": int(country_id),
                     "data": {
                         "campaign": latest_active_campaign.obr_name,
+                        "campaign_id": str(latest_active_campaign.id),
                         **stats,
                         "country_name": org_unit.name,
                         "round_number": round_number,
@@ -103,7 +104,11 @@ class LQASIMGlobalMapViewSet(LqasAfroViewset):
             else:
                 result = {
                     "id": int(country_id),
-                    "data": {"campaign": latest_active_campaign.obr_name, "country_name": org_unit.name},
+                    "data": {
+                        "campaign": latest_active_campaign.obr_name,
+                        "campaign_id": str(latest_active_campaign.id),
+                        "country_name": org_unit.name,
+                    },
                     "geo_json": shapes,
                     "status": LQASStatus.InScope,
                 }

--- a/plugins/polio/api/lqas_im/lqasim_zoom_in_map.py
+++ b/plugins/polio/api/lqas_im/lqasim_zoom_in_map.py
@@ -177,6 +177,7 @@ class LQASIMZoominMapViewSet(LqasAfroViewset):
                         "id": district.id,
                         "data": {
                             "campaign": latest_active_campaign.obr_name,
+                            "campaign_id": str(latest_active_campaign.id),
                             **district_stats,
                             "district_name": district.name,
                             "round_number": round_number,
@@ -192,6 +193,7 @@ class LQASIMZoominMapViewSet(LqasAfroViewset):
                         "id": district.id,
                         "data": {
                             "campaign": latest_active_campaign.obr_name,
+                            "campaign_id": str(latest_active_campaign.id),
                             "district_name": district.name,
                             "region_name": district.parent.name,
                         },

--- a/plugins/polio/tests/test_lqas_map.py
+++ b/plugins/polio/tests/test_lqas_map.py
@@ -450,6 +450,7 @@ class PolioLqasAfroMapTestCase(APITestCase):
         )
         self.assertTrue(results_for_first_country is not None)
         self.assertEqual(results_for_first_country["data"]["campaign"], self.campaign_1.obr_name)
+        self.assertEqual(results_for_first_country["data"]["campaign_id"], str(self.campaign_1.id))
         self.assertEqual(len(results_for_first_country["data"]["rounds"]), self.campaign_1.rounds.count())
         self.assertEqual(
             results_for_first_country["data"]["rounds"][0]["data"],
@@ -647,6 +648,7 @@ class PolioLqasAfroMapTestCase(APITestCase):
         )
         self.assertTrue(results_for_first_district is not None)
         self.assertEqual(results_for_first_district["data"]["campaign"], self.campaign_1.obr_name)
+        self.assertEqual(results_for_first_district["data"]["campaign_id"], str(self.campaign_1.id))
         self.assertEqual(
             results_for_first_district["data"]["district_name"],
             self.district_org_unit_1.name,


### PR DESCRIPTION
Link from lqas afro map to lqas country view was broken because some shapes had no campaign_id

Related JIRA tickets : POLIO-2068

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

- ensured the shapes returned by the lqas afro map api always have a `campaign_id`

## How to test

Go to Afro map, click a shape with no data (grey)
follow link
Try with both country and district view ( you need to zoom in for the district view to "kick in")

## Print screen / video



https://github.com/user-attachments/assets/a959604a-d79a-4cd1-9dad-7c0088741305


