### PR TITLE
IA-4321: Add User-Agent information to `json_body` for BulkUploads

### DIFF
--- a/iaso/api/mobile/bulk_uploads.py
+++ b/iaso/api/mobile/bulk_uploads.py
@@ -87,7 +87,9 @@ class MobileBulkUploadsViewSet(ViewSet):
                 user=user,
                 import_type="bulk",
                 file=zip_file,
-                json_body={},
+                json_body={
+                    "user_agent": request.META.get("HTTP_USER_AGENT"),
+                },
             )
 
             process_mobile_bulk_upload(

--- a/iaso/tests/api/test_mobile_bulkuploads.py
+++ b/iaso/tests/api/test_mobile_bulkuploads.py
@@ -31,6 +31,7 @@ class MobileBulkUploadsAPITestCase(APITestCase):
             f"{BASE_URL}?app_id={APP_ID}",
             {"zip_file": SimpleUploadedFile(file_name, b"Some file content")},
             format="multipart",
+            HTTP_USER_AGENT="my_user_agent",
         )
         self.assertJSONResponse(response, 204)
 
@@ -39,6 +40,8 @@ class MobileBulkUploadsAPITestCase(APITestCase):
         self.assertEqual(api_import.import_type, "bulk")
         self.assertFalse(api_import.has_problem)
         self.assertIsNotNone(api_import.file)
+        self.assertIn("user_agent", api_import.json_body)
+        self.assertEqual(api_import.json_body["user_agent"], "my_user_agent")
 
         expected_file_name = api_import_upload_to(api_import, file_name)
         self.assertEqual(api_import.file.name, expected_file_name)
@@ -53,6 +56,7 @@ class MobileBulkUploadsAPITestCase(APITestCase):
             f"{BASE_URL}?app_id={APP_ID}",
             {"zip_file": SimpleUploadedFile("file.zip", b"Some file content")},
             format="multipart",
+            HTTP_USER_AGENT="my_user_agent",
         )
         self.assertJSONResponse(response, 204)
 
@@ -61,6 +65,8 @@ class MobileBulkUploadsAPITestCase(APITestCase):
         self.assertEqual(api_import.import_type, "bulk")
         self.assertFalse(api_import.has_problem)
         self.assertIsNotNone(api_import.file)
+        self.assertIn("user_agent", api_import.json_body)
+        self.assertEqual(api_import.json_body["user_agent"], "my_user_agent")
 
         task = Task.objects.last()
         self.assertEqual(task.created_by, None)


### PR DESCRIPTION
When bulk uploads files are received, we lose some information about the mobile app that created it. 
This stores the User-Agent information which contains information about the phone and the mobile app.

```kotlin
"Iaso/${BuildConfig.VERSION_NAME} (" +
                "${BuildConfig.APPLICATION_ID}; " +
                "flavor:${BuildConfig.FLAVOR};  " +
                "build:${BuildConfig.VERSION_CODE}; " +
                "Android ${Build.VERSION.RELEASE} [${Build.VERSION.SDK_INT}]" +
                ") ${OkHttp.VERSION}"
```

Related JIRA tickets : IA-4321

## Self proofreading checklist

- [X] Did I use eslint and ruff formatters?
- [X] Is my code clear enough and well documented?
- [X] Are there enough tests?

## Changes

We now store the `request.META.get("HTTP_USER_AGENT")` value in the  `APIImport` object's `json_body`.

## How to test

Send a zip file through the mobile app and check that the user agent was correctly saved.

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
