### PR TITLE
IA-4693: Fix application crashes when the OrgUnit list is the landing page

### DIFF
--- a/hat/assets/js/apps/Iaso/hooks/useGetColors.ts
+++ b/hat/assets/js/apps/Iaso/hooks/useGetColors.ts
@@ -32,14 +32,15 @@ export const getColor = (
     i: number,
     colors?: string[],
     usedColors?: string[],
+    defaultColor: string = 'transparent',
 ): string => {
-    if (!colors) return 'transparent';
-    if (colors.length === 0) return 'transparent';
+    if (!colors) return defaultColor;
+    if (colors.length === 0) return defaultColor;
 
     const availableColors = colors.filter(
         color => !usedColors?.includes(color),
     );
-    if (availableColors.length === 0) return 'transparent';
+    if (availableColors.length === 0) return defaultColor;
 
     return availableColors[i % availableColors.length];
 };

--- a/hat/assets/js/apps/Iaso/routing/utils.ts
+++ b/hat/assets/js/apps/Iaso/routing/utils.ts
@@ -20,6 +20,11 @@ export const getOrgUnitsUrl = (
             searches: `[{"validation_status":"all", "color":"${getColor(
                 0,
                 colors,
+                [],
+                // It's possible colors is empty when we arrive here.
+                // If that's the case `getColor` will return 'transparent' by default which will crash later when React tries to
+                // parse `#transparent`. Therefore, it's best to hardcode a different value here.
+                '#42a5f5',
             ).replace('#', '')}"}]`,
         },
         '',


### PR DESCRIPTION
When a user has only the OrgUnit management rights, their landing page is the OrgUnit list. When this happens, they are redirected to a page that crashes due to an incorrect color.

Related JIRA tickets : IA-4693

## Self proofreading checklist

- [X] Did I use eslint and ruff formatters?
- [X] Is my code clear enough and well documented?
- [X] Are my typescript files well typed?

## Changes

I have changed `getColor` to take an optional default color and used that default optional color in the routing.

## How to test

Create a user with only the "Organisation units management" and log in with that user. It should not crash.

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
