### PR TITLE
IA-4689: diff-file-displays-empty-code-value-as-modified-for-new-ou

### DIFF
--- a/iaso/diffing/comparisons.py
+++ b/iaso/diffing/comparisons.py
@@ -26,12 +26,22 @@ class NameFieldType(FieldType):
             return None
         return org_unit.name
 
+    def is_same(self, value, other_value):
+        normalized_value = None if (value is None or value == "") else value
+        normalized_other = None if (other_value is None or other_value == "") else other_value
+        return normalized_value == normalized_other
+
 
 class CodeFieldType(FieldType):
     def access(self, org_unit):
         if org_unit is None:
             return None  # code is not nullable, but we return None to differentiate a blank code from a missing orgunit
         return org_unit.code
+
+    def is_same(self, value, other_value):
+        normalized_value = None if (value is None or value == "") else value
+        normalized_other = None if (other_value is None or other_value == "") else other_value
+        return normalized_value == normalized_other
 
 
 class GeometryFieldType(FieldType):


### PR DESCRIPTION
IA-4689: Treat None and empty string as the same for NameFieldType 
Related JIRA tickets : IA-4689

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?

## Changes


Added is_same() method to overrides  NameFieldType and CodeFieldType


## How to test

- Create an org unit in one source with empty code and name fields
- Create a new org unit in another source with missing name fields
- Run diff comparison between the two versions
- Verify that name and code fields show as "same" in the diff output


