### PR TITLE
WC2-866: ETL Nigeria Failing

### DIFF
--- a/plugins/wfp/admin.py
+++ b/plugins/wfp/admin.py
@@ -137,7 +137,7 @@ class MonthlyStatisticsAdmin(admin.ModelAdmin):
 
 
 @admin.register(Dhis2SyncResults)
-class Dhis2SyncResults(admin.ModelAdmin):
+class Dhis2SyncResultsAdmin(admin.ModelAdmin):
     list_display = (
         "id",
         "org_unit_dhis2_id",
@@ -156,7 +156,7 @@ class Dhis2SyncResults(admin.ModelAdmin):
     search_fields = (
         "account__name",
         "org_unit_dhis2_id",
-        "org_unit__id",
+        "org_unit_id",
         "data_set_id",
         "period",
         "year__icontains",

--- a/plugins/wfp/common.py
+++ b/plugins/wfp/common.py
@@ -511,7 +511,7 @@ class ETL:
             quantity = step.get("quantity", 0)
             ration_type = ""
             if step.get("_total_number_of_sachets") is not None and step.get("_total_number_of_sachets") != "":
-                quantity = step.get("_total_number_of_sachets", 0)
+                quantity = step.get("_total_number_of_sachets")
             elif step.get("_csb_packets") is not None:
                 quantity = step.get("_csb_packets", 0)
 
@@ -570,9 +570,21 @@ class ETL:
             ):
                 quantity = 0
                 ration_size = step.get("ration_size", step.get("ration_limit"))
-            else:
-                if step.get("_total_number_of_sachets_rutf") == "" or step.get("_total_number_of_sachets") == "":
+            elif step.get("ration_type") in ["rusf", "rutf"]:
+                if (
+                    step.get("_total_number_of_sachets") == ""
+                    or step.get("_total_number_of_sachets") == "."
+                    or (
+                        step.get("_total_number_of_sachets_rutf") is not None
+                        and (
+                            step.get("_total_number_of_sachets_rutf") == ""
+                            or step.get("_total_number_of_sachets_rutf") == "."
+                        )
+                    )
+                ):
                     quantity = 0
+                else:
+                    quantity = step.get("_total_number_of_sachets", step.get("_total_number_of_sachets_rutf", quantity))
             assistance = {
                 "type": step.get("ration_type", step.get("ration")),
                 "quantity": quantity,

--- a/plugins/wfp/common.py
+++ b/plugins/wfp/common.py
@@ -990,7 +990,7 @@ class ETL:
             MonthlyStatistics.objects.prefetch_related("account", "org_unit")
             .values()
             .filter(account=account)
-            .filter(org_unit_id__in=[758, 622, 43])
+            .filter(org_unit__source_ref__isnull=False)
         )
         journey_by_org_units = groupby(list(monthlyStatistics), key=itemgetter("org_unit_id"))
         dhis2_aggregated_data = []

--- a/plugins/wfp/tasks.py
+++ b/plugins/wfp/tasks.py
@@ -46,8 +46,11 @@ def etl_ng(all_data=None):
     logger.info(
         f"----------------------------- Aggregating journey for {account} per org unit, admission and period(month and year) -----------------------------"
     )
-    MonthlyStatistics.objects.filter(account=account, programme_type="U5").delete()
-    ETL().journey_with_visit_and_steps_per_visit(account, "U5")
+    org_units_with_updated_data = ETL([entity_type_U5_code]).get_org_unit_ids_with_updated_data(last_success_task_date)
+    MonthlyStatistics.objects.filter(
+        account=account, programme_type="U5", org_unit_id__in=org_units_with_updated_data
+    ).delete()
+    ETL().journey_with_visit_and_steps_per_visit(account, "U5", org_units_with_updated_data)
     entity_type_pbwg_code = "nigeria_pbwg"
     pbwg_account = ETL([entity_type_pbwg_code]).account_related_to_entity_type()
     updated_pbwg_beneficiaries = ETL([entity_type_pbwg_code]).get_updated_entity_ids(last_success_task_date)
@@ -56,8 +59,10 @@ def etl_ng(all_data=None):
     logger.info(
         f"----------------------------- Aggregating PBWG journey for {pbwg_account} per org unit, admission and period(month and year) -----------------------------"
     )
-    MonthlyStatistics.objects.filter(account=pbwg_account, programme_type="PLW").delete()
-    ETL().journey_with_visit_and_steps_per_visit(pbwg_account, "PLW")
+    MonthlyStatistics.objects.filter(
+        account=pbwg_account, programme_type="PLW", org_unit_id__in=org_units_with_updated_data
+    ).delete()
+    ETL().journey_with_visit_and_steps_per_visit(pbwg_account, "PLW", org_units_with_updated_data)
 
 
 @shared_task()
@@ -86,8 +91,11 @@ def etl_ssd(all_data=None):
     logger.info(
         f"----------------------------- Aggregating Children under 5 journey for {child_account} per org unit, admission and period(month and year) -----------------------------"
     )
-    MonthlyStatistics.objects.filter(account=child_account, programme_type="U5").delete()
-    ETL().journey_with_visit_and_steps_per_visit(child_account, "U5")
+    org_units_with_updated_data = ETL([entity_type_U5_code]).get_org_unit_ids_with_updated_data(last_success_task_date)
+    MonthlyStatistics.objects.filter(
+        account=child_account, programme_type="U5", org_unit_id__in=org_units_with_updated_data
+    ).delete()
+    ETL().journey_with_visit_and_steps_per_visit(child_account, "U5", org_units_with_updated_data)
 
     entity_type_pbwg_code = "ssd_pbwg"
     pbwg_account = ETL([entity_type_pbwg_code]).account_related_to_entity_type()
@@ -97,8 +105,11 @@ def etl_ssd(all_data=None):
     logger.info(
         f"----------------------------- Aggregating PBWG journey for {pbwg_account} per org unit, admission and period(month and year) -----------------------------"
     )
-    MonthlyStatistics.objects.filter(account=pbwg_account, programme_type="PLW").delete()
-    ETL().journey_with_visit_and_steps_per_visit(pbwg_account, "PLW")
+
+    MonthlyStatistics.objects.filter(
+        account=pbwg_account, programme_type="PLW", org_unit_id__in=org_units_with_updated_data
+    ).delete()
+    ETL().journey_with_visit_and_steps_per_visit(pbwg_account, "PLW", org_units_with_updated_data)
 
     external_credential = ExternalCredentials.objects.filter(account=pbwg_account).first()
     if external_credential is not None and (
@@ -106,7 +117,7 @@ def etl_ssd(all_data=None):
         and external_credential.login is not None
         and external_credential.password is not None
     ):
-        ETL().aggregating_data_to_push_to_dhis2(pbwg_account)
+        ETL().aggregating_data_to_push_to_dhis2(pbwg_account, org_units_with_updated_data)
         pushed_data = Dhis2().save_dhis2_sync_results(entity_type_pbwg_code, external_credential)
         logger.info(
             f"----------------------------- Pushed to DHIS2 on U5 and PBW for {len(pushed_data)} rows aggregated per year and month -----------------------------"
@@ -143,8 +154,11 @@ def etl_ethiopia(all_data=None):
     logger.info(
         f"----------------------------- Aggregating Children under 5 journey for {child_account} per org unit, admission and period(month and year) -----------------------------"
     )
-    MonthlyStatistics.objects.filter(account=child_account, programme_type="U5").delete()
-    ETL().journey_with_visit_and_steps_per_visit(child_account, "U5")
+    org_units_with_updated_data = ETL([entity_type_U5_code]).get_org_unit_ids_with_updated_data(last_success_task_date)
+    MonthlyStatistics.objects.filter(
+        account=child_account, programme_type="U5", org_unit_id__in=org_units_with_updated_data
+    ).delete()
+    ETL().journey_with_visit_and_steps_per_visit(child_account, "U5", org_units_with_updated_data)
 
     entity_type_pbwg_code = "ethiopia_pbwg"
     pbwg_account = ETL([entity_type_pbwg_code]).account_related_to_entity_type()
@@ -155,5 +169,7 @@ def etl_ethiopia(all_data=None):
     logger.info(
         f"----------------------------- Aggregating PBWG journey for {pbwg_account} per org unit, admission and period(month and year) -----------------------------"
     )
-    MonthlyStatistics.objects.filter(account=pbwg_account, programme_type="PLW").delete()
-    ETL().journey_with_visit_and_steps_per_visit(pbwg_account, "PLW")
+    MonthlyStatistics.objects.filter(
+        account=pbwg_account, programme_type="PLW", org_unit_id__in=org_units_with_updated_data
+    ).delete()
+    ETL().journey_with_visit_and_steps_per_visit(pbwg_account, "PLW", org_units_with_updated_data)


### PR DESCRIPTION
What problem is this PR solving? Explain here in one sentence.

Related JIRA tickets : [WC2-866](https://bluesquare.atlassian.net/browse/WC2-866)

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).

## Changes

- Added a check on the ration type and number of sachet given for assistance visit for empty quantity given
- Allowed to push to dhis2 data linked to org unit with source ref value
- Reaggragated monthly data linked only to org unit with updated entities.

## How to test

- From a local instance with wfp coda database Nigeria data, try to update an assistance visit from django admin by removing value in json field for `_total_number_of_sachets` and keep it empty like ` "_total_number_of_sachets": "",`  and try to run ETL for all_data  with `docker compose run iaso manage etl_ng all_data` the ETL script in order to generate data for tableau dashboard. The script should succeed.

- Try to update a submission linked to Nigeria from django admin and rerun ETL without all_data parameter, it should regenerate less data. You will see in the terminal less entities regenerated. It's just entities updated after the last succeed ETL task from the [Task Result table](http://localhost:8081/admin/django_celery_results/taskresult/)

- Try to rerun ETL for SSD data with `docker compose run iaso manage etl_ssd all_data` and check in the [dhis2 sync result table](http://localhost:8081/admin/wfp/dhis2syncresults/?account__id__exact=1), you should see only rows with values in the field `Org unit dhis2 id` with the created_at date set to today 


## Print screen / video

Upload here print screens or videos showing the changes.

## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.


[WC2-866]: https://bluesquare.atlassian.net/browse/WC2-866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ