### PR TITLE
IA-4694: duplicate-username-error-when-updating-existing-user

### DIFF
--- a/iaso/api/profiles/profiles.py
+++ b/iaso/api/profiles/profiles.py
@@ -593,8 +593,8 @@ class ProfilesViewSet(viewsets.ViewSet):
             return  # username cannot be updated for multi-account users
 
         username = request.data.get("user_name")
-        # Skip validation if username not provided or did not change
-        if not username or user.username == username:
+        # Skip validation if username not provided or did not change (case-insensitive)
+        if not username or user.username.lower() == username.lower():
             return
 
         existing_user = User.objects.filter(username__iexact=username).filter(~Q(pk=user.id))

--- a/iaso/api/profiles/profiles.py
+++ b/iaso/api/profiles/profiles.py
@@ -509,7 +509,9 @@ class ProfilesViewSet(viewsets.ViewSet):
         else:
             user.first_name = request.data.get("first_name", "")
             user.last_name = request.data.get("last_name", "")
-            user.username = request.data.get("user_name")
+            user_name = request.data.get("user_name")
+            if user_name:
+                user.username = user_name
             user.email = request.data.get("email", "")
             self.update_password(user, request)
 

--- a/iaso/api/profiles/profiles.py
+++ b/iaso/api/profiles/profiles.py
@@ -591,8 +591,9 @@ class ProfilesViewSet(viewsets.ViewSet):
             return  # username cannot be updated for multi-account users
 
         username = request.data.get("user_name")
-        if not username:
-            raise ProfileError(field="user_name", detail=_("Nom d'utilisateur requis"))
+        # Skip validation if username not provided or did not change
+        if not username or user.username == username:
+            return
 
         existing_user = User.objects.filter(username__iexact=username).filter(~Q(pk=user.id))
         if existing_user:

--- a/iaso/api/profiles/profiles.py
+++ b/iaso/api/profiles/profiles.py
@@ -594,7 +594,7 @@ class ProfilesViewSet(viewsets.ViewSet):
 
         username = request.data.get("user_name")
         # Skip validation if username not provided or did not change (case-insensitive)
-        if not username or user.username.lower() == username.lower():
+        if not username or user.username == username:
             return
 
         existing_user = User.objects.filter(username__iexact=username).filter(~Q(pk=user.id))

--- a/iaso/tests/api/test_profiles.py
+++ b/iaso/tests/api/test_profiles.py
@@ -2042,3 +2042,36 @@ class ProfileAPITestCase(APITestCase):
             expected_order,
             f"Users not sorted correctly by first role. Expected: {expected_order}, got: {actual_order}",
         )
+
+    def test_update_user_with_same_username_should_skip_validation(self):
+        """Test that profile update with same username skips validation."""
+        self.client.force_authenticate(self.john)
+        profile_to_edit = Profile.objects.get(user=self.jim)
+        original_username = self.jim.username
+
+        data = {
+            "user_name": original_username,
+            "first_name": "Updated First Name",
+        }
+        response = self.client.patch(f"/api/profiles/{profile_to_edit.id}/", data=data, format="json")
+
+        self.assertEqual(response.status_code, 200)
+        self.jim.refresh_from_db()
+        self.assertEqual(self.jim.username, original_username)
+        self.assertEqual(self.jim.first_name, "Updated First Name")
+
+    def test_update_user_without_username_should_skip_validation(self):
+        """Test that profile update without username skips validation."""
+        self.client.force_authenticate(self.john)
+        profile_to_edit = Profile.objects.get(user=self.jim)
+        original_username = self.jim.username
+
+        data = {
+            "first_name": "Updated First Name",
+        }
+        response = self.client.patch(f"/api/profiles/{profile_to_edit.id}/", data=data, format="json")
+
+        self.assertEqual(response.status_code, 200)
+        self.jim.refresh_from_db()
+        self.assertEqual(self.jim.username, original_username)
+        self.assertEqual(self.jim.first_name, "Updated First Name")


### PR DESCRIPTION
[IA-4694](https://bluesquare.atlassian.net/browse/IA-4694):  Allows users with duplicate usernames to update their profile

Related JIRA tickets : IA-4694

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?

## Changes

Skip validation if the username didn't change

## How to test

- Open any user's profile 
- update only "First Name" and leave username unchanged
- Click "Save" button
- Expected: Profile saves successfully



[IA-4694]: https://bluesquare.atlassian.net/browse/IA-4694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ