### PR TITLE
IA-4683: Fix back button is not working in planning assignments

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/assignments/hooks/useGetAssignmentData.ts
+++ b/hat/assets/js/apps/Iaso/domains/assignments/hooks/useGetAssignmentData.ts
@@ -86,9 +86,9 @@ export const useGetAssignmentData = ({
         isLoading: boolean;
     } = useGetPlanningDetails(planningId);
     const { data: teams = [], isFetched: isTeamsFetched } = useGetTeamsDropdown(
-        { ancestor: `${planning?.team}` },
+        { ancestor: `${planning?.team_details?.id}` },
         undefined,
-        planning?.team ? true : false,
+        planning?.team_details?.id ? true : false,
         true,
     );
     const [profiles, setProfiles] = useBoundState<ProfileWithColor[]>(

--- a/hat/assets/js/apps/Iaso/domains/assignments/hooks/useGetOrgUnitParentIds.ts
+++ b/hat/assets/js/apps/Iaso/domains/assignments/hooks/useGetOrgUnitParentIds.ts
@@ -23,7 +23,7 @@ export const useGetOrgUnitParentIds = ({
         let orgUnitParentIds: number[] | undefined;
         if (planning && !isLoadingAssignments) {
             if (currentTeam) {
-                if (currentTeam?.id !== planning.team) {
+                if (currentTeam?.id !== planning.team_details?.id) {
                     const existingAssignmentsForTeamOrUser =
                         allAssignments.filter(
                             assignment => assignment.team === currentTeam.id,
@@ -34,7 +34,9 @@ export const useGetOrgUnitParentIds = ({
                         );
                     }
                 } else {
-                    orgUnitParentIds = [planning.org_unit];
+                    orgUnitParentIds = planning.org_unit_details
+                        ? [planning.org_unit_details.id]
+                        : [];
                 }
             }
         }

--- a/hat/assets/js/apps/Iaso/domains/assignments/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/assignments/index.tsx
@@ -13,7 +13,6 @@ import {
     useSkipEffectOnMount,
     useRedirectTo,
     useRedirectToReplace,
-    useGoBack,
 } from 'bluesquare-components';
 import TopBar from '../../components/nav/TopBarComponent';
 import { baseUrls } from '../../constants/urls';
@@ -260,7 +259,6 @@ export const Assignments: FunctionComponent = () => {
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [planning?.id, currentTeam?.id]);
-    const goBack = useGoBack(baseUrls.planning);
     return (
         <>
             <TopBar
@@ -268,7 +266,7 @@ export const Assignments: FunctionComponent = () => {
                     planning?.name ?? ''
                 }`}
                 displayBackButton
-                goBack={goBack}
+                goBack={() => redirectToReplace(baseUrls.planning)}
             />
             <ParentDialog
                 childrenOrgunits={childrenOrgunits}

--- a/hat/assets/js/apps/Iaso/domains/assignments/sampling/customForms/ExcludedOrgUnits.tsx
+++ b/hat/assets/js/apps/Iaso/domains/assignments/sampling/customForms/ExcludedOrgUnits.tsx
@@ -32,7 +32,7 @@ export const ExcludedOrgUnits: FunctionComponent<Props> = ({
     const { data: orgUnits, isFetching: isFetchingOrgUnits } =
         useGetOrgUnitsByOrgUnitTypeId({
             orgUnitTypeId,
-            projectId: planning.project,
+            projectId: planning.project_details?.id,
             excludedOrgUnitParentIds: excludedOrgUnitIds || undefined,
         });
 

--- a/hat/assets/js/apps/Iaso/domains/assignments/sampling/customForms/LQASForm.tsx
+++ b/hat/assets/js/apps/Iaso/domains/assignments/sampling/customForms/LQASForm.tsx
@@ -220,8 +220,9 @@ export const LQASForm: FunctionComponent<Props> = ({
 
             setAllowConfirm(
                 Boolean(allLevelsFilled) &&
-                    (!planning.target_org_unit_type ||
-                        latestOptions?.value === planning.target_org_unit_type),
+                    (!planning.target_org_unit_type_details ||
+                        latestOptions?.value ===
+                            planning.target_org_unit_type_details?.id),
             );
         } else {
             setAllowConfirm(false);
@@ -232,7 +233,7 @@ export const LQASForm: FunctionComponent<Props> = ({
         org_unit_type_criteria,
         org_unit_type_quantities,
         canAddLevel,
-        planning.target_org_unit_type,
+        planning.target_org_unit_type_details?.id,
         latestOptions?.value,
     ]);
 

--- a/hat/assets/js/apps/Iaso/domains/plannings/components/ActionsCell.tsx
+++ b/hat/assets/js/apps/Iaso/domains/plannings/components/ActionsCell.tsx
@@ -31,7 +31,7 @@ export const ActionsCell: FunctionComponent<ActionsCellProps> = ({
                 />
             </DisplayIfUserHasPerm>
             <IconButtonComponent
-                url={`/${baseUrls.assignments}/planningId/${planning.id}/team/${planning.team}`}
+                url={`/${baseUrls.assignments}/planningId/${planning.id}/team/${planning.team_details?.id}`}
                 tooltipMessage={MESSAGES.assignments}
                 size="small"
                 replace={false}

--- a/hat/assets/js/apps/Iaso/domains/plannings/components/LinkToPlanning.tsx
+++ b/hat/assets/js/apps/Iaso/domains/plannings/components/LinkToPlanning.tsx
@@ -16,7 +16,7 @@ export const LinkToPlanning: FunctionComponent<Props> = ({ planning }) => {
         [PLANNING_READ, PLANNING_WRITE],
         user,
     );
-    const url = `/${baseUrls.assignments}/planningId/${planning.id}/team/${planning.team}`;
+    const url = `/${baseUrls.assignments}/planningId/${planning.id}/team/${planning.team_details?.id}`;
     const { name: text } = planning;
 
     return <LinkTo condition={condition} url={url} text={text} />;

--- a/hat/assets/js/apps/Iaso/domains/plannings/config.tsx
+++ b/hat/assets/js/apps/Iaso/domains/plannings/config.tsx
@@ -45,14 +45,14 @@ const ActionCell: FunctionComponent<Props> = ({ samplingResult, planning }) => {
                 {
                     validation_status: 'VALID',
                     color: greenColor,
-                    levels: `${planning.org_unit}`,
-                    orgUnitTypeId: `${planning.target_org_unit_type}`,
+                    levels: `${planning.org_unit_details?.id}`,
+                    orgUnitTypeId: `${planning.target_org_unit_type_details?.id}`,
                 },
                 {
                     validation_status: 'VALID',
                     color: purpleColor,
                     group: `${samplingResult.group_id}`,
-                    orgUnitTypeId: `${planning.target_org_unit_type}`,
+                    orgUnitTypeId: `${planning.target_org_unit_type_details?.id}`,
                 },
             ]),
         }),


### PR DESCRIPTION
When you open a planning's assignments' screen, using the back arrow button didn't work.

Related JIRA tickets : IA-4683

## Self proofreading checklist

- [X] Did I use eslint and ruff formatters?
- [X] Is my code clear enough and well documented?
- [X] Are my typescript files well typed?

## Changes

The problem was the back button was using `goBack` which goes to the previous URL. But, when we open the assignments, the URL is changed to include the filters. So pressing back was just going to the URL without the filters which was changed again to include the filters. Therefore, we could not go back and were stuck in a loop.

I have also fixed the code were some removed properties were called on the `Planning` object.

## How to test

1. Go in the plannings
2. Click on the assignments button of one of them. 
3. Wait for the data to load
4. Click back.
5. Enjoy

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
