### PR TITLE
POLIO-2074: Add a command to scans all pending files

### DIFF
--- a/plugins/polio/management/commands/scan_files_for_viruses.py
+++ b/plugins/polio/management/commands/scan_files_for_viruses.py
@@ -1,0 +1,50 @@
+from typing import Optional, Tuple
+
+from django.core.management.base import BaseCommand
+
+from iaso.utils.virus_scan.clamav import scan_disk_file_for_virus
+from iaso.utils.virus_scan.model import ModelWithFile, VirusScanStatus
+from plugins.polio.models import (
+    DestructionReport,
+    IncidentReport,
+    NotificationImport,
+    OutgoingStockMovement,
+    VaccineRequestForm,
+)
+
+
+class Command(BaseCommand):
+    help = "[POLIO] Scan unscanned files for viruses"
+
+    def _scan_files(self, clazz: type[ModelWithFile], name: str) -> Tuple[int, int, int]:
+        queryset = clazz.objects.filter(file_scan_status=VirusScanStatus.PENDING)
+        self.stdout.write(f" - {name}: {queryset.count()}")
+        clean, infected, errors = 0, 0, 0
+        for model_with_file in queryset.all():
+            # No need for try/except, `scan_disk_file_for_virus` is already wrapped.
+            result, timestamp = scan_disk_file_for_virus(model_with_file.file.path)
+            model_with_file.file_last_scan = timestamp
+            model_with_file.file_scan_status = result
+            model_with_file.save()
+            if result is VirusScanStatus.CLEAN:
+                clean += 1
+                self.stdout.write(self.style.SUCCESS(f"   -> file: {model_with_file.file.name} is clean ✔"))
+            elif result is VirusScanStatus.INFECTED:
+                infected += 1
+                self.stdout.write(self.style.ERROR(f"   -> file: {model_with_file.file.name} is infected ☠️"))
+            else:
+                errors += 1
+                self.stdout.write(
+                    self.style.WARNING(f"   -> file: {model_with_file.file.name} could not be scanned ❌")
+                )
+        self.stdout.write(self.style.SUCCESS(f"   clean : {clean}, infected: {infected}, errors: {errors}"))
+        return clean, infected, errors
+
+    def handle(self, *args, **options) -> Optional[str]:
+        self.stdout.write("Scanning files for viruses...")
+        self._scan_files(VaccineRequestForm, "Vaccine Request Forms")
+        self._scan_files(OutgoingStockMovement, "Form As")
+        self._scan_files(DestructionReport, "Destruction Reports")
+        self._scan_files(IncidentReport, "Incident Reports")
+        self._scan_files(NotificationImport, "Notifications")
+        self.stdout.write(self.style.SUCCESS("Scan done!"))

--- a/plugins/polio/models/__init__.py
+++ b/plugins/polio/models/__init__.py
@@ -3,4 +3,13 @@ from .chronogram import Chronogram, ChronogramTask, ChronogramTemplateTask
 from .lqas_im import *
 
 
-__all__ = ["Chronogram", "ChronogramTask", "ChronogramTemplateTask"]
+__all__ = [
+    "Chronogram",
+    "ChronogramTask",
+    "ChronogramTemplateTask",
+    "NotificationImport",
+    "VaccineRequestForm",
+    "OutgoingStockMovement",
+    "DestructionReport",
+    "IncidentReport",
+]

--- a/plugins/polio/models/__init__.py
+++ b/plugins/polio/models/__init__.py
@@ -12,4 +12,5 @@ __all__ = [
     "OutgoingStockMovement",
     "DestructionReport",
     "IncidentReport",
+    "VaccinePreAlert",
 ]


### PR DESCRIPTION
Add a command to scan all pending files in Polio

Related JIRA tickets : POLIO-2074

## Self proofreading checklist

- [X] Did I use eslint and ruff formatters?
- [X] Is my code clear enough and well documented?
- [ ] Are there enough tests?

## Changes

Adding a command to scan all pending files in Polio

## How to test

execute the following command:
```bash 
docker compose exec iaso ./manage.py scan_files_for_viruses
```

## Print screen / video

<img width="1705" height="479" alt="image" src="https://github.com/user-attachments/assets/fde5787d-3d64-49ef-a664-02ef4158efed" />

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
