### PR TITLE
IA-4699: Shape of org unit is not visible on map details page

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/orgUnitMap/OrgUnitMap/OrgUnitMap.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/orgUnitMap/OrgUnitMap/OrgUnitMap.tsx
@@ -13,6 +13,7 @@ import { pink } from '@mui/material/colors';
 import { makeStyles } from '@mui/styles';
 import { useSafeIntl, useSkipEffectOnMount } from 'bluesquare-components';
 import 'leaflet-draw';
+import { Map as LeafletMap } from 'leaflet';
 
 import { GeoJSON, MapContainer, Pane, ScaleControl } from 'react-leaflet';
 import { ExtendedDataSource } from 'Iaso/domains/orgUnits/requests';
@@ -99,7 +100,7 @@ export const OrgUnitMap: FunctionComponent<Props> = ({
     const classes: Record<string, string> = useStyles();
     const theme = useTheme();
     const currentUser = useCurrentUser();
-    const map: any = useRef();
+    const map = useRef<LeafletMap | null>(null);
     // These 2 refs are needed because we need to initialize the EditableGroups only once, but we need the map to be ready
     // and we can't predict exactly how many renders that will require
     const didLocationInitialize = useRef(false);
@@ -519,9 +520,7 @@ export const OrgUnitMap: FunctionComponent<Props> = ({
                     zoom={zoom}
                     zoomControl={false}
                     keyboard={false}
-                    whenCreated={mapInstance => {
-                        map.current = mapInstance;
-                    }}
+                    ref={map}
                 >
                     <CustomZoomControl
                         bounds={bounds}

--- a/plugins/polio/js/src/domains/LQAS-IM/LQAS/LqasAfroOverview/Map/LqasAfroMap.tsx
+++ b/plugins/polio/js/src/domains/LQAS-IM/LQAS/LqasAfroOverview/Map/LqasAfroMap.tsx
@@ -1,17 +1,17 @@
 import React, { FunctionComponent, useState, useMemo, useContext } from 'react';
 import { MapContainer } from 'react-leaflet';
 
+import { CustomTileLayer } from '../../../../../../../../../hat/assets/js/apps/Iaso/components/maps/tools/CustomTileLayer';
 import { CustomZoomControl } from '../../../../../../../../../hat/assets/js/apps/Iaso/components/maps/tools/CustomZoomControl';
+import { Tile } from '../../../../../../../../../hat/assets/js/apps/Iaso/components/maps/tools/TilesSwitchControl';
 import TILES from '../../../../../../../../../hat/assets/js/apps/Iaso/constants/mapTiles';
 
-import { CustomTileLayer } from '../../../../../../../../../hat/assets/js/apps/Iaso/components/maps/tools/CustomTileLayer';
-import { Tile } from '../../../../../../../../../hat/assets/js/apps/Iaso/components/maps/tools/TilesSwitchControl';
-import { LqasAfroMapPanesContainer } from './LqasAfroMapPanesContainer';
-import { AfroMapParams } from '../types';
-import { LqasAfroMapLegend } from './LqasAfroMapLegend';
+import { Side } from '../../../../../../src/constants/types';
 import { defaultViewport } from '../../../../Calendar/campaignCalendar/map/constants';
 import { LqasAfroOverviewContext } from '../Context/LqasAfroOverviewContext';
-import { Side } from '../../../../../../src/constants/types';
+import { AfroMapParams } from '../types';
+import { LqasAfroMapLegend } from './LqasAfroMapLegend';
+import { LqasAfroMapPanesContainer } from './LqasAfroMapPanesContainer';
 
 type Props = {
     params: AfroMapParams & { accountId: string };
@@ -57,9 +57,6 @@ export const LqasAfroMap: FunctionComponent<Props> = ({
             zoom={defaultZoom}
             zoomControl={false}
             scrollWheelZoom={false}
-            whenCreated={mapInstance => {
-                setBounds(mapInstance.getBounds());
-            }}
         >
             <LqasAfroMapLegend displayedShape={displayedShape} />
             <CustomTileLayer


### PR DESCRIPTION
Shape of an org unit is not visible anymore on detail page

Related JIRA tickets : IA-4699

## Self proofreading checklist

- [x] Did I use eslint and ruff formatters?
- [x] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

-

## Changes

Explain the changes that were made.

- use `ref` on org unit map
- use `whenReady` on Lqas Afro map

## How to test

Open the detail page of an org unit with a geo json, make sure you can see the shape
Make sure the the LQAS afro map is still working properly !

## Print screen / video

<img width="1277" height="980" alt="Screenshot 2026-01-14 at 13 32 00" src="https://github.com/user-attachments/assets/6e502f06-1103-4d9a-8b79-71d2170dc0c6" />

## Notes

-
