### PR TITLE
SNT-267: Fix webpack font import

### DIFF
--- a/hat/webpack.dev.js
+++ b/hat/webpack.dev.js
@@ -188,38 +188,26 @@ module.exports = {
                 : newBrowsersConfig),
             {
                 test: /\.css$/,
-                use: [{ loader: 'style-loader' }, { loader: 'css-loader' }],
+                use: [
+                    { loader: 'style-loader' },
+                    {
+                        loader: 'css-loader',
+                        options: {
+                            url: true, // Ensure css-loader processes url() statements
+                        },
+                    },
+                ],
             },
             {
                 test: /\.(png|jpg|jpeg|gif|svg)$/,
                 type: 'asset/resource',
             },
             {
-                test: /\.woff(\?v=\d+\.\d+\.\d+)?$/,
+                test: /\.(woff|woff2|ttf|eot|otf)$/,
                 type: 'asset/resource',
                 generator: {
                     filename: 'fonts/[name].[hash][ext]',
-                },
-            },
-            {
-                test: /\.woff2(\?v=\d+\.\d+\.\d+)?$/,
-                type: 'asset/resource',
-                generator: {
-                    filename: 'fonts/[name].[hash][ext]',
-                },
-            },
-            {
-                test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/,
-                type: 'asset/resource',
-                generator: {
-                    filename: 'fonts/[name].[hash][ext]',
-                },
-            },
-            {
-                test: /\.eot(\?v=\d+\.\d+\.\d+)?$/,
-                type: 'asset/resource',
-                generator: {
-                    filename: 'fonts/[name].[hash][ext]',
+                    publicPath: '/static/', // Ensure URLs in CSS point to the correct path
                 },
             },
             {

--- a/hat/webpack.prod.js
+++ b/hat/webpack.prod.js
@@ -228,38 +228,26 @@ module.exports = {
             },
             {
                 test: /\.css$/,
-                use: [MiniCssExtractPlugin.loader, 'css-loader'],
+                use: [
+                    MiniCssExtractPlugin.loader,
+                    {
+                        loader: 'css-loader',
+                        options: {
+                            url: true,
+                        },
+                    },
+                ],
             },
             {
                 test: /\.(png|jpg|jpeg|gif|svg)$/,
                 type: 'asset/resource',
             },
             {
-                test: /\.woff(\?v=\d+\.\d+\.\d+)?$/,
+                test: /\.(woff|woff2|ttf|eot|otf)$/,
                 type: 'asset/resource',
                 generator: {
                     filename: 'fonts/[name].[hash][ext]',
-                },
-            },
-            {
-                test: /\.woff2(\?v=\d+\.\d+\.\d+)?$/,
-                type: 'asset/resource',
-                generator: {
-                    filename: 'fonts/[name].[hash][ext]',
-                },
-            },
-            {
-                test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/,
-                type: 'asset/resource',
-                generator: {
-                    filename: 'fonts/[name].[hash][ext]',
-                },
-            },
-            {
-                test: /\.eot(\?v=\d+\.\d+\.\d+)?$/,
-                type: 'asset/resource',
-                generator: {
-                    filename: 'fonts/[name].[hash][ext]',
+                    publicPath: '/static/',
                 },
             },
             {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
                 "@date-io/moment": "1.x",
                 "@emotion/react": "^11.11.1",
                 "@emotion/styled": "^11.11.0",
+                "@fontsource/roboto": "^5.2.9",
                 "@mui/icons-material": "^5.15.7",
                 "@mui/lab": "^5.0.0-alpha.150",
                 "@mui/material": "^5.15.7",
@@ -2688,6 +2689,15 @@
             "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
             "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
             "license": "MIT"
+        },
+        "node_modules/@fontsource/roboto": {
+            "version": "5.2.9",
+            "resolved": "https://registry.npmjs.org/@fontsource/roboto/-/roboto-5.2.9.tgz",
+            "integrity": "sha512-ZTkyHiPk74B/aj8BZWbsxD5Yu+Lq+nR64eV4wirlrac2qXR7jYk2h6JlLYuOuoruTkGQWNw2fMuKNavw7/rg0w==",
+            "license": "OFL-1.1",
+            "funding": {
+                "url": "https://github.com/sponsors/ayuhito"
+            }
         },
         "node_modules/@formatjs/cli": {
             "version": "4.8.4",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
         "@date-io/moment": "1.x",
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
+        "@fontsource/roboto": "^5.2.9",
         "@mui/icons-material": "^5.15.7",
         "@mui/lab": "^5.0.0-alpha.150",
         "@mui/material": "^5.15.7",


### PR DESCRIPTION
Fix web pack font loader to make it possible to load fontsource fonts and install @fontsource/roboto

Related JIRA tickets : SNT-267

## Self proofreading checklist

- [ ] Did I use eslint and ruff formatters?
- [ ] Is my code clear enough and well documented?
- [ ] Are my typescript files well typed?
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] My migrations file are included
- [ ] Are there enough tests?
- [ ] Documentation has been included (for new feature)

## Doc

N/A

## Changes

Fonts are defined to use Roboto, Helvetica. 
As Roboto was never installed, it was falling back to Helvetica.
In order to be able to align more with UX (especially font size and font weight), we need to use Roboto.
However, web pack was not resolving properly font coming from @fontsource. 
This PR intend to fix that.


Note: I didn't include loading the font for Iaso as I don't want to break it right now.
          It will only be applied to SNT_malaria

## How to test

First of all, make sure everything still render / work as before (it should be the case as I didn't find any custom font).
You can also verify that applied font is Helvetica in developer tool of your browser.
Then, you can go to hat/assets/js/Iaso/index.tsx and add the following lines: 
import '@fontsource/roboto/300.css';
import '@fontsource/roboto/400.css';
import '@fontsource/roboto/500.css';
import '@fontsource/roboto/700.css';

Rebuild docker and verify that the font is set to Roboto.

## Print screen / video

Upload here print screens or videos showing the changes.

## Notes

SNT PR: https://github.com/BLSQ/snt-malaria/pull/166

## Follow the Conventional Commits specification

The **merge message** of a pull request must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

This convention helps to automatically generate release notes.

Use lowercase for consistency.

[Example](https://github.com/BLSQ/iaso/commit/8b8d7d3064138c1e57878f17b4eb922516ab0112):

```
fix: empty instance pop up

Refs: IA-3665
```

Note that the Jira reference is preceded by a _line break_.

Both the line break and the Jira reference are entered in the _Add an optional extended description…_ field.
