### PR TITLE
IA-4707: Pressing enter reveals your password

### DIFF
--- a/hat/templates/iaso/login.html
+++ b/hat/templates/iaso/login.html
@@ -43,7 +43,7 @@
         {% csrf_token %}
         <div class="form-group">
         {{ form }}
-          <button id="display-password">
+          <button id="display-password" type="button">
             {% include "./icons/eye.html" %}
             {% include "./icons/eye-slash.html" %}
           </button>


### PR DESCRIPTION
## What problem is this PR solving?

When you type your password and press enter on the login page, it used to submit the form, but now, it reveals the password of the user, which is problematic for security and for the UX. 

### Related JIRA tickets

IA-4707

## Changes

Html is using the first button he can find while pressing enter. Submit button was before toggle password button before previous changes. By adding `type="button" `to the toggle action, html knows he should not use this button to submit the form..

## How to test

Go to login page, enter dummy username and password, press enter, it should submit the form.
Make sure toggle password action is still working

## Print screen / video

https://github.com/user-attachments/assets/822d1ac2-6c0b-4f68-ab2d-f2256d5a3be8



## Notes
-

## Doc
-
