### PR TITLE
[IA-4704] Fix Authentication not required but posting OrgUnits errors out

### DIFF
--- a/iaso/api/mobile/org_units.py
+++ b/iaso/api/mobile/org_units.py
@@ -20,7 +20,7 @@ from iaso.api.instances.instances import InstanceFileSerializer
 from iaso.api.org_units import import_org_units
 from iaso.api.permission_checks import (
     AuthenticationEnforcedPermission,
-    IsAuthenticatedOrReadOnlyWhenNoAuthenticationRequired,
+    IsAuthenticatedWhenAuthenticationRequired,
 )
 from iaso.api.query_params import APP_ID, IDS, LIMIT, PAGE
 from iaso.api.serializers import AppIdSerializer
@@ -148,7 +148,7 @@ class MobileOrgUnitSerializer(serializers.ModelSerializer):
         return org_unit.location.z if org_unit.location else None
 
 
-class HasOrgUnitPermission(IsAuthenticatedOrReadOnlyWhenNoAuthenticationRequired):
+class HasOrgUnitPermission(IsAuthenticatedWhenAuthenticationRequired):
     def has_object_permission(self, request, view, obj):
         if not (
             request.user.is_authenticated


### PR DESCRIPTION
## What problem is this PR solving?

When posting new OrgUnits on a project that doesn't require authentication, the endpoints returns an error asking for an authentication.

### Related JIRA tickets

IA-4704

## Changes

I duplicated the class `IsAuthenticatedOrReadOnlyWhenNoAuthenticationRequired` to return `True`  when the user is not authenticated and the project doesn't require authentication.
I wanted to make it more generic and not duplicate the logic but any abstraction I could find made it so much harder to read that I preferred to duplicate the code.

## How to test

-  Take a setuper account (or an account with OUs and OUT configured)
-  Make sure the project doesn't have authentication enabled (use the main_project one).
- Configure the project to be able to create an OrgUnit from the mobile app (At least one OUT must have a "sub orgunit type to create" configured)
- Configure the mobile app to use that project
- Create a new OrgUnit in the mobile app
- Synchronize your changes

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).
