### PR TITLE
Fix `LOGIN_LOGO_PATH` doesn't fallback on `LOGO_PATH`

### DIFF
--- a/hat/settings.py
+++ b/hat/settings.py
@@ -714,7 +714,7 @@ EMAIL_USE_TLS = os.environ.get("EMAIL_TLS", "true") == "true"
 APP_TITLE = os.environ.get("APP_TITLE", "IASO")
 FAVICON_PATH = os.environ.get("FAVICON_PATH", "images/iaso-favicon.png")
 LOGO_PATH = os.environ.get("LOGO_PATH", "images/logo.png")
-LOGIN_LOGO_PATH = os.environ.get("LOGIN_LOGO_PATH", "images/login_logo.png")
+LOGIN_LOGO_PATH = os.environ.get("LOGIN_LOGO_PATH", None)
 THEME_PRIMARY_COLOR = os.environ.get("THEME_PRIMARY_COLOR", "#006699")
 THEME_SECONDARY_COLOR = os.environ.get("THEME_SECONDARY_COLOR", "#ff7961")
 THEME_PRIMARY_BACKGROUND_COLOR = os.environ.get("THEME_PRIMARY_BACKGROUND_COLOR", "#F5F5F5")


### PR DESCRIPTION
## What problem is this PR solving?

The default IASO's `LOGIN_LOGO_PATH` is used everywhere.

### Related JIRA tickets

IA-4708

## Changes

Remove the default `LOGIN_LOGO_PATH`.

## How to test

Start IASO without a `LOGIN_LOGO_PATH`  environment variable.
On the login page, you should see the default logo.

## Print screen / video

<img width="597" height="929" alt="image" src="https://github.com/user-attachments/assets/c036d96d-ec0b-4abf-b918-b71a3aed4e88" />

## Notes

We should add an environment variable to all IASO instances:

```
LOGIN_LOGO_PATH="images/login_logo.png"
```
