### PR TITLE
IA-4718: [LifeNet] Submissions not reaching IASO web after successful submission on mobile app

### DIFF
--- a/iaso/api/instances/instances.py
+++ b/iaso/api/instances/instances.py
@@ -1051,16 +1051,8 @@ def import_data(instances, user, app_id):
         accuracy_raw = instance_data.get("accuracy", None)
         if accuracy_raw is not None:
             accuracy_serializer = InstanceImportAccuracySerializer(data={"accuracy": accuracy_raw})
-            if accuracy_serializer.is_valid():
-                instance.accuracy = accuracy_serializer.validated_data.get("accuracy")
-            else:
-                logger.warning(
-                    "Invalid accuracy value %s for instance %s: %s",
-                    accuracy_raw,
-                    uuid,
-                    accuracy_serializer.errors,
-                )
-                instance.accuracy = None
+            accuracy_serializer.is_valid(raise_exception=True)
+            instance.accuracy = accuracy_serializer.validated_data.get("accuracy")
 
         tentative_org_unit_id = instance_data.get("orgUnitId", None)
         if str(tentative_org_unit_id).isdigit():

--- a/iaso/api/instances/serializers.py
+++ b/iaso/api/instances/serializers.py
@@ -1,4 +1,18 @@
+import decimal
+
 from rest_framework import serializers
+
+from iaso.utils.serializer.rounded_decimal_field import RoundedDecimalField
+
+
+class InstanceImportAccuracySerializer(serializers.Serializer):
+    accuracy = RoundedDecimalField(
+        max_digits=7,
+        decimal_places=2,
+        rounding=decimal.ROUND_HALF_UP,
+        allow_null=True,
+        required=False,
+    )
 
 
 class FileTypeSerializer(serializers.Serializer):

--- a/iaso/tests/api/instances/test_instances.py
+++ b/iaso/tests/api/instances/test_instances.py
@@ -386,6 +386,91 @@ class InstancesAPITestCase(TaskAPITestCase):
         self.assertEqual(self.form_1, last_instance.form)
         self.assertIsNotNone(last_instance.project)
 
+    def test_instance_create_with_valid_accuracy(self):
+        """POST /api/instances/ with a valid accuracy value"""
+        from decimal import Decimal
+
+        instance_uuid = str(uuid4())
+        body = [
+            {
+                "id": instance_uuid,
+                "created_at": 1565258153704,
+                "updated_at": 1565258153709,
+                "orgUnitId": self.jedi_council_corruscant.id,
+                "formId": self.form_1.id,
+                "period": "202002",
+                "latitude": 50.2,
+                "longitude": 4.4,
+                "accuracy": 15.5,
+                "altitude": 100,
+                "file": "\/storage\/emulated\/0\/odk\/instances\/test_accuracy\/test.xml",
+                "name": "test_accuracy",
+            }
+        ]
+        response = self.client.post(
+            "/api/instances/?app_id=stars.empire.agriculture.hydroponics", data=body, format="json"
+        )
+        self.assertEqual(response.status_code, 200)
+
+        last_instance = m.Instance.objects.get(uuid=instance_uuid)
+        self.assertEqual(Decimal("15.50"), last_instance.accuracy)
+
+    def test_instance_create_with_accuracy_rounded(self):
+        """POST /api/instances/ with accuracy having more than 2 decimal places should be rounded"""
+        from decimal import Decimal
+
+        instance_uuid = str(uuid4())
+        body = [
+            {
+                "id": instance_uuid,
+                "created_at": 1565258153704,
+                "updated_at": 1565258153709,
+                "orgUnitId": self.jedi_council_corruscant.id,
+                "formId": self.form_1.id,
+                "period": "202002",
+                "latitude": 50.2,
+                "longitude": 4.4,
+                "accuracy": 12.345,
+                "altitude": 100,
+                "file": "\/storage\/emulated\/0\/odk\/instances\/test_accuracy_rounded\/test.xml",
+                "name": "test_accuracy_rounded",
+            }
+        ]
+        response = self.client.post(
+            "/api/instances/?app_id=stars.empire.agriculture.hydroponics", data=body, format="json"
+        )
+        self.assertEqual(response.status_code, 200)
+
+        last_instance = m.Instance.objects.get(uuid=instance_uuid)
+        self.assertEqual(Decimal("12.35"), last_instance.accuracy)
+
+    def test_instance_create_with_invalid_accuracy(self):
+        """POST /api/instances/ with invalid accuracy value should result in None"""
+        instance_uuid = str(uuid4())
+        body = [
+            {
+                "id": instance_uuid,
+                "created_at": 1565258153704,
+                "updated_at": 1565258153709,
+                "orgUnitId": self.jedi_council_corruscant.id,
+                "formId": self.form_1.id,
+                "period": "202002",
+                "latitude": 50.2,
+                "longitude": 4.4,
+                "accuracy": "not_a_number",
+                "altitude": 100,
+                "file": "\/storage\/emulated\/0\/odk\/instances\/test_invalid_accuracy\/test.xml",
+                "name": "test_invalid_accuracy",
+            }
+        ]
+        response = self.client.post(
+            "/api/instances/?app_id=stars.empire.agriculture.hydroponics", data=body, format="json"
+        )
+        self.assertEqual(response.status_code, 200)
+
+        last_instance = m.Instance.objects.get(uuid=instance_uuid)
+        self.assertIsNone(last_instance.accuracy)
+
     def test_instance_create_pre_existing(self):
         """POST /api/instances/ with pre-existing, deleted instance"""
 

--- a/iaso/tests/api/instances/test_instances.py
+++ b/iaso/tests/api/instances/test_instances.py
@@ -445,7 +445,7 @@ class InstancesAPITestCase(TaskAPITestCase):
         self.assertEqual(Decimal("12.35"), last_instance.accuracy)
 
     def test_instance_create_with_invalid_accuracy(self):
-        """POST /api/instances/ with invalid accuracy value should result in None"""
+        """POST /api/instances/ with invalid accuracy value should fail the import"""
         instance_uuid = str(uuid4())
         body = [
             {
@@ -467,9 +467,11 @@ class InstancesAPITestCase(TaskAPITestCase):
             "/api/instances/?app_id=stars.empire.agriculture.hydroponics", data=body, format="json"
         )
         self.assertEqual(response.status_code, 200)
+        self.assertIn("problem happened", response.json()["res"])
 
-        last_instance = m.Instance.objects.get(uuid=instance_uuid)
-        self.assertIsNone(last_instance.accuracy)
+        # Instance should not be created when accuracy validation fails
+        with self.assertRaises(m.Instance.DoesNotExist):
+            m.Instance.objects.get(uuid=instance_uuid)
 
     def test_instance_create_pre_existing(self):
         """POST /api/instances/ with pre-existing, deleted instance"""


### PR DESCRIPTION
## What problem is this PR solving?

fix: round accuracy value during instance import

### Related JIRA tickets

IA-4718

## Changes
iaso/api/instances/serializers.py: Added InstanceImportAccuracySerializer with RoundedDecimalField
iaso/api/instances/instances.py: Added decimal validation with InstanceImportAccuracySerializer

## How to test

because it's hard to simulate instance creation I test it with Django shell.
python manage.py shell

```
import time

import requests

from iaso.models import Form, Instance, OrgUnit

RUN_ID = int(time.time())

BASE_URL = "http://localhost:8081"
USERNAME = "iaso"
PASSWORD = "iaso"
APP_ID = "com.bluesquarehub.iaso.lifenet.datatrac"

# Get actual org_unit and form IDs from mock data
org_unit = OrgUnit.objects.filter(name__startswith='REPLACE').first()
form = Form.objects.filter(name__startswith='REPLACE').first()


auth_response = requests.post(
    f"{BASE_URL}/api/token/",
    data={"username": USERNAME, "password": PASSWORD}
)
token = auth_response.json().get("access")
headers = {"Authorization": f"Bearer {token}"}

# 2. Test import with problematic accuracy values
test_cases = [
    {"accuracy": 699.999, "expected": "700.00"},
    {"accuracy": 2299.999, "expected": "2300.00"},
    {"accuracy": 1458111.7, "expected": None},
]

for i, case in enumerate(test_cases):
    payload = [{
        "id": f"test-{RUN_ID}-{i}",
        "name": f"Test Submission {RUN_ID}-{i}",
        "file": f"test-{RUN_ID}-{i}.xml",
        "formId": form.id,
        "accuracy": case["accuracy"],
        "orgUnitId": org_unit.id,
        "period": f"20251{i:02d}"
    }]

    response = requests.post(
        f"{BASE_URL}/api/instances/",
        params={"app_id": APP_ID},
        headers=headers,
        json=payload
    )


# 3. Verify instances via database
print(f"\n--- Verifying created instances (RUN_ID={RUN_ID}) ---")
instances = Instance.objects.filter(uuid__startswith=f"test-{RUN_ID}")
for inst in instances:
    print(f"  Instance {inst.uuid}: accuracy={inst.accuracy}")

```

# you should get
Instance test-1769011186-0: accuracy=700.00
Instance test-1769011186-1: accuracy=2300.00
Instance test-1769011186-2: accuracy=None



