### PR TITLE
IA-4722 react-query dev tools

### DIFF
--- a/docs/pages/dev/how_to/use_react_query_dev_tools/use_react_query_dev_tools_en.md
+++ b/docs/pages/dev/how_to/use_react_query_dev_tools/use_react_query_dev_tools_en.md
@@ -1,0 +1,9 @@
+# React Query Devtools in IASO
+
+## Purpose
+- Inspect React Query cache, query/mutation status, and retry/fetch history directly in the browser.
+
+## How to activate
+1. Open the IASO app in your browser and open the browser console.
+2. Run `window.showReactQueryDevtools?.()` to inject the React Query Devtools UI (it appears closed by default).
+3. If you want to remove it, run `window.hideReactQueryDevtools?.()`.

--- a/docs/pages/dev/reference/guidelines/front-end/front-end.en.md
+++ b/docs/pages/dev/reference/guidelines/front-end/front-end.en.md
@@ -564,6 +564,12 @@ queryClient.invalidateQueries(['forms', formId]);
 // This invalidates 'possible_fields', 'versions', etc.
 ```
 
+### React Query Devtools
+
+- To inspect cache, queries, and mutations in the browser, use the built-in React Query Devtools.
+- In the browser console run `window.showReactQueryDevtools?.()` to inject the panel (it opens hidden by default).
+- Run `window.hideReactQueryDevtools?.()` to remove it when done.
+
 ## Remarks
 
 - order translations by alphanumeric

--- a/hat/assets/js/apps/Iaso/hooks/useReactQueryDevTools.ts
+++ b/hat/assets/js/apps/Iaso/hooks/useReactQueryDevTools.ts
@@ -1,0 +1,14 @@
+import { useEffect, useState } from 'react';
+
+export const useReactQueryDevTools = () => {
+    const [showDevtools, setShowDevtools] = useState(false);
+    useEffect(() => {
+        window.showReactQueryDevtools = () => setShowDevtools(true);
+        window.hideReactQueryDevtools = () => setShowDevtools(false);
+        return () => {
+            delete window.showReactQueryDevtools;
+            delete window.hideReactQueryDevtools;
+        };
+    }, []);
+    return showDevtools;
+};

--- a/hat/assets/js/apps/Iaso/index.tsx
+++ b/hat/assets/js/apps/Iaso/index.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
-import { createRoot } from 'react-dom/client';
+
 import { GlobalStyles } from '@mui/material';
 import CssBaseline from '@mui/material/CssBaseline';
 import { ThemeProvider } from '@mui/material/styles';
 import { theme } from 'bluesquare-components';
 import { SnackbarProvider } from 'notistack';
 import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import { QueryClient, QueryClientProvider } from 'react-query';
+import { ReactQueryDevtools } from 'react-query/devtools';
 
 import './libs/polyfills';
 
@@ -19,6 +21,7 @@ import {
     ThemeConfigContext,
 } from './domains/app/contexts/ThemeConfigContext';
 import App from './domains/app/index';
+import { useReactQueryDevTools } from './hooks/useReactQueryDevTools';
 import { PluginsContext } from './plugins/context';
 import { usePlugins } from './plugins/hooks/usePlugins';
 import { getGlobalOverrides, getOverriddenTheme } from './styles';
@@ -45,6 +48,8 @@ declare global {
             themeConfig: ThemeConfig,
             userHomePage: string,
         ) => void;
+        showReactQueryDevtools?: () => void;
+        hideReactQueryDevtools?: () => void;
     }
 }
 
@@ -54,6 +59,7 @@ const IasoApp: React.FC<{
     themeConfig: ThemeConfig;
     userHomePage: string;
 }> = ({ element, enabledPluginsName, themeConfig, userHomePage }) => {
+    const showDevtools = useReactQueryDevTools();
     const { plugins, pluginHomePage, pluginTheme } =
         usePlugins(enabledPluginsName);
     const usedTheme = pluginTheme || getOverriddenTheme(theme, themeConfig);
@@ -86,6 +92,9 @@ const IasoApp: React.FC<{
                                         />
                                     </SnackbarProvider>
                                 </LocalizedAppComponent>
+                                {showDevtools && (
+                                    <ReactQueryDevtools initialIsOpen={false} />
+                                )}
                             </LocaleProvider>
                         </SidebarProvider>
                     </ThemeProvider>

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
                 "@mui/x-tree-view": "^6.0.0-beta.0",
                 "@sentry/browser": "^8.35.0",
                 "@superset-ui/embedded-sdk": "^0.1.2",
+                "@tanstack/react-query-devtools": "^5.91.2",
                 "@terraformer/wkt": "^2.1.2",
                 "@types/react": "^18.0.0",
                 "@types/react-dom": "^18.0.0",
@@ -4415,6 +4416,61 @@
             "resolved": "https://registry.npmjs.org/@superset-ui/switchboard/-/switchboard-0.20.3.tgz",
             "integrity": "sha512-qEMXFwdRLfXug4gXXdBEGpFtBWZoxdZkCJLBVxj1IR8cQvSqjkWAQOzSSYYdcIeREWqi8iP+iK6apNV1ZQCKcA==",
             "license": "Apache-2.0"
+        },
+        "node_modules/@tanstack/query-core": {
+            "version": "5.90.19",
+            "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.19.tgz",
+            "integrity": "sha512-GLW5sjPVIvH491VV1ufddnfldyVB+teCnpPIvweEfkpRx7CfUmUGhoh9cdcUKBh/KwVxk22aNEDxeTsvmyB/WA==",
+            "license": "MIT",
+            "peer": true,
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/tannerlinsley"
+            }
+        },
+        "node_modules/@tanstack/query-devtools": {
+            "version": "5.92.0",
+            "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.92.0.tgz",
+            "integrity": "sha512-N8D27KH1vEpVacvZgJL27xC6yPFUy0Zkezn5gnB3L3gRCxlDeSuiya7fKge8Y91uMTnC8aSxBQhcK6ocY7alpQ==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/tannerlinsley"
+            }
+        },
+        "node_modules/@tanstack/react-query": {
+            "version": "5.90.19",
+            "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.19.tgz",
+            "integrity": "sha512-qTZRZ4QyTzQc+M0IzrbKHxSeISUmRB3RPGmao5bT+sI6ayxSRhn0FXEnT5Hg3as8SBFcRosrXXRFB+yAcxVxJQ==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@tanstack/query-core": "5.90.19"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/tannerlinsley"
+            },
+            "peerDependencies": {
+                "react": "^18 || ^19"
+            }
+        },
+        "node_modules/@tanstack/react-query-devtools": {
+            "version": "5.91.2",
+            "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.91.2.tgz",
+            "integrity": "sha512-ZJ1503ay5fFeEYFUdo7LMNFzZryi6B0Cacrgr2h1JRkvikK1khgIq6Nq2EcblqEdIlgB/r7XDW8f8DQ89RuUgg==",
+            "license": "MIT",
+            "dependencies": {
+                "@tanstack/query-devtools": "5.92.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/tannerlinsley"
+            },
+            "peerDependencies": {
+                "@tanstack/react-query": "^5.90.14",
+                "react": "^18 || ^19"
+            }
         },
         "node_modules/@terraformer/wkt": {
             "version": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
         "@mui/x-tree-view": "^6.0.0-beta.0",
         "@sentry/browser": "^8.35.0",
         "@superset-ui/embedded-sdk": "^0.1.2",
+        "@tanstack/react-query-devtools": "^5.91.2",
         "@terraformer/wkt": "^2.1.2",
         "@types/react": "^18.0.0",
         "@types/react-dom": "^18.0.0",


### PR DESCRIPTION
## What problem is this PR solving?

We could use r[eact-query dev tools](https://tanstack.com/query/v5/docs/framework/react/devtools) to inspect cache, mutation status, ... 
We should be able to enable or disable it with the console, disabled by default


### Related JIRA tickets

IA-4722

## Changes

- install dep
- custom hook to show/hide panel
- some doc 

## How to test

- run `npm ci`
- launch Iaso
- open the console and run `window.showReactQueryDevtools()` dec tools should be visible
- run `window.shideReactQueryDevtools()` it should remove it

## Print screen / video

https://github.com/user-attachments/assets/4962b8f5-17bc-4cfe-81ba-9c814762fa2b

## Notes
-

## Doc

docs/pages/dev/how_to/use_react_query_dev_tools/use_react_query_dev_tools_en.md

