### PR TITLE
IA-4720: Error in Org Unit logs

### DIFF
--- a/hat/audit/modifications/values_serializer.py
+++ b/hat/audit/modifications/values_serializer.py
@@ -15,7 +15,11 @@ class OrgUnitValuesSerializer(ValuesSerializer):
     @staticmethod
     def map_field(field: str, value: str) -> Union[str, dict]:
         if field == "org_unit_type":
-            return {"id": value, "name": OrgUnitType.objects.get(pk=value).name}
+            try:
+                name = OrgUnitType.objects.get(pk=value).name
+            except OrgUnitType.DoesNotExist:
+                name = "--"
+            return {"id": value, "name": name}
         return value
 
     def serialize(self, values: Union[JSONField, Any]) -> Union[JSONField, list[dict]]:


### PR DESCRIPTION
## What problem is this PR solving?

Fix an error when org unit modification logs refer to a non-existent OrgUnitType.

### Related JIRA tickets

IA-4720

## Changes

Added a small fix to show "--" instead of the name of the OrgUnitType that doesn't exist.

## How to test

- Create a new OrgUnit in the dashboard and keep it open in a tab
- Go to the django admin, Modifications `/admin/audit/modification/`
- Open the Modification object for the org unit you just created (should be the most recent one at the top of the list)
- In the `New value` json field, find the `org_unit_type` key and set its value to a random invalid id (therefore referencing an OrgUnitType that doesn't exist). Save the modification.
- Go back to the OrgUnit you created in the dashboard, and go to the History tab.
- Click the details icon for the modification in the list (if you just created the org unit, there should only be one)
- The creation details for the Org Unit should appear without error, and it should have a field that reads:
  - Organisation unit type
  - -- (id: 1234) (the id you setup in the admin)


## Print screen / video

/

## Notes

/ 

## Doc

/