### PR TITLE
IA-4723: remove unstable_viewTransition

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
                 "abortcontroller-polyfill": "^1.7.5",
                 "array-flat-polyfill": "^1.0.1",
                 "babel-plugin-formatjs": "^10.3.4",
-                "bluesquare-components": "github:BLSQ/bluesquare-components#IA-4640_safe_date_picker",
+                "bluesquare-components": "github:BLSQ/bluesquare-components#IA-4639_iaso_version",
                 "classnames": "^2.2.6",
                 "color": "^3.1.2",
                 "dom-to-pdf": "^0.3.1",
@@ -7214,7 +7214,7 @@
         },
         "node_modules/bluesquare-components": {
             "version": "1.0.0",
-            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#248c883496b2d323042a1c45a6758c602b47cd61",
+            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#d56da556da4e8575004759081e130a6b5d5fcccd",
             "license": "Apache-2.0",
             "dependencies": {
                 "@babel/plugin-transform-class-properties": "^7.24.6",
@@ -7250,7 +7250,6 @@
                 "formik": "^2.2.9",
                 "moment": "^2.20.1",
                 "notistack": "^3.0.1",
-                "prop-types": "^15.7.2",
                 "react": "17.0.2||^18.0.0",
                 "react-dom": "17.0.2||^18.0.0",
                 "react-dropzone": "^14.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,6 @@
                 "npm": "10.9.3",
                 "pdfjs-dist": "^4.8.69",
                 "polyfill-object.fromentries": "^1.0.1",
-                "prop-types": "^15.7.2",
                 "quill": "^2.0.2",
                 "react": "^18.2.0",
                 "react-color": "^2.17.3",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
         "npm": "10.9.3",
         "pdfjs-dist": "^4.8.69",
         "polyfill-object.fromentries": "^1.0.1",
-        "prop-types": "^15.7.2",
         "quill": "^2.0.2",
         "react": "^18.2.0",
         "react-color": "^2.17.3",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
         "abortcontroller-polyfill": "^1.7.5",
         "array-flat-polyfill": "^1.0.1",
         "babel-plugin-formatjs": "^10.3.4",
-        "bluesquare-components": "github:BLSQ/bluesquare-components#IA-4640_safe_date_picker",
+        "bluesquare-components": "github:BLSQ/bluesquare-components#IA-4639_iaso_version",
         "classnames": "^2.2.6",
         "color": "^3.1.2",
         "dom-to-pdf": "^0.3.1",


### PR DESCRIPTION
## What problem is this PR solving?

This props ia a feature flag that should create an animation from one page to another while redirecting with react-router. This is unstable, used only in specific browser and is never used in IASO or Gaps project

<img width="1480" height="901" alt="Screenshot 2026-01-26 at 10 39 35" src="https://github.com/user-attachments/assets/6bc57f5c-b88b-44e5-819f-1cabe33069eb" />


### Related JIRA tickets

IA-4723

## Changes

- upgrade bluesquare-components to use [those](https://github.com/BLSQ/bluesquare-components/pull/204) changes 

## How to test

- run npm ci
- launch webpack dev
- you should not have this warning int the console


## Print screen / video

-
## Notes

-

## Doc

-
