### PR TITLE
IA-4712: Datasource sync preview disabled

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/dataSources/components/sync/ConfirmSyncButton.tsx
+++ b/hat/assets/js/apps/Iaso/domains/dataSources/components/sync/ConfirmSyncButton.tsx
@@ -116,6 +116,7 @@ export const ConfirmSyncButton: FunctionComponent<Props> = ({
         setIsPreviewDone(false);
         setIsLoading(false);
         setSyncName(undefined);
+        setSyncId(undefined);
         setJsonDiffResult(undefined);
         setErrors([]);
     }, []);


### PR DESCRIPTION
## What problem is this PR solving?

After cancelling a previous sync try, the synchronization name field got greyed and can't be filled anymore

<img width="464" height="512" alt="image" src="https://github.com/user-attachments/assets/4eef8092-c456-4ca5-8fcc-382c65c0a135" />

### Related JIRA tickets

IA-4712

## Changes

 empty syncId when closing the dialog

## How to test

Launch a sync between two version of the same data source, give it a name, click on preview.
Close the dialog
Reopen it, you should be able to relaunch a preview


## Print screen / video


https://github.com/user-attachments/assets/cbb83486-9f4b-46df-ada6-64c469a88def



## Notes

-

## Doc

-
