### PR TITLE
IA-4727: Upgrade critical dependency jspdf

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1972,9 +1972,9 @@
             }
         },
         "node_modules/@cypress/request": {
-            "version": "3.0.9",
-            "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.9.tgz",
-            "integrity": "sha512-I3l7FdGRXluAS44/0NguwWlO83J18p0vlr2FYHrJkWdNYhgVoiYo61IXPqaOsL+vNxU1ZqMACzItGK3/KKDsdw==",
+            "version": "3.0.10",
+            "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.10.tgz",
+            "integrity": "sha512-hauBrOdvu08vOsagkZ/Aju5XuiZx6ldsLfByg1htFeldhex+PeMrYauANzFsMJeAA0+dyPLbDoX2OYuvVoLDkQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -1991,7 +1991,7 @@
                 "json-stringify-safe": "~5.0.1",
                 "mime-types": "~2.1.19",
                 "performance-now": "^2.1.0",
-                "qs": "6.14.0",
+                "qs": "~6.14.1",
                 "safe-buffer": "^5.1.2",
                 "tough-cookie": "^5.0.0",
                 "tunnel-agent": "^0.6.0",
@@ -4254,9 +4254,9 @@
             }
         },
         "node_modules/@remix-run/router": {
-            "version": "1.23.1",
-            "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.1.tgz",
-            "integrity": "sha512-vDbaOzF7yT2Qs4vO6XV1MHcJv+3dgR1sT+l3B8xxOVhUC336prMvqrvsLL/9Dnw2xr6Qhz4J0dmS0llNAbnUmQ==",
+            "version": "1.23.2",
+            "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
+            "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
             "license": "MIT",
             "engines": {
                 "node": ">=14.0.0"
@@ -4992,6 +4992,12 @@
                 "@types/node": "*"
             }
         },
+        "node_modules/@types/pako": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+            "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+            "license": "MIT"
+        },
         "node_modules/@types/parse-json": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
@@ -5150,6 +5156,13 @@
             "dependencies": {
                 "@types/jest": "*"
             }
+        },
+        "node_modules/@types/trusted-types": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+            "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/@types/use-sync-external-store": {
             "version": "0.0.3",
@@ -6723,18 +6736,6 @@
             "license": "ISC",
             "engines": {
                 "node": ">= 4.0.0"
-            }
-        },
-        "node_modules/atob": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-            "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
-            "license": "(MIT OR Apache-2.0)",
-            "bin": {
-                "atob": "bin/atob.js"
-            },
-            "engines": {
-                "node": ">= 4.5.0"
             }
         },
         "node_modules/attr-accept": {
@@ -10042,18 +10043,6 @@
                 "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
             }
         },
-        "node_modules/btoa": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
-            "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
-            "license": "(MIT OR Apache-2.0)",
-            "bin": {
-                "btoa": "bin/btoa.js"
-            },
-            "engines": {
-                "node": ">= 0.4.0"
-            }
-        },
         "node_modules/buffer": {
             "version": "5.7.1",
             "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
@@ -11683,11 +11672,14 @@
             "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
         },
         "node_modules/dompurify": {
-            "version": "2.5.8",
-            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.8.tgz",
-            "integrity": "sha512-o1vSNgrmYMQObbSSvF/1brBYEQPHhV1+gsmrusO7/GXtp1T9rCS8cXFqVxK/9crT1jA6Ccv+5MTSjBNqr7Sovw==",
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
+            "integrity": "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==",
             "license": "(MPL-2.0 OR Apache-2.0)",
-            "optional": true
+            "optional": true,
+            "optionalDependencies": {
+                "@types/trusted-types": "^2.0.7"
+            }
         },
         "node_modules/dotenv": {
             "version": "10.0.0",
@@ -13129,6 +13121,17 @@
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/fast-png": {
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
+            "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/pako": "^2.0.3",
+                "iobuffer": "^5.3.2",
+                "pako": "^2.1.0"
+            }
         },
         "node_modules/fast-uri": {
             "version": "3.1.0",
@@ -14758,6 +14761,12 @@
                 "tslib": "^2.8.0"
             }
         },
+        "node_modules/iobuffer": {
+            "version": "5.4.0",
+            "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
+            "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
+            "license": "MIT"
+        },
         "node_modules/ipaddr.js": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.3.0.tgz",
@@ -16155,20 +16164,19 @@
             }
         },
         "node_modules/jspdf": {
-            "version": "2.5.2",
-            "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-2.5.2.tgz",
-            "integrity": "sha512-myeX9c+p7znDWPk0eTrujCzNjT+CXdXyk7YmJq5nD5V7uLLKmSXnlQ/Jn/kuo3X09Op70Apm0rQSnFWyGK8uEQ==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.0.0.tgz",
+            "integrity": "sha512-w12U97Z6edKd2tXDn3LzTLg7C7QLJlx0BPfM3ecjK2BckUl9/81vZ+r5gK4/3KQdhAcEZhENUxRhtgYBj75MqQ==",
             "license": "MIT",
             "dependencies": {
-                "@babel/runtime": "^7.23.2",
-                "atob": "^2.1.2",
-                "btoa": "^1.2.1",
+                "@babel/runtime": "^7.28.4",
+                "fast-png": "^6.2.0",
                 "fflate": "^0.8.1"
             },
             "optionalDependencies": {
-                "canvg": "^3.0.6",
+                "canvg": "^3.0.11",
                 "core-js": "^3.6.0",
-                "dompurify": "^2.5.4",
+                "dompurify": "^3.2.4",
                 "html2canvas": "^1.0.0-rc.5"
             }
         },
@@ -16519,15 +16527,15 @@
             }
         },
         "node_modules/lodash": {
-            "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+            "version": "4.17.23",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+            "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
             "license": "MIT"
         },
         "node_modules/lodash-es": {
-            "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-            "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+            "version": "4.17.23",
+            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
+            "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
             "license": "MIT"
         },
         "node_modules/lodash.assign": {
@@ -20734,6 +20742,12 @@
             "dev": true,
             "license": "BlueOak-1.0.0"
         },
+        "node_modules/pako": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+            "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+            "license": "(MIT AND Zlib)"
+        },
         "node_modules/parchment": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/parchment/-/parchment-3.0.0.tgz",
@@ -21446,9 +21460,9 @@
             }
         },
         "node_modules/qs": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-            "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+            "version": "6.14.1",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
+            "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -21927,12 +21941,12 @@
             "license": "MIT"
         },
         "node_modules/react-router": {
-            "version": "6.30.2",
-            "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.2.tgz",
-            "integrity": "sha512-H2Bm38Zu1bm8KUE5NVWRMzuIyAV8p/JrOaBJAwVmp37AXG72+CZJlEBw6pdn9i5TBgLMhNDgijS4ZlblpHyWTA==",
+            "version": "6.30.3",
+            "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
+            "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
             "license": "MIT",
             "dependencies": {
-                "@remix-run/router": "1.23.1"
+                "@remix-run/router": "1.23.2"
             },
             "engines": {
                 "node": ">=14.0.0"
@@ -21942,13 +21956,13 @@
             }
         },
         "node_modules/react-router-dom": {
-            "version": "6.30.2",
-            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.2.tgz",
-            "integrity": "sha512-l2OwHn3UUnEVUqc6/1VMmR1cvZryZ3j3NzapC2eUXO1dB0sYp5mvwdjiXhpUbRb21eFow3qSxpP8Yv6oAU824Q==",
+            "version": "6.30.3",
+            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
+            "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
             "license": "MIT",
             "dependencies": {
-                "@remix-run/router": "1.23.1",
-                "react-router": "6.30.2"
+                "@remix-run/router": "1.23.2",
+                "react-router": "6.30.3"
             },
             "engines": {
                 "node": ">=14.0.0"
@@ -23211,9 +23225,9 @@
             }
         },
         "node_modules/sinon/node_modules/diff": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
-            "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+            "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
             "dev": true,
             "license": "BSD-3-Clause",
             "engines": {

--- a/package.json
+++ b/package.json
@@ -165,6 +165,7 @@
         "webpack-dev-server": "^4.15.1"
     },
     "overrides": {
-        "canvg": "4.0.3"
+        "canvg": "4.0.3",
+        "jspdf": "4.0.0"
     }
 }

--- a/plugins/polio/js/src/domains/Calendar/campaignCalendar/PdfExportButton.tsx
+++ b/plugins/polio/js/src/domains/Calendar/campaignCalendar/PdfExportButton.tsx
@@ -1,9 +1,9 @@
 import React, { FunctionComponent, useCallback } from 'react';
-import { Button } from '@mui/material';
 import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf';
-import domToPdf from 'dom-to-pdf';
-import { useSafeIntl } from 'bluesquare-components';
+import { Button } from '@mui/material';
 import { makeStyles } from '@mui/styles';
+import { useSafeIntl } from 'bluesquare-components';
+import domToPdf from 'dom-to-pdf';
 import MESSAGES from '../../../constants/messages';
 
 const pageWidth = 1980;


### PR DESCRIPTION
## What problem is this PR solving?

jspdf used by dom-to-pdf needs to be override in order to fix critical dep warning while running `npm ci`

We can also run npm audit fixto fix deps that can be fixed automatically

<img width="560" height="47" alt="image" src="https://github.com/user-attachments/assets/18d264e2-3abd-4694-af11-23d0e95379c7" />

### Related JIRA tickets

IA-4727

## Changes

- run `npm audit fix` to fix dependencies without breaking changes
- force jspdf version to version 4.0.0 to remove critical warning


## How to test

- run `npm ci`
- run `npm run dev`
- make sure app is working properly, especially calendar export to pdf feature (dom-to-pdf is used only there)

## Print screen / video

<img width="438" height="41" alt="Screenshot 2026-01-28 at 17 26 25" src="https://github.com/user-attachments/assets/a5c3dc2a-4483-4859-a699-820c806c2257" />

 
## Notes

-

## Doc

-