### PR TITLE
IA-4614: As a newly invited user, I'm stuck if my invitation email link expires

### DIFF
--- a/iaso/tests/api/test_profiles.py
+++ b/iaso/tests/api/test_profiles.py
@@ -2241,20 +2241,50 @@ class ProfileAPITestCase(APITestCase):
         """Test that creating a user with send_email_invitation=True sets a random password instead of an unusable one."""
         self.client.force_authenticate(self.jim)
         data = {
-            "user_name": "invited_user",
+            "user_name": "invited_user_empty_password",
             "password": "",
             "first_name": "Invited",
             "last_name": "User",
             "send_email_invitation": True,
-            "email": "invited@test.com",
+            "email": "invited1@test.com",
         }
 
         response = self.client.post("/api/profiles/", data=data, format="json")
         self.assertEqual(response.status_code, 200)
 
-        user = get_user_model().objects.get(username="invited_user")
+        user = get_user_model().objects.get(username="invited_user_empty_password")
         self.assertTrue(user.has_usable_password(), "Invited user should have a usable password")
 
-        self.assertEqual(len(mail.outbox), 1)
-        email = mail.outbox[0]
-        self.assertEqual(email.to, ["invited@test.com"])
+        data = {
+            "user_name": "invited_user_missing_password",
+            "first_name": "Invited",
+            "last_name": "User",
+            "send_email_invitation": True,
+            "email": "invited2@test.com",
+        }
+
+        response = self.client.post("/api/profiles/", data=data, format="json")
+        self.assertEqual(response.status_code, 200)
+
+        user = get_user_model().objects.get(username="invited_user_missing_password")
+        self.assertTrue(user.has_usable_password())
+
+        data = {
+            "user_name": "invited_user_password_is_none",
+            "password": None,
+            "first_name": "Invited",
+            "last_name": "User",
+            "send_email_invitation": True,
+            "email": "invited3@test.com",
+        }
+
+        response = self.client.post("/api/profiles/", data=data, format="json")
+        self.assertEqual(response.status_code, 200)
+
+        user = get_user_model().objects.get(username="invited_user_password_is_none")
+        self.assertTrue(user.has_usable_password())
+
+        self.assertEqual(len(mail.outbox), 3)
+        self.assertEqual(mail.outbox[0].to, ["invited1@test.com"])
+        self.assertEqual(mail.outbox[1].to, ["invited2@test.com"])
+        self.assertEqual(mail.outbox[2].to, ["invited3@test.com"])


### PR DESCRIPTION
## What problem is this PR solving?

Django blocks email sending when a user was created with set_unusable_password. This PR ensures that a random password is set when no password is provided.

### Related JIRA tickets

IA-4614

## Changes

  iaso/api/profiles/profiles.py: Modified `update_password` method to set random passwords for invited users instead of unusable passwords.


## How to test

- Login as admin to the Iaso platform
- Navigate to Users > Create User
- Check "Send Email Invitation"
- Leave password field empty
- Verify invitation email sent
- DO NOT click the invitation link
- Go to login page and click "Forgot Password"
- Enter the new user's email
- Verify password reset email is sent


