### PR TITLE
IA-4709: prevent date overwrite on OU patch

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitForm.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitForm.tsx
@@ -84,8 +84,15 @@ export const OrgUnitForm: FunctionComponent<Props> = ({
     );
     const [orgUnitModified, setOrgUnitModified] = useState(false);
     const handleSave = () => {
-        const newOrgUnit = mapValues(formState, v =>
-            Object.prototype.hasOwnProperty.call(v, 'value') ? v.value : v,
+        const newOrgUnit: Record<string, any> = Object.fromEntries(
+            Object.entries(formState).map(([key, v]: [string, any]) => {
+                const value = 'value' in v ? v.value : v;
+                // For opening_date and closed_date, send null if value is undefined/null/empty
+                if (key === 'opening_date' || key === 'closed_date') {
+                    return [key, value ?? null];
+                }
+                return [key, value];
+            }),
         );
         newOrgUnit.parent_id =
             isNewOrgunit && params.parentOrgUnitId && !newOrgUnit.parent?.id

--- a/iaso/api/org_units.py
+++ b/iaso/api/org_units.py
@@ -744,9 +744,10 @@ class OrgUnitViewSet(viewsets.ViewSet):
                     )
             else:
                 org_unit.default_image = None
-
-        org_unit.opening_date = self.get_date(request.data.get("opening_date"))
-        org_unit.closed_date = self.get_date(request.data.get("closed_date"))
+        if "opening_date" in request.data:
+            org_unit.opening_date = self.get_date(request.data.get("opening_date"))
+        if "closed_date" in request.data:
+            org_unit.closed_date = self.get_date(request.data.get("closed_date"))
 
         if not errors:
             try:

--- a/iaso/tests/api/test_orgunits.py
+++ b/iaso/tests/api/test_orgunits.py
@@ -1799,6 +1799,14 @@ class OrgUnitAPITestCase(APITestCase):
         self.assertEqual(ou.opening_date, datetime.date(2024, 6, 22))
         self.assertEqual(ou.closed_date, datetime.date(2025, 10, 30))
 
+        data = {"name": "yabadabadoo"}
+        response = self.client.patch(f"/api/orgunits/{ou.id}/", format="json", data=data)
+        self.assertJSONResponse(response, 200)
+        ou.refresh_from_db()
+        # expect dates not to be overwritten if not in the request body
+        self.assertEqual(ou.opening_date, datetime.date(2024, 6, 22))
+        self.assertEqual(ou.closed_date, datetime.date(2025, 10, 30))
+
         data = {"opening_date": None, "closed_date": ""}
         response = self.client.patch(f"/api/orgunits/{ou.id}/", format="json", data=data)
         self.assertJSONResponse(response, 200)


### PR DESCRIPTION
## What problem is this PR solving?

PATCH requests on org unit API would overwrite opening and closed date if the param wasn't in the request body

### Related JIRA tickets

IA-4709

## Changes

Explain the changes that were made.

- Update API to check for the presence of the param before overwriting
- Add test
- Update OrgUnit save code in front-end to send `null` when deleting field

## How to test

With django API, try PATCHing an org unit:
- without `opening_date`or `closed_date` param --> should not be overwritten
- with `opening_date:""` or `opening_date:null` --> should be overwritten. Same with closed_date

Go to OrgUnit > details
- Add/remove opening and closed dates: it should save correctly, ie: save the date, and remove it when emptying the field

## Print screen / video

https://github.com/user-attachments/assets/888b7c3a-c394-45a8-bf48-9819128a532f

