### PR TITLE
IA-4752: raise 404 i.o 500 on project not found

### DIFF
--- a/iaso/api/mobile/org_units.py
+++ b/iaso/api/mobile/org_units.py
@@ -8,7 +8,7 @@ from django.contrib.gis.db.models.functions import GeomOutputGeoFunc
 from django.core.cache import cache
 from django.db.models.expressions import RawSQL
 from django.db.models.functions import Cast
-from django.http import HttpResponseNotFound
+from django.http import Http404, HttpResponseNotFound
 from django.shortcuts import get_object_or_404
 from rest_framework import serializers
 from rest_framework.decorators import action
@@ -313,7 +313,7 @@ class MobileOrgUnitViewSet(ModelViewSet):
         try:
             new_org_units = import_org_units(data, request.user, self.get_app_id())
         except Project.DoesNotExist:
-            new_org_units = []
+            raise Http404
         return Response([org_unit.as_dict() for org_unit in new_org_units])
 
     @action(detail=False, methods=["GET"])

--- a/iaso/api/org_units.py
+++ b/iaso/api/org_units.py
@@ -958,7 +958,10 @@ class OrgUnitViewSet(viewsets.ViewSet):
     @safe_api_import("orgUnit")
     def create(self, _, request):
         """This endpoint is used by mobile app"""
-        new_org_units = import_org_units(request.data, request.user, request.query_params.get("app_id"))
+        try:
+            new_org_units = import_org_units(request.data, request.user, request.query_params.get("app_id"))
+        except Project.DoesNotExist:
+            new_org_units = []
         return Response([org_unit.as_dict() for org_unit in new_org_units])
 
     def retrieve(self, request, pk=None):

--- a/iaso/api/org_units.py
+++ b/iaso/api/org_units.py
@@ -13,7 +13,7 @@ from django.core.exceptions import ValidationError
 from django.core.paginator import Paginator
 from django.db import IntegrityError
 from django.db.models import Count, IntegerField, OuterRef, Q, Subquery, Value
-from django.http import HttpResponse, JsonResponse, StreamingHttpResponse
+from django.http import Http404, HttpResponse, JsonResponse, StreamingHttpResponse
 from django.shortcuts import get_object_or_404
 from django.utils.translation import gettext as _
 from rest_framework import permissions, status, viewsets
@@ -961,7 +961,7 @@ class OrgUnitViewSet(viewsets.ViewSet):
         try:
             new_org_units = import_org_units(request.data, request.user, request.query_params.get("app_id"))
         except Project.DoesNotExist:
-            new_org_units = []
+            raise Http404
         return Response([org_unit.as_dict() for org_unit in new_org_units])
 
     def retrieve(self, request, pk=None):

--- a/iaso/management/commands/reimport_failed_imports.py
+++ b/iaso/management/commands/reimport_failed_imports.py
@@ -3,6 +3,7 @@ from django.core.management.base import BaseCommand
 from hat.api_import.models import APIImport
 from iaso.api.instances.instances import import_data as import_instances
 from iaso.api.org_units import import_org_units
+from iaso.models import Project
 
 
 class Command(BaseCommand):
@@ -17,6 +18,8 @@ class Command(BaseCommand):
                 i.has_problem = False
                 i.save()
                 unit_count = unit_count + 1
+            except Project.DoesNotExist:
+                print(f"No Project found for app id {i}")
             except Exception as e:
                 print("An error happened", e)
 

--- a/iaso/management/commands/reimport_failed_imports.py
+++ b/iaso/management/commands/reimport_failed_imports.py
@@ -18,8 +18,8 @@ class Command(BaseCommand):
                 i.has_problem = False
                 i.save()
                 unit_count = unit_count + 1
-            except Project.DoesNotExist:
-                print(f"No Project found for app id {i}")
+            except Project.DoesNotExist as e:
+                print(f"No Project found for app id {i} {str(e)}")
             except Exception as e:
                 print("An error happened", e)
 

--- a/iaso/test.py
+++ b/iaso/test.py
@@ -308,11 +308,11 @@ class APITestCase(BaseAPITestCase, IasoTestCaseMixin):
         has_problems: bool,
         check_auth_header: bool = False,
         exception_contains_string: str = None,
+        exception_contains_code: str = None,
     ):
         """Make sure that a APIImport has been correctly generated"""
 
         last_api_import = APIImport.objects.order_by("-created_at").first()
-        assert last_api_import is not None
         self.assertIsNotNone(last_api_import)
         self.assertIsInstance(last_api_import.headers, dict)
         self.assertEqual(last_api_import.json_body, request_body)
@@ -326,8 +326,10 @@ class APITestCase(BaseAPITestCase, IasoTestCaseMixin):
 
         if has_problems is False:
             self.assertEqual(last_api_import.exception, "")
-        elif exception_contains_string is not None:
+        if exception_contains_string is not None:
             self.assertTrue(exception_contains_string in last_api_import.exception)
+        if exception_contains_code is not None:
+            self.assertTrue(exception_contains_code in last_api_import.exception)
 
     def assertValidProjectData(self, project_data: typing.Mapping):
         self.assertHasField(project_data, "id", int)

--- a/iaso/tests/test_api.py
+++ b/iaso/tests/test_api.py
@@ -241,6 +241,7 @@ class BasicAPITestCase(APITestCase):
             request_body=unit_body_2,
             has_problems=True,
             exception_contains_string="Could not find project for user",
+            exception_contains_code="404",
         )
 
         # Wrong app id - An APIImport record with has_problem set to True should be created
@@ -251,6 +252,7 @@ class BasicAPITestCase(APITestCase):
             request_body=unit_body_2,
             has_problems=True,
             exception_contains_string="Could not find project for user",
+            exception_contains_code="404",
         )
 
     def test_instance_insertion(self):


### PR DESCRIPTION
## What problem is this PR solving?

The `import_org_units`method would raise a 500 when not finding a project for the given `app_id` which would clutter Sentry

### Related JIRA tickets

IA-4752

## Changes

- wrapped `import_org_units` in a `try/except` in the org unit api and mobile org units api and raise a 404
- Add specific exception for `Project.DoesNotExist` in:
    - mobile bulk upload
    - reimport command
    
- update test to check for error code 

## How to test

The tests should cover it

## Print screen / video

N/A

