### PR TITLE
WC2-877: Show mismatches on debug page

### DIFF
--- a/plugins/wfp/templates/debug.html
+++ b/plugins/wfp/templates/debug.html
@@ -102,7 +102,7 @@
 
 {% for visit in journey.visit_set.all %}
 <div style="padding-left:30px">
-    <h4>Visit {{ visit.id }}</h4>
+    <h4>Visit {{ visit.id }} <a href="/dashboard/forms/submission/instanceId/{{visit.instance_id}}">View submission</a></h4>
     <table>
         <tr>
             <th>date</th>

--- a/plugins/wfp/templates/debug_summary.html
+++ b/plugins/wfp/templates/debug_summary.html
@@ -1,141 +1,302 @@
 <html>
-<head>
-    <style>
-        th, td {
-            border: 1px black solid;
-            padding: 5px;
-        }
+    <head>
+        <style>
+            th,
+            td {
+                border: 1px black solid;
+                padding: 5px;
+            }
 
-        th {
-            text-align: right;
-            background-color: #f2f2f2;
-        }
+            th {
+                text-align: right;
+                background-color: #f2f2f2;
+            }
 
-        .navbar {
-            background-color: #000000;
-            padding: 15px;
-            position: -webkit-sticky;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            margin-bottom: 20px;
-        }
+            .navbar {
+                background-color: #000000;
+                padding: 15px;
+                position: -webkit-sticky;
+                position: sticky;
+                top: 0;
+                z-index: 1000;
+                margin-bottom: 20px;
+            }
 
-        .navbar a {
-            color: #ffffff;
-            text-decoration: none;
-            font-weight: bold;
-            margin-right: 20px;
-            font-family: sans-serif;
-        }
+            .navbar a {
+                color: #ffffff;
+                text-decoration: none;
+                font-weight: bold;
+                margin-right: 20px;
+                font-family: sans-serif;
+            }
 
-        .navbar a:hover {
-            text-decoration: underline;
-        }
+            .navbar a:hover {
+                text-decoration: underline;
+            }
 
-        .section-anchor {
-            scroll-margin-top: 80px;
-        }
-        
-        body {
-            margin: 0;
-            padding: 0 0 20px 0; 
-        }
-        
-        .content-container {
-            padding: 20px;
-        }
-    </style>
-</head>
-<body>
+            .section-anchor {
+                scroll-margin-top: 80px;
+            }
 
-    <div class="navbar">
-        <a href="#negative_durations">1. Negative Durations ({{ negative_count }})</a>
-        <a href="#future_visits">2. Future Visits ({{ future_count }})</a>
-    </div>
+            body {
+                margin: 0;
+                padding: 0 0 20px 0;
+            }
 
-    <div class="content-container">
-        <h1>ETL Debug Summary</h1>
+            .content-container {
+                padding: 20px;
+            }
+        </style>
+    </head>
+    <body>
+        <div class="navbar">
+            <a href="#negative_durations"
+                >1. Negative Durations ({{ negative_count }})</a
+            >
+            <a href="#future_visits">2. Future Visits ({{ future_count }})</a>
+            <a href="#visits_without_date"
+                >3. Visits without date ({{ without_date_count }})</a
+            >
+        </div>
 
-        <div id="negative_durations" class="section-anchor">
-            <h2>Issue: Negative Durations</h2>
-            <p>Total Anomalies Found: {{ negative_count }}</p>
-            
-            {% for journey in recent_negatives %}
-            <h3>Journey {{ journey.id }}</h3>
-            <table>
-                <tr><th>Beneficiary ID</th><td>{{ journey.beneficiary.id }}</td></tr>
-                <tr><th>Entity ID</th><td>{{ journey.beneficiary.entity_id }}</td></tr>
-                <tr><th>Link</th>
-                    <td><a href="/dashboard/entities/details/accountId/{{ journey.beneficiary.account.id }}/entityId/{{ journey.beneficiary.entity_id }}">/dashboard/entities/details/accountId/{{ journey.beneficiary.account.id }}/entityId/{{ journey.beneficiary.entity_id }}</a></td>
-                </tr>
-                <tr><th>admission_criteria</th><td>{{ journey.admission_criteria }}</td></tr>
-                <tr><th>admission_type</th><td>{{ journey.admission_type }}</td></tr>
-                <tr><th>nutrition_programme</th><td>{{ journey.nutrition_programme }}</td></tr>
-                <tr><th>programme_type</th><td>{{ journey.programme_type }}</td></tr>
-                <tr><th>muac_size</th><td>{{ journey.muac_size }}</td></tr>
-                <tr><th>whz_score</th><td>{{ journey.whz_score }}</td></tr>
-                <tr><th>initial_weight</th><td>{{ journey.initial_weight }}</td></tr>
-                <tr><th>discharge_weight</th><td>{{ journey.discharge_weight }}</td></tr>
-                <tr><th>weight_gain</th><td>{{ journey.weight_gain }}</td></tr>
-                <tr><th>weight_loss</th><td>{{ journey.weight_loss }}</td></tr>
-                <tr><th>Start date</th><td>{{ journey.start_date | date }}</td></tr>
-                <tr><th>End date</th><td>{{ journey.end_date | date }}</td></tr>
-                <tr><th>Number of days (Duration)</th><td>{{ journey.duration }}</td></tr>
-                <tr><th>exit_type</th><td>{{ journey.exit_type }}</td></tr>
-                <tr><th>instance_id</th><td>{{ journey.instance_id }}</td></tr>
-            </table>
+        <div class="content-container">
+            <h1>ETL Debug Summary</h1>
 
-            {% for visit in journey.visit_set.all %}
-            <div style="padding-left:30px">
-                <h4>Visit {{ visit.id }}</h4>
+            <div id="negative_durations" class="section-anchor">
+                <h2>Issue: Negative Durations</h2>
+                <p>Total Anomalies Found: {{ negative_count }}</p>
+
+                {% for journey in recent_negatives %}
+                <h3>Journey {{ journey.id }}</h3>
                 <table>
-                    <tr><th>date</th><td>{{ visit.date | date }}</td></tr>
-                    <tr><th>number</th><td>{{ visit.number }}</td></tr>
-                    <tr><th>muac_size</th><td>{{ visit.muac_size }}</td></tr>
-                    <tr><th>whz_color</th><td>{{ visit.whz_color }}</td></tr>
-                    <tr><th>oedema</th><td>{{ visit.oedema }}</td></tr>
-                    <tr><th>entry_point</th><td>{{ visit.entry_point }}</td></tr>
-                    <tr><th>org_unit</th><td>{{ visit.org_unit.name }}</td></tr>
-                    <tr><th>instance_id</th><td>{{ visit.instance_id }}</td></tr>
+                    <tr>
+                        <th>Beneficiary ID</th>
+                        <td>{{ journey.beneficiary.id }}</td>
+                    </tr>
+                    <tr>
+                        <th>Entity ID</th>
+                        <td>{{ journey.beneficiary.entity_id }}</td>
+                    </tr>
+                    <tr>
+                        <th>Link</th>
+                        <td>
+                            <a
+                                href="/dashboard/entities/details/accountId/{{journey.beneficiary.account.id}}/entityId/{{journey.beneficiary.entity_id}}"
+                                >/dashboard/entities/details/accountId/{{journey.beneficiary.account.id}}/entityId/{{journey.beneficiary.entity_id}}</a
+                            >
+                        </td>
+                    </tr>
+                    <tr>
+                        <th>admission_criteria</th>
+                        <td>{{ journey.admission_criteria }}</td>
+                    </tr>
+                    <tr>
+                        <th>admission_type</th>
+                        <td>{{ journey.admission_type }}</td>
+                    </tr>
+                    <tr>
+                        <th>nutrition_programme</th>
+                        <td>{{ journey.nutrition_programme }}</td>
+                    </tr>
+                    <tr>
+                        <th>programme_type</th>
+                        <td>{{ journey.programme_type }}</td>
+                    </tr>
+                    <tr>
+                        <th>muac_size</th>
+                        <td>{{ journey.muac_size }}</td>
+                    </tr>
+                    <tr>
+                        <th>whz_score</th>
+                        <td>{{ journey.whz_score }}</td>
+                    </tr>
+                    <tr>
+                        <th>initial_weight</th>
+                        <td>{{ journey.initial_weight }}</td>
+                    </tr>
+                    <tr>
+                        <th>discharge_weight</th>
+                        <td>{{ journey.discharge_weight }}</td>
+                    </tr>
+                    <tr>
+                        <th>weight_gain</th>
+                        <td>{{ journey.weight_gain }}</td>
+                    </tr>
+                    <tr>
+                        <th>weight_loss</th>
+                        <td>{{ journey.weight_loss }}</td>
+                    </tr>
+                    <tr>
+                        <th>Start date</th>
+                        <td>{{ journey.start_date | date }}</td>
+                    </tr>
+                    <tr>
+                        <th>End date</th>
+                        <td>{{ journey.end_date | date }}</td>
+                    </tr>
+                    <tr>
+                        <th>Number of days (Duration)</th>
+                        <td>{{ journey.duration }}</td>
+                    </tr>
+                    <tr>
+                        <th>exit_type</th>
+                        <td>{{ journey.exit_type }}</td>
+                    </tr>
+                    <tr>
+                        <th>instance_id</th>
+                        <td>{{ journey.instance_id }}</td>
+                    </tr>
                 </table>
 
-                {% for step in visit.step_set.all %}
-                <div style="padding-left:60px">
-                    <h5>Step {{ step.id }} <a href="/dashboard/forms/submission/instanceId/{{step.instance_id}}">View submission</a></h5>
+                {% for visit in journey.visit_set.all %}
+                <div style="padding-left: 30px">
+                    <h4>Visit {{ visit.id }}</h4>
                     <table>
-                        <tr><th>assistance_type</th><td>{{ step.assistance_type }}</td></tr>
-                        <tr><th>quantity_given</th><td>{{ step.quantity_given }}</td></tr>
-                        <tr><th>ration_size</th><td>{{ step.ration_size }}</td></tr>
-                        <tr><th>instance_id</th><td>{{ step.instance_id }}</td></tr>
+                        <tr>
+                            <th>date</th>
+                            <td>{{ visit.date | date }}</td>
+                        </tr>
+                        <tr>
+                            <th>number</th>
+                            <td>{{ visit.number }}</td>
+                        </tr>
+                        <tr>
+                            <th>muac_size</th>
+                            <td>{{ visit.muac_size }}</td>
+                        </tr>
+                        <tr>
+                            <th>whz_color</th>
+                            <td>{{ visit.whz_color }}</td>
+                        </tr>
+                        <tr>
+                            <th>oedema</th>
+                            <td>{{ visit.oedema }}</td>
+                        </tr>
+                        <tr>
+                            <th>entry_point</th>
+                            <td>{{ visit.entry_point }}</td>
+                        </tr>
+                        <tr>
+                            <th>org_unit</th>
+                            <td>{{ visit.org_unit.name }}</td>
+                        </tr>
+                        <tr>
+                            <th>instance_id</th>
+                            <td>{{ visit.instance_id }}</td>
+                        </tr>
                     </table>
+
+                    {% for step in visit.step_set.all %}
+                    <div style="padding-left: 60px">
+                        <h5>
+                            Step {{ step.id }}
+                            <a
+                                href="/dashboard/forms/submission/instanceId/{{step.instance_id}}"
+                                >View submission</a
+                            >
+                        </h5>
+                        <table>
+                            <tr>
+                                <th>assistance_type</th>
+                                <td>{{ step.assistance_type }}</td>
+                            </tr>
+                            <tr>
+                                <th>quantity_given</th>
+                                <td>{{ step.quantity_given }}</td>
+                            </tr>
+                            <tr>
+                                <th>ration_size</th>
+                                <td>{{ step.ration_size }}</td>
+                            </tr>
+                            <tr>
+                                <th>instance_id</th>
+                                <td>{{ step.instance_id }}</td>
+                            </tr>
+                        </table>
+                    </div>
+                    {% endfor %}
                 </div>
                 {% endfor %}
+                <br />
+                <hr />
+                {% endfor %}
             </div>
-            {% endfor %}
-            <br><hr>
-            {% endfor %}
+
+            <div id="future_visits" class="section-anchor">
+                <h2>Issue: Future Visit Dates</h2>
+                <p>Total Anomalies Found: {{ future_count }}</p>
+
+                {% for visit in recent_future_visits %}
+                <h3>Future Visit Detected: {{ visit.id }}</h3>
+                <table>
+                    <tr>
+                        <th>Visit Date</th>
+                        <td>{{ visit.date | date }}</td>
+                    </tr>
+                    <tr>
+                        <th>Visit Number</th>
+                        <td>{{ visit.number }}</td>
+                    </tr>
+                    <tr>
+                        <th>Journey ID</th>
+                        <td>{{ visit.journey.id }}</td>
+                    </tr>
+                    <tr>
+                        <th>Beneficiary ID</th>
+                        <td>{{ visit.journey.beneficiary.id }}</td>
+                    </tr>
+                    <tr>
+                        <th>Link</th>
+                        <td>
+                            <a
+                                href="/dashboard/entities/details/accountId/{{visit.journey.beneficiary.account.id}}/entityId/{{visit.journey.beneficiary.entity_id}}"
+                                >/dashboard/entities/details/accountId/{{visit.journey.beneficiary.account.id}}/entityId/{{visit.journey.beneficiary.entity_id }}</a
+                            >
+                        </td>
+                    </tr>
+                </table>
+                <br />
+                <hr />
+                {% endfor %}
+            </div>
+
+            <div id="visits_without_date" class="section-anchor">
+                <h2>Issue: Visit without Dates</h2>
+                <p>Total Anomalies Found: {{ without_date_count }}</p>
+
+                {% for visit in visits_without_date %}
+                <h3>Future Visit Detected: {{ visit.id }}</h3>
+                <table>
+                    <tr>
+                        <th>Visit Date</th>
+                        <td>{{ visit.date | date }}</td>
+                    </tr>
+                    <tr>
+                        <th>Visit Number</th>
+                        <td>{{ visit.number }}</td>
+                    </tr>
+                    <tr>
+                        <th>Journey ID</th>
+                        <td>{{ visit.journey.id }}</td>
+                    </tr>
+                    <tr>
+                        <th>Beneficiary ID</th>
+                        <td>{{ visit.journey.beneficiary.id }}</td>
+                    </tr>
+                    <tr>
+                        <th>Link</th>
+                        <td>
+                            <a
+                                href="/dashboard/entities/details/accountId/{{ visit.journey.beneficiary.account.id }}/entityId/{{ visit.journey.beneficiary.entity_id }}"
+                                >/dashboard/entities/details/accountId/{{visit.journey.beneficiary.account.id}}/entityId/{{visit.journey.beneficiary.entity_id}}</a
+                            >
+                        </td>
+                    </tr>
+                </table>
+                <br />
+                <hr />
+                {% endfor %}
+            </div>
         </div>
-
-        <div id="future_visits" class="section-anchor">
-            <h2>Issue: Future Visit Dates</h2>
-            <p>Total Anomalies Found: {{ future_count }}</p>
-
-            {% for visit in recent_future_visits %}
-            <h3>Future Visit Detected: {{ visit.id }}</h3>
-            <table>
-                <tr><th>Visit Date</th><td>{{ visit.date | date }}</td></tr>
-                <tr><th>Visit Number</th><td>{{ visit.number }}</td></tr>
-                <tr><th>Journey ID</th><td>{{ visit.journey.id }}</td></tr>
-                <tr><th>Beneficiary ID</th><td>{{ visit.journey.beneficiary.id }}</td></tr>
-                <tr><th>Link</th>
-                    <td><a href="/dashboard/entities/details/accountId/{{ visit.journey.beneficiary.account.id }}/entityId/{{ visit.journey.beneficiary.entity_id }}">/dashboard/entities/details/accountId/{{ visit.journey.beneficiary.account.id }}/entityId/{{ visit.journey.beneficiary.entity_id }}</a></td>
-                </tr>
-            </table>
-            <br><hr>
-            {% endfor %}
-        </div>
-    </div>
-
-</body>
+    </body>
 </html>

--- a/plugins/wfp/templates/debug_summary.html
+++ b/plugins/wfp/templates/debug_summary.html
@@ -1,7 +1,6 @@
 <html>
 <head>
     <style>
-        /* Maintain original table styling */
         th, td {
             border: 1px black solid;
             padding: 5px;
@@ -12,11 +11,10 @@
             background-color: #f2f2f2;
         }
 
-        /* Navbar Styling */
         .navbar {
             background-color: #000000;
             padding: 15px;
-            position: -webkit-sticky; /* Support for Safari */
+            position: -webkit-sticky;
             position: sticky;
             top: 0;
             z-index: 1000;
@@ -35,14 +33,13 @@
             text-decoration: underline;
         }
 
-        /* Prevent anchor jumps from hiding titles behind the sticky navbar */
         .section-anchor {
             scroll-margin-top: 80px;
         }
         
         body {
             margin: 0;
-            padding: 0 0 20px 0; /* Removing top padding to let navbar sit flush */
+            padding: 0 0 20px 0; 
         }
         
         .content-container {

--- a/plugins/wfp/templates/debug_summary.html
+++ b/plugins/wfp/templates/debug_summary.html
@@ -1,0 +1,144 @@
+<html>
+<head>
+    <style>
+        /* Maintain original table styling */
+        th, td {
+            border: 1px black solid;
+            padding: 5px;
+        }
+
+        th {
+            text-align: right;
+            background-color: #f2f2f2;
+        }
+
+        /* Navbar Styling */
+        .navbar {
+            background-color: #000000;
+            padding: 15px;
+            position: -webkit-sticky; /* Support for Safari */
+            position: sticky;
+            top: 0;
+            z-index: 1000;
+            margin-bottom: 20px;
+        }
+
+        .navbar a {
+            color: #ffffff;
+            text-decoration: none;
+            font-weight: bold;
+            margin-right: 20px;
+            font-family: sans-serif;
+        }
+
+        .navbar a:hover {
+            text-decoration: underline;
+        }
+
+        /* Prevent anchor jumps from hiding titles behind the sticky navbar */
+        .section-anchor {
+            scroll-margin-top: 80px;
+        }
+        
+        body {
+            margin: 0;
+            padding: 0 0 20px 0; /* Removing top padding to let navbar sit flush */
+        }
+        
+        .content-container {
+            padding: 20px;
+        }
+    </style>
+</head>
+<body>
+
+    <div class="navbar">
+        <a href="#negative_durations">1. Negative Durations ({{ negative_count }})</a>
+        <a href="#future_visits">2. Future Visits ({{ future_count }})</a>
+    </div>
+
+    <div class="content-container">
+        <h1>ETL Debug Summary</h1>
+
+        <div id="negative_durations" class="section-anchor">
+            <h2>Issue: Negative Durations</h2>
+            <p>Total Anomalies Found: {{ negative_count }}</p>
+            
+            {% for journey in recent_negatives %}
+            <h3>Journey {{ journey.id }}</h3>
+            <table>
+                <tr><th>Beneficiary ID</th><td>{{ journey.beneficiary.id }}</td></tr>
+                <tr><th>Entity ID</th><td>{{ journey.beneficiary.entity_id }}</td></tr>
+                <tr><th>Link</th>
+                    <td><a href="/dashboard/entities/details/accountId/{{ journey.beneficiary.account.id }}/entityId/{{ journey.beneficiary.entity_id }}">/dashboard/entities/details/accountId/{{ journey.beneficiary.account.id }}/entityId/{{ journey.beneficiary.entity_id }}</a></td>
+                </tr>
+                <tr><th>admission_criteria</th><td>{{ journey.admission_criteria }}</td></tr>
+                <tr><th>admission_type</th><td>{{ journey.admission_type }}</td></tr>
+                <tr><th>nutrition_programme</th><td>{{ journey.nutrition_programme }}</td></tr>
+                <tr><th>programme_type</th><td>{{ journey.programme_type }}</td></tr>
+                <tr><th>muac_size</th><td>{{ journey.muac_size }}</td></tr>
+                <tr><th>whz_score</th><td>{{ journey.whz_score }}</td></tr>
+                <tr><th>initial_weight</th><td>{{ journey.initial_weight }}</td></tr>
+                <tr><th>discharge_weight</th><td>{{ journey.discharge_weight }}</td></tr>
+                <tr><th>weight_gain</th><td>{{ journey.weight_gain }}</td></tr>
+                <tr><th>weight_loss</th><td>{{ journey.weight_loss }}</td></tr>
+                <tr><th>Start date</th><td>{{ journey.start_date | date }}</td></tr>
+                <tr><th>End date</th><td>{{ journey.end_date | date }}</td></tr>
+                <tr><th>Number of days (Duration)</th><td>{{ journey.duration }}</td></tr>
+                <tr><th>exit_type</th><td>{{ journey.exit_type }}</td></tr>
+                <tr><th>instance_id</th><td>{{ journey.instance_id }}</td></tr>
+            </table>
+
+            {% for visit in journey.visit_set.all %}
+            <div style="padding-left:30px">
+                <h4>Visit {{ visit.id }}</h4>
+                <table>
+                    <tr><th>date</th><td>{{ visit.date | date }}</td></tr>
+                    <tr><th>number</th><td>{{ visit.number }}</td></tr>
+                    <tr><th>muac_size</th><td>{{ visit.muac_size }}</td></tr>
+                    <tr><th>whz_color</th><td>{{ visit.whz_color }}</td></tr>
+                    <tr><th>oedema</th><td>{{ visit.oedema }}</td></tr>
+                    <tr><th>entry_point</th><td>{{ visit.entry_point }}</td></tr>
+                    <tr><th>org_unit</th><td>{{ visit.org_unit.name }}</td></tr>
+                    <tr><th>instance_id</th><td>{{ visit.instance_id }}</td></tr>
+                </table>
+
+                {% for step in visit.step_set.all %}
+                <div style="padding-left:60px">
+                    <h5>Step {{ step.id }} <a href="/dashboard/forms/submission/instanceId/{{step.instance_id}}">View submission</a></h5>
+                    <table>
+                        <tr><th>assistance_type</th><td>{{ step.assistance_type }}</td></tr>
+                        <tr><th>quantity_given</th><td>{{ step.quantity_given }}</td></tr>
+                        <tr><th>ration_size</th><td>{{ step.ration_size }}</td></tr>
+                        <tr><th>instance_id</th><td>{{ step.instance_id }}</td></tr>
+                    </table>
+                </div>
+                {% endfor %}
+            </div>
+            {% endfor %}
+            <br><hr>
+            {% endfor %}
+        </div>
+
+        <div id="future_visits" class="section-anchor">
+            <h2>Issue: Future Visit Dates</h2>
+            <p>Total Anomalies Found: {{ future_count }}</p>
+
+            {% for visit in recent_future_visits %}
+            <h3>Future Visit Detected: {{ visit.id }}</h3>
+            <table>
+                <tr><th>Visit Date</th><td>{{ visit.date | date }}</td></tr>
+                <tr><th>Visit Number</th><td>{{ visit.number }}</td></tr>
+                <tr><th>Journey ID</th><td>{{ visit.journey.id }}</td></tr>
+                <tr><th>Beneficiary ID</th><td>{{ visit.journey.beneficiary.id }}</td></tr>
+                <tr><th>Link</th>
+                    <td><a href="/dashboard/entities/details/accountId/{{ visit.journey.beneficiary.account.id }}/entityId/{{ visit.journey.beneficiary.entity_id }}">/dashboard/entities/details/accountId/{{ visit.journey.beneficiary.account.id }}/entityId/{{ visit.journey.beneficiary.entity_id }}</a></td>
+                </tr>
+            </table>
+            <br><hr>
+            {% endfor %}
+        </div>
+    </div>
+
+</body>
+</html>

--- a/plugins/wfp/urls.py
+++ b/plugins/wfp/urls.py
@@ -2,6 +2,7 @@ from django.urls import path
 
 from .views import (
     debug,
+    debug_summary,
     delete_all_instances_and_entities,
     delete_beneficiaries_analytics,
     show_missing_entities_in_analytics,
@@ -10,6 +11,7 @@ from .views import (
 
 urlpatterns = [
     path("debug/<int:id>/", debug, name="wfp_debug"),
+    path("debug_summary/", debug_summary, name="wfp_debug_summary"),
     path("delete_beneficiaries_analytics/", delete_beneficiaries_analytics, name="delete_beneficiaries_analytics"),
     path(
         "delete_all_instances_and_entities/",

--- a/plugins/wfp/views.py
+++ b/plugins/wfp/views.py
@@ -60,7 +60,7 @@ def debug_summary(request):
         "future_count": future_count,
         "recent_future_visits": recent_future_visits,
         "without_date_count": without_date_count,
-        "visits_without_date": visits_without_date
+        "visits_without_date": visits_without_date,
     }
     return HttpResponse(template.render(context, request))
 

--- a/plugins/wfp/views.py
+++ b/plugins/wfp/views.py
@@ -44,8 +44,14 @@ def debug_summary(request):
         date__gt=now, journey__beneficiary__entity_id__in=allowed_entity_ids
     ).select_related("journey__beneficiary", "journey__beneficiary__account")
 
+    visits_with_missing_date = Visit.objects.filter(
+        date__isnull=True, journey__beneficiary__entity_id__in=allowed_entity_ids
+    ).select_related("journey__beneficiary", "journey__beneficiary__account")
+
     future_count = future_visits_qs.count()
     recent_future_visits = future_visits_qs.order_by("-date")[:3]
+    visits_without_date = visits_with_missing_date
+    without_date_count = visits_with_missing_date.count()
 
     template = loader.get_template("debug_summary.html")
     context = {
@@ -53,6 +59,8 @@ def debug_summary(request):
         "recent_negatives": recent_negatives,
         "future_count": future_count,
         "recent_future_visits": recent_future_visits,
+        "without_date_count": without_date_count,
+        "visits_without_date": visits_without_date
     }
     return HttpResponse(template.render(context, request))
 


### PR DESCRIPTION
## What problem is this PR solving?

This PR is about adding a new debug page that will show the mismatches in the data generated by ETL. 

### Related JIRA tickets

[WC2-877](https://bluesquare.atlassian.net/browse/WC2-877)

## Changes

In `plugins/wfp/views.py`, I added a view to scan the database to see 2 issues: 
- negative durations caused by start_date > end_date 
- future visitis caused by the entry of a date in the future in the `Visit` table
The view will count the mismatches and fetch all the data related to the tables queried during those mismatches

In `plugins/wfp/urls.py`, I added the url for the new page

in `plugins/wfp/templates/debug_summary.html`, I wrote a html code to display the mismatches found in the data with a navbar allowing the user to navigate through the different issues and see the data affected.

## How to test

1. Deactivate the `@login_required` decorator in `plugins/wfp/views.py`
2. Navigate to `http://localhost:8081/wfp/debug_summary/`

## Print screen / video

<img width="1850" height="1016" alt="Screenshot from 2026-01-30 15-16-46" src="https://github.com/user-attachments/assets/338fa396-51ee-4c49-a178-d9d90e5f40dc" />

## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).


[WC2-877]: https://bluesquare.atlassian.net/browse/WC2-877?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ