### PR TITLE
SLEEP-1723: Fix slow form dropdown on entity search page

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/entities/entityTypes/hooks/requests/forms.ts
+++ b/hat/assets/js/apps/Iaso/domains/entities/entityTypes/hooks/requests/forms.ts
@@ -11,9 +11,14 @@ export const useGetForms = (
     enabled: boolean,
     fields?: string[] | undefined,
 ): UseQueryResult<Form[], Error> => {
-    const apiUrl = '/api/forms/?fields=id,name,latest_form_version,form_id';
-    const url = fields ? `${apiUrl},${fields.join(',')}` : apiUrl;
+    const params = new URLSearchParams({
+        fields: (
+            fields ?? ['id', 'name', 'latest_form_version', 'form_id']
+        ).join(','),
+        order: 'name',
+    });
 
+    const url = `/api/forms/?${params}`;
     return useSnackQuery({
         queryKey: ['entitiesForms', 'forms'],
         queryFn: () => getRequest(url),


### PR DESCRIPTION
refs: SLEEP-1723

## What problem is this PR solving?

Fixes the slow loading of the "Search in submitted fields" component on the entities list page.

### Related JIRA tickets

https://bluesquare.atlassian.net/browse/SLEEP-1723
Similar to: IA-4677

## Changes

This PR adds `name` to the `order` parameter to the URL when fetching the list of forms.

Without the parameter, the backend was defaulting to expensive annotations for the query. 

## How to test

- Go to the entities list page (Menu > Entities > Entities list)
- Check that "Search in submitted fields" appears quickly and seems to work correctly
- You can also check in the dev tools that the endpoint is being called with the &order in the querystring `/api/forms/?fields=id%2Cname%2Clatest_form_version%2Cform_id&order=name`

## Print screen / video

/

## Notes

Thanks @beygorghor for finding a quick fix!

## Doc

/