### PR TITLE
POLIO-2081: fix form reset on close

### DIFF
--- a/plugins/polio/js/src/domains/Campaigns/CampaignsList/DashboardButtons.tsx
+++ b/plugins/polio/js/src/domains/Campaigns/CampaignsList/DashboardButtons.tsx
@@ -1,11 +1,11 @@
 import React, { FunctionComponent } from 'react';
+import Add from '@mui/icons-material/Add';
 import { Box, Grid } from '@mui/material';
 import { makeStyles } from '@mui/styles';
-import Add from '@mui/icons-material/Add';
+import { commonStyles, LinkButton, useSafeIntl } from 'bluesquare-components';
 import { CsvButton } from '../../../../../../../hat/assets/js/apps/Iaso/components/Buttons/CsvButton';
 import { userHasPermission } from '../../../../../../../hat/assets/js/apps/Iaso/domains/users/utils';
 import { useCurrentUser } from '../../../../../../../hat/assets/js/apps/Iaso/utils/usersUtils';
-import { commonStyles, LinkButton, useSafeIntl } from 'bluesquare-components';
 import MESSAGES from '../../../constants/messages';
 import { baseUrls } from '../../../constants/urls';
 


### PR DESCRIPTION
## What problem is this PR solving?

When creating campaign, the details page state would not reset after going back to the list view

### Related JIRA tickets

POLIO-2081

## Changes

- Add condition before merging `intialData`with campaign in cache in `useCampaignFormState`
- Add boolean in `useCampaignFormState` to better control the title displayed by `TopBar`

## How to test

- Go to polio > campaigns
- click create
- create a campaign + save
- click back
- click create again: the form should be empty

## Print screen / video

https://github.com/user-attachments/assets/2f4cda24-9321-4ad5-b56e-04963540084d

