### PR TITLE
IA-4769: Fix too precise accuracy fails import

### DIFF
--- a/iaso/tests/api/instances/test_instances.py
+++ b/iaso/tests/api/instances/test_instances.py
@@ -2,6 +2,7 @@ import datetime
 import json
 import typing
 
+from decimal import Decimal
 from unittest import mock
 from unittest.mock import patch
 from uuid import uuid4
@@ -417,7 +418,6 @@ class InstancesAPITestCase(TaskAPITestCase):
 
     def test_instance_create_with_accuracy_rounded(self):
         """POST /api/instances/ with accuracy having more than 2 decimal places should be rounded"""
-        from decimal import Decimal
 
         instance_uuid = str(uuid4())
         body = [
@@ -446,7 +446,6 @@ class InstancesAPITestCase(TaskAPITestCase):
 
     def test_instance_create_with_accuracy_rounded_with_long_number(self):
         """POST /api/instances/ with accuracy having more than 2 decimal places should be rounded"""
-        from decimal import Decimal
 
         instance_uuid = str(uuid4())
         body = [

--- a/iaso/tests/api/instances/test_instances.py
+++ b/iaso/tests/api/instances/test_instances.py
@@ -444,6 +444,35 @@ class InstancesAPITestCase(TaskAPITestCase):
         last_instance = m.Instance.objects.get(uuid=instance_uuid)
         self.assertEqual(Decimal("12.35"), last_instance.accuracy)
 
+    def test_instance_create_with_accuracy_rounded_with_long_number(self):
+        """POST /api/instances/ with accuracy having more than 2 decimal places should be rounded"""
+        from decimal import Decimal
+
+        instance_uuid = str(uuid4())
+        body = [
+            {
+                "id": instance_uuid,
+                "created_at": 1565258153704,
+                "updated_at": 1565258153709,
+                "orgUnitId": self.jedi_council_corruscant.id,
+                "formId": self.form_1.id,
+                "period": "202002",
+                "latitude": 50.2,
+                "longitude": 4.4,
+                "accuracy": 48.622852,
+                "altitude": 100,
+                "file": "\/storage\/emulated\/0\/odk\/instances\/test_accuracy_rounded\/test.xml",
+                "name": "test_accuracy_rounded",
+            }
+        ]
+        response = self.client.post(
+            "/api/instances/?app_id=stars.empire.agriculture.hydroponics", data=body, format="json"
+        )
+        self.assertEqual(response.status_code, 200)
+
+        last_instance = m.Instance.objects.get(uuid=instance_uuid)
+        self.assertEqual(Decimal("48.62"), last_instance.accuracy)
+
     def test_instance_create_with_invalid_accuracy(self):
         """POST /api/instances/ with invalid accuracy value should fail the import"""
         instance_uuid = str(uuid4())

--- a/iaso/tests/utils/test_rounded_decimal_field.py
+++ b/iaso/tests/utils/test_rounded_decimal_field.py
@@ -21,9 +21,12 @@ class RoundedDecimalFieldTestCase(TestCase):
         self.assertEqual(field.to_internal_value("1.235"), decimal.Decimal("1.24"))
 
         field = RoundedDecimalField(max_digits=2, decimal_places=1)
+        self.assertEqual(field.to_internal_value("1.19"), decimal.Decimal("1.2"))
+
+        field = RoundedDecimalField(max_digits=2, decimal_places=1)
         with self.assertRaises(ValidationError) as error:
-            field.to_internal_value("1.19")
-        self.assertIn("Ensure that there are no more than 2 digits in total.", error.exception.detail)
+            field.to_internal_value("21.19")
+        self.assertIn("Ensure that there are no more than 1 digits before the decimal point.", error.exception.detail)
 
         field = RoundedDecimalField(max_digits=4, decimal_places=2)
         with self.assertRaises(ValidationError) as error:

--- a/iaso/utils/serializer/rounded_decimal_field.py
+++ b/iaso/utils/serializer/rounded_decimal_field.py
@@ -26,9 +26,11 @@ class RoundedDecimalField(serializers.DecimalField):
             # 123.45
             total_digits = len(digittuple)
             whole_digits = total_digits - abs(exponent)
+            # total_digits will vary based on how much we round. Therefore, we should validate on that number.
+            total_digits = whole_digits + min(self.decimal_places, abs(exponent))
         else:
             # 0.001234
-            total_digits = abs(exponent)
+            total_digits = min(self.decimal_places, abs(exponent))
             whole_digits = 0
 
         if self.max_whole_digits is not None and whole_digits > self.max_whole_digits:


### PR DESCRIPTION
When the accuracy is too precise, rounding is not enough. We have to take into consideration what the actual size will be before validating.

## What problem is this PR solving?

Some instances cannot be imported because their accuracy is too precise. 
The previous rounding fix was not enough because the total amount of numbers is still too big for the validation.

### Related JIRA tickets

IA-4769

## Changes

I have changed how the validation check for size.

## How to test

1. Call the endpoint `POST /api/instances/` with an accuracy that will be 7 digits or less in total when rounded but with more digits before being rounded.
E.g.:  48.622852 (value from production that failed)
