### PR TITLE
WC2-889: ETL Optimization

### DIFF
--- a/plugins/wfp/common.py
+++ b/plugins/wfp/common.py
@@ -49,7 +49,7 @@ class ETL:
         print("EXISTING JOURNEY DELETED", beneficiary[1]["wfp.Journey"])
 
     def account_related_to_entity_type(self):
-        entity_type = EntityType.objects.prefetch_related("account").filter(code=self.entity_type).first()
+        entity_type = EntityType.objects.select_related("account").filter(code=self.entity_type).first()
         account = entity_type.account
         return account
 
@@ -77,8 +77,7 @@ class ETL:
             .filter(form__isnull=False)
             .exclude(deleted=True)
             .exclude(entity__deleted_at__isnull=False)
-            .select_related("entity")
-            .prefetch_related("entity", "form", "org_unit")
+            .prefetch_related("entity_idform__form_id", "org_unit__id")
             .values(
                 "id",
                 "created_at",
@@ -87,7 +86,6 @@ class ETL:
                 "deleted",
                 "form__form_id",
                 "org_unit_id",
-                "org_unit",
                 "updated_at",
                 "form",
                 "entity__deleted_at",

--- a/plugins/wfp/common.py
+++ b/plugins/wfp/common.py
@@ -69,9 +69,7 @@ class ETL:
         entities = self.get_updated_data(updated_at)
         if updated_at is not None:
             entities = entities.filter(updated_at__gte=updated_at)
-        entities = entities.values("entity_id").distinct()
-        beneficiary_ids = list(map(lambda entity: entity["entity_id"], entities))
-        return list(set(beneficiary_ids))
+        return entities.distinct().values_list("entity_id", flat=True)
 
     def retrieve_entities(self, entity_ids):
         steps_id = self.steps_to_exclude()

--- a/plugins/wfp/common.py
+++ b/plugins/wfp/common.py
@@ -80,7 +80,7 @@ class ETL:
             .filter(form__isnull=False)
             .exclude(deleted=True)
             .exclude(entity__deleted_at__isnull=False)
-            .prefetch_related("entity_idform__form_id", "org_unit__id")
+            .prefetch_related("entity_id", "form__form_id", "org_unit__id")
             .values(
                 "id",
                 "created_at",

--- a/plugins/wfp/management/commands/ethiopia/Under5.py
+++ b/plugins/wfp/management/commands/ethiopia/Under5.py
@@ -130,7 +130,7 @@ class ET_Under5:
             )
         )
 
-    def run(self, type, updated_beneficiaries):
+    def run(self, type, updated_beneficiaries, task_name):
         etl_type = ETL(type)
         account = etl_type.account_related_to_entity_type()
         beneficiaries = etl_type.retrieve_entities(updated_beneficiaries)
@@ -149,24 +149,25 @@ class ET_Under5:
             all_journeys = []
             all_beneficiaries = []
             for index, instance in enumerate(instances):
+                current_entity_id = instance["entity_id"]
                 logger.info(
-                    f"---------------------------------------- Beneficiary N° {(index + 1)} {instance['entity_id']}-----------------------------------"
+                    f"---------------------------------------- Beneficiary N° {(index + 1)} {current_entity_id}-----------------------------------"
                 )
                 instance["journey"] = self.journeyMapper(instance["visits"], ADMISSION_ANTHROPOMETRIC_FORMS)
                 beneficiary = Beneficiary()
                 if (
-                    instance["entity_id"] not in existing_beneficiaries
+                    current_entity_id not in existing_beneficiaries
                     and len(instance["journey"][0]["visits"]) > 0
                     and instance["journey"][0].get("nutrition_programme") is not None
                 ):
                     beneficiary.gender = instance["gender"]
                     beneficiary.birth_date = instance["birth_date"]
-                    beneficiary.entity_id = instance["entity_id"]
+                    beneficiary.entity_id = current_entity_id
                     beneficiary.account = account
                     all_beneficiaries.append(beneficiary)
                     logger.info("Created new beneficiary")
                 else:
-                    beneficiary = Beneficiary.objects.filter(entity_id=instance["entity_id"]).first()
+                    beneficiary = Beneficiary.objects.filter(entity_id=current_entity_id).first()
 
                 logger.info("Retrieving journey linked to beneficiary")
                 if beneficiary is not None:
@@ -190,10 +191,10 @@ class ET_Under5:
                     logger.info(
                         "---------------------------------------------------------------------------------------------\n\n"
                     )
-            Beneficiary.objects.bulk_create(all_beneficiaries)
-            Journey.objects.bulk_create(all_journeys)
-            Visit.objects.bulk_create(all_visits)
-            Step.objects.bulk_create(all_steps)
+            task = Task(name=f"{task_name}  on Page {page} for {type}", account=account, status="QUEUED")
+            etl.save_analytics_data(
+                all_beneficiaries, all_journeys, all_visits, all_steps, account, current_entity_id, task
+            )
 
     def journeyMapper(self, visits, admission_form):
         current_journey = {"visits": [], "steps": []}

--- a/plugins/wfp/management/commands/ethiopia/Under5.py
+++ b/plugins/wfp/management/commands/ethiopia/Under5.py
@@ -23,11 +23,12 @@ class ET_Under5:
         initial_date = None
         current_date = None
         duration = 0
+        etl = ETL()
         for entity_id, entity in instances_by_entity:
             instances.append({"entity_id": entity_id, "visits": [], "journey": []})
             for visit in entity:
                 current_record = visit.get("json", None)
-                instances[i]["program"] = ETL().program_mapper(current_record)
+                instances[i]["program"] = etl.program_mapper(current_record)
                 if current_record is not None and current_record != None:
                     if (
                         current_record.get("actual_birthday__date__") is not None
@@ -39,7 +40,7 @@ class ET_Under5:
                         current_record.get("age_entry", None) is not None
                         and current_record.get("age_entry", None) != ""
                     ):
-                        calculated_date = ETL().calculate_birth_date(current_record)
+                        calculated_date = etl.calculate_birth_date(current_record)
                         instances[i]["birth_date"] = calculated_date
                     if current_record.get("gender") is not None:
                         gender = current_record.get("gender", "")
@@ -94,7 +95,7 @@ class ET_Under5:
                         duration = (current_date - initial_date).days
                         current_record["start_date"] = initial_date.strftime("%Y-%m-%d")
 
-                    weight = ETL().compute_gained_weight(initial_weight, current_weight, duration)
+                    weight = etl.compute_gained_weight(initial_weight, current_weight, duration)
                     current_record["end_date"] = current_date.strftime("%Y-%m-%d")
                     current_record["weight_gain"] = weight["weight_gain"]
                     current_record["weight_loss"] = weight["weight_loss"]
@@ -123,23 +124,25 @@ class ET_Under5:
                     and instance.get("gender") != ""
                     and instance.get("birth_date") is not None
                     and instance.get("birth_date") != ""
-                    and len(ETL().admission_forms(instance.get("visits"), ADMISSION_ANTHROPOMETRIC_FORMS)) > 0
+                    and len(etl.admission_forms(instance.get("visits"), ADMISSION_ANTHROPOMETRIC_FORMS)) > 0
                 ),
                 instances,
             )
         )
 
     def run(self, type, updated_beneficiaries):
-        entity_type = ETL([type])
-        account = entity_type.account_related_to_entity_type()
-        beneficiaries = entity_type.retrieve_entities(updated_beneficiaries)
+        etl_type = ETL(type)
+        account = etl_type.account_related_to_entity_type()
+        beneficiaries = etl_type.retrieve_entities(updated_beneficiaries)
         pages = beneficiaries.page_range
 
         logger.info(f"Instances linked to Child Under 5 program: {beneficiaries.count} for {account}")
 
+        etl = ETL()
+
         for page in pages:
             entities = sorted(list(beneficiaries.page(page).object_list), key=itemgetter("entity_id"))
-            existing_beneficiaries = ETL().existing_beneficiaries()
+            existing_beneficiaries = etl.existing_beneficiaries()
             instances = self.group_visit_by_entity(entities)
             all_steps = []
             all_visits = []
@@ -171,14 +174,14 @@ class ET_Under5:
                         if len(journey_instance["visits"]) > 0:
                             journey = self.save_journey(beneficiary, journey_instance)
                             all_journeys.append(journey)
-                            visits = ETL().save_visit(journey_instance["visits"], journey)
+                            visits = etl.save_visit(journey_instance["visits"], journey)
                             all_visits.extend(visits)
                             logger.info(f"Inserted {len(visits)} Visits")
-                            grouped_steps = ETL().get_admission_steps(journey_instance["steps"])
+                            grouped_steps = etl.get_admission_steps(journey_instance["steps"])
                             admission_step = grouped_steps[0]
 
-                            followUpVisits = ETL().group_followup_steps(grouped_steps, admission_step)
-                            steps = ETL().save_steps(visits, followUpVisits)
+                            followUpVisits = etl.group_followup_steps(grouped_steps, admission_step)
+                            steps = etl.save_steps(visits, followUpVisits)
                             all_steps.extend(steps)
                             logger.info(f"Inserted {len(steps)} Steps")
                             # exit()
@@ -200,22 +203,24 @@ class ET_Under5:
         ]
 
         visit_nutrition_program = [visit for visit in visits if visit["form_id"] in admission_form]
+        etl = ETL()
 
         if len(visit_nutrition_program) > 0:
-            nutrition_programme = ETL().program_mapper(visit_nutrition_program[0])
+            nutrition_programme = etl.program_mapper(visit_nutrition_program[0])
             if nutrition_programme in ["TSFP_MAM", "TSFP-MAM", "TSFP"]:
                 current_journey["nutrition_programme"] = "TSFP"
             elif nutrition_programme in ["OTP_SAM", "OTP-SAM", "OTP"]:
                 current_journey["nutrition_programme"] = "OTP"
             else:
                 current_journey["nutrition_programme"] = nutrition_programme
-        journey = ETL().entity_journey_mapper(
+        journey = etl.entity_journey_mapper(
             visits, anthropometric_followup_visit_forms, admission_form, current_journey
         )
         return journey
 
     def save_journey(self, beneficiary, record):
         journey = Journey()
+        etl = ETL()
         journey.initial_weight = record.get("initial_weight", None)
         journey.discharge_weight = record.get("discharge_weight", None)
         # Calculate the weight gain only for cured and Transfer from OTP to TSFP cases!
@@ -229,4 +234,4 @@ class ET_Under5:
             journey.weight_gain = record.get("weight_gain", 0)
             journey.weight_loss = record.get("weight_loss", 0)
 
-        return ETL().save_entity_journey(journey, beneficiary, record, "U5")
+        return etl.save_entity_journey(journey, beneficiary, record, "U5")

--- a/plugins/wfp/management/commands/nigeria/Pbwg.py
+++ b/plugins/wfp/management/commands/nigeria/Pbwg.py
@@ -14,15 +14,17 @@ ADMISSION_ANTHROPOMETRIC_FORMS = ["ng_pbwg_anthropometric"]
 
 class NG_PBWG:
     def run(self, type, updated_beneficiaries):
-        entity_type = ETL([type])
-        account = entity_type.account_related_to_entity_type()
-        beneficiaries = entity_type.retrieve_entities(updated_beneficiaries)
+        etl_type = ETL(type)
+        account = etl_type.account_related_to_entity_type()
+        beneficiaries = etl_type.retrieve_entities(updated_beneficiaries)
         pages = beneficiaries.page_range
         logger.info(f"Instances linked to PBWG program: {beneficiaries.count} for {account}")
 
+        etl = ETL()
+
         for page in pages:
             entities = sorted(list(beneficiaries.page(page).object_list), key=itemgetter("entity_id"))
-            existing_beneficiaries = ETL().existing_beneficiaries()
+            existing_beneficiaries = etl.existing_beneficiaries()
             instances = self.group_visit_by_entity(entities)
             all_steps = []
             all_visits = []
@@ -53,15 +55,15 @@ class NG_PBWG:
                     if len(journey_instance["visits"]) > 0:
                         journey = self.save_journey(beneficiary, journey_instance)
                         all_journeys.append(journey)
-                        visits = ETL().save_visit(journey_instance["visits"], journey)
+                        visits = etl.save_visit(journey_instance["visits"], journey)
                         all_visits.extend(visits)
                         logger.info(f"Inserted {len(visits)} Visits")
 
-                        grouped_steps = ETL().get_admission_steps(journey_instance["steps"])
+                        grouped_steps = etl.get_admission_steps(journey_instance["steps"])
                         admission_step = grouped_steps[0]
-                        followUpVisits = ETL().group_followup_steps(grouped_steps, admission_step)
+                        followUpVisits = etl.group_followup_steps(grouped_steps, admission_step)
 
-                        steps = ETL().save_steps(visits, followUpVisits)
+                        steps = etl.save_steps(visits, followUpVisits)
                         all_steps.extend(steps)
                         logger.info(f"Inserted {len(steps)} Steps")
                     else:
@@ -76,15 +78,17 @@ class NG_PBWG:
 
     def save_journey(self, beneficiary, record):
         journey = Journey()
+        etl = ETL()
 
         if record.get("exit_type", None) is not None and record.get("exit_type", None) != "":
             journey.duration = record.get("duration", None)
             journey.end_date = record.get("end_date", None)
 
-        return ETL().save_entity_journey(journey, beneficiary, record, "PLW")
+        return etl.save_entity_journey(journey, beneficiary, record, "PLW")
 
     def journeyMapper(self, visits, admission_form):
         current_journey = {"visits": [], "steps": []}
+        etl = ETL()
         anthropometric_visit_forms = [
             "wfp_coda_pbwg_luctating_followup_anthro",
             "wfp_coda_pbwg_followup_anthro",
@@ -93,7 +97,7 @@ class NG_PBWG:
         visit_nutrition_program = [visit for visit in visits if visit["form_id"] == "ng_pbwg_registration"][0]
         if len(visit_nutrition_program) > 0:
             current_journey["nutrition_programme"] = visit_nutrition_program.get("physiology_status", None)
-        journey = ETL().entity_journey_mapper(visits, anthropometric_visit_forms, admission_form, current_journey)
+        journey = etl.entity_journey_mapper(visits, anthropometric_visit_forms, admission_form, current_journey)
         return journey
 
     def group_visit_by_entity(self, entities):
@@ -102,6 +106,7 @@ class NG_PBWG:
         instances_by_entity = groupby(list(entities), key=itemgetter("entity_id"))
         initial_date = None
         duration = 0
+        etl = ETL()
 
         for entity_id, entity in instances_by_entity:
             instances.append({"entity_id": entity_id, "visits": [], "journey": []})
@@ -109,7 +114,7 @@ class NG_PBWG:
             for visit in entity:
                 current_record = visit.get("json", None)
 
-                instances[i]["program"] = ETL().program_mapper(current_record)
+                instances[i]["program"] = etl.program_mapper(current_record)
                 if current_record is not None and current_record != None:
                     if (
                         current_record.get("actual_birthday__date__") is not None
@@ -127,7 +132,7 @@ class NG_PBWG:
                         current_record.get("age_entry", None) is not None
                         and current_record.get("age_entry", None) != ""
                     ):
-                        calculated_date = ETL().calculate_birth_date(current_record)
+                        calculated_date = etl.calculate_birth_date(current_record)
                         instances[i]["birth_date"] = calculated_date
 
                     if current_record.get("last_name") is not None:

--- a/plugins/wfp/management/commands/nigeria/Pbwg.py
+++ b/plugins/wfp/management/commands/nigeria/Pbwg.py
@@ -3,6 +3,7 @@ import logging
 from itertools import groupby
 from operator import itemgetter
 
+from iaso.models import Task
 from plugins.wfp.common import ETL
 from plugins.wfp.models import *
 
@@ -13,7 +14,7 @@ ADMISSION_ANTHROPOMETRIC_FORMS = ["ng_pbwg_anthropometric"]
 
 
 class NG_PBWG:
-    def run(self, type, updated_beneficiaries):
+    def run(self, type, updated_beneficiaries, task_name):
         etl_type = ETL(type)
         account = etl_type.account_related_to_entity_type()
         beneficiaries = etl_type.retrieve_entities(updated_beneficiaries)
@@ -31,23 +32,24 @@ class NG_PBWG:
             all_journeys = []
             all_beneficiaries = []
             for index, instance in enumerate(instances):
+                current_entity_id = instance["entity_id"]
                 logger.info(
-                    f"---------------------------------------- Beneficiary N° {(index + 1)} {instance['entity_id']}-----------------------------------"
+                    f"---------------------------------------- Beneficiary N° {(index + 1)} {current_entity_id}-----------------------------------"
                 )
 
                 instance["journey"] = self.journeyMapper(instance["visits"], ADMISSION_ANTHROPOMETRIC_FORMS)
                 beneficiary = Beneficiary()
 
-                if instance["entity_id"] not in existing_beneficiaries and len(instance["journey"][0]["visits"]) > 0:
+                if current_entity_id not in existing_beneficiaries and len(instance["journey"][0]["visits"]) > 0:
                     beneficiary.gender = ""
-                    beneficiary.entity_id = instance["entity_id"]
+                    beneficiary.entity_id = current_entity_id
                     beneficiary.account = account
                     if instance.get("birth_date") is not None:
                         beneficiary.birth_date = instance["birth_date"]
                         all_beneficiaries.append(beneficiary)
                         logger.info("Created new beneficiary")
                 else:
-                    beneficiary = Beneficiary.objects.filter(entity_id=instance["entity_id"]).first()
+                    beneficiary = Beneficiary.objects.filter(entity_id=current_entity_id).first()
 
                 logger.info("Retrieving journey linked to beneficiary")
 
@@ -71,10 +73,10 @@ class NG_PBWG:
                 logger.info(
                     "---------------------------------------------------------------------------------------------\n\n"
                 )
-            Beneficiary.objects.bulk_create(all_beneficiaries)
-            Journey.objects.bulk_create(all_journeys)
-            Visit.objects.bulk_create(all_visits)
-            Step.objects.bulk_create(all_steps)
+            task = Task(name=f"{task_name}  on Page {page} for {type}", account=account, status="QUEUED")
+            etl.save_analytics_data(
+                all_beneficiaries, all_journeys, all_visits, all_steps, account, current_entity_id, task
+            )
 
     def save_journey(self, beneficiary, record):
         journey = Journey()

--- a/plugins/wfp/management/commands/south_sudan/Dhis2.py
+++ b/plugins/wfp/management/commands/south_sudan/Dhis2.py
@@ -2,15 +2,11 @@ import json
 
 from dhis2 import Api, RequestException
 
-from plugins.wfp.common import ETL
-from plugins.wfp.models import *
+from plugins.wfp.models import Dhis2SyncResults
 
 
 class Dhis2:
-    def sync_data(self, type, external_credential):
-        etl_type = ETL(type)
-        account = etl_type.account_related_to_entity_type()
-        monthly_data = etl_type.aggregating_data_to_push_to_dhis2(account)
+    def sync_data(self, external_credential, account, monthly_data):
         api = Api(external_credential.url, external_credential.login, external_credential.password)
 
         results = []
@@ -49,6 +45,6 @@ class Dhis2:
 
         return results
 
-    def save_dhis2_sync_results(self, type, external_credential):
-        results = self.sync_data(type, external_credential)
+    def save_dhis2_sync_results(self, external_credential, account, monthly_data):
+        results = self.sync_data(external_credential, account, monthly_data)
         return Dhis2SyncResults.objects.bulk_create(results)

--- a/plugins/wfp/management/commands/south_sudan/Dhis2.py
+++ b/plugins/wfp/management/commands/south_sudan/Dhis2.py
@@ -8,9 +8,9 @@ from plugins.wfp.models import *
 
 class Dhis2:
     def sync_data(self, type, external_credential):
-        entity_type = ETL([type])
-        account = entity_type.account_related_to_entity_type()
-        monthly_data = entity_type.aggregating_data_to_push_to_dhis2(account)
+        etl_type = ETL(type)
+        account = etl_type.account_related_to_entity_type()
+        monthly_data = etl_type.aggregating_data_to_push_to_dhis2(account)
         api = Api(external_credential.url, external_credential.login, external_credential.password)
 
         results = []

--- a/plugins/wfp/management/commands/south_sudan/Pbwg.py
+++ b/plugins/wfp/management/commands/south_sudan/Pbwg.py
@@ -19,19 +19,21 @@ ANTHROPOMETRIC_FOLLOWUP_FORMS = [
 
 class PBWG:
     def run(self, type, updated_beneficiaries):
-        entity_type = ETL([type])
-        account = entity_type.account_related_to_entity_type()
-        beneficiaries = entity_type.retrieve_entities(updated_beneficiaries)
+        etl_type = ETL(type)
+        account = etl_type.account_related_to_entity_type()
+        beneficiaries = etl_type.retrieve_entities(updated_beneficiaries)
         pages = beneficiaries.page_range
 
         logger.info(f"Instances linked to PBWG program: {beneficiaries.count} for {account}")
+
+        etl = ETL()
 
         for page in pages:
             entities = sorted(
                 list(beneficiaries.page(page).object_list),
                 key=itemgetter("entity_id"),
             )
-            existing_beneficiaries = ETL().existing_beneficiaries()
+            existing_beneficiaries = etl.existing_beneficiaries()
             instances = self.group_visit_by_entity(entities)
             all_steps = []
             all_visits = []
@@ -60,15 +62,15 @@ class PBWG:
                     if len(journey_instance["visits"]) > 0:
                         journey = self.save_journey(beneficiary, journey_instance)
                         all_journeys.append(journey)
-                        visits = ETL().save_visit(journey_instance["visits"], journey)
+                        visits = etl.save_visit(journey_instance["visits"], journey)
                         all_visits.extend(visits)
                         logger.info(f"Inserted {len(visits)} Visits")
 
-                        grouped_steps = ETL().get_admission_steps(journey_instance["steps"])
+                        grouped_steps = etl.get_admission_steps(journey_instance["steps"])
                         admission_step = grouped_steps[0]
-                        followUpVisits = ETL().group_followup_steps(grouped_steps, admission_step)
+                        followUpVisits = etl.group_followup_steps(grouped_steps, admission_step)
 
-                        steps = ETL().save_steps(visits, followUpVisits)
+                        steps = etl.save_steps(visits, followUpVisits)
                         all_steps.extend(steps)
                         logger.info(f"Inserted {len(steps)} Steps")
                     else:
@@ -83,19 +85,21 @@ class PBWG:
 
     def save_journey(self, beneficiary, record):
         journey = Journey()
+        etl = ETL()
 
         if record.get("exit_type", None) is not None and record.get("exit_type", None) != "":
             journey.duration = record.get("duration", None)
             journey.end_date = record.get("end_date", None)
 
-        return ETL().save_entity_journey(journey, beneficiary, record, "PLW")
+        return etl.save_entity_journey(journey, beneficiary, record, "PLW")
 
     def journeyMapper(self, visits, admission_form):
         current_journey = {"visits": [], "steps": []}
+        etl = ETL()
         visit_nutrition_program = [visit for visit in visits if visit["form_id"] == "wfp_coda_pbwg_registration"][0]
         if len(visit_nutrition_program) > 0:
             current_journey["nutrition_programme"] = visit_nutrition_program.get("physiology_status", None)
-        journey = ETL().entity_journey_mapper(visits, ANTHROPOMETRIC_FOLLOWUP_FORMS, admission_form, current_journey)
+        journey = etl.entity_journey_mapper(visits, ANTHROPOMETRIC_FOLLOWUP_FORMS, admission_form, current_journey)
         return journey
 
     def group_visit_by_entity(self, entities):
@@ -104,6 +108,7 @@ class PBWG:
         instances_by_entity = groupby(list(entities), key=itemgetter("entity_id"))
         initial_date = None
         duration = 0
+        etl = ETL()
 
         for entity_id, entity in instances_by_entity:
             instances.append({"entity_id": entity_id, "visits": [], "journey": []})
@@ -111,7 +116,7 @@ class PBWG:
             for visit in entity:
                 current_record = visit.get("json", None)
 
-                instances[i]["program"] = ETL().program_mapper(current_record)
+                instances[i]["program"] = etl.program_mapper(current_record)
                 if current_record is not None and current_record != None:
                     if (
                         current_record.get("actual_birthday__date__") is not None
@@ -129,7 +134,7 @@ class PBWG:
                         current_record.get("age_entry", None) is not None
                         and current_record.get("age_entry", None) != ""
                     ):
-                        calculated_date = ETL().calculate_birth_date(current_record)
+                        calculated_date = etl.calculate_birth_date(current_record)
                         instances[i]["birth_date"] = calculated_date
 
                     if current_record.get("last_name") is not None:
@@ -166,7 +171,7 @@ class PBWG:
                     instance.get("visits")
                     and instance.get("birth_date") is not None
                     and instance.get("birth_date") != ""
-                    and len(ETL().admission_forms(instance.get("visits"), ADMISSION_ANTHROPOMETRIC_FORMS)) > 0
+                    and len(etl.admission_forms(instance.get("visits"), ADMISSION_ANTHROPOMETRIC_FORMS)) > 0
                 ),
                 instances,
             )

--- a/plugins/wfp/management/commands/south_sudan/Screening.py
+++ b/plugins/wfp/management/commands/south_sudan/Screening.py
@@ -17,8 +17,8 @@ FORMS = ["screening_tally"]
 
 class Screening:
     def run(self, account, update_at):
-        entity_type = ETL([type])
-        instances = entity_type.get_screening_data(FORMS, account, update_at)
+        etl_type = ETL(type)
+        instances = etl_type.get_screening_data(FORMS, account, update_at)
         pages = instances.page_range
 
         all_screening_data = []

--- a/plugins/wfp/management/commands/south_sudan/Under5.py
+++ b/plugins/wfp/management/commands/south_sudan/Under5.py
@@ -35,11 +35,12 @@ class Under5:
         initial_date = None
         current_date = None
         duration = 0
+        etl = ETL()
         for entity_id, entity in instances_by_entity:
             instances.append({"entity_id": entity_id, "visits": [], "journey": []})
             for visit in entity:
                 current_record = visit.get("json", None)
-                instances[i]["program"] = ETL().program_mapper(current_record)
+                instances[i]["program"] = etl.program_mapper(current_record)
                 if current_record is not None and current_record != None:
                     if current_record.get("guidelines"):
                         instances[i]["guidelines"] = current_record.get("guidelines")
@@ -53,7 +54,7 @@ class Under5:
                         current_record.get("age_entry", None) is not None
                         and current_record.get("age_entry", None) != ""
                     ):
-                        calculated_date = ETL().calculate_birth_date(current_record)
+                        calculated_date = etl.calculate_birth_date(current_record)
                         instances[i]["birth_date"] = calculated_date
                     if current_record.get("gender") is not None:
                         gender = current_record.get("gender", "")
@@ -101,7 +102,7 @@ class Under5:
                         duration = (current_date - initial_date).days
                         current_record["start_date"] = initial_date.strftime("%Y-%m-%d")
 
-                    weight = ETL().compute_gained_weight(initial_weight, current_weight, duration)
+                    weight = etl.compute_gained_weight(initial_weight, current_weight, duration)
                     current_record["end_date"] = current_date.strftime("%Y-%m-%d")
                     current_record["weight_gain"] = weight["weight_gain"]
                     current_record["weight_loss"] = weight["weight_loss"]
@@ -134,7 +135,7 @@ class Under5:
                     and instance.get("gender") != ""
                     and instance.get("birth_date") is not None
                     and instance.get("birth_date") != ""
-                    and len(ETL().admission_forms(instance.get("visits"), ADMISSION_ANTHROPOMETRIC_FORMS)) > 0
+                    and len(etl.admission_forms(instance.get("visits"), ADMISSION_ANTHROPOMETRIC_FORMS)) > 0
                 ),
                 instances,
             )
@@ -142,14 +143,16 @@ class Under5:
 
     def journeyMapper(self, visits, admission_form):
         current_journey = {"visits": [], "steps": []}
+        etl = ETL()
         visit_nutrition_program = [visit for visit in visits if visit["form_id"] in admission_form]
         if len(visit_nutrition_program) > 0:
-            current_journey["nutrition_programme"] = ETL().program_mapper(visit_nutrition_program[0])
-        journey = ETL().entity_journey_mapper(visits, ANTHROPOMETRIC_FOLLOWUP_FORMS, admission_form, current_journey)
+            current_journey["nutrition_programme"] = etl.program_mapper(visit_nutrition_program[0])
+        journey = etl.entity_journey_mapper(visits, ANTHROPOMETRIC_FOLLOWUP_FORMS, admission_form, current_journey)
         return journey
 
     def save_journey(self, beneficiary, record):
         journey = Journey()
+        etl = ETL()
         journey.initial_weight = record.get("initial_weight", None)
 
         # Calculate the weight gain only for cured and Transfer from OTP to TSFP cases!
@@ -162,22 +165,24 @@ class Under5:
             journey.weight_gain = record.get("weight_gain", 0)
             journey.weight_loss = record.get("weight_loss", 0)
 
-        return ETL().save_entity_journey(journey, beneficiary, record, "U5")
+        return etl.save_entity_journey(journey, beneficiary, record, "U5")
 
     def run(self, type, updated_beneficiaries):
-        entity_type = ETL([type])
-        account = entity_type.account_related_to_entity_type()
-        beneficiaries = entity_type.retrieve_entities(updated_beneficiaries)
+        etl_type = ETL(type)
+        account = etl_type.account_related_to_entity_type()
+        beneficiaries = etl_type.retrieve_entities(updated_beneficiaries)
         pages = beneficiaries.page_range
 
         logger.info(f"Instances linked to Child Under 5 program: {beneficiaries.count} for {account}")
+
+        etl = ETL()
 
         for page in pages:
             entities = sorted(
                 list(beneficiaries.page(page).object_list),
                 key=itemgetter("entity_id"),
             )
-            existing_beneficiaries = ETL().existing_beneficiaries()
+            existing_beneficiaries = etl.existing_beneficiaries()
             instances = self.group_visit_by_entity(entities)
             all_steps = []
             all_visits = []
@@ -213,14 +218,14 @@ class Under5:
                         if len(journey_instance["visits"]) > 0:
                             journey = self.save_journey(beneficiary, journey_instance)
                             all_journeys.append(journey)
-                            visits = ETL().save_visit(journey_instance["visits"], journey)
+                            visits = etl.save_visit(journey_instance["visits"], journey)
                             all_visits.extend(visits)
                             logger.info(f"Inserted {len(visits)} Visits")
-                            grouped_steps = ETL().get_admission_steps(journey_instance["steps"])
+                            grouped_steps = etl.get_admission_steps(journey_instance["steps"])
                             admission_step = grouped_steps[0]
 
-                            followUpVisits = ETL().group_followup_steps(grouped_steps, admission_step)
-                            steps = ETL().save_steps(visits, followUpVisits)
+                            followUpVisits = etl.group_followup_steps(grouped_steps, admission_step)
+                            steps = etl.save_steps(visits, followUpVisits)
                             all_steps.extend(steps)
                             logger.info(f"Inserted {len(steps)} Steps")
                         else:

--- a/plugins/wfp/management/commands/ssd_aggregate_and_push_data_to_dhis2.py
+++ b/plugins/wfp/management/commands/ssd_aggregate_and_push_data_to_dhis2.py
@@ -1,0 +1,14 @@
+from django.core.management.base import BaseCommand
+
+from plugins.wfp.tasks import ssd_aggregate_and_push_data_to_dhis2
+
+
+class Command(BaseCommand):
+    help = "Aggregate WFP monthly analytics data by org unit and push to dhis2"
+
+    def add_arguments(self, parser):
+        parser.add_argument("all_data", nargs="?", help="Aggregate monthly analytics data and Push to dhis2")
+
+    def handle(self, *args, **options):
+        all_data = options["all_data"]
+        ssd_aggregate_and_push_data_to_dhis2(all_data)

--- a/plugins/wfp/tasks.py
+++ b/plugins/wfp/tasks.py
@@ -75,22 +75,25 @@ def etl_ng(all_data=None):
 
     logger.info("Starting ETL for Nigeria")
     entity_type_U5_code = "nigeria_under5"
-    account = ETL([entity_type_U5_code]).account_related_to_entity_type()
-    updated_U5_beneficiaries = ETL([entity_type_U5_code]).get_updated_entity_ids(last_success_task_date)
+    etl_u5 = ETL(entity_type_U5_code)
+    etl = ETL()
+    account = etl_u5.account_related_to_entity_type()
+    updated_U5_beneficiaries = etl_u5.get_updated_entity_ids(last_success_task_date)
     Beneficiary.objects.filter(account=account, entity_id__in=updated_U5_beneficiaries).delete()
 
     NG_Under5().run(entity_type_U5_code, updated_U5_beneficiaries)
     logger.info(
         f"----------------------------- Aggregating journey for {account} per org unit, admission and period(month and year) -----------------------------"
     )
-    org_units_with_updated_data = ETL([entity_type_U5_code]).get_org_unit_ids_with_updated_data(last_success_task_date)
+    org_units_with_updated_data = etl_u5.get_org_unit_ids_with_updated_data(last_success_task_date)
     MonthlyStatistics.objects.filter(
         account=account, programme_type="U5", org_unit_id__in=org_units_with_updated_data
     ).delete()
-    ETL().journey_with_visit_and_steps_per_visit(account, "U5", org_units_with_updated_data)
+    etl.journey_with_visit_and_steps_per_visit(account, "U5", org_units_with_updated_data)
     entity_type_pbwg_code = "nigeria_pbwg"
-    pbwg_account = ETL([entity_type_pbwg_code]).account_related_to_entity_type()
-    updated_pbwg_beneficiaries = ETL([entity_type_pbwg_code]).get_updated_entity_ids(last_success_task_date)
+    etl_pbwg = ETL(entity_type_pbwg_code)
+    pbwg_account = etl_pbwg.account_related_to_entity_type()
+    updated_pbwg_beneficiaries = etl_pbwg.get_updated_entity_ids(last_success_task_date)
     Beneficiary.objects.filter(entity_id__in=updated_pbwg_beneficiaries).delete()
     NG_PBWG().run(entity_type_pbwg_code, updated_pbwg_beneficiaries)
     logger.info(
@@ -99,7 +102,7 @@ def etl_ng(all_data=None):
     MonthlyStatistics.objects.filter(
         account=pbwg_account, programme_type="PLW", org_unit_id__in=org_units_with_updated_data
     ).delete()
-    ETL().journey_with_visit_and_steps_per_visit(pbwg_account, "PLW", org_units_with_updated_data)
+    etl.journey_with_visit_and_steps_per_visit(pbwg_account, "PLW", org_units_with_updated_data)
 
 
 @shared_task()
@@ -122,23 +125,26 @@ def etl_ssd(all_data=None):
         last_success_task_date = None
     logger.info("Starting ETL for South Sudan")
     entity_type_U5_code = "ssd_under5"
-    child_account = ETL([entity_type_U5_code]).account_related_to_entity_type()
-    updated_U5_beneficiaries = ETL([entity_type_U5_code]).get_updated_entity_ids(last_success_task_date)
+    etl_u5 = ETL(entity_type_U5_code)
+    etl = ETL()
+    child_account = etl_u5.account_related_to_entity_type()
+    updated_U5_beneficiaries = etl_u5.get_updated_entity_ids(last_success_task_date)
     Beneficiary.objects.filter(account=child_account, entity_id__in=updated_U5_beneficiaries).delete()
     Under5().run(entity_type_U5_code, updated_U5_beneficiaries)
 
     logger.info(
         f"----------------------------- Aggregating Children under 5 journey for {child_account} per org unit, admission and period(month and year) -----------------------------"
     )
-    org_units_with_updated_data = ETL([entity_type_U5_code]).get_org_unit_ids_with_updated_data(last_success_task_date)
+    org_units_with_updated_data = etl_u5.get_org_unit_ids_with_updated_data(last_success_task_date)
     MonthlyStatistics.objects.filter(
         account=child_account, programme_type="U5", org_unit_id__in=org_units_with_updated_data
     ).delete()
-    ETL().journey_with_visit_and_steps_per_visit(child_account, "U5", org_units_with_updated_data)
+    etl.journey_with_visit_and_steps_per_visit(child_account, "U5", org_units_with_updated_data)
 
     entity_type_pbwg_code = "ssd_pbwg"
-    pbwg_account = ETL([entity_type_pbwg_code]).account_related_to_entity_type()
-    updated_pbwg_beneficiaries = ETL([entity_type_pbwg_code]).get_updated_entity_ids(last_success_task_date)
+    etl_pbwg = ETL(entity_type_pbwg_code)
+    pbwg_account = etl_pbwg.account_related_to_entity_type()
+    updated_pbwg_beneficiaries = etl_pbwg.get_updated_entity_ids(last_success_task_date)
     Beneficiary.objects.filter(entity_id__in=updated_pbwg_beneficiaries).delete()
     PBWG().run(entity_type_pbwg_code, updated_pbwg_beneficiaries)
     logger.info(
@@ -148,7 +154,9 @@ def etl_ssd(all_data=None):
     MonthlyStatistics.objects.filter(
         account=pbwg_account, programme_type="PLW", org_unit_id__in=org_units_with_updated_data
     ).delete()
-    ETL().journey_with_visit_and_steps_per_visit(pbwg_account, "PLW", org_units_with_updated_data)
+    etl.journey_with_visit_and_steps_per_visit(pbwg_account, "PLW", org_units_with_updated_data)
+
+    Screening().run(child_account, last_success_task_date)
 
     Screening().run(child_account, last_success_task_date)
 
@@ -158,7 +166,7 @@ def etl_ssd(all_data=None):
         and external_credential.login is not None
         and external_credential.password is not None
     ):
-        ETL().aggregating_data_to_push_to_dhis2(pbwg_account, org_units_with_updated_data)
+        etl.aggregating_data_to_push_to_dhis2(pbwg_account, org_units_with_updated_data)
         pushed_data = Dhis2().save_dhis2_sync_results(entity_type_pbwg_code, external_credential)
         logger.info(
             f"----------------------------- Pushed to DHIS2 on U5 and PBW for {len(pushed_data)} rows aggregated per year and month -----------------------------"
@@ -189,23 +197,26 @@ def etl_ethiopia(all_data=None):
 
     logger.info("Starting ETL for Ethiopia")
     entity_type_U5_code = "ethiopia_under5"
-    child_account = ETL([entity_type_U5_code]).account_related_to_entity_type()
-    updated_U5_beneficiaries = ETL([entity_type_U5_code]).get_updated_entity_ids(last_success_task_date)
+    etl_u5 = ETL(entity_type_U5_code)
+    etl = ETL()
+    child_account = etl_u5.account_related_to_entity_type()
+    updated_U5_beneficiaries = etl_u5.get_updated_entity_ids(last_success_task_date)
     Beneficiary.objects.filter(account=child_account, entity_id__in=updated_U5_beneficiaries).delete()
     ET_Under5().run(entity_type_U5_code, updated_U5_beneficiaries)
 
     logger.info(
         f"----------------------------- Aggregating Children under 5 journey for {child_account} per org unit, admission and period(month and year) -----------------------------"
     )
-    org_units_with_updated_data = ETL([entity_type_U5_code]).get_org_unit_ids_with_updated_data(last_success_task_date)
+    org_units_with_updated_data = etl_u5.get_org_unit_ids_with_updated_data(last_success_task_date)
     MonthlyStatistics.objects.filter(
         account=child_account, programme_type="U5", org_unit_id__in=org_units_with_updated_data
     ).delete()
-    ETL().journey_with_visit_and_steps_per_visit(child_account, "U5", org_units_with_updated_data)
+    etl.journey_with_visit_and_steps_per_visit(child_account, "U5", org_units_with_updated_data)
 
     entity_type_pbwg_code = "ethiopia_pbwg"
-    pbwg_account = ETL([entity_type_pbwg_code]).account_related_to_entity_type()
-    updated_pbwg_beneficiaries = ETL([entity_type_pbwg_code]).get_updated_entity_ids(last_success_task_date)
+    etl_pbwg = ETL(entity_type_pbwg_code)
+    pbwg_account = etl_pbwg.account_related_to_entity_type()
+    updated_pbwg_beneficiaries = etl_pbwg.get_updated_entity_ids(last_success_task_date)
     Beneficiary.objects.filter(entity_id__in=updated_pbwg_beneficiaries).delete()
     PBWG().run(entity_type_pbwg_code, updated_pbwg_beneficiaries)
 
@@ -215,4 +226,4 @@ def etl_ethiopia(all_data=None):
     MonthlyStatistics.objects.filter(
         account=pbwg_account, programme_type="PLW", org_unit_id__in=org_units_with_updated_data
     ).delete()
-    ETL().journey_with_visit_and_steps_per_visit(pbwg_account, "PLW", org_units_with_updated_data)
+    etl.journey_with_visit_and_steps_per_visit(pbwg_account, "PLW", org_units_with_updated_data)

--- a/plugins/wfp/tasks.py
+++ b/plugins/wfp/tasks.py
@@ -59,7 +59,8 @@ def etl_ng(all_data=None):
     """Extract beneficiary data from Iaso tables and store them in the format expected by existing tableau dashboards"""
     from django_celery_results.models import TaskResult
 
-    last_success_task = TaskResult.objects.filter(task_name="plugins.wfp.tasks.etl_ng", status="SUCCESS").first()
+    task_name = "plugins.wfp.tasks.etl_ng"
+    last_success_task = TaskResult.objects.filter(task_name=task_name, status="SUCCESS").first()
 
     if last_success_task:
         # A task was found, use its creation date
@@ -81,7 +82,7 @@ def etl_ng(all_data=None):
     updated_U5_beneficiaries = etl_u5.get_updated_entity_ids(last_success_task_date)
     Beneficiary.objects.filter(account=account, entity_id__in=updated_U5_beneficiaries).delete()
 
-    NG_Under5().run(entity_type_U5_code, updated_U5_beneficiaries)
+    NG_Under5().run(entity_type_U5_code, updated_U5_beneficiaries, task_name)
     logger.info(
         f"----------------------------- Aggregating journey for {account} per org unit, admission and period(month and year) -----------------------------"
     )
@@ -95,7 +96,7 @@ def etl_ng(all_data=None):
     pbwg_account = etl_pbwg.account_related_to_entity_type()
     updated_pbwg_beneficiaries = etl_pbwg.get_updated_entity_ids(last_success_task_date)
     Beneficiary.objects.filter(entity_id__in=updated_pbwg_beneficiaries).delete()
-    NG_PBWG().run(entity_type_pbwg_code, updated_pbwg_beneficiaries)
+    NG_PBWG().run(entity_type_pbwg_code, updated_pbwg_beneficiaries, task_name)
     logger.info(
         f"----------------------------- Aggregating PBWG journey for {pbwg_account} per org unit, admission and period(month and year) -----------------------------"
     )
@@ -110,7 +111,8 @@ def etl_ssd(all_data=None):
     """Extract beneficiary data from Iaso tables and store them in the format expected by existing tableau dashboards"""
     from django_celery_results.models import TaskResult
 
-    last_success_task = TaskResult.objects.filter(task_name="plugins.wfp.tasks.etl_ssd", status="SUCCESS").first()
+    task_name = "plugins.wfp.tasks.etl_ssd"
+    last_success_task = TaskResult.objects.filter(task_name=task_name, status="SUCCESS").first()
 
     if last_success_task:
         # A task was found, use its creation date
@@ -130,7 +132,7 @@ def etl_ssd(all_data=None):
     child_account = etl_u5.account_related_to_entity_type()
     updated_U5_beneficiaries = etl_u5.get_updated_entity_ids(last_success_task_date)
     Beneficiary.objects.filter(account=child_account, entity_id__in=updated_U5_beneficiaries).delete()
-    Under5().run(entity_type_U5_code, updated_U5_beneficiaries)
+    Under5().run(entity_type_U5_code, updated_U5_beneficiaries, task_name)
 
     logger.info(
         f"----------------------------- Aggregating Children under 5 journey for {child_account} per org unit, admission and period(month and year) -----------------------------"
@@ -146,7 +148,7 @@ def etl_ssd(all_data=None):
     pbwg_account = etl_pbwg.account_related_to_entity_type()
     updated_pbwg_beneficiaries = etl_pbwg.get_updated_entity_ids(last_success_task_date)
     Beneficiary.objects.filter(entity_id__in=updated_pbwg_beneficiaries).delete()
-    PBWG().run(entity_type_pbwg_code, updated_pbwg_beneficiaries)
+    PBWG().run(entity_type_pbwg_code, updated_pbwg_beneficiaries, task_name)
     logger.info(
         f"----------------------------- Aggregating PBWG journey for {pbwg_account} per org unit, admission and period(month and year) -----------------------------"
     )
@@ -207,7 +209,8 @@ def etl_ethiopia(all_data=None):
     """Extract beneficiary data from Iaso tables and store them in the format expected by existing tableau dashboards"""
     from django_celery_results.models import TaskResult
 
-    last_success_task = TaskResult.objects.filter(task_name="plugins.wfp.tasks.etl_ethiopia", status="SUCCESS").first()
+    task_name = "plugins.wfp.tasks.etl_ethiopia"
+    last_success_task = TaskResult.objects.filter(task_name=task_name, status="SUCCESS").first()
 
     if last_success_task:
         # A task was found, use its creation date
@@ -228,7 +231,7 @@ def etl_ethiopia(all_data=None):
     child_account = etl_u5.account_related_to_entity_type()
     updated_U5_beneficiaries = etl_u5.get_updated_entity_ids(last_success_task_date)
     Beneficiary.objects.filter(account=child_account, entity_id__in=updated_U5_beneficiaries).delete()
-    ET_Under5().run(entity_type_U5_code, updated_U5_beneficiaries)
+    ET_Under5().run(entity_type_U5_code, updated_U5_beneficiaries, task_name)
 
     logger.info(
         f"----------------------------- Aggregating Children under 5 journey for {child_account} per org unit, admission and period(month and year) -----------------------------"
@@ -244,7 +247,7 @@ def etl_ethiopia(all_data=None):
     pbwg_account = etl_pbwg.account_related_to_entity_type()
     updated_pbwg_beneficiaries = etl_pbwg.get_updated_entity_ids(last_success_task_date)
     Beneficiary.objects.filter(entity_id__in=updated_pbwg_beneficiaries).delete()
-    PBWG().run(entity_type_pbwg_code, updated_pbwg_beneficiaries)
+    PBWG().run(entity_type_pbwg_code, updated_pbwg_beneficiaries, task_name)
 
     logger.info(
         f"----------------------------- Aggregating PBWG journey for {pbwg_account} per org unit, admission and period(month and year) -----------------------------"

--- a/plugins/wfp/tasks.py
+++ b/plugins/wfp/tasks.py
@@ -196,6 +196,10 @@ def ssd_aggregate_and_push_data_to_dhis2(all_data=None):
         logger.info(
             f"----------------------------- Pushed to DHIS2 on U5 and PBW for {len(pushed_data)} rows aggregated per year and month -----------------------------"
         )
+    else:
+        logger.info(
+            f"----------------------------- No DHIS2 credentials found for {account} -----------------------------"
+        )
 
 
 @shared_task()

--- a/plugins/wfp/tasks.py
+++ b/plugins/wfp/tasks.py
@@ -158,22 +158,44 @@ def etl_ssd(all_data=None):
 
     Screening().run(child_account, last_success_task_date)
 
-    Screening().run(child_account, last_success_task_date)
+    # print("len(connection.queries)", len(connection.queries))  # Uncomment this line to see the number of SQL queries executed
+    # print(connection.queries) # Uncomment this line to see the SQL queries executed
 
-    external_credential = ExternalCredentials.objects.filter(account=pbwg_account).first()
+
+@shared_task()
+def ssd_aggregate_and_push_data_to_dhis2(all_data=None):
+    from django_celery_results.models import TaskResult
+
+    last_success_task = TaskResult.objects.filter(
+        task_name="plugins.wfp.tasks.ssd_aggregate_and_push_data_to_dhis2", status="SUCCESS"
+    ).first()
+    if last_success_task:
+        last_success_task_date = last_success_task.date_created.strftime("%Y-%m-%d")
+    else:
+        last_success_task_date = None
+
+    # Allow to re-run on the whole data
+    if all_data is not None:
+        last_success_task_date = None
+
+    etl = ETL("ssd_under5")
+    account = etl.account_related_to_entity_type()
+    org_units_with_updated_data = etl.get_org_unit_ids_with_updated_data(last_success_task_date)
+
+    external_credential = ExternalCredentials.objects.filter(account=account).first()
     if external_credential is not None and (
         external_credential.url is not None
         and external_credential.login is not None
         and external_credential.password is not None
     ):
-        etl.aggregating_data_to_push_to_dhis2(pbwg_account, org_units_with_updated_data)
-        pushed_data = Dhis2().save_dhis2_sync_results(entity_type_pbwg_code, external_credential)
+        logger.info(
+            f"----------------------------- Aggregating monthly data to push to DHIS2 for {len(org_units_with_updated_data)} org unit on {account} -----------------------------"
+        )
+        monthly_data = etl.aggregating_data_to_push_to_dhis2(account, org_units_with_updated_data)
+        pushed_data = Dhis2().save_dhis2_sync_results(external_credential, account, monthly_data)
         logger.info(
             f"----------------------------- Pushed to DHIS2 on U5 and PBW for {len(pushed_data)} rows aggregated per year and month -----------------------------"
         )
-
-    # print("len(connection.queries)", len(connection.queries))  # Uncomment this line to see the number of SQL queries executed
-    # print(connection.queries) # Uncomment this line to see the SQL queries executed
 
 
 @shared_task()


### PR DESCRIPTION
## What problem is this PR solving?

Explain here in one sentence.

### Related JIRA tickets

[WC2-889](https://bluesquare.atlassian.net/browse/WC2-889)

## Changes

- Integrate Matteo's suggestions to refactor and improve instances creation
- Replacing list of ids by a queryset to try to get better performances from postgres
- Removed an extra unneeded filter when retrieve entities to integrate in analytics tables and clean unnecessary codes for better performance.
- Added a possibility to catch an exception an let ETL to continue run by storing the error in `TakLog` table

## How to test

Run ETL for SSD data with:
- `docker compose run iaso manage etl_ssd all_data`,  to get analytics data. It should run faster.
- `docker compose run iaso manage ssd_aggregate_and_push_data_to_dhis2` to aggregate monthly data by org unit and period and push to dhis2. 

Then login on django admin and check each analytic table by filter on South Sudan account:
- [Beneficiary](http://localhost:8081/admin/wfp/beneficiary/?account__id__exact=1)
- [Journey](http://localhost:8081/admin/wfp/journey/?beneficiary__account__id__exact=1)
- [Visit](http://localhost:8081/admin/wfp/visit/?journey__beneficiary__account__id__exact=1)
- [Step](http://localhost:8081/admin/wfp/step/?visit__journey__beneficiary__account__id__exact=1)
- [Monthly statistics](http://localhost:8081/admin/wfp/monthlystatistics/?account__id__exact=1)
- [Screening data](http://localhost:8081/admin/wfp/screeningdata/?account__id__exact=1)
- [Dhis2 sync results](http://localhost:8081/admin/wfp/dhis2syncresults/?account__id__exact=1)
- [TaskLog](http://localhost:8081/admin/iaso/tasklog/)

**The QA database dump is avalaible on:** https://drive.google.com/file/d/1wHLbUb_Ra6DUq3KA-dgUndKuNea1OKGL/view?usp=drive_link

## Print screen / video

[Capture vidéo du 12-02-2026 10:17:20.webm](https://github.com/user-attachments/assets/763761dc-cf0e-4413-be00-40261e9f05e1)

When an exception has raised, it stored in database:

<img width="1531" height="588" alt="image" src="https://github.com/user-attachments/assets/19a1b22c-c461-4616-aa11-c01c32de077f" />



## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).


[WC2-889]: https://bluesquare.atlassian.net/browse/WC2-889?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ