### PR TITLE
Accept white space for thousand separator

### DIFF
--- a/hat/assets/js/apps/Iaso/components/forms/InputComponent.tsx
+++ b/hat/assets/js/apps/Iaso/components/forms/InputComponent.tsx
@@ -45,7 +45,7 @@ export type NumberInputOptions = {
     max?: number;
     decimalScale?: number;
     decimalSeparator?: '.' | ',';
-    thousandSeparator?: '.' | ',';
+    thousandSeparator?: '.' | ',' | ' ';
     thousandsGroupStyle?: 'thousand' | 'lakh' | 'wan';
 };
 
@@ -99,7 +99,7 @@ export type InputComponentProps = {
         max?: number;
         decimalScale?: number;
         decimalSeparator?: '.' | ',';
-        thousandSeparator?: '.' | ',';
+        thousandSeparator?: '.' | ',' | ' ';
     };
     phoneInputOptions?: PhoneInputOptions;
     setFieldError?: (keyValue: string, message: string) => void;


### PR DESCRIPTION
## What problem is this PR solving?

For year inputs, we don't want a sparator but providing undefined uses a default "," and we don't allow whitespace / empty string 

### Related JIRA tickets

SNT-269

## Changes

Accept white space as thousand separator on inputs

## How to test

Doesn't break current behavior if nothing is specified.

## Print screen / video

 N/A

## Notes

SNT Malaria related PR: https://github.com/BLSQ/snt-malaria/pull/182

## Doc

N/A
