### PR TITLE
IA-4770: Remove old references to flake8

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -41,7 +41,7 @@ case "$1" in
   "test" )
     export TESTING=true
     # Linting tasks first
-    flake8 ./hat
+    ruff check ./hat
     npm run lint
     # Then tests
     ./scripts/wait_for_dbs.sh
@@ -51,7 +51,7 @@ case "$1" in
   ;;
   "test_lint" )
     export TESTING=true
-    flake8 ./hat -v
+    ruff check -v ./hat
     npm run lint
   ;;
   "test_js" )

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,0 @@
-[flake8]
-max-line-length=120
-exclude=migrations
-
-# flake8-mypy expects the following for sensible formatting
-show_column_numbers=True


### PR DESCRIPTION
## What problem is this PR solving?

We still had setup.cfg file that was used only for flake8 (which we removed when switching to ruff). We also had flake8 commands in entrypoint.sh that had to be replaced with ruff commands. 

### Related JIRA tickets

IA-4770

## Changes

- Delete setup.cfg
- Replace flake8 commands by ruff commands

## How to test

Run the docker in test or test_lint
