### PR TITLE
IA-4768: Modify handleOrgUnitChange output to return a string and not an array

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/TreeView/requests.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/TreeView/requests.ts
@@ -175,7 +175,7 @@ export const useGetOrgUnit = (
     );
 
 const getOrgUnits = async (
-    orgUnitsIds: string[] | string,
+    orgUnitsIds: string | (number | string)[] | undefined,
     statusSettings = 'all',
 ): Promise<OrgUnit[]> => {
     const idsString = Array.isArray(orgUnitsIds)
@@ -186,7 +186,7 @@ const getOrgUnits = async (
 };
 
 export const useGetMultipleOrgUnits = (
-    orgUnitsIds: string[] | string,
+    orgUnitsIds: string | (number | string)[] | undefined,
     statusSettings = 'all',
 ): UseQueryResult<OrgUnit[], Error> => {
     return useSnackQuery({

--- a/hat/assets/js/apps/Iaso/hooks/useFilterState.ts
+++ b/hat/assets/js/apps/Iaso/hooks/useFilterState.ts
@@ -201,41 +201,6 @@ export const useMultiTreeviewFilterState = ({
     );
 };
 
-type TreeviewArgs = {
-    paramId: string | undefined;
-    handleChange: (key: string, value: (string | number)[] | undefined) => void;
-};
-
-type TreeviewFilter = {
-    initialOrgUnit: OrgUnit;
-    handleOrgUnitChange: (orgUnit: OrgUnit | undefined) => void;
-};
-
-// todo : remove this, it seems unused ?
-export const useTreeviewFilterState = ({
-    paramId,
-    handleChange,
-}: TreeviewArgs): TreeviewFilter => {
-    const [initialOrgUnitId, setInitialOrgUnitId] = useState<
-        string | (number | string)[] | undefined
-    >(paramId);
-    const { data: initialOrgUnit } = useGetOrgUnit(initialOrgUnitId);
-
-    const handleOrgUnitChange = useCallback(
-        orgUnit => {
-            const id = orgUnit ? [orgUnit.id] : undefined;
-            setInitialOrgUnitId(id);
-            handleChange('org_unit', id);
-        },
-        [handleChange],
-    );
-
-    return useMemo(
-        () => ({ initialOrgUnit, handleOrgUnitChange }),
-        [handleOrgUnitChange, initialOrgUnit],
-    );
-};
-
 type CheckBoxFilterArgs = {
     keyValue: string;
     handleChange: (key: string, value: boolean) => void;

--- a/hat/assets/js/apps/Iaso/hooks/useFilterState.ts
+++ b/hat/assets/js/apps/Iaso/hooks/useFilterState.ts
@@ -167,12 +167,12 @@ export const useFilterState = ({
 
 type MultiTreeviewArgs = {
     paramIds: string | undefined;
-    handleChange: (key: string, value: (string | number)[] | undefined) => void;
+    handleChange: (key: string, value: string | string[] | undefined) => void;
 };
 
 type MultiTreeviewFilter = {
-    initialOrgUnits: OrgUnit[];
-    handleOrgUnitChange: (orgUnits: (number | string)[] | undefined) => void;
+    initialOrgUnits: OrgUnit[] | undefined;
+    handleOrgUnitChange: (orgUnits: OrgUnit[] | undefined) => void;
 };
 
 export const useMultiTreeviewFilterState = ({
@@ -185,11 +185,11 @@ export const useMultiTreeviewFilterState = ({
     const { data: initialOrgUnits } = useGetMultipleOrgUnits(initialOrgUnitIds);
 
     const handleOrgUnitChange = useCallback(
-        orgUnits => {
+        (orgUnits: OrgUnit[] | undefined) => {
             const ids = orgUnits ? orgUnits.map(orgUnit => orgUnit.id) : [];
             // When "emptying" the treeview, the value is [],
             // so we force it to undefined to avoid an empty string in the param org_unit which leads to a 404
-            handleChange('org_unit', ids.length ? ids : undefined);
+            handleChange('org_unit', ids?.length ? ids?.join(',') : undefined);
             setInitialOrgUnitIds(ids);
         },
         [handleChange],
@@ -211,6 +211,7 @@ type TreeviewFilter = {
     handleOrgUnitChange: (orgUnit: OrgUnit | undefined) => void;
 };
 
+// todo : remove this, it seems unused ?
 export const useTreeviewFilterState = ({
     paramId,
     handleChange,


### PR DESCRIPTION
## What problem is this PR solving?

On the [duplicates page](https://iaso-staging.bluesquare.org/dashboard/entities/duplicates/), picking a location for filtering and hitting search triggers errors when calling the api because the URL would contain `org_unit/["x","y"]/` instead of `org_unit/x,y/`

### Related JIRA tickets

IA-4768

## Changes

* Change the filter state function so it outputs a string instead of an array
* Some type fixing
* Added a todo for what seems to be an unused function

## How to test

Manual testing, select any location in the corresponding filter, it shouldn't return an error anymore upon clicking the search button. 


