### PR TITLE
POLIOPM-510: remove filter on on hold campaigns

### DIFF
--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/CreateEditDestruction.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/CreateEditDestruction.tsx
@@ -12,21 +12,21 @@ import { isEqual } from 'lodash';
 import { EditIconButton } from '../../../../../../../../../hat/assets/js/apps/Iaso/components/Buttons/EditIconButton';
 import DocumentUploadWithPreview from '../../../../../../../../../hat/assets/js/apps/Iaso/components/files/pdf/DocumentUploadWithPreview';
 import { processErrorDocsBase } from '../../../../../../../../../hat/assets/js/apps/Iaso/components/files/pdf/utils';
-import { SingleSelect } from '../../../../../components/Inputs/SingleSelect';
 import {
     DateInput,
     NumberInput,
     TextInput,
 } from '../../../../../components/Inputs';
+import { SingleSelect } from '../../../../../components/Inputs/SingleSelect';
 import { Vaccine } from '../../../../../constants/types';
 import {
     useCheckDestructionDuplicate,
     useSaveDestruction,
 } from '../../hooks/api';
 import MESSAGES from '../../messages';
-import { useDestructionValidation } from './validation';
 import { DosesPerVialDropdown } from '../../types';
 import { useAvailablePresentations } from './dropdownOptions';
+import { useDestructionValidation } from './validation';
 
 type Props = {
     destruction?: any;

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/CreateEditEarmarked.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/CreateEditEarmarked.tsx
@@ -15,12 +15,12 @@ import { VaccineForStock } from '../../../../../constants/types';
 import { useGetVrfListByRound } from '../../../SupplyChain/hooks/api/vrf';
 import { useCampaignOptions, useSaveEarmarked } from '../../hooks/api';
 import MESSAGES from '../../messages';
+import { DosesPerVialDropdown } from '../../types';
 import {
     useAvailablePresentations,
     useEarmarkOptions,
 } from './dropdownOptions';
 import { useEarmarkValidation } from './validation';
-import { DosesPerVialDropdown } from '../../types';
 
 type Props = {
     earmark?: any;

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/CreateEditFormA.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/CreateEditFormA.tsx
@@ -14,6 +14,8 @@ import {
 } from 'bluesquare-components';
 import { Field, FormikProvider, useFormik } from 'formik';
 import { isEqual } from 'lodash';
+import InputComponent from 'Iaso/components/forms/InputComponent';
+import { useSkipEffectUntilValue } from 'Iaso/hooks/useSkipEffectUntilValue';
 import { EditIconButton } from '../../../../../../../../../hat/assets/js/apps/Iaso/components/Buttons/EditIconButton';
 import DocumentUploadWithPreview from '../../../../../../../../../hat/assets/js/apps/Iaso/components/files/pdf/DocumentUploadWithPreview';
 import { processErrorDocsBase } from '../../../../../../../../../hat/assets/js/apps/Iaso/components/files/pdf/utils';
@@ -26,12 +28,9 @@ import { SingleSelect } from '../../../../../components/Inputs/SingleSelect';
 import { Vaccine } from '../../../../../constants/types';
 import { useCampaignOptions, useSaveFormA } from '../../hooks/api';
 import MESSAGES from '../../messages';
-import { useFormAValidation } from './validation';
-import InputComponent from 'Iaso/components/forms/InputComponent';
-import { DropdownOptions } from 'Iaso/types/utils';
 import { DosesPerVialDropdown } from '../../types';
 import { useAvailablePresentations } from './dropdownOptions';
-import { useSkipEffectUntilValue } from 'Iaso/hooks/useSkipEffectUntilValue';
+import { useFormAValidation } from './validation';
 
 type Props = {
     formA?: any;

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/CreateEditIncident.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Modals/CreateEditIncident.tsx
@@ -29,12 +29,12 @@ import { Vaccine } from '../../../../../constants/types';
 import { useSaveIncident } from '../../hooks/api';
 import { useGetMovementDescription } from '../../hooks/useGetMovementDescription';
 import MESSAGES from '../../messages';
+import { DosesPerVialDropdown } from '../../types';
 import {
     useAvailablePresentations,
     useIncidentOptions,
 } from './dropdownOptions';
 import { useIncidentValidation } from './validation';
-import { DosesPerVialDropdown } from '../../types';
 
 type Props = {
     incident?: any;

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/hooks/api.ts
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/hooks/api.ts
@@ -25,13 +25,13 @@ import {
 } from '../../../Campaigns/hooks/api/useGetCampaigns';
 import { patchRequest2, postRequest2 } from '../../SupplyChain/hooks/api/vrf';
 import MESSAGES from '../messages';
+import { FormAFormValues } from '../StockVariation/Modals/CreateEditFormA';
 import {
     DosesPerVialDropdown,
     StockManagementDetailsParams,
     StockManagementListParams,
     StockVariationParams,
 } from '../types';
-import { FormAFormValues } from '../StockVariation/Modals/CreateEditFormA';
 
 const defaults = { order: 'country', pageSize: 20, page: 1 };
 const options = {
@@ -131,7 +131,6 @@ export const useGetUnusableVials = (
     });
 };
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars, no-unused-vars
 const getStockManagementSummary = async (id?: string) => {
     return getRequest(`${apiUrl}${id}/summary/`);
 };
@@ -305,14 +304,12 @@ export const useCampaignOptions = (
     );
     const roundOptions = useMemo(() => {
         return selectedCampaign
-            ? selectedCampaign.rounds
-                  .filter(r => !r.on_hold || r.number === round)
-                  .map(rnd => {
-                      return {
-                          label: `${formatMessage(MESSAGES.round)} ${rnd.number}`,
-                          value: rnd.id,
-                      };
-                  })
+            ? selectedCampaign.rounds.map(rnd => {
+                  return {
+                      label: `${formatMessage(MESSAGES.round)} ${rnd.number}`,
+                      value: rnd.id,
+                  };
+              })
             : [];
     }, [campaignName, data, formatMessage, selectedCampaign, round]);
 
@@ -331,18 +328,9 @@ export const useCampaignOptions = (
     }, [campaignName, data, formatMessage, selectedCampaign]);
 
     const campaignOptions = useMemo(() => {
-        const campaignsList = (data ?? [])
-            // @ts-ignore
-            .filter(
-                c =>
-                    (!c.on_hold &&
-                        !c.is_test &&
-                        !c.rounds.every(rnd => rnd.on_hold)) ||
-                    c.id === selectedCampaign?.id,
-            )
-            .map(c => {
-                return { label: c.obr_name, value: c.obr_name };
-            });
+        const campaignsList = (data ?? []).map(c => {
+            return { label: c.obr_name, value: c.obr_name };
+        });
         const defaultList = [{ label: campaignName, value: campaignName }];
         if ((campaignsList ?? []).length > 0) {
             return campaignsList;
@@ -696,9 +684,9 @@ export const useCheckDestructionDuplicate = ({
         options: {
             enabled: Boolean(
                 vaccineStockId &&
-                    destructionReportDate &&
-                    unusableVialsDestroyed &&
-                    moment(destructionReportDate, 'YYYY-MM-DD', true).isValid(),
+                destructionReportDate &&
+                unusableVialsDestroyed &&
+                moment(destructionReportDate, 'YYYY-MM-DD', true).isValid(),
             ),
             staleTime: 1000 * 60 * 15, // in MS
             keepPreviousData: false,

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/SupplyChainTabs.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/SupplyChainTabs.tsx
@@ -1,7 +1,7 @@
+import React, { FunctionComponent } from 'react';
 import { Tab, Tabs } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import { commonStyles, useSafeIntl } from 'bluesquare-components';
-import React, { FunctionComponent } from 'react';
 import { TabWithInfoIcon } from '../../../../../../../../hat/assets/js/apps/Iaso/components/nav/TabWithInfoIcon';
 import { PREALERT, VAR, VRF } from '../constants';
 import MESSAGES from '../messages';

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/VaccineRequestForm/VaccineRequestForm.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/VaccineRequestForm/VaccineRequestForm.tsx
@@ -7,6 +7,7 @@ import React, {
 import { Box, Grid, Typography } from '@mui/material';
 import { useSafeIntl } from 'bluesquare-components';
 import { Field, useFormikContext } from 'formik';
+import { useSkipEffectUntilValue } from 'Iaso/hooks/useSkipEffectUntilValue';
 import DocumentUploadWithPreview from '../../../../../../../../../hat/assets/js/apps/Iaso/components/files/pdf/DocumentUploadWithPreview';
 import { processErrorDocsBase } from '../../../../../../../../../hat/assets/js/apps/Iaso/components/files/pdf/utils';
 import InputComponent from '../../../../../../../../../hat/assets/js/apps/Iaso/components/forms/InputComponent';
@@ -21,7 +22,6 @@ import {
 } from '../../hooks/api/vrf';
 import MESSAGES from '../../messages';
 import { useSharedStyles } from '../shared';
-import { useSkipEffectUntilValue } from 'Iaso/hooks/useSkipEffectUntilValue';
 
 type Props = { className?: string; vrfData: any };
 

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/hooks/api/vrf.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/hooks/api/vrf.tsx
@@ -166,16 +166,7 @@ export const useCampaignDropDowns = ({
             .filter(
                 c => c.separate_scopes_per_round || (c.scopes ?? []).length > 0,
             )
-            // filter out on hold campaign, except selected campaign to avoid UI bug
-            .filter(
-                c => !c.on_hold || c.obr_name === selectedCampaign?.obr_name,
-            )
-            // filter out campaign with all rounds on hold, except selected campaign to avoid UI bug
-            .filter(
-                c =>
-                    !c.rounds.every(rnd => rnd.on_hold) ||
-                    c.obr_name === selectedCampaign?.obr_name,
-            )
+
             .map(c => ({
                 label: c.obr_name,
                 value: c.obr_name,


### PR DESCRIPTION
## What problem is this PR solving?

user need to be able to create VRF, FormA and Earmarked stock for campaigns on hold

### Related JIRA tickets

POLIOPM-510

## Changes

- removed the front-end filtering of on hold campaigns /rounds in VRF, FormA and Earmarked
- reorder some imports

## How to test

In polio:
- Create a new campaign
- put it on hold (check box in first tab) and save
- Go to Vaccine Module > Supply chain
- Select Create
- You should be able to select your campaign and save it

- Go to Vaccine Module > Vaccine Stock
- Select the country + vaccine of your campaign
- If the stock doesn't exist, create it
- Enter the stock
- Go to stock variation
- Try adding a FormA and an Earmarked: in both cases you should be able to sleect your campaign and save

## Print screen / video


https://github.com/user-attachments/assets/aaeb174f-960c-40fd-956e-9e3b952c6fc9


https://github.com/user-attachments/assets/ce02f110-248e-4673-b49e-4a5fc255611d



## Notes

should be hotfixed
