### PR TITLE
HOTFIX: POLIOPM-510: show on hold rounds

### DIFF
--- a/plugins/polio/js/src/domains/Campaigns/Rounds/RoundForm.tsx
+++ b/plugins/polio/js/src/domains/Campaigns/Rounds/RoundForm.tsx
@@ -1,12 +1,12 @@
-import { Box, Grid } from '@mui/material';
-import { useSafeIntl } from 'bluesquare-components';
-import { Field, useFormikContext } from 'formik';
 import React, {
     FunctionComponent,
     useCallback,
     useMemo,
     useState,
 } from 'react';
+import { Box, Grid } from '@mui/material';
+import { useSafeIntl } from 'bluesquare-components';
+import { Field, useFormikContext } from 'formik';
 import {
     BooleanInput,
     DateInput,
@@ -58,7 +58,7 @@ export const RoundForm: FunctionComponent<Props> = ({ roundNumber }) => {
     const isRequiredForPlannedRnd =
         isCampaignPlanned ||
         isEarlierRoundPlanned ||
-        rounds[roundIndex].is_planned;
+        Boolean(rounds[roundIndex]?.is_planned);
 
     // Logic is duplicated for is_planned and on_hold because abstracting it away in a hook
     // caused weird state bugs (probably due to formik's use of the context API)

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/hooks/api.ts
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/hooks/api.ts
@@ -19,6 +19,7 @@ import {
 
 import { DropdownOptions } from '../../../../../../../../hat/assets/js/apps/Iaso/types/utils';
 import { commaSeparatedIdsToStringArray } from '../../../../../../../../hat/assets/js/apps/Iaso/utils/forms';
+import { Campaign } from '../../../../constants/types';
 import {
     CAMPAIGNS_ENDPOINT,
     useGetCampaigns,
@@ -311,7 +312,7 @@ export const useCampaignOptions = (
                   };
               })
             : [];
-    }, [campaignName, data, formatMessage, selectedCampaign, round]);
+    }, [formatMessage, selectedCampaign]);
 
     const roundNumberOptions = useMemo(() => {
         return selectedCampaign
@@ -325,10 +326,10 @@ export const useCampaignOptions = (
                       };
                   })
             : [];
-    }, [campaignName, data, formatMessage, selectedCampaign]);
+    }, [formatMessage, round, selectedCampaign]);
 
     const campaignOptions = useMemo(() => {
-        const campaignsList = (data ?? []).map(c => {
+        const campaignsList = ((data ?? []) as Campaign[]).map(c => {
             return { label: c.obr_name, value: c.obr_name };
         });
         const defaultList = [{ label: campaignName, value: campaignName }];
@@ -339,7 +340,7 @@ export const useCampaignOptions = (
             return defaultList;
         }
         return [];
-    }, [campaignName, data, selectedCampaign?.id]);
+    }, [campaignName, data]);
 
     return useMemo(() => {
         return {

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/hooks/api/vrf.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/hooks/api/vrf.tsx
@@ -190,12 +190,6 @@ export const useCampaignDropDowns = ({
                           (!selectedCampaign?.separate_scopes_per_round &&
                               (selectedCampaign?.scopes ?? []).length > 0),
                   )
-                  // filter out rounds on_hold, except selected round to avoid UI bug
-                  .filter(
-                      round =>
-                          !round.on_hold ||
-                          (rndsParams ?? []).includes(round.number),
-                  )
                   .map(round => ({
                       label: `Round ${round.number}`,
                       value: `${round.number}`,


### PR DESCRIPTION
## What problem is this PR solving?

Rounds on hold can't be selected

### Related JIRA tickets

POLIOPM-510

## Changes

- remove condition on round filter
- Fix bug crash when using back button on campaign creation

## How to test

Duplicate campaign in ticket on local DB
Go to vaccine module > Supplychain > Create
Create VRF for the campaign: it should be visible in the dropdown list

## Print screen / video

<img width="2476" height="1362" alt="Screenshot 2026-02-13 at 10 57 03" src="https://github.com/user-attachments/assets/f1cffe0f-e035-4d18-bbd1-4f01934aa137" />


