### PR TITLE
[IA-4596] don't allow instance creation

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -343,6 +343,7 @@
     "iaso.forms.new": "new",
     "iaso.forms.newCap": "New",
     "iaso.forms.no": "No",
+    "iaso.forms.noFormVersion": "There is no version yet of your form",
     "iaso.forms.noResultsFound": "No results found",
     "iaso.forms.notValidated": "Not validated",
     "iaso.forms.org_unit_type": "Organisation unit type",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -345,6 +345,7 @@
     "iaso.forms.new": "nouveau",
     "iaso.forms.newCap": "Nouveau",
     "iaso.forms.no": "Non",
+    "iaso.forms.noFormVersion": "Aucune version de votre formulaire n'est encore disponible.",
     "iaso.forms.noResultsFound": "Aucun résultat trouvé",
     "iaso.forms.notValidated": "Non validé",
     "iaso.forms.org_unit_type": "Type d'unité d'organisation",

--- a/hat/assets/js/apps/Iaso/domains/forms/components/CreateSubmissionModal/CreateSubmissionModal.tsx
+++ b/hat/assets/js/apps/Iaso/domains/forms/components/CreateSubmissionModal/CreateSubmissionModal.tsx
@@ -1,8 +1,16 @@
 import { makeFullModal } from 'bluesquare-components';
-import { CreateReAssignDialogComponent } from '../../../instances/components/CreateReAssignDialogComponent';
+import {
+    CreateReAssignDialogComponent,
+    Props as DialogProps,
+} from '../../../instances/components/CreateReAssignDialogComponent';
 import { CreateSubmissionModalButton } from './CreateSubmissionModalButton';
 
-export const CreateSubmissionModal = makeFullModal(
+type ButtonProps = {
+    onClick: () => void;
+    disabled?: boolean;
+};
+
+export const CreateSubmissionModal = makeFullModal<DialogProps, ButtonProps>(
     CreateReAssignDialogComponent,
     CreateSubmissionModalButton,
 );

--- a/hat/assets/js/apps/Iaso/domains/forms/components/CreateSubmissionModal/CreateSubmissionModal.tsx
+++ b/hat/assets/js/apps/Iaso/domains/forms/components/CreateSubmissionModal/CreateSubmissionModal.tsx
@@ -1,16 +1,16 @@
 import { makeFullModal } from 'bluesquare-components';
 import {
     CreateReAssignDialogComponent,
-    Props as DialogProps,
+    CreateReAssignDialogProps,
 } from '../../../instances/components/CreateReAssignDialogComponent';
 import { CreateSubmissionModalButton } from './CreateSubmissionModalButton';
 
 type ButtonProps = {
     onClick: () => void;
-    disabled?: boolean;
+    disabled: boolean;
 };
 
-export const CreateSubmissionModal = makeFullModal<DialogProps, ButtonProps>(
-    CreateReAssignDialogComponent,
-    CreateSubmissionModalButton,
-);
+export const CreateSubmissionModal = makeFullModal<
+    CreateReAssignDialogProps,
+    ButtonProps
+>(CreateReAssignDialogComponent, CreateSubmissionModalButton);

--- a/hat/assets/js/apps/Iaso/domains/forms/components/CreateSubmissionModal/CreateSubmissionModalButton.tsx
+++ b/hat/assets/js/apps/Iaso/domains/forms/components/CreateSubmissionModal/CreateSubmissionModalButton.tsx
@@ -1,16 +1,21 @@
 import React, { FunctionComponent } from 'react';
-import { IconButton } from 'bluesquare-components';
 import PublishIcon from '@mui/icons-material/Publish';
+import { IconButton } from 'bluesquare-components';
 import MESSAGES from '../../messages';
 
-type Props = { onClick: () => void };
+type Props = {
+    onClick: () => void;
+    disabled?: boolean;
+};
 
 export const CreateSubmissionModalButton: FunctionComponent<Props> = ({
     onClick,
+    disabled,
 }) => {
     return (
         <IconButton
             onClick={onClick}
+            disabled={disabled}
             overrideIcon={PublishIcon}
             tooltipMessage={MESSAGES.addSubmissionForForm}
         />

--- a/hat/assets/js/apps/Iaso/domains/forms/components/CreateSubmissionModal/CreateSubmissionModalButton.tsx
+++ b/hat/assets/js/apps/Iaso/domains/forms/components/CreateSubmissionModal/CreateSubmissionModalButton.tsx
@@ -5,12 +5,12 @@ import MESSAGES from '../../messages';
 
 type Props = {
     onClick: () => void;
-    disabled?: boolean;
+    disabled: false;
 };
 
 export const CreateSubmissionModalButton: FunctionComponent<Props> = ({
     onClick,
-    disabled,
+    disabled = false,
 }) => {
     return (
         <IconButton

--- a/hat/assets/js/apps/Iaso/domains/forms/components/CreateSubmissionModal/CreateSubmissionModalButton.tsx
+++ b/hat/assets/js/apps/Iaso/domains/forms/components/CreateSubmissionModal/CreateSubmissionModalButton.tsx
@@ -5,7 +5,7 @@ import MESSAGES from '../../messages';
 
 type Props = {
     onClick: () => void;
-    disabled: false;
+    disabled?: boolean;
 };
 
 export const CreateSubmissionModalButton: FunctionComponent<Props> = ({

--- a/hat/assets/js/apps/Iaso/domains/forms/components/FormActions.tsx
+++ b/hat/assets/js/apps/Iaso/domains/forms/components/FormActions.tsx
@@ -1,8 +1,9 @@
 import React, { FunctionComponent, useState } from 'react';
 import { Download } from '@mui/icons-material';
 import FormatListBulleted from '@mui/icons-material/FormatListBulleted';
+import { Tooltip } from '@mui/material';
 import { Menu, MenuItem } from '@mui/material';
-import { IconButton } from 'bluesquare-components';
+import { IconButton, useSafeIntl } from 'bluesquare-components';
 import { Link } from 'react-router-dom';
 import DeleteDialog from '../../../components/dialogs/DeleteDialogComponent';
 import { DisplayIfUserHasPerm } from '../../../components/DisplayIfUserHasPerm';
@@ -48,6 +49,7 @@ export const FormActions: FunctionComponent<Props> = ({
     // Restore and delete form's hooks
     const { mutateAsync: restoreForm } = useRestoreForm();
     const hasNoVersion = settings.row.original.latest_form_version === null;
+    const { formatMessage } = useSafeIntl();
 
     return (
         <section>
@@ -79,28 +81,56 @@ export const FormActions: FunctionComponent<Props> = ({
                             <DisplayIfUserHasPerm
                                 permissions={[Permission.SUBMISSIONS_UPDATE]}
                             >
-                                <CreateSubmissionModal
-                                    titleMessage={
-                                        MESSAGES.instanceCreationDialogTitle
+                                <Tooltip
+                                    title={
+                                        hasNoVersion
+                                            ? formatMessage(
+                                                  MESSAGES.noFormVersion,
+                                              )
+                                            : ''
                                     }
-                                    confirmMessage={MESSAGES.ok}
-                                    cancelMessage={MESSAGES.cancel}
-                                    formType={{
-                                        id: settings.row.original.id,
-                                        periodType:
-                                            settings.row.original.period_type,
-                                    }}
-                                    onCreateOrReAssign={(
-                                        currentForm,
-                                        payload,
-                                    ) => createInstance(currentForm, payload)}
-                                    orgUnitTypes={
-                                        settings.row.original.org_unit_type_ids
-                                    }
-                                    iconProps={{
-                                        disabled: hasNoVersion,
-                                    }}
-                                />
+                                    arrow
+                                >
+                                    <span
+                                        style={
+                                            hasNoVersion
+                                                ? {
+                                                      display: 'inline-block',
+                                                      cursor: 'not-allowed',
+                                                  }
+                                                : {}
+                                        }
+                                    >
+                                        <CreateSubmissionModal
+                                            titleMessage={
+                                                MESSAGES.instanceCreationDialogTitle
+                                            }
+                                            confirmMessage={MESSAGES.ok}
+                                            cancelMessage={MESSAGES.cancel}
+                                            formType={{
+                                                id: settings.row.original.id,
+                                                periodType:
+                                                    settings.row.original.period_type,
+                                            }}
+                                            onCreateOrReAssign={(
+                                                currentForm,
+                                                payload,
+                                            ) =>
+                                                createInstance(
+                                                    currentForm,
+                                                    payload,
+                                                )
+                                            }
+                                            orgUnitTypes={
+                                                settings.row.original
+                                                    .org_unit_type_ids
+                                            }
+                                            iconProps={{
+                                                disabled: hasNoVersion,
+                                            }}
+                                                />
+                                    </span>
+                                </Tooltip>
                             </DisplayIfUserHasPerm>
 
                             <DisplayIfUserHasPerm

--- a/hat/assets/js/apps/Iaso/domains/forms/components/FormActions.tsx
+++ b/hat/assets/js/apps/Iaso/domains/forms/components/FormActions.tsx
@@ -19,7 +19,7 @@ type Props = {
     baseUrls: any;
     showDeleted: boolean;
     hasDhis2Module: boolean;
-    deleteForm: (body: {id: number}) => Promise<any>;
+    deleteForm: (body: { id: number }) => Promise<any>;
 };
 
 export const FormActions: FunctionComponent<Props> = ({
@@ -47,6 +47,7 @@ export const FormActions: FunctionComponent<Props> = ({
     urlToInstances = `${urlToInstances}/tab/list`;
     // Restore and delete form's hooks
     const { mutateAsync: restoreForm } = useRestoreForm();
+    const hasNoVersion = settings.row.original.latest_form_version === null;
 
     return (
         <section>
@@ -96,7 +97,9 @@ export const FormActions: FunctionComponent<Props> = ({
                                     orgUnitTypes={
                                         settings.row.original.org_unit_type_ids
                                     }
-                                    iconProps={{}}
+                                    iconProps={{
+                                        disabled: hasNoVersion,
+                                    }}
                                 />
                             </DisplayIfUserHasPerm>
 

--- a/hat/assets/js/apps/Iaso/domains/forms/messages.ts
+++ b/hat/assets/js/apps/Iaso/domains/forms/messages.ts
@@ -739,6 +739,10 @@ const MESSAGES = defineMessages({
         defaultMessage: 'Informations',
         id: 'iaso.instance.infos',
     },
+    noFormVersion: {
+        id: 'iaso.forms.noFormVersion',
+        defaultMessage: 'There is no version yet of your form',
+    },
 });
 
 export default MESSAGES;

--- a/hat/assets/js/apps/Iaso/domains/instances/components/CreateReAssignDialogComponent.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/CreateReAssignDialogComponent.tsx
@@ -14,7 +14,7 @@ import { isValidPeriod } from '../../periods/utils';
 import { ReassignInstancePayload } from '../hooks/useReassignInstance';
 import MESSAGES from '../messages';
 
-type Props = {
+type CreateReAssignDialogProps = {
     titleMessage: any;
     confirmMessage: any;
     cancelMessage: any;
@@ -39,7 +39,9 @@ type Props = {
     closeDialog: () => void;
 };
 
-export const CreateReAssignDialogComponent: FunctionComponent<Props> = ({
+export const CreateReAssignDialogComponent: FunctionComponent<
+    CreateReAssignDialogProps
+> = ({
     titleMessage,
     confirmMessage = MESSAGES.ok,
     cancelMessage = MESSAGES.cancel,
@@ -164,4 +166,4 @@ export const ReAssignDialog = makeFullModal(
     UpdateIcon,
 );
 
-export { CreateReAssignDialog, Props };
+export { CreateReAssignDialog, CreateReAssignDialogProps };

--- a/hat/assets/js/apps/Iaso/domains/instances/components/CreateReAssignDialogComponent.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/CreateReAssignDialogComponent.tsx
@@ -164,4 +164,4 @@ export const ReAssignDialog = makeFullModal(
     UpdateIcon,
 );
 
-export { CreateReAssignDialog };
+export { CreateReAssignDialog, Props };


### PR DESCRIPTION
## What problem is this PR solving?

This PR is about solving the issue of a user trying to create an instance from a form without latest version.

### Related JIRA tickets

[IA-4596](https://bluesquare.atlassian.net/browse/IA-4596)

## Changes

Explain the changes that were made.

Exported the props from `hat/assets/js/apps/Iaso/domains/instances/Components/CreateReassignDialogComponent.tsx` to pass them in the modal in `hat/assets/js/apps/Iaso/domains/instances/Components/CreateSubmissionModal.tsx`. This allowed the definition of the ButtonProps with a disabled attribute which is used to check if a form has a version or not in `hat/assets/js/apps/Iaso/domains/forms/components/FormActions.tsx`


## How to test

- Start the app with `docker compose -f docker-compose.yml -f docker/docker-compose-enketo.yml up`
- Go to the page of the Forms list
- Create a form but do not create a version
The 'add submission' button should be disabled

## Print screen / video

<img width="1920" height="1080" alt="Screenshot from 2026-02-16 14-34-22" src="https://github.com/user-attachments/assets/a8fb8ee7-986a-43da-bdc8-5c38e049183b" />


## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).


[IA-4596]: https://bluesquare.atlassian.net/browse/IA-4596?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ