### PR TITLE
[IA-4692]Add Restrictions On Planning Details Page

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -999,6 +999,7 @@
     "iaso.modules.trypelim_project": "Trypelim project",
     "iaso.openHexa.label.pipelineDetails": "Pipeline details",
     "iaso.openHexa.label.pipelines": "Pipelines",
+    "iaso.openHexaIntegration.planningAlreadyPublished": "Planning is already published",
     "iaso.openHexalabel.addLevel": "Add level",
     "iaso.openHexalabel.collapse": "Collapse",
     "iaso.openHexalabel.excludedOrgUnits": "Excluded org units",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -999,7 +999,7 @@
     "iaso.modules.trypelim_project": "Trypelim project",
     "iaso.openHexa.label.pipelineDetails": "Pipeline details",
     "iaso.openHexa.label.pipelines": "Pipelines",
-    "iaso.openHexaIntegration.planningAlreadyPublished": "Planning is already published",
+    "iaso.planning.label.planningAlreadyPublished": "Planning is already published",
     "iaso.openHexalabel.addLevel": "Add level",
     "iaso.openHexalabel.collapse": "Collapse",
     "iaso.openHexalabel.excludedOrgUnits": "Excluded org units",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -1000,6 +1000,7 @@
     "iaso.modules.trypelim_project": "Projet Trypelim",
     "iaso.openHexa.label.pipelineDetails": "Détails de la pipeline",
     "iaso.openHexa.label.pipelines": "Pipelines",
+    "iaso.openHexaIntegration.planningAlreadyPublished": "Planification déjà publiée",
     "iaso.openHexalabel.addLevel": "Ajouter un niveau",
     "iaso.openHexalabel.collapse": "Réduire",
     "iaso.openHexalabel.excludedOrgUnits": "Unités d'org. exclues",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -1000,7 +1000,7 @@
     "iaso.modules.trypelim_project": "Projet Trypelim",
     "iaso.openHexa.label.pipelineDetails": "Détails de la pipeline",
     "iaso.openHexa.label.pipelines": "Pipelines",
-    "iaso.openHexaIntegration.planningAlreadyPublished": "Planification déjà publiée",
+    "iaso.planning.label.planningAlreadyPublished": "Planning déjà publié",
     "iaso.openHexalabel.addLevel": "Ajouter un niveau",
     "iaso.openHexalabel.collapse": "Réduire",
     "iaso.openHexalabel.excludedOrgUnits": "Unités d'org. exclues",

--- a/hat/assets/js/apps/Iaso/domains/plannings/components/PlanningForm.tsx
+++ b/hat/assets/js/apps/Iaso/domains/plannings/components/PlanningForm.tsx
@@ -158,6 +158,8 @@ export const PlanningForm: FunctionComponent<Props> = ({
         validationSchema: schema,
         onSubmit: save,
     });
+    // const publishingStatusValue = formik.values.publishingStatus;
+    const isPublishing = formik.values.publishingStatus === 'published';
     const {
         values,
         setFieldValue,
@@ -275,6 +277,7 @@ export const PlanningForm: FunctionComponent<Props> = ({
                         label={MESSAGES.name}
                         required
                         withMarginTop={false}
+                        disabled={isPublishing}
                     />
 
                     <DatesRange
@@ -287,6 +290,7 @@ export const PlanningForm: FunctionComponent<Props> = ({
                         keyDateTo="endDate"
                         errors={[getErrors('startDate'), getErrors('endDate')]}
                         blockInvalidDates={false}
+                        disabled={isPublishing}
                     />
                     <InputComponent
                         keyValue="description"
@@ -295,6 +299,7 @@ export const PlanningForm: FunctionComponent<Props> = ({
                         errors={getErrors('description')}
                         type="textarea"
                         label={MESSAGES.description}
+                        disabled={isPublishing}
                     />
                 </Grid>
 
@@ -319,6 +324,7 @@ export const PlanningForm: FunctionComponent<Props> = ({
                                         required
                                         options={projectsDropdown}
                                         loading={isFetchingProjects}
+                                        disabled={isPublishing}
                                     />
                                 </Grid>
                                 <Grid xs={6} item>
@@ -332,7 +338,9 @@ export const PlanningForm: FunctionComponent<Props> = ({
                                         required
                                         options={teamsDropdown || []}
                                         loading={isFetchingTeams}
-                                        disabled={!values.project}
+                                        disabled={
+                                            !values.project || isPublishing
+                                        }
                                     />
                                 </Grid>
                             </Grid>
@@ -352,7 +360,7 @@ export const PlanningForm: FunctionComponent<Props> = ({
                                 multi
                                 options={formsDropdown}
                                 loading={isFetchingForms}
-                                disabled={!values.project}
+                                disabled={!values.project || isPublishing}
                             />
                         </Box>
                     </InputWithInfos>
@@ -373,6 +381,7 @@ export const PlanningForm: FunctionComponent<Props> = ({
                             value={values.pipelineUuids}
                             errors={getErrors('pipelineUuids')}
                             label={MESSAGES.pipelines}
+                            disabled={isPublishing}
                         />
                     )}
                 </Grid>
@@ -388,6 +397,7 @@ export const PlanningForm: FunctionComponent<Props> = ({
                                 label={formatMessage(MESSAGES.selectOrgUnit)}
                                 name="selectedOrgUnit"
                                 errors={getErrors('selectedOrgUnit')}
+                                disabled={isPublishing}
                             />
                             <InputComponent
                                 type="select"
@@ -401,7 +411,9 @@ export const PlanningForm: FunctionComponent<Props> = ({
                                         ? undefined
                                         : values.targetOrgUnitType
                                 }
-                                disabled={!values.selectedOrgUnit}
+                                disabled={
+                                    !values.selectedOrgUnit || isPublishing
+                                }
                                 options={orgunitTypes || []}
                                 loading={
                                     isFetchingOrgunitTypes ||
@@ -476,6 +488,7 @@ export const PlanningForm: FunctionComponent<Props> = ({
                                                         startIcon={
                                                             <DeleteIcon />
                                                         }
+                                                        disabled={isPublishing}
                                                     >
                                                         {formatMessage(
                                                             MESSAGES.delete,

--- a/hat/assets/js/apps/Iaso/domains/plannings/components/PlanningForm.tsx
+++ b/hat/assets/js/apps/Iaso/domains/plannings/components/PlanningForm.tsx
@@ -158,11 +158,11 @@ export const PlanningForm: FunctionComponent<Props> = ({
         validationSchema: schema,
         onSubmit: save,
     });
-    const isPublishing = formik.values.publishingStatus === 'published';
+    const isPublished = formik.values.publishingStatus === 'published';
     const hasStarted =
         formik.values.startDate &&
         moment().isAfter(moment(formik.values.startDate), 'day');
-    const isPublishingDisabled = Boolean(isPublishing || hasStarted);
+    const isEditingDisabled = Boolean(isPublished || hasStarted);
     const {
         values,
         setFieldValue,
@@ -280,7 +280,7 @@ export const PlanningForm: FunctionComponent<Props> = ({
                         label={MESSAGES.name}
                         required
                         withMarginTop={false}
-                        disabled={isPublishingDisabled}
+                        disabled={isEditingDisabled}
                     />
 
                     <DatesRange
@@ -293,7 +293,7 @@ export const PlanningForm: FunctionComponent<Props> = ({
                         keyDateTo="endDate"
                         errors={[getErrors('startDate'), getErrors('endDate')]}
                         blockInvalidDates={false}
-                        disabled={isPublishingDisabled}
+                        disabled={isEditingDisabled}
                     />
                     <InputComponent
                         keyValue="description"
@@ -302,7 +302,7 @@ export const PlanningForm: FunctionComponent<Props> = ({
                         errors={getErrors('description')}
                         type="textarea"
                         label={MESSAGES.description}
-                        disabled={isPublishingDisabled}
+                        disabled={isEditingDisabled}
                     />
                 </Grid>
 
@@ -327,7 +327,7 @@ export const PlanningForm: FunctionComponent<Props> = ({
                                         required
                                         options={projectsDropdown}
                                         loading={isFetchingProjects}
-                                        disabled={isPublishingDisabled}
+                                        disabled={isEditingDisabled}
                                     />
                                 </Grid>
                                 <Grid xs={6} item>
@@ -342,8 +342,7 @@ export const PlanningForm: FunctionComponent<Props> = ({
                                         options={teamsDropdown || []}
                                         loading={isFetchingTeams}
                                         disabled={
-                                            !values.project ||
-                                            isPublishingDisabled
+                                            !values.project || isEditingDisabled
                                         }
                                     />
                                 </Grid>
@@ -364,9 +363,7 @@ export const PlanningForm: FunctionComponent<Props> = ({
                                 multi
                                 options={formsDropdown}
                                 loading={isFetchingForms}
-                                disabled={
-                                    !values.project || isPublishingDisabled
-                                }
+                                disabled={!values.project || isEditingDisabled}
                             />
                         </Box>
                     </InputWithInfos>
@@ -387,7 +384,7 @@ export const PlanningForm: FunctionComponent<Props> = ({
                             value={values.pipelineUuids}
                             errors={getErrors('pipelineUuids')}
                             label={MESSAGES.pipelines}
-                            disabled={isPublishingDisabled}
+                            disabled={isEditingDisabled}
                         />
                     )}
                 </Grid>
@@ -403,7 +400,7 @@ export const PlanningForm: FunctionComponent<Props> = ({
                                 label={formatMessage(MESSAGES.selectOrgUnit)}
                                 name="selectedOrgUnit"
                                 errors={getErrors('selectedOrgUnit')}
-                                disabled={isPublishingDisabled}
+                                disabled={isEditingDisabled}
                             />
                             <InputComponent
                                 type="select"
@@ -418,8 +415,7 @@ export const PlanningForm: FunctionComponent<Props> = ({
                                         : values.targetOrgUnitType
                                 }
                                 disabled={
-                                    !values.selectedOrgUnit ||
-                                    isPublishingDisabled
+                                    !values.selectedOrgUnit || isEditingDisabled
                                 }
                                 options={orgunitTypes || []}
                                 loading={
@@ -496,7 +492,7 @@ export const PlanningForm: FunctionComponent<Props> = ({
                                                             <DeleteIcon />
                                                         }
                                                         disabled={
-                                                            isPublishingDisabled
+                                                            isEditingDisabled
                                                         }
                                                     >
                                                         {formatMessage(

--- a/hat/assets/js/apps/Iaso/domains/plannings/components/PlanningForm.tsx
+++ b/hat/assets/js/apps/Iaso/domains/plannings/components/PlanningForm.tsx
@@ -158,8 +158,11 @@ export const PlanningForm: FunctionComponent<Props> = ({
         validationSchema: schema,
         onSubmit: save,
     });
-    // const publishingStatusValue = formik.values.publishingStatus;
     const isPublishing = formik.values.publishingStatus === 'published';
+    const hasStarted =
+        formik.values.startDate &&
+        moment().isAfter(moment(formik.values.startDate), 'day');
+    const isPublishingDisabled = isPublishing || !hasStarted;
     const {
         values,
         setFieldValue,
@@ -277,7 +280,7 @@ export const PlanningForm: FunctionComponent<Props> = ({
                         label={MESSAGES.name}
                         required
                         withMarginTop={false}
-                        disabled={isPublishing}
+                        disabled={isPublishingDisabled}
                     />
 
                     <DatesRange
@@ -290,7 +293,7 @@ export const PlanningForm: FunctionComponent<Props> = ({
                         keyDateTo="endDate"
                         errors={[getErrors('startDate'), getErrors('endDate')]}
                         blockInvalidDates={false}
-                        disabled={isPublishing}
+                        disabled={isPublishingDisabled}
                     />
                     <InputComponent
                         keyValue="description"
@@ -299,7 +302,7 @@ export const PlanningForm: FunctionComponent<Props> = ({
                         errors={getErrors('description')}
                         type="textarea"
                         label={MESSAGES.description}
-                        disabled={isPublishing}
+                        disabled={isPublishingDisabled}
                     />
                 </Grid>
 
@@ -324,7 +327,7 @@ export const PlanningForm: FunctionComponent<Props> = ({
                                         required
                                         options={projectsDropdown}
                                         loading={isFetchingProjects}
-                                        disabled={isPublishing}
+                                        disabled={isPublishingDisabled}
                                     />
                                 </Grid>
                                 <Grid xs={6} item>
@@ -339,7 +342,8 @@ export const PlanningForm: FunctionComponent<Props> = ({
                                         options={teamsDropdown || []}
                                         loading={isFetchingTeams}
                                         disabled={
-                                            !values.project || isPublishing
+                                            !values.project ||
+                                            isPublishingDisabled
                                         }
                                     />
                                 </Grid>
@@ -360,7 +364,9 @@ export const PlanningForm: FunctionComponent<Props> = ({
                                 multi
                                 options={formsDropdown}
                                 loading={isFetchingForms}
-                                disabled={!values.project || isPublishing}
+                                disabled={
+                                    !values.project || isPublishingDisabled
+                                }
                             />
                         </Box>
                     </InputWithInfos>
@@ -381,7 +387,7 @@ export const PlanningForm: FunctionComponent<Props> = ({
                             value={values.pipelineUuids}
                             errors={getErrors('pipelineUuids')}
                             label={MESSAGES.pipelines}
-                            disabled={isPublishing}
+                            disabled={isPublishingDisabled}
                         />
                     )}
                 </Grid>
@@ -397,7 +403,7 @@ export const PlanningForm: FunctionComponent<Props> = ({
                                 label={formatMessage(MESSAGES.selectOrgUnit)}
                                 name="selectedOrgUnit"
                                 errors={getErrors('selectedOrgUnit')}
-                                disabled={isPublishing}
+                                disabled={isPublishingDisabled}
                             />
                             <InputComponent
                                 type="select"
@@ -412,7 +418,8 @@ export const PlanningForm: FunctionComponent<Props> = ({
                                         : values.targetOrgUnitType
                                 }
                                 disabled={
-                                    !values.selectedOrgUnit || isPublishing
+                                    !values.selectedOrgUnit ||
+                                    isPublishingDisabled
                                 }
                                 options={orgunitTypes || []}
                                 loading={
@@ -488,7 +495,9 @@ export const PlanningForm: FunctionComponent<Props> = ({
                                                         startIcon={
                                                             <DeleteIcon />
                                                         }
-                                                        disabled={isPublishing}
+                                                        disabled={
+                                                            isPublishingDisabled
+                                                        }
                                                     >
                                                         {formatMessage(
                                                             MESSAGES.delete,

--- a/hat/assets/js/apps/Iaso/domains/plannings/components/PlanningForm.tsx
+++ b/hat/assets/js/apps/Iaso/domains/plannings/components/PlanningForm.tsx
@@ -162,7 +162,7 @@ export const PlanningForm: FunctionComponent<Props> = ({
     const hasStarted =
         formik.values.startDate &&
         moment().isAfter(moment(formik.values.startDate), 'day');
-    const isPublishingDisabled = isPublishing || hasStarted;
+    const isPublishingDisabled = Boolean(isPublishing || hasStarted);
     const {
         values,
         setFieldValue,

--- a/hat/assets/js/apps/Iaso/domains/plannings/components/PlanningForm.tsx
+++ b/hat/assets/js/apps/Iaso/domains/plannings/components/PlanningForm.tsx
@@ -435,7 +435,16 @@ export const PlanningForm: FunctionComponent<Props> = ({
                                     value={values.publishingStatus}
                                     errors={getErrors('publishingStatus')}
                                     label={MESSAGES.publishingStatus}
-                                    options={publishingStatusOptions}
+                                    options={useMemo(
+                                        () =>
+                                            publishingStatusOptions.map(
+                                                option => ({
+                                                    ...option,
+                                                    disabled: hasStarted,
+                                                }),
+                                            ),
+                                        [publishingStatusOptions, hasStarted],
+                                    )}
                                     required
                                 />
                             </Box>

--- a/hat/assets/js/apps/Iaso/domains/plannings/components/PlanningForm.tsx
+++ b/hat/assets/js/apps/Iaso/domains/plannings/components/PlanningForm.tsx
@@ -162,7 +162,7 @@ export const PlanningForm: FunctionComponent<Props> = ({
     const hasStarted =
         formik.values.startDate &&
         moment().isAfter(moment(formik.values.startDate), 'day');
-    const isPublishingDisabled = isPublishing || !hasStarted;
+    const isPublishingDisabled = isPublishing || hasStarted;
     const {
         values,
         setFieldValue,

--- a/hat/assets/js/apps/Iaso/domains/plannings/constants.ts
+++ b/hat/assets/js/apps/Iaso/domains/plannings/constants.ts
@@ -12,6 +12,7 @@ export const useGetPublishingStatusOptions = () => {
             {
                 label: formatMessage(MESSAGES.published),
                 value: 'published',
+                disabled: true,
             },
             {
                 label: formatMessage(MESSAGES.draft),

--- a/hat/assets/js/apps/Iaso/domains/plannings/messages.ts
+++ b/hat/assets/js/apps/Iaso/domains/plannings/messages.ts
@@ -339,6 +339,10 @@ const MESSAGES = defineMessages({
         id: 'iaso.assignment.bulkDeleteAssignmentsSuccess',
         defaultMessage: 'Assignments deleted successfully',
     },
+    planningAlreadyPublished: {
+        id: 'iaso.openHexaIntegration.planningAlreadyPublished',
+        defaultMessage: 'Planning is already published',
+    },
 });
 
 export default MESSAGES;

--- a/hat/assets/js/apps/Iaso/domains/plannings/messages.ts
+++ b/hat/assets/js/apps/Iaso/domains/plannings/messages.ts
@@ -340,7 +340,7 @@ const MESSAGES = defineMessages({
         defaultMessage: 'Assignments deleted successfully',
     },
     planningAlreadyPublished: {
-        id: 'iaso.openHexaIntegration.planningAlreadyPublished',
+        id: 'iaso.planning.label.planningAlreadyPublished',
         defaultMessage: 'Planning is already published',
     },
 });

--- a/hat/assets/js/apps/Iaso/domains/plannings/sampling/OpenhexaIntegrationDrawer.tsx
+++ b/hat/assets/js/apps/Iaso/domains/plannings/sampling/OpenhexaIntegrationDrawer.tsx
@@ -139,7 +139,7 @@ export const OpenhexaIntegrationDrawer: FunctionComponent<Props> = ({
         setCurrentStep(1);
         setTaskStatus(undefined);
     };
-
+    const isPublished = Boolean(planning.published_at);
     useEffect(() => {
         if (isSubmitting && !isLaunchingTask) {
             setIsSubmitting(false);
@@ -147,7 +147,16 @@ export const OpenhexaIntegrationDrawer: FunctionComponent<Props> = ({
     }, [isSubmitting, isLaunchingTask]);
     return (
         <>
-            <Tooltip title={disabled ? disabledMessage : undefined}>
+            <Tooltip
+                title={
+                    // eslint-disable-next-line no-nested-ternary
+                    disabled
+                        ? disabledMessage
+                        : isPublished
+                          ? formatMessage(MESSAGES.planningAlreadyPublished)
+                          : ''
+                }
+            >
                 <Box>
                     <Button
                         variant="outlined"
@@ -156,7 +165,7 @@ export const OpenhexaIntegrationDrawer: FunctionComponent<Props> = ({
                             setIsOpen(true);
                         }}
                         sx={styles.button}
-                        disabled={disabled}
+                        disabled={disabled || isPublished}
                     >
                         <PlusIcon sx={styles.icon} />
                         {formatMessage(MESSAGES.openHexaIntegration)}

--- a/hat/assets/js/apps/Iaso/domains/plannings/sampling/OpenhexaIntegrationDrawer.tsx
+++ b/hat/assets/js/apps/Iaso/domains/plannings/sampling/OpenhexaIntegrationDrawer.tsx
@@ -18,6 +18,7 @@ import {
     Tooltip,
 } from '@mui/material';
 import { LoadingSpinner, useSafeIntl } from 'bluesquare-components';
+import moment from 'moment';
 import { useGetPipelineDetails } from 'Iaso/domains/openHexa/hooks/useGetPipelineDetails';
 import { useLaunchTask } from 'Iaso/domains/openHexa/hooks/useLaunchTask';
 import { ParameterValues } from 'Iaso/domains/openHexa/types/pipeline';
@@ -140,6 +141,11 @@ export const OpenhexaIntegrationDrawer: FunctionComponent<Props> = ({
         setTaskStatus(undefined);
     };
     const isPublished = Boolean(planning.published_at);
+    const hasStarted = Boolean(
+        planning.started_at &&
+        moment().isAfter(moment(planning.started_at), 'day'),
+    );
+    const isCreateSamplingDisabled = isPublished || hasStarted;
     useEffect(() => {
         if (isSubmitting && !isLaunchingTask) {
             setIsSubmitting(false);
@@ -152,7 +158,7 @@ export const OpenhexaIntegrationDrawer: FunctionComponent<Props> = ({
                     // eslint-disable-next-line no-nested-ternary
                     disabled
                         ? disabledMessage
-                        : isPublished
+                        : isCreateSamplingDisabled
                           ? formatMessage(MESSAGES.planningAlreadyPublished)
                           : ''
                 }
@@ -165,7 +171,7 @@ export const OpenhexaIntegrationDrawer: FunctionComponent<Props> = ({
                             setIsOpen(true);
                         }}
                         sx={styles.button}
-                        disabled={disabled || isPublished}
+                        disabled={disabled || isCreateSamplingDisabled}
                     >
                         <PlusIcon sx={styles.icon} />
                         {formatMessage(MESSAGES.openHexaIntegration)}


### PR DESCRIPTION
## What problem is this PR solving?

This PR is about implementing the changes from this figma design: [figma](https://www.figma.com/design/WHiBFFHHUhkUen2Sy5XZSX/Assignments-Planning-IASO?node-id=0-1&p=f&t=X93QOfMCFdjIgM9K-0)

### Related JIRA tickets

[IA-4692](https://bluesquare.atlassian.net/browse/IA-4692)

## Changes

Added some checks to match the proposed figma design

## How to test

- Create a planning, put it in Draft, all the fields should activated except `Assignments`.
- put the same planning in `Planning`, all the fields should be deactivated except `Assignments` and `Save` buttons.
- If the Start Date is < to today's date, meaning the published planning in ongoing, the fields are deactivated.

To Test with Pipeline:
- Follow the openhexa integration doc: [here](https://github.com/BLSQ/iaso/blob/develop/docs/pages/dev/how_to/openhexa-integration/openhexa-integration.en.md)
- Put the planning in `Draft`, if the start date > to today's date, the fields are activated, except `Assignments`
- Put the planning in `Published`, the fields should be deactivated
- same if the planning is ongoing

## Print screen / video


https://github.com/user-attachments/assets/ff419a88-cbca-4570-9bb4-56056ba1df66



## Notes

Things that the reviewers should know:

- There are no `Delete Assignments` and `Delete Samplings` buttons
- This PR should be merged with the PR to implement those buttons

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).


[IA-4692]: https://bluesquare.atlassian.net/browse/IA-4692?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ