### PR TITLE
WC2-875: Add command to clean-up instance duplicates

### DIFF
--- a/iaso/management/commands/clean_up_duplicate_submissions.py
+++ b/iaso/management/commands/clean_up_duplicate_submissions.py
@@ -54,7 +54,7 @@ class Command(BaseCommand):
         for index, duplicate in enumerate(duplicates):
             has_content = Instance.objects.filter(
                 uuid=duplicate["uuid"], file_name=duplicate["file_name"], json__isnull=False
-            )
+            ).order_by("pk")
             if has_content.count() == 1:
                 self.stdout.write(
                     f"{index}. Duplicate with uuid '{duplicate['uuid']}' has only one instance with content."
@@ -74,7 +74,11 @@ class Command(BaseCommand):
                 multiple_content += 1
             else:
                 self.stdout.write(f"{index}. Duplicate with uuid '{duplicate['uuid']}' has no instances with content.")
-                first = Instance.objects.filter(uuid=duplicate["uuid"], file_name=duplicate["file_name"]).first()
+                first = (
+                    Instance.objects.filter(uuid=duplicate["uuid"], file_name=duplicate["file_name"])
+                    .order_by("pk")
+                    .first()
+                )
                 # First, let's keep only one
                 self._delete_instances(uuid=duplicate["uuid"], file_name=duplicate["file_name"], first_id=first.id)
                 # We should look if there are Instances with the same `file_name` but no `uuid` and reimport them

--- a/iaso/management/commands/clean_up_duplicate_submissions.py
+++ b/iaso/management/commands/clean_up_duplicate_submissions.py
@@ -1,0 +1,91 @@
+from django.core.management import BaseCommand
+from django.db import transaction
+from django.db.models import Count
+
+from iaso.models import Entity, Instance
+
+
+class Command(BaseCommand):
+    help = "Clean-up duplicate submissions"
+
+    @transaction.atomic
+    def handle(self, *args, **options):
+        self.stdout.write("Computing duplicate submissions...")
+        duplicates = Instance.objects.values("uuid", "file_name").annotate(total=Count("uuid")).filter(total__gt=1)
+        if len(duplicates) <= 0:
+            self.stdout.write(self.style.SUCCESS("No duplicate submissions found!"))
+            return
+
+        self.stdout.write(self.style.ERROR(f"Duplicates: {len(duplicates)}"))
+        single_content, multiple_content, no_content_no_file, no_content_with_file = 0, 0, 0, 0
+        for index, duplicate in enumerate(duplicates):
+            has_content = Instance.objects.filter(
+                uuid=duplicate["uuid"], file_name=duplicate["file_name"], json__isnull=False
+            )
+            if has_content.count() == 1:
+                self.stdout.write(
+                    f"{index}. Duplicate with uuid '{duplicate['uuid']}' has only one instance with content."
+                )
+                self._delete_instances(
+                    uuid=duplicate["uuid"], file_name=duplicate["file_name"], first_id=has_content.first().id
+                )
+                single_content += 1
+            elif has_content.count() > 1:
+                self.stdout.write(
+                    f"{index}. Duplicate with uuid '{duplicate['uuid']}' has {has_content.count()} instances with content."
+                )
+                # Based on the code of `Instance.import_data`, the first one is always the one that has the data.
+                self._delete_instances(
+                    uuid=duplicate["uuid"], file_name=duplicate["file_name"], first_id=has_content.first().id
+                )
+                multiple_content += 1
+            else:
+                self.stdout.write(f"{index}. Duplicate with uuid '{duplicate['uuid']}' has no instances with content.")
+                first = Instance.objects.filter(uuid=duplicate["uuid"], file_name=duplicate["file_name"]).first()
+                # First, let's keep only one
+                self._delete_instances(uuid=duplicate["uuid"], file_name=duplicate["file_name"], first_id=first.id)
+                # We should look if there are Instances with the same `file_name` but no `uuid` and reimport them
+                if duplicate["file_name"] is None:
+                    self.stdout.write(self.style.ERROR(" - file_name is None, that's odd!"))
+                    continue
+                # We should use the content of the latest file received.
+                file_name = Instance.objects.filter(uuid__isnull=True, file_name=duplicate["file_name"]).order_by(
+                    "-created_at"
+                )
+                if file_name.exists():
+                    self.stdout.write(
+                        self.style.SUCCESS(f" - Found {file_name.count()} instances with file_name matching.")
+                    )
+                    file = file_name.first()
+                    first.json = file.json
+                    first.file = file.file
+                    if file.location:
+                        first.location = file.location
+                        first.accuracy = file.accuracy
+                    first.device = file.device
+                    if not first.correlation_id:
+                        first.correlation_id = file.correlation_id
+                    first.save()
+                    self.stdout.write(self.style.WARNING(" - Deleting instances with file_name matching."))
+                    file_name.delete()
+                    no_content_with_file += 1
+                else:
+                    no_content_no_file += 1
+                    self.stdout.write(self.style.WARNING(" - No file_name Instance match!"))
+
+        self.stdout.write(self.style.SUCCESS("\n\n\nSummary:"))
+        self.stdout.write(self.style.SUCCESS(f" - Single instance with content corrected: {single_content}"))
+        self.stdout.write(self.style.SUCCESS(f" - Multiple instances with content corrected: {multiple_content}"))
+        self.stdout.write(self.style.SUCCESS(f" - No instances with content corrected: {no_content_with_file}"))
+        self.stdout.write(self.style.WARNING(f" - No instances with content still empty: {no_content_no_file}"))
+        duplicates = Instance.objects.values("uuid", "file_name").annotate(total=Count("uuid")).filter(total__gt=1)
+        if len(duplicates) <= 0:
+            self.stdout.write(self.style.SUCCESS("No duplicate submissions found anymore!"))
+        else:
+            self.stdout.write(self.style.ERROR(f"Duplicates: {len(duplicates)}"))
+
+    def _delete_instances(self, uuid: str, file_name: str, first_id: str):
+        to_delete = Instance.objects.filter(uuid=uuid, file_name=file_name).exclude(id=first_id)
+        self.stdout.write(self.style.WARNING(f" - Deleting {to_delete.count()} instances and linked entities"))
+        Entity.objects.filter(attributes__in=to_delete).delete()
+        to_delete.delete()

--- a/iaso/management/commands/clean_up_duplicate_submissions.py
+++ b/iaso/management/commands/clean_up_duplicate_submissions.py
@@ -1,8 +1,10 @@
 import argparse
 
+from typing import Union
+
 from django.core.management import BaseCommand
 from django.db import transaction
-from django.db.models import Count
+from django.db.models import Count, QuerySet
 
 from iaso.models import Entity, Instance
 
@@ -19,13 +21,35 @@ class Command(BaseCommand):
     @transaction.atomic
     def handle(self, *args, **options):
         dry_run = options[DRY_RUN_ARG]
+
+        # As there could be instances with the same `uuid` but different `file_name`, we first need to merge duplicates
+        # based on grouping on those two fields. This will ensure that all data has been processed before merging
+        # instances solely based on their `uuid`
         self.stdout.write("Computing duplicate submissions...")
         duplicates = Instance.objects.values("uuid", "file_name").annotate(total=Count("uuid")).filter(total__gt=1)
-        if len(duplicates) <= 0:
+        if duplicates.count() <= 0:
             self.stdout.write(self.style.SUCCESS("No duplicate submissions found!"))
             return
+        self.stdout.write(self.style.ERROR(f"Duplicates: {duplicates.count()}"))
+        self._cleanup_based_on_uuid_and_filename(duplicates)
 
-        self.stdout.write(self.style.ERROR(f"Duplicates: {len(duplicates)}"))
+        duplicates = Instance.objects.values("uuid").annotate(total=Count("uuid")).filter(total__gt=1)
+        if duplicates.count() <= 0:
+            self.stdout.write(self.style.SUCCESS("No duplicate submissions found anymore!"))
+        else:
+            self.stdout.write(self.style.ERROR(f"Duplicates: {duplicates.count()}"))
+            self._cleanup_based_on_uuid_only(duplicates)
+
+            # Let's check one last time to see if everything went smoothly.
+            if duplicates.count() <= 0:
+                self.stdout.write(self.style.SUCCESS("No duplicate submissions found anymore!"))
+            else:
+                self.stdout.write(self.style.ERROR(f"Duplicates: {duplicates.count()}"))
+
+        if dry_run:
+            raise Exception("Rollback, this was a dry-run!")
+
+    def _cleanup_based_on_uuid_and_filename(self, duplicates: QuerySet[Instance]):
         single_content, multiple_content, no_content_no_file, no_content_with_file = 0, 0, 0, 0
         for index, duplicate in enumerate(duplicates):
             has_content = Instance.objects.filter(
@@ -88,17 +112,38 @@ class Command(BaseCommand):
         self.stdout.write(self.style.SUCCESS(f" - No instances with content corrected: {no_content_with_file}"))
         self.stdout.write(self.style.WARNING(f" - No instances with content still empty: {no_content_no_file}"))
 
-        duplicates = Instance.objects.values("uuid").annotate(total=Count("uuid")).filter(total__gt=1)
-        if len(duplicates) <= 0:
-            self.stdout.write(self.style.SUCCESS("No duplicate submissions found anymore!"))
-        else:
-            self.stdout.write(self.style.ERROR(f"Duplicates: {len(duplicates)}"))
+    def _cleanup_based_on_uuid_only(self, duplicates: QuerySet[Instance]):
+        single_content, multiple_content, no_content = 0, 0, 0
+        for index, duplicate in enumerate(duplicates):
+            has_content = Instance.objects.filter(uuid=duplicate["uuid"], json__isnull=False).order_by("-created_at")
+            if has_content.count() == 1:
+                self.stdout.write(
+                    f"{index}. Duplicate with uuid '{duplicate['uuid']}' has only one instance with content."
+                )
+                self._delete_instances(uuid=duplicate["uuid"], file_name=None, first_id=has_content.first().id)
+                single_content += 1
+            elif has_content.count() > 1:
+                self.stdout.write(
+                    f"{index}. Duplicate with uuid '{duplicate['uuid']}' has {has_content.count()} instances with content."
+                )
+                # We sorted by `-created_at` which should leave us with the one with the most recent data
+                self._delete_instances(uuid=duplicate["uuid"], file_name=None, first_id=has_content.first().id)
+                multiple_content += 1
+            else:
+                self.stdout.write(f"{index}. Duplicate with uuid '{duplicate['uuid']}' has no content.")
+                # It doesn't matter which ones we delete, so let's keep the most recent one.
+                self._delete_instances(uuid=duplicate["uuid"], file_name=None, first_id=has_content.first().id)
+                no_content += 1
 
-        if dry_run:
-            raise Exception("Rollback, this was a dry-run!")
+            self.stdout.write(self.style.SUCCESS("\n\n\nSummary:"))
+            self.stdout.write(self.style.SUCCESS(f" - Single instance with content corrected: {single_content}"))
+            self.stdout.write(self.style.SUCCESS(f" - Multiple instances with content corrected: {multiple_content}"))
+            self.stdout.write(self.style.SUCCESS(f" - No instances with no content: {no_content}"))
 
-    def _delete_instances(self, uuid: str, file_name: str, first_id: str):
-        to_delete = Instance.objects.filter(uuid=uuid, file_name=file_name).exclude(id=first_id)
+    def _delete_instances(self, uuid: str, file_name: Union[str, None], first_id: str):
+        to_delete = Instance.objects.filter(uuid=uuid).exclude(id=first_id)
+        if file_name:
+            to_delete = to_delete.filter(file_name=file_name)
         self.stdout.write(self.style.WARNING(f" - Deleting {to_delete.count()} instances and linked entities"))
         Entity.objects.filter(attributes__in=to_delete).delete()
         to_delete.delete()

--- a/plugins/wfp/tasks.py
+++ b/plugins/wfp/tasks.py
@@ -5,7 +5,7 @@ from django.core.management import call_command
 from django.db import connection
 
 from iaso.management.commands import unique_indexes
-from iaso.models import *
+from iaso.management.commands.clean_up_duplicate_submissions import DRY_RUN_ARG
 from iaso.models.base import ExternalCredentials
 from plugins.wfp.common import ETL
 
@@ -71,6 +71,11 @@ def create_index_on_instance_uuid():
 @shared_task()
 def clean_up_duplicate_instances():
     call_command("clean_up_duplicate_submissions")
+
+
+@shared_task()
+def clean_up_duplicate_instances_dry_run():
+    call_command("clean_up_duplicate_submissions", f"--{DRY_RUN_ARG}")
 
 
 @shared_task()


### PR DESCRIPTION
## What problem is this PR solving?

Some instances have duplicates instances (Instance with the same UUID). This adds a command and a celery task to fix the issue.

### Related JIRA tickets

WC2-875

## Changes

The command looks for duplicate. Then, for each one, it tries to merge them the best it can.

## How to test

With a dump of a database with duplicates. Either execute the command or launch the celery task.
