### PR TITLE
SNT-285: Don't show warning if no label specified

### DIFF
--- a/hat/assets/js/apps/Iaso/components/forms/InputComponent.tsx
+++ b/hat/assets/js/apps/Iaso/components/forms/InputComponent.tsx
@@ -182,10 +182,15 @@ const InputComponent: React.FC<InputComponentProps> = ({
     };
     const inputValue =
         value === null || typeof value === 'undefined' ? '' : value;
-    const labelText =
-        typeof labelString === 'string'
-            ? labelString
-            : formatMessage(label || MESSAGES[keyValue]);
+    let labelText = '';
+    if (labelString && typeof labelString === 'string') {
+        labelText = labelString;
+    } else if (label) {
+        labelText = formatMessage(label);
+    } else if (MESSAGES[keyValue]) {
+        labelText = formatMessage(MESSAGES[keyValue]);
+    }
+
     const renderInput = () => {
         switch (type) {
             case 'email':


### PR DESCRIPTION
## What problem is this PR solving?

Prevent warning in console if no label is provided to inputs.

### Related JIRA tickets

SNT-285

## Changes

If no label is provided and nothing matches in MESSAGES, just display blank without warning.

## How to test

Verify that it doesn't break current behavior.

## Print screen / video

Upload here print screens or videos showing the changes.

## Notes

Related to SNT malaria PR: https://github.com/BLSQ/snt-malaria/pull/191

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).
