### PR TITLE
IA-4780: fix react render cycle in PeriodPicker

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/instances/components/InstancesFiltersComponent.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/InstancesFiltersComponent.tsx
@@ -12,12 +12,12 @@ import {
     AsyncSelect,
 } from 'bluesquare-components';
 
+import { UserOrgUnitRestriction } from 'Iaso/components/UserOrgUnitRestriction';
 import { useGetFormsDropdownOptions } from 'Iaso/domains/forms/hooks/useGetFormsDropdownOptions';
+import { getInstancesFilterValues, useFormState } from 'Iaso/hooks/form';
+import { LocationLimit } from 'Iaso/utils/map/LocationLimit';
 import DatesRange from '../../../components/filters/DatesRange';
 import InputComponent from '../../../components/forms/InputComponent';
-import { UserOrgUnitRestriction } from '../../../components/UserOrgUnitRestriction';
-import { getInstancesFilterValues, useFormState } from '../../../hooks/form';
-import { LocationLimit } from '../../../utils/map/LocationLimit';
 import { Popper } from '../../forms/fields/components/Popper';
 import { useGetFormDescriptor } from '../../forms/fields/hooks/useGetFormDescriptor';
 import { useGetQueryBuilderListToReplace } from '../../forms/fields/hooks/useGetQueryBuilderListToReplace';
@@ -34,7 +34,6 @@ import { useGetPlanningsOptions } from '../../plannings/hooks/requests/useGetPla
 import { useGetProjectsDropdownOptions } from '../../projects/hooks/requests';
 import { INSTANCE_STATUSES } from '../constants';
 
-import { useGetForms } from '../hooks';
 import { getUsersDropDown } from '../hooks/requests/getUsersDropDown';
 import { useGetProfilesDropdown } from '../hooks/useGetProfilesDropdown';
 import MESSAGES from '../messages';
@@ -90,7 +89,7 @@ const InstancesFiltersComponent = ({
     formDetails,
     tableColumns,
     tab,
-}) => {
+}: Props) => {
     const { formatMessage } = useSafeIntl();
     const classes = useStyles();
 
@@ -181,7 +180,7 @@ const InstancesFiltersComponent = ({
     ]);
 
     const handleFormChange = useCallback(
-        (key, value) => {
+        (key: string, value: any) => {
             // checking only as value can be null or false
             if (key === 'formIds') {
                 setFormState('fieldsSearch', null);

--- a/hat/assets/js/apps/Iaso/domains/periods/components/PeriodPicker.tsx
+++ b/hat/assets/js/apps/Iaso/domains/periods/components/PeriodPicker.tsx
@@ -77,15 +77,15 @@ const PeriodPicker: FunctionComponent<Props> = ({
     message,
 }) => {
     const [currentPeriod, setCurrentPeriod] =
-        useState<Partial<PeriodObject> | null>(
-            activePeriodString && Period.getPeriodType(activePeriodString)
-                ? Period.parse(activePeriodString)[1]
-                : null,
-        );
+        useState<Partial<PeriodObject> | null>(null);
 
     useEffect(() => {
-        setCurrentPeriod(null);
-    }, [periodType]);
+        if (activePeriodString && Period.getPeriodType(activePeriodString)) {
+            setCurrentPeriod(Period.parse(activePeriodString)[1]);
+        } else {
+            setCurrentPeriod(null);
+        }
+    }, [activePeriodString]);
 
     const handleChange = (
         changedKeyName: 'month' | 'year' | 'quarter' | 'semester',


### PR DESCRIPTION
## What problem is this PR solving?

In the form submission list, the startPeriod and endPeriod filters wouldn't take into account initial values from URL and be empty. 

### Related JIRA tickets

IA-4780

## Changes

* Fixed the PeriodPicker react lifecycle by moving away the logic from useState into a useEffect with correct dependencies

## How to test

Access the URL with any initial statePeriod and/or endPeriod (e.g /dashboard/forms/submissions/accountId/7/page/1/periodType/WEEK/startPeriod/2017W1/endPeriod/2026W6/tab/list/showDeleted/false/mapResults/3000/isSearchActive/true): the fields should be filled in. 