### PR TITLE
IA-4779: fix DeleteInstanceDialog lifecycle

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/instances/components/DeleteInstanceDialog.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/DeleteInstanceDialog.tsx
@@ -1,8 +1,9 @@
-import React, { useState, FunctionComponent, useEffect } from 'react';
+import React, { FunctionComponent } from 'react';
 import DeleteIcon from '@mui/icons-material/Delete';
 import RestoreFromTrashIcon from '@mui/icons-material/RestoreFromTrash';
 import { DialogContentText, IconButton } from '@mui/material';
 import { FormattedMessage } from 'react-intl';
+import { useBoundState } from 'Iaso/hooks/useBoundState';
 import ConfirmCancelDialogComponent from '../../../components/dialogs/ConfirmCancelDialogComponent';
 import { bulkDelete } from '../actions';
 import MESSAGES from '../messages';
@@ -25,13 +26,10 @@ const DeleteInstanceDialog: FunctionComponent<Props> = ({
     resetSelection,
     isUnDeleteAction,
 }) => {
-    const [allowConfirm, setAllowConfirm] = useState(false);
-
-    useEffect(() => {
-        if (selection?.selectCount) {
-            setAllowConfirm(true);
-        }
-    }, [selection]);
+    const [allowConfirm, setAllowConfirm] = useBoundState(
+        false,
+        Boolean(selection?.selectCount),
+    );
 
     const onConfirm = closeDialog => {
         setAllowConfirm(false);

--- a/hat/assets/js/apps/Iaso/domains/instances/components/DeleteInstanceDialog.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/DeleteInstanceDialog.tsx
@@ -1,19 +1,11 @@
-import React, { useState, FunctionComponent } from 'react';
+import React, { useState, FunctionComponent, useEffect } from 'react';
 import DeleteIcon from '@mui/icons-material/Delete';
 import RestoreFromTrashIcon from '@mui/icons-material/RestoreFromTrash';
-import { DialogContentText } from '@mui/material';
-import { makeStyles } from '@mui/styles';
+import { DialogContentText, IconButton } from '@mui/material';
 import { FormattedMessage } from 'react-intl';
-import { bulkDelete } from '../actions';
 import ConfirmCancelDialogComponent from '../../../components/dialogs/ConfirmCancelDialogComponent';
+import { bulkDelete } from '../actions';
 import MESSAGES from '../messages';
-
-const useStyles = makeStyles(() => ({
-    iconDisabled: {
-        opacity: 0.3,
-        cursor: 'not-allowed',
-    },
-}));
 
 type Props = {
     selection: { selectCount: number; filters?: any };
@@ -33,29 +25,34 @@ const DeleteInstanceDialog: FunctionComponent<Props> = ({
     resetSelection,
     isUnDeleteAction,
 }) => {
-    const classes = useStyles();
-    const [allowConfirm, setAllowConfirm] = useState(true);
+    const [allowConfirm, setAllowConfirm] = useState(false);
+
+    useEffect(() => {
+        if (selection?.selectCount) {
+            setAllowConfirm(true);
+        }
+    }, [selection]);
+
     const onConfirm = closeDialog => {
         setAllowConfirm(false);
         bulkDelete(selection, filters, isUnDeleteAction, () => {
             closeDialog();
             resetSelection();
             setForceRefresh();
-            setAllowConfirm(false);
         });
     };
 
     const renderTrigger = ({ openDialog }) => {
-        const iconProps = {
-            className:
-                selection.selectCount === 0 ? classes.iconDisabled : null,
+        const iconButtonProps = {
             onClick: selection.selectCount > 0 ? openDialog : () => null,
-            disabled: selection.selectCount === 0,
+            disabled: selection.selectCount === 0
         };
-        if (isUnDeleteAction) {
-            return <RestoreFromTrashIcon {...iconProps} />;
-        }
-        return <DeleteIcon {...iconProps} />;
+
+        return (
+            <IconButton {...iconButtonProps}>
+                {isUnDeleteAction ? <RestoreFromTrashIcon /> : <DeleteIcon />}
+            </IconButton>
+        );
     };
     const titleMessage = isUnDeleteAction
         ? MESSAGES.unDeleteInstanceCount


### PR DESCRIPTION
## What problem is this PR solving?

From the form submissions list, it was not possible to bulk delete form submissions twice in a row, at the second time the confirm button on the modal would always be greyed out. 

### Related JIRA tickets

IA-4779

## Changes

* Fix the react lifecycle of the related component
* Adjust the components to be more TS compliant and MUI compliant

## How to test

In form submission UI : 

* Search for entries
* From the sidebar , select all 
* From the sidebar, delete and confirm
* Without reloading the page, do a new search
* From the sidebar, select all then delete
* The Confirm button in the modal should not be greyed out
