### PR TITLE
Snt 294 users can define scales with a UI in which they can select range and colors

### DIFF
--- a/iaso/api/metrics/serializers.py
+++ b/iaso/api/metrics/serializers.py
@@ -91,9 +91,7 @@ class MetricTypeCreateSerializer(MetricTypeWriteSerializer):
 
     def create(self, validated_data):
         account = self.context["request"].user.iaso_profile.account
-        instance = super().create({**validated_data, "account": account})
-        instance.save()
-        return instance
+        return super().create({**validated_data, "account": account})
 
     def validate_code(self, value):
         if any(char.isspace() for char in value):

--- a/iaso/api/metrics/serializers.py
+++ b/iaso/api/metrics/serializers.py
@@ -6,7 +6,6 @@ from rest_framework import serializers
 from iaso.api.metrics.utils import REQUIRED_METRIC_VALUES_HEADERS, get_missing_headers
 from iaso.models import MetricType, MetricValue
 from iaso.models.org_unit import OrgUnit
-from iaso.utils import legend
 from iaso.utils.org_units import get_valid_org_units_with_geography
 
 
@@ -46,7 +45,7 @@ class MetricTypeWriteSerializer(serializers.ModelSerializer):
     unit_symbol = serializers.CharField(required=False, allow_blank=True, max_length=2)
     origin = serializers.ChoiceField(choices=MetricType.MetricTypeOrigin, required=False, allow_blank=True)
     legend_type = serializers.ChoiceField(choices=MetricType.LegendType, required=True, allow_blank=False)
-    scale = serializers.JSONField(allow_null=False, write_only=True)
+    legend_config = serializers.JSONField(allow_null=False, write_only=True)
 
     class Meta:
         model = MetricType
@@ -58,22 +57,14 @@ class MetricTypeWriteSerializer(serializers.ModelSerializer):
             "unit_symbol",
             "legend_type",
             "origin",
-            "scale",
+            "legend_config",
         ]
-
-    def _get_legend_config_from_scale(self, instance, scale):
-        return legend.get_legend_config(instance, scale) if scale else instance.legend_config
-
-    def update(self, instance, validated_data):
-        scale = validated_data.pop("scale", None)
-        legend_config = self._get_legend_config_from_scale(instance, scale)
-        return super().update(instance, {**validated_data, "legend_config": legend_config})
 
     def validate(self, data):
         legend_type = data.get("legend_type")
-        scale = data.get("scale")
+        legend_config = data.get("legend_config")
 
-        scale_count = len(scale.split(",")) if scale else 0
+        scale_count = len(legend_config.get("domain", [])) if legend_config else 0
         if legend_type == MetricType.LegendType.THRESHOLD:
             if scale_count < 2:
                 raise serializers.ValidationError(_("Threshold legend type requires at least two scale items."))
@@ -99,9 +90,7 @@ class MetricTypeCreateSerializer(MetricTypeWriteSerializer):
 
     def create(self, validated_data):
         account = self.context["request"].user.iaso_profile.account
-        scale = validated_data.pop("scale", None)
         instance = super().create({**validated_data, "account": account})
-        instance.legend_config = self._get_legend_config_from_scale(instance, scale)
         instance.save()
         return instance
 

--- a/iaso/api/metrics/serializers.py
+++ b/iaso/api/metrics/serializers.py
@@ -7,6 +7,7 @@ from iaso.api.metrics.utils import REQUIRED_METRIC_VALUES_HEADERS, get_missing_h
 from iaso.models import MetricType, MetricValue
 from iaso.models.org_unit import OrgUnit
 from iaso.utils.org_units import get_valid_org_units_with_geography
+from iaso.utils.serializer.json_schema_field import JSONSchemaField
 
 
 class MetricTypeSerializer(serializers.ModelSerializer):
@@ -45,7 +46,7 @@ class MetricTypeWriteSerializer(serializers.ModelSerializer):
     unit_symbol = serializers.CharField(required=False, allow_blank=True, max_length=2)
     origin = serializers.ChoiceField(choices=MetricType.MetricTypeOrigin, required=False, allow_blank=True)
     legend_type = serializers.ChoiceField(choices=MetricType.LegendType, required=True, allow_blank=False)
-    legend_config = serializers.JSONField(allow_null=False, write_only=True)
+    legend_config = JSONSchemaField(schema=MetricType.LEGEND_CONFIG_SCHEMA, allow_null=False, write_only=True)
 
     class Meta:
         model = MetricType

--- a/iaso/models/metric.py
+++ b/iaso/models/metric.py
@@ -15,6 +15,21 @@ class MetricType(models.Model):
         CUSTOM = "custom", _("Custom")
         OTHER = "other", _("Other")
 
+    LEGEND_CONFIG_SCHEMA = {
+        "type": "object",
+        "properties": {
+            "domain": {
+                "type": "array",
+                "items": {"type": ["number", "string"]},
+            },
+            "range": {
+                "type": "array",
+                "items": {"type": "string"},
+            },
+        },
+        "required": ["domain", "range"],
+    }
+
     class Meta:
         ordering = ["id"]  # force ordering in order of creation (for demo)
         unique_together = [

--- a/iaso/tests/api/metrics/test_serializers.py
+++ b/iaso/tests/api/metrics/test_serializers.py
@@ -315,7 +315,7 @@ class MetricTypeCreateSerializerTestCase(TestCase):
             expected_legend_config,
         )
 
-    def test_create_metric_type_invalid_scale(self):
+    def test_create_metric_type_invalid_legend_config(self):
         invalid_data = self.request_data.copy()
         invalid_data["legend_config"] = {
             "domain": [10],
@@ -378,6 +378,17 @@ class MetricTypeCreateSerializerTestCase(TestCase):
         self.assertIn(
             "Ordinal legend type allows a maximum of four scale items.", serializer.errors["non_field_errors"]
         )
+
+    def test_create_metric_type_invalid_legend_type_schema(self):
+        invalid_data = self.request_data.copy()
+        invalid_data["legend_config"] = {
+            "domain": "not an array",
+            "range": "not an array",
+        }
+        serializer_context = {"request": self.request}
+        serializer = MetricTypeCreateSerializer(data=invalid_data, context=serializer_context)
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("'not an array' is not of type 'array'", serializer.errors["legend_config"][0])
 
 
 class MetricValueSerializerTestCase(TestCase):

--- a/iaso/tests/api/metrics/test_serializers.py
+++ b/iaso/tests/api/metrics/test_serializers.py
@@ -72,7 +72,10 @@ class MetricTypeWriteSerializerTestCase(TestCase):
             "unit_symbol": "u",
             "description": "An existing metric type",
             "origin": "custom",
-            "scale": "[10, 20, 30, 40, 50, 60, 70]",
+            "legend_config": {
+                "domain": [10, 20, 30, 40, 50, 60, 70],
+                "range": ["#A2CAEA", "#ACDF9B", "#F5F1A0", "#F2B16E", "#A93A42", "#BADA55", "#C0FFEE"],
+            },
         }
 
         cls.metric_type = MetricType.objects.create(
@@ -81,7 +84,7 @@ class MetricTypeWriteSerializerTestCase(TestCase):
             name="Metric Type 1",
             category="Category 1",
             legend_type="threshold",
-            legend_config={"thresholds": [10, 20, 30]},
+            legend_config={"domain": [10, 20, 30], "range": ["#A2CAEA", "#ACDF9B", "#F5F1A0"]},
         )
 
     def test_fields(self):
@@ -94,7 +97,7 @@ class MetricTypeWriteSerializerTestCase(TestCase):
             "unit_symbol",
             "legend_type",
             "origin",
-            "scale",
+            "legend_config",
         }
         self.assertEqual(set(serializer.Meta.fields), expected_fields)
 
@@ -110,7 +113,10 @@ class MetricTypeWriteSerializerTestCase(TestCase):
                 "unit_symbol": "uu",
                 "legend_type": "threshold",
                 "origin": "custom",
-                "scale": "[5, 15, 25, 35]",
+                "legend_config": {
+                    "domain": [5.0, 15.0, 25.0, 35.0],
+                    "range": ["#A2CAEA", "#ACDF9B", "#F5F1A0", "#F2B16E", "#A93A42"],
+                },
             },
             context=serializer_context,
         )
@@ -145,13 +151,30 @@ class MetricTypeWriteSerializerTestCase(TestCase):
 
     def test_update_metric_type_invalid_scale(self):
         invalid_data = self.request_data.copy()
-        invalid_data["scale"] = "[10]"  # Invalid for threshold (needs at least 2)
+        invalid_data["legend_config"] = {
+            "domain": [10],
+            "range": ["#A2CAEA"],
+        }  # Invalid for threshold (needs at least 2)
         serializer_context = {"request": self.request}
         serializer = MetricTypeWriteSerializer(data=invalid_data, context=serializer_context)
         self.assertFalse(serializer.is_valid())
         self.assertIn("Threshold legend type requires at least two scale items.", serializer.errors["non_field_errors"])
 
-        invalid_data["scale"] = "[10, 20, 30, 40, 50, 60, 70, 80, 90, 100]"  # Invalid for threshold (max 9)
+        invalid_data["legend_config"] = {
+            "domain": [10, 20, 30, 40, 50, 60, 70, 80, 90, 100],
+            "range": [
+                "#A2CAEA",
+                "#ACDF9B",
+                "#F5F1A0",
+                "#F2B16E",
+                "#A93A42",
+                "#A2CAEA",
+                "#ACDF9B",
+                "#F5F1A0",
+                "#F2B16E",
+                "#A93A42",
+            ],
+        }  # Invalid for threshold (max 9)
         serializer = MetricTypeWriteSerializer(data=invalid_data, context=serializer_context)
         self.assertFalse(serializer.is_valid())
         self.assertIn(
@@ -160,21 +183,30 @@ class MetricTypeWriteSerializerTestCase(TestCase):
 
         invalid_data = self.request_data.copy()
         invalid_data["legend_type"] = "linear"
-        invalid_data["scale"] = "[10, 20, 30]"  # Invalid for linear (needs exactly 2)
+        invalid_data["legend_config"] = {
+            "domain": [10, 20, 30],
+            "range": ["#A2CAEA", "#ACDF9B", "#F5F1A0"],
+        }  # Invalid for linear (needs exactly 2)
         serializer = MetricTypeWriteSerializer(data=invalid_data, context=serializer_context)
         self.assertFalse(serializer.is_valid())
         self.assertIn("Linear legend type requires exactly two scale items.", serializer.errors["non_field_errors"])
 
         invalid_data = self.request_data.copy()
         invalid_data["legend_type"] = "ordinal"
-        invalid_data["scale"] = "[10]"  # Invalid for ordinal (needs at least 2)
+        invalid_data["legend_config"] = {
+            "domain": [10],
+            "range": ["#A2CAEA"],
+        }  # Invalid for ordinal (needs at least 2)
         serializer = MetricTypeWriteSerializer(data=invalid_data, context=serializer_context)
         self.assertFalse(serializer.is_valid())
         self.assertIn("Ordinal legend type requires at least two scale items.", serializer.errors["non_field_errors"])
 
         invalid_data = self.request_data.copy()
         invalid_data["legend_type"] = "ordinal"
-        invalid_data["scale"] = "[10, 20, 30, 40, 50]"  # Invalid for ordinal (max 4)
+        invalid_data["legend_config"] = {
+            "domain": [10, 20, 30, 40, 50],
+            "range": ["#A2CAEA", "#ACDF9B", "#F5F1A0", "#F2B16E", "#A93A42"],
+        }  # Invalid for ordinal (max 4)
         serializer = MetricTypeWriteSerializer(data=invalid_data, context=serializer_context)
         self.assertFalse(serializer.is_valid())
         self.assertIn(
@@ -206,7 +238,10 @@ class MetricTypeCreateSerializerTestCase(TestCase):
             "unit_symbol": "u",
             "description": "An existing metric type",
             "origin": "custom",
-            "scale": "[10, 20, 30, 40, 50, 60, 70]",
+            "legend_config": {
+                "domain": [10, 20, 30, 40, 50, 60, 70],
+                "range": ["#A2CAEA", "#6BD39D", "#ACDF9B", "#F5F1A0", "#F2B16E", "#E4754F", "#C54A53", "#A93A42"],
+            },
         }
 
     def test_fields(self):
@@ -220,7 +255,7 @@ class MetricTypeCreateSerializerTestCase(TestCase):
             "unit_symbol",
             "legend_type",
             "origin",
-            "scale",
+            "legend_config",
         }
         self.assertEqual(set(serializer.Meta.fields), expected_fields)
 
@@ -282,13 +317,30 @@ class MetricTypeCreateSerializerTestCase(TestCase):
 
     def test_create_metric_type_invalid_scale(self):
         invalid_data = self.request_data.copy()
-        invalid_data["scale"] = "[10]"  # Invalid for threshold (needs at least 2)
+        invalid_data["legend_config"] = {
+            "domain": [10],
+            "range": ["#A2CAEA"],
+        }  # Invalid for threshold (needs at least 2)
         serializer_context = {"request": self.request}
         serializer = MetricTypeCreateSerializer(data=invalid_data, context=serializer_context)
         self.assertFalse(serializer.is_valid())
         self.assertIn("Threshold legend type requires at least two scale items.", serializer.errors["non_field_errors"])
 
-        invalid_data["scale"] = "[10, 20, 30, 40, 50, 60, 70, 80, 90, 100]"  # Invalid for threshold (max 9)
+        invalid_data["legend_config"] = {
+            "domain": [10, 20, 30, 40, 50, 60, 70, 80, 90, 100],
+            "range": [
+                "#A2CAEA",
+                "#ACDF9B",
+                "#F5F1A0",
+                "#F2B16E",
+                "#A93A42",
+                "#A2CAEA",
+                "#ACDF9B",
+                "#F5F1A0",
+                "#F2B16E",
+                "#A93A42",
+            ],
+        }  # Invalid for threshold (max 9)
         serializer = MetricTypeCreateSerializer(data=invalid_data, context=serializer_context)
         self.assertFalse(serializer.is_valid())
         self.assertIn(
@@ -297,21 +349,30 @@ class MetricTypeCreateSerializerTestCase(TestCase):
 
         invalid_data = self.request_data.copy()
         invalid_data["legend_type"] = "linear"
-        invalid_data["scale"] = "[10, 20, 30]"  # Invalid for linear (needs exactly 2)
+        invalid_data["legend_config"] = {
+            "domain": [10, 20, 30],
+            "range": ["#A2CAEA", "#ACDF9B", "#F5F1A0"],
+        }  # Invalid for linear (needs exactly 2)
         serializer = MetricTypeCreateSerializer(data=invalid_data, context=serializer_context)
         self.assertFalse(serializer.is_valid())
         self.assertIn("Linear legend type requires exactly two scale items.", serializer.errors["non_field_errors"])
 
         invalid_data = self.request_data.copy()
         invalid_data["legend_type"] = "ordinal"
-        invalid_data["scale"] = "[10]"  # Invalid for ordinal (needs at least 2)
+        invalid_data["legend_config"] = {
+            "domain": [10],
+            "range": ["#A2CAEA"],
+        }  # Invalid for ordinal (needs at least 2)
         serializer = MetricTypeCreateSerializer(data=invalid_data, context=serializer_context)
         self.assertFalse(serializer.is_valid())
         self.assertIn("Ordinal legend type requires at least two scale items.", serializer.errors["non_field_errors"])
 
         invalid_data = self.request_data.copy()
         invalid_data["legend_type"] = "ordinal"
-        invalid_data["scale"] = "[10, 20, 30, 40, 50]"  # Invalid for ordinal (max 4)
+        invalid_data["legend_config"] = {
+            "domain": [10, 20, 30, 40, 50],
+            "range": ["#A2CAEA", "#ACDF9B", "#F5F1A0", "#F2B16E", "#A93A42"],
+        }  # Invalid for ordinal (max 4)
         serializer = MetricTypeCreateSerializer(data=invalid_data, context=serializer_context)
         self.assertFalse(serializer.is_valid())
         self.assertIn(
@@ -349,7 +410,7 @@ class ImportMetricValuesSerializerTestCase(TestCase):
             name="Metric Type 1",
             category="Category 1",
             legend_type="threshold",
-            legend_config={"thresholds": [10, 20, 30]},
+            legend_config={"domain": [10, 20, 30], "range": ["#A2CAEA", "#ACDF9B", "#F5F1A0"]},
         )
         cls.mt_2 = MetricType.objects.create(
             account=cls.account,
@@ -357,7 +418,7 @@ class ImportMetricValuesSerializerTestCase(TestCase):
             name="Metric Type 2",
             category="Category 2",
             legend_type="linear",
-            legend_config={"thresholds": [5, 15, 25]},
+            legend_config={"domain": [5, 15, 25], "range": ["#A2CAEA", "#ACDF9B", "#F5F1A0"]},
         )
 
         # Create Org Units

--- a/iaso/tests/api/metrics/test_views.py
+++ b/iaso/tests/api/metrics/test_views.py
@@ -67,7 +67,7 @@ class MetricTypeAPITestCase(APITestCase):
                 "description": "Description for Metric Type 3",
                 "category": "Category C",
                 "origin": MetricType.MetricTypeOrigin.CUSTOM.value,
-                "scale": "[1, 2, 3]",
+                "legend_config": {"domain": [1.0, 2.0, 3.0], "range": ["#A2CAEA", "#ACDF9B", "#F2B16E", "#A93A42"]},
                 "legend_type": MetricType.LegendType.THRESHOLD.value,
             },
         )
@@ -99,7 +99,7 @@ class MetricTypeAPITestCase(APITestCase):
                 "description": "Description for Metric Type 3",
                 "category": "Category C",
                 "origin": MetricType.MetricTypeOrigin.CUSTOM.value,
-                "scale": "[1, 2, 3]",
+                "legend_config": {"domain": [1.0, 2.0, 3.0], "range": ["#A2CAEA", "#ACDF9B", "#F2B16E", "#A93A42"]},
                 "legend_type": MetricType.LegendType.THRESHOLD.value,
             },
         )
@@ -115,7 +115,10 @@ class MetricTypeAPITestCase(APITestCase):
                 "description": "Updated description for Metric Type 1",
                 "origin": MetricType.MetricTypeOrigin.CUSTOM.value,
                 "category": "Category A",
-                "scale": "[1, 2, 3, 4]",
+                "legend_config": {
+                    "domain": [1.0, 2.0, 3.0, 4.0],
+                    "range": ["#A2CAEA", "#ACDF9B", "#F2B16E", "#A93A42"],
+                },
                 "legend_type": MetricType.LegendType.THRESHOLD.value,
             },
         )
@@ -135,7 +138,10 @@ class MetricTypeAPITestCase(APITestCase):
                 "description": "Updated description for Metric Type 1",
                 "origin": MetricType.MetricTypeOrigin.CUSTOM.value,
                 "category": "Category A",
-                "scale": "[1, 2, 3, 4]",
+                "legend_config": {
+                    "domain": [1.0, 2.0, 3.0, 4.0],
+                    "range": ["#A2CAEA", "#ACDF9B", "#F2B16E", "#A93A42"],
+                },
                 "legend_type": MetricType.LegendType.THRESHOLD.value,
             },
         )


### PR DESCRIPTION
## What problem is this PR solving?

Replace json text field to a custom component for metric type scales

### Related JIRA tickets

SNT-294

## Changes

- Added a new form for legend_config of a metric type.
- Modified B-E to accept this input instead of a json string
- Add limits on array items based on legend_type

## How to test

Go to SNT with an admin account (you can setup BFA dummy account).
Go to settings (on the burger navigation) which will bring you to the Layer tab of the settings.
From there, you can create a metric type (aka layer). 
Try to play with the legend it should:

- Have two items by default
- Have type threshold by default
- Should not allow less than 2 items
- Should not allow more than 9 item for threshold, 4 for ordinal and 2 for linear.
- Should show an error if a value is already defined
- For threshold and linear, it should only accept numbers
- For ordinal it should allow strings

## Print screen / video

<img width="1198" height="456" alt="image" src="https://github.com/user-attachments/assets/f2cd2c42-ae9d-4830-a2e8-67db5393febf" />


## Notes

There is an SNT PR for the FE part: https://github.com/BLSQ/snt-malaria/pull/194

## Doc

N/A
