### PR TITLE
POLIO-2097: enable pdf deletion

### DIFF
--- a/hat/assets/js/apps/Iaso/components/files/pdf/DocumentUploadWithPreview.tsx
+++ b/hat/assets/js/apps/Iaso/components/files/pdf/DocumentUploadWithPreview.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Grid } from '@mui/material';
-import { FilesUpload, useSafeIntl } from 'bluesquare-components';
+import { FilesUpload, IconButton, useSafeIntl } from 'bluesquare-components';
 import MESSAGES from './messages';
 import { PdfPreview } from './PdfPreview';
 import { acceptPDF } from './utils';
@@ -13,6 +13,7 @@ type DocumentUploadWithPreviewProps = {
     scanResult?: string | undefined;
     scanTimestamp?: number | undefined;
     coloredScanResultIcon?: boolean;
+    enableDelete?: boolean;
 };
 
 const DocumentUploadWithPreview: React.FC<DocumentUploadWithPreviewProps> = ({
@@ -23,6 +24,7 @@ const DocumentUploadWithPreview: React.FC<DocumentUploadWithPreviewProps> = ({
     scanResult,
     scanTimestamp,
     coloredScanResultIcon,
+    enableDelete = false,
 }) => {
     const { formatMessage } = useSafeIntl();
 
@@ -38,10 +40,16 @@ const DocumentUploadWithPreview: React.FC<DocumentUploadWithPreviewProps> = ({
     } else if (document instanceof File) {
         pdfUrl = URL.createObjectURL(document);
     }
+    let mainGridSize = 12;
+    if (document && enableDelete) {
+        mainGridSize = 9;
+    } else if (document) {
+        mainGridSize = 10;
+    }
 
     return (
         <Grid container spacing={2} alignItems="center">
-            <Grid item xs={document ? 10 : 12}>
+            <Grid item xs={mainGridSize}>
                 <FilesUpload
                     accept={acceptPDF}
                     files={document ? [document as unknown as File] : []}
@@ -53,14 +61,27 @@ const DocumentUploadWithPreview: React.FC<DocumentUploadWithPreviewProps> = ({
                 />
             </Grid>
             {pdfUrl && (
-                <Grid item xs={2} sx={{ textAlign: 'right' }}>
-                    <PdfPreview
-                        pdfUrl={pdfUrl}
-                        scanResult={scanResult}
-                        scanTimestamp={scanTimestamp}
-                        coloredScanResultIcon={coloredScanResultIcon}
-                    />
-                </Grid>
+                <>
+                    <Grid
+                        item
+                        xs={enableDelete ? 3 : 2}
+                        sx={{ textAlign: 'right' }}
+                    >
+                        {enableDelete && (
+                            <IconButton
+                                icon="delete"
+                                onClick={() => onFilesSelect([])}
+                                tooltipMessage={MESSAGES.delete}
+                            />
+                        )}
+                        <PdfPreview
+                            pdfUrl={pdfUrl}
+                            scanResult={scanResult}
+                            scanTimestamp={scanTimestamp}
+                            coloredScanResultIcon={coloredScanResultIcon}
+                        />
+                    </Grid>
+                </>
             )}
         </Grid>
     );

--- a/hat/assets/js/apps/Iaso/components/files/pdf/messages.ts
+++ b/hat/assets/js/apps/Iaso/components/files/pdf/messages.ts
@@ -45,14 +45,16 @@ const MESSAGES = defineMessages({
         id: 'iaso.label.fileScanSafeIconTooltip',
     },
     fileScanInfectedIconTooltip: {
-        defaultMessage:
-            'This file contains a virus',
+        defaultMessage: 'This file contains a virus',
         id: 'iaso.label.fileScanInfectedIconTooltip',
     },
     fileScanPendingIconTooltip: {
-        defaultMessage:
-            'This file has not been scanned',
+        defaultMessage: 'This file has not been scanned',
         id: 'iaso.label.fileScanPendingIconTooltip',
+    },
+    delete: {
+        id: 'iaso.label.delete',
+        defaultMessage: 'Delete',
     },
 });
 

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/VaccineRequestForm/VaccineRequestForm.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/VaccineRequestForm/VaccineRequestForm.tsx
@@ -323,7 +323,7 @@ export const VaccineRequestForm: FunctionComponent<Props> = ({
                                         <DocumentUploadWithPreview
                                             errors={documentErrors}
                                             onFilesSelect={files => {
-                                                if (files.length) {
+                                                if (Array.isArray(files)) {
                                                     setFieldTouched(
                                                         'vrf.file',
                                                         true,
@@ -345,6 +345,7 @@ export const VaccineRequestForm: FunctionComponent<Props> = ({
                                                 values?.vrf?.scan_timestamp
                                             }
                                             coloredScanResultIcon
+                                            enableDelete
                                         />
                                     </Box>
                                 </Grid>

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/VaccineSupplyChain.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/VaccineSupplyChain.tsx
@@ -1,23 +1,23 @@
 import React, { FunctionComponent } from 'react';
+import { Box, Grid } from '@mui/material';
 import {
     AddButton,
     useSafeIntl,
     useRedirectTo,
     UrlParams,
 } from 'bluesquare-components';
-import { Box, Grid } from '@mui/material';
-import { useParamsObject } from '../../../../../../../hat/assets/js/apps/Iaso/routing/hooks/useParamsObject';
 import { DisplayIfUserHasPerm } from '../../../../../../../hat/assets/js/apps/Iaso/components/DisplayIfUserHasPerm';
+import TopBar from '../../../../../../../hat/assets/js/apps/Iaso/components/nav/TopBarComponent';
+import { useParamsObject } from '../../../../../../../hat/assets/js/apps/Iaso/routing/hooks/useParamsObject';
 import {
     POLIO_SUPPLY_CHAIN_READ,
     POLIO_SUPPLY_CHAIN_WRITE,
 } from '../../../../../../../hat/assets/js/apps/Iaso/utils/permissions';
-import TopBar from '../../../../../../../hat/assets/js/apps/Iaso/components/nav/TopBarComponent';
+import { baseUrls } from '../../../constants/urls';
 import { useStyles } from '../../../styles/theme';
+import { VaccineSupplyChainFilters } from './Filters/VaccineSupplyChainFilters';
 import MESSAGES from './messages';
 import { VaccineSupplyChainTable } from './Table/VaccineSupplyChainTable';
-import { VaccineSupplyChainFilters } from './Filters/VaccineSupplyChainFilters';
-import { baseUrls } from '../../../constants/urls';
 
 type VaccineSupplyChainParams = {
     accountId: string;


### PR DESCRIPTION
## What problem is this PR solving?

user needs to be able to remove uploaded file. Currently only replacing is possible

### Related JIRA tickets
POLIO-2097

## Changes

- optional delete iconbutton in VRF form

## How to test
Go to polio > vaccine module > supplychain
Open or create a VRF
Add a file and save if no VRF with file
Open VRF with file
try the delete icon and save

## Print screen / video



https://github.com/user-attachments/assets/00163567-7260-4745-8521-8d91a53f86b6


## Notes
There is an annoying bug that prevents the file name from showing. It's not part of this PR: https://bluesquare.atlassian.net/browse/POLIO-2105

