### PR TITLE
[IA-4600] Removing the column from the default columns in the table

### DIFF
--- a/hat/assets/js/apps/Iaso/constants/urls.ts
+++ b/hat/assets/js/apps/Iaso/constants/urls.ts
@@ -160,6 +160,7 @@ export const baseRouteConfigs: Record<string, RouteConfig> = {
             'searchActive',
             'searches',
             'isClusterActive',
+            'fields',
         ],
     },
     orgUnitDetails: {

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/TableList.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/TableList.tsx
@@ -14,6 +14,7 @@ import {
 
 import { UseMutateAsyncFunction } from 'react-query';
 
+import { ColumnsSelectDrawer } from '../../../components/tables/ColumnSelectDrawer';
 import { TableWithDeepLink } from '../../../components/tables/TableWithDeepLink';
 import { baseUrls } from '../../../constants/urls';
 
@@ -26,6 +27,7 @@ import {
 import { userHasPermission } from '../../users/utils';
 import { Result as OrgUnitResult } from '../hooks/requests/useGetOrgUnits';
 import { useGetOrgUnitsTableColumns } from '../hooks/useGetOrgUnitsTableColumns';
+import { useOrgUnitsColumnSelectDrawer } from '../hooks/useOrgUnitsColumnSelectDrawer';
 import MESSAGES from '../messages';
 import { OrgUnit, OrgUnitParams } from '../types/orgUnit';
 import { Search } from '../types/search';
@@ -37,6 +39,7 @@ type Props = {
     params: OrgUnitParams;
     orgUnitsData?: OrgUnitResult;
     saveMulti: UseMutateAsyncFunction<unknown, unknown, unknown, unknown>;
+    isFetching: boolean;
 };
 
 const baseUrl = baseUrls.orgUnits;
@@ -44,6 +47,7 @@ export const TableList: FunctionComponent<Props> = ({
     params,
     orgUnitsData,
     saveMulti,
+    isFetching,
 }) => {
     const { formatMessage } = useSafeIntl();
 
@@ -60,7 +64,15 @@ export const TableList: FunctionComponent<Props> = ({
         [params.searches],
     );
 
-    const columns = useGetOrgUnitsTableColumns(searches);
+    const allColumns = useGetOrgUnitsTableColumns(searches);
+
+    const {
+        options,
+        setOptions,
+        visibleColumns,
+        handleApplyOptions,
+        isDisabled,
+    } = useOrgUnitsColumnSelectDrawer(allColumns, params, baseUrl);
 
     const multiEditDisabled =
         !userHasPermission(ORG_UNITS, currentUser) ||
@@ -113,17 +125,27 @@ export const TableList: FunctionComponent<Props> = ({
                 selection={selection}
                 saveMulti={saveMulti}
             />
-            <Box mt={-4} pb={2}>
+            <Box display="flex" justifyContent="flex-end" mb={2} mt={-4}>
+                <ColumnsSelectDrawer
+                    options={options}
+                    setOptions={setOptions}
+                    minColumns={2}
+                    handleApplyOptions={handleApplyOptions}
+                    disabled={isFetching}
+                    isDisabled={isDisabled}
+                />
+            </Box>
+            <Box pb={2}>
                 <TableWithDeepLink
                     data={orgUnitsData?.orgunits || []}
                     count={orgUnitsData?.count}
                     pages={orgUnitsData?.pages}
                     params={params}
-                    columns={columns}
+                    columns={visibleColumns}
                     baseUrl={baseUrl}
                     marginTop={false}
                     extraProps={{
-                        columns,
+                        columns: visibleColumns,
                         data: orgUnitsData?.orgunits || [],
                         count: orgUnitsData?.count,
                     }}

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/hooks/requests/useGetOrgUnits.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/hooks/requests/useGetOrgUnits.ts
@@ -24,13 +24,27 @@ export const DEFAULT_ORG_UNIT_COLUMNS = [
     'id',
     'projects',
     'name',
-    'org_unit_type__name',
+    'org_unit_type_name',
     'source',
     'validation_status',
     'created_at',
     'updated_at',
     'actions',
 ];
+
+export const NON_SELECTABLE_COLUMNS = ['actions', 'selection'];
+
+const getCleanFields = (fields?: string | string[]): string | undefined => {
+    const fieldsArray = Array.isArray(fields)
+        ? fields
+        : (fields?.split(',') ?? DEFAULT_ORG_UNIT_COLUMNS);
+
+    const filtered = fieldsArray.filter(
+        f => f && !NON_SELECTABLE_COLUMNS.includes(f),
+    );
+
+    return filtered.length > 0 ? filtered.join(',') : undefined;
+};
 
 type Props = {
     params: ApiParams;
@@ -55,7 +69,7 @@ export const useGetOrgUnits = ({
     const onSuccess = () => callback();
     const apiParams = {
         ...params,
-        fields: params.fields ?? DEFAULT_ORG_UNIT_COLUMNS.join(','),
+        fields: getCleanFields(params.fields),
     };
     const queryString = new URLSearchParams(apiParams);
     return useSnackQuery({

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/hooks/requests/useGetOrgUnits.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/hooks/requests/useGetOrgUnits.ts
@@ -20,6 +20,18 @@ export type Result = Pagination & {
     counts: Count[];
 };
 
+export const DEFAULT_ORG_UNIT_COLUMNS = [
+    'id',
+    'projects',
+    'name',
+    'org_unit_type__name',
+    'source',
+    'validation_status',
+    'created_at',
+    'updated_at',
+    'actions',
+];
+
 type Props = {
     params: ApiParams;
     callback?: () => void;
@@ -41,9 +53,13 @@ export const useGetOrgUnits = ({
     enabled = false,
 }: Props): UseQueryResult<Result, Error> => {
     const onSuccess = () => callback();
-    const queryString = new URLSearchParams(params);
+    const apiParams = {
+        ...params,
+        fields: params.fields ?? DEFAULT_ORG_UNIT_COLUMNS.join(','),
+    };
+    const queryString = new URLSearchParams(apiParams);
     return useSnackQuery({
-        queryKey: ['orgunits', params],
+        queryKey: ['orgunits', apiParams],
         queryFn: () => getRequest(`/api/orgunits/?${queryString.toString()}`),
         options: {
             enabled,

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/hooks/useGetApiParams.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/hooks/useGetApiParams.ts
@@ -10,6 +10,7 @@ export type ApiParams = {
     searches: string;
     asLocation?: string;
     locationLimit: string;
+    fields?: string;
 };
 
 type Result = {
@@ -41,6 +42,7 @@ export const useGetApiParams = (
         page: params.page ? params.page : '1',
         searches: JSON.stringify(tempSearches),
         locationLimit: params.locationLimit,
+        fields: params.fields,
     };
 
     if (asLocation) {

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/hooks/useGetOrgUnitsTableColumns.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/hooks/useGetOrgUnitsTableColumns.tsx
@@ -68,7 +68,7 @@ export const useGetOrgUnitsTableColumns = (searches: [Search]): Column[] => {
             {
                 Header: formatMessage(MESSAGES.type),
                 accessor: 'org_unit_type_name',
-                id: 'org_unit_type__name',
+                id: 'org_unit_type_name',
             },
             {
                 Header: formatMessage(MESSAGES.source),

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/hooks/useGetOrgUnitsTableColumns.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/hooks/useGetOrgUnitsTableColumns.tsx
@@ -81,10 +81,6 @@ export const useGetOrgUnitsTableColumns = (searches: [Search]): Column[] => {
                 Cell: settings => getStatusMessage(settings.value),
             },
             {
-                Header: formatMessage(MESSAGES.instances_count),
-                accessor: 'instances_count',
-            },
-            {
                 Header: formatMessage(MESSAGES.created_at),
                 accessor: 'created_at',
                 Cell: DateTimeCell,

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/hooks/useGetOrgUnitsTableColumns.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/hooks/useGetOrgUnitsTableColumns.tsx
@@ -81,6 +81,10 @@ export const useGetOrgUnitsTableColumns = (searches: [Search]): Column[] => {
                 Cell: settings => getStatusMessage(settings.value),
             },
             {
+                Header: formatMessage(MESSAGES.instances_count),
+                accessor: 'instances_count',
+            },
+            {
                 Header: formatMessage(MESSAGES.created_at),
                 accessor: 'created_at',
                 Cell: DateTimeCell,

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/hooks/useOrgUnitsColumnSelectDrawer.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/hooks/useOrgUnitsColumnSelectDrawer.tsx
@@ -4,6 +4,8 @@ import { Option } from '../../../components/tables/ColumnSelectDrawer';
 import { OrgUnitParams } from '../types/orgUnit';
 import { DEFAULT_ORG_UNIT_COLUMNS } from './requests/useGetOrgUnits';
 
+const HIDDEN_COLUMNS = ['actions', 'selection'];
+
 export const useOrgUnitsColumnSelectDrawer = (
     columns: Column[],
     params: OrgUnitParams,
@@ -15,26 +17,29 @@ export const useOrgUnitsColumnSelectDrawer = (
     handleApplyOptions: () => void;
     isDisabled: boolean;
 } => {
+    const getCleanKeys = useCallback((fields?: string): string[] => {
+        const keys = fields ? fields.split(',') : DEFAULT_ORG_UNIT_COLUMNS;
+        return keys.filter(key => !HIDDEN_COLUMNS.includes(key));
+    }, []);
+
     const [visibleColumnsKeys, setVisibleColumnsKeys] = useState<string[]>(
-        params?.fields?.split(',') ?? DEFAULT_ORG_UNIT_COLUMNS,
+        getCleanKeys(params?.fields),
     );
 
     useEffect(() => {
-        setVisibleColumnsKeys(
-            params?.fields?.split(',') ?? DEFAULT_ORG_UNIT_COLUMNS,
-        );
-    }, [params.fields]);
+        setVisibleColumnsKeys(getCleanKeys(params?.fields));
+    }, [params.fields, getCleanKeys]);
 
     const activeFieldKeys = useMemo(() => {
-        return params?.fields?.split(',') ?? DEFAULT_ORG_UNIT_COLUMNS;
-    }, [params.fields]);
+        return getCleanKeys(params?.fields);
+    }, [params.fields, getCleanKeys]);
 
     const options = useMemo(() => {
         return columns
-            .filter(
-                column =>
-                    (column.id || column.accessor) && column.id !== 'actions',
-            )
+            .filter(column => {
+                const key = (column.id || column.accessor) as string;
+                return key && key !== 'actions' && key !== 'selection';
+            })
             .map(column => {
                 const key = (column.id || column.accessor) as string;
                 return {
@@ -58,13 +63,13 @@ export const useOrgUnitsColumnSelectDrawer = (
     }, [visibleColumnsKeys, activeFieldKeys]);
 
     const visibleColumns = useMemo(() => {
-        return columns.filter(
-            column =>
-                column.id === 'actions' ||
-                (column.id && activeFieldKeys.includes(column.id as string)) ||
-                (column.accessor &&
-                    activeFieldKeys.includes(column.accessor as string)),
-        );
+        return columns.filter(column => {
+            const key = (column.id || column.accessor) as string;
+            if (key === 'actions' || key === 'selection') {
+                return true;
+            }
+            return activeFieldKeys.includes(key);
+        });
     }, [columns, activeFieldKeys]);
 
     const redirectToReplace = useRedirectToReplace();

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/hooks/useOrgUnitsColumnSelectDrawer.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/hooks/useOrgUnitsColumnSelectDrawer.tsx
@@ -1,0 +1,86 @@
+import { useState, useMemo, useCallback, useEffect } from 'react';
+import { useRedirectToReplace, Column } from 'bluesquare-components';
+import { Option } from '../../../components/tables/ColumnSelectDrawer';
+import { OrgUnitParams } from '../types/orgUnit';
+import { DEFAULT_ORG_UNIT_COLUMNS } from './requests/useGetOrgUnits';
+
+export const useOrgUnitsColumnSelectDrawer = (
+    columns: Column[],
+    params: OrgUnitParams,
+    baseUrl: string,
+): {
+    options: Option[];
+    setOptions: (options: Option[]) => void;
+    visibleColumns: Column[];
+    handleApplyOptions: () => void;
+    isDisabled: boolean;
+} => {
+    const [visibleColumnsKeys, setVisibleColumnsKeys] = useState<string[]>(
+        params?.fields?.split(',') ?? DEFAULT_ORG_UNIT_COLUMNS,
+    );
+
+    useEffect(() => {
+        setVisibleColumnsKeys(
+            params?.fields?.split(',') ?? DEFAULT_ORG_UNIT_COLUMNS,
+        );
+    }, [params.fields]);
+
+    const activeFieldKeys = useMemo(() => {
+        return params?.fields?.split(',') ?? DEFAULT_ORG_UNIT_COLUMNS;
+    }, [params.fields]);
+
+    const options = useMemo(() => {
+        return columns
+            .filter(
+                column =>
+                    (column.id || column.accessor) && column.id !== 'actions',
+            )
+            .map(column => {
+                const key = (column.id || column.accessor) as string;
+                return {
+                    key,
+                    label: column.Header || key,
+                    active: visibleColumnsKeys.includes(key),
+                    disabled: false,
+                };
+            }) as Option[];
+    }, [columns, visibleColumnsKeys]);
+
+    const setOptions = (newOptions: Option[]) => {
+        setVisibleColumnsKeys(newOptions.filter(o => o.active).map(o => o.key));
+    };
+
+    const isDisabled = useMemo(() => {
+        return (
+            [...visibleColumnsKeys].sort().join(',') ===
+            [...activeFieldKeys].sort().join(',')
+        );
+    }, [visibleColumnsKeys, activeFieldKeys]);
+
+    const visibleColumns = useMemo(() => {
+        return columns.filter(
+            column =>
+                column.id === 'actions' ||
+                (column.id && activeFieldKeys.includes(column.id as string)) ||
+                (column.accessor &&
+                    activeFieldKeys.includes(column.accessor as string)),
+        );
+    }, [columns, activeFieldKeys]);
+
+    const redirectToReplace = useRedirectToReplace();
+
+    const handleApplyOptions = useCallback(() => {
+        redirectToReplace(baseUrl, {
+            ...params,
+            fields: visibleColumnsKeys.join(','),
+        });
+    }, [params, redirectToReplace, visibleColumnsKeys, baseUrl]);
+
+    return {
+        options,
+        setOptions,
+        visibleColumns,
+        handleApplyOptions,
+        isDisabled,
+    };
+};

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/types/orgUnit.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/types/orgUnit.ts
@@ -103,6 +103,7 @@ export type OrgUnitParams = UrlParams & {
     searchActive?: string;
     searches: string;
     isClusterActive?: string;
+    fields: string;
 };
 
 export type OrgUnitsApi = {

--- a/iaso/api/common.py
+++ b/iaso/api/common.py
@@ -489,3 +489,16 @@ class DropdownOptionsListViewSet(ViewSet):
         status_choices = self.get_status_choices()
         serializer = self.serializer(status_choices, many=True)
         return Response(serializer.data)
+
+
+def is_field_referenced(field_name, requested_fields, order):
+    """
+    Checks if a field is needed for the response, either because it was
+    explicitly requested or because it's being used for sorting.
+    if no fields specified... do as if all fields are requested
+    """
+    if not requested_fields:
+        return True
+
+    fields_list = requested_fields.split(",")
+    return ":all" in fields_list or field_name in fields_list or field_name in order or f"-{field_name}" in order

--- a/iaso/api/forms.py
+++ b/iaso/api/forms.py
@@ -14,6 +14,7 @@ from rest_framework.request import Request
 
 from hat.api.export_utils import Echo, generate_xlsx, iter_items
 from hat.audit.models import FORM_API, log_modification
+from iaso.api.common import is_field_referenced
 from iaso.api.permission_checks import (
     AuthenticationEnforcedPermission,
     IsAuthenticatedOrReadOnlyWhenNoAuthenticationRequired,
@@ -236,23 +237,6 @@ class FormSerializer(DynamicFieldsModelSerializer):
         form = super(FormSerializer, self).create(validated_data)
         log_modification(None, form, FORM_API, user=self.context["request"].user)
         return form
-
-
-# empty fields then do return true assume it's give me all the fields like the forms page list
-# if specified fields contains :all or field_name then do return True
-# else False
-def is_field_referenced(field_name, requested_fields, order):
-    result = False
-
-    if (
-        not requested_fields
-        or ":all" in requested_fields.split(",")
-        or field_name in requested_fields.split(",")
-        or field_name in order
-    ):
-        result = True
-
-    return result
 
 
 class FormsViewSet(ModelViewSet):

--- a/iaso/api/org_unit_search.py
+++ b/iaso/api/org_unit_search.py
@@ -271,6 +271,7 @@ def annotate_query(queryset, count_instances, count_per_form, forms):
             instances_count=Count(
                 "instance",
                 filter=(~Q(instance__file="") & ~Q(instance__device__test_device=True) & ~Q(instance__deleted=True)),
+                distinct=True,
             )
         )
 

--- a/iaso/api/org_units.py
+++ b/iaso/api/org_units.py
@@ -30,6 +30,7 @@ from iaso.exports import CleaningFileResponse, parquet
 from iaso.gpkg import org_units_to_gpkg_bytes
 from iaso.models import DataSource, Form, Group, Instance, InstanceFile, OrgUnit, OrgUnitType, Project, SourceVersion
 from iaso.models.microplanning import Assignment
+from iaso.api.common import is_field_referenced
 from iaso.permissions.core_permissions import (
     CORE_FORMS_PERMISSION,
     CORE_ORG_UNITS_PERMISSION,
@@ -44,7 +45,6 @@ from iaso.utils.gis import simplify_geom
 from ..plugins import is_polio_plugin_active
 from ..utils.models.common import get_creator_name, get_org_unit_parents_ref
 from .serializers import OrgUnitImportSerializer
-
 
 logger = logging.getLogger(__name__)
 
@@ -95,21 +95,6 @@ class HasOrgUnitPermission(permissions.BasePermission):
         account_ids = [p.account_id for p in projects]
 
         return user_account.id in account_ids
-
-
-def is_field_referenced(field_name, requested_fields, order):
-    if not requested_fields:
-        # no fields specified... do as if all fields are requested
-        return True
-
-    fields_list = requested_fields.split(",")
-    return (
-        ":all" in fields_list
-        or field_name in fields_list
-        or field_name in order
-        or field_name in order
-        or f"-{field_name}" in order
-    )
 
 
 # noinspection PyMethodMayBeStatic

--- a/iaso/api/org_units.py
+++ b/iaso/api/org_units.py
@@ -225,7 +225,7 @@ class OrgUnitViewSet(viewsets.ViewSet):
                 is_field_referenced("instances_count", requested_fields, order),
             ]
         )
-        if with_shapes or as_location:
+        if with_shapes or as_location or parquet_format:
             count_instances = False
         count_per_form = csv_format or xlsx_format
         # add annotation(s) if needed

--- a/iaso/api/org_units.py
+++ b/iaso/api/org_units.py
@@ -98,15 +98,13 @@ class HasOrgUnitPermission(permissions.BasePermission):
 
 
 def is_field_referenced(field_name, requested_fields, order):
-        if not requested_fields:
-            return False
-        
-        fields_list = requested_fields.split(",")
-        return (
-            ":all" in fields_list 
-            or field_name in fields_list 
-            or field_name in order
-    )
+    if not requested_fields:
+        return False
+
+    fields_list = requested_fields.split(",")
+    return ":all" in fields_list or field_name in fields_list or field_name in order
+
+
 # noinspection PyMethodMayBeStatic
 class OrgUnitViewSet(viewsets.ViewSet):
     f"""Org units API
@@ -218,10 +216,12 @@ class OrgUnitViewSet(viewsets.ViewSet):
         order = request.query_params.get("order", "name").split(",")
         # Annotate number of instance per org unit to sort by it
         # order_by_instance_count = "instances_count" in order or "-instances_count" in order
-        count_instances = any([
-            is_export,
-            is_field_referenced("instances_count", requested_fields, order),
-        ])
+        count_instances = any(
+            [
+                is_export,
+                is_field_referenced("instances_count", requested_fields, order),
+            ]
+        )
         count_per_form = csv_format or xlsx_format
         # add annotation(s) if needed
         queryset = annotate_query(queryset, count_instances, count_per_form, forms)

--- a/iaso/api/org_units.py
+++ b/iaso/api/org_units.py
@@ -97,6 +97,16 @@ class HasOrgUnitPermission(permissions.BasePermission):
         return user_account.id in account_ids
 
 
+def is_field_referenced(field_name, requested_fields, order):
+        if not requested_fields:
+            return False
+        
+        fields_list = requested_fields.split(",")
+        return (
+            ":all" in fields_list 
+            or field_name in fields_list 
+            or field_name in order
+    )
 # noinspection PyMethodMayBeStatic
 class OrgUnitViewSet(viewsets.ViewSet):
     f"""Org units API
@@ -204,9 +214,14 @@ class OrgUnitViewSet(viewsets.ViewSet):
         if as_location:
             queryset = queryset.filter(Q(location__isnull=False) | Q(simplified_geom__isnull=False))
 
+        requested_fields = request.query_params.get("fields", None)
+        order = request.query_params.get("order", "name").split(",")
         # Annotate number of instance per org unit to sort by it
-        order_by_instance_count = "instances_count" in order or "-instances_count" in order
-        count_instances = order_by_instance_count or is_export
+        # order_by_instance_count = "instances_count" in order or "-instances_count" in order
+        count_instances = any([
+            is_export,
+            is_field_referenced("instances_count", requested_fields, order),
+        ])
         count_per_form = csv_format or xlsx_format
         # add annotation(s) if needed
         queryset = annotate_query(queryset, count_instances, count_per_form, forms)

--- a/iaso/api/org_units.py
+++ b/iaso/api/org_units.py
@@ -22,7 +22,7 @@ from rest_framework.response import Response
 
 from hat.api.export_utils import Echo, generate_xlsx, iter_items
 from hat.audit import models as audit_models
-from iaso.api.common import CONTENT_TYPE_CSV, CONTENT_TYPE_XLSX, safe_api_import
+from iaso.api.common import CONTENT_TYPE_CSV, CONTENT_TYPE_XLSX, is_field_referenced, safe_api_import
 from iaso.api.org_unit_search import annotate_query, build_org_units_queryset
 from iaso.api.permission_checks import AuthenticationEnforcedPermission
 from iaso.api.serializers import OrgUnitSearchSerializer, OrgUnitSmallSearchSerializer, OrgUnitTreeSearchSerializer
@@ -30,7 +30,6 @@ from iaso.exports import CleaningFileResponse, parquet
 from iaso.gpkg import org_units_to_gpkg_bytes
 from iaso.models import DataSource, Form, Group, Instance, InstanceFile, OrgUnit, OrgUnitType, Project, SourceVersion
 from iaso.models.microplanning import Assignment
-from iaso.api.common import is_field_referenced
 from iaso.permissions.core_permissions import (
     CORE_FORMS_PERMISSION,
     CORE_ORG_UNITS_PERMISSION,

--- a/iaso/api/org_units.py
+++ b/iaso/api/org_units.py
@@ -99,10 +99,17 @@ class HasOrgUnitPermission(permissions.BasePermission):
 
 def is_field_referenced(field_name, requested_fields, order):
     if not requested_fields:
-        return False
+        # no fields specified... do as if all fields are requested
+        return True
 
     fields_list = requested_fields.split(",")
-    return ":all" in fields_list or field_name in fields_list or field_name in order
+    return (
+        ":all" in fields_list
+        or field_name in fields_list
+        or field_name in order
+        or field_name in order
+        or f"-{field_name}" in order
+    )
 
 
 # noinspection PyMethodMayBeStatic
@@ -213,18 +220,11 @@ class OrgUnitViewSet(viewsets.ViewSet):
             queryset = queryset.filter(Q(location__isnull=False) | Q(simplified_geom__isnull=False))
 
         requested_fields = request.query_params.get("fields", None)
-        if requested_fields is None:
-            requested_fields = ",".join(OrgUnitSearchSerializer.Meta.default_fields)
+
         order = request.query_params.get("order", "name").split(",")
         # Annotate number of instance per org unit to sort by it
-        order_by_instance_count = "instances_count" in order or "-instances_count" in order
-        count_instances = any(
-            [
-                is_export,
-                order_by_instance_count,
-                is_field_referenced("instances_count", requested_fields, order),
-            ]
-        )
+        count_instances = is_export or is_field_referenced("instances_count", requested_fields, order)
+
         if with_shapes or as_location or parquet_format:
             count_instances = False
         count_per_form = csv_format or xlsx_format

--- a/iaso/api/org_units.py
+++ b/iaso/api/org_units.py
@@ -45,6 +45,7 @@ from ..plugins import is_polio_plugin_active
 from ..utils.models.common import get_creator_name, get_org_unit_parents_ref
 from .serializers import OrgUnitImportSerializer
 
+
 logger = logging.getLogger(__name__)
 
 # noinspection PyMethodMayBeStatic

--- a/iaso/api/org_units.py
+++ b/iaso/api/org_units.py
@@ -213,15 +213,20 @@ class OrgUnitViewSet(viewsets.ViewSet):
             queryset = queryset.filter(Q(location__isnull=False) | Q(simplified_geom__isnull=False))
 
         requested_fields = request.query_params.get("fields", None)
+        if requested_fields is None:
+            requested_fields = ",".join(OrgUnitSearchSerializer.Meta.default_fields)
         order = request.query_params.get("order", "name").split(",")
         # Annotate number of instance per org unit to sort by it
-        # order_by_instance_count = "instances_count" in order or "-instances_count" in order
+        order_by_instance_count = "instances_count" in order or "-instances_count" in order
         count_instances = any(
             [
                 is_export,
+                order_by_instance_count,
                 is_field_referenced("instances_count", requested_fields, order),
             ]
         )
+        if with_shapes or as_location:
+            count_instances = False
         count_per_form = csv_format or xlsx_format
         # add annotation(s) if needed
         queryset = annotate_query(queryset, count_instances, count_per_form, forms)
@@ -291,7 +296,11 @@ class OrgUnitViewSet(viewsets.ViewSet):
                 res = {
                     "count": paginator.count,
                     "counts": counts,
-                    "orgunits": serializer(page.object_list, many=True).data,
+                    "orgunits": serializer(
+                        page.object_list,
+                        many=True,
+                        context={"request": request},
+                    ).data,
                     "has_next": page.has_next(),
                     "has_previous": page.has_previous(),
                     "page": page_offset,

--- a/iaso/api/serializers.py
+++ b/iaso/api/serializers.py
@@ -3,7 +3,7 @@ from django.db.models import Q
 from rest_framework import serializers
 
 from hat.api.export_utils import timestamp_to_utc_datetime
-from iaso.api.common import TimestampField
+from iaso.api.common import DynamicFieldsModelSerializer, TimestampField
 from iaso.api.query_params import APP_ID
 from iaso.models import Group, OrgUnit, OrgUnitType
 from iaso.utils.serializer.three_dim_point_field import ThreeDimPointField
@@ -190,7 +190,7 @@ class OrgUnitDropdownSerializer(OrgUnitSerializer):
 
 
 # noinspection PyMethodMayBeStatic
-class OrgUnitSearchSerializer(OrgUnitSerializer):
+class OrgUnitSearchSerializer(OrgUnitSerializer, DynamicFieldsModelSerializer):
     parent = OrgUnitSearchParentSerializer()
     instances_count = serializers.SerializerMethodField()
     creator = serializers.SerializerMethodField()
@@ -231,6 +231,19 @@ class OrgUnitSearchSerializer(OrgUnitSerializer):
             "creator",
             "projects",
             "default_image",
+        ]
+
+        default_fields = [
+            "id",
+            "projects",
+            "name",
+            "org_unit_type_name",
+            "source",
+            "source_ref",
+            "instances_count",
+            "validation_status",
+            "created_at",
+            "updated_at",
         ]
 
 

--- a/iaso/tests/api/test_orgunits.py
+++ b/iaso/tests/api/test_orgunits.py
@@ -7,6 +7,7 @@ import typing
 from django.contrib.gis.geos import GEOSGeometry, MultiPolygon, Point, Polygon
 from django.db import connection
 from django.test import SimpleTestCase
+from django.test.utils import CaptureQueriesContext
 from rest_framework import status
 
 from hat.audit.models import Modification
@@ -16,6 +17,9 @@ from iaso.models import OrgUnit, OrgUnitType
 from iaso.permissions.core_permissions import CORE_ORG_UNITS_PERMISSION, CORE_ORG_UNITS_READ_PERMISSION
 from iaso.test import APITestCase
 from iaso.utils.gis import simplify_geom
+
+
+COUNT_INSTANCES = 'COUNT(DISTINCT "iaso_instance"."id")'.lower()
 
 
 class OrgUnitAPIUtilsTestCase(SimpleTestCase):
@@ -859,19 +863,26 @@ class OrgUnitAPITestCase(APITestCase):
         parent_instances_count = response_parent.json()["instances_count"]
         self.assertEqual(parent_instances_count, 2)
 
-    def test_org_unit_performance_optimization_no_instances(self):
+    def test_org_unit_performance_optimization_no_instance_count(self):
         """Test if instances_count is NOT queried when not in 'fields'"""
         self.client.force_authenticate(self.yoda)
 
         # Request without 'instances_count'
         url = "/api/orgunits/?fields=id,name,org_unit_type_name&limit=10"
 
-        response = self.client.get(url)
+        with CaptureQueriesContext(connection) as ctx:
+            response = self.client.get(url)
 
-        self.assertJSONResponse(response, 200)
-        data = response.json()["orgunits"]
+            self.assertJSONResponse(response, 200)
+            data = response.json()["orgunits"]
 
-        self.assertNotIn("instances_count", data[0])
+            self.assertNotIn("instances_count", data[0])
+
+        # Ensure none of the executed SQL queries contain the heavy computations
+        for q in ctx.captured_queries:
+            sql = q["sql"].lower()
+            self.assertNotIn(COUNT_INSTANCES, sql, f"Found unexpected query: {sql}")
+            self.assertNotIn("instances_count", sql, f"Found unexpected query: {sql}")
 
     def test_org_unit_requested_instances_count_success(self):
         """Verify that instances_count is correctly returned when requested"""
@@ -880,8 +891,21 @@ class OrgUnitAPITestCase(APITestCase):
         # Explicitly request instances_count
         url = "/api/orgunits/?fields=id,name,instances_count&limit=10&order=id"
 
-        response = self.client.get(url)
+        with CaptureQueriesContext(connection) as ctx:
+            response = self.client.get(url)
         self.assertJSONResponse(response, 200)
+
+        # Ensure none of the executed SQL queries contain the heavy computations
+        at_least_one_instances_count_query = False
+        for q in ctx.captured_queries:
+            sql = q["sql"].lower()
+            if COUNT_INSTANCES in sql:
+                at_least_one_instances_count_query = True
+
+        self.assertTrue(
+            at_least_one_instances_count_query,
+            "Expected at least one query with instances_count computation : " + COUNT_INSTANCES,
+        )
 
         corruscant = next(ou for ou in response.json()["orgunits"] if ou["id"] == self.jedi_council_corruscant.id)
 

--- a/iaso/tests/api/test_orgunits.py
+++ b/iaso/tests/api/test_orgunits.py
@@ -859,6 +859,36 @@ class OrgUnitAPITestCase(APITestCase):
         parent_instances_count = response_parent.json()["instances_count"]
         self.assertEqual(parent_instances_count, 2)
 
+    def test_org_unit_performance_optimization_no_instances(self):
+        """Test if instances_count is NOT queried when not in 'fields'"""
+        self.client.force_authenticate(self.yoda)
+
+        # Request without 'instances_count'
+        url = "/api/orgunits/?fields=id,name,org_unit_type_name&limit=10"
+
+        response = self.client.get(url)
+
+        self.assertJSONResponse(response, 200)
+        data = response.json()["orgunits"]
+
+        self.assertNotIn("instances_count", data[0])
+
+    def test_org_unit_requested_instances_count_success(self):
+        """Verify that instances_count is correctly returned when requested"""
+        self.client.force_authenticate(self.yoda)
+
+        # Explicitly request instances_count
+        url = "/api/orgunits/?fields=id,name,instances_count&limit=10&order=id"
+
+        response = self.client.get(url)
+        self.assertJSONResponse(response, 200)
+
+        corruscant = next(ou for ou in response.json()["orgunits"] if ou["id"] == self.jedi_council_corruscant.id)
+
+        # Corruscant has: 1 reference + 1 non-reference + 3 study instances = 5 total
+        self.assertIn("instances_count", corruscant)
+        self.assertEqual(corruscant["instances_count"], 5)
+
     def test_can_retrieve_org_units_in_csv_format(self):
         self.client.force_authenticate(self.yoda)
         response = self.client.get(
@@ -2475,7 +2505,7 @@ class OrgUnitAPITestCase(APITestCase):
 
         jedi_squad_endor_2_children.save()
 
-        with self.assertNumQueries(7):
+        with self.assertNumQueries(5):
             response = self.client.get(
                 f"/api/orgunits/?&parent_id={self.jedi_council_endor.pk}&limit=10&page=1&order=name&validation_status=all&onlyDirectChildren=true"
             )


### PR DESCRIPTION
## What problem is this PR solving?

This PR is about removing the 'Number of submissions' column from the default columns

### Related JIRA tickets

[IA-4600](https://bluesquare.atlassian.net/browse/IA-4600)

## Changes
- Implemented a helper in `iaso/api/org_units.py` to do the heavy calculation only when the `instances_count` field is  requested.
- Changed `/home/crebert/Desktop/iaso/hat/assets/js/apps/Iaso/domains/orgUnits/hooks/requests/useGetOrgUnits.ts` to handle the dynamic field selection.
- implemented the useOrgUnitsColumnSelectDrawer hook in `/home/crebert/Desktop/iaso/hat/assets/js/apps/Iaso/domains/orgUnits/hooks/useOrgUnitsColumnSelectDrawer.tsx` to handle the table columns
- Implemented the ColumnsSelectDrawer in `/home/crebert/Desktop/iaso/hat/assets/js/apps/Iaso/domains/orgUnits/components/TableList.tsx` to let the user select the columns with the `Number of submissions` columns disabled by default.
- Modified the BaseRouteConfig of orgUnits to let it handle the fields selection

## How to test

- Go to orgunits list
- You should see a `select visible columns` drawer with the Number of submissions column disabled by default

## Print screen / video


https://github.com/user-attachments/assets/c9833484-36d8-410d-977a-98f6b6233a13





## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).


[IA-4600]: https://bluesquare.atlassian.net/browse/IA-4600?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ