### PR TITLE
IA-4692: fix planning validation, delete assignments dialog, remove useless parameters

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/assignments/hooks/requests/useBulkDeleteAssignments.tsx
+++ b/hat/assets/js/apps/Iaso/domains/assignments/hooks/requests/useBulkDeleteAssignments.tsx
@@ -22,7 +22,7 @@ export const useBulkDeleteAssignments = (): UseMutationResult => {
     return useSnackMutation({
         mutationFn: ({ planning, user, team }) =>
             bulkDeleteAssignments({ planning, user, team }),
-        invalidateQueryKey: ['assignmentsList'],
+        invalidateQueryKey: ['assignmentsList', 'planningDetails'],
         snackSuccessMessage: MESSAGES.bulkDeleteAssignmentsSuccess,
     });
 };

--- a/hat/assets/js/apps/Iaso/domains/assignments/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/assignments/index.tsx
@@ -84,17 +84,6 @@ export const Assignments: FunctionComponent = () => {
                             <ChevronRight sx={{ fontSize: 40, px: 1 }} />
                             {planning.target_org_unit_type_details?.name}
                         </Typography>
-                        <Button
-                            variant="outlined"
-                            color="error"
-                            onClick={() => {
-                                deleteAssignments({ planning: planningId });
-                            }}
-                            startIcon={<DeleteIcon />}
-                            disabled={!assignments?.allAssignments?.length}
-                        >
-                            {formatMessage(MESSAGES.deleteAllAssignments)}
-                        </Button>
                         <DeleteDialog
                             iconColor="error"
                             titleMessage={MESSAGES.deleteAllAssignments}

--- a/hat/assets/js/apps/Iaso/domains/assignments/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/assignments/index.tsx
@@ -3,6 +3,7 @@ import ChevronRight from '@mui/icons-material/ChevronRight';
 import DeleteIcon from '@mui/icons-material/Delete';
 import { Box, Button, Grid, Typography } from '@mui/material';
 import { useSafeIntl, useGoBack } from 'bluesquare-components';
+import DeleteDialog from 'Iaso/components/dialogs/DeleteDialogComponent';
 import { MainWrapper } from 'Iaso/components/MainWrapper';
 import TopBar from '../../components/nav/TopBarComponent';
 import { baseUrls } from '../../constants/urls';
@@ -59,7 +60,7 @@ export const Assignments: FunctionComponent = () => {
         selectedUser,
         selectedTeam,
     });
-    const { mutateAsync: deleteAll } = useBulkDeleteAssignments();
+    const { mutateAsync: deleteAssignments } = useBulkDeleteAssignments();
 
     return (
         <>
@@ -87,13 +88,44 @@ export const Assignments: FunctionComponent = () => {
                             variant="outlined"
                             color="error"
                             onClick={() => {
-                                deleteAll({ planning: planningId });
+                                deleteAssignments({ planning: planningId });
                             }}
                             startIcon={<DeleteIcon />}
                             disabled={!assignments?.allAssignments?.length}
                         >
                             {formatMessage(MESSAGES.deleteAllAssignments)}
                         </Button>
+                        <DeleteDialog
+                            iconColor="error"
+                            titleMessage={MESSAGES.deleteAllAssignments}
+                            message={{
+                                ...MESSAGES.deleteAssignmentsWarning,
+                                values: {
+                                    count: planning?.assignments_count,
+                                },
+                            }}
+                            onConfirm={() =>
+                                deleteAssignments({ planning: planningId })
+                            }
+                            keyName="delete-all-assignments"
+                            Trigger={({ onClick }) => (
+                                <Button
+                                    variant="outlined"
+                                    color="error"
+                                    onClick={onClick}
+                                    disabled={planning.assignments_count === 0}
+                                    startIcon={<DeleteIcon />}
+                                    sx={{
+                                        marginRight: theme => theme.spacing(2),
+                                        whiteSpace: 'nowrap',
+                                    }}
+                                >
+                                    {formatMessage(
+                                        MESSAGES.deleteAllAssignments,
+                                    )}
+                                </Button>
+                            )}
+                        />
                     </Box>
                 )}
 

--- a/hat/assets/js/apps/Iaso/domains/assignments/messages.ts
+++ b/hat/assets/js/apps/Iaso/domains/assignments/messages.ts
@@ -122,6 +122,10 @@ const MESSAGES = defineMessages({
         defaultMessage: 'Delete all assignments',
         id: 'iaso.assignment.deleteAllAssignments',
     },
+    deleteAssignmentsWarning: {
+        id: 'iaso.assignment.deleteAssignmentsWarning',
+        defaultMessage: 'Are you sure you want to delete {count} assignments?',
+    },
 });
 
 export default MESSAGES;

--- a/hat/assets/js/apps/Iaso/domains/openHexa/components/Parameters.tsx
+++ b/hat/assets/js/apps/Iaso/domains/openHexa/components/Parameters.tsx
@@ -242,19 +242,9 @@ export const Parameters: React.FC<ParametersProps> = ({
         ],
     );
 
-    if (!parameters || parameters.length === 0) {
-        return (
-            <Box>
-                <Typography variant="body2" color="text.secondary">
-                    No parameters available
-                </Typography>
-            </Box>
-        );
-    }
-
     return (
         <Box>
-            {parameters.map(parameter => (
+            {parameters?.map(parameter => (
                 <Box key={parameter.code}>
                     {renderParameterInput(parameter)}
                 </Box>

--- a/hat/assets/js/apps/Iaso/domains/plannings/components/PlanningForm.tsx
+++ b/hat/assets/js/apps/Iaso/domains/plannings/components/PlanningForm.tsx
@@ -170,7 +170,9 @@ export const PlanningForm: FunctionComponent<Props> = ({
         formik.values.startDate &&
         moment().isAfter(moment(formik.values.startDate, 'DD/MM/YYYY'), 'day'),
     );
-    const isEditingDisabled = Boolean(isPublished || hasStarted);
+    const isEditingDisabled = Boolean(
+        (isPublished || hasStarted) && mode === 'edit',
+    );
     const {
         values,
         setFieldValue,
@@ -522,24 +524,52 @@ export const PlanningForm: FunctionComponent<Props> = ({
                                         </LinkButton>
                                         <Box
                                             display="flex"
-                                            justifyContent="space-between"
+                                            sx={{ flexWrap: 'nowrap' }}
                                         >
-                                            {canAssign && Boolean(planning) && (
-                                                <Button
-                                                    variant="outlined"
-                                                    color="error"
-                                                    onClick={deleteAssignments}
-                                                    startIcon={<DeleteIcon />}
-                                                    sx={{
-                                                        marginRight: theme =>
-                                                            theme.spacing(2),
+                                            {planning && Boolean(planning) && (
+                                                <DeleteDialog
+                                                    iconColor="error"
+                                                    titleMessage={
+                                                        MESSAGES.deleteAllAssignments
+                                                    }
+                                                    message={{
+                                                        ...MESSAGES.deleteAssignmentsWarning,
+                                                        values: {
+                                                            count: planning?.assignments_count,
+                                                        },
                                                     }}
-                                                    disabled={!planning}
-                                                >
-                                                    {formatMessage(
-                                                        MESSAGES.deleteAllAssignments,
+                                                    onConfirm={
+                                                        deleteAssignments
+                                                    }
+                                                    keyName="delete-all-assignments"
+                                                    Trigger={({ onClick }) => (
+                                                        <Button
+                                                            variant="outlined"
+                                                            color="error"
+                                                            onClick={onClick}
+                                                            disabled={
+                                                                planning.assignments_count ===
+                                                                0
+                                                            }
+                                                            startIcon={
+                                                                <DeleteIcon />
+                                                            }
+                                                            sx={{
+                                                                marginRight:
+                                                                    theme =>
+                                                                        theme.spacing(
+                                                                            2,
+                                                                        ),
+                                                                whiteSpace:
+                                                                    'nowrap',
+                                                            }}
+                                                        >
+                                                            {formatMessage(
+                                                                MESSAGES.deleteAllAssignments,
+                                                            )}
+                                                        </Button>
                                                     )}
-                                                </Button>
+                                                />
                                             )}
                                             <LinkButton
                                                 disabled={!canAssign}

--- a/hat/assets/js/apps/Iaso/domains/plannings/components/PlanningForm.tsx
+++ b/hat/assets/js/apps/Iaso/domains/plannings/components/PlanningForm.tsx
@@ -526,7 +526,7 @@ export const PlanningForm: FunctionComponent<Props> = ({
                                             display="flex"
                                             sx={{ flexWrap: 'nowrap' }}
                                         >
-                                            {planning && Boolean(planning) && (
+                                            {Boolean(planning) && (
                                                 <DeleteDialog
                                                     iconColor="error"
                                                     titleMessage={

--- a/hat/assets/js/apps/Iaso/domains/plannings/sampling/OpenhexaIntegrationDrawer.tsx
+++ b/hat/assets/js/apps/Iaso/domains/plannings/sampling/OpenhexaIntegrationDrawer.tsx
@@ -3,6 +3,7 @@ import React, {
     useCallback,
     useEffect,
     useState,
+    useMemo,
 } from 'react';
 import PlusIcon from '@mui/icons-material/Add';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
@@ -65,6 +66,16 @@ const styles: SxStyles = {
     },
 };
 
+const parametersToRemove = [
+    'task_id',
+    'pipeline_id',
+    'connection_host',
+    'connection_token',
+    'sampling_name',
+    'planning_id',
+    'version',
+];
+
 export const OpenhexaIntegrationDrawer: FunctionComponent<Props> = ({
     planning,
     disabled = false,
@@ -90,11 +101,7 @@ export const OpenhexaIntegrationDrawer: FunctionComponent<Props> = ({
     const { formatMessage } = useSafeIntl();
 
     const { data: pipeline, isFetching: isFetchingPipeline } =
-        useGetPipelineDetails(selectedPipelineId, [
-            'task_id',
-            'pipeline_id',
-            'planning_id',
-        ]);
+        useGetPipelineDetails(selectedPipelineId, parametersToRemove);
     const {
         mutate: launchTask,
         data: launchResult,
@@ -151,18 +158,15 @@ export const OpenhexaIntegrationDrawer: FunctionComponent<Props> = ({
             setIsSubmitting(false);
         }
     }, [isSubmitting, isLaunchingTask]);
+    const title = useMemo(() => {
+        if (disabled) return disabledMessage;
+        if (isCreateSamplingDisabled)
+            return formatMessage(MESSAGES.planningAlreadyPublished);
+        return undefined;
+    }, [disabled, disabledMessage, formatMessage, isCreateSamplingDisabled]);
     return (
         <>
-            <Tooltip
-                title={
-                    // eslint-disable-next-line no-nested-ternary
-                    disabled
-                        ? disabledMessage
-                        : isCreateSamplingDisabled
-                          ? formatMessage(MESSAGES.planningAlreadyPublished)
-                          : ''
-                }
-            >
+            <Tooltip title={title}>
                 <Box>
                     <Button
                         variant="outlined"

--- a/hat/assets/js/apps/Iaso/domains/plannings/types.ts
+++ b/hat/assets/js/apps/Iaso/domains/plannings/types.ts
@@ -49,6 +49,7 @@ export type Planning = {
     pipeline_uuids: string[];
     target_org_unit_type_details?: PlanningTargetOrgUnitTypeDetails | null;
     selected_sampling_result?: SamplingResult;
+    assignments_count: number;
 };
 export type PageMode = 'create' | 'edit' | 'copy';
 

--- a/iaso/api/microplanning/serializers.py
+++ b/iaso/api/microplanning/serializers.py
@@ -126,6 +126,8 @@ class PlanningWriteSerializer(serializers.ModelSerializer):
 
 
 class PlanningReadSerializer(serializers.ModelSerializer):
+    assignments_count = serializers.SerializerMethodField()
+
     class Meta:
         model = Planning
         fields = [
@@ -138,12 +140,16 @@ class PlanningReadSerializer(serializers.ModelSerializer):
             "ended_at",
             "pipeline_uuids",
             "selected_sampling_result",
+            "assignments_count",
             "team_details",
             "org_unit_details",
             "project_details",
             "target_org_unit_type_details",
         ]
         read_only_fields = fields
+
+    def get_assignments_count(self, obj):
+        return getattr(obj, "assignments_count", 0)
 
     selected_sampling_result = NestedPlanningSamplingResultSerializer(read_only=True)
     team_details = NestedTeamSerializer(source="team", read_only=True)

--- a/iaso/api/microplanning/views.py
+++ b/iaso/api/microplanning/views.py
@@ -1,4 +1,5 @@
 from django.db import transaction
+from django.db.models import Count, Q
 from django.utils import timezone
 from django.utils.translation import gettext as _
 from django_filters.rest_framework import DjangoFilterBackend  # type: ignore
@@ -116,6 +117,11 @@ class PlanningViewSet(AuditMixin, ModelViewSet):
             self.queryset.filter_for_user(user)
             .select_related("project", "org_unit", "team", "selected_sampling_result")
             .prefetch_related("forms")
+            .annotate(
+                assignments_count=Count(
+                    "assignment", filter=Q(assignment__deleted_at__isnull=True)
+                )
+            )
         )
 
     def _read_response(self, instance, status_code=status.HTTP_200_OK):

--- a/iaso/api/microplanning/views.py
+++ b/iaso/api/microplanning/views.py
@@ -117,11 +117,7 @@ class PlanningViewSet(AuditMixin, ModelViewSet):
             self.queryset.filter_for_user(user)
             .select_related("project", "org_unit", "team", "selected_sampling_result")
             .prefetch_related("forms")
-            .annotate(
-                assignments_count=Count(
-                    "assignment", filter=Q(assignment__deleted_at__isnull=True)
-                )
-            )
+            .annotate(assignments_count=Count("assignment", filter=Q(assignment__deleted_at__isnull=True)))
         )
 
     def _read_response(self, instance, status_code=status.HTTP_200_OK):

--- a/iaso/tests/api/microplanning/test_microplanning.py
+++ b/iaso/tests/api/microplanning/test_microplanning.py
@@ -99,6 +99,24 @@ class PlanningTestCase(APITestCase):
             r,
         )
 
+    def test_query_id_includes_assignments_count(self):
+        """Test that planning detail response includes assignments_count."""
+        self.client.force_authenticate(self.user)
+        # Planning has no assignments by default
+        response = self.client.get(f"/api/microplanning/plannings/{self.planning.id}/", format="json")
+        r = self.assertJSONResponse(response, 200)
+        self.assertIn("assignments_count", r)
+        self.assertEqual(r["assignments_count"], 0)
+
+        # Create assignments
+        Assignment.objects.create(planning=self.planning, user=self.user, org_unit=self.org_unit)
+        child_ou = OrgUnit.objects.create(version=self.org_unit.version, name="child", parent=self.org_unit)
+        Assignment.objects.create(planning=self.planning, user=self.user, org_unit=child_ou)
+
+        response = self.client.get(f"/api/microplanning/plannings/{self.planning.id}/", format="json")
+        r = self.assertJSONResponse(response, 200)
+        self.assertEqual(r["assignments_count"], 2)
+
     def test_serializer(self):
         user = User.objects.get(username="test")
         request = mock.Mock(user=user)

--- a/iaso/tests/api/microplanning/test_microplanning.py
+++ b/iaso/tests/api/microplanning/test_microplanning.py
@@ -94,6 +94,7 @@ class PlanningTestCase(APITestCase):
                 "pipeline_uuids": [],
                 "target_org_unit_type_details": None,
                 "selected_sampling_result": None,
+                "assignments_count": 0,
             },
             r,
         )

--- a/iaso/tests/api/microplanning/test_serializers.py
+++ b/iaso/tests/api/microplanning/test_serializers.py
@@ -36,6 +36,7 @@ class PlanningSerializersTestCase(PlanningSerializersTestBase):
                     "group_id": None,
                     "task_id": None,
                 },
+                "assignments_count": 0,
                 "team_details": {
                     "id": self.team_1.id,
                     "name": self.team_1.name,


### PR DESCRIPTION
## What problem is this PR solving?

- while creating a planning dates should not block the creations

https://github.com/user-attachments/assets/e60c2ad6-4239-4926-afdf-91ee680e1601

- we need a validation dialog to delete assignments
- we need to ignore some more parameter such as connection_host, connection_token has filled up automatically 

### Related JIRA tickets

IA-4692

## Changes

- adding a dialog to confirm delete assignments, 
- added assignments_count to planning details on api
- disable date check while creating a planning
- remove automatic parameters

## How to test

- create a planning , make sure you can edit the planning if you choose a starting date in the past
- save the planning
- make sure you cannot click on delete assignments while no assignments are done
- publish the planning, go to assignments and assign some org unit. make sure you have a dialog to confirm assignments deletion



