### PR TITLE
IA-4796 IA-4802 plannings fixes

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/assignments/components/AssignmentsMap.tsx
+++ b/hat/assets/js/apps/Iaso/domains/assignments/components/AssignmentsMap.tsx
@@ -24,6 +24,7 @@ import {
     useGetPlanningOrgUnitsChildren,
     useGetPlanningOrgUnitsRoot,
 } from '../../teams/hooks/requests/useGetPlanningOrgUnits';
+import { parentColor } from '../constants/colors';
 import { AssignmentsResult } from '../hooks/requests/useGetAssignments';
 
 type Props = {
@@ -79,7 +80,46 @@ export const AssignmentsMap: FunctionComponent<Props> = ({
     const [currentTile, setCurrentTile] = useState<Tile>(tiles.osm);
 
     const getAssignmentColor = useGetAssignmentColor(assignments, rootTeam);
+    const unassignedGeoJson = useMemo(() => {
+        return childrenOrgUnits?.filter(
+            ou =>
+                ou.has_geo_json &&
+                ou.org_unit_type_id ===
+                    planning?.target_org_unit_type_details?.id &&
+                !assignments?.allAssignments?.find(
+                    assignment => assignment.org_unit === ou.id,
+                ),
+        );
+    }, [
+        childrenOrgUnits,
+        planning?.target_org_unit_type_details?.id,
+        assignments?.allAssignments,
+    ]);
 
+    const assignedGeoJson = useMemo(() => {
+        return childrenOrgUnits?.filter(
+            ou =>
+                ou.has_geo_json &&
+                ou.org_unit_type_id ===
+                    planning?.target_org_unit_type_details?.id &&
+                assignments?.allAssignments?.find(
+                    assignment => assignment.org_unit === ou.id,
+                ),
+        );
+    }, [
+        childrenOrgUnits,
+        planning?.target_org_unit_type_details?.id,
+        assignments?.allAssignments,
+    ]);
+
+    const parentGeoJson = useMemo(() => {
+        return childrenOrgUnits?.filter(
+            ou =>
+                ou.has_geo_json &&
+                ou.org_unit_type_id !==
+                    planning?.target_org_unit_type_details?.id,
+        );
+    }, [childrenOrgUnits, planning?.target_org_unit_type_details?.id]);
     const isLoading =
         isLoadingChildrenOrgUnits ||
         isLoadingRootTeam ||
@@ -116,70 +156,72 @@ export const AssignmentsMap: FunctionComponent<Props> = ({
                         <GeoJSON
                             key={rootOrgUnit?.id}
                             data={rootOrgUnit.geo_json}
-                        />
+                        >
+                            <MapToolTip
+                                pane="popupPane"
+                                label={rootOrgUnit.name}
+                            />
+                        </GeoJSON>
                     </Pane>
                 )}
+                <Pane name="org-units-shapes-parent" style={{ zIndex: 201 }}>
+                    {parentGeoJson?.map(ou => (
+                        <GeoJSON
+                            key={ou.id}
+                            data={ou.geo_json}
+                            style={{
+                                color: parentColor,
+                                fillOpacity: 0.3,
+                                fillColor: parentColor,
+                            }}
+                        >
+                            <MapToolTip pane="popupPane" label={ou.name} />
+                        </GeoJSON>
+                    ))}
+                </Pane>
                 <Pane
                     name="target-org-units-shapes-unassigned"
-                    style={{ zIndex: 201 }}
+                    style={{ zIndex: 202 }}
                 >
-                    {childrenOrgUnits
-                        ?.filter(
-                            ou =>
-                                ou.has_geo_json &&
-                                !assignments?.allAssignments?.find(
-                                    assignment => assignment.org_unit === ou.id,
-                                ),
-                        )
-                        .map(ou => (
-                            <GeoJSON
-                                key={ou.id}
-                                eventHandlers={{
-                                    click: () =>
-                                        canAssign &&
-                                        handleSaveAssignment(ou.id),
-                                }}
-                                data={ou.geo_json}
-                                style={{
-                                    color: getAssignmentColor(ou.id),
-                                    fillOpacity: 0.3,
-                                    fillColor: getAssignmentColor(ou.id),
-                                }}
-                            >
-                                <MapToolTip pane="popupPane" label={ou.name} />
-                            </GeoJSON>
-                        ))}
+                    {unassignedGeoJson?.map(ou => (
+                        <GeoJSON
+                            key={ou.id}
+                            eventHandlers={{
+                                click: () =>
+                                    canAssign && handleSaveAssignment(ou.id),
+                            }}
+                            data={ou.geo_json}
+                            style={{
+                                color: getAssignmentColor(ou.id),
+                                fillOpacity: 0.3,
+                                fillColor: getAssignmentColor(ou.id),
+                            }}
+                        >
+                            <MapToolTip pane="popupPane" label={ou.name} />
+                        </GeoJSON>
+                    ))}
                 </Pane>
                 <Pane
                     name="target-org-units-shapes-assigned"
-                    style={{ zIndex: 201 }}
+                    style={{ zIndex: 203 }}
                 >
-                    {childrenOrgUnits
-                        ?.filter(
-                            ou =>
-                                ou.has_geo_json &&
-                                assignments?.allAssignments?.find(
-                                    assignment => assignment.org_unit === ou.id,
-                                ),
-                        )
-                        .map(ou => (
-                            <GeoJSON
-                                key={ou.id}
-                                eventHandlers={{
-                                    click: () =>
-                                        canAssign &&
-                                        handleSaveAssignment(ou.id),
-                                }}
-                                data={ou.geo_json}
-                                style={{
-                                    color: getAssignmentColor(ou.id),
-                                    fillOpacity: 0.8,
-                                    fillColor: getAssignmentColor(ou.id),
-                                }}
-                            >
-                                <MapToolTip pane="popupPane" label={ou.name} />
-                            </GeoJSON>
-                        ))}
+                    {assignedGeoJson?.map(ou => (
+                        <GeoJSON
+                            key={ou.id}
+                            eventHandlers={{
+                                click: () =>
+                                    canAssign && handleSaveAssignment(ou.id),
+                            }}
+                            data={ou.geo_json}
+                            style={{
+                                color: getAssignmentColor(ou.id),
+                                fillOpacity: 0.8,
+                                fillColor: getAssignmentColor(ou.id),
+                            }}
+                        >
+                            <MapToolTip pane="popupPane" label={ou.name} />
+                        </GeoJSON>
+                    ))}
                 </Pane>
                 <Pane name="target-org-units-locations" style={{ zIndex: 202 }}>
                     {childrenOrgUnits

--- a/hat/assets/js/apps/Iaso/domains/assignments/components/teams/TeamTable.tsx
+++ b/hat/assets/js/apps/Iaso/domains/assignments/components/teams/TeamTable.tsx
@@ -7,6 +7,7 @@ import {
     TableHead,
     TableRow,
     Typography,
+    Box,
 } from '@mui/material';
 import { useSafeIntl, LoadingSpinner } from 'bluesquare-components';
 import MESSAGES from 'Iaso/domains/assignments/messages';
@@ -14,11 +15,27 @@ import { useSaveTeam } from 'Iaso/domains/teams/hooks/requests/useSaveTeam';
 import { SubTeam, Team } from 'Iaso/domains/teams/types/team';
 import { User } from 'Iaso/domains/teams/types/team';
 import { useSaveProfileColor } from 'Iaso/domains/users/hooks/useSaveProfile';
+import { SxStyles } from 'Iaso/types/general';
 import getDisplayName from 'Iaso/utils/usersUtils';
 import { AssignmentsResult } from '../../hooks/requests/useGetAssignments';
 import { AssigneeRow } from './AssigneeRow';
 
 const defaultHeight = '80vh';
+
+const styles: SxStyles = {
+    paper: {
+        height: defaultHeight,
+    },
+    title: {
+        pt: theme => theme.spacing(2),
+        pl: theme => theme.spacing(2),
+    },
+    tableContainer: {
+        maxHeight: '75vh',
+        overflow: 'auto',
+        scrollbarWidth: 'thin',
+    },
+};
 
 type Props = {
     rootTeam?: Team;
@@ -68,94 +85,105 @@ export const TeamTable: FunctionComponent<Props> = ({
     );
     return (
         <>
-            <Paper sx={{ height: defaultHeight }}>
+            <Paper sx={styles.paper}>
                 {isLoadingRootTeam && (
                     <LoadingSpinner fixed={false} transparent absolute />
                 )}
                 {rootTeam && (
                     <>
-                        <Typography variant="h6">{rootTeam?.name}</Typography>
-                        <Table size="small">
-                            <TableHead>
-                                <TableRow>
-                                    <TableCell
-                                        sx={{
-                                            width: 50,
-                                        }}
-                                    >
-                                        {formatMessage(MESSAGES.selection)}
-                                    </TableCell>
-                                    <TableCell
-                                        sx={{
-                                            width: 50,
-                                        }}
-                                    >
-                                        {formatMessage(MESSAGES.color)}
-                                    </TableCell>
-                                    <TableCell>
-                                        {formatMessage(MESSAGES.name)}
-                                    </TableCell>
-                                    <TableCell>
-                                        {formatMessage(
-                                            MESSAGES.assignationsCount,
-                                        )}
-                                    </TableCell>
-                                    <TableCell />
-                                </TableRow>
-                            </TableHead>
-                            <TableBody>
-                                {rootTeam?.sub_teams_details.map(subTeam => (
-                                    <AssigneeRow
-                                        key={subTeam.id}
-                                        isActive={
-                                            selectedTeam?.id === subTeam.id
-                                        }
-                                        setSelectedRow={() =>
-                                            setSelectedTeam(subTeam)
-                                        }
-                                        currentColor={subTeam?.color}
-                                        displayName={subTeam?.name}
-                                        count={countTeams(subTeam)}
-                                        onColorChange={color => {
-                                            updateTeam({
-                                                id: subTeam.id,
-                                                color,
-                                            });
-                                        }}
-                                        team={subTeam}
-                                        planningId={planningId}
-                                    />
-                                ))}
-                                {rootTeam?.users_details
-                                    .sort((a, b) =>
-                                        a.username.localeCompare(b.username),
-                                    )
-                                    .map(user => (
-                                        <AssigneeRow
-                                            key={user.id}
-                                            isActive={
-                                                selectedUser?.id === user.id
-                                            }
-                                            setSelectedRow={() =>
-                                                setSelectedUser(user)
-                                            }
-                                            currentColor={user?.color}
-                                            count={assignmentsCountForUser(
-                                                user,
-                                            )}
-                                            onColorChange={color => {
-                                                updateUser({
-                                                    id: user.iaso_profile_id,
-                                                    color,
-                                                });
+                        <Typography sx={styles.title} variant="h6">
+                            {rootTeam?.name}
+                        </Typography>
+                        <Box sx={styles.tableContainer}>
+                            <Table size="small">
+                                <TableHead>
+                                    <TableRow>
+                                        <TableCell
+                                            sx={{
+                                                width: 50,
                                             }}
-                                            user={user}
-                                            displayName={getDisplayName(user)}
-                                            planningId={planningId}
-                                        />
-                                    ))}
-                            </TableBody>
-                        </Table>
+                                        >
+                                            {formatMessage(MESSAGES.selection)}
+                                        </TableCell>
+                                        <TableCell
+                                            sx={{
+                                                width: 50,
+                                            }}
+                                        >
+                                            {formatMessage(MESSAGES.color)}
+                                        </TableCell>
+                                        <TableCell>
+                                            {formatMessage(MESSAGES.name)}
+                                        </TableCell>
+                                        <TableCell>
+                                            {formatMessage(
+                                                MESSAGES.assignationsCount,
+                                            )}
+                                        </TableCell>
+                                        <TableCell />
+                                    </TableRow>
+                                </TableHead>
+                                <TableBody>
+                                    {rootTeam?.sub_teams_details.map(
+                                        subTeam => (
+                                            <AssigneeRow
+                                                key={subTeam.id}
+                                                isActive={
+                                                    selectedTeam?.id ===
+                                                    subTeam.id
+                                                }
+                                                setSelectedRow={() =>
+                                                    setSelectedTeam(subTeam)
+                                                }
+                                                currentColor={subTeam?.color}
+                                                displayName={subTeam?.name}
+                                                count={countTeams(subTeam)}
+                                                onColorChange={color => {
+                                                    updateTeam({
+                                                        id: subTeam.id,
+                                                        color,
+                                                    });
+                                                }}
+                                                team={subTeam}
+                                                planningId={planningId}
+                                            />
+                                        ),
+                                    )}
+                                    {rootTeam?.users_details
+                                        .sort((a, b) =>
+                                            a.username.localeCompare(
+                                                b.username,
+                                            ),
+                                        )
+                                        .map(user => (
+                                            <AssigneeRow
+                                                key={user.id}
+                                                isActive={
+                                                    selectedUser?.id === user.id
+                                                }
+                                                setSelectedRow={() =>
+                                                    setSelectedUser(user)
+                                                }
+                                                currentColor={user?.color}
+                                                count={assignmentsCountForUser(
+                                                    user,
+                                                )}
+                                                onColorChange={color => {
+                                                    updateUser({
+                                                        id: user.iaso_profile_id,
+                                                        color,
+                                                    });
+                                                }}
+                                                user={user}
+                                                displayName={getDisplayName(
+                                                    user,
+                                                )}
+                                                planningId={planningId}
+                                            />
+                                        ))}
+                                </TableBody>
+                            </Table>
+                        </Box>
                     </>
                 )}
             </Paper>

--- a/hat/assets/js/apps/Iaso/domains/assignments/hooks/requests/useSaveAssignment.ts
+++ b/hat/assets/js/apps/Iaso/domains/assignments/hooks/requests/useSaveAssignment.ts
@@ -44,6 +44,7 @@ export const useSaveAssignment = ({
     const onSuccess = () => {
         queryClient.invalidateQueries('orgUnits');
         queryClient.invalidateQueries('assignmentsList');
+        queryClient.invalidateQueries('planningDetails');
         queryClient.invalidateQueries('orgUnitsList');
     };
     const mutation = useSnackMutation<unknown, unknown, SaveAssignmentQuery>({

--- a/hat/assets/js/apps/Iaso/domains/plannings/components/ActionsCell.tsx
+++ b/hat/assets/js/apps/Iaso/domains/plannings/components/ActionsCell.tsx
@@ -2,6 +2,7 @@ import React, { FunctionComponent } from 'react';
 import { Assignment } from '@mui/icons-material';
 import FileCopyIcon from '@mui/icons-material/FileCopy';
 import { IconButton as IconButtonComponent } from 'bluesquare-components';
+import moment from 'moment';
 import DeleteDialog from 'Iaso/components/dialogs/DeleteDialogComponent';
 import { DisplayIfUserHasPerm } from 'Iaso/components/DisplayIfUserHasPerm';
 import { baseUrls } from 'Iaso/constants/urls';
@@ -20,6 +21,11 @@ export const ActionsCell: FunctionComponent<ActionsCellProps> = ({
     deletePlanning,
 }) => {
     const canAssign = canAssignPlanning(planning);
+    const hasStarted = Boolean(
+        planning.started_at &&
+        moment().isAfter(moment(planning.started_at, 'DD/MM/YYYY'), 'day'),
+    );
+    const cannotDelete = Boolean(planning.published_at || hasStarted);
     return (
         <>
             <DisplayIfUserHasPerm permissions={[PLANNING_WRITE]}>
@@ -60,7 +66,7 @@ export const ActionsCell: FunctionComponent<ActionsCellProps> = ({
                             name: planning.name,
                         },
                     }}
-                    disabled={false}
+                    disabled={cannotDelete}
                     onConfirm={() => deletePlanning(planning.id)}
                     keyName="delete-planning"
                 />

--- a/hat/assets/js/apps/Iaso/domains/plannings/components/PlanningForm.tsx
+++ b/hat/assets/js/apps/Iaso/domains/plannings/components/PlanningForm.tsx
@@ -548,7 +548,7 @@ export const PlanningForm: FunctionComponent<Props> = ({
                                                             color="error"
                                                             onClick={onClick}
                                                             disabled={
-                                                                planning.assignments_count ===
+                                                                planning?.assignments_count ===
                                                                 0
                                                             }
                                                             startIcon={

--- a/hat/assets/js/apps/Iaso/domains/plannings/config.tsx
+++ b/hat/assets/js/apps/Iaso/domains/plannings/config.tsx
@@ -24,12 +24,10 @@ import { Planning, SamplingResult } from './types';
 
 type Props = {
     samplingResult: SamplingResult;
-    planning: Planning;
 };
 
-const ActionCell: FunctionComponent<Props> = ({ samplingResult, planning }) => {
+const ActionCell: FunctionComponent<Props> = ({ samplingResult }) => {
     const { data: colors } = useGetColors(true);
-    const greenColor = getColor(31, colors).replace('#', '');
     const purpleColor = getColor(3, colors).replace('#', '');
     const urlParams: Record<string, any> = useMemo(
         () => ({
@@ -44,19 +42,12 @@ const ActionCell: FunctionComponent<Props> = ({ samplingResult, planning }) => {
             searches: encodeUriSearches([
                 {
                     validation_status: 'VALID',
-                    color: greenColor,
-                    levels: `${planning.org_unit_details?.id}`,
-                    orgUnitTypeId: `${planning.target_org_unit_type_details?.id}`,
-                },
-                {
-                    validation_status: 'VALID',
                     color: purpleColor,
                     group: `${samplingResult.group_id}`,
-                    orgUnitTypeId: `${planning.target_org_unit_type_details?.id}`,
                 },
             ]),
         }),
-        [greenColor, purpleColor, planning, samplingResult],
+        [purpleColor, samplingResult],
     );
 
     return (
@@ -200,10 +191,7 @@ export const useSamplingResultsColumns = (
                 accessor: 'actions',
                 sortable: false,
                 Cell: settings => (
-                    <ActionCell
-                        samplingResult={settings.row.original}
-                        planning={planning}
-                    />
+                    <ActionCell samplingResult={settings.row.original} />
                 ),
             },
             {

--- a/hat/assets/js/apps/Iaso/domains/plannings/sampling/OpenhexaIntegrationDrawer.tsx
+++ b/hat/assets/js/apps/Iaso/domains/plannings/sampling/OpenhexaIntegrationDrawer.tsx
@@ -73,7 +73,6 @@ const parametersToRemove = [
     'connection_token',
     'sampling_name',
     'planning_id',
-    'version',
 ];
 
 export const OpenhexaIntegrationDrawer: FunctionComponent<Props> = ({
@@ -283,7 +282,7 @@ export const OpenhexaIntegrationDrawer: FunctionComponent<Props> = ({
                                 setAllowConfirm={setAllowConfirm}
                                 orgunitTypes={orgunitTypes}
                                 isFetchingOrgunitTypes={isFetchingOrgunitTypes}
-                                taskStatus={taskStatus}
+                                taskStatus={taskStatus ?? 'QUEUED'}
                                 taskId={taskId}
                             />
                         </Box>

--- a/hat/assets/js/apps/Iaso/domains/plannings/sampling/components/PipelineSelect.tsx
+++ b/hat/assets/js/apps/Iaso/domains/plannings/sampling/components/PipelineSelect.tsx
@@ -1,6 +1,7 @@
 import React, { FunctionComponent, useCallback, useMemo } from 'react';
 import { Box, Typography } from '@mui/material';
 import { useSafeIntl } from 'bluesquare-components';
+import { useQueryClient } from 'react-query';
 import InputComponent from 'Iaso/components/forms/InputComponent';
 import { Parameters } from 'Iaso/domains/openHexa/components/Parameters';
 import { useGetPipelineConfig } from 'Iaso/domains/openHexa/hooks/useGetPipelineConfig';
@@ -14,6 +15,7 @@ import { OrgUnitTypeHierarchyDropdownValues } from 'Iaso/domains/orgUnits/orgUni
 import { LQASForm } from 'Iaso/domains/plannings/sampling/customForms/LQASForm';
 
 import { Planning } from 'Iaso/domains/plannings/types';
+import { useGetTaskDetails } from 'Iaso/domains/tasks/hooks/useGetTasks';
 import { TaskStatus } from 'Iaso/domains/tasks/types';
 import MESSAGES from '../../messages';
 
@@ -68,6 +70,17 @@ export const PipelineSelect: FunctionComponent<Props> = ({
         [setParameterValues],
     );
 
+    const queryClient = useQueryClient();
+    useGetTaskDetails(
+        taskStatus === 'SUCCESS' ? taskId : undefined,
+        false,
+        data => {
+            if (data.result?.group_id) {
+                queryClient.invalidateQueries('planningSamplingResults');
+            }
+        },
+    );
+
     return (
         <Box>
             <InputComponent
@@ -106,8 +119,6 @@ export const PipelineSelect: FunctionComponent<Props> = ({
                             handleParameterChange={handleParameterChange}
                             orgunitTypes={orgunitTypes}
                             isFetchingOrgunitTypes={isFetchingOrgunitTypes}
-                            taskStatus={taskStatus ?? 'QUEUED'}
-                            taskId={taskId}
                         />
                     )}
                     {pipeline.code !== lQAS_code && (

--- a/hat/assets/js/apps/Iaso/domains/plannings/sampling/customForms/LQASForm.tsx
+++ b/hat/assets/js/apps/Iaso/domains/plannings/sampling/customForms/LQASForm.tsx
@@ -9,10 +9,8 @@ import PlusIcon from '@mui/icons-material/Add';
 import { Box, Button, Paper } from '@mui/material';
 import { grey } from '@mui/material/colors';
 import { useSafeIntl } from 'bluesquare-components';
-import { useQueryClient } from 'react-query';
 import { OrgUnitTypeHierarchyDropdownValues } from 'Iaso/domains/orgUnits/orgUnitTypes/hooks/useGetOrgUnitTypesHierarchy';
 import { Planning } from 'Iaso/domains/plannings/types';
-import { useGetTaskDetails } from 'Iaso/domains/tasks/hooks/useGetTasks';
 import { SxStyles } from 'Iaso/types/general';
 import {
     addToArray,
@@ -21,7 +19,7 @@ import {
 } from 'Iaso/utils/arrays';
 import MESSAGES from '../../messages';
 
-import { Criteria, TaskStatus } from '../types';
+import { Criteria } from '../types';
 import { Level } from './Level';
 
 const styles: SxStyles = {
@@ -62,8 +60,6 @@ type Props = {
     handleParameterChange: (parameterName: string, value: any) => void;
     orgunitTypes: OrgUnitTypeHierarchyDropdownValues;
     isFetchingOrgunitTypes: boolean;
-    taskStatus: TaskStatus;
-    taskId?: number;
 };
 
 export const LQASForm: FunctionComponent<Props> = ({
@@ -73,8 +69,6 @@ export const LQASForm: FunctionComponent<Props> = ({
     handleParameterChange,
     orgunitTypes,
     isFetchingOrgunitTypes,
-    taskStatus,
-    taskId,
 }) => {
     const { formatMessage } = useSafeIntl();
     const [expandedLevels, setExpandedLevels] = useState<boolean[]>([false]);
@@ -167,18 +161,6 @@ export const LQASForm: FunctionComponent<Props> = ({
         },
         [update],
     );
-
-    const queryClient = useQueryClient();
-    useGetTaskDetails(
-        taskStatus === 'SUCCESS' ? taskId : undefined,
-        false,
-        data => {
-            if (data.result?.group_id) {
-                queryClient.invalidateQueries('planningSamplingResults');
-            }
-        },
-    );
-
     // Memoized values
     const levels = useMemo(() => {
         const orgunitTypeIds =
@@ -235,6 +217,7 @@ export const LQASForm: FunctionComponent<Props> = ({
         canAddLevel,
         planning.target_org_unit_type_details?.id,
         latestOptions?.value,
+        planning.target_org_unit_type_details,
     ]);
 
     return (

--- a/hat/assets/js/apps/Iaso/domains/plannings/types.ts
+++ b/hat/assets/js/apps/Iaso/domains/plannings/types.ts
@@ -100,4 +100,5 @@ export type PlanningOrgUnits = {
     has_geo_json: boolean;
     latitude: number;
     longitude: number;
+    org_unit_type_id: number;
 };

--- a/iaso/api/microplanning/serializers.py
+++ b/iaso/api/microplanning/serializers.py
@@ -445,8 +445,8 @@ class PlanningOrgUnitSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = OrgUnit
-        fields = ["id", "name", "geo_json", "has_geo_json", "latitude", "longitude"]
-        read_only_fields = ["id", "name", "geo_json", "has_geo_json", "latitude", "longitude"]
+        fields = ["id", "name", "geo_json", "has_geo_json", "latitude", "longitude", "org_unit_type_id"]
+        read_only_fields = ["id", "name", "geo_json", "has_geo_json", "latitude", "longitude", "org_unit_type_id"]
 
     def get_geo_json(self, org_unit: OrgUnit):
         if not self.get_has_geo_json(org_unit):

--- a/iaso/api/microplanning/serializers.py
+++ b/iaso/api/microplanning/serializers.py
@@ -290,9 +290,7 @@ class AssignmentSerializer(serializers.ModelSerializer):
         users_in_account = User.objects.filter(iaso_profile__account=account)
 
         self.fields["user"].queryset = users_in_account
-        self.fields["planning"].queryset = (
-            Planning.objects.filter_for_user(user).select_related("org_unit")
-        )
+        self.fields["planning"].queryset = Planning.objects.filter_for_user(user).select_related("org_unit")
         self.fields["team"].queryset = Team.objects.filter_for_user(user)
         self.fields["org_unit"].queryset = OrgUnit.objects.filter_for_user_and_app_id(user, None)
 

--- a/iaso/api/microplanning/serializers.py
+++ b/iaso/api/microplanning/serializers.py
@@ -290,7 +290,9 @@ class AssignmentSerializer(serializers.ModelSerializer):
         users_in_account = User.objects.filter(iaso_profile__account=account)
 
         self.fields["user"].queryset = users_in_account
-        self.fields["planning"].queryset = Planning.objects.filter_for_user(user)
+        self.fields["planning"].queryset = (
+            Planning.objects.filter_for_user(user).select_related("org_unit")
+        )
         self.fields["team"].queryset = Team.objects.filter_for_user(user)
         self.fields["org_unit"].queryset = OrgUnit.objects.filter_for_user_and_app_id(user, None)
 
@@ -317,7 +319,7 @@ class AssignmentSerializer(serializers.ModelSerializer):
 
         org_units_available: OrgUnitQuerySet = self.fields["org_unit"].queryset
         org_units_available = org_units_available.descendants(planning.org_unit)
-        if org_unit not in org_units_available:
+        if not org_units_available.filter(pk=org_unit.pk).exists():
             raise serializers.ValidationError({"org_unit": "OrgUnit is not in planning scope"})
         # TODO More complex check possible:
         # - Team or user should be under the root planning team

--- a/iaso/tests/api/microplanning/test_serializers.py
+++ b/iaso/tests/api/microplanning/test_serializers.py
@@ -99,6 +99,7 @@ class PlanningSerializersTestCase(PlanningSerializersTestBase):
         self.assertEqual(feature["id"], self.org_unit_parent.id)
         self.assertEqual(feature["geometry"], org_unit.geo_json)
         self.assertTrue(serializer.data["has_geo_json"])
+        self.assertEqual(serializer.data["org_unit_type_id"], self.org_unit_type_parent.id)
 
     def test_planning_org_unit_serializer_without_geo_json(self):
         self.org_unit_parent.simplified_geom = None
@@ -109,6 +110,7 @@ class PlanningSerializersTestCase(PlanningSerializersTestBase):
 
         self.assertIsNone(serializer.data["geo_json"])
         self.assertFalse(serializer.data["has_geo_json"])
+        self.assertEqual(serializer.data["org_unit_type_id"], self.org_unit_type_parent.id)
 
 
 class AssignmentSerializesTestCase(PlanningSerializersTestBase):


### PR DESCRIPTION
## What problem is this PR solving?

- Improve assignments POST, can take 20 secs on prod
- Improve org unit visualization from sampling, only display sampling result, remove all options possible
- Refresh samplings is not working while task / pipeline is finished
- Disable buttons on planning list view
- Team list overflow
<img width="1920" height="911" alt="image" src="https://github.com/user-attachments/assets/a52e1322-f2d4-4487-ad4c-8f3d8c9294f5" />


### Related JIRA tickets

IA-4796, IA-4802

## Changes

- added a container on team table to force overflow
- adapt planning list button to disable delete if published or ongoing
- improve POST when saving assignment
- moved up hook to invalidate samplings
- remove the first tab on visualization of the sampling

## How to test
Take a unpublished planning, run a sampling with a pipeline, make sur table is refreshing. 
Click on the eye of a sampling, it should open org unit search with only one tab displaying result of the sampling. 
Publish the planning, delete button should be disable on list view
Open assignments for it. try to assign a user, it should take less than 300ms

For the team list on assignments page you need to assign a huge team (lot's of children) to a planning.

