### PR TITLE
[SNT-293] integrate DATABASES from plugin_settings.py

### DIFF
--- a/hat/settings.py
+++ b/hat/settings.py
@@ -822,6 +822,9 @@ for plugin_name in PLUGINS:
         if hasattr(plugin_settings, "WEBPACK_LOADER"):
             WEBPACK_LOADER |= plugin_settings.WEBPACK_LOADER
 
+        if hasattr(plugin_settings, "DATABASES"):
+            DATABASES.update(plugin_settings.DATABASES)
+
     except ModuleNotFoundError:  # Use "basic" plugin system if no settings file found
         print(
             f"\tno plugin_settings.py file found for plugin {plugin_name}, appending plugins.{plugin_name} to INSTALLED_APPS"


### PR DESCRIPTION
## What problem is this PR solving?

Pulls DATABASES from plugin_settings. Allows any plugin do define its own (additional) databases. 

### Related JIRA tickets

SNT-293

## Changes

This change integrates the DATABASES configuration block from plugin_settings, so plugins can define their own databases. This is needed in SNT where we integrate with multiple PostgreSQL databases through unmanaged Django ORM models.