### PR TITLE
WC2-875: Fix issue with the duplication clean up script

### DIFF
--- a/iaso/management/commands/clean_up_duplicate_submissions.py
+++ b/iaso/management/commands/clean_up_duplicate_submissions.py
@@ -136,7 +136,8 @@ class Command(BaseCommand):
             else:
                 self.stdout.write(f"{index}. Duplicate with uuid '{duplicate['uuid']}' has no content.")
                 # It doesn't matter which ones we delete, so let's keep the most recent one.
-                self._delete_instances(uuid=duplicate["uuid"], file_name=None, first_id=has_content.first().id)
+                first = Instance.objects.filter(uuid=duplicate["uuid"]).order_by("-created_at").first()
+                self._delete_instances(uuid=duplicate["uuid"], file_name=None, first_id=first.id)
                 no_content += 1
 
             self.stdout.write(self.style.SUCCESS("\n\n\nSummary:"))


### PR DESCRIPTION
## What problem is this PR solving?

In the second phase, when there are no content, we are trying to take the first element of the empty query.

### Related JIRA tickets

WC2-875

## Changes

Re-query the database to retrieve all the duplicates without content instead of using the `has_content` which is empty.

## How to test

Can't test this.

Here is the stacktrace from production:
```
Traceback (most recent call last):
File "/usr/local/lib/python3.9/site-packages/celery/app/trace.py", line 477, in trace_task
R = retval = fun(*args, **kwargs)
File "/usr/local/lib/python3.9/site-packages/sentry_sdk/integrations/celery.py", line 306, in _inner
reraise(*exc_info)
File "/usr/local/lib/python3.9/site-packages/sentry_sdk/_compat.py", line 115, in reraise
raise value
File "/usr/local/lib/python3.9/site-packages/sentry_sdk/integrations/celery.py", line 301, in _inner
return f(*args, **kwargs)
File "/usr/local/lib/python3.9/site-packages/celery/app/trace.py", line 760, in __protected_call__
return self.run(*args, **kwargs)
File "/opt/app/plugins/wfp/tasks.py", line 78, in clean_up_duplicate_instances_dry_run
call_command("clean_up_duplicate_submissions", f"--{DRY_RUN_ARG}")
File "/usr/local/lib/python3.9/site-packages/django/core/management/__init__.py", line 194, in call_command
return command.execute(*args, **defaults)
File "/usr/local/lib/python3.9/site-packages/django/core/management/base.py", line 458, in execute
output = self.handle(*args, **options)
File "/usr/local/lib/python3.9/contextlib.py", line 79, in inner
return func(*args, **kwds)
File "/opt/app/iaso/management/commands/clean_up_duplicate_submissions.py", line 41, in handle
self._cleanup_based_on_uuid_only(duplicates)
File "/opt/app/iaso/management/commands/clean_up_duplicate_submissions.py", line 139, in _cleanup_based_on_uuid_only
self._delete_instances(uuid=duplicate["uuid"], file_name=None, first_id=has_content.first().id)
AttributeError: 'NoneType' object has no attribute 'id'
```
