### PR TITLE
IA-4824: LIVE_COMPONENTS not working

### DIFF
--- a/hat/webpack.dev.js
+++ b/hat/webpack.dev.js
@@ -166,11 +166,14 @@ module.exports = {
                     eager: true,
                     requiredVersion: false,
                 },
-                'bluesquare-components': {
-                    singleton: true,
-                    eager: true,
-                    requiredVersion: false,
-                },
+                // Exclude from shared when LIVE_COMPONENTS so resolve.alias to local src works
+                ...(process.env.LIVE_COMPONENTS !== 'true' && {
+                    'bluesquare-components': {
+                        singleton: true,
+                        eager: true,
+                        requiredVersion: false,
+                    },
+                }),
             },
         }),
     ],
@@ -236,9 +239,49 @@ module.exports = {
             'IasoModules/translations/configs': combinedTranslationsPath,
             'IasoModules/language/configs': languageConfigsPath,
             ...(process.env.LIVE_COMPONENTS === 'true' && {
+                // Alias bluesquare-components to local source
                 'bluesquare-components': path.resolve(
                     __dirname,
                     '../../bluesquare-components/src/',
+                ),
+                // Force host's singleton deps so bluesquare-components src uses same instances
+                // (avoids duplicate react-router-dom → useNavigate outside Router context)
+                react: path.resolve(__dirname, '../node_modules/react'),
+                'react-dom': path.resolve(
+                    __dirname,
+                    '../node_modules/react-dom',
+                ),
+                'react-router': path.resolve(
+                    __dirname,
+                    '../node_modules/react-router',
+                ),
+                'react-router-dom': path.resolve(
+                    __dirname,
+                    '../node_modules/react-router-dom',
+                ),
+                'react-intl': path.resolve(
+                    __dirname,
+                    '../node_modules/react-intl',
+                ),
+                '@mui/material': path.resolve(
+                    __dirname,
+                    '../node_modules/@mui/material',
+                ),
+                '@mui/styles': path.resolve(
+                    __dirname,
+                    '../node_modules/@mui/styles',
+                ),
+                '@emotion/react': path.resolve(
+                    __dirname,
+                    '../node_modules/@emotion/react',
+                ),
+                '@emotion/styled': path.resolve(
+                    __dirname,
+                    '../node_modules/@emotion/styled',
+                ),
+                'react-query': path.resolve(
+                    __dirname,
+                    '../node_modules/react-query',
                 ),
             }),
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -8208,7 +8208,7 @@
         },
         "node_modules/bluesquare-components": {
             "version": "1.0.0",
-            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#91163b53448f8264bf5143ced0f6e038d17c3b45",
+            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#27db629d5b607ecd6ce8dc86263b76cdc6d72597",
             "license": "Apache-2.0",
             "dependencies": {
                 "@babel/plugin-transform-class-properties": "^7.24.6",


### PR DESCRIPTION
## What problem is this PR solving? 

While running webpack using LIVE_COMPONENTS=true it should use local repository of bluesquare-components

### Related JIRA tickets

IA-4824

## Changes

Fix Webpack config to use 'bluesquare-components' locally 

## How to test

Make sure you pull [this](https://github.com/BLSQ/bluesquare-components/pull/209) branch  from bluesquare-components, repository should be at the same level as IASO repository.

Run `LIVE_COMPONENTS=true npm run dev`or `LIVE_COMPONENTS=true docker compose up`
Open 'bluesquare-components' code and make some changes, it should live reload and you should see your changes directly

## Notes

This [PR](https://github.com/BLSQ/bluesquare-components/pull/209) is fixing some typings issue we had while exporting, displaying some warning on the compilation.