### PR TITLE
POLIO-2113: fix pdf display and download

### DIFF
--- a/hat/assets/js/apps/Iaso/components/files/DocumentsItemComponent.tsx
+++ b/hat/assets/js/apps/Iaso/components/files/DocumentsItemComponent.tsx
@@ -124,7 +124,7 @@ const PdfItem: FunctionComponent<PdfItemProps> = ({
 }) => {
     return (
         <PdfPreview
-            pdfUrl={filePath}
+            pdf={filePath}
             OpenButtonComponent={OpenButtonComponent}
             buttonProps={{
                 label: getDisplayName(filePath),

--- a/hat/assets/js/apps/Iaso/components/files/pdf/DocumentUploadWithPreview.tsx
+++ b/hat/assets/js/apps/Iaso/components/files/pdf/DocumentUploadWithPreview.tsx
@@ -89,7 +89,7 @@ const DocumentUploadWithPreview: React.FC<DocumentUploadWithPreviewProps> = ({
                             />
                         )}
                         <PdfPreview
-                            pdfUrl={pdfUrl}
+                            pdf={pdfUrl}
                             scanResult={scanResult}
                             scanTimestamp={scanTimestamp}
                             coloredScanResultIcon={coloredScanResultIcon}

--- a/hat/assets/js/apps/Iaso/components/files/pdf/PdfPreview.tsx
+++ b/hat/assets/js/apps/Iaso/components/files/pdf/PdfPreview.tsx
@@ -32,7 +32,7 @@ if (!pdfjs.GlobalWorkerOptions.workerSrc) {
 }
 
 type PdfPreviewProps = {
-    pdfUrl?: string;
+    pdf?: string | { path: string; name: string };
     OpenButtonComponent?: ComponentType<{
         onClick: () => void;
         disabled: boolean;
@@ -92,8 +92,33 @@ const styles: SxStyles = {
     },
 };
 
+export const getPdfPath = (
+    pdf?: string | { path: string; name: string },
+): string => {
+    if (typeof pdf === 'string') {
+        return pdf;
+    }
+    if (typeof pdf === 'object' && pdf && 'path' in pdf && 'name' in pdf) {
+        return pdf.path;
+    }
+    return '';
+};
+
+export const getLinkDownLoad = (
+    pdf?: string | { path: string; name: string },
+): string => {
+    if (typeof pdf === 'string') {
+        const urlParts = pdf.split('/');
+        return urlParts[urlParts.length - 1] || 'document.pdf';
+    }
+    if (typeof pdf === 'object' && pdf && 'path' in pdf && 'name' in pdf) {
+        return pdf.name;
+    }
+    return '';
+};
+
 export const PdfPreview: FunctionComponent<PdfPreviewProps> = ({
-    pdfUrl,
+    pdf,
     OpenButtonComponent,
     buttonProps,
     scanResult,
@@ -117,19 +142,20 @@ export const PdfPreview: FunctionComponent<PdfPreviewProps> = ({
     const handleClose = () => {
         setOpen(false);
     };
-
+    const pdfUrl = getPdfPath(pdf);
     const isFileSafeToDisplayAndDownload =
         !scanResult || scanResult !== fileScanResultInfected;
 
     const handleDownload = useCallback(() => {
-        if (pdfUrl && isFileSafeToDisplayAndDownload) {
+        if (pdf && isFileSafeToDisplayAndDownload) {
             const link = document.createElement('a');
             link.href = pdfUrl;
-            const urlParts = pdfUrl.split('/');
-            link.download = urlParts[urlParts.length - 1] || 'document.pdf';
-            link.click();
+            link.download = getLinkDownLoad(pdf);
+            if (link.download) {
+                link.click();
+            }
         }
-    }, [isFileSafeToDisplayAndDownload, pdfUrl]);
+    }, [isFileSafeToDisplayAndDownload, pdf, pdfUrl]);
 
     const onDocumentLoadSuccess = ({
         numPages: nextNumPages,
@@ -153,7 +179,7 @@ export const PdfPreview: FunctionComponent<PdfPreviewProps> = ({
         <>
             <OpenButton
                 onClick={handleOpen}
-                disabled={!pdfUrl}
+                disabled={!pdf}
                 coloredIcon={coloredScanResultIcon}
                 scanResult={scanResult}
                 {...buttonProps}

--- a/plugins/polio/js/src/domains/VaccineModule/Repository/components/DocumentCell.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/Repository/components/DocumentCell.tsx
@@ -1,13 +1,13 @@
-import { Box } from '@mui/material';
 import React, { FunctionComponent } from 'react';
+import { Box } from '@mui/material';
 
 import { textPlaceholder } from 'bluesquare-components';
 import { DateCell } from '../../../../../../../../hat/assets/js/apps/Iaso/components/Cells/DateTimeCell';
 import { PdfPreview } from '../../../../../../../../hat/assets/js/apps/Iaso/components/files/pdf/PdfPreview';
 import { SxStyles } from '../../../../../../../../hat/assets/js/apps/Iaso/types/general';
+import { NO_PDF_COLOR, WITH_PDF_COLOR } from '../constants';
 import { DocumentData } from '../types';
 import { OpenButtonComponent } from './OpenButton';
-import { NO_PDF_COLOR, WITH_PDF_COLOR } from '../constants';
 
 export const CELL_HEIGHT = '40px';
 
@@ -52,7 +52,7 @@ export const DocumentCell: FunctionComponent<DocumentData> = ({
     return (
         <Box sx={defaultStyles.withPdf}>
             <PdfPreview
-                pdfUrl={file}
+                pdf={file}
                 OpenButtonComponent={OpenButtonComponent}
                 buttonProps={{
                     date,

--- a/plugins/polio/js/src/domains/VaccineModule/Repository/components/FormADocumentCell.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/Repository/components/FormADocumentCell.tsx
@@ -1,13 +1,13 @@
+import React, { FunctionComponent } from 'react';
 import { Box } from '@mui/material';
 import { textPlaceholder } from 'bluesquare-components';
-import React, { FunctionComponent } from 'react';
 import { DateCell } from '../../../../../../../../hat/assets/js/apps/Iaso/components/Cells/DateTimeCell';
 import { PdfPreview } from '../../../../../../../../hat/assets/js/apps/Iaso/components/files/pdf/PdfPreview';
 import { SxStyles } from '../../../../../../../../hat/assets/js/apps/Iaso/types/general';
+import { FORM_A_IS_LATE_COLOR } from '../constants';
 import { DocumentData } from '../types';
 import { defaultStyles } from './DocumentCell';
 import { OpenButtonComponent } from './OpenButton';
-import { FORM_A_IS_LATE_COLOR } from '../constants';
 
 const LateStyle = {
     backgroundColor: FORM_A_IS_LATE_COLOR,
@@ -46,7 +46,7 @@ export const FormADocumentCell: FunctionComponent<Props> = ({
     return (
         <Box sx={boxStyle}>
             <PdfPreview
-                pdfUrl={file}
+                pdf={file}
                 OpenButtonComponent={OpenButtonComponent}
                 buttonProps={{
                     date,

--- a/plugins/polio/js/src/domains/VaccineModule/Repository/components/VrfDocumentCell.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/Repository/components/VrfDocumentCell.tsx
@@ -1,6 +1,6 @@
+import React, { FunctionComponent } from 'react';
 import { Box } from '@mui/material';
 import { textPlaceholder, useSafeIntl } from 'bluesquare-components';
-import React, { FunctionComponent } from 'react';
 import { DateCell } from '../../../../../../../../hat/assets/js/apps/Iaso/components/Cells/DateTimeCell';
 import { PdfPreview } from '../../../../../../../../hat/assets/js/apps/Iaso/components/files/pdf/PdfPreview';
 import { SxStyles } from '../../../../../../../../hat/assets/js/apps/Iaso/types/general';
@@ -45,7 +45,7 @@ export const VrfDocumentCell: FunctionComponent<Props> = ({
     return (
         <Box sx={defaultStyles.withPdf}>
             <PdfPreview
-                pdfUrl={file}
+                pdf={file}
                 OpenButtonComponent={OpenButtonComponent}
                 buttonProps={{
                     date,

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Table/columns.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/StockVariation/Table/columns.tsx
@@ -1,5 +1,7 @@
 import React, { useMemo } from 'react';
 import EditIcon from '@mui/icons-material/Edit';
+import WarningAmberOutlinedIcon from '@mui/icons-material/WarningAmberOutlined';
+import { Box, Tooltip } from '@mui/material';
 import { Column, textPlaceholder, useSafeIntl } from 'bluesquare-components';
 import { BreakWordCell } from '../../../../../../../../../hat/assets/js/apps/Iaso/components/Cells/BreakWordCell';
 import { DateCell } from '../../../../../../../../../hat/assets/js/apps/Iaso/components/Cells/DateTimeCell';
@@ -15,7 +17,6 @@ import {
 } from '../../../../../constants/permissions';
 import { VaccineForStock } from '../../../../../constants/types';
 import { REGULAR, USED } from '../../constants';
-import WarningAmberOutlinedIcon from '@mui/icons-material/WarningAmberOutlined';
 import {
     useDeleteDestruction,
     useDeleteEarmarked,
@@ -27,7 +28,6 @@ import { EditDestruction } from '../Modals/CreateEditDestruction';
 import { EditEarmarked } from '../Modals/CreateEditEarmarked';
 import { EditFormA } from '../Modals/CreateEditFormA';
 import { EditIncident } from '../Modals/CreateEditIncident';
-import { Box, Tooltip } from '@mui/material';
 import { CampaignNameWithWarning } from './CampaignNameWithWarning';
 
 export const useFormATableColumns = (
@@ -114,7 +114,7 @@ export const useFormATableColumns = (
                     return (
                         <>
                             <PdfPreview
-                                pdfUrl={settings.row.original.file}
+                                pdf={settings.row.original.file}
                                 scanResult={settings.row.original.scan_result}
                                 scanTimestamp={
                                     settings.row.original.scan_timestamp
@@ -226,7 +226,7 @@ export const useDestructionTableColumns = (
                     return (
                         <>
                             <PdfPreview
-                                pdfUrl={settings.row.original.file}
+                                pdf={settings.row.original.file}
                                 scanResult={settings.row.original.scan_result}
                                 scanTimestamp={
                                     settings.row.original.scan_timestamp
@@ -357,7 +357,7 @@ export const useIncidentTableColumns = (
                     return (
                         <>
                             <PdfPreview
-                                pdfUrl={settings.row.original.file}
+                                pdf={settings.row.original.file}
                                 scanResult={settings.row.original.scan_result}
                                 scanTimestamp={
                                     settings.row.original.scan_timestamp


### PR DESCRIPTION
## What problem is this PR solving?

In vaccine stock tables, the existing pdfs couldn't be displayed or downloaded

### Related JIRA tickets

POLIO-2113

## Changes

- updated `PdfPreview` to handle objects as well as strings and generate the download links accordingly
- renamed `pdfFile` prop for clarity

## How to test
Go to Polio> Vaccine module > vaccine stock > stock variation
click on any active pdf icon in the table
pdf preview should display
pdf should be donloadable

## Print screen / video


https://github.com/user-attachments/assets/644cb2fe-f907-497a-8e1e-9eb3b0bed135



## Notes
Needs to be released


