### PR TITLE
IA-4850: Do not return reference instances with deleted forms

### DIFF
--- a/iaso/api/mobile/org_units.py
+++ b/iaso/api/mobile/org_units.py
@@ -353,6 +353,7 @@ class MobileOrgUnitViewSet(ModelViewSet):
 
         reference_instances = (
             org_unit.reference_instances(manager="non_deleted_objects")
+            .filter(form__deleted_at__isnull=True)
             .prefetch_related("instancefile_set")
             .order_by("id")
         )

--- a/iaso/tests/api/test_mobile_orgunits.py
+++ b/iaso/tests/api/test_mobile_orgunits.py
@@ -1,3 +1,5 @@
+import datetime
+
 import time_machine
 
 from django.contrib.gis.geos import MultiPolygon, Point, Polygon
@@ -412,9 +414,16 @@ class MobileOrgUnitAPITestCase(APITestCase):
             form=form2, org_unit=self.raditz, json={"key": "bar"}, form_version=form_version2
         )
         instance_file1 = InstanceFile.objects.create(instance=instance2, file="test1.jpg")
+        # Instance 3. Form is soft-deleted
+        form3 = Form.objects.create(name="Form 3", deleted_at=datetime.datetime.now())
+        form_version3 = FormVersion.objects.create(form=form3, version_id=9)
+        instance3 = Instance.objects.create(
+            form=form3, org_unit=self.raditz, json={"key": "foobar"}, form_version=form_version3
+        )
         # Mark instances as reference instances.
         OrgUnitReferenceInstance.objects.create(org_unit=self.raditz, instance=instance1, form=form1)
         OrgUnitReferenceInstance.objects.create(org_unit=self.raditz, instance=instance2, form=form2)
+        OrgUnitReferenceInstance.objects.create(org_unit=self.raditz, instance=instance3, form=form3)
 
         self.client.force_authenticate(self.user)
 


### PR DESCRIPTION
## What problem is this PR solving?

The mobile receives instances that are linked to deleted forms, which prevents it from importing them.

### Related JIRA tickets

IA-4850

## Changes

The endpoints filters out instances that are linked to deleted forms.

## How to test

1. Configure an OrgUnit to have at least one reference form
2. Add a reference instance to the OrgUnit
3. call `/api/mobile/orgunits/{ID}/reference_instances/?app_id={YOUR APP ID}` (with the proper ID and YOUR_APP_ID)
4. Ensure that the reference instance is returned
5. Mark the form as deleted
6. Redo call from 3.
7. Ensure the reference instance is NOT returned.
