### PR TITLE
[IA-4762] Fix/users frontend improvement

### DIFF
--- a/hat/assets/js/apps/Iaso/components/Buttons/EditButton.tsx
+++ b/hat/assets/js/apps/Iaso/components/Buttons/EditButton.tsx
@@ -2,10 +2,10 @@
 import React, { FunctionComponent } from 'react';
 import Edit from '@mui/icons-material/Edit';
 import { Button } from '@mui/material';
+import { ButtonProps } from '@mui/material/Button/Button';
+import { makeStyles } from '@mui/styles';
 import { commonStyles, IntlMessage, useSafeIntl } from 'bluesquare-components';
 import MESSAGES from '../../domains/users/messages';
-import { makeStyles } from '@mui/styles';
-import { ButtonProps } from '@mui/material/Button/Button';
 
 const useStyles = makeStyles(theme => ({
     ...commonStyles(theme),
@@ -14,7 +14,7 @@ const useStyles = makeStyles(theme => ({
 type Props = {
     message?: IntlMessage;
     id?: string;
-} & Omit<ButtonProps, "children">;
+} & Omit<ButtonProps, 'children'>;
 
 export const EditButton: FunctionComponent<Props> = ({
     onClick,
@@ -28,6 +28,7 @@ export const EditButton: FunctionComponent<Props> = ({
 }) => {
     const classes = useStyles();
     const { formatMessage } = useSafeIntl();
+
     return (
         <Button
             variant={variant}

--- a/hat/assets/js/apps/Iaso/domains/users/components/CreateUserDialog.tsx
+++ b/hat/assets/js/apps/Iaso/domains/users/components/CreateUserDialog.tsx
@@ -11,7 +11,6 @@ import {
     ConfirmCancelModal,
     IntlMessage,
     makeFullModal,
-    theme,
     useSafeIntl,
 } from 'bluesquare-components';
 
@@ -33,7 +32,7 @@ import { WarningModal } from './WarningModal/WarningModal';
 
 const styles: SxStyles = {
     tabs: {
-        marginBottom: theme.spacing(3),
+        marginBottom: theme => theme.spacing(1),
     },
     root: {
         position: 'relative',

--- a/hat/assets/js/apps/Iaso/domains/users/components/EditPasswordUserDialog.tsx
+++ b/hat/assets/js/apps/Iaso/domains/users/components/EditPasswordUserDialog.tsx
@@ -7,8 +7,8 @@ import {
 } from 'bluesquare-components';
 import { FormikProvider, useFormik } from 'formik';
 import { MutateFunction } from 'react-query';
-import InputComponent from 'Iaso/components/forms/InputComponent';
 import { EditButton } from 'Iaso/components/Buttons/EditButton';
+import InputComponent from 'Iaso/components/forms/InputComponent';
 import MESSAGES from 'Iaso/domains/users/messages';
 import { SaveUserPasswordQuery } from 'Iaso/domains/users/types';
 import { useUserPasswordValidation } from 'Iaso/domains/users/validation';
@@ -122,15 +122,23 @@ const EditPasswordUserDialogComponent: FunctionComponent<Props> = ({
     );
 };
 
-type PasswordEditButtonProps = Omit<React.ComponentProps<typeof EditButton>, "message" | "color">
+type PasswordEditButtonProps = Omit<
+    React.ComponentProps<typeof EditButton>,
+    'message' | 'color'
+>;
 
 const PasswordEditButton = (props: PasswordEditButtonProps) => {
-
+    const extendedProps = {
+        ...props,
+        sx: {
+            color: 'white',
+        },
+    };
     return (
         <EditButton
             message={MESSAGES.updatePasswordButtonLabel}
-            color={"warning"}
-            {...props}
+            color={'warning'}
+            {...extendedProps}
         />
     );
 };

--- a/hat/assets/js/apps/Iaso/domains/users/components/EditUserDialog.tsx
+++ b/hat/assets/js/apps/Iaso/domains/users/components/EditUserDialog.tsx
@@ -9,15 +9,17 @@ import { Box, Tab, Tabs } from '@mui/material';
 import {
     ConfirmCancelModal,
     IntlMessage,
-    makeFullModal, theme,
+    makeFullModal,
+    theme,
     useSafeIntl,
 } from 'bluesquare-components';
 
 import { MutateFunction, useQueryClient } from 'react-query';
 
+import { EditButton } from 'Iaso/components/Buttons/EditButton';
 import { EditIconButton } from 'Iaso/components/Buttons/EditIconButton';
 import { OrgUnit } from 'Iaso/domains/orgUnits/types/orgUnit';
-import { EditButton } from 'Iaso/components/Buttons/EditButton';
+import { SxStyles } from 'Iaso/types/general';
 import * as Permissions from 'Iaso/utils/permissions';
 import { Profile, useCurrentUser } from 'Iaso/utils/usersUtils';
 import MESSAGES from '../messages';
@@ -29,7 +31,6 @@ import UsersDialogTabDisabled from './UsersDialogTabDisabled';
 import { UsersInfos } from './UsersInfos';
 import UsersLocations from './UsersLocations';
 import { WarningModal } from './WarningModal/WarningModal';
-import { SxStyles } from 'Iaso/types/general';
 
 const styles: SxStyles = {
     tabs: {
@@ -45,7 +46,7 @@ const styles: SxStyles = {
         zIndex: -10,
         opacity: 0,
     },
-}
+};
 
 type Props = {
     titleMessage: IntlMessage;
@@ -92,9 +93,9 @@ const EditUserDialogComponent: FunctionComponent<Props> = ({
                 currentUser[key] = user?.[key].value?.map(
                     (orgUnit: OrgUnit) => orgUnit?.id,
                 );
-            } else if(key === 'user_roles'){
+            } else if (key === 'user_roles') {
                 currentUser[key] = user?.[key].value?.map(
-                    (userRole) => userRole?.id ?? userRole,
+                    userRole => userRole?.id ?? userRole,
                 );
             } else {
                 currentUser[key] = user[key].value;
@@ -130,7 +131,8 @@ const EditUserDialogComponent: FunctionComponent<Props> = ({
     const userRolesPermissions = user?.user_roles_permissions.value ?? [];
 
     const isPhoneNumberUpdated =
-        (user.phone_number.value ?? '') !== (initialData?.phone_number ?? '') && !!user.id?.value;
+        (user.phone_number.value ?? '') !== (initialData?.phone_number ?? '') &&
+        !!user.id?.value;
 
     const isUserWithoutPermissions =
         userPermissions.length === 0 &&
@@ -260,9 +262,7 @@ const EditUserDialogComponent: FunctionComponent<Props> = ({
                     )}
                 </Tabs>
                 <Box sx={styles.root} id="user-profile-dialog">
-                    <Box
-                        sx={tab === 'infos' ? null : styles.hiddenOpacity}
-                    >
+                    <Box sx={tab === 'infos' ? null : styles.hiddenOpacity}>
                         <UsersInfos
                             setFieldValue={(key, value) =>
                                 setFieldValue(key, value)
@@ -315,15 +315,13 @@ const EditUserDialogComponent: FunctionComponent<Props> = ({
     );
 };
 
-type EditUserButtonProps = Omit<React.ComponentProps<typeof EditButton>, "message">
+type EditUserButtonProps = Omit<
+    React.ComponentProps<typeof EditButton>,
+    'message'
+>;
 
 const EditUserButton = (props: EditUserButtonProps) => {
-    return (
-        <EditButton
-            message={MESSAGES.updateUser}
-            {...props}
-        />
-    );
+    return <EditButton message={MESSAGES.updateUser} {...props} />;
 };
 const modalWithButton = makeFullModal(EditUserDialogComponent, EditUserButton);
 const modalWithIcon = makeFullModal(EditUserDialogComponent, EditIconButton);

--- a/hat/assets/js/apps/Iaso/domains/users/components/EditUserDialog.tsx
+++ b/hat/assets/js/apps/Iaso/domains/users/components/EditUserDialog.tsx
@@ -10,7 +10,6 @@ import {
     ConfirmCancelModal,
     IntlMessage,
     makeFullModal,
-    theme,
     useSafeIntl,
 } from 'bluesquare-components';
 
@@ -34,7 +33,7 @@ import { WarningModal } from './WarningModal/WarningModal';
 
 const styles: SxStyles = {
     tabs: {
-        marginBottom: theme.spacing(3),
+        marginBottom: theme => theme.spacing(1),
     },
     root: {
         position: 'relative',

--- a/hat/assets/js/apps/Iaso/domains/users/components/UserDetailViewComponents/TopActions.tsx
+++ b/hat/assets/js/apps/Iaso/domains/users/components/UserDetailViewComponents/TopActions.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
+import { useSafeIntl } from 'bluesquare-components';
+import { DeleteButton } from 'Iaso/components/Buttons/DeleteButton';
+import DeleteDialog from 'Iaso/components/dialogs/DeleteDialogComponent';
+import { DisplayIfUserHasPerm } from 'Iaso/components/DisplayIfUserHasPerm';
+import { EditPasswordUserWithButtonDialog } from 'Iaso/domains/users/components/EditPasswordUserDialog';
 import { EditUserWithButtonDialog } from 'Iaso/domains/users/components/EditUserDialog';
 import MESSAGES from 'Iaso/domains/users/messages';
-import { EditPasswordUserWithButtonDialog } from 'Iaso/domains/users/components/EditPasswordUserDialog';
-import { DisplayIfUserHasPerm } from 'Iaso/components/DisplayIfUserHasPerm';
-import * as Permissions from 'Iaso/utils/permissions';
-import DeleteDialog from 'Iaso/components/dialogs/DeleteDialogComponent';
-import { DeleteButton } from 'Iaso/components/Buttons/DeleteButton';
-import { useSafeIntl } from 'bluesquare-components';
-import { useCurrentUser } from 'Iaso/utils/usersUtils';
 import { ProfileRetrieveResponseItem } from 'Iaso/domains/users/types';
+import * as Permissions from 'Iaso/utils/permissions';
+import { useCurrentUser } from 'Iaso/utils/usersUtils';
 
 type Props = {
     userId?: number | string;
@@ -17,47 +17,46 @@ type Props = {
     savePassword: void;
     saveProfile: void;
     onDeleteProfile: void;
-}
+};
 export const TopActions = ({
-                               saveProfile,
-                               profile,
-                               canBypassProjectRestrictions,
-                               savePassword,
-                               userId,
-                               onDeleteProfile,
-                           }: Props) => {
+    saveProfile,
+    profile,
+    canBypassProjectRestrictions,
+    savePassword,
+    userId,
+    onDeleteProfile,
+}: Props) => {
     const { formatMessage } = useSafeIntl();
     const currentUser = useCurrentUser();
 
-    return <>
-        <EditUserWithButtonDialog
-            initialData={profile}
-            titleMessage={formatMessage(MESSAGES.updateUser)}
-            saveProfile={saveProfile}
-            canBypassProjectRestrictions={
-                canBypassProjectRestrictions
-            }
-        />
-        <EditPasswordUserWithButtonDialog
-            titleMessage={MESSAGES.updateUserPassword}
-            savePassword={savePassword}
-            userId={userId}
-        />
-        {
-            currentUser?.id?.toString() !== userId
-            &&
-            <DisplayIfUserHasPerm
-                permissions={[Permissions.USERS_ADMIN, Permissions.USERS_MANAGEMENT]}
-            >
-                <DeleteDialog
-                    titleMessage={
-                        MESSAGES.deleteUserTitle
-                    }
-                    message={MESSAGES.deleteUserText}
-                    onConfirm={onDeleteProfile}
-                    Trigger={DeleteButton}
-                />
-            </DisplayIfUserHasPerm>
-        }
-    </>;
+    return (
+        <>
+            <EditUserWithButtonDialog
+                initialData={profile}
+                titleMessage={formatMessage(MESSAGES.updateUser)}
+                saveProfile={saveProfile}
+                canBypassProjectRestrictions={canBypassProjectRestrictions}
+            />
+            <EditPasswordUserWithButtonDialog
+                titleMessage={MESSAGES.updateUserPassword}
+                savePassword={savePassword}
+                userId={userId}
+            />
+            {currentUser?.id?.toString() !== userId && (
+                <DisplayIfUserHasPerm
+                    permissions={[
+                        Permissions.USERS_ADMIN,
+                        Permissions.USERS_MANAGEMENT,
+                    ]}
+                >
+                    <DeleteDialog
+                        titleMessage={MESSAGES.deleteUserTitle}
+                        message={MESSAGES.deleteUserText}
+                        onConfirm={onDeleteProfile}
+                        Trigger={DeleteButton}
+                    />
+                </DisplayIfUserHasPerm>
+            )}
+        </>
+    );
 };

--- a/hat/assets/js/apps/Iaso/domains/users/components/UsersDialogTabDisabled.tsx
+++ b/hat/assets/js/apps/Iaso/domains/users/components/UsersDialogTabDisabled.tsx
@@ -1,18 +1,26 @@
-import { Grid, Tab, Tooltip } from '@mui/material';
 import React, { FunctionComponent } from 'react';
 import InfoIcon from '@mui/icons-material/Info';
+import { Grid, Tab, Tooltip } from '@mui/material';
+import { SxStyles } from 'Iaso/types/general';
 
 type Props = {
     label: string;
     disabled: boolean;
     tooltipMessage: string;
 };
+
+const styles: SxStyles = {
+    tab: {
+        marginBottom: theme => theme.spacing(1),
+    },
+};
+
 const UsersDialogTabDisabled: FunctionComponent<Props> = ({
     tooltipMessage,
     ...tabProps
 }) => {
     return (
-        <Grid container alignItems="center">
+        <Grid container alignItems="center" sx={styles.tab}>
             <Grid item>
                 <Tab label={tabProps.label} disabled={tabProps.disabled} />
             </Grid>


### PR DESCRIPTION
## What problem is this PR solving?

Spacing was too big for the tabs in the create / edit user dialogs and "update password button" had text in black

### Related JIRA tickets

IA-4762

## Changes

* Reduce spacing for tabs 
* Added white color for button

## How to test

* Go to User managements
* Click create button or edit icon : tabs spacing should be reduced
* Click on any eye icon to view the details of a user
* Edit password button should have white text

## Print screen / video

<img width="1440" height="1193" alt="screencapture-localhost-8000-dashboard-settings-users-management-accountId-8-orgUnitTypes-28-order-user-username-pageSize-20-page-1-2026-03-10-14_28_47" src="https://github.com/user-attachments/assets/e8aae25e-fdc7-4e24-aad2-9e5085c164a4" />

