### PR TITLE
[IA-4863] Fix setuper

### DIFF
--- a/setuper/create_llin_campaign_forms_submissions.py
+++ b/setuper/create_llin_campaign_forms_submissions.py
@@ -51,7 +51,10 @@ def create_form_submissions(account_name, iaso_client, form, orgunit):
 
 def create_org_units_submissions(account_name, iaso_client, facility_type_id, form):
     limit = 20
-    orgUnits = iaso_client.get("/api/orgunits/", params={"limit": limit, "orgUnitTypeId": facility_type_id})["orgunits"]
+    orgUnits = iaso_client.get(
+        "/api/orgunits/",
+        params={"limit": limit, "orgUnitTypeId": facility_type_id, "fields": "id,longitude,latitude,altitude"},
+    )["orgunits"]
 
     for orgUnit in orgUnits:
         create_form_submissions(account_name, iaso_client, form, orgUnit)

--- a/setuper/create_submission_with_picture.py
+++ b/setuper/create_submission_with_picture.py
@@ -51,7 +51,11 @@ def create_submission_with_picture(account_name, iaso_client):
     limit = form["number_of_org_units"]
     orgunits = iaso_client.get(
         "/api/orgunits/",
-        params={"limit": limit, "orgUnitTypeId": form["org_unit_type_id"]},
+        params={
+            "limit": limit,
+            "orgUnitTypeId": form["org_unit_type_id"],
+            "fields": "id,longitude,latitude,altitude,org_unit_type_name",
+        },
     )["orgunits"]
     current_datetime = int(datetime.now().timestamp())
 

--- a/setuper/data_collection.py
+++ b/setuper/data_collection.py
@@ -59,9 +59,14 @@ def setup_instances(account_name, iaso_client):
         iaso_client.put(f"/api/v2/orgunittypes/{org_unit_type_id}/", json=org_unit_type)
 
         limit = org_unit_type["units_count"]
-        orgunits = iaso_client.get("/api/orgunits/", params={"limit": limit, "orgUnitTypeId": org_unit_type_id})[
-            "orgunits"
-        ]
+        orgunits = iaso_client.get(
+            "/api/orgunits/",
+            params={
+                "limit": limit,
+                "orgUnitTypeId": org_unit_type_id,
+                "fields": "id,longitude,latitude,altitude,org_unit_type_name",
+            },
+        )["orgunits"]
         print("-- Submitting %d submissions" % limit)
         count = 0
         for orgunit in orgunits:

--- a/setuper/default_healthFacility_form.py
+++ b/setuper/default_healthFacility_form.py
@@ -53,7 +53,11 @@ def setup_health_facility_level_default_form(account_name, iaso_client):
     limit = 20
     orgunits = iaso_client.get(
         "/api/orgunits/",
-        params={"limit": limit, "orgUnitTypeId": health_facility_type["id"]},
+        params={
+            "limit": limit,
+            "orgUnitTypeId": health_facility_type["id"],
+            "fields": "id,longitude,latitude,altitude",
+        },
     )["orgunits"]
     print("-- Submitting %d submissions" % limit)
 

--- a/setuper/entities.py
+++ b/setuper/entities.py
@@ -216,7 +216,10 @@ def setup_entities(account_name, iaso_client, entity_type, new_entity_type):
 
     # fetch orgunit ids
     limit = 20
-    orgunits = iaso_client.get("/api/orgunits/", params={"limit": limit, "orgUnitTypeId": hf_out["id"]})["orgunits"]
+    orgunits = iaso_client.get(
+        "/api/orgunits/",
+        params={"limit": limit, "orgUnitTypeId": hf_out["id"], "fields": "id,longitude,latitude,altitude"},
+    )["orgunits"]
 
     # Getting the latest form version for reference form
     if new_entity_type["reference_form"]["id"]:

--- a/setuper/micro_planning.py
+++ b/setuper/micro_planning.py
@@ -47,7 +47,7 @@ def setup_users_teams_micro_planning(account_name, iaso_client):
         }
         iaso_client.post("/api/profiles/", json=user)
 
-    users = iaso_client.get("/api/profiles?limit=20000")["profiles"]
+    users = iaso_client.get("/api/profiles?limit=20000")["results"]
 
     print(f"\t{len(users) - 1} users created")
 

--- a/setuper/review_change_proposal.py
+++ b/setuper/review_change_proposal.py
@@ -21,9 +21,14 @@ def setup_review_change_proposal(account_name, iaso_client):
 
     # fetch orgunit ids
     limit = 12
-    orgunits = iaso_client.get("/api/orgunits/", params={"limit": limit, "orgUnitTypeId": health_facility_type["id"]})[
-        "orgunits"
-    ]
+    orgunits = iaso_client.get(
+        "/api/orgunits/",
+        params={
+            "limit": limit,
+            "orgUnitTypeId": health_facility_type["id"],
+            "fields": "id,longitude,latitude,altitude,name",
+        },
+    )["orgunits"]
     org_unit_group_ids = [org_unit_group["id"] for org_unit_group in org_unit_groups]
     for org_unit in orgunits:
         location = [None, {**org_unit_gps_point(org_unit)}]


### PR DESCRIPTION
## What problem is this PR solving?

Fix setuper after API breaking changes (OrgUnit, Profile)

### Related JIRA tickets

IA-4863

## Changes

- passed `fields=` to OrgUnit calls to fetch fields that are no longer present
- changes the result key in `Profile` results

## How to test

- Configure `setuper/credentials.py`
- Run the setuper on the configured server, using `python setuper.py -a -n <choose_an_available_account_name>`
  - You'll wait for a while, but the setuper should not crash

## Print screen / video

<img width="1068" height="187" alt="image" src="https://github.com/user-attachments/assets/b937430a-3eb6-4984-8268-f6dd192d1217" />


## Notes
/

## Doc

/
