### PR TITLE
IA-4865: Add an endpoint for mobile to retrieve instance's information

### DIFF
--- a/iaso/api/instances/serializers.py
+++ b/iaso/api/instances/serializers.py
@@ -2,6 +2,9 @@ import decimal
 
 from rest_framework import serializers
 
+from iaso.api.common import TimestampField
+from iaso.models import Instance
+from iaso.utils.file_utils import get_file_type
 from iaso.utils.serializer.rounded_decimal_field import RoundedDecimalField
 
 
@@ -20,3 +23,33 @@ class FileTypeSerializer(serializers.Serializer):
     video_only = serializers.BooleanField(default=False)
     document_only = serializers.BooleanField(default=False)
     other_only = serializers.BooleanField(default=False)
+
+
+class InstanceFileSerializer(serializers.Serializer):
+    id = serializers.IntegerField(read_only=True)
+    file = serializers.FileField(use_url=True)
+    file_type = serializers.SerializerMethodField()
+    name = serializers.CharField(read_only=True)
+
+    def get_file_type(self, obj):
+        return get_file_type(obj.file)
+
+
+class MobileInstancesSerializer(serializers.ModelSerializer):
+    created_at = TimestampField(read_only=True, source="source_created_at_with_fallback")
+    updated_at = TimestampField(read_only=True, source="source_updated_at_with_fallback")
+    instance_files = InstanceFileSerializer(many=True, read_only=True, source="instancefile_set")
+
+    class Meta:
+        model = Instance
+        fields = [
+            "id",
+            "uuid",
+            "org_unit_id",
+            "form_id",
+            "form_version_id",
+            "created_at",
+            "updated_at",
+            "json",
+            "instance_files",
+        ]

--- a/iaso/api/instances/views_mobile.py
+++ b/iaso/api/instances/views_mobile.py
@@ -1,13 +1,13 @@
 from django.db.models import Prefetch
 from rest_framework.decorators import action
-from rest_framework.exceptions import MethodNotAllowed
 from rest_framework.generics import get_object_or_404
+from rest_framework.mixins import RetrieveModelMixin
 from rest_framework.permissions import BasePermission
+from rest_framework.viewsets import GenericViewSet
 
-from iaso.api.common import ModelViewSet
-from iaso.api.instances.instances import HasInstancePermission, InstanceFileSerializer
-from iaso.api.instances.serializers import FileTypeSerializer
-from iaso.api.mobile.org_units import ReferenceInstancesSerializer
+from iaso.api.common import Paginator
+from iaso.api.instances.instances import HasInstancePermission
+from iaso.api.instances.serializers import FileTypeSerializer, InstanceFileSerializer, MobileInstancesSerializer
 from iaso.models import (
     Instance,
     InstanceFile,
@@ -24,16 +24,19 @@ class DenyAll(BasePermission):
         return False
 
 
-class InstancesMobileViewSet(ModelViewSet):
+class InstancesMobileViewSet(GenericViewSet, RetrieveModelMixin):
     """Mobile Instances API
 
+    GET /api/mobile/instances/<id>/
     GET /api/mobile/instances/<id>/attachments
     """
 
     permission_classes = [HasInstancePermission]
     http_method_names = ["get"]
     lookup_field = "uuid"
-    serializer_class = ReferenceInstancesSerializer
+    lookup_url_kwarg = "uuid"
+    serializer_class = MobileInstancesSerializer
+    pagination_class = Paginator
 
     def get_queryset(self):
         request = self.request
@@ -44,15 +47,16 @@ class InstancesMobileViewSet(ModelViewSet):
         )
         return queryset
 
-    def list(self, request, *args, **kwargs):
-        raise MethodNotAllowed("GET")
-
-    @action(["GET"], detail=True, permission_classes=[HasInstancePermission])
-    def attachments(self, request, uuid):
+    def get_object(self):
+        uuid = self.kwargs.get(self.lookup_field)
         try:
-            instance = self.get_queryset().get(uuid=uuid)
+            return self.get_queryset().get(uuid=uuid)
         except Instance.DoesNotExist:
-            instance = get_object_or_404(self.get_queryset(), pk=uuid)
+            return get_object_or_404(self.get_queryset(), pk=uuid)
+
+    @action(["GET"], detail=True)
+    def attachments(self, request, uuid):
+        instance = self.get_object()
 
         file_type_serializer = FileTypeSerializer(data=request.query_params)
         file_type_serializer.is_valid(raise_exception=True)

--- a/iaso/api/instances/views_mobile.py
+++ b/iaso/api/instances/views_mobile.py
@@ -1,12 +1,16 @@
+from django.db.models import Prefetch
 from rest_framework.decorators import action
+from rest_framework.exceptions import MethodNotAllowed
 from rest_framework.generics import get_object_or_404
 from rest_framework.permissions import BasePermission
 
 from iaso.api.common import ModelViewSet
 from iaso.api.instances.instances import HasInstancePermission, InstanceFileSerializer
 from iaso.api.instances.serializers import FileTypeSerializer
+from iaso.api.mobile.org_units import ReferenceInstancesSerializer
 from iaso.models import (
     Instance,
+    InstanceFile,
     InstanceQuerySet,
 )
 
@@ -26,15 +30,22 @@ class InstancesMobileViewSet(ModelViewSet):
     GET /api/mobile/instances/<id>/attachments
     """
 
-    permission_classes = [DenyAll]
+    permission_classes = [HasInstancePermission]
     http_method_names = ["get"]
     lookup_field = "uuid"
+    serializer_class = ReferenceInstancesSerializer
 
     def get_queryset(self):
         request = self.request
         queryset: InstanceQuerySet = Instance.objects
         queryset = queryset.filter_for_user(request.user).filter_on_user_projects(user=request.user)
+        queryset = queryset.prefetch_related(
+            Prefetch("instancefile_set", queryset=InstanceFile.objects_with_file_extensions.all())
+        )
         return queryset
+
+    def list(self, request, *args, **kwargs):
+        raise MethodNotAllowed("GET")
 
     @action(["GET"], detail=True, permission_classes=[HasInstancePermission])
     def attachments(self, request, uuid):

--- a/iaso/tests/api/instances/test_views_mobile.py
+++ b/iaso/tests/api/instances/test_views_mobile.py
@@ -48,6 +48,7 @@ class InstancesMobileAPITestCase(TaskAPITestCase):
             project=cls.project,
             created_by=cls.user,
             export_id="Vzhn0nceudr",
+            json={"foo": "bar"},
         )
         cls.instance_2 = cls.create_form_instance(
             form=cls.form,
@@ -55,6 +56,7 @@ class InstancesMobileAPITestCase(TaskAPITestCase):
             org_unit=cls.org_unit,
             project=cls.project,
             created_by=cls.user,
+            json={"bar": "foo"},
         )
 
         cls.project.unit_types.add(cls.org_unit_type)
@@ -65,41 +67,57 @@ class InstancesMobileAPITestCase(TaskAPITestCase):
     def test_attachments_permission_denied_when_anonymous(self):
         """GET /mobile/instances/{instance.pk}/attachments/"""
         instance = self.form.instances.first()
-        response = self.client.get(f"/api/mobile/instances/{instance.pk}/attachments/")
+        response = self.client.get(f"/api/mobile/instances/{instance.uuid}/attachments/")
         self.assertJSONResponse(response, 401)
 
     def test_get_when_logged_in(self):
         """GET /mobile/instances/{instance.pk}/attachments/"""
         self.client.force_authenticate(self.user)
-        instance = self.form.instances.first()
-        response = self.client.get(f"/api/mobile/instances/{instance.pk}/")
-        self.assertJSONResponse(response, 403)
+        instance = self.instance_1
+        m.InstanceFile.objects.create(instance=instance, file="test1.jpg")
+        m.InstanceFile.objects.create(instance=instance, file="test2.pdf")
+        with self.assertNumQueries(8):
+            # 1. SELECT FROM "auth_permission"
+            # 2. SELECT FROM "auth_permission"
+            # 3. SELECT "iaso_orgunit"
+            # 4. SELECT "iaso_project"
+            # 5. SELECT "iaso_instance"
+            # 6. SELECT "iaso_instancefile"
+            # 7. SELECT "iaso_orgunit"
+            # 8. SELECT "iaso_form"
+            response = self.client.get(f"/api/mobile/instances/{instance.uuid}/")
+        self.assertJSONResponse(response, 200)
+        data = response.json()
+        self.assertEqual(data["json"], {"foo": "bar"})
+        self.assertEqual(len(data["instance_files"]), 2)
+        self.assertTrue(data["instance_files"][0]["file"].endswith("test1.jpg"))
+        self.assertTrue(data["instance_files"][1]["file"].endswith("test2.pdf"))
 
     def test_list_when_logged_in(self):
         """GET /mobile/instances/{instance.pk}/attachments/"""
         self.client.force_authenticate(self.user)
         response = self.client.get("/api/mobile/instances/")
-        self.assertJSONResponse(response, 403)
+        self.assertJSONResponse(response, 405)
 
     def test_delete_when_logged_in(self):
         """GET /mobile/instances/{instance.pk}/attachments/"""
         self.client.force_authenticate(self.user)
         instance = self.form.instances.first()
-        response = self.client.delete(f"/api/mobile/instances/{instance.pk}/")
-        self.assertJSONResponse(response, 403)
+        response = self.client.delete(f"/api/mobile/instances/{instance.uuid}/")
+        self.assertJSONResponse(response, 405)
 
     def test_post_when_logged_in(self):
         """GET /mobile/instances/{instance.pk}/attachments/"""
         self.client.force_authenticate(self.user)
         response = self.client.post("/api/mobile/instances/", data={})
-        self.assertJSONResponse(response, 403)
+        self.assertJSONResponse(response, 405)
 
     def test_patch_when_logged_in(self):
         """GET /mobile/instances/{instance.pk}/attachments/"""
         self.client.force_authenticate(self.user)
         instance = self.form.instances.first()
-        response = self.client.patch(f"/api/mobile/instances/{instance.pk}/", data={})
-        self.assertJSONResponse(response, 403)
+        response = self.client.patch(f"/api/mobile/instances/{instance.uuid}/", data={})
+        self.assertJSONResponse(response, 405)
 
     def test_wrong_id_passed(self):
         """GET /mobile/instances/{instance.pk}/attachments/"""
@@ -113,21 +131,44 @@ class InstancesMobileAPITestCase(TaskAPITestCase):
         instance = self.instance_1
         m.InstanceFile.objects.create(instance=instance, file="test1.jpg")
         m.InstanceFile.objects.create(instance=instance, file="test2.pdf")
-        response = self.client.get(f"/api/mobile/instances/{instance.pk}/attachments/")
+        with self.assertNumQueries(10):
+            # 1. SELECT FROM "auth_permission"
+            # 2. SELECT FROM "auth_permission"
+            # 3. SELECT "iaso_orgunit"
+            # 4. SELECT "iaso_project"
+            # 5. SELECT "iaso_instance"
+            # 6. SELECT "iaso_orgunit"
+            # 7. SELECT "iaso_instance"
+            # 8. SELECT "iaso_instancefile"
+            # 9. SELECT "iaso_orgunit"
+            # 10. SELECT "iaso_form"
+            response = self.client.get(f"/api/mobile/instances/{instance.pk}/attachments/")
         self.assertJSONResponse(response, 200)
         data = response.json()["attachments"]
         self.assertEqual(len(data), 2)
         self.assertTrue(data[0]["file"].endswith("test1.jpg"))
         self.assertTrue(data[1]["file"].endswith("test2.pdf"))
 
-        response = self.client.get(f"/api/mobile/instances/{instance.uuid}/attachments/")
+        with self.assertNumQueries(5):
+            # 1. SELECT "iaso_orgunit"
+            # 2. SELECT "iaso_instance"
+            # 3. SELECT "iaso_instancefile"
+            # 4. SELECT "iaso_orgunit"
+            # 5. SELECT "iaso_form"
+            response = self.client.get(f"/api/mobile/instances/{instance.uuid}/attachments/")
         self.assertJSONResponse(response, 200)
         data = response.json()["attachments"]
         self.assertEqual(len(data), 2)
         self.assertTrue(data[0]["file"].endswith("test1.jpg"))
         self.assertTrue(data[1]["file"].endswith("test2.pdf"))
 
-        response = self.client.get(f"/api/mobile/instances/{self.instance_2.pk}/attachments/")
+        with self.assertNumQueries(5):
+            # 1. SELECT "iaso_orgunit"
+            # 2. SELECT "iaso_instance"
+            # 3. SELECT "iaso_instancefile"
+            # 4. SELECT "iaso_orgunit"
+            # 5. SELECT "iaso_form"
+            response = self.client.get(f"/api/mobile/instances/{self.instance_2.pk}/attachments/")
         self.assertJSONResponse(response, 200)
         data = response.json()["attachments"]
         self.assertEqual(len(data), 0)
@@ -138,7 +179,18 @@ class InstancesMobileAPITestCase(TaskAPITestCase):
         instance = self.instance_1
         m.InstanceFile.objects.create(instance=instance, file="test1.jpg")
         m.InstanceFile.objects.create(instance=instance, file="test2.pdf")
-        response = self.client.get(f"/api/mobile/instances/{instance.pk}/attachments/", data={IMAGE_ONLY: True})
+        with self.assertNumQueries(10):
+            # 1. SELECT FROM "auth_permission"
+            # 2. SELECT FROM "auth_permission"
+            # 3. SELECT "iaso_orgunit"
+            # 4. SELECT "iaso_project"
+            # 5. SELECT "iaso_instance"
+            # 6. SELECT "iaso_orgunit"
+            # 7. SELECT "iaso_instance"
+            # 8. SELECT "iaso_instancefile"
+            # 9. SELECT "iaso_orgunit"
+            # 10. SELECT "iaso_form"
+            response = self.client.get(f"/api/mobile/instances/{instance.uuid}/attachments/", data={IMAGE_ONLY: True})
         self.assertJSONResponse(response, 200)
         data = response.json()["attachments"]
         self.assertEqual(len(data), 1)

--- a/iaso/tests/api/instances/test_views_mobile.py
+++ b/iaso/tests/api/instances/test_views_mobile.py
@@ -76,19 +76,18 @@ class InstancesMobileAPITestCase(TaskAPITestCase):
         instance = self.instance_1
         m.InstanceFile.objects.create(instance=instance, file="test1.jpg")
         m.InstanceFile.objects.create(instance=instance, file="test2.pdf")
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(6):
             # 1. SELECT FROM "auth_permission"
             # 2. SELECT FROM "auth_permission"
             # 3. SELECT "iaso_orgunit"
             # 4. SELECT "iaso_project"
             # 5. SELECT "iaso_instance"
             # 6. SELECT "iaso_instancefile"
-            # 7. SELECT "iaso_orgunit"
-            # 8. SELECT "iaso_form"
             response = self.client.get(f"/api/mobile/instances/{instance.uuid}/")
         self.assertJSONResponse(response, 200)
         data = response.json()
         self.assertEqual(data["json"], {"foo": "bar"})
+        self.assertEqual(data["org_unit_id"], self.org_unit.id)
         self.assertEqual(len(data["instance_files"]), 2)
         self.assertTrue(data["instance_files"][0]["file"].endswith("test1.jpg"))
         self.assertTrue(data["instance_files"][1]["file"].endswith("test2.pdf"))
@@ -97,7 +96,7 @@ class InstancesMobileAPITestCase(TaskAPITestCase):
         """GET /mobile/instances/{instance.pk}/attachments/"""
         self.client.force_authenticate(self.user)
         response = self.client.get("/api/mobile/instances/")
-        self.assertJSONResponse(response, 405)
+        self.assertEqual(404, response.status_code)
 
     def test_delete_when_logged_in(self):
         """GET /mobile/instances/{instance.pk}/attachments/"""
@@ -110,7 +109,7 @@ class InstancesMobileAPITestCase(TaskAPITestCase):
         """GET /mobile/instances/{instance.pk}/attachments/"""
         self.client.force_authenticate(self.user)
         response = self.client.post("/api/mobile/instances/", data={})
-        self.assertJSONResponse(response, 405)
+        self.assertEqual(404, response.status_code)
 
     def test_patch_when_logged_in(self):
         """GET /mobile/instances/{instance.pk}/attachments/"""
@@ -123,7 +122,7 @@ class InstancesMobileAPITestCase(TaskAPITestCase):
         """GET /mobile/instances/{instance.pk}/attachments/"""
         self.client.force_authenticate(self.user)
         response = self.client.get("/api/mobile/instances/test/attachments/", data={})
-        self.assertJSONResponse(response, 404)
+        self.assertEqual(404, response.status_code)
 
     def test_attachments_when_logged_in(self):
         """GET /mobile/instances/{instance.pk}/attachments/"""
@@ -131,7 +130,7 @@ class InstancesMobileAPITestCase(TaskAPITestCase):
         instance = self.instance_1
         m.InstanceFile.objects.create(instance=instance, file="test1.jpg")
         m.InstanceFile.objects.create(instance=instance, file="test2.pdf")
-        with self.assertNumQueries(10):
+        with self.assertNumQueries(8):
             # 1. SELECT FROM "auth_permission"
             # 2. SELECT FROM "auth_permission"
             # 3. SELECT "iaso_orgunit"
@@ -140,8 +139,6 @@ class InstancesMobileAPITestCase(TaskAPITestCase):
             # 6. SELECT "iaso_orgunit"
             # 7. SELECT "iaso_instance"
             # 8. SELECT "iaso_instancefile"
-            # 9. SELECT "iaso_orgunit"
-            # 10. SELECT "iaso_form"
             response = self.client.get(f"/api/mobile/instances/{instance.pk}/attachments/")
         self.assertJSONResponse(response, 200)
         data = response.json()["attachments"]
@@ -149,7 +146,7 @@ class InstancesMobileAPITestCase(TaskAPITestCase):
         self.assertTrue(data[0]["file"].endswith("test1.jpg"))
         self.assertTrue(data[1]["file"].endswith("test2.pdf"))
 
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(3):
             # 1. SELECT "iaso_orgunit"
             # 2. SELECT "iaso_instance"
             # 3. SELECT "iaso_instancefile"
@@ -165,9 +162,9 @@ class InstancesMobileAPITestCase(TaskAPITestCase):
         with self.assertNumQueries(5):
             # 1. SELECT "iaso_orgunit"
             # 2. SELECT "iaso_instance"
-            # 3. SELECT "iaso_instancefile"
-            # 4. SELECT "iaso_orgunit"
-            # 5. SELECT "iaso_form"
+            # 3. SELECT "iaso_orgunit"
+            # 4. SELECT "iaso_instance"
+            # 5. SELECT "iaso_instancefile"
             response = self.client.get(f"/api/mobile/instances/{self.instance_2.pk}/attachments/")
         self.assertJSONResponse(response, 200)
         data = response.json()["attachments"]
@@ -179,7 +176,7 @@ class InstancesMobileAPITestCase(TaskAPITestCase):
         instance = self.instance_1
         m.InstanceFile.objects.create(instance=instance, file="test1.jpg")
         m.InstanceFile.objects.create(instance=instance, file="test2.pdf")
-        with self.assertNumQueries(10):
+        with self.assertNumQueries(8):
             # 1. SELECT FROM "auth_permission"
             # 2. SELECT FROM "auth_permission"
             # 3. SELECT "iaso_orgunit"
@@ -188,8 +185,6 @@ class InstancesMobileAPITestCase(TaskAPITestCase):
             # 6. SELECT "iaso_orgunit"
             # 7. SELECT "iaso_instance"
             # 8. SELECT "iaso_instancefile"
-            # 9. SELECT "iaso_orgunit"
-            # 10. SELECT "iaso_form"
             response = self.client.get(f"/api/mobile/instances/{instance.uuid}/attachments/", data={IMAGE_ONLY: True})
         self.assertJSONResponse(response, 200)
         data = response.json()["attachments"]


### PR DESCRIPTION
## What problem is this PR solving?

The mobile needs an endpoint to retrieve instance information in order to download them.

### Related JIRA tickets

IA-4865

## Changes

Allowed `/api/mobile/instances/{id}/` endpoint and return the same data as the reference instances.

## How to test

Call `/api/mobile/instances/{id}/` with the ID of a known instance.
