### PR TITLE
[IA-4732] Allow to search by organization + tests

### DIFF
--- a/iaso/api/profiles/filters.py
+++ b/iaso/api/profiles/filters.py
@@ -49,6 +49,7 @@ class ProfileListFilter(django_filters.rest_framework.FilterSet):
             | Q(user__tenant_user__main_user__username__icontains=value)
             | Q(user__first_name__icontains=value)
             | Q(user__last_name__icontains=value)
+            | Q(organization__icontains=value)
         ).distinct()
 
     def filter_location(self, queryset, name, value):

--- a/iaso/tests/api/test_profiles.py
+++ b/iaso/tests/api/test_profiles.py
@@ -2523,3 +2523,26 @@ class ProfileAPITestCase(APITestCase):
         response_data = self.assertJSONResponse(response, 200)
         self.assertEqual(response_data["count"], 7)
         self.assertEqual(response_data["results"][0]["user_name"], "janedoe")
+
+    def test_search_users_by_organization(self):
+        self.jane.iaso_profile.organization = "Some organization"
+        self.jane.iaso_profile.save()
+
+        self.client.force_authenticate(self.jane)
+        response = self.client.get(reverse("profiles-list", kwargs={"version": "v2"}), {"limit": 100})
+        response_data = self.assertJSONResponse(response, 200)
+        self.assertValidProfileListData(response_data, 7)
+
+        for parameter in ["so", "some org", "Some organization"]:
+            with self.subTest(f"Searching with {parameter}"):
+                response = self.client.get(
+                    reverse("profiles-list", kwargs={"version": "v2"}), {"limit": 100, "search": parameter}
+                )
+                response_data = self.assertJSONResponse(response, 200)
+                self.assertValidProfileListData(response_data, 1)
+
+        response = self.client.get(
+            reverse("profiles-list", kwargs={"version": "v2"}), {"limit": 100, "search": "wrong search"}
+        )
+        response_data = self.assertJSONResponse(response, 200)
+        self.assertValidProfileListData(response_data, 0)


### PR DESCRIPTION
## What problem is this PR solving?

It should be possible to filter users by organization through the search input on "list user" UI

### Related JIRA tickets

IA-4732

## Changes

Adapt  the search filter to contain organization as well

## How to test

* Python tests were added
* Front-end:
  * Go to Management => Users 
  * In the "search" input, type a value related to an organization (icontains, partial or exact), it should filter the users that icontains this organization 