### PR TITLE
IA-4864: Reverting the default fields back to fix the pipelines

### DIFF
--- a/iaso/api/org_units.py
+++ b/iaso/api/org_units.py
@@ -208,7 +208,10 @@ class OrgUnitViewSet(viewsets.ViewSet):
 
         order = request.query_params.get("order", "name").split(",")
         # Annotate number of instance per org unit to sort by it
-        count_instances = is_export or is_field_referenced("instances_count", requested_fields, order)
+        if requested_fields is None:
+            count_instances = True
+        else:
+            count_instances = is_export or is_field_referenced("instances_count", requested_fields, order)
 
         if with_shapes or as_location or parquet_format:
             count_instances = False

--- a/iaso/api/serializers.py
+++ b/iaso/api/serializers.py
@@ -233,19 +233,6 @@ class OrgUnitSearchSerializer(OrgUnitSerializer, DynamicFieldsModelSerializer):
             "default_image",
         ]
 
-        default_fields = [
-            "id",
-            "projects",
-            "name",
-            "org_unit_type_name",
-            "source",
-            "source_ref",
-            "instances_count",
-            "validation_status",
-            "created_at",
-            "updated_at",
-        ]
-
 
 # noinspection PyMethodMayBeStatic
 class OrgUnitTreeSearchSerializer(TimestampSerializerMixin, serializers.ModelSerializer):


### PR DESCRIPTION
## What problem is this PR solving?

The changes made in [IA-4600](https://bluesquare.atlassian.net/browse/IA-4600) broke the OpenHexa pipeline. This PR is about fixing it

### Related JIRA tickets

[IA-4864](https://bluesquare.atlassian.net/browse/IA-4864)

## Changes

- Reverted back to the original fields list in the `OrgUnitSearchSerializer`
- Implemented a check for the list view to return the heavy instances computation only when necessary


## How to test

Explain how to test your PR.

If a specific config is required explain it here: dataset, account, profile, etc.

## Print screen / video

Upload here print screens or videos showing the changes.

## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).


[IA-4600]: https://bluesquare.atlassian.net/browse/IA-4600?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IA-4864]: https://bluesquare.atlassian.net/browse/IA-4864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ