### PR TITLE
[IA-4866] replace drf-yasg by drf-spectacular

### DIFF
--- a/hat/settings.py
+++ b/hat/settings.py
@@ -219,7 +219,8 @@ INSTALLED_APPS += [
     "beanstalk_worker",
     "django_comments",
     "django_filters",
-    "drf_yasg",
+    "drf_spectacular",
+    "drf_spectacular_sidecar",
     "django_json_widget",
     "phonenumber_field",
 ]
@@ -475,6 +476,21 @@ REST_FRAMEWORK = {
         "no_underscore_before_number": True,
     },
     "TEST_REQUEST_DEFAULT_FORMAT": "json",  # The default format that should be used when making test requests.
+    "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
+}
+
+SPECTACULAR_SETTINGS = {
+    "SWAGGER_UI_DIST": "SIDECAR",
+    "SWAGGER_UI_FAVICON_HREF": "SIDECAR",
+    "REDOC_DIST": "SIDECAR",
+    "TITLE": "Iaso",
+    "DESCRIPTION": "Iaso Swagger",
+    "VERSION": "v1",
+    "SERVE_PERMISSIONS": [
+        "rest_framework.permissions.IsAdminUser",
+        "iaso.drf_spectacular_utils.permissions.HasAccountAndProfile",
+    ],
+    "TAGS": [{"name": "polio-configs", "description": "Polio configuration"}],
 }
 
 REST_FRAMEWORK_SERIALIZER_FIELDS_MAPPINGS = {

--- a/hat/urls.py
+++ b/hat/urls.py
@@ -9,11 +9,9 @@ from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin, auth
 from django.shortcuts import render
-from django.urls import include, path, re_path
+from django.urls import include, path
 from django.views.generic import RedirectView, TemplateView
-from drf_yasg import openapi
-from drf_yasg.views import get_schema_view
-from rest_framework import permissions
+from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView, SpectacularSwaggerView
 
 from iaso.views import ModelDataView, health, health_clamav, page, robots_txt
 
@@ -124,22 +122,12 @@ else:
         else:
             print(f"URL module not found for plugin: {plugin_name}")
 
-    # Swagger config
-    schema_view = get_schema_view(
-        openapi.Info(
-            title="Iaso",
-            default_version="v1",
-            description="Iaso Swagger",
-        ),
-        public=False,
-        urlconf="hat.urls",
-        permission_classes=(permissions.IsAdminUser,),
-    )
-
-    urlpatterns = urlpatterns + [
-        re_path(r"^swagger(?P<format>\.json|\.yaml)$", schema_view.without_ui(cache_timeout=0), name="schema-json"),
-        path("swagger/", schema_view.with_ui("swagger", cache_timeout=0), name="schema-swagger-ui"),
-        path("redoc/", schema_view.with_ui("redoc", cache_timeout=0), name="schema-redoc"),
+    # swagger
+    urlpatterns += [
+        path("swagger/", SpectacularAPIView.as_view(), name="swagger-schema"),
+        # Optional UI:
+        path("swagger-ui/", SpectacularSwaggerView.as_view(url_name="swagger-schema"), name="swagger-ui"),
+        path("redoc/", SpectacularRedocView.as_view(url_name="swagger-schema"), name="redoc"),
     ]
 
     if settings.BEANSTALK_WORKER or settings.DEBUG or settings.IN_TESTS:

--- a/iaso/api/check_version.py
+++ b/iaso/api/check_version.py
@@ -1,6 +1,5 @@
 from django.utils.datastructures import MultiValueDictKeyError
-from drf_yasg import openapi
-from drf_yasg.utils import swagger_auto_schema
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import permissions, status
 from rest_framework.exceptions import ValidationError
 from rest_framework.generics import get_object_or_404
@@ -27,29 +26,29 @@ class CheckVersionViewSet(ViewSet):
     http_method_names = ["get", "head", "options"]
     lookup_url_kwarg = [APP_ID, APP_VERSION]
 
-    app_id_param = openapi.Parameter(
-        name=APP_ID,
-        in_=openapi.IN_QUERY,
-        required=True,
-        description="Application id",
-        type=openapi.TYPE_STRING,
-    )
-    app_version_param = openapi.Parameter(
-        name=APP_VERSION,
-        in_=openapi.IN_QUERY,
-        required=True,
-        description="Version to be tested",
-        type=openapi.TYPE_INTEGER,
-    )
-
-    @swagger_auto_schema(
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name=APP_ID,
+                description="Application id",
+                required=True,
+                type=str,
+                location=OpenApiParameter.QUERY,
+            ),
+            OpenApiParameter(
+                name=APP_VERSION,
+                description="Version to be tested",
+                required=True,
+                type=int,
+                location=OpenApiParameter.QUERY,
+            ),
+        ],
         responses={
             204: "version provided for given app id is valid",
             400: f"parameters '{APP_ID}' or '{APP_VERSION}' were not provided or '{APP_VERSION}' is not an integer",
             404: "project for given app id doesn't exist",
             426: "version provided for given app id is **not** valid",
         },
-        manual_parameters=[app_id_param, app_version_param],
     )
     def list(self, request: Request, *args, **kwargs):
         # region input validation

--- a/iaso/api/completeness_stats.py
+++ b/iaso/api/completeness_stats.py
@@ -354,7 +354,6 @@ class CompletenessStatsV2ViewSet(viewsets.ViewSet):
         ),  # type: ignore
     ]  # type: ignore
 
-    # @swagger_auto_schema(query_serializer=ParamSerializer())
     def list(self, request: Request, *args, **kwargs) -> Response:
         """Completeness of form submission"""
         paramsSerializer = ParamSerializer(data=request.query_params, context={"request": request})

--- a/iaso/api/config.py
+++ b/iaso/api/config.py
@@ -1,4 +1,4 @@
-from drf_yasg.utils import swagger_auto_schema
+from drf_spectacular.utils import extend_schema
 from rest_framework import serializers
 
 from iaso.api.common import ModelViewSet
@@ -14,7 +14,7 @@ class ConfigSerializer(serializers.ModelSerializer):
     key = serializers.CharField(source="slug")
 
 
-@swagger_auto_schema(tags=["polio-configs"])
+@extend_schema(tags=["polio-configs"])
 class ConfigViewSet(ModelViewSet):
     http_method_names = ["get"]
     serializer_class = ConfigSerializer

--- a/iaso/api/data_store.py
+++ b/iaso/api/data_store.py
@@ -1,5 +1,5 @@
 from django.utils.text import slugify
-from drf_yasg.utils import swagger_auto_schema
+from drf_spectacular.utils import extend_schema
 from rest_framework import permissions, serializers
 
 from iaso.api.common import ModelViewSet
@@ -69,7 +69,7 @@ class DataStorePermission(permissions.BasePermission):
         return False
 
 
-@swagger_auto_schema(tags=["datastore"])
+@extend_schema(tags=["datastore"])
 class DataStoreViewSet(ModelViewSet):
     http_method_names = ["get", "post", "put", "delete"]
     permission_classes = [DataStorePermission]

--- a/iaso/api/deduplication/entity_duplicate.py
+++ b/iaso/api/deduplication/entity_duplicate.py
@@ -12,8 +12,8 @@ from django.db.models import Q
 from django.http import JsonResponse
 from django.utils.text import slugify
 from django_filters.rest_framework import DjangoFilterBackend  # type: ignore
-from drf_yasg import openapi
-from drf_yasg.utils import swagger_auto_schema
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import permissions, serializers, status
 from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError
@@ -390,12 +390,12 @@ class EntityDuplicatePostSerializer(serializers.Serializer):
         }
 
 
-duplicate_detail_entities_param = openapi.Parameter(
+duplicate_detail_entities_param = OpenApiParameter(
     name="entities",
-    in_=openapi.IN_QUERY,
-    description="Comma separeted list of 2 entities ids to to retrieve the duplicate about",
-    type=openapi.TYPE_STRING,
+    location=OpenApiParameter.QUERY,
+    description="Comma separated list of 2 entity ids to retrieve the duplicate about",
     required=True,
+    type=OpenApiTypes.STR,
 )
 
 
@@ -435,7 +435,7 @@ class EntityDuplicateViewSet(ModelViewSet):
         user_account = self.request.user.iaso_profile.account
         return EntityDuplicate.objects.filter_for_account(user_account)
 
-    @swagger_auto_schema(manual_parameters=[duplicate_detail_entities_param])
+    @extend_schema(parameters=[duplicate_detail_entities_param])
     @action(detail=False, methods=["get"], url_path="detail", pagination_class=None, filter_backends=[])
     def detail_view(self, request):
         """
@@ -561,7 +561,7 @@ class EntityDuplicateViewSet(ModelViewSet):
 
         return JsonResponse(return_data, safe=False)
 
-    @swagger_auto_schema(request_body=EntityDuplicatePostSerializer(many=False))
+    @extend_schema(request=EntityDuplicatePostSerializer)
     def create(self, request, pk=None, *args, **kwargs):
         """
         POST /api/entityduplicates/

--- a/iaso/api/deduplication/entity_duplicate_analyzis.py
+++ b/iaso/api/deduplication/entity_duplicate_analyzis.py
@@ -1,6 +1,6 @@
 from django.contrib.auth.models import User
 from django_filters.rest_framework import DjangoFilterBackend
-from drf_yasg.utils import swagger_auto_schema
+from drf_spectacular.utils import extend_schema
 from rest_framework import filters, permissions, serializers, status
 from rest_framework.response import Response
 
@@ -195,8 +195,8 @@ class EntityDuplicateAnalyzisViewSet(ModelViewSet):
 
         return Response(status=status.HTTP_204_NO_CONTENT)
 
-    @swagger_auto_schema(
-        request_body=AnalyzePostBodySerializer,
+    @extend_schema(
+        request=AnalyzePostBodySerializer,
     )
     def create(self, request, *args, **kwargs):
         """

--- a/iaso/api/form_predefined_filters/views.py
+++ b/iaso/api/form_predefined_filters/views.py
@@ -1,5 +1,5 @@
-from drf_yasg import openapi
-from drf_yasg.utils import swagger_auto_schema
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import exceptions
 from rest_framework.generics import get_object_or_404
 from rest_framework.request import Request
@@ -62,19 +62,19 @@ class FormPredefinedFiltersViewSet(ModelViewSet):
             queryset = queryset.filter(form=form)
         return queryset.order_by(*orders).distinct()
 
-    form_id_param = openapi.Parameter(
+    form_id_param = OpenApiParameter(
         name=FORM_ID,
-        in_=openapi.IN_QUERY,
+        location=OpenApiParameter.QUERY,
         description="Form id",
-        type=openapi.TYPE_NUMBER,
+        type=OpenApiTypes.NUMBER,
     )
 
-    @swagger_auto_schema(
+    @extend_schema(
         responses={
             200: "provides the latest updated dates",
             404: "Form for given form id doesn't exist",
         },
-        manual_parameters=[form_id_param],
+        parameters=[form_id_param],
     )
     def list(self, request: Request):
         return super().list(request)

--- a/iaso/api/mobile/bulk_uploads.py
+++ b/iaso/api/mobile/bulk_uploads.py
@@ -3,8 +3,8 @@ import logging
 from traceback import format_exc
 
 from django.core.files.uploadhandler import TemporaryFileUploadHandler
-from drf_yasg import openapi
-from drf_yasg.utils import swagger_auto_schema
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import permissions, serializers, status
 from rest_framework.generics import get_object_or_404
 from rest_framework.parsers import MultiPartParser
@@ -45,28 +45,30 @@ class MobileBulkUploadsViewSet(ViewSet):
     parser_classes = [MultiPartParser]
     permission_classes = [AuthenticationEnforcedPermission, MobileBulkUploadsPermission]
 
-    app_id_param = openapi.Parameter(
+    app_id_param = OpenApiParameter(
         name=APP_ID,
-        in_=openapi.IN_QUERY,
+        location=OpenApiParameter.QUERY,
         required=True,
         description="Application id",
-        type=openapi.TYPE_STRING,
+        type=OpenApiTypes.STR,
     )
-    zip_file_param = openapi.Parameter(
-        name="zip_file",
-        in_=openapi.IN_FORM,
-        required=True,
-        description="file to import",
-        type=openapi.TYPE_FILE,
-    )
+    # todo : this should be a serializer
+    # zip_file_param = OpenApiParameter(
+    #     name="zip_file",
+    #     location=OpenApiParameter.FORM,
+    #     required=True,
+    #     description="file to import",
+    #     type=OpenApiTypes.BINARY,
+    # )
 
-    @swagger_auto_schema(
+    @extend_schema(
         responses={
             204: "Import was successful",
             400: f"parameters '{APP_ID}' was not provided or post didn't contain an zip",
             404: "project for given app id doesn't exist",
         },
-        manual_parameters=[app_id_param, zip_file_param],
+        parameters=[app_id_param],
+        request=OpenApiTypes.BINARY,
     )
     def create(self, request):
         request.upload_handlers = [TemporaryFileUploadHandler(request)]

--- a/iaso/api/mobile/group_sets.py
+++ b/iaso/api/mobile/group_sets.py
@@ -1,7 +1,7 @@
 from django.db.models import BooleanField, ExpressionWrapper, Q
 from django.db.models.query import QuerySet
-from drf_yasg import openapi
-from drf_yasg.utils import swagger_auto_schema
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import permissions, serializers
 from rest_framework.generics import get_object_or_404
 from rest_framework.mixins import ListModelMixin
@@ -46,21 +46,21 @@ class MobileGroupSetsViewSet(ListModelMixin, GenericViewSet):
     permission_classes = [AuthenticationEnforcedPermission, permissions.AllowAny]
     serializer_class = MobileGroupSetSerializer
 
-    app_id_param = openapi.Parameter(
+    app_id_param = OpenApiParameter(
         name=APP_ID,
-        in_=openapi.IN_QUERY,
+        location=OpenApiParameter.QUERY,
         required=True,
         description="Application id (`Project.app_id`)",
-        type=openapi.TYPE_STRING,
+        type=OpenApiTypes.STR,
     )
 
-    @swagger_auto_schema(
+    @extend_schema(
         responses={
             200: f"List of groupset for the given '{APP_ID}'.",
             400: f"Parameter '{APP_ID}' is required.",
             404: f"Project for given '{APP_ID}' doesn't exist.",
         },
-        manual_parameters=[app_id_param],
+        parameters=[app_id_param],
     )
     def list(self, request: Request, *args, **kwargs) -> Response:
         return super().list(request, *args, **kwargs)

--- a/iaso/api/mobile/groups.py
+++ b/iaso/api/mobile/groups.py
@@ -1,7 +1,7 @@
 from django.db.models import BooleanField, ExpressionWrapper, Q, Value
 from django.db.models.query import QuerySet
-from drf_yasg import openapi
-from drf_yasg.utils import swagger_auto_schema
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import permissions, serializers
 from rest_framework.generics import get_object_or_404
 from rest_framework.mixins import ListModelMixin
@@ -40,30 +40,30 @@ class MobileGroupsViewSet(ListModelMixin, GenericViewSet):
     permission_classes = [AuthenticationEnforcedPermission, permissions.AllowAny]
     serializer_class = MobileGroupSerializer
 
-    app_id_param = openapi.Parameter(
+    app_id_param = OpenApiParameter(
         name=APP_ID,
-        in_=openapi.IN_QUERY,
+        location=OpenApiParameter.QUERY,
         required=True,
         description="Application id (`Project.app_id`)",
-        type=openapi.TYPE_STRING,
+        type=OpenApiTypes.STR,
     )
 
-    show_deleted_param = openapi.Parameter(
+    show_deleted_param = OpenApiParameter(
         name=SHOW_DELETED,
-        in_=openapi.IN_QUERY,
+        location=OpenApiParameter.QUERY,
         required=False,
         description="Include deleted groups",
-        type=openapi.TYPE_BOOLEAN,
+        type=OpenApiTypes.BOOL,
         default=False,
     )
 
-    @swagger_auto_schema(
+    @extend_schema(
         responses={
             200: f"List of groups for the given '{APP_ID}'.",
             400: f"Parameter '{APP_ID}' is required.",
             404: f"Project for given '{APP_ID}' doesn't exist.",
         },
-        manual_parameters=[app_id_param, show_deleted_param],
+        parameters=[app_id_param, show_deleted_param],
     )
     def list(self, request: Request, *args, **kwargs) -> Response:
         return super().list(request, *args, **kwargs)

--- a/iaso/api/mobile/metadata/last_updates.py
+++ b/iaso/api/mobile/metadata/last_updates.py
@@ -1,7 +1,7 @@
 from django.db.models import Max
 from django.shortcuts import get_object_or_404
-from drf_yasg import openapi
-from drf_yasg.utils import swagger_auto_schema
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import permissions, status
 from rest_framework.exceptions import ValidationError
 from rest_framework.request import Request
@@ -27,21 +27,21 @@ class LastUpdatesViewSet(ViewSet):
     http_method_names = ["get", "head", "options"]
     lookup_url_kwarg = [APP_ID]
 
-    app_id_param = openapi.Parameter(
+    app_id_param = OpenApiParameter(
         name=APP_ID,
-        in_=openapi.IN_QUERY,
+        location=OpenApiParameter.QUERY,
         required=True,
         description="Application id",
-        type=openapi.TYPE_STRING,
+        type=OpenApiTypes.STR,
     )
 
-    @swagger_auto_schema(
+    @extend_schema(
         responses={
             200: "provides the latest updated dates",
             400: f"parameter '{APP_ID}' was not provided",
             404: "project for given app id doesn't exist",
         },
-        manual_parameters=[app_id_param],
+        parameters=[app_id_param],
     )
     def list(self, request: Request):
         app_id = request.query_params.get(APP_ID)

--- a/iaso/api/mobile/storage.py
+++ b/iaso/api/mobile/storage.py
@@ -1,6 +1,6 @@
 from django.utils.datastructures import MultiValueDictKeyError
-from drf_yasg import openapi
-from drf_yasg.utils import swagger_auto_schema
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 from rest_framework.generics import get_object_or_404
@@ -38,21 +38,21 @@ class MobileStoragePasswordViewSet(ModelViewSet):
     serializer_class = MobileStoragePasswordSerializer
     lookup_url_kwarg = APP_ID
 
-    app_id_param = openapi.Parameter(
+    app_id_param = OpenApiParameter(
         name=APP_ID,
-        in_=openapi.IN_QUERY,
+        location=OpenApiParameter.QUERY,
         required=True,
         description="Application id",
-        type=openapi.TYPE_STRING,
+        type=OpenApiTypes.STR,
     )
 
-    @swagger_auto_schema(
+    @extend_schema(
         responses={
             200: "version provided for given app id is valid",
             400: f"parameters '{APP_ID}' was not provided",
             404: "project for given app id doesn't exist",
         },
-        manual_parameters=[app_id_param],
+        parameters=[app_id_param],
     )
     def get_queryset(self):
         try:

--- a/iaso/api/org_unit_change_request_configurations/views_mobile.py
+++ b/iaso/api/org_unit_change_request_configurations/views_mobile.py
@@ -4,8 +4,8 @@ import django_filters
 
 from django.db.models import Q
 from django.utils import timezone
-from drf_yasg import openapi
-from drf_yasg.utils import swagger_auto_schema
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import viewsets
 from rest_framework.mixins import ListModelMixin
 from rest_framework.request import Request
@@ -30,19 +30,19 @@ class MobileOrgUnitChangeRequestConfigurationViewSet(ListModelMixin, viewsets.Ge
     serializer_class = MobileOrgUnitChangeRequestConfigurationListSerializer
     pagination_class = OrgUnitChangeRequestConfigurationPagination
 
-    app_id_param = openapi.Parameter(
+    app_id_param = OpenApiParameter(
         name=APP_ID,
-        in_=openapi.IN_QUERY,
+        location=OpenApiParameter.QUERY,
         required=True,
         description="Application id (`Project.app_id`)",
-        type=openapi.TYPE_STRING,
+        type=OpenApiTypes.STR,
     )
-    include_creation_param = openapi.Parameter(
+    include_creation_param = OpenApiParameter(
         name=INCLUDE_CREATION,
-        in_=openapi.IN_QUERY,
+        location=OpenApiParameter.QUERY,
         required=True,
         description="Whether to include OUCRC creations (used for legacy reasons)",
-        type=openapi.TYPE_BOOLEAN,
+        type=OpenApiTypes.STR,
     )
 
     def get_queryset(self):
@@ -56,7 +56,7 @@ class MobileOrgUnitChangeRequestConfigurationViewSet(ListModelMixin, viewsets.Ge
             .order_by("org_unit_type_id")
         )
 
-    @swagger_auto_schema(manual_parameters=[app_id_param])
+    @extend_schema(parameters=[app_id_param])
     def list(self, request: Request, *args, **kwargs) -> Response:
         """
         Because some Org Unit Type restrictions are also configurable at the `Profile` level,

--- a/iaso/api/payments/views.py
+++ b/iaso/api/payments/views.py
@@ -8,8 +8,8 @@ from django.db.models.functions import Coalesce
 from django.http import HttpResponse, StreamingHttpResponse
 from django.utils import translation
 from django.utils.translation import get_language_from_request, gettext as _
-from drf_yasg import openapi
-from drf_yasg.utils import swagger_auto_schema
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import filters, permissions, status
 from rest_framework.exceptions import NotFound, ValidationError
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
@@ -149,39 +149,37 @@ class PaymentLotsViewSet(ModelViewSet):
 
         return queryset
 
-    @swagger_auto_schema(
-        manual_parameters=[
-            openapi.Parameter(
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
                 name="user",
-                in_=openapi.IN_QUERY,
+                location=OpenApiParameter.QUERY,
                 description="A comma-separated list of User IDs associated with the payment lots creation",
-                type=openapi.TYPE_STRING,
+                type=OpenApiTypes.STR,
             ),
-            openapi.Parameter(
+            OpenApiParameter(
                 name="status",
-                in_=openapi.IN_QUERY,
+                location=OpenApiParameter.QUERY,
                 description="A comma-separated list of the possible payment lot status",
-                type=openapi.TYPE_STRING,
+                type=OpenApiTypes.STR,
             ),
-            openapi.Parameter(
+            OpenApiParameter(
                 name="parent_id",
-                in_=openapi.IN_QUERY,
+                location=OpenApiParameter.QUERY,
                 description="The ID of the parent organization unit linked to the change requests. This should also include child units.",
-                type=openapi.TYPE_INTEGER,
+                type=OpenApiTypes.INT,
             ),
-            openapi.Parameter(
+            OpenApiParameter(
                 name="created_at_after",
-                in_=openapi.IN_QUERY,
+                location=OpenApiParameter.QUERY,
                 description="The start date for when the lots has been created. Format: YYYY-MM-DD",
-                type=openapi.TYPE_STRING,
-                format=openapi.FORMAT_DATE,
+                type=OpenApiTypes.DATE,
             ),
-            openapi.Parameter(
+            OpenApiParameter(
                 name="created_at_before",
-                in_=openapi.IN_QUERY,
+                location=OpenApiParameter.QUERY,
                 description="The end date for when the lots has been created. Format: YYYY-MM-DD",
-                type=openapi.TYPE_STRING,
-                format=openapi.FORMAT_DATE,
+                type=OpenApiTypes.DATE,
             ),
         ]
     )
@@ -189,14 +187,14 @@ class PaymentLotsViewSet(ModelViewSet):
         queryset = self.filter_queryset(self.get_queryset())
         return super().list(request, queryset)
 
-    @swagger_auto_schema(
+    @extend_schema(
         responses={status.HTTP_200_OK: PaymentLotSerializer()},
-        manual_parameters=[
-            openapi.Parameter(
+        parameters=[
+            OpenApiParameter(
                 name="mark_payments_as_sent",
-                in_=openapi.IN_QUERY,
+                location=OpenApiParameter.QUERY,
                 description="If set to true, all related payments will be marked as sent",
-                type=openapi.TYPE_BOOLEAN,
+                type=OpenApiTypes.BOOL,
             ),
         ],
     )
@@ -224,8 +222,8 @@ class PaymentLotsViewSet(ModelViewSet):
                     status=status.HTTP_201_CREATED,
                 )
 
-    @swagger_auto_schema(
-        request_body=PaymentLotCreateSerializer,
+    @extend_schema(
+        request=PaymentLotCreateSerializer,
         responses={status.HTTP_201_CREATED: PaymentLotSerializer()},
     )
     def create(self, request):
@@ -504,61 +502,59 @@ class PotentialPaymentsViewSet(ModelViewSet, AuditMixin):
 
         OrgUnitChangeRequest.objects.bulk_update(change_requests, ["potential_payment"])
 
-    @swagger_auto_schema(auto_schema=None)
+    @extend_schema(exclude=True)
     def retrieve(self, request, *args, **kwargs):
         raise NotFound("Retrieve operation is not allowed.")
 
-    @swagger_auto_schema(
-        manual_parameters=[
-            openapi.Parameter(
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
                 name="users",
-                in_=openapi.IN_QUERY,
+                location=OpenApiParameter.QUERY,
                 description="A comma-separated list of User IDs associated with the payments",
-                type=openapi.TYPE_STRING,
+                type=OpenApiTypes.STR,
             ),
-            openapi.Parameter(
+            OpenApiParameter(
                 name="user_roles",
-                in_=openapi.IN_QUERY,
+                location=OpenApiParameter.QUERY,
                 description="A comma-separated list of User Role IDs associated with the payments",
-                type=openapi.TYPE_STRING,
+                type=OpenApiTypes.STR,
             ),
-            openapi.Parameter(
+            OpenApiParameter(
                 name="parent_id",
-                in_=openapi.IN_QUERY,
+                location=OpenApiParameter.QUERY,
                 description="The ID of the parent organization unit linked to the change requests. This should also include child units.",
-                type=openapi.TYPE_INTEGER,
+                type=OpenApiTypes.INT,
             ),
-            openapi.Parameter(
+            OpenApiParameter(
                 name="change_requests__created_at_after",
-                in_=openapi.IN_QUERY,
+                location=OpenApiParameter.QUERY,
                 description="The start date for when the change request has been validated. Format: YYYY-MM-DD",
-                type=openapi.TYPE_STRING,
-                format=openapi.FORMAT_DATE,
+                type=OpenApiTypes.DATE,
             ),
-            openapi.Parameter(
+            OpenApiParameter(
                 name="change_requests__created_at_before",
-                in_=openapi.IN_QUERY,
+                location=OpenApiParameter.QUERY,
                 description="The end date for when the change request has been validated. Format: YYYY-MM-DD",
-                type=openapi.TYPE_STRING,
-                format=openapi.FORMAT_DATE,
+                type=OpenApiTypes.DATE,
             ),
-            openapi.Parameter(
+            OpenApiParameter(
                 name="select_all",
-                in_=openapi.IN_QUERY,
+                location=OpenApiParameter.QUERY,
                 description="Select all potential payments from the query",
-                type=openapi.TYPE_BOOLEAN,
+                type=OpenApiTypes.BOOL,
             ),
-            openapi.Parameter(
+            OpenApiParameter(
                 name="selected_ids",
-                in_=openapi.IN_QUERY,
+                location=OpenApiParameter.QUERY,
                 description="A comma-separated list of Potential Payments IDs selected to return from the query",
-                type=openapi.TYPE_STRING,
+                type=OpenApiTypes.STR,
             ),
-            openapi.Parameter(
+            OpenApiParameter(
                 name="unselected_ids",
-                in_=openapi.TYPE_STRING,
+                location=OpenApiParameter.QUERY,
                 description="A comma-separated list of Potential Payments IDs to exlude from the query",
-                type=openapi.TYPE_STRING,
+                type=OpenApiTypes.STR,
             ),
         ]
     )

--- a/iaso/api/profiles/bulk_create_users.py
+++ b/iaso/api/profiles/bulk_create_users.py
@@ -12,7 +12,7 @@ from django.core.files.base import ContentFile
 from django.db import transaction
 from django.db.models import Q
 from django.http import FileResponse
-from drf_yasg.utils import no_body, swagger_auto_schema
+from drf_spectacular.utils import extend_schema
 from rest_framework import permissions, serializers
 from rest_framework.decorators import action
 from rest_framework.response import Response
@@ -925,7 +925,7 @@ class BulkCreateUserFromCsvViewSet(ModelViewSet):
                 source=f"{PROFILE_API_BULK}_create",
             )
 
-    @swagger_auto_schema(request_body=no_body)
+    @extend_schema(request=None)
     @action(detail=False, methods=["get"], url_path="getsample")
     def download_sample_csv(self, request):
         return FileResponse(open("iaso/api/fixtures/sample_bulk_user_creation.csv", "rb"))

--- a/iaso/api/superset.py
+++ b/iaso/api/superset.py
@@ -1,7 +1,6 @@
 import requests
 
 from django.conf import settings
-from drf_yasg.utils import swagger_auto_schema
 from rest_framework import status, viewsets
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
@@ -9,7 +8,6 @@ from rest_framework.response import Response
 from iaso.api.permission_checks import AuthenticationEnforcedPermission
 
 
-@swagger_auto_schema()
 class SupersetTokenViewSet(viewsets.ViewSet):
     """
     POST /api/superset/token

--- a/iaso/api/workflows/changes.py
+++ b/iaso/api/workflows/changes.py
@@ -1,6 +1,6 @@
 from django.shortcuts import get_object_or_404
-from drf_yasg import openapi
-from drf_yasg.utils import no_body, swagger_auto_schema
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import permissions
 from rest_framework.response import Response
 
@@ -12,11 +12,11 @@ from iaso.models import WorkflowChange
 from iaso.permissions.core_permissions import CORE_WORKFLOW_PERMISSION
 
 
-version_id_param = openapi.Parameter(
+version_id_param = OpenApiParameter(
     name="version_id",
-    in_=openapi.IN_QUERY,
+    location=OpenApiParameter.QUERY,
     description="The workflow version id for which we create or delete a change",
-    type=openapi.TYPE_STRING,
+    type=OpenApiTypes.STR,
     required=True,
 )
 
@@ -43,9 +43,9 @@ class WorkflowChangeViewSet(ModelViewSet):
     serializer_class = ser.WorkflowChangeSerializer
     http_method_names = ["get", "post", "delete", "put"]
 
-    @swagger_auto_schema(
-        manual_parameters=[version_id_param],
-        request_body=ser.WorkflowChangeCreateSerializer,
+    @extend_schema(
+        parameters=[version_id_param],
+        request=ser.WorkflowChangeCreateSerializer,
     )
     def get_queryset(self):
         orders = self.request.query_params.get("order", "updated_at").split(",")
@@ -85,7 +85,7 @@ class WorkflowChangeViewSet(ModelViewSet):
 
         return Response(serializer.data, status=200)
 
-    @swagger_auto_schema(request_body=no_body)
+    @extend_schema(request=None)
     def destroy(self, request, *args, **kwargs):
         id_to_deleted = kwargs.get("pk")
 

--- a/iaso/api/workflows/followups.py
+++ b/iaso/api/workflows/followups.py
@@ -1,6 +1,6 @@
 from django_filters.rest_framework import DjangoFilterBackend  # type: ignore
-from drf_yasg import openapi
-from drf_yasg.utils import no_body, swagger_auto_schema
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import filters, permissions
 from rest_framework.decorators import action
 from rest_framework.response import Response
@@ -13,11 +13,11 @@ from iaso.models import WorkflowFollowup
 from iaso.permissions.core_permissions import CORE_WORKFLOW_PERMISSION
 
 
-workflow_version_id_param = openapi.Parameter(
+workflow_version_id_param = OpenApiParameter(
     name="workflow_version_id",
-    in_=openapi.IN_QUERY,
+    location=OpenApiParameter.QUERY,
     description="The workflow version id for which we create a followup",
-    type=openapi.TYPE_STRING,
+    type=OpenApiTypes.STR,
     required=True,
 )
 
@@ -63,9 +63,7 @@ class WorkflowFollowupViewSet(ModelViewSet):
     filterset_fields = {"workflow_version": ["exact"]}
     http_method_names = ["post", "delete"]
 
-    @swagger_auto_schema(
-        manual_parameters=[workflow_version_id_param], request_body=ser.WorkflowFollowupCreateSerializer
-    )
+    @extend_schema(parameters=[workflow_version_id_param], request=ser.WorkflowFollowupCreateSerializer)
     def create(self, request, *args, **kwargs):
         version_id = request.query_params.get("version_id", kwargs.get("version_id"))
         utils.validate_version_id(version_id, request.user)
@@ -77,7 +75,7 @@ class WorkflowFollowupViewSet(ModelViewSet):
         serialized_data = ser.WorkflowFollowupSerializer(res).data
         return Response(serialized_data)
 
-    @swagger_auto_schema(request_body=ser.WorkflowFollowupModifySerializer(many=True))
+    @extend_schema(request=ser.WorkflowFollowupModifySerializer(many=True))
     @action(detail=False, methods=["post"], url_path="bulkupdate")
     def bulk_update(self, request, *args, **kwargs):
         modifs = []
@@ -94,7 +92,7 @@ class WorkflowFollowupViewSet(ModelViewSet):
         resp = ser.WorkflowFollowupSerializer(modifs, many=True).data
         return Response(resp)
 
-    @swagger_auto_schema(request_body=no_body)
+    @extend_schema(request=None)
     def destroy(self, request, *args, **kwargs):
         followup_id = request.query_params.get("followup_id", kwargs.get("followup_id"))
         wf = WorkflowFollowup.objects.get(pk=followup_id)

--- a/iaso/api/workflows/mobile.py
+++ b/iaso/api/workflows/mobile.py
@@ -1,7 +1,7 @@
 import json
 
-from drf_yasg import openapi
-from drf_yasg.utils import swagger_auto_schema
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import permissions, serializers
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
@@ -57,8 +57,8 @@ class MobileWorkflowVersionSerializer(serializers.ModelSerializer):
         ]
 
 
-app_id_param = openapi.Parameter(
-    name="app_id", in_=openapi.IN_QUERY, description="The app id", type=openapi.TYPE_STRING, required=True
+app_id_param = OpenApiParameter(
+    name="app_id", location=OpenApiParameter.QUERY, description="The app id", type=OpenApiTypes.STR, required=True
 )
 
 
@@ -78,7 +78,7 @@ class MobileWorkflowViewSet(GenericViewSet):
     pagination_class = None
     paginator = None
 
-    @swagger_auto_schema(manual_parameters=[app_id_param])
+    @extend_schema(parameters=[app_id_param])
     def list(self, request, *args, **kwargs):
         app_id = AppIdSerializer(data=request.query_params).get_app_id(raise_exception=False)
 

--- a/iaso/api/workflows/versions.py
+++ b/iaso/api/workflows/versions.py
@@ -1,7 +1,7 @@
 from django.db.models import Q
 from django.shortcuts import get_object_or_404
 from django_filters.rest_framework import DjangoFilterBackend  # type: ignore
-from drf_yasg.utils import no_body, swagger_auto_schema
+from drf_spectacular.utils import extend_schema
 from rest_framework import filters, permissions
 from rest_framework.decorators import action
 from rest_framework.response import Response
@@ -33,7 +33,7 @@ class WorkflowVersionViewSet(ModelViewSet):
     filterset_fields = {"workflow__entity_type": ["exact"], "status": ["exact"], "id": ["exact"]}
     http_method_names = ["get", "post", "patch", "delete"]
 
-    @swagger_auto_schema(request_body=no_body)
+    @extend_schema(request=None)
     @action(detail=True, methods=["post"])
     def copy(self, request, **kwargs):
         """POST /api/workflowversions/{version_id}/copy
@@ -46,7 +46,7 @@ class WorkflowVersionViewSet(ModelViewSet):
         serialized_data = ser.WorkflowVersionSerializer(new_vw).data
         return Response(serialized_data)
 
-    @swagger_auto_schema(request_body=ser.WorkflowPartialUpdateSerializer)
+    @extend_schema(request=ser.WorkflowPartialUpdateSerializer)
     def partial_update(self, request, *args, **kwargs):
         version_id = request.query_params.get("version_id", kwargs.get("version_id"))
         wv_orig = get_object_or_404(WorkflowVersion, pk=version_id)
@@ -57,7 +57,7 @@ class WorkflowVersionViewSet(ModelViewSet):
         serialized_data = ser.WorkflowVersionSerializer(res).data
         return Response(serialized_data)
 
-    @swagger_auto_schema(request_body=ser.WorkflowPostSerializer)
+    @extend_schema(request=ser.WorkflowPostSerializer)
     def create(self, request, *args, **kwargs):
         """POST /api/workflowversions/
         Create a new empty and DRAFT workflow version for the workflow connected to Entity Type 'entity_type_id'

--- a/iaso/drf_spectacular_utils/permissions.py
+++ b/iaso/drf_spectacular_utils/permissions.py
@@ -1,0 +1,16 @@
+from rest_framework import permissions
+
+
+class HasAccountAndProfile(permissions.BasePermission):
+    def has_permission(self, request, view):
+        user = request.user
+        if not user or not user.is_authenticated:
+            return False
+
+        if not getattr(user, "iaso_profile", None):
+            return False
+
+        if not getattr(user.iaso_profile, "account", None):
+            return False
+
+        return True

--- a/iaso/tests/test_open_api.py
+++ b/iaso/tests/test_open_api.py
@@ -1,0 +1,46 @@
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+
+from iaso.models import Account
+from iaso.test import TestCase
+
+
+class TestDRFSpectacular(TestCase):
+    def setUp(self):
+        account = Account.objects.create(name="account")
+        self.user = get_user_model().objects.create(username="random user", password="random", email="random@test.com")
+        self.authenticated_super_user = get_user_model().objects.create(
+            username="random super user", password="random", email="randomsuperuser@test.com", is_superuser=True
+        )
+        self.superuser_with_profile = self.create_user_with_profile(account=account, username="user 1")
+        self.superuser_with_profile.is_superuser = True
+        self.superuser_with_profile.is_staff = True
+        self.superuser_with_profile.save()
+
+    def test_permissions(self):
+        for url in ["swagger-ui", "redoc", "swagger-schema"]:
+            for user in [self.user, self.authenticated_super_user]:
+                with self.subTest(f"Accessing url {url} with user {user} should raise 403"):
+                    self.client.force_login(user)
+                    res = self.client.get(reverse(url))
+                    self.assertEqual(res.status_code, 403)
+
+            with self.subTest(f"Accessing url {url} with anonymous user should raise 401"):
+                self.client.logout()
+                res = self.client.get(reverse(url))
+                self.assertEqual(res.status_code, 401)
+
+            with self.subTest(f"Accessing url {url} with right user should work"):
+                self.client.force_login(self.superuser_with_profile)
+                res = self.client.get(reverse(url))
+                self.assertEqual(res.status_code, 200)
+
+    def test_swagger_schema_view_is_working(self):
+        self.client.force_login(self.superuser_with_profile)
+        response = self.client.get(reverse("swagger-schema"))
+        self.assertEqual(response.status_code, 200)
+
+        self.assertIn(settings.SPECTACULAR_SETTINGS["TITLE"], response.content.decode())
+        self.assertIn("openapi", response.content.decode())
+        self.assertIn("paths", response.content.decode())

--- a/mypy.ini
+++ b/mypy.ini
@@ -13,9 +13,6 @@ ignore_missing_imports = True
 [mypy-dhis2.*]
 ignore_missing_imports = True
 
-[mypy-drf_yasg.*]
-ignore_missing_imports = True
-
 [mypy-responses.*]
 ignore_missing_imports = True
 

--- a/plugins/polio/api/dashboards/launch_powerbi.py
+++ b/plugins/polio/api/dashboards/launch_powerbi.py
@@ -1,4 +1,3 @@
-from drf_yasg.utils import swagger_auto_schema
 from rest_framework import permissions, serializers, status, viewsets
 from rest_framework.response import Response
 
@@ -10,7 +9,6 @@ class PowerBIRefreshSerializer(serializers.Serializer):
     data_set_id = serializers.UUIDField()
 
 
-@swagger_auto_schema()
 class LaunchPowerBIRefreshViewSet(viewsets.ViewSet):
     serializer_class = PowerBIRefreshSerializer
     # Open to all to make it work while calling this api from a iframe in RRT

--- a/plugins/polio/api/lqas_im/countries_with_lqas_im.py
+++ b/plugins/polio/api/lqas_im/countries_with_lqas_im.py
@@ -1,5 +1,5 @@
 from django_filters.rest_framework import DjangoFilterBackend  # type: ignore
-from drf_yasg.utils import swagger_auto_schema
+from drf_spectacular.utils import extend_schema
 from rest_framework import filters, permissions
 
 from iaso.api.common import ModelViewSet
@@ -7,7 +7,7 @@ from iaso.api.serializers import OrgUnitDropdownSerializer
 from iaso.models import OrgUnit
 
 
-@swagger_auto_schema(tags=["lqasimcountries"])
+@extend_schema(tags=["lqasimcountries"])
 class CountriesWithLqasIMConfigViewSet(ModelViewSet):
     http_method_names = ["get"]
     permission_classes = [permissions.IsAuthenticatedOrReadOnly]

--- a/plugins/polio/api/lqas_im/lqasim_global_map.py
+++ b/plugins/polio/api/lqas_im/lqasim_global_map.py
@@ -1,4 +1,4 @@
-from drf_yasg.utils import swagger_auto_schema
+from drf_spectacular.utils import extend_schema
 from rest_framework.response import Response
 
 from iaso.api.common import ReadOnlyOrHasPermission
@@ -11,7 +11,7 @@ from plugins.polio.api.lqas_im.lqasim_zoom_in_map import get_latest_active_campa
 from plugins.polio.permissions import POLIO_CONFIG_PERMISSION, POLIO_PERMISSION
 
 
-@swagger_auto_schema(tags=["lqasglobal"])
+@extend_schema(tags=["lqasglobal"])
 class LQASIMGlobalMapViewSet(LqasAfroViewset):
     http_method_names = ["get"]
     permission_classes = [ReadOnlyOrHasPermission(POLIO_PERMISSION, POLIO_CONFIG_PERMISSION)]

--- a/plugins/polio/api/lqas_im/lqasim_zoom_in_map.py
+++ b/plugins/polio/api/lqas_im/lqasim_zoom_in_map.py
@@ -5,7 +5,7 @@ from datetime import timedelta
 
 from django.contrib.gis.geos import Polygon
 from django.db.models import Q, Subquery
-from drf_yasg.utils import swagger_auto_schema
+from drf_spectacular.utils import extend_schema
 from rest_framework import permissions
 from rest_framework.response import Response
 
@@ -60,7 +60,7 @@ def get_latest_active_campaign_and_rounds(org_unit, start_date_after, end_date_b
     return latest_active_campaign, latest_active_campaign_rounds, round_numbers
 
 
-@swagger_auto_schema(tags=["lqaszoomin"])
+@extend_schema(tags=["lqaszoomin"])
 class LQASIMZoominMapViewSet(LqasAfroViewset):
     http_method_names = ["get"]
     permission_classes = [permissions.IsAuthenticatedOrReadOnly]
@@ -206,7 +206,7 @@ class LQASIMZoominMapViewSet(LqasAfroViewset):
         return Response({"results": results})
 
 
-@swagger_auto_schema(tags=["lqaszoominbackground"])
+@extend_schema(tags=["lqaszoominbackground"])
 class LQASIMZoominMapBackgroundViewSet(ModelViewSet):
     http_method_names = ["get"]
     permission_classes = [permissions.IsAuthenticatedOrReadOnly]

--- a/plugins/polio/api/rounds/round_date_history/views.py
+++ b/plugins/polio/api/rounds/round_date_history/views.py
@@ -1,5 +1,5 @@
 from django_filters.rest_framework import DjangoFilterBackend  # type: ignore
-from drf_yasg.utils import swagger_auto_schema
+from drf_spectacular.utils import extend_schema
 from rest_framework import filters, permissions
 
 from iaso.api.common import ModelViewSet
@@ -7,7 +7,7 @@ from plugins.polio.api.rounds.round_date_history.serializers import RoundDateHis
 from plugins.polio.models import RoundDateHistoryEntry
 
 
-@swagger_auto_schema(tags=["datelogs"])
+@extend_schema(tags=["datelogs"])
 class RoundDateHistoryEntryViewset(ModelViewSet):
     http_method_names = ["get"]
     permission_classes = [permissions.IsAuthenticatedOrReadOnly]

--- a/plugins/polio/api/rounds/views.py
+++ b/plugins/polio/api/rounds/views.py
@@ -1,5 +1,5 @@
 from django.db.models.expressions import Subquery
-from drf_yasg.utils import swagger_auto_schema
+from drf_spectacular.utils import extend_schema
 from rest_framework import serializers, status
 from rest_framework.decorators import action
 from rest_framework.response import Response
@@ -10,7 +10,7 @@ from plugins.polio.models import Campaign, Round
 from plugins.polio.permissions import POLIO_CONFIG_PERMISSION, POLIO_PERMISSION
 
 
-@swagger_auto_schema(tags=["rounds"], request_body=LqasDistrictsUpdateSerializer)
+@extend_schema(tags=["rounds"], request=LqasDistrictsUpdateSerializer)
 class RoundViewSet(ModelViewSet):
     # Patch should be in the list to allow updatelqasfields to work
     http_method_names = ["patch"]

--- a/plugins/polio/api/vaccines/repository_forms.py
+++ b/plugins/polio/api/vaccines/repository_forms.py
@@ -3,8 +3,8 @@
 from datetime import timedelta
 
 from django.db.models import Case, CharField, Exists, Max, Min, OuterRef, Q, Subquery, When
-from drf_yasg import openapi
-from drf_yasg.utils import swagger_auto_schema
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import filters, permissions, serializers
 from rest_framework.exceptions import ValidationError
 from rest_framework.filters import OrderingFilter, SearchFilter
@@ -168,51 +168,51 @@ class VaccineRepositoryFormsViewSet(GenericViewSet, ListModelMixin):
     permission_classes = [permissions.IsAuthenticatedOrReadOnly]
     default_page_size = 50
 
-    file_type_param = openapi.Parameter(
+    file_type_param = OpenApiParameter(
         "file_type",
-        openapi.IN_QUERY,
+        location=OpenApiParameter.QUERY,
         description="Filter by file type (VRF, PRE_ALERT, FORM_A)",
-        type=openapi.TYPE_STRING,
+        type=OpenApiTypes.STR,
     )
 
-    campaign_status_param = openapi.Parameter(
+    campaign_status_param = OpenApiParameter(
         "campaign_status",
-        openapi.IN_QUERY,
+        location=OpenApiParameter.QUERY,
         description="Filter by campaign status (ONGOING, PAST, PREPARING)",
-        type=openapi.TYPE_STRING,
+        type=OpenApiTypes.STR,
     )
 
-    vrf_type_param = openapi.Parameter(
+    vrf_type_param = OpenApiParameter(
         "vrf_type",
-        openapi.IN_QUERY,
+        location=OpenApiParameter.QUERY,
         description="Filter by VRF type (Normal, Missing, Not Required)",
-        type=openapi.TYPE_STRING,
+        type=OpenApiTypes.STR,
     )
 
-    campaign_id_param = openapi.Parameter(
+    campaign_id_param = OpenApiParameter(
         "campaign",
-        openapi.IN_QUERY,
+        location=OpenApiParameter.QUERY,
         description="Filter by campaign ID (OBR name)",
-        type=openapi.TYPE_STRING,
+        type=OpenApiTypes.STR,
     )
 
-    country_block_param = openapi.Parameter(
+    country_block_param = OpenApiParameter(
         "country_block",
-        openapi.IN_QUERY,
+        location=OpenApiParameter.QUERY,
         description="Filter by country block (comma separated list of org unit group ids)",
-        type=openapi.TYPE_STRING,
+        type=OpenApiTypes.STR,
     )
 
-    country_param = openapi.Parameter(
+    country_param = OpenApiParameter(
         "country",
-        openapi.IN_QUERY,
+        location=OpenApiParameter.QUERY,
         description="Filter by country (id of country)",
-        type=openapi.TYPE_STRING,
+        type=OpenApiTypes.STR,
     )
 
     # @method_decorator(cache_page(60 * 5))  # Cache for 5 minutes
-    @swagger_auto_schema(
-        manual_parameters=[
+    @extend_schema(
+        parameters=[
             file_type_param,
             campaign_status_param,
             vrf_type_param,

--- a/plugins/polio/api/vaccines/repository_reports.py
+++ b/plugins/polio/api/vaccines/repository_reports.py
@@ -1,8 +1,8 @@
 """API endpoints and serializers for vaccine repository reports."""
 
 from django.db.models import Q
-from drf_yasg import openapi
-from drf_yasg.utils import swagger_auto_schema
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import filters, permissions, serializers
 from rest_framework.exceptions import ValidationError
 from rest_framework.filters import OrderingFilter, SearchFilter
@@ -122,31 +122,31 @@ class VaccineRepositoryReportsViewSet(GenericViewSet, ListModelMixin):
 
         return base_qs.filter(Q(destructionreport__isnull=False) | Q(incidentreport__isnull=False))
 
-    @swagger_auto_schema(
-        manual_parameters=[
-            openapi.Parameter(
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
                 "file_type",
-                openapi.IN_QUERY,
+                location=OpenApiParameter.QUERY,
                 description="Filter by file type (IR, DR)",
-                type=openapi.TYPE_STRING,
+                type=OpenApiTypes.STR,
             ),
-            openapi.Parameter(
+            OpenApiParameter(
                 "country_block",
-                openapi.IN_QUERY,
+                location=OpenApiParameter.QUERY,
                 description="Filter by country block (comma separated list of org unit group ids)",
-                type=openapi.TYPE_STRING,
+                type=OpenApiTypes.STR,
             ),
-            openapi.Parameter(
+            OpenApiParameter(
                 "countries",
-                openapi.IN_QUERY,
+                location=OpenApiParameter.QUERY,
                 description="Filter by countries (comma separated list of country ids)",
-                type=openapi.TYPE_STRING,
+                type=OpenApiTypes.STR,
             ),
-            openapi.Parameter(
+            OpenApiParameter(
                 "vaccine_name",
-                openapi.IN_QUERY,
+                location=OpenApiParameter.QUERY,
                 description="Filter by vaccine name",
-                type=openapi.TYPE_STRING,
+                type=OpenApiTypes.STR,
             ),
         ]
     )

--- a/plugins/polio/api/vaccines/stock_management.py
+++ b/plugins/polio/api/vaccines/stock_management.py
@@ -9,8 +9,8 @@ from django.db.models import Q
 from django.http import HttpResponse
 from django.utils.dateparse import parse_date
 from django_filters.rest_framework import FilterSet, NumberFilter
-from drf_yasg import openapi
-from drf_yasg.utils import swagger_auto_schema
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import filters, permissions, serializers, status
 from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError
@@ -55,11 +55,11 @@ class CampaignCategory(str, Enum):
     REGULAR = "REGULAR"
 
 
-vaccine_stock_id_param = openapi.Parameter(
+vaccine_stock_id_param = OpenApiParameter(
     name="vaccine_stock",
-    in_=openapi.IN_QUERY,
+    location=OpenApiParameter.QUERY,
     description="The Vaccine Stock id related to the current object",
-    type=openapi.TYPE_INTEGER,
+    type=OpenApiTypes.INT,
     required=False,
 )
 
@@ -201,8 +201,8 @@ class VaccineStockSubitemBase(ModelViewSet):
     allowed_methods = ["get", "post", "head", "options", "patch", "delete"]
     model_class = None
 
-    @swagger_auto_schema(
-        manual_parameters=[vaccine_stock_id_param],
+    @extend_schema(
+        parameters=[vaccine_stock_id_param],
     )
     def list(self, request, *args, **kwargs):
         return super().list(request, *args, **kwargs)

--- a/plugins/polio/api/vaccines/vaccine_authorization.py
+++ b/plugins/polio/api/vaccines/vaccine_authorization.py
@@ -5,7 +5,7 @@ import itertools
 from typing import Any
 
 from django_filters.rest_framework import DjangoFilterBackend  # type: ignore
-from drf_yasg.utils import swagger_auto_schema
+from drf_spectacular.utils import extend_schema
 from rest_framework import filters, serializers
 from rest_framework.decorators import action
 from rest_framework.request import Request
@@ -118,7 +118,7 @@ class HasVaccineAuthorizationsPermissions(GenericReadWritePerm):
     write_perm = POLIO_VACCINE_AUTHORIZATIONS_ADMIN_PERMISSION
 
 
-@swagger_auto_schema(tags=["vaccineauthorizations"])
+@extend_schema(tags=["vaccineauthorizations"])
 class VaccineAuthorizationViewSet(ModelViewSet):
     """
     Vaccine Authorizations API

--- a/plugins/polio/budget/api.py
+++ b/plugins/polio/budget/api.py
@@ -4,7 +4,7 @@ from django.db.models import F, Q, QuerySet
 from django.http import HttpResponse
 from django.shortcuts import redirect
 from django_filters.rest_framework import DjangoFilterBackend  # type: ignore
-from drf_yasg.utils import swagger_auto_schema
+from drf_spectacular.utils import extend_schema
 from rest_framework import filters, permissions, serializers, status
 from rest_framework.decorators import action
 from rest_framework.generics import get_object_or_404
@@ -40,7 +40,7 @@ from plugins.polio.models import Campaign, Round
 from plugins.polio.permissions import POLIO_BUDGET_ADMIN_PERMISSION, POLIO_BUDGET_PERMISSION
 
 
-@swagger_auto_schema(tags=["budget"])
+@extend_schema(tags=["budget"])
 class BudgetProcessViewSet(ModelViewSet, CSVExportMixin):
     """
     Budget information endpoint.
@@ -188,7 +188,7 @@ class BudgetProcessViewSet(ModelViewSet, CSVExportMixin):
         return Response(available_rounds.as_ui_dropdown_data()["rounds"], status=status.HTTP_200_OK)
 
 
-@swagger_auto_schema(tags=["budget"])
+@extend_schema(tags=["budget"])
 class BudgetStepViewSet(ModelViewSet):
     """
     Step on a budget process, to progress the budget workflow.
@@ -262,7 +262,7 @@ class BudgetStepViewSet(ModelViewSet):
 
 
 # noinspection PyMethodMayBeStatic
-@swagger_auto_schema(tags=["budget"])
+@extend_schema(tags=["budget"])
 class WorkflowViewSet(ViewSet):
     """
     Info on the budge workflow

--- a/plugins/polio/budget/serializers.py
+++ b/plugins/polio/budget/serializers.py
@@ -2,7 +2,7 @@ from collections import OrderedDict
 from enum import Enum
 
 from django.db import transaction
-from drf_yasg.utils import swagger_serializer_method
+from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
 from iaso.api.common import DynamicFieldsModelSerializer, UserSerializer
@@ -298,7 +298,7 @@ class BudgetProcessSerializer(DynamicFieldsModelSerializer, serializers.ModelSer
                 "label": node.label,
             }
 
-    @swagger_serializer_method(serializer_or_field=TransitionSerializer(many=True))
+    @extend_schema_field(TransitionSerializer(many=True))
     def get_next_transitions(self, budget_process: BudgetProcess):
         # // get transition from workflow engine.
         workflow = get_workflow()
@@ -324,20 +324,20 @@ class BudgetProcessSerializer(DynamicFieldsModelSerializer, serializers.ModelSer
         return TransitionSerializer(transitions, many=True).data
 
     # this is used for filter dropdown
-    @swagger_serializer_method(serializer_or_field=NodeSerializer(many=True))
+    @extend_schema_field(NodeSerializer(many=True))
     def get_possible_states(self, _budget_process: BudgetProcess):
         workflow = get_workflow()
         nodes = workflow.nodes
         return NodeSerializer(nodes, many=True).data
 
     # this is used for filter dropdown
-    @swagger_serializer_method(serializer_or_field=TransitionSerializer(many=True))
+    @extend_schema_field(TransitionSerializer(many=True))
     def get_possible_transitions(self, _budget_process: BudgetProcess):
         workflow = get_workflow()
         transitions = workflow.transitions
         return NestedTransitionSerializer(transitions, many=True).data
 
-    @swagger_serializer_method(serializer_or_field=TimelineSerializer())
+    @extend_schema_field(TimelineSerializer())
     def get_timeline(self, budget_process: BudgetProcess):
         """Represent the progression of the budget process, per category
 
@@ -751,7 +751,7 @@ class BudgetStepSerializer(serializers.ModelSerializer):
     created_by_team: serializers.SlugRelatedField = serializers.SlugRelatedField(slug_field="name", read_only=True)
     created_by = UserSerializer()
 
-    @swagger_serializer_method(serializer_or_field=serializers.CharField)
+    @extend_schema_field(serializers.CharField)
     def get_transition_label(self, budget_step: BudgetStep) -> str:
         workflow = get_workflow()
         return workflow.get_transition_label_safe(budget_step.transition_key)

--- a/plugins/registry/api/registry.py
+++ b/plugins/registry/api/registry.py
@@ -1,6 +1,6 @@
 from django.http import JsonResponse
-from drf_yasg import openapi
-from drf_yasg.utils import swagger_auto_schema
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import serializers
 from rest_framework.decorators import action
 from rest_framework.request import Request
@@ -139,13 +139,13 @@ class PublicRegistryConfigSerializer(serializers.ModelSerializer):
 class PublicRegistryViewSet(ViewSet):
     permission_classes = []
 
-    @swagger_auto_schema(
-        manual_parameters=[
-            openapi.Parameter(
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
                 "registry_slug",
-                openapi.IN_QUERY,
+                location=OpenApiParameter.QUERY,
                 description="Slug of the public registry configuration",
-                type=openapi.TYPE_STRING,
+                type=OpenApiTypes.STR,
                 required=True,
             ),
         ]
@@ -164,13 +164,13 @@ class PublicRegistryViewSet(ViewSet):
         return JsonResponse(serializer.data)
 
     # http://127.0.0.1:8000/api/public/registry/instances/7/
-    @swagger_auto_schema(
-        manual_parameters=[
-            openapi.Parameter(
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
                 "instance_id",
-                openapi.IN_PATH,
+                location=OpenApiParameter.PATH,
                 description="ID of the instance",
-                type=openapi.TYPE_INTEGER,
+                type=OpenApiTypes.INT,
                 required=True,
             ),
         ]
@@ -204,27 +204,27 @@ class PublicRegistryViewSet(ViewSet):
 
         return JsonResponse(instance_data)
 
-    @swagger_auto_schema(
-        manual_parameters=[
-            openapi.Parameter(
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
                 "registry_slug",
-                openapi.IN_QUERY,
+                location=OpenApiParameter.QUERY,
                 description="Slug of the public registry configuration",
-                type=openapi.TYPE_STRING,
+                type=OpenApiTypes.STR,
                 required=False,
             ),
-            openapi.Parameter(
+            OpenApiParameter(
                 "page",
-                openapi.IN_QUERY,
+                location=OpenApiParameter.QUERY,
                 description="Page number",
-                type=openapi.TYPE_INTEGER,
+                type=OpenApiTypes.INT,
                 required=False,
             ),
-            openapi.Parameter(
+            OpenApiParameter(
                 "limit",
-                openapi.IN_QUERY,
+                location=OpenApiParameter.QUERY,
                 description="Number of items per page",
-                type=openapi.TYPE_INTEGER,
+                type=OpenApiTypes.INT,
                 required=False,
             ),
         ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ django-cors-headers==4.3.1  # https://github.com/adamchainz/django-cors-headers/
 djangorestframework-csv==3.0.2  # https://github.com/mjumbewu/django-rest-framework-csv/tags
 djangorestframework==3.14.0  # https://github.com/encode/django-rest-framework/tags
 djangorestframework_simplejwt==5.3.1  # https://github.com/jazzband/djangorestframework-simplejwt/tags
-drf-yasg==1.21.7  # https://github.com/axnsan12/drf-yasg/tags
+drf-spectacular[sidecar]==0.29.0  # https://github.com/tfranzel/drf-spectacular
 pyjwt==1.7.1  # https://github.com/jpadilla/pyjwt/tags
 nested-multipart-parser==1.5.0 # https://github.com/remigermain/nested-multipart-parser
 djangorestframework-camel-case==1.4.2 # https://github.com/vbabiy/djangorestframework-camel-case


### PR DESCRIPTION
## What problem is this PR solving?

Our swagger wasn't working and using drf-yasg that is no more maintained.

### Related JIRA tickets

IA-4866

## Changes

* Replace drf-yasg by drf-spectacular
* Made the related changes
* Added a test to always check that our swagger is working

## How to test

* Create a superuser with an account and profile
* Open the urls /swagger, /swagger-ui or /redoc
* Enjoy

## Notes

drf-spectacular, on the opposite to drf-yasg, actually looks at the viewsets and serializer. 

Hence had a lot of errors saying "User has no attribute iaso_profile" or "Profile has no attribute account" because the code assumes everywhere that user.iaso_profile.account exists. 

In order to fix this, instead of modifying the code everywhere, I added a "permission check" to access swagger to actually have that iaso_profile and account. So you'll need a superuser with iaso_profile and account, contrary to drf-yasg  
