### PR TITLE
IA-4870: Slow forms api

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/forms/hooks/useGetForms.tsx
+++ b/hat/assets/js/apps/Iaso/domains/forms/hooks/useGetForms.tsx
@@ -46,7 +46,7 @@ const getForms = (params: FormsParams) => {
 };
 
 export const tableDefaults = {
-    order: 'instance_updated_at',
+    order: 'name',
     limit: 50,
     page: 1,
 };

--- a/iaso/api/forms.py
+++ b/iaso/api/forms.py
@@ -300,7 +300,7 @@ class FormsViewSet(ModelViewSet):
         requested_fields = self.request.query_params.get("fields")
 
         is_request_from_manifest = self.request.path.endswith("/manifest/")
-        default_order = "id" if is_request_from_manifest or self.action == "retrieve" else "instance_updated_at"
+        default_order = "id" if is_request_from_manifest else "name"
 
         order = self.request.query_params.get("order", default_order).split(",")
 


### PR DESCRIPTION
## What problem is this PR solving?

The Forms API is slow when ordering by the time of `last_saved_instance`, as it requires an expensive annotation. This is the default sorting order for the Forms list and therefore often triggered by accident. This PR sets the default ordering to `name` to avoid these accidental expensive calls. 

### Related JIRA tickets

IA-4870

## Changes

- Replace the default ordering on the backend api view from `last_saved_instance` to `name`
- On the frontend, set the default ordering on the forms list page to `name`

## How to test

Visit the Forms list page and check that the default ordering is by name. 

## Print screen / video

/ 

## Notes

/

## Doc

/ 