### PR TITLE
IA-4874: Correct usage of OSM tiles to avoid 403

### DIFF
--- a/hat/assets/js/apps/Iaso/constants/mapTiles.js
+++ b/hat/assets/js/apps/Iaso/constants/mapTiles.js
@@ -2,10 +2,10 @@ const arcgisPattern =
     'https://server.arcgisonline.com/ArcGIS/rest/services/{}/MapServer/tile/{z}/{y}/{x}.jpg';
 const tiles = {
     osm: {
-        maxZoom: 18,
-        url: 'https://{s}.tile.osm.org/{z}/{x}/{y}.png',
+        maxZoom: 19,
+        url: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
         attribution:
-            '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors',
+            '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
     },
     'arcgis-street': {
         maxZoom: 18,

--- a/hat/templates/iaso/base.html
+++ b/hat/templates/iaso/base.html
@@ -7,6 +7,8 @@
   <title>{{ app_title }}</title>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  {# OSM tile policy requires valid Referer; avoid restrictive Referrer-Policy #}
+  <meta name="referrer" content="strict-origin-when-cross-origin">
   <meta name="description" content="">
   <meta name="keywords" content="">
   {# favicon #}


### PR DESCRIPTION
## What problem is this PR solving?

<img width="1312" height="1090" alt="image (15)" src="https://github.com/user-attachments/assets/fb55ec52-edc2-41ab-b4f8-7f130710f74d" />
We need to follow OSM [wiki](https://operations.osmfoundation.org/policies/tiles/)


### Related JIRA tickets

IA-4874

## Changes

- meta referer
- adapt copyright

## How to test

This PR need to be deployed to see the changes, i deployed this PR on staging and it worked

## Print screen / video

<img width="862" height="789" alt="Screenshot 2026-03-16 at 15 32 30" src="https://github.com/user-attachments/assets/3b6a7c76-44a9-427e-86a9-54653ebc2eff" />
