### PR TITLE
IA-4870: Slow forms api (cont.)

### DIFF
--- a/iaso/api/forms.py
+++ b/iaso/api/forms.py
@@ -1,11 +1,10 @@
-from iaso.models.base import Mapping
 import typing
 
 from copy import copy
 from datetime import timedelta
 from xml.sax.saxutils import escape
 
-from django.db.models import BooleanField, Case, Count, Exists, Max, OuterRef, Prefetch, Q, When, Subquery
+from django.db.models import Count, Exists, OuterRef, Prefetch, Q, Subquery
 from django.http import HttpResponse, StreamingHttpResponse
 from django.utils.dateparse import parse_date
 from rest_framework import permissions, serializers, status
@@ -30,8 +29,9 @@ from iaso.models import (
     OrgUnit,
     OrgUnitType,
     Project,
-    ProjectFeatureFlags, Instance,
+    ProjectFeatureFlags,
 )
+from iaso.models.base import Mapping
 from iaso.permissions.core_permissions import CORE_FORMS_PERMISSION
 from iaso.utils.date_and_time import timestamp_to_datetime
 
@@ -375,15 +375,11 @@ class FormsViewSet(ModelViewSet):
         if search:
             queryset = queryset.filter(name__icontains=search)
 
-        # spare 8 or more sql when not needed
         if not is_request_from_manifest:
             # prefetch all relations returned by default ex /api/forms/?order=name&limit=50&page=1
             # TODO
             #  - be smarter cfr is_field_referenced
-            #  - wild guess form_versions is no more needed cfr with_latest_version that is "optimizing" it
-
             prefetch_relations = [
-                "form_versions",
                 "projects",
                 "projects__feature_flags",
                 "reference_of_org_unit_types",

--- a/iaso/api/forms.py
+++ b/iaso/api/forms.py
@@ -1,10 +1,11 @@
+from iaso.models.base import Mapping
 import typing
 
 from copy import copy
 from datetime import timedelta
 from xml.sax.saxutils import escape
 
-from django.db.models import BooleanField, Case, Count, Exists, Max, OuterRef, Prefetch, Q, When
+from django.db.models import BooleanField, Case, Count, Exists, Max, OuterRef, Prefetch, Q, When, Subquery
 from django.http import HttpResponse, StreamingHttpResponse
 from django.utils.dateparse import parse_date
 from rest_framework import permissions, serializers, status
@@ -25,10 +26,11 @@ from iaso.models import (
     Form,
     FormAttachment,
     FormVersion,
+    Instance,
     OrgUnit,
     OrgUnitType,
     Project,
-    ProjectFeatureFlags,
+    ProjectFeatureFlags, Instance,
 )
 from iaso.permissions.core_permissions import CORE_FORMS_PERMISSION
 from iaso.utils.date_and_time import timestamp_to_datetime
@@ -305,14 +307,8 @@ class FormsViewSet(ModelViewSet):
         order = self.request.query_params.get("order", default_order).split(",")
 
         if is_field_referenced("has_mappings", requested_fields, order):
-            queryset = queryset.annotate(
-                mapping_count=Count("mapping"),
-                has_mappings=Case(
-                    When(mapping_count__gt=0, then=True),
-                    default=False,
-                    output_field=BooleanField(),
-                ),
-            )
+            mappings_exist = Mapping.objects.filter(form_id=OuterRef("pk"))
+            queryset = queryset.annotate(has_mappings=Exists(mappings_exist))
 
         if is_field_referenced("has_attachments", requested_fields, order) and not is_request_from_manifest:
             attachment_exists = FormAttachment.objects.filter(form_id=OuterRef("pk"))
@@ -324,7 +320,8 @@ class FormsViewSet(ModelViewSet):
             profile = False
 
         if is_field_referenced("instance_updated_at", requested_fields, order) and not is_request_from_manifest:
-            queryset = queryset.annotate(instance_updated_at=Max("instances__updated_at"))
+            latest_instance = Instance.objects.filter(form=OuterRef("pk")).order_by("-updated_at")
+            queryset = queryset.annotate(instance_updated_at=Subquery(latest_instance.values("updated_at")[:1]))
 
         enable_count = is_field_referenced("instances_count", requested_fields, order) and not is_request_from_manifest
 

--- a/iaso/management/commands/create_index_form_perf.py
+++ b/iaso/management/commands/create_index_form_perf.py
@@ -1,0 +1,37 @@
+"""
+Management command to create an index outside of the regular deployment/migration process.
+
+Once it has been created, this file can be deleted and moved to a standard django migration.
+
+refs: IA-4870
+"""
+
+import time
+
+from django.core.management.base import BaseCommand
+from django.db import connection
+
+
+class Command(BaseCommand):
+    help = "Create a composite index on iaso_instance for form_id and updated_at."
+
+    def handle(self, *args, **options):
+        name = "iaso_instance_form_id_updated_at_composite"
+        sql = f"""
+            CREATE INDEX CONCURRENTLY IF NOT EXISTS {name}
+            ON iaso_instance (form_id, updated_at);
+        """
+
+        self.stdout.write(f"Starting concurrent index creation for: {name}")
+
+        start_time = time.time()
+
+        try:
+            with connection.cursor() as cursor:
+                cursor.execute(sql)
+
+            elapsed = time.time() - start_time
+            self.stdout.write(self.style.SUCCESS(f"Successfully created index in {elapsed:.2f} seconds."))
+
+        except Exception as e:
+            self.stdout.write(self.style.ERROR(f"Failed to create index: {str(e)}"))

--- a/iaso/tests/api/test_forms.py
+++ b/iaso/tests/api/test_forms.py
@@ -876,7 +876,7 @@ class FormsAPITestCase(APITestCase):
             self.assertNotIn(MAX_QUERY_INSTANCE_UPDATED_AT, sql, f"Found unexpected query: {sql}")
             self.assertNotIn(COUNT_QUERY_INSTANCE, sql, f"Found unexpected query: {sql}")
 
-        self.assertEqual(len(ctx.captured_queries), 8)
+        self.assertEqual(len(ctx.captured_queries), 9)
 
     def test_form_details_full_details(self):
         self.client.force_authenticate(self.yoda)

--- a/iaso/tests/api/test_forms.py
+++ b/iaso/tests/api/test_forms.py
@@ -876,7 +876,7 @@ class FormsAPITestCase(APITestCase):
             self.assertNotIn(MAX_QUERY_INSTANCE_UPDATED_AT, sql, f"Found unexpected query: {sql}")
             self.assertNotIn(COUNT_QUERY_INSTANCE, sql, f"Found unexpected query: {sql}")
 
-        self.assertEqual(len(ctx.captured_queries), 10)
+        self.assertEqual(len(ctx.captured_queries), 8)
 
     def test_form_details_full_details(self):
         self.client.force_authenticate(self.yoda)
@@ -896,4 +896,4 @@ class FormsAPITestCase(APITestCase):
                 at_least_one_query_with_max_and_count = True
 
         self.assertTrue(at_least_one_query_with_max_and_count)
-        self.assertEqual(len(ctx.captured_queries), 11)
+        self.assertEqual(len(ctx.captured_queries), 10)

--- a/iaso/tests/api/test_mobileforms.py
+++ b/iaso/tests/api/test_mobileforms.py
@@ -111,7 +111,7 @@ class MobileFormsAPITestCase(APITestCase):
             "updated_at",
             "reference_form_of_org_unit_types",
         ]
-        with self.assertNumQueries(14):
+        with self.assertNumQueries(13):
             response = self.client.get(
                 f"/api/mobile/forms/?fields={','.join(custom_fields)}", headers={"Content-Type": "application/json"}
             )


### PR DESCRIPTION
## What problem is this PR solving?

Improve performance of the forms API in the forms listing and when called from the submissions list.

### Related JIRA tickets

IA-4870

## Changes

- Fix issue with annotations causing a cartesian product and unnecessary joins
- Removed an unnecessary prefetch (thanks to Stéphan's previous optimizations)
  - This should fix the slow query as originally reported from Sentry
- Add a command to create a composite index for improved "latest submission" performance.

## How to test

- Visit the forms page and check that the forms load correctly (also check with setting all visible columns)
- Check the form submissions page forms dropdown.

## Print screen / video

/

## Notes

- Will add a celery task for WFP in a separate ticket / PR to create the index on Instances

## Doc

/