### PR TITLE
IA-4879: better user detail page

### DIFF
--- a/hat/assets/js/__tests__/integration/users/Users.integration.test.tsx
+++ b/hat/assets/js/__tests__/integration/users/Users.integration.test.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { faker } from '@faker-js/faker';
 import { screen } from '@testing-library/react';
-import { randomLanguage } from '../../factories/language';
-import { renderWithTheme } from '../../../tests/helpers';
 import { IntlProvider } from 'react-intl';
-import MESSAGES from "Iaso/domains/users/messages";
-import { Details } from "Iaso/domains/users/details";
+import { Details } from 'Iaso/domains/users/details';
+import MESSAGES from 'Iaso/domains/users/messages';
 import PERMISSIONS_MESSAGES from 'Iaso/domains/users/permissionsMessages';
+import { renderWithTheme } from '../../../tests/helpers';
+import { randomLanguage } from '../../factories/language';
 
 // mocking hooks
 vi.mock('bluesquare-components', async () => {
@@ -46,7 +46,6 @@ vi.mock('Iaso/utils/usersUtils', async () => {
         ...actual,
         useCurrentUser: mockCurrentUser,
     };
-
 });
 
 const mockSavePassword = vi.fn();
@@ -74,7 +73,6 @@ vi.mock('Iaso/domains/users/hooks/useSaveProfile', () => ({
     },
 }));
 
-
 vi.mock('Iaso/domains/users/hooks/useDeleteProfile', () => ({
     useDeleteProfile: () => {
         return {
@@ -84,6 +82,11 @@ vi.mock('Iaso/domains/users/hooks/useDeleteProfile', () => ({
     },
 }));
 
+vi.mock('@mui/lab', () => ({
+    Masonry: ({ children }: { children: React.ReactNode }) => (
+        <div data-testid="masonry">{children}</div>
+    ),
+}));
 
 // fake data
 
@@ -120,23 +123,10 @@ const randomUser = {
     phone_number: faker.phone.number(),
     home_page: faker.internet.url(),
     color: faker.color.rgb({ format: 'hex' }),
-    projects: [
-        getRandomProject(),
-        getRandomProject(),
-    ],
-    org_units: [
-        getRandomOrgUnit(),
-        getRandomOrgUnit(),
-    ],
-    user_roles_permissions: [
-        getRandomUserRole(),
-        getRandomUserRole(),
-    ],
-    permissions: [
-        'iaso_completeness',
-        'iaso_mappings'
-    ],
-
+    projects: [getRandomProject(), getRandomProject()],
+    org_units: [getRandomOrgUnit(), getRandomOrgUnit()],
+    user_roles_permissions: [getRandomUserRole(), getRandomUserRole()],
+    permissions: ['iaso_completeness', 'iaso_mappings'],
 };
 
 // actual tests
@@ -163,68 +153,56 @@ describe('User detail view integration test', () => {
             </IntlProvider>,
         );
 
-        expect(screen.getByText(MESSAGES.generalInfo.defaultMessage)).toBeInTheDocument();
-        expect(screen.getByText(MESSAGES.projects.defaultMessage)).toBeInTheDocument();
-        expect(screen.getByText(MESSAGES.locations.defaultMessage)).toBeInTheDocument();
-        expect(screen.queryAllByText(MESSAGES.permissions.defaultMessage)).not.toBeNull();
-        expect(screen.getByText(MESSAGES.user_roles.defaultMessage)).toBeInTheDocument();
+        expect(
+            screen.getByText(MESSAGES.generalInfo.defaultMessage),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByText(MESSAGES.projects.defaultMessage),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByText(MESSAGES.locations.defaultMessage),
+        ).toBeInTheDocument();
+        expect(
+            screen.queryAllByText(MESSAGES.permissions.defaultMessage),
+        ).not.toBeNull();
+        expect(
+            screen.getByText(MESSAGES.user_roles.defaultMessage),
+        ).toBeInTheDocument();
 
-        randomUser.projects.forEach(({name}) => {
-            expect(screen.getByText(name)).toBeInTheDocument()
-        })
+        randomUser.projects.forEach(({ name }) => {
+            expect(screen.getByText(name)).toBeInTheDocument();
+        });
 
-        randomUser.org_units.forEach(({name}) => {
-            expect(screen.getByText(name)).toBeInTheDocument()
-        })
+        randomUser.org_units.forEach(({ name }) => {
+            expect(screen.getByText(name)).toBeInTheDocument();
+        });
 
-        randomUser.user_roles_permissions.forEach(({name}) => {
-            expect(screen.getByText(name)).toBeInTheDocument()
-        })
+        randomUser.user_roles_permissions.forEach(({ name }) => {
+            expect(screen.getByText(name)).toBeInTheDocument();
+        });
 
         randomUser.permissions.forEach((perm: string) => {
             // @ts-ignore
-            expect(screen.getByText(PERMISSIONS_MESSAGES?.[perm]?.defaultMessage)).toBeInTheDocument()
-        })
-
-
+            expect(
+                screen.getByText(PERMISSIONS_MESSAGES?.[perm]?.defaultMessage),
+            ).toBeInTheDocument();
+        });
     });
-    it('deletes user and redirects to user list', async () => {
-
-    });
-    it('has all the initial fields filled in when updating the user', async () => {
-
-    });
-    it('reloads the data upon successful edit', async () => {
-
-    });
-    it('doesn\'t reload the page upon successful password modification', async () => {
-
-    });
-    it('displays the user data', async () => {
-
-    });
+    it('deletes user and redirects to user list', async () => {});
+    it('has all the initial fields filled in when updating the user', async () => {});
+    it('reloads the data upon successful edit', async () => {});
+    it("doesn't reload the page upon successful password modification", async () => {});
+    it('displays the user data', async () => {});
 });
 
 describe('User list integration test', () => {
-    it('has all the initial fields filled in when updating the user', async () => {
-
-    });
-    it('reloads the data upon successful edit', async () => {
-
-    });
-    it('deletes user and reload data', async () => {
-
-    });
-    it('reloads data upon successful create', async () => {
-
-    });
+    it('has all the initial fields filled in when updating the user', async () => {});
+    it('reloads the data upon successful edit', async () => {});
+    it('deletes user and reload data', async () => {});
+    it('reloads data upon successful create', async () => {});
 });
 
 describe('User general integration test', () => {
-    it('allows going to a user detail view from the list view by clicking on the icon', () => {
-
-    });
-    it('allows going back to the user list from user detail view', () => {
-
-    });
+    it('allows going to a user detail view from the list view by clicking on the icon', () => {});
+    it('allows going back to the user list from user detail view', () => {});
 });

--- a/hat/assets/js/apps/Iaso/domains/users/components/EditPasswordUserDialog.tsx
+++ b/hat/assets/js/apps/Iaso/domains/users/components/EditPasswordUserDialog.tsx
@@ -1,4 +1,6 @@
 import React, { FunctionComponent } from 'react';
+import PasswordIcon from '@mui/icons-material/Password';
+import { Button } from '@mui/material';
 import {
     ConfirmCancelModal,
     IntlMessage,
@@ -140,12 +142,12 @@ const PasswordEditButton = (props: PasswordEditButtonProps) => {
             color: 'white',
         },
     };
+    const { formatMessage } = useSafeIntl();
     return (
-        <EditButton
-            message={MESSAGES.updatePasswordButtonLabel}
-            color={'warning'}
-            {...extendedProps}
-        />
+        <Button variant={'contained'} color={'warning'} {...extendedProps}>
+            <PasswordIcon sx={{ mr: 1 }} />
+            {formatMessage(MESSAGES.updatePasswordButtonLabel)}
+        </Button>
     );
 };
 

--- a/hat/assets/js/apps/Iaso/domains/users/components/EditPasswordUserDialog.tsx
+++ b/hat/assets/js/apps/Iaso/domains/users/components/EditPasswordUserDialog.tsx
@@ -5,8 +5,8 @@ import {
     makeFullModal,
     useSafeIntl,
 } from 'bluesquare-components';
-import { FormikProvider, useFormik } from 'formik';
-import { MutateFunction } from 'react-query';
+import { FormikProps, FormikProvider, useFormik } from 'formik';
+import { UseMutateFunction } from 'react-query';
 import { EditButton } from 'Iaso/components/Buttons/EditButton';
 import InputComponent from 'Iaso/components/forms/InputComponent';
 import MESSAGES from 'Iaso/domains/users/messages';
@@ -16,11 +16,17 @@ import {
     useApiErrorValidation,
     useTranslatedErrors,
 } from 'Iaso/libs/validation';
-import { Profile } from 'Iaso/utils/usersUtils';
+import { DjangoError } from 'Iaso/types/general';
+import { User } from 'Iaso/utils/usersUtils';
 
 type Props = {
     titleMessage: IntlMessage;
-    savePassword: MutateFunction<Profile, any>;
+    savePassword: UseMutateFunction<
+        User,
+        DjangoError,
+        User | Partial<User>,
+        unknown
+    >;
     closeDialog: () => void;
     isOpen: boolean;
 };
@@ -54,7 +60,7 @@ const EditPasswordUserDialogComponent: FunctionComponent<Props> = ({
         validationSchema: schema,
     });
 
-    const onChange = (keyValue, value) => {
+    const onChange = (keyValue: string, value: string) => {
         setFieldTouched(keyValue, true);
         setFieldValue(keyValue, value);
     };
@@ -68,7 +74,7 @@ const EditPasswordUserDialogComponent: FunctionComponent<Props> = ({
         isValid,
         handleSubmit,
         resetForm,
-    } = formik;
+    }: FormikProps<Partial<SaveUserPasswordQuery>> = formik;
 
     const getErrors = useTranslatedErrors({
         errors,

--- a/hat/assets/js/apps/Iaso/domains/users/components/EditUserDialog.tsx
+++ b/hat/assets/js/apps/Iaso/domains/users/components/EditUserDialog.tsx
@@ -14,15 +14,15 @@ import {
     useSafeIntl,
 } from 'bluesquare-components';
 
-import { MutateFunction, useQueryClient } from 'react-query';
+import { UseMutateFunction, useQueryClient } from 'react-query';
 
 import { EditButton } from 'Iaso/components/Buttons/EditButton';
 import { EditIconButton } from 'Iaso/components/Buttons/EditIconButton';
 import { OrgUnit } from 'Iaso/domains/orgUnits/types/orgUnit';
 import { useGetProfile } from 'Iaso/domains/users/hooks/useGetProfiles';
-import { SxStyles } from 'Iaso/types/general';
+import { DjangoError, SxStyles } from 'Iaso/types/general';
 import * as Permissions from 'Iaso/utils/permissions';
-import { Profile, useCurrentUser } from 'Iaso/utils/usersUtils';
+import { useCurrentUser, User } from 'Iaso/utils/usersUtils';
 import MESSAGES from '../messages';
 import PermissionsAttribution from './PermissionsAttribution';
 import { useInitialUser } from './useInitialUser';
@@ -50,8 +50,13 @@ const styles: SxStyles = {
 
 type Props = {
     titleMessage: IntlMessage;
-    userId: string;
-    saveProfile: MutateFunction<Profile, any>;
+    userId?: number | string;
+    saveProfile: UseMutateFunction<
+        User,
+        DjangoError,
+        User | Partial<User>,
+        unknown
+    >;
     allowSendEmailInvitation?: boolean;
     isOpen: boolean;
     closeDialog: () => void;

--- a/hat/assets/js/apps/Iaso/domains/users/components/EditUserDialog.tsx
+++ b/hat/assets/js/apps/Iaso/domains/users/components/EditUserDialog.tsx
@@ -19,11 +19,13 @@ import { UseMutateFunction, useQueryClient } from 'react-query';
 import { EditButton } from 'Iaso/components/Buttons/EditButton';
 import { EditIconButton } from 'Iaso/components/Buttons/EditIconButton';
 import { OrgUnit } from 'Iaso/domains/orgUnits/types/orgUnit';
+import { UserRole } from 'Iaso/domains/userRoles/types/userRoles';
 import { useGetProfile } from 'Iaso/domains/users/hooks/useGetProfiles';
 import { DjangoError, SxStyles } from 'Iaso/types/general';
 import * as Permissions from 'Iaso/utils/permissions';
 import { useCurrentUser, User } from 'Iaso/utils/usersUtils';
 import MESSAGES from '../messages';
+import { InitialUserData } from '../types';
 import PermissionsAttribution from './PermissionsAttribution';
 import { useInitialUser } from './useInitialUser';
 import { UserOrgUnitWriteTypes } from './UserOrgUnitWriteTypes';
@@ -87,7 +89,7 @@ const EditUserDialogComponent: FunctionComponent<Props> = ({
         setPhoneNumber,
         hasErrors,
         setEmail,
-    } = useInitialUser(initialData);
+    } = useInitialUser(initialData as InitialUserData | undefined);
 
     const [tab, setTab] = useState('infos');
     const [openWarning, setOpenWarning] = useState<boolean>(false);
@@ -97,15 +99,17 @@ const EditUserDialogComponent: FunctionComponent<Props> = ({
         const currentUser: any = {};
         Object.keys(user).forEach(key => {
             if (key === 'org_units') {
-                currentUser[key] = user?.[key].value?.map(
-                    (orgUnit: OrgUnit) => orgUnit?.id,
-                );
+                currentUser[key] = (
+                    user?.[key]?.value as OrgUnit[] | undefined
+                )?.map(orgUnit => orgUnit?.id);
             } else if (key === 'user_roles') {
-                currentUser[key] = user?.[key].value?.map(
-                    userRole => userRole?.id ?? userRole,
+                currentUser[key] = user?.user_roles?.value?.map(
+                    (userRole: UserRole | number) =>
+                        (userRole as UserRole)?.id ?? userRole,
                 );
             } else {
-                currentUser[key] = user[key].value;
+                const userRecord = user as Record<string, { value: unknown }>;
+                currentUser[key] = userRecord[key]?.value;
             }
         });
 
@@ -288,7 +292,7 @@ const EditUserDialogComponent: FunctionComponent<Props> = ({
                                     setFieldValue={(key, value) =>
                                         setFieldValue(key, value)
                                     }
-                                    initialData={initialData}
+                                    initialData={initialData ?? {}}
                                     currentUser={user}
                                     allowSendEmailInvitation={
                                         allowSendEmailInvitation

--- a/hat/assets/js/apps/Iaso/domains/users/components/PermissionTable.tsx
+++ b/hat/assets/js/apps/Iaso/domains/users/components/PermissionTable.tsx
@@ -1,32 +1,46 @@
 import React, { FunctionComponent, useMemo } from 'react';
-import {
-    Column,
-    Table,
-    useSafeIntl,
-} from 'bluesquare-components';
+import { Box } from '@mui/material';
+import { Column, Table, useSafeIntl } from 'bluesquare-components';
 import PermissionTooltip from 'Iaso/domains/users/components/PermissionTooltip';
 import MESSAGES from 'Iaso/domains/users/messages';
 import PERMISSIONS_MESSAGES from 'Iaso/domains/users/permissionsMessages';
+import { SxStyles } from 'Iaso/types/general';
 
 type Props = {
     data: string[];
 };
 
+const styles: SxStyles = {
+    root: {
+        width: '100%',
+        maxHeight: '307px',
+        overflow: 'auto',
+        '& thead': {
+            display: 'none',
+        },
+    },
+};
 
-const usePermissionTableColumns = () => {
+const usePermissionTableColumns = (): Column[] => {
     const { formatMessage } = useSafeIntl();
     return useMemo(() => {
-        const columns = [
+        const columns: Column[] = [
             {
                 Header: '',
                 id: 'tooltip',
                 sortable: false,
-                align: 'center',
+                align: 'center' as const,
                 width: 50,
-                Cell: settings => {
+                Cell: ({
+                    row: {
+                        original: { permissionName },
+                    },
+                }: {
+                    row: { original: { permissionName: string } };
+                }) => {
                     return (
                         <PermissionTooltip
-                            codename={`${settings.row.original}_tooltip`}
+                            codename={`${permissionName}_tooltip`}
                         />
                     );
                 },
@@ -38,31 +52,42 @@ const usePermissionTableColumns = () => {
                 sortable: false,
                 width: 250,
                 align: 'left',
-                Cell: settings => {
-                    return PERMISSIONS_MESSAGES?.[settings.row.original] ? formatMessage(PERMISSIONS_MESSAGES?.[settings.row.original]) : settings.row.original;
+                Cell: ({
+                    row: {
+                        original: { permissionName },
+                    },
+                }: {
+                    row: { original: { permissionName: string } };
+                }) => {
+                    const message =
+                        permissionName in PERMISSIONS_MESSAGES
+                            ? PERMISSIONS_MESSAGES[
+                                  permissionName as keyof typeof PERMISSIONS_MESSAGES
+                              ]
+                            : undefined;
+                    return message ? formatMessage(message) : permissionName;
                 },
             },
         ];
         return columns;
-    }, [
-        formatMessage,
-    ]);
+    }, [formatMessage]);
 };
 export const PermissionTable: FunctionComponent<Props> = ({ data }) => {
-
     const columns: Column[] = usePermissionTableColumns();
 
     return (
-        <>
+        <Box sx={styles.root}>
             <Table
                 columns={columns}
-                data={data}
+                data={data.map(permission => ({
+                    permissionName: permission,
+                }))}
                 showPagination={false}
                 countOnTop={false}
                 marginTop={false}
                 marginBottom={false}
                 elevation={0}
             />
-        </>
+        </Box>
     );
 };

--- a/hat/assets/js/apps/Iaso/domains/users/components/UserDetailViewComponents/GeneralInfoWidgetPaper.tsx
+++ b/hat/assets/js/apps/Iaso/domains/users/components/UserDetailViewComponents/GeneralInfoWidgetPaper.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, Table, TableBody } from '@mui/material';
+import { Table, TableBody } from '@mui/material';
 import { LoadingSpinner, useSafeIntl } from 'bluesquare-components';
 import { ColorBadge } from 'Iaso/components/ColorBadge';
 import WidgetPaper from 'Iaso/components/papers/WidgetPaperComponent';
@@ -22,85 +22,82 @@ export const GeneralInfoWidgetPaper = ({
         <WidgetPaper
             title={formatMessage(MESSAGES.generalInfo)}
             data-testid={'general-info-box'}
+            sx={{ position: 'relative' }}
         >
-            {savingProfile ? (
-                <Box sx={{ my: 2 }}>
-                    <LoadingSpinner absolute={false} fixed={false} />
-                </Box>
-            ) : (
-                <Table size="small">
-                    <TableBody>
-                        <Row
-                            field={{
-                                label: formatMessage(MESSAGES.userName),
-                                value: profile?.user_name,
-                            }}
-                        />
-                        <Row
-                            field={{
-                                label: formatMessage(MESSAGES.firstName),
-                                value: profile?.first_name,
-                            }}
-                        />
-                        <Row
-                            field={{
-                                label: formatMessage(MESSAGES.lastName),
-                                value: profile?.last_name,
-                            }}
-                        />
-                        <Row
-                            field={{
-                                label: formatMessage(MESSAGES.email),
-                                value: profile?.email && (
-                                    <a href={`mailto:${profile?.email}`}>
-                                        {profile?.email}
-                                    </a>
-                                ),
-                            }}
-                        />
-                        <Row
-                            field={{
-                                label: formatMessage(MESSAGES.language),
-                                value: profile?.language,
-                            }}
-                        />
-                        <Row
-                            field={{
-                                label: formatMessage(MESSAGES.organization),
-                                value: profile?.organization,
-                            }}
-                        />
-                        <Row
-                            field={{
-                                label: formatMessage(MESSAGES.phoneNumber),
-                                value: profile?.phone_number && (
-                                    <a href={`tel:${profile?.phone_number}`}>
-                                        {profile?.phone_number}
-                                    </a>
-                                ),
-                            }}
-                        />
-                        <Row
-                            field={{
-                                label: formatMessage(MESSAGES.homePage),
-                                value: profile?.home_page,
-                            }}
-                        />
-                        <Row
-                            field={{
-                                label: formatMessage(MESSAGES.color),
-                                value: profile?.color && (
-                                    <ColorBadge
-                                        data-testid={'user-color-badge'}
-                                        backgroundColor={profile?.color}
-                                        tabIndex={0}
-                                    />
-                                ),
-                            }}
-                        />
-                    </TableBody>
-                </Table>
-            )}
+            {savingProfile && <LoadingSpinner absolute fixed={false} />}
+
+            <Table size="small">
+                <TableBody>
+                    <Row
+                        field={{
+                            label: formatMessage(MESSAGES.userName),
+                            value: profile?.user_name,
+                        }}
+                    />
+                    <Row
+                        field={{
+                            label: formatMessage(MESSAGES.firstName),
+                            value: profile?.first_name,
+                        }}
+                    />
+                    <Row
+                        field={{
+                            label: formatMessage(MESSAGES.lastName),
+                            value: profile?.last_name,
+                        }}
+                    />
+                    <Row
+                        field={{
+                            label: formatMessage(MESSAGES.email),
+                            value: profile?.email && (
+                                <a href={`mailto:${profile?.email}`}>
+                                    {profile?.email}
+                                </a>
+                            ),
+                        }}
+                    />
+                    <Row
+                        field={{
+                            label: formatMessage(MESSAGES.language),
+                            value: profile?.language,
+                        }}
+                    />
+                    <Row
+                        field={{
+                            label: formatMessage(MESSAGES.organization),
+                            value: profile?.organization,
+                        }}
+                    />
+                    <Row
+                        field={{
+                            label: formatMessage(MESSAGES.phoneNumber),
+                            value: profile?.phone_number && (
+                                <a href={`tel:${profile?.phone_number}`}>
+                                    {profile?.phone_number}
+                                </a>
+                            ),
+                        }}
+                    />
+                    <Row
+                        field={{
+                            label: formatMessage(MESSAGES.homePage),
+                            value: profile?.home_page,
+                        }}
+                    />
+                    <Row
+                        field={{
+                            label: formatMessage(MESSAGES.color),
+                            value: profile?.color && (
+                                <ColorBadge
+                                    data-testid={'user-color-badge'}
+                                    backgroundColor={profile?.color}
+                                    tabIndex={0}
+                                />
+                            ),
+                        }}
+                    />
+                </TableBody>
+            </Table>
         </WidgetPaper>
     );
 };

--- a/hat/assets/js/apps/Iaso/domains/users/components/UserDetailViewComponents/LocationsInfoWidgetPaper.tsx
+++ b/hat/assets/js/apps/Iaso/domains/users/components/UserDetailViewComponents/LocationsInfoWidgetPaper.tsx
@@ -1,44 +1,41 @@
-import WidgetPaper from 'Iaso/components/papers/WidgetPaperComponent';
 import React from 'react';
-import { LoadingSpinner, useSafeIntl } from 'bluesquare-components';
-import MESSAGES from 'Iaso/domains/users/messages';
 import { Alert, List, ListItem } from '@mui/material';
+import { LoadingSpinner, useSafeIntl } from 'bluesquare-components';
+import WidgetPaper from 'Iaso/components/papers/WidgetPaperComponent';
+import { LinkToOrgUnit } from 'Iaso/domains/orgUnits/components/LinkToOrgUnit';
 import { OrgUnit } from 'Iaso/domains/orgUnits/types/orgUnit';
+import MESSAGES from 'Iaso/domains/users/messages';
 import { ProfileRetrieveResponseItem } from 'Iaso/domains/users/types';
 
 type Props = {
     savingProfile?: boolean;
-    profile?: ProfileRetrieveResponseItem
-}
+    profile?: ProfileRetrieveResponseItem;
+};
 
-export const LocationsInfoWidgetPaper = ({
-                                             savingProfile,
-                                             profile,
-                                         }: Props) => {
+export const LocationsInfoWidgetPaper = ({ savingProfile, profile }: Props) => {
     const { formatMessage } = useSafeIntl();
 
-    return <WidgetPaper title={formatMessage(MESSAGES.locations)} data-testid={'locations-info-box'}>
-        {savingProfile ? <LoadingSpinner absolute={false} fixed={false} /> :
-            (profile?.org_units?.length ? (
+    return (
+        <WidgetPaper
+            title={formatMessage(MESSAGES.locations)}
+            data-testid={'locations-info-box'}
+        >
+            {savingProfile && <LoadingSpinner absolute fixed={false} />}
+
+            {profile?.org_units?.length && (
                 <List>
-                    {profile?.org_units?.map(
-                        (orgUnit: OrgUnit) => (
-                            <ListItem
-                                key={`orgUnit-${orgUnit.id}`}
-                            >
-                                {orgUnit.name}
-                            </ListItem>
-                        ),
-                    )}
+                    {profile?.org_units?.map((orgUnit: OrgUnit) => (
+                        <ListItem key={`orgUnit-${orgUnit.id}`}>
+                            <LinkToOrgUnit orgUnit={orgUnit} />
+                        </ListItem>
+                    ))}
                 </List>
-            ) : (
-                <Alert
-                    color={'info'}
-                    severity={'info'}
-                    sx={{ mx: 2, mb: 2 }}
-                >
+            )}
+            {!profile?.org_units?.length && (
+                <Alert color={'info'} severity={'info'} sx={{ mx: 2, mb: 2 }}>
                     {formatMessage(MESSAGES.noResultsFound)}
                 </Alert>
-            ))}
-    </WidgetPaper>;
+            )}
+        </WidgetPaper>
+    );
 };

--- a/hat/assets/js/apps/Iaso/domains/users/components/UserDetailViewComponents/PermissionsInfoWidgetPaper.tsx
+++ b/hat/assets/js/apps/Iaso/domains/users/components/UserDetailViewComponents/PermissionsInfoWidgetPaper.tsx
@@ -1,39 +1,41 @@
 import React from 'react';
-import { LoadingSpinner, useSafeIntl } from 'bluesquare-components';
-import { ProfileRetrieveResponseItem } from 'Iaso/domains/users/types';
-import WidgetPaper from 'Iaso/components/papers/WidgetPaperComponent';
 import { Alert } from '@mui/material';
-import { PermissionTable } from '../PermissionTable';
+import { LoadingSpinner, useSafeIntl } from 'bluesquare-components';
+import WidgetPaper from 'Iaso/components/papers/WidgetPaperComponent';
 import MESSAGES from 'Iaso/domains/users/messages';
+import { ProfileRetrieveResponseItem } from 'Iaso/domains/users/types';
+import { PermissionTable } from '../PermissionTable';
 
 type Props = {
     savingProfile?: boolean;
     profile?: ProfileRetrieveResponseItem;
-}
+};
 
 export const PermissionsInfoWidgetPaper = ({
-                                               savingProfile,
-                                               profile,
-                                           }: Props) => {
+    savingProfile,
+    profile,
+}: Props) => {
     const { formatMessage } = useSafeIntl();
-    return <WidgetPaper
-        title={formatMessage(MESSAGES.permissions)}
-        expandable={true}
-        data-testid={'permissions-info-box'}
-    >
-        {savingProfile ? <LoadingSpinner absolute={false} fixed={false} /> : (
-            profile?.permissions?.length ? (
-                <PermissionTable
-                    data={profile?.permissions}
-                />
-            ) : (
-                <Alert
-                    color={'info'}
-                    severity={'info'}
-                    sx={{ mx: 2, mb: 2 }}
-                >
-                    {formatMessage(MESSAGES.noResultsFound)}
-                </Alert>
-            ))}
-    </WidgetPaper>;
+
+    let content;
+    if (savingProfile) {
+        content = <LoadingSpinner absolute={false} fixed={false} />;
+    } else if (profile?.permissions?.length) {
+        content = <PermissionTable data={profile?.permissions} />;
+    } else {
+        content = (
+            <Alert color={'info'} severity={'info'} sx={{ mx: 2, mb: 2 }}>
+                {formatMessage(MESSAGES.noResultsFound)}
+            </Alert>
+        );
+    }
+
+    return (
+        <WidgetPaper
+            title={formatMessage(MESSAGES.permissions)}
+            data-testid={'permissions-info-box'}
+        >
+            {content}
+        </WidgetPaper>
+    );
 };

--- a/hat/assets/js/apps/Iaso/domains/users/components/UserDetailViewComponents/PermissionsInfoWidgetPaper.tsx
+++ b/hat/assets/js/apps/Iaso/domains/users/components/UserDetailViewComponents/PermissionsInfoWidgetPaper.tsx
@@ -16,26 +16,21 @@ export const PermissionsInfoWidgetPaper = ({
     profile,
 }: Props) => {
     const { formatMessage } = useSafeIntl();
-
-    let content;
-    if (savingProfile) {
-        content = <LoadingSpinner absolute={false} fixed={false} />;
-    } else if (profile?.permissions?.length) {
-        content = <PermissionTable data={profile?.permissions} />;
-    } else {
-        content = (
-            <Alert color={'info'} severity={'info'} sx={{ mx: 2, mb: 2 }}>
-                {formatMessage(MESSAGES.noResultsFound)}
-            </Alert>
-        );
-    }
-
     return (
         <WidgetPaper
             title={formatMessage(MESSAGES.permissions)}
             data-testid={'permissions-info-box'}
+            sx={{ position: 'relative' }}
         >
-            {content}
+            {savingProfile && <LoadingSpinner absolute fixed={false} />}
+            {profile?.permissions?.length && (
+                <PermissionTable data={profile?.permissions} />
+            )}
+            {!profile?.permissions?.length && (
+                <Alert color={'info'} severity={'info'} sx={{ mx: 2, mb: 2 }}>
+                    {formatMessage(MESSAGES.noResultsFound)}
+                </Alert>
+            )}
         </WidgetPaper>
     );
 };

--- a/hat/assets/js/apps/Iaso/domains/users/components/UserDetailViewComponents/ProjectsInfoWidgetPaper.tsx
+++ b/hat/assets/js/apps/Iaso/domains/users/components/UserDetailViewComponents/ProjectsInfoWidgetPaper.tsx
@@ -1,43 +1,48 @@
-import MESSAGES from 'Iaso/domains/users/messages';
-import { LoadingSpinner, useSafeIntl } from 'bluesquare-components';
-import { Alert, List, ListItem } from '@mui/material';
-import { ProjectChip } from 'Iaso/domains/projects/components/ProjectChip';
-import WidgetPaper from 'Iaso/components/papers/WidgetPaperComponent';
 import React from 'react';
+import { Alert, Box } from '@mui/material';
+import { LoadingSpinner, useSafeIntl } from 'bluesquare-components';
+import WidgetPaper from 'Iaso/components/papers/WidgetPaperComponent';
+import { ProjectChip } from 'Iaso/domains/projects/components/ProjectChip';
+import MESSAGES from 'Iaso/domains/users/messages';
 import { ProfileRetrieveResponseItem } from 'Iaso/domains/users/types';
 
 type Props = {
     savingProfile?: boolean;
-    profile?: ProfileRetrieveResponseItem
-}
-export const ProjectsInfoWidgetPaper = ({
-                                            savingProfile,
-                                            profile,
-                                        }: Props) => {
+    profile?: ProfileRetrieveResponseItem;
+};
+export const ProjectsInfoWidgetPaper = ({ savingProfile, profile }: Props) => {
     const { formatMessage } = useSafeIntl();
 
-    return <WidgetPaper title={formatMessage(MESSAGES.projects)} data-testid={'projects-info-box'}>
-        {savingProfile ? <LoadingSpinner absolute={false} fixed={false} /> :
-
-            profile?.projects?.length ? (
-                <List>
+    return (
+        <WidgetPaper
+            title={formatMessage(MESSAGES.projects)}
+            data-testid={'projects-info-box'}
+        >
+            {savingProfile && <LoadingSpinner absolute fixed={false} />}
+            {profile?.projects?.length && (
+                <Box
+                    sx={{
+                        display: 'flex',
+                        flexDirection: 'row',
+                        gap: 1,
+                        px: 2,
+                        pb: 2,
+                    }}
+                >
                     {profile?.projects?.map(project => {
                         return (
-                            <ListItem key={project.name}>
-                                <ProjectChip project={project}
-                                />
-                            </ListItem>
+                            <Box key={project.name}>
+                                <ProjectChip project={project} />
+                            </Box>
                         );
-                    })}</List>
-            ) : (
-                <Alert
-                    color={'info'}
-                    severity={'info'}
-                    sx={{ mx: 2, mb: 2 }}
-                >
+                    })}
+                </Box>
+            )}
+            {!profile?.projects?.length && (
+                <Alert color={'info'} severity={'info'} sx={{ mx: 2, mb: 2 }}>
                     {formatMessage(MESSAGES.noResultsFound)}
                 </Alert>
-            )
-        }
-    </WidgetPaper>;
+            )}
+        </WidgetPaper>
+    );
 };

--- a/hat/assets/js/apps/Iaso/domains/users/components/UserDetailViewComponents/TopActions.tsx
+++ b/hat/assets/js/apps/Iaso/domains/users/components/UserDetailViewComponents/TopActions.tsx
@@ -1,20 +1,27 @@
 import React from 'react';
 import { useSafeIntl } from 'bluesquare-components';
+import { UseMutateFunction } from 'react-query';
 import { DeleteButton } from 'Iaso/components/Buttons/DeleteButton';
 import DeleteDialog from 'Iaso/components/dialogs/DeleteDialogComponent';
 import { DisplayIfUserHasPerm } from 'Iaso/components/DisplayIfUserHasPerm';
 import { EditPasswordUserWithButtonDialog } from 'Iaso/domains/users/components/EditPasswordUserDialog';
 import { EditUserWithButtonDialog } from 'Iaso/domains/users/components/EditUserDialog';
 import MESSAGES from 'Iaso/domains/users/messages';
+import { DjangoError } from 'Iaso/types/general';
 import * as Permissions from 'Iaso/utils/permissions';
-import { useCurrentUser } from 'Iaso/utils/usersUtils';
+import { useCurrentUser, User } from 'Iaso/utils/usersUtils';
 
 type Props = {
     userId?: number | string;
     canBypassProjectRestrictions: boolean;
-    savePassword: void;
-    saveProfile: void;
-    onDeleteProfile: void;
+    savePassword: UseMutateFunction<
+        User,
+        DjangoError,
+        User | Partial<User>,
+        unknown
+    >;
+    saveProfile: UseMutateFunction<User, DjangoError, User | Partial<User>>;
+    onDeleteProfile: () => void;
 };
 export const TopActions = ({
     saveProfile,
@@ -33,11 +40,12 @@ export const TopActions = ({
                 titleMessage={formatMessage(MESSAGES.updateUser)}
                 saveProfile={saveProfile}
                 canBypassProjectRestrictions={canBypassProjectRestrictions}
+                iconProps={{}}
             />
             <EditPasswordUserWithButtonDialog
                 titleMessage={MESSAGES.updateUserPassword}
                 savePassword={savePassword}
-                userId={userId}
+                iconProps={{}}
             />
             {currentUser?.id?.toString() !== userId && (
                 <DisplayIfUserHasPerm

--- a/hat/assets/js/apps/Iaso/domains/users/components/UserDetailViewComponents/TopActions.tsx
+++ b/hat/assets/js/apps/Iaso/domains/users/components/UserDetailViewComponents/TopActions.tsx
@@ -40,12 +40,10 @@ export const TopActions = ({
                 titleMessage={formatMessage(MESSAGES.updateUser)}
                 saveProfile={saveProfile}
                 canBypassProjectRestrictions={canBypassProjectRestrictions}
-                iconProps={{}}
             />
             <EditPasswordUserWithButtonDialog
                 titleMessage={MESSAGES.updateUserPassword}
                 savePassword={savePassword}
-                iconProps={{}}
             />
             {currentUser?.id?.toString() !== userId && (
                 <DisplayIfUserHasPerm

--- a/hat/assets/js/apps/Iaso/domains/users/components/UserDetailViewComponents/UserRolesInfoWidgetPaper.tsx
+++ b/hat/assets/js/apps/Iaso/domains/users/components/UserDetailViewComponents/UserRolesInfoWidgetPaper.tsx
@@ -1,49 +1,50 @@
-import MESSAGES from 'Iaso/domains/users/messages';
-import { LoadingSpinner, useSafeIntl } from 'bluesquare-components';
-import { Alert, Chip, List, ListItem } from '@mui/material';
-import WidgetPaper from 'Iaso/components/papers/WidgetPaperComponent';
 import React from 'react';
+import { Alert, Box, Chip } from '@mui/material';
+import { LoadingSpinner, useSafeIntl } from 'bluesquare-components';
+import WidgetPaper from 'Iaso/components/papers/WidgetPaperComponent';
+import MESSAGES from 'Iaso/domains/users/messages';
 import { ProfileRetrieveResponseItem } from 'Iaso/domains/users/types';
 
 type Props = {
     savingProfile?: boolean;
     profile?: ProfileRetrieveResponseItem;
-}
-export const UserRolesInfoWidgetPaper = ({
-                                             savingProfile,
-                                             profile,
-                                         }: Props) => {
+};
+export const UserRolesInfoWidgetPaper = ({ savingProfile, profile }: Props) => {
     const { formatMessage } = useSafeIntl();
 
-    return <WidgetPaper title={formatMessage(MESSAGES.userRoles)} data-testid={'user-roles-info-box'}>
-        {savingProfile ? <LoadingSpinner absolute={false} fixed={false} /> : (
-            profile?.user_roles_permissions?.length ? (
-                <List>
-                    {profile?.user_roles_permissions?.map(
-                        userRole => {
-                            return (
-                                <ListItem
-                                    key={`user-role-${userRole.id}`}
-                                >
-                                    <Chip
-                                        color={'primary'}
-                                        label={
-                                            userRole.name
-                                        }
-                                    />
-                                </ListItem>
-                            );
-                        },
-                    )}
-                </List>
-            ) : (
-                <Alert
-                    color={'info'}
-                    severity={'info'}
-                    sx={{ mx: 2, mb: 2 }}
+    return (
+        <WidgetPaper
+            title={formatMessage(MESSAGES.userRoles)}
+            data-testid={'user-roles-info-box'}
+        >
+            {savingProfile && <LoadingSpinner absolute fixed={false} />}
+            {profile?.user_roles_permissions?.length && (
+                <Box
+                    sx={{
+                        display: 'flex',
+                        flexDirection: 'row',
+                        gap: 1,
+                        px: 2,
+                        pb: 2,
+                    }}
                 >
+                    {profile?.user_roles_permissions?.map(userRole => {
+                        return (
+                            <Box key={userRole.id}>
+                                <Chip
+                                    color={'secondary'}
+                                    label={userRole.name}
+                                />
+                            </Box>
+                        );
+                    })}
+                </Box>
+            )}
+            {!profile?.user_roles_permissions?.length && (
+                <Alert color={'info'} severity={'info'} sx={{ mx: 2, mb: 2 }}>
                     {formatMessage(MESSAGES.noResultsFound)}
                 </Alert>
-            ))}
-    </WidgetPaper>;
+            )}
+        </WidgetPaper>
+    );
 };

--- a/hat/assets/js/apps/Iaso/domains/users/components/UserDetailsView.test.tsx
+++ b/hat/assets/js/apps/Iaso/domains/users/components/UserDetailsView.test.tsx
@@ -1,15 +1,15 @@
 import React from 'react';
 
-import { UserDetailsView } from 'Iaso/domains/users/components/UserDetailsView';
-import { screen, within } from '@testing-library/react';
-import { renderWithTheme } from '../../../../../tests/helpers';
-import Page404 from 'Iaso/components/errors/Page404';
-import { textPlaceholder } from 'bluesquare-components';
 import { faker } from '@faker-js/faker';
-import { randomLanguage } from '../../../../../__tests__/factories/language';
+import { screen, within } from '@testing-library/react';
+import { textPlaceholder } from 'bluesquare-components';
+import Page404 from 'Iaso/components/errors/Page404';
+import { Project } from 'Iaso/domains/projects/types/project';
+import { UserDetailsView } from 'Iaso/domains/users/components/UserDetailsView';
 import MESSAGES from 'Iaso/domains/users/messages';
 import * as Permission from 'Iaso/utils/permissions';
-import { Project } from 'Iaso/domains/projects/types/project';
+import { randomLanguage } from '../../../../../__tests__/factories/language';
+import { renderWithTheme } from '../../../../../tests/helpers';
 
 // mock utilities functions
 const mockRedirectTo = vi.fn();
@@ -18,19 +18,18 @@ vi.mock('bluesquare-components', async () => {
     const actual = await vi.importActual('bluesquare-components');
     return {
         ...actual,
-        LoadingSpinner: () => (
-            <div data-testid="loading-spinner" />),
+        LoadingSpinner: () => <div data-testid="loading-spinner" />,
         useRedirectTo: () => mockRedirectTo,
         useSafeIntl: () => ({
             formatMessage: (msg: any) =>
-                typeof msg === 'string' ? msg : msg?.defaultMessage ?? 'msg',
+                typeof msg === 'string' ? msg : (msg?.defaultMessage ?? 'msg'),
         }),
     };
 });
 
 const { mockCurrentUser } = vi.hoisted(() => {
-  return { mockCurrentUser: vi.fn() }
-})
+    return { mockCurrentUser: vi.fn() };
+});
 
 vi.mock('Iaso/utils/usersUtils', async () => {
     const actual = await vi.importActual('Iaso/utils/usersUtils');
@@ -38,20 +37,18 @@ vi.mock('Iaso/utils/usersUtils', async () => {
         ...actual,
         useCurrentUser: mockCurrentUser,
     };
-
 });
-
 
 // mocking hooks
 const { mockUseGetProfile } = vi.hoisted(() => {
-  return { mockUseGetProfile: vi.fn() }
-})
+    return { mockUseGetProfile: vi.fn() };
+});
 
 vi.mock('Iaso/domains/users/hooks/useGetProfiles', () => {
     return {
         ...vi.importActual('Iaso/domains/users/hooks/useGetProfiles'),
-        useGetProfile: mockUseGetProfile
-    }
+        useGetProfile: mockUseGetProfile,
+    };
 });
 
 const mockSavePassword = vi.fn();
@@ -90,8 +87,12 @@ vi.mock('Iaso/domains/users/hooks/useDeleteProfile', () => ({
 
 // mock components
 vi.mock('Iaso/components/errors/Page404', () => ({
-    default: ({ customMessage, ...props }: React.ComponentProps<typeof Page404>) => <div
-        data-testid={'page-404'}>{customMessage}</div>,
+    default: ({
+        customMessage,
+        ...props
+    }: React.ComponentProps<typeof Page404>) => (
+        <div data-testid={'page-404'}>{customMessage}</div>
+    ),
 }));
 
 vi.mock('Iaso/components/dialogs/DeleteDialogComponent', () => ({
@@ -99,26 +100,43 @@ vi.mock('Iaso/components/dialogs/DeleteDialogComponent', () => ({
 }));
 
 vi.mock('Iaso/domains/users/components/EditPasswordUserDialog', () => ({
-    EditPasswordUserWithButtonDialog: () => <div data-testid={'edit-user-password-dialog'}></div>,
+    EditPasswordUserWithButtonDialog: () => (
+        <div data-testid={'edit-user-password-dialog'}></div>
+    ),
 }));
 
 vi.mock('Iaso/components/dialogs/EditUserDialog', () => ({
-    EditUserWithButtonDialog: () => <div data-testid={'edit-user-dialog'}></div>,
+    EditUserWithButtonDialog: () => (
+        <div data-testid={'edit-user-dialog'}></div>
+    ),
 }));
 
 vi.mock('Iaso/domains/projects/components/ProjectChip', () => ({
-    ProjectChip: ({ project }: {project: Project}) => <div data-testid={'project-chip'}>
-        {project?.name}
-    </div>,
+    ProjectChip: ({ project }: { project: Project }) => (
+        <div data-testid={'project-chip'}>{project?.name}</div>
+    ),
 }));
 
 vi.mock('Iaso/domains/users/components/PermissionTable', () => {
     return {
-        PermissionTable: ({data}: {data?: string[]}) => <div data-testid={"permission-table"}>
-            {data?.map((d: string) => <span key={d}>{d}<br/></span>)}
-        </div>
-    }
-})
+        PermissionTable: ({ data }: { data?: string[] }) => (
+            <div data-testid={'permission-table'}>
+                {data?.map((d: string) => (
+                    <span key={d}>
+                        {d}
+                        <br />
+                    </span>
+                ))}
+            </div>
+        ),
+    };
+});
+
+vi.mock('@mui/lab', () => ({
+    Masonry: ({ children }: { children: React.ReactNode }) => (
+        <div data-testid="masonry">{children}</div>
+    ),
+}));
 
 // fake data
 const randomUser = {
@@ -145,16 +163,16 @@ const getRandomProject = () => {
 const getRandomOrgUnit = () => {
     return {
         id: faker.string.numeric(3),
-        name: faker.word.noun()
+        name: faker.word.noun(),
     };
 };
 
 const getRandomUserRole = () => {
     return {
         id: faker.string.numeric(3),
-        name: faker.word.noun()
-    }
-}
+        name: faker.word.noun(),
+    };
+};
 
 describe('UsersDetailView unit tests', () => {
     beforeEach(() => {
@@ -171,14 +189,14 @@ describe('UsersDetailView unit tests', () => {
             error: null,
         });
 
-
         renderWithTheme(<UserDetailsView userId="1" />);
         expect(screen.queryAllByTestId('loading-spinner')).toHaveLength(1);
-        expect(screen.queryByText(MESSAGES.generalInfo.defaultMessage)).toBeNull();
+        expect(
+            screen.queryByText(MESSAGES.generalInfo.defaultMessage),
+        ).toBeNull();
         expect(screen.queryByTestId('delete-dialog')).toBeNull();
         expect(screen.queryByTestId('edit-user-dialog')).toBeNull();
         expect(screen.queryByTestId('edit-user-password-dialog')).toBeNull();
-
     });
     it('renders 404 page if user is not found', () => {
         mockUseGetProfile.mockReturnValue({
@@ -194,50 +212,72 @@ describe('UsersDetailView unit tests', () => {
         expect(screen.queryByTestId('delete-dialog')).toBeNull();
         expect(screen.queryByTestId('edit-user-dialog')).toBeNull();
         expect(screen.queryByTestId('edit-user-password-dialog')).toBeNull();
-
     });
-    it.each(
-        [
-            {
-                label: 'general info',
-                title: MESSAGES.generalInfo.defaultMessage,
-                sectionDataTestId: 'general-info-box',
-            },
-            { label: 'projects', title: MESSAGES.projects.defaultMessage, sectionDataTestId: 'projects-info-box' },
-            { label: 'user roles', title: MESSAGES.userRoles.defaultMessage, sectionDataTestId: 'user-roles-info-box' },
-            { label: 'locations', title: MESSAGES.locations.defaultMessage, sectionDataTestId: 'locations-info-box' },
-            {
-                label: 'permissions',
-                title: MESSAGES.permissions.defaultMessage,
-                sectionDataTestId: 'permissions-info-box',
-            }],
-    )('renders a spinner in the user $label box while saving', ({ title, sectionDataTestId }: {
-        title: string,
-        sectionDataTestId: string
-    }) => {
-        mockIsSaveProfileLoading.mockReturnValue(true);
-        mockUseGetProfile.mockReturnValue({
-            data: randomUser,
-            isLoading: false,
-            error: null,
-        });
+    it.each([
+        {
+            label: 'general info',
+            title: MESSAGES.generalInfo.defaultMessage,
+            sectionDataTestId: 'general-info-box',
+        },
+        {
+            label: 'projects',
+            title: MESSAGES.projects.defaultMessage,
+            sectionDataTestId: 'projects-info-box',
+        },
+        {
+            label: 'user roles',
+            title: MESSAGES.userRoles.defaultMessage,
+            sectionDataTestId: 'user-roles-info-box',
+        },
+        {
+            label: 'locations',
+            title: MESSAGES.locations.defaultMessage,
+            sectionDataTestId: 'locations-info-box',
+        },
+        {
+            label: 'permissions',
+            title: MESSAGES.permissions.defaultMessage,
+            sectionDataTestId: 'permissions-info-box',
+        },
+    ])(
+        'renders a spinner in the user $label box while saving',
+        ({
+            title,
+            sectionDataTestId,
+        }: {
+            title: string;
+            sectionDataTestId: string;
+        }) => {
+            mockIsSaveProfileLoading.mockReturnValue(true);
+            mockUseGetProfile.mockReturnValue({
+                data: randomUser,
+                isLoading: false,
+                error: null,
+            });
 
-        renderWithTheme(<UserDetailsView userId={'1'} />);
+            renderWithTheme(<UserDetailsView userId={'1'} />);
 
-        expect(within(screen.getByTestId(sectionDataTestId)).getByTestId('loading-spinner')).toBeInTheDocument();
-        expect(screen.getByText(title)).toBeInTheDocument();
-    });
+            expect(
+                within(screen.getByTestId(sectionDataTestId)).getByTestId(
+                    'loading-spinner',
+                ),
+            ).toBeInTheDocument();
+            expect(screen.getByText(title)).toBeInTheDocument();
+        },
+    );
 
     it('renders correctly user general info', () => {
-        mockUseGetProfile.mockReturnValueOnce({
-            data: null,
-            isLoading: false,
-            error: null,
-        }).mockReturnValueOnce({
-            data: randomUser,
-            isLoading: false,
-            error: null,
-        });
+        mockUseGetProfile
+            .mockReturnValueOnce({
+                data: null,
+                isLoading: false,
+                error: null,
+            })
+            .mockReturnValueOnce({
+                data: randomUser,
+                isLoading: false,
+                error: null,
+            });
         const { rerender } = renderWithTheme(<UserDetailsView userId={'1'} />);
 
         expect(screen.getByText('General info')).toBeInTheDocument();
@@ -246,19 +286,21 @@ describe('UsersDetailView unit tests', () => {
         rerender(<UserDetailsView userId={'1'} />);
         expect(screen.getByText('General info')).toBeInTheDocument();
         expect(screen.queryByText(textPlaceholder)).toBeNull();
-        Object.entries(randomUser).filter(([k, _]) => k !== 'color').forEach(([k, v]) => {
-            // @ts-ignore
-            expect(screen.getByText(v), `Field ${k} with value ${v} should be in the document`).toBeInTheDocument();
-        });
+        Object.entries(randomUser)
+            .filter(([k, _]) => k !== 'color')
+            .forEach(([k, v]) => {
+                // @ts-ignore
+                expect(
+                    screen.getByText(v),
+                    `Field ${k} with value ${v} should be in the document`,
+                ).toBeInTheDocument();
+            });
 
         const emailLink = screen.getByRole('link', {
             name: randomUser.email,
         });
 
-        expect(emailLink).toHaveAttribute(
-            'href',
-            `mailto:${randomUser.email}`,
-        );
+        expect(emailLink).toHaveAttribute('href', `mailto:${randomUser.email}`);
 
         const phoneLink = screen.getByRole('link', {
             name: randomUser.phone_number,
@@ -270,40 +312,42 @@ describe('UsersDetailView unit tests', () => {
         );
 
         expect(screen.getByTestId('user-color-badge')).toBeInTheDocument();
-
     });
 
     it('renders correctly projects info', () => {
+        const projects = [getRandomProject(), getRandomProject()];
 
-        const projects = [
-            getRandomProject(),
-            getRandomProject(),
-        ];
-
-        mockUseGetProfile.mockReturnValueOnce({
-            data: null,
-            isLoading: false,
-            error: null,
-        }).mockReturnValueOnce({
-            data: {
-                projects: [],
-            },
-            isLoading: false,
-            error: null,
-        }).mockReturnValueOnce({
-            data: {
-                projects: projects,
-            },
-            isLoading: false,
-            error: null,
-        });
+        mockUseGetProfile
+            .mockReturnValueOnce({
+                data: null,
+                isLoading: false,
+                error: null,
+            })
+            .mockReturnValueOnce({
+                data: {
+                    projects: [],
+                },
+                isLoading: false,
+                error: null,
+            })
+            .mockReturnValueOnce({
+                data: {
+                    projects: projects,
+                },
+                isLoading: false,
+                error: null,
+            });
 
         const { rerender } = renderWithTheme(<UserDetailsView userId={'1'} />);
 
-        expect(within(screen.getByTestId('projects-info-box')).getByRole('alert')).toHaveTextContent(MESSAGES.noResultsFound.defaultMessage);
+        expect(
+            within(screen.getByTestId('projects-info-box')).getByRole('alert'),
+        ).toHaveTextContent(MESSAGES.noResultsFound.defaultMessage);
 
         rerender(<UserDetailsView userId={'1'} />);
-        expect(within(screen.getByTestId('projects-info-box')).getByRole('alert')).toHaveTextContent(MESSAGES.noResultsFound.defaultMessage);
+        expect(
+            within(screen.getByTestId('projects-info-box')).getByRole('alert'),
+        ).toHaveTextContent(MESSAGES.noResultsFound.defaultMessage);
 
         rerender(<UserDetailsView userId={'1'} />);
         // check that we render some projects
@@ -311,124 +355,142 @@ describe('UsersDetailView unit tests', () => {
         projects.forEach(({ name }) => {
             expect(screen.getByText(name)).toBeInTheDocument();
         });
-
     });
 
     it('renders correctly user roles info', () => {
-        const user_roles = [
-            getRandomUserRole(),
-            getRandomUserRole(),
-        ];
+        const user_roles = [getRandomUserRole(), getRandomUserRole()];
 
-        mockUseGetProfile.mockReturnValueOnce({
-            data: null,
-            isLoading: false,
-            error: null,
-        }).mockReturnValueOnce({
-            data: {
-                user_roles_permissions: [],
-            },
-            isLoading: false,
-            error: null,
-
-        }).mockReturnValueOnce({
-            data: {
-                user_roles_permissions: user_roles,
-            },
-            isLoading: false,
-            error: false,
-        });
+        mockUseGetProfile
+            .mockReturnValueOnce({
+                data: null,
+                isLoading: false,
+                error: null,
+            })
+            .mockReturnValueOnce({
+                data: {
+                    user_roles_permissions: [],
+                },
+                isLoading: false,
+                error: null,
+            })
+            .mockReturnValueOnce({
+                data: {
+                    user_roles_permissions: user_roles,
+                },
+                isLoading: false,
+                error: false,
+            });
 
         const { rerender } = renderWithTheme(<UserDetailsView userId={'1'} />);
-        expect(within(screen.getByTestId('user-roles-info-box')).getByRole('alert')).toHaveTextContent(MESSAGES.noResultsFound.defaultMessage);
+        expect(
+            within(screen.getByTestId('user-roles-info-box')).getByRole(
+                'alert',
+            ),
+        ).toHaveTextContent(MESSAGES.noResultsFound.defaultMessage);
 
         rerender(<UserDetailsView userId={'1'} />);
-        expect(within(screen.getByTestId('user-roles-info-box')).getByRole('alert')).toHaveTextContent(MESSAGES.noResultsFound.defaultMessage);
+        expect(
+            within(screen.getByTestId('user-roles-info-box')).getByRole(
+                'alert',
+            ),
+        ).toHaveTextContent(MESSAGES.noResultsFound.defaultMessage);
 
         rerender(<UserDetailsView userId={'1'} />);
         user_roles.forEach(({ name }) => {
-            expect(within(screen.getByTestId('user-roles-info-box')).getByText(name)).toBeInTheDocument();
+            expect(
+                within(screen.getByTestId('user-roles-info-box')).getByText(
+                    name,
+                ),
+            ).toBeInTheDocument();
         });
     });
 
     it('renders correctly permissions info', () => {
+        const permissions = [faker.word.verb(), faker.word.verb()];
 
-        const permissions = [
-            faker.word.verb(),
-            faker.word.verb()
-        ];
-
-        mockUseGetProfile.mockReturnValueOnce({
-            data: null,
-            isLoading: false,
-            error: null,
-        }).mockReturnValueOnce({
-            data: {
-                permissions: [],
-            },
-            isLoading: false,
-            error: null,
-
-        }).mockReturnValueOnce({
-            data: {
-                permissions: permissions,
-            },
-            isLoading: false,
-            error: false,
-        });
+        mockUseGetProfile
+            .mockReturnValueOnce({
+                data: null,
+                isLoading: false,
+                error: null,
+            })
+            .mockReturnValueOnce({
+                data: {
+                    permissions: [],
+                },
+                isLoading: false,
+                error: null,
+            })
+            .mockReturnValueOnce({
+                data: {
+                    permissions: permissions,
+                },
+                isLoading: false,
+                error: false,
+            });
 
         const { rerender } = renderWithTheme(<UserDetailsView userId={'1'} />);
-        expect(within(screen.getByTestId('locations-info-box')).getByRole('alert')).toHaveTextContent(MESSAGES.noResultsFound.defaultMessage);
+        expect(
+            within(screen.getByTestId('locations-info-box')).getByRole('alert'),
+        ).toHaveTextContent(MESSAGES.noResultsFound.defaultMessage);
 
         rerender(<UserDetailsView userId={'1'} />);
-        expect(within(screen.getByTestId('locations-info-box')).getByRole('alert')).toHaveTextContent(MESSAGES.noResultsFound.defaultMessage);
+        expect(
+            within(screen.getByTestId('locations-info-box')).getByRole('alert'),
+        ).toHaveTextContent(MESSAGES.noResultsFound.defaultMessage);
 
         rerender(<UserDetailsView userId={'1'} />);
-        expect(screen.getByTestId('permission-table')).toBeDefined()
-        permissions.forEach((perm) => {
-            expect(within(screen.getByTestId('permission-table')).getByText(perm)).toBeInTheDocument();
+        expect(screen.getByTestId('permission-table')).toBeDefined();
+        permissions.forEach(perm => {
+            expect(
+                within(screen.getByTestId('permission-table')).getByText(perm),
+            ).toBeInTheDocument();
         });
-
     });
 
     it('renders correctly locations info', () => {
-        const org_units = [
-            getRandomOrgUnit(),
-            getRandomOrgUnit(),
-        ];
+        const org_units = [getRandomOrgUnit(), getRandomOrgUnit()];
 
-        mockUseGetProfile.mockReturnValueOnce({
-            data: null,
-            isLoading: false,
-            error: null,
-        }).mockReturnValueOnce({
-            data: {
-                org_units: [],
-            },
-            isLoading: false,
-            error: null,
-
-        }).mockReturnValueOnce({
-            data: {
-                org_units: org_units,
-            },
-            isLoading: false,
-            error: false,
-        });
+        mockUseGetProfile
+            .mockReturnValueOnce({
+                data: null,
+                isLoading: false,
+                error: null,
+            })
+            .mockReturnValueOnce({
+                data: {
+                    org_units: [],
+                },
+                isLoading: false,
+                error: null,
+            })
+            .mockReturnValueOnce({
+                data: {
+                    org_units: org_units,
+                },
+                isLoading: false,
+                error: false,
+            });
 
         const { rerender } = renderWithTheme(<UserDetailsView userId={'1'} />);
-        expect(within(screen.getByTestId('locations-info-box')).getByRole('alert')).toHaveTextContent(MESSAGES.noResultsFound.defaultMessage);
+        expect(
+            within(screen.getByTestId('locations-info-box')).getByRole('alert'),
+        ).toHaveTextContent(MESSAGES.noResultsFound.defaultMessage);
 
         rerender(<UserDetailsView userId={'1'} />);
-        expect(within(screen.getByTestId('locations-info-box')).getByRole('alert')).toHaveTextContent(MESSAGES.noResultsFound.defaultMessage);
+        expect(
+            within(screen.getByTestId('locations-info-box')).getByRole('alert'),
+        ).toHaveTextContent(MESSAGES.noResultsFound.defaultMessage);
 
         rerender(<UserDetailsView userId={'1'} />);
         org_units.forEach(({ name }) => {
-            expect(within(screen.getByTestId('locations-info-box')).getByText(name)).toBeInTheDocument();
+            expect(
+                within(screen.getByTestId('locations-info-box')).getByText(
+                    name,
+                ),
+            ).toBeInTheDocument();
         });
-
     });
-
 
     it('does not show delete button for own profile', () => {
         mockUseGetProfile.mockReturnValue({
@@ -444,11 +506,9 @@ describe('UsersDetailView unit tests', () => {
         renderWithTheme(<UserDetailsView userId={'1'} />);
 
         expect(screen.queryByTestId('delete-dialog')).toBeNull();
-
     });
 
     it('shows delete button for admin on other user', () => {
-
         mockUseGetProfile.mockReturnValue({
             data: randomUser,
             isLoading: false,
@@ -457,10 +517,7 @@ describe('UsersDetailView unit tests', () => {
 
         mockCurrentUser.mockReturnValue({
             id: 1,
-            permissions: [
-                Permission.USERS_ADMIN,
-                Permission.USERS_MANAGEMENT,
-            ],
+            permissions: [Permission.USERS_ADMIN, Permission.USERS_MANAGEMENT],
         });
 
         renderWithTheme(<UserDetailsView userId={'2'} />);
@@ -481,6 +538,4 @@ describe('UsersDetailView unit tests', () => {
         renderWithTheme(<UserDetailsView userId={'2'} />);
         expect(screen.queryByTestId('delete-dialog')).toBeNull();
     });
-
-
 });

--- a/hat/assets/js/apps/Iaso/domains/users/components/UserDetailsView.tsx
+++ b/hat/assets/js/apps/Iaso/domains/users/components/UserDetailsView.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react';
 import { Masonry } from '@mui/lab';
-import { Container, Stack, Box } from '@mui/material';
+import { Stack, Box } from '@mui/material';
 import {
     LoadingSpinner,
     useRedirectTo,

--- a/hat/assets/js/apps/Iaso/domains/users/components/UserDetailsView.tsx
+++ b/hat/assets/js/apps/Iaso/domains/users/components/UserDetailsView.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback } from 'react';
-import { Grid, Container, Stack, Box } from '@mui/material';
+import { Masonry } from '@mui/lab';
+import { Container, Stack, Box } from '@mui/material';
 import {
     LoadingSpinner,
     useRedirectTo,
@@ -52,7 +53,7 @@ export const UserDetailsView = ({ userId }: Props) => {
                 redirectTo(baseUrls.users);
             },
         });
-    }, [deleteProfile]);
+    }, [deleteProfile, redirectTo]);
 
     if (!isLoading && error?.status === 404) {
         return (
@@ -64,75 +65,63 @@ export const UserDetailsView = ({ userId }: Props) => {
     }
 
     return (
-        <Container
-            disableGutters
-            sx={{ pt: { xs: 2, md: 4 }, pb: { xs: 2, md: 4 } }}
-            maxWidth={'xl'}
-        >
+        <Box>
             {isLoading ? (
                 <LoadingSpinner />
             ) : (
                 <Stack spacing={2}>
-                    <Box sx={{ px: 2 }}>
-                        <Grid container>
-                            <Grid
-                                item
-                                xs={12}
-                                sx={{
-                                    justifyContent: 'flex-end',
-                                    display: 'flex',
-                                }}
-                            >
-                                <Stack direction={'row'} spacing={2}>
-                                    <TopActions
-                                        saveProfile={saveProfile}
-                                        onDeleteProfile={onDeleteProfile}
-                                        userId={userId}
-                                        savePassword={savePassword}
-                                        canBypassProjectRestrictions={
-                                            canBypassProjectRestrictions
-                                        }
-                                    />
-                                </Stack>
-                            </Grid>
-                        </Grid>
+                    <Box pt={2} px={2}>
+                        <Stack
+                            direction="row"
+                            spacing={2}
+                            justifyContent="flex-end"
+                        >
+                            <TopActions
+                                saveProfile={saveProfile}
+                                onDeleteProfile={onDeleteProfile}
+                                userId={userId}
+                                savePassword={savePassword}
+                                canBypassProjectRestrictions={
+                                    canBypassProjectRestrictions
+                                }
+                            />
+                        </Stack>
                     </Box>
-                    <Box sx={{ px: 2 }}>
-                        <Grid container spacing={4}>
-                            <Grid item xs={12} md={6}>
-                                <GeneralInfoWidgetPaper
-                                    profile={profile}
-                                    savingProfile={savingProfile}
-                                />
-                            </Grid>
-                        </Grid>
-                    </Box>
-                    <Box sx={{ px: 2 }}>
-                        <Grid container spacing={4}>
-                            <Grid item xs={12} md={6}>
-                                <ProjectsInfoWidgetPaper
-                                    profile={profile}
-                                    savingProfile={savingProfile}
-                                />
-                                <LocationsInfoWidgetPaper
-                                    profile={profile}
-                                    savingProfile={savingProfile}
-                                />
-                            </Grid>
-                            <Grid item xs={12} md={6}>
-                                <UserRolesInfoWidgetPaper
-                                    profile={profile}
-                                    savingProfile={savingProfile}
-                                />
-                                <PermissionsInfoWidgetPaper
-                                    profile={profile}
-                                    savingProfile={savingProfile}
-                                />
-                            </Grid>
-                        </Grid>
-                    </Box>
+                    <Masonry columns={{ xs: 1, md: 2 }} spacing={4}>
+                        <Box>
+                            <GeneralInfoWidgetPaper
+                                profile={profile}
+                                savingProfile={savingProfile}
+                            />
+                        </Box>
+                        <Box>
+                            <PermissionsInfoWidgetPaper
+                                profile={profile}
+                                savingProfile={savingProfile}
+                            />
+                        </Box>
+                        <Box>
+                            <ProjectsInfoWidgetPaper
+                                profile={profile}
+                                savingProfile={savingProfile}
+                            />
+                        </Box>
+                        <Box>
+                            <LocationsInfoWidgetPaper
+                                profile={profile}
+                                savingProfile={savingProfile}
+                            />
+                        </Box>
+                        <Box>
+                            <UserRolesInfoWidgetPaper
+                                profile={profile}
+                                savingProfile={savingProfile}
+                            />
+                        </Box>
+                    </Masonry>
                 </Stack>
             )}
-        </Container>
+            {/* </Container> */}
+        </Box>
     );
 };

--- a/hat/assets/js/apps/Iaso/domains/users/components/UserDetailsView.tsx
+++ b/hat/assets/js/apps/Iaso/domains/users/components/UserDetailsView.tsx
@@ -70,7 +70,7 @@ export const UserDetailsView = ({ userId }: Props) => {
                 <LoadingSpinner />
             ) : (
                 <Stack spacing={2}>
-                    <Box pt={2} px={2}>
+                    <Box pt={4} px={2}>
                         <Stack
                             direction="row"
                             spacing={2}
@@ -121,7 +121,6 @@ export const UserDetailsView = ({ userId }: Props) => {
                     </Masonry>
                 </Stack>
             )}
-            {/* </Container> */}
         </Box>
     );
 };

--- a/hat/assets/js/apps/Iaso/domains/users/components/UsersInfos.tsx
+++ b/hat/assets/js/apps/Iaso/domains/users/components/UsersInfos.tsx
@@ -10,7 +10,7 @@ import { useAppLocales } from '../../app/constants';
 
 import { useGetProjectsDropdownOptions } from '../../projects/hooks/requests';
 import MESSAGES from '../messages';
-import { InitialUserData, UserDialogData } from '../types';
+import { InitialUserData, ProfileRetrieveResponseItem, UserDialogData } from '../types';
 import { userHasAccessToModule } from '../utils';
 
 const styles: SxStyles = {
@@ -25,7 +25,7 @@ const styles: SxStyles = {
 type Props = {
     setFieldValue: (key: string, value: string) => void;
     currentUser: UserDialogData;
-    initialData: InitialUserData;
+    initialData: InitialUserData | ProfileRetrieveResponseItem;
     allowSendEmailInvitation: boolean;
     canBypassProjectRestrictions: boolean;
     setPhoneNumber: (phoneNumber: string, countryCode: string) => void;

--- a/hat/assets/js/apps/Iaso/domains/users/components/useInitialUser.ts
+++ b/hat/assets/js/apps/Iaso/domains/users/components/useInitialUser.ts
@@ -17,98 +17,99 @@ export type InitialUserUtils = {
 };
 
 export const useInitialUser = (
-    initialData: InitialUserData,
+    initialData: InitialUserData | undefined,
 ): InitialUserUtils => {
     const { formatMessage } = useSafeIntl();
     const initialUser: UserDialogData = useMemo(() => {
+        const data: InitialUserData = initialData ?? {};
         return {
-            id: { value: get(initialData, 'id', null), errors: [] },
+            id: { value: get(data, 'id', null), errors: [] },
             user_name: {
-                value: get(initialData, 'user_name', ''),
+                value: get(data, 'user_name', ''),
                 errors: [],
             },
             first_name: {
-                value: get(initialData, 'first_name', ''),
+                value: get(data, 'first_name', ''),
                 errors: [],
             },
             last_name: {
-                value: get(initialData, 'last_name', ''),
+                value: get(data, 'last_name', ''),
                 errors: [],
             },
-            email: { value: get(initialData, 'email', ''), errors: [] },
+            email: { value: get(data, 'email', ''), errors: [] },
             password: { value: '', errors: [] },
             permissions: {
-                value: get(initialData, 'permissions', []),
+                value: get(data, 'permissions', []),
                 errors: [],
             },
             org_units: {
-                value: get(initialData, 'org_units', []),
+                value: get(data, 'org_units', []),
                 errors: [],
             },
             language: {
-                value: get(initialData, 'language', ''),
+                value: get(data, 'language', ''),
                 errors: [],
             },
             home_page: {
-                value: get(initialData, 'home_page', ''),
+                value: get(data, 'home_page', ''),
                 errors: [],
             },
             organization: {
-                value: get(initialData, 'organization', undefined),
+                value: get(data, 'organization', undefined),
                 errors: [],
             },
             dhis2_id: {
-                value: get(initialData, 'dhis2_id', ''),
+                value: get(data, 'dhis2_id', ''),
                 errors: [],
             },
             user_roles: {
-                value: get(initialData, 'user_roles', []),
+                value: get(data, 'user_roles', []),
                 errors: [],
             },
             user_roles_permissions: {
-                value: get(initialData, 'user_roles_permissions', []),
+                value: get(data, 'user_roles_permissions', []),
                 errors: [],
             },
             user_permissions: {
-                value: get(initialData, 'user_permissions', []),
+                value: get(data, 'user_permissions', []),
                 errors: [],
             },
             send_email_invitation: {
-                value: get(initialData, 'send_email_invitation', false),
+                value: get(data, 'send_email_invitation', false),
                 errors: [],
             },
             projects: {
-                value: get(initialData, 'projects', []).map(
-                    project => project.id,
+                value: get(data, 'projects', []).map(
+                    (project: { id: number }) => project.id,
                 ),
                 errors: [],
             },
             phone_number: {
-                value: get(initialData, 'phone_number', ''),
+                value: get(data, 'phone_number', ''),
                 errors: [],
             },
             country_code: {
-                value: get(initialData, 'country_code', ''),
+                value: get(data, 'country_code', ''),
                 errors: [],
             },
             editable_org_unit_type_ids: {
-                value: get(initialData, 'editable_org_unit_type_ids', []),
+                value: get(data, 'editable_org_unit_type_ids', []),
                 errors: [],
             },
             user_roles_editable_org_unit_type_ids: {
                 value: get(
-                    initialData,
+                    data,
                     'user_roles_editable_org_unit_type_ids',
                     [],
                 ),
                 errors: [],
             },
             has_multiple_accounts: {
-                value: get(initialData, 'other_accounts', [])?.length > 0,
+                value: get(data, 'other_accounts', [])?.length > 0,
                 errors: [],
             },
             color: {
-                value: get(initialData, "color", ""),
+                value: get(data, 'color', ''),
                 errors: [],
             },
         };

--- a/hat/assets/js/apps/Iaso/domains/users/hooks/useGetProfiles.ts
+++ b/hat/assets/js/apps/Iaso/domains/users/hooks/useGetProfiles.ts
@@ -7,6 +7,7 @@ import { getRequest } from 'Iaso/libs/Api';
 import { useSnackQuery } from 'Iaso/libs/apiHooks';
 import { makeUrlWithParams } from 'Iaso/libs/utils';
 import { Pagination } from 'Iaso/types/general';
+import { DjangoError } from 'Iaso/types/general';
 import { Profile } from 'Iaso/utils/usersUtils';
 
 export const useGetProfilesApiParams = params => {
@@ -54,7 +55,7 @@ const getProfile = async (profileId?: string): Promise<Profile> => {
 
 export const useGetProfile = (
     profileId?: string,
-): UseQueryResult<ProfileRetrieveResponseItem, Error> => {
+): UseQueryResult<ProfileRetrieveResponseItem, DjangoError> => {
     const queryKey: any[] = ['userDetail', profileId];
     return useSnackQuery({
         queryKey,

--- a/hat/assets/js/apps/Iaso/domains/users/hooks/useGetProfiles.ts
+++ b/hat/assets/js/apps/Iaso/domains/users/hooks/useGetProfiles.ts
@@ -49,12 +49,12 @@ export const useGetProfiles = (params): UseQueryResult<ListResponse, Error> => {
     return useSnackQuery(['profiles', apiParams], () => getRequest(url));
 };
 
-const getProfile = async (profileId?: string): Promise<Profile> => {
+const getProfile = async (profileId?: number | string): Promise<Profile> => {
     return getRequest(`/api/profiles/${profileId}/`);
 };
 
 export const useGetProfile = (
-    profileId?: string,
+    profileId?: number | string,
 ): UseQueryResult<ProfileRetrieveResponseItem, DjangoError> => {
     const queryKey: any[] = ['userDetail', profileId];
     return useSnackQuery({

--- a/hat/assets/js/apps/Iaso/domains/users/hooks/useSavePassword.ts
+++ b/hat/assets/js/apps/Iaso/domains/users/hooks/useSavePassword.ts
@@ -4,7 +4,6 @@ import { useSnackMutation } from 'Iaso/libs/apiHooks';
 import { DjangoError } from 'Iaso/types/general';
 import { User } from 'Iaso/utils/usersUtils';
 
-
 export const useSavePassword = (
     id: number | string | undefined,
     showSuccessSnackBar = true,

--- a/hat/assets/js/apps/Iaso/domains/users/hooks/useSaveProfile.ts
+++ b/hat/assets/js/apps/Iaso/domains/users/hooks/useSaveProfile.ts
@@ -7,14 +7,24 @@ import { User } from 'Iaso/utils/usersUtils';
 type UseSaveProfileParams = {
     id?: number | string;
     showSuccessSnackBar?: boolean;
-}
+};
 
-export const useSaveProfile = (
-    { id, showSuccessSnackBar = true }: UseSaveProfileParams = {},
-): UseMutationResult<User, DjangoError, User | Partial<User>> =>
+export const useSaveProfile = ({
+    id,
+    showSuccessSnackBar = true,
+}: UseSaveProfileParams = {}): UseMutationResult<
+    User,
+    DjangoError,
+    User | Partial<User>
+> =>
     useSnackMutation({
         mutationFn: ({ id: userId, ...body }) =>
             patchRequest(`/api/profiles/${id ?? userId}/`, body),
-        invalidateQueryKey: ['profiles', 'usersHistoryList', 'team', 'userDetail'],
+        invalidateQueryKey: [
+            'profiles',
+            'usersHistoryList',
+            'team',
+            'userDetail',
+        ],
         showSuccessSnackBar,
     });

--- a/hat/assets/js/apps/Iaso/domains/users/types.ts
+++ b/hat/assets/js/apps/Iaso/domains/users/types.ts
@@ -74,7 +74,7 @@ export type SaveUserPasswordQuery = {
     confirm_password: string;
 };
 
-type UserRole = {
+type NestedUserRole = {
     id: number | string;
     name: string;
 };
@@ -161,7 +161,7 @@ export type ProfileListResponseItem = {
     country_code?: string;
     editable_org_unit_type_ids: string[] | number[];
     user_roles_editable_org_unit_type_ids: string[] | number[];
-    user_roles: UserRole[];
+    user_roles: NestedUserRole[];
     color: string;
     projects: NestedProject[];
     user_permissions: string[];

--- a/hat/assets/js/apps/Iaso/domains/users/types.ts
+++ b/hat/assets/js/apps/Iaso/domains/users/types.ts
@@ -20,6 +20,7 @@ export type UserDialogData = {
     org_units?: ValueAndErrors<number[]>;
     permissions: ValueAndErrors<string[]>;
     user_permissions: ValueAndErrors<string[]>;
+    user_roles?: ValueAndErrors<Array<UserRole | number>>;
     user_roles_permissions: ValueAndErrors<UserRole[]>;
     language: ValueAndErrors<string | null>;
     password: ValueAndErrors<string | null>;

--- a/hat/assets/js/apps/Iaso/libs/validation.tsx
+++ b/hat/assets/js/apps/Iaso/libs/validation.tsx
@@ -1,8 +1,8 @@
+import { useCallback, useMemo, useState } from 'react';
 import { IntlFormatMessage, IntlMessage } from 'bluesquare-components';
 import { FormikErrors, FormikHelpers, FormikTouched } from 'formik';
 import { isEqual } from 'lodash';
-import { useCallback, useMemo, useState } from 'react';
-import { UseMutateAsyncFunction } from 'react-query';
+import { UseMutateAsyncFunction, UseMutateFunction } from 'react-query';
 import { TestConfig, TestContext } from 'yup';
 import { ValidationError } from '../types/utils';
 import { ApiError } from './Api';
@@ -16,7 +16,9 @@ import { ApiError } from './Api';
 
 type Params = {
     // Typing for this function is taken from react-query's docs.
-    mutationFn: UseMutateAsyncFunction<any, any, any>;
+    mutationFn:
+        | UseMutateAsyncFunction<any, any, any>
+        | UseMutateFunction<any, any, any>;
     onSuccess?: any;
     onError?: any;
     onCatch?: any;


### PR DESCRIPTION
## What problem is this PR solving?

- All new profiles files have eslint and TS errors
- Detail page UI needs to be improved

### Related JIRA tickets

IA-4879

## Changes

- fixed eslint errors
- fixed TS errors
- review lay-out with mansonry
- block permissions height + overflow

## How to test

Go to detail page of a user.
Play with the page, change the permissions, user roles, projects, save, ...

## Print screen / video

<img width="1713" height="1057" alt="Screenshot 2026-03-18 at 12 25 31" src="https://github.com/user-attachments/assets/506036da-1cd5-4e75-a7e6-00f4d5b66f5f" />


## Notes

We still have a lot's of duplicates on the backend side @hugo093 
<img width="732" height="160" alt="Screenshot 2026-03-18 at 13 17 17" src="https://github.com/user-attachments/assets/44419c35-0d8b-4113-be9a-3f63f27494fa" />
