### PR TITLE
IA-4883 iconProps should be optional while creating a dialog

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8459,7 +8459,7 @@
         },
         "node_modules/bluesquare-components": {
             "version": "1.0.0",
-            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#b953ab57f7ff5fcdd1eca4495df876d838de461a",
+            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#335550331e56a6b42ff1c7ee4237a090cdb80a28",
             "license": "Apache-2.0",
             "dependencies": {
                 "@babel/plugin-transform-class-properties": "^7.24.6",


### PR DESCRIPTION
## What problem is this PR solving?

iconProps is required while using makeFullMal, and shouldn't, it raises an TS error on iaso side if not set

### Related JIRA tickets

IA-4883

## Changes

Make iconProps optional on bluesquare-components

## How to test

Run`npm ci` make sure it build and that TS is not complaining if iconProps
