### PR TITLE
WC2-875: Fix ProtectedError with the script

### DIFF
--- a/iaso/management/commands/clean_up_duplicate_submissions.py
+++ b/iaso/management/commands/clean_up_duplicate_submissions.py
@@ -155,5 +155,7 @@ class Command(BaseCommand):
         entities_to_delete = Entity.objects.filter(attributes__in=to_delete)
         first_instance = Instance.objects.get(id=first_id)
         Instance.objects.filter(entity__in=entities_to_delete).update(entity=first_instance.entity)
+        # Need to set foreign key relation to NULL to avoid ProtectedError
+        entities_to_delete.update(attributes_id=None)
         entities_to_delete.delete()
         to_delete.delete()


### PR DESCRIPTION
## What problem is this PR solving?

When trying to delete instances linked to entities, we need to set their `attributes_id` to `None`

### Related JIRA tickets

WC2-875

## Changes

Set the entities's `attributes_id` to `None` before deleting them.

## How to test

We can, that's what makes it so fun! /s