### PR TITLE
IA-4887: Entity search improvements

### DIFF
--- a/iaso/api/entities/filters.py
+++ b/iaso/api/entities/filters.py
@@ -61,9 +61,14 @@ class EntityFilterSet(FilterSet):
                 raise ValidationError(f"Failed parsing uuids in search '{value}'")
             return queryset.filter(uuid__in=uuids)
 
-        return queryset.filter(
-            Q(name__icontains=value) | Q(uuid__icontains=value) | Q(attributes__json__icontains=value)
-        )
+        tokens = re.findall(r'"[^"]*"|\S+', value)
+        tokens = [t.strip('"') for t in tokens]
+        q = Q()
+        for token in tokens:
+            q &= Q(name__icontains=token) | Q(attributes__json__icontains=token)
+        q |= Q(uuid__icontains=value)
+
+        return queryset.filter(q)
 
 
 class EntityDateFilterBackend(filters.BaseFilterBackend):

--- a/iaso/api/entities/filters.py
+++ b/iaso/api/entities/filters.py
@@ -61,10 +61,8 @@ class EntityFilterSet(FilterSet):
                 raise ValidationError(f"Failed parsing uuids in search '{value}'")
             return queryset.filter(uuid__in=uuids)
 
-        tokens = re.findall(r'"[^"]*"|\S+', value)
-        tokens = [t.strip('"') for t in tokens]
         q = Q()
-        for token in tokens:
+        for token in value.split():
             q &= Q(name__icontains=token) | Q(attributes__json__icontains=token)
         q |= Q(uuid__icontains=value)
 

--- a/iaso/tests/api/entities/test_entities.py
+++ b/iaso/tests/api/entities/test_entities.py
@@ -223,17 +223,6 @@ class WebEntityAPITestCase(EntityAPITestCase):
         self.assertEqual(len(data["result"]), 1)
         self.assertEqual(data["result"][0]["id"], entity_1.id)
 
-        # Exact search (double quotes)
-        response = self.client.get("/api/entities/", data={"search": '"New Client"'}, format="json")
-        data = self.assertJSONResponse(response, 200)
-        self.assertEqual(len(data["result"]), 1)
-        self.assertEqual(data["result"][0]["id"], entity_1.id)
-
-        # Exact search, no matches
-        response = self.client.get("/api/entities/", data={"search": '"Client New"'}, format="json")
-        data = self.assertJSONResponse(response, 200)
-        self.assertEqual(len(data["result"]), 0)
-
         # 'ids:' prefix search
         response = self.client.get("/api/entities/", data={"search": f"ids:{entity_2.id}"}, format="json")
         data = self.assertJSONResponse(response, 200)

--- a/iaso/tests/api/entities/test_entities.py
+++ b/iaso/tests/api/entities/test_entities.py
@@ -167,52 +167,84 @@ class WebEntityAPITestCase(EntityAPITestCase):
         """
         Test the 'search' filter of /api/entities
 
-        This parameter allows to filter either by name, UUID or attributes (of the reference form)
+        This parameter allows to filter either by name, UUID, attributes (of the reference form),
+        as well as explicit ids: and uuids: prefixes.
         """
         self.client.force_authenticate(self.yoda)
 
         instance = Instance.objects.create(
             org_unit=self.ou_country,
             form=self.form_1,
+            uuid=uuid.uuid4(),
             json={"name": "c", "age": 30, "gender": "F"},
         )
 
-        payload = {
-            "name": "New Client",
-            "entity_type": self.entity_type.pk,
-            "attributes": instance.uuid,
-            "account": self.yoda.iaso_profile.account.pk,
-        }
+        entity_1 = Entity.objects.create(
+            name="New Client",
+            entity_type=self.entity_type,
+            account=self.yoda.iaso_profile.account,
+            attributes=instance,
+        )
 
-        self.client.post("/api/entities/", data=payload, format="json")
+        second_instance = Instance.objects.create(
+            org_unit=self.ou_country,
+            form=self.form_1,
+            uuid=uuid.uuid4(),
+            json={"name": "c", "age": 30, "gender": "F"},
+        )
 
-        newly_added_entity = Entity.objects.last()
+        entity_2 = Entity.objects.create(
+            name="Client Old",
+            entity_type=self.entity_type,
+            account=self.yoda.iaso_profile.account,
+            attributes=second_instance,
+        )
 
-        # Case 1: search by entity name
-        response = self.client.get("/api/entities/?search=Client", format="json")
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.json()["result"]), 1)
-        the_result = response.json()["result"][0]
-        self.assertEqual(the_result["id"], newly_added_entity.id)
-
-        # Case 2: search by entity name - make sure it's case-insensitive and ignores white space
+        # search by entity name - make sure it's case-insensitive and ignores white space
         response = self.client.get("/api/entities/", data={"search": " cLiEnT "}, format="json")
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.json()["result"]), 1)
-        the_result = response.json()["result"][0]
-        self.assertEqual(the_result["id"], newly_added_entity.id)
+        data = self.assertJSONResponse(response, 200)
+        self.assertEqual(len(data["result"]), 2)
 
-        # Case 3: search by entity UUID
-        response = self.client.get(f"/api/entities/?search={newly_added_entity.uuid}", format="json")
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.json()["result"]), 1)
-        self.assertEqual(the_result["id"], newly_added_entity.id)
+        # Search by entity UUID
+        response = self.client.get("/api/entities/", data={"search": entity_1.uuid}, format="json")
+        data = self.assertJSONResponse(response, 200)
+        self.assertEqual(len(data["result"]), 1)
+        self.assertEqual(data["result"][0]["id"], entity_1.id)
 
-        # Case 4: search by JSON attribute
-        response = self.client.get("/api/entities/?search=age", format="json")
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.json()["result"]), 1)
-        self.assertEqual(the_result["id"], newly_added_entity.id)
+        # Search by JSON attribute
+        response = self.client.get("/api/entities/", data={"search": "30"}, format="json")
+        data = self.assertJSONResponse(response, 200)
+        # Both entities share the same instance attributes in this setup
+        self.assertEqual(len(data["result"]), 2)
+
+        # Multi-word search. "client new" should match "New Client"
+        response = self.client.get("/api/entities/", data={"search": "client new"}, format="json")
+        data = self.assertJSONResponse(response, 200)
+        self.assertEqual(len(data["result"]), 1)
+        self.assertEqual(data["result"][0]["id"], entity_1.id)
+
+        # Exact search (double quotes)
+        response = self.client.get("/api/entities/", data={"search": '"New Client"'}, format="json")
+        data = self.assertJSONResponse(response, 200)
+        self.assertEqual(len(data["result"]), 1)
+        self.assertEqual(data["result"][0]["id"], entity_1.id)
+
+        # Exact search, no matches
+        response = self.client.get("/api/entities/", data={"search": '"Client New"'}, format="json")
+        data = self.assertJSONResponse(response, 200)
+        self.assertEqual(len(data["result"]), 0)
+
+        # 'ids:' prefix search
+        response = self.client.get("/api/entities/", data={"search": f"ids:{entity_2.id}"}, format="json")
+        data = self.assertJSONResponse(response, 200)
+        self.assertEqual(len(data["result"]), 1)
+        self.assertEqual(data["result"][0]["id"], entity_2.id)
+
+        # 'uuids:' prefix search
+        response = self.client.get("/api/entities/", data={"search": f"uuids:{entity_2.uuid}"}, format="json")
+        data = self.assertJSONResponse(response, 200)
+        self.assertEqual(len(data["result"]), 1)
+        self.assertEqual(data["result"][0]["id"], entity_2.id)
 
     def test_list_entities_annotate_duplicates(self):
         """

--- a/iaso/tests/utils/test_jsonlogic.py
+++ b/iaso/tests/utils/test_jsonlogic.py
@@ -171,6 +171,12 @@ class JsonLogicTests(TestCase):
             "(AND: ('var1__exact', 1), (NOT (AND: ('var2__exact', 1))), ('var3__gt', 1), ('var4__gte', 1), ('var5__lt', 1), ('var6__lte', 1))",
         )
 
+    def test_jsonlogic_to_q_filters_trim(self) -> None:
+        """Test that jsonlogic_to_q trims whitespaces on values."""
+        filters = {"and": [{"==": [{"var": "gender"}, "F "]}, {"<": [{"var": "age"}, " 25"]}]}
+        q, _ = jsonlogic_to_q(filters)
+        self.assertEqual(str(q), "(AND: ('gender__exact', 'F'), ('age__lt', '25'))")
+
 
 class JsonLogicSomeAllStringFieldTests(TestCase):
     def test_some_operator_all_values_present(self):

--- a/iaso/utils/jsonlogic.py
+++ b/iaso/utils/jsonlogic.py
@@ -170,6 +170,9 @@ def jsonlogic_to_q(
         # Since inside the json everything is cast as string we cast back as int
         extract = "__forcefloat"
 
+    if isinstance(value, str):
+        value = value.strip()
+
     lookup = EXTENDED_OPERATOR_LOOKUPS[op]
 
     f = f"{field_name}{extract}__{lookup}"


### PR DESCRIPTION
## What problem is this PR solving?

White spaces in the search queries and in the json data itself can make some entities hard to find. This PR seeks to provide some fixes and workarounds.

### Related JIRA tickets

IA-4887 (partially addresses IA-4566)

## Changes

- Trim whitespace on json logic queries inputs
- Change the default entity search behavior to search independently of word order or white spaces.
- Support searching phrases in double quotes for exact search.

## How to test

Go to the entities list page and test:
- Search in submitted fields: pick a form and field and include some extra white spaces into your query, you should still get results. 
- Regular search: Try a mix of single word, multiple words and quoted search queries. The expected behavior should be: 
  - quoted searches are exact (case-insensitive) matches. 
  - multiple words are AND-ed together and should match values in the entity attributes json in different orders. 

## Print screen / video

/

## Notes

What is not fixed by this PR is:
- If the json data itself contains white spaces, the entries will still not be found when using the "search in submitted fields" feature. However, as a workaround, if they're on the entity attributes form, they can still be found with the search field. 

## Doc

/