### PR TITLE
HOTFIX: IA-4874 IA-4864 IA-4862 WC2-875

### DIFF
--- a/hat/assets/js/apps/Iaso/constants/mapTiles.js
+++ b/hat/assets/js/apps/Iaso/constants/mapTiles.js
@@ -2,10 +2,10 @@ const arcgisPattern =
     'https://server.arcgisonline.com/ArcGIS/rest/services/{}/MapServer/tile/{z}/{y}/{x}.jpg';
 const tiles = {
     osm: {
-        maxZoom: 18,
-        url: 'https://{s}.tile.osm.org/{z}/{x}/{y}.png',
+        maxZoom: 19,
+        url: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
         attribution:
-            '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors',
+            '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
     },
     'arcgis-street': {
         maxZoom: 18,

--- a/hat/assets/js/apps/Iaso/constants/mapTiles.js
+++ b/hat/assets/js/apps/Iaso/constants/mapTiles.js
@@ -2,7 +2,7 @@ const arcgisPattern =
     'https://server.arcgisonline.com/ArcGIS/rest/services/{}/MapServer/tile/{z}/{y}/{x}.jpg';
 const tiles = {
     osm: {
-        maxZoom: 19,
+        maxZoom: 18,
         url: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
         attribution:
             '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',

--- a/hat/templates/iaso/base.html
+++ b/hat/templates/iaso/base.html
@@ -7,6 +7,8 @@
   <title>{{ app_title }}</title>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  {# OSM tile policy requires valid Referer; avoid restrictive Referrer-Policy #}
+  <meta name="referrer" content="strict-origin-when-cross-origin">
   <meta name="description" content="">
   <meta name="keywords" content="">
   {# favicon #}

--- a/iaso/api/org_unit_change_requests/views.py
+++ b/iaso/api/org_unit_change_requests/views.py
@@ -160,6 +160,11 @@ class OrgUnitChangeRequestViewSet(viewsets.ModelViewSet):
         """
         POST to create an `OrgUnitChangeRequest`.
         """
+        if (
+            serializer.validated_data["uuid"]
+            and OrgUnitChangeRequest.objects.filter(uuid=serializer.validated_data["uuid"]).exists()
+        ):
+            return
         org_unit_to_change = serializer.validated_data["org_unit"]
         self.has_org_unit_permission(org_unit_to_change)
         serializer.validated_data["created_by"] = self.request.user

--- a/iaso/api/org_units.py
+++ b/iaso/api/org_units.py
@@ -208,7 +208,10 @@ class OrgUnitViewSet(viewsets.ViewSet):
 
         order = request.query_params.get("order", "name").split(",")
         # Annotate number of instance per org unit to sort by it
-        count_instances = is_export or is_field_referenced("instances_count", requested_fields, order)
+        if requested_fields is None:
+            count_instances = True
+        else:
+            count_instances = is_export or is_field_referenced("instances_count", requested_fields, order)
 
         if with_shapes or as_location or parquet_format:
             count_instances = False

--- a/iaso/api/serializers.py
+++ b/iaso/api/serializers.py
@@ -233,19 +233,6 @@ class OrgUnitSearchSerializer(OrgUnitSerializer, DynamicFieldsModelSerializer):
             "default_image",
         ]
 
-        default_fields = [
-            "id",
-            "projects",
-            "name",
-            "org_unit_type_name",
-            "source",
-            "source_ref",
-            "instances_count",
-            "validation_status",
-            "created_at",
-            "updated_at",
-        ]
-
 
 # noinspection PyMethodMayBeStatic
 class OrgUnitTreeSearchSerializer(TimestampSerializerMixin, serializers.ModelSerializer):

--- a/iaso/management/commands/clean_up_duplicate_submissions.py
+++ b/iaso/management/commands/clean_up_duplicate_submissions.py
@@ -155,5 +155,7 @@ class Command(BaseCommand):
         entities_to_delete = Entity.objects.filter(attributes__in=to_delete)
         first_instance = Instance.objects.get(id=first_id)
         Instance.objects.filter(entity__in=entities_to_delete).update(entity=first_instance.entity)
+        # Need to set foreign key relation to NULL to avoid ProtectedError
+        entities_to_delete.update(attributes_id=None)
         entities_to_delete.delete()
         to_delete.delete()

--- a/iaso/tests/api/org_unit_change_requests/test_org_unit_change_requests.py
+++ b/iaso/tests/api/org_unit_change_requests/test_org_unit_change_requests.py
@@ -174,6 +174,45 @@ class OrgUnitChangeRequestAPITestCase(TaskAPITestCase):
         self.assertEqual(change_request.requested_fields, ["new_name", "new_org_unit_type"])
 
     @time_machine.travel(DT, tick=False)
+    def test_create_same_uuid_ok(self):
+        self.client.force_authenticate(self.user)
+        data = {
+            "uuid": "9eedf036-b444-47ad-b8a2-7169b87e89bf",
+            "org_unit_id": self.org_unit.id,
+            "new_name": "I want this new name",
+            "new_org_unit_type_id": self.org_unit_type.pk,
+        }
+        response = self.client.post("/api/orgunits/changes/", data=data, format="json")
+        self.assertEqual(response.status_code, 201)
+        change_request = m.OrgUnitChangeRequest.objects.get(new_name=data["new_name"])
+        self.assertEqual(change_request.uuid.__str__(), data["uuid"])
+        self.assertEqual(change_request.new_name, data["new_name"])
+        self.assertEqual(change_request.new_org_unit_type, self.org_unit_type)
+        self.assertEqual(change_request.created_at, self.DT)
+        self.assertEqual(change_request.created_by, self.user)
+        self.assertEqual(change_request.updated_at, self.DT)
+        self.assertEqual(change_request.requested_fields, ["new_name", "new_org_unit_type"])
+        self.assertEqual(m.OrgUnitChangeRequest.objects.count(), 1)
+
+        new_data = {
+            "uuid": data["uuid"],
+            "org_unit_id": data["org_unit_id"],
+            "new_name": "I want this new name 2",
+            "new_org_unit_type_id": data["new_org_unit_type_id"],
+        }
+        response = self.client.post("/api/orgunits/changes/", data=new_data, format="json")
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(m.OrgUnitChangeRequest.objects.count(), 1)
+        change_request = m.OrgUnitChangeRequest.objects.get(uuid=data["uuid"])
+        self.assertEqual(change_request.uuid.__str__(), data["uuid"])
+        self.assertEqual(change_request.new_name, data["new_name"])
+        self.assertEqual(change_request.new_org_unit_type, self.org_unit_type)
+        self.assertEqual(change_request.created_at, self.DT)
+        self.assertEqual(change_request.created_by, self.user)
+        self.assertEqual(change_request.updated_at, self.DT)
+        self.assertEqual(change_request.requested_fields, ["new_name", "new_org_unit_type"])
+
+    @time_machine.travel(DT, tick=False)
     def test_create_ok_erase_fields(self):
         self.client.force_authenticate(self.user)
         data = {
@@ -225,7 +264,7 @@ class OrgUnitChangeRequestAPITestCase(TaskAPITestCase):
             "new_name": "I want this new name",
             "new_org_unit_type_id": self.org_unit_type.pk,
         }
-        with self.assertNumQueries(11):
+        with self.assertNumQueries(12):
             response = self.client.post("/api/orgunits/changes/", data=data, format="json")
         self.assertEqual(response.status_code, 201)
         change_request = m.OrgUnitChangeRequest.objects.get(new_name=data["new_name"])
@@ -247,7 +286,7 @@ class OrgUnitChangeRequestAPITestCase(TaskAPITestCase):
             "org_unit_id": self.org_unit.id,
             "new_name": "Bar",
         }
-        with self.assertNumQueries(12):
+        with self.assertNumQueries(13):
             response = self.client.post("/api/orgunits/changes/?app_id=foo.bar.baz", data=data, format="json")
         self.assertEqual(response.status_code, 201)
         change_request = m.OrgUnitChangeRequest.objects.get(uuid=data["uuid"])
@@ -269,7 +308,7 @@ class OrgUnitChangeRequestAPITestCase(TaskAPITestCase):
             "new_location_accuracy": 1.2345,
         }
 
-        with self.assertNumQueries(12):
+        with self.assertNumQueries(13):
             response = self.client.post("/api/orgunits/changes/?app_id=foo.bar.baz", data=data, format="json")
         self.assertEqual(response.status_code, 201)
         change_request = m.OrgUnitChangeRequest.objects.get(uuid=data["uuid"])


### PR DESCRIPTION
## What problem is this PR solving?

HOTFIX with related PR's: 
- IA-4874: Correct usage of OSM tiles to avoid 403
- IA-4864: Org Units API: latest changes were breaking
- IA-4862: HTTP 500 error when sending CR from mobile
- WC2-875: Unsuccessful mobile bulk uploads

### Related JIRA tickets

IA-4874 IA-4864 IA-4862 WC2-875

## Changes

Cherry pick of merged PR's

