### PR TITLE
[IA-4885]: Added a setting to disable warning and error for drf-spectacular

### DIFF
--- a/hat/settings.py
+++ b/hat/settings.py
@@ -491,6 +491,8 @@ SPECTACULAR_SETTINGS = {
         "iaso.drf_spectacular_utils.permissions.HasAccountAndProfile",
     ],
     "TAGS": [{"name": "polio-configs", "description": "Polio configuration"}],
+    "DISABLE_ERRORS_AND_WARNINGS": os.environ.get("DRF_SPECTACULAR_DISABLE_ERRORS_AND_WARNINGS", "true").lower()
+    in ["true", "1"],
 }
 
 REST_FRAMEWORK_SERIALIZER_FIELDS_MAPPINGS = {


### PR DESCRIPTION
## What problem is this PR solving?

The logs are flooded with warnings and errors from drf-spectacular

### Related JIRA tickets

IA-4885

## Changes

Added an env variable DRF_SPECTACULAR_DISABLE_ERRORS_AND_WARNINGS to disable the warnign and errors. By default, if nothing is provided it's disabled

## How to test

Either access /swagger-ui/ or run the test test_open_api with different env values. It shoudl either print a bunch of warning errors or not.  
