### PR TITLE
SNT-387: Topbar accept SX

### DIFF
--- a/hat/assets/js/apps/Iaso/components/nav/TopBarComponent.tsx
+++ b/hat/assets/js/apps/Iaso/components/nav/TopBarComponent.tsx
@@ -1,22 +1,30 @@
 import React, { useContext, FunctionComponent } from 'react';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import MenuIcon from '@mui/icons-material/Menu';
-import { Box, Grid, IconButton, useMediaQuery, useTheme } from '@mui/material';
+import {
+    Box,
+    Grid,
+    IconButton,
+    SxProps,
+    Theme,
+    useMediaQuery,
+    useTheme,
+} from '@mui/material';
 import AppBar from '@mui/material/AppBar';
 import Toolbar from '@mui/material/Toolbar';
 import Typography from '@mui/material/Typography';
 import { makeStyles } from '@mui/styles';
+import { DjangoAdminPanelButton } from 'Iaso/components/nav/DjangoAdminPanelButton';
 import { useSidebar } from '../../domains/app/contexts/SideBarContext';
 import { ThemeConfigContext } from '../../domains/app/contexts/ThemeConfigContext';
 import { LangSwitch } from '../../domains/home/components/LangSwitch';
 import { useFindCustomComponent } from '../../plugins/hooks/customComponents';
-import { useCurrentUser } from '../../utils/usersUtils.ts';
-import { CurrentUserInfos } from './CurrentUser/index.tsx';
-import { HomePageButton } from './HomePageButton.tsx';
-import { LogoutButton } from './LogoutButton.tsx';
-import { DjangoAdminPanelButton } from 'Iaso/components/nav/DjangoAdminPanelButton';
+import { useCurrentUser } from '../../utils/usersUtils';
+import { CurrentUserInfos } from './CurrentUser/index';
+import { HomePageButton } from './HomePageButton';
+import { LogoutButton } from './LogoutButton';
 
-const styles = theme => ({
+const styles = (theme: Theme) => ({
     menuButton: {
         [theme.breakpoints.up('md')]: {
             marginRight: `${theme.spacing(2)} !important`,
@@ -48,6 +56,7 @@ type Props = {
     goBack?: () => void;
     displayMenuButton?: boolean;
     disableShadow?: boolean;
+    sx?: SxProps;
 };
 
 const TopBar: FunctionComponent<Props> = ({
@@ -57,6 +66,7 @@ const TopBar: FunctionComponent<Props> = ({
     goBack = () => null,
     displayMenuButton = true,
     disableShadow = false,
+    sx = {},
 }) => {
     const classes = useStyles();
 
@@ -71,13 +81,14 @@ const TopBar: FunctionComponent<Props> = ({
     const theme = useTheme();
     const isMobileLayout = useMediaQuery(theme.breakpoints.down('md'));
     const Disclaimer = useFindCustomComponent('topbar.disclaimer');
+
     return (
         <AppBar
             position="relative"
             color="primary"
             id="top-bar"
-            sx={{ zIndex: 10 }}
             elevation={disableShadow ? 0 : 4}
+            sx={{ zIndex: 10, ...sx }}
         >
             <Toolbar className={classes.root}>
                 {Disclaimer && (


### PR DESCRIPTION
## What problem is this PR solving?

SNT-387 TopBar styling

### Related JIRA tickets

SNT-387

## Changes

Top bar accepts a SX prop. 
Did this as there is no default theme in iaso yet and I didn't wanted to break any other plugins.
Otherwise we should have use theme overrides.

## How to test

Check related SNT PR to test this : https://github.com/BLSQ/snt-malaria/pull/239
But in IASO it should break anything.

## Print screen / video

N/A

## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).
