### PR TITLE
[IA-4906]: backend adapt cu calls for node templates to provide a position parameter

### DIFF
--- a/iaso/api/validation_workflows_node_templates/serializers/create.py
+++ b/iaso/api/validation_workflows_node_templates/serializers/create.py
@@ -1,22 +1,24 @@
 from django.db import transaction
 from rest_framework import serializers
-from rest_framework.exceptions import ValidationError
 
 from iaso.api.common import HiddenSlugRelatedField, ModelSerializer
 from iaso.api.validation_workflows_node_templates.serializers.common import ValidationWorkflowContextDefault
 from iaso.models import UserRole, ValidationNodeTemplate, ValidationWorkflow
+from iaso.models.validation_workflow.templates import PositionChoices
 
 
 class ValidationNodeTemplateCreateSerializer(ModelSerializer):
     roles_required = serializers.PrimaryKeyRelatedField(
         many=True, write_only=True, required=False, queryset=UserRole.objects.none()
     )
-    previous_node_templates = serializers.SlugRelatedField(
+    parent_node_templates = serializers.SlugRelatedField(
         slug_field="slug", many=True, write_only=True, required=False, queryset=ValidationNodeTemplate.objects.none()
     )
-    next_node_templates = serializers.SlugRelatedField(
-        slug_field="slug", many=True, write_only=True, required=False, queryset=ValidationNodeTemplate.objects.none()
+
+    position = serializers.ChoiceField(
+        choices=PositionChoices.choices, default=PositionChoices.last, write_only=True, required=False
     )
+
     workflow = HiddenSlugRelatedField(
         slug_field="slug",
         write_only=True,
@@ -33,8 +35,8 @@ class ValidationNodeTemplateCreateSerializer(ModelSerializer):
             "description",
             "slug",
             "roles_required",
-            "previous_node_templates",
-            "next_node_templates",
+            "position",
+            "parent_node_templates",
             "can_skip_previous_nodes",
             "workflow",
         ]
@@ -49,60 +51,48 @@ class ValidationNodeTemplateCreateSerializer(ModelSerializer):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+
         request = self.context.get("request")
         user = getattr(request, "user", None)
-        self.fields["roles_required"].child_relation.queryset = UserRole.objects.filter(
-            account=user.iaso_profile.account
-        )
-        for field in ["previous_node_templates", "next_node_templates"]:
-            self.fields[field].child_relation.queryset = ValidationNodeTemplate.objects.select_related(
+        iaso_profile = getattr(user, "iaso_profile", None)
+
+        if getattr(iaso_profile, "account", None):
+            self.fields["roles_required"].child_relation.queryset = UserRole.objects.filter(
+                account=user.iaso_profile.account
+            )
+            self.fields[
+                "parent_node_templates"
+            ].child_relation.queryset = ValidationNodeTemplate.objects.select_related(
                 "workflow", "workflow__account"
             ).filter(workflow__account=user.iaso_profile.account)
-        self.fields["workflow"].queryset = ValidationWorkflow.objects.prefetch_related("node_templates").filter(
-            account=user.iaso_profile.account
-        )
+            self.fields["workflow"].queryset = ValidationWorkflow.objects.filter(account=user.iaso_profile.account)
 
-    def validate_previous_node_templates(self, data):
+    def validate_parent_node_templates(self, data):
         ids = [item.id for item in data]
-        if len(ids) != len(set(ids)):
-            raise serializers.ValidationError("Duplicate nodes are not allowed.")
 
         # linear for the moment
         if len(ids) > 1:
             raise serializers.ValidationError("One node maximum allowed.")
 
-        return data
-
-    def validate_next_node_templates(self, data):
-        ids = [item.id for item in data]
+        # won't happen for the moment but might be useful later when we allow more than one node
         if len(ids) != len(set(ids)):
             raise serializers.ValidationError("Duplicate nodes are not allowed.")
-
-        # linear for the moment
-        if len(ids) > 1:
-            raise serializers.ValidationError("One node maximum allowed.")
 
         return data
 
     def validate(self, attrs):
-        if not attrs.get("next_node_templates") and not attrs.get("previous_node_templates"):
-            # we check that it's really the only node in the workflow
-            related_validation_workflow = attrs.get("workflow")
-            if related_validation_workflow.node_templates.exists():
-                raise ValidationError("You must specify either next node templates or previous node templates.")
-
-        if attrs.get("previous_node_templates") and attrs.get("next_node_templates"):
-            # we check that some ids are not present in both.
-            if set(attrs["previous_node_templates"]).intersection(set(attrs["next_node_templates"])):
-                raise ValidationError("There are duplicate nodes in previous and next node templates.")
-
-        # todo: more checks
-        # can we insert between two nodes? (+ adding a start, adding a last)
-
+        if attrs.get("position", "") == PositionChoices.child_of and not attrs.get("parent_node_templates"):
+            raise serializers.ValidationError(
+                f"Parent node templates are required if position is set to {PositionChoices.child_of}."
+            )
         return attrs
 
     @transaction.atomic
     def save(self, **kwargs):
+        position = self.validated_data.pop("position", None)
+        parent_node_templates = self.validated_data.pop("parent_node_templates", None)
+
         instance = super().save(**kwargs)
-        self.validated_data["workflow"].insert_node_template(instance)
+
+        self.validated_data["workflow"].insert_node_template(instance, position, parent_node_templates)
         return instance

--- a/iaso/api/validation_workflows_node_templates/serializers/move.py
+++ b/iaso/api/validation_workflows_node_templates/serializers/move.py
@@ -1,31 +1,43 @@
 from rest_framework import serializers
-from rest_framework.exceptions import ValidationError
 
 from iaso.models import ValidationNodeTemplate
+from iaso.models.validation_workflow.templates import PositionChoices
 
 
 class ValidationNodeTemplateMoveSerializer(serializers.Serializer):
-    new_previous_nodes = serializers.SlugRelatedField(
-        many=True, write_only=True, queryset=ValidationNodeTemplate.objects.none(), slug_field="slug", required=False
+    parent_node_templates = serializers.SlugRelatedField(
+        slug_field="slug", many=True, write_only=True, required=False, queryset=ValidationNodeTemplate.objects.none()
     )
-    new_next_nodes = serializers.SlugRelatedField(
-        many=True, write_only=True, queryset=ValidationNodeTemplate.objects.none(), slug_field="slug", required=False
-    )
+
+    position = serializers.ChoiceField(choices=PositionChoices.choices, write_only=True, required=True)
 
     def __init__(self, *args, **kwargs):
         super(ValidationNodeTemplateMoveSerializer, self).__init__(*args, **kwargs)
         request = self.context.get("request")
         user = getattr(request, "user", None)
+        iaso_profile = getattr(user, "iaso_profile", None)
 
-        for f in ["new_previous_nodes", "new_next_nodes"]:
-            self.fields[f].child_relation.queryset = ValidationNodeTemplate.objects.filter(
+        if getattr(iaso_profile, "account", None):
+            self.fields["parent_node_templates"].child_relation.queryset = ValidationNodeTemplate.objects.filter(
                 workflow__account=user.iaso_profile.account
             ).exclude(pk=self.instance.pk)
 
+    def validate_parent_node_templates(self, data):
+        ids = [item.id for item in data]
+
+        # linear for the moment
+        if len(ids) > 1:
+            raise serializers.ValidationError("One node maximum allowed.")
+
+        # won't happen for the moment but might be useful later when we allow more than one node
+        if len(ids) != len(set(ids)):
+            raise serializers.ValidationError("Duplicate nodes are not allowed.")
+
+        return data
+
     def validate(self, attrs):
-        if not attrs.get("new_previous_nodes") and not attrs.get("new_next_nodes"):
-            raise ValidationError("You must provide one of those : new_next_nodes, new_previous_nodes.")
-
-        # todo: more checks
-
+        if attrs.get("position", "") == PositionChoices.child_of and not attrs.get("parent_node_templates"):
+            raise serializers.ValidationError(
+                f"Parent node templates are required if position is set to {PositionChoices.child_of}."
+            )
         return attrs

--- a/iaso/api/validation_workflows_node_templates/views.py
+++ b/iaso/api/validation_workflows_node_templates/views.py
@@ -24,7 +24,7 @@ from iaso.api.validation_workflows_node_templates.serializers.list import Valida
 from iaso.api.validation_workflows_node_templates.serializers.move import ValidationNodeTemplateMoveSerializer
 from iaso.api.validation_workflows_node_templates.serializers.retrieve import ValidationNodeTemplateRetrieveSerializer
 from iaso.api.validation_workflows_node_templates.serializers.update import ValidationNodeTemplateUpdateSerializer
-from iaso.models import UserRole, ValidationNodeTemplate, ValidationWorkflow
+from iaso.models import UserRole, ValidationNodeTemplate
 
 
 @extend_schema(tags=["Validation workflow node templates"])
@@ -68,19 +68,11 @@ class ValidationNodeTemplatesView(NestedViewSetMixin, ModelViewSet):
         qs = qs.filter(workflow__account=account)
         if self.action in ["delete"]:
             return qs.prefetch_related("roles_required", "next_node_templates", "previous_node_templates")
-        # if self.action in ["move"]:
-        #     return qs.prefetch_related("next_node_templates", "previous_node_templates")
         if self.action in ["retrieve", "list"]:
             return qs.select_related("workflow", "workflow__account").prefetch_related(
                 Prefetch("roles_required", queryset=UserRole.objects.select_related("group"))
             )
         return qs.select_related("workflow", "workflow__account")
-
-    def get_validation_workflow(self):
-        account = self.request.user.iaso_profile.account
-        return ValidationWorkflow.objects.prefetch_related("node_templates").get(
-            account=account, slug=self.kwargs.get("parent_lookup_workflow__slug")
-        )
 
     # This endpoint returns a plain list (not paginated).
     # pagination_class=None ensures the OpenAPI schema reflects that.

--- a/iaso/api/validation_workflows_node_templates/views.py
+++ b/iaso/api/validation_workflows_node_templates/views.py
@@ -105,7 +105,11 @@ class ValidationNodeTemplatesView(NestedViewSetMixin, ModelViewSet):
     def perform_destroy(self, instance):
         instance.workflow.delete_node_template(instance)
 
-    @extend_schema(description="Move a node to a new position in the workflow")
+    @extend_schema(
+        description="Move a node to a new position in the workflow",
+        responses={"204": None},
+        request=ValidationNodeTemplateMoveSerializer,
+    )
     @action(detail=True, methods=["PUT"])
     def move(self, request, *args, **kwargs):
         instance = self.get_object()

--- a/iaso/models/validation_workflow/templates.py
+++ b/iaso/models/validation_workflow/templates.py
@@ -88,7 +88,7 @@ class ValidationWorkflow(CreatedAndUpdatedModel, SoftDeletableModel):
         node.delete()
 
     @transaction.atomic
-    def insert_node_template(self, node, position=PositionChoices.last, parent_nodes=None):
+    def insert_node_template(self, node, position=PositionChoices.last, parent_node_templates=None):
         """
         Function to insert a node in the workflow
         """
@@ -104,10 +104,10 @@ class ValidationWorkflow(CreatedAndUpdatedModel, SoftDeletableModel):
             )
 
         if position == PositionChoices.child_of:
-            if not parent_nodes:
+            if not parent_node_templates:
                 raise ValueError("parent_nodes is required")
 
-            previous_nodes = [x.pk for x in parent_nodes]
+            previous_nodes = [x.pk for x in parent_node_templates]
 
             next_nodes = list(
                 ValidationNodeTemplate.objects.filter(previous_node_templates__pk__in=previous_nodes)
@@ -145,12 +145,41 @@ class ValidationWorkflow(CreatedAndUpdatedModel, SoftDeletableModel):
             )
 
     @transaction.atomic
-    def move_node_template(self, node, new_previous_nodes=None, new_next_nodes=None):
-        new_previous_nodes = [n.pk for n in new_previous_nodes or []]
-        new_next_nodes = [n.pk for n in new_next_nodes or []]
+    def move_node_template(self, node, position=None, parent_node_templates=None):
+        if not position:
+            raise ValueError("Position is required")
 
-        if not new_next_nodes and not new_previous_nodes:
-            raise ValueError
+        if position == PositionChoices.last and not node.next_node_templates:
+            # nothing to do , node is already last
+            return
+
+        if position == PositionChoices.first and not node.previous_node_templates:
+            # nothing to do , node is already first
+            return
+
+        if position == PositionChoices.child_of and not parent_node_templates:
+            raise ValueError("parent_nodes is required")
+
+        new_previous_nodes = []
+        new_next_nodes = []
+
+        if position == PositionChoices.first:
+            new_next_nodes = list(
+                set(self.node_templates.filter(previous_node_templates__isnull=True).values_list("pk", flat=True))
+            )
+
+        if position == PositionChoices.last:
+            new_previous_nodes = list(
+                set(self.node_templates.filter(next_node_templates__isnull=True).values_list("pk", flat=True))
+            )
+
+        if position == PositionChoices.child_of:
+            new_next_nodes = list(
+                ValidationNodeTemplate.objects.filter(previous_node_templates__in=parent_node_templates)
+                .values_list("pk", flat=True)
+                .distinct()
+            )
+            new_previous_nodes = [x.pk for x in parent_node_templates]
 
         old_previous = list(node.previous_node_templates.values_list("pk", flat=True))
         old_next = list(node.next_node_templates.values_list("pk", flat=True))

--- a/iaso/models/validation_workflow/templates.py
+++ b/iaso/models/validation_workflow/templates.py
@@ -16,6 +16,12 @@ from iaso.utils.models.color import ColorField
 from iaso.utils.models.soft_deletable import DefaultSoftDeletableManager, SoftDeletableModel
 
 
+class PositionChoices(models.TextChoices):
+    last = "last", "Last"
+    first = "first", "First"
+    child_of = "child_of", "Child Of"
+
+
 class ValidationWorkflow(CreatedAndUpdatedModel, SoftDeletableModel):
     """
     Static definition of a workflow
@@ -81,44 +87,62 @@ class ValidationWorkflow(CreatedAndUpdatedModel, SoftDeletableModel):
 
         node.delete()
 
-    @staticmethod
     @transaction.atomic
-    def insert_node_template(node):
+    def insert_node_template(self, node, position=PositionChoices.last, parent_nodes=None):
         """
         Function to insert a node in the workflow
         """
 
-        previous_nodes = list(node.previous_node_templates.values_list("pk", flat=True))
-        next_nodes = list(node.next_node_templates.values_list("pk", flat=True))
+        if position == PositionChoices.last:
+            node.previous_node_templates.set(
+                self.node_templates.filter(next_node_templates__isnull=True).exclude(pk=node.pk)
+            )
 
-        # future previous nodes should be updated and get their next nodes removed
-        through_table = node.next_node_templates.through
+        if position == PositionChoices.first:
+            node.next_node_templates.set(
+                self.node_templates.filter(previous_node_templates__isnull=True).exclude(pk=node.pk)
+            )
 
-        to_delete = Q()
-        for prev in previous_nodes:
-            for nxt in next_nodes:
-                to_delete |= Q(
-                    from_validationnodetemplate_id=prev,
-                    to_validationnodetemplate_id=nxt,
-                )
-        if to_delete:
-            through_table.objects.filter(to_delete).delete()
+        if position == PositionChoices.child_of:
+            if not parent_nodes:
+                raise ValueError("parent_nodes is required")
 
-        # update the related previous nodes to point to the current inserted node and update the next nodes so their previous node is current inserted node
-        through_table.objects.bulk_create(
-            [
-                through_table(
-                    from_validationnodetemplate_id=prev,
-                    to_validationnodetemplate_id=node.id,
-                )
-                for prev in previous_nodes
-            ]
-            + [
-                through_table(from_validationnodetemplate_id=node.id, to_validationnodetemplate_id=nxt)
-                for nxt in next_nodes
-            ],
-            ignore_conflicts=True,
-        )
+            previous_nodes = [x.pk for x in parent_nodes]
+
+            next_nodes = list(
+                ValidationNodeTemplate.objects.filter(previous_node_templates__pk__in=previous_nodes)
+                .values_list("pk", flat=True)
+                .distinct("pk")
+            )
+
+            # future previous nodes should be updated and get their next nodes removed
+            through_table = node.next_node_templates.through
+
+            to_delete = Q()
+            for prev in previous_nodes:
+                for nxt in next_nodes:
+                    to_delete |= Q(
+                        from_validationnodetemplate_id=prev,
+                        to_validationnodetemplate_id=nxt,
+                    )
+            if to_delete:
+                through_table.objects.filter(to_delete).delete()
+
+            # update the related previous nodes to point to the current inserted node and update the next nodes so their previous node is current inserted node
+            through_table.objects.bulk_create(
+                [
+                    through_table(
+                        from_validationnodetemplate_id=prev,
+                        to_validationnodetemplate_id=node.id,
+                    )
+                    for prev in previous_nodes
+                ]
+                + [
+                    through_table(from_validationnodetemplate_id=node.id, to_validationnodetemplate_id=nxt)
+                    for nxt in next_nodes
+                ],
+                ignore_conflicts=True,
+            )
 
     @transaction.atomic
     def move_node_template(self, node, new_previous_nodes=None, new_next_nodes=None):

--- a/iaso/tests/api/validation_workflows_node_templates/test_serializers/test_create.py
+++ b/iaso/tests/api/validation_workflows_node_templates/test_serializers/test_create.py
@@ -1,20 +1,15 @@
+from django.contrib.auth.models import Group
 from django.test import RequestFactory
 from rest_framework.settings import api_settings
 
 from iaso.api.validation_workflows_node_templates.serializers.create import ValidationNodeTemplateCreateSerializer
-from iaso.models import Account
+from iaso.models import Account, UserRole
 from iaso.models.validation_workflow.templates import PositionChoices, ValidationNodeTemplate, ValidationWorkflow
 from iaso.permissions.core_permissions import CORE_VALIDATION_WORKFLOW_PERMISSION
 from iaso.test import TestCase
 
 
 class TestValidationNodeTemplateCreateSerializer(TestCase):
-    @staticmethod
-    def snake_case_to_camel_case(value):
-        camel_string = "".join(x.capitalize() for x in value.lower().split("_"))
-
-        return value[0].lower() + camel_string[1:]
-
     def setUp(self):
         request = RequestFactory()
 
@@ -23,6 +18,9 @@ class TestValidationNodeTemplateCreateSerializer(TestCase):
         self.validation_workflow = ValidationWorkflow.objects.create(name="test", account=self.account)
         self.other_validation_workflow = ValidationWorkflow.objects.create(name="test2", account=self.other_account)
 
+        self.other_user_role = UserRole.objects.create(
+            account=self.other_account, group=Group.objects.create(name="group")
+        )
         self.first_node_template = ValidationNodeTemplate.objects.create(
             name="first", workflow=self.validation_workflow
         )
@@ -76,6 +74,18 @@ class TestValidationNodeTemplateCreateSerializer(TestCase):
             f"Parent node templates are required if position is set to {PositionChoices.child_of}.",
         )
 
+        serializer = ValidationNodeTemplateCreateSerializer(
+            data={"position": PositionChoices.child_of, "name": "random name", "parent_node_templates": []},
+            context=self.context,
+        )
+        self.assertFalse(serializer.is_valid())
+
+        self.assertCountEqual([api_settings.NON_FIELD_ERRORS_KEY], serializer.errors.keys())
+        self.assertEqual(
+            serializer.errors[api_settings.NON_FIELD_ERRORS_KEY][0],
+            f"Parent node templates are required if position is set to {PositionChoices.child_of}.",
+        )
+
     def test_validation_parent_nodes_max_one(self):
         serializer = ValidationNodeTemplateCreateSerializer(
             data={
@@ -117,6 +127,18 @@ class TestValidationNodeTemplateCreateSerializer(TestCase):
 
         self.assertCountEqual(["roles_required"], serializer.errors.keys())
         self.assertEqual(serializer.errors["roles_required"][0], 'Invalid pk "222" - object does not exist.')
+
+    def test_validation_roles_belongs_to_account(self):
+        serializer = ValidationNodeTemplateCreateSerializer(
+            data={"name": "random name", "roles_required": [self.other_user_role.pk]}, context=self.context
+        )
+
+        self.assertFalse(serializer.is_valid())
+
+        self.assertCountEqual(["roles_required"], serializer.errors.keys())
+        self.assertEqual(
+            serializer.errors["roles_required"][0], f'Invalid pk "{self.other_user_role.pk}" - object does not exist.'
+        )
 
     def test_validation_workflow_slug_from_context(self):
         serializer = ValidationNodeTemplateCreateSerializer(

--- a/iaso/tests/api/validation_workflows_node_templates/test_serializers/test_create.py
+++ b/iaso/tests/api/validation_workflows_node_templates/test_serializers/test_create.py
@@ -1,0 +1,146 @@
+from django.test import RequestFactory
+from rest_framework.settings import api_settings
+
+from iaso.api.validation_workflows_node_templates.serializers.create import ValidationNodeTemplateCreateSerializer
+from iaso.models import Account
+from iaso.models.validation_workflow.templates import PositionChoices, ValidationNodeTemplate, ValidationWorkflow
+from iaso.permissions.core_permissions import CORE_VALIDATION_WORKFLOW_PERMISSION
+from iaso.test import TestCase
+
+
+class TestValidationNodeTemplateCreateSerializer(TestCase):
+    @staticmethod
+    def snake_case_to_camel_case(value):
+        camel_string = "".join(x.capitalize() for x in value.lower().split("_"))
+
+        return value[0].lower() + camel_string[1:]
+
+    def setUp(self):
+        request = RequestFactory()
+
+        self.account = Account.objects.create(name="account")
+        self.other_account = Account.objects.create(name="account2")
+        self.validation_workflow = ValidationWorkflow.objects.create(name="test", account=self.account)
+        self.other_validation_workflow = ValidationWorkflow.objects.create(name="test2", account=self.other_account)
+
+        self.first_node_template = ValidationNodeTemplate.objects.create(
+            name="first", workflow=self.validation_workflow
+        )
+        self.second_node_template = ValidationNodeTemplate.objects.create(
+            name="second", workflow=self.validation_workflow
+        )
+
+        self.outer_node = ValidationNodeTemplate.objects.create(
+            name="outer node", workflow=self.other_validation_workflow
+        )
+
+        self.john_wick = self.create_user_with_profile(
+            username="john.wick", account=self.account, permissions=[CORE_VALIDATION_WORKFLOW_PERMISSION]
+        )
+
+        request.user = self.john_wick
+
+        self.context = {"request": request, "workflow_slug": self.validation_workflow.slug}
+
+    def test_validation_empty_data(self):
+        serializer = ValidationNodeTemplateCreateSerializer(data={}, context=self.context)
+        self.assertFalse(serializer.is_valid())
+
+        self.assertCountEqual(["name"], serializer.errors.keys())
+        self.assertEqual(serializer.errors["name"][0], "This field is required.")
+
+    def test_validation_name_required(self):
+        serializer = ValidationNodeTemplateCreateSerializer(data={"name": ""}, context=self.context)
+        self.assertFalse(serializer.is_valid())
+
+        self.assertCountEqual(["name"], serializer.errors.keys())
+        self.assertEqual(serializer.errors["name"][0], "This field may not be blank.")
+
+        serializer = ValidationNodeTemplateCreateSerializer(
+            data={"name": None, "workflow": "random"}, context=self.context
+        )
+        self.assertFalse(serializer.is_valid())
+
+        self.assertCountEqual(["name"], serializer.errors.keys())
+        self.assertEqual(serializer.errors["name"][0], "This field may not be null.")
+
+    def test_validation_no_parent_node_templates_if_position_is_child_of(self):
+        serializer = ValidationNodeTemplateCreateSerializer(
+            data={"position": PositionChoices.child_of, "name": "random name"}, context=self.context
+        )
+        self.assertFalse(serializer.is_valid())
+
+        self.assertCountEqual([api_settings.NON_FIELD_ERRORS_KEY], serializer.errors.keys())
+        self.assertEqual(
+            serializer.errors[api_settings.NON_FIELD_ERRORS_KEY][0],
+            f"Parent node templates are required if position is set to {PositionChoices.child_of}.",
+        )
+
+    def test_validation_parent_nodes_max_one(self):
+        serializer = ValidationNodeTemplateCreateSerializer(
+            data={
+                "position": PositionChoices.child_of,
+                "name": "random name",
+                "parent_node_templates": [self.first_node_template.slug, self.second_node_template.slug],
+            },
+            context=self.context,
+        )
+        self.assertFalse(serializer.is_valid())
+
+        self.assertCountEqual(["parent_node_templates"], serializer.errors.keys())
+        self.assertEqual(serializer.errors["parent_node_templates"][0], "One node maximum allowed.")
+
+    def test_validation_parent_nodes_belong_to_workflow(self):
+        serializer = ValidationNodeTemplateCreateSerializer(
+            data={
+                "position": PositionChoices.child_of,
+                "name": "random name",
+                "parent_node_templates": [self.outer_node.slug],
+            },
+            context=self.context,
+        )
+
+        self.assertFalse(serializer.is_valid())
+
+        self.assertCountEqual(["parent_node_templates"], serializer.errors.keys())
+
+        self.assertEqual(
+            serializer.errors["parent_node_templates"][0], f"Object with slug={self.outer_node.slug} does not exist."
+        )
+
+    def test_validation_roles_required(self):
+        serializer = ValidationNodeTemplateCreateSerializer(
+            data={"name": "random name", "roles_required": [222]}, context=self.context
+        )
+
+        self.assertFalse(serializer.is_valid())
+
+        self.assertCountEqual(["roles_required"], serializer.errors.keys())
+        self.assertEqual(serializer.errors["roles_required"][0], 'Invalid pk "222" - object does not exist.')
+
+    def test_validation_workflow_slug_from_context(self):
+        serializer = ValidationNodeTemplateCreateSerializer(
+            data={
+                "name": "random name",
+            },
+            context={"request": self.context["request"]},
+        )
+
+        self.assertFalse(serializer.is_valid())
+
+        self.assertCountEqual(["workflow"], serializer.errors.keys())
+        self.assertEqual(serializer.errors["workflow"][0], "This field may not be null.")
+
+        serializer = ValidationNodeTemplateCreateSerializer(
+            data={
+                "name": "random name",
+            },
+            context={"request": self.context["request"], "workflow_slug": self.other_validation_workflow.slug},
+        )
+        self.assertFalse(serializer.is_valid())
+
+        self.assertCountEqual(["workflow"], serializer.errors.keys())
+
+        self.assertEqual(
+            serializer.errors["workflow"][0], f"Object with slug={self.other_validation_workflow.slug} does not exist."
+        )

--- a/iaso/tests/api/validation_workflows_node_templates/test_serializers/test_move.py
+++ b/iaso/tests/api/validation_workflows_node_templates/test_serializers/test_move.py
@@ -78,6 +78,19 @@ class TestValidationNodeTemplateMoveSerializer(TestCase):
             f"Parent node templates are required if position is set to {PositionChoices.child_of}.",
         )
 
+        serializer = ValidationNodeTemplateMoveSerializer(
+            data={"position": PositionChoices.child_of, "name": "random name", "parent_node_templates": []},
+            context=self.context,
+            instance=self.first_node_template,
+        )
+        self.assertFalse(serializer.is_valid())
+
+        self.assertCountEqual([api_settings.NON_FIELD_ERRORS_KEY], serializer.errors.keys())
+        self.assertEqual(
+            serializer.errors[api_settings.NON_FIELD_ERRORS_KEY][0],
+            f"Parent node templates are required if position is set to {PositionChoices.child_of}.",
+        )
+
     def test_validation_parent_nodes_max_one(self):
         serializer = ValidationNodeTemplateMoveSerializer(
             data={

--- a/iaso/tests/api/validation_workflows_node_templates/test_serializers/test_move.py
+++ b/iaso/tests/api/validation_workflows_node_templates/test_serializers/test_move.py
@@ -1,0 +1,131 @@
+from django.test import RequestFactory
+from rest_framework.settings import api_settings
+
+from iaso.api.validation_workflows_node_templates.serializers.move import ValidationNodeTemplateMoveSerializer
+from iaso.models import Account
+from iaso.models.validation_workflow.templates import PositionChoices, ValidationNodeTemplate, ValidationWorkflow
+from iaso.permissions.core_permissions import CORE_VALIDATION_WORKFLOW_PERMISSION
+from iaso.test import TestCase
+
+
+class TestValidationNodeTemplateMoveSerializer(TestCase):
+    def setUp(self):
+        request = RequestFactory()
+
+        self.account = Account.objects.create(name="account")
+        self.other_account = Account.objects.create(name="account2")
+        self.validation_workflow = ValidationWorkflow.objects.create(name="test", account=self.account)
+        self.other_validation_workflow = ValidationWorkflow.objects.create(name="test2", account=self.other_account)
+
+        self.first_node_template = ValidationNodeTemplate.objects.create(
+            name="first", workflow=self.validation_workflow
+        )
+        self.second_node_template = ValidationNodeTemplate.objects.create(
+            name="second", workflow=self.validation_workflow
+        )
+        self.third_node_template = ValidationNodeTemplate.objects.create(
+            name="third", workflow=self.validation_workflow
+        )
+
+        self.outer_node = ValidationNodeTemplate.objects.create(
+            name="outer node", workflow=self.other_validation_workflow
+        )
+
+        self.john_wick = self.create_user_with_profile(
+            username="john.wick", account=self.account, permissions=[CORE_VALIDATION_WORKFLOW_PERMISSION]
+        )
+
+        request.user = self.john_wick
+        self.context = {"request": request}
+
+    def test_validation_empty_data(self):
+        serializer = ValidationNodeTemplateMoveSerializer(
+            data={}, context=self.context, instance=self.first_node_template
+        )
+        self.assertFalse(serializer.is_valid())
+
+        self.assertCountEqual(["position"], serializer.errors.keys())
+        self.assertEqual(serializer.errors["position"][0], "This field is required.")
+
+    def test_validation_position_required(self):
+        serializer = ValidationNodeTemplateMoveSerializer(
+            data={"position": ""}, context=self.context, instance=self.first_node_template
+        )
+        self.assertFalse(serializer.is_valid())
+
+        self.assertCountEqual(["position"], serializer.errors.keys())
+        self.assertEqual(serializer.errors["position"][0], '"" is not a valid choice.')
+
+        serializer = ValidationNodeTemplateMoveSerializer(
+            data={"position": None}, context=self.context, instance=self.first_node_template
+        )
+        self.assertFalse(serializer.is_valid())
+
+        self.assertCountEqual(["position"], serializer.errors.keys())
+        self.assertEqual(serializer.errors["position"][0], "This field may not be null.")
+
+    def test_validation_no_parent_node_templates_if_position_is_child_of(self):
+        serializer = ValidationNodeTemplateMoveSerializer(
+            data={"position": PositionChoices.child_of, "name": "random name"},
+            context=self.context,
+            instance=self.first_node_template,
+        )
+        self.assertFalse(serializer.is_valid())
+
+        self.assertCountEqual([api_settings.NON_FIELD_ERRORS_KEY], serializer.errors.keys())
+        self.assertEqual(
+            serializer.errors[api_settings.NON_FIELD_ERRORS_KEY][0],
+            f"Parent node templates are required if position is set to {PositionChoices.child_of}.",
+        )
+
+    def test_validation_parent_nodes_max_one(self):
+        serializer = ValidationNodeTemplateMoveSerializer(
+            data={
+                "position": PositionChoices.child_of,
+                "name": "random name",
+                "parent_node_templates": [self.first_node_template.slug, self.second_node_template.slug],
+            },
+            context=self.context,
+            instance=self.third_node_template,
+        )
+        self.assertFalse(serializer.is_valid())
+
+        self.assertCountEqual(["parent_node_templates"], serializer.errors.keys())
+        self.assertEqual(serializer.errors["parent_node_templates"][0], "One node maximum allowed.")
+
+    def test_validation_parent_nodes_exclude_instance(self):
+        serializer = ValidationNodeTemplateMoveSerializer(
+            data={
+                "position": PositionChoices.child_of,
+                "name": "random name",
+                "parent_node_templates": [self.first_node_template.slug],
+            },
+            context=self.context,
+            instance=self.first_node_template,
+        )
+        self.assertFalse(serializer.is_valid())
+
+        self.assertCountEqual(["parent_node_templates"], serializer.errors.keys())
+        self.assertEqual(
+            serializer.errors["parent_node_templates"][0],
+            f"Object with slug={self.first_node_template.slug} does not exist.",
+        )
+
+    def test_validation_parent_nodes_belong_to_workflow(self):
+        serializer = ValidationNodeTemplateMoveSerializer(
+            data={
+                "position": PositionChoices.child_of,
+                "name": "random name",
+                "parent_node_templates": [self.outer_node.slug],
+            },
+            context=self.context,
+            instance=self.first_node_template,
+        )
+
+        self.assertFalse(serializer.is_valid())
+
+        self.assertCountEqual(["parent_node_templates"], serializer.errors.keys())
+
+        self.assertEqual(
+            serializer.errors["parent_node_templates"][0], f"Object with slug={self.outer_node.slug} does not exist."
+        )

--- a/iaso/tests/api/validation_workflows_node_templates/test_views/test_bulk_create.py
+++ b/iaso/tests/api/validation_workflows_node_templates/test_views/test_bulk_create.py
@@ -31,6 +31,12 @@ class ValidationNodeTemplateAPIBulkCreateTestCase(BaseApiTestCase):
             created_by=self.john_doe,
             account=self.account,
         )
+        self.other_validation_workflow = ValidationWorkflow.objects.create(
+            name="Random other name 2",
+            description="Random description",
+            created_by=self.john_doe,
+            account=self.account_2,
+        )
 
     def test_permissions(self):
         res = self.client.post(
@@ -58,6 +64,33 @@ class ValidationNodeTemplateAPIBulkCreateTestCase(BaseApiTestCase):
             )
         )
         self.assertJSONResponse(res, status.HTTP_400_BAD_REQUEST)
+
+    def test_check_validation_workflow_parent_slug_access(self):
+        self.client.force_authenticate(self.john_wick)
+        res = self.client.post(
+            reverse(
+                "validation_node_templates-bulk",
+                kwargs={"parent_lookup_workflow__slug": self.other_validation_workflow.slug},
+            ),
+            data=[
+                {
+                    "name": "First node",
+                    "color": "#740d54",
+                    "description": "Here we should check something",
+                },
+                {
+                    "name": "First-node",
+                    "color": "#fdd75b",
+                    "canSkipPreviousNodes": True,
+                    "rolesRequired": [self.user_role.pk],
+                },
+            ],
+        )
+        res_data = self.assertJSONResponse(res, status.HTTP_400_BAD_REQUEST)
+        for error in res_data:
+            self.assertHasError(
+                error, "workflow", f"Object with slug={self.other_validation_workflow.slug} does not exist."
+            )
 
     def test_validation(self):
         self.client.force_authenticate(self.john_wick)

--- a/iaso/tests/api/validation_workflows_node_templates/test_views/test_bulk_update.py
+++ b/iaso/tests/api/validation_workflows_node_templates/test_views/test_bulk_update.py
@@ -33,6 +33,16 @@ class ValidationNodeTemplateAPIBulkUpdateTestCase(BaseApiTestCase):
             account=self.account,
         )
 
+        self.other_validation_workflow = ValidationWorkflow.objects.create(
+            name="Random other name 2",
+            description="Random description",
+            account=self.account_2,
+        )
+
+        self.other_node = ValidationNodeTemplate.objects.create(
+            name="other node", description="other node description", workflow=self.other_validation_workflow
+        )
+
         # create some nodes
         self.first_node = ValidationNodeTemplate.objects.create(
             name="First node", workflow=self.validation_workflow, description="first node desc", color="#ffffff"
@@ -52,6 +62,45 @@ class ValidationNodeTemplateAPIBulkUpdateTestCase(BaseApiTestCase):
         self.second_node.roles_required.add(self.user_role)
 
         self.other_user_role = UserRole.objects.create(group=self.other_group, account=self.account_2)
+
+    def test_check_validation_workflow_parent_slug_access(self):
+        self.client.force_authenticate(self.john_wick)
+        res = self.client.put(
+            reverse(
+                "validation_node_templates-bulk",
+                kwargs={"parent_lookup_workflow__slug": self.other_validation_workflow.slug},
+            ),
+            data=[
+                {"slug": self.third_node.slug, "name": "new first node", "rolesRequired": [self.user_role.pk]},
+                {"slug": self.first_node.slug, "name": "new second node", "canSkipPreviousNodes": True},
+                {
+                    "slug": self.second_node.slug,
+                    "name": "new third node",
+                    "description": "some description",
+                    "color": "#ebebeb",
+                },
+            ],
+        )
+        res_data = self.assertJSONResponse(res, status.HTTP_400_BAD_REQUEST)
+        self.assertHasError(
+            res_data,
+            self.snake_case_to_camel_case(api_settings.NON_FIELD_ERRORS_KEY),
+            "The slugs provided don't match the existing ones",
+        )
+
+        res = self.client.put(
+            reverse(
+                "validation_node_templates-bulk",
+                kwargs={"parent_lookup_workflow__slug": self.other_validation_workflow.slug},
+            ),
+            data=[{"slug": self.other_node.slug, "name": "new first node"}],
+        )
+        res_data = self.assertJSONResponse(res, status.HTTP_400_BAD_REQUEST)
+        self.assertHasError(
+            res_data,
+            self.snake_case_to_camel_case(api_settings.NON_FIELD_ERRORS_KEY),
+            "The slugs provided don't match the existing ones",
+        )
 
     def test_uniqueness_of_slug(self):
         self.client.force_authenticate(self.john_wick)

--- a/iaso/tests/api/validation_workflows_node_templates/test_views/test_create.py
+++ b/iaso/tests/api/validation_workflows_node_templates/test_views/test_create.py
@@ -1,9 +1,9 @@
 from django.contrib.auth.models import Group
 from django.urls import reverse
 from rest_framework import status
-from rest_framework.settings import api_settings
 
 from iaso.models import Account, Project, UserRole, ValidationNodeTemplate, ValidationWorkflow
+from iaso.models.validation_workflow.templates import PositionChoices
 from iaso.permissions.core_permissions import CORE_VALIDATION_WORKFLOW_PERMISSION
 from iaso.tests.api.validation_workflows_node_templates.test_views.common import BaseApiTestCase
 
@@ -33,7 +33,7 @@ class ValidationNodeTemplateAPICreateTestCase(BaseApiTestCase):
         )
 
         self.other_validation_workflow = ValidationWorkflow.objects.create(
-            name="Random other name",
+            name="Random other name 2",
             description="Random description",
             created_by=self.john_doe,
             account=self.account_2,
@@ -72,115 +72,65 @@ class ValidationNodeTemplateAPICreateTestCase(BaseApiTestCase):
         )
         self.assertJSONResponse(res, status.HTTP_400_BAD_REQUEST)
 
-    def test_validation(self):
+    def test_check_validation_workflow_parent_slug_access(self):
         self.client.force_authenticate(self.john_wick)
         res = self.client.post(
             reverse(
-                "validation_node_templates-list", kwargs={"parent_lookup_workflow__slug": self.validation_workflow.slug}
+                "validation_node_templates-list",
+                kwargs={"parent_lookup_workflow__slug": self.other_validation_workflow.slug},
+            ),
+            data={"name": "random"},
+        )
+        res_data = self.assertJSONResponse(res, status.HTTP_400_BAD_REQUEST)
+        self.assertHasError(
+            res_data, "workflow", f"Object with slug={self.other_validation_workflow.slug} does not exist."
+        )
+
+    def test_num_queries_insert_first(self):
+        self.client.force_authenticate(self.john_wick)
+
+        with self.assertNumQueries(16):
+            res = self.client.post(
+                reverse(
+                    "validation_node_templates-list",
+                    kwargs={"parent_lookup_workflow__slug": self.validation_workflow.slug},
+                ),
+                data={
+                    "name": "Random name 2",
+                    "description": "Random description",
+                    "color": "#377760",
+                    "rolesRequired": [self.user_role.pk],
+                    "position": PositionChoices.first,
+                    "canSkipPreviousNodes": True,
+                },
             )
-        )
-        res_data = self.assertJSONResponse(res, status.HTTP_400_BAD_REQUEST)
-        self.assertHasError(res_data, "name", "This field is required.")
 
-        res = self.client.post(
-            reverse(
-                "validation_node_templates-list", kwargs={"parent_lookup_workflow__slug": self.validation_workflow.slug}
-            ),
-            data={"name": "Random name"},
-        )
-        res_data = self.assertJSONResponse(res, status.HTTP_400_BAD_REQUEST)
-        self.assertHasError(
-            res_data,
-            self.snake_case_to_camel_case(api_settings.NON_FIELD_ERRORS_KEY),
-            "You must specify either next node templates or previous node templates.",
-        )
+            self.assertJSONResponse(res, status.HTTP_201_CREATED)
 
-        res = self.client.post(
-            reverse(
-                "validation_node_templates-list", kwargs={"parent_lookup_workflow__slug": self.validation_workflow.slug}
-            ),
-            data={"name": "Random name", "rolesRequired": [222]},
-        )
-        res_data = self.assertJSONResponse(res, status.HTTP_400_BAD_REQUEST)
-        self.assertHasError(res_data, "rolesRequired", 'Invalid pk "222" - object does not exist.')
-
-        res = self.client.post(
-            reverse(
-                "validation_node_templates-list", kwargs={"parent_lookup_workflow__slug": self.validation_workflow.slug}
-            ),
-            data={
-                "name": "Random name",
-                "previousNodeTemplates": [self.outer_workflow_node.slug],
-                "nextNodeTemplates": [self.outer_workflow_node.slug],
-            },
-        )
-        res_data = self.assertJSONResponse(res, status.HTTP_400_BAD_REQUEST)
-        self.assertHasError(
-            res_data, "previousNodeTemplates", f"Object with slug={self.outer_workflow_node.slug} does not exist."
-        )
-        self.assertHasError(
-            res_data, "nextNodeTemplates", f"Object with slug={self.outer_workflow_node.slug} does not exist."
-        )
-
-        res = self.client.post(
-            reverse(
-                "validation_node_templates-list", kwargs={"parent_lookup_workflow__slug": self.validation_workflow.slug}
-            ),
-            data={
-                "name": "Random name",
-                "previousNodeTemplates": [self.first_node.slug, self.first_node.slug],
-                "nextNodeTemplates": [self.first_node.slug, self.first_node.slug],
-            },
-        )
-        res_data = self.assertJSONResponse(res, status.HTTP_400_BAD_REQUEST)
-        self.assertHasError(res_data, "previousNodeTemplates", "Duplicate nodes are not allowed.")
-        self.assertHasError(res_data, "nextNodeTemplates", "Duplicate nodes are not allowed.")
-
-        res = self.client.post(
-            reverse(
-                "validation_node_templates-list", kwargs={"parent_lookup_workflow__slug": self.validation_workflow.slug}
-            ),
-            data={
-                "name": "Random name",
-                "previousNodeTemplates": [self.first_node.slug, self.second_node.slug],
-            },
-        )
-        res_data = self.assertJSONResponse(res, status.HTTP_400_BAD_REQUEST)
-        self.assertHasError(res_data, "previousNodeTemplates", "One node maximum allowed.")
-
-        res = self.client.post(
-            reverse(
-                "validation_node_templates-list", kwargs={"parent_lookup_workflow__slug": self.validation_workflow.slug}
-            ),
-            data={
-                "name": "Random name",
-                "nextNodeTemplates": [self.first_node.slug, self.second_node.slug],
-            },
-        )
-        res_data = self.assertJSONResponse(res, status.HTTP_400_BAD_REQUEST)
-        self.assertHasError(res_data, "nextNodeTemplates", "One node maximum allowed.")
-
-        res = self.client.post(
-            reverse(
-                "validation_node_templates-list", kwargs={"parent_lookup_workflow__slug": self.validation_workflow.slug}
-            ),
-            data={
-                "name": "Random name",
-                "previousNodeTemplates": [self.first_node.slug],
-                "nextNodeTemplates": [self.first_node.slug],
-            },
-        )
-        res_data = self.assertJSONResponse(res, status.HTTP_400_BAD_REQUEST)
-        self.assertHasError(
-            res_data,
-            self.snake_case_to_camel_case(api_settings.NON_FIELD_ERRORS_KEY),
-            "There are duplicate nodes in previous and next node templates.",
-        )
-
-    def test_num_queries(self):
+    def test_num_queries_insert_last(self):
         self.client.force_authenticate(self.john_wick)
-        # todo : could we reduce the num of queries ?
-        with self.assertNumQueries(24):
+
+        with self.assertNumQueries(16):
+            res = self.client.post(
+                reverse(
+                    "validation_node_templates-list",
+                    kwargs={"parent_lookup_workflow__slug": self.validation_workflow.slug},
+                ),
+                data={
+                    "name": "Random name 3",
+                    "description": "Random description",
+                    "color": "#377760",
+                    "rolesRequired": [self.user_role.pk],
+                    "position": PositionChoices.last,
+                    "canSkipPreviousNodes": True,
+                },
+            )
+
+            self.assertJSONResponse(res, status.HTTP_201_CREATED)
+
+    def test_num_queries_insert_between(self):
+        self.client.force_authenticate(self.john_wick)
+        with self.assertNumQueries(17):
             res = self.client.post(
                 reverse(
                     "validation_node_templates-list",
@@ -191,8 +141,8 @@ class ValidationNodeTemplateAPICreateTestCase(BaseApiTestCase):
                     "description": "Random description",
                     "color": "#377760",
                     "rolesRequired": [self.user_role.pk],
-                    "previousNodeTemplates": [self.first_node.slug],
-                    "nextNodeTemplates": [self.second_node.slug],
+                    "position": PositionChoices.child_of,
+                    "parentNodeTemplates": [self.first_node.slug],
                     "canSkipPreviousNodes": True,
                 },
             )
@@ -210,8 +160,8 @@ class ValidationNodeTemplateAPICreateTestCase(BaseApiTestCase):
                 "description": "Random description",
                 "color": "#377760",
                 "rolesRequired": [self.user_role.pk],
-                "previousNodeTemplates": [self.first_node.slug],
-                "nextNodeTemplates": [self.second_node.slug],
+                "position": PositionChoices.child_of,
+                "parentNodeTemplates": [self.first_node.slug],
                 "canSkipPreviousNodes": True,
             },
         )
@@ -251,8 +201,7 @@ class ValidationNodeTemplateAPICreateTestCase(BaseApiTestCase):
                     "name": "Random starting node",
                     "description": "Random description",
                     "color": "#377760",
-                    "rolesRequired": [self.user_role.pk],
-                    "nextNodeTemplates": [self.first_node.slug],
+                    "position": PositionChoices.first,
                     "canSkipPreviousNodes": True,
                 },
             )
@@ -311,8 +260,7 @@ class ValidationNodeTemplateAPICreateTestCase(BaseApiTestCase):
                     "name": "Random last node",
                     "description": "Random description",
                     "color": "#377760",
-                    "rolesRequired": [self.user_role.pk],
-                    "previousNodeTemplates": [self.second_node.slug],
+                    "position": PositionChoices.last,
                     "canSkipPreviousNodes": True,
                 },
             )

--- a/iaso/tests/api/validation_workflows_node_templates/test_views/test_delete.py
+++ b/iaso/tests/api/validation_workflows_node_templates/test_views/test_delete.py
@@ -31,6 +31,16 @@ class ValidationNodeTemplateAPIDeleteTestCase(BaseApiTestCase):
             account=self.account,
         )
 
+        self.other_validation_workflow = ValidationWorkflow.objects.create(
+            name="Random other name 2",
+            description="Random description",
+            created_by=self.john_doe,
+            account=self.account_2,
+        )
+        self.other_node = ValidationNodeTemplate.objects.create(
+            name="Other node", workflow=self.other_validation_workflow
+        )
+
         # create some nodes
         self.first_node = ValidationNodeTemplate.objects.create(name="First node", workflow=self.validation_workflow)
         self.second_node = ValidationNodeTemplate.objects.create(name="Second node", workflow=self.validation_workflow)
@@ -78,6 +88,19 @@ class ValidationNodeTemplateAPIDeleteTestCase(BaseApiTestCase):
                 )
             )
             self.assertJSONResponse(res, status.HTTP_204_NO_CONTENT)
+
+    def test_check_validation_workflow_parent_slug_access(self):
+        self.client.force_authenticate(self.john_wick)
+        res = self.client.delete(
+            reverse(
+                "validation_node_templates-detail",
+                kwargs={
+                    "parent_lookup_workflow__slug": self.other_validation_workflow.slug,
+                    "slug": self.other_node.slug,
+                },
+            )
+        )
+        self.assertJSONResponse(res, status.HTTP_404_NOT_FOUND)
 
     def test_happy_flow(self):
         self.client.force_authenticate(self.john_wick)

--- a/iaso/tests/api/validation_workflows_node_templates/test_views/test_list.py
+++ b/iaso/tests/api/validation_workflows_node_templates/test_views/test_list.py
@@ -31,6 +31,17 @@ class ValidationNodeTemplateAPIListTestCase(BaseApiTestCase):
             account=self.account,
         )
 
+        self.other_validation_workflow = ValidationWorkflow.objects.create(
+            name="Random other name 2",
+            description="Random description",
+            created_by=self.john_doe,
+            account=self.account_2,
+        )
+
+        self.other_node = ValidationNodeTemplate.objects.create(
+            name="Other node", workflow=self.other_validation_workflow
+        )
+
         # create some nodes
         self.first_node = ValidationNodeTemplate.objects.create(name="First node", workflow=self.validation_workflow)
         self.second_node = ValidationNodeTemplate.objects.create(
@@ -68,6 +79,17 @@ class ValidationNodeTemplateAPIListTestCase(BaseApiTestCase):
             )
         )
         self.assertJSONResponse(res, status.HTTP_200_OK)
+
+    def test_check_validation_workflow_parent_slug_access(self):
+        self.client.force_authenticate(self.john_wick)
+        res = self.client.get(
+            reverse(
+                "validation_node_templates-list",
+                kwargs={"parent_lookup_workflow__slug": self.other_validation_workflow.slug},
+            )
+        )
+        res_data = self.assertJSONResponse(res, status.HTTP_200_OK)
+        self.assertValidListData(list_data=res_data, results_key="results", expected_length=0)
 
     def test_number_queries(self):
         self.client.force_authenticate(self.john_wick)

--- a/iaso/tests/api/validation_workflows_node_templates/test_views/test_move.py
+++ b/iaso/tests/api/validation_workflows_node_templates/test_views/test_move.py
@@ -1,9 +1,9 @@
 from django.contrib.auth.models import Group
 from django.urls import reverse
 from rest_framework import status
-from rest_framework.settings import api_settings
 
 from iaso.models import Account, Project, UserRole, ValidationNodeTemplate, ValidationWorkflow
+from iaso.models.validation_workflow.templates import PositionChoices
 from iaso.permissions.core_permissions import CORE_VALIDATION_WORKFLOW_PERMISSION
 from iaso.tests.api.validation_workflows_node_templates.test_views.common import BaseApiTestCase
 
@@ -65,7 +65,7 @@ class ValidationNodeTemplateAPIMoveTestCase(BaseApiTestCase):
                 },
             ),
             data={
-                "newNextNodes": [self.other_second_node.slug],
+                "position": PositionChoices.first,
             },
         )
         self.assertJSONResponse(res, status.HTTP_404_NOT_FOUND)
@@ -77,9 +77,7 @@ class ValidationNodeTemplateAPIMoveTestCase(BaseApiTestCase):
                 "validation_node_templates-move",
                 kwargs={"parent_lookup_workflow__slug": self.validation_workflow.slug, "slug": self.second_node.slug},
             ),
-            data={
-                "newNextNodes": [self.first_node.slug],
-            },
+            data={"position": PositionChoices.first},
         )
 
         self.assertEqual(res.status_code, status.HTTP_204_NO_CONTENT)
@@ -93,10 +91,7 @@ class ValidationNodeTemplateAPIMoveTestCase(BaseApiTestCase):
                 "validation_node_templates-move",
                 kwargs={"parent_lookup_workflow__slug": self.validation_workflow.slug, "slug": self.second_node.slug},
             ),
-            data={
-                "newPreviousNodes": [self.first_node.slug],
-                "newNextNodes": [self.third_node.slug],
-            },
+            data={"position": PositionChoices.child_of, "parentNodeTemplates": [self.first_node.slug]},
         )
 
         self.assertEqual(res.status_code, status.HTTP_204_NO_CONTENT)
@@ -107,9 +102,7 @@ class ValidationNodeTemplateAPIMoveTestCase(BaseApiTestCase):
                 "validation_node_templates-move",
                 kwargs={"parent_lookup_workflow__slug": self.validation_workflow.slug, "slug": self.second_node.slug},
             ),
-            data={
-                "newPreviousNodes": [self.third_node.slug],
-            },
+            data={"position": PositionChoices.last},
         )
 
         self.assertEqual(res.status_code, status.HTTP_204_NO_CONTENT)
@@ -121,9 +114,7 @@ class ValidationNodeTemplateAPIMoveTestCase(BaseApiTestCase):
                 "validation_node_templates-move",
                 kwargs={"parent_lookup_workflow__slug": self.validation_workflow.slug, "slug": self.second_node.slug},
             ),
-            data={
-                "newNextNodes": [self.first_node.slug],
-            },
+            data={"position": PositionChoices.first},
         )
 
         self.assertEqual(res.status_code, status.HTTP_401_UNAUTHORIZED)
@@ -134,9 +125,7 @@ class ValidationNodeTemplateAPIMoveTestCase(BaseApiTestCase):
                 "validation_node_templates-move",
                 kwargs={"parent_lookup_workflow__slug": self.validation_workflow.slug, "slug": self.second_node.slug},
             ),
-            data={
-                "newNextNodes": [self.first_node.slug],
-            },
+            data={"position": PositionChoices.first},
         )
 
         self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
@@ -147,58 +136,10 @@ class ValidationNodeTemplateAPIMoveTestCase(BaseApiTestCase):
                 "validation_node_templates-move",
                 kwargs={"parent_lookup_workflow__slug": self.validation_workflow.slug, "slug": self.second_node.slug},
             ),
-            data={
-                "newNextNodes": [self.first_node.slug],
-            },
+            data={"position": PositionChoices.first},
         )
 
         self.assertEqual(res.status_code, status.HTTP_204_NO_CONTENT)
-
-    def test_validation(self):
-        self.client.force_authenticate(self.john_wick)
-
-        res = self.client.put(
-            reverse(
-                "validation_node_templates-move",
-                kwargs={"parent_lookup_workflow__slug": self.validation_workflow.slug, "slug": self.second_node.slug},
-            )
-        )
-        res_data = self.assertJSONResponse(res, status.HTTP_400_BAD_REQUEST)
-        self.assertHasError(
-            res_data,
-            self.snake_case_to_camel_case(api_settings.NON_FIELD_ERRORS_KEY),
-            "You must provide one of those : new_next_nodes, new_previous_nodes.",
-        )
-
-        res = self.client.put(
-            reverse(
-                "validation_node_templates-move",
-                kwargs={"parent_lookup_workflow__slug": self.validation_workflow.slug, "slug": self.second_node.slug},
-            ),
-            data={
-                "newPreviousNodes": [self.second_node.slug],
-                "newNextNodes": [self.second_node.slug],
-            },
-        )
-        res_data = self.assertJSONResponse(res, status.HTTP_400_BAD_REQUEST)
-
-        self.assertHasError(res_data, "newPreviousNodes", "Object with slug=second-node does not exist.")
-        self.assertHasError(res_data, "newNextNodes", "Object with slug=second-node does not exist.")
-
-        res = self.client.put(
-            reverse(
-                "validation_node_templates-move",
-                kwargs={"parent_lookup_workflow__slug": self.validation_workflow.slug, "slug": self.second_node.slug},
-            ),
-            data={
-                "newPreviousNodes": ["wrong"],
-                "newNextNodes": ["wrong"],
-            },
-        )
-        res_data = self.assertJSONResponse(res, status.HTTP_400_BAD_REQUEST)
-
-        self.assertHasError(res_data, "newPreviousNodes", "Object with slug=wrong does not exist.")
-        self.assertHasError(res_data, "newNextNodes", "Object with slug=wrong does not exist.")
 
     def test_num_queries(self):
         self.client.force_authenticate(self.john_wick)
@@ -207,9 +148,7 @@ class ValidationNodeTemplateAPIMoveTestCase(BaseApiTestCase):
                 "validation_node_templates-move",
                 kwargs={"parent_lookup_workflow__slug": self.validation_workflow.slug, "slug": self.second_node.slug},
             ),
-            data={
-                "newNextNodes": [self.first_node.slug],
-            },
+            data={"position": PositionChoices.first},
         )
 
         self.assertEqual(res.status_code, status.HTTP_204_NO_CONTENT)
@@ -227,10 +166,7 @@ class ValidationNodeTemplateAPIMoveTestCase(BaseApiTestCase):
                         "slug": self.second_node.slug,
                     },
                 ),
-                data={
-                    "newPreviousNodes": [self.first_node.slug],
-                    "newNextNodes": [self.third_node.slug],
-                },
+                data={"position": PositionChoices.child_of, "parentNodeTemplates": [self.first_node.slug]},
             )
 
             self.assertEqual(res.status_code, status.HTTP_204_NO_CONTENT)

--- a/iaso/tests/api/validation_workflows_node_templates/test_views/test_move.py
+++ b/iaso/tests/api/validation_workflows_node_templates/test_views/test_move.py
@@ -32,12 +32,43 @@ class ValidationNodeTemplateAPIMoveTestCase(BaseApiTestCase):
             account=self.account,
         )
 
+        self.other_validation_workflow = ValidationWorkflow.objects.create(
+            name="Random other name 2",
+            description="Random description",
+            created_by=self.john_doe,
+            account=self.account_2,
+        )
+
+        self.other_node = ValidationNodeTemplate.objects.create(
+            name="First node 2", workflow=self.other_validation_workflow
+        )
+        self.other_second_node = ValidationNodeTemplate.objects.create(
+            name="Second node 2", workflow=self.other_validation_workflow
+        )
+        self.other_second_node.previous_node_templates.add(self.other_node)
+
         # create some nodes
         self.first_node = ValidationNodeTemplate.objects.create(name="First node", workflow=self.validation_workflow)
         self.second_node = ValidationNodeTemplate.objects.create(name="Second node", workflow=self.validation_workflow)
         self.third_node = ValidationNodeTemplate.objects.create(name="Third node", workflow=self.validation_workflow)
         self.second_node.previous_node_templates.add(self.first_node)
         self.second_node.next_node_templates.add(self.third_node)
+
+    def test_check_validation_workflow_parent_slug_access(self):
+        self.client.force_authenticate(self.john_wick)
+        res = self.client.put(
+            reverse(
+                "validation_node_templates-move",
+                kwargs={
+                    "parent_lookup_workflow__slug": self.other_validation_workflow.slug,
+                    "slug": self.other_node.slug,
+                },
+            ),
+            data={
+                "newNextNodes": [self.other_second_node.slug],
+            },
+        )
+        self.assertJSONResponse(res, status.HTTP_404_NOT_FOUND)
 
     def test_happy_flow(self):
         self.client.force_authenticate(self.john_wick)

--- a/iaso/tests/api/validation_workflows_node_templates/test_views/test_partial_update.py
+++ b/iaso/tests/api/validation_workflows_node_templates/test_views/test_partial_update.py
@@ -27,6 +27,17 @@ class ValidationTemplateAPIPartialUpdateTestCase(BaseApiTestCase):
             username="john.wick", account=self.account, permissions=[CORE_VALIDATION_WORKFLOW_PERMISSION]
         )
 
+        self.other_validation_workflow = ValidationWorkflow.objects.create(
+            name="Random other name 2",
+            description="Random description",
+            created_by=self.john_doe,
+            account=self.account_2,
+        )
+
+        self.other_node = ValidationNodeTemplate.objects.create(
+            name="First node 2", workflow=self.other_validation_workflow
+        )
+
         self.validation_workflow = ValidationWorkflow.objects.create(
             name="Random other name",
             description="Random description",
@@ -42,6 +53,20 @@ class ValidationTemplateAPIPartialUpdateTestCase(BaseApiTestCase):
             color="#ffffff",
             can_skip_previous_nodes=True,
         )
+
+    def test_check_validation_workflow_parent_slug_access(self):
+        self.client.force_authenticate(self.john_wick)
+        res = self.client.patch(
+            reverse(
+                "validation_node_templates-detail",
+                kwargs={
+                    "parent_lookup_workflow__slug": self.other_validation_workflow.slug,
+                    "slug": self.other_node.slug,
+                },
+            ),
+            data={"name": "test"},
+        )
+        self.assertJSONResponse(res, status.HTTP_404_NOT_FOUND)
 
     def test_happy_flow(self):
         self.client.force_authenticate(self.john_wick)

--- a/iaso/tests/api/validation_workflows_node_templates/test_views/test_retrieve.py
+++ b/iaso/tests/api/validation_workflows_node_templates/test_views/test_retrieve.py
@@ -44,6 +44,29 @@ class ValidationNodeTemplateAPIRetrieveTestCase(BaseApiTestCase):
         self.second_node.previous_node_templates.add(self.first_node)
         self.second_node.next_node_templates.add(self.third_node)
         self.second_node.roles_required.add(self.user_role)
+        self.other_validation_workflow = ValidationWorkflow.objects.create(
+            name="Random other name 2",
+            description="Random description",
+            created_by=self.john_doe,
+            account=self.account_2,
+        )
+
+        self.other_node = ValidationNodeTemplate.objects.create(
+            name="First node 2", workflow=self.other_validation_workflow
+        )
+
+    def test_check_validation_workflow_parent_slug_access(self):
+        self.client.force_authenticate(self.john_wick)
+        res = self.client.get(
+            reverse(
+                "validation_node_templates-detail",
+                kwargs={
+                    "parent_lookup_workflow__slug": self.other_validation_workflow.slug,
+                    "slug": self.other_node.slug,
+                },
+            )
+        )
+        self.assertJSONResponse(res, status.HTTP_404_NOT_FOUND)
 
     def test_permissions(self):
         res = self.client.get(

--- a/iaso/tests/api/validation_workflows_node_templates/test_views/test_update.py
+++ b/iaso/tests/api/validation_workflows_node_templates/test_views/test_update.py
@@ -37,6 +37,31 @@ class ValidationNodeTemplateAPIUpdateTestCase(BaseApiTestCase):
         # create some nodes
         self.node = ValidationNodeTemplate.objects.create(name="First node", workflow=self.validation_workflow)
 
+        self.other_validation_workflow = ValidationWorkflow.objects.create(
+            name="Random other name 2",
+            description="Random description",
+            created_by=self.john_doe,
+            account=self.account_2,
+        )
+
+        self.other_node = ValidationNodeTemplate.objects.create(
+            name="First node 2", workflow=self.other_validation_workflow
+        )
+
+    def test_check_validation_workflow_parent_slug_access(self):
+        self.client.force_authenticate(self.john_wick)
+        res = self.client.put(
+            reverse(
+                "validation_node_templates-detail",
+                kwargs={
+                    "parent_lookup_workflow__slug": self.other_validation_workflow.slug,
+                    "slug": self.other_node.slug,
+                },
+            ),
+            data={"name": "test"},
+        )
+        self.assertJSONResponse(res, status.HTTP_404_NOT_FOUND)
+
     def test_happy_flow(self):
         self.client.force_authenticate(self.john_wick)
 


### PR DESCRIPTION
## What problem is this PR solving?

Right now, to create/update a node template and position it correctly in the workflow, we require the slug of the previous and/or next node templates => it might be a bit cumbersome for the front end , we should switch to a “position” field (like django-treebeard does)

### Related JIRA tickets

IA-4906

## Changes

* Added a general position parameter
* Adapted the create and move serializer
* Adapted tests
* Moved some test from test_views to test_serializer
* Added some tests to check permissions on parent workflow slug in nested viewsets
 
## How to test

Call the endpoints /api/validation-workflows/{parent_lookup_workflow__slug}/node-templates/ (POST) or /api/validation-workflows/{parent_lookup_workflow__slug}/node-templates/{slug}/move/ with the parameter position and enjoy

