### PR TITLE
[SNT-392] Fix middlewares

### DIFF
--- a/hat/settings.py
+++ b/hat/settings.py
@@ -258,11 +258,11 @@ MIDDLEWARE += [
 ]
 if DEBUG:
     MIDDLEWARE += [
-        "iaso.middleware.SafeQueryCountMiddleware",
+        "iaso.middlewares.query_count.SafeQueryCountMiddleware",
     ]
 
 MIDDLEWARE += [
-    "iaso.middleware.CustomCamelCaseMiddleWare",
+    "iaso.middlewares.camel_case.CustomCamelCaseMiddleWare",
 ]
 
 ROOT_URLCONF = "hat.urls"

--- a/iaso/middlewares/camel_case.py
+++ b/iaso/middlewares/camel_case.py
@@ -1,0 +1,16 @@
+from django.urls import Resolver404, resolve
+from djangorestframework_camel_case.middleware import CamelCaseMiddleWare
+
+
+class CustomCamelCaseMiddleWare(CamelCaseMiddleWare):
+    def __call__(self, request):
+        # we only execute this middleware on profiles API at the moment
+        route = ""
+        try:
+            route = resolve(request.path_info).route
+        except Resolver404:
+            pass
+
+        if route.startswith(("/api/v2/profiles", "/api/validation-workflows")):
+            return super().__call__(request)
+        return self.get_response(request)

--- a/iaso/middlewares/query_count.py
+++ b/iaso/middlewares/query_count.py
@@ -1,22 +1,6 @@
 from collections import defaultdict
 
-from django.urls import Resolver404, resolve
-from djangorestframework_camel_case.middleware import CamelCaseMiddleWare
 from querycount.middleware import QueryCountMiddleware
-
-
-class CustomCamelCaseMiddleWare(CamelCaseMiddleWare):
-    def __call__(self, request):
-        # we only execute this middleware on profiles API at the moment
-        route = ""
-        try:
-            route = resolve(request.path_info).route
-        except Resolver404:
-            pass
-
-        if route.startswith(("/api/v2/profiles", "/api/validation-workflows")):
-            return super().__call__(request)
-        return self.get_response(request)
 
 
 class SafeQueryCountMiddleware(QueryCountMiddleware):

--- a/iaso/tests/api/test_forms_attachment.py
+++ b/iaso/tests/api/test_forms_attachment.py
@@ -382,7 +382,9 @@ class FormAttachmentsAPITestCase(APITestCase):
         return response.content
 
     @override_settings(
-        MIDDLEWARE=[mw for mw in settings.MIDDLEWARE if "querycount.middleware.QueryCountMiddleware" not in mw],
+        MIDDLEWARE=[
+            mw for mw in settings.MIDDLEWARE if "iaso.middlewares.query_count.SafeQueryCountMiddleware" not in mw
+        ],
         DEBUG=True,
     )
     def test_manifest_anonymous_app_id(self):


### PR DESCRIPTION
## What problem is this PR solving?

Fix middleware issues from #2855 

### Related JIRA tickets

SNT-392

## Changes

- Split middlewares into different files to avoid loading the safe querycount middleware when not running in DEBUG mode


## How to test

- run django not in DEBUG mode, everything should work fine, querycount shouldn't raise any issue


## Print screen / video

/

## Notes

/

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).
