### PR TITLE
[IA-4878]: implement post create to trigger validation workflow, added tests

### DIFF
--- a/iaso/api/instances/instances.py
+++ b/iaso/api/instances/instances.py
@@ -45,6 +45,7 @@ from iaso.api.instances.serializers import FileTypeSerializer, InstanceImportAcc
 from iaso.api.org_units import HasCreateOrgUnitPermission
 from iaso.api.permission_checks import AuthenticationEnforcedPermission
 from iaso.api.serializers import OrgUnitSerializer
+from iaso.engine.validation_workflow import ValidationWorkflowEngine
 from iaso.exports import CleaningFileResponse, parquet
 from iaso.models import (
     Account,
@@ -676,7 +677,21 @@ class InstancesViewSet(viewsets.ViewSet):
 
     @safe_api_import("instance")
     def create(self, _, request):
-        import_data(request.data, request.user, request.query_params.get("app_id"))
+        instances = import_data(request.data, request.user, request.query_params.get("app_id"))
+
+        if instances:
+            for instance in instances:
+                validation_workflow = getattr(instance.form, "validation_workflow", None)
+                if validation_workflow and getattr(validation_workflow, "node_templates", None):
+                    try:
+                        ValidationWorkflowEngine.start(
+                            instance.form.validation_workflow,
+                            request.user if request.user.is_authenticated else None,
+                            instance,
+                        )
+                    except Exception as e:
+                        # so we avoid the whole instance creation crashing
+                        logger.error(e)
 
         return Response({"res": "ok"})
 
@@ -1036,6 +1051,7 @@ def import_data(instances, user, app_id):
     the second endpoint (POST /sync/form_upload/).
     """
     project = Project.objects.get_for_user_and_app_id(user, app_id)
+    rtn_instances = []
 
     for instance_data in instances:
         uuid = instance_data.get("id", None)
@@ -1129,6 +1145,9 @@ def import_data(instances, user, app_id):
                 oucr.new_reference_instances.set([instance])
                 oucr.requested_fields = ["new_reference_instances"]
                 oucr.save()
+
+        rtn_instances.append(instance)
+    return rtn_instances
 
 
 def _entity_correctness_score(entity):

--- a/iaso/test.py
+++ b/iaso/test.py
@@ -318,7 +318,7 @@ class APITestCase(BaseAPITestCase, IasoTestCaseMixin):
         self.assertIsInstance(last_api_import.headers, dict)
         self.assertEqual(last_api_import.json_body, request_body)
         self.assertEqual(last_api_import.import_type, import_type)
-        self.assertEqual(has_problems, last_api_import.has_problem, last_api_import)
+        self.assertEqual(has_problems, last_api_import.has_problem, f"{last_api_import} - {last_api_import.exception}")
 
         self.assertIsInstance(last_api_import.headers, dict)
         if check_auth_header:

--- a/iaso/tests/api/instances/test_validation_workflow.py
+++ b/iaso/tests/api/instances/test_validation_workflow.py
@@ -1,0 +1,182 @@
+import logging
+
+from unittest import mock
+from uuid import uuid4
+
+from iaso.models import (
+    Account,
+    DataSource,
+    Form,
+    Instance,
+    OrgUnit,
+    Project,
+    SourceVersion,
+    ValidationNode,
+    ValidationNodeTemplate,
+    ValidationWorkflow,
+)
+from iaso.models.common import ValidationWorkflowArtefactStatus
+from iaso.permissions.core_permissions import CORE_ORG_UNITS_PERMISSION, CORE_SUBMISSIONS_PERMISSION
+from iaso.test import APITestCase
+
+
+class InstancesAPITestCase(APITestCase):
+    def tearDown(self):
+        logging.disable(logging.CRITICAL)
+
+    def setUp(self):
+        logging.disable(logging.NOTSET)
+
+        self.account = Account.objects.create(name="Account")
+
+        self.john_doe = self.create_user_with_profile(
+            username="john.doe",
+            last_name="John",
+            first_name="Doe",
+            account=self.account,
+            permissions=[CORE_SUBMISSIONS_PERMISSION, CORE_ORG_UNITS_PERMISSION],
+        )
+
+        self.validation_workflow = ValidationWorkflow.objects.create(name="validation-workflow", account=self.account)
+
+        self.data_source = DataSource.objects.create(name="Data source")
+        self.source_version = SourceVersion.objects.create(data_source=self.data_source, number=1)
+
+        self.org_unit_uuid = str(uuid4())
+        self.org_unit = OrgUnit.objects.create(
+            name="Org Unit",
+            source_ref="org_unit",
+            version=self.source_version,
+            validation_status="VALID",
+            uuid=self.org_unit_uuid,
+        )
+
+        self.project = Project.objects.create(
+            name="Hydroponic gardens", app_id="agriculture.hydroponics", account=self.account
+        )
+
+        self.project_2 = Project.objects.create(name="Project number 2", app_id="project.two", account=self.account)
+
+        self.data_source.projects.add(self.project)
+
+        self.form_1 = Form.objects.create()
+
+        self.form_2 = Form.objects.create()
+
+        self.project.forms.add(self.form_1)
+        self.project.forms.add(self.form_2)
+
+        self.validation_workflow.form_set.add(self.form_1)
+
+        ValidationNodeTemplate.objects.create(name="First node", workflow=self.validation_workflow)
+
+    def test_does_not_trigger_validation_workflow_if_form_does_not_have_any(self):
+        instance_uuid = str(uuid4())
+        body = [
+            {
+                "id": instance_uuid,
+                "created_at": 1565258153704,
+                "updated_at": 1565258153709,
+                "orgUnitId": self.org_unit.id,
+                "formId": self.form_2.id,
+                "period": "202002",
+                "latitude": 50.2,
+                "longitude": 4.4,
+                "accuracy": 15.5,
+                "altitude": 100,
+                "file": "\/storage\/emulated\/0\/odk\/instances\/test_accuracy\/test.xml",
+                "name": "test_accuracy",
+            }
+        ]
+        self.client.post("/api/instances/?app_id=agriculture.hydroponics", data=body, format="json")
+
+        self.assertAPIImport("instance", request_body=body, has_problems=False)
+
+        instance = Instance.objects.get(uuid=instance_uuid)
+
+        self.assertEqual(instance.validationnode_set.count(), 0)
+
+    def test_does_not_trigger_validation_workflow_in_case_of_error(self):
+        instance_uuid = str(uuid4())
+        body = [
+            {
+                "id": instance_uuid,
+                "created_at": 1565258153704,
+                "updated_at": 1565258153709,
+                "orgUnitId": self.org_unit.id,
+                "formId": self.form_1.id,
+                "period": "abbbbbb",
+                "latitude": "gesg",
+                "longitude": "gesg",
+                "accuracy": "gesg",
+                "altitude": "gesg",
+                "name": "test_accuracy",
+            }
+        ]
+        self.client.post("/api/instances/?app_id=agriculture.hydroponics", data=body, format="json")
+
+        self.assertAPIImport("instance", request_body=body, has_problems=True)
+
+        self.assertFalse(Instance.objects.filter(uuid=instance_uuid).exists())
+
+        self.assertEqual(ValidationNode.objects.all().count(), 0)
+
+    @mock.patch("iaso.engine.validation_workflow.ValidationWorkflowEngine.start")
+    def test_unknown_exception_in_start_engine_should_not_avoid_instance_creation(self, m):
+        m.side_effect = Exception("Oops")
+
+        instance_uuid = str(uuid4())
+        body = [
+            {
+                "id": instance_uuid,
+                "created_at": 1565258153704,
+                "updated_at": 1565258153709,
+                "orgUnitId": self.org_unit.id,
+                "formId": self.form_1.id,
+                "period": "202002",
+                "latitude": 50.2,
+                "longitude": 4.4,
+                "accuracy": 15.5,
+                "altitude": 100,
+                "file": "\/storage\/emulated\/0\/odk\/instances\/test_accuracy\/test.xml",
+                "name": "test_accuracy",
+            }
+        ]
+
+        with self.assertLogs(logging.getLogger("iaso.api.instances.instances"), level="ERROR") as msg:
+            self.client.post("/api/instances/?app_id=agriculture.hydroponics", data=body, format="json")
+
+        self.assertEqual(len(msg.output), 1)
+        self.assertIn("Oops", msg.output[0])
+
+        self.assertAPIImport("instance", request_body=body, has_problems=False)
+
+        self.assertTrue(Instance.objects.filter(uuid=instance_uuid).exists())
+
+        self.assertEqual(ValidationNode.objects.all().count(), 0)
+
+    def test_trigger_validation_workflow(self):
+        instance_uuid = str(uuid4())
+        body = [
+            {
+                "id": instance_uuid,
+                "created_at": 1565258153704,
+                "updated_at": 1565258153709,
+                "orgUnitId": self.org_unit.id,
+                "formId": self.form_1.id,
+                "period": "202002",
+                "latitude": 50.2,
+                "longitude": 4.4,
+                "accuracy": 15.5,
+                "altitude": 100,
+                "file": "\/storage\/emulated\/0\/odk\/instances\/test_accuracy\/test.xml",
+                "name": "test_accuracy",
+            }
+        ]
+        self.client.post("/api/instances/?app_id=agriculture.hydroponics", data=body, format="json")
+
+        self.assertAPIImport("instance", request_body=body, has_problems=False)
+
+        instance = Instance.objects.get(uuid=instance_uuid)
+
+        self.assertEqual(instance.get_general_validation_status(), ValidationWorkflowArtefactStatus.PENDING)


### PR DESCRIPTION
## What problem is this PR solving?

When creating an instance, we need to trigger a validation workflow if needed

### Related JIRA tickets

IA-4878

## Changes

Added a "post create" trigger to start a validation workflow after instance has been created

Tests

## How to test

Create a validation Workflow with some Nodes
Create a Form, link it to that validation workflow
Create an instance (linked to the form), it should trigger a validation process 