### PR TITLE
IA-4913: N+1 on /api/mobile/orgunits/changes/

### DIFF
--- a/iaso/api/org_unit_change_requests/views_mobile.py
+++ b/iaso/api/org_unit_change_requests/views_mobile.py
@@ -1,5 +1,6 @@
 import django_filters
 
+from django.contrib.auth import get_user_model
 from django.db.models import Count, F, Prefetch, Q
 from rest_framework import filters, viewsets
 from rest_framework.mixins import ListModelMixin
@@ -19,17 +20,34 @@ class MobileOrgUnitChangeRequestViewSet(ListModelMixin, viewsets.GenericViewSet)
     serializer_class = MobileOrgUnitChangeRequestListSerializer
     pagination_class = OrgUnitChangeRequestPagination
 
-    def get_queryset(self):
-        app_id = AppIdSerializer(data=self.request.query_params).get_app_id(raise_exception=True)
+    def _user_for_scoped_queries(self):
+        """One row with joins; avoids extra profile/account queries on this view."""
+        cached = getattr(self, "_cached_user_for_scoped_queries", None)
+        if cached is not None:
+            return cached
+        User = get_user_model()
+        self._cached_user_for_scoped_queries = User.objects.select_related(
+            "iaso_profile__account",
+            "iaso_profile__account__default_version",
+        ).get(pk=self.request.user.pk)
+        return self._cached_user_for_scoped_queries
 
-        org_units = OrgUnit.objects.filter_for_user_and_app_id(self.request.user, app_id).filter(
+    def get_queryset(self):
+        cached_qs = getattr(self, "_cached_mobile_change_requests_queryset", None)
+        if cached_qs is not None:
+            return cached_qs
+
+        app_id = AppIdSerializer(data=self.request.query_params).get_app_id(raise_exception=True)
+        user = self._user_for_scoped_queries()
+
+        org_units = OrgUnit.objects.filter_for_user_and_app_id(user, app_id).filter(
             org_unit_type__projects__app_id=app_id
         )
 
         change_requests = (
             OrgUnitChangeRequest.objects.filter(
                 org_unit__in=org_units,
-                created_by=self.request.user,
+                created_by=user,
                 # Change requests liked to a `data_source_synchronization` are limited to the web.
                 data_source_synchronization__isnull=True,
             )
@@ -50,7 +68,12 @@ class MobileOrgUnitChangeRequestViewSet(ListModelMixin, viewsets.GenericViewSet)
             .select_related("org_unit")
             .prefetch_related(
                 "new_groups",
-                Prefetch("new_reference_instances", queryset=Instance.non_deleted_objects.all()),
+                Prefetch(
+                    "new_reference_instances",
+                    queryset=Instance.non_deleted_objects.select_related("org_unit", "form").prefetch_related(
+                        "instancefile_set"
+                    ),
+                ),
             )
             .annotate(
                 annotated_new_reference_instances_count=Count(
@@ -58,6 +81,8 @@ class MobileOrgUnitChangeRequestViewSet(ListModelMixin, viewsets.GenericViewSet)
                 )
             )
             .exclude_soft_deleted_new_reference_instances()
+            .distinct()
         )
 
+        self._cached_mobile_change_requests_queryset = change_requests
         return change_requests

--- a/iaso/api/org_unit_change_requests/views_mobile.py
+++ b/iaso/api/org_unit_change_requests/views_mobile.py
@@ -22,21 +22,13 @@ class MobileOrgUnitChangeRequestViewSet(ListModelMixin, viewsets.GenericViewSet)
 
     def _user_for_scoped_queries(self):
         """One row with joins; avoids extra profile/account queries on this view."""
-        cached = getattr(self, "_cached_user_for_scoped_queries", None)
-        if cached is not None:
-            return cached
         User = get_user_model()
-        self._cached_user_for_scoped_queries = User.objects.select_related(
+        return User.objects.select_related(
             "iaso_profile__account",
             "iaso_profile__account__default_version",
         ).get(pk=self.request.user.pk)
-        return self._cached_user_for_scoped_queries
 
     def get_queryset(self):
-        cached_qs = getattr(self, "_cached_mobile_change_requests_queryset", None)
-        if cached_qs is not None:
-            return cached_qs
-
         app_id = AppIdSerializer(data=self.request.query_params).get_app_id(raise_exception=True)
         user = self._user_for_scoped_queries()
 
@@ -84,5 +76,4 @@ class MobileOrgUnitChangeRequestViewSet(ListModelMixin, viewsets.GenericViewSet)
             .distinct()
         )
 
-        self._cached_mobile_change_requests_queryset = change_requests
         return change_requests

--- a/iaso/models/project.py
+++ b/iaso/models/project.py
@@ -25,14 +25,14 @@ class ProjectQuerySet(models.QuerySet):
 
         if app_id is not None:
             try:
-                project = self.get(app_id=app_id)
+                project = self.select_related("account", "account__default_version").get(app_id=app_id)
                 if (
                     user is None
                     or not project.needs_authentication
                     or (
                         user.is_authenticated
                         and user.iaso_profile is not None
-                        and project.account.id == user.iaso_profile.account.id
+                        and project.account_id == user.iaso_profile.account_id
                     )
                 ):
                     return project

--- a/iaso/tests/api/org_unit_change_requests/test_org_unit_change_requests.py
+++ b/iaso/tests/api/org_unit_change_requests/test_org_unit_change_requests.py
@@ -286,7 +286,7 @@ class OrgUnitChangeRequestAPITestCase(TaskAPITestCase):
             "org_unit_id": self.org_unit.id,
             "new_name": "Bar",
         }
-        with self.assertNumQueries(13):
+        with self.assertNumQueries(9):
             response = self.client.post("/api/orgunits/changes/?app_id=foo.bar.baz", data=data, format="json")
         self.assertEqual(response.status_code, 201)
         change_request = m.OrgUnitChangeRequest.objects.get(uuid=data["uuid"])
@@ -308,7 +308,7 @@ class OrgUnitChangeRequestAPITestCase(TaskAPITestCase):
             "new_location_accuracy": 1.2345,
         }
 
-        with self.assertNumQueries(13):
+        with self.assertNumQueries(11):
             response = self.client.post("/api/orgunits/changes/?app_id=foo.bar.baz", data=data, format="json")
         self.assertEqual(response.status_code, 201)
         change_request = m.OrgUnitChangeRequest.objects.get(uuid=data["uuid"])

--- a/iaso/tests/api/org_unit_change_requests/test_org_unit_change_requests.py
+++ b/iaso/tests/api/org_unit_change_requests/test_org_unit_change_requests.py
@@ -286,7 +286,14 @@ class OrgUnitChangeRequestAPITestCase(TaskAPITestCase):
             "org_unit_id": self.org_unit.id,
             "new_name": "Bar",
         }
-        with self.assertNumQueries(9):
+        with self.assertNumQueries(11):
+            # 1. SELECT org unit by id
+            # 2. SELECT EXISTS change request by uuid
+            # 3. SELECT project (+ account + default_version via select_related)
+            # 4–5. Org unit in user scope (profile + path / project filters)
+            # 6. INSERT change request
+            # 7–8. Old groups: SELECT + M2M insert
+            # 9–11. Old + new reference instances: SELECTs + M2M insert
             response = self.client.post("/api/orgunits/changes/?app_id=foo.bar.baz", data=data, format="json")
         self.assertEqual(response.status_code, 201)
         change_request = m.OrgUnitChangeRequest.objects.get(uuid=data["uuid"])

--- a/iaso/tests/api/org_unit_change_requests/test_org_unit_change_requests_mobile.py
+++ b/iaso/tests/api/org_unit_change_requests/test_org_unit_change_requests_mobile.py
@@ -80,7 +80,7 @@ class MobileOrgUnitChangeRequestAPITestCase(APITestCase):
 
         self.client.force_authenticate(self.user)
 
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(7):
             # filter_for_user_and_app_id
             #   1. SELECT OrgUnit
             #   2. SELECT Project

--- a/iaso/tests/api/stocks/test_views_mobile.py
+++ b/iaso/tests/api/stocks/test_views_mobile.py
@@ -91,7 +91,9 @@ class StockKeepingUnitMobileAPITestCase(APITestCase):
             response = self.client.get(SKU_URL, data={"app_id": self.project_2.app_id})
         self.assertJSONResponse(response, rest_framework.status.HTTP_200_OK)
         self.assertEqual(2, len(response.data["results"]))
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(2):
+            # 1. SELECT project (+ account + default_version via select_related)
+            # 2. SELECT COUNT(*) — no SKUs for project_3 / other account, so no page SELECT or prefetches
             response = self.client.get(SKU_URL, data={"app_id": self.project_3.app_id})
         self.assertJSONResponse(response, rest_framework.status.HTTP_200_OK)
         self.assertEqual(0, len(response.data["results"]))

--- a/iaso/tests/api/stocks/test_views_mobile.py
+++ b/iaso/tests/api/stocks/test_views_mobile.py
@@ -78,17 +78,16 @@ class StockKeepingUnitMobileAPITestCase(APITestCase):
 
     def test_list_authenticated_with_app_id(self):
         self.client.force_authenticate(self.user_without_rights)
-        with self.assertNumQueries(6):
-            # 1. SELECT project
-            # 2. SELECT account
-            # 3. SELECT COUNT(*)
-            # 4. SELECT stockkeepingunit
-            # 5. SELECT stockkeepingunit_org_unit_types
-            # 6. SELECT stockkeepingunit_forms
+        with self.assertNumQueries(5):
+            # 1. SELECT project (+ account + default_version via select_related)
+            # 2. SELECT COUNT(*)
+            # 3. SELECT stockkeepingunit
+            # 4. SELECT stockkeepingunit_org_unit_types
+            # 5. SELECT stockkeepingunit_forms
             response = self.client.get(SKU_URL, data={"app_id": self.project_1.app_id})
         self.assertJSONResponse(response, rest_framework.status.HTTP_200_OK)
         self.assertEqual(1, len(response.data["results"]))
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(5):
             response = self.client.get(SKU_URL, data={"app_id": self.project_2.app_id})
         self.assertJSONResponse(response, rest_framework.status.HTTP_200_OK)
         self.assertEqual(2, len(response.data["results"]))
@@ -204,36 +203,33 @@ class StockRulesVersionMobileAPITestCase(APITestCase):
 
     def test_authenticated_without_rights_list(self):
         self.client.force_authenticate(self.user_without_rights)
-        with self.assertNumQueries(3):
-            # 1. SELECT Project
-            # 2. SELECT Account
-            # 3. SELECT COUNT(*)
+        with self.assertNumQueries(2):
+            # 1. SELECT project (+ account + default_version via select_related)
+            # 2. SELECT StockRulesVersion (none published → 204)
             response = self.client.get(RULES_VERSION_URL, data={"app_id": self.project_1.app_id})
             self.assertJSONResponse(response, rest_framework.status.HTTP_204_NO_CONTENT)
 
         self.version_1.status = m.StockRulesVersionsStatus.PUBLISHED
         self.version_1.save()
 
-        with self.assertNumQueries(6):
-            # 1. SELECT Project
-            # 2. SELECT Account
-            # 3. SELECT StockRulesVersion
-            # 4. SELECT StockItemRules
-            # 5. SELECT StockKeepingUnit
-            # 6. SELECT Form
+        with self.assertNumQueries(5):
+            # 1. SELECT project (+ account + default_version via select_related)
+            # 2. SELECT StockRulesVersion
+            # 3. SELECT StockItemRules
+            # 4. SELECT StockKeepingUnit
+            # 5. SELECT Form
             response = self.client.get(RULES_VERSION_URL, data={"app_id": self.project_1.app_id})
             self.assertJSONResponse(response, rest_framework.status.HTTP_200_OK)
         self.assertEqual("version_1", response.data["name"])
         self.assertEqual(m.StockRulesVersionsStatus.PUBLISHED, response.data["status"])
         self.assertEqual(2, len(response.data["rules"]))
 
-        with self.assertNumQueries(6):
-            # 1. SELECT Project
-            # 2. SELECT Account
-            # 3. SELECT StockRulesVersion
-            # 4. SELECT StockItemRules
-            # 5. SELECT StockKeepingUnit
-            # 6. SELECT Form
+        with self.assertNumQueries(5):
+            # 1. SELECT project (+ account + default_version via select_related)
+            # 2. SELECT StockRulesVersion
+            # 3. SELECT StockItemRules
+            # 4. SELECT StockKeepingUnit
+            # 5. SELECT Form
             response = self.client.get(RULES_VERSION_URL, data={"app_id": self.project_2.app_id})
             self.assertJSONResponse(response, rest_framework.status.HTTP_200_OK)
         self.assertEqual("version_1", response.data["name"])
@@ -363,11 +359,10 @@ class StockLedgerItemMobileAPITestCase(APITestCase):
 
     def test_authenticated_without_rights_list(self):
         self.client.force_authenticate(self.user_without_rights)
-        with self.assertNumQueries(4):
-            # 1. SELECT Project
-            # 2. SELECT Account
-            # 3. SELECT COUNT(*)
-            # 4. SELECT StockLedgerItem
+        with self.assertNumQueries(3):
+            # 1. SELECT project (+ account + default_version via select_related)
+            # 2. SELECT COUNT(*)
+            # 3. SELECT StockLedgerItem
             response = self.client.get(LEDGER_ITEM_URL, data={"app_id": self.project_1.app_id})
             self.assertJSONResponse(response, rest_framework.status.HTTP_200_OK)
         self.assertEqual(2, response.data["count"])

--- a/iaso/tests/api/test_mobile_orgunits.py
+++ b/iaso/tests/api/test_mobile_orgunits.py
@@ -165,22 +165,21 @@ class MobileOrgUnitAPITestCase(APITestCase):
     def test_org_unit_have_correct_parent_id_without_limit(self):
         self.client.force_authenticate(self.user)
         with self.assertNumQueries(14):
-            # 1. SELECT  FROM "iaso_project"
-            # 2. SELECT FROM "iaso_account"
-            # 3. SELECT FROM "iaso_orgunit"
-            # 4. SELECT FROM "django_cache_table"
-            # 5. SELECT FROM "iaso_project"
-            # 6. SELECT FROM "iaso_account"
-            # 7. SELECT "iaso_featureflag"
-            # 8. SELECT FROM "iaso_sourceversion"
-            # 9. SELECT FROM "iaso_orgunit"
-            # 10. SELECT FROM "iaso_project" INNER JOIN "iaso_orgunittype_projects"
-            # 11. SELECT FROM "iaso_group"
-            # 12. SELECT COUNT(*) FROM "django_cache_table"
-            # 13. SAVEPOINT "s128932915669888_x20"
-            # 14. SELECT FROM "django_cache_table"
-            # 15. INSERT INTO "django_cache_table"
-            # 16. RELEASE SAVEPOINT "s128932915669888_x20"
+            # 1. SELECT "iaso_project" (permission / app lookup by app_id)
+            # 2. SELECT "iaso_account"
+            # 3. SELECT "iaso_orgunit" … profile roots (org_units M2M)
+            # 4. SELECT "django_cache_table" (cache get)
+            # 5. SELECT "iaso_project" LEFT JOIN "iaso_account" + "iaso_sourceversion"
+            #    (Project.get_for_user_and_app_id — select_related avoids extra account/version queries)
+            # 6. SELECT EXISTS "iaso_featureflag" (LIMIT_OU_DOWNLOAD_TO_ROOTS)
+            # 7. SELECT "iaso_orgunit" … (main list + parent + org unit type)
+            # 8. Prefetch org unit types → projects (M2M)
+            # 9. Prefetch org units → groups
+            # 10. SELECT COUNT(*) FROM "django_cache_table"
+            # 11. SAVEPOINT (atomic cache write)
+            # 12. SELECT "django_cache_table" (cache key)
+            # 13. INSERT "django_cache_table"
+            # 14. RELEASE SAVEPOINT
             response = self.client.get(BASE_URL, data={APP_ID: BASE_APP_ID})
         self.assertJSONResponse(response, 200)
         self.assertEqual([self.raditz.id, self.goku.id], response.json()["roots"])
@@ -207,22 +206,21 @@ class MobileOrgUnitAPITestCase(APITestCase):
         self.goku.save()
         self.client.force_authenticate(self.user)
         with self.assertNumQueries(14):
-            # 1. SELECT  FROM "iaso_project"
-            # 2. SELECT FROM "iaso_account"
-            # 3. SELECT FROM "iaso_orgunit"
-            # 4. SELECT FROM "django_cache_table"
-            # 5. SELECT FROM "iaso_project"
-            # 6. SELECT FROM "iaso_account"
-            # 7. SELECT "iaso_featureflag"
-            # 8. SELECT FROM "iaso_sourceversion"
-            # 9. SELECT FROM "iaso_orgunit"
-            # 10. SELECT FROM "iaso_project" INNER JOIN "iaso_orgunittype_projects"
-            # 11. SELECT FROM "iaso_group"
-            # 12. SELECT COUNT(*) FROM "django_cache_table"
-            # 13. SAVEPOINT "s128932915669888_x20"
-            # 14. SELECT FROM "django_cache_table"
-            # 15. INSERT INTO "django_cache_table"
-            # 16. RELEASE SAVEPOINT "s128932915669888_x20"
+            # 1. SELECT "iaso_project" (permission / app lookup by app_id)
+            # 2. SELECT "iaso_account"
+            # 3. SELECT "iaso_orgunit" … profile roots (org_units M2M)
+            # 4. SELECT "django_cache_table" (cache get)
+            # 5. SELECT "iaso_project" LEFT JOIN "iaso_account" + "iaso_sourceversion"
+            #    (Project.get_for_user_and_app_id — select_related avoids extra account/version queries)
+            # 6. SELECT EXISTS "iaso_featureflag" (LIMIT_OU_DOWNLOAD_TO_ROOTS)
+            # 7. SELECT "iaso_orgunit" … (main list + parent + org unit type)
+            # 8. Prefetch org unit types → projects (M2M)
+            # 9. Prefetch org units → groups
+            # 10. SELECT COUNT(*) FROM "django_cache_table"
+            # 11. SAVEPOINT (atomic cache write)
+            # 12. SELECT "django_cache_table" (cache key)
+            # 13. INSERT "django_cache_table"
+            # 14. RELEASE SAVEPOINT
             response = self.client.get(BASE_URL, data={APP_ID: BASE_APP_ID})
         self.assertJSONResponse(response, 200)
         self.assertEqual([self.raditz.id, self.goku.id], response.json()["roots"])
@@ -253,22 +251,21 @@ class MobileOrgUnitAPITestCase(APITestCase):
         self.goku.save()
         self.client.force_authenticate(self.user)
         with self.assertNumQueries(14):
-            # 1. SELECT  FROM "iaso_project"
-            # 2. SELECT FROM "iaso_account"
-            # 3. SELECT FROM "iaso_orgunit"
-            # 4. SELECT FROM "django_cache_table"
-            # 5. SELECT FROM "iaso_project"
-            # 6. SELECT FROM "iaso_account"
-            # 7. SELECT "iaso_featureflag"
-            # 8. SELECT FROM "iaso_sourceversion"
-            # 9. SELECT FROM "iaso_orgunit"
-            # 10. SELECT FROM "iaso_project" INNER JOIN "iaso_orgunittype_projects"
-            # 11. SELECT FROM "iaso_group"
-            # 12. SELECT COUNT(*) FROM "django_cache_table"
-            # 13. SAVEPOINT "s128932915669888_x20"
-            # 14. SELECT FROM "django_cache_table"
-            # 15. INSERT INTO "django_cache_table"
-            # 16. RELEASE SAVEPOINT "s128932915669888_x20"
+            # 1. SELECT "iaso_project" (permission / app lookup by app_id)
+            # 2. SELECT "iaso_account"
+            # 3. SELECT "iaso_orgunit" … profile roots (org_units M2M)
+            # 4. SELECT "django_cache_table" (cache get)
+            # 5. SELECT "iaso_project" LEFT JOIN "iaso_account" + "iaso_sourceversion"
+            #    (Project.get_for_user_and_app_id — select_related avoids extra account/version queries)
+            # 6. SELECT EXISTS "iaso_featureflag" (LIMIT_OU_DOWNLOAD_TO_ROOTS)
+            # 7. SELECT "iaso_orgunit" … (main list + parent + org unit type)
+            # 8. Prefetch org unit types → projects (M2M)
+            # 9. Prefetch org units → groups
+            # 10. SELECT COUNT(*) FROM "django_cache_table"
+            # 11. SAVEPOINT (atomic cache write)
+            # 12. SELECT "django_cache_table" (cache key)
+            # 13. INSERT "django_cache_table"
+            # 14. RELEASE SAVEPOINT
             response = self.client.get(BASE_URL, data={APP_ID: BASE_APP_ID})
         self.assertJSONResponse(response, 200)
         self.assertEqual([self.raditz.id, self.goku.id], response.json()["roots"])

--- a/iaso/tests/api/test_mobile_orgunits.py
+++ b/iaso/tests/api/test_mobile_orgunits.py
@@ -164,7 +164,7 @@ class MobileOrgUnitAPITestCase(APITestCase):
 
     def test_org_unit_have_correct_parent_id_without_limit(self):
         self.client.force_authenticate(self.user)
-        with self.assertNumQueries(16):
+        with self.assertNumQueries(14):
             # 1. SELECT  FROM "iaso_project"
             # 2. SELECT FROM "iaso_account"
             # 3. SELECT FROM "iaso_orgunit"
@@ -206,7 +206,7 @@ class MobileOrgUnitAPITestCase(APITestCase):
         self.goku.validation_status = OrgUnit.VALIDATION_VALID
         self.goku.save()
         self.client.force_authenticate(self.user)
-        with self.assertNumQueries(16):
+        with self.assertNumQueries(14):
             # 1. SELECT  FROM "iaso_project"
             # 2. SELECT FROM "iaso_account"
             # 3. SELECT FROM "iaso_orgunit"
@@ -252,7 +252,7 @@ class MobileOrgUnitAPITestCase(APITestCase):
         self.goku.org_unit_type = self.nameks
         self.goku.save()
         self.client.force_authenticate(self.user)
-        with self.assertNumQueries(16):
+        with self.assertNumQueries(14):
             # 1. SELECT  FROM "iaso_project"
             # 2. SELECT FROM "iaso_account"
             # 3. SELECT FROM "iaso_orgunit"


### PR DESCRIPTION
## What problem is this PR solving?

4 k events in sentry on this api 

### Related JIRA tickets

IA-4913

## Changes

Some api optimisation

## How to test

Call /api/mobile/orgunits/changes/ ?app_id=SOME_APP_ID where the app id is the app of a project with change requests.
Inspect the terminal, you should have 0 duplicates here

## Print screen / video

<img width="584" height="107" alt="Screenshot 2026-03-26 at 11 44 32" src="https://github.com/user-attachments/assets/defffdd4-c33c-47b6-8cd4-8dac1712350a" />
