### PR TITLE
[IA-4915]: added permissions to validation node actions + tests

### DIFF
--- a/iaso/api/validation_workflows_nodes/views.py
+++ b/iaso/api/validation_workflows_nodes/views.py
@@ -1,3 +1,4 @@
+from django.db.models import Prefetch
 from django.shortcuts import get_object_or_404
 from djangorestframework_camel_case.parser import CamelCaseJSONParser
 from djangorestframework_camel_case.render import CamelCaseBrowsableAPIRenderer, CamelCaseJSONRenderer
@@ -29,14 +30,24 @@ class ValidationNodeViewSet(GenericViewSet):
                 Instance.objects.select_related("project__account", "form", "form__validation_workflow")
                 .filter_for_user(self.request.user)
                 .filter(form__deleted_at__isnull=True)
-                .prefetch_related("validationnode_set")
+                .prefetch_related(
+                    Prefetch(
+                        "validationnode_set",
+                        queryset=ValidationNode.objects.select_related("node__workflow__account").all(),
+                    )
+                )
             )
 
-        qs = ValidationNode.objects.select_related("instance").filter(
-            instance__in=Instance.objects.select_related("project__account", "form")
+        qs = (
+            ValidationNode.objects.select_related("instance", "node__workflow__account")
+            .filter(
+                instance__in=Instance.objects.select_related("project__account", "form")
+                .filter_for_user(self.request.user)
+                .filter(form__deleted_at__isnull=True)
+            )
             .filter_for_user(self.request.user)
-            .filter(form__deleted_at__isnull=True)
         )
+
         if self.action == "complete":
             return qs.select_related("node").prefetch_related("node__roles_required", "node__next_node_templates")
         if self.action == "undo":

--- a/iaso/engine/validation_workflow.py
+++ b/iaso/engine/validation_workflow.py
@@ -160,14 +160,6 @@ class ValidationWorkflowEngine:
         We check if the user has the permission to complete this node.
         """
 
-        if getattr(user, "is_superuser", False):
-            return
-
-        required_roles = validation_node.node.roles_required.all()
-
-        if not required_roles:
-            return  # No perm required , anybody can do it
-
         if user is None or getattr(user, "is_anonymous", True):  # not sure it'll happen IRL
             raise PermissionDenied("User required")
 
@@ -176,6 +168,17 @@ class ValidationWorkflowEngine:
 
         if not user.iaso_profile:  # not sure it'll happen IRL
             raise PermissionDenied("User required")
+
+        if validation_node.node.workflow.account != user.iaso_profile.account:
+            raise PermissionDenied
+
+        if getattr(user, "is_superuser", False):
+            return
+
+        required_roles = validation_node.node.roles_required.all()
+
+        if not required_roles:
+            return  # No perm required , anybody can do it
 
         user_role_ids = user.iaso_profile.user_roles.values_list("pk", flat=True)
 
@@ -186,6 +189,18 @@ class ValidationWorkflowEngine:
 
     @staticmethod
     def _can_undo_node(validation_node: ValidationNode, user):
+        if user is None or getattr(user, "is_anonymous", True):  # not sure it'll happen IRL
+            raise PermissionDenied("User required")
+
+        if not hasattr(user, "iaso_profile"):  # not sure it'll happen IRL
+            raise PermissionDenied("User required")
+
+        if not user.iaso_profile:  # not sure it'll happen IRL
+            raise PermissionDenied("User required")
+
+        if validation_node.node.workflow.account != user.iaso_profile.account:
+            raise PermissionDenied
+
         if validation_node.status == ValidationNodeStatus.UNKNOWN:
             raise ValidationWorkflowEngineException("Cannot undo node that hasn't been completed yet")
 

--- a/iaso/models/validation_workflow/validation_node.py
+++ b/iaso/models/validation_workflow/validation_node.py
@@ -14,6 +14,14 @@ class ValidationNodeStatus(models.TextChoices):
     UNKNOWN = "UNKNOWN", _("Unknown")
 
 
+class ValidationNodeQuerySet(models.QuerySet):
+    def filter_for_user(self, user):
+        iaso_profile = getattr(user, "iaso_profile", None)
+        if getattr(iaso_profile, "account", None):
+            return self.filter(node__workflow__account=iaso_profile.account)
+        return self.none()
+
+
 class ValidationNode(CreatedAndUpdatedModel):
     """
     Represents a runtime instance of a ValidationNodeTemplate.
@@ -42,3 +50,5 @@ class ValidationNode(CreatedAndUpdatedModel):
 
     class Meta:
         ordering = ["-created_at"]
+
+    objects = models.Manager.from_queryset(ValidationNodeQuerySet)()

--- a/iaso/tests/api/validation_workflow_nodes/test_views/test_complete.py
+++ b/iaso/tests/api/validation_workflow_nodes/test_views/test_complete.py
@@ -1,7 +1,11 @@
+import uuid
+
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.settings import api_settings
 
+from iaso.engine.validation_workflow import ValidationWorkflowEngine
+from iaso.models import Account, Form, Project, ValidationNodeTemplate, ValidationWorkflow
 from iaso.models.common import ValidationWorkflowArtefactStatus
 from iaso.models.validation_workflow.validation_node import ValidationNodeStatus
 from iaso.tests.api.validation_workflow_nodes.test_views.common import BaseAPITestCase
@@ -181,3 +185,48 @@ class ValidationNodeAPICompleteTestCase(BaseAPITestCase):
 
     def test_approve_as_super_user(self):
         self.base_test_approve(self.superuser)
+
+    def test_try_to_complete_another_validation_node_account(self):
+        other_account = Account.objects.create(name="other-account")
+
+        stranger = self.create_user_with_profile(
+            username="stranger", account=other_account, is_staff=True, is_superuser=True
+        )
+
+        other_validation_workflow = ValidationWorkflow.objects.create(
+            name="other-validation-workflow", account=other_account
+        )
+
+        other_node = ValidationNodeTemplate.objects.create(name="other first node", workflow=other_validation_workflow)
+        other_form = Form.objects.create(name="other form")
+        other_project = Project.objects.create(account=other_account, app_id="1.3")
+        other_project.forms.add(other_form)
+
+        other_instance = self.create_form_instance(
+            form=other_form,
+            project=other_project,
+            uuid=str(uuid.uuid4()),
+        )
+
+        other_validation_workflow.form_set.add(other_form)
+        ValidationWorkflowEngine.start(other_validation_workflow, stranger, other_instance)
+
+        self.assertEqual(other_node.validationnode_set.count(), 1)
+
+        node_pk = other_node.validationnode_set.first().pk
+
+        self.client.force_authenticate(self.john_wick)
+
+        res = self.client.post(
+            reverse(
+                "validation_workflow_nodes-complete",
+                kwargs={
+                    "instance_id": other_instance.id,
+                    "pk": node_pk,
+                },
+            ),
+            data={"comment": "LGTM", "approved": True},
+        )
+        self.assertEqual(res.status_code, status.HTTP_404_NOT_FOUND)
+
+        self.assertEqual(other_node.validationnode_set.count(), 1)

--- a/iaso/tests/api/validation_workflow_nodes/test_views/test_complete_bypass.py
+++ b/iaso/tests/api/validation_workflow_nodes/test_views/test_complete_bypass.py
@@ -1,6 +1,10 @@
+import uuid
+
 from django.urls import reverse
 from rest_framework import status
 
+from iaso.engine.validation_workflow import ValidationWorkflowEngine
+from iaso.models import Account, Form, Project, ValidationNodeTemplate, ValidationWorkflow
 from iaso.models.common import ValidationWorkflowArtefactStatus
 from iaso.models.validation_workflow.validation_node import ValidationNodeStatus
 from iaso.tests.api.validation_workflow_nodes.test_views.common import BaseAPITestCase
@@ -37,7 +41,7 @@ class ValidationNodeAPICompleteBypassTestCase(BaseAPITestCase):
         instance_id = self.instance.id
         self.client.force_authenticate(self.john_wick)
         # todo : optimize later
-        with self.assertNumQueries(36):
+        with self.assertNumQueries(35):
             res = self.client.post(
                 reverse("validation_workflow_nodes-complete-bypass", kwargs={"instance_id": instance_id}),
                 data={"node": "third-node", "approved": True, "comment": "OK"},
@@ -96,3 +100,44 @@ class ValidationNodeAPICompleteBypassTestCase(BaseAPITestCase):
             self.instance.validationnode_set.filter(node__slug="third-node").first().status,
             ValidationNodeStatus.REJECTED,
         )
+
+    def test_try_to_complete_bypass_another_validation_node_account(self):
+        other_account = Account.objects.create(name="other-account")
+
+        stranger = self.create_user_with_profile(
+            username="stranger", account=other_account, is_staff=True, is_superuser=True
+        )
+
+        other_validation_workflow = ValidationWorkflow.objects.create(
+            name="other-validation-workflow", account=other_account
+        )
+
+        other_node = ValidationNodeTemplate.objects.create(name="other first node", workflow=other_validation_workflow)
+        other_second_node = ValidationNodeTemplate.objects.create(
+            name="other second node", workflow=other_validation_workflow
+        )
+        other_second_node.previous_node_templates.add(other_node)
+        other_form = Form.objects.create(name="other form")
+        other_project = Project.objects.create(account=other_account, app_id="1.3")
+        other_project.forms.add(other_form)
+
+        other_instance = self.create_form_instance(
+            form=other_form,
+            project=other_project,
+            uuid=str(uuid.uuid4()),
+        )
+
+        other_validation_workflow.form_set.add(other_form)
+        ValidationWorkflowEngine.start(other_validation_workflow, stranger, other_instance)
+
+        self.assertEqual(other_node.validationnode_set.count(), 1)
+
+        self.client.force_authenticate(self.john_wick)
+
+        res = self.client.post(
+            reverse("validation_workflow_nodes-complete-bypass", kwargs={"instance_id": other_instance.id}),
+            data={"node": other_second_node.slug, "approved": False, "comment": "Nope"},
+        )
+        self.assertEqual(res.status_code, status.HTTP_404_NOT_FOUND)
+
+        self.assertEqual(other_node.validationnode_set.count(), 1)

--- a/iaso/tests/api/validation_workflow_nodes/test_views/test_undo.py
+++ b/iaso/tests/api/validation_workflow_nodes/test_views/test_undo.py
@@ -1,7 +1,10 @@
+import uuid
+
 from django.urls import reverse
 from rest_framework import status
 
 from iaso.engine.validation_workflow import ValidationWorkflowEngine
+from iaso.models import Account, Form, Project, ValidationNodeTemplate, ValidationWorkflow
 from iaso.models.common import ValidationWorkflowArtefactStatus
 from iaso.models.validation_workflow.validation_node import ValidationNodeStatus
 from iaso.tests.api.validation_workflow_nodes.test_views.common import BaseAPITestCase
@@ -86,3 +89,40 @@ class ValidationNodeAPIUndoTestCase(BaseAPITestCase):
         node.refresh_from_db()
 
         self.assertEqual(node.status, ValidationNodeStatus.UNKNOWN)
+
+    def test_try_to_undo_another_validation_node_account(self):
+        other_account = Account.objects.create(name="other-account")
+
+        stranger = self.create_user_with_profile(
+            username="stranger", account=other_account, is_staff=True, is_superuser=True
+        )
+
+        other_validation_workflow = ValidationWorkflow.objects.create(
+            name="other-validation-workflow", account=other_account
+        )
+
+        other_node = ValidationNodeTemplate.objects.create(name="other first node", workflow=other_validation_workflow)
+        other_form = Form.objects.create(name="other form")
+        other_project = Project.objects.create(account=other_account, app_id="1.3")
+        other_project.forms.add(other_form)
+
+        other_instance = self.create_form_instance(
+            form=other_form,
+            project=other_project,
+            uuid=str(uuid.uuid4()),
+        )
+
+        other_validation_workflow.form_set.add(other_form)
+        ValidationWorkflowEngine.start(other_validation_workflow, stranger, other_instance)
+
+        self.assertEqual(other_node.validationnode_set.count(), 1)
+
+        node_pk = other_node.validationnode_set.first().pk
+
+        self.client.force_authenticate(self.john_wick)
+        res = self.client.post(
+            reverse("validation_workflow_nodes-undo", kwargs={"instance_id": other_instance.id, "pk": node_pk})
+        )
+        self.assertEqual(res.status_code, status.HTTP_404_NOT_FOUND)
+
+        self.assertEqual(other_node.validationnode_set.count(), 1)

--- a/iaso/tests/test_engine/test_validation_workflow.py
+++ b/iaso/tests/test_engine/test_validation_workflow.py
@@ -1,13 +1,12 @@
-from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser, Group
 from django.core.exceptions import PermissionDenied
-from django.test import TestCase
 
 from iaso.engine.exceptions import ValidationWorkflowEngineException
 from iaso.engine.validation_workflow import ValidationWorkflowEngine
-from iaso.models import Account, Form, Instance, Profile, UserRole, ValidationNodeTemplate, ValidationWorkflow
+from iaso.models import Account, Form, Instance, UserRole, ValidationNodeTemplate, ValidationWorkflow
 from iaso.models.common import ValidationWorkflowArtefactStatus
 from iaso.models.validation_workflow.validation_node import ValidationNodeStatus
+from iaso.test import TestCase
 
 
 class TestSimpleLinearValidationWorkflowEngine(TestCase):
@@ -25,8 +24,8 @@ class TestSimpleLinearValidationWorkflowEngine(TestCase):
 
     def setUp(self):
         account = Account.objects.create(name="account")
-        self.user = get_user_model().objects.create_user(username="noprofile", password="testpass")
-        self.other_user = get_user_model().objects.create(username="john.doe", password="testpass")
+        self.user = self.create_user_with_profile(username="noprofile", password="testpass", account=account)
+        self.other_user = self.create_user_with_profile(username="john.doe", password="testpass", account=account)
         self.workflow = ValidationWorkflow.objects.create(name="test workflow", account=account)
         self.check_file_node = ValidationNodeTemplate.objects.create(workflow=self.workflow, name="check_file_node")
 
@@ -165,8 +164,8 @@ class TestMultiLinearValidationWorkflowEngine(TestCase):
 
     def setUp(self):
         account = Account.objects.create(name="test")
-        self.user = get_user_model().objects.create_user(username="noprofile", password="testpass")
-        self.other_user = get_user_model().objects.create(username="john.doe", password="testpass")
+        self.user = self.create_user_with_profile(username="noprofile", password="testpass", account=account)
+        self.other_user = self.create_user_with_profile(username="john.doe", password="testpass", account=account)
         self.workflow = ValidationWorkflow.objects.get_or_create(name="test workflow", account=account)[0]
         self.check_file_type_node = ValidationNodeTemplate.objects.create(
             workflow=self.workflow, name="check_file_type"
@@ -373,15 +372,15 @@ class TestPermissionCheck(TestCase):
         user_role_1 = UserRole.objects.create(group=group_1, account=account)
         user_role_2 = UserRole.objects.create(group=group_2, account=account)
 
-        self.user = get_user_model().objects.create_user(username="noprofile", password="testpass")
-        self.other_user = get_user_model().objects.create(username="john.doe", password="testpass")
-        self.superuser = get_user_model().objects.create_superuser(username="john.super", password="testpass")
-
-        profile = Profile.objects.create(account=account, user=self.user)
-        profile.user_roles.set([user_role_1, user_role_2])
-
-        profile_with_just_one_role = Profile.objects.create(account=account, user=self.other_user)
-        profile_with_just_one_role.user_roles.add(user_role_1)
+        self.user = self.create_user_with_profile(
+            username="noprofile", password="testpass", account=account, user_roles=[user_role_1, user_role_2]
+        )
+        self.other_user = self.create_user_with_profile(
+            username="john.doe", password="testpass", account=account, user_roles=[user_role_1]
+        )
+        self.superuser = self.create_user_with_profile(
+            username="john.super", password="testpass", account=account, is_staff=True, is_superuser=True
+        )
 
         self.workflow = ValidationWorkflow.objects.get_or_create(name="test workflow", account=account)[0]
         self.check_file_node = ValidationNodeTemplate.objects.create(workflow=self.workflow, name="check_file_node")
@@ -583,8 +582,9 @@ class TestUndoFeature(TestCase):
 
     def setUp(self):
         account = Account.objects.create(name="test account")
-        self.user = get_user_model().objects.create_user(username="noprofile", password="testpass")
-        self.other_user = get_user_model().objects.create_user(username="john.doe", password="testpass")
+
+        self.user = self.create_user_with_profile(username="noprofile", password="testpass", account=account)
+        self.other_user = self.create_user_with_profile(username="john.doe", password="testpass", account=account)
         self.workflow = ValidationWorkflow.objects.get_or_create(name="test workflow", account=account)[0]
         self.check_file_type_node = ValidationNodeTemplate.objects.create(
             workflow=self.workflow, name="check_file_type"
@@ -778,7 +778,7 @@ class TestResubmitFeature(TestCase):
 
     def setUp(self):
         account = Account.objects.create(name="account")
-        self.user = get_user_model().objects.create_user(username="noprofile", password="testpass")
+        self.user = self.create_user_with_profile(username="noprofile", password="testpass", account=account)
         self.workflow = ValidationWorkflow.objects.get_or_create(name="test workflow", account=account)[0]
         self.check_file_type_node = ValidationNodeTemplate.objects.create(
             workflow=self.workflow, name="check_file_type"
@@ -887,19 +887,18 @@ class TestByPassFeature(TestCase):
         user_role_2 = UserRole.objects.create(group=group_2, account=account)
         user_role_3 = UserRole.objects.create(group=group_3, account=account)
 
-        self.jim = get_user_model().objects.create_user(username="jim.halpert", password="testpass")
-        self.dwight = get_user_model().objects.create(username="dwight.schrute", password="testpass")
-        self.michael = get_user_model().objects.create(username="michael.scott", password="testpass")
-        self.superuser = get_user_model().objects.create_superuser(username="john.super", password="testpass")
-
-        profile_seller = Profile.objects.create(account=account, user=self.jim)
-        profile_seller.user_roles.set([user_role_1])
-
-        profile_assistant_to_the_regional_manager = Profile.objects.create(account=account, user=self.dwight)
-        profile_assistant_to_the_regional_manager.user_roles.add(user_role_2)
-
-        profile_regional_manager = Profile.objects.create(account=account, user=self.michael)
-        profile_regional_manager.user_roles.add(user_role_3)
+        self.jim = self.create_user_with_profile(
+            username="jim.halpert", password="testpass", account=account, user_roles=[user_role_1]
+        )
+        self.dwight = self.create_user_with_profile(
+            username="dwight.schrute", password="testpass", account=account, user_roles=[user_role_2]
+        )
+        self.michael = self.create_user_with_profile(
+            username="michael.scott", password="testpass", account=account, user_roles=[user_role_3]
+        )
+        self.superuser = self.create_user_with_profile(
+            username="john.super", password="testpass", account=account, is_staff=True, is_superuser=True
+        )
 
         self.workflow = ValidationWorkflow.objects.get_or_create(name="test workflow", account=account)[0]
         self.check_file_type_node = ValidationNodeTemplate.objects.create(
@@ -1250,10 +1249,10 @@ class TestUndoFeatureForSkipNodes(TestCase):
 
     def setUp(self):
         account = Account.objects.create(name="test account")
-        self.jim = get_user_model().objects.create_user(username="jim.halpert", password="testpass")
-        self.dwight = get_user_model().objects.create(username="dwight.schrute", password="testpass")
-        self.michael = get_user_model().objects.create(username="michael.scott", password="testpass")
-        self.david = get_user_model().objects.create(username="david.wallace", password="testpass")
+        self.jim = self.create_user_with_profile(username="jim.halpert", password="testpass", account=account)
+        self.dwight = self.create_user_with_profile(username="dwight.schrute", password="testpass", account=account)
+        self.michael = self.create_user_with_profile(username="michael.scott", password="testpass", account=account)
+        self.david = self.create_user_with_profile(username="david.wallace", password="testpass", account=account)
 
         self.workflow = ValidationWorkflow.objects.get_or_create(name="test workflow", account=account)[0]
         self.check_file_type_node = ValidationNodeTemplate.objects.create(
@@ -1518,3 +1517,78 @@ class TestUndoFeatureForSkipNodes(TestCase):
 
         # fourth node
         self.assertFalse(self.big_boss_approves_node.validationnode_set.exists())
+
+
+class TestAccessFromAnotherAccount(TestCase):
+    """
+    Purpose of this test is to check that a user from account A cannot do anything on ValidationNode that belongs to another account B.
+
+    Setup represents a longer linear workflow :
+    * Multiple nodes aka task (e.g check file type, check file name, etc)
+    * Only the last node is capable to approve/reject without waiting for others
+
+    In summary:
+
+    [ node: check file type ]
+        |
+        |
+        v
+    [ node: check file name ]
+        |
+        |
+        v
+    [ node: manager approves ]
+    """
+
+    def setUp(self):
+        account = Account.objects.create(name="test")
+
+        self.jim = self.create_user_with_profile(username="jim.halpert", password="testpass", account=account)
+
+        self.stranger = self.create_user_with_profile(
+            username="stranger", password="testpass", account=Account.objects.create(name="other_test")
+        )
+
+        self.workflow = ValidationWorkflow.objects.get_or_create(name="test workflow", account=account)[0]
+        self.check_file_type_node = ValidationNodeTemplate.objects.create(
+            workflow=self.workflow, name="check_file_type"
+        )
+
+        self.check_file_name_node = ValidationNodeTemplate.objects.create(
+            workflow=self.workflow, name="check_file_node"
+        )
+        self.check_file_name_node.previous_node_templates.add(self.check_file_type_node)
+
+        self.manager_approves_node = ValidationNodeTemplate.objects.create(
+            workflow=self.workflow, name="manager_approves_node", can_skip_previous_nodes=True
+        )
+        self.manager_approves_node.previous_node_templates.add(self.check_file_name_node)
+
+        self.form = Form.objects.create()
+        self.workflow.form_set.add(self.form)
+
+        self.instance = Instance.objects.create(form=self.form)
+        self.workflow.refresh_from_db()
+
+    def test_cannot_complete(self):
+        ValidationWorkflowEngine.start(self.workflow, self.jim, self.instance)
+
+        with self.assertRaises(PermissionDenied):
+            ValidationWorkflowEngine.complete_node(
+                self.instance.get_next_pending_nodes().first(), self.stranger, self.instance, True
+            )
+
+    def test_cannot_undo(self):
+        ValidationWorkflowEngine.start(self.workflow, self.jim, self.instance)
+        node = self.instance.get_next_pending_nodes().first()
+        ValidationWorkflowEngine.complete_node(node, self.jim, self.instance, True)
+        with self.assertRaises(PermissionDenied):
+            ValidationWorkflowEngine.undo_node(node, self.stranger, self.instance, self.workflow)
+
+    def test_cannot_complete_by_pass(self):
+        ValidationWorkflowEngine.start(self.workflow, self.jim, self.instance)
+
+        with self.assertRaises(PermissionDenied):
+            ValidationWorkflowEngine.complete_node_by_passing(
+                self.manager_approves_node, self.stranger, self.instance, self.workflow, True
+            )


### PR DESCRIPTION
## What problem is this PR solving?

Validation node operations were not restricted to a user account

### Related JIRA tickets

IA-4915

## Changes

* Filter queryset in views
* Double check in engine if the user account is right
