### PR TITLE
IA-4933: Fix accuracy can be bigger than 5 digits

### DIFF
--- a/iaso/api/instances/serializers.py
+++ b/iaso/api/instances/serializers.py
@@ -10,7 +10,8 @@ from iaso.utils.serializer.rounded_decimal_field import RoundedDecimalField
 
 class InstanceImportAccuracySerializer(serializers.Serializer):
     accuracy = RoundedDecimalField(
-        max_digits=7,
+        coerce_max_value=99999,
+        max_digits=None,
         decimal_places=2,
         rounding=decimal.ROUND_HALF_UP,
         allow_null=True,

--- a/iaso/tests/api/instances/test_instances.py
+++ b/iaso/tests/api/instances/test_instances.py
@@ -444,6 +444,62 @@ class InstancesAPITestCase(TaskAPITestCase):
         last_instance = m.Instance.objects.get(uuid=instance_uuid)
         self.assertEqual(Decimal("12.35"), last_instance.accuracy)
 
+    def test_instance_create_with_accuracy_coerced(self):
+        """POST /api/instances/ with accuracy having more than 2 decimal places should be rounded"""
+
+        instance_uuid = str(uuid4())
+        body = [
+            {
+                "id": instance_uuid,
+                "created_at": 1565258153704,
+                "updated_at": 1565258153709,
+                "orgUnitId": self.jedi_council_corruscant.id,
+                "formId": self.form_1.id,
+                "period": "202002",
+                "latitude": 50.2,
+                "longitude": 4.4,
+                "accuracy": 126264.07,
+                "altitude": 100,
+                "file": "\/storage\/emulated\/0\/odk\/instances\/test_accuracy_rounded\/test.xml",
+                "name": "test_accuracy_rounded",
+            }
+        ]
+        response = self.client.post(
+            "/api/instances/?app_id=stars.empire.agriculture.hydroponics", data=body, format="json"
+        )
+        self.assertEqual(response.status_code, 200)
+
+        last_instance = m.Instance.objects.get(uuid=instance_uuid)
+        self.assertEqual(Decimal("99999.00"), last_instance.accuracy)
+
+    def test_instance_create_with_accuracy_coerced_and_rounded(self):
+        """POST /api/instances/ with accuracy having more than 2 decimal places should be rounded"""
+
+        instance_uuid = str(uuid4())
+        body = [
+            {
+                "id": instance_uuid,
+                "created_at": 1565258153704,
+                "updated_at": 1565258153709,
+                "orgUnitId": self.jedi_council_corruscant.id,
+                "formId": self.form_1.id,
+                "period": "202002",
+                "latitude": 50.2,
+                "longitude": 4.4,
+                "accuracy": 126264.345,
+                "altitude": 100,
+                "file": "\/storage\/emulated\/0\/odk\/instances\/test_accuracy_rounded\/test.xml",
+                "name": "test_accuracy_rounded",
+            }
+        ]
+        response = self.client.post(
+            "/api/instances/?app_id=stars.empire.agriculture.hydroponics", data=body, format="json"
+        )
+        self.assertEqual(response.status_code, 200)
+
+        last_instance = m.Instance.objects.get(uuid=instance_uuid)
+        self.assertEqual(Decimal("99999.00"), last_instance.accuracy)
+
     def test_instance_create_with_accuracy_rounded_with_long_number(self):
         """POST /api/instances/ with accuracy having more than 2 decimal places should be rounded"""
 

--- a/iaso/tests/utils/test_rounded_decimal_field.py
+++ b/iaso/tests/utils/test_rounded_decimal_field.py
@@ -32,3 +32,14 @@ class RoundedDecimalFieldTestCase(TestCase):
         with self.assertRaises(ValidationError) as error:
             field.to_internal_value("100.22")
         self.assertIn("Ensure that there are no more than 2 digits before the decimal point.", error.exception.detail)
+
+        field = RoundedDecimalField(max_digits=2, coerce_max_value=1, decimal_places=1)
+        self.assertEqual(field.to_internal_value("2.19"), decimal.Decimal("1"))
+
+        field = RoundedDecimalField(max_digits=None, coerce_max_value=99, decimal_places=1)
+        self.assertEqual(field.to_internal_value("102.4"), decimal.Decimal("99"))
+
+        field = RoundedDecimalField(max_digits=3, coerce_max_value=99, decimal_places=1)
+        with self.assertRaises(ValidationError) as error:
+            field.to_internal_value("102.4")
+        self.assertIn("Ensure that there are no more than 2 digits before the decimal point.", error.exception.detail)

--- a/iaso/utils/serializer/rounded_decimal_field.py
+++ b/iaso/utils/serializer/rounded_decimal_field.py
@@ -1,12 +1,19 @@
+import decimal
+
 from rest_framework import serializers
 
 
 class RoundedDecimalField(serializers.DecimalField):
     """
     Some devices send accuracy with more than 2 decimals (IA-4159).
+    Some devices send accuracy with more than 5 numbers before the decimal (IA-4933).
 
     This field will round the value to the number specified in `decimal_places`.
     """
+
+    def __init__(self, coerce_max_value=None, **kwargs):
+        super().__init__(**kwargs)
+        self.coerce_max_value = coerce_max_value
 
     def validate_precision(self, value):
         """
@@ -40,3 +47,12 @@ class RoundedDecimalField(serializers.DecimalField):
             self.fail("max_digits", max_digits=self.max_digits)
 
         return value
+
+    def quantize(self, value):
+        """
+        Quantize the decimal value to the configured precision.
+        """
+        if self.coerce_max_value and value > self.coerce_max_value:
+            return decimal.Decimal(self.coerce_max_value)
+
+        return super().quantize(value)


### PR DESCRIPTION
## What problem is this PR solving?

Some accuracy values are bigger than 5 digits and that causes issues when sending instances.

### Related JIRA tickets

IA-4933

## Changes

Added a `coerce_max_value` to `RoundedDecimalField` in order to ensure we won't have more than 5 digits.

## How to test

Send an instance with an accuracy with more than 5 digits, the APIImport should show it successful.
E.g.:
``` 
[{
    "id": "81e7f105-07f8-4e2f-85d0-f65e4db75290",
    "file": "/storage/emulated/0/Android/data/com.bluesquarehub.iaso/files/Documents/test/instances/1042_13_2026-03-18_12-44-15/1042_13_22c354d4-2b39-4c3f-96a8-08ee1543371b_2026-03-18_12-44-15.xml",
    "name": "A form",
    "formId": "1042",
    "accuracy": 126264.07,
    "altitude": 0.0,
    "latitude": -0.0669936,
    "longitude": 0.2245277,
    "orgUnitId": "123",
    "created_at": 1773830726.597,
    "updated_at": 1773830726.597
  }]
 ```

`formId` and `orgUnitId` must exist in your project.
