### PR TITLE
[IA-4642] Refactoring the update_trads script to add translations from plugin to IASO folder

### DIFF
--- a/scripts/update_trads.py
+++ b/scripts/update_trads.py
@@ -29,74 +29,70 @@ from collections import OrderedDict, defaultdict
 
 def extract_translations(path, trad_dir):
     print(f"Extracting translations for {path}...")
-    extracted_name = "extracted_translation.json"
-    extracted_path = trad_dir + extracted_name
-
-    extract_cmd = (
+    extracted_path = trad_dir + "extracted_translation.json"
+    os.system(
         f"./node_modules/.bin/formatjs extract --out-file '{extracted_path}' '{path}**/*.{{js,tsx,ts}}' --format=simple"
     )
-    os.system(extract_cmd)
-
     extracted = json.load(open(extracted_path, encoding="utf8"))
-    print(f"Translations extracted {len(extracted)}")
+    print(f"Translations extracted: {len(extracted)}")
     return extracted
 
 
-# command to manually extract trad
-# ./node_modules/.bin/formatjs extract --out-file 'extracted.json' './hat/assets/js/apps/Iaso/**/*.[js]sx?' --format=simple
+def process_translations(path, previous_trad, missing_translations, missing_translations_keys):
+    trad_dir = path["translations_dir"]
+    extracted = extract_translations(path["source_files"], trad_dir)
+
+    for lang in ["en", "fr"]:
+        added_trad = 0
+        original_name = trad_dir + lang + ".json"
+        original = json.load(open(original_name, encoding="utf8"))
+        previous_trad_for_lang = previous_trad[lang]
+
+        for new_key, value in extracted.items():
+            if new_key.startswith("blsq") or new_key in previous_trad_for_lang:
+                continue
+            if new_key not in original:
+                added_trad += 1
+                missing_translations += 1
+                original[new_key] = value + " CHECKME"
+                missing_translations_keys.append(new_key)
+            elif "CHECKME" in original.get(new_key, ""):
+                missing_translations += 1
+
+        print(f"Translations added: {added_trad} for {lang}")
+        previous_trad_for_lang.update(original)
+
+        sorted_dict = OrderedDict(sorted(original.items(), key=lambda x: x[0].lower().replace("_", "!")))
+        with open(original_name, "w+", encoding="utf8") as f:
+            json.dump(sorted_dict, fp=f, indent=4, ensure_ascii=False)
+
+    return missing_translations
 
 
-# expect the "main" dir to be before the plugin
 paths = [
     {
         "source_files": "./hat/assets/js/apps/Iaso/",
         "translations_dir": "hat/assets/js/apps/Iaso/domains/app/translations/",
     },
-    {"source_files": "./plugins/polio/js/", "translations_dir": "plugins/polio/js/src/constants/translations/"},
+    {
+        "source_files": "./plugins/polio/js/",
+        "translations_dir": "plugins/polio/js/src/constants/translations/",
+    },
 ]
+
 if __name__ == "__main__":
-    if os.getcwd().endswith("scripts"):  # we are in the script directory, go up a level
+    if os.getcwd().endswith("scripts"):
         os.chdir("..")
 
     missing_translations = 0
-
     missing_translations_keys = []
-
-    # keep trace of what we set in previous traduction file. so we can detect properly
-    # if a plugin reuse a translation from the main file
     previous_trad: typing.DefaultDict[str, typing.Dict[str, str]]
     previous_trad = defaultdict(dict)
     for path in paths:
-        trad_dir = path["translations_dir"]
-        extracted = extract_translations(path["source_files"], trad_dir)
+        missing_translations = process_translations(
+            path, previous_trad, missing_translations, missing_translations_keys
+        )
 
-        added_trad = 0
-        for lang in ["en", "fr"]:
-            original_name = trad_dir + lang + ".json"
-            original = json.load(open(original_name, encoding="utf8"))
-            previous_trad_for_lang = previous_trad[lang]
-
-            for new_key, value in extracted.items():
-                if (
-                    new_key not in original.keys()
-                    and not new_key.startswith("blsq")
-                    and new_key not in previous_trad_for_lang
-                ):
-                    added_trad += 1
-                    missing_translations += 1
-                    # ADD CHECKME so we can see the new strings easily
-                    original[new_key] = value + " CHECKME"
-                    missing_translations_keys.append(new_key)
-                elif "CHECKME" in original.get(new_key, ""):
-                    missing_translations += 1
-
-            print(f"Translations added: {added_trad} for {lang}")
-            previous_trad_for_lang.update(original)
-            # somehow try to replicate VSCODE bizarre keys ordering
-            sorted_dict = OrderedDict(sorted(original.items(), key=lambda x: x[0].lower().replace("_", "!")))
-            with open(original_name, "w+", encoding="utf8") as file_write:
-                # ensure_ascii is necessary otherwise it didn't properly encode unicode, not sure why.
-                json.dump(sorted_dict, fp=file_write, indent=4, ensure_ascii=False)
     if missing_translations:
         print("Please translate the translation containing CHECKME and remove it.")
         for key in missing_translations_keys:


### PR DESCRIPTION
…o iaso

## What problem is this PR solving?

When the update_scripts run, the extracted translation from a plugin were being added to the iaso's extracted translation. This ticket is about fixing this issue.

### Related JIRA tickets

[IA-4642](https://bluesquare.atlassian.net/browse/IA-4642)

## Changes
- Moved the extractions processing into a helper function `process_translations`
- Changed the __main__ block to handle orchestration
- Fixed `added_trad` counter being shared across languages


## How to test

>Add a translation for a permission in polio, eg iaso.permissions.iaso_polio_whatever_permissions
>define a message that uses it
>make sure the translation exists for both en and fr
>run `./scripts/update_trads.py` 
 


Before the PR:
The script adds the translations in the iaso en.json and fr.json, then flags them as duplicate

After the PR:
No error and no missing translation found



## Print screen / video

Upload here print screens or videos showing the changes.

## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).


[IA-4642]: https://bluesquare.atlassian.net/browse/IA-4642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ