### PR TITLE
[IA-4897] make main org unit optional

### DIFF
--- a/setuper/README.md
+++ b/setuper/README.md
@@ -89,3 +89,9 @@ Once the script has run, you can log in to your server using the account name as
        You will need to add param `-n <name>`:
 
            python3 setuper.py -n ThisNameWasCarefullyChosen
+   
+   - If you want create a main org unit on the new account, 
+        
+       You will need to add param `--create_main_org_unit`:
+
+           python3 setuper.py --create_main_org_unit

--- a/setuper/setuper.py
+++ b/setuper/setuper.py
@@ -49,7 +49,7 @@ def admin_login(server_url, username, password):
     return iaso_admin_client
 
 
-def setup_account(account_name, server_url, username, password):
+def setup_account(account_name, server_url, username, password, create_main_org_unit):
     data = {
         "account_name": account_name,
         "user_username": account_name,
@@ -73,7 +73,7 @@ def setup_account(account_name, server_url, username, password):
             "SHOW_LINK_INSTANCE_REFERENCE",
             "ALLOW_CATCHMENT_EDITION",
         ],
-        "create_main_org_unit": True,
+        "create_main_org_unit": create_main_org_unit,
         "create_demo_form": True,
     }
     iaso_admin_client = admin_login(server_url, username, password)
@@ -113,10 +113,11 @@ def create_account(
     password: str,
     optional_account_name: str,
     additional_projects: bool,
+    create_main_org_unit: bool,
 ):
     account_name = validate_account_name(optional_account_name)
     print("Creating account:", account_name)
-    iaso_client = setup_account(account_name, server_url, username, password)
+    iaso_client = setup_account(account_name, server_url, username, password, create_main_org_unit)
     setup_orgunits(iaso_client=iaso_client)
     create_user_role(iaso_client)
 
@@ -158,6 +159,12 @@ if __name__ == "__main__":
     parser.add_argument("-s", "--server_url", type=str, help="Server URL")
     parser.add_argument("-n", "--name", help="Account name (max 147 characters; a-z, A-Z, 0-9)")
     parser.add_argument("-a", "--additional_projects", action="store_true")
+    # Added a new flag to control the creation of the main org unit
+    parser.add_argument(
+        "--create_main_org_unit",
+        action="store_true",
+        help="Flag to create the main organizational unit (default: False)",
+    )
 
     args = parser.parse_args()
     server_url = args.server_url
@@ -165,6 +172,7 @@ if __name__ == "__main__":
     password = args.password
     account_name = args.name
     additional_projects = args.additional_projects
+    create_main_org_unit = args.create_main_org_unit
 
     if server_url is None or username is None or password is None:
         from credentials import *
@@ -185,4 +193,4 @@ if __name__ == "__main__":
     if not server_url or not username or not password:
         sys.exit("ERROR: Values for server url, user name and password are all required")
 
-    create_account(server_url, username, password, account_name, additional_projects)
+    create_account(server_url, username, password, account_name, additional_projects, create_main_org_unit)


### PR DESCRIPTION
## What problem is this PR solving?

This ticket is about making the creation of the main org unit optional in the setuper

### Related JIRA tickets

[IA-4897](https://bluesquare.atlassian.net/browse/IA-4897)
## Changes

Just added `--create_main_org_unit` command line arg to control whether this field is active or not

## How to test
>Run the setuper with the new flag `--create_main_org_unit`
>Go to the Admin dashboard to check the orgunit types associated with the newly created account, you see `Main org uni type` with Depth: 0
> Run the setuper without the new flag
>Go to the Admin Dashboard to check the orgunit types associated with the newly created account, it should start with `COUNT` at Depth: `


## Print screen / video

Upload here print screens or videos showing the changes.

## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).


[IA-4897]: https://bluesquare.atlassian.net/browse/IA-4897?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ