### PR TITLE
[IA-4938]: smoke test for polio dashboards

### DIFF
--- a/hat/assets/js/__tests__/playwright/setup/setup.helpers.ts
+++ b/hat/assets/js/__tests__/playwright/setup/setup.helpers.ts
@@ -1,13 +1,11 @@
 import dotenv from 'dotenv';
 
 export function loadEnv(project: 'smoke' | 'e2e', required: Array<any>): void {
-  dotenv.config({ path: `.env.${project}` });
+    dotenv.config({ path: `.env.${project}` });
 
-  for (const key of required) {
-    if (!process.env[key]) {
-      throw new Error(
-        `Missing ${key} in .env.${project}`
-      );
+    for (const key of required) {
+        if (!process.env[key]) {
+            throw new Error(`Missing ${key} in .env.${project}`);
+        }
     }
-  }
 }

--- a/hat/assets/js/__tests__/playwright/smoke/example.test.ts
+++ b/hat/assets/js/__tests__/playwright/smoke/example.test.ts
@@ -1,17 +1,25 @@
 import { test, expect } from '@playwright/test';
 
-test('login page appears', async ({ page }) => {
-  await page.goto('');
+test.skip('login page appears', async ({ page }) => {
+    await page.goto('');
 
-  await expect(page).toHaveURL(`/login/?next=${encodeURIComponent('/dashboard/home/')}`)
-  await expect(page).toHaveTitle("IASO")
+    await expect(page).toHaveURL(
+        `/login/?next=${encodeURIComponent('/dashboard/home/')}`,
+    );
+    await expect(page).toHaveTitle('IASO');
 });
 
-test('login works', async({page}) => {
-  await page.goto(`/login/?next=${encodeURIComponent('/dashboard/home/')}`)
-  await page.fill('input[name="username"]', process.env?.LOGIN_USERNAME ?? '')
-  await page.fill('input[name="password"]', process.env?.LOGIN_PASSWORD ?? '')
-  await page.click('button[type="submit"]');
-  await expect(page).toHaveURL('/dashboard/setupAccount');
-  await expect(page).toHaveTitle(/Welcome/);
-})
+test.skip('login works', async ({ page }) => {
+    await page.goto(`/login/?next=${encodeURIComponent('/dashboard/home/')}`);
+    await page.fill(
+        'input[name="username"]',
+        process.env?.LOGIN_USERNAME ?? '',
+    );
+    await page.fill(
+        'input[name="password"]',
+        process.env?.LOGIN_PASSWORD ?? '',
+    );
+    await page.click('button[type="submit"]');
+    await expect(page).toHaveURL('/dashboard/setupAccount');
+    await expect(page).toHaveTitle(/Welcome/);
+});

--- a/hat/assets/js/__tests__/playwright/smoke/polioDashboards.test.ts
+++ b/hat/assets/js/__tests__/playwright/smoke/polioDashboards.test.ts
@@ -1,0 +1,187 @@
+import { test as base, expect } from '@playwright/test';
+import type { Page } from 'playwright-core';
+
+const SAVE_SCREENSHOTS = process.env?.SAVE_SMOKE_TEST_SCREENSHOT ?? false;
+const MONITOR_CONSOLE_ERRORS =
+    process.env?.SMOKE_TEST_MONITOR_CONSOLE_ERRORS ?? false;
+
+const expectNoErrors = async ({ page }: { page: Page }) => {
+    await expect(
+        page.locator('.error-container, .notistack-MuiContent-error'),
+    ).toHaveCount(0);
+    await expect(page.getByText('An exception occurred')).toHaveCount(0);
+};
+
+const openDashboard = async ({
+    page,
+    url,
+    title,
+}: {
+    page: Page;
+    url: string;
+    title: string;
+}) => {
+    await page.goto(url);
+    await page.waitForLoadState('networkidle');
+    await expect(page.getByRole('progressbar')).toHaveCount(0);
+    await expect(page).toHaveTitle(title);
+
+    await expectNoErrors({ page });
+};
+
+type Fixtures = {
+    errors: string[];
+};
+
+const test = base.extend<Fixtures>({
+    errors: [
+        async (
+            { page }: { page: Page },
+            use: (value: string[]) => Promise<void>,
+        ) => {
+            if (!MONITOR_CONSOLE_ERRORS) {
+                await use([]);
+                return;
+            }
+            const errors: string[] = [];
+
+            page.on('console', msg => {
+                if (msg.type() === 'error') {
+                    errors.push(msg.text());
+                }
+            });
+
+            page.on('pageerror', error => {
+                errors.push(error.message);
+            });
+
+            await use(errors);
+
+            if (errors.length > 0) {
+                throw new Error('Console/page errors:\n' + errors.join('\n'));
+            }
+        },
+        { auto: true },
+    ],
+});
+
+test.describe('polio dashboards', () => {
+    test.afterEach(async ({ page }, testInfo) => {
+        if (SAVE_SCREENSHOTS) {
+            await page.screenshot({
+                path: testInfo.outputPath(`screenshot.png`),
+                fullPage: true,
+            });
+        }
+    });
+
+    test('dashboard "calendar" is working', async ({ page }) => {
+        await openDashboard({
+            page,
+            url: 'https://staging.poliooutbreaks.com/dashboard/polio/embeddedCalendar/campaignType/polio/',
+            title: 'DEMO GPEI',
+        });
+
+        // check the tiles are rendered
+        await expect(page.locator('.leaflet-container')).toBeVisible();
+        await expect(page.locator('.leaflet-tile').first()).toBeVisible();
+        await expect(
+            page.locator('.leaflet-tile-loaded').first(),
+        ).toBeVisible();
+    });
+
+    test('dashboard "vaccine repository" is working', async ({ page }) => {
+        await openDashboard({
+            page,
+            url: 'https://staging.poliooutbreaks.com/dashboard/polio/embeddedVaccineRepository/',
+            title: 'DEMO GPEI',
+        });
+
+        // check that table is rendered with columns
+        expect(page.getByRole('table')).toBeVisible();
+
+        const columns = [
+            'Country',
+            'OBR Name',
+            'Round number(s)',
+            'Vaccine',
+            'Start date',
+            'VRF',
+            'Pre Alert',
+            'Form A',
+        ];
+
+        columns.forEach(column => {
+            expect(
+                page.getByRole('columnheader', { name: column }),
+            ).toBeVisible();
+        });
+    });
+
+    test('dashboard "vaccine stock" is working', async ({ page }) => {
+        await openDashboard({
+            page,
+            url: 'https://staging.poliooutbreaks.com/dashboard/polio/embeddedVaccineStock/',
+            title: 'DEMO GPEI',
+        });
+
+        // check some data
+        await expect(page.getByText('COUNTRY STOCK CARDS')).toBeVisible();
+
+        const columns = [
+            'Country',
+            'Vaccine',
+            'Date',
+            'Vials type',
+            'Action type',
+            'Action',
+            'Vials IN',
+            'Vials OUT',
+            'Doses IN',
+            'Doses OUT',
+        ];
+
+        columns.forEach(column => {
+            expect(
+                page.getByRole('columnheader', { name: column, exact: true }),
+            ).toBeVisible();
+        });
+    });
+
+    test('dashboard "LQAS country" is working', async ({ page }) => {
+        await openDashboard({
+            page,
+            url: 'https://staging.poliooutbreaks.com/dashboard/polio/embeddedLqasCountry/',
+            title: 'DEMO GPEI | LQAS',
+        });
+
+        // check the tiles are rendered and data
+        await expect(
+            page.getByRole('heading', { name: 'LQAS', exact: true }),
+        ).toBeVisible();
+        expect(await page.locator('.leaflet-container').count()).toBe(2);
+        expect(await page.locator('.leaflet-container').first()).toBeVisible();
+        expect(await page.locator('.leaflet-container').last()).toBeVisible();
+
+        await expect(page.locator('.leaflet-tile').first()).toBeVisible();
+        await expect(
+            page.locator('.leaflet-tile-loaded').first(),
+        ).toBeVisible();
+    });
+
+    test('dashboard "LQAS continent" is working', async ({ page }) => {
+        await openDashboard({
+            page,
+            url: 'https://staging.poliooutbreaks.com/dashboard/polio/embeddedLqasMap/',
+            title: 'DEMO GPEI | LQAS map',
+        });
+
+        // check data
+        await expect(
+            page.getByRole('heading', { name: 'LQAS map', exact: true }),
+        ).toBeVisible();
+        expect(await page.locator('.leaflet-container').count()).toBe(2);
+        await expect(page.locator('.leaflet-container').first()).toBeVisible();
+        await expect(page.locator('.leaflet-container').last()).toBeVisible();
+    });
+});

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
         "test:coverage": "vitest run --coverage --config vitest.config.ts",
         "test:smoke": "playwright test --project=smoke",
         "test:smoke:healthcheck": "playwright test --project=smoke healthcheck.test.ts",
+        "test:smoke:polio-dashboards": "playwright test --project=smoke polioDashboards.test.ts",
         "test:e2e": "playwright test --project=e2e",
         "build": "npm run webpack",
         "webpack": "webpack --config ./hat/webpack.dev.js",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -35,9 +35,6 @@ export default defineConfig({
         loadEnv('smoke', ['LOGIN_USERNAME', 'LOGIN_PASSWORD', 'GIT_TAG']);
         return {
           ...devices['Desktop Chrome'],
-          ...devices['Desktop Firefox'],
-          ...devices['Desktop Safari'],
-          ...devices['iPhone 12'],
           screenshot: 'only-on-failure'
         };
       })()
@@ -48,9 +45,6 @@ export default defineConfig({
       testMatch: '**/*.test.ts',
       use: {
         ...devices['Desktop Chrome'],
-        // ...devices['Desktop Firefox'],
-        // ...devices['Desktop Safari'],
-        // ...devices['iPhone 12'],
         screenshot: 'only-on-failure'
       },
     }


### PR DESCRIPTION
## What problem is this PR solving?

Writing smoke automatic tests for polio dashboards

### Related JIRA tickets

IA-4938

## Changes

* Adapted playwright config
* Skipped example tests
* Wrote smoke tests for polioDashboards

## How to test

run the command `npm run test:smoke:polio-dashboards`

in your .env.smoke file, you can set two options : 

* SAVE_SMOKE_TEST_SCREENSHOT=boolean
* SMOKE_TEST_MONITOR_CONSOLE_ERRORS=boolean

SAVE_SMOKE_TEST_SCREENSHOT: If set to true, the smoke tests will take a screenshot of the visited pages
SMOKE_TEST_MONITOR_CONSOLE_ERRORS: If set to true, the smoke tests will monitor for any console.error output in the visited pages and fail if any are found. 

