### PR TITLE
[IA-4839]: add option to clear phone field in User dialogs

### DIFF
--- a/hat/assets/js/apps/Iaso/components/forms/InputComponent.a11y.test.tsx
+++ b/hat/assets/js/apps/Iaso/components/forms/InputComponent.a11y.test.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { faker } from '@faker-js/faker';
+import { act, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event/dist/cjs/index.js';
+import { axe } from 'jest-axe';
+import { IntlProvider } from 'react-intl';
+import InputComponent from 'Iaso/components/forms/InputComponent';
+import { renderWithTheme } from '../../../../tests/helpers';
+
+const Wrapper = () => {
+    const [value, setValue] = React.useState(null);
+    return (
+        <InputComponent
+            type={'phone'}
+            keyValue={'phone'}
+            value={value}
+            onChange={(key, newValue) => setValue(newValue)}
+            label={{ id: 'test', defaultMessage: 'phone' }}
+            phoneInputOptions={{
+                countryCodeEditable: true,
+            }}
+        />
+    );
+};
+
+describe('Phone InputComponent accessibility', () => {
+    it('has no accessibility violations', async () => {
+        const { container } = renderWithTheme(
+            <IntlProvider locale={'en'} messages={{}}>
+                <Wrapper />
+            </IntlProvider>,
+        );
+
+        const user = userEvent.setup();
+
+        const randomBelgianNumber = faker.helpers.fromRegExp('+3265[0-9]{6}');
+
+        await act(async () => {
+            await user.type(
+                screen.getByRole('textbox', { name: 'phone' }),
+                randomBelgianNumber,
+            );
+        });
+
+        expect(screen.getByTitle('Belgium: + 32')).toBeVisible();
+        expect(screen.getByRole('textbox', { name: 'phone' })).toHaveValue(
+            randomBelgianNumber,
+        );
+
+        const results = await axe(container);
+
+        expect(results).toHaveNoViolations();
+    });
+});

--- a/hat/assets/js/apps/Iaso/components/forms/InputComponent.test.tsx
+++ b/hat/assets/js/apps/Iaso/components/forms/InputComponent.test.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { faker } from '@faker-js/faker';
+import { act, waitFor } from '@testing-library/react';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { IntlProvider } from 'react-intl';
+import InputComponent from 'Iaso/components/forms/InputComponent';
+import { renderWithTheme } from '../../../../tests/helpers';
+
+const Wrapper = () => {
+    const [value, setValue] = React.useState(null);
+    return (
+        <InputComponent
+            type={'phone'}
+            keyValue={'phone'}
+            value={value}
+            onChange={(key, newValue) => setValue(newValue)}
+            label={{ id: 'test', defaultMessage: 'phone' }}
+            phoneInputOptions={{
+                countryCodeEditable: true,
+            }}
+        />
+    );
+};
+
+describe('Phone InputComponent', () => {
+    it('clears the whole field and dropdown when countryCodeEditable is set to true', async () => {
+        renderWithTheme(
+            <IntlProvider locale={'en'} messages={{}}>
+                <Wrapper />
+            </IntlProvider>,
+        );
+
+        const user = userEvent.setup();
+
+        const randomBelgianNumber = faker.helpers.fromRegExp('+3265[0-9]{6}');
+
+        await act(async () => {
+            await user.type(
+                screen.getByRole('textbox', { name: 'phone' }),
+                randomBelgianNumber,
+            );
+        });
+
+        expect(screen.getByTitle('Belgium: + 32')).toBeVisible();
+        expect(screen.getByRole('textbox', { name: 'phone' })).toHaveValue(
+            randomBelgianNumber,
+        );
+
+        await act(async () => {
+            await user.clear(screen.getByRole('textbox', { name: 'phone' }));
+        });
+
+        await waitFor(() => {
+            expect(screen.getByRole('textbox', { name: 'phone' })).toHaveValue(
+                '',
+            );
+        });
+    });
+
+    it('leaves the whole field and dropdown when countryCodeEditable is set to true', async () => {
+        renderWithTheme(
+            <IntlProvider locale={'en'} messages={{}}>
+                <Wrapper />
+            </IntlProvider>,
+        );
+
+        const user = userEvent.setup();
+
+        const randomBelgianNumber = faker.helpers.fromRegExp('+3265[0-9]{6}');
+
+        await act(async () => {
+            await user.type(
+                screen.getByRole('textbox', { name: 'phone' }),
+                randomBelgianNumber,
+            );
+        });
+
+        expect(screen.getByTitle('Belgium: + 32')).toBeVisible();
+        expect(screen.getByRole('textbox', { name: 'phone' })).toHaveValue(
+            randomBelgianNumber,
+        );
+
+        await act(async () => {
+            await user.clear(screen.getByRole('textbox', { name: 'phone' }));
+        });
+
+        await waitFor(() => {
+            expect(screen.getByRole('textbox', { name: 'phone' })).toHaveValue(
+                '',
+            );
+        });
+
+        // todo: bugged here, comes from the lib that isn't updated
+        // expect(screen.getByTitle('Belgium: + 32')).not.toBeVisible();
+    });
+});

--- a/hat/assets/js/apps/Iaso/components/forms/InputComponent.tsx
+++ b/hat/assets/js/apps/Iaso/components/forms/InputComponent.tsx
@@ -63,7 +63,11 @@ export type InputComponentProps = {
     keyValue: string;
     value?: any;
     errors?: string[];
-    onChange?: (key: string, value: any, countryData?: BaseCountryData) => void;
+    onChange?: (
+        key: string | null,
+        value: any,
+        countryData?: BaseCountryData,
+    ) => void;
     onBlur?: FocusEventHandler<HTMLInputElement | HTMLTextAreaElement>;
     onFocus?:
         | FocusEventHandler<HTMLInputElement | HTMLTextAreaElement>

--- a/hat/assets/js/apps/Iaso/domains/users/components/UsersInfos.tsx
+++ b/hat/assets/js/apps/Iaso/domains/users/components/UsersInfos.tsx
@@ -1,14 +1,10 @@
 import React, { FunctionComponent, useCallback } from 'react';
 import { Alert, Box, Grid } from '@mui/material';
-import {
-    useSafeIntl,
-    InputWithInfos,
-    BaseCountryData,
-} from 'bluesquare-components';
+import { useSafeIntl, InputWithInfos } from 'bluesquare-components';
 import isEmpty from 'lodash/isEmpty';
+import { SxStyles } from 'Iaso/types/general';
+import { useCurrentUser } from 'Iaso/utils/usersUtils';
 import InputComponent from '../../../components/forms/InputComponent';
-import { SxStyles } from '../../../types/general';
-import { useCurrentUser } from '../../../utils/usersUtils';
 import { useAppLocales } from '../../app/constants';
 
 import { useSavePassword } from '../hooks/useSavePassword';
@@ -196,6 +192,7 @@ export const UsersInfos: FunctionComponent<Props> = ({
                         phoneInputOptions={{
                             country:
                                 currentUser.country_code?.value ?? undefined,
+                            countryCodeEditable: true,
                         }}
                         label={MESSAGES.phoneNumber}
                     />


### PR DESCRIPTION
## What problem is this PR solving?

Phone field in user dialogs could not be cleared fully

### Related JIRA tickets

IA-4839

## Changes

* Added countryCodeEditable option to InputComponent
* Added tests to InputComponent


## How to test

Go to /dashboard/settings/users/management/ , when creating and/or editing a user, you should be able to clear the phone field if you want to. 

## Notes

* The flag option dropdown doesn't get cleared out because  of the main library that isn't updated in bluesquare-components 

