### PR TITLE
POLIO-2120: add styling for cmp with on hold rnd

### DIFF
--- a/plugins/polio/api/calendar/serializers.py
+++ b/plugins/polio/api/calendar/serializers.py
@@ -64,6 +64,7 @@ class ListRoundSerializer(RoundSerializer):
             "vaccine_names",
             "target_population",
             "is_planned",
+            "on_hold",
         ]
 
 

--- a/plugins/polio/js/src/constants/types.ts
+++ b/plugins/polio/js/src/constants/types.ts
@@ -232,6 +232,7 @@ type CalendarRound = {
     target_population: Nullable<number>;
     vaccine_names: string;
     is_planned: boolean;
+    on_hold: boolean;
 };
 
 export type CalendarSubActivity = {

--- a/plugins/polio/js/src/domains/Calendar/campaignCalendar/utils/campaigns.ts
+++ b/plugins/polio/js/src/domains/Calendar/campaignCalendar/utils/campaigns.ts
@@ -245,7 +245,7 @@ export const mapCampaigns = (
             original: c,
             isPreventive: c.is_preventive,
             isTest: c.is_test,
-            onHold: c.on_hold,
+            onHold: c.on_hold || Boolean(rounds.find(rnd => rnd.on_hold)),
             isPlanned: c.is_planned,
             separateScopesPerRound: c.separate_scopes_per_round,
             scopes: c.scopes,

--- a/plugins/polio/tests/api/calendar/test_campaign_calendar_v2.py
+++ b/plugins/polio/tests/api/calendar/test_campaign_calendar_v2.py
@@ -113,6 +113,7 @@ class CampaignCalendarV2TestCase(APITestCase, PolioTestCaseMixin):
             self.assertEqual(rnd["started_at"], ref_round.started_at.strftime("%Y-%m-%d"))
             self.assertEqual(rnd["ended_at"], ref_round.ended_at.strftime("%Y-%m-%d"))
             self.assertEqual(rnd["id"], ref_round.pk)
+            self.assertEqual(rnd["on_hold"], ref_round.on_hold)
 
         round1 = rounds[0]
         round2 = rounds[1]


### PR DESCRIPTION
## What problem is this PR solving?

Styling was missing for campaigns witha round on hold, though they are considered "fully" on hold

### Related JIRA tickets

POLIO-2120

## Changes

Explain the changes that were made.

- Add `on_hold` to fields returned by `ListRoundSerializer`
- Update tests
- use `round.on_hold` to format styling

## How to test

Explain how to test your PR.
On a polio DB: 
- make sureto have a campaign with a round on hold
- go to campaign calendar
- make sure to display the dates of your campaign
- filter campaign category: on hold
- The campaign should appear and the rounds should have the red dots styling

## Print screen / video

<img width="1702" height="1282" alt="Screenshot 2026-04-08 at 12 18 59" src="https://github.com/user-attachments/assets/cb972ae7-82b6-44aa-b40a-a718a2ad8183" />



