### PR TITLE
POLIO-2111: remove unused fields

### DIFF
--- a/plugins/polio/api/vaccines/supply_chain.py
+++ b/plugins/polio/api/vaccines/supply_chain.py
@@ -575,8 +575,6 @@ class VaccineRequestFormDetailSerializer(ModelWithFileSerializer):
             "date_vrf_submission_to_orpg",
             "quantities_approved_by_orpg_in_doses",
             "date_rrt_orpg_approval",
-            "date_vrf_submitted_to_dg",
-            "quantities_approved_by_dg_in_doses",
             "comment",
             "country_name",
             "country_id",

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/VaccineRequestForm/VaccineRequestForm.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/VaccineRequestForm/VaccineRequestForm.tsx
@@ -288,32 +288,24 @@ export const VaccineRequestForm: FunctionComponent<Props> = ({
                                 </Grid>
                             </Grid>
                             <Grid container item xs={12} spacing={2}>
+                                <Grid item xs={12} lg={6}>
+                                    <InputComponent
+                                        type="textarea"
+                                        keyValue="vrf.comment"
+                                        value={values?.vrf?.comment ?? ''}
+                                        // errors={errors.comment ? errors.comment : []}
+                                        label={MESSAGES.comments}
+                                        onChange={onCommentChange}
+                                        disabled={isFieldDisabledEdit(vrfData)}
+                                        withMarginTop={false}
+                                    />
+                                </Grid>
                                 <Grid item xs={6} md={3}>
                                     <Field
                                         label={formatMessage(
                                             MESSAGES.date_vrf_submission_dg,
                                         )}
                                         name="vrf.date_vrf_submitted_to_dg"
-                                        component={DateInput}
-                                        disabled={isFieldDisabledEdit(vrfData)}
-                                    />
-                                </Grid>
-                                <Grid item xs={6} md={3}>
-                                    <Field
-                                        label={formatMessage(
-                                            MESSAGES.quantities_approved_by_dg_in_doses,
-                                        )}
-                                        name="vrf.quantities_approved_by_dg_in_doses"
-                                        component={NumberInput}
-                                        disabled={isFieldDisabledEdit(vrfData)}
-                                    />
-                                </Grid>
-                                <Grid item xs={6} md={3}>
-                                    <Field
-                                        label={formatMessage(
-                                            MESSAGES.date_dg_approval,
-                                        )}
-                                        name="vrf.date_dg_approval"
                                         component={DateInput}
                                         disabled={isFieldDisabledEdit(vrfData)}
                                     />
@@ -350,7 +342,7 @@ export const VaccineRequestForm: FunctionComponent<Props> = ({
                                     </Box>
                                 </Grid>
                             </Grid>
-                            <Grid container item xs={12} spacing={2}>
+                            {/* <Grid container item xs={12} spacing={2}>
                                 <Grid item xs={12} lg={6}>
                                     <InputComponent
                                         type="textarea"
@@ -363,7 +355,7 @@ export const VaccineRequestForm: FunctionComponent<Props> = ({
                                         withMarginTop={false}
                                     />
                                 </Grid>
-                            </Grid>
+                            </Grid> */}
                         </>
                     )}
                 </Grid>

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/VaccineRequestForm/VaccineRequestForm.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/Details/VaccineRequestForm/VaccineRequestForm.tsx
@@ -342,20 +342,6 @@ export const VaccineRequestForm: FunctionComponent<Props> = ({
                                     </Box>
                                 </Grid>
                             </Grid>
-                            {/* <Grid container item xs={12} spacing={2}>
-                                <Grid item xs={12} lg={6}>
-                                    <InputComponent
-                                        type="textarea"
-                                        keyValue="vrf.comment"
-                                        value={values?.vrf?.comment ?? ''}
-                                        // errors={errors.comment ? errors.comment : []}
-                                        label={MESSAGES.comments}
-                                        onChange={onCommentChange}
-                                        disabled={isFieldDisabledEdit(vrfData)}
-                                        withMarginTop={false}
-                                    />
-                                </Grid>
-                            </Grid> */}
                         </>
                     )}
                 </Grid>

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/types.ts
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/types.ts
@@ -1,5 +1,5 @@
-import { FormikProps } from 'formik';
 import React from 'react';
+import { FormikProps } from 'formik';
 import { UseMutateAsyncFunction } from 'react-query';
 import {
     DropdownOptions,
@@ -27,8 +27,8 @@ export type VRF = {
     date_vrf_submission_orpg?: string; // date in string form
     quantities_approved_by_orpg_in_doses?: number;
     date_rrt_orpg_approval?: string; // date in string form
-    date_vrf_submitted_to_dg?: string; // date in string form
-    quantities_approved_by_dg_in_doses?: number;
+    // date_vrf_submitted_to_dg?: string; // date in string form
+    // quantities_approved_by_dg_in_doses?: number;
     date_dg_approval?: string; // date in string form
     target_population?: number;
     comments?: string;

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/types.ts
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/types.ts
@@ -27,9 +27,7 @@ export type VRF = {
     date_vrf_submission_orpg?: string; // date in string form
     quantities_approved_by_orpg_in_doses?: number;
     date_rrt_orpg_approval?: string; // date in string form
-    // date_vrf_submitted_to_dg?: string; // date in string form
-    // quantities_approved_by_dg_in_doses?: number;
-    date_dg_approval?: string; // date in string form
+    date_vrf_submitted_to_dg?: string; // date in string form
     target_population?: number;
     comments?: string;
     vrf_type: 'Normal' | 'Missing' | 'Not Required';


### PR DESCRIPTION
## What problem is this PR solving?

Vaccine request form details has too many fields, client asked to remove 2

### Related JIRA tickets

POLIO-2111

## Changes

- Remove fields and reorder form in `VaccineRequestForm`
- Remove fields from API response

## How to test

Go to Vaccine Module > Supply chain > Vaccine Request form: fields `quantities_approved_by_dg_in_doses` and `date_vrf_submitted_to_dg` should be absent from both UI and API response

## Print screen / video

<img width="2694" height="1282" alt="Screenshot 2026-04-08 at 12 46 34" src="https://github.com/user-attachments/assets/2078d95d-2411-4ff8-92d6-2e5b8960291b" />

