### PR TITLE
POLIO-2119: fix filter bug

### DIFF
--- a/plugins/polio/js/src/domains/Calendar/campaignCalendar/CampaignsFilters.tsx
+++ b/plugins/polio/js/src/domains/Calendar/campaignCalendar/CampaignsFilters.tsx
@@ -115,7 +115,11 @@ export const CampaignsFilters: FunctionComponent<Props> = ({
                     undefined,
                 page: undefined,
                 campaignType,
-                campaignCategory,
+                campaignCategory: campaignCategory ?? 'all',
+                on_hold:
+                    campaignCategory === 'all' || campaignCategory === 'on_hold'
+                        ? 'true'
+                        : 'false',
                 showOnlyDeleted: showOnlyDeleted ? 'true' : undefined,
                 show_test: hideTest ? 'false' : 'true',
                 campaignGroups,
@@ -124,6 +128,7 @@ export const CampaignsFilters: FunctionComponent<Props> = ({
                 periodType: params?.periodType,
                 showIntegrated: showIntegrated ? 'true' : 'false',
             };
+
             redirectToReplace(redirectUrl, urlParams);
         }
     }, [


### PR DESCRIPTION
## What problem is this PR solving?
Sometimes when using the campaign filters, on hold campaigns disappear with no apparent reason

### Related JIRA tickets

POLIO-2119

## Changes
- The bug was appeared with `cxampaign category` filter:
    - When the filter was left empty, it would send `campaign_category=all&on_hold=false` to the backend
    - When the filter actively selected `all`, it would send `campaign_category=all&on_hold=true`
    - The fix forces the right value to `on_hold` (Front-end)

## How to test

Go to polio > Campaigns > find a campaign with a round on hold 
- Filter on the campaign country, with no filter on category: the campaign should appear (add a search by obr name for easier parsing of results)
- Same with category == all --> same result expected
- category== on_hold --> only on hold
- category == regular || planned || preventive --> the campaign should not appear in the results

## Print screen / video

https://github.com/user-attachments/assets/34b0eadf-9506-4e77-b0a6-75a849abf5b1


## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?


