### PR TITLE
[IA-4951]Setting the updated name on the group object before saving

### DIFF
--- a/iaso/api/user_roles.py
+++ b/iaso/api/user_roles.py
@@ -92,6 +92,7 @@ class UserRoleSerializer(serializers.ModelSerializer):
                 permission = get_object_or_404(Permission, codename__startswith="iaso_", codename=permission_codename)
                 group.permissions.add(permission)
 
+        group.name = group_name
         group.save()
         user_role.save()
         user_role.editable_org_unit_types.set(editable_org_unit_types)

--- a/iaso/tests/api/test_user_roles.py
+++ b/iaso/tests/api/test_user_roles.py
@@ -169,6 +169,7 @@ class UserRoleAPITestCase(APITestCase):
         r = self.assertJSONResponse(response, 200)
         expected_name = self.user_role.group.name.removeprefix(f"{self.account.id}_")
         self.assertEqual(r["name"], expected_name)
+        self.assertEqual(self.group.name, f"{self.account.id}_user role modified")
 
     def test_partial_update_permissions_modification(self):
         self.client.force_authenticate(self.user)


### PR DESCRIPTION
## What problem is this PR solving?

When updating the name of the user role, IASO showed a sucess message but the name didn't update. This PR is about fixing it

### Related JIRA tickets

[IA-4951](https://bluesquare.atlassian.net/browse/IA-4951)

## Changes

Added one line to set the update name on the group object.



## How to test

> Go to User role page
> Update the name of an existing user role
> The name should be updated correctly

If a specific config is required explain it here: dataset, account, profile, etc.

## Print screen / video


https://github.com/user-attachments/assets/1e1b7908-d059-4119-ac2e-c3c670bfb0d9



## Notes

Things that the reviewers should know:

While resolving the ticket, I found these duplicates issues: 
<img width="946" height="184" alt="image" src="https://github.com/user-attachments/assets/e3722df2-9b49-496d-ba3d-f7fcbcfb3be7" />

This performance issue could be resolved by removing the `get_object_or_404` that fetchs each permission one by one and implement a check that fetchs all the permissions at once. The same issue is present in the Post Request. 
Let me know if it should stay like this or needs to be optimized knowing that the invalid permissions would return 400 listing all invalid values and could be dangerous for any client relying on a 404 response

The result of the optimization would look like this: 
<img width="937" height="197" alt="image" src="https://github.com/user-attachments/assets/bb7fc466-ac65-435a-830f-dbae38cb01c4" />


## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).


[IA-4951]: https://bluesquare.atlassian.net/browse/IA-4951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ