### PR TITLE
[IA-4958]: Permission issue in planning API

### DIFF
--- a/iaso/api/microplanning/views.py
+++ b/iaso/api/microplanning/views.py
@@ -15,6 +15,7 @@ from hat.audit.audit_mixin import AuditMixin
 from hat.audit.models import Modification
 from iaso.api.common import (
     DeletionFilterBackend,
+    HasPermission,
     ModelViewSet,
     ReadOnlyOrHasPermission,
 )
@@ -97,7 +98,7 @@ class PlanningOrgunitsViewSet(AuditMixin, ViewSet):
 @extend_schema(tags=["Micro plannings", "Plannings"])
 class PlanningViewSet(AuditMixin, ModelViewSet):
     remove_results_key_if_paginated = True
-    permission_classes = [AuthenticationEnforcedPermission, ReadOnlyOrHasPermission(CORE_PLANNING_WRITE_PERMISSION)]  # type: ignore
+    permission_classes = [AuthenticationEnforcedPermission, HasPermission(CORE_PLANNING_WRITE_PERMISSION)]  # type: ignore
     queryset = Planning.objects.all()
     filter_backends = [
         filters.OrderingFilter,

--- a/iaso/tests/api/microplanning/test_microplanning.py
+++ b/iaso/tests/api/microplanning/test_microplanning.py
@@ -30,9 +30,9 @@ class PlanningTestCase(APITestCase):
         cls.team1 = Team.objects.create(project=project1, name="team1", manager=user)
         Team.objects.create(project=project2, name="team2", manager=user)
         other_account = Account.objects.create(name="other account")
-        other_user = cls.create_user_with_profile(username="user", account=other_account)
+        cls.other_user = cls.create_user_with_profile(username="user", account=other_account)
         cls.other_project = other_account.project_set.create(name="other_project")
-        cls.other_team = Team.objects.create(name="other team", project=cls.other_project, manager=other_user)
+        cls.other_team = Team.objects.create(name="other team", project=cls.other_project, manager=cls.other_user)
         source = DataSource.objects.create(name="Evil Empire")
         source.projects.add(project1)
         version = SourceVersion.objects.create(data_source=source, number=1)
@@ -58,6 +58,14 @@ class PlanningTestCase(APITestCase):
         self.assertEqual(len(r), 1)
 
     maxDiff = None
+
+    def test_permissions(self):
+        res = self.client.get("/api/microplanning/plannings/")
+        self.assertEqual(res.status_code, status.HTTP_401_UNAUTHORIZED)
+
+        self.client.force_authenticate(self.other_user)
+        res = self.client.get("/api/microplanning/plannings/")
+        self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_query_id(self):
         self.client.force_authenticate(self.user)

--- a/iaso/tests/api/microplanning/test_microplanning.py
+++ b/iaso/tests/api/microplanning/test_microplanning.py
@@ -50,8 +50,12 @@ class PlanningTestCase(APITestCase):
             ended_at="2025-01-10",
         )
 
+        cls.user_with_perms = cls.create_user_with_profile(
+            username="user_with_perms", account=cls.account, permissions=[CORE_PLANNING_WRITE_PERMISSION]
+        )
+
     def test_query_happy_path(self):
-        self.client.force_authenticate(self.user)
+        self.client.force_authenticate(self.user_with_perms)
         with self.assertNumQueries(5):
             response = self.client.get("/api/microplanning/plannings/", format="json")
         r = self.assertJSONResponse(response, 200)
@@ -68,7 +72,7 @@ class PlanningTestCase(APITestCase):
         self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_query_id(self):
-        self.client.force_authenticate(self.user)
+        self.client.force_authenticate(self.user_with_perms)
         id = self.planning.id
         response = self.client.get(f"/api/microplanning/plannings/{id}/", format="json")
         r = self.assertJSONResponse(response, 200)
@@ -109,7 +113,7 @@ class PlanningTestCase(APITestCase):
 
     def test_query_id_includes_assignments_count(self):
         """Test that planning detail response includes assignments_count."""
-        self.client.force_authenticate(self.user)
+        self.client.force_authenticate(self.user_with_perms)
         # Planning has no assignments by default
         response = self.client.get(f"/api/microplanning/plannings/{self.planning.id}/", format="json")
         r = self.assertJSONResponse(response, 200)
@@ -181,10 +185,8 @@ class PlanningTestCase(APITestCase):
             org_unit=self.org_unit,
             team=self.team1,
         )
-        user_with_perms = self.create_user_with_profile(
-            username="user_with_perms", account=self.account, permissions=[CORE_PLANNING_WRITE_PERMISSION]
-        )
-        self.client.force_authenticate(user_with_perms)
+
+        self.client.force_authenticate(self.user_with_perms)
         data = {
             "name": "My Planning",
             "forms": [self.form1.id, self.form2.id],
@@ -213,10 +215,7 @@ class PlanningTestCase(APITestCase):
             org_unit=self.org_unit,
             team=self.team1,
         )
-        user_with_perms = self.create_user_with_profile(
-            username="user_with_perms", account=self.account, permissions=[CORE_PLANNING_WRITE_PERMISSION]
-        )
-        self.client.force_authenticate(user_with_perms)
+        self.client.force_authenticate(self.user_with_perms)
         data = {
             "name": "My Planning",
             "forms": [self.form1.id, self.form2.id],
@@ -237,10 +236,7 @@ class PlanningTestCase(APITestCase):
             org_unit=self.org_unit,
             team=self.team1,
         )
-        user_with_perms = self.create_user_with_profile(
-            username="user_with_perms", account=self.account, permissions=[CORE_PLANNING_WRITE_PERMISSION]
-        )
-        self.client.force_authenticate(user_with_perms)
+        self.client.force_authenticate(self.user_with_perms)
         data = {
             "name": "My Planning",
             "forms": [self.form1.id, self.form2.id],
@@ -255,10 +251,7 @@ class PlanningTestCase(APITestCase):
         self.assertEqual(r["ended_at"][0], "publishedWithoutEndDate")
 
     def test_create_api(self):
-        user_with_perms = self.create_user_with_profile(
-            username="user_with_perms", account=self.account, permissions=[CORE_PLANNING_WRITE_PERMISSION]
-        )
-        self.client.force_authenticate(user_with_perms)
+        self.client.force_authenticate(self.user_with_perms)
         data = {
             "name": "My Planning",
             "org_unit": self.org_unit.id,
@@ -351,7 +344,7 @@ class PlanningTestCase(APITestCase):
         self.planning.save()
 
         # Authenticate user and test GET request
-        self.client.force_authenticate(self.user)
+        self.client.force_authenticate(self.user_with_perms)
         response = self.client.get(f"/api/microplanning/plannings/{self.planning.id}/", format="json")
         self.assertEqual(response.status_code, 200)
         r = response.json()
@@ -360,10 +353,7 @@ class PlanningTestCase(APITestCase):
 
     def test_planning_api_create_with_pipeline_uuids(self):
         """Test creating planning via API with pipeline_uuids."""
-        user_with_perms = self.create_user_with_profile(
-            username="user_with_perms", account=self.account, permissions=[CORE_PLANNING_WRITE_PERMISSION]
-        )
-        self.client.force_authenticate(user_with_perms)
+        self.client.force_authenticate(self.user_with_perms)
 
         test_uuids = ["60fcb048-a5f6-4a79-9529-1ccfa55e75d1", "70fcb048-a5f6-4a79-9529-1ccfa55e75d2"]
 
@@ -388,10 +378,7 @@ class PlanningTestCase(APITestCase):
 
     def test_planning_api_patch_with_pipeline_uuids(self):
         """Test updating planning via API with pipeline_uuids."""
-        user_with_perms = self.create_user_with_profile(
-            username="user_with_perms", account=self.account, permissions=[CORE_PLANNING_WRITE_PERMISSION]
-        )
-        self.client.force_authenticate(user_with_perms)
+        self.client.force_authenticate(self.user_with_perms)
 
         test_uuids = ["60fcb048-a5f6-4a79-9529-1ccfa55e75d1", "70fcb048-a5f6-4a79-9529-1ccfa55e75d2"]
 
@@ -422,10 +409,7 @@ class PlanningTestCase(APITestCase):
             version=version, name="Child Health Post", org_unit_type=org_unit_type, parent=root_org_unit
         )
 
-        user_with_perms = self.create_user_with_profile(
-            username="user_with_perms", account=self.account, permissions=[CORE_PLANNING_WRITE_PERMISSION]
-        )
-        self.client.force_authenticate(user_with_perms)
+        self.client.force_authenticate(self.user_with_perms)
 
         data = {
             "name": "Planning with Target Type",
@@ -505,10 +489,7 @@ class PlanningTestCase(APITestCase):
             org_unit=root_org_unit,
         )
 
-        user_with_perms = self.create_user_with_profile(
-            username="user_with_perms", account=self.account, permissions=[CORE_PLANNING_WRITE_PERMISSION]
-        )
-        self.client.force_authenticate(user_with_perms)
+        self.client.force_authenticate(self.user_with_perms)
 
         data = {
             "target_org_unit_types": [org_unit_type.id],
@@ -528,10 +509,7 @@ class PlanningTestCase(APITestCase):
         org_unit_type = OrgUnitType.objects.create(name="Wrong Project Type")
         org_unit_type.projects.add(self.project2)
 
-        user_with_perms = self.create_user_with_profile(
-            username="user_with_perms", account=self.account, permissions=[CORE_PLANNING_WRITE_PERMISSION]
-        )
-        self.client.force_authenticate(user_with_perms)
+        self.client.force_authenticate(self.user_with_perms)
 
         data = {
             "name": "Planning with Wrong Target Type",
@@ -586,14 +564,11 @@ class PlanningTestCase(APITestCase):
         self.assertJSONResponse(response, 401)
 
     def test_planning_sampling_results_create(self):
-        user_with_perms = self.create_user_with_profile(
-            username="sampling_user", account=self.account, permissions=[CORE_PLANNING_WRITE_PERMISSION]
-        )
-        self.client.force_authenticate(user_with_perms)
+        self.client.force_authenticate(self.user_with_perms)
         task = Task.objects.create(
             name="sampling-create",
             account=self.account,
-            created_by=user_with_perms,
+            created_by=self.user_with_perms,
         )
         group = Group.objects.create(name="Sampling group", source_version=self.org_unit.version)
         group.org_units.add(self.org_unit)
@@ -611,7 +586,7 @@ class PlanningTestCase(APITestCase):
         data = self.assertJSONResponse(response, 201)
         sampling = PlanningSamplingResult.objects.get(id=data["id"])
         self.assertEqual(sampling.pipeline_id, "pipeline-2")
-        self.assertEqual(sampling.created_by, user_with_perms)
+        self.assertEqual(sampling.created_by, self.user_with_perms)
         self.assertEqual(sampling.task, task)
         self.assertEqual(data["group_details"]["org_unit_count"], 1)
         self.assertIsInstance(data["created_at"], float)
@@ -661,17 +636,14 @@ class PlanningTestCase(APITestCase):
         self.assertJSONResponse(response, 403)
 
     def test_planning_patch_sets_selected_sampling_result(self):
-        user_with_perms = self.create_user_with_profile(
-            username="user_with_perms", account=self.account, permissions=[CORE_PLANNING_WRITE_PERMISSION]
-        )
-        self.client.force_authenticate(user_with_perms)
+        self.client.force_authenticate(self.user_with_perms)
         sampling = PlanningSamplingResult.objects.create(
             planning=self.planning,
             pipeline_id="pipeline-detail",
             pipeline_version="v1",
             pipeline_name="detail run",
             parameters={"limit": 5},
-            created_by=user_with_perms,
+            created_by=self.user_with_perms,
         )
 
         response = self.client.patch(
@@ -687,17 +659,14 @@ class PlanningTestCase(APITestCase):
         self.assertEqual(r["selected_sampling_result"]["pipeline_id"], "pipeline-detail")
 
     def test_planning_patch_keeps_selected_sampling_result_when_field_absent(self):
-        user_with_perms = self.create_user_with_profile(
-            username="user_with_perms", account=self.account, permissions=[CORE_PLANNING_WRITE_PERMISSION]
-        )
-        self.client.force_authenticate(user_with_perms)
+        self.client.force_authenticate(self.user_with_perms)
         sampling = PlanningSamplingResult.objects.create(
             planning=self.planning,
             pipeline_id="pipeline-keep",
             pipeline_version="v1",
             pipeline_name="keep run",
             parameters={"limit": 1},
-            created_by=user_with_perms,
+            created_by=self.user_with_perms,
         )
         self.planning.selected_sampling_result = sampling
         self.planning.save()
@@ -714,17 +683,14 @@ class PlanningTestCase(APITestCase):
         self.assertEqual(r["selected_sampling_result"]["id"], sampling.id)
 
     def test_planning_patch_unsets_selected_sampling_result_with_null(self):
-        user_with_perms = self.create_user_with_profile(
-            username="user_with_perms", account=self.account, permissions=[CORE_PLANNING_WRITE_PERMISSION]
-        )
-        self.client.force_authenticate(user_with_perms)
+        self.client.force_authenticate(self.user_with_perms)
         sampling = PlanningSamplingResult.objects.create(
             planning=self.planning,
             pipeline_id="pipeline-clear",
             pipeline_version="v1",
             pipeline_name="clear run",
             parameters={"limit": 2},
-            created_by=user_with_perms,
+            created_by=self.user_with_perms,
         )
         self.planning.selected_sampling_result = sampling
         self.planning.save()
@@ -741,10 +707,7 @@ class PlanningTestCase(APITestCase):
         self.assertIsNone(r["selected_sampling_result"])
 
     def test_planning_patch_selected_sampling_result_wrong_planning(self):
-        user_with_perms = self.create_user_with_profile(
-            username="user_with_perms", account=self.account, permissions=[CORE_PLANNING_WRITE_PERMISSION]
-        )
-        self.client.force_authenticate(user_with_perms)
+        self.client.force_authenticate(self.user_with_perms)
         other_planning = Planning.objects.create(
             project=self.project1, name="other", team=self.team1, org_unit=self.org_unit
         )
@@ -754,7 +717,7 @@ class PlanningTestCase(APITestCase):
             pipeline_version="v1",
             pipeline_name="wrong run",
             parameters={"limit": 1},
-            created_by=user_with_perms,
+            created_by=self.user_with_perms,
         )
 
         response = self.client.patch(
@@ -767,7 +730,7 @@ class PlanningTestCase(APITestCase):
         self.assertEqual(r["selected_sampling_result"][0], "samplingNotForPlanning")
 
     def test_planning_detail_includes_selected_sampling_result(self):
-        self.client.force_authenticate(self.user)
+        self.client.force_authenticate(self.user_with_perms)
         group = Group.objects.create(name="Sampling group", source_version=self.org_unit.version)
         group.org_units.add(self.org_unit)
         task = Task.objects.create(name="sampling-detail", account=self.account, created_by=self.user)
@@ -821,10 +784,7 @@ class PlanningTestCase(APITestCase):
         org_unit_type = OrgUnitType.objects.create(name="Wrong Patch Type")
         org_unit_type.projects.add(self.project2)
 
-        user_with_perms = self.create_user_with_profile(
-            username="user_with_perms", account=self.account, permissions=[CORE_PLANNING_WRITE_PERMISSION]
-        )
-        self.client.force_authenticate(user_with_perms)
+        self.client.force_authenticate(self.user_with_perms)
 
         data = {
             "target_org_unit_types": [org_unit_type.id],
@@ -846,10 +806,7 @@ class PlanningTestCase(APITestCase):
 
         root_org_unit = OrgUnit.objects.create(version=version, name="Root", org_unit_type=self.org_unit.org_unit_type)
 
-        user_with_perms = self.create_user_with_profile(
-            username="user_with_perms", account=self.account, permissions=[CORE_PLANNING_WRITE_PERMISSION]
-        )
-        self.client.force_authenticate(user_with_perms)
+        self.client.force_authenticate(self.user_with_perms)
 
         data = {
             "name": "Planning with No Matching Descendants",
@@ -880,10 +837,7 @@ class PlanningTestCase(APITestCase):
         root_org_unit = OrgUnit.objects.create(version=version, name="District 1", org_unit_type=parent_type)
         OrgUnit.objects.create(version=version, name="Health Post 1", org_unit_type=target_type, parent=root_org_unit)
 
-        user_with_perms = self.create_user_with_profile(
-            username="user_with_perms", account=self.account, permissions=[CORE_PLANNING_WRITE_PERMISSION]
-        )
-        self.client.force_authenticate(user_with_perms)
+        self.client.force_authenticate(self.user_with_perms)
 
         data = {
             "name": "Planning with Valid Descendants",


### PR DESCRIPTION
## What problem is this PR solving?

When an anonymous user would try to access planning API, it wouldn't get a 401 as expected
### Related JIRA tickets

IA-4958

## Changes

Changed permissions on the viewset + tests

## How to test

call planning API endpoints (e.g /api/microplanning/plannings/ ) while unauthenticated, you should get a 401 and not a 500.