### PR TITLE
[IA-4966] Fixing the n+1 write issues on the put endpoint and adapting the tests

### DIFF
--- a/iaso/api/user_roles.py
+++ b/iaso/api/user_roles.py
@@ -1,6 +1,5 @@
 from django.contrib.auth.models import Group, Permission
 from django.db.models import Q, QuerySet
-from django.shortcuts import get_object_or_404
 from drf_spectacular.utils import extend_schema
 from rest_framework import permissions, serializers, status
 from rest_framework.response import Response

--- a/iaso/api/user_roles.py
+++ b/iaso/api/user_roles.py
@@ -90,8 +90,8 @@ class UserRoleSerializer(serializers.ModelSerializer):
             permission_objects = Permission.objects.filter(codename__startswith="iaso_", codename__in=permissions)
             found_codenames = set(permission_objects.values_list("codename", flat=True))
             invalid = [p for p in permissions if p not in found_codenames]
-            invalid_str = ", ".join(invalid)
             if invalid:
+                invalid_str = ", ".join(invalid)
                 raise serializers.ValidationError({"permissions": f"Invalid permission codenames: {invalid_str}"})
             group.permissions.set(permission_objects)
 

--- a/iaso/api/user_roles.py
+++ b/iaso/api/user_roles.py
@@ -87,10 +87,13 @@ class UserRoleSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError({"name": "User role already exists"})
 
         if permissions is not None:
-            group.permissions.clear()
-            for permission_codename in permissions:
-                permission = get_object_or_404(Permission, codename__startswith="iaso_", codename=permission_codename)
-                group.permissions.add(permission)
+            permission_objects = Permission.objects.filter(codename__startswith="iaso_", codename__in=permissions)
+            found_codenames = set(permission_objects.values_list("codename", flat=True))
+            invalid = [p for p in permissions if p not in found_codenames]
+            invalid_str = ", ".join(invalid)
+            if invalid:
+                raise serializers.ValidationError({"permissions": f"Invalid permission codenames: {invalid_str}"})
+            group.permissions.set(permission_objects)
 
         group.name = group_name
         group.save()

--- a/iaso/api/user_roles.py
+++ b/iaso/api/user_roles.py
@@ -61,17 +61,20 @@ class UserRoleSerializer(serializers.ModelSerializer):
         if Group.objects.filter(name__iexact=group_name).exists():
             raise serializers.ValidationError({"name": "User role already exists"})
 
-        group = Group(name=group_name)
-        group.save()
+        if permissions is not None:
+            permission_objects = Permission.objects.filter(codename__startswith="iaso_", codename__in=permissions)
+            found_codenames = set(permission_objects.values_list("codename", flat=True))
+            invalid = [p for p in permissions if p not in found_codenames]
+            if invalid:
+                invalid_str = ", ".join(invalid)
+                raise serializers.ValidationError({"permissions": f"Invalid permission codenames: {invalid_str}"})
 
-        if group.id and len(permissions) > 0:
-            for permission_codename in permissions:
-                permission = get_object_or_404(Permission, codename__startswith="iaso_", codename=permission_codename)
-                group.permissions.add(permission)
-            group.save()
+        group = Group.objects.create(name=group_name)
+
+        if permission_objects:
+            group.permissions.set(permission_objects)
 
         user_role = UserRole.objects.create(group=group, account=account)
-        user_role.save()
         user_role.editable_org_unit_types.set(editable_org_unit_types)
         return user_role
 

--- a/iaso/tests/api/test_user_roles.py
+++ b/iaso/tests/api/test_user_roles.py
@@ -1,4 +1,5 @@
 from django.contrib.auth.models import Group, Permission
+from rest_framework import status
 
 from iaso import models as m
 from iaso.permissions.core_permissions import CORE_USERS_ROLES_PERMISSION
@@ -42,7 +43,7 @@ class UserRoleAPITestCase(APITestCase):
             name="admin permission", content_type_id=1, codename="admin_permission1"
         )
         cls.permission_not_allowable2 = Permission.objects.create(
-            name="admin permission", content_type_id=2, codename="admin_permission2"
+            name="admin permission", content_type_id=1, codename="admin_permission2"
         )
         cls.group = Group.objects.create(name=str(account.id) + "user role")
 
@@ -192,7 +193,7 @@ class UserRoleAPITestCase(APITestCase):
     def test_partial_update_not_allowable_permissions_modification(self):
         self.client.force_authenticate(self.user)
 
-        invalid_perms = self.permission_not_allowable.codename, self.permission_not_allowable2.codename
+        invalid_perms = [self.permission_not_allowable.codename, self.permission_not_allowable2.codename]
 
         payload = {
             "name": self.user_role.group.name,
@@ -200,10 +201,10 @@ class UserRoleAPITestCase(APITestCase):
         }
         response = self.client.put(f"/api/userroles/{self.user_role.id}/", data=payload, format="json")
 
-        r = self.assertJSONResponse(response, 400)
-        self.assertIn("permissions", r)
+        result = self.assertJSONResponse(response, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("permissions", result)
         expected_error_message = "Invalid permission codenames: admin_permission1, admin_permission2"
-        self.assertIn(expected_error_message, r["permissions"])
+        self.assertIn(expected_error_message, result["permissions"])
 
     def test_delete_user_role(self):
         self.client.force_authenticate(self.user)

--- a/iaso/tests/api/test_user_roles.py
+++ b/iaso/tests/api/test_user_roles.py
@@ -41,6 +41,9 @@ class UserRoleAPITestCase(APITestCase):
         cls.permission_not_allowable = Permission.objects.create(
             name="admin permission", content_type_id=1, codename="admin_permission1"
         )
+        cls.permission_not_allowable2 = Permission.objects.create(
+            name="admin permission", content_type_id=2, codename="admin_permission2"
+        )
         cls.group = Group.objects.create(name=str(account.id) + "user role")
 
         cls.group.permissions.add(cls.permission)
@@ -189,17 +192,18 @@ class UserRoleAPITestCase(APITestCase):
     def test_partial_update_not_allowable_permissions_modification(self):
         self.client.force_authenticate(self.user)
 
+        invalid_perms = self.permission_not_allowable.codename, self.permission_not_allowable2.codename
+
         payload = {
             "name": self.user_role.group.name,
-            "permissions": [self.permission_not_allowable.codename],
+            "permissions": invalid_perms,
         }
         response = self.client.put(f"/api/userroles/{self.user_role.id}/", data=payload, format="json")
 
-        r = self.assertJSONResponse(response, 404)
-        self.assertEqual(
-            r["detail"],
-            "Not found.",
-        )
+        r = self.assertJSONResponse(response, 400)
+        self.assertIn("permissions", r)
+        expected_error_message = "Invalid permission codenames: admin_permission1, admin_permission2"
+        self.assertIn(expected_error_message, r["permissions"])
 
     def test_delete_user_role(self):
         self.client.force_authenticate(self.user)

--- a/iaso/tests/api/test_user_roles.py
+++ b/iaso/tests/api/test_user_roles.py
@@ -64,6 +64,20 @@ class UserRoleAPITestCase(APITestCase):
         self.assertIsNotNone(r["id"])
         self.assertEqual(r["editable_org_unit_type_ids"], [self.org_unit_type.id])
 
+    def test_create_user_role_no_allowable_permissions(self):
+        self.client.force_authenticate(self.user)
+
+        payload = {
+            "name": "New user role name",
+            "permissions": [self.permission_not_allowable.codename, self.permission_not_allowable2.codename],
+        }
+        response = self.client.post("/api/userroles/", data=payload, format="json")
+
+        result = self.assertJSONResponse(response, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("permissions", result)
+        expected_error_message = "Invalid permission codenames: admin_permission1, admin_permission2"
+        self.assertIn(expected_error_message, result["permissions"])
+
     def test_create_user_role_without_name(self):
         self.client.force_authenticate(self.user)
 


### PR DESCRIPTION
## What problem is this PR solving?

N+1 issues on the user roles PUT endpoint. This PR is about fixing it

### Related JIRA tickets

[IA-4966](https://bluesquare.atlassian.net/browse/IA-4966)

## Changes

Removed the get_object_or_404 method that was causing extra computations

## How to test

Go to user roles page
Update a role
the docker logs should display a diminition in the number of duplicates


## Print screen / video

<img width="765" height="191" alt="image" src="https://github.com/user-attachments/assets/17bf00d5-8b58-4abd-a153-20119f86bad6" />

## Notes

Things that the reviewers should know:

Same performance issue appear on the Post endpoint

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).


[IA-4966]: https://bluesquare.atlassian.net/browse/IA-4966?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ