### PR TITLE
[IA-4949] Removing the clearable option from the PeriodPicker

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/periods/components/PeriodPicker.tsx
+++ b/hat/assets/js/apps/Iaso/domains/periods/components/PeriodPicker.tsx
@@ -181,6 +181,7 @@ const PeriodPicker: FunctionComponent<Props> = ({
                                 <InputComponent
                                     keyValue="year"
                                     onChange={handleChange}
+                                    clearable
                                     value={currentPeriod && currentPeriod.year}
                                     type="select"
                                     options={yearOptions}
@@ -232,6 +233,7 @@ const PeriodPicker: FunctionComponent<Props> = ({
                                             (currentPeriod &&
                                                 !currentPeriod.year)
                                         }
+                                        clearable
                                         value={
                                             currentPeriod &&
                                             currentPeriod.quarter
@@ -246,6 +248,7 @@ const PeriodPicker: FunctionComponent<Props> = ({
                                     <InputComponent
                                         keyValue="semester"
                                         onChange={handleChange}
+                                        clearable
                                         disabled={
                                             !currentPeriod ||
                                             (currentPeriod &&
@@ -265,6 +268,7 @@ const PeriodPicker: FunctionComponent<Props> = ({
                                         keyValue="week"
                                         onChange={handleChange}
                                         disabled={!currentPeriod?.year}
+                                        clearable
                                         value={currentPeriod?.week}
                                         type="select"
                                         options={weekOptions}

--- a/hat/assets/js/apps/Iaso/domains/periods/components/PeriodPicker.tsx
+++ b/hat/assets/js/apps/Iaso/domains/periods/components/PeriodPicker.tsx
@@ -181,7 +181,6 @@ const PeriodPicker: FunctionComponent<Props> = ({
                                 <InputComponent
                                     keyValue="year"
                                     onChange={handleChange}
-                                    clearable
                                     value={currentPeriod && currentPeriod.year}
                                     type="select"
                                     options={yearOptions}
@@ -214,13 +213,13 @@ const PeriodPicker: FunctionComponent<Props> = ({
                                                 !currentPeriod.year)
                                         }
                                         onChange={handleChange}
-                                        clearable
                                         value={
                                             currentPeriod && currentPeriod.month
                                         }
                                         type="select"
                                         options={monthOptions}
                                         label={MESSAGES.month}
+                                        clearable={false}
                                     />
                                 )}
                                 {(periodType === PERIOD_TYPE_QUARTER ||
@@ -233,7 +232,6 @@ const PeriodPicker: FunctionComponent<Props> = ({
                                             (currentPeriod &&
                                                 !currentPeriod.year)
                                         }
-                                        clearable
                                         value={
                                             currentPeriod &&
                                             currentPeriod.quarter
@@ -248,7 +246,6 @@ const PeriodPicker: FunctionComponent<Props> = ({
                                     <InputComponent
                                         keyValue="semester"
                                         onChange={handleChange}
-                                        clearable
                                         disabled={
                                             !currentPeriod ||
                                             (currentPeriod &&
@@ -268,7 +265,6 @@ const PeriodPicker: FunctionComponent<Props> = ({
                                         keyValue="week"
                                         onChange={handleChange}
                                         disabled={!currentPeriod?.year}
-                                        clearable
                                         value={currentPeriod?.week}
                                         type="select"
                                         options={weekOptions}


### PR DESCRIPTION
## What problem is this PR solving?

The month in the PeriodPicker component should not be clearable

### Related JIRA tickets

[IA-4949](https://bluesquare.atlassian.net/browse/IA-4949)

## Changes

Explain the changes that were made.

Set the clearable props to false

## How to test

>Go to Form Submissions
>In the Filter, you should see Periodicity
>Choose Month
>The year should be clearable but not the month

## Print screen / video

<img width="1593" height="882" alt="image" src="https://github.com/user-attachments/assets/d37626b4-4395-4e31-90a5-ac6a66b9f37c" />


## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).


[IA-4949]: https://bluesquare.atlassian.net/browse/IA-4949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ