### PR TITLE
[IA-4728] Change demo account password

### DIFF
--- a/hat/settings.py
+++ b/hat/settings.py
@@ -912,3 +912,4 @@ if IN_TESTS:
         ENCRYPTED_TEXT_FIELD_KEY = "71Eax4PGazWNj7vaXrucAD1bYUzjI-Fxubv8MZzcSyk="
 
 ENABLE_SETUPER_SANDBOX = os.environ.get("ENABLE_SETUPER_SANDBOX", "false").lower() == "true"
+SETUPER_SANDBOX_PASSWORD = os.environ.get("SETUPER_SANDBOX_PASSSWORD", "district")

--- a/iaso/tasks/setuper_sandbox.py
+++ b/iaso/tasks/setuper_sandbox.py
@@ -148,6 +148,17 @@ def run_setuper(account_name: str, password: str):
         return False
 
 
+def update_main_user_password(name: str):
+    try:
+        user = User.objects.get(username=name)
+        user.set_password(settings.SETUPER_SANDBOX_PASSWORD)
+        user.save()
+        logger.info("Successfully updated main user password")
+    except User.DoesNotExist:
+        logger.warning(f"Main user {name} not found, skipping password update.")
+        return
+
+
 @task_decorator(task_name="setuper_sandbox")
 def setuper_sandbox(name="admin", task=Task):
     if settings.ENABLE_SETUPER_SANDBOX:
@@ -162,5 +173,6 @@ def setuper_sandbox(name="admin", task=Task):
             task.report_progress_and_stop_if_killed(progress_value=50, progress_message=message, end_value=100)
 
         recreate_account(account_name, task)
+        update_main_user_password(account_name)
     else:
         logger.info("No setuper sandbox task")


### PR DESCRIPTION
## What problem is this PR solving?

Change demo account password

### Related JIRA tickets

IA-4728

## Changes

- Changed the demo account user password after recreating the account
- Settings read a new env var in order to check which password should be set

## How to test

- It's very difficult to test because it's a special task that's supposed to be called by a cron job, there's no command or endpoint to trigger it, so we'll need to deploy this in order to test it
  - if you really want to test, there were some explanations on how to trigger this task [in this PR](https://github.com/BLSQ/iaso/pull/2445), but I never managed to run the setuper because of some HTTPS misconfiguration :man_shrugging: 


## Print screen / video

/

## Notes
/

## Doc

/
