### PR TITLE
WC2-917: Monthly statistics data duplication with periodic task

### DIFF
--- a/plugins/wfp/aggregator.py
+++ b/plugins/wfp/aggregator.py
@@ -116,7 +116,7 @@ class Aggregator:
                 org_unit_ids = page_info.object_list
                 logger.info(f"Processing data for {len(org_unit_ids)} org unit on page {page} for {account}")
 
-                if rows is None:
+                if rows is None or len(org_unit_ids) == 0:
                     continue
 
                 records = ETL._process_monthly_data(programme_type, rows, account)
@@ -151,7 +151,7 @@ class Aggregator:
 
     @staticmethod
     def _map_fields(entry, program_name, mapper):
-        """Extracts valid data values based on the dhis2 mapper file."""
+        """Extracts valid data values based on the dhis2 mapper file and excludes o values in the datavalues"""
         data_values = []
         target_group = entry.get("target_group")
 
@@ -159,16 +159,20 @@ class Aggregator:
             prog = "screening_reporting"
             for group in ["Male", "Female", "pregnant", "breastfeeding"]:
                 mapping_template = mapper.get(prog, {}).get(group, {}).get(field)
+                if not mapping_template:
+                    continue
                 data_value = entry.get(prog, {}).get(group, {}).get(field)
-                if data_value is not None and mapping_template:
+                if data_value and data_value > 0:
                     data_values.append({**mapping_template, "value": data_value})
 
         nutrition_fields = [(DEFAULT_FIELDS, program_name), (HEALTH_WORKERS_FIELDS, "community_health_worker")]
         for fields, prog in nutrition_fields:
             for field in fields:
                 mapping_template = mapper.get(prog, {}).get(target_group, {}).get(field)
+                if not mapping_template:
+                    continue
                 data_value = entry.get(field)
-                if data_value is not None and mapping_template:
+                if data_value and data_value > 0:
                     data_values.append({**mapping_template, "value": data_value})
         return data_values
 

--- a/plugins/wfp/common.py
+++ b/plugins/wfp/common.py
@@ -1501,7 +1501,7 @@ class ETL:
 
         for row in aggregated_data:
             # Check if there is any value in the row
-            has_data = any((row.get(field)) > 0 for field in row if field not in fields_to_ignore)
+            has_data = any((row.get(field) or 0) > 0 for field in row if field not in fields_to_ignore)
             # Skip the row if all needed columns are 0
             if not has_data:
                 continue

--- a/plugins/wfp/common.py
+++ b/plugins/wfp/common.py
@@ -1483,8 +1483,29 @@ class ETL:
     # ------------------------------------------------------------------
     @staticmethod
     def _process_monthly_data(program_type, aggregated_data, account):
+        """Processing monthly data by excluding rows with 0 values in the needed columns."""
         all_journeys = []
+        fields_to_ignore = {
+            "org_unit_id",
+            "year",
+            "month",
+            "dhis2_id",
+            "period",
+            "gender",
+            "physiology_status",
+            "nutrition_programme",
+            "programme_type",
+            "total_beneficiaries",
+            "number_visits",
+        }
+
         for row in aggregated_data:
+            # Check if there is any value in the row
+            has_data = any((row.get(field)) > 0 for field in row if field not in fields_to_ignore)
+            # Skip the row if all needed columns are 0
+            if not has_data:
+                continue
+
             journey_by_org_unit_period = MonthlyStatistics(
                 account=account,
                 programme_type=program_type,

--- a/plugins/wfp/common.py
+++ b/plugins/wfp/common.py
@@ -833,17 +833,16 @@ class ETL:
 
             gender = extract_gender(data)
             physiology = extract_pbwg_physiology(data)
-            guidelines = extract_guidelines(sub)
+
             if physiology:
                 info["physiology"] = physiology
                 info["gender"] = None
             elif gender in ("Male", "Female"):
                 info["gender"] = gender
+                info["guidelines"] = extract_guidelines(sub)
             birth_date = calculate_birth_date(data)
             if birth_date is not None:
                 info["birth_date"] = birth_date
-            if guidelines:
-                info["guidelines"] = guidelines
         return info
 
     @staticmethod

--- a/plugins/wfp/tasks.py
+++ b/plugins/wfp/tasks.py
@@ -72,7 +72,7 @@ def etl_ng(all_data=None):
     from .management.commands.nigeria.Under5 import NG_Under5
 
     task_name = "plugins.wfp.tasks.etl_ng"
-    last_success_task = TaskResult.objects.filter(task_name=task_name, status="SUCCESS").first()
+    last_success_task = TaskResult.objects.filter(task_name=task_name, status="SUCCESS").order_by("-id").first()
 
     if last_success_task:
         # A task was found, use its creation date
@@ -118,10 +118,14 @@ def etl_ng(all_data=None):
 def ssd_aggregate_and_push_data_to_dhis2(all_data=None):
     from django_celery_results.models import TaskResult
 
-    last_success_task = TaskResult.objects.filter(
-        task_name="plugins.wfp.tasks.ssd_aggregate_and_push_data_to_dhis2",
-        status="SUCCESS",
-    ).first()
+    last_success_task = (
+        TaskResult.objects.filter(
+            task_name="plugins.wfp.tasks.ssd_aggregate_and_push_data_to_dhis2",
+            status="SUCCESS",
+        )
+        .order_by("-id")
+        .first()
+    )
     if last_success_task:
         last_success_task_date = last_success_task.date_created.strftime("%Y-%m-%d")
     else:
@@ -168,7 +172,7 @@ def etl_ssd(all_data=None):
     from .management.commands.south_sudan.Under5 import Under5
 
     task_name = "plugins.wfp.tasks.etl_ssd"
-    last_success_task = TaskResult.objects.filter(task_name=task_name, status="SUCCESS").first()
+    last_success_task = TaskResult.objects.filter(task_name=task_name, status="SUCCESS").order_by("-id").first()
 
     if last_success_task:
         last_success_task_date = last_success_task.date_created.strftime("%Y-%m-%d")
@@ -190,6 +194,7 @@ def etl_ssd(all_data=None):
 
     logger.info(f"Aggregating Children under 5 journey for {child_account} per org unit, admission and period")
     org_units = etl_u5.get_org_unit_and_period_with_updated_data(last_success_task_date)
+
     Aggregator.reset_monthly_statistics(child_account, "U5", org_units)
     Aggregator.aggregate_monthly_data_by_org_unit(child_account, org_units, "U5")
 
@@ -202,6 +207,7 @@ def etl_ssd(all_data=None):
 
     logger.info(f"Aggregating PBWG journey for {pbwg_account} per org unit, admission and period")
     pbwg_org_units = etl_pbwg.get_org_unit_and_period_with_updated_data(last_success_task_date)
+
     Aggregator.reset_monthly_statistics(pbwg_account, "PLW", pbwg_org_units)
     Aggregator.aggregate_monthly_data_by_org_unit(pbwg_account, pbwg_org_units, "PLW")
 
@@ -217,7 +223,7 @@ def etl_ethiopia(all_data=None):
     from .management.commands.south_sudan.Pbwg import Pbwg
 
     task_name = "plugins.wfp.tasks.etl_ethiopia"
-    last_success_task = TaskResult.objects.filter(task_name=task_name, status="SUCCESS").first()
+    last_success_task = TaskResult.objects.filter(task_name=task_name, status="SUCCESS").order_by("-id").first()
 
     if last_success_task:
         # A task was found, use its creation date


### PR DESCRIPTION
## What problem is this PR solving?

Explain here in one sentence.

### Related JIRA tickets

[WC2-917](https://bluesquare.atlassian.net/browse/WC2-917)

## Changes

- Excluded from monthly statistics data, rows with 0 values
- Excluded in the datavalues to push to dhis2, all row with 0 values
- Extract guidelines for only U5

## How to test

You can get the QA database dump in the JIRA ticket  and start to play with from your local setup with the QA database. Then:

1. Try first to edit some submissions http://localhost:8081/admin/iaso/instance/9418/change/ and http://localhost:8081/admin/iaso/instance/17143./change/ by just opening and saving the instance to update the **updated_at** field and : 
         - Start Celery with : `docker compose --profile celery up`
         - Schedule celery task with : `docker compose run --rm iaso start_celery_beat`
         - Allow worker to execute the scheduled task with: `docker compose run --rm iaso start_celery_worker`
        
Once the task is triggered, you should see in the monthly statistics data for org unit [Aroyo Static](http://localhost:8081/admin/wfp/monthlystatistics/?q=744&account__id__exact=1) and [Nyamlell PHCC](http://localhost:8081/admin/wfp/monthlystatistics/?q=867+Nyamlell+PHCC&account__id__exact=1) distinct single rows for January 2025.

2. Run ETL for South Sudan on all data: `docker compose run iaso manage etl_ssd all_data`, then login on django admin try to filter beneficiary by [Program type](http://localhost:8081/admin/wfp/beneficiary/?o=-5) , you should see guidelines for only U5

3. You should see in the monthly statistics, rows with values > 0 at least in one of the needed columns except "total beneficiaries" and "number_visits".

## Print screen / video

Upload here print screens or videos showing the changes.

## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).


[WC2-917]: https://bluesquare.atlassian.net/browse/WC2-917?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ