### PR TITLE
[IA-4622] Payments tables do not update data

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/payments/LotsPayments.tsx
+++ b/hat/assets/js/apps/Iaso/domains/payments/LotsPayments.tsx
@@ -67,7 +67,10 @@ export const LotsPayments: FunctionComponent = () => {
                     columns={columns}
                     baseUrl={baseUrl}
                     params={params}
-                    extraProps={{ loading: isLoading }}
+                    extraProps={{
+                        loading: isLoading,
+                        defaultPageSize: parseInt(params.pageSize, 10) || 20,
+                    }}
                 />
             </Box>
         </>

--- a/hat/assets/js/apps/Iaso/domains/payments/hooks/requests/useGetPaymentLots.tsx
+++ b/hat/assets/js/apps/Iaso/domains/payments/hooks/requests/useGetPaymentLots.tsx
@@ -18,7 +18,7 @@ const getPaymentLots = (options: PaymentLotsParams) => {
     } = options;
     const apiParams = {
         order: options.order || '-created_at',
-        limit: options.pageSize || 10,
+        limit: options.pageSize || 20,
         page,
         created_at_after: formatDateString(
             created_at_after,

--- a/iaso/api/payments/serializers.py
+++ b/iaso/api/payments/serializers.py
@@ -64,8 +64,8 @@ class NestedPaymentSerializer(serializers.ModelSerializer):
         return OrgChangeRequestNestedSerializer(change_requests, many=True, context=self.context).data
 
     def get_can_see_change_requests(self, obj):
-        user = self.context.get("request").user
-        if user.is_superuser:
+        user = getattr(self.context.get("request", None), "user", None)
+        if getattr(user, "is_superuser", False):
             return True
         user_org_units = self.context.get("user_org_units")
         change_requests = getattr(obj, "prefetched_change_requests", None)
@@ -110,11 +110,7 @@ class PaymentLotSerializer(serializers.ModelSerializer):
             return True
         org_unit_ids = []
         for payment in obj.payments.all():
-            change_requests = getattr(payment, "prefetched_change_requests", None)
-            if change_requests is None:
-                change_requests = payment.change_requests.all()
-            for change_request in change_requests:
-                org_unit_ids.append(change_request.org_unit.id)
+            org_unit_ids.extend([cr.org_unit_id for cr in payment.prefetched_change_requests])
         return set(org_unit_ids).issubset(set(self.context["user_org_units"]))
 
     def get_payments(self, obj):

--- a/iaso/api/payments/serializers.py
+++ b/iaso/api/payments/serializers.py
@@ -4,7 +4,6 @@ from rest_framework import serializers
 from hat.audit.audit_logger import AuditLogger
 from hat.audit.models import PAYMENT_API, PAYMENT_LOT_API
 from iaso.api.payments.filters.potential_payments import filter_by_dates, filter_by_forms, filter_by_parent
-from iaso.api.payments.pagination import PaymentPagination
 from iaso.models import OrgUnitChangeRequest, Payment, PaymentLot, PotentialPayment
 from iaso.models.payments import PaymentStatuses
 from iaso.models.task import Task
@@ -100,7 +99,6 @@ class PaymentLotSerializer(serializers.ModelSerializer):
         ]
         read_only_fields = ["id", "created_at"]
 
-    pagination_class = PaymentPagination
     created_by = UserNestedSerializer()
     created_at = TimestampField(read_only=True)
 
@@ -127,7 +125,6 @@ class PotentialPaymentSerializer(serializers.ModelSerializer):
         fields = ["id", "user", "change_requests", "payment_lot", "can_see_change_requests"]
         read_only_fields = ["id", "payment_lot", "can_see_change_requests"]
 
-    pagination_class = PaymentPagination
     user = UserNestedSerializer()
 
     def get_change_requests(self, obj):
@@ -178,8 +175,6 @@ class PaymentSerializer(serializers.ModelSerializer):
             "payment_lot",
             "updated_by",
         ]
-
-    pagination_class = PaymentPagination
 
     def validate_status(self, status):
         if status not in PaymentStatuses:

--- a/iaso/api/payments/serializers.py
+++ b/iaso/api/payments/serializers.py
@@ -58,18 +58,20 @@ class NestedPaymentSerializer(serializers.ModelSerializer):
         read_only_fields = ["id"]
 
     def get_change_requests(self, obj):
-        change_requests = obj.change_requests.all()
+        change_requests = getattr(obj, "prefetched_change_requests", None)
+        if change_requests is None:
+            change_requests = obj.change_requests.all()
         return OrgChangeRequestNestedSerializer(change_requests, many=True, context=self.context).data
 
     def get_can_see_change_requests(self, obj):
-        change_requests = self.get_change_requests(obj)
-
-        blocked_change_requests = [
-            change_request for change_request in change_requests if change_request["can_see_change_request"] == False
-        ]
-        if blocked_change_requests:
-            return False
-        return True
+        user = self.context.get("request").user
+        if user.is_superuser:
+            return True
+        user_org_units = self.context.get("user_org_units")
+        change_requests = getattr(obj, "prefetched_change_requests", None)
+        if change_requests is None:
+            change_requests = obj.change_requests.all()
+        return all(cr.org_unit.id in user_org_units for cr in change_requests)
 
 
 class NestedTaskSerializer(serializers.ModelSerializer):
@@ -106,10 +108,14 @@ class PaymentLotSerializer(serializers.ModelSerializer):
         user = self.context.get("request").user
         if user.is_superuser:
             return True
-        change_requests_org_units_for_lot = obj.payments.values_list(
-            "change_requests__org_unit__id", flat=True
-        ).distinct()
-        return set(change_requests_org_units_for_lot).issubset(set(self.context["user_org_units"]))
+        org_unit_ids = []
+        for payment in obj.payments.all():
+            change_requests = getattr(payment, "prefetched_change_requests", None)
+            if change_requests is None:
+                change_requests = payment.change_requests.all()
+            for change_request in change_requests:
+                org_unit_ids.append(change_request.org_unit.id)
+        return set(org_unit_ids).issubset(set(self.context["user_org_units"]))
 
     def get_payments(self, obj):
         payments = obj.payments.all()

--- a/iaso/api/payments/views.py
+++ b/iaso/api/payments/views.py
@@ -119,14 +119,15 @@ class PaymentLotsViewSet(ModelViewSet):
 
         payments_prefetch = Prefetch(
             "payments",
-            queryset=Payment.objects.select_related("user__iaso_profile"),
+            queryset=Payment.objects.select_related("user__iaso_profile").prefetch_related(
+                Prefetch(
+                    "change_requests",
+                    queryset=OrgUnitChangeRequest.objects.select_related("org_unit"),
+                    to_attr="prefetched_change_requests",
+                )
+            ),
         )
-        change_requests_prefetch = Prefetch(
-            "payments__change_requests",
-            queryset=OrgUnitChangeRequest.objects.select_related("org_unit"),
-            to_attr="prefetched_change_requests",
-        )
-        queryset = queryset.prefetch_related(payments_prefetch, change_requests_prefetch)
+        queryset = queryset.prefetch_related(payments_prefetch)
 
         change_requests_count = (
             OrgUnitChangeRequest.objects.filter(payment__payment_lot=OuterRef("pk"))

--- a/iaso/api/payments/views.py
+++ b/iaso/api/payments/views.py
@@ -117,12 +117,16 @@ class PaymentLotsViewSet(ModelViewSet):
         )
         queryset = PaymentLot.objects.filter(id__in=payments)
 
+        payments_prefetch = Prefetch(
+            "payments",
+            queryset=Payment.objects.select_related("user__iaso_profile"),
+        )
         change_requests_prefetch = Prefetch(
             "payments__change_requests",
-            queryset=OrgUnitChangeRequest.objects.all(),
+            queryset=OrgUnitChangeRequest.objects.select_related("org_unit"),
             to_attr="prefetched_change_requests",
         )
-        queryset = queryset.prefetch_related("payments", change_requests_prefetch)
+        queryset = queryset.prefetch_related(payments_prefetch, change_requests_prefetch)
 
         change_requests_count = (
             OrgUnitChangeRequest.objects.filter(payment__payment_lot=OuterRef("pk"))
@@ -146,7 +150,9 @@ class PaymentLotsViewSet(ModelViewSet):
             change_requests_count=Coalesce(Subquery(change_requests_count, output_field=models.IntegerField()), 0),
             payments_count=Coalesce(Subquery(payments_count, output_field=models.IntegerField()), 0),
         )
-        queryset = queryset.filter(created_by__iaso_profile__account=self.request.user.iaso_profile.account).distinct()
+        queryset = queryset.filter(
+            created_by__iaso_profile__account=self.request.user.iaso_profile.account
+        ).select_related("created_by__iaso_profile", "task").distinct()
 
         return queryset
 

--- a/iaso/api/payments/views.py
+++ b/iaso/api/payments/views.py
@@ -150,9 +150,11 @@ class PaymentLotsViewSet(ModelViewSet):
             change_requests_count=Coalesce(Subquery(change_requests_count, output_field=models.IntegerField()), 0),
             payments_count=Coalesce(Subquery(payments_count, output_field=models.IntegerField()), 0),
         )
-        queryset = queryset.filter(
-            created_by__iaso_profile__account=self.request.user.iaso_profile.account
-        ).select_related("created_by__iaso_profile", "task").distinct()
+        queryset = (
+            queryset.filter(created_by__iaso_profile__account=self.request.user.iaso_profile.account)
+            .select_related("created_by__iaso_profile", "task")
+            .distinct()
+        )
 
         return queryset
 

--- a/iaso/api/payments/views.py
+++ b/iaso/api/payments/views.py
@@ -23,6 +23,7 @@ from iaso.api.payments.filters import (
     payments_lots as payments_lots_filters,
     potential_payments as potential_payments_filters,
 )
+from iaso.api.payments.pagination import PaymentPagination
 from iaso.api.permission_checks import AuthenticationEnforcedPermission
 from iaso.api.tasks.serializers import TaskSerializer
 from iaso.models import OrgUnitChangeRequest, Payment, PaymentLot, PotentialPayment
@@ -102,6 +103,7 @@ class PaymentLotsViewSet(ModelViewSet):
     ordering = ["updated_at"]
     serializer_class = PaymentLotSerializer
     http_method_names = ["get", "post", "patch", "head", "options", "trace"]
+    pagination_class = PaymentPagination
 
     def get_serializer_context(self):
         context = super().get_serializer_context()
@@ -470,6 +472,7 @@ class PotentialPaymentsViewSet(ModelViewSet, AuditMixin):
     ordering = ["user__last_name"]
 
     serializer_class = PotentialPaymentSerializer
+    pagination_class = PaymentPagination
 
     results_key = "results"
     http_method_names = ["get", "head", "options", "trace"]
@@ -598,6 +601,7 @@ class PaymentsViewSet(ModelViewSet):
     http_method_names = ["patch", "get", "options"]
     results_key = "results"
     serializer_class = PaymentSerializer
+    pagination_class = PaymentPagination
     permission_classes = [permissions.IsAuthenticated, HasPermission(CORE_PAYMENTS_PERMISSION)]
 
     def get_serializer_context(self):

--- a/iaso/tests/api/payments/test_payment_lots.py
+++ b/iaso/tests/api/payments/test_payment_lots.py
@@ -341,6 +341,84 @@ class PaymentLotsViewSetAPITestCase(TaskAPITestCase):
         # No new payment lot created, we find only the one from setup
         self.assertEqual(m.PaymentLot.objects.count(), 1)
 
+    def test_list_payment_lots_num_queries_constant(self):
+        self.client.force_authenticate(self.user)
+
+        self.client.get("/api/payments/lots/", format="json")
+
+        with self.assertNumQueries(5):
+            response = self.client.get("/api/payments/lots/", format="json")
+        self.assertJSONResponse(response, 200)
+        self.assertEqual(len(response.data["results"]), 1)
+
+        # Include a task on the extra lot — catches the task FK N+1 (null task skips the query).
+        extra_task = m.Task.objects.create(launcher=self.user, account=self.user.iaso_profile.account, status="SUCCESS")
+        extra_lot = m.PaymentLot.objects.create(name="Extra lot", created_by=self.user, updated_by=self.user, task=extra_task)
+        extra_payment = m.Payment.objects.create(
+            user=self.payment_beneficiary,
+            payment_lot=extra_lot,
+            status=PaymentStatuses.PENDING,
+            created_by=self.user,
+        )
+        m.OrgUnitChangeRequest.objects.create(
+            org_unit=self.org_unit,
+            new_name="Extra place",
+            status=m.OrgUnitChangeRequest.Statuses.APPROVED,
+            payment=extra_payment,
+        )
+
+        # Same count with 2 lots — proves O(1), not O(N)
+        with self.assertNumQueries(5):
+            response = self.client.get("/api/payments/lots/", format="json")
+        self.assertJSONResponse(response, 200)
+        self.assertEqual(len(response.data["results"]), 2)
+
+    def test_list_payment_lots_response_structure(self):
+        self.client.force_authenticate(self.user)
+        response = self.client.get("/api/payments/lots/", format="json")
+        self.assertJSONResponse(response, 200)
+
+        results = response.data["results"]
+        self.assertEqual(len(results), 1)
+        lot = results[0]
+
+        self.assertEqual(lot["name"], "Test Payment Lot")
+        self.assertEqual(lot["status"], "new")
+        self.assertIsNone(lot["comment"])
+        self.assertIsNone(lot["task"])
+        self.assertIn("id", lot)
+        self.assertIn("created_at", lot)
+        self.assertIn("can_see_change_requests", lot)
+
+        created_by = lot["created_by"]
+        self.assertEqual(created_by["username"], "user")
+        self.assertIn("id", created_by)
+        self.assertIn("first_name", created_by)
+        self.assertIn("last_name", created_by)
+        self.assertIn("phone_number", created_by)
+
+        payments = lot["payments"]
+        self.assertEqual(len(payments), 2)
+        payment = payments[0]
+        self.assertEqual(payment["status"], "pending")
+        self.assertIn("id", payment)
+        self.assertIn("can_see_change_requests", payment)
+
+        user = payment["user"]
+        self.assertEqual(user["username"], "payment_beneficiary")
+        self.assertEqual(user["first_name"], "John")
+        self.assertEqual(user["last_name"], "Doe")
+        self.assertIn("id", user)
+        self.assertIn("phone_number", user)
+
+        change_requests = payment["change_requests"]
+        self.assertEqual(len(change_requests), 1)
+        change_request = change_requests[0]
+        self.assertEqual(change_request["org_unit_id"], self.org_unit.id)
+        self.assertIn("id", change_request)
+        self.assertIn("uuid", change_request)
+        self.assertIn("can_see_change_request", change_request)
+
     def test_geo_limited_user_cannot_see_change_requests_not_in_org_units(self):
         self.client.force_authenticate(self.geo_limited_user)
         response = self.client.get("/api/payments/lots/", format="json")

--- a/iaso/tests/api/payments/test_payment_lots.py
+++ b/iaso/tests/api/payments/test_payment_lots.py
@@ -207,7 +207,7 @@ class PaymentLotsViewSetAPITestCase(TaskAPITestCase):
         )
         extra_change_request.new_reference_instances.set([self.instance1, self.instance2, self.instance3])
 
-        with self.assertNumQueries(10):
+        with self.assertNumQueries(11):
             response = self.client.get(f"/api/payments/lots/{self.payment_lot.id}/?xlsx=true", format="json")
             excel_columns, excel_data = self.assertXlsxFileResponse(response)
 

--- a/iaso/tests/api/payments/test_payment_lots.py
+++ b/iaso/tests/api/payments/test_payment_lots.py
@@ -346,7 +346,7 @@ class PaymentLotsViewSetAPITestCase(TaskAPITestCase):
 
         self.client.get("/api/payments/lots/", format="json")
 
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(6):
             response = self.client.get("/api/payments/lots/", format="json")
         self.assertJSONResponse(response, 200)
         self.assertEqual(len(response.data["results"]), 1)
@@ -370,7 +370,7 @@ class PaymentLotsViewSetAPITestCase(TaskAPITestCase):
         )
 
         # Same count with 2 lots — proves O(1), not O(N)
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(6):
             response = self.client.get("/api/payments/lots/", format="json")
         self.assertJSONResponse(response, 200)
         self.assertEqual(len(response.data["results"]), 2)
@@ -379,6 +379,7 @@ class PaymentLotsViewSetAPITestCase(TaskAPITestCase):
         self.client.force_authenticate(self.user)
         response = self.client.get("/api/payments/lots/", format="json")
         self.assertJSONResponse(response, 200)
+        self.assertIn("count", response.data)
 
         results = response.data["results"]
         self.assertEqual(len(results), 1)

--- a/iaso/tests/api/payments/test_payment_lots.py
+++ b/iaso/tests/api/payments/test_payment_lots.py
@@ -353,7 +353,9 @@ class PaymentLotsViewSetAPITestCase(TaskAPITestCase):
 
         # Include a task on the extra lot — catches the task FK N+1 (null task skips the query).
         extra_task = m.Task.objects.create(launcher=self.user, account=self.user.iaso_profile.account, status="SUCCESS")
-        extra_lot = m.PaymentLot.objects.create(name="Extra lot", created_by=self.user, updated_by=self.user, task=extra_task)
+        extra_lot = m.PaymentLot.objects.create(
+            name="Extra lot", created_by=self.user, updated_by=self.user, task=extra_task
+        )
         extra_payment = m.Payment.objects.create(
             user=self.payment_beneficiary,
             payment_lot=extra_lot,

--- a/iaso/tests/api/payments/test_payments.py
+++ b/iaso/tests/api/payments/test_payments.py
@@ -49,6 +49,7 @@ class PaymentViewSetAPITestCase(APITestCase):
         self.client.force_authenticate(user=self.user)
         response = self.client.get("/api/payments/")
         r = self.assertJSONResponse(response, 200)
+        self.assertIn("count", r)
         results = r["results"]
         result = results[0]
         self.assertEqual(len(results), 1)

--- a/iaso/tests/api/payments/test_potential_payments.py
+++ b/iaso/tests/api/payments/test_potential_payments.py
@@ -77,11 +77,12 @@ class PotentialPaymentsViewSetAPITestCase(APITestCase):
 
         self.client.force_authenticate(self.user_with_perm)
 
-        with self.assertNumQueries(17):
+        with self.assertNumQueries(18):
             response = self.client.get("/api/potential_payments/")
             self.assertJSONResponse(response, 200)
 
         response = self.client.get("/api/potential_payments/")
+        self.assertIn("count", response.data)
         self.assertJSONResponse(response, 200)
 
         # Check that the correct number of PotentialPayment objects were created


### PR DESCRIPTION
## What problem is this PR solving?

On the payment lot page, the manual change of page number, results by page, don't result in a results list refresh. This PR is about fixing it

### Related JIRA tickets

[IA-4622](https://bluesquare.atlassian.net/browse/IA-4622)

## Changes
===== Frontend====
Added the defaultPageSize and isLoading props accuratly

===== Backend =======

`Views.py`
- Added `select_related("user__iaso_profile")` on the Payments Prefetch queryset to avoid 1 query per payment when getting the phone_number

- Added `select_related("org_unit")` on the OrgUnitChangeRequest queryset queryset to eliminate 1 query per change_request while checking who can see the change_requests

- Also added `select_related("created_by__iaso_profile", "task")` on the lot queryset to avoid 1 query per lot for each

`Serializers`
- In the `get_change_requests` function: changed `obj.change_requests.all()` to read from
  `prefetched_change_requests` (the in-memory list set by Django's prefetch machinery
  via `to_attr`). The previous call ignored the prefetch and was making 1 call per payment

- in the `NestedPaymentSerializer.get_can_see_change_requests`: removed the double serialization of the `change_requests`, and the double querying of `OrgChangeRequestNestedSerializer`. It now reads directly from the prefetched instances

- Finally in the PaymentLotSerializer's get_can_see_change_requests, I implemented a for loop that itirates the already fetched `obj.payments` and I removed the `values_list()` ignoring the prefetch

`Tests`
- Added a test to prove the 0(1) query count
- Added another one to confirm the API contract

## How to test

> Go to Payment lots table
> Change the number of results displayed in the tables
> It should work correctly


## Print screen / video

https://github.com/user-attachments/assets/7f517e3b-0e7e-45c4-97a7-c37af67df62c

Endpoint Calls went from this:
<img width="1298" height="192" alt="image" src="https://github.com/user-attachments/assets/70498cbf-3fe3-4ee3-b7d2-d93c79c5bc8b" />

To this:
<img width="1298" height="192" alt="image" src="https://github.com/user-attachments/assets/77e5412a-8932-4cca-a261-a0e277e3f35a" />

## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).


[IA-4622]: https://bluesquare.atlassian.net/browse/IA-4622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ