### PR TITLE
SNT-408: Use delimiter from CSV when importing metric values

### DIFF
--- a/iaso/api/metrics/serializers.py
+++ b/iaso/api/metrics/serializers.py
@@ -1,3 +1,5 @@
+import csv
+
 import pandas as pd
 
 from django.utils.translation import gettext_lazy as _
@@ -136,7 +138,9 @@ class ImportMetricValuesSerializer(serializers.Serializer):
         if not value.name.endswith(".csv"):
             raise serializers.ValidationError(_("The file must be a CSV."))
 
-        df = pd.read_csv(value)
+        dialect = csv.Sniffer().sniff(value.read(1024).decode("utf-8", errors="ignore"))
+        value.seek(0)  # Reset file pointer after reading for dialect inference
+        df = pd.read_csv(value, sep=dialect.delimiter)
 
         header_errors = get_missing_headers(df, REQUIRED_METRIC_VALUES_HEADERS)
         if header_errors:


### PR DESCRIPTION
## What problem is this PR solving?

Sniff delimiter from input CSV when importing metric values

### Related JIRA tickets

SNT-408

## Changes

Define delimiter when reading CSV by first sniffing the CSV.

## How to test

Go to SNT Malaria, go to DataLayers, create at least one custom layer.
Export the template CSV which uses "," delimiter and try to import it directly, it is empty but it should work.
Now, modify it to use ";" delimiter and try to import it, it should work as well.

## Print screen / video

N/A

## Notes

N/A

## Doc

N/A
