### PR TITLE
[IA-4988]: validation workflows: remove permission check on mobile

### DIFF
--- a/iaso/api/validation_workflows/permissions.py
+++ b/iaso/api/validation_workflows/permissions.py
@@ -1,3 +1,4 @@
+from django.utils.translation import gettext_lazy as _
 from rest_framework.permissions import BasePermission
 
 from iaso.permissions.core_permissions import CORE_VALIDATION_WORKFLOW_PERMISSION
@@ -15,6 +16,8 @@ class HasValidationWorkflowPermission(BasePermission):
 
 
 class HasAccountFeatureFlag(BasePermission):
+    message = _("This feature is disabled for your account.")
+
     def has_permission(self, request, view):
         if not request.user.iaso_profile:
             return False

--- a/iaso/api/validation_workflows/views_mobile.py
+++ b/iaso/api/validation_workflows/views_mobile.py
@@ -7,7 +7,7 @@ from rest_framework.viewsets import GenericViewSet
 from iaso.api.common.mixin import CustomPaginationListModelMixin
 from iaso.api.validation_workflows.filters import MobileValidationWorkflowListFilter
 from iaso.api.validation_workflows.pagination import MobileValidationWorkflowPagination
-from iaso.api.validation_workflows.permissions import HasValidationWorkflowPermission
+from iaso.api.validation_workflows.permissions import HasAccountFeatureFlag
 from iaso.api.validation_workflows.serializers.mobile import MobileValidationWorkflowListSerializer
 from iaso.models import Instance
 
@@ -15,7 +15,7 @@ from iaso.models import Instance
 @extend_schema(tags=["Validation workflows", "Mobile"])
 class ValidationWorkflowMobileViewSet(CustomPaginationListModelMixin, GenericViewSet):
     filter_backends = [DjangoFilterBackend]
-    permission_classes = (IsAuthenticated, HasValidationWorkflowPermission)
+    permission_classes = (IsAuthenticated, HasAccountFeatureFlag)
     filterset_class = MobileValidationWorkflowListFilter
     pagination_class = MobileValidationWorkflowPagination
     serializer_class = MobileValidationWorkflowListSerializer

--- a/iaso/locale/fr/LC_MESSAGES/django.po
+++ b/iaso/locale/fr/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-09 06:31+0000\n"
+"POT-Creation-Date: 2026-04-21 09:22+0000\n"
 "PO-Revision-Date: 2025-02-06 10:24+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -26,6 +26,14 @@ msgstr "Le modèle {value} n'existe pas."
 #: iaso/api/comment.py
 msgid "Invalid value."
 msgstr "Valeur invalide"
+
+#: iaso/api/common/serializer_fields.py
+msgid "Enter a valid phone number."
+msgstr "Veuillez saisir un numéro de téléphone valide."
+
+#: iaso/api/common/serializer_fields.py
+msgid "Both phone number and country code must be provided"
+msgstr "Le numéro de téléphone et le code pays doivent être fournis"
 
 #: iaso/api/common/validators.py
 #, python-format
@@ -468,14 +476,6 @@ msgstr ""
 msgid "Some projects are outside your scope."
 msgstr "Certains projets ne relèvent pas de votre champ d'action'."
 
-#: iaso/api/profiles/serializers/common.py
-msgid "Enter a valid phone number."
-msgstr "Veuillez saisir un numéro de téléphone valide."
-
-#: iaso/api/profiles/serializers/common.py
-msgid "Both phone number and country code must be provided"
-msgstr "Le numéro de téléphone et le code pays doivent être fournis"
-
 #: iaso/api/profiles/serializers/create.py
 #: iaso/api/profiles/serializers/update.py
 msgid "One or more user roles do not belong to the provided account."
@@ -537,6 +537,14 @@ msgstr "ID de Formulaire"
 #: iaso/api/stocks/filters.py
 msgid "Form Version ID"
 msgstr "ID de Version de Formulaire"
+
+#: iaso/api/validation_workflows/permissions.py
+msgid "This feature is disabled for your account."
+msgstr "Cette fonctionnalité est désactivée pour votre compte."
+
+#: iaso/auth/forms.py
+msgid "Too many login attempts. Please try again later."
+msgstr "Trop de tentatives de connexion. Veuillez réessayer plus tard."
 
 #: iaso/models/base.py
 msgid "Aggregate"
@@ -1252,7 +1260,3 @@ msgstr "Erreur lors de l'analyse"
 
 #~ msgid "Invalid phone number"
 #~ msgstr "Numéro de téléphone invalide"
-
-msgid "Too many login attempts. Please try again later."
-msgstr "Trop de tentatives de connexion. Veuillez réessayer plus tard."
-

--- a/iaso/tests/api/validation_workflows/test_views_mobile.py
+++ b/iaso/tests/api/validation_workflows/test_views_mobile.py
@@ -6,10 +6,9 @@ from django.urls import reverse
 from rest_framework import status
 
 from iaso.engine.validation_workflow import ValidationWorkflowEngine
-from iaso.models import Account, Form, Project, ValidationNodeTemplate, ValidationWorkflow
+from iaso.models import Account, AccountFeatureFlag, Form, Project, ValidationNodeTemplate, ValidationWorkflow
 from iaso.models.common import ValidationWorkflowArtefactStatus
 from iaso.models.validation_workflow.validation_node import ValidationNodeStatus
-from iaso.permissions.core_permissions import CORE_VALIDATION_WORKFLOW_PERMISSION
 from iaso.test import APITestCase
 
 
@@ -17,22 +16,19 @@ class MobileValidationWorkflowAPITestCase(APITestCase):
     def setUp(self):
         self.account = Account.objects.create(name="account")
         self.other_account = Account.objects.create(name="account2")
+        self.another_account = Account.objects.create(name="account3")
 
+        self.enable_validation_workflow_feature_flag(self.account, self.other_account)
         self.john_doe = self.create_user_with_profile(
-            username="john.doe", account=self.account, first_name="John", last_name="Doe"
+            username="user.without.feature.flag", account=self.another_account, first_name="User", last_name="NoFlag"
         )
 
-        self.john_wick = self.create_user_with_profile(
-            username="john.wick", account=self.account, permissions=[CORE_VALIDATION_WORKFLOW_PERMISSION]
-        )
+        self.john_wick = self.create_user_with_profile(username="john.wick", account=self.account)
 
-        self.jane_doe = self.create_user_with_profile(
-            username="jane.doe", account=self.other_account, permissions=[CORE_VALIDATION_WORKFLOW_PERMISSION]
-        )
+        self.jane_doe = self.create_user_with_profile(username="jane.doe", account=self.other_account)
         self.superuser = self.create_user_with_profile(
             username="john.super",
             account=self.other_account,
-            permissions=[CORE_VALIDATION_WORKFLOW_PERMISSION],
             is_staff=True,
             is_superuser=True,
         )
@@ -78,6 +74,15 @@ class MobileValidationWorkflowAPITestCase(APITestCase):
             uuid=str(uuid.uuid4()),
         )
 
+    @staticmethod
+    def enable_validation_workflow_feature_flag(*accounts):
+        feature_flag, _ = AccountFeatureFlag.objects.get_or_create(
+            code="SUBMISSION_VALIDATION_WORKFLOW",
+            defaults={"name": "Web: Enable validation workflow"},
+        )
+        for account in accounts:
+            account.feature_flags.add(feature_flag)
+
     def setup_start(self):
         ValidationWorkflowEngine.start(self.validation_workflow, self.john_wick, self.instance)
 
@@ -116,7 +121,8 @@ class MobileValidationWorkflowAPITestCase(APITestCase):
 
         self.client.force_authenticate(self.john_doe)
         res = self.client.get(reverse("mobile_validation_workflows-list"))
-        self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
+        res_data = self.assertJSONResponse(res, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(res_data["detail"], "This feature is disabled for your account.")
 
         self.client.force_authenticate(self.john_wick)
         res = self.client.get(reverse("mobile_validation_workflows-list"))
@@ -576,8 +582,8 @@ class MobileValidationWorkflowAPITestCase(APITestCase):
     def test_num_queries(self):
         self.client.force_authenticate(self.john_wick)
         self.setup_approve()
-        with self.assertNumQueries(7):
-            # 1-2: PERM
+        with self.assertNumQueries(6):
+            # 1: PERM
             # 3 ORGUNIT
             # 4-5: QUERYSET + FILTER
             # 6-7: SERIALIZER


### PR DESCRIPTION
## What problem is this PR solving?

Validation workflow mobile endpoint was checking against the permissions when it shouldn't.

### Related JIRA tickets

IA-4988

## Changes

* Remove permission check
* Added feature flag check + custom message
* Added tests

## How to test

Call the endpoint mobile/validation-workflows with a user without perm and the right feature flag (SUBMISSION_VALIDATION_WORKFLOW), it shouldn't raise a 403.