### PR TITLE
IA-5004: FileActive record - make age optionnal

### DIFF
--- a/plugins/active_list/migrations/0013_alter_record_age_nullable.py
+++ b/plugins/active_list/migrations/0013_alter_record_age_nullable.py
@@ -1,0 +1,17 @@
+# Allow Record.age to be unset when import data does not provide age (e.g. follow-up forms).
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("active_list", "0012_alter_record_sex_nullable"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="record",
+            name="age",
+            field=models.IntegerField(blank=True, null=True, verbose_name="Âge"),
+        ),
+    ]

--- a/plugins/active_list/models.py
+++ b/plugins/active_list/models.py
@@ -178,7 +178,7 @@ class Record(models.Model):
     period = models.TextField(db_index=True, verbose_name="Période")
     patient = models.ForeignKey(Patient, on_delete=models.CASCADE, related_name="records")
     sex = models.TextField(choices=SEX_CHOICES, null=True, blank=True, verbose_name="Sexe")
-    age = models.IntegerField(verbose_name="Âge")
+    age = models.IntegerField(null=True, blank=True, verbose_name="Âge")
     weight = models.IntegerField(null=True, verbose_name="Poids")
     new_inclusion = models.BooleanField(verbose_name="Nouvelle inclusion")
     transfer_in = models.BooleanField(verbose_name="Transfert entrant")


### PR DESCRIPTION
## What problem is this PR solving?

null value in column "age" of relation "active_list_record" violates not-null constraint DETAIL

### Related JIRA tickets

IA-5004

## Changes

make age optional + migration

