### PR TITLE
[IA-5001]: fix csv detection in FileTypeValidator for bulk create user

### DIFF
--- a/iaso/api/bulk_create_users/serializers.py
+++ b/iaso/api/bulk_create_users/serializers.py
@@ -308,7 +308,7 @@ class BulkCreateUserSerializer(ModelSerializer):
             "file": {
                 "write_only": True,
                 "validators": [
-                    FileTypeValidator(allowed_mimetypes=["text/csv"]),
+                    FileTypeValidator(allowed_mimetypes=["text/csv", "text/plain"]),
                     FileExtensionValidator(allowed_extensions=["csv"]),
                 ],
             },

--- a/iaso/tests/api/bulk_create_users/test_serializers.py
+++ b/iaso/tests/api/bulk_create_users/test_serializers.py
@@ -5,7 +5,7 @@ from iaso.models import Account
 from iaso.test import TestCase
 
 
-class Test(TestCase):
+class TestBulkCreateItemSerializer(TestCase):
     def setUp(self):
         account = Account.objects.create(name="account")
         self.user = self.create_user_with_profile(username="test", account=account)

--- a/iaso/tests/api/bulk_create_users/test_views.py
+++ b/iaso/tests/api/bulk_create_users/test_views.py
@@ -11,6 +11,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission, User
 from django.core.files.storage import default_storage
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.urls import reverse
 from rest_framework import status
 
 from iaso import models as m
@@ -1140,3 +1141,20 @@ class BulkCreateCsvTestCase(APITestCase):
         user = User.objects.get(username="projectid_user")
         self.assertEqual(user.iaso_profile.projects.count(), 1)
         self.assertEqual(user.iaso_profile.projects.first().id, self.project.id)
+
+    def test_file_from_sample_does_not_trigger_invalid_file_type(self):
+        self.client.force_authenticate(self.yoda)
+
+        response = self.client.get(reverse("bulkcreateuser-download-sample-csv"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "text/csv")
+
+        csv_content = b"".join(response.streaming_content)
+
+        uploaded_file = SimpleUploadedFile(name="test.csv", content=csv_content)
+
+        response = self.client.post(f"{BASE_URL}", {"file": uploaded_file}, format="multipart")
+
+        res_data = self.assertJSONResponse(response, status.HTTP_400_BAD_REQUEST)
+        self.assertNotIn("file", res_data)


### PR DESCRIPTION
## What problem is this PR solving?

Using a csv file without \n at the end would cause the bulk create user API to raise a 400 error with "Invalid file type"

### Related JIRA tickets

IA-5001

## Changes

Added plain/text as valid file types.
python-magic checks the signature of the file and .csv files don't have any. So to avoid any unreliable checks, I added this file type.

## How to test

Go to users management and try to create from a file without eol  like the one attached. It shouldn't raise an "Invalid file type" error
[bulk_create_user_csv_no_eof.csv](https://github.com/user-attachments/files/26934153/bulk_create_user_csv_no_eof.csv)


## Notes

Didn't put too much effort into the tests cause : 
* I couldn't make it work properly after 2 hours
* we might ditch .csv and switch to xlsx

