### PR TITLE
POLIO-2128: handle shared url error gracefully

### DIFF
--- a/plugins/polio/api/dashboards/preparedness/views.py
+++ b/plugins/polio/api/dashboards/preparedness/views.py
@@ -1,5 +1,5 @@
 from drf_spectacular.utils import extend_schema
-from rest_framework import viewsets
+from rest_framework import status, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
 
@@ -62,7 +62,10 @@ class PreparednessDashboardViewSet(viewsets.ViewSet):
         )
         if round_qs.count() > 1:
             rounds_list = list(round_qs.values_list("id", flat=True))
-            raise Exception(f"Found more than one round for url: {rounds_list}")
+            return Response(
+                {"error": f"Found more than one round for url: {rounds_list}"},
+                status=status.HTTP_409_CONFLICT,
+            )
 
         round_obj = round_qs.first()
         obj.round_id = round_obj.id if round_obj else None

--- a/plugins/polio/api/dashboards/preparedness/views.py
+++ b/plugins/polio/api/dashboards/preparedness/views.py
@@ -49,14 +49,12 @@ class PreparednessDashboardViewSet(viewsets.ViewSet):
         params_serializer = ParamsSerializer(data=request.query_params)
         params_serializer.is_valid(raise_exception=True)
         queryset = self.get_queryset()
+        url_param = request.query_params.get("url")
         filter = PreparednessScoreFilter(request.query_params, queryset=queryset)
         filtered_qs = filter.qs
         obj = filtered_qs.first()
-        if not obj:
-            return Response({})
-
         round_qs = (
-            Round.objects.filter(preparedness_spreadsheet_url=obj.url)
+            Round.objects.filter(preparedness_spreadsheet_url=url_param)
             .select_related("campaign")
             .only("id", "number", "campaign__obr_name")
         )
@@ -66,6 +64,9 @@ class PreparednessDashboardViewSet(viewsets.ViewSet):
                 {"error": f"Found more than one round for url: {rounds_list}"},
                 status=status.HTTP_409_CONFLICT,
             )
+
+        if not obj:
+            return Response({})
 
         round_obj = round_qs.first()
         obj.round_id = round_obj.id if round_obj else None

--- a/plugins/polio/tests/api/preparedness_dashboard/test_views.py
+++ b/plugins/polio/tests/api/preparedness_dashboard/test_views.py
@@ -295,8 +295,8 @@ class PreparednessDashboardScoreAPITestCase(PreparednessDashboardAPIBase):
         self.assertEqual(campaign_details["round_number"], 4)
         self.assertEqual(campaign_details["campaign"], "test-campaign")
 
-    def test_score_raises_when_multiple_rounds_share_url(self):
-        """When multiple rounds share the same preparedness URL, the view raises."""
+    def test_score_returns_409_when_multiple_rounds_share_url(self):
+        """When multiple rounds share the same preparedness URL, the view returns 409."""
         from plugins.polio.models.base import Round
 
         shared_url = "https://docs.google.com/spreadsheets/d/shared"
@@ -308,6 +308,6 @@ class PreparednessDashboardScoreAPITestCase(PreparednessDashboardAPIBase):
         Round.objects.create(campaign=self.campaign, number=10, preparedness_spreadsheet_url=shared_url)
         Round.objects.create(campaign=self.campaign, number=11, preparedness_spreadsheet_url=shared_url)
 
-        with self.assertRaises(Exception) as ctx:
-            self.client.get(self.SCORE_URL, {"url": shared_url, "date": "2030-01-01"})
-        self.assertIn("Found more than one round for url:", str(ctx.exception))
+        response = self.client.get(self.SCORE_URL, {"url": shared_url, "date": "2030-01-01"})
+        data = self.assertJSONResponse(response, status.HTTP_409_CONFLICT)
+        self.assertIn("Found more than one round for url:", data["error"])


### PR DESCRIPTION

## What problem is this PR solving?
scores API raises unhandled error, clogging Sentry

Explain here in one sentence.

### Related JIRA tickets

POLIO-2128

## Changes

- return 409 i.o raw exception

## How to test

- In polio > campaigns, create 2 rounds with start date in the future
- set the same preparedness url for both
- via swagger or django api or Bruno, call: /api/polio/preparedness_dashboard/score/?url=<preparedness url>&date=<YYYY-MM-dd>

you should get a 409

## Print screen / video

Upload here print screens or videos showing the changes.

## Notes

Can be hotfixed to reduce Sentry errors


