### PR TITLE
[IA-4998]: reverse order of instance validation workflow data

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/instances/components/ValidationWorkflow/InstanceValidation.test.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/ValidationWorkflow/InstanceValidation.test.tsx
@@ -57,6 +57,30 @@ describe('InstanceValidation (Vitest)', () => {
     const date = moment(Date.now()).format(apiMobileDateFormat);
     const timeline = [
         {
+            canValidate: true,
+            color: '#ffffff',
+            content: {
+                description: 'desc2',
+            },
+            label: 'Node2',
+            nodeId: 3,
+            nodeSlug: 'node2',
+            order: 2,
+        },
+        {
+            color: '#bbbbbb',
+            content: {
+                author: 'John',
+                comment: 'ok',
+                date: date,
+                description: 'desc1',
+            },
+            label: 'Node1',
+            nodeSlug: 'node1',
+            order: 1,
+            status: 'ACCEPTED',
+        },
+        {
             color: '#bbbbbb',
             content: {
                 author: 'John',
@@ -64,11 +88,11 @@ describe('InstanceValidation (Vitest)', () => {
                 date: date,
                 description: 'desc1',
             },
-            label: 'Submission',
+            label: 'New version',
             nodeSlug: 'node1',
             order: 1,
             previous: true,
-            status: 'SUBMISSION',
+            status: 'NEW_VERSION',
         },
         {
             color: '#ffffff',
@@ -92,35 +116,11 @@ describe('InstanceValidation (Vitest)', () => {
                 date: date,
                 description: 'desc1',
             },
-            label: 'New version',
+            label: 'Submission',
             nodeSlug: 'node1',
             order: 1,
             previous: true,
-            status: 'NEW_VERSION',
-        },
-        {
-            color: '#bbbbbb',
-            content: {
-                author: 'John',
-                comment: 'ok',
-                date: date,
-                description: 'desc1',
-            },
-            label: 'Node1',
-            nodeSlug: 'node1',
-            order: 1,
-            status: 'ACCEPTED',
-        },
-        {
-            canValidate: true,
-            color: '#ffffff',
-            content: {
-                description: 'desc2',
-            },
-            label: 'Node2',
-            nodeId: 3,
-            nodeSlug: 'node2',
-            order: 2,
+            status: 'SUBMISSION',
         },
     ];
 
@@ -159,22 +159,27 @@ describe('InstanceValidation (Vitest)', () => {
         const steps = screen.getAllByTestId('step');
 
         // step 1
-        expect(within(steps[0]).getByText('Submission')).toBeInTheDocument();
-        expect(within(steps[0]).getByText('John')).toBeInTheDocument();
+        expect(within(steps[0]).queryByText('Submission')).toBeNull();
+        expect(within(steps[0]).queryByText('John')).toBeNull();
+        expect(within(steps[0]).getByText('Node2')).toBeInTheDocument();
+        expect(within(steps[0]).getByText('desc2')).toBeInTheDocument();
         expect(
-            within(steps[0]).getByText(
+            within(steps[0]).getByText('2', { exact: true }),
+        ).toBeInTheDocument();
+        expect(
+            within(steps[0]).queryByText(
                 moment(date, apiMobileDateFormat).format('DD-MM-YYYY HH:mm:ss'),
             ),
-        ).toBeInTheDocument();
-        expect(within(steps[0]).getByTestId('SendIcon')).toBeInTheDocument();
+        ).toBeNull();
+        expect(within(steps[0]).queryByTestId('SendIcon')).toBeNull();
 
         // step 2
         expect(within(steps[1]).queryByText('Submission')).toBeNull();
         expect(within(steps[1]).getByText('John')).toBeInTheDocument();
-        expect(within(steps[1]).getByText('Nope')).toBeInTheDocument();
-        expect(within(steps[1]).getByText('Node2')).toBeInTheDocument();
+        expect(within(steps[1]).getByText('ok')).toBeInTheDocument();
+        expect(within(steps[1]).getByText('Node1')).toBeInTheDocument();
         expect(
-            within(steps[1]).getByText('2', { exact: true }),
+            within(steps[1]).getByText('1', { exact: true }),
         ).toBeInTheDocument();
         expect(
             within(steps[1]).getByText(
@@ -196,10 +201,10 @@ describe('InstanceValidation (Vitest)', () => {
         // step 4
         expect(within(steps[3]).queryByText('Submission')).toBeNull();
         expect(within(steps[3]).getByText('John')).toBeInTheDocument();
-        expect(within(steps[3]).getByText('ok')).toBeInTheDocument();
-        expect(within(steps[3]).getByText('Node1')).toBeInTheDocument();
+        expect(within(steps[3]).getByText('Nope')).toBeInTheDocument();
+        expect(within(steps[3]).getByText('Node2')).toBeInTheDocument();
         expect(
-            within(steps[3]).getByText('1', { exact: true }),
+            within(steps[3]).getByText('2', { exact: true }),
         ).toBeInTheDocument();
         expect(
             within(steps[3]).getByText(
@@ -209,19 +214,14 @@ describe('InstanceValidation (Vitest)', () => {
         expect(within(steps[3]).queryByTestId('SendIcon')).toBeNull();
 
         // step 5
-        expect(within(steps[4]).queryByText('Submission')).toBeNull();
-        expect(within(steps[4]).queryByText('John')).toBeNull();
-        expect(within(steps[4]).getByText('Node2')).toBeInTheDocument();
-        expect(within(steps[4]).getByText('desc2')).toBeInTheDocument();
+        expect(within(steps[4]).getByText('Submission')).toBeInTheDocument();
+        expect(within(steps[4]).getByText('John')).toBeInTheDocument();
         expect(
-            within(steps[4]).getByText('2', { exact: true }),
-        ).toBeInTheDocument();
-        expect(
-            within(steps[4]).queryByText(
+            within(steps[4]).getByText(
                 moment(date, apiMobileDateFormat).format('DD-MM-YYYY HH:mm:ss'),
             ),
-        ).toBeNull();
-        expect(within(steps[4]).queryByTestId('SendIcon')).toBeNull();
+        ).toBeInTheDocument();
+        expect(within(steps[4]).getByTestId('SendIcon')).toBeInTheDocument();
     });
 
     it('applies correct color to each step', () => {
@@ -229,8 +229,8 @@ describe('InstanceValidation (Vitest)', () => {
 
         const labels = screen.getAllByTestId('step-label');
 
-        expect(labels[3]).toHaveAttribute('data-color', '#bbbbbb');
-        expect(labels[4]).toHaveAttribute('data-color', '#ffffff');
+        expect(labels[1]).toHaveAttribute('data-color', '#bbbbbb');
+        expect(labels[0]).toHaveAttribute('data-color', '#ffffff');
     });
 
     it('renders validation modal only when allowed', () => {

--- a/hat/assets/js/apps/Iaso/domains/instances/components/ValidationWorkflow/useValidationTimeline.test.ts
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/ValidationWorkflow/useValidationTimeline.test.ts
@@ -125,6 +125,30 @@ describe('useValidationTimeline', () => {
 
         expect(result.current).toEqual([
             {
+                canValidate: true,
+                color: '#00ff00',
+                content: {
+                    description: 'desc2',
+                },
+                label: 'Node2',
+                nodeId: 3,
+                nodeSlug: 'node2',
+                order: 2,
+            },
+            {
+                color: '#ff0000',
+                content: {
+                    author: 'John',
+                    comment: 'ok',
+                    date: date,
+                    description: 'desc1',
+                },
+                label: 'Node1',
+                nodeSlug: 'node1',
+                order: 1,
+                status: 'ACCEPTED',
+            },
+            {
                 color: '#ff0000',
                 content: {
                     author: 'John',
@@ -132,11 +156,11 @@ describe('useValidationTimeline', () => {
                     date: date,
                     description: 'desc1',
                 },
-                label: 'Submission',
+                label: 'New version',
                 nodeSlug: 'node1',
                 order: 1,
                 previous: true,
-                status: 'SUBMISSION',
+                status: 'NEW_VERSION',
             },
             {
                 color: '#00ff00',
@@ -160,35 +184,11 @@ describe('useValidationTimeline', () => {
                     date: date,
                     description: 'desc1',
                 },
-                label: 'New version',
+                label: 'Submission',
                 nodeSlug: 'node1',
                 order: 1,
                 previous: true,
-                status: 'NEW_VERSION',
-            },
-            {
-                color: '#ff0000',
-                content: {
-                    author: 'John',
-                    comment: 'ok',
-                    date: date,
-                    description: 'desc1',
-                },
-                label: 'Node1',
-                nodeSlug: 'node1',
-                order: 1,
-                status: 'ACCEPTED',
-            },
-            {
-                canValidate: true,
-                color: '#00ff00',
-                content: {
-                    description: 'desc2',
-                },
-                label: 'Node2',
-                nodeId: 3,
-                nodeSlug: 'node2',
-                order: 2,
+                status: 'SUBMISSION',
             },
         ]);
 
@@ -268,20 +268,6 @@ describe('useValidationTimeline', () => {
 
         expect(result.current).toEqual([
             {
-                color: '#ff0000',
-                content: {
-                    author: 'John',
-                    comment: '',
-                    date: date,
-                    description: 'desc1',
-                },
-                label: 'Submission',
-                nodeSlug: 'node1',
-                order: 1,
-                previous: true,
-                status: 'SUBMISSION',
-            },
-            {
                 color: '#00ff00',
                 content: {
                     author: 'John',
@@ -292,8 +278,20 @@ describe('useValidationTimeline', () => {
                 label: 'Node2',
                 nodeSlug: 'node2',
                 order: 2,
-                previous: true,
                 status: 'REJECTED',
+            },
+            {
+                color: '#ff0000',
+                content: {
+                    author: 'John',
+                    comment: 'ok',
+                    date: date,
+                    description: 'desc1',
+                },
+                label: 'Node1',
+                nodeSlug: 'node1',
+                order: 1,
+                status: 'ACCEPTED',
             },
             {
                 color: '#ff0000',
@@ -310,19 +308,6 @@ describe('useValidationTimeline', () => {
                 status: 'NEW_VERSION',
             },
             {
-                color: '#ff0000',
-                content: {
-                    author: 'John',
-                    comment: 'ok',
-                    date: date,
-                    description: 'desc1',
-                },
-                label: 'Node1',
-                nodeSlug: 'node1',
-                order: 1,
-                status: 'ACCEPTED',
-            },
-            {
                 color: '#00ff00',
                 content: {
                     author: 'John',
@@ -333,7 +318,22 @@ describe('useValidationTimeline', () => {
                 label: 'Node2',
                 nodeSlug: 'node2',
                 order: 2,
+                previous: true,
                 status: 'REJECTED',
+            },
+            {
+                color: '#ff0000',
+                content: {
+                    author: 'John',
+                    comment: '',
+                    date: date,
+                    description: 'desc1',
+                },
+                label: 'Submission',
+                nodeSlug: 'node1',
+                order: 1,
+                previous: true,
+                status: 'SUBMISSION',
             },
         ]);
     });

--- a/hat/assets/js/apps/Iaso/domains/instances/components/ValidationWorkflow/useValidationTimeline.ts
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/ValidationWorkflow/useValidationTimeline.ts
@@ -177,8 +177,8 @@ const insertIntoResults = (props: InsertIntoResultsProps): void => {
     };
 
     if (type === 'PREVIOUS_HISTORY') {
-        // we insert at the beginning of the array
-        results.unshift(
+        // we insert at the end of the array
+        results.push(
             getResultItem({
                 ...base,
                 data,
@@ -190,7 +190,8 @@ const insertIntoResults = (props: InsertIntoResultsProps): void => {
     }
 
     if (type === 'NEXT_TASKS') {
-        results.push(
+        // we insert at the beginning of the array
+        results.unshift(
             getResultItem({
                 ...base,
                 data,
@@ -202,7 +203,8 @@ const insertIntoResults = (props: InsertIntoResultsProps): void => {
     }
 
     if (type === 'NEXT_BYPASS') {
-        results.push(
+        // we insert at the beginning of the array
+        results.unshift(
             getResultItem({
                 ...base,
                 data,
@@ -213,7 +215,7 @@ const insertIntoResults = (props: InsertIntoResultsProps): void => {
         return;
     }
 
-    results.push(
+    results.unshift(
         getResultItem({
             ...base,
             data,


### PR DESCRIPTION
## What problem is this PR solving?

Validation steps should be presented in reverse order (most recent on top not at the bottom)

### Related JIRA tickets

IA-4998

## Changes

reversed order of instance validation workflow timeline

## How to test

* js tests
* Go to any instance detail view , with some validation workflow data (use the script below). The data should be from most recent on top to older on bottom

```python 

import os
import django
os.environ.setdefault("DJANGO_SETTINGS_MODULE", "hat.local_settings")


django.setup()
from django.contrib.auth import get_user_model

from iaso.engine.validation_workflow import ValidationWorkflowEngine
from iaso.models import ValidationWorkflow, Instance
import time


workflow_template_slug = "test-validation-workflow"
user = get_user_model().objects.get(username="tryqrgx")
instance = Instance.objects.get(id="260")

instance.validationnode_set.all().delete()

workflow_template = ValidationWorkflow.objects.get(slug=workflow_template_slug)

ValidationWorkflowEngine.start(workflow_template, user, instance)

time.sleep(2)
# reject
ValidationWorkflowEngine.complete_node(instance.get_next_pending_nodes(workflow_template).first(), user, instance, approved=False, comment="No")
time.sleep(2)
# for resubmission
ValidationWorkflowEngine.start(workflow_template, user, instance)
time.sleep(2)
instance.refresh_from_db()

ValidationWorkflowEngine.complete_node(instance.get_next_pending_nodes(workflow_template).first(), user, instance, approved=True, comment="LGTM")
time.sleep(2)
instance.refresh_from_db()
ValidationWorkflowEngine.complete_node(instance.get_next_pending_nodes(workflow_template).first(), user, instance, approved=False, comment="Nope")
```

## Screenshots

<img width="448" height="661" alt="image" src="https://github.com/user-attachments/assets/9b1cef58-cf6c-4566-a981-67c976535987" />

