### PR TITLE
SNT-436: Flag to show menu item if no permissions on menu item

### DIFF
--- a/hat/assets/js/apps/Iaso/constants/menu.tsx
+++ b/hat/assets/js/apps/Iaso/constants/menu.tsx
@@ -507,11 +507,11 @@ export const useMenuItems = (): MenuItems => {
             menuItemsTemp.push(admin as MenuItem);
         }
         const authorizedItems = menuItemsTemp.filter(menuItem => {
-            if (menuItem.ignorePermissions) {
+            const permissionsList = listMenuPermission(menuItem);
+            // If not permission set on the menuItem, we consider that everyone has access to it
+            if (permissionsList.length === 0) {
                 return true;
             }
-
-            const permissionsList = listMenuPermission(menuItem);
             return userHasOneOfPermissions(permissionsList, currentUser);
         });
         if (hasFeatureFlag(currentUser, SHOW_DEV_FEATURES)) {

--- a/hat/assets/js/apps/Iaso/constants/menu.tsx
+++ b/hat/assets/js/apps/Iaso/constants/menu.tsx
@@ -507,6 +507,10 @@ export const useMenuItems = (): MenuItems => {
             menuItemsTemp.push(admin as MenuItem);
         }
         const authorizedItems = menuItemsTemp.filter(menuItem => {
+            if (menuItem.ignorePermissions) {
+                return true;
+            }
+
             const permissionsList = listMenuPermission(menuItem);
             return userHasOneOfPermissions(permissionsList, currentUser);
         });

--- a/hat/assets/js/apps/Iaso/domains/app/types.ts
+++ b/hat/assets/js/apps/Iaso/domains/app/types.ts
@@ -4,7 +4,6 @@ import { IntlMessage } from 'bluesquare-components';
 export type MenuItem = {
     label: string | IntlMessage;
     permissions?: string[];
-    ignorePermissions?: boolean;
     key?: string;
     mapKey?: string;
     icon?: (props: Record<string, any>) => ReactNode;

--- a/hat/assets/js/apps/Iaso/domains/app/types.ts
+++ b/hat/assets/js/apps/Iaso/domains/app/types.ts
@@ -4,6 +4,7 @@ import { IntlMessage } from 'bluesquare-components';
 export type MenuItem = {
     label: string | IntlMessage;
     permissions?: string[];
+    ignorePermissions?: boolean;
     key?: string;
     mapKey?: string;
     icon?: (props: Record<string, any>) => ReactNode;


### PR DESCRIPTION
## What problem is this PR solving?

If a menu entry has an empty array for permissions, it will never be shown (except for admins), accept a flag to override this behavior.

### Related JIRA tickets

SNT-436

## Changes

Add a ignorePermissions flag on menuItem to always show the menu item.

## How to test

With an account which is not Admin, take one of the nav that you see and modify the permission list of the menu item to be an empty array. 
The menu should disappear. 
add ignorePermissions: true to menuItem and verify that it nows appears.

## Print screen / video

N/A

## Notes

N/A

## Doc

N/A
