### PR TITLE
[IA-5000]: fix the impossibility to clear projects when editing a user

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/users/components/UsersInfosExtraFields.test.tsx
+++ b/hat/assets/js/apps/Iaso/domains/users/components/UsersInfosExtraFields.test.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { act, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import { UsersInfosExtraFields } from 'Iaso/domains/users/components/UsersInfosExtraFields';
+import {
+    renderWithThemeAndIntlProvider,
+    selectFromComboBoxWithAsync,
+} from '../../../../../tests/helpers';
+
+// mock
+const { mockUseGetProjectsDropdownOptions } = vi.hoisted(() => {
+    return { mockUseGetProjectsDropdownOptions: vi.fn() };
+});
+
+vi.mock('Iaso/domains/projects/hooks/requests', async () => {
+    return {
+        useGetProjectsDropdownOptions: mockUseGetProjectsDropdownOptions,
+    };
+});
+
+describe('UsersInfosExtraFields test', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockUseGetProjectsDropdownOptions.mockReturnValue({
+            isFetching: false,
+            data: [
+                {
+                    label: 'projectOption',
+                    value: 1,
+                    color: '#bbbbbb',
+                },
+            ],
+        });
+    });
+    it('sets projects value', async () => {
+        const mockSetFieldValue = vi.fn();
+        let currentUser = {
+            projects: {
+                value: '',
+                errors: [],
+            },
+            color: {
+                value: '',
+                errors: [],
+            },
+        };
+        const { rerender } = renderWithThemeAndIntlProvider(
+            <UsersInfosExtraFields
+                setFieldValue={mockSetFieldValue}
+                // @ts-ignore
+                currentUser={currentUser}
+                // @ts-ignore
+                loggedUser={currentUser}
+                canBypassProjectRestrictions={true}
+            />,
+        );
+
+        await act(async () => {
+            await selectFromComboBoxWithAsync({
+                nameComboBox: /projects/i,
+                nameOption: 'projectOption',
+            });
+        });
+
+        expect(mockSetFieldValue).toHaveBeenCalledWith('projects', [1]);
+        currentUser = {
+            projects: {
+                value: '1',
+                errors: [],
+            },
+            color: {
+                value: '',
+                errors: [],
+            },
+        };
+
+        rerender(
+            <UsersInfosExtraFields
+                setFieldValue={mockSetFieldValue}
+                // @ts-ignore
+                currentUser={currentUser}
+                // @ts-ignore
+                loggedUser={currentUser}
+                canBypassProjectRestrictions={true}
+            />,
+        );
+
+        expect(screen.getByText('projectOption')).toBeVisible();
+
+        // click the delete icon
+        const usrEvent = userEvent.setup();
+        await act(async () => {
+            await usrEvent.click(screen.getByTestId('CancelIcon'));
+        });
+
+        expect(mockSetFieldValue).toHaveBeenCalledWith('projects', []);
+    });
+});

--- a/hat/assets/js/apps/Iaso/domains/users/components/UsersInfosExtraFields.tsx
+++ b/hat/assets/js/apps/Iaso/domains/users/components/UsersInfosExtraFields.tsx
@@ -1,9 +1,9 @@
 import React, { FunctionComponent, useMemo } from 'react';
 import { Box } from '@mui/material';
 import { ColorPicker } from 'Iaso/components/forms/ColorPicker';
+import { useGetProjectsDropdownOptions } from 'Iaso/domains/projects/hooks/requests';
+import { User } from 'Iaso/utils/usersUtils';
 import InputComponent from '../../../components/forms/InputComponent';
-import { User } from '../../../utils/usersUtils';
-import { useGetProjectsDropdownOptions } from '../../projects/hooks/requests';
 import MESSAGES from '../messages';
 import { UserDialogData } from '../types';
 
@@ -38,14 +38,14 @@ export const UsersInfosExtraFields: FunctionComponent<Props> = ({
         <>
             <InputComponent
                 keyValue="projects"
-                onChange={(key, value) =>
+                onChange={(key: string, value) =>
                     setFieldValue(
                         key,
                         value
                             ?.split(',')
                             .map((projectId: string) =>
                                 parseInt(projectId, 10),
-                            ),
+                            ) ?? [],
                     )
                 }
                 value={currentUser.projects.value}

--- a/iaso/api/profiles/serializers/create.py
+++ b/iaso/api/profiles/serializers/create.py
@@ -25,22 +25,20 @@ class ProfileCreateSerializer(ModelSerializer):
     user_name = serializers.CharField(required=True, write_only=True)
     user_roles = serializers.PrimaryKeyRelatedField(
         allow_empty=True,
-        allow_null=True,
         many=True,
         queryset=UserRole.objects.none(),
         required=False,
         error_messages={"does_not_exist": _("One or more user roles do not belong to the provided account.")},
     )
     projects = serializers.PrimaryKeyRelatedField(
-        allow_empty=True, allow_null=True, queryset=Project.objects.none(), required=False, many=True
+        allow_empty=True, queryset=Project.objects.none(), required=False, many=True
     )
     org_units = serializers.PrimaryKeyRelatedField(
-        allow_empty=True, allow_null=True, many=True, queryset=OrgUnit.objects.all(), required=False
+        allow_empty=True, many=True, queryset=OrgUnit.objects.all(), required=False
     )
     editable_org_unit_type_ids = serializers.PrimaryKeyRelatedField(
         source="editable_org_unit_types",
         allow_empty=True,
-        allow_null=True,
         queryset=OrgUnitType.objects.all(),
         required=False,
         many=True,

--- a/iaso/api/profiles/serializers/update.py
+++ b/iaso/api/profiles/serializers/update.py
@@ -30,7 +30,7 @@ class ProfileUpdateSerializer(BaseProfileUpdateSerializer):
     country_code = serializers.CharField(write_only=True, required=False, allow_blank=True, allow_null=True)
 
     projects = serializers.PrimaryKeyRelatedField(
-        allow_empty=True, allow_null=True, queryset=Project.objects.none(), required=False, many=True
+        allow_empty=True, queryset=Project.objects.none(), required=False, many=True
     )
     user_permissions = serializers.SlugRelatedField(
         slug_field="codename", many=True, queryset=Permission.objects.none(), required=False
@@ -38,7 +38,6 @@ class ProfileUpdateSerializer(BaseProfileUpdateSerializer):
 
     user_roles = serializers.PrimaryKeyRelatedField(
         allow_empty=True,
-        allow_null=True,
         many=True,
         queryset=UserRole.objects.none(),
         required=False,
@@ -46,12 +45,11 @@ class ProfileUpdateSerializer(BaseProfileUpdateSerializer):
     )
 
     org_units = serializers.PrimaryKeyRelatedField(
-        allow_empty=True, allow_null=True, many=True, queryset=OrgUnit.objects.all(), required=False
+        allow_empty=True, many=True, queryset=OrgUnit.objects.all(), required=False
     )
     editable_org_unit_type_ids = serializers.PrimaryKeyRelatedField(
         source="editable_org_unit_types",
         allow_empty=True,
-        allow_null=True,
         queryset=OrgUnitType.objects.all(),
         required=False,
         many=True,


### PR DESCRIPTION
## What problem is this PR solving?

It was impossible to clear projects data when updating an user

### Related JIRA tickets

IA-5000

## Changes

Within the field, set the value to an empty array instead of undefined when empty field. 
Removed the allow_null=True from api as it made no  sense
JS tests

## How to test

Go to users management view, try to update a user with existing projects. Clear the project field, it should work and update the user so it doesn't have projects anymore
