### PR TITLE
IA-4994 fix: move submission validations into validation menu

### DIFF
--- a/hat/assets/js/__tests__/integration/validationWorkflows/ValidationWorkflowList.integration.test.tsx
+++ b/hat/assets/js/__tests__/integration/validationWorkflows/ValidationWorkflowList.integration.test.tsx
@@ -205,14 +205,14 @@ describe('Validation workflow list UI integration test', () => {
         expect(screen.getByRole('link', { name: '' })).toBeInTheDocument();
         expect(screen.getByRole('link', { name: '' })).toHaveAttribute(
             'href',
-            `/forms/submissions/validation/detail/slug/${validationWorkFlows?.results?.[0]?.slug}`,
+            `/validation/submissions/detail/slug/${validationWorkFlows?.results?.[0]?.slug}`,
         );
 
         expect(
             screen.getByTestId('SettingsIcon').parentElement,
         ).toHaveAttribute(
             'href',
-            `/forms/submissions/validation/detail/slug/${validationWorkFlows?.results?.[0]?.slug}`,
+            `/validation/submissions/detail/slug/${validationWorkFlows?.results?.[0]?.slug}`,
         );
 
         currentUser = currentUserFactory.build({
@@ -318,7 +318,7 @@ describe('Validation workflow list UI integration test', () => {
         ).toBeInTheDocument();
         expect(screen.getByRole('link', { name: 'Create' })).toHaveAttribute(
             'href',
-            '/forms/submissions/validation/detail/',
+            '/validation/submissions/detail/',
         );
 
         // it shouldn't be disabled as the router handles the perm there

--- a/hat/assets/js/apps/Iaso/constants/menu.test.tsx
+++ b/hat/assets/js/apps/Iaso/constants/menu.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { currentUserFactory } from '../../../__tests__/factories/users';
+import { SUBMISSION_VALIDATION_WORKFLOW } from '../utils/featureFlags';
+import * as paths from './routes';
+import { useMenuItems } from './menu';
+
+vi.mock('../utils/usersUtils', () => ({
+    useCurrentUser: vi.fn(),
+}));
+
+vi.mock('bluesquare-components', async importOriginal => {
+    const actual = await importOriginal<typeof import('bluesquare-components')>();
+    return {
+        ...actual,
+        useSafeIntl: () => ({
+            formatMessage: (msg: any) =>
+                msg?.defaultMessage ?? msg?.id ?? 'msg',
+        }),
+    };
+});
+
+vi.mock('../domains/entities/hooks/requests', () => ({
+    useGetEntityTypesDropdown: () => ({ data: [] }),
+}));
+
+vi.mock('../domains/home/hooks/useGetOrgunitsExtraPath', () => ({
+    useGetOrgunitsExtraPath: () => undefined,
+}));
+
+import { useCurrentUser } from '../utils/usersUtils';
+
+const mockUseCurrentUser = vi.mocked(useCurrentUser);
+
+const createMockUser = (featureFlags: string[] = []) => ({
+    ...currentUserFactory.build(),
+    is_staff: false,
+    permissions: paths.instancesValidationPath.permissions,
+    account: {
+        feature_flags: featureFlags,
+        modules: [],
+        default_version: {
+            data_source: {
+                url: null,
+            },
+        },
+    },
+});
+const renderUseMenuItems = () => renderHook(() => useMenuItems());
+
+const getValidationSubmissionsEntry = (menuItems: any[]) =>
+    menuItems
+        .find(item => item.key === 'validation')
+        ?.subMenu?.find(entry => entry.key === 'submissions');
+
+describe('useMenuItems - SUBMISSION_VALIDATION_WORKFLOW', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('adds the submissions entry to the validation menu when the feature flag is enabled', () => {
+        mockUseCurrentUser.mockReturnValue(
+            createMockUser([SUBMISSION_VALIDATION_WORKFLOW]),
+        );
+
+        const { result } = renderUseMenuItems();
+
+        const submissionsEntry = getValidationSubmissionsEntry(result.current);
+
+        expect(submissionsEntry).toMatchObject({
+            label: 'Submissions',
+            key: 'submissions',
+            permissions: paths.instancesValidationPath.permissions,
+        });
+    });
+
+    it('does not add the submissions entry when the feature flag is disabled', () => {
+        mockUseCurrentUser.mockReturnValue(createMockUser([]));
+
+        const { result } = renderUseMenuItems();
+
+        expect(getValidationSubmissionsEntry(result.current)).toBeUndefined();
+    });
+
+    it('does not duplicate the submissions entry across rerenders', () => {
+        mockUseCurrentUser.mockReturnValue(
+            createMockUser([SUBMISSION_VALIDATION_WORKFLOW]),
+        );
+
+        const { result, rerender } = renderUseMenuItems();
+        rerender();
+
+        const validationMenu = result.current.find(
+            item => item.key === 'validation',
+        );
+        const submissionsEntries =
+            validationMenu?.subMenu?.filter(
+                entry => entry.key === 'submissions',
+            ) ?? [];
+
+        expect(submissionsEntries).toHaveLength(1);
+    });
+});

--- a/hat/assets/js/apps/Iaso/constants/menu.tsx
+++ b/hat/assets/js/apps/Iaso/constants/menu.tsx
@@ -202,17 +202,10 @@ const menuItems = (
                 },
                 {
                     label: formatMessage(MESSAGES.submissionsTitle),
-                    key: 'submissions',
-                    icon: props => <Input {...props} />,
-                    subMenu: [
-                        {
-                            label: formatMessage(MESSAGES.list),
-                            extraPath: `/tab/list/mapResults/${locationLimitMax}`,
-                            permissions: paths.instancesPath.permissions,
-                            key: 'list',
-                            icon: props => <FormatListBulleted {...props} />,
-                        },
-                    ],
+                    key: 'submissions/list',
+                    icon: props => <FormatListBulleted {...props} />,
+                    permissions: paths.instancesPath.permissions,
+                    extraPath: `/tab/list/mapResults/${locationLimitMax}`,
                 },
 
                 {
@@ -312,6 +305,7 @@ const menuItems = (
                     key: `${CHANGE_REQUEST_CONFIG}`,
                     icon: props => <CategoryIcon {...props} />,
                 },
+                
             ],
         },
         {
@@ -459,17 +453,19 @@ export const useMenuItems = (): MenuItems => {
     }
 
     // add feature flags
-    if (hasFeatureFlag(currentUser, SUBMISSION_VALIDATION_WORKFLOW)) {
-        const formsMenuEntry = basicItems.find(item => item.key === 'forms');
+    if (hasFeatureFlag(currentUser, SUBMISSION_VALIDATION_WORKFLOW)){
+        const validationMenuEntry = basicItems.find(
+            item => item.key === 'validation',
+        );
         if (
-            !formsMenuEntry?.subMenu?.find(
-                entry => entry.key === 'submissions/validation',
+            !validationMenuEntry?.subMenu?.find(
+                entry => entry.key === 'submissions',
             )
         ) {
-            formsMenuEntry?.subMenu?.push({
-                label: formatMessage(MESSAGES.validation),
-                permissions: paths.instancesPath.permissions,
-                key: 'submissions/validation',
+            validationMenuEntry?.subMenu?.push({
+                label: formatMessage(MESSAGES.submissionValidations),
+                permissions: paths.instancesValidationPath.permissions,
+                key: 'submissions',
                 icon: props => <RuleIcon {...props} />,
             });
         }

--- a/hat/assets/js/apps/Iaso/constants/menu.tsx
+++ b/hat/assets/js/apps/Iaso/constants/menu.tsx
@@ -463,7 +463,7 @@ export const useMenuItems = (): MenuItems => {
             )
         ) {
             validationMenuEntry?.subMenu?.push({
-                label: formatMessage(MESSAGES.submissionValidations),
+                label: formatMessage(MESSAGES.submissions),
                 permissions: paths.instancesValidationPath.permissions,
                 key: 'submissions',
                 icon: props => <RuleIcon {...props} />,

--- a/hat/assets/js/apps/Iaso/constants/messages.js
+++ b/hat/assets/js/apps/Iaso/constants/messages.js
@@ -206,9 +206,9 @@ const MESSAGES = defineMessages({
         defaultMessage: 'Potential payments',
         id: 'iaso.payments.potentialPayments',
     },
-    submissionValidations: {
-        defaultMessage: 'Submissions validations',
-        id: 'iaso.label.submissionValidations',
+    submissions: {
+        defaultMessage: 'Submissions',
+        id: 'iaso.label.submissions',
     },
     lots: {
         defaultMessage: 'Payments lots',

--- a/hat/assets/js/apps/Iaso/constants/messages.js
+++ b/hat/assets/js/apps/Iaso/constants/messages.js
@@ -206,6 +206,10 @@ const MESSAGES = defineMessages({
         defaultMessage: 'Potential payments',
         id: 'iaso.payments.potentialPayments',
     },
+    submissionValidations: {
+        defaultMessage: 'Submissions validations',
+        id: 'iaso.label.submissionValidations',
+    },
     lots: {
         defaultMessage: 'Payments lots',
         id: 'iaso.payments.lots',

--- a/hat/assets/js/apps/Iaso/constants/urls.ts
+++ b/hat/assets/js/apps/Iaso/constants/urls.ts
@@ -126,7 +126,7 @@ export const baseRouteConfigs: Record<string, RouteConfig> = {
         params: ['accountId', 'instanceId', 'referenceFormId'],
     },
     instanceValidation: {
-        url: 'forms/submissions/validation',
+        url: 'validation/submissions',
         params: [
             'accountId',
             'forms',
@@ -136,7 +136,7 @@ export const baseRouteConfigs: Record<string, RouteConfig> = {
         ],
     },
     instanceValidationDetail: {
-        url: 'forms/submissions/validation/detail',
+        url: 'validation/submissions/detail',
         params: ['accountId', 'slug'],
     },
     compareInstanceLogs: {

--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -895,6 +895,7 @@
     "iaso.label.validateXLSFormLink": "online tool",
     "iaso.label.validation": "Validation",
     "iaso.label.validator": "Validator",
+    "iaso.label.submissionValidations": "Submissions validations",
     "iaso.label.value": "Value",
     "iaso.label.valueFrom": "Value from",
     "iaso.label.valueTo": "Value to",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -895,7 +895,7 @@
     "iaso.label.validateXLSFormLink": "online tool",
     "iaso.label.validation": "Validation",
     "iaso.label.validator": "Validator",
-    "iaso.label.submissionValidations": "Submissions validations",
+    "iaso.label.submissions": "Submissions",
     "iaso.label.value": "Value",
     "iaso.label.valueFrom": "Value from",
     "iaso.label.valueTo": "Value to",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/es.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/es.json
@@ -820,6 +820,7 @@
     "iaso.label.validateXLSFormLink": "online tool",
     "iaso.label.validation": "Validation",
     "iaso.label.validator": "Validator",
+    "iaso.label.submissionValidations": "Validaciones de envios",
     "iaso.label.value": "Value",
     "iaso.label.valueFrom": "Valor de",
     "iaso.label.valueTo": "Value a",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/es.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/es.json
@@ -820,7 +820,7 @@
     "iaso.label.validateXLSFormLink": "online tool",
     "iaso.label.validation": "Validation",
     "iaso.label.validator": "Validator",
-    "iaso.label.submissionValidations": "Validaciones de envios",
+    "iaso.label.submissions": "Envios",
     "iaso.label.value": "Value",
     "iaso.label.valueFrom": "Valor de",
     "iaso.label.valueTo": "Value a",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -896,6 +896,7 @@
     "iaso.label.validateXLSFormLink": "l'outil en ligne",
     "iaso.label.validation": "Validation",
     "iaso.label.validator": "Validateur",
+    "iaso.label.submissionValidations": "Validations des soumissions",
     "iaso.label.value": "Valeur",
     "iaso.label.valueFrom": "Valeur à partir de",
     "iaso.label.valueTo": "Valeur jusqu'à",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -896,7 +896,7 @@
     "iaso.label.validateXLSFormLink": "l'outil en ligne",
     "iaso.label.validation": "Validation",
     "iaso.label.validator": "Validateur",
-    "iaso.label.submissionValidations": "Validations des soumissions",
+    "iaso.label.submissions": "Soumissions",
     "iaso.label.value": "Valeur",
     "iaso.label.valueFrom": "Valeur à partir de",
     "iaso.label.valueTo": "Valeur jusqu'à",


### PR DESCRIPTION
## What problem is this PR solving?

This PR moves the submission validation workflow entry out of the Forms > Submissions navigation and into the Validation menu, with a clearer label.

### Related JIRA tickets

IA-4994

## Changes

- moved the submission validation workflow menu entry from the Forms menu to the Validation menu
- updated the related route from `/forms/submissions/validation` to `/validation/submissions` so the URL matches the navigation structure
- renamed the menu label to `Validations des soumissions`


## How to test

1. Run the frontend locally.
2. Log in with a user/account that can see the submission validation workflow entry.
3. Open the sidebar.
4. Verify that `Validations des soumissions` appears under the `Validation` menu.
5. Verify that it does not appear anymore under `Forms`.
6. Click the entry and verify that the page opens on `/validation/submissions`.

If needed for local testing, make sure the account has the `SUBMISSION_VALIDATION_WORKFLOW` feature flag enabled.

## Print screen / video
<img width="2880" height="1620" alt="Capture d’écran du 2026-04-24 10-38-03" src="https://github.com/user-attachments/assets/241147ab-2950-438f-a2ba-1214e2cc45c1" />



