### PR TITLE
IA-5012: Planning dropdowns should be displayed if user doesn't have the correct permissions

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/completenessStats/CompletenessStatsFilters.tsx
+++ b/hat/assets/js/apps/Iaso/domains/completenessStats/CompletenessStatsFilters.tsx
@@ -16,13 +16,11 @@ import {
 import intersection from 'lodash/intersection';
 import isEqual from 'lodash/isEqual';
 import uniq from 'lodash/uniq';
-import { DisplayIfUserHasPerm } from 'Iaso/components/DisplayIfUserHasPerm';
 import { UserAsyncSelect } from 'Iaso/components/filters/UserAsyncSelect';
 import { SearchButton } from 'Iaso/components/SearchButton';
 import { baseUrls } from 'Iaso/constants/urls';
 import { useFilterState } from 'Iaso/hooks/useFilterState';
 import { DropdownOptionsWithOriginal } from 'Iaso/types/utils';
-import { PLANNING_READ, PLANNING_WRITE } from 'Iaso/utils/permissions';
 import InputComponent from '../../components/forms/InputComponent';
 import { OrgUnitTreeviewModal } from '../orgUnits/components/TreeView/OrgUnitTreeviewModal';
 import { useGetOrgUnit } from '../orgUnits/components/TreeView/requests';
@@ -30,7 +28,7 @@ import { useGetGroupDropdown } from '../orgUnits/hooks/requests/useGetGroups';
 import { useGetOrgUnitValidationStatus } from '../orgUnits/hooks/utils/useGetOrgUnitValidationStatus';
 import PeriodPicker from '../periods/components/PeriodPicker';
 import { NO_PERIOD, PERIOD_TYPE_PLACEHOLDER } from '../periods/constants';
-import { useGetPlanningsOptions } from '../plannings/hooks/requests/useGetPlannings';
+import { PlanningsDropdown } from '../plannings/components/PlanningsDropdown';
 import { useGetProjectsDropdownOptions } from '../projects/hooks/requests';
 import { useGetTeamsDropdown } from '../teams/hooks/requests/useGetTeams';
 import { useGetOrgUnitTypesOptions } from './hooks/api/useGetOrgUnitTypesOptions';
@@ -73,8 +71,6 @@ export const CompletenessStatsFilters: FunctionComponent<Props> = ({
 
     const { data: orgUnitTypes, isFetching: fetchingTypes } =
         useGetOrgUnitTypesOptions(filters.parentId);
-    const { data: availablePlannings, isFetching: fetchingPlannings } =
-        useGetPlanningsOptions(filters.formId);
     const { data: teamsDropdown, isFetching: isFetchingTeams } =
         useGetTeamsDropdown({});
     useSkipEffectOnMount(() => {
@@ -216,19 +212,12 @@ export const CompletenessStatsFilters: FunctionComponent<Props> = ({
                         loading={fetchingTypes}
                         options={orgUnitTypes ?? []}
                     />
-                    <DisplayIfUserHasPerm
-                        permissions={[PLANNING_READ, PLANNING_WRITE]}
-                    >
-                        <InputComponent
-                            type="select"
-                            onChange={handleChange}
-                            keyValue="planningId"
-                            label={MESSAGES.planning}
-                            value={filters.planningId}
-                            loading={fetchingPlannings}
-                            options={availablePlannings ?? []}
-                        />
-                    </DisplayIfUserHasPerm>
+                    <PlanningsDropdown
+                        handleChange={handleChange}
+                        value={filters.planningId}
+                        formIds={filters.formId}
+                        keyValue="planningId"
+                    />
                 </Grid>
 
                 <Grid item xs={12} md={3}>

--- a/hat/assets/js/apps/Iaso/domains/forms/components/Filters.tsx
+++ b/hat/assets/js/apps/Iaso/domains/forms/components/Filters.tsx
@@ -11,6 +11,7 @@ import {
 
 import { SearchButton } from 'Iaso/components/SearchButton';
 import { baseUrls } from 'Iaso/constants/urls';
+import { PlanningsDropdown } from 'Iaso/domains/plannings/components/PlanningsDropdown';
 import { useQueryString } from 'Iaso/hooks/useApiParams';
 import * as Permission from 'Iaso/utils/permissions';
 import { DisplayIfUserHasPerm } from '../../../components/DisplayIfUserHasPerm';
@@ -18,7 +19,6 @@ import DownloadButtonsComponent from '../../../components/DownloadButtonsCompone
 import InputComponent from '../../../components/forms/InputComponent';
 import { useFilterState } from '../../../hooks/useFilterState';
 import { useGetOrgUnitTypesDropdownOptions } from '../../orgUnits/orgUnitTypes/hooks/useGetOrgUnitTypesDropdownOptions';
-import { useGetPlanningsOptions } from '../../plannings/hooks/requests/useGetPlannings';
 import { useGetProjectsDropdownOptions } from '../../projects/hooks/requests';
 import { baseUrl } from '../config';
 import { FormResponse, tableDefaults } from '../hooks/useGetForms';
@@ -57,7 +57,6 @@ const Filters: FunctionComponent<Props> = ({
         },
         [handleChange],
     );
-    const { data: planningsDropdownOptions } = useGetPlanningsOptions();
     const { data: orgUnitTypes, isFetching: isFetchingOuTypes } =
         useGetOrgUnitTypesDropdownOptions();
     const { data: allProjects, isFetching: isFetchingProjects } =
@@ -121,14 +120,11 @@ const Filters: FunctionComponent<Props> = ({
                     />
                 </Grid>
                 <Grid item xs={12} md={3}>
-                    <InputComponent
-                        type="select"
-                        multi
-                        keyValue="planning"
-                        onChange={handleChange}
+                    <PlanningsDropdown
+                        handleChange={handleChange}
                         value={filters.planning}
-                        label={MESSAGES.planning}
-                        options={planningsDropdownOptions}
+                        keyValue="planning"
+                        multi
                     />
                 </Grid>
             </Grid>

--- a/hat/assets/js/apps/Iaso/domains/forms/components/Filters.tsx
+++ b/hat/assets/js/apps/Iaso/domains/forms/components/Filters.tsx
@@ -12,8 +12,11 @@ import {
 import { SearchButton } from 'Iaso/components/SearchButton';
 import { baseUrls } from 'Iaso/constants/urls';
 import { PlanningsDropdown } from 'Iaso/domains/plannings/components/PlanningsDropdown';
+import { userHasOneOfPermissions } from 'Iaso/domains/users/utils';
 import { useQueryString } from 'Iaso/hooks/useApiParams';
 import * as Permission from 'Iaso/utils/permissions';
+import { PLANNING_READ, PLANNING_WRITE } from 'Iaso/utils/permissions';
+import { useCurrentUser } from 'Iaso/utils/usersUtils';
 import { DisplayIfUserHasPerm } from '../../../components/DisplayIfUserHasPerm';
 import DownloadButtonsComponent from '../../../components/DownloadButtonsComponent';
 import InputComponent from '../../../components/forms/InputComponent';
@@ -77,6 +80,12 @@ const Filters: FunctionComponent<Props> = ({
     );
     const csvUrl = `${dwnldBaseUrl}/?${downloadQueryString}&csv=true`;
     const xlsxUrl = `${dwnldBaseUrl}/?${downloadQueryString}&xlsx=true`;
+
+    const currentUser = useCurrentUser();
+    const hasPlanningPermission = userHasOneOfPermissions(
+        [PLANNING_READ, PLANNING_WRITE],
+        currentUser,
+    );
     return (
         <Grid container>
             <Grid container item xs={12} spacing={2}>
@@ -126,17 +135,28 @@ const Filters: FunctionComponent<Props> = ({
                         keyValue="planning"
                         multi
                     />
+                    {!hasPlanningPermission && (
+                        <InputComponent
+                            keyValue="showDeleted"
+                            onChange={handleShowDeleted}
+                            value={filters.showDeleted === 'true'}
+                            type="checkbox"
+                            label={MESSAGES.showDeleted}
+                        />
+                    )}
                 </Grid>
             </Grid>
             <Grid container item xs={12} spacing={2}>
                 <Grid item xs={12} md={3}>
-                    <InputComponent
-                        keyValue="showDeleted"
-                        onChange={handleShowDeleted}
-                        value={filters.showDeleted === 'true'}
-                        type="checkbox"
-                        label={MESSAGES.showDeleted}
-                    />
+                    {hasPlanningPermission && (
+                        <InputComponent
+                            keyValue="showDeleted"
+                            onChange={handleShowDeleted}
+                            value={filters.showDeleted === 'true'}
+                            type="checkbox"
+                            label={MESSAGES.showDeleted}
+                        />
+                    )}
                 </Grid>
                 <Grid item xs={12} md={9}>
                     <Box

--- a/hat/assets/js/apps/Iaso/domains/instances/components/InstancesFiltersComponent.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/InstancesFiltersComponent.tsx
@@ -14,6 +14,7 @@ import {
 import { UserAsyncSelect } from 'Iaso/components/filters/UserAsyncSelect';
 import { UserOrgUnitRestriction } from 'Iaso/components/UserOrgUnitRestriction';
 import { useGetFormsDropdownOptions } from 'Iaso/domains/forms/hooks/useGetFormsDropdownOptions';
+import { PlanningsDropdown } from 'Iaso/domains/plannings/components/PlanningsDropdown';
 import { getInstancesFilterValues, useFormState } from 'Iaso/hooks/form';
 import { LocationLimit } from 'Iaso/utils/map/LocationLimit';
 import DatesRange from '../../../components/filters/DatesRange';
@@ -30,7 +31,6 @@ import { periodTypeOptions } from '../../periods/constants';
 import { Period } from '../../periods/models';
 import { isValidPeriod } from '../../periods/utils';
 
-import { useGetPlanningsOptions } from '../../plannings/hooks/requests/useGetPlannings';
 import { useGetProjectsDropdownOptions } from '../../projects/hooks/requests';
 import { INSTANCE_STATUSES } from '../constants';
 
@@ -118,8 +118,6 @@ const InstancesFiltersComponent = ({
     const [textSearchError, setTextSearchError] = useState(false);
     const [initialOrgUnitId, setInitialOrgUnitId] = useState(params?.levels);
     const { data: initialOrgUnit } = useGetOrgUnit(initialOrgUnitId);
-    const { data: planningsDropdownOptions, isFetching: fetchingPlannings } =
-        useGetPlanningsOptions();
     useSkipEffectOnMount(() => {
         Object.entries(params).forEach(([key, value]) => {
             if (key === 'showDeleted') {
@@ -415,16 +413,14 @@ const InstancesFiltersComponent = ({
                         label={MESSAGES.org_unit_type_id}
                         loading={isFetchingOuTypes}
                     />
-                    <InputComponent
-                        type="select"
-                        multi
-                        keyValue="planningIds"
-                        onChange={handleFormChange}
-                        value={formState.planningIds.value || null}
-                        options={planningsDropdownOptions}
-                        label={MESSAGES.planning}
-                        loading={fetchingPlannings}
-                    />
+                    <Box mt={2}>
+                        <UserAsyncSelect
+                            keyValue="userIds"
+                            label={MESSAGES.user}
+                            filterUsers={formState?.userIds?.value}
+                            handleChange={joinValuesBeforeHandleFormChange}
+                        />
+                    </Box>
                 </Grid>
                 <Grid item xs={12} sm={6} md={3}>
                     <DatesRange
@@ -480,14 +476,12 @@ const InstancesFiltersComponent = ({
                             </Typography>
                         </Box>
                     )}
-                    <Box mt={2}>
-                        <UserAsyncSelect
-                            keyValue="userIds"
-                            label={MESSAGES.user}
-                            filterUsers={formState?.userIds?.value}
-                            handleChange={joinValuesBeforeHandleFormChange}
-                        />
-                    </Box>
+                    <PlanningsDropdown
+                        handleChange={handleFormChange}
+                        value={formState.planningIds.value || null}
+                        keyValue="planningIds"
+                        multi
+                    />
                 </Grid>
             </Grid>
 

--- a/hat/assets/js/apps/Iaso/domains/plannings/components/PlanningsDropdown.test.tsx
+++ b/hat/assets/js/apps/Iaso/domains/plannings/components/PlanningsDropdown.test.tsx
@@ -1,0 +1,145 @@
+import React from 'react';
+import { act, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderWithThemeAndIntlProvider } from '../../../../../tests/helpers';
+import { PlanningsDropdown } from './PlanningsDropdown';
+
+const { mockCurrentUser } = vi.hoisted(() => ({
+    mockCurrentUser: vi.fn(),
+}));
+
+vi.mock('Iaso/utils/usersUtils', () => ({
+    useCurrentUser: mockCurrentUser,
+}));
+
+const { mockUseGetPlanningsOptions } = vi.hoisted(() => ({
+    mockUseGetPlanningsOptions: vi.fn(),
+}));
+
+vi.mock('Iaso/domains/plannings/hooks/requests/useGetPlannings', () => ({
+    useGetPlanningsOptions: mockUseGetPlanningsOptions,
+}));
+
+const userWithPlanningRead = {
+    id: 1,
+    permissions: ['iaso_planning_read'],
+};
+
+const planningOptions = [
+    { value: 1, label: 'Planning Alpha' },
+    { value: 2, label: 'Planning Beta' },
+];
+
+const Wrapper = ({
+    formIds,
+    multi,
+}: {
+    formIds?: string;
+    multi?: boolean;
+} = {}) => {
+    const [value, setValue] = React.useState<number | null>(null);
+    return (
+        <PlanningsDropdown
+            formIds={formIds}
+            multi={multi}
+            keyValue="planningId"
+            value={value}
+            handleChange={(_key, newValue) => setValue(newValue)}
+        />
+    );
+};
+
+describe('PlanningsDropdown', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockCurrentUser.mockReturnValue(userWithPlanningRead);
+        mockUseGetPlanningsOptions.mockReturnValue({
+            data: planningOptions,
+            isFetching: false,
+        });
+    });
+
+    it('renders the planning select when the user has planning permissions', () => {
+        renderWithThemeAndIntlProvider(<Wrapper />);
+
+        expect(
+            screen.getByRole('combobox', { name: 'Planning' }),
+        ).toBeVisible();
+        expect(mockUseGetPlanningsOptions).toHaveBeenCalledWith(
+            undefined,
+            true,
+        );
+    });
+
+    it('updates the selected value when the user picks a planning', async () => {
+        const user = userEvent.setup();
+        renderWithThemeAndIntlProvider(<Wrapper />);
+
+        const combobox = screen.getByRole('combobox', { name: 'Planning' });
+
+        await act(async () => {
+            await user.click(combobox);
+        });
+
+        await act(async () => {
+            await user.click(
+                await screen.findByRole('option', { name: 'Planning Beta' }),
+            );
+        });
+
+        await waitFor(() => {
+            expect(combobox).toHaveValue('Planning Beta');
+        });
+    });
+
+    it('clears the selection when the user clears the combobox', async () => {
+        const user = userEvent.setup();
+        renderWithThemeAndIntlProvider(<Wrapper />);
+
+        const combobox = screen.getByRole('combobox', { name: 'Planning' });
+
+        await act(async () => {
+            await user.click(combobox);
+        });
+
+        await act(async () => {
+            await user.click(
+                await screen.findByRole('option', { name: 'Planning Alpha' }),
+            );
+        });
+
+        await waitFor(() => {
+            expect(combobox).toHaveValue('Planning Alpha');
+        });
+
+        await act(async () => {
+            await user.clear(combobox);
+        });
+
+        await waitFor(() => {
+            expect(combobox).toHaveValue('');
+        });
+    });
+
+    it('does not render the field when the user lacks planning permissions', () => {
+        mockCurrentUser.mockReturnValue({
+            id: 2,
+            permissions: [],
+        });
+
+        const { container } = renderWithThemeAndIntlProvider(<Wrapper />);
+
+        expect(container.querySelector('input')).toBeNull();
+        expect(mockUseGetPlanningsOptions).toHaveBeenCalledWith(
+            undefined,
+            false,
+        );
+    });
+
+    it('passes formIds to the plannings options hook', () => {
+        renderWithThemeAndIntlProvider(<Wrapper formIds="10,20" />);
+
+        expect(mockUseGetPlanningsOptions).toHaveBeenCalledWith('10,20', true);
+    });
+});

--- a/hat/assets/js/apps/Iaso/domains/plannings/components/PlanningsDropdown.tsx
+++ b/hat/assets/js/apps/Iaso/domains/plannings/components/PlanningsDropdown.tsx
@@ -1,0 +1,44 @@
+import React, { FunctionComponent } from 'react';
+import InputComponent from 'Iaso/components/forms/InputComponent';
+import { userHasOneOfPermissions } from 'Iaso/domains/users/utils';
+import { PLANNING_READ, PLANNING_WRITE } from 'Iaso/utils/permissions';
+import { useCurrentUser } from 'Iaso/utils/usersUtils';
+import { useGetPlanningsOptions } from '../hooks/requests/useGetPlannings';
+import MESSAGES from '../messages';
+
+type Props = {
+    multi?: boolean;
+    handleChange: (keyValue: string, value: any) => void;
+    value: any;
+    formIds?: string;
+    keyValue: string;
+};
+
+export const PlanningsDropdown: FunctionComponent<Props> = ({
+    multi = false,
+    handleChange,
+    value,
+    formIds,
+    keyValue,
+}) => {
+    const currentUser = useCurrentUser();
+    const hasPermissions = userHasOneOfPermissions(
+        [PLANNING_READ, PLANNING_WRITE],
+        currentUser,
+    );
+    const { data: availablePlannings, isFetching: fetchingPlannings } =
+        useGetPlanningsOptions(formIds, hasPermissions);
+
+    return hasPermissions ? (
+        <InputComponent
+            type="select"
+            onChange={(_key, value: any) => handleChange(keyValue, value)}
+            keyValue={keyValue}
+            label={MESSAGES.planning}
+            value={value}
+            multi={multi}
+            loading={fetchingPlannings}
+            options={availablePlannings ?? []}
+        />
+    ) : null;
+};

--- a/hat/assets/js/apps/Iaso/domains/plannings/hooks/requests/useGetPlannings.test.tsx
+++ b/hat/assets/js/apps/Iaso/domains/plannings/hooks/requests/useGetPlannings.test.tsx
@@ -1,0 +1,185 @@
+import React from 'react';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { endpoint } from '../../constants';
+import { PlanningParams } from '../../types';
+import { useGetPlannings, useGetPlanningsOptions } from './useGetPlannings';
+
+const { mockGetRequest } = vi.hoisted(() => ({
+    mockGetRequest: vi.fn(),
+}));
+
+vi.mock('Iaso/libs/Api', () => ({
+    getRequest: (...args: unknown[]) => mockGetRequest(...args),
+}));
+
+vi.mock('Iaso/utils/dates', () => ({
+    dateRangePickerToDateApi: vi.fn((dateStr?: string) =>
+        dateStr ? `api:${dateStr}` : undefined,
+    ),
+    dateApiToDateRangePicker: vi.fn((dateStr?: string) =>
+        dateStr ? `picker:${dateStr}` : null,
+    ),
+}));
+
+const createWrapper = () => {
+    const queryClient = new QueryClient({
+        defaultOptions: {
+            queries: { retry: false },
+        },
+    });
+    const Wrapper = ({ children }: { children: React.ReactNode }) => (
+        <IntlProvider locale="en" messages={{}}>
+            <QueryClientProvider client={queryClient}>
+                {children}
+            </QueryClientProvider>
+        </IntlProvider>
+    );
+    Wrapper.displayName = 'TestQueryClientWrapper';
+    return Wrapper;
+};
+
+const minimalPlanning = {
+    id: 1,
+    name: 'Alpha',
+    forms: [] as number[],
+    pipeline_uuids: [] as string[],
+    assignments_count: 0,
+    started_at: '2024-01-01',
+    ended_at: '2024-01-31',
+};
+
+describe('useGetPlanningsOptions', () => {
+    beforeEach(() => {
+        mockGetRequest.mockReset();
+    });
+
+    it('returns dropdown options mapped from the API response', async () => {
+        mockGetRequest.mockResolvedValue([
+            {
+                ...minimalPlanning,
+                id: 10,
+                name: 'Plan A',
+            },
+        ]);
+
+        const { result } = renderHook(
+            () => useGetPlanningsOptions(undefined, true),
+            { wrapper: createWrapper() },
+        );
+
+        await waitFor(() => {
+            expect(result.current.isSuccess).toBe(true);
+        });
+
+        expect(result.current.data).toEqual([
+            {
+                value: 10,
+                label: 'Plan A',
+                original: {
+                    ...minimalPlanning,
+                    id: 10,
+                    name: 'Plan A',
+                },
+            },
+        ]);
+        expect(mockGetRequest).toHaveBeenCalledWith(`${endpoint}?`);
+    });
+
+    it('requests form_ids when formIds is provided', async () => {
+        mockGetRequest.mockResolvedValue([]);
+
+        renderHook(() => useGetPlanningsOptions('12,34', true), {
+            wrapper: createWrapper(),
+        });
+
+        await waitFor(() => {
+            expect(mockGetRequest).toHaveBeenCalledWith(
+                `${endpoint}?form_ids=12%2C34`,
+            );
+        });
+    });
+
+    it('does not call the API when enabled is false', async () => {
+        renderHook(() => useGetPlanningsOptions('1', false), {
+            wrapper: createWrapper(),
+        });
+
+        await act(async () => {
+            await Promise.resolve();
+            await Promise.resolve();
+        });
+
+        expect(mockGetRequest).not.toHaveBeenCalled();
+    });
+});
+
+describe('useGetPlannings', () => {
+    beforeEach(() => {
+        mockGetRequest.mockReset();
+    });
+
+    const listOptions = {
+        publishingStatus: 'all',
+        dateFrom: '01-01-2024',
+        dateTo: '31-01-2024',
+        pageSize: '20',
+        page: '1',
+    } as PlanningParams;
+
+    it('requests list params and maps results in select', async () => {
+        mockGetRequest.mockResolvedValue({
+            count: 2,
+            results: [
+                {
+                    ...minimalPlanning,
+                    id: 1,
+                    published_at: '2024-06-01',
+                },
+                {
+                    ...minimalPlanning,
+                    id: 2,
+                    name: 'Draft plan',
+                    published_at: undefined,
+                },
+            ],
+        });
+
+        const { result } = renderHook(() => useGetPlannings(listOptions), {
+            wrapper: createWrapper(),
+        });
+
+        await waitFor(() => {
+            expect(result.current.isSuccess).toBe(true);
+        });
+
+        const calledUrl = mockGetRequest.mock.calls[0][0] as string;
+        expect(calledUrl).toContain(`${endpoint}?`);
+        expect(calledUrl).toContain('publishing_status=all');
+        expect(calledUrl).toContain('limit=20');
+        expect(calledUrl).toContain('started_at__gte=api%3A01-01-2024');
+        expect(calledUrl).toContain('ended_at__lte=api%3A31-01-2024');
+
+        expect(result.current.data?.results).toEqual([
+            {
+                ...minimalPlanning,
+                id: 1,
+                published_at: '2024-06-01',
+                status: 'published',
+                started_at: 'picker:2024-01-01',
+                ended_at: 'picker:2024-01-31',
+            },
+            {
+                ...minimalPlanning,
+                id: 2,
+                name: 'Draft plan',
+                published_at: undefined,
+                status: 'draft',
+                started_at: 'picker:2024-01-01',
+                ended_at: 'picker:2024-01-31',
+            },
+        ]);
+    });
+});

--- a/hat/assets/js/apps/Iaso/domains/plannings/hooks/requests/useGetPlannings.ts
+++ b/hat/assets/js/apps/Iaso/domains/plannings/hooks/requests/useGetPlannings.ts
@@ -81,12 +81,14 @@ const getPlanningsOptions = async (formIds?: string): Promise<Planning[]> => {
 };
 export const useGetPlanningsOptions = (
     formIds?: string,
+    enabled = true,
 ): UseQueryResult<DropdownOptions<number>[], Error> => {
     const queryKey: any[] = ['planningsList', formIds];
     return useSnackQuery({
         queryKey,
         queryFn: () => getPlanningsOptions(formIds),
         options: {
+            enabled,
             select: (data: Planning[]) => {
                 return data?.map(planning => {
                     return {

--- a/hat/assets/js/apps/Iaso/domains/plannings/hooks/requests/useGetPlannings.ts
+++ b/hat/assets/js/apps/Iaso/domains/plannings/hooks/requests/useGetPlannings.ts
@@ -81,7 +81,7 @@ const getPlanningsOptions = async (formIds?: string): Promise<Planning[]> => {
 };
 export const useGetPlanningsOptions = (
     formIds?: string,
-    enabled = true,
+    enabled = false,
 ): UseQueryResult<DropdownOptions<number>[], Error> => {
     const queryKey: any[] = ['planningsList', formIds];
     return useSnackQuery({

--- a/hat/assets/js/apps/Iaso/domains/plannings/messages.ts
+++ b/hat/assets/js/apps/Iaso/domains/plannings/messages.ts
@@ -376,6 +376,10 @@ const MESSAGES = defineMessages({
             'Editting dates or status can impact the actual data collection',
         id: 'iaso.planning.label.planningWarningMessage',
     },
+    planning: {
+        defaultMessage: 'Planning',
+        id: 'iaso.label.planning',
+    },
 });
 
 export default MESSAGES;

--- a/hat/assets/js/apps/Iaso/domains/users/utils.ts
+++ b/hat/assets/js/apps/Iaso/domains/users/utils.ts
@@ -25,7 +25,10 @@ export const userHasPermission = (permission, user) => {
  * @param {Object} user
  * @return {Boolean}
  */
-export const userHasOneOfPermissions = (permissions = [], user) => {
+export const userHasOneOfPermissions = (
+    permissions: string[] = [],
+    user: User,
+): boolean => {
     if (!user) {
         return false;
     }


### PR DESCRIPTION
## What problem is this PR solving?

Recently api has been changed to check planning permission. Frontend is still trying to fetch planning a bit everywhere in the app, we should hide those filters if user doesn’t have the permission

### Related JIRA tickets

IA-5012

## Changes

- generic component for dropdown planning
- frontend tests

## How to test

Make sure you have one user with a planning permission and one without.


Visit those pages and make sure:
- user with permissions can filter per planning
- user without doesn't have the planing dropdown AND the api call is not done

/dashboard/forms/stats/completenessStats
/dashboard/forms/list
/dashboard/forms/submissions/list

## Print screen / video

<img width="2550" height="626" alt="Screenshot 2026-04-24 at 16 06 00" src="https://github.com/user-attachments/assets/a4ecaaf0-e943-454c-8629-fbf3d58c94e5" />
<img width="2546" height="581" alt="Screenshot 2026-04-24 at 16 05 46" src="https://github.com/user-attachments/assets/5b63646f-72ff-448e-ba9e-015f68a1b0a6" />
<img width="2459" height="665" alt="Screenshot 2026-04-24 at 15 53 45" src="https://github.com/user-attachments/assets/f14434df-5962-4d15-a992-e386f9273dda" />
