### PR TITLE
[IA-5016]: backward compatibility for dynamic model field

### DIFF
--- a/dynamic_fields/filter_backends.py
+++ b/dynamic_fields/filter_backends.py
@@ -11,8 +11,15 @@ class DynamicFieldsFilterBackend(BaseFilterBackend):
     It doesn't actually filter anything like a classic DRF filter would.
     """
 
+    # for backward compatibility purposes
+    string_field = False
+
     def filter_queryset(self, request, queryset, view):
-        values = request.query_params.getlist(settings.DYNAMIC_FIELDS_QUERY_PARAM_NAME)
+        values = (
+            request.query_params.getlist(settings.DYNAMIC_FIELDS_QUERY_PARAM_NAME)
+            if not self.string_field
+            else request.query_params.get(settings.DYNAMIC_FIELDS_QUERY_PARAM_NAME, "").split(",")
+        )
         values = [v for v in values if v]  # filter out empty
         if not values:
             return queryset
@@ -42,6 +49,24 @@ class DynamicFieldsFilterBackend(BaseFilterBackend):
         if not issubclass(serializer_class, DynamicFieldsModelSerializerMixin):
             return []
 
+        if self.string_field:
+            return [
+                {
+                    "name": settings.DYNAMIC_FIELDS_QUERY_PARAM_NAME,
+                    "in": "query",
+                    "required": False,
+                    "description": (
+                        f"Dynamic serializer fields. String of comma separated values. Use '{settings.DYNAMIC_FIELDS_ALL_FIELDS_PARAM_VALUE}' or '{settings.DYNAMIC_FIELDS_DEFAULT_FIELDS_PARAM_VALUE}' or specific field names."
+                    ),
+                    "schema": {
+                        "type": "array",
+                        "items": {"type": "string", "enum": serializer_class.get_valid_options()},
+                    },
+                    "style": "form",
+                    "explode": False,
+                }
+            ]
+
         return [
             {
                 "name": settings.DYNAMIC_FIELDS_QUERY_PARAM_NAME,
@@ -58,3 +83,11 @@ class DynamicFieldsFilterBackend(BaseFilterBackend):
                 "explode": True,
             }
         ]
+
+
+class DynamicFieldsFilterBackendBackwardCompatible(DynamicFieldsFilterBackend):
+    """
+    Same as dynamic fields filter , except that the fields parameter is a string with comma separated values
+    """
+
+    string_field = True

--- a/dynamic_fields/serializer.py
+++ b/dynamic_fields/serializer.py
@@ -7,6 +7,7 @@ class DynamicFieldsModelSerializerMixin(serializers.Serializer):
         # todo: should be settings.DYNAMIC_FIELDS_QUERY_PARAM_NAME directly , but polio serializers crash if not so
         # todo: is it also really needed, it's only used in some places like OrgUnitType
         self.dynamic_fields = kwargs.pop(getattr(settings, "DYNAMIC_FIELDS_QUERY_PARAM_NAME", "fields"), None)
+        self.string_field = kwargs.pop("string_field", False)
         super().__init__(*args, **kwargs)
         self._applied_dynamic_fields = False
 
@@ -48,6 +49,14 @@ class DynamicFieldsModelSerializerMixin(serializers.Serializer):
 
     def get_fields_value_from_query(self):
         if self.context.get("request", None):
+            if self.string_field:
+                return [
+                    v
+                    for v in self.context.get("request")
+                    .query_params.get(settings.DYNAMIC_FIELDS_QUERY_PARAM_NAME, "")
+                    .split(",")
+                    if v
+                ]
             return [
                 v
                 for v in self.context.get("request").query_params.getlist(settings.DYNAMIC_FIELDS_QUERY_PARAM_NAME)
@@ -58,3 +67,9 @@ class DynamicFieldsModelSerializerMixin(serializers.Serializer):
 
 class DynamicFieldsModelSerializer(DynamicFieldsModelSerializerMixin, serializers.ModelSerializer):
     pass
+
+
+class DynamicFieldsModelSerializerBackwardCompatible(DynamicFieldsModelSerializerMixin, serializers.ModelSerializer):
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("string_field", True)
+        super().__init__(*args, **kwargs)

--- a/dynamic_fields/serializer.py
+++ b/dynamic_fields/serializer.py
@@ -65,11 +65,19 @@ class DynamicFieldsModelSerializerMixin(serializers.Serializer):
         return []
 
 
+class DynamicFieldsModelSerializerBackwardCompatibleMixin(DynamicFieldsModelSerializerMixin):
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("string_field", True)
+        super().__init__(*args, **kwargs)
+
+
 class DynamicFieldsModelSerializer(DynamicFieldsModelSerializerMixin, serializers.ModelSerializer):
     pass
 
 
-class DynamicFieldsModelSerializerBackwardCompatible(DynamicFieldsModelSerializerMixin, serializers.ModelSerializer):
+class DynamicFieldsModelSerializerBackwardCompatible(
+    DynamicFieldsModelSerializerBackwardCompatibleMixin, serializers.ModelSerializer
+):
     def __init__(self, *args, **kwargs):
         kwargs.setdefault("string_field", True)
         super().__init__(*args, **kwargs)

--- a/dynamic_fields/tests/test_filter_backends.py
+++ b/dynamic_fields/tests/test_filter_backends.py
@@ -5,7 +5,7 @@ from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.test import APIRequestFactory
 
-from dynamic_fields.filter_backends import DynamicFieldsFilterBackend
+from dynamic_fields.filter_backends import DynamicFieldsFilterBackend, DynamicFieldsFilterBackendBackwardCompatible
 from dynamic_fields.serializer import DynamicFieldsModelSerializerMixin
 
 
@@ -90,5 +90,86 @@ class DynamicFieldsFilterBackendTest(TestCase):
                 },
                 "style": "form",
                 "explode": True,
+            },
+        )
+
+
+@override_settings(
+    DYNAMIC_FIELDS_QUERY_PARAM_NAME="fields",
+    DYNAMIC_FIELDS_DEFAULT_FIELDS_PARAM_VALUE=":default",
+    DYNAMIC_FIELDS_ALL_FIELDS_PARAM_VALUE=":all",
+    DYNAMIC_FIELDS_DEFAULT_FIELDS_META_PARAM="default_fields",
+    DYNAMIC_FIELDS_ALL_FIELDS_META_PARAM="fields",
+)
+class DynamicFieldsFilterBackendBackwardCompatibleTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.factory = APIRequestFactory()
+        cls.queryset = get_user_model().objects.all()
+
+    def setUp(self):
+        self.backend = DynamicFieldsFilterBackendBackwardCompatible()
+
+    def test_no_query_params_returns_queryset(self):
+        request = Request(self.factory.get("/"))
+
+        result = self.backend.filter_queryset(request, self.queryset, DummyView())
+        self.assertEqual(result, self.queryset)
+
+    def test_valid_fields_pass(self):
+        request = Request(self.factory.get("/?fields=name,age"))
+
+        result = self.backend.filter_queryset(request, self.queryset, DummyView())
+        self.assertEqual(result, self.queryset)
+
+    def test_invalid_fields_raises(self):
+        request = Request(self.factory.get("/?fields=invalid"))
+
+        with self.assertRaises(ValidationError):
+            self.backend.filter_queryset(request, self.queryset, DummyView())
+
+    def test_conflicting_params_raises(self):
+        request = Request(self.factory.get("/?fields=:all,:default"))
+
+        with self.assertRaises(ValidationError):
+            self.backend.filter_queryset(request, self.queryset, DummyView())
+
+    def test_get_schema_operation_parameters(self):
+        class TestSerializer(DynamicFieldsModelSerializerMixin, serializers.Serializer):
+            name = serializers.CharField()
+            age = serializers.IntegerField()
+            email = serializers.EmailField()
+
+            def __init__(self, *args, **kwargs):
+                kwargs.setdefault("string_field", True)
+                super().__init__(*args, **kwargs)
+
+            class Meta:
+                fields = ["name", "age", "email"]
+                default_fields = ["name", "age"]
+
+        class View:
+            def get_serializer_class(self):
+                return TestSerializer
+
+        backend = DynamicFieldsFilterBackendBackwardCompatible()
+        params = backend.get_schema_operation_parameters(View())
+
+        self.assertEqual(len(params), 1)
+        self.assertEqual(
+            params[0],
+            {
+                "name": "fields",
+                "in": "query",
+                "required": False,
+                "description": (
+                    "Dynamic serializer fields. String of comma separated values. Use ':all' or ':default' or specific field names."
+                ),
+                "schema": {
+                    "type": "array",
+                    "items": {"type": "string", "enum": [":all", ":default", "name", "age", "email"]},
+                },
+                "style": "form",
+                "explode": False,
             },
         )

--- a/dynamic_fields/tests/test_serializer.py
+++ b/dynamic_fields/tests/test_serializer.py
@@ -94,3 +94,88 @@ class DynamicFieldsSerializerTest(TestCase):
         data = serializer.to_representation(self.get_instance())
 
         self.assertSetEqual(set(data.keys()), {"name", "age", "email"})
+
+
+@override_settings(
+    DYNAMIC_FIELDS_QUERY_PARAM_NAME="fields",
+    DYNAMIC_FIELDS_DEFAULT_FIELDS_PARAM_VALUE=":default",
+    DYNAMIC_FIELDS_ALL_FIELDS_PARAM_VALUE=":all",
+    DYNAMIC_FIELDS_DEFAULT_FIELDS_META_PARAM="default_fields",
+    DYNAMIC_FIELDS_ALL_FIELDS_META_PARAM="fields",
+)
+class DynamicFieldsSerializerBackwardCompatibleTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.factory = APIRequestFactory()
+
+    def get_instance(self):
+        return {"name": "John", "age": 30, "email": "john@example.com"}
+
+    def test_default_fields_applied(self):
+        serializer = TestSerializer(string_field=True)
+
+        data = serializer.to_representation(self.get_instance())
+        self.assertSetEqual(set(data.keys()), {"name", "age"})
+
+    def test_all_fields(self):
+        serializer = TestSerializer(fields=":all", string_field=True)
+
+        data = serializer.to_representation(self.get_instance())
+        self.assertSetEqual(set(data.keys()), {"name", "age", "email"})
+
+    def test_specific_fields(self):
+        serializer = TestSerializer(fields="email", string_field=True)
+
+        data = serializer.to_representation(self.get_instance())
+        self.assertSetEqual(set(data.keys()), {"email"})
+
+    def test_default_keyword(self):
+        serializer = TestSerializer(fields=":default", string_field=True)
+
+        data = serializer.to_representation(self.get_instance())
+        self.assertSetEqual(set(data.keys()), {"name", "age"})
+
+    def test_request_overrides_serializer_fields(self):
+        request = Request(self.factory.get("/?fields=email"))
+
+        serializer = TestSerializer(
+            self.get_instance(),
+            string_field=True,
+            context={"request": request},
+            fields=["name", "age"],  # should be ignored
+        )
+
+        data = serializer.to_representation(self.get_instance())
+
+        self.assertSetEqual(set(data.keys()), {"email"})
+
+    def test_request_all_fields(self):
+        request = Request(self.factory.get("/?fields=:all"))
+
+        serializer = TestSerializer(self.get_instance(), context={"request": request}, string_field=True)
+
+        data = serializer.to_representation(self.get_instance())
+
+        self.assertSetEqual(set(data.keys()), {"name", "age", "email"})
+
+    def test_default_overrides_specific_fields(self):
+        request = Request(self.factory.get("/?fields=:default,email"))
+
+        serializer = TestSerializer(
+            self.get_instance(), context={"request": request}, fields="email", string_field=True
+        )
+
+        data = serializer.to_representation(self.get_instance())
+
+        self.assertSetEqual(set(data.keys()), {"name", "age"})
+
+    def test_all_overrides_specific_fields(self):
+        request = Request(self.factory.get("/?fields=:all,email"))
+
+        serializer = TestSerializer(
+            self.get_instance(), context={"request": request}, fields="email", string_field=True
+        )
+
+        data = serializer.to_representation(self.get_instance())
+
+        self.assertSetEqual(set(data.keys()), {"name", "age", "email"})

--- a/hat/assets/js/apps/Iaso/domains/dataSources/hooks/useGetDataSourceVersionsSynchronizationDropdown.ts
+++ b/hat/assets/js/apps/Iaso/domains/dataSources/hooks/useGetDataSourceVersionsSynchronizationDropdown.ts
@@ -27,7 +27,7 @@ export const useSearchDataSourceVersionsSynchronization = () => {
             return queryClient
                 .fetchQuery(newQueryKey, async ({ queryKey }) => {
                     const [, searchTerm] = queryKey;
-                    const url = `/api/datasources/sync/?fields=id&fields=name&name__icontains=${searchTerm}`;
+                    const url = `/api/datasources/sync/?fields=id,name&name__icontains=${searchTerm}`;
                     return getRequest(url);
                 })
                 .then(data => searchOptions.select?.(data) ?? []);
@@ -45,9 +45,7 @@ export const useGetDataSourceVersionsSynchronizationDropdown = (
         queryKey: ['dataSourceVersionsSynchronizationDropdown', id],
         queryFn: () => {
             if (!id) return [];
-            return getRequest(
-                `/api/datasources/sync/${id}/?fields=id&fields=name`,
-            );
+            return getRequest(`/api/datasources/sync/${id}/?fields=id,name`);
         },
         snackErrorMsg: MESSAGES.error,
         options: {

--- a/hat/assets/js/apps/Iaso/domains/entities/entityTypes/hooks/requests/forms.ts
+++ b/hat/assets/js/apps/Iaso/domains/entities/entityTypes/hooks/requests/forms.ts
@@ -13,7 +13,9 @@ export const useGetForms = (
     fields?: string[] | undefined,
 ): UseQueryResult<Form[], Error> => {
     const queryString = createSearchParamsWithArray({
-        fields: fields ? ['id', 'name', 'latest_form_version', 'form_id'] : [],
+        fields:
+            fields ??
+            ['id', 'name', 'latest_form_version', 'form_id'].join(','),
         order: 'name',
     }).toString();
 
@@ -46,7 +48,11 @@ export const useGetFormForEntityType = ({
     const { data: currentForm, isFetching: isFetchingForm } = useGetForm(
         formId,
         enabled && Boolean(formId),
-        ['possible_fields_with_latest_version', 'name', 'latest_form_version'],
+        [
+            'possible_fields_with_latest_version',
+            'name',
+            'latest_form_version',
+        ].join(','),
     );
     return {
         ...usePossibleFields(

--- a/hat/assets/js/apps/Iaso/domains/forms/detail.tsx
+++ b/hat/assets/js/apps/Iaso/domains/forms/detail.tsx
@@ -122,7 +122,7 @@ const FormDetail: FunctionComponent = () => {
             'legend_threshold',
             'change_request_mode',
             'validation_workflow',
-        ],
+        ].join(','),
     );
     const [isLoading, setIsLoading] = useState(false);
     const [isSaved, setIsSaved] = useState(false);

--- a/hat/assets/js/apps/Iaso/domains/forms/hooks/useGetForms.tsx
+++ b/hat/assets/js/apps/Iaso/domains/forms/hooks/useGetForms.tsx
@@ -36,9 +36,10 @@ const FIELDS_PARAMS = [
 ];
 
 const getForms = (params: FormsParams) => {
-    const fields = (
-        params.fields ? params.fields : DEFAULT_VISIBLE_COLUMNS
-    ).concat(FIELDS_PARAMS);
+    const fields = `${
+        params.fields ? params.fields : DEFAULT_VISIBLE_COLUMNS.join(',')
+    },${FIELDS_PARAMS}`;
+
     const queryString = createSearchParamsWithArray({
         ...params,
         fields,
@@ -73,16 +74,15 @@ export const useGetForms = (
     if (safeParams?.fields) {
         delete safeParams.fields;
     }
-    const fields = useMemo(() => {
-        if (typeof params?.fields === 'string') {
-            return params?.fields
+    const fields = useMemo(
+        () =>
+            params?.fields
                 ?.split(',')
-                ?.filter(p => p !== 'actions')
-                ?.sort();
-        } else {
-            return params?.fields?.filter(p => p !== 'actions')?.sort();
-        }
-    }, [params?.fields]);
+                .filter(p => p !== 'actions')
+                .sort()
+                .join(','),
+        [params?.fields],
+    );
     return useSnackQuery({
         queryKey: ['forms', safeParams, fields],
         queryFn: () =>

--- a/hat/assets/js/apps/Iaso/domains/forms/hooks/useGetFormsDropdownOptions.ts
+++ b/hat/assets/js/apps/Iaso/domains/forms/hooks/useGetFormsDropdownOptions.ts
@@ -74,7 +74,7 @@ export const useGetFormsDropdownOptions = (
     );
     const queryParams = useMemo(() => {
         return {
-            fields: allFields,
+            fields: allFields.join(','),
             order: 'name', // Default order
             ...params, // User params override defaults
         };

--- a/hat/assets/js/apps/Iaso/domains/forms/hooks/useGetPossibleFields.ts
+++ b/hat/assets/js/apps/Iaso/domains/forms/hooks/useGetPossibleFields.ts
@@ -2,10 +2,10 @@ import { useMemo } from 'react';
 import { cloneDeep } from 'lodash';
 import { UseQueryResult } from 'react-query';
 import { FormState } from 'Iaso/domains/entities/components/EntitiesQuerybuilder/utils';
+import { getRequest } from 'Iaso/libs/Api';
+import { useSnackQueries, useSnackQuery } from 'Iaso/libs/apiHooks';
 import { createSearchParamsWithArray } from 'Iaso/libs/utils';
-import { getRequest } from '../../../libs/Api';
-import { useSnackQueries, useSnackQuery } from '../../../libs/apiHooks';
-import { DropdownOptions } from '../../../types/utils';
+import { DropdownOptions } from 'Iaso/types/utils';
 
 import MESSAGES from '../messages';
 import { useGetForm } from '../requests';
@@ -193,7 +193,7 @@ type FormVersionHookResult = {
 const useGetFormVersion = (
     formId: number | undefined,
     enabled: boolean,
-    fields?: string[],
+    fields?: string,
 ): UseQueryResult<FormVersionsApiResult, Error> => {
     const queryKey: any[] = ['formVersions', formId];
 
@@ -242,10 +242,10 @@ export const useGetPossibleFieldsByFormVersion = (
     formId?: number,
 ): FormVersionHookResult => {
     const { data: currentFormVersion, isFetching: isFetchingForm } =
-        useGetFormVersion(formId, Boolean(formId), [
-            'version_id',
-            'possible_fields',
-            'created_at',
-        ]);
+        useGetFormVersion(
+            formId,
+            Boolean(formId),
+            ['version_id', 'possible_fields', 'created_at'].join(','),
+        );
     return useVersionPossibleFields(isFetchingForm, currentFormVersion);
 };

--- a/hat/assets/js/apps/Iaso/domains/forms/hooks/useGetPossibleFields.ts
+++ b/hat/assets/js/apps/Iaso/domains/forms/hooks/useGetPossibleFields.ts
@@ -50,7 +50,7 @@ export const useGetPossibleFields = (
     const { data: currentForm, isFetching: isFetchingForm } = useGetForm(
         formId,
         Boolean(formId),
-        ['possible_fields'],
+        'possible_fields',
         appId,
     );
     return usePossibleFields(isFetchingForm, currentForm);

--- a/hat/assets/js/apps/Iaso/domains/forms/requests.ts
+++ b/hat/assets/js/apps/Iaso/domains/forms/requests.ts
@@ -14,7 +14,7 @@ import { Form } from './types/forms';
 export const useGetForm = (
     formId: number | string | undefined,
     enabled = Boolean(formId) && formId !== '0',
-    fields?: string[] | undefined,
+    fields?: string,
     appId?: string,
 ): UseQueryResult<Form, Error> => {
     const queryKey: any[] = ['forms', formId];

--- a/hat/assets/js/apps/Iaso/domains/forms/types/forms.ts
+++ b/hat/assets/js/apps/Iaso/domains/forms/types/forms.ts
@@ -187,6 +187,6 @@ export type FormsParams = {
     showDeleted?: string;
     planning?: string;
     projectsIds?: string;
-    fields?: string[] | string;
+    fields?: string;
     orgUnitId: string;
 };

--- a/hat/assets/js/apps/Iaso/domains/instances/components/InstancesLabelKeys.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/InstancesLabelKeys.tsx
@@ -15,7 +15,7 @@ export const InstancesLabelKeys: FunctionComponent<Props> = ({
     const { data: currentForm, isFetching: isFetchingForm } = useGetForm(
         currentInstance?.form_id,
         undefined,
-        ['name', 'label_keys', 'id', 'possible_fields'],
+        ['name', 'label_keys', 'id', 'possible_fields'].join(','),
     );
     const getLabelKeyLabel = useCallback(
         (labelKey: string) => {

--- a/hat/assets/js/apps/Iaso/domains/instances/hooks/speeddials.ts
+++ b/hat/assets/js/apps/Iaso/domains/instances/hooks/speeddials.ts
@@ -70,7 +70,7 @@ export const useGetFormDefForInstance = (
     formId: number | string | undefined,
 ): UseQueryResult<FormDef, Error> => {
     const queryString = createSearchParamsWithArray({
-        fields: ['org_unit_type_ids', 'period_type'],
+        fields: ['org_unit_type_ids', 'period_type'].join(','),
     }).toString();
     return useSnackQuery(
         ['forms', formId, 'org_unit_types'],

--- a/hat/assets/js/apps/Iaso/domains/instances/requests.ts
+++ b/hat/assets/js/apps/Iaso/domains/instances/requests.ts
@@ -12,7 +12,7 @@ export const fetchFormDetailsForInstance = (formId: number) => {
             'label_keys',
             'id',
             'org_unit_type_ids',
-        ],
+        ].join(','),
     }).toString();
 
     return getRequest(`/api/forms/${formId}/?${queryString}`);

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/groupSets/hooks/requests.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/groupSets/hooks/requests.ts
@@ -45,7 +45,7 @@ export const useGetGroupSets = params => {
 
     const queryString = createSearchParamsWithArray({
         ...newParams,
-        fields: ['id', 'name', 'groups', 'created_at', 'updated_at'],
+        fields: ['id', 'name', 'groups', 'created_at', 'updated_at'].join(','),
     }).toString();
 
     return useSnackQuery(

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/hooks/requests/useGetOrgUnits.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/hooks/requests/useGetOrgUnits.ts
@@ -40,7 +40,7 @@ export const DEFAULT_ORG_UNIT_COLUMNS = [
 
 export const NON_SELECTABLE_COLUMNS = ['actions', 'selection'];
 
-const getCleanFields = (fields?: string | string[]): string[] | undefined => {
+const getCleanFields = (fields?: string | string[]): string | undefined => {
     const fieldsArray = Array.isArray(fields)
         ? fields
         : (fields?.split(',') ?? DEFAULT_ORG_UNIT_COLUMNS);
@@ -49,7 +49,7 @@ const getCleanFields = (fields?: string | string[]): string[] | undefined => {
         f => f && !NON_SELECTABLE_COLUMNS.includes(f),
     );
 
-    return filtered.length > 0 ? filtered : undefined;
+    return filtered.length > 0 ? filtered.join(',') : undefined;
 };
 
 type Props = {

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/hooks/useGetApiParams.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/hooks/useGetApiParams.ts
@@ -10,7 +10,7 @@ export type ApiParams = {
     searches: string;
     asLocation?: string;
     locationLimit: string;
-    fields?: string[];
+    fields?: string;
 };
 
 type Result = {

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/types/orgUnit.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/types/orgUnit.ts
@@ -102,7 +102,7 @@ export type OrgUnitParams = UrlParams & {
     searchTabIndex: string;
     searches: string;
     isClusterActive?: string;
-    fields: string[];
+    fields: string;
 };
 
 export type OrgUnitsApi = {

--- a/iaso/api/data_source_versions_synchronization/serializers.py
+++ b/iaso/api/data_source_versions_synchronization/serializers.py
@@ -1,7 +1,7 @@
 from django.contrib.auth.models import User
 from rest_framework import serializers
 
-from dynamic_fields.serializer import DynamicFieldsModelSerializer
+from dynamic_fields.serializer import DynamicFieldsModelSerializerBackwardCompatible
 from iaso.models import (
     Account,
     DataSourceVersionsSynchronization,
@@ -34,9 +34,9 @@ class DataSourceVersionNestedSerializer(serializers.ModelSerializer):
         fields = ["id", "number", "description", "data_source", "data_source_name"]
 
 
-class DataSourceVersionsSynchronizationSerializer(DynamicFieldsModelSerializer):
+class DataSourceVersionsSynchronizationSerializer(DynamicFieldsModelSerializerBackwardCompatible):
     """
-    Inheriting from DynamicFieldsModelSerializer allows to fetch the data with only a specific subset of fields.
+    Inheriting from DynamicFieldsModelSerializerBackwardCompatible allows to fetch the data with only a specific subset of fields.
     This is useful e.g. to build a dropdown in the UI with only the name and ID of objects.
     """
 

--- a/iaso/api/data_source_versions_synchronization/views.py
+++ b/iaso/api/data_source_versions_synchronization/views.py
@@ -8,7 +8,7 @@ from rest_framework.generics import get_object_or_404
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from dynamic_fields.filter_backends import DynamicFieldsFilterBackend
+from dynamic_fields.filter_backends import DynamicFieldsFilterBackendBackwardCompatible
 from iaso.api.data_source_versions_synchronization.filters import DataSourceVersionsSynchronizationFilter
 from iaso.api.data_source_versions_synchronization.pagination import DataSourceVersionsSynchronizationPagination
 from iaso.api.data_source_versions_synchronization.permissions import DataSourceVersionsSynchronizationPermission
@@ -26,7 +26,7 @@ class DataSourceVersionsSynchronizationViewSet(viewsets.ModelViewSet):
     filter_backends = [
         filters.OrderingFilter,
         django_filters.rest_framework.DjangoFilterBackend,
-        DynamicFieldsFilterBackend,
+        DynamicFieldsFilterBackendBackwardCompatible,
     ]
     filterset_class = DataSourceVersionsSynchronizationFilter
     ordering_fields = [

--- a/iaso/api/form_attachments.py
+++ b/iaso/api/form_attachments.py
@@ -14,7 +14,7 @@ from iaso.utils.encryption import calculate_md5
 from iaso.utils.virus_scan.clamav import scan_uploaded_file_for_virus
 
 from .common import ModelViewSet, TimestampField
-from .forms import HasFormPermission
+from .forms.permissions import HasFormPermission
 from .query_params import APP_ID
 
 

--- a/iaso/api/form_predefined_filters/permissions.py
+++ b/iaso/api/form_predefined_filters/permissions.py
@@ -1,4 +1,4 @@
-from iaso.api.forms import HasFormPermission
+from iaso.api.forms.permissions import HasFormPermission
 from iaso.api.query_params import APP_ID
 from iaso.models import Form
 

--- a/iaso/api/form_versions/permissions.py
+++ b/iaso/api/form_versions/permissions.py
@@ -1,4 +1,4 @@
-from iaso.api.forms import HasFormPermission
+from iaso.api.forms.permissions import HasFormPermission
 from iaso.api.query_params import APP_ID
 from iaso.models import Form
 

--- a/iaso/api/form_versions/serializers.py
+++ b/iaso/api/form_versions/serializers.py
@@ -4,9 +4,9 @@ from django.contrib.auth.models import User
 from rest_framework import exceptions, serializers
 from rest_framework.fields import Field
 
-from dynamic_fields.serializer import DynamicFieldsModelSerializer
+from dynamic_fields.serializer import DynamicFieldsModelSerializerBackwardCompatible
 from iaso.api.common import TimestampField
-from iaso.api.forms import HasFormPermission
+from iaso.api.forms.permissions import HasFormPermission
 from iaso.models import Form, FormVersion
 from iaso.odk import parsing, validate_xls_form
 
@@ -18,7 +18,7 @@ class UserNestedSerializer(serializers.ModelSerializer):
         ref_name = "UserNestedSerializerForFormVersions"
 
 
-class FormVersionSerializer(DynamicFieldsModelSerializer):
+class FormVersionSerializer(DynamicFieldsModelSerializerBackwardCompatible):
     class Meta:
         model = FormVersion
         default_fields = [

--- a/iaso/api/form_versions/views.py
+++ b/iaso/api/form_versions/views.py
@@ -5,7 +5,7 @@ from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import extend_schema
 from rest_framework import exceptions, parsers
 
-from dynamic_fields.filter_backends import DynamicFieldsFilterBackend
+from dynamic_fields.filter_backends import DynamicFieldsFilterBackendBackwardCompatible
 from iaso.api.common import ModelViewSet
 from iaso.api.form_versions.permissions import HasFormVersionPermission
 from iaso.api.form_versions.serializers import FormVersionSerializer
@@ -34,7 +34,7 @@ class FormVersionsViewSet(ModelViewSet):
     queryset = FormVersion.objects.all()
     parser_classes = (parsers.MultiPartParser, parsers.JSONParser)
     http_method_names = ["get", "put", "post", "head", "options", "trace", "patch"]
-    filter_backends = [DjangoFilterBackend, DynamicFieldsFilterBackend]
+    filter_backends = [DjangoFilterBackend, DynamicFieldsFilterBackendBackwardCompatible]
 
     def get_queryset(self):
         orders = self.request.query_params.get("order", "full_name").split(",")

--- a/iaso/api/forms/permissions.py
+++ b/iaso/api/forms/permissions.py
@@ -1,0 +1,22 @@
+from rest_framework import permissions
+
+from iaso.api.permission_checks import IsAuthenticatedOrReadOnlyWhenNoAuthenticationRequired
+from iaso.models import Form
+from iaso.permissions.core_permissions import CORE_FORMS_PERMISSION
+
+
+class HasFormPermission(IsAuthenticatedOrReadOnlyWhenNoAuthenticationRequired):
+    def has_permission(self, request, view):
+        if request.method in permissions.SAFE_METHODS:
+            return super().has_permission(request, view)
+
+        return request.user.is_authenticated and request.user.has_perm(CORE_FORMS_PERMISSION.full_name())
+
+    def has_object_permission(self, request, view, obj):
+        if not self.has_permission(request, view):
+            return False
+        return (
+            Form.objects_include_deleted.filter_for_user_and_app_id(request.user, request.query_params.get("app_id"))
+            .filter(id=obj.id)
+            .exists()
+        )

--- a/iaso/api/forms/serializers.py
+++ b/iaso/api/forms/serializers.py
@@ -4,7 +4,7 @@ from copy import copy
 
 from rest_framework import serializers
 
-from dynamic_fields.serializer import DynamicFieldsModelSerializer
+from dynamic_fields.serializer import DynamicFieldsModelSerializerBackwardCompatible
 from hat.audit.models import FORM_API, log_modification
 from iaso.api.common import ModelSerializer, TimestampField
 from iaso.api.form_predefined_filters.serializers import FormPredefinedFilterSerializer
@@ -21,7 +21,7 @@ class FormVersionNestedSerializer(ModelSerializer):
         fields = ["id", "version_id", "file", "xls_file", "created_at", "updated_at"]
 
 
-class FormSerializer(DynamicFieldsModelSerializer):
+class FormSerializer(DynamicFieldsModelSerializerBackwardCompatible):
     class Meta:
         model = Form
         default_fields = [

--- a/iaso/api/forms/serializers.py
+++ b/iaso/api/forms/serializers.py
@@ -1,0 +1,194 @@
+import typing
+
+from copy import copy
+
+from rest_framework import serializers
+
+from dynamic_fields.serializer import DynamicFieldsModelSerializer
+from hat.audit.models import FORM_API, log_modification
+from iaso.api.common import ModelSerializer, TimestampField
+from iaso.api.form_predefined_filters.serializers import FormPredefinedFilterSerializer
+from iaso.api.projects import ProjectSerializer
+from iaso.models import EntityDuplicateAnalyzis, Form, FormVersion, OrgUnitType, Project
+
+
+class FormVersionNestedSerializer(ModelSerializer):
+    created_at = TimestampField(read_only=True)
+    updated_at = TimestampField(read_only=True)
+
+    class Meta:
+        model = FormVersion
+        fields = ["id", "version_id", "file", "xls_file", "created_at", "updated_at"]
+
+
+class FormSerializer(DynamicFieldsModelSerializer):
+    class Meta:
+        model = Form
+        default_fields = [
+            "id",
+            "name",
+            "form_id",
+            "device_field",
+            "location_field",
+            "org_unit_types",
+            "org_unit_type_ids",
+            "projects",
+            "project_ids",
+            "period_type",
+            "single_per_period",
+            "periods_before_allowed",
+            "periods_after_allowed",
+            "latest_form_version",
+            "instances_count",
+            "instance_updated_at",
+            "created_at",
+            "updated_at",
+            "deleted_at",
+            "derived",
+            "fields",
+            "label_keys",
+            "reference_form_of_org_unit_types",
+            "legend_threshold",
+            "change_request_mode",
+            "has_mappings",
+            "validation_workflow",
+        ]
+        fields = [
+            "id",
+            "name",
+            "form_id",
+            "device_field",
+            "location_field",
+            "org_unit_types",
+            "org_unit_type_ids",
+            "projects",
+            "project_ids",
+            "period_type",
+            "single_per_period",
+            "periods_before_allowed",
+            "periods_after_allowed",
+            "latest_form_version",
+            "instances_count",
+            "instance_updated_at",
+            "created_at",
+            "updated_at",
+            "deleted_at",
+            "derived",
+            "possible_fields",
+            "label_keys",
+            "predefined_filters",
+            "has_attachments",
+            "reference_form_of_org_unit_types",
+            "legend_threshold",
+            "change_request_mode",
+            "has_mappings",
+            "possible_fields_with_latest_version",
+            "validation_workflow",
+        ]
+        read_only_fields = [
+            "id",
+            "form_id",
+            "org_unit_types",
+            "projects",
+            "instances_count",
+            "instance_updated_at",
+            "created_at",
+            "updated_at",
+            "possible_fields",
+            "fields",
+            "has_attachments",
+            "reference_form_of_org_unit_types",
+            "has_mappings",
+        ]
+
+    org_unit_types = serializers.SerializerMethodField()
+    org_unit_type_ids = serializers.PrimaryKeyRelatedField(
+        source="org_unit_types", many=True, allow_empty=True, queryset=OrgUnitType.objects.all()
+    )
+    projects = ProjectSerializer(read_only=True, many=True)
+    project_ids = serializers.PrimaryKeyRelatedField(
+        source="projects", many=True, allow_empty=False, queryset=Project.objects.all()
+    )
+    latest_form_version = FormVersionNestedSerializer(source="latest_version", required=False)
+    instances_count = serializers.IntegerField(read_only=True)
+    instance_updated_at = TimestampField(read_only=True)
+    predefined_filters = FormPredefinedFilterSerializer(many=True, read_only=True)
+    created_at = TimestampField(read_only=True)
+    updated_at = TimestampField(read_only=True)
+    deleted_at = TimestampField(allow_null=True, required=False)
+    has_attachments = serializers.SerializerMethodField()
+    reference_form_of_org_unit_types = serializers.SerializerMethodField()
+    has_mappings = serializers.BooleanField(read_only=True)
+    possible_fields_with_latest_version = serializers.SerializerMethodField()
+
+    @staticmethod
+    def get_org_unit_types(obj: Form):
+        return [t.as_dict() for t in obj.org_unit_types.all()]
+
+    @staticmethod
+    def get_reference_form_of_org_unit_types(obj: Form):
+        return [org_unit.as_dict() for org_unit in obj.reference_of_org_unit_types.all()]
+
+    @staticmethod
+    def get_has_attachments(obj: Form):
+        if hasattr(obj, "has_attachments"):
+            return obj.has_attachments
+        return obj.attachments.exists()
+
+    @staticmethod
+    def get_possible_fields_with_latest_version(obj: Form):
+        possible_fields = [
+            field for field in obj.possible_fields if field["type"] in EntityDuplicateAnalyzis.SUPPORTED_FIELD_TYPES
+        ]
+
+        latest_version = obj.latest_version
+        if not latest_version:
+            return possible_fields
+
+        # Get the field names from the latest version
+        latest_version_fields = set(question["name"] for question in latest_version.questions_by_name().values())
+
+        # Add a flag to each possible field indicating if it's part of the latest version
+        return [{**field, "is_latest": field["name"] in latest_version_fields} for field in possible_fields]
+
+    def validate(self, data: typing.Mapping):
+        # validate projects (access check)
+        if "projects" in data:
+            for project in data["projects"]:
+                if self.context["request"].user.iaso_profile.account != project.account:
+                    raise serializers.ValidationError({"project_ids": "Invalid project ids"})
+
+            # validate org_unit_types against projects
+            allowed_org_unit_types = [ut for p in data["projects"] for ut in p.unit_types.all()]
+            if len(set(data["org_unit_types"]) - set(allowed_org_unit_types)) > 0:
+                raise serializers.ValidationError({"org_unit_type_ids": "Invalid org unit type ids"})
+
+        # If the period type is None, some period-specific fields must have specific values
+        if "period_type" in data:
+            tracker_errors = {}
+            if data["period_type"] is None:
+                if data["periods_before_allowed"] != 0:
+                    tracker_errors["periods_before_allowed"] = "Should be 0 when period type is not specified"
+                if data["periods_after_allowed"] != 0:
+                    tracker_errors["periods_after_allowed"] = "Should be 0 when period type is not specified"
+            else:
+                before = data.get("periods_before_allowed", 0)
+                after = data.get("periods_after_allowed", 0)
+                if before + after < 1:
+                    tracker_errors["periods_allowed"] = (
+                        "periods_before_allowed + periods_after_allowed should be greater than or equal to 1"
+                    )
+            if tracker_errors:
+                raise serializers.ValidationError(tracker_errors)
+        return data
+
+    def update(self, form, validated_data):
+        original = copy(form)
+        form = super(FormSerializer, self).update(form, validated_data)
+        log_modification(original, form, FORM_API, user=self.context["request"].user)
+        return form
+
+    def create(self, validated_data):
+        form = super(FormSerializer, self).create(validated_data)
+        log_modification(None, form, FORM_API, user=self.context["request"].user)
+        return form

--- a/iaso/api/forms/utils.py
+++ b/iaso/api/forms/utils.py
@@ -1,0 +1,47 @@
+from xml.sax.saxutils import escape
+
+from django.http import HttpResponse
+from rest_framework import status
+from rest_framework.request import Request
+
+from iaso.api.enketo import public_url_for_enketo
+from iaso.models import Form, FormAttachment
+
+
+def generate_manifest_for_form(form: Form, request: Request) -> HttpResponse:
+    attachments = form.attachments.all()
+    media_files = []
+    for attachment in attachments:
+        attachment_file_url: str = attachment.file.url
+        if not attachment_file_url.startswith("http"):
+            # Needed for local dev
+            attachment_file_url = public_url_for_enketo(request, attachment_file_url)
+        media_files.append(generate_manifest_media_file(attachment, attachment_file_url))
+
+    manifest = generate_manifest_structure(media_files)
+    return HttpResponse(
+        status=status.HTTP_200_OK,
+        content_type="text/xml",
+        headers={
+            "X-OpenRosa-Version": "1.0",
+        },
+        content=manifest,
+    )
+
+
+def generate_manifest_media_file(attachment: FormAttachment, url: str) -> str:
+    return f"""<mediaFile>
+        <filename>{escape(attachment.name)}</filename>
+        <hash>md5:{attachment.md5}</hash>
+        <downloadUrl>{escape(url)}</downloadUrl>
+    </mediaFile>"""
+
+
+def generate_manifest_structure(content: list[str]) -> str:
+    nl = "\n"  # Backslashes are not allowed in f-string ¯\_(ツ)_/¯
+    return (
+        f"""<?xml version="1.0" encoding="UTF-8"?>
+<manifest xmlns="http://openrosa.org/xforms/xformsManifest">
+    {nl.join(content)}
+</manifest>""",
+    )

--- a/iaso/api/forms/views.py
+++ b/iaso/api/forms/views.py
@@ -12,7 +12,7 @@ from rest_framework.decorators import action
 from rest_framework.generics import get_object_or_404
 from rest_framework.request import Request
 
-from dynamic_fields.filter_backends import DynamicFieldsFilterBackend
+from dynamic_fields.filter_backends import DynamicFieldsFilterBackendBackwardCompatible
 from hat.api.export_utils import Echo, generate_xlsx, iter_items
 from hat.audit.models import FORM_API, log_modification
 from iaso.api.common import CONTENT_TYPE_CSV, CONTENT_TYPE_XLSX, ModelViewSet, is_field_referenced
@@ -56,7 +56,7 @@ class FormsViewSet(ModelViewSet):
         {"title": "Date de modification", "width": 20},
     )
     EXPORT_FILE_NAME = "forms"
-    filter_backends = [DjangoFilterBackend, DynamicFieldsFilterBackend]
+    filter_backends = [DjangoFilterBackend, DynamicFieldsFilterBackendBackwardCompatible]
 
     def get_queryset(self):
         form_objects = Form.objects

--- a/iaso/api/forms/views.py
+++ b/iaso/api/forms/views.py
@@ -1,250 +1,31 @@
 import typing
 
-from copy import copy
 from datetime import timedelta
-from xml.sax.saxutils import escape
 
 from django.db.models import Count, Exists, OuterRef, Prefetch, Q, Subquery
 from django.http import HttpResponse, StreamingHttpResponse
 from django.utils.dateparse import parse_date
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import extend_schema
-from rest_framework import permissions, serializers, status
+from rest_framework import status
 from rest_framework.decorators import action
 from rest_framework.generics import get_object_or_404
 from rest_framework.request import Request
 
 from dynamic_fields.filter_backends import DynamicFieldsFilterBackend
-from dynamic_fields.serializer import DynamicFieldsModelSerializer
 from hat.api.export_utils import Echo, generate_xlsx, iter_items
 from hat.audit.models import FORM_API, log_modification
-from iaso.api.common import is_field_referenced
-from iaso.api.permission_checks import (
-    AuthenticationEnforcedPermission,
-    IsAuthenticatedOrReadOnlyWhenNoAuthenticationRequired,
-    ReadOnly,
-)
-from iaso.models import (
-    EntityDuplicateAnalyzis,
-    Form,
-    FormAttachment,
-    FormVersion,
-    Instance,
-    OrgUnit,
-    OrgUnitType,
-    Project,
-    ProjectFeatureFlags,
-)
-from iaso.models.base import Mapping
+from iaso.api.common import CONTENT_TYPE_CSV, CONTENT_TYPE_XLSX, ModelViewSet, is_field_referenced
+from iaso.api.forms.utils import generate_manifest_for_form
+from iaso.api.permission_checks import AuthenticationEnforcedPermission, ReadOnly
+from iaso.api.serializers import AppIdSerializer
+from iaso.enketo.enketo_url import enketo_settings, verify_signed_url
+from iaso.models import Form, FormAttachment, Instance, Mapping, OrgUnit, ProjectFeatureFlags
 from iaso.permissions.core_permissions import CORE_FORMS_PERMISSION
 from iaso.utils.date_and_time import timestamp_to_datetime
 
-from ..enketo import enketo_settings
-from ..enketo.enketo_url import verify_signed_url
-from .common import CONTENT_TYPE_CSV, CONTENT_TYPE_XLSX, ModelViewSet, TimestampField
-from .enketo import public_url_for_enketo
-from .form_predefined_filters.serializers import FormPredefinedFilterSerializer
-from .projects import ProjectSerializer
-from .serializers import AppIdSerializer
-
-
-class HasFormPermission(IsAuthenticatedOrReadOnlyWhenNoAuthenticationRequired):
-    def has_permission(self, request, view):
-        if request.method in permissions.SAFE_METHODS:
-            return super().has_permission(request, view)
-
-        return request.user.is_authenticated and request.user.has_perm(CORE_FORMS_PERMISSION.full_name())
-
-    def has_object_permission(self, request, view, obj):
-        if not self.has_permission(request, view):
-            return False
-        return (
-            Form.objects_include_deleted.filter_for_user_and_app_id(request.user, request.query_params.get("app_id"))
-            .filter(id=obj.id)
-            .exists()
-        )
-
-
-class FormVersionNestedSerializer(serializers.ModelSerializer):
-    created_at = TimestampField(read_only=True)
-    updated_at = TimestampField(read_only=True)
-
-    class Meta:
-        model = FormVersion
-        fields = ["id", "version_id", "file", "xls_file", "created_at", "updated_at"]
-
-
-class FormSerializer(DynamicFieldsModelSerializer):
-    class Meta:
-        model = Form
-        default_fields = [
-            "id",
-            "name",
-            "form_id",
-            "device_field",
-            "location_field",
-            "org_unit_types",
-            "org_unit_type_ids",
-            "projects",
-            "project_ids",
-            "period_type",
-            "single_per_period",
-            "periods_before_allowed",
-            "periods_after_allowed",
-            "latest_form_version",
-            "instances_count",
-            "instance_updated_at",
-            "created_at",
-            "updated_at",
-            "deleted_at",
-            "derived",
-            "fields",
-            "label_keys",
-            "reference_form_of_org_unit_types",
-            "legend_threshold",
-            "change_request_mode",
-            "has_mappings",
-            "validation_workflow",
-        ]
-        fields = [
-            "id",
-            "name",
-            "form_id",
-            "device_field",
-            "location_field",
-            "org_unit_types",
-            "org_unit_type_ids",
-            "projects",
-            "project_ids",
-            "period_type",
-            "single_per_period",
-            "periods_before_allowed",
-            "periods_after_allowed",
-            "latest_form_version",
-            "instances_count",
-            "instance_updated_at",
-            "created_at",
-            "updated_at",
-            "deleted_at",
-            "derived",
-            "possible_fields",
-            "label_keys",
-            "predefined_filters",
-            "has_attachments",
-            "reference_form_of_org_unit_types",
-            "legend_threshold",
-            "change_request_mode",
-            "has_mappings",
-            "possible_fields_with_latest_version",
-            "validation_workflow",
-        ]
-        read_only_fields = [
-            "id",
-            "form_id",
-            "org_unit_types",
-            "projects",
-            "instances_count",
-            "instance_updated_at",
-            "created_at",
-            "updated_at",
-            "possible_fields",
-            "fields",
-            "has_attachments",
-            "reference_form_of_org_unit_types",
-            "has_mappings",
-        ]
-
-    org_unit_types = serializers.SerializerMethodField()
-    org_unit_type_ids = serializers.PrimaryKeyRelatedField(
-        source="org_unit_types", many=True, allow_empty=True, queryset=OrgUnitType.objects.all()
-    )
-    projects = ProjectSerializer(read_only=True, many=True)
-    project_ids = serializers.PrimaryKeyRelatedField(
-        source="projects", many=True, allow_empty=False, queryset=Project.objects.all()
-    )
-    latest_form_version = FormVersionNestedSerializer(source="latest_version", required=False)
-    instances_count = serializers.IntegerField(read_only=True)
-    instance_updated_at = TimestampField(read_only=True)
-    predefined_filters = FormPredefinedFilterSerializer(many=True, read_only=True)
-    created_at = TimestampField(read_only=True)
-    updated_at = TimestampField(read_only=True)
-    deleted_at = TimestampField(allow_null=True, required=False)
-    has_attachments = serializers.SerializerMethodField()
-    reference_form_of_org_unit_types = serializers.SerializerMethodField()
-    has_mappings = serializers.BooleanField(read_only=True)
-    possible_fields_with_latest_version = serializers.SerializerMethodField()
-
-    @staticmethod
-    def get_org_unit_types(obj: Form):
-        return [t.as_dict() for t in obj.org_unit_types.all()]
-
-    @staticmethod
-    def get_reference_form_of_org_unit_types(obj: Form):
-        return [org_unit.as_dict() for org_unit in obj.reference_of_org_unit_types.all()]
-
-    @staticmethod
-    def get_has_attachments(obj: Form):
-        if hasattr(obj, "has_attachments"):
-            return obj.has_attachments
-        return obj.attachments.exists()
-
-    @staticmethod
-    def get_possible_fields_with_latest_version(obj: Form):
-        possible_fields = [
-            field for field in obj.possible_fields if field["type"] in EntityDuplicateAnalyzis.SUPPORTED_FIELD_TYPES
-        ]
-
-        latest_version = obj.latest_version
-        if not latest_version:
-            return possible_fields
-
-        # Get the field names from the latest version
-        latest_version_fields = set(question["name"] for question in latest_version.questions_by_name().values())
-
-        # Add a flag to each possible field indicating if it's part of the latest version
-        return [{**field, "is_latest": field["name"] in latest_version_fields} for field in possible_fields]
-
-    def validate(self, data: typing.Mapping):
-        # validate projects (access check)
-        if "projects" in data:
-            for project in data["projects"]:
-                if self.context["request"].user.iaso_profile.account != project.account:
-                    raise serializers.ValidationError({"project_ids": "Invalid project ids"})
-
-            # validate org_unit_types against projects
-            allowed_org_unit_types = [ut for p in data["projects"] for ut in p.unit_types.all()]
-            if len(set(data["org_unit_types"]) - set(allowed_org_unit_types)) > 0:
-                raise serializers.ValidationError({"org_unit_type_ids": "Invalid org unit type ids"})
-
-        # If the period type is None, some period-specific fields must have specific values
-        if "period_type" in data:
-            tracker_errors = {}
-            if data["period_type"] is None:
-                if data["periods_before_allowed"] != 0:
-                    tracker_errors["periods_before_allowed"] = "Should be 0 when period type is not specified"
-                if data["periods_after_allowed"] != 0:
-                    tracker_errors["periods_after_allowed"] = "Should be 0 when period type is not specified"
-            else:
-                before = data.get("periods_before_allowed", 0)
-                after = data.get("periods_after_allowed", 0)
-                if before + after < 1:
-                    tracker_errors["periods_allowed"] = (
-                        "periods_before_allowed + periods_after_allowed should be greater than or equal to 1"
-                    )
-            if tracker_errors:
-                raise serializers.ValidationError(tracker_errors)
-        return data
-
-    def update(self, form, validated_data):
-        original = copy(form)
-        form = super(FormSerializer, self).update(form, validated_data)
-        log_modification(original, form, FORM_API, user=self.context["request"].user)
-        return form
-
-    def create(self, validated_data):
-        form = super(FormSerializer, self).create(validated_data)
-        log_modification(None, form, FORM_API, user=self.context["request"].user)
-        return form
+from .permissions import HasFormPermission
+from .serializers import FormSerializer
 
 
 @extend_schema(tags=["Forms"])
@@ -276,10 +57,8 @@ class FormsViewSet(ModelViewSet):
     )
     EXPORT_FILE_NAME = "forms"
     filter_backends = [DjangoFilterBackend, DynamicFieldsFilterBackend]
-    EXPORT_ADDITIONAL_SERIALIZER_FIELDS = ("instance_updated_at", "instances_count")
-    FORM_PK = "form_pk"
 
-    def get_queryset(self, mobile=False):
+    def get_queryset(self):
         form_objects = Form.objects
         if self.request.query_params.get("only_deleted", None):
             form_objects = Form.objects_only_deleted
@@ -333,7 +112,7 @@ class FormsViewSet(ModelViewSet):
 
         enable_count = is_field_referenced("instances_count", requested_fields, order) and not is_request_from_manifest
 
-        if not mobile and enable_count:
+        if enable_count:
             if profile and profile.org_units.exists():
                 orgunits = OrgUnit.objects.hierarchy(profile.org_units.all())
                 queryset = queryset.annotate(
@@ -396,13 +175,12 @@ class FormsViewSet(ModelViewSet):
                 "org_unit_types__sub_unit_types",
                 "org_unit_types__allow_creating_sub_unit_types",
             ]
-            if not mobile:
-                prefetch_relations.append(
-                    Prefetch(
-                        "projects__projectfeatureflags_set",
-                        queryset=ProjectFeatureFlags.objects.select_related("featureflag"),
-                    )
+            prefetch_relations.append(
+                Prefetch(
+                    "projects__projectfeatureflags_set",
+                    queryset=ProjectFeatureFlags.objects.select_related("featureflag"),
                 )
+            )
             queryset = queryset.prefetch_related(*prefetch_relations)
 
         # optimize latest version loading to not trigger a select n+1 on form_version
@@ -508,55 +286,4 @@ class FormsViewSet(ModelViewSet):
                 "X-OpenRosa-Version": "1.0",
             },
             content="<error>Invalid URL signature</error>",
-        )
-
-
-def generate_manifest_for_form(form: Form, request: Request) -> HttpResponse:
-    attachments = form.attachments.all()
-    media_files = []
-    for attachment in attachments:
-        attachment_file_url: str = attachment.file.url
-        if not attachment_file_url.startswith("http"):
-            # Needed for local dev
-            attachment_file_url = public_url_for_enketo(request, attachment_file_url)
-        media_files.append(generate_manifest_media_file(attachment, attachment_file_url))
-
-    manifest = generate_manifest_structure(media_files)
-    return HttpResponse(
-        status=status.HTTP_200_OK,
-        content_type="text/xml",
-        headers={
-            "X-OpenRosa-Version": "1.0",
-        },
-        content=manifest,
-    )
-
-
-def generate_manifest_media_file(attachment: FormAttachment, url: str) -> str:
-    return f"""<mediaFile>
-        <filename>{escape(attachment.name)}</filename>
-        <hash>md5:{attachment.md5}</hash>
-        <downloadUrl>{escape(url)}</downloadUrl>
-    </mediaFile>"""
-
-
-def generate_manifest_structure(content: list[str]) -> str:
-    nl = "\n"  # Backslashes are not allowed in f-string ¯\_(ツ)_/¯
-    return (
-        f"""<?xml version="1.0" encoding="UTF-8"?>
-<manifest xmlns="http://openrosa.org/xforms/xformsManifest">
-    {nl.join(content)}
-</manifest>""",
-    )
-
-
-@extend_schema(tags=["Mobile", "Forms"])
-class MobileFormViewSet(FormsViewSet):
-    # Filtering out forms without form versions to prevent mobile app from crashing
-    def get_queryset(self):
-        return (
-            super()
-            .get_queryset(mobile=True)
-            .exclude(form_versions=None)
-            .prefetch_related("predefined_filters", "attachments", "reference_of_org_unit_types__sub_unit_types")
         )

--- a/iaso/api/forms/views_mobile.py
+++ b/iaso/api/forms/views_mobile.py
@@ -1,0 +1,242 @@
+import typing
+
+from datetime import timedelta
+
+from django.db.models import Exists, OuterRef, Q, Subquery
+from django.http import HttpResponse, StreamingHttpResponse
+from django.utils.dateparse import parse_date
+from django_filters.rest_framework import DjangoFilterBackend
+from drf_spectacular.utils import extend_schema
+from rest_framework import status
+from rest_framework.decorators import action
+from rest_framework.generics import get_object_or_404
+from rest_framework.request import Request
+
+from dynamic_fields.filter_backends import DynamicFieldsFilterBackendBackwardCompatible
+from hat.api.export_utils import Echo, generate_xlsx, iter_items
+from hat.audit.models import FORM_API, log_modification
+from iaso.api.common import CONTENT_TYPE_CSV, CONTENT_TYPE_XLSX, ModelViewSet, is_field_referenced
+from iaso.api.forms.utils import generate_manifest_for_form
+from iaso.api.permission_checks import AuthenticationEnforcedPermission, ReadOnly
+from iaso.api.serializers import AppIdSerializer
+from iaso.enketo.enketo_url import enketo_settings, verify_signed_url
+from iaso.models import Form, FormAttachment, Instance, Mapping
+from iaso.utils.date_and_time import timestamp_to_datetime
+
+from .permissions import HasFormPermission
+from .serializers import FormSerializer
+
+
+@extend_schema(tags=["Mobile", "Forms"])
+class MobileFormViewSet(ModelViewSet):
+    permission_classes = [AuthenticationEnforcedPermission, HasFormPermission]
+    results_key = "forms"
+    filter_backends = [DjangoFilterBackend, DynamicFieldsFilterBackendBackwardCompatible]
+    serializer_class = FormSerializer
+
+    EXPORT_TABLE_COLUMNS = (
+        {"title": "ID du formulaire", "width": 20},
+        {"title": "Nom", "width": 40},
+        {"title": "Enregistrement(s)", "width": 20},
+        {"title": "Type", "width": 20},
+        {"title": "Date de création", "width": 20},
+        {"title": "Date de modification", "width": 20},
+    )
+    EXPORT_FILE_NAME = "forms"
+
+    def get_serializer(self, *args, **kwargs):
+        kwargs.setdefault("string_field", True)
+        return super().get_serializer(*args, **kwargs)
+
+    # Filtering out forms without form versions to prevent mobile app from crashing
+    def get_queryset(self):
+        form_objects = Form.objects
+        if self.request.query_params.get("only_deleted", None):
+            form_objects = Form.objects_only_deleted
+
+        show_deleted = self.request.query_params.get("showDeleted", "false")
+        if show_deleted == "true":
+            form_objects = Form.objects_only_deleted
+
+        queryset = form_objects.filter_for_user_and_app_id(
+            self.request.user, self.request.query_params.get("app_id")
+        ).filter_on_user_projects(self.request.user)
+        org_unit_id = self.request.query_params.get("orgUnitId", None)
+        if org_unit_id:
+            queryset = queryset.filter(instances__org_unit__id=org_unit_id)
+
+        planning_ids = self.request.query_params.get("planning", None)
+        if planning_ids:
+            queryset = queryset.filter(plannings__id__in=planning_ids.split(","))
+
+        org_unit_type_ids = self.request.query_params.get("orgUnitTypeIds")
+        if org_unit_type_ids:
+            queryset = queryset.filter(org_unit_types__id__in=org_unit_type_ids.split(","))
+
+        projects_ids = self.request.query_params.get("projectsIds")
+        if projects_ids:
+            queryset = queryset.filter(projects__id__in=projects_ids.split(","))
+
+        requested_fields = self.request.query_params.get("fields")
+
+        is_request_from_manifest = self.request.path.endswith("/manifest/")
+        default_order = "id" if is_request_from_manifest else "name"
+
+        order = self.request.query_params.get("order", default_order).split(",")
+
+        if is_field_referenced("has_mappings", requested_fields, order):
+            mappings_exist = Mapping.objects.filter(form_id=OuterRef("pk"))
+            queryset = queryset.annotate(has_mappings=Exists(mappings_exist))
+
+        if is_field_referenced("has_attachments", requested_fields, order) and not is_request_from_manifest:
+            attachment_exists = FormAttachment.objects.filter(form_id=OuterRef("pk"))
+            queryset = queryset.annotate(has_attachments=Exists(attachment_exists))
+
+        if is_field_referenced("instance_updated_at", requested_fields, order) and not is_request_from_manifest:
+            latest_instance = Instance.objects.filter(form=OuterRef("pk")).order_by("-updated_at")
+            queryset = queryset.annotate(instance_updated_at=Subquery(latest_instance.values("updated_at")[:1]))
+
+        from_date = self.request.query_params.get("date_from", None)
+        if from_date:
+            queryset = queryset.filter(
+                Q(instance_updated_at__gte=from_date) | Q(created_at__gte=from_date) | Q(updated_at__gte=from_date)
+            )
+        to_date = self.request.query_params.get("date_to", None)
+        if to_date:
+            parsed_to_date = parse_date(to_date) + timedelta(days=1)
+            queryset = queryset.filter(
+                Q(instance_updated_at__lt=parsed_to_date)
+                | Q(created_at__lt=parsed_to_date)
+                | Q(updated_at__lt=parsed_to_date)
+            )
+
+        org_unit_type_id = self.request.query_params.get("orgUnitTypeId", None)
+        if org_unit_type_id:
+            queryset = queryset.filter(org_unit_types__id=org_unit_type_id)
+
+        search = self.request.query_params.get("search", None)
+        if search:
+            queryset = queryset.filter(name__icontains=search)
+
+        if not is_request_from_manifest:
+            # prefetch all relations returned by default ex /api/forms/?order=name&limit=50&page=1
+            # TODO
+            #  - be smarter cfr is_field_referenced
+            prefetch_relations = [
+                "projects",
+                "projects__feature_flags",
+                "reference_of_org_unit_types",
+                "org_unit_types",
+                "org_unit_types__reference_forms",
+                "org_unit_types__sub_unit_types",
+                "org_unit_types__allow_creating_sub_unit_types",
+            ]
+
+            queryset = queryset.prefetch_related(*prefetch_relations)
+
+        # optimize latest version loading to not trigger a select n+1 on form_version
+        queryset = queryset.with_latest_version()
+
+        # TODO: allow this only from a predefined list for security purposes
+
+        queryset = queryset.order_by(*order)
+
+        # Ensure duplicates are removed after all joins and annotations
+        queryset = queryset.distinct()
+
+        return queryset.exclude(form_versions=None).prefetch_related(
+            "predefined_filters", "attachments", "reference_of_org_unit_types__sub_unit_types"
+        )
+
+    def list(self, request: Request, *args, **kwargs):
+        # TODO: use accept header to determine format - or at least the standard "format" parameter
+        # DRF also provides a mechanic for custom renderer
+        # see https://www.django-rest-framework.org/api-guide/renderers/
+        csv_format = bool(request.query_params.get("csv"))
+        xlsx_format = bool(request.query_params.get("xlsx"))
+
+        if csv_format:
+            return self.list_to_csv()
+        if xlsx_format:
+            return self.list_to_xlsx()
+
+        return super().list(request, *args, **kwargs)
+
+    def list_to_csv(self):
+        response = StreamingHttpResponse(
+            streaming_content=(iter_items(self.get_queryset(), Echo(), self.EXPORT_TABLE_COLUMNS, self._get_table_row)),
+            content_type=CONTENT_TYPE_CSV,
+        )
+        response["Content-Disposition"] = f"attachment; filename={self.EXPORT_FILE_NAME}.csv"
+
+        return response
+
+    def list_to_xlsx(self):
+        response = HttpResponse(
+            generate_xlsx("Forms", self.EXPORT_TABLE_COLUMNS, self.get_queryset(), self._get_table_row),
+            content_type=CONTENT_TYPE_XLSX,
+        )
+        response["Content-Disposition"] = f"attachment; filename={self.EXPORT_FILE_NAME}.xlsx"
+
+        return response
+
+    def _get_table_row(self, form: typing.Mapping, **kwargs):  # TODO: use serializer
+        form_data = self.get_serializer(form).data
+        created_at = timestamp_to_datetime(form_data.get("created_at"))
+        updated_at = (
+            timestamp_to_datetime(form_data.get("instance_updated_at"))
+            if form_data.get("instance_updated_at")
+            else "2019-01-01 00:00:00"
+        )
+        org_unit_types = ", ".join([o["name"] for o in form_data.get("org_unit_types") if o is not None])
+        return [
+            form_data.get("form_id"),
+            form_data.get("name"),
+            form_data.get("instances_count"),
+            org_unit_types,
+            created_at,
+            updated_at,
+        ]
+
+    def destroy(self, request, *args, **kwargs):
+        original = get_object_or_404(Form, pk=self.kwargs["pk"])
+        response = super().destroy(request, *args, **kwargs)
+        destroyed_form = Form.objects_only_deleted.get(pk=original.id)
+        log_modification(original, destroyed_form, FORM_API, user=request.user)
+        return response
+
+    @action(detail=True, methods=["get"])
+    def manifest(self, request, *args, **kwargs):
+        """Returns a xml manifest file in the openrosa format for the Form
+
+        This is used for the mobile app to fetch the list of files attached to the Form
+        see https://docs.getodk.org/openrosa-form-list/#the-manifest-document
+        """
+        form = self.get_object()
+        return generate_manifest_for_form(form, request)
+
+    @extend_schema(tags=["Enketo"])
+    @action(detail=True, methods=["get"], permission_classes=[ReadOnly])
+    def manifest_enketo(self, request, pk, *args, **kwargs):
+        """Returns a xml manifest file in the openrosa format for the Form
+
+        This is used by enketo to fetch the list of files attached to the Form
+        see https://docs.getodk.org/openrosa-form-list/#the-manifest-document
+        """
+        enketo_secret = enketo_settings("ENKETO_SIGNING_SECRET")
+        if verify_signed_url(request, enketo_secret):
+            app_id = AppIdSerializer(data=request.query_params).get_app_id(raise_exception=True)
+            queryset = Form.objects.filter(
+                projects__app_id=app_id
+            )  # Not using the default queryset because there's no auth
+            form = get_object_or_404(queryset, pk=pk)
+            return generate_manifest_for_form(form, request)
+
+        return HttpResponse(
+            status=status.HTTP_400_BAD_REQUEST,
+            content_type="text/xml",
+            headers={
+                "X-OpenRosa-Version": "1.0",
+            },
+            content="<error>Invalid URL signature</error>",
+        )

--- a/iaso/api/group_sets/serializers.py
+++ b/iaso/api/group_sets/serializers.py
@@ -2,7 +2,7 @@ import typing
 
 from rest_framework import serializers
 
-from dynamic_fields.serializer import DynamicFieldsModelSerializer
+from dynamic_fields.serializer import DynamicFieldsModelSerializerBackwardCompatible
 from hat.audit import models as audit_models
 from iaso.api.common import TimestampField
 from iaso.models import DataSource, Group, GroupSet, SourceVersion
@@ -34,7 +34,7 @@ class GroupSerializer(serializers.ModelSerializer):
     source_version = SourceVersionSerializerForGroupset(read_only=True)
 
 
-class GroupSetSerializer(DynamicFieldsModelSerializer):
+class GroupSetSerializer(DynamicFieldsModelSerializerBackwardCompatible):
     class Meta:
         model = GroupSet
         default_fields = [

--- a/iaso/api/group_sets/views.py
+++ b/iaso/api/group_sets/views.py
@@ -5,7 +5,7 @@ from rest_framework import filters, permissions, serializers, status
 from rest_framework.decorators import action
 from rest_framework.response import Response
 
-from dynamic_fields.filter_backends import DynamicFieldsFilterBackend
+from dynamic_fields.filter_backends import DynamicFieldsFilterBackendBackwardCompatible
 from iaso.api.common import Paginator
 from iaso.api.permission_checks import AuthenticationEnforcedPermission
 from iaso.models import GroupSet, Project, SourceVersion
@@ -81,7 +81,7 @@ class GroupSetsViewSet(ModelViewSet):
             return [
                 filters.OrderingFilter,
                 django_filters.rest_framework.DjangoFilterBackend,
-                DynamicFieldsFilterBackend,
+                DynamicFieldsFilterBackendBackwardCompatible,
             ]
         return [filters.OrderingFilter, django_filters.rest_framework.DjangoFilterBackend]
 

--- a/iaso/api/mapping_versions.py
+++ b/iaso/api/mapping_versions.py
@@ -8,15 +8,15 @@ from rest_framework import permissions, serializers
 
 import iaso.models as m
 
-from dynamic_fields.filter_backends import DynamicFieldsFilterBackend
-from dynamic_fields.serializer import DynamicFieldsModelSerializer
+from dynamic_fields.filter_backends import DynamicFieldsFilterBackendBackwardCompatible
+from dynamic_fields.serializer import DynamicFieldsModelSerializerBackwardCompatible
 from iaso.models import FormVersion, MappingVersion
 from iaso.permissions.core_permissions import CORE_MAPPINGS_PERMISSION
 
 from .common import HasPermission, ModelViewSet, TimestampField
 
 
-class MappingVersionSerializer(DynamicFieldsModelSerializer):
+class MappingVersionSerializer(DynamicFieldsModelSerializerBackwardCompatible):
     class Meta:
         model = MappingVersion
         default_fields = [
@@ -191,7 +191,7 @@ class MappingVersionsViewSet(ModelViewSet):
 
     permission_classes = [permissions.IsAuthenticated, HasPermission(CORE_MAPPINGS_PERMISSION)]  # type: ignore
     serializer_class = MappingVersionSerializer
-    filter_backends = [DjangoFilterBackend, DynamicFieldsFilterBackend]
+    filter_backends = [DjangoFilterBackend, DynamicFieldsFilterBackendBackwardCompatible]
     results_key = "mapping_versions"
     queryset = MappingVersion.objects.all()
     http_method_names = ["get", "post", "patch", "head", "options", "trace"]

--- a/iaso/api/org_unit_types/serializers.py
+++ b/iaso/api/org_unit_types/serializers.py
@@ -3,7 +3,7 @@ import typing
 from django.db.models import Q
 from rest_framework import serializers
 
-from dynamic_fields.serializer import DynamicFieldsModelSerializer, DynamicFieldsModelSerializerBackwardCompatible
+from dynamic_fields.serializer import DynamicFieldsModelSerializerBackwardCompatible
 from iaso.models import Form, OrgUnit, OrgUnitType, Project
 
 from ..common import TimestampField
@@ -137,7 +137,7 @@ class OrgUnitTypeSerializerV1(DynamicFieldsModelSerializerBackwardCompatible):
         return super().to_representation(instance)
 
 
-class OrgUnitTypeSerializerV2(DynamicFieldsModelSerializer):
+class OrgUnitTypeSerializerV2(DynamicFieldsModelSerializerBackwardCompatible):
     """This one is a bit cryptic: sub_unit_types is only needed for "root" org unit types
     (the ones returned by the viewset queryset), and they need to be filtered by app_id,
     hence the SerializerMethodField()"""

--- a/iaso/api/org_unit_types/serializers.py
+++ b/iaso/api/org_unit_types/serializers.py
@@ -3,11 +3,11 @@ import typing
 from django.db.models import Q
 from rest_framework import serializers
 
-from dynamic_fields.serializer import DynamicFieldsModelSerializer
+from dynamic_fields.serializer import DynamicFieldsModelSerializer, DynamicFieldsModelSerializerBackwardCompatible
 from iaso.models import Form, OrgUnit, OrgUnitType, Project
 
 from ..common import TimestampField
-from ..forms import FormSerializer
+from ..forms.serializers import FormSerializer
 from ..projects.serializers import ProjectSerializer
 
 
@@ -38,7 +38,7 @@ def validate_reference_forms(data):
 
 
 # Kept for the mobile
-class OrgUnitTypeSerializerV1(DynamicFieldsModelSerializer):
+class OrgUnitTypeSerializerV1(DynamicFieldsModelSerializerBackwardCompatible):
     """
     V1 kept for mobile where sub_types is actually `allow_creating_sub_unit_types`
 

--- a/iaso/api/org_unit_types/viewsets.py
+++ b/iaso/api/org_unit_types/viewsets.py
@@ -5,7 +5,7 @@ from rest_framework import permissions, status
 from rest_framework.decorators import action
 from rest_framework.response import Response
 
-from dynamic_fields.filter_backends import DynamicFieldsFilterBackend, DynamicFieldsFilterBackendBackwardCompatible
+from dynamic_fields.filter_backends import DynamicFieldsFilterBackendBackwardCompatible
 from iaso.api.org_unit_types.permissions import HasOrgUnitTypeWritePermission
 from iaso.api.permission_checks import (
     AuthenticationEnforcedPermission,
@@ -103,7 +103,7 @@ class OrgUnitTypeViewSetV2(ModelViewSet):
     serializer_class = OrgUnitTypeSerializerV2
     results_key = "orgUnitTypes"
     http_method_names = ["get", "post", "patch", "put", "delete", "head", "options", "trace"]
-    filter_backends = [DjangoFilterBackend, DynamicFieldsFilterBackend]
+    filter_backends = [DjangoFilterBackend, DynamicFieldsFilterBackendBackwardCompatible]
 
     def destroy(self, request, pk):
         t = OrgUnitType.objects.get(pk=pk)

--- a/iaso/api/org_unit_types/viewsets.py
+++ b/iaso/api/org_unit_types/viewsets.py
@@ -5,7 +5,7 @@ from rest_framework import permissions, status
 from rest_framework.decorators import action
 from rest_framework.response import Response
 
-from dynamic_fields.filter_backends import DynamicFieldsFilterBackend
+from dynamic_fields.filter_backends import DynamicFieldsFilterBackend, DynamicFieldsFilterBackendBackwardCompatible
 from iaso.api.org_unit_types.permissions import HasOrgUnitTypeWritePermission
 from iaso.api.permission_checks import (
     AuthenticationEnforcedPermission,
@@ -48,7 +48,7 @@ class OrgUnitTypeViewSet(ModelViewSet):
     serializer_class = OrgUnitTypeSerializerV1
     results_key = "orgUnitTypes"
     http_method_names = ["get", "post", "patch", "put", "delete", "head", "options", "trace"]
-    filter_backends = [DjangoFilterBackend, DynamicFieldsFilterBackend]
+    filter_backends = [DjangoFilterBackend, DynamicFieldsFilterBackendBackwardCompatible]
 
     def destroy(self, request, pk):
         t = OrgUnitType.objects.get(pk=pk)

--- a/iaso/api/org_units.py
+++ b/iaso/api/org_units.py
@@ -22,7 +22,7 @@ from rest_framework import permissions, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
 
-from dynamic_fields.filter_backends import DynamicFieldsFilterBackend
+from dynamic_fields.filter_backends import DynamicFieldsFilterBackendBackwardCompatible
 from hat.api.export_utils import Echo, generate_xlsx, iter_items
 from hat.audit import models as audit_models
 from iaso.api.common import CONTENT_TYPE_CSV, CONTENT_TYPE_XLSX, is_field_referenced, safe_api_import
@@ -119,7 +119,7 @@ class OrgUnitViewSet(viewsets.ViewSet):
     # this HasOrgUnitPermission bypass UserAccessPermission and allow anonymous access
     # except if AuthenticationEnforcedPermission is enabled
     permission_classes = [AuthenticationEnforcedPermission, HasOrgUnitPermission]
-    filter_backends = [DjangoFilterBackend, DynamicFieldsFilterBackend]
+    filter_backends = [DjangoFilterBackend, DynamicFieldsFilterBackendBackwardCompatible]
     dynamic_fields_serializer_class = OrgUnitSearchSerializer
 
     def get_queryset(self):

--- a/iaso/api/profiles/serializers/list.py
+++ b/iaso/api/profiles/serializers/list.py
@@ -1,7 +1,7 @@
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
-from dynamic_fields.serializer import DynamicFieldsModelSerializer
+from dynamic_fields.serializer import DynamicFieldsModelSerializerBackwardCompatible
 from iaso.api.common import ModelSerializer
 from iaso.models import Profile, Project, UserRole
 
@@ -25,7 +25,7 @@ class NestedUserRoleSerializer(ModelSerializer):
         return tail if sep else obj.group.name
 
 
-class ProfileListSerializer(DynamicFieldsModelSerializer):
+class ProfileListSerializer(DynamicFieldsModelSerializerBackwardCompatible):
     first_name = serializers.SerializerMethodField(read_only=True)
     user_name = serializers.SerializerMethodField(read_only=True)
     last_name = serializers.SerializerMethodField(read_only=True)

--- a/iaso/api/profiles/views.py
+++ b/iaso/api/profiles/views.py
@@ -26,7 +26,7 @@ from rest_framework.decorators import action
 from rest_framework.filters import OrderingFilter
 from rest_framework.response import Response
 
-from dynamic_fields.filter_backends import DynamicFieldsFilterBackend
+from dynamic_fields.filter_backends import DynamicFieldsFilterBackendBackwardCompatible
 from hat.api.export_utils import Echo, generate_xlsx, iter_items
 from hat.audit.models import PROFILE_API
 from iaso.api.bulk_create_users.constants import BULK_CREATE_USER_COLUMNS_LIST
@@ -101,7 +101,7 @@ class ProfilesViewSet(ModelViewSet):
     @property
     def filter_backends(self):
         if self.action in ["list"]:
-            return [OrderingFilter, DjangoFilterBackend, DynamicFieldsFilterBackend]
+            return [OrderingFilter, DjangoFilterBackend, DynamicFieldsFilterBackendBackwardCompatible]
         return [OrderingFilter, DjangoFilterBackend]
 
     def get_serializer_class(self):

--- a/iaso/api/serializers.py
+++ b/iaso/api/serializers.py
@@ -2,7 +2,7 @@ from django.db import models
 from django.db.models import Q
 from rest_framework import serializers
 
-from dynamic_fields.serializer import DynamicFieldsModelSerializerMixin
+from dynamic_fields.serializer import DynamicFieldsModelSerializerBackwardCompatibleMixin
 from hat.api.export_utils import timestamp_to_utc_datetime
 from iaso.api.common import TimestampField
 from iaso.api.query_params import APP_ID
@@ -191,7 +191,7 @@ class OrgUnitDropdownSerializer(OrgUnitSerializer):
 
 
 # noinspection PyMethodMayBeStatic
-class OrgUnitSearchSerializer(DynamicFieldsModelSerializerMixin, OrgUnitSerializer):
+class OrgUnitSearchSerializer(DynamicFieldsModelSerializerBackwardCompatibleMixin, OrgUnitSerializer):
     parent = OrgUnitSearchParentSerializer()
     instances_count = serializers.SerializerMethodField()
     creator = serializers.SerializerMethodField()

--- a/iaso/tests/api/data_source_versions_synchronization/test_views.py
+++ b/iaso/tests/api/data_source_versions_synchronization/test_views.py
@@ -99,7 +99,9 @@ class DataSourceVersionsSynchronizationViewSetTestCase(TaskAPITestCase):
         This can be useful to e.g. build a frontend dropdown.
         """
         self.client.force_authenticate(self.user)
-        response = self.client.get("/api/datasources/sync/", data={"name__icontains": "foo", "fields": ["id", "name"]})
+        response = self.client.get(
+            "/api/datasources/sync/", data={"name__icontains": "foo", "fields": ",".join(["id", "name"])}
+        )
         self.assertEqual(1, len(response.data["results"]))
         expected_result = {
             "id": self.data_source_sync_1.pk,

--- a/iaso/tests/api/form_versions/test_form_versions.py
+++ b/iaso/tests/api/form_versions/test_form_versions.py
@@ -185,6 +185,17 @@ class FormsVersionAPITestCase(APITestCase):
         self.assertValidFormVersionData(form_version_data)
         self.assertHasField(form_version_data, "descriptor", dict)
 
+    def test_form_versions_dynamic_fields(self):
+        self.client.force_authenticate(self.yoda)
+        response = self.client.get(f"/api/formversions/{self.form_2.form_versions.first().id}/?fields=:all")
+        form_version_data = self.assertJSONResponse(response, 200)
+        self.assertValidFormVersionData(form_version_data)
+        self.assertHasField(form_version_data, "descriptor", dict)
+
+        response = self.client.get(f"/api/formversions/{self.form_2.form_versions.first().id}/?fields=id,created_at")
+        form_version_data = self.assertJSONResponse(response, 200)
+        self.assertCountEqual(form_version_data.keys(), ["id", "created_at"])
+
     def test_form_versions_update(self):
         """PUT /formversions/<form_id>: ok"""
         form_version = self.form_2.form_versions.first()

--- a/iaso/tests/api/profiles/test_views/test_list.py
+++ b/iaso/tests/api/profiles/test_views/test_list.py
@@ -553,7 +553,7 @@ class ProfileListAPITestCase(BaseProfileAPITestCase):
         for item in response_data["results"]:
             self.assertCountEqual(item.keys(), ["id", "user_id", "user_display"])
 
-        response = self.client.get(reverse("profiles-list"), data={"fields": ["email", "last_name"]})
+        response = self.client.get(reverse("profiles-list"), data={"fields": ",".join(["email", "last_name"])})
         response_data = self.assertJSONResponse(response, 200)
         # self.assertValidProfileListData(response_data, 7)
 

--- a/iaso/tests/api/test_forms.py
+++ b/iaso/tests/api/test_forms.py
@@ -769,7 +769,9 @@ class FormsAPITestCase(APITestCase):
 
         # Test with specific fields that don't include instances_count or :all
         response = self.client.get(
-            "/api/forms/", data={"fields": ["id", "name", "form_id"]}, headers={"Content-Type": "application/json"}
+            "/api/forms/",
+            data={"fields": ",".join(["id", "name", "form_id"])},
+            headers={"Content-Type": "application/json"},
         )
         self.assertJSONResponse(response, 200)
 
@@ -780,7 +782,7 @@ class FormsAPITestCase(APITestCase):
         # Test that instances_count is included when explicitly requested
         response = self.client.get(
             "/api/forms/",
-            data={"fields": ["id", "name", "instances_count"]},
+            data={"fields": ",".join(["id", "name", "instances_count"])},
             headers={"Content-Type": "application/json"},
         )
         self.assertJSONResponse(response, 200)
@@ -825,7 +827,7 @@ class FormsAPITestCase(APITestCase):
         self.client.force_authenticate(self.yoda)
 
         response = self.client.get(
-            "/api/forms/", data={"fields": ["id", "name"]}, headers={"Content-Type": "application/json"}
+            "/api/forms/", data={"fields": ",".join(["id", "name"])}, headers={"Content-Type": "application/json"}
         )
         self.assertJSONResponse(response, 200)
         for form_data in response.json()["forms"]:
@@ -833,7 +835,7 @@ class FormsAPITestCase(APITestCase):
 
         response = self.client.get(
             "/api/forms/",
-            data={"fields": ["id", "name", "has_attachments"]},
+            data={"fields": ",".join(["id", "name", "has_attachments"])},
             headers={"Content-Type": "application/json"},
         )
         self.assertJSONResponse(response, 200)
@@ -858,7 +860,9 @@ class FormsAPITestCase(APITestCase):
             .get()
         )
 
-        api_request = Request(APIRequestFactory().get("/api/forms/", data={"fields": ["id", "has_attachments"]}))
+        api_request = Request(
+            APIRequestFactory().get("/api/forms/", data={"fields": ",".join(["id", "has_attachments"])})
+        )
         api_request.user = self.yoda
 
         with self.assertNumQueries(0):

--- a/iaso/tests/api/test_forms.py
+++ b/iaso/tests/api/test_forms.py
@@ -10,7 +10,7 @@ from rest_framework.test import APIRequestFactory
 
 from iaso import models as m
 from iaso.api.common import CONTENT_TYPE_XLSX
-from iaso.api.forms import FormSerializer
+from iaso.api.forms.serializers import FormSerializer
 from iaso.api.query_params import APP_ID
 from iaso.models import (
     AGGREGATE,

--- a/iaso/tests/api/test_forms_serializers.py
+++ b/iaso/tests/api/test_forms_serializers.py
@@ -5,7 +5,7 @@ from django.test import TestCase
 from rest_framework.test import APIRequestFactory
 
 from iaso import models as m
-from iaso.api.forms import FormSerializer
+from iaso.api.forms.serializers import FormSerializer
 
 
 class FormsSerializerTestCase(TestCase):

--- a/iaso/tests/api/test_group_sets.py
+++ b/iaso/tests/api/test_group_sets.py
@@ -384,7 +384,7 @@ class GroupSetsAPITestCase(APITestCase):
         record_1, record_2 = self.seed_list()
         # Search all
 
-        resp = self.client.get("/api/group_sets/", data={"fields": ["id", "name"]})
+        resp = self.client.get("/api/group_sets/", data={"fields": ",".join(["id", "name"])})
         self.assertEqual(
             resp.json()["group_sets"],
             [
@@ -396,26 +396,30 @@ class GroupSetsAPITestCase(APITestCase):
     def test_list_groupsets_search_by_name(self):
         record_1, record_2 = self.seed_list()
 
-        resp = self.client.get("/api/group_sets/", data={"fields": ["id", "name"], "search": "src 1"})
+        resp = self.client.get("/api/group_sets/", data={"fields": ",".join(["id", "name"]), "search": "src 1"})
         self.assertEqual(resp.json()["group_sets"], [record_1])
 
-        resp = self.client.get("/api/group_sets/", data={"fields": ["id", "name"], "search": "src"})
+        resp = self.client.get("/api/group_sets/", data={"fields": ",".join(["id", "name"]), "search": "src"})
         self.assertEqual(resp.json()["group_sets"], [record_1, record_2])
 
     def test_list_groupsets_search_by_default_version(self):
         record_1, record_2 = self.seed_list()
 
-        resp = self.client.get("/api/group_sets/", data={"fields": ["id", "name"], "default_version": "true"})
+        resp = self.client.get("/api/group_sets/", data={"fields": ",".join(["id", "name"]), "default_version": "true"})
         self.assertJSONResponse(resp, status.HTTP_200_OK)
         self.assertEqual(resp.json()["group_sets"], [record_1])
 
     def test_list_groupsets_search_by_version(self):
         record_1, record_2 = self.seed_list()
 
-        resp = self.client.get("/api/group_sets/", data={"fields": ["id", "name"], "version": self.source_version_1.id})
+        resp = self.client.get(
+            "/api/group_sets/", data={"fields": ",".join(["id", "name"]), "version": self.source_version_1.id}
+        )
         self.assertEqual(resp.json()["group_sets"], [record_1])
 
-        resp = self.client.get("/api/group_sets/", data={"fields": ["id", "name"], "version": self.source_version_2.id})
+        resp = self.client.get(
+            "/api/group_sets/", data={"fields": ",".join(["id", "name"]), "version": self.source_version_2.id}
+        )
         self.assertEqual(resp.json()["group_sets"], [record_2])
 
     def test_list_groupsets_search_return_dynamic_fields(self):
@@ -428,7 +432,7 @@ class GroupSetsAPITestCase(APITestCase):
         self.seed_list()
 
         resp = self.client.get(
-            "/api/group_sets/", data={"fields": ["id", "name", "groups"], "version": self.source_version_1.id}
+            "/api/group_sets/", data={"fields": ",".join(["id", "name", "groups"]), "version": self.source_version_1.id}
         )
         resp_data = self.assertJSONResponse(resp, status.HTTP_200_OK)
         groups_name = [g["name"] for g in resp_data["group_sets"][0]["groups"]]

--- a/iaso/tests/api/test_mobileforms.py
+++ b/iaso/tests/api/test_mobileforms.py
@@ -100,17 +100,19 @@ class MobileFormsAPITestCase(APITestCase):
         self.form_1.form_versions.create(file=self.create_file_mock(name="data.xml"), version_id="20250813")
 
         self.client.force_authenticate(self.yoda)
-        custom_fields = [
-            "id",
-            "name",
-            "periods_before_allowed",
-            "periods_after_allowed",
-            "predefined_filters",
-            "has_attachments",
-            "created_at",
-            "updated_at",
-            "reference_form_of_org_unit_types",
-        ]
+        custom_fields = ",".join(
+            [
+                "id",
+                "name",
+                "periods_before_allowed",
+                "periods_after_allowed",
+                "predefined_filters",
+                "has_attachments",
+                "created_at",
+                "updated_at",
+                "reference_form_of_org_unit_types",
+            ]
+        )
         with self.assertNumQueries(13):
             response = self.client.get(
                 "/api/mobile/forms/", data={"fields": custom_fields}, headers={"Content-Type": "application/json"}

--- a/iaso/tests/api/test_org_unit_types.py
+++ b/iaso/tests/api/test_org_unit_types.py
@@ -113,6 +113,18 @@ class OrgUnitTypesAPITestCase(APITestCase):
         self.assertJSONResponse(response, 200)
         self.assertValidOrgUnitTypeData(response.json())
 
+    def test_dynamic_fields(self):
+        self.client.force_authenticate(self.jane)
+        response = self.client.get(f"/api/orgunittypes/{self.org_unit_type_1.id}/", data={"fields": ":all"})
+        res_data = self.assertJSONResponse(response, 200)
+        self.assertValidOrgUnitTypeData(res_data)
+
+        response = self.client.get(
+            f"/api/orgunittypes/{self.org_unit_type_1.id}/", data={"fields": "id,name,short_name"}
+        )
+        res_data = self.assertJSONResponse(response, 200)
+        self.assertCountEqual(res_data.keys(), ["id", "name", "short_name"])
+
     def test_org_unit_type_create_no_auth(self):
         """POST /orgunittypes/ without auth: 401"""
 

--- a/iaso/tests/api/test_orgunits.py
+++ b/iaso/tests/api/test_orgunits.py
@@ -1672,20 +1672,18 @@ class OrgUnitAPITestCase(APITestCase):
         old_created_at = ou.created_at
         previous_updated_at = ou.updated_at
 
-        requested_fields = ",".join(
-            [
-                "id",
-                "name",
-                "validation_status",
-                "aliases",
-                "latitude",
-                "longitude",
-                "org_unit_type_id",
-                "updated_at",
-            ]
-        )
+        requested_fields = [
+            "id",
+            "name",
+            "validation_status",
+            "aliases",
+            "latitude",
+            "longitude",
+            "org_unit_type_id",
+            "updated_at",
+        ]
 
-        url = f"/api/orgunits/{ou.id}/?{urlencode({'fields': requested_fields}, True)}"
+        url = f"/api/orgunits/{ou.id}/?{urlencode({'fields': ','.join(requested_fields)}, True)}"
 
         payload = {
             "name": "Updated Jedi HQ",

--- a/iaso/tests/api/test_orgunits.py
+++ b/iaso/tests/api/test_orgunits.py
@@ -871,7 +871,7 @@ class OrgUnitAPITestCase(APITestCase):
 
         # Request without 'instances_count'
         requested_fields = ["id", "name", "org_unit_type_name"]
-        url = f"/api/orgunits/?{urlencode({'fields': requested_fields, 'limit': 10}, True)}"
+        url = f"/api/orgunits/?{urlencode({'fields': ','.join(requested_fields), 'limit': 10}, True)}"
 
         with CaptureQueriesContext(connection) as ctx:
             response = self.client.get(url)
@@ -892,7 +892,7 @@ class OrgUnitAPITestCase(APITestCase):
         self.client.force_authenticate(self.yoda)
 
         # Explicitly request instances_count
-        requested_fields = ["id", "name", "instances_count"]
+        requested_fields = ",".join(["id", "name", "instances_count"])
         url = f"/api/orgunits/?{urlencode({'fields': requested_fields, 'limit': 10, 'order': 'id'}, True)}"
 
         with CaptureQueriesContext(connection) as ctx:
@@ -1672,16 +1672,18 @@ class OrgUnitAPITestCase(APITestCase):
         old_created_at = ou.created_at
         previous_updated_at = ou.updated_at
 
-        requested_fields = [
-            "id",
-            "name",
-            "validation_status",
-            "aliases",
-            "latitude",
-            "longitude",
-            "org_unit_type_id",
-            "updated_at",
-        ]
+        requested_fields = ",".join(
+            [
+                "id",
+                "name",
+                "validation_status",
+                "aliases",
+                "latitude",
+                "longitude",
+                "org_unit_type_id",
+                "updated_at",
+            ]
+        )
 
         url = f"/api/orgunits/{ou.id}/?{urlencode({'fields': requested_fields}, True)}"
 

--- a/iaso/urls.py
+++ b/iaso/urls.py
@@ -58,7 +58,8 @@ from .api.feature_flags import FeatureFlagViewSet
 from .api.form_attachments import FormAttachmentsViewSet
 from .api.form_predefined_filters.views import FormPredefinedFiltersViewSet
 from .api.form_versions.views import FormVersionsViewSet
-from .api.forms import FormsViewSet, MobileFormViewSet
+from .api.forms.views import FormsViewSet
+from .api.forms.views_mobile import MobileFormViewSet
 from .api.group_sets.views import GroupSetsViewSet
 from .api.groups.views import GroupsViewSet
 from .api.hesabu_descriptors import HesabuDescriptorsViewSet

--- a/plugins/polio/api/chronogram/serializers.py
+++ b/plugins/polio/api/chronogram/serializers.py
@@ -1,7 +1,7 @@
 from django.contrib.auth.models import User
 from rest_framework import serializers
 
-from dynamic_fields.serializer import DynamicFieldsModelSerializer
+from dynamic_fields.serializer import DynamicFieldsModelSerializerBackwardCompatibleMixin
 from plugins.polio.models import Campaign, Chronogram, ChronogramTask, ChronogramTemplateTask, Round
 from plugins.polio.permissions import POLIO_CHRONOGRAM_PERMISSION, POLIO_CHRONOGRAM_RESTRICTED_WRITE_PERMISSION
 
@@ -14,7 +14,7 @@ class UserNestedSerializer(serializers.ModelSerializer):
         fields = ["id", "username", "full_name"]
 
 
-class ChronogramTaskSerializer(DynamicFieldsModelSerializer, serializers.ModelSerializer):
+class ChronogramTaskSerializer(DynamicFieldsModelSerializerBackwardCompatibleMixin, serializers.ModelSerializer):
     def get_fields(self, *args, **kwargs):
         fields = super().get_fields(*args, **kwargs)
         user = getattr(self.context.get("request", {}), "user", None)
@@ -85,7 +85,7 @@ class ChronogramTaskSerializer(DynamicFieldsModelSerializer, serializers.ModelSe
         }
 
 
-class ChronogramSerializer(DynamicFieldsModelSerializer, serializers.ModelSerializer):
+class ChronogramSerializer(DynamicFieldsModelSerializerBackwardCompatibleMixin, serializers.ModelSerializer):
     campaign_obr_name = serializers.CharField(source="round.campaign.obr_name")
     round_number = serializers.CharField(source="round.number")
     round_start_date = serializers.CharField(source="round.started_at")
@@ -127,7 +127,9 @@ class ChronogramSerializer(DynamicFieldsModelSerializer, serializers.ModelSerial
         }
 
 
-class ChronogramTemplateTaskSerializer(DynamicFieldsModelSerializer, serializers.ModelSerializer):
+class ChronogramTemplateTaskSerializer(
+    DynamicFieldsModelSerializerBackwardCompatibleMixin, serializers.ModelSerializer
+):
     class Meta:
         model = ChronogramTemplateTask
         fields = [

--- a/plugins/polio/api/chronogram/views.py
+++ b/plugins/polio/api/chronogram/views.py
@@ -8,7 +8,7 @@ from rest_framework.decorators import action
 from rest_framework.permissions import SAFE_METHODS
 from rest_framework.response import Response
 
-from dynamic_fields.filter_backends import DynamicFieldsFilterBackend
+from dynamic_fields.filter_backends import DynamicFieldsFilterBackendBackwardCompatible
 from iaso.api.common import Paginator
 from plugins.polio.api.chronogram.filters import ChronogramFilter, ChronogramTaskFilter
 from plugins.polio.api.chronogram.permissions import HasChronogramPermission, HasChronogramRestrictedWritePermission
@@ -39,7 +39,7 @@ class ChronogramViewSet(viewsets.ModelViewSet):
             return [
                 filters.OrderingFilter,
                 django_filters.rest_framework.DjangoFilterBackend,
-                DynamicFieldsFilterBackend,
+                DynamicFieldsFilterBackendBackwardCompatible,
             ]
         return [filters.OrderingFilter, django_filters.rest_framework.DjangoFilterBackend]
 
@@ -150,7 +150,7 @@ class ChronogramTaskViewSet(viewsets.ModelViewSet):
             return [
                 filters.OrderingFilter,
                 django_filters.rest_framework.DjangoFilterBackend,
-                DynamicFieldsFilterBackend,
+                DynamicFieldsFilterBackendBackwardCompatible,
             ]
         return [filters.OrderingFilter, django_filters.rest_framework.DjangoFilterBackend]
 
@@ -195,7 +195,7 @@ class ChronogramTemplateTaskViewSet(viewsets.ModelViewSet):
             return [
                 filters.OrderingFilter,
                 django_filters.rest_framework.DjangoFilterBackend,
-                DynamicFieldsFilterBackend,
+                DynamicFieldsFilterBackendBackwardCompatible,
             ]
         return [filters.OrderingFilter, django_filters.rest_framework.DjangoFilterBackend]
 

--- a/plugins/polio/budget/api.py
+++ b/plugins/polio/budget/api.py
@@ -11,7 +11,7 @@ from rest_framework.generics import get_object_or_404
 from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
 
-from dynamic_fields.filter_backends import DynamicFieldsFilterBackend
+from dynamic_fields.filter_backends import DynamicFieldsFilterBackendBackwardCompatible
 from iaso.api.common import (
     CSVExportMixin,
     DeletionFilterBackend,
@@ -54,7 +54,12 @@ class BudgetProcessViewSet(ModelViewSet, CSVExportMixin):
     permission_classes = [HasPermission(POLIO_BUDGET_PERMISSION)]
     use_field_order = True
     http_method_names = ["delete", "get", "head", "patch", "post"]
-    filter_backends = [filters.OrderingFilter, DjangoFilterBackend, DeletionFilterBackend, DynamicFieldsFilterBackend]
+    filter_backends = [
+        filters.OrderingFilter,
+        DjangoFilterBackend,
+        DeletionFilterBackend,
+        DynamicFieldsFilterBackendBackwardCompatible,
+    ]
     filterset_class = BudgetProcessFilter
     dynamic_fields_serializer_class = BudgetProcessSerializer
     ordering_fields = [

--- a/plugins/polio/budget/serializers.py
+++ b/plugins/polio/budget/serializers.py
@@ -5,7 +5,7 @@ from django.db import transaction
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
-from dynamic_fields.serializer import DynamicFieldsModelSerializer
+from dynamic_fields.serializer import DynamicFieldsModelSerializerBackwardCompatibleMixin
 from iaso.api.common import UserSerializer
 from iaso.models.team import Team
 
@@ -213,7 +213,7 @@ class BudgetProcessWriteSerializer(serializers.ModelSerializer):
         return budget_process
 
 
-class BudgetProcessSerializer(DynamicFieldsModelSerializer, serializers.ModelSerializer):
+class BudgetProcessSerializer(DynamicFieldsModelSerializerBackwardCompatibleMixin, serializers.ModelSerializer):
     class Meta:
         model = BudgetProcess
         fields = [

--- a/plugins/polio/js/src/domains/Budget/hooks/api/useGetBudget.ts
+++ b/plugins/polio/js/src/domains/Budget/hooks/api/useGetBudget.ts
@@ -128,7 +128,7 @@ export const useGetBudgets = (options: Option): any => {
         current_state_key: options.current_state_key,
         countries: options.countries,
         org_unit_groups: options.org_unit_groups,
-        fields: budgetFields,
+        fields: budgetFields.join(','),
     };
 
     return useSnackQuery({
@@ -172,7 +172,7 @@ export const useGetBudgetForCampaign = (
     id: Optional<string>,
 ): UseQueryResult<Partial<Budget>> => {
     const params = {
-        fields: ['id', 'obr_name', 'current_state', 'next_transitions', 'possible_transitions' ,'rounds' ,' timeline']
+        fields: ['id', 'obr_name', 'current_state', 'next_transitions', 'possible_transitions' ,'rounds' ,' timeline'].join(',')
     };
 
     return useSnackQuery({

--- a/plugins/polio/tests/api/test_budget.py
+++ b/plugins/polio/tests/api/test_budget.py
@@ -330,7 +330,7 @@ class BudgetProcessViewSetTestCase(APITestCase):
         GET /api/polio/budget/?fields=obr_name,country_name
         """
         self.client.force_login(self.user)
-        response = self.client.get("/api/polio/budget/", data={"fields": ["obr_name", "country_name"]})
+        response = self.client.get("/api/polio/budget/", data={"fields": ",".join(["obr_name", "country_name"])})
         response_data = self.assertJSONResponse(response, 200)
         for budget_process in response_data["results"]:
             self.assertEqual(budget_process["obr_name"], "test campaign")
@@ -793,7 +793,7 @@ class BudgetProcessViewSetTestCase(APITestCase):
 
     def test_csv_export(self):
         self.client.force_login(self.user)
-        r = self.client.get("/api/polio/budget/export_csv/", data={"fields": ["obr_name", "rounds"]})
+        r = self.client.get("/api/polio/budget/export_csv/", data={"fields": ",".join(["obr_name", "rounds"])})
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r["Content-Type"], "text/csv")
         self.assertEqual(r.content, b'OBR name,Rounds\r\ntest campaign,"1,2"\r\ntest campaign,3\r\n')

--- a/plugins/polio/tests/api/test_budget_serializers.py
+++ b/plugins/polio/tests/api/test_budget_serializers.py
@@ -452,10 +452,10 @@ class BudgetProcessSerializerTestCase(TestCase):
             },
         )
 
-        # Ask for a set of fields (this is done via `DynamicFieldsModelSerializer`).
-        self.request.query_params.setlist(
-            "fields", "id,who_sent_budget_at_WFEDITABLE,payment_mode,district_count".split(",")
-        )
+        # Ask for a set of fields (this is done via `DynamicFieldsModelSerializerBackwardCompatible`).
+
+        self.request.query_params.setlist("fields", "id,who_sent_budget_at_WFEDITABLE,payment_mode,district_count")
+
         serializer = BudgetProcessSerializer(instance=budget_process, context={"request": self.request})
         self.assertEqual(
             serializer.data,
@@ -467,7 +467,7 @@ class BudgetProcessSerializerTestCase(TestCase):
             },
         )
 
-        # Ask for all fields (this is done via `DynamicFieldsModelSerializer`).
+        # Ask for all fields (this is done via `DynamicFieldsModelSerializerBackwardCompatible`).
         self.request.query_params["fields"] = ":all"
         serializer = BudgetProcessSerializer(instance=budget_process, context={"request": self.request})
 

--- a/plugins/polio/tests/api/test_budget_serializers.py
+++ b/plugins/polio/tests/api/test_budget_serializers.py
@@ -454,7 +454,7 @@ class BudgetProcessSerializerTestCase(TestCase):
 
         # Ask for a set of fields (this is done via `DynamicFieldsModelSerializerBackwardCompatible`).
 
-        self.request.query_params.setlist("fields", "id,who_sent_budget_at_WFEDITABLE,payment_mode,district_count")
+        self.request.query_params["fields"] = "id,who_sent_budget_at_WFEDITABLE,payment_mode,district_count"
 
         serializer = BudgetProcessSerializer(instance=budget_process, context={"request": self.request})
         self.assertEqual(


### PR DESCRIPTION
## What problem is this PR solving?

New dynamic model field serializer didn't take into account mobile API that was still calling with comma separated values and other endpoints. 

### Related JIRA tickets

IA-5016

## Changes

* Add some data to make the DynamicModelFieldSerializer backward compatible
* Revert back all the endpoints to use the compatible mode
* Reorganize a bit the form api code
* Fix the front end (revert)

## How to test

* python tests
* the affected endpoints are : 

/api/forms/
/api/formversions/
/api/datasources/sync/
/api/group_sets/
/api/orgunittypes/
/api/v2/orgunittypes/
/api/mappingversions/
/api/orgunits/
/api/polio/chronograms/tasks/
/api/polio/chronograms/template_tasks/
/api/polio/chronograms/
/api/polio/budget/

UI and backend should be tested to see that the old behavior is still working (aka fields=x,y,z)

## Notes

We should slowly start moving apis to a v2 that only the front end would consume. And keep the "old v1" for the mobile only. 