### PR TITLE
[IA-4882] Fixing the findIndex method check

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/forms/components/FormsFilterComponent.test.tsx
+++ b/hat/assets/js/apps/Iaso/domains/forms/components/FormsFilterComponent.test.tsx
@@ -1,0 +1,535 @@
+import React from 'react';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderWithThemeAndIntlProvider } from '../../../../../tests/helpers';
+import * as useGetInstancesModule from '../hooks/useGetInstances';
+import { FormsFilterComponent } from './FormsFilterComponent';
+
+const mockUseGetColors = vi.fn();
+
+vi.mock('../hooks/useGetInstances', () => ({
+    useGetInstances: vi.fn(),
+}));
+
+const mockUseGetInstances = vi.mocked(
+    useGetInstancesModule.useGetInstances,
+) as any;
+
+vi.mock('Iaso/hooks/useGetColors', () => ({
+    useGetColors: (arg: boolean) => mockUseGetColors(arg),
+    getColor: (index: number, colors: any[]) => {
+        if (!colors || colors.length === 0) return '#FF0000';
+        return colors[index % colors.length];
+    },
+}));
+
+vi.mock('bluesquare-components', async () => {
+    const actual = await vi.importActual('bluesquare-components');
+    return {
+        ...actual,
+        useSafeIntl: () => ({
+            formatMessage: (msg: { defaultMessage?: string } | string) =>
+                typeof msg === 'string' ? msg : (msg?.defaultMessage ?? ''),
+        }),
+        Select: ({
+            keyValue,
+            label,
+            disabled,
+            loading,
+            options,
+            value,
+            onChange,
+        }: Record<string, any>) => (
+            <div data-testid={`select-${keyValue}`}>
+                <label htmlFor={`select-input-${keyValue}`}>
+                    {label}
+                    <select
+                        id={`select-input-${keyValue}`}
+                        data-testid={`select-input-${keyValue}`}
+                        disabled={Boolean(disabled || loading)}
+                        value={
+                            Array.isArray(value)
+                                ? value.map(v => v.id).join(',')
+                                : ''
+                        }
+                        onChange={event => {
+                            const selectedIds = event.target.value
+                                .split(',')
+                                .filter(id => id !== '');
+                            const selectedForms = options.filter(
+                                (opt: { id: string }) =>
+                                    selectedIds.includes(opt.id),
+                            );
+                            onChange(selectedForms);
+                        }}
+                    >
+                        <option value="">-- Select forms --</option>
+                        {options.map((opt: any) => (
+                            <option key={opt.id} value={opt.id}>
+                                {opt.name}
+                            </option>
+                        ))}
+                    </select>
+                </label>
+                {loading && (
+                    <span data-testid="select-loading">Loading...</span>
+                )}
+            </div>
+        ),
+        IconButton: ({
+            onClick,
+            icon,
+            tooltipMessage,
+            disabled,
+        }: Record<string, any>) => (
+            <button
+                data-testid={`icon-button-${icon}`}
+                onClick={onClick}
+                disabled={Boolean(disabled)}
+                title={
+                    typeof tooltipMessage === 'string'
+                        ? tooltipMessage
+                        : tooltipMessage?.defaultMessage
+                }
+            >
+                {icon}
+            </button>
+        ),
+        renderTags:
+            (getLabel: (obj: any) => string) => (selectedItems: any[]) =>
+                selectedItems.map(item => getLabel(item)).join(', '),
+    };
+});
+
+describe('FormsFilterComponent', () => {
+    const mockMapRef = { current: { fitBounds: vi.fn() } };
+
+    const baseProps = {
+        formsSelected: [],
+        setFormsSelected: vi.fn(),
+        currentOrgUnit: { id: 1 },
+        map: mockMapRef,
+    };
+
+    const mockColorArray = ['#FF0000', '#00FF00', '#0000FF'];
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockMapRef.current.fitBounds = vi.fn();
+        mockUseGetInstances.mockReturnValue({
+            data: null,
+            isLoading: false,
+        });
+        mockUseGetColors.mockReturnValue({
+            data: mockColorArray,
+            isLoading: false,
+        });
+    });
+
+    describe('Form Grouping Logic (findIndex bug fix)', () => {
+        it('should display only one option for 3 instances with same form_id', () => {
+            const mockInstances = [
+                {
+                    id: 1,
+                    form_id: 'form1',
+                    form_name: 'Form A',
+                    latitude: 48.8566,
+                    longitude: 2.3522,
+                },
+                {
+                    id: 2,
+                    form_id: 'form1',
+                    form_name: 'Form A',
+                    latitude: 48.86,
+                    longitude: 2.35,
+                },
+                {
+                    id: 3,
+                    form_id: 'form1',
+                    form_name: 'Form A',
+                    latitude: 48.865,
+                    longitude: 2.355,
+                },
+            ];
+
+            mockUseGetInstances.mockReturnValue({
+                data: { instances: mockInstances },
+                isLoading: false,
+            });
+
+            renderWithThemeAndIntlProvider(
+                <FormsFilterComponent {...baseProps} />,
+            );
+
+            const selectInput = screen.getByTestId('select-input-forms');
+            const formOptions = selectInput.querySelectorAll('option');
+            const formAOptions = Array.from(formOptions).filter(opt =>
+                opt.textContent?.includes('Form A'),
+            );
+            expect(formAOptions).toHaveLength(1);
+        });
+
+        it('should display two separate options for different form_ids', () => {
+            const mockInstances = [
+                {
+                    id: 1,
+                    form_id: 'formA',
+                    form_name: 'Form A',
+                    latitude: 48.8566,
+                    longitude: 2.3522,
+                },
+                {
+                    id: 2,
+                    form_id: 'formB',
+                    form_name: 'Form B',
+                    latitude: 48.86,
+                    longitude: 2.35,
+                },
+            ];
+
+            mockUseGetInstances.mockReturnValue({
+                data: { instances: mockInstances },
+                isLoading: false,
+            });
+
+            renderWithThemeAndIntlProvider(
+                <FormsFilterComponent {...baseProps} />,
+            );
+
+            const selectInput = screen.getByTestId('select-input-forms');
+            expect(selectInput).toHaveTextContent('Form A');
+            expect(selectInput).toHaveTextContent('Form B');
+        });
+
+        it('should assign different colors to grouped forms', () => {
+            const mockInstances = [
+                {
+                    id: 1,
+                    form_id: 'form1',
+                    form_name: 'Form A',
+                    latitude: 48.8566,
+                    longitude: 2.3522,
+                },
+            ];
+
+            mockUseGetInstances.mockReturnValue({
+                data: { instances: mockInstances },
+                isLoading: false,
+            });
+
+            mockUseGetColors.mockReturnValue({
+                data: ['#AABBCC', '#DDDDDD'],
+                isLoading: false,
+            });
+
+            renderWithThemeAndIntlProvider(
+                <FormsFilterComponent {...baseProps} />,
+            );
+
+            expect(mockUseGetColors).toHaveBeenCalledWith(true);
+        });
+    });
+
+    describe('UI States', () => {
+        it('should show loading state when isLoading is true', () => {
+            mockUseGetInstances.mockReturnValue({
+                data: null,
+                isLoading: true,
+            });
+
+            renderWithThemeAndIntlProvider(
+                <FormsFilterComponent {...baseProps} />,
+            );
+
+            expect(screen.getByTestId('select-loading')).toBeInTheDocument();
+        });
+
+        it('should disable select when data.instances is empty', () => {
+            mockUseGetInstances.mockReturnValue({
+                data: { instances: [] },
+                isLoading: false,
+            });
+
+            renderWithThemeAndIntlProvider(
+                <FormsFilterComponent {...baseProps} />,
+            );
+
+            const selectInput = screen.getByTestId('select-input-forms');
+            expect(selectInput).toBeDisabled();
+        });
+
+        it('should disable select when data is undefined', () => {
+            mockUseGetInstances.mockReturnValue({
+                data: undefined,
+                isLoading: false,
+            });
+
+            renderWithThemeAndIntlProvider(
+                <FormsFilterComponent {...baseProps} />,
+            );
+
+            const selectInput = screen.getByTestId('select-input-forms');
+            expect(selectInput).toBeDisabled();
+        });
+    });
+
+    describe('Filter Interactions', () => {
+        it('should call setFormsSelected when form is selected', async () => {
+            const user = userEvent.setup();
+            const mockInstances = [
+                {
+                    id: 1,
+                    form_id: 'form1',
+                    form_name: 'Form A',
+                    latitude: 48.8566,
+                    longitude: 2.3522,
+                },
+            ];
+
+            mockUseGetInstances.mockReturnValue({
+                data: { instances: mockInstances },
+                isLoading: false,
+            });
+
+            const setFormsSelected = vi.fn();
+            renderWithThemeAndIntlProvider(
+                <FormsFilterComponent
+                    {...baseProps}
+                    setFormsSelected={setFormsSelected}
+                />,
+            );
+
+            const selectInput = screen.getByTestId('select-input-forms');
+            await user.selectOptions(selectInput, 'form1');
+
+            await waitFor(() => {
+                expect(setFormsSelected).toHaveBeenCalled();
+            });
+        });
+    });
+
+    describe('Geographic Logic - Bounds Calculation', () => {
+        it('should enable fit to bounds button when form has valid coordinates', () => {
+            mockUseGetInstances.mockReturnValue({
+                data: {
+                    instances: [
+                        {
+                            id: 1,
+                            form_id: 'form1',
+                            form_name: 'Form A',
+                            latitude: 48.8566,
+                            longitude: 2.3522,
+                        },
+                    ],
+                },
+                isLoading: false,
+            });
+
+            const selectedForms = [
+                {
+                    id: 'form1',
+                    name: 'Form A',
+                    color: '#FF0000',
+                    instances: [
+                        {
+                            id: 1,
+                            form_id: 'form1',
+                            form_name: 'Form A',
+                            latitude: 48.8566,
+                            longitude: 2.3522,
+                        },
+                    ],
+                },
+            ];
+
+            renderWithThemeAndIntlProvider(
+                <FormsFilterComponent
+                    {...baseProps}
+                    formsSelected={selectedForms}
+                />,
+            );
+
+            const fitBoundsButton = screen.getByTestId(
+                'icon-button-remove-red-eye',
+            );
+            expect(fitBoundsButton).not.toBeDisabled();
+        });
+
+        it('should disable fit to bounds button when instances have no coordinates', () => {
+            mockUseGetInstances.mockReturnValue({
+                data: {
+                    instances: [
+                        {
+                            id: 1,
+                            form_id: 'form1',
+                            form_name: 'Form A',
+                            latitude: null,
+                            longitude: null,
+                        },
+                    ],
+                },
+                isLoading: false,
+            });
+
+            const selectedForms = [
+                {
+                    id: 'form1',
+                    name: 'Form A',
+                    color: '#FF0000',
+                    instances: [
+                        {
+                            id: 1,
+                            form_id: 'form1',
+                            form_name: 'Form A',
+                            latitude: null,
+                            longitude: null,
+                        },
+                    ],
+                },
+            ];
+
+            renderWithThemeAndIntlProvider(
+                <FormsFilterComponent
+                    {...baseProps}
+                    formsSelected={selectedForms}
+                />,
+            );
+
+            const fitBoundsButton = screen.getByTestId(
+                'icon-button-remove-red-eye',
+            );
+            expect(fitBoundsButton).toBeDisabled();
+        });
+
+        it('should call fitBounds when fit to bounds button is clicked', async () => {
+            const user = userEvent.setup();
+            mockUseGetInstances.mockReturnValue({
+                data: {
+                    instances: [
+                        {
+                            id: 1,
+                            form_id: 'form1',
+                            form_name: 'Form A',
+                            latitude: 48.8566,
+                            longitude: 2.3522,
+                        },
+                    ],
+                },
+                isLoading: false,
+            });
+
+            const selectedForms = [
+                {
+                    id: 'form1',
+                    name: 'Form A',
+                    color: '#FF0000',
+                    instances: [
+                        {
+                            id: 1,
+                            form_id: 'form1',
+                            form_name: 'Form A',
+                            latitude: 48.8566,
+                            longitude: 2.3522,
+                        },
+                    ],
+                },
+            ];
+
+            renderWithThemeAndIntlProvider(
+                <FormsFilterComponent
+                    {...baseProps}
+                    formsSelected={selectedForms}
+                />,
+            );
+
+            const fitBoundsButton = screen.getByTestId(
+                'icon-button-remove-red-eye',
+            );
+            await user.click(fitBoundsButton);
+
+            expect(mockMapRef.current.fitBounds).toHaveBeenCalled();
+        });
+    });
+
+    describe('Edge Cases', () => {
+        it('should filter out instances with missing longitude but present latitude', () => {
+            mockUseGetInstances.mockReturnValue({
+                data: {
+                    instances: [
+                        {
+                            id: 1,
+                            form_id: 'form1',
+                            form_name: 'Form A',
+                            latitude: 48.8566,
+                            longitude: null,
+                        },
+                        {
+                            id: 2,
+                            form_id: 'form1',
+                            form_name: 'Form A',
+                            latitude: 48.86,
+                            longitude: 2.35,
+                        },
+                    ],
+                },
+                isLoading: false,
+            });
+
+            const selectedForms = [
+                {
+                    id: 'form1',
+                    name: 'Form A',
+                    color: '#FF0000',
+                    instances: [
+                        {
+                            id: 1,
+                            form_id: 'form1',
+                            form_name: 'Form A',
+                            latitude: 48.8566,
+                            longitude: null,
+                        },
+                        {
+                            id: 2,
+                            form_id: 'form1',
+                            form_name: 'Form A',
+                            latitude: 48.86,
+                            longitude: 2.35,
+                        },
+                    ],
+                },
+            ];
+
+            renderWithThemeAndIntlProvider(
+                <FormsFilterComponent
+                    {...baseProps}
+                    formsSelected={selectedForms}
+                />,
+            );
+
+            const fitBoundsButton = screen.getByTestId(
+                'icon-button-remove-red-eye',
+            );
+            expect(fitBoundsButton).not.toBeDisabled();
+        });
+
+        it('should call useGetInstances with correct orgUnitId', () => {
+            const orgUnitId = 42;
+            mockUseGetInstances.mockReturnValue({
+                data: null,
+                isLoading: false,
+            });
+
+            renderWithThemeAndIntlProvider(
+                <FormsFilterComponent
+                    {...baseProps}
+                    currentOrgUnit={{ id: orgUnitId }}
+                />,
+            );
+
+            expect(mockUseGetInstances).toHaveBeenCalledWith({
+                orgUnitId,
+            });
+        });
+    });
+});

--- a/hat/assets/js/apps/Iaso/domains/forms/components/FormsFilterComponent.tsx
+++ b/hat/assets/js/apps/Iaso/domains/forms/components/FormsFilterComponent.tsx
@@ -8,11 +8,28 @@ import {
 } from 'bluesquare-components';
 import L from 'leaflet';
 import { useGetColors, getColor } from 'Iaso/hooks/useGetColors';
+import { Instance } from '../../instances/types/instance';
 import { useGetInstances } from '../hooks/useGetInstances';
 import MESSAGES from '../messages';
+import { Form } from '../types/forms';
+
+type instance = {
+    id: number;
+    form_id: Instance['form_id'];
+    form_name: Instance['form_name'];
+    latitude?: Instance['latitude'];
+    longitude?: Instance['longitude'];
+};
+
+type newForms = {
+    id: Form['id'];
+    name: Form['name'];
+    color: string;
+    instances: instance[];
+};
 
 type Props = {
-    formsSelected: any[];
+    formsSelected: newForms[];
     setFormsSelected: React.Dispatch<React.SetStateAction<any>>;
     currentOrgUnit: Record<string, any>;
     map: Record<string, any>;
@@ -31,11 +48,13 @@ export const FormsFilterComponent: FunctionComponent<Props> = ({
 
     const { data: colors } = useGetColors(true);
     const forms = useMemo(() => {
-        const newForms = [];
+        const newForms: newForms[] = [];
         if (data?.instances) {
-            const uniqueFormIds = new Set(data.instances.map(i => i.form_id));
+            const uniqueFormIds = new Set(
+                data.instances.map((i: instance) => i.form_id),
+            );
 
-            data.instances.forEach(i => {
+            data.instances.forEach((i: instance) => {
                 if (uniqueFormIds.has(i.form_id)) {
                     const exisitingFormIndex = newForms.findIndex(
                         f => f.id === i.form_id,
@@ -58,9 +77,11 @@ export const FormsFilterComponent: FunctionComponent<Props> = ({
 
     const computedBounds = useMemo(() => {
         const latLngs = formsSelected
-            .flatMap(form => form.instances || [])
-            .filter(i => i.latitude && i.longitude)
-            .map(i => L.latLng(i.latitude, i.longitude));
+            .flatMap((form: newForms) => form.instances || [])
+            .filter((i: instance) => i.latitude && i.longitude)
+            .map((i: instance) =>
+                L.latLng(i.latitude as number, i.longitude as number),
+            );
         if (latLngs.length === 0) return undefined;
         const bounds = L.latLngBounds(latLngs);
         return bounds.isValid() ? bounds : undefined;
@@ -93,8 +114,13 @@ export const FormsFilterComponent: FunctionComponent<Props> = ({
                         clearable
                         multi
                         value={formsSelected}
-                        getOptionLabel={option => option && option.name}
-                        getOptionSelected={(option, val) => {
+                        getOptionLabel={(option: newForms) =>
+                            option && option.name
+                        }
+                        getOptionSelected={(
+                            option: newForms,
+                            val: newForms,
+                        ) => {
                             return val && option.id === val.id;
                         }}
                         options={forms}
@@ -102,7 +128,7 @@ export const FormsFilterComponent: FunctionComponent<Props> = ({
                         onChange={newValue => {
                             setFormsSelected(newValue || []);
                         }}
-                        renderTags={renderTags(o => o.name)}
+                        renderTags={renderTags((o: newForms) => o.name)}
                     />
                 </Grid>
                 <Grid

--- a/hat/assets/js/apps/Iaso/domains/forms/components/FormsFilterComponent.tsx
+++ b/hat/assets/js/apps/Iaso/domains/forms/components/FormsFilterComponent.tsx
@@ -40,7 +40,7 @@ export const FormsFilterComponent: FunctionComponent<Props> = ({
                     const exisitingFormIndex = newForms.findIndex(
                         f => f.id === i.form_id,
                     );
-                    if (exisitingFormIndex) {
+                    if (exisitingFormIndex === -1) {
                         newForms.push({
                             id: i.form_id,
                             name: i.form_name,


### PR DESCRIPTION
## What problem is this PR solving?

The Form submissions filter on the map tab in the org units details was returning duplicate. This PR is about fixing it.

### Related JIRA tickets

[IA-4882](https://bluesquare.atlassian.net/browse/IA-4882)

## Changes

Explain the changes that were made.

findIndex() method returns `0` when the element is found at index `0` which  accidentally works and pushes a new instance. But when findIndex returns in index > 0, instead of pushing a new instance because the form already exists, it created a new form thus creating the duplicates. 
To fix this, I compared to `-1`. 

## How to test

> Go to org unit list,
> Go to details
> Go to map tab
> Filter the form submissions
> No duplicates should appear

## Print screen / video

Upload here print screens or videos showing the changes.

## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).


[IA-4882]: https://bluesquare.atlassian.net/browse/IA-4882?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ