### PR TITLE
Fix/IA-4980 make box from validation detail wider 

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/instances/validationWorkflow/details/WorkflowBaseInfo.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/validationWorkflow/details/WorkflowBaseInfo.tsx
@@ -51,7 +51,7 @@ const Row: FunctionComponent<RowProps> = ({ label, value }) => {
         <TableRow>
             <TableCell
                 className={classes.leftCell}
-                sx={{ whiteSpace: 'nowrap' }}
+                sx={{ whiteSpace: 'nowrap' }}   
             >
                 {label}
             </TableCell>

--- a/hat/assets/js/apps/Iaso/domains/instances/validationWorkflow/details/WorkflowBaseInfo.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/validationWorkflow/details/WorkflowBaseInfo.tsx
@@ -51,7 +51,7 @@ const Row: FunctionComponent<RowProps> = ({ label, value }) => {
         <TableRow>
             <TableCell
                 className={classes.leftCell}
-                sx={{ wordBreak: 'break-word' }}
+                sx={{ whiteSpace: 'nowrap' }}
             >
                 {label}
             </TableCell>

--- a/hat/assets/js/apps/Iaso/domains/instances/validationWorkflow/details/WorkflowConfiguration.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/validationWorkflow/details/WorkflowConfiguration.tsx
@@ -77,7 +77,7 @@ export const WorkflowConfiguration: FunctionComponent = () => {
             <Box className={`${classes.containerFullHeightNoTabPadded}`}>
                 <Box mb={2}>
                     <Grid container spacing={2}>
-                        <Grid container item xs={4}>
+                        <Grid container item xs={12} md={8} lg={6}>
                             <WidgetPaper
                                 className={classes.infoPaper}
                                 title={formatMessage(MESSAGES.infos)}

--- a/hat/assets/js/apps/Iaso/domains/instances/validationWorkflow/details/WorkflowConfiguration.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/validationWorkflow/details/WorkflowConfiguration.tsx
@@ -81,7 +81,7 @@ export const WorkflowConfiguration: FunctionComponent = () => {
                             <WidgetPaper
                                 className={classes.infoPaper}
                                 title={formatMessage(MESSAGES.infos)}
-                                sx={{ position: 'relative' }}
+                                sx={{ position: 'relative' }}   
                             >
                                 <Box className={classes.infoPaperBox}>
                                     {isLoading && <LoadingSpinner absolute />}


### PR DESCRIPTION
## What problem is this PR solving?

This PR makes the information panel wider on the submission validation workflow detail page to avoid label wrapping in French.

### Related JIRA tickets

IA-4980

## Changes

On /forms/submissions/validation/detail/, the information card layout was adjusted so it takes more horizontal space on medium and large screens.

The main change is in WorkflowConfiguration.tsx, where the grid sizing of the information panel was updated from a fixed narrow width to a responsive width (xs={12} md={8} lg={6}).

## How to test

- Go to /forms/submissions/validation/detail/.

- Open or create a validation workflow and switch the UI language to French.

- Check the "Informations" card and confirm that:

- the card is wider than before on desktop
- labels such as Créé par, Mise à jour, and Formulaires do not wrap
- long values in the right column still wrap correctly if needed
- the layout still looks correct on smaller screen sizes
Explain how to test your PR.

If a specific config is required explain it here: dataset, account, profile, etc.

## Print screen / video

<img width="741" height="1147" alt="image" src="https://github.com/user-attachments/assets/c7490616-b28e-4242-9223-537bdf454079" />