### PR TITLE
IA-4979 fix: remove id in user role

### DIFF
--- a/iaso/api/validation_workflow_instances/serializers.py
+++ b/iaso/api/validation_workflow_instances/serializers.py
@@ -11,11 +11,14 @@ from iaso.utils.serializer.color import ColorFieldSerializer
 
 
 class NestedUserRoleSerializer(ModelSerializer):
-    name = serializers.CharField(read_only=True, source="group.name")
+    name = serializers.SerializerMethodField()
 
     class Meta:
         model = UserRole
-        fields = ["id", "name"]
+        fields = ["name", "id"]
+
+    def get_name(self, obj):
+        return obj.group.name.removeprefix(f"{obj.account_id}_")
 
 
 class NestedHistorySerializer(ModelSerializer):

--- a/iaso/api/validation_workflows/serializers/retrieve.py
+++ b/iaso/api/validation_workflows/serializers/retrieve.py
@@ -7,11 +7,12 @@ from iaso.models import Form, UserRole, ValidationNodeTemplate, ValidationWorkfl
 
 
 class NestedRolesRequiredSerializer(ModelSerializer):
-    name = serializers.CharField(read_only=True, source="group.name")
-
+    name = serializers.SerializerMethodField()
     class Meta:
         model = UserRole
         fields = ["name", "id"]
+    def get_name(self, obj):
+        return obj.group.name.removeprefix(f"{obj.account_id}_")
 
 
 class NestedValidationNodeTemplateSerializer(ModelSerializer):

--- a/iaso/api/validation_workflows/serializers/retrieve.py
+++ b/iaso/api/validation_workflows/serializers/retrieve.py
@@ -8,9 +8,11 @@ from iaso.models import Form, UserRole, ValidationNodeTemplate, ValidationWorkfl
 
 class NestedRolesRequiredSerializer(ModelSerializer):
     name = serializers.SerializerMethodField()
+
     class Meta:
         model = UserRole
         fields = ["name", "id"]
+
     def get_name(self, obj):
         return obj.group.name.removeprefix(f"{obj.account_id}_")
 

--- a/iaso/api/validation_workflows_node_templates/serializers/list.py
+++ b/iaso/api/validation_workflows_node_templates/serializers/list.py
@@ -5,11 +5,14 @@ from iaso.models import UserRole, ValidationNodeTemplate
 
 
 class NestedRolesRequiredSerializer(ModelSerializer):
-    name = serializers.CharField(read_only=True, source="group.name")
+    name = serializers.SerializerMethodField()
 
     class Meta:
         model = UserRole
         fields = ["name", "id"]
+
+    def get_name(self, obj):
+        return obj.group.name.removeprefix(f"{obj.account_id}_")
 
 
 class ValidationNodeTemplateListSerializer(ModelSerializer):

--- a/iaso/api/validation_workflows_node_templates/serializers/retrieve.py
+++ b/iaso/api/validation_workflows_node_templates/serializers/retrieve.py
@@ -5,11 +5,14 @@ from iaso.models import UserRole, ValidationNodeTemplate
 
 
 class NestedRolesRequiredSerializer(ModelSerializer):
-    name = serializers.CharField(read_only=True, source="group.name")
+    name = serializers.SerializerMethodField()
 
     class Meta:
         model = UserRole
         fields = ["name", "id"]
+
+    def get_name(self, obj):
+        return obj.group.name.removeprefix(f"{obj.account_id}_")
 
 
 class ValidationNodeTemplateRetrieveSerializer(ModelSerializer):


### PR DESCRIPTION
## What problem is this PR solving?

This PR removes the account ID prefix from role names in the `Roles required` column on the validation workflow detail screen.

### Related JIRA tickets

IA-4979

## Changes

This change is limited to the validation workflow detail retrieve endpoint.

- Replaced the direct `group.name` serialization with a computed value that removes the `{account_id}_` prefix.


Expected behavior:
- Before: `1_data manager`
- After: `data manager`

## How to test

1. Start the app locally.
2. Open `/dashboard/forms/submissions/validation/detail/`.
3. Check the `Roles required` column in the steps table.
4. Confirm that the role name is displayed without the account ID prefix.



## Print screen / video
<img width="1766" height="378" alt="image" src="https://github.com/user-attachments/assets/d890d7fa-562f-4517-ad93-00dc95c4d7c0" />



## Notes

- Scope intentionally kept limited to the workflow detail screen API.
- Other endpoints that may expose raw `group.name` are out of scope for this PR.

## Doc

No additional documentation required.
