### PR TITLE
IA-4947 fix assets to be relative for form preview

### DIFF
--- a/docker/odk-preview/vite.config.js
+++ b/docker/odk-preview/vite.config.js
@@ -3,7 +3,7 @@ import vue from '@vitejs/plugin-vue';
 
 export default defineConfig({
     plugins: [vue()],
-    base: '/static/odk-preview/',
+    base: './',
     build: {
         target: 'esnext',
         outDir: '../../iaso/static/odk-preview',

--- a/hat/assets/js/apps/Iaso/domains/formAI/components/FormPreview.tsx
+++ b/hat/assets/js/apps/Iaso/domains/formAI/components/FormPreview.tsx
@@ -15,7 +15,7 @@ type Props = {
     xformXml: string | null;
 };
 
-const ODK_PREVIEW_BASE = '/static/odk-preview/index.html';
+const ODK_PREVIEW_BASE = `${window.STATIC_URL ?? '/static'}/odk-preview/index.html`;
 
 export const FormPreview: FunctionComponent<Props> = ({
     xlsformUuid,

--- a/iaso/static/odk-preview/index.html
+++ b/iaso/static/odk-preview/index.html
@@ -31,8 +31,8 @@
         text-align: center;
       }
     </style>
-    <script type="module" crossorigin src="/static/odk-preview/assets/index-ClXKaQoR.js"></script>
-    <link rel="modulepreload" crossorigin href="/static/odk-preview/assets/index-BYKrQSL_-Bnc0Z75W.js">
+    <script type="module" crossorigin src="./assets/index-ClXKaQoR.js"></script>
+    <link rel="modulepreload" crossorigin href="./assets/index-BYKrQSL_-Bnc0Z75W.js">
   </head>
   <body>
     <div id="app"></div>


### PR DESCRIPTION
## What problem is this PR solving?

once deployed the urls should use STATIC_URL and css/js should be relative

### Related JIRA tickets

IA-4947

## Changes


## How to test

see you can test locally but the real issue is deployed with collectstatic and s3.
seed + enable module + add api keys

## Print screen / video

<img width="2557" height="666" alt="image" src="https://github.com/user-attachments/assets/0e982859-4d80-465f-bc8a-291aa15afa71" />


## Notes

