### PR TITLE
IA-5024: fix django-axes errors on failed login

### DIFF
--- a/hat/settings.py
+++ b/hat/settings.py
@@ -781,10 +781,9 @@ AUTHENTICATION_BACKENDS = [
 
 # The API will rate limit login attempts based on 2 parameters:
 # - AUTH_RATE_LIMIT_MAX_FAILURES:
-#  Number of failed login attempts allowed before the user is locked out temporarily
+#  Number of failed login attempts before the user is locked out temporarily
 # - AUTH_RATE_LIMIT_COOLOFF_SECONDS:
-#  Sets the duration of the lockout period *and* the TTL of the failure counter
-#  (See AxesCacheHandler for more information)
+#  Sets the duration of the lockout period
 AUTH_RATE_LIMIT_MAX_FAILURES = int(get_env_as_float("AUTH_RATE_LIMIT_MAX_FAILURES", "10"))
 AUTH_RATE_LIMIT_COOLOFF_SECONDS = get_env_as_float("AUTH_RATE_LIMIT_COOLOFF_SECONDS", "30")
 AXES_COOLOFF_TIME = lambda request: timedelta(seconds=AUTH_RATE_LIMIT_COOLOFF_SECONDS)
@@ -792,7 +791,8 @@ AXES_FAILURE_LIMIT = AUTH_RATE_LIMIT_MAX_FAILURES
 AXES_LOCKOUT_PARAMETERS = ["username"]
 AXES_COOLOFF_MESSAGE = "Too many login attempts. Please try again later."
 AXES_HTTP_RESPONSE_CODE = 429
-AXES_HANDLER = "axes.handlers.cache.AxesCacheHandler"
+AXES_HANDLER = "axes.handlers.database.AxesDatabaseHandler"
+AXES_DISABLE_ACCESS_LOG = True
 if IN_TESTS:
     AXES_HANDLER = "axes.handlers.dummy.AxesDummyHandler"
 

--- a/iaso/tests/auth/test_rate_limiting.py
+++ b/iaso/tests/auth/test_rate_limiting.py
@@ -1,11 +1,11 @@
-from django.core.cache import cache
+from axes.handlers.proxy import AxesProxyHandler
 from django.test import Client, TestCase, override_settings
 from rest_framework import status
 from rest_framework.test import APIClient
 
 
 @override_settings(
-    AXES_HANDLER="axes.handlers.cache.AxesCacheHandler",
+    AXES_HANDLER="axes.handlers.database.AxesDatabaseHandler",
     AXES_FAILURE_LIMIT=3,
     AXES_LOCKOUT_PARAMETERS=["username"],
 )
@@ -22,7 +22,7 @@ class AxesRateLimitTests(TestCase):
         self.client = APIClient()
         self.django_client = Client()
 
-        cache.clear()
+        AxesProxyHandler.reset_attempts()  # works with every type of axe handlers
 
     def test_api_token_rate_limit(self):
         """Test that /api/token/ locks out the user after AXES_FAILURE_LIMIT attempts."""


### PR DESCRIPTION
## What problem is this PR solving?

This fixes an issue introduced with PR https://github.com/BLSQ/iaso/pull/2860 (rate limiting on login), where a data race could trigger on failed login attempts. 

(See upstream issue https://github.com/jazzband/django-axes/issues/1144)

### Related JIRA tickets

IA-5024 

## Changes

Switched from the cache handler to the `AxesDatabaseHandler`, which shouldn't have that issue.

## How to test

- Try to login more than 10 times with a wrong password:
  - on the login page on the dashboard
  - or using the api (POST /api/token/, present in our Bruno config)
- Check that you can login again after a cooldown period (30 seconds)

## Print screen / video

/ 

## Notes

Used `AXES_DISABLE_ACCESS_LOG = True` so that we don't keep an ever-growing access log that we'd have to maintain. This feature didn't exist for the cache backend. Only the table `axes_accessattempt` should have entries (when failing to login), the two other axes tables should stay empty.

## Doc

/