### PR TITLE
IA-4982 feat: restyle form submissions timeline

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/instances/components/ValidationWorkflow/InstanceValidation.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/ValidationWorkflow/InstanceValidation.tsx
@@ -33,14 +33,6 @@ const timelineContentSx = {
     backgroundColor: 'rgba(0, 0, 0, 0.04)',
 };
 
-const timelineLineSx = {
-    width: 0,
-    flexShrink: 0,
-    alignSelf: 'stretch',
-    my: 0.5,
-    borderLeft: '3px dashed rgba(0, 0, 0, 0.32)',
-};
-
 const timelineBodySx = {
     flex: 1,
     display: 'flex',
@@ -172,7 +164,6 @@ export const InstanceValidation: FunctionComponent<Props> = ({ id, data }) => {
                                         }}
                                     >
                                         <Box sx={timelineContentSx}>
-                                            <Box sx={timelineLineSx} />
                                             <Box sx={timelineBodySx}>
                                                 {formatStepContent(step)}
                                                 {step.canValidate && (

--- a/hat/assets/js/apps/Iaso/domains/instances/components/ValidationWorkflow/InstanceValidation.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/ValidationWorkflow/InstanceValidation.tsx
@@ -20,6 +20,34 @@ import {
 } from './useValidationTimeline';
 import { ValidateNodeModal } from './ValidationModal';
 
+const timelineContentSx = {
+    mt: 1,
+    ml: 1,
+    px: 2,
+    py: 1.5,
+    display: 'flex',
+    gap: 2,
+    alignItems: 'stretch',
+    border: '1px solid rgba(0, 0, 0, 0.18)',
+    borderRadius: 1,
+    backgroundColor: 'rgba(0, 0, 0, 0.04)',
+};
+
+const timelineLineSx = {
+    width: 0,
+    flexShrink: 0,
+    alignSelf: 'stretch',
+    my: 0.5,
+    borderLeft: '3px dashed rgba(0, 0, 0, 0.32)',
+};
+
+const timelineBodySx = {
+    flex: 1,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 1.5,
+};
+
 const formatStepContent = (step: UseValidationTimelineResult) => {
     if (step?.status === 'SUBMISSION' || step?.status === 'NEW_VERSION') {
         return (
@@ -134,19 +162,48 @@ export const InstanceValidation: FunctionComponent<Props> = ({ id, data }) => {
                                     }}
                                 >
                                     <Box>{step.label}</Box>
-                                    <StepContent sx={{ fontWeight: 'normal' }}>
-                                        {formatStepContent(step)}
-                                        {step.canValidate && (
-                                            <ValidateNodeModal
-                                                key={step.nodeSlug}
-                                                instanceId={id as number}
-                                                nodeSlug={step.nodeSlug}
-                                                nodeId={step.nodeId}
-                                                iconProps={{
-                                                    buttonText: `${formatMessage(MESSAGES.validate)}`,
-                                                }}
-                                            />
-                                        )}
+                                    <StepContent
+                                        sx={{
+                                            fontWeight: 'normal',
+                                            borderLeft: 'none',
+                                            marginLeft: 0,
+                                            paddingLeft: 0,
+                                            paddingRight: 0,
+                                        }}
+                                    >
+                                        <Box sx={timelineContentSx}>
+                                            <Box sx={timelineLineSx} />
+                                            <Box sx={timelineBodySx}>
+                                                {formatStepContent(step)}
+                                                {step.canValidate && (
+                                                    <Box
+                                                        sx={{
+                                                            display: 'flex',
+                                                            justifyContent:
+                                                                'flex-end',
+                                                            pt: 1,
+                                                            borderTop:
+                                                                '1px solid rgba(0, 0, 0, 0.2)',
+                                                        }}
+                                                    >
+                                                        <ValidateNodeModal
+                                                            key={step.nodeSlug}
+                                                            instanceId={
+                                                                id as number
+                                                            }
+                                                            nodeSlug={
+                                                                step.nodeSlug
+                                                            }
+                                                            nodeId={step.nodeId}
+                                                            iconProps={{
+                                                                buttonText: `${formatMessage(MESSAGES.validate)}`,
+                                                                size: 'medium',
+                                                            }}
+                                                        />
+                                                    </Box>
+                                                )}
+                                            </Box>
+                                        </Box>
                                     </StepContent>
                                 </StepLabel>
                             </Step>


### PR DESCRIPTION
## What problem is this PR solving?

This PR restyles the validation timeline so the comment/details area is visually distinct from the main timeline.

### Related JIRA tickets

IA-4982

## Changes

- This PR updates the validation timeline rendering in  
  `hat/assets/js/apps/Iaso/domains/instances/components/ValidationWorkflow/InstanceValidation.tsx`.

The main changes are:
- removed the default MUI `StepContent` left border, which was too close visually to the actual timeline 
- grouped each step’s details inside a dedicated content card so comment/description metadata is easier to distinguish from the main timeline
- added a simpler secondary vertical separator inside the card
- aligned the `VALIDATE` button inside the same card as the step content
- kept the existing timeline data logic unchanged: this PR only changes the presentation layer

Tests were kept in place and still pass:
- `InstanceValidation.test.tsx`
- `InstanceValidation.a11y.test.tsx`

## How to test

Create a validation workflows with at least a node template that can skip previous steps
Submit an instance that triggers that VF

You can use this python script to help you

- in your terminal you can use this commande :

```bash
docker compose exec -T iaso ./manage.py shell <<'PY'
```

```python 

import os
import django
os.environ.setdefault("DJANGO_SETTINGS_MODULE", "hat.local_settings")


django.setup()
from django.contrib.auth import get_user_model

from iaso.engine.validation_workflow import ValidationWorkflowEngine
from iaso.models import ValidationWorkflow, Instance
import time


workflow_template_slug = "test"
user = get_user_model().objects.get(username="axkoefm")
instance = Instance.objects.get(id="259")

# uncomment if you want a fresh new data, otherwise it will resubmit if possible
# instance.validationnode_set.all().delete()

workflow_template = ValidationWorkflow.objects.get(slug=workflow_template_slug)

ValidationWorkflowEngine.start(workflow_template, user, instance)

```


## Print screen / video
<img width="585" height="673" alt="Capture d’écran du 2026-04-30 11-42-46" src="https://github.com/user-attachments/assets/a621b719-4b06-4cc1-b6c6-2ab7aa54d1dc" />
<img width="585" height="844" alt="Capture d’écran du 2026-04-30 11-41-22" src="https://github.com/user-attachments/assets/dae8b31d-d1cb-439a-889e-015305934f22" />


## Notes

- This PR only affects the visual rendering of the validation timeline.