### PR TITLE
IA-4961: Assignments checkboxes should be a radio buttons

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/assignments/components/teams/AssigneeRow.tsx
+++ b/hat/assets/js/apps/Iaso/domains/assignments/components/teams/AssigneeRow.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent, useCallback } from 'react';
-import { TableCell, TableRow, Checkbox, useTheme } from '@mui/material';
+import { TableCell, TableRow, Radio, useTheme } from '@mui/material';
 import { IconButton } from 'bluesquare-components';
 import { ColorPicker } from 'Iaso/components/forms/ColorPicker';
 import { SubTeam, User } from 'Iaso/domains/teams/types/team';
@@ -10,6 +10,7 @@ type Props = {
     user?: User;
     team?: SubTeam;
     planningId: string;
+    radioGroupName: string;
     isActive: boolean;
     setSelectedRow: () => void;
     currentColor: string;
@@ -22,6 +23,7 @@ export const AssigneeRow: FunctionComponent<Props> = ({
     user,
     team,
     planningId,
+    radioGroupName,
     isActive,
     setSelectedRow,
     currentColor,
@@ -52,7 +54,8 @@ export const AssigneeRow: FunctionComponent<Props> = ({
                     textAlign: 'center',
                 }}
             >
-                <Checkbox
+                <Radio
+                    name={radioGroupName}
                     checked={isActive}
                     onChange={() => setSelectedRow()}
                 />

--- a/hat/assets/js/apps/Iaso/domains/assignments/components/teams/TeamTable.tsx
+++ b/hat/assets/js/apps/Iaso/domains/assignments/components/teams/TeamTable.tsx
@@ -85,6 +85,7 @@ export const TeamTable: FunctionComponent<Props> = ({
         },
         [assignments],
     );
+    const assigneeRadioGroupName = `assignee-${planningId}`;
     return (
         <>
             <Paper sx={styles.paper}>
@@ -130,13 +131,15 @@ export const TeamTable: FunctionComponent<Props> = ({
                                         subTeam => (
                                             <AssigneeRow
                                                 key={subTeam.id}
+                                                radioGroupName={assigneeRadioGroupName}
                                                 isActive={
                                                     selectedTeam?.id ===
                                                     subTeam.id
                                                 }
-                                                setSelectedRow={() =>
-                                                    setSelectedTeam(subTeam)
-                                                }
+                                                setSelectedRow={() => {
+                                                    setSelectedTeam(subTeam);
+                                                    setSelectedUser(undefined);
+                                                }}
                                                 currentColor={subTeam?.color}
                                                 displayName={subTeam?.name}
                                                 count={countTeams(subTeam)}
@@ -160,12 +163,14 @@ export const TeamTable: FunctionComponent<Props> = ({
                                         .map(user => (
                                             <AssigneeRow
                                                 key={user.id}
+                                                radioGroupName={assigneeRadioGroupName}
                                                 isActive={
                                                     selectedUser?.id === user.id
                                                 }
-                                                setSelectedRow={() =>
-                                                    setSelectedUser(user)
-                                                }
+                                                setSelectedRow={() => {
+                                                    setSelectedUser(user);
+                                                    setSelectedTeam(undefined);
+                                                }}
                                                 currentColor={user?.color}
                                                 count={assignmentsCountForUser(
                                                     user,


### PR DESCRIPTION
## What problem is this PR solving?

On assignments page, on the right panel, while selecting a user or a team, checkboxes should be radio button
<img width="994" height="772" alt="image" src="https://github.com/user-attachments/assets/b679f271-e19a-41a4-bf66-1749816fe29a" />


### Related JIRA tickets

IA-4961

## Changes

Just replace check boxes with radio button, adding radio group name.

## How to test

Open assignments for a specific planning, make sure you can still assign a user or a team to an org unit

## Print screen / video

<img width="1684" height="755" alt="Screenshot 2026-04-30 at 12 21 48" src="https://github.com/user-attachments/assets/697b17f8-ec43-4c74-ac17-233363e7a400" />


## Notes

No frontend tests here, this part of the code will change to allow nested teams and users