### PR TITLE
POLIO-2135 improve perf by avoid cross products and use exist, defer geometries related fields

### DIFF
--- a/plugins/polio/api/vaccines/repository_reports.py
+++ b/plugins/polio/api/vaccines/repository_reports.py
@@ -1,6 +1,6 @@
 """API endpoints and serializers for vaccine repository reports."""
 
-from django.db.models import Q
+from django.db.models import Exists, OuterRef
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import filters, permissions, serializers
@@ -10,7 +10,7 @@ from rest_framework.mixins import ListModelMixin
 from rest_framework.viewsets import GenericViewSet
 
 from iaso.api.common import Paginator
-from plugins.polio.models import VaccineStock
+from plugins.polio.models import DestructionReport, IncidentReport, VaccineStock
 
 
 class VaccineReportingFilterBackend(filters.BaseFilterBackend):
@@ -22,12 +22,12 @@ class VaccineReportingFilterBackend(filters.BaseFilterBackend):
         if vaccine_name:
             queryset = queryset.filter(vaccine=vaccine_name)
 
-        # Filter by country block
+        # Filter by country block — .distinct() is scoped here because the M2M join can duplicate rows
         country_block = request.query_params.get("country_block", None)
         if country_block:
             try:
                 country_block_ids = [int(id) for id in country_block.split(",")]
-                queryset = queryset.filter(country__groups__in=country_block_ids)
+                queryset = queryset.filter(country__groups__in=country_block_ids).distinct()
             except ValueError:
                 raise ValidationError("country_block must be a comma-separated list of integers")
 
@@ -40,7 +40,7 @@ class VaccineReportingFilterBackend(filters.BaseFilterBackend):
             except ValueError:
                 raise ValidationError("countries must be a comma-separated list of integers")
 
-        # Filter by file type
+        # Filter by file type — use Exists() to avoid row multiplication and DISTINCT
         file_type = request.query_params.get("file_type", None)
         if file_type:
             try:
@@ -50,19 +50,20 @@ class VaccineReportingFilterBackend(filters.BaseFilterBackend):
                 has_destruction = "DESTRUCTION" in filetypes
 
                 if has_incident and has_destruction:
-                    # Both types specified - must have both
-                    queryset = queryset.filter(incidentreport__isnull=False, destructionreport__isnull=False)
+                    queryset = queryset.filter(
+                        Exists(IncidentReport.objects.filter(vaccine_stock_id=OuterRef("pk"))),
+                        Exists(DestructionReport.objects.filter(vaccine_stock_id=OuterRef("pk"))),
+                    )
                 elif has_incident:
-                    # Only incident reports
-                    queryset = queryset.filter(incidentreport__isnull=False)
+                    queryset = queryset.filter(Exists(IncidentReport.objects.filter(vaccine_stock_id=OuterRef("pk"))))
                 elif has_destruction:
-                    # Only destruction reports
-                    queryset = queryset.filter(destructionreport__isnull=False)
-                # If no types specified, show all (no filtering needed)
+                    queryset = queryset.filter(
+                        Exists(DestructionReport.objects.filter(vaccine_stock_id=OuterRef("pk")))
+                    )
             except ValueError:
                 raise ValidationError("file_type must be a comma-separated list of strings")
 
-        return queryset.distinct()
+        return queryset
 
 
 class VaccineRepositoryReportSerializer(serializers.Serializer):
@@ -111,17 +112,29 @@ class VaccineRepositoryReportsViewSet(GenericViewSet, ListModelMixin):
     def get_queryset(self):
         """Get the queryset for VaccineStock objects."""
 
-        base_qs = VaccineStock.objects.select_related(
-            "country",
-        ).prefetch_related(
-            "incidentreport_set",
-            "destructionreport_set",
+        base_qs = (
+            VaccineStock.objects.select_related(
+                "country",
+            )
+            .defer(
+                "country__geom",
+                "country__simplified_geom",
+                "country__catchment",
+                "country__location",
+            )
+            .prefetch_related(
+                "incidentreport_set",
+                "destructionreport_set",
+            )
         )
 
         if self.request.user and self.request.user.is_authenticated:
             base_qs = base_qs.filter(account=self.request.user.iaso_profile.account)
 
-        return base_qs.filter(Q(destructionreport__isnull=False) | Q(incidentreport__isnull=False))
+        return base_qs.filter(
+            Exists(DestructionReport.objects.filter(vaccine_stock_id=OuterRef("pk")))
+            | Exists(IncidentReport.objects.filter(vaccine_stock_id=OuterRef("pk")))
+        )
 
     @extend_schema(
         parameters=[

--- a/plugins/polio/tests/test_vaccine_repository_reports.py
+++ b/plugins/polio/tests/test_vaccine_repository_reports.py
@@ -1,6 +1,8 @@
 import datetime
 
 from django.contrib.auth.models import AnonymousUser
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 from django.utils.timezone import now
 
 from iaso import models as m
@@ -179,3 +181,89 @@ class VaccineRepositoryReportsAPITestCase(APITestCase, PolioTestCaseMixin):
         data = response.json()["results"]
         self.assertEqual(data[0]["vaccine"], pm.VACCINES[0][0])
         self.assertEqual(data[1]["vaccine"], pm.VACCINES[1][0])
+
+
+class VaccineRepositoryReportsQueryPerformanceTestCase(APITestCase, PolioTestCaseMixin):
+    """Assert that get_queryset() optimisations (select_related, defer, prefetch_related) hold."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.data_source = m.DataSource.objects.create(name="perf_source")
+        cls.source_version = m.SourceVersion.objects.create(data_source=cls.data_source, number=1)
+        cls.account = m.Account.objects.create(name="perf_account", default_version=cls.source_version)
+        cls.org_unit_type = m.OrgUnitType.objects.create(name="Country")
+        cls.user = cls.create_user_with_profile(username="perf_user", account=cls.account)
+
+    def _make_stock_with_reports(self, name):
+        country = m.OrgUnit.objects.create(
+            org_unit_type=self.org_unit_type,
+            version=self.source_version,
+            name=name,
+            validation_status=m.OrgUnit.VALIDATION_VALID,
+        )
+        stock = pm.VaccineStock.objects.create(account=self.account, country=country, vaccine=pm.VACCINES[0][0])
+        pm.IncidentReport.objects.create(
+            vaccine_stock=stock,
+            date_of_incident_report=now(),
+            incident_report_received_by_rrt=now(),
+            usable_vials=10,
+            unusable_vials=0,
+            doses_per_vial=20,
+            stock_correction=pm.IncidentReport.StockCorrectionChoices.VVM_REACHED_DISCARD_POINT,
+            title="ir",
+            comment="",
+        )
+        pm.DestructionReport.objects.create(
+            vaccine_stock=stock,
+            rrt_destruction_report_reception_date=now(),
+            destruction_report_date=now(),
+            unusable_vials_destroyed=5,
+            action="EXPIRED",
+            comment="",
+            doses_per_vial=20,
+        )
+        return stock
+
+    def test_query_count_does_not_scale_with_result_size(self):
+        """prefetch_related must keep query count constant regardless of how many stocks are returned."""
+        self.client.force_authenticate(user=self.user)
+
+        self._make_stock_with_reports("Country-baseline")
+        with CaptureQueriesContext(connection) as ctx_one:
+            response = self.client.get(REPORTS_URL)
+        self.assertEqual(response.status_code, 200)
+        baseline_count = len(ctx_one)
+
+        for i in range(19):
+            self._make_stock_with_reports(f"Country-{i}")
+
+        with CaptureQueriesContext(connection) as ctx_many:
+            response = self.client.get(REPORTS_URL)
+        self.assertEqual(response.status_code, 200)
+
+        self.assertEqual(
+            len(ctx_many),
+            baseline_count,
+            msg=(
+                f"Query count grew from {baseline_count} (1 stock) to {len(ctx_many)} (20 stocks). "
+                "N+1 regression — check prefetch_related on incidentreport_set / destructionreport_set."
+            ),
+        )
+
+    def test_geometry_fields_are_deferred(self):
+        """defer() must keep heavy geometry columns out of every SELECT issued by the list endpoint."""
+        self._make_stock_with_reports("Country-geo")
+        self.client.force_authenticate(user=self.user)
+
+        with CaptureQueriesContext(connection) as ctx:
+            self.client.get(REPORTS_URL)
+
+        for query in ctx:
+            sql = query["sql"]
+            for field in ("geom", "simplified_geom", "catchment"):
+                # Match the exact column reference as it appears in SQL: "table"."field"
+                self.assertNotIn(
+                    f'"."{field}"',
+                    sql,
+                    msg=f"Deferred field '{field}' found in SQL — defer() on country geometry was removed.",
+                )


### PR DESCRIPTION
## What problem is this PR solving?

Slow queries triggering a lot of tmp storage due to crossjoin generated between 1500 records and lot of orgunits and unicity on non trivial fields (geom, simplified_geom).

### Related JIRA tickets

POLIO-2135

## Changes

The previous sql was outer joining orgunits, reports,... 
The new one use exists

## How to test

The bad news to have enough data to trigger the problem you need to restore a production like copy.


## Print screen / video

before locally

<img width="1006" height="1053" alt="image" src="https://github.com/user-attachments/assets/3e79b483-7f61-46b1-b829-c48c17307b49" />

after 

https://github.com/user-attachments/assets/abf8e231-e419-40f3-9a54-26cf141337a4



## Notes

I'm not a polio expert

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).
