### PR TITLE
WC2-933: OTP - Under 6 must appear in the new guideline

### DIFF
--- a/plugins/wfp/common.py
+++ b/plugins/wfp/common.py
@@ -103,6 +103,7 @@ ASSISTANCE_FORMS = frozenset(
         "ethiopia_child_assistance_follow_up",
     ]
 )
+# Program to exclude in the data to push to dhis2
 EXCLUDED_PROGRAMMES = [None, "", "Not Eligible", "OTP - Under 6"]
 
 
@@ -115,6 +116,8 @@ NEW_GUIDE_LINES_FORMS = [
     "Anthropometric visit child_2",
     "child_antropometric_followUp_otp_2",
     "child_antropometric_followUp_tsfp_2",
+    "Anthropometric visit child_U6",
+    "antropometric_followUp_otp_u6",
 ]
 
 ACCOUNT_WITH_GUIDELINE = "South Sudan"


### PR DESCRIPTION
## What problem is this PR solving?

Explain here in one sentence.

### Related JIRA tickets

[WC2-933](https://bluesquare.atlassian.net/browse/WC2-933)

## Changes

The OTP - Under 6 program was introduced with the new guideline. So all beneficiaries admitted in this program should appear in the New Guidelines.

Added the admission and anthropometric followup forms for OTP - Under 6 program in the New Guidelines 

## How to test


Run ETL for SSD data with docker compose run iaso manage etl_ssd all_data then login to django admin to check in [the journey](http://localhost:8081/admin/wfp/journey/?beneficiary__account__id__exact=1&nutrition_programme__exact=OTP+-+Under+6&o=-9&programme_type__exact=U5) table , try to filter by [guidelines](http://localhost:8081/admin/wfp/journey/?beneficiary__account__id__exact=1&nutrition_programme__exact=OTP+-+Under+6&o=-9&programme_type__exact=U5)  on:
- [New](http://localhost:8081/admin/wfp/journey/?beneficiary__account__id__exact=1&beneficiary__guidelines=NEW&nutrition_programme__exact=OTP+-+Under+6&o=-9&programme_type__exact=U5)

- [OLD](http://localhost:8081/admin/wfp/journey/?beneficiary__account__id__exact=1&beneficiary__guidelines=OLD&nutrition_programme__exact=OTP+-+Under+6) : you should see data for New Guidelines only.



[WC2-933]: https://bluesquare.atlassian.net/browse/WC2-933?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ