### PR TITLE
IA-5036: disable API query if no perm

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/instances/components/ValidationWorkflow/useGetSubmissionValidationStatus.ts
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/ValidationWorkflow/useGetSubmissionValidationStatus.ts
@@ -1,7 +1,10 @@
 import { ValidationNodeRetrieveResponse } from 'Iaso/domains/instances/validationWorkflow/types/validationNodes';
 import { ValidationWorkflowRetrieveResponseItem } from 'Iaso/domains/instances/validationWorkflow/types/validationWorkflows';
+import { userHasPermission } from 'Iaso/domains/users/utils';
 import { getRequest } from 'Iaso/libs/Api';
 import { useSnackQuery } from 'Iaso/libs/apiHooks';
+import { VALIDATION_WORKFLOWS } from 'Iaso/utils/permissions';
+import { useCurrentUser } from 'Iaso/utils/usersUtils';
 import { API_URL } from '../../validationWorkflow/constants';
 
 const getSubmissionValidationStatus = (
@@ -11,6 +14,8 @@ const getSubmissionValidationStatus = (
 };
 
 export const useGetSubmissionValidationStatus = (id?: number) => {
+    const user = useCurrentUser();
+    const hasPermission = userHasPermission(VALIDATION_WORKFLOWS, user);
     return useSnackQuery({
         queryKey: ['submission-validation-status', id],
         queryFn: () => getSubmissionValidationStatus(id!),
@@ -19,7 +24,7 @@ export const useGetSubmissionValidationStatus = (id?: number) => {
             cacheTime: Infinity,
             retry: false,
             keepPreviousData: true,
-            enabled: Boolean(id),
+            enabled: Boolean(id) && hasPermission,
         },
     });
 };


### PR DESCRIPTION
## What problem is this PR solving?

Users without WF validation enabled would get API errors on submission details page

### Related JIRA tickets

IA-5036

## Changes

- Disable API hook if user doesn't have permission

## How to test
- Create a user without the validation workflow permission
- go to an instance details page
- No API error snack should pop up, no call to workflow validation API should be made 

## Print screen / video



https://github.com/user-attachments/assets/e69d5621-d719-4169-b16b-c64d9e73d5ca

<img width="2664" height="1368" alt="Screenshot 2026-05-06 at 11 59 31" src="https://github.com/user-attachments/assets/d4c0cdca-5136-4978-b30b-c99e97f9472f" />

## Notes

Will be hotfixed
