### PR TITLE
IA-5023 centralize user role name seralization

### DIFF
--- a/iaso/api/common/serializer.py
+++ b/iaso/api/common/serializer.py
@@ -3,6 +3,10 @@ from django.contrib.auth.models import User
 from django.utils.module_loading import import_string
 from rest_framework import serializers
 
+from iaso.models import UserRole
+
+from .serializer_fields import UserRoleNameField
+
 
 class UserSerializer(serializers.ModelSerializer):
     full_name = serializers.CharField(source="get_full_name")
@@ -10,6 +14,14 @@ class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
         fields = ["id", "first_name", "last_name", "username", "full_name"]
+
+
+class UserRoleNameSerializer(serializers.ModelSerializer):
+    name = UserRoleNameField(source="*", read_only=True)
+
+    class Meta:
+        model = UserRole
+        fields = ["name", "id"]
 
 
 class ModelSerializerFieldMappingMixin:

--- a/iaso/api/common/serializer.py
+++ b/iaso/api/common/serializer.py
@@ -7,6 +7,7 @@ from iaso.models import UserRole
 
 from .serializer_fields import UserRoleNameField
 
+
 class UserSerializer(serializers.ModelSerializer):
     full_name = serializers.CharField(source="get_full_name")
 
@@ -35,12 +36,14 @@ class ModelSerializerFieldMappingMixin:
 class ModelSerializer(ModelSerializerFieldMappingMixin, serializers.ModelSerializer):
     pass
 
+
 class UserRoleNameSerializer(ModelSerializer):
     name = UserRoleNameField(source="group.name", read_only=True)
 
     class Meta:
         model = UserRole
         fields = ["name", "id"]
+
 
 class DropdownOptionsSerializer(serializers.Serializer):
     value = serializers.CharField()

--- a/iaso/api/common/serializer.py
+++ b/iaso/api/common/serializer.py
@@ -7,21 +7,12 @@ from iaso.models import UserRole
 
 from .serializer_fields import UserRoleNameField
 
-
 class UserSerializer(serializers.ModelSerializer):
     full_name = serializers.CharField(source="get_full_name")
 
     class Meta:
         model = User
         fields = ["id", "first_name", "last_name", "username", "full_name"]
-
-
-class UserRoleNameSerializer(serializers.ModelSerializer):
-    name = UserRoleNameField(source="*", read_only=True)
-
-    class Meta:
-        model = UserRole
-        fields = ["name", "id"]
 
 
 class ModelSerializerFieldMappingMixin:
@@ -44,6 +35,12 @@ class ModelSerializerFieldMappingMixin:
 class ModelSerializer(ModelSerializerFieldMappingMixin, serializers.ModelSerializer):
     pass
 
+class UserRoleNameSerializer(ModelSerializer):
+    name = UserRoleNameField(source="group.name", read_only=True)
+
+    class Meta:
+        model = UserRole
+        fields = ["name", "id"]
 
 class DropdownOptionsSerializer(serializers.Serializer):
     value = serializers.CharField()

--- a/iaso/api/common/serializer_fields.py
+++ b/iaso/api/common/serializer_fields.py
@@ -81,7 +81,8 @@ class AccountPrefixedSlugRelatedField(serializers.SlugRelatedField):
 class UserRoleNameField(serializers.Field):
     def to_representation(self, user_role):
         return user_role.group.name.removeprefix(f"{user_role.account_id}_")
-        
+
+
 class SlugOrPrimaryKeyRelatedField(serializers.SlugRelatedField):
     def to_internal_value(self, data):
         if isinstance(data, int):

--- a/iaso/api/common/serializer_fields.py
+++ b/iaso/api/common/serializer_fields.py
@@ -77,6 +77,11 @@ class AccountPrefixedSlugRelatedField(serializers.SlugRelatedField):
         return super().to_internal_value(prefixed_name)
 
 
+@extend_schema_field(OpenApiTypes.STR)
+class UserRoleNameField(serializers.Field):
+    def to_representation(self, user_role):
+        return user_role.group.name.removeprefix(f"{user_role.account_id}_")
+        
 class SlugOrPrimaryKeyRelatedField(serializers.SlugRelatedField):
     def to_internal_value(self, data):
         if isinstance(data, int):

--- a/iaso/api/common/serializer_fields.py
+++ b/iaso/api/common/serializer_fields.py
@@ -1,4 +1,5 @@
 import json
+import re
 
 from datetime import date, datetime
 
@@ -78,9 +79,9 @@ class AccountPrefixedSlugRelatedField(serializers.SlugRelatedField):
 
 
 @extend_schema_field(OpenApiTypes.STR)
-class UserRoleNameField(serializers.Field):
-    def to_representation(self, user_role):
-        return user_role.group.name.removeprefix(f"{user_role.account_id}_")
+class UserRoleNameField(serializers.CharField):
+    def to_representation(self, value):
+        return re.sub(r"^\d+_", "", value)
 
 
 class SlugOrPrimaryKeyRelatedField(serializers.SlugRelatedField):

--- a/iaso/api/profiles/serializers/list.py
+++ b/iaso/api/profiles/serializers/list.py
@@ -3,6 +3,7 @@ from rest_framework import serializers
 
 from dynamic_fields.serializer import DynamicFieldsModelSerializerBackwardCompatible
 from iaso.api.common import ModelSerializer
+from iaso.api.common.serializer_fields import UserRoleNameField
 from iaso.models import Profile, Project, UserRole
 
 
@@ -13,16 +14,11 @@ class RelatedProjectSerializer(ModelSerializer):
 
 
 class NestedUserRoleSerializer(ModelSerializer):
-    name = serializers.SerializerMethodField()
+    name = UserRoleNameField(source="group.name", read_only=True)
 
     class Meta:
         model = UserRole
         fields = ["id", "name"]
-
-    @extend_schema_field(serializers.CharField())
-    def get_name(self, obj):
-        head, sep, tail = obj.group.name.partition("_")
-        return tail if sep else obj.group.name
 
 
 class ProfileListSerializer(DynamicFieldsModelSerializerBackwardCompatible):

--- a/iaso/api/profiles/serializers/retrieve.py
+++ b/iaso/api/profiles/serializers/retrieve.py
@@ -6,6 +6,7 @@ from phonenumbers.phonenumberutil import region_code_for_number
 from rest_framework import serializers
 
 from iaso.api.common import ModelSerializer, TimestampField
+from iaso.api.common.serializer_fields import UserRoleNameField
 from iaso.models import Account, DataSource, OrgUnit, OrgUnitType, Profile, Project, SourceVersion, UserRole
 
 
@@ -93,7 +94,7 @@ class NestedUserRoleSerializer(ModelSerializer):
     Mimic UserRole as_dict method
     """
 
-    name = serializers.SerializerMethodField()
+    name = UserRoleNameField(source="group.name", read_only=True)
     permissions = serializers.SlugRelatedField(
         many=True, read_only=True, slug_field="codename", source="get_iaso_permissions"
     )
@@ -103,11 +104,6 @@ class NestedUserRoleSerializer(ModelSerializer):
     class Meta:
         model = UserRole
         fields = ["id", "name", "group_id", "permissions", "created_at", "updated_at"]
-
-    @extend_schema_field(serializers.CharField(required=True))
-    def get_name(self, obj):
-        head, sep, tail = obj.group.name.partition("_")
-        return tail if sep else obj.group.name
 
 
 class NestedProjectSerializer(ModelSerializer):

--- a/iaso/api/user_roles.py
+++ b/iaso/api/user_roles.py
@@ -8,6 +8,7 @@ from iaso.models import OrgUnitType, Project, UserRole
 from iaso.permissions.core_permissions import CORE_USERS_ROLES_PERMISSION
 
 from .common import ModelViewSet, TimestampField
+from .common.serializer_fields import UserRoleNameField
 
 
 class HasUserRolePermission(permissions.BasePermission):
@@ -25,7 +26,7 @@ class PermissionSerializer(serializers.ModelSerializer):
 
 class UserRoleSerializer(serializers.ModelSerializer):
     permissions = serializers.SerializerMethodField("get_permissions")
-    name = serializers.CharField(source="group.name")
+    name = UserRoleNameField(source="group.name")
     created_at = TimestampField(read_only=True)
     updated_at = TimestampField(read_only=True)
     editable_org_unit_type_ids = serializers.PrimaryKeyRelatedField(
@@ -39,12 +40,6 @@ class UserRoleSerializer(serializers.ModelSerializer):
     class Meta:
         model = UserRole
         fields = ["id", "name", "permissions", "editable_org_unit_type_ids", "created_at", "updated_at"]
-
-    def to_representation(self, instance):
-        user_role = super().to_representation(instance)
-        account_id = user_role["name"].split("_")[0]
-        user_role["name"] = user_role["name"].removeprefix(f"{account_id}_")
-        return user_role
 
     def get_permissions(self, obj):
         return [permission["codename"] for permission in PermissionSerializer(obj.group.permissions, many=True).data]

--- a/iaso/api/validation_workflow_instances/serializers.py
+++ b/iaso/api/validation_workflow_instances/serializers.py
@@ -3,23 +3,12 @@ from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
 from iaso.api.common import ModelSerializer
+from iaso.api.common.serializer import UserRoleNameSerializer
 from iaso.api.validation_workflows.serializers.common import UserDisplayNameField
 from iaso.models import Instance, UserRole, ValidationNode, ValidationNodeTemplate
 from iaso.models.common import ValidationWorkflowArtefactStatus
 from iaso.models.validation_workflow.validation_node import ValidationNodeStatus
 from iaso.utils.serializer.color import ColorFieldSerializer
-
-
-class NestedUserRoleSerializer(ModelSerializer):
-    name = serializers.SerializerMethodField()
-
-    class Meta:
-        model = UserRole
-        fields = ["name", "id"]
-
-    def get_name(self, obj):
-        return obj.group.name.removeprefix(f"{obj.account_id}_")
-
 
 class NestedHistorySerializer(ModelSerializer):
     color = ColorFieldSerializer(source="node.color", read_only=True)
@@ -45,7 +34,7 @@ class NestedHistorySerializer(ModelSerializer):
 
 
 class NextTasksSerializer(ModelSerializer):
-    user_roles = NestedUserRoleSerializer(read_only=True, many=True, source="node.roles_required")
+    user_roles = UserRoleNameSerializer(read_only=True, many=True, source="node.roles_required")
     name = serializers.CharField(read_only=True, source="node.name")
     node_template_slug = serializers.CharField(read_only=True, source="node.slug")
 
@@ -55,7 +44,7 @@ class NextTasksSerializer(ModelSerializer):
 
 
 class NextByPassSerializer(ModelSerializer):
-    user_roles = NestedUserRoleSerializer(read_only=True, many=True, source="roles_required")
+    user_roles = UserRoleNameSerializer(read_only=True, many=True, source="roles_required")
 
     class Meta:
         model = ValidationNodeTemplate

--- a/iaso/api/validation_workflow_instances/serializers.py
+++ b/iaso/api/validation_workflow_instances/serializers.py
@@ -10,6 +10,7 @@ from iaso.models.common import ValidationWorkflowArtefactStatus
 from iaso.models.validation_workflow.validation_node import ValidationNodeStatus
 from iaso.utils.serializer.color import ColorFieldSerializer
 
+
 class NestedHistorySerializer(ModelSerializer):
     color = ColorFieldSerializer(source="node.color", read_only=True)
     level = serializers.CharField(read_only=True, source="node.name")

--- a/iaso/api/validation_workflows/serializers/retrieve.py
+++ b/iaso/api/validation_workflows/serializers/retrieve.py
@@ -2,23 +2,13 @@ from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
 from iaso.api.common import ModelSerializer
+from iaso.api.common.serializer import UserRoleNameSerializer
 from iaso.api.validation_workflows.serializers.common import UserDisplayNameField
-from iaso.models import Form, UserRole, ValidationNodeTemplate, ValidationWorkflow
-
-
-class NestedRolesRequiredSerializer(ModelSerializer):
-    name = serializers.SerializerMethodField()
-
-    class Meta:
-        model = UserRole
-        fields = ["name", "id"]
-
-    def get_name(self, obj):
-        return obj.group.name.removeprefix(f"{obj.account_id}_")
+from iaso.models import Form, ValidationNodeTemplate, ValidationWorkflow
 
 
 class NestedValidationNodeTemplateSerializer(ModelSerializer):
-    roles_required = NestedRolesRequiredSerializer(read_only=True, many=True)
+    roles_required = UserRoleNameSerializer(read_only=True, many=True)
 
     class Meta:
         model = ValidationNodeTemplate

--- a/iaso/api/validation_workflows_node_templates/serializers/list.py
+++ b/iaso/api/validation_workflows_node_templates/serializers/list.py
@@ -1,22 +1,10 @@
-from rest_framework import serializers
-
 from iaso.api.common import ModelSerializer
-from iaso.models import UserRole, ValidationNodeTemplate
-
-
-class NestedRolesRequiredSerializer(ModelSerializer):
-    name = serializers.SerializerMethodField()
-
-    class Meta:
-        model = UserRole
-        fields = ["name", "id"]
-
-    def get_name(self, obj):
-        return obj.group.name.removeprefix(f"{obj.account_id}_")
+from iaso.api.common.serializer import UserRoleNameSerializer
+from iaso.models import ValidationNodeTemplate
 
 
 class ValidationNodeTemplateListSerializer(ModelSerializer):
-    roles_required = NestedRolesRequiredSerializer(read_only=True, many=True)
+    roles_required = UserRoleNameSerializer(read_only=True, many=True)
 
     class Meta:
         model = ValidationNodeTemplate

--- a/iaso/api/validation_workflows_node_templates/serializers/retrieve.py
+++ b/iaso/api/validation_workflows_node_templates/serializers/retrieve.py
@@ -1,22 +1,10 @@
-from rest_framework import serializers
-
 from iaso.api.common import ModelSerializer
-from iaso.models import UserRole, ValidationNodeTemplate
-
-
-class NestedRolesRequiredSerializer(ModelSerializer):
-    name = serializers.SerializerMethodField()
-
-    class Meta:
-        model = UserRole
-        fields = ["name", "id"]
-
-    def get_name(self, obj):
-        return obj.group.name.removeprefix(f"{obj.account_id}_")
+from iaso.api.common.serializer import UserRoleNameSerializer
+from iaso.models import ValidationNodeTemplate
 
 
 class ValidationNodeTemplateRetrieveSerializer(ModelSerializer):
-    roles_required = NestedRolesRequiredSerializer(many=True, read_only=True)
+    roles_required = UserRoleNameSerializer(many=True, read_only=True)
 
     class Meta:
         model = ValidationNodeTemplate

--- a/iaso/tests/api/common/test_serializer_fields.py
+++ b/iaso/tests/api/common/test_serializer_fields.py
@@ -1,0 +1,33 @@
+from django.contrib.auth.models import Group
+from rest_framework import serializers
+
+from iaso.api.common.serializer import UserRoleNameSerializer
+from iaso.api.common.serializer_fields import UserRoleNameField
+from iaso.models import Account, UserRole
+from iaso.test import TestCase
+
+
+class UserRoleNameFieldTestSerializer(serializers.Serializer):
+    name = UserRoleNameField(source="*", read_only=True)
+
+
+class UserRoleNameFieldTestCase(TestCase):
+    def setUp(self):
+        self.account = Account.objects.create(name="test")
+
+    def test_removes_account_prefix_from_group_name(self):
+        group = Group.objects.create(name=f"{self.account.id}_data manager")
+        user_role = UserRole.objects.create(account=self.account, group=group)
+
+        self.assertEqual(UserRoleNameFieldTestSerializer(user_role).data, {"name": "data manager"})
+    def test_keeps_group_name_without_matching_account_prefix(self):
+        group = Group.objects.create(name="data_manager")
+        user_role = UserRole.objects.create(account=self.account, group=group)
+
+        self.assertEqual(UserRoleNameFieldTestSerializer(user_role).data, {"name": "data_manager"})
+
+    def test_user_role_name_serializer_uses_shared_field(self):
+        group = Group.objects.create(name=f"{self.account.id}_reviewer")
+        user_role = UserRole.objects.create(account=self.account, group=group)
+
+        self.assertEqual(UserRoleNameSerializer(user_role).data, {"id": user_role.pk, "name": "reviewer"})

--- a/iaso/tests/api/common/test_serializer_fields.py
+++ b/iaso/tests/api/common/test_serializer_fields.py
@@ -20,6 +20,7 @@ class UserRoleNameFieldTestCase(TestCase):
         user_role = UserRole.objects.create(account=self.account, group=group)
 
         self.assertEqual(UserRoleNameFieldTestSerializer(user_role).data, {"name": "data manager"})
+
     def test_keeps_group_name_without_matching_account_prefix(self):
         group = Group.objects.create(name="data_manager")
         user_role = UserRole.objects.create(account=self.account, group=group)

--- a/iaso/tests/api/common/test_serializer_fields.py
+++ b/iaso/tests/api/common/test_serializer_fields.py
@@ -8,7 +8,7 @@ from iaso.test import TestCase
 
 
 class UserRoleNameFieldTestSerializer(serializers.Serializer):
-    name = UserRoleNameField(source="*", read_only=True)
+    name = UserRoleNameField(source="group.name", read_only=True)
 
 
 class UserRoleNameFieldTestCase(TestCase):

--- a/iaso/tests/api/profiles/test_views/test_list.py
+++ b/iaso/tests/api/profiles/test_views/test_list.py
@@ -27,6 +27,17 @@ class ProfileListAPITestCase(BaseProfileAPITestCase):
         response_data = self.assertJSONResponse(response, 200)
         self.assertValidProfileListData(response_data, 7)
 
+    def test_profile_list_user_roles_do_not_include_account_prefix(self):
+        group = Group.objects.create(name=f"{self.account.id}_Data manager")
+        user_role = UserRole.objects.create(group=group, account=self.account)
+        self.jane.iaso_profile.user_roles.set([user_role])
+
+        self.client.force_authenticate(self.jane)
+        response = self.client.get(reverse("profiles-list"), {"fields": ":all", "search": self.jane.username})
+        response_data = self.assertJSONResponse(response, 200)
+
+        self.assertEqual(response_data["results"][0]["user_roles"], [{"id": user_role.id, "name": "Data manager"}])
+
     def test_profile_list_user_admin_ok(self):
         """GET /profiles/ with auth (user has user admin permissions)"""
         self.client.force_authenticate(self.jim)

--- a/iaso/tests/api/profiles/test_views/test_retrieve.py
+++ b/iaso/tests/api/profiles/test_views/test_retrieve.py
@@ -1,8 +1,9 @@
 from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
 from django.urls import reverse
 from rest_framework import status
 
-from iaso.models import AccountFeatureFlag, Project
+from iaso.models import AccountFeatureFlag, Project, UserRole
 from iaso.permissions.core_permissions import CORE_FORMS_PERMISSION
 from iaso.tests.api.profiles.test_views.common import BaseProfileAPITestCase
 from iaso.utils.colors import DEFAULT_COLOR
@@ -98,6 +99,16 @@ class ProfileRetrieveAPITestCase(BaseProfileAPITestCase):
         self.assertHasField(response_data, "date_joined", str)
         expected_date = self.jane.date_joined.isoformat().replace("+00:00", "Z")
         self.assertEqual(response_data["date_joined"], expected_date)
+
+    def test_retrieve_profile_user_roles_permissions_do_not_include_account_prefix(self):
+        group = Group.objects.create(name=f"{self.account.id}_Data manager")
+        user_role = UserRole.objects.create(group=group, account=self.account)
+        self.jane.iaso_profile.user_roles.set([user_role])
+
+        self.client.force_authenticate(self.jane)
+        response = self.client.get(reverse("profiles-detail", kwargs={"pk": "me"}))
+        response_data = self.assertJSONResponse(response, 200)
+        self.assertEqual(response_data["user_roles_permissions"][0]["name"], "Data manager")
 
     def test_retrieve_profile_me_no_profile(self):
         """GET /profiles/me/ with auth, but without profile

--- a/iaso/tests/api/validation_workflow_instances/test_views.py
+++ b/iaso/tests/api/validation_workflow_instances/test_views.py
@@ -17,7 +17,7 @@ class ValidationWorkflowInstanceAPIRetrieveTestCase(APITestCase):
         self.account = Account.objects.create(name="account")
         self.other_account = Account.objects.create(name="account2")
 
-        self.group = Group.objects.create(name="group")
+        self.group = Group.objects.create(name=f"{self.account.id}_group")
         self.user_role = UserRole.objects.create(account=self.account, group=self.group)
         self.john_doe = self.create_user_with_profile(
             username="john.doe", account=self.account, first_name="John", last_name="Doe"
@@ -208,7 +208,7 @@ class ValidationWorkflowInstanceAPIRetrieveTestCase(APITestCase):
                             "id": next_task.pk,
                             "name": next_task.node.name,
                             "node_template_slug": "first-node",
-                            "user_roles": [{"id": self.user_role.id, "name": self.user_role.group.name}],
+                            "user_roles": [{"id": self.user_role.id, "name": "group"}],
                         }
                     ],
                 )

--- a/iaso/tests/api/validation_workflows/test_views/test_retrieve.py
+++ b/iaso/tests/api/validation_workflows/test_views/test_retrieve.py
@@ -13,7 +13,7 @@ class ValidationWorkflowAPIRetrieveTestCase(BaseValidationWorkflowAPITestCase):
         self.account_2 = Account.objects.create(name="account_2")
         self.enable_validation_workflow_feature_flag(self.account, self.account_2)
 
-        self.group = Group.objects.create(name="Group")
+        self.group = Group.objects.create(name=f"{self.account.id}_Group")
         self.user_role = UserRole.objects.create(group=self.group, account=self.account)
 
         self.form = Form.objects.create(name="form")

--- a/iaso/tests/api/validation_workflows_node_templates/test_views/test_list.py
+++ b/iaso/tests/api/validation_workflows_node_templates/test_views/test_list.py
@@ -13,7 +13,7 @@ class ValidationNodeTemplateAPIListTestCase(BaseApiTestCase):
         self.account_2 = Account.objects.create(name="account_2")
         self.enable_validation_workflow_feature_flag(self.account, self.account_2)
 
-        self.group = Group.objects.create(name="Group")
+        self.group = Group.objects.create(name=f"{self.account.id}_Group")
         self.user_role = UserRole.objects.create(group=self.group, account=self.account)
 
         self.validation_workflow = ValidationWorkflow.objects.create(

--- a/iaso/tests/api/validation_workflows_node_templates/test_views/test_retrieve.py
+++ b/iaso/tests/api/validation_workflows_node_templates/test_views/test_retrieve.py
@@ -13,7 +13,7 @@ class ValidationNodeTemplateAPIRetrieveTestCase(BaseApiTestCase):
         self.account_2 = Account.objects.create(name="account_2")
         self.enable_validation_workflow_feature_flag(self.account, self.account_2)
 
-        self.group = Group.objects.create(name="Group")
+        self.group = Group.objects.create(name=f"{self.account.id}_Group")
         self.user_role = UserRole.objects.create(group=self.group, account=self.account)
 
         (
@@ -155,6 +155,6 @@ class ValidationNodeTemplateAPIRetrieveTestCase(BaseApiTestCase):
                 self.assertEqual(res_data["description"], "some description")
                 self.assertEqual(res_data["color"], "#FFFFFF")
                 self.assertEqual(
-                    res_data["roles_required"], [{"id": self.user_role.pk, "name": self.user_role.group.name}]
+                    res_data["roles_required"], [{"id": self.user_role.pk, "name": "Group"}]
                 )
                 self.assertTrue(res_data["can_skip_previous_nodes"])

--- a/iaso/tests/api/validation_workflows_node_templates/test_views/test_retrieve.py
+++ b/iaso/tests/api/validation_workflows_node_templates/test_views/test_retrieve.py
@@ -154,7 +154,5 @@ class ValidationNodeTemplateAPIRetrieveTestCase(BaseApiTestCase):
                 self.assertEqual(res_data["name"], "Second node")
                 self.assertEqual(res_data["description"], "some description")
                 self.assertEqual(res_data["color"], "#FFFFFF")
-                self.assertEqual(
-                    res_data["roles_required"], [{"id": self.user_role.pk, "name": "Group"}]
-                )
+                self.assertEqual(res_data["roles_required"], [{"id": self.user_role.pk, "name": "Group"}])
                 self.assertTrue(res_data["can_skip_previous_nodes"])


### PR DESCRIPTION
## What problem is this PR solving?

Role names exposed by validation workflow APIs should not include the account ID prefix.

### Related JIRA tickets

IA-5023

## Changes

Centralized user role name serialization in a shared `UserRoleNameField` and `UserRoleNameSerializer`.

The shared field removes only the exact `{account_id}_` prefix from `UserRole.group.name`, so names like `data_manager` are preserved when they do not match the account prefix.

Updated validation workflow serializers to use the shared serializer for role names in:
- validation workflow retrieve responses
- validation workflow node template list/retrieve responses
- validation workflow instance 

Added focused tests for the shared field/serializer and updated impacted API tests to assert that prefixed group names are returned without the account prefix.

## How to test

1. Start the app locally.
2. Open `/dashboard/forms/submissions/validation/detail/`.
3. Check the `Roles required` column in the steps table.
4. Confirm that the role name is displayed without the account ID prefix.

## Print screen / video

<img width="1766" height="378" alt="image" src="https://github.com/user-attachments/assets/d890d7fa-562f-4517-ad93-00dc95c4d7c0" />