### PR TITLE
[SNT-451] add captchas with `django-simple-captcha`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,7 @@ RDS_DB_NAME="iaso"
 RDS_HOSTNAME="db"
 RDS_PASSWORD="postgres"
 RDS_USERNAME="postgres"
+RDS_PORT=5432
 
 # ============================================================
 # PLUGINS

--- a/README.md
+++ b/README.md
@@ -712,6 +712,13 @@ Once the environment variables are configured, you can create embedded Superset 
 
 The embedded dashboard will be accessible at `/pages/{your-slug}/` and will use guest token authentication for secure access.
 
+## Captchas
+
+Captchas are generated with [django-simple-captcha](https://github.com/mbi/django-simple-captcha/).
+To generate a new captcha, you need to make a GET call to `/api/captcha/refresh/` with a specific header: `"x-requested-with": "XMLHttpRequest"`.
+This will return the new captcha identifier, as well as a path to visualize it.
+
+
 # Contributing
 
 If you are not using the Docker container for development, please ensure that

--- a/bruno/captcha/generate_and_visualize_captcha.bru
+++ b/bruno/captcha/generate_and_visualize_captcha.bru
@@ -1,0 +1,21 @@
+meta {
+  name: generate_and_visualize_captcha
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{HOST}}/api/captcha/image/{{captcha_key}}/
+  body: none
+  auth: none
+}
+
+script:pre-request {
+  const response = await bru.runRequest("captcha/generate_captcha");
+  bru.setVar("captcha_key", response.data.key);
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/bruno/captcha/generate_and_visualize_captcha_2x_size.bru
+++ b/bruno/captcha/generate_and_visualize_captcha_2x_size.bru
@@ -1,0 +1,21 @@
+meta {
+  name: generate_and_visualize_captcha_2x_size
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{HOST}}/api/captcha/image/{{captcha_key}}@2/
+  body: none
+  auth: none
+}
+
+script:pre-request {
+  const response = await bru.runRequest("captcha/generate_captcha");
+  bru.setVar("captcha_key", response.data.key);
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/bruno/captcha/generate_captcha.bru
+++ b/bruno/captcha/generate_captcha.bru
@@ -1,0 +1,20 @@
+meta {
+  name: generate_captcha
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{HOST}}/api/captcha/refresh/
+  body: none
+  auth: none
+}
+
+headers {
+  x-requested-with: XMLHttpRequest
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/hat/settings.py
+++ b/hat/settings.py
@@ -234,6 +234,7 @@ INSTALLED_APPS += [
     "django_json_widget",
     "phonenumber_field",
     "axes",
+    "captcha",
 ]
 
 if USE_CELERY:
@@ -863,6 +864,9 @@ CLAMAV_CONFIGURATION = {
     "stream": True,  # Streaming file content instead of sending files as is
 }
 
+# django-simple-captcha config
+CAPTCHA_CHALLENGE_FUNCT = "captcha.helpers.math_challenge"
+
 # Plugin config
 print("Enabled plugins:", PLUGINS)
 for plugin_name in PLUGINS:
@@ -911,6 +915,7 @@ if IN_TESTS:
     }
     if not ENCRYPTED_TEXT_FIELD_KEY:
         ENCRYPTED_TEXT_FIELD_KEY = "71Eax4PGazWNj7vaXrucAD1bYUzjI-Fxubv8MZzcSyk="
+    CAPTCHA_TEST_MODE = True
 
 ENABLE_SETUPER_SANDBOX = get_env_var_or_default("ENABLE_SETUPER_SANDBOX", "false").lower() == "true"
 SETUPER_SANDBOX_PASSWORD = get_env_var_or_default("SETUPER_SANDBOX_PASSSWORD", "district")

--- a/iaso/tests/test_auth_enforcement.py
+++ b/iaso/tests/test_auth_enforcement.py
@@ -43,6 +43,10 @@ PUBLIC_ENDPOINTS = {
     # verify signature but return 400 to not interfere with enketo
     ("/api/forms/1/manifest_enketo/", "GET"),
     ("/api/mobile/forms/1/manifest_enketo/", "GET"),
+    # captchas
+    *any_methods("/api/captcha/image/"),
+    *any_methods("/api/captcha/audio/"),
+    *any_methods("/api/captcha/refresh/"),
     # task worker endpoints
     *any_methods("/tasks/launch_task/export_task/my_user_name/"),
     *any_methods("/tasks/cron/"),
@@ -98,6 +102,7 @@ CONVERTER_SAMPLES = {
     "token": "456fdg-sdf546sdf-dsf54",
     "task_name": "export_task",
     "user_name": "my_user_name",
+    "key": "1",  # used by captchas URLs
 }
 
 DEFAULT_SAMPLE = "1"

--- a/iaso/urls.py
+++ b/iaso/urls.py
@@ -308,6 +308,7 @@ urlpatterns: URLList = [
         "enketo/instance_files/<instance_file_id>/<file_name>", view=enketo_instance_files, name="enketo-instance-files"
     ),
     path("logout-iaso", auth.views.LogoutView.as_view(next_page="login"), name="logout-iaso"),
+    path("captcha/", include("captcha.urls")),
 ]
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -72,6 +72,7 @@ names-generator==0.2.0 # https://github.com/glentner/names_generator
 django-autoslug==1.9.9 # https://github.com/justinmayer/django-autoslug
 python-magic==0.4.27 # https://github.com/ahupp/python-magic
 jsonref==1.1.0 # https://github.com/gazpachoking/jsonref
+django-simple-captcha==0.6.3  # https://github.com/mbi/django-simple-captcha/tags
 
 # Exporting tools.
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
## What problem is this PR solving?

add captchas with `django-simple-captcha`

### Related JIRA tickets

SNT-451

## Changes

- added the [django-simple-captcha](https://github.com/mbi/django-simple-captcha/) lib
- added Bruno files to illustrate how to generate captchas
- added a missing value in `.env.example`

## How to test

- Try to generate a captcha (see Bruno files or README for explanations)
  - there's no endpoint that consumes captchas yet (it's going to be used first [in SNT](https://github.com/BLSQ/snt-malaria/pull/283))
  - captcha generation should be public, no need to be logged in

## Print screen / video

<img width="1313" height="490" alt="image" src="https://github.com/user-attachments/assets/e33a6487-0693-49c4-98ed-6ba0a80e7c29" />

<img width="1168" height="425" alt="image" src="https://github.com/user-attachments/assets/d968c18c-626d-4d85-b9e1-aecff672b112" />


## Notes

/

## Doc

See README
