### PR TITLE
[POLIO-2140] N+1 issues on the vaccine authorization API

### DIFF
--- a/plugins/polio/api/vaccines/vaccine_authorization.py
+++ b/plugins/polio/api/vaccines/vaccine_authorization.py
@@ -139,7 +139,9 @@ class VaccineAuthorizationViewSet(ModelViewSet):
         user_access_ou = OrgUnit.objects.filter_for_user_and_app_id(user, None)
         user_access_ou = user_access_ou.filter(org_unit_type__name=COUNTRY)
         country_id = self.request.query_params.get("country", None)
-        queryset = VaccineAuthorization.objects.filter(account=user.iaso_profile.account, country__in=user_access_ou)
+        queryset = VaccineAuthorization.objects.select_related("country").filter(
+            account=user.iaso_profile.account, country__in=user_access_ou
+        )
         block_country = self.request.query_params.get("block_country", None)
         search = self.request.query_params.get("search", None)
         auth_status = self.request.query_params.get("auth_status", None)
@@ -190,36 +192,32 @@ class VaccineAuthorizationViewSet(ModelViewSet):
         user = self.request.user
         user_access_ou = OrgUnit.objects.filter_for_user_and_app_id(user, None)
         user_access_ou = user_access_ou.filter(org_unit_type__name=COUNTRY)
-        queryset = VaccineAuthorization.objects.filter(account=user.iaso_profile.account, country__in=user_access_ou)
+        all_auths = list(
+            VaccineAuthorization.objects.select_related("country")
+            .filter(account=user.iaso_profile.account, country__in=user_access_ou, deleted_at__isnull=True)
+            .order_by("expiration_date")
+        )
         auth_status = self.request.query_params.get("auth_status", None)
         block_country = self.request.query_params.get("block_country", None)
-        country_list = []
-        response = []
-
         ordering = request.query_params.get("order", None)
 
-        for auth in queryset:
-            if auth.country not in country_list:
-                country_list.append(auth.country)
+        auths_by_country = {}
+        for auth in all_auths:
+            if auth.country not in auths_by_country:
+                auths_by_country[auth.country] = []
+            auths_by_country[auth.country].append(auth)
 
-        for country in country_list:
-            last_validated_or_expired = (
-                queryset.filter(country=country, status__in=["VALIDATED", "EXPIRED"], deleted_at__isnull=True)
-                .order_by("-expiration_date")
-                .first()
-            )
+        response = []
 
-            next_expiration_auth = (
-                queryset.filter(country=country, status__in=["ONGOING", "SIGNATURE"], deleted_at__isnull=True)
-                .order_by("-expiration_date")
-                .first()
-            )
+        for country, auths in auths_by_country.items():
+            validated_or_expired_auths = [a for a in auths if a.status in ["VALIDATED", "EXPIRED"]]
+            last_validated_or_expired = validated_or_expired_auths[-1] if validated_or_expired_auths else None
 
-            last_entry = queryset.filter(country=country, deleted_at__isnull=True).last()
+            ongoing_or_signature_auths = [a for a in auths if a.status in ["ONGOING", "SIGNATURE"]]
+            next_expiration_auth = ongoing_or_signature_auths[-1] if ongoing_or_signature_auths else None
 
-            last_entry_date_check = VaccineAuthorization.objects.filter(
-                country=country, account=self.request.user.iaso_profile.account, deleted_at__isnull=True
-            ).last()
+            last_entry = auths[-1] if auths else None
+            last_entry_date_check = max(auths, key=lambda a: a.id) if auths else None
 
             if last_entry_date_check and last_entry:
                 if last_entry_date_check.expiration_date > last_entry.expiration_date:

--- a/plugins/polio/tests/test_vaccine_authorizations.py
+++ b/plugins/polio/tests/test_vaccine_authorizations.py
@@ -5,7 +5,9 @@ from datetime import date
 from django.contrib.auth.models import User
 from django.core import mail
 from django.core.exceptions import ObjectDoesNotExist
+from django.db import connection
 from django.shortcuts import get_object_or_404
+from django.test.utils import CaptureQueriesContext
 from django.utils.timezone import now
 from rest_framework import status
 from rest_framework.test import APIClient
@@ -333,6 +335,68 @@ class VaccineAuthorizationAPITestCase(APITestCase):
         self.assertEqual(response.data[0]["next_expiration_date"], None)
         self.assertEqual(response.data[0]["start_date"], datetime.date(2224, 2, 1))
 
+    def test_get_most_recent_authorizations_is_o1_queries(self):
+        """
+        Ensure the endpoint does not suffer from N+1 queries by comparing
+        the query count of 1 country vs multiple countries.
+        """
+        self.client.force_authenticate(self.user_1)
+
+        self.user_1.iaso_profile.org_units.set([self.org_unit_DRC.pk])
+
+        self.client.post(
+            "/api/polio/vaccineauthorizations/",
+            data={
+                "country": self.org_unit_DRC.pk,
+                "quantity": 12346,
+                "status": "VALIDATED",
+                "comment": "baseline auth",
+                "expiration_date": "2224-03-01",
+                "start_date": "2224-02-01",
+            },
+        )
+
+        with CaptureQueriesContext(connection) as baseline_ctx:
+            response_baseline = self.client.get("/api/polio/vaccineauthorizations/get_most_recent_authorizations/")
+
+        baseline_query_count = len(baseline_ctx.captured_queries)
+        self.assertEqual(response_baseline.status_code, 200)
+
+        bulk_org_units = [
+            self.org_unit_CHAD,
+            self.org_unit_BURKINA_FASO,
+            self.org_unit_ZIMBABWE,
+            self.org_unit_SIERRA_LEONE,
+            self.org_unit_ALGERIA,
+            self.org_unit_SOMALIA,
+        ]
+
+        self.user_1.iaso_profile.org_units.add(*bulk_org_units)
+
+        for ou in bulk_org_units:
+            self.client.post(
+                "/api/polio/vaccineauthorizations/",
+                data={
+                    "country": ou.pk,
+                    "quantity": 5000,
+                    "status": "ONGOING",
+                    "comment": f"bulk auth for {ou.name}",
+                    "expiration_date": "2224-04-01",
+                    "start_date": "2224-03-01",
+                },
+            )
+
+        with CaptureQueriesContext(connection) as bulk_ctx:
+            response_bulk = self.client.get("/api/polio/vaccineauthorizations/get_most_recent_authorizations/")
+
+        bulk_query_count = len(bulk_ctx.captured_queries)
+        self.assertEqual(response_bulk.status_code, 200)
+        self.assertLessEqual(
+            bulk_query_count,
+            baseline_query_count,
+            f"N+1 Regression: Queries jumped from {baseline_query_count} to {bulk_query_count}!",
+        )
+
     def test_filters(self):
         self.client.force_authenticate(self.user_1)
 
@@ -482,28 +546,29 @@ class VaccineAuthorizationAPITestCase(APITestCase):
         self.assertEqual(len(response.data), 2)
 
     def test_get_recent_without_expired_or_validated_data_must_return_ongoing_or_signature(self):
-        def test_get_most_recent_authorizations(self):
-            self.client.force_authenticate(self.user_1)
-            self.user_1.iaso_profile.org_units.set([self.org_unit_DRC.pk])
+        self.client.force_authenticate(self.user_1)
+        self.user_1.iaso_profile.org_units.set([self.org_unit_DRC.pk])
 
-            self.client.post(
-                "/api/polio/vaccineauthorizations/",
-                data={
-                    "country": self.org_unit_DRC.pk,
-                    "quantity": 12346,
-                    "status": "ONGOING",
-                    "comment": "waiting for approval.",
-                    "expiration_date": (datetime.date.today() + datetime.timedelta(days=1)).strftime("%Y-%m-%d"),
-                },
-            )
+        tomorrow_str = datetime.date.today() + datetime.timedelta(days=1)
 
-            response = self.client.get("/api/polio/vaccineauthorizations/get_most_recent_authorizations/")
+        self.client.post(
+            "/api/polio/vaccineauthorizations/",
+            data={
+                "country": self.org_unit_DRC.pk,
+                "quantity": 12346,
+                "status": "ONGOING",
+                "comment": "waiting for approval.",
+                "expiration_date": (datetime.date.today() + datetime.timedelta(days=1)).strftime("%Y-%m-%d"),
+            },
+        )
 
-            self.assertEqual(response.status_code, 200)
-            self.assertEqual(response.data[0]["comment"], "waiting for approval.")
-            self.assertEqual(response.data[0]["status"], "ongoing")
-            self.assertEqual(response.data[0]["current_expiration_date"], None)
-            self.assertEqual(response.data[0]["next_expiration_date"], datetime.date(2024, 2, 1))
+        response = self.client.get("/api/polio/vaccineauthorizations/get_most_recent_authorizations/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data[0]["comment"], "waiting for approval.")
+        self.assertEqual(response.data[0]["status"], "ONGOING")
+        self.assertEqual(response.data[0]["current_expiration_date"], None)
+        self.assertEqual(response.data[0]["next_expiration_date"], tomorrow_str)
 
     def test_can_edit_authorizations(self):
         self.client.force_authenticate(self.user_1)


### PR DESCRIPTION
## What problem is this PR solving?

This PR is about increasing the performance on the Vaccine Authorization get endpoint by eliminating the n+1 issues

### Related JIRA tickets

[POLIO-2140](https://bluesquare.atlassian.net/browse/POLIO-2140)

## Changes

- Instead of querying the DB many times to fetch `last_validated_or_expired`, `next_expiration_auth`,  `last_entry` and `last_entry_date_check`, I made a single query and fetched all of them
- Added some tests

## How to test

Explain how to test your PR.

If a specific config is required explain it here: dataset, account, profile, etc.

## Print screen / video
Went from this: 
<img width="1608" height="214" alt="image" src="https://github.com/user-attachments/assets/c99f52f9-bf58-4b63-8e23-18427ed08716" />


to this: 
<img width="1608" height="214" alt="image" src="https://github.com/user-attachments/assets/d5ea410c-7db8-4b08-984a-28c1a47a1260" />


## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).


[POLIO-2140]: https://bluesquare.atlassian.net/browse/POLIO-2140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ