### PR TITLE
SNT-457 Custom population layers

### DIFF
--- a/iaso/api/metrics/serializers.py
+++ b/iaso/api/metrics/serializers.py
@@ -2,6 +2,8 @@ import csv
 
 import pandas as pd
 
+from django.db import transaction
+from django.db.models import Q
 from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 
@@ -136,6 +138,7 @@ class MetricValueSerializer(serializers.ModelSerializer):
 
 class ImportMetricValuesSerializer(serializers.Serializer):
     file = serializers.FileField(required=True)
+    year = serializers.IntegerField(required=True, allow_null=False)
 
     def validate_file(self, value):
         if not value.name.endswith(".csv"):
@@ -144,7 +147,7 @@ class ImportMetricValuesSerializer(serializers.Serializer):
         dialect = csv.Sniffer().sniff(value.read(1024).decode("utf-8", errors="ignore"))
         value.seek(0)  # Reset file pointer after reading for dialect inference
         df = pd.read_csv(value, sep=dialect.delimiter)
-
+        self.context["metric_values_df"] = df  # Store the DataFrame for use in the save method
         header_errors = get_missing_headers(df, REQUIRED_METRIC_VALUES_HEADERS)
         if header_errors:
             message = _("The CSV must contain '{missing_headers}' columns.").format(
@@ -161,15 +164,13 @@ class ImportMetricValuesSerializer(serializers.Serializer):
         user = self.context.get("request").user
         account = user.iaso_profile.account
         existing_metric_types = MetricType.objects.filter(account=account, code__in=metric_type_codes).values_list(
-            "code", "id", "legend_config"
+            "code", "id", "metric_kind"
         )
         missing_metric_types = metric_type_codes - set(mt[0] for mt in existing_metric_types)
         if missing_metric_types:
             raise serializers.ValidationError(
                 _("The following metric types do not exist: ") + ", ".join(missing_metric_types)
             )
-
-        existing_metric_types_map = {mt[0]: mt[1] for mt in existing_metric_types}
 
         if df.shape[0] == 0:
             raise serializers.ValidationError(_("The CSV must contain at least one value row."))
@@ -184,29 +185,50 @@ class ImportMetricValuesSerializer(serializers.Serializer):
                 _("The following org unit IDs do not exist: ") + ", ".join(str(ou_id) for ou_id in missing_org_unit_ids)
             )
 
-        # Prepare metric values but don't save yet
+        self.context["existing_metric_types_map"] = {
+            mt[0]: {"id": mt[1], "metric_kind": mt[2]} for mt in existing_metric_types
+        }
+
+        return value
+
+    def validate_year(self, value):
+        if value < 1900 or value > 2100:
+            raise serializers.ValidationError(_("Year must be between 1900 and 2100."))
+        return value
+
+    def save(self, **kwargs):
+        df = self.context["metric_values_df"]
+        existing_metric_types_map = self.context["existing_metric_types_map"]
+        year = self.validated_data["year"]
         metric_values = []
         for index, row in df.iterrows():
             org_unit_id = row["ADM2_ID"]
-            for code in metric_type_codes:
+            for code in existing_metric_types_map.keys():
                 value = row.get(code)
                 if pd.isna(value):
                     continue
-                metric_type_id = existing_metric_types_map[code]
-                mv = MetricValue(org_unit_id=org_unit_id, metric_type_id=metric_type_id)
+                metric_type_info = existing_metric_types_map[code]
+                mv = MetricValue(org_unit_id=org_unit_id, metric_type_id=metric_type_info["id"])
                 try:
                     # Parse the value as a float
                     mv.value = float(value)
                 except ValueError:
                     mv.value = None
                     mv.string_value = value
+
+                if metric_type_info["metric_kind"] == MetricType.MetricKind.POPULATION:
+                    mv.year = year
                 metric_values.append(mv)
 
-        self.context["metric_values"] = metric_values
+        with transaction.atomic():
+            # Clear existing metric values to avoid duplicates
+            metric_type_ids = set(mv.metric_type_id for mv in metric_values)
+            org_unit_ids = set(mv.org_unit_id for mv in metric_values)
+            MetricValue.objects.filter(
+                Q(metric_type_id__in=metric_type_ids, org_unit_id__in=org_unit_ids), Q(year=year) | Q(year__isnull=True)
+            ).delete()
 
-        # Do we want to validate all values already here?
-
-        return value
+            return MetricValue.objects.bulk_create(metric_values)
 
 
 class OrgUnitIdSerializer(serializers.Serializer):

--- a/iaso/api/metrics/views.py
+++ b/iaso/api/metrics/views.py
@@ -1,6 +1,5 @@
 import csv
 
-from django.db import transaction
 from django.http import HttpResponse
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import extend_schema

--- a/iaso/api/metrics/views.py
+++ b/iaso/api/metrics/views.py
@@ -122,14 +122,7 @@ class MetricValueViewSet(viewsets.ModelViewSet):
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
-        metric_values = serializer.context.get("metric_values")
-        with transaction.atomic():
-            # Clear existing metric values to avoid duplicates
-            metric_type_ids = set(mv.metric_type_id for mv in metric_values)
-            org_unit_ids = set(mv.org_unit_id for mv in metric_values)
-            MetricValue.objects.filter(metric_type_id__in=metric_type_ids, org_unit_id__in=org_unit_ids).delete()
-
-            MetricValue.objects.bulk_create(metric_values)
+        metric_values = serializer.save()
 
         return Response(
             {

--- a/iaso/api/metrics/views.py
+++ b/iaso/api/metrics/views.py
@@ -38,6 +38,10 @@ class MetricTypeViewSet(viewsets.ModelViewSet):
         include_utility = self.request.query_params.get("include_utility", "false").lower() == "true"
         if not include_utility:
             queryset = queryset.filter(is_utility=False)
+
+        metric_kind = self.request.query_params.get("metric_kind")
+        if metric_kind:
+            queryset = queryset.filter(metric_kind=metric_kind)
         return queryset
 
     def get_serializer_class(self):

--- a/iaso/locale/fr/LC_MESSAGES/django.po
+++ b/iaso/locale/fr/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-11 10:48+0000\n"
+"POT-Creation-Date: 2026-05-11 12:19+0000\n"
 "PO-Revision-Date: 2025-02-06 10:24+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -179,6 +179,10 @@ msgstr "Le CSV doit avoir au moins une ligne avec des valeurs."
 #: iaso/api/metrics/serializers.py
 msgid "The following org unit IDs do not exist: "
 msgstr "Ces IDs d'org unit n'existent pas:"
+
+#: iaso/api/metrics/serializers.py
+msgid "Year must be between 1900 and 2100."
+msgstr "L'année doit être entre 1900 et 2100,"
 
 #: iaso/api/microplanning/views.py
 msgid "Planning is missing sampling group or target org unit scope"

--- a/iaso/tests/api/metrics/test_serializers.py
+++ b/iaso/tests/api/metrics/test_serializers.py
@@ -12,7 +12,7 @@ from iaso.api.metrics.serializers import (
 )
 from iaso.models.base import Account
 from iaso.models.data_source import DataSource, SourceVersion
-from iaso.models.metric import MetricType
+from iaso.models.metric import MetricType, MetricValue
 from iaso.models.org_unit import OrgUnit, OrgUnitType
 from iaso.models.project import Project
 from iaso.test import TestCase
@@ -449,6 +449,16 @@ class ImportMetricValuesSerializerTestCase(TestCase):
             legend_config={"domain": [5, 15, 25], "range": ["#A2CAEA", "#ACDF9B", "#F5F1A0"]},
         )
 
+        cls.mt_population = MetricType.objects.create(
+            account=cls.account,
+            code="POP",
+            name="Population",
+            category="Demographics",
+            legend_type="linear",
+            metric_kind="population",
+            legend_config={"domain": [1000, 10000], "range": ["#A2CAEA", "#ACDF9B"]},
+        )
+
         # Create Org Units
         cls.project = project = Project.objects.create(
             name="Project",
@@ -517,55 +527,70 @@ class ImportMetricValuesSerializerTestCase(TestCase):
     def test_validate_metric_types_all_exist(self):
         csv_content = f"ADM1_NAME,ADM2_NAME,ADM2_ID,MT1\nDISTRICT,District 1,{self.district1.id},1\nDISTRICT,District 2,{self.district2.id},20"
         valid_file = SimpleUploadedFile("test.csv", csv_content.encode(), content_type="text/csv")
-        serializer = ImportMetricValuesSerializer(data={"file": valid_file}, context={"request": self.request})
+        serializer = ImportMetricValuesSerializer(
+            data={"file": valid_file, "year": 2024}, context={"request": self.request}
+        )
         self.assertTrue(serializer.is_valid())
-        self.assertEqual(len(serializer.context["metric_values"]), 2)
 
     def test_validate_wrong_file_type(self):
         invalid_file = SimpleUploadedFile("test.txt", b"Some text content", content_type="text/plain")
-        serializer = ImportMetricValuesSerializer(data={"file": invalid_file}, context={"request": self.request})
+        serializer = ImportMetricValuesSerializer(
+            data={"file": invalid_file, "year": 2024}, context={"request": self.request}
+        )
         self.assertFalse(serializer.is_valid())
         self.assertIn("The file must be a CSV.", serializer.errors["file"][0])
 
     def test_validate_metric_types_some_missing(self):
         csv_content = "ADM1_NAME,ADM2_NAME,ADM2_ID,MT3\nCOMOE,DS BANFORA,738,1"
         invalid_file = SimpleUploadedFile("test.csv", csv_content.encode(), content_type="text/csv")
-        serializer = ImportMetricValuesSerializer(data={"file": invalid_file}, context={"request": self.request})
+        serializer = ImportMetricValuesSerializer(
+            data={"file": invalid_file, "year": 2024}, context={"request": self.request}
+        )
         self.assertFalse(serializer.is_valid())
         self.assertIn("The following metric types do not exist: MT3", serializer.errors["file"][0])
 
     def test_validate_no_metric_type(self):
         csv_content = "ADM1_NAME,ADM2_NAME,ADM2_ID\n"
         invalid_file = SimpleUploadedFile("test.csv", csv_content.encode(), content_type="text/csv")
-        serializer = ImportMetricValuesSerializer(data={"file": invalid_file}, context={"request": self.request})
+        serializer = ImportMetricValuesSerializer(
+            data={"file": invalid_file, "year": 2024}, context={"request": self.request}
+        )
         self.assertFalse(serializer.is_valid())
         self.assertIn("The CSV must contain at least one metric type column.", serializer.errors["file"][0])
 
     def test_validate_missing_required_headers(self):
         csv_content = "MT1\nCOMOE,738,1"
         invalid_file = SimpleUploadedFile("test.csv", csv_content.encode(), content_type="text/csv")
-        serializer = ImportMetricValuesSerializer(data={"file": invalid_file}, context={"request": self.request})
+        serializer = ImportMetricValuesSerializer(
+            data={"file": invalid_file, "year": 2024}, context={"request": self.request}
+        )
         self.assertFalse(serializer.is_valid())
         self.assertIn("The CSV must contain 'ADM1_NAME, ADM2_NAME, ADM2_ID' columns.", serializer.errors["file"][0])
 
     def test_validate_no_row(self):
         csv_content = "ADM1_NAME,ADM2_NAME,ADM2_ID,MT2"
         invalid_file = SimpleUploadedFile("test.csv", csv_content.encode(), content_type="text/csv")
-        serializer = ImportMetricValuesSerializer(data={"file": invalid_file}, context={"request": self.request})
+        serializer = ImportMetricValuesSerializer(
+            data={"file": invalid_file, "year": 2024}, context={"request": self.request}
+        )
         self.assertFalse(serializer.is_valid())
         self.assertIn("The CSV must contain at least one value row.", serializer.errors["file"][0])
 
     def test_validate_missing_org_unit_ids(self):
         csv_content = "ADM1_NAME,ADM2_NAME,ADM2_ID,MT1\nCOMOE,DS BANFORA,9999,1"
         invalid_file = SimpleUploadedFile("test.csv", csv_content.encode(), content_type="text/csv")
-        serializer = ImportMetricValuesSerializer(data={"file": invalid_file}, context={"request": self.request})
+        serializer = ImportMetricValuesSerializer(
+            data={"file": invalid_file, "year": 2024}, context={"request": self.request}
+        )
         self.assertFalse(serializer.is_valid())
         self.assertIn("The following org unit IDs do not exist: 9999", serializer.errors["file"][0])
 
     def test_validate_invalid_org_units(self):
         csv_content = f"ADM1_NAME,ADM2_NAME,ADM2_ID,MT1\nDISTRICT,District Rejected,{self.district_rejected.id},1\nDISTRICT,District New,{self.district_new.id},1\nDISTRICT,District Wrong Version,{self.district_wrong_version.id},1\nDISTRICT,District No Location,{self.district_no_location.id},1"
         invalid_file = SimpleUploadedFile("test.csv", csv_content.encode(), content_type="text/csv")
-        serializer = ImportMetricValuesSerializer(data={"file": invalid_file}, context={"request": self.request})
+        serializer = ImportMetricValuesSerializer(
+            data={"file": invalid_file, "year": 2024}, context={"request": self.request}
+        )
         self.assertFalse(serializer.is_valid())
         error_message = serializer.errors["file"][0]
         self.assertIn("The following org unit IDs do not exist: ", error_message)
@@ -573,6 +598,129 @@ class ImportMetricValuesSerializerTestCase(TestCase):
         self.assertIn(str(self.district_new.id), error_message)
         self.assertIn(str(self.district_wrong_version.id), error_message)
         self.assertIn(str(self.district_no_location.id), error_message)
+
+    def test_validate_missing_year(self):
+        csv_content = f"ADM1_NAME,ADM2_NAME,ADM2_ID,MT1\nDISTRICT,District 1,{self.district1.id},1"
+        valid_file = SimpleUploadedFile("test.csv", csv_content.encode(), content_type="text/csv")
+        serializer = ImportMetricValuesSerializer(data={"file": valid_file}, context={"request": self.request})
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("This field is required.", serializer.errors["year"][0])
+
+    def test_validate_year_not_integer(self):
+        csv_content = f"ADM1_NAME,ADM2_NAME,ADM2_ID,MT1\nDISTRICT,District 1,{self.district1.id},1"
+        valid_file = SimpleUploadedFile("test.csv", csv_content.encode(), content_type="text/csv")
+        serializer = ImportMetricValuesSerializer(
+            data={"file": valid_file, "year": "not an integer"}, context={"request": self.request}
+        )
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("A valid integer is required.", serializer.errors["year"][0])
+
+    def test_validate_year_out_of_range(self):
+        csv_content = f"ADM1_NAME,ADM2_NAME,ADM2_ID,MT1\nDISTRICT,District 1,{self.district1.id},1"
+        valid_file = SimpleUploadedFile("test.csv", csv_content.encode(), content_type="text/csv")
+        serializer = ImportMetricValuesSerializer(
+            data={"file": valid_file, "year": 1800}, context={"request": self.request}
+        )
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("Year must be between 1900 and 2100.", serializer.errors["year"][0])
+
+        valid_file.seek(0)
+        serializer = ImportMetricValuesSerializer(
+            data={"file": valid_file, "year": 2101}, context={"request": self.request}
+        )
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("Year must be between 1900 and 2100.", serializer.errors["year"][0])
+
+    def test_validate_save_valid_file(self):
+        csv_content = f"ADM1_NAME,ADM2_NAME,ADM2_ID,MT1,MT2,POP\nDISTRICT,District 1,{self.district1.id},1,5,15000\nDISTRICT,District 2,{self.district2.id},20,15,20000"
+        valid_file = SimpleUploadedFile("test.csv", csv_content.encode(), content_type="text/csv")
+        serializer = ImportMetricValuesSerializer(
+            data={"file": valid_file, "year": 2024},
+            context={"request": self.request},
+        )
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        metric_values = serializer.save()
+        self.assertEqual(len(metric_values), 6)
+        mv1 = metric_values[0]
+        mv2 = metric_values[1]
+        mv_population_1 = metric_values[2]
+        mv3 = metric_values[3]
+        mv4 = metric_values[4]
+        mv_population_2 = metric_values[5]
+
+        self.assertEqual(mv1.metric_type, self.mt_1)
+        self.assertEqual(mv1.org_unit, self.district1)
+        self.assertEqual(mv1.year, None)
+        self.assertEqual(mv1.value, 1)
+        self.assertEqual(mv1.string_value, "")
+
+        self.assertEqual(mv2.metric_type, self.mt_2)
+        self.assertEqual(mv2.org_unit, self.district1)
+        self.assertEqual(mv2.year, None)
+        self.assertEqual(mv2.value, 5)
+        self.assertEqual(mv2.string_value, "")
+
+        self.assertEqual(mv_population_1.metric_type, self.mt_population)
+        self.assertEqual(mv_population_1.org_unit, self.district1)
+        self.assertEqual(mv_population_1.year, 2024)
+        self.assertEqual(mv_population_1.value, 15000)
+        self.assertEqual(mv_population_1.string_value, "")
+
+        self.assertEqual(mv3.metric_type, self.mt_1)
+        self.assertEqual(mv3.org_unit, self.district2)
+        self.assertEqual(mv3.year, None)
+        self.assertEqual(mv3.value, 20)
+        self.assertEqual(mv3.string_value, "")
+
+        self.assertEqual(mv4.metric_type, self.mt_2)
+        self.assertEqual(mv4.org_unit, self.district2)
+        self.assertEqual(mv4.year, None)
+        self.assertEqual(mv4.value, 15)
+        self.assertEqual(mv4.string_value, "")
+
+        self.assertEqual(mv_population_2.metric_type, self.mt_population)
+        self.assertEqual(mv_population_2.org_unit, self.district2)
+        self.assertEqual(mv_population_2.year, 2024)
+        self.assertEqual(mv_population_2.value, 20000)
+        self.assertEqual(mv_population_2.string_value, "")
+
+    def test_save_other_year_doesnt_override(self):
+        csv_content = f"ADM1_NAME,ADM2_NAME,ADM2_ID,MT1,MT2,POP\nDISTRICT,District 1,{self.district1.id},1,5,15000\nDISTRICT,District 2,{self.district2.id},20,15,20000"
+        valid_file = SimpleUploadedFile("test.csv", csv_content.encode(), content_type="text/csv")
+        serializer = ImportMetricValuesSerializer(
+            data={"file": valid_file, "year": 2024},
+            context={"request": self.request},
+        )
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+
+        csv_content_2 = f"ADM1_NAME,ADM2_NAME,ADM2_ID,MT1,MT2,POP\nDISTRICT,District 1,{self.district1.id},1,5,12000\nDISTRICT,District 2,{self.district2.id},20,15,15000"
+        valid_file_2 = SimpleUploadedFile("test.csv", csv_content_2.encode(), content_type="text/csv")
+
+        serializer_2 = ImportMetricValuesSerializer(
+            data={"file": valid_file_2, "year": 2025},
+            context={"request": self.request},
+        )
+        serializer_2.is_valid(raise_exception=True)
+        serializer_2.save()
+
+        ou1_2024_population = MetricValue.objects.filter(
+            metric_type__code="POP", org_unit=self.district1, year=2024
+        ).first()
+        ou2_2024_population = MetricValue.objects.filter(
+            metric_type__code="POP", org_unit=self.district2, year=2024
+        ).first()
+        ou1_2025_population = MetricValue.objects.filter(
+            metric_type__code="POP", org_unit=self.district1, year=2025
+        ).first()
+        ou2_2025_population = MetricValue.objects.filter(
+            metric_type__code="POP", org_unit=self.district2, year=2025
+        ).first()
+
+        self.assertEqual(ou1_2024_population.value, 15000)
+        self.assertEqual(ou2_2024_population.value, 20000)
+        self.assertEqual(ou1_2025_population.value, 12000)
+        self.assertEqual(ou2_2025_population.value, 15000)
 
 
 class OrgUnitIdSerializerTestCase(TestCase):

--- a/iaso/tests/api/metrics/test_views.py
+++ b/iaso/tests/api/metrics/test_views.py
@@ -169,6 +169,25 @@ class MetricTypeAPITestCase(APITestCase):
         utility_metric = next(item for item in data if item["code"] == "POP001")
         self.assertEqual(utility_metric["metric_kind"], "population")
 
+    def test_metric_type_list_filter_by_metric_kind(self):
+        MetricType.objects.create(
+            account=self.account,
+            code="POP001",
+            name="Population Metric",
+            description="Utility metric",
+            category="Population",
+            is_utility=False,
+            metric_kind="population",
+            origin=MetricType.MetricTypeOrigin.OPENHEXA.value,
+        )
+
+        self.client.force_authenticate(self.user)
+        response = self.client.get(f"{self.BASE_URL}?metric_kind=population")
+        data = self.assertJSONResponse(response, status.HTTP_200_OK)
+
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]["code"], "POP001")
+
     def test_metric_type_update_unauthenticated(self):
         payload = {
             "code": "MT001",

--- a/plugins/polio/locale/fr/LC_MESSAGES/django.po
+++ b/plugins/polio/locale/fr/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-07 12:16+0000\n"
+"POT-Creation-Date: 2026-05-11 12:19+0000\n"
 "PO-Revision-Date: 2025-02-05 14:43+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -418,6 +418,14 @@ msgid "Not Required"
 msgstr "Non requis"
 
 #: plugins/polio/models/base.py
+msgid "Temporary"
+msgstr "Temporaire"
+
+#: plugins/polio/models/base.py
+msgid "Received"
+msgstr "Reçu"
+
+#: plugins/polio/models/base.py
 msgid "VVM reached the discard point"
 msgstr "La VVM a atteint le point de rejet"
 
@@ -460,14 +468,6 @@ msgstr "Compte-gouttes manquants"
 #: plugins/polio/models/base.py
 msgid "Created"
 msgstr "Créé"
-
-#: plugins/polio/models/base.py
-msgid "Temporary"
-msgstr "Temporaire"
-
-#: plugins/polio/models/base.py
-msgid "Received"
-msgstr "Reçu"
 
 #: plugins/polio/models/base.py
 msgid "Used"


### PR DESCRIPTION
## What problem is this PR solving?

Allow to create custom population metric and set the year for which it is provided.

### Related JIRA tickets

SNT-457

## Changes

- Allow to filter metrics by metric kind
- Add the metric_kind and a year when uploading metrics from CSV
- Moved logic from view to the save of the serializer

## How to test

Not testable here but on SNT related PR: https://github.com/BLSQ/snt-malaria/pull/287

## Print screen / video

N/A

## Notes

Related SNT PR: https://github.com/BLSQ/snt-malaria/pull/287

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).
