### PR TITLE
IA-4001 Add  test for data source read-only toggle

### DIFF
--- a/iaso/tests/api/test_data_sources.py
+++ b/iaso/tests/api/test_data_sources.py
@@ -286,7 +286,7 @@ class DataSourcesAPITestCase(APITestCase):
         response = self.client.get("/api/datasources/dropdown/?order=name")
         self.assertJSONResponse(response, 403)
 
-     def test_datasource_update_can_unset_read_only(self):
+    def test_datasource_update_can_unset_read_only(self):
         self.client.force_authenticate(self.joe)
         self.data_source.read_only = True
         self.data_source.save()

--- a/iaso/tests/api/test_data_sources.py
+++ b/iaso/tests/api/test_data_sources.py
@@ -315,3 +315,29 @@ class DataSourcesAPITestCase(APITestCase):
         response = self.client.get(f"/api/datasources/{self.data_source.id}/")
         json_response = self.assertJSONResponse(response, 200)
         self.assertFalse(json_response["read_only"])
+
+    def test_datasource_update_without_read_only_does_not_alter_it(self):
+        self.client.force_authenticate(self.joe)
+        self.data_source.read_only = True
+        self.data_source.save()
+
+        data = {
+            "id": self.data_source.id,
+            "name": self.data_source.name,
+            "credentials": None,
+            "description": self.data_source.description,
+            "created_at": None,
+            "updated_at": None,
+            "default_version": None,
+            "tree_config_status_fields": self.data_source.tree_config_status_fields,
+            "projects": None,
+            "versions": None,
+            "url": None,
+        }
+
+        response = self.client.put(f"/api/datasources/{self.data_source.id}/", format="json", data=data)
+        json_response = self.assertJSONResponse(response, 200)
+
+        self.assertTrue(json_response["read_only"])
+        self.data_source.refresh_from_db()
+        self.assertTrue(self.data_source.read_only)

--- a/iaso/tests/api/test_data_sources.py
+++ b/iaso/tests/api/test_data_sources.py
@@ -285,3 +285,33 @@ class DataSourcesAPITestCase(APITestCase):
         self.client.force_authenticate(self.jim)
         response = self.client.get("/api/datasources/dropdown/?order=name")
         self.assertJSONResponse(response, 403)
+
+     def test_datasource_update_can_unset_read_only(self):
+        self.client.force_authenticate(self.joe)
+        self.data_source.read_only = True
+        self.data_source.save()
+        data = {
+            "id": self.data_source.id,
+            "name": self.data_source.name,
+            "read_only": False,
+            "credentials": None,
+            "description": self.data_source.description,
+            "created_at": None,
+            "updated_at": None,
+            "default_version": None,
+            "tree_config_status_fields": self.data_source.tree_config_status_fields,
+            "projects": None,
+            "versions": None,
+            "url": None,
+        }
+
+        response = self.client.put(f"/api/datasources/{self.data_source.id}/", format="json", data=data)
+        json_response = self.assertJSONResponse(response, 200)
+
+        self.assertFalse(json_response["read_only"])
+        self.data_source.refresh_from_db()
+        self.assertFalse(self.data_source.read_only)
+
+        response = self.client.get(f"/api/datasources/{self.data_source.id}/")
+        json_response = self.assertJSONResponse(response, 200)
+        self.assertFalse(json_response["read_only"])


### PR DESCRIPTION
## What problem is this PR solving?

Add a regression test for updating a data source from read-only back to editable.

### Related JIRA tickets

IA-4001

## Changes

Added a backend API test covering the `read_only=True -> False` update case for data sources.

The test verifies that:
- the update request succeeds
- `read_only=False` is persisted in DB
- a later GET still returns `read_only: false`
 
## How to test

aso.tests.api.test_data_sources 