### PR TITLE
Feature SNT-374: public account creation additions

### DIFF
--- a/hat/urls.py
+++ b/hat/urls.py
@@ -13,7 +13,7 @@ from django.urls import include, path
 from django.views.generic import RedirectView, TemplateView
 from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView, SpectacularSwaggerView
 
-from iaso.auth.views import IasoPasswordResetView
+from iaso.auth.views import IasoLogoutView, IasoPasswordResetView
 from iaso.views import ModelDataView, health, health_clamav, page, robots_txt
 
 
@@ -90,7 +90,7 @@ else:
         path("api/", include("iaso.urls")),
         path("pages/<page_slug>/", page, name="pages"),
         path("i18n/", include("django.conf.urls.i18n")),
-        path("logout-iaso", auth.views.LogoutView.as_view(next_page="/login/"), name="logout-iaso"),
+        path("logout-iaso", IasoLogoutView.as_view(next_page="/login/"), name="logout-iaso"),
         path(
             "forgot-password/",
             IasoPasswordResetView.as_view(

--- a/iaso/api/profiles/serializers/update.py
+++ b/iaso/api/profiles/serializers/update.py
@@ -15,7 +15,25 @@ class BaseProfileUpdateSerializer(ModelSerializer):
 
 
 class ProfileMeUpdateSerializer(BaseProfileUpdateSerializer):
-    pass
+    """
+    Serializer used by `PATCH /api/profiles/me/`.
+
+    Any logged-in user can update a small set of self-service fields without
+    holding any user-admin permission (see `HasProfilePermission`, which
+    short-circuits when `pk == PK_ME`).
+
+    `first_name`, `last_name` and `email` live on the `User` model rather than
+    on `Profile`. They are declared here as plain serializer fields (matching
+    the pattern in `ProfileUpdateSerializer`) and written back to the user by
+    `ProfilesViewSet._post_update_user` when they appear in `validated_data`.
+    """
+
+    email = serializers.EmailField(required=False, allow_blank=True, write_only=True)
+    first_name = serializers.CharField(required=False, allow_blank=True, write_only=True, max_length=150)
+    last_name = serializers.CharField(required=False, allow_blank=True, write_only=True, max_length=150)
+
+    class Meta(BaseProfileUpdateSerializer.Meta):
+        fields = BaseProfileUpdateSerializer.Meta.fields + ["first_name", "last_name", "email"]
 
 
 class ProfileUpdateSerializer(BaseProfileUpdateSerializer):

--- a/iaso/auth/views.py
+++ b/iaso/auth/views.py
@@ -1,5 +1,7 @@
-from django.contrib.auth.views import PasswordResetView
+from django.conf import settings
+from django.contrib.auth.views import LogoutView, PasswordResetView
 from django.contrib.sites.shortcuts import get_current_site
+from django.utils.http import url_has_allowed_host_and_scheme
 
 from iaso.mail.branding import core_email_branding_context
 
@@ -12,3 +14,36 @@ class IasoPasswordResetView(PasswordResetView):
         domain = get_current_site(self.request).domain
         self.extra_email_context = core_email_branding_context(protocol=protocol, domain=domain)
         return super().form_valid(form)
+
+
+class IasoLogoutView(LogoutView):
+    """LogoutView that honours ``?next=<path>`` only when it appears in
+    ``settings.LOGOUT_NEXT_ALLOWED_PATHS`` (and is a same-host relative URL).
+    Anything else falls back to ``next_page``.
+
+    Strict allow-listing (rather than just a same-host check) closes
+    CWE-601 / OWASP "Unvalidated Redirects and Forwards": an internal page
+    on the same host can still be weaponised for phishing.
+
+    Plugins extend the allow-list via their ``plugin_settings.CONSTANTS``.
+    """
+
+    def get_redirect_url(self):
+        candidate = (
+            self.request.POST.get(self.redirect_field_name) or self.request.GET.get(self.redirect_field_name) or ""
+        )
+        if candidate and self._is_allowed(candidate):
+            return candidate
+        # Returning "" makes ``get_success_url`` fall through to
+        # ``get_default_redirect_url`` (which uses ``next_page``).
+        return ""
+
+    def _is_allowed(self, candidate: str) -> bool:
+        allowed = set(getattr(settings, "LOGOUT_NEXT_ALLOWED_PATHS", []))
+        if candidate not in allowed:
+            return False
+        return url_has_allowed_host_and_scheme(
+            candidate,
+            allowed_hosts={self.request.get_host()},
+            require_https=self.request.is_secure(),
+        )

--- a/iaso/tests/api/profiles/test_views/test_update.py
+++ b/iaso/tests/api/profiles/test_views/test_update.py
@@ -872,3 +872,58 @@ class ProfileUpdateAPITestCase(BaseProfileAPITestCase):
         response = self.client.patch(reverse("profiles-detail", kwargs={"pk": jim.id}), data=data, format="json")
 
         self.assertJSONResponse(response, 200)
+
+    def test_me_endpoint_updates_own_first_last_name_and_email(self):
+        """A user with no admin permission can update their own name and email via `/me/`."""
+        # `jom` has no permissions at all (see common.py).
+        self.client.force_authenticate(self.jom)
+        new_data = {
+            "first_name": "Jom",
+            "last_name": "Doe",
+            "email": "jom@example.org",
+        }
+        response = self.client.patch(reverse("profiles-detail", kwargs={"pk": PK_ME}), data=new_data, format="json")
+        self.assertJSONResponse(response, 200)
+
+        self.jom.refresh_from_db()
+        self.assertEqual(self.jom.first_name, "Jom")
+        self.assertEqual(self.jom.last_name, "Doe")
+        self.assertEqual(self.jom.email, "jom@example.org")
+
+    def test_me_endpoint_persists_user_and_profile_fields_in_one_patch(self):
+        """A single PATCH writes both `User` fields (e.g. `first_name`) and `Profile` fields (e.g. `language`)."""
+        self.client.force_authenticate(self.jom)
+        new_data = {"first_name": "Jom", "language": "en"}
+        response = self.client.patch(reverse("profiles-detail", kwargs={"pk": PK_ME}), data=new_data, format="json")
+        self.assertJSONResponse(response, 200)
+
+        self.jom.refresh_from_db()
+        self.jom.iaso_profile.refresh_from_db()
+        self.assertEqual(self.jom.first_name, "Jom")
+        self.assertEqual(self.jom.iaso_profile.language, "en")
+
+    def test_me_endpoint_rejects_invalid_email(self):
+        self.client.force_authenticate(self.jom)
+        response = self.client.patch(
+            reverse("profiles-detail", kwargs={"pk": PK_ME}),
+            data={"email": "not-an-email"},
+            format="json",
+        )
+        self.assertJSONResponse(response, 400)
+
+    def test_me_endpoint_ignores_fields_outside_the_self_service_allow_list(self):
+        """`PATCH /api/profiles/me/` silently drops fields not in its allow-list, so a user cannot self-grant permissions."""
+        self.client.force_authenticate(self.jom)
+        self.assertEqual(self.jom.user_permissions.count(), 0)
+        response = self.client.patch(
+            reverse("profiles-detail", kwargs={"pk": PK_ME}),
+            data={
+                "first_name": "Jom",
+                "user_permissions": [CORE_USERS_ADMIN_PERMISSION.codename],
+            },
+            format="json",
+        )
+        self.assertJSONResponse(response, 200)
+        self.jom.refresh_from_db()
+        self.assertEqual(self.jom.first_name, "Jom")
+        self.assertEqual(self.jom.user_permissions.count(), 0)

--- a/iaso/tests/auth/test_logout_view.py
+++ b/iaso/tests/auth/test_logout_view.py
@@ -1,0 +1,68 @@
+from django.contrib.auth import get_user_model
+from django.test import override_settings
+from django.urls import reverse
+
+from iaso.test import TestCase
+
+
+User = get_user_model()
+
+
+@override_settings(LOGOUT_NEXT_ALLOWED_PATHS=["/example/allowed-target"])
+class IasoLogoutViewTestCase(TestCase):
+    """Tests for IasoLogoutView's allow-listed ``next`` behaviour."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create_user(username="logout_user", password="hunter2")
+
+    def setUp(self):
+        self.client.force_login(self.user)
+        self.logout_url = reverse("logout-iaso")
+
+    def test_default_redirect_when_no_next(self):
+        response = self.client.get(self.logout_url)
+        self.assertRedirects(response, "/login/", fetch_redirect_response=False)
+
+    def test_redirects_to_allowed_next(self):
+        response = self.client.get(self.logout_url, {"next": "/example/allowed-target"})
+        self.assertRedirects(response, "/example/allowed-target", fetch_redirect_response=False)
+
+    def test_falls_back_when_next_not_in_allowlist(self):
+        response = self.client.get(self.logout_url, {"next": "/dashboard/"})
+        self.assertRedirects(response, "/login/", fetch_redirect_response=False)
+
+    def test_falls_back_when_next_is_absolute_url(self):
+        response = self.client.get(self.logout_url, {"next": "https://evil.example.com/example/allowed-target"})
+        self.assertRedirects(response, "/login/", fetch_redirect_response=False)
+
+    def test_falls_back_when_next_has_protocol_relative_host(self):
+        response = self.client.get(self.logout_url, {"next": "//evil.example.com/"})
+        self.assertRedirects(response, "/login/", fetch_redirect_response=False)
+
+    def test_post_with_allowed_next(self):
+        response = self.client.post(self.logout_url, data={"next": "/example/allowed-target"})
+        self.assertRedirects(response, "/example/allowed-target", fetch_redirect_response=False)
+
+    def test_user_is_logged_out(self):
+        self.client.get(self.logout_url, {"next": "/example/allowed-target"})
+        # Subsequent request to a login-required endpoint should not show the user as authenticated.
+        response = self.client.get("/api/profiles/me/")
+        self.assertIn(response.status_code, (401, 403))
+
+
+@override_settings(LOGOUT_NEXT_ALLOWED_PATHS=[])
+class IasoLogoutViewWithoutAllowlistTestCase(TestCase):
+    """When the allow-list is empty, every ``next`` value falls back to ``next_page``."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create_user(username="logout_user_no_allowlist", password="hunter2")
+
+    def setUp(self):
+        self.client.force_login(self.user)
+        self.logout_url = reverse("logout-iaso")
+
+    def test_any_next_falls_back(self):
+        response = self.client.get(self.logout_url, {"next": "/example/allowed-target"})
+        self.assertRedirects(response, "/login/", fetch_redirect_response=False)


### PR DESCRIPTION
## What problem is this PR solving?

* Custom `?next=<path>` redirect after `/logout-iaso`
* Permission-free PATCH of `first_name`, `last_name`, `email` for logged-in users

### Related JIRA tickets

SNT-374

## Changes

This PR covers two changes which are prerequisites for the public account creation in SNT Malaria

### Custom `?next=<path>` redirect after `/logout-iaso`

The custom `?next=<path>` redirect after logout is for a use case where account creation was not successful. We log the user out and redirect them to the public account creation to start over if they want to. Without this, the user would see the login page instead.

Technically this is achieved by subclassing Django's default `LogoutView` as a backwards-compatible drop-in for the `/logout-iaso` endpoint.

Since this is a potential attack vector (see [CWE-601](https://cwe.mitre.org/data/definitions/601.html)), only allow-listed redirects (`settings.LOGOUT_NEXT_ALLOWED_PATHS`) are being followed.

### Permission-free PATCH of `first_name`, `last_name`, `email` for logged-in users

This  simply allows any logged-in user to `PATCH` their own `first_name`, `last_name` and `email` which is required by our account-creation wizard.