### PR TITLE
[IA-4777] set valid status by default

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/home/hooks/useGetOrgunitsExtraPath.ts
+++ b/hat/assets/js/apps/Iaso/domains/home/hooks/useGetOrgunitsExtraPath.ts
@@ -15,5 +15,5 @@ export const useGetOrgunitsExtraPath = (): string => {
         sourceOrVersionParam = `,"source":${defaultSourceVersion.source.id}`;
     }
 
-    return `/locationLimit/${locationLimitMax}/order/id/pageSize/20/page/1/searchTabIndex/0/searches/[{"validation_status":"all","color":"${defaultColor}"${sourceOrVersionParam}}]`;
+    return `/locationLimit/${locationLimitMax}/order/id/pageSize/20/page/1/searchTabIndex/0/searches/[{"validation_status":"VALID","color":"${defaultColor}"${sourceOrVersionParam}}]`;
 };

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitFiltersContainer.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitFiltersContainer.tsx
@@ -167,7 +167,7 @@ export const OrgUnitFiltersContainer: FunctionComponent<Props> = ({
     );
     const defaultItem = useMemo(
         () => ({
-            validation_status: 'all',
+            validation_status: 'VALID',
             color: defaultColor.replace('#', ''),
             source: defaultSource && defaultSource.id,
             version: defaultVersion?.id,

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/details.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/details.tsx
@@ -32,6 +32,7 @@ import {
 } from '../../utils/usersUtils';
 import { FormsTable } from '../forms/components/FormsTable';
 import { FormsParams } from '../forms/types/forms';
+import { useGetOrgunitsExtraPath } from '../home/hooks/useGetOrgunitsExtraPath';
 import { userHasPermission } from '../users/utils';
 import { OrgUnitBreadcrumbs } from './components/breadcrumbs/OrgUnitBreadcrumbs';
 import { OrgUnitForm } from './components/OrgUnitForm';
@@ -118,7 +119,8 @@ const tabs = [
 const OrgUnitDetail: FunctionComponent = () => {
     const classes: Record<string, string> = useStyles();
     const params = useParamsObject(baseUrl);
-    const goBack = useGoBack(baseUrls.orgUnits);
+    const orgUnitExtrapath = useGetOrgunitsExtraPath();
+    const goBack = useGoBack(`${baseUrls.orgUnits}/${orgUnitExtrapath}`);
     const { mutateAsync: saveOu, isLoading: savingOu } = useSaveOrgUnit();
     const queryClient = useQueryClient();
     const { formatMessage } = useSafeIntl();

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/hooks/useGetApiParams.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/hooks/useGetApiParams.ts
@@ -34,6 +34,8 @@ export const useGetApiParams = (
             getFromDateString(activeSearches[i].dateFrom) || undefined;
         tempSearches[i].dateTo =
             getToDateString(activeSearches[i].dateTo) || undefined;
+        tempSearches[i].validation_status =
+            tempSearches[i].validation_status ?? 'VALID';
     });
 
     const apiParams: ApiParams = {


### PR DESCRIPTION
## What problem is this PR solving?

This ticket is about setting the default value in the validation_status filter to `VALID` instead of `all`

### Related JIRA tickets

[IA-4777](https://bluesquare.atlassian.net/browse/IA-4777)

## Changes

- Changed the url variabl
- Fixed the go back buttons on the org units details page

## How to test

> Go to org unit lists, the table should filter the first search to valid ones only
> Go to org units details page
> Open the url of the details into another tab
> Go Back, and you should see the org units list

## Print screen / video

[Screencast from 11-05-26 16:47:47.webm](https://github.com/user-attachments/assets/71c3f26e-782a-4fe0-9f2d-a0cdcb11bb34)


[IA-4777]: https://bluesquare.atlassian.net/browse/IA-4777?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ