### PR TITLE
SNT-374: public account creation (prerequisites)

### DIFF
--- a/hat/settings.py
+++ b/hat/settings.py
@@ -459,6 +459,7 @@ PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))
 
 LOGIN_URL = "/login"
 LOGIN_REDIRECT_URL = "/"
+LOGOUT_REDIRECT_URL = "/login/"
 
 AUTH_CLASSES = [
     "rest_framework_simplejwt.authentication.JWTAuthentication",

--- a/hat/settings.py
+++ b/hat/settings.py
@@ -460,6 +460,8 @@ PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))
 LOGIN_URL = "/login"
 LOGIN_REDIRECT_URL = "/"
 LOGOUT_REDIRECT_URL = "/login/"
+# Extra paths IasoLogoutView accepts as ?next=... (in addition to the default).
+LOGOUT_NEXT_ALLOWED_PATHS = env.list("LOGOUT_NEXT_ALLOWED_PATHS", default=[], delimiter=",")
 
 AUTH_CLASSES = [
     "rest_framework_simplejwt.authentication.JWTAuthentication",

--- a/hat/urls.py
+++ b/hat/urls.py
@@ -95,7 +95,7 @@ else:
         path("api/etl/", include(("iaso.urls_etl", "api-etl"), namespace="api-etl")),
         path("pages/<page_slug>/", page, name="pages"),
         path("i18n/", include("django.conf.urls.i18n")),
-        path("logout-iaso", IasoLogoutView.as_view(next_page="/login/"), name="logout-iaso"),
+        path("logout-iaso", IasoLogoutView.as_view(), name="logout-iaso"),
         path(
             "forgot-password/",
             IasoPasswordResetView.as_view(

--- a/hat/urls.py
+++ b/hat/urls.py
@@ -13,7 +13,7 @@ from django.urls import include, path
 from django.views.generic import RedirectView, TemplateView
 from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView, SpectacularSwaggerView
 
-from iaso.auth.views import IasoPasswordResetView
+from iaso.auth.views import IasoLogoutView, IasoPasswordResetView
 from iaso.views import ModelDataView, health, health_clamav, page, robots_txt
 
 
@@ -95,7 +95,7 @@ else:
         path("api/etl/", include(("iaso.urls_etl", "api-etl"), namespace="api-etl")),
         path("pages/<page_slug>/", page, name="pages"),
         path("i18n/", include("django.conf.urls.i18n")),
-        path("logout-iaso", auth.views.LogoutView.as_view(next_page="/login/"), name="logout-iaso"),
+        path("logout-iaso", IasoLogoutView.as_view(next_page="/login/"), name="logout-iaso"),
         path(
             "forgot-password/",
             IasoPasswordResetView.as_view(

--- a/hat/urls.py
+++ b/hat/urls.py
@@ -13,7 +13,7 @@ from django.urls import include, path
 from django.views.generic import RedirectView, TemplateView
 from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView, SpectacularSwaggerView
 
-from iaso.auth.views import IasoPasswordResetView
+from iaso.auth.views import IasoLogoutView, IasoPasswordResetView
 from iaso.views import ModelDataView, health, health_clamav, page, robots_txt
 
 
@@ -90,7 +90,7 @@ else:
         path("api/", include("iaso.urls")),
         path("pages/<page_slug>/", page, name="pages"),
         path("i18n/", include("django.conf.urls.i18n")),
-        path("logout-iaso", auth.views.LogoutView.as_view(next_page="/login/"), name="logout-iaso"),
+        path("logout-iaso", IasoLogoutView.as_view(next_page="/login/"), name="logout-iaso"),
         path(
             "forgot-password/",
             IasoPasswordResetView.as_view(

--- a/iaso/api/profiles/serializers/update.py
+++ b/iaso/api/profiles/serializers/update.py
@@ -9,39 +9,29 @@ from iaso.models import OrgUnit, OrgUnitType, Profile, Project, TenantUser, User
 
 
 class BaseProfileUpdateSerializer(ModelSerializer):
-    class Meta:
-        model = Profile
-        fields = ["language", "home_page"]
-
-
-class ProfileMeUpdateSerializer(BaseProfileUpdateSerializer):
     """
-    Serializer used by `PATCH /api/profiles/me/`.
+    Base for profile PATCH serializers.
 
-    Any logged-in user can update a small set of self-service fields without
-    holding any user-admin permission (see `HasProfilePermission`, which
-    short-circuits when `pk == PK_ME`).
+    Used directly for ``PATCH /api/profiles/me/``: any authenticated user may
+    update this field set without user-admin permissions (see
+    ``HasProfilePermission`` when ``pk == PK_ME``).
 
-    `first_name`, `last_name` and `email` live on the `User` model rather than
-    on `Profile`. They are declared here as plain serializer fields (matching
-    the pattern in `ProfileUpdateSerializer`) and written back to the user by
-    `ProfilesViewSet._post_update_user` when they appear in `validated_data`.
+    ``first_name``, ``last_name`` and ``email`` live on ``User``;
+    ``ProfilesViewSet._post_update_user`` applies them when present in
+    ``validated_data``.
     """
 
     email = serializers.EmailField(required=False, allow_blank=True, write_only=True)
     first_name = serializers.CharField(required=False, allow_blank=True, write_only=True, max_length=150)
     last_name = serializers.CharField(required=False, allow_blank=True, write_only=True, max_length=150)
 
-    class Meta(BaseProfileUpdateSerializer.Meta):
-        fields = BaseProfileUpdateSerializer.Meta.fields + ["first_name", "last_name", "email"]
+    class Meta:
+        model = Profile
+        fields = ["language", "home_page", "first_name", "last_name", "email"]
 
 
 class ProfileUpdateSerializer(BaseProfileUpdateSerializer):
     _org_units_unchanged = False
-
-    email = serializers.EmailField(required=False, allow_blank=True, write_only=True)
-    first_name = serializers.CharField(required=False, allow_blank=True, write_only=True)
-    last_name = serializers.CharField(required=False, allow_blank=True, write_only=True)
 
     user_name = serializers.CharField(required=False, write_only=True)
 
@@ -78,11 +68,8 @@ class ProfileUpdateSerializer(BaseProfileUpdateSerializer):
     class Meta(BaseProfileUpdateSerializer.Meta):
         model = Profile
         fields = BaseProfileUpdateSerializer.Meta.fields + [
-            "first_name",
             "organization",
-            "last_name",
             "user_name",
-            "email",
             "color",
             "phone_number",
             "country_code",

--- a/iaso/api/profiles/serializers/update.py
+++ b/iaso/api/profiles/serializers/update.py
@@ -15,7 +15,25 @@ class BaseProfileUpdateSerializer(ModelSerializer):
 
 
 class ProfileMeUpdateSerializer(BaseProfileUpdateSerializer):
-    pass
+    """
+    Serializer used by `PATCH /api/profiles/me/`.
+
+    Any logged-in user can update a small set of self-service fields without
+    holding any user-admin permission (see `HasProfilePermission`, which
+    short-circuits when `pk == PK_ME`).
+
+    `first_name`, `last_name` and `email` live on the `User` model rather than
+    on `Profile`. They are declared here as plain serializer fields (matching
+    the pattern in `ProfileUpdateSerializer`) and written back to the user by
+    `ProfilesViewSet._post_update_user` when they appear in `validated_data`.
+    """
+
+    email = serializers.EmailField(required=False, allow_blank=True, write_only=True)
+    first_name = serializers.CharField(required=False, allow_blank=True, write_only=True, max_length=150)
+    last_name = serializers.CharField(required=False, allow_blank=True, write_only=True, max_length=150)
+
+    class Meta(BaseProfileUpdateSerializer.Meta):
+        fields = BaseProfileUpdateSerializer.Meta.fields + ["first_name", "last_name", "email"]
 
 
 class ProfileUpdateSerializer(BaseProfileUpdateSerializer):

--- a/iaso/api/profiles/views.py
+++ b/iaso/api/profiles/views.py
@@ -51,7 +51,7 @@ from iaso.api.profiles.serializers import (
     ProfileUserFallbackRetrieveSerializer,
 )
 from iaso.api.profiles.serializers.dropdown import ProfileDropdownSerializer
-from iaso.api.profiles.serializers.update import ProfileMeUpdateSerializer, ProfileUpdatePasswordSerializer
+from iaso.api.profiles.serializers.update import BaseProfileUpdateSerializer, ProfileUpdatePasswordSerializer
 from iaso.mail.branding import core_email_branding_context
 from iaso.models import OrgUnit, Profile, TenantUser, UserRole
 from iaso.permissions.core_permissions import CORE_USERS_ADMIN_PERMISSION, CORE_USERS_MANAGED_PERMISSION
@@ -76,7 +76,7 @@ class ProfilesViewSet(ModelViewSet):
     GET /api/profiles/export-csv/
     GET /api/profiles/export-xlsx/
     POST /api/profiles/
-    PATCH /api/profiles/me => current user, can only set language field
+    PATCH /api/profiles/me => current user (language, home page, name, email)
     PATCH /api/profiles/<id>
     DELETE /api/profiles/<id>
     DELETE /api/profiles/me => current user
@@ -113,7 +113,7 @@ class ProfilesViewSet(ModelViewSet):
             return ProfileListSerializer
         if self.action in ["update", "partial_update"]:
             if self.kwargs.get(self.lookup_url_kwarg or self.lookup_field, "") == PK_ME:
-                return ProfileMeUpdateSerializer
+                return BaseProfileUpdateSerializer
             return ProfileUpdateSerializer
         if self.action in ["update_password"]:
             return ProfileUpdatePasswordSerializer

--- a/iaso/auth/views.py
+++ b/iaso/auth/views.py
@@ -1,5 +1,7 @@
-from django.contrib.auth.views import PasswordResetView
+from django.conf import settings
+from django.contrib.auth.views import LogoutView, PasswordResetView
 from django.contrib.sites.shortcuts import get_current_site
+from django.utils.http import url_has_allowed_host_and_scheme
 
 from iaso.mail.branding import core_email_branding_context
 
@@ -12,3 +14,36 @@ class IasoPasswordResetView(PasswordResetView):
         domain = get_current_site(self.request).domain
         self.extra_email_context = core_email_branding_context(protocol=protocol, domain=domain)
         return super().form_valid(form)
+
+
+class IasoLogoutView(LogoutView):
+    """LogoutView that honours ``?next=<path>`` only when it appears in
+    ``settings.LOGOUT_NEXT_ALLOWED_PATHS`` (and is a same-host relative URL).
+    Anything else falls back to ``next_page``.
+
+    Strict allow-listing (rather than just a same-host check) closes
+    CWE-601 / OWASP "Unvalidated Redirects and Forwards": an internal page
+    on the same host can still be weaponised for phishing.
+
+    Plugins extend the allow-list via their ``plugin_settings.CONSTANTS``.
+    """
+
+    def get_redirect_url(self):
+        candidate = (
+            self.request.POST.get(self.redirect_field_name) or self.request.GET.get(self.redirect_field_name) or ""
+        )
+        if candidate and self._is_allowed(candidate):
+            return candidate
+        # Returning "" makes ``get_success_url`` fall through to
+        # ``get_default_redirect_url`` (which uses ``next_page``).
+        return ""
+
+    def _is_allowed(self, candidate: str) -> bool:
+        allowed = set(getattr(settings, "LOGOUT_NEXT_ALLOWED_PATHS", []))
+        if candidate not in allowed:
+            return False
+        return url_has_allowed_host_and_scheme(
+            candidate,
+            allowed_hosts={self.request.get_host()},
+            require_https=self.request.is_secure(),
+        )

--- a/iaso/auth/views.py
+++ b/iaso/auth/views.py
@@ -1,7 +1,6 @@
 from django.conf import settings
 from django.contrib.auth.views import LogoutView, PasswordResetView
 from django.contrib.sites.shortcuts import get_current_site
-from django.utils.http import url_has_allowed_host_and_scheme
 
 from iaso.mail.branding import core_email_branding_context
 
@@ -18,41 +17,22 @@ class IasoPasswordResetView(PasswordResetView):
 
 class IasoLogoutView(LogoutView):
     """LogoutView that honours ``?next=<path>`` only when it appears in
-    ``settings.LOGOUT_NEXT_ALLOWED_PATHS`` (and is a same-host relative URL).
-    Anything else falls back to the default redirect (``next_page`` or
-    ``settings.LOGOUT_REDIRECT_URL``).
+    ``settings.LOGOUT_NEXT_ALLOWED_PATHS``. Anything else falls back to
+    the default redirect (``next_page`` or ``settings.LOGOUT_REDIRECT_URL``).
 
-    Strict allow-listing (rather than just a same-host check) closes
-    CWE-601 / OWASP "Unvalidated Redirects and Forwards": an internal page
-    on the same host can still be weaponised for phishing.
+    Strict allow-listing (rather than just the same-host check Django's
+    ``LogoutView`` already does) closes CWE-601 / OWASP "Unvalidated
+    Redirects and Forwards": an internal page on the same host can still
+    be weaponised for phishing.
 
-    Plugins extend the allow-list via their ``plugin_settings.CONSTANTS``.
+    Allow-list entries are matched after trailing-slash normalisation, so
+    ``/foo`` and ``/foo/`` both match a configured ``/foo``.
     """
 
     def get_redirect_url(self):
-        candidate = (
-            self.request.POST.get(self.redirect_field_name) or self.request.GET.get(self.redirect_field_name) or ""
-        )
-        if candidate:
-            allowed_path = self._get_allowed_path(candidate)
-            if allowed_path:
-                return allowed_path
-        # Returning "" makes ``get_success_url`` fall through to
-        # ``get_default_redirect_url`` (which uses ``next_page``).
-        return ""
-
-    def _get_allowed_path(self, candidate: str) -> str:
-        """Return the matching allowlisted path, or empty string if not allowed.
-
-        Strips trailing slashes before comparison; returns the configured path.
-        """
-        normalized = candidate.rstrip("/")
-        allowed_paths = getattr(settings, "LOGOUT_NEXT_ALLOWED_PATHS", [])
-        for allowed_path in allowed_paths:
-            if normalized == allowed_path.rstrip("/") and url_has_allowed_host_and_scheme(
-                allowed_path,
-                allowed_hosts={self.request.get_host()},
-                require_https=self.request.is_secure(),
-            ):
-                return allowed_path
+        redirect = super().get_redirect_url()
+        normalized = redirect.rstrip("/")
+        allowlist = {p.rstrip("/") for p in settings.LOGOUT_NEXT_ALLOWED_PATHS}
+        if normalized and normalized in allowlist:
+            return normalized
         return ""

--- a/iaso/auth/views.py
+++ b/iaso/auth/views.py
@@ -19,7 +19,8 @@ class IasoPasswordResetView(PasswordResetView):
 class IasoLogoutView(LogoutView):
     """LogoutView that honours ``?next=<path>`` only when it appears in
     ``settings.LOGOUT_NEXT_ALLOWED_PATHS`` (and is a same-host relative URL).
-    Anything else falls back to ``next_page``.
+    Anything else falls back to the default redirect (``next_page`` or
+    ``settings.LOGOUT_REDIRECT_URL``).
 
     Strict allow-listing (rather than just a same-host check) closes
     CWE-601 / OWASP "Unvalidated Redirects and Forwards": an internal page

--- a/iaso/auth/views.py
+++ b/iaso/auth/views.py
@@ -33,18 +33,26 @@ class IasoLogoutView(LogoutView):
         candidate = (
             self.request.POST.get(self.redirect_field_name) or self.request.GET.get(self.redirect_field_name) or ""
         )
-        if candidate and self._is_allowed(candidate):
-            return candidate
+        if candidate:
+            allowed_path = self._get_allowed_path(candidate)
+            if allowed_path:
+                return allowed_path
         # Returning "" makes ``get_success_url`` fall through to
         # ``get_default_redirect_url`` (which uses ``next_page``).
         return ""
 
-    def _is_allowed(self, candidate: str) -> bool:
-        allowed = set(getattr(settings, "LOGOUT_NEXT_ALLOWED_PATHS", []))
-        if candidate not in allowed:
-            return False
-        return url_has_allowed_host_and_scheme(
-            candidate,
-            allowed_hosts={self.request.get_host()},
-            require_https=self.request.is_secure(),
-        )
+    def _get_allowed_path(self, candidate: str) -> str:
+        """Return the matching allowlisted path, or empty string if not allowed.
+
+        Strips trailing slashes before comparison; returns the configured path.
+        """
+        normalized = candidate.rstrip("/")
+        allowed_paths = getattr(settings, "LOGOUT_NEXT_ALLOWED_PATHS", [])
+        for allowed_path in allowed_paths:
+            if normalized == allowed_path.rstrip("/") and url_has_allowed_host_and_scheme(
+                allowed_path,
+                allowed_hosts={self.request.get_host()},
+                require_https=self.request.is_secure(),
+            ):
+                return allowed_path
+        return ""

--- a/iaso/tests/api/profiles/test_views/test_update.py
+++ b/iaso/tests/api/profiles/test_views/test_update.py
@@ -872,3 +872,58 @@ class ProfileUpdateAPITestCase(BaseProfileAPITestCase):
         response = self.client.patch(reverse("profiles-detail", kwargs={"pk": jim.id}), data=data, format="json")
 
         self.assertJSONResponse(response, 200)
+
+    def test_me_endpoint_updates_own_first_last_name_and_email(self):
+        """A user with no admin permission can update their own name and email via `/me/`."""
+        # `jom` has no permissions at all (see common.py).
+        self.client.force_authenticate(self.jom)
+        new_data = {
+            "first_name": "Jom",
+            "last_name": "Doe",
+            "email": "jom@example.org",
+        }
+        response = self.client.patch(reverse("profiles-detail", kwargs={"pk": PK_ME}), data=new_data, format="json")
+        self.assertJSONResponse(response, 200)
+
+        self.jom.refresh_from_db()
+        self.assertEqual(self.jom.first_name, "Jom")
+        self.assertEqual(self.jom.last_name, "Doe")
+        self.assertEqual(self.jom.email, "jom@example.org")
+
+    def test_me_endpoint_persists_user_and_profile_fields_in_one_patch(self):
+        """A single PATCH writes both `User` fields (e.g. `first_name`) and `Profile` fields (e.g. `language`)."""
+        self.client.force_authenticate(self.jom)
+        new_data = {"first_name": "Jom", "language": "en"}
+        response = self.client.patch(reverse("profiles-detail", kwargs={"pk": PK_ME}), data=new_data, format="json")
+        self.assertJSONResponse(response, 200)
+
+        self.jom.refresh_from_db()
+        self.jom.iaso_profile.refresh_from_db()
+        self.assertEqual(self.jom.first_name, "Jom")
+        self.assertEqual(self.jom.iaso_profile.language, "en")
+
+    def test_me_endpoint_rejects_invalid_email(self):
+        self.client.force_authenticate(self.jom)
+        response = self.client.patch(
+            reverse("profiles-detail", kwargs={"pk": PK_ME}),
+            data={"email": "not-an-email"},
+            format="json",
+        )
+        self.assertJSONResponse(response, 400)
+
+    def test_me_endpoint_ignores_fields_outside_the_self_service_allow_list(self):
+        """`PATCH /api/profiles/me/` silently drops fields not in its allow-list, so a user cannot self-grant permissions."""
+        self.client.force_authenticate(self.jom)
+        self.assertEqual(self.jom.user_permissions.count(), 0)
+        response = self.client.patch(
+            reverse("profiles-detail", kwargs={"pk": PK_ME}),
+            data={
+                "first_name": "Jom",
+                "user_permissions": [CORE_USERS_ADMIN_PERMISSION.codename],
+            },
+            format="json",
+        )
+        self.assertJSONResponse(response, 200)
+        self.jom.refresh_from_db()
+        self.assertEqual(self.jom.first_name, "Jom")
+        self.assertEqual(self.jom.user_permissions.count(), 0)

--- a/iaso/tests/auth/test_logout_view.py
+++ b/iaso/tests/auth/test_logout_view.py
@@ -50,6 +50,20 @@ class IasoLogoutViewTestCase(TestCase):
         response = self.client.get("/api/profiles/me/")
         self.assertIn(response.status_code, (401, 403))
 
+    # Edge cases: paths are normalized before matching.
+    def test_trailing_slash_normalized(self):
+        """Trailing slashes are stripped before matching."""
+        response = self.client.get(self.logout_url, {"next": "/example/allowed-target/"})
+        self.assertRedirects(response, "/example/allowed-target", fetch_redirect_response=False)
+
+    def test_query_params_not_matched(self):
+        response = self.client.get(self.logout_url, {"next": "/example/allowed-target?foo=bar"})
+        self.assertRedirects(response, "/login/", fetch_redirect_response=False)
+
+    def test_fragment_not_matched(self):
+        response = self.client.get(self.logout_url, {"next": "/example/allowed-target#section"})
+        self.assertRedirects(response, "/login/", fetch_redirect_response=False)
+
 
 @override_settings(LOGOUT_NEXT_ALLOWED_PATHS=[])
 class IasoLogoutViewWithoutAllowlistTestCase(TestCase):

--- a/iaso/tests/auth/test_logout_view.py
+++ b/iaso/tests/auth/test_logout_view.py
@@ -1,0 +1,68 @@
+from django.contrib.auth import get_user_model
+from django.test import override_settings
+from django.urls import reverse
+
+from iaso.test import TestCase
+
+
+User = get_user_model()
+
+
+@override_settings(LOGOUT_NEXT_ALLOWED_PATHS=["/example/allowed-target"])
+class IasoLogoutViewTestCase(TestCase):
+    """Tests for IasoLogoutView's allow-listed ``next`` behaviour."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create_user(username="logout_user", password="hunter2")
+
+    def setUp(self):
+        self.client.force_login(self.user)
+        self.logout_url = reverse("logout-iaso")
+
+    def test_default_redirect_when_no_next(self):
+        response = self.client.get(self.logout_url)
+        self.assertRedirects(response, "/login/", fetch_redirect_response=False)
+
+    def test_redirects_to_allowed_next(self):
+        response = self.client.get(self.logout_url, {"next": "/example/allowed-target"})
+        self.assertRedirects(response, "/example/allowed-target", fetch_redirect_response=False)
+
+    def test_falls_back_when_next_not_in_allowlist(self):
+        response = self.client.get(self.logout_url, {"next": "/dashboard/"})
+        self.assertRedirects(response, "/login/", fetch_redirect_response=False)
+
+    def test_falls_back_when_next_is_absolute_url(self):
+        response = self.client.get(self.logout_url, {"next": "https://evil.example.com/example/allowed-target"})
+        self.assertRedirects(response, "/login/", fetch_redirect_response=False)
+
+    def test_falls_back_when_next_has_protocol_relative_host(self):
+        response = self.client.get(self.logout_url, {"next": "//evil.example.com/"})
+        self.assertRedirects(response, "/login/", fetch_redirect_response=False)
+
+    def test_post_with_allowed_next(self):
+        response = self.client.post(self.logout_url, data={"next": "/example/allowed-target"})
+        self.assertRedirects(response, "/example/allowed-target", fetch_redirect_response=False)
+
+    def test_user_is_logged_out(self):
+        self.client.get(self.logout_url, {"next": "/example/allowed-target"})
+        # Subsequent request to a login-required endpoint should not show the user as authenticated.
+        response = self.client.get("/api/profiles/me/")
+        self.assertIn(response.status_code, (401, 403))
+
+
+@override_settings(LOGOUT_NEXT_ALLOWED_PATHS=[])
+class IasoLogoutViewWithoutAllowlistTestCase(TestCase):
+    """When the allow-list is empty, every ``next`` value falls back to ``next_page``."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create_user(username="logout_user_no_allowlist", password="hunter2")
+
+    def setUp(self):
+        self.client.force_login(self.user)
+        self.logout_url = reverse("logout-iaso")
+
+    def test_any_next_falls_back(self):
+        response = self.client.get(self.logout_url, {"next": "/example/allowed-target"})
+        self.assertRedirects(response, "/login/", fetch_redirect_response=False)


### PR DESCRIPTION
## What problem is this PR solving?

* Custom `?next=<path>` redirect after `/logout-iaso`
* Permission-free PATCH of `first_name`, `last_name`, `email` for logged-in users

### Related JIRA tickets

SNT-374

## Changes

This PR covers two changes which are prerequisites for the public account creation in SNT Malaria

### Custom `?next=<path>` redirect after `/logout-iaso`

The custom `?next=<path>` redirect after logout is for a use case where account creation was not successful. We log the user out and redirect them to the public account creation to start over if they want to. Without this, the user would see the login page instead.

Technically this is achieved by subclassing Django's default `LogoutView` as a backwards-compatible drop-in for the `/logout-iaso` endpoint.

Since this is a potential attack vector (see [CWE-601](https://cwe.mitre.org/data/definitions/601.html)), only allow-listed redirects (`settings.LOGOUT_NEXT_ALLOWED_PATHS`) are being followed.

### Permission-free PATCH of `first_name`, `last_name`, `email` for logged-in users

This  simply allows any logged-in user to `PATCH` their own `first_name`, `last_name` and `email` which is required by our account-creation wizard.