### PR TITLE
IA-5060 chat-ai : test fails because of pyxform closing the file

### DIFF
--- a/iaso/api/form_ai/agent.py
+++ b/iaso/api/form_ai/agent.py
@@ -265,8 +265,11 @@ def convert_to_xform_xml(xlsform_buffer: io.BytesIO) -> Optional[str]:
     """Convert an XLSForm to XForm XML using pyxform."""
     try:
         xlsform_buffer.seek(0)
-        xlsform_buffer.name = "form.xlsx"
-        survey = create_survey_from_xls(xlsform_buffer, default_name="data")
+        # pyxform closes the file-like object it receives, so pass a copy to
+        # avoid invalidating the caller's buffer.
+        copy = io.BytesIO(xlsform_buffer.read())
+        copy.name = "form.xlsx"
+        survey = create_survey_from_xls(copy, default_name="data")
         return survey.to_xml(validate=False)
     except Exception as e:
         logger.error("Failed to convert XLSForm to XForm XML: %s", e)


### PR DESCRIPTION
## What problem is this PR solving?

 Root cause: pyxform's create_survey_from_xls closes the file-like object it receives. So after convert_to_xform_xml(xlsform_buffer) returned, the original xlsform_buffer was in a closed state. The next line xlsform_buffer.seek(0) then raised
  ValueError: I/O operation on closed file, which was caught by the broad except Exception handler and turned into a 400 response.

  Fix: In agent.py:convert_to_xform_xml, make a copy of the buffer (io.BytesIO(xlsform_buffer.read())) before passing it to pyxform. This lets pyxform close its own copy while leaving the caller's buffer intact and still seekable.


### Related JIRA tickets

IA-5060

## Changes

 Root cause: pyxform 2.0.0 → 2.0.3 upgrade, introduced in commit 0fe9c2b03.

  The key change in xls2json_backends.py:

  2.0.0: workbook = openpyxl.open(filename=path_or_file, ...) — passes the BytesIO straight to openpyxl, which does not close it
  2.0.3: with closing(file) as wb_file: — wraps the BytesIO in contextlib.closing(), which explicitly calls .close() on it when the with block exits

  In 2.0.0, workbook.close() only closed openpyxl's internal ZipFile; the underlying BytesIO was left open. In 2.0.3, pyxform added proper resource management with contextlib.closing() — technically correct for file paths, but a breaking change for
  callers that reuse a BytesIO after calling xlsx_to_dict.

  The test (and the Form AI feature itself) were written and tested against 2.0.0. The bump to 2.0.3 in 0fe9c2b03 silently broke test_successful_form_generation because convert_to_xform_xml was reusing the buffer after passing it to pyxform. The fix
  (copying the buffer before passing it to pyxform) is the correct defensive approach.

## How to test

docker compose exec iaso ./manage.py test iaso.tests.api.test_form_ai.FormAIChatTestCase --keepdb

## Print screen / video

Upload here print screens or videos showing the changes.

## Notes

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).
