### PR TITLE
[IA-5063]: refactor to centralise permission for HasAccountFeatureFlag

### DIFF
--- a/iaso/api/common/permissions.py
+++ b/iaso/api/common/permissions.py
@@ -1,3 +1,4 @@
+from django.utils.translation import gettext_lazy as _
 from rest_framework import permissions
 
 
@@ -89,3 +90,31 @@ class GenericReadWritePerm(permissions.BasePermission):
             ) or request.user.is_superuser
             return can_post
         return False
+
+
+class HasAccountFeatureFlag:
+    def __init__(self, *feature_flags):
+        class PermissionClass(permissions.BasePermission):
+            message = _("This feature is disabled for your account.")
+
+            def has_permission(self, request, view):
+                if not request.user or not request.user.is_authenticated:
+                    return False
+
+                if request.user.is_superuser:
+                    return True
+
+                if not getattr(request.user, "iaso_profile", None):
+                    return False
+
+                if feature_flags:
+                    flags = request.user.iaso_profile.account.feature_flags.filter(code__in=feature_flags).values_list(
+                        "code", flat=True
+                    )
+                    return set(feature_flags).issubset(flags)
+                return True
+
+        self._permission_class = PermissionClass
+
+    def __call__(self, *args, **kwargs):
+        return self._permission_class()

--- a/iaso/api/validation_workflows/permissions.py
+++ b/iaso/api/validation_workflows/permissions.py
@@ -1,4 +1,3 @@
-from django.utils.translation import gettext_lazy as _
 from rest_framework.permissions import BasePermission
 
 from iaso.permissions.core_permissions import CORE_VALIDATION_WORKFLOW_PERMISSION
@@ -13,12 +12,3 @@ class HasValidationWorkflowPermission(BasePermission):
         if request.user.is_superuser:
             return True
         return request.user.has_perm(CORE_VALIDATION_WORKFLOW_PERMISSION.full_name())
-
-
-class HasAccountFeatureFlag(BasePermission):
-    message = _("This feature is disabled for your account.")
-
-    def has_permission(self, request, view):
-        if not request.user.iaso_profile:
-            return False
-        return request.user.iaso_profile.account.feature_flags.filter(code="SUBMISSION_VALIDATION_WORKFLOW").exists()

--- a/iaso/api/validation_workflows/views.py
+++ b/iaso/api/validation_workflows/views.py
@@ -7,9 +7,10 @@ from rest_framework.filters import OrderingFilter
 from rest_framework.response import Response
 
 from iaso.api.common import ModelViewSet
+from iaso.api.common.permissions import HasAccountFeatureFlag
 from iaso.api.validation_workflows.filters import ValidationWorkflowListFilter
 from iaso.api.validation_workflows.pagination import ValidationWorkflowPagination
-from iaso.api.validation_workflows.permissions import HasAccountFeatureFlag, HasValidationWorkflowPermission
+from iaso.api.validation_workflows.permissions import HasValidationWorkflowPermission
 from iaso.api.validation_workflows.serializers.create import ValidationWorkflowCreateSerializer
 from iaso.api.validation_workflows.serializers.dropdown import ValidationWorkflowDropdownSerializer
 from iaso.api.validation_workflows.serializers.list import ValidationWorkflowListSerializer
@@ -20,7 +21,11 @@ from iaso.models import ValidationWorkflow
 
 @extend_schema(tags=["Validation workflows"])
 class ValidationWorkflowViewSet(ModelViewSet):
-    permission_classes = [permissions.IsAuthenticated, HasValidationWorkflowPermission, HasAccountFeatureFlag]
+    permission_classes = [
+        permissions.IsAuthenticated,
+        HasValidationWorkflowPermission,
+        HasAccountFeatureFlag("SUBMISSION_VALIDATION_WORKFLOW"),
+    ]
     filter_backends = [OrderingFilter, DjangoFilterBackend]
     pagination_class = ValidationWorkflowPagination
     http_method_names = ["get", "post", "put", "patch", "delete"]

--- a/iaso/api/validation_workflows/views_mobile.py
+++ b/iaso/api/validation_workflows/views_mobile.py
@@ -5,9 +5,9 @@ from rest_framework.renderers import BrowsableAPIRenderer, JSONRenderer
 from rest_framework.viewsets import GenericViewSet
 
 from iaso.api.common.mixin import CustomPaginationListModelMixin
+from iaso.api.common.permissions import HasAccountFeatureFlag
 from iaso.api.validation_workflows.filters import MobileValidationWorkflowListFilter
 from iaso.api.validation_workflows.pagination import MobileValidationWorkflowPagination
-from iaso.api.validation_workflows.permissions import HasAccountFeatureFlag
 from iaso.api.validation_workflows.serializers.mobile import MobileValidationWorkflowListSerializer
 from iaso.models import Instance
 
@@ -15,7 +15,7 @@ from iaso.models import Instance
 @extend_schema(tags=["Validation workflows", "Mobile"])
 class ValidationWorkflowMobileViewSet(CustomPaginationListModelMixin, GenericViewSet):
     filter_backends = [DjangoFilterBackend]
-    permission_classes = (IsAuthenticated, HasAccountFeatureFlag)
+    permission_classes = (IsAuthenticated, HasAccountFeatureFlag("SUBMISSION_VALIDATION_WORKFLOW"))
     filterset_class = MobileValidationWorkflowListFilter
     pagination_class = MobileValidationWorkflowPagination
     serializer_class = MobileValidationWorkflowListSerializer

--- a/iaso/api/validation_workflows_node_templates/permissions.py
+++ b/iaso/api/validation_workflows_node_templates/permissions.py
@@ -12,10 +12,3 @@ class HasValidationNodeTemplatePermission(BasePermission):
         if request.user.is_superuser:
             return True
         return request.user.has_perm(CORE_VALIDATION_WORKFLOW_PERMISSION.full_name())
-
-
-class HasAccountFeatureFlag(BasePermission):
-    def has_permission(self, request, view):
-        if not request.user.iaso_profile:
-            return False
-        return request.user.iaso_profile.account.feature_flags.filter(code="SUBMISSION_VALIDATION_WORKFLOW").exists()

--- a/iaso/api/validation_workflows_node_templates/views.py
+++ b/iaso/api/validation_workflows_node_templates/views.py
@@ -9,9 +9,9 @@ from rest_framework.response import Response
 from rest_framework_extensions.mixins import NestedViewSetMixin
 
 from iaso.api.common import ModelViewSet
+from iaso.api.common.permissions import HasAccountFeatureFlag
 from iaso.api.validation_workflows_node_templates.pagination import ValidationNodeTemplatePagination
 from iaso.api.validation_workflows_node_templates.permissions import (
-    HasAccountFeatureFlag,
     HasValidationNodeTemplatePermission,
 )
 from iaso.api.validation_workflows_node_templates.serializers.bulk_create import (
@@ -32,7 +32,11 @@ from iaso.models import UserRole, ValidationNodeTemplate
 class ValidationNodeTemplatesView(NestedViewSetMixin, ModelViewSet):
     lookup_field = "slug"
     lookup_url_kwarg = "slug"
-    permission_classes = [IsAuthenticated, HasValidationNodeTemplatePermission, HasAccountFeatureFlag]
+    permission_classes = [
+        IsAuthenticated,
+        HasValidationNodeTemplatePermission,
+        HasAccountFeatureFlag("SUBMISSION_VALIDATION_WORKFLOW"),
+    ]
     model = ValidationNodeTemplate
     filter_backends = [OrderingFilter]
     pagination_class = ValidationNodeTemplatePagination

--- a/iaso/api/validation_workflows_nodes/permissions.py
+++ b/iaso/api/validation_workflows_nodes/permissions.py
@@ -1,4 +1,3 @@
-from django.utils.translation import gettext_lazy as _
 from rest_framework.permissions import BasePermission
 
 from iaso.permissions.core_permissions import CORE_VALIDATION_WORKFLOW_PERMISSION
@@ -13,12 +12,3 @@ class HasValidationWorkflowPermission(BasePermission):
         if request.user.is_superuser:
             return True
         return request.user.has_perm(CORE_VALIDATION_WORKFLOW_PERMISSION.full_name())
-
-
-class HasAccountFeatureFlag(BasePermission):
-    message = _("This feature is disabled for your account.")
-
-    def has_permission(self, request, view):
-        if not request.user.iaso_profile:
-            return False
-        return request.user.iaso_profile.account.feature_flags.filter(code="SUBMISSION_VALIDATION_WORKFLOW").exists()

--- a/iaso/api/validation_workflows_nodes/views.py
+++ b/iaso/api/validation_workflows_nodes/views.py
@@ -7,7 +7,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
-from iaso.api.validation_workflows_node_templates.permissions import HasAccountFeatureFlag
+from iaso.api.common.permissions import HasAccountFeatureFlag
 from iaso.api.validation_workflows_nodes.permissions import HasValidationWorkflowPermission
 from iaso.api.validation_workflows_nodes.serializers.complete import ValidationNodeCompleteSerializer
 from iaso.api.validation_workflows_nodes.serializers.complete_bypass import ValidationNodeCompleteBypassSerializer
@@ -18,7 +18,11 @@ from iaso.models.validation_workflow.validation_node import ValidationNodeStatus
 
 @extend_schema(tags=["Validation nodes"])
 class ValidationNodeViewSet(GenericViewSet):
-    permission_classes = [IsAuthenticated, HasValidationWorkflowPermission, HasAccountFeatureFlag]
+    permission_classes = [
+        IsAuthenticated,
+        HasValidationWorkflowPermission,
+        HasAccountFeatureFlag("SUBMISSION_VALIDATION_WORKFLOW"),
+    ]
     http_method_names = ["get", "post"]
     pagination_class = None
 

--- a/iaso/tests/api/common/test_permissions.py
+++ b/iaso/tests/api/common/test_permissions.py
@@ -1,0 +1,84 @@
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import AnonymousUser
+from django.test import RequestFactory
+
+from iaso.api.common.permissions import HasAccountFeatureFlag
+from iaso.models import Account, AccountFeatureFlag
+from iaso.test import TestCase
+
+
+class TestHasAccountFeatureFlagPermission(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.account = Account.objects.create(name="account")
+        self.account_feature_flag_1 = AccountFeatureFlag.objects.create(name="ff", code="ff")
+        self.account_feature_flag_2 = AccountFeatureFlag.objects.create(name="ff2", code="ff2")
+
+    def test_unauthenticated_user_is_rejected(self):
+        request = RequestFactory()
+        request.user = AnonymousUser()
+
+        self.assertFalse(HasAccountFeatureFlag("a")().has_permission(request, None))
+
+    def test_superuser_is_approved(self):
+        request = RequestFactory()
+        user = get_user_model().objects.create_user(is_superuser=True, email="", password="", username="superuser")
+        request.user = user
+        self.assertTrue(HasAccountFeatureFlag("a")().has_permission(request, None))
+
+    def test_authenticated_user_without_iaso_profile_is_rejected(self):
+        request = RequestFactory()
+        user = get_user_model().objects.create_user(is_superuser=False, email="", password="", username="normaluser")
+        request.user = user
+        self.assertFalse(HasAccountFeatureFlag("a")().has_permission(request, None))
+
+    def test_no_feature_flags(self):
+        request = RequestFactory()
+        request.user = self.create_user_with_profile(
+            username="normaluser", password="password", email="email", account=self.account
+        )
+
+        self.assertTrue(HasAccountFeatureFlag()().has_permission(request, None))
+
+    def test_one_feature_flag(self):
+        request = RequestFactory()
+        user = self.create_user_with_profile(
+            username="normaluser", password="password", email="email", account=self.account
+        )
+        request.user = user
+
+        self.assertFalse(HasAccountFeatureFlag(self.account_feature_flag_1.code)().has_permission(request, None))
+
+        self.account.feature_flags.add(self.account_feature_flag_2.code)
+
+        self.assertFalse(HasAccountFeatureFlag(self.account_feature_flag_1.code)().has_permission(request, None))
+        self.assertTrue(HasAccountFeatureFlag(self.account_feature_flag_2.code)().has_permission(request, None))
+
+    def test_multiple_feature_flags(self):
+        request = RequestFactory()
+        user = self.create_user_with_profile(
+            username="normaluser", password="password", email="email", account=self.account
+        )
+        request.user = user
+
+        self.assertFalse(
+            HasAccountFeatureFlag(self.account_feature_flag_1.code, self.account_feature_flag_2.code)().has_permission(
+                request, None
+            )
+        )
+
+        self.account.feature_flags.add(self.account_feature_flag_2.code)
+
+        self.assertFalse(
+            HasAccountFeatureFlag(self.account_feature_flag_1.code, self.account_feature_flag_2.code)().has_permission(
+                request, None
+            )
+        )
+
+        self.account.feature_flags.add(self.account_feature_flag_1.code)
+
+        self.assertTrue(
+            HasAccountFeatureFlag(self.account_feature_flag_1.code, self.account_feature_flag_2.code)().has_permission(
+                request, None
+            )
+        )


### PR DESCRIPTION
## What problem is this PR solving?

This code was repeated in a lot of place so it had to be refactored and centralized : 
```python
class HasAccountFeatureFlag(BasePermission):
    message = _("This feature is disabled for your account.")

    def has_permission(self, request, view):
        if not request.user.iaso_profile:
            return False
        return request.user.iaso_profile.account.feature_flags.filter(code="SUBMISSION_VALIDATION_WORKFLOW").exists()
```

### Related JIRA tickets

IA-5063

## Changes

* Refactored into one single class that we can parameter 
* Added tests
* Adapted current viewsets implementations 

## How to test

Python tests but the affected endpoints should still behave accordingly (aka raise a "This feature is disabled for your account."  message )