### PR TITLE
[IA-5070]: fix show only deleted checkbox on submissions page

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/forms/components/Filters.test.tsx
+++ b/hat/assets/js/apps/Iaso/domains/forms/components/Filters.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { renderWithThemeAndIntlProvider } from '../../../../../tests/helpers';
+import MESSAGES from '../messages';
+import { Filters } from './Filters';
+
+describe('Filters test', () => {
+    it('should render the show only deleted checkbox', async () => {
+        renderWithThemeAndIntlProvider(
+            <MemoryRouter>
+                <Filters
+                    isLoadingForms={false}
+                    forms={{ forms: [1] }}
+                    params={{}}
+                />
+            </MemoryRouter>,
+        );
+        await waitFor(() => {
+            expect(
+                screen.getByRole('checkbox', {
+                    name: MESSAGES.onlyDeleted.defaultMessage,
+                }),
+            ).toBeInTheDocument();
+        });
+    });
+});

--- a/hat/assets/js/apps/Iaso/domains/forms/components/Filters.tsx
+++ b/hat/assets/js/apps/Iaso/domains/forms/components/Filters.tsx
@@ -8,14 +8,16 @@ import {
     useRedirectTo,
     useSafeIntl,
 } from 'bluesquare-components';
-
 import { DisplayIfUserHasPerm } from 'Iaso/components/DisplayIfUserHasPerm';
 import { SearchButton } from 'Iaso/components/SearchButton';
 import { baseUrls } from 'Iaso/constants/urls';
 import { PlanningsDropdown } from 'Iaso/domains/plannings/components/PlanningsDropdown';
+import { userHasOneOfPermissions } from 'Iaso/domains/users/utils';
 import { useQueryString } from 'Iaso/hooks/useApiParams';
 import { useFilterState } from 'Iaso/hooks/useFilterState';
+import { PLANNING_READ, PLANNING_WRITE } from 'Iaso/utils/permissions';
 import * as Permission from 'Iaso/utils/permissions';
+import { useCurrentUser } from 'Iaso/utils/usersUtils';
 import DownloadButtonsComponent from '../../../components/DownloadButtonsComponent';
 import InputComponent from '../../../components/forms/InputComponent';
 import { useGetOrgUnitTypesDropdownOptions } from '../../orgUnits/orgUnitTypes/hooks/useGetOrgUnitTypesDropdownOptions';
@@ -46,6 +48,11 @@ const Filters = ({ params, forms, isLoadingForms }: Props) => {
         searchAlwaysEnabled: true,
     });
     const [textSearchError, setTextSearchError] = useState<boolean>(false);
+    const currentUser = useCurrentUser();
+    const hasPlanningPermission = userHasOneOfPermissions(
+        [PLANNING_READ, PLANNING_WRITE],
+        currentUser,
+    );
     const handleOnlyDeleted = useCallback(
         (key, value) => {
             const valueForParam = value ? '1' : undefined;
@@ -123,17 +130,28 @@ const Filters = ({ params, forms, isLoadingForms }: Props) => {
                         keyValue="planning"
                         multi
                     />
+                    {!hasPlanningPermission && (
+                        <InputComponent
+                            keyValue="onlyDeleted"
+                            onChange={handleOnlyDeleted}
+                            value={filters.onlyDeleted === '1'}
+                            type="checkbox"
+                            label={MESSAGES.onlyDeleted}
+                        />
+                    )}
                 </Grid>
             </Grid>
             <Grid container item xs={12} spacing={2}>
                 <Grid item xs={12} md={3}>
-                    <InputComponent
-                        keyValue="onlyDeleted"
-                        onChange={handleOnlyDeleted}
-                        value={filters.onlyDeleted === '1'}
-                        type="checkbox"
-                        label={MESSAGES.onlyDeleted}
-                    />
+                    {hasPlanningPermission && (
+                        <InputComponent
+                            keyValue="onlyDeleted"
+                            onChange={handleOnlyDeleted}
+                            value={filters.onlyDeleted === '1'}
+                            type="checkbox"
+                            label={MESSAGES.onlyDeleted}
+                        />
+                    )}
                 </Grid>
                 <Grid item xs={12} md={9}>
                     <Box

--- a/hat/assets/js/apps/Iaso/domains/forms/components/Filters.tsx
+++ b/hat/assets/js/apps/Iaso/domains/forms/components/Filters.tsx
@@ -1,4 +1,4 @@
-import React, { useState, FunctionComponent, useCallback } from 'react';
+import React, { useState, useCallback } from 'react';
 
 import Add from '@mui/icons-material/Add';
 import { Grid, Button, Box, useMediaQuery, useTheme } from '@mui/material';
@@ -9,18 +9,15 @@ import {
     useSafeIntl,
 } from 'bluesquare-components';
 
+import { DisplayIfUserHasPerm } from 'Iaso/components/DisplayIfUserHasPerm';
 import { SearchButton } from 'Iaso/components/SearchButton';
 import { baseUrls } from 'Iaso/constants/urls';
 import { PlanningsDropdown } from 'Iaso/domains/plannings/components/PlanningsDropdown';
-import { userHasOneOfPermissions } from 'Iaso/domains/users/utils';
 import { useQueryString } from 'Iaso/hooks/useApiParams';
+import { useFilterState } from 'Iaso/hooks/useFilterState';
 import * as Permission from 'Iaso/utils/permissions';
-import { PLANNING_READ, PLANNING_WRITE } from 'Iaso/utils/permissions';
-import { useCurrentUser } from 'Iaso/utils/usersUtils';
-import { DisplayIfUserHasPerm } from '../../../components/DisplayIfUserHasPerm';
 import DownloadButtonsComponent from '../../../components/DownloadButtonsComponent';
 import InputComponent from '../../../components/forms/InputComponent';
-import { useFilterState } from '../../../hooks/useFilterState';
 import { useGetOrgUnitTypesDropdownOptions } from '../../orgUnits/orgUnitTypes/hooks/useGetOrgUnitTypesDropdownOptions';
 import { useGetProjectsDropdownOptions } from '../../projects/hooks/requests';
 import { baseUrl } from '../config';
@@ -38,11 +35,7 @@ type Props = {
     isLoadingForms: boolean;
 };
 
-const Filters: FunctionComponent<Props> = ({
-    params,
-    forms,
-    isLoadingForms,
-}) => {
+const Filters = ({ params, forms, isLoadingForms }: Props) => {
     const classes: Record<string, string> = useStyles();
     const { formatMessage } = useSafeIntl();
     const redirectTo = useRedirectTo();
@@ -81,11 +74,6 @@ const Filters: FunctionComponent<Props> = ({
     const csvUrl = `${dwnldBaseUrl}/?${downloadQueryString}&csv=true`;
     const xlsxUrl = `${dwnldBaseUrl}/?${downloadQueryString}&xlsx=true`;
 
-    const currentUser = useCurrentUser();
-    const hasPlanningPermission = userHasOneOfPermissions(
-        [PLANNING_READ, PLANNING_WRITE],
-        currentUser,
-    );
     return (
         <Grid container>
             <Grid container item xs={12} spacing={2}>
@@ -135,29 +123,17 @@ const Filters: FunctionComponent<Props> = ({
                         keyValue="planning"
                         multi
                     />
-                    {!hasPlanningPermission && (
-                        <InputComponent
-                            keyValue="showDeleted"
-                            onChange={handleShowDeleted}
-                            value={filters.showDeleted === 'true'}
-                            type="checkbox"
-                            label={MESSAGES.showDeleted}
-                        />
-                    )}
                 </Grid>
             </Grid>
             <Grid container item xs={12} spacing={2}>
                 <Grid item xs={12} md={3}>
-                  {hasPlanningPermission && (
-                      <InputComponent
+                    <InputComponent
                         keyValue="onlyDeleted"
                         onChange={handleOnlyDeleted}
                         value={filters.onlyDeleted === '1'}
                         type="checkbox"
                         label={MESSAGES.onlyDeleted}
-                      />
-                   )}
-
+                    />
                 </Grid>
                 <Grid item xs={12} md={9}>
                     <Box


### PR DESCRIPTION
## What problem is this PR solving?

For user without planning permission, submissions search page was crashing

### Related JIRA tickets

IA-5070

## Changes

* Merge the two checkboxes into one
* Added 

## How to test

Create a user without the planning permissions

Go to /dashboard/forms/submissions/list/ 

It shouldn't crash