### PR TITLE
[IA-5071]: fix etl api call in case of file None

### DIFF
--- a/iaso/api/instances/serializers/etl.py
+++ b/iaso/api/instances/serializers/etl.py
@@ -90,7 +90,7 @@ class NestedHistorySerializer(ModelSerializer):
 
 class ETLInstanceListSerializer(ModelSerializer):
     file_content = serializers.SerializerMethodField()
-    file_url = serializers.URLField(source="file.url", read_only=True)
+    file_url = serializers.SerializerMethodField()
     org_unit = NestedOrgUnitSerializer(read_only=True)
     history = serializers.SerializerMethodField()
 
@@ -106,6 +106,12 @@ class ETLInstanceListSerializer(ModelSerializer):
     @extend_schema_field(serializers.JSONField)
     def get_file_content(self, obj):
         return obj.get_and_save_json_of_xml()
+
+    @extend_schema_field(serializers.URLField(allow_null=True, allow_blank=True))
+    def get_file_url(self, obj):
+        if obj.file:
+            return obj.file.url
+        return None
 
     @extend_schema_field(NestedHistorySerializer(many=True))
     def get_history(self, obj):

--- a/iaso/tests/api/instances/test_views_etl.py
+++ b/iaso/tests/api/instances/test_views_etl.py
@@ -187,3 +187,12 @@ class ETLInstanceTestCase(SwaggerTestCaseMixin, APITestCase):
 
         self.assertEqual(history, [])
         self.assertEqual(len(history), 0)
+
+    def test_instance_without_file(self):
+        self.client.force_authenticate(self.john_wick)
+
+        self.instance_1.file = None
+        self.instance_1.save()
+
+        res = self.client.get(reverse("api-etl:instances-list"))
+        res_data = self.assertJSONResponse(res, status.HTTP_200_OK)


### PR DESCRIPTION
## What problem is this PR solving?

calling /api/etl/instances crashes if one instance has no file associated

### Related JIRA tickets

IA-5071

## Changes

* Fix backend 
* Test
