### PR TITLE
[IA-5105] fix user creation

### DIFF
--- a/iaso/api/profiles/serializers/create.py
+++ b/iaso/api/profiles/serializers/create.py
@@ -2,7 +2,6 @@ import django.core.exceptions as django_exceptions
 
 from django.contrib.auth.models import Permission
 from django.contrib.auth.password_validation import validate_password
-from django.utils.crypto import get_random_string
 from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 
@@ -108,15 +107,6 @@ class ProfileCreateSerializer(ModelSerializer):
         if data.get("send_email_invitation") and not data.get("email"):
             raise serializers.ValidationError({"email": _("This field is required.")})
 
-    def set_user_password(self, user, password, send_email_invitation, email):
-        if password:
-            user.set_password(password)
-            user.save()
-        elif send_email_invitation:
-            random_password = get_random_string(32)
-            user.set_password(random_password)
-            user.save()
-
     def create(self, validated_data):
         account = self._get_account()
 
@@ -160,7 +150,7 @@ class ProfileCreateSerializer(ModelSerializer):
         )
 
         try:
-            if account.enforce_password_validation:
+            if account.enforce_password_validation and "password" in validated_data:
                 validate_password(password=validated_data["password"], user=user)
         except django_exceptions.ValidationError as e:
             raise serializers.ValidationError({"password": e.messages})

--- a/iaso/api/profiles/serializers/create.py
+++ b/iaso/api/profiles/serializers/create.py
@@ -150,7 +150,7 @@ class ProfileCreateSerializer(ModelSerializer):
         )
 
         try:
-            if account.enforce_password_validation and "password" in validated_data:
+            if account.enforce_password_validation and validated_data.get("password"):
                 validate_password(password=validated_data["password"], user=user)
         except django_exceptions.ValidationError as e:
             raise serializers.ValidationError({"password": e.messages})

--- a/iaso/tests/api/profiles/test_views/test_create.py
+++ b/iaso/tests/api/profiles/test_views/test_create.py
@@ -298,13 +298,16 @@ class ProfileCreateAPITestCase(BaseProfileAPITestCase):
             "email": "test@test.com",
         }
 
-        response = self.client.post(reverse("profiles-list"), data=data, format="json")
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            response = self.client.post(reverse("profiles-list"), data=data, format="json")
         result = self.assertJSONResponse(response, status.HTTP_201_CREATED)
 
         profile = Profile.objects.get(pk=result["id"])
         user = profile.user
 
         self.assertTrue(user.has_usable_password())  # because the view sets a random 32-char password
+        self.assertEqual(len(callbacks), 1)
+        self.assertEqual(len(mail.outbox), 1)
 
     def test_create_profile_with_managed_geo_limit(self):
         self.client.force_authenticate(self.user_managed_geo_limit)

--- a/iaso/tests/api/profiles/test_views/test_create.py
+++ b/iaso/tests/api/profiles/test_views/test_create.py
@@ -4,6 +4,7 @@ from django.contrib.auth import get_user_model
 from django.core import mail
 from django.test import override_settings
 from django.urls import reverse
+from rest_framework import status
 
 from iaso.models import Profile, Project, UserRole
 from iaso.permissions.core_permissions import CORE_FORMS_PERMISSION
@@ -283,6 +284,27 @@ class ProfileCreateAPITestCase(BaseProfileAPITestCase):
         result = self.assertJSONResponse(response, 400)
 
         self.assertHasError(result, "password", "This field is required.")
+
+    def test_create_profile_without_password_and_send_email_and_account_password_validation(self):
+        self.account.enforce_password_validation = True
+        self.account.save()
+
+        self.client.force_authenticate(self.jim)
+        data = {
+            "user_name": "userTest",
+            "first_name": "unittest_first_name",
+            "last_name": "unittest_last_name",
+            "send_email_invitation": True,  # password validation should not cause any issue because none was set
+            "email": "test@test.com",
+        }
+
+        response = self.client.post(reverse("profiles-list"), data=data, format="json")
+        result = self.assertJSONResponse(response, status.HTTP_201_CREATED)
+
+        profile = Profile.objects.get(pk=result["id"])
+        user = profile.user
+
+        self.assertTrue(user.has_usable_password())  # because the view sets a random 32-char password
 
     def test_create_profile_with_managed_geo_limit(self):
         self.client.force_authenticate(self.user_managed_geo_limit)


### PR DESCRIPTION
## What problem is this PR solving?

 fix user creation when no password is set but password validation is enabled

### Related JIRA tickets

IA-5105

## Changes

- triggered password validation only if a password was received
- small cleanup of dead code

## How to test

- have an `Account` where `enforce_password_validation=True` (set it in the admin panel in case you need)
- login, go to the users page and create a new user:
  - leave the `password` field empty
  - fill out the `email` field
  - tick the `send invitation email` box
- you should not get an error about a missing password, the email should be sent and the user should be created

## Print screen / video

/

## Notes

- we'll probably need to hotfix this

## Doc

/
