### PR TITLE
[IA-5075] Add `display_name` to mobile Instance Validation's endpoint

### DIFF
--- a/iaso/api/validation_workflows/serializers/mobile.py
+++ b/iaso/api/validation_workflows/serializers/mobile.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
@@ -43,12 +45,14 @@ class MobileValidationWorkflowListSerializer(ModelSerializer):
     rejection_comment = serializers.SerializerMethodField(read_only=True)
     updated_at = serializers.SerializerMethodField(label="Timestamp of the last update (history)", read_only=True)
     name = serializers.CharField(read_only=True, source="form.name")
+    display_name = serializers.SerializerMethodField(read_only=True)
 
     class Meta:
         model = Instance
         fields = [
             "instance_id",
             "name",
+            "display_name",
             "validation_status",
             "rejection_comment",
             "created_at",
@@ -77,3 +81,12 @@ class MobileValidationWorkflowListSerializer(ModelSerializer):
     def get_updated_at(self, obj):
         updated_at = getattr(obj.validationnode_set.all().order_by("-updated_at").first(), "updated_at", None)
         return updated_at.timestamp() if updated_at else None
+
+    @extend_schema_field({"type": "string", "nullable": True})
+    def get_display_name(self, obj: Instance) -> Optional[str]:
+        form = obj.form
+        label_keys = form.label_keys
+        if not label_keys or not obj.json:
+            return None
+        values = [str(obj.json[k]) if k in obj.json else None for k in label_keys]
+        return " ".join([x for x in values if x is not None])

--- a/iaso/tests/api/validation_workflows/test_views_mobile.py
+++ b/iaso/tests/api/validation_workflows/test_views_mobile.py
@@ -47,7 +47,7 @@ class MobileValidationWorkflowAPITestCase(APITestCase):
 
         self.third_node = ValidationNodeTemplate.objects.create(name="Third node", workflow=self.validation_workflow)
         self.third_node.previous_node_templates.add(self.second_node)
-        self.form = Form.objects.create(name="Form")
+        self.form = Form.objects.create(name="Form", label_keys=["A", "C", "E"])
         self.other_form = Form.objects.create(name="Form 2")
 
         self.validation_workflow.form_set.set([self.form, self.other_form])
@@ -62,6 +62,12 @@ class MobileValidationWorkflowAPITestCase(APITestCase):
             form=self.form,
             project=self.project,
             uuid=str(uuid.uuid4()),
+            json={
+                "A": "Item A",
+                "B": "Item B",
+                "C": "Item C",
+                "D": "Item D",
+            },
         )
 
         self.other_instance = self.create_form_instance(
@@ -293,6 +299,7 @@ class MobileValidationWorkflowAPITestCase(APITestCase):
         self.assertEqual(instance_data["validation_status"], ValidationWorkflowArtefactStatus.PENDING)
         self.assertIsNone(instance_data["rejection_comment"])
         self.assertEqual(instance_data["name"], self.form.name)
+        self.assertEqual(instance_data["display_name"], "Item A Item C")
 
         self.assertHasField(instance_data, "created_at", float)
         self.assertHasField(instance_data, "updated_at", float)
@@ -338,6 +345,7 @@ class MobileValidationWorkflowAPITestCase(APITestCase):
         self.assertEqual(instance_data["validation_status"], ValidationWorkflowArtefactStatus.APPROVED)
         self.assertIsNone(instance_data["rejection_comment"])
         self.assertEqual(instance_data["name"], self.form.name)
+        self.assertEqual(instance_data["display_name"], "Item A Item C")
 
         self.assertHasField(instance_data, "created_at", float)
         self.assertHasField(instance_data, "updated_at", float)
@@ -399,6 +407,7 @@ class MobileValidationWorkflowAPITestCase(APITestCase):
         self.assertEqual(instance_data["validation_status"], ValidationWorkflowArtefactStatus.APPROVED)
         self.assertIsNone(instance_data["rejection_comment"])
         self.assertEqual(instance_data["name"], self.form.name)
+        self.assertEqual(instance_data["display_name"], "Item A Item C")
 
         self.assertHasField(instance_data, "created_at", float)
         self.assertHasField(instance_data, "updated_at", float)
@@ -462,6 +471,7 @@ class MobileValidationWorkflowAPITestCase(APITestCase):
         self.assertEqual(instance_data["validation_status"], ValidationWorkflowArtefactStatus.REJECTED)
         self.assertEqual(instance_data["rejection_comment"], "Nope")
         self.assertEqual(instance_data["name"], self.form.name)
+        self.assertEqual(instance_data["display_name"], "Item A Item C")
 
         self.assertHasField(instance_data, "created_at", float)
         self.assertHasField(instance_data, "updated_at", float)
@@ -519,6 +529,7 @@ class MobileValidationWorkflowAPITestCase(APITestCase):
         self.assertEqual(instance_data["validation_status"], ValidationWorkflowArtefactStatus.PENDING)
         self.assertIsNone(instance_data["rejection_comment"])
         self.assertEqual(instance_data["name"], self.form.name)
+        self.assertEqual(instance_data["display_name"], "Item A Item C")
 
         self.assertHasField(instance_data, "created_at", float)
         self.assertHasField(instance_data, "updated_at", float)


### PR DESCRIPTION
## What problem is this PR solving?

The mobile needs to display the labels for the validation to help differentiate them to the user.

### Related JIRA tickets

IA-5075

## Changes

Added a new field called `display_name` (same as on mobile) that concatenates the `Instance`'s values based on the `Form`'s label keys, if any.

## How to test

1. Have an instance with a validation status.
1. Add label keys to the corresponding form.
1. Call the mobile endpoint (`/api/mobile/validation-workflows/ `) 
1. Check that the `display_name` field is correct.
