### PR TITLE
IA-5110: missing forum and user guide links on all IASO envs

### DIFF
--- a/iaso/api/profiles/serializers/retrieve.py
+++ b/iaso/api/profiles/serializers/retrieve.py
@@ -65,9 +65,17 @@ class NestedAccountSerializer(ModelSerializer):
     created_at = TimestampField(read_only=True)
     updated_at = TimestampField(read_only=True)
     feature_flags = serializers.SlugRelatedField(many=True, read_only=True, slug_field="code")
-    user_manual_path = serializers.ReadOnlyField(default=settings.USER_MANUAL_PATH)
-    forum_path = serializers.ReadOnlyField(default=settings.FORUM_PATH)
+    user_manual_path = serializers.SerializerMethodField()
+    forum_path = serializers.SerializerMethodField()
     default_version = NestedDefaultVersionSerializer(read_only=True)
+
+    @extend_schema_field(OpenApiTypes.STR)
+    def get_user_manual_path(self, obj):
+        return obj.user_manual_path or settings.USER_MANUAL_PATH
+
+    @extend_schema_field(OpenApiTypes.STR)
+    def get_forum_path(self, obj):
+        return obj.forum_path or settings.FORUM_PATH
 
     class Meta:
         model = Account

--- a/iaso/tests/api/profiles/test_views/test_retrieve.py
+++ b/iaso/tests/api/profiles/test_views/test_retrieve.py
@@ -1,5 +1,7 @@
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
+from django.test import override_settings
 from django.urls import reverse
 from rest_framework import status
 
@@ -10,6 +12,25 @@ from iaso.utils.colors import DEFAULT_COLOR
 
 
 class ProfileRetrieveAPITestCase(BaseProfileAPITestCase):
+    @override_settings(
+        USER_MANUAL_PATH="https://www.openiaso.com/user-manual/",
+        FORUM_PATH="https://forum.example.com/",
+    )
+    def test_account_paths_fallback_to_settings_when_empty(self):
+        self.account.user_manual_path = ""
+        self.account.forum_path = None
+        self.account.save(update_fields=["user_manual_path", "forum_path"])
+
+        self.client.force_authenticate(self.jane)
+        response = self.client.get(reverse("profiles-detail", kwargs={"pk": "me"}))
+        response_data = self.assertJSONResponse(response, 200)
+
+        self.assertEqual(
+            response_data["account"]["user_manual_path"],
+            settings.USER_MANUAL_PATH,
+        )
+        self.assertEqual(response_data["account"]["forum_path"], settings.FORUM_PATH)
+
     def test_account_feature_flags_is_included(self):
         aff = AccountFeatureFlag.objects.create(code="shape", name="Can edit shape")
         AccountFeatureFlag.objects.create(code="not-used", name="this is not used")


### PR DESCRIPTION
## What problem is this PR solving?

USER_MANUAL_PATH and FORUM_PATH are set on all IASO beanstalk environment but the links are not present.

<img width="780" height="955" alt="Screenshot 2026-05-21 at 11 39 27" src="https://github.com/user-attachments/assets/c0fe7004-7693-46f5-8647-796ae80a939d" />



### Related JIRA tickets

IA-5110

## Changes

- use SerializerMethodField
- adapt tests

## How to test

Make sure you have USER_MANUAL_PATH and FORUM_PATH set in your env file
You should see two links in the left menu

This is working locally while specifying those in my .env file


## Print screen / video

<img width="372" height="468" alt="Screenshot 2026-05-21 at 12 04 51" src="https://github.com/user-attachments/assets/c5ab0e5e-f721-4ac8-9133-a932b1c9a3bc" />
