### PR TITLE
[IA-5112] fix: don't display bypass nodes if the user can't take action

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/instances/components/ValidationWorkflow/timeline/AvatarTimeline.test.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/ValidationWorkflow/timeline/AvatarTimeline.test.tsx
@@ -4,10 +4,43 @@ import { describe, expect, it } from 'vitest';
 import { AvatarTimeline } from './AvatarTimeline';
 
 describe('AvatarTimeline', () => {
-    it('renders MoreHoriz icon when type is NEXT_BYPASS', () => {
-        render(<AvatarTimeline type="NEXT_BYPASS" status="ACCEPTED" />);
+    it('renders MoreHoriz icon without background color when type is NEXT_BYPASS and user cannot do action', () => {
+        render(
+            <AvatarTimeline
+                type="NEXT_BYPASS"
+                status="ACCEPTED"
+                userCanDoActions={false}
+            />,
+        );
 
         expect(screen.getByTestId('MoreHorizIcon')).toBeInTheDocument();
+        expect(screen.getByTestId('next-step')).toBeInTheDocument();
+    });
+
+    it('renders MoreHoriz icon without background color when type is NEXT_STEP', () => {
+        render(
+            <AvatarTimeline
+                type="NEXT_STEP"
+                status="ACCEPTED"
+                userCanDoActions={false}
+            />,
+        );
+
+        expect(screen.getByTestId('MoreHorizIcon')).toBeInTheDocument();
+        expect(screen.getByTestId('next-step')).toBeInTheDocument();
+    });
+
+    it('renders MoreHoriz icon withbackground color when type is NEXT_BYPASS and user can do action', () => {
+        render(
+            <AvatarTimeline
+                type="NEXT_BYPASS"
+                status="ACCEPTED"
+                userCanDoActions={true}
+            />,
+        );
+
+        expect(screen.getByTestId('MoreHorizIcon')).toBeInTheDocument();
+        expect(screen.queryByTestId('next-step')).toBeNull();
     });
 
     it('renders Clear icon when status is REJECTED', () => {

--- a/hat/assets/js/apps/Iaso/domains/instances/components/ValidationWorkflow/timeline/AvatarTimeline.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/ValidationWorkflow/timeline/AvatarTimeline.tsx
@@ -6,12 +6,24 @@ import SkipNextIcon from '@mui/icons-material/SkipNext';
 import { Avatar } from '@mui/material';
 import { Timeline } from 'Iaso/domains/validationWorkflowsConfiguration/types/validationNodes';
 
-type AvatarTimelineProps = Pick<Timeline, 'status' | 'type'>;
+type AvatarTimelineProps = {
+    userCanDoActions: Timeline['user_can_do_actions'];
+} & Pick<Timeline, 'status' | 'type'>;
 
-export const AvatarTimeline = ({ status, type }: AvatarTimelineProps) => {
-    if (type === 'NEXT_BYPASS') {
+export const AvatarTimeline = ({
+    status,
+    type,
+    userCanDoActions,
+}: AvatarTimelineProps) => {
+    if (type === 'NEXT_BYPASS' && userCanDoActions) {
         return (
             <Avatar sx={{ bgcolor: 'background.warning' }}>
+                <MoreHorizIcon />
+            </Avatar>
+        );
+    } else if (type === 'NEXT_BYPASS' || type === 'NEXT_STEP') {
+        return (
+            <Avatar data-testid={'next-step'}>
                 <MoreHorizIcon />
             </Avatar>
         );

--- a/hat/assets/js/apps/Iaso/domains/instances/components/ValidationWorkflow/timeline/ListItemSecondaryText.test.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/ValidationWorkflow/timeline/ListItemSecondaryText.test.tsx
@@ -29,16 +29,45 @@ describe('ListItemSecondaryText', () => {
         id: 1,
         status: 'ACCEPTED',
         updated_by: 'John Doe',
-        updated_at: '2024-01-01T10:00:00Z',
+        updated_at: '2024-01-01T10:00:00',
         comment: 'Looks good',
         user_can_do_actions: false,
         node_template_slug: 'node-slug',
         order: 1,
         name: 'Node 1',
-        created_at: '2024-01-01T09:00:00Z',
+        created_at: '2024-01-01T09:00:00',
     };
 
-    it('renders pending text for most recent UNKNOWN item', () => {
+    it('renders nothing if type is NEXT_STEP', () => {
+        const { container } = renderWithThemeAndIntlProvider(
+            <ListItemSecondaryText
+                timelineItem={{
+                    ...baseTimelineItem,
+                    type: 'NEXT_STEP',
+                    status: 'UNKNOWN',
+                }}
+                instanceId={123}
+            />,
+        );
+        expect(container.innerHTML).toBe('');
+    });
+
+    it("renders nothing if type is NEXT_BYPASS and user can't do action", () => {
+        const { container } = renderWithThemeAndIntlProvider(
+            <ListItemSecondaryText
+                timelineItem={{
+                    ...baseTimelineItem,
+                    type: 'NEXT_BYPASS',
+                    user_can_do_actions: false,
+                    status: 'UNKNOWN',
+                }}
+                instanceId={123}
+            />,
+        );
+        expect(container.innerHTML).toBe('');
+    });
+
+    it('renders pending text for UNKNOWN item', () => {
         renderWithThemeAndIntlProvider(
             <ListItemSecondaryText
                 timelineItem={{
@@ -63,7 +92,6 @@ describe('ListItemSecondaryText', () => {
                     status: 'UNKNOWN',
                     user_can_do_actions: true,
                 }}
-                isMostRecent={true}
                 instanceId={123}
             />,
         );
@@ -85,7 +113,6 @@ describe('ListItemSecondaryText', () => {
                     status: 'UNKNOWN',
                     user_can_do_actions: true,
                 }}
-                isMostRecent={true}
                 instanceId={123}
             />,
         );
@@ -106,7 +133,6 @@ describe('ListItemSecondaryText', () => {
                     type: 'TIMELINE',
                     status: 'SKIPPED',
                 }}
-                isMostRecent={false}
                 instanceId={123}
             />,
         );
@@ -120,9 +146,8 @@ describe('ListItemSecondaryText', () => {
                 timelineItem={{
                     ...baseTimelineItem,
                     type: 'TIMELINE',
-                    status: 'UNKNOWN',
+                    status: 'APPROVED',
                 }}
-                isMostRecent={false}
                 instanceId={123}
             />,
         );
@@ -138,9 +163,8 @@ describe('ListItemSecondaryText', () => {
                 timelineItem={{
                     ...baseTimelineItem,
                     type: 'TIMELINE',
-                    status: 'UNKNOWN',
+                    status: 'REJECTED',
                 }}
-                isMostRecent={false}
                 instanceId={123}
             />,
         );
@@ -159,7 +183,6 @@ describe('ListItemSecondaryText', () => {
                     status: 'ACCEPTED',
                     comment: '',
                 }}
-                isMostRecent={false}
                 instanceId={123}
             />,
         );
@@ -176,7 +199,6 @@ describe('ListItemSecondaryText', () => {
                     status: 'UNKNOWN',
                     user_can_do_actions: false,
                 }}
-                isMostRecent={true}
                 instanceId={123}
             />,
         );

--- a/hat/assets/js/apps/Iaso/domains/instances/components/ValidationWorkflow/timeline/ListItemSecondaryText.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/ValidationWorkflow/timeline/ListItemSecondaryText.tsx
@@ -13,123 +13,134 @@ import MESSAGES from '../../../messages';
 
 type ListItemSecondaryTextProps = {
     timelineItem: Timeline;
-    isMostRecent: boolean;
     instanceId: number;
 };
 export const ListItemSecondaryText = ({
     timelineItem,
-    isMostRecent,
     instanceId,
 }: ListItemSecondaryTextProps) => {
     const { formatMessage } = useSafeIntl();
 
     if (
-        isMostRecent &&
-        (timelineItem.type === 'NEXT_BYPASS' ||
-            timelineItem.status === 'UNKNOWN')
+        timelineItem.type === 'NEXT_STEP' ||
+        (timelineItem.type === 'NEXT_BYPASS' &&
+            !timelineItem.user_can_do_actions)
+    ) {
+        return;
+    }
+
+    if (
+        timelineItem.type === 'NEXT_BYPASS' &&
+        timelineItem.user_can_do_actions
     ) {
         return (
             <>
                 <Typography sx={{ textTransform: 'uppercase' }}>
                     {formatMessage(MESSAGES.pending)}
                 </Typography>
-                {timelineItem.user_can_do_actions &&
-                    timelineItem.type !== 'NEXT_BYPASS' && (
-                        <Box
-                            sx={{
-                                display: 'flex',
-                                justifyContent: 'space-between',
-                                my: 1,
-                                pr: 2,
-                                flexWrap: 'wrap',
-                            }}
-                        >
-                            <ValidateNodeRejectModal
-                                nodeId={timelineItem.id}
-                                iconProps={{
-                                    buttonText: formatMessage(MESSAGES.reject),
-                                    color: 'error',
-                                }}
-                                instanceId={instanceId}
-                            />
-                            <ValidateNodeApproveModal
-                                nodeId={timelineItem.id}
-                                iconProps={{
-                                    buttonText: formatMessage(MESSAGES.approve),
-                                    color: 'success',
-                                }}
-                                instanceId={instanceId}
-                            />
-                        </Box>
-                    )}
-                {timelineItem.user_can_do_actions &&
-                    timelineItem.type === 'NEXT_BYPASS' && (
-                        <Box
-                            sx={{
-                                display: 'flex',
-                                justifyContent: 'space-between',
-                                my: 1,
-                                pr: 2,
-                                flexWrap: 'wrap',
-                            }}
-                        >
-                            <ValidateNodeRejectByPassModal
-                                nodeSlug={timelineItem.node_template_slug}
-                                iconProps={{
-                                    buttonText: formatMessage(MESSAGES.reject),
-                                    color: 'error',
-                                }}
-                                instanceId={instanceId}
-                            />
-                            <ValidateNodeApproveByPassModal
-                                nodeSlug={timelineItem.node_template_slug}
-                                iconProps={{
-                                    buttonText: formatMessage(MESSAGES.approve),
-                                    color: 'success',
-                                }}
-                                instanceId={instanceId}
-                            />
-                        </Box>
-                    )}
+                <Box
+                    sx={{
+                        display: 'flex',
+                        justifyContent: 'space-between',
+                        my: 1,
+                        pr: 2,
+                        flexWrap: 'wrap',
+                    }}
+                >
+                    <ValidateNodeRejectByPassModal
+                        nodeSlug={timelineItem.node_template_slug}
+                        iconProps={{
+                            buttonText: formatMessage(MESSAGES.reject),
+                            color: 'error',
+                        }}
+                        instanceId={instanceId}
+                    />
+                    <ValidateNodeApproveByPassModal
+                        nodeSlug={timelineItem.node_template_slug}
+                        iconProps={{
+                            buttonText: formatMessage(MESSAGES.approve),
+                            color: 'success',
+                        }}
+                        instanceId={instanceId}
+                    />
+                </Box>
             </>
         );
     }
+
+    if (timelineItem.status === 'UNKNOWN') {
+        return (
+            <>
+                <Typography sx={{ textTransform: 'uppercase' }}>
+                    {formatMessage(MESSAGES.pending)}
+                </Typography>
+                {timelineItem.user_can_do_actions && (
+                    <Box
+                        sx={{
+                            display: 'flex',
+                            justifyContent: 'space-between',
+                            my: 1,
+                            pr: 2,
+                            flexWrap: 'wrap',
+                        }}
+                    >
+                        <ValidateNodeRejectModal
+                            nodeId={timelineItem.id}
+                            iconProps={{
+                                buttonText: formatMessage(MESSAGES.reject),
+                                color: 'error',
+                            }}
+                            instanceId={instanceId}
+                        />
+                        <ValidateNodeApproveModal
+                            nodeId={timelineItem.id}
+                            iconProps={{
+                                buttonText: formatMessage(MESSAGES.approve),
+                                color: 'success',
+                            }}
+                            instanceId={instanceId}
+                        />
+                    </Box>
+                )}
+            </>
+        );
+    }
+
     if (timelineItem.status === 'SKIPPED') {
         return (
             <Typography sx={{ textTransform: 'uppercase' }}>
                 {formatMessage(MESSAGES.skipped)}
             </Typography>
         );
-    } else {
-        return (
-            <>
-                <Typography color="text.secondary" sx={{ fontSize: '0.7rem' }}>
-                    {formatMessage(MESSAGES.validationTimelineByOn, {
-                        user: timelineItem.updated_by,
-                        date: moment(timelineItem.updated_at).format(
-                            'YYYY-MM-DD HH:mm:ss',
-                        ),
-                    })}
-                </Typography>
-                {timelineItem?.comment &&
-                    formatMessage(MESSAGES.validationTimelineComment, {
-                        firstTag: (chunks: ReactNode[]) => (
-                            <Typography
-                                fontWeight={'bold'}
-                                component={'span'}
-                                variant={'body2'}
-                            >
-                                {chunks}
-                            </Typography>
-                        ),
-                        secondTag: (chunks: ReactNode[]) => (
-                            <Typography component={'span'} variant={'body2'}>
-                                {chunks}
-                            </Typography>
-                        ),
-                        comment: timelineItem.comment,
-                    })}
-            </>
-        );
     }
+    return (
+        <>
+            <Typography color="text.secondary" sx={{ fontSize: '0.7rem' }}>
+                {formatMessage(MESSAGES.validationTimelineByOn, {
+                    user: timelineItem.updated_by as string,
+                    date: moment(timelineItem.updated_at).format(
+                        'YYYY-MM-DD HH:mm:ss',
+                    ),
+                })}
+            </Typography>
+            {timelineItem?.comment &&
+                formatMessage(MESSAGES.validationTimelineComment, {
+                    firstTag: (chunks: ReactNode[]) => (
+                        <Typography
+                            fontWeight={'bold'}
+                            component={'span'}
+                            variant={'body2'}
+                        >
+                            {chunks}
+                        </Typography>
+                    ),
+                    secondTag: (chunks: ReactNode[]) => (
+                        <Typography component={'span'} variant={'body2'}>
+                            {chunks}
+                        </Typography>
+                    ),
+                    comment: timelineItem.comment,
+                })}
+        </>
+    );
 };

--- a/hat/assets/js/apps/Iaso/domains/instances/components/ValidationWorkflow/timeline/SubmissionAccordion.test.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/ValidationWorkflow/timeline/SubmissionAccordion.test.tsx
@@ -32,7 +32,7 @@ describe('SubmissionAccordion', () => {
         submission: baseSubmission,
         order: 1,
         isMostRecent: false,
-        createdAt: '2024-01-01T10:00:00Z',
+        createdAt: '2024-01-01T10:00:00',
         createdBy: 'John Doe',
         instanceId: 123,
     };
@@ -137,17 +137,11 @@ describe('SubmissionAccordion', () => {
 
     it('passes correct props to SubmissionList', () => {
         renderWithThemeAndIntlProvider(
-            <SubmissionAccordion
-                {...defaultProps}
-                totalSteps={7}
-                isMostRecent={true}
-            />,
+            <SubmissionAccordion {...defaultProps} totalSteps={7} />,
         );
 
         expect(
-            screen.getByText(
-                /SubmissionList - totalSteps: 7 - mostRecent: true/i,
-            ),
+            screen.getByText(/SubmissionList - totalSteps: 7/i),
         ).toBeInTheDocument();
     });
 

--- a/hat/assets/js/apps/Iaso/domains/instances/components/ValidationWorkflow/timeline/SubmissionAccordion.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/ValidationWorkflow/timeline/SubmissionAccordion.tsx
@@ -142,7 +142,6 @@ export const SubmissionAccordion = ({
                 <SubmissionList
                     timeline={submission.timeline}
                     totalSteps={totalSteps}
-                    isMostRecent={isMostRecent}
                     instanceId={instanceId}
                 />
             </AccordionDetails>

--- a/hat/assets/js/apps/Iaso/domains/instances/components/ValidationWorkflow/timeline/SubmissionList.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/ValidationWorkflow/timeline/SubmissionList.tsx
@@ -20,37 +20,43 @@ export const SubmissionList = ({
 }: SubmissionListProps) => {
     return (
         <List sx={{ width: '100%', bgcolor: 'background.paper' }}>
-            {timeline?.map(timelineItem => {
-                return (
-                    <ListItem
-                        alignItems="flex-start"
-                        key={timelineItem.id}
-                        sx={{
-                            bgcolor: 'background.paper',
-                            border: '1px solid',
-                            borderColor: 'divider',
-                            boxShadow: 1,
-                        }}
-                    >
-                        <ListItemAvatar>
-                            <AvatarTimeline
-                                status={timelineItem.status}
-                                type={timelineItem.type}
-                            />
-                        </ListItemAvatar>
-                        <ListItemText
-                            primary={`${timelineItem.name} (${timelineItem.order}/${totalSteps})`}
-                            secondary={
-                                <ListItemSecondaryText
-                                    timelineItem={timelineItem}
-                                    isMostRecent={isMostRecent}
-                                    instanceId={instanceId}
+            {timeline
+                ?.filter(
+                    timelineItem =>
+                        timelineItem.type !== 'NEXT_BYPASS' ||
+                        timelineItem.user_can_do_actions,
+                )
+                ?.map(timelineItem => {
+                    return (
+                        <ListItem
+                            alignItems="flex-start"
+                            key={timelineItem.id}
+                            sx={{
+                                bgcolor: 'background.paper',
+                                border: '1px solid',
+                                borderColor: 'divider',
+                                boxShadow: 1,
+                            }}
+                        >
+                            <ListItemAvatar>
+                                <AvatarTimeline
+                                    status={timelineItem.status}
+                                    type={timelineItem.type}
                                 />
-                            }
-                        ></ListItemText>
-                    </ListItem>
-                );
-            })}
+                            </ListItemAvatar>
+                            <ListItemText
+                                primary={`${timelineItem.name} (${timelineItem.order}/${totalSteps})`}
+                                secondary={
+                                    <ListItemSecondaryText
+                                        timelineItem={timelineItem}
+                                        isMostRecent={isMostRecent}
+                                        instanceId={instanceId}
+                                    />
+                                }
+                            ></ListItemText>
+                        </ListItem>
+                    );
+                })}
         </List>
     );
 };

--- a/hat/assets/js/apps/Iaso/domains/instances/components/ValidationWorkflow/timeline/SubmissionList.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/ValidationWorkflow/timeline/SubmissionList.tsx
@@ -8,55 +8,49 @@ import { AvatarTimeline } from './AvatarTimeline';
 type SubmissionListProps = {
     totalSteps: number;
     instanceId: number;
-    isMostRecent: boolean;
     timeline: Timeline[];
 };
 
 export const SubmissionList = ({
     timeline,
     totalSteps,
-    isMostRecent,
     instanceId,
 }: SubmissionListProps) => {
     return (
         <List sx={{ width: '100%', bgcolor: 'background.paper' }}>
-            {timeline
-                ?.filter(
-                    timelineItem =>
-                        timelineItem.type !== 'NEXT_BYPASS' ||
-                        timelineItem.user_can_do_actions,
-                )
-                ?.map(timelineItem => {
-                    return (
-                        <ListItem
-                            alignItems="flex-start"
-                            key={timelineItem.id}
-                            sx={{
-                                bgcolor: 'background.paper',
-                                border: '1px solid',
-                                borderColor: 'divider',
-                                boxShadow: 1,
-                            }}
-                        >
-                            <ListItemAvatar>
-                                <AvatarTimeline
-                                    status={timelineItem.status}
-                                    type={timelineItem.type}
-                                />
-                            </ListItemAvatar>
-                            <ListItemText
-                                primary={`${timelineItem.name} (${timelineItem.order}/${totalSteps})`}
-                                secondary={
-                                    <ListItemSecondaryText
-                                        timelineItem={timelineItem}
-                                        isMostRecent={isMostRecent}
-                                        instanceId={instanceId}
-                                    />
+            {timeline?.map(timelineItem => {
+                return (
+                    <ListItem
+                        alignItems="flex-start"
+                        key={timelineItem.id}
+                        sx={{
+                            bgcolor: 'background.paper',
+                            border: '1px solid',
+                            borderColor: 'divider',
+                            boxShadow: 1,
+                        }}
+                    >
+                        <ListItemAvatar>
+                            <AvatarTimeline
+                                status={timelineItem.status}
+                                type={timelineItem.type}
+                                userCanDoActions={
+                                    timelineItem.user_can_do_actions
                                 }
-                            ></ListItemText>
-                        </ListItem>
-                    );
-                })}
+                            />
+                        </ListItemAvatar>
+                        <ListItemText
+                            primary={`${timelineItem.name} (${timelineItem.order}/${totalSteps})`}
+                            secondary={
+                                <ListItemSecondaryText
+                                    timelineItem={timelineItem}
+                                    instanceId={instanceId}
+                                />
+                            }
+                        ></ListItemText>
+                    </ListItem>
+                );
+            })}
         </List>
     );
 };

--- a/hat/assets/js/apps/Iaso/domains/validationWorkflowsConfiguration/types/validationNodes.ts
+++ b/hat/assets/js/apps/Iaso/domains/validationWorkflowsConfiguration/types/validationNodes.ts
@@ -42,7 +42,7 @@ export type Timeline = {
         | 'NEW_VERSION'
         | 'SUBMISSION';
     updated_by?: string;
-    type: 'NEXT_BYPASS' | 'TIMELINE';
+    type: 'NEXT_BYPASS' | 'TIMELINE' | 'NEXT_STEP';
     user_can_do_actions: boolean;
     order: number;
 };

--- a/iaso/api/validation_workflow_instances/serializers/retrieve.py
+++ b/iaso/api/validation_workflow_instances/serializers/retrieve.py
@@ -73,7 +73,7 @@ class NestedTimelineSerializer(BaseNestedTimelineSerializer):
             "order",
         ]
 
-    @extend_schema_field(serializers.ChoiceField(choices=["TIMELINE", "NEXT_BYPASS"]))
+    @extend_schema_field(serializers.ChoiceField(choices=["TIMELINE", "NEXT_BYPASS", "NEXT_STEP"]))
     def get_type(self, obj):
         return "TIMELINE"
 
@@ -84,7 +84,7 @@ class NestedTimelineSerializer(BaseNestedTimelineSerializer):
         return [x.pk for x in obj.node.roles_required.all()]
 
 
-class NestedTimelineNextBypassSerializer(BaseNestedTimelineSerializer):
+class NestedTimelineNextTemplatesSerializer(BaseNestedTimelineSerializer):
     """
     Must be similar to NestedTimelineSerializer for swagger compliance (see get_timeline method) hence the get_methods that return None
     """
@@ -121,7 +121,7 @@ class NestedTimelineNextBypassSerializer(BaseNestedTimelineSerializer):
         return None
 
     def get_type(self, obj):
-        return "NEXT_BYPASS"
+        return "NEXT_BYPASS" if obj.can_skip_previous_nodes else "NEXT_STEP"
 
     def get_node_slug(self, obj):
         return obj.slug
@@ -193,7 +193,8 @@ class NestedSubmissionSerializer(ModelSerializer):
     def get_timeline(self, obj):
         instance = self._get_instance(obj)
 
-        # get history
+        status = self.get_general_validation_status(obj)
+
         nodes = instance.prefetched_validation_nodes
         nodes_timeline = [
             n
@@ -202,45 +203,46 @@ class NestedSubmissionSerializer(ModelSerializer):
         ]
         nodes_timeline = sorted(nodes_timeline, key=lambda n: n.updated_at, reverse=True)
 
-        next_bypass = None
-        if not obj.next_created_at and instance.general_validation_status == ValidationWorkflowArtefactStatus.PENDING:
-            node_order = list(reversed(self.context["node_dumps"]))
+        if status in [ValidationWorkflowArtefactStatus.REJECTED, ValidationWorkflowArtefactStatus.APPROVED]:
+            return NestedTimelineSerializer(nodes_timeline, context=self.context, many=True).data
 
-            ordering = Case(
-                *[When(slug=slug, then=pos) for pos, slug in enumerate(node_order)],
-                output_field=IntegerField(),
+        # means there we're in PENDING, so we need to display whole graph
+        node_order = list(reversed(self.context["node_dumps"]))
+
+        ordering = Case(
+            *[When(slug=slug, then=pos) for pos, slug in enumerate(node_order)],
+            output_field=IntegerField(),
+        )
+
+        next_templates = (
+            ValidationNodeTemplate.objects.prefetch_related("roles_required")
+            .filter(
+                workflow=instance.form.validation_workflow,
             )
-
-            next_bypass = (
-                ValidationNodeTemplate.objects.prefetch_related("roles_required")
-                .filter(
-                    can_skip_previous_nodes=True,
-                    workflow=instance.form.validation_workflow,
-                )
-                .filter(
-                    Q(
-                        ~Exists(
-                            ValidationNode.objects.exclude(created_at__lt=obj.created_at).filter(
-                                instance=instance,
-                                node=OuterRef("pk"),
-                            )
-                        )
-                    )
-                    & Q(
-                        ~Exists(
-                            ValidationNode.objects.exclude(created_at__lt=obj.created_at).filter(
-                                instance=instance,
-                                node=OuterRef("pk"),
-                                status=ValidationNodeStatus.UNKNOWN,
-                            )
+            .filter(
+                Q(
+                    ~Exists(
+                        ValidationNode.objects.exclude(created_at__lt=obj.created_at).filter(
+                            instance=instance,
+                            node=OuterRef("pk"),
                         )
                     )
                 )
-                .order_by(ordering)
+                & Q(
+                    ~Exists(
+                        ValidationNode.objects.exclude(created_at__lt=obj.created_at).filter(
+                            instance=instance,
+                            node=OuterRef("pk"),
+                            status=ValidationNodeStatus.UNKNOWN,
+                        )
+                    )
+                )
             )
+            .order_by(ordering)
+        )
 
         return (
-            NestedTimelineNextBypassSerializer(next_bypass, many=True, context=self.context).data
+            NestedTimelineNextTemplatesSerializer(next_templates, many=True, context=self.context).data
             + NestedTimelineSerializer(nodes_timeline, context=self.context, many=True).data
         )
 

--- a/iaso/tests/api/validation_workflow_instances/test_views/test_retrieve.py
+++ b/iaso/tests/api/validation_workflow_instances/test_views/test_retrieve.py
@@ -194,7 +194,7 @@ class ValidationWorkflowInstanceAPIRetrieveTestCase(SwaggerTestCaseMixin, APITes
                 self.assertIsNone(first_submission["next_created_at"])
                 self.assertEqual(first_submission["created_by"], self.john_wick.username)
 
-                self.assertEqual(len(first_submission["timeline"]), 2)
+                self.assertEqual(len(first_submission["timeline"]), 3)
 
                 timeline = first_submission["timeline"]
 
@@ -214,16 +214,29 @@ class ValidationWorkflowInstanceAPIRetrieveTestCase(SwaggerTestCaseMixin, APITes
 
                 second_item = timeline[1]
                 self.assertIsNotNone(second_item["id"])
-                self.assertEqual(second_item["name"], "First node")
-                self.assertEqual(second_item["node_template_slug"], "first-node")
-                self.assertEqual(second_item["comment"], "")
-                self.assertIsNotNone(second_item["updated_at"])
-                self.assertIsNotNone(second_item["created_at"])
-                self.assertEqual(second_item["status"], ValidationNodeStatus.UNKNOWN)
-                self.assertIsNone(second_item["updated_by"], self.john_wick.username)
-                self.assertEqual(second_item["type"], "TIMELINE")
-                self.assertEqual(second_item["order"], 1)
-                self.assertTrue(second_item["user_can_do_actions"])
+                self.assertEqual(second_item["name"], "Second node")
+                self.assertEqual(second_item["node_template_slug"], "second-node")
+                self.assertIsNone(first_item["comment"])
+                self.assertIsNotNone(first_item["updated_at"])
+                self.assertIsNotNone(first_item["created_at"])
+                self.assertIsNone(first_item["status"])
+                self.assertIsNone(first_item["updated_by"])
+                self.assertEqual(first_item["type"], "NEXT_BYPASS")
+                self.assertEqual(first_item["order"], 3)
+                self.assertTrue(first_item["user_can_do_actions"])
+
+                third_item = timeline[2]
+                self.assertIsNotNone(third_item["id"])
+                self.assertEqual(third_item["name"], "First node")
+                self.assertEqual(third_item["node_template_slug"], "first-node")
+                self.assertEqual(third_item["comment"], "")
+                self.assertIsNotNone(third_item["updated_at"])
+                self.assertIsNotNone(third_item["created_at"])
+                self.assertEqual(third_item["status"], ValidationNodeStatus.UNKNOWN)
+                self.assertIsNone(third_item["updated_by"], self.john_wick.username)
+                self.assertEqual(third_item["type"], "TIMELINE")
+                self.assertEqual(third_item["order"], 1)
+                self.assertTrue(third_item["user_can_do_actions"])
 
     def test_data_approved(self):
         self.setup_approve()
@@ -457,7 +470,7 @@ class ValidationWorkflowInstanceAPIRetrieveTestCaseResubmissionWithNextByPass(Sw
         self.assertIsNone(first_submission["next_created_at"])
         self.assertEqual(first_submission["created_by"], self.john_wick.username)
 
-        self.assertEqual(len(first_submission["timeline"]), 3)
+        self.assertEqual(len(first_submission["timeline"]), 4)
 
         timeline = first_submission["timeline"]
 
@@ -490,16 +503,29 @@ class ValidationWorkflowInstanceAPIRetrieveTestCaseResubmissionWithNextByPass(Sw
 
         third_item = timeline[2]
         self.assertIsNotNone(third_item["id"])
-        self.assertEqual(third_item["name"], "First node")
-        self.assertEqual(third_item["node_template_slug"], "first-node")
-        self.assertEqual(third_item["comment"], "")
+        self.assertEqual(third_item["name"], "Second node")
+        self.assertEqual(third_item["node_template_slug"], "second-node")
+        self.assertIsNone(third_item["comment"])
         self.assertIsNotNone(third_item["updated_at"])
         self.assertIsNotNone(third_item["created_at"])
-        self.assertEqual(third_item["status"], ValidationNodeStatus.UNKNOWN)
+        self.assertIsNone(third_item["status"])
         self.assertIsNone(third_item["updated_by"])
-        self.assertEqual(third_item["type"], "TIMELINE")
-        self.assertEqual(third_item["order"], 1)
+        self.assertEqual(third_item["type"], "NEXT_STEP")
+        self.assertEqual(third_item["order"], 2)
         self.assertTrue(third_item["user_can_do_actions"])
+
+        fourth_item = timeline[3]
+        self.assertIsNotNone(fourth_item["id"])
+        self.assertEqual(fourth_item["name"], "First node")
+        self.assertEqual(fourth_item["node_template_slug"], "first-node")
+        self.assertEqual(fourth_item["comment"], "")
+        self.assertIsNotNone(fourth_item["updated_at"])
+        self.assertIsNotNone(fourth_item["created_at"])
+        self.assertEqual(fourth_item["status"], ValidationNodeStatus.UNKNOWN)
+        self.assertIsNone(fourth_item["updated_by"])
+        self.assertEqual(fourth_item["type"], "TIMELINE")
+        self.assertEqual(fourth_item["order"], 1)
+        self.assertTrue(fourth_item["user_can_do_actions"])
 
         second_submission = res_data["submissions"][1]
 
@@ -559,7 +585,7 @@ class ValidationWorkflowInstanceAPIRetrieveTestCaseResubmissionWithNextByPass(Sw
         self.assertIsNone(first_submission["next_created_at"])
         self.assertEqual(first_submission["created_by"], self.john_wick.username)
 
-        self.assertEqual(len(first_submission["timeline"]), 3)
+        self.assertEqual(len(first_submission["timeline"]), 4)
 
         timeline = first_submission["timeline"]
 
@@ -592,16 +618,29 @@ class ValidationWorkflowInstanceAPIRetrieveTestCaseResubmissionWithNextByPass(Sw
 
         third_item = timeline[2]
         self.assertIsNotNone(third_item["id"])
-        self.assertEqual(third_item["name"], "First node")
-        self.assertEqual(third_item["node_template_slug"], "first-node")
-        self.assertEqual(third_item["comment"], "")
+        self.assertEqual(third_item["name"], "Second node")
+        self.assertEqual(third_item["node_template_slug"], "second-node")
+        self.assertIsNone(third_item["comment"])
         self.assertIsNotNone(third_item["updated_at"])
         self.assertIsNotNone(third_item["created_at"])
-        self.assertEqual(third_item["status"], ValidationNodeStatus.UNKNOWN)
+        self.assertIsNone(third_item["status"])
         self.assertIsNone(third_item["updated_by"])
-        self.assertEqual(third_item["type"], "TIMELINE")
-        self.assertEqual(third_item["order"], 1)
+        self.assertEqual(third_item["type"], "NEXT_STEP")
+        self.assertEqual(third_item["order"], 2)
         self.assertTrue(third_item["user_can_do_actions"])
+
+        fourth_item = timeline[3]
+        self.assertIsNotNone(fourth_item["id"])
+        self.assertEqual(fourth_item["name"], "First node")
+        self.assertEqual(fourth_item["node_template_slug"], "first-node")
+        self.assertEqual(fourth_item["comment"], "")
+        self.assertIsNotNone(fourth_item["updated_at"])
+        self.assertIsNotNone(fourth_item["created_at"])
+        self.assertEqual(fourth_item["status"], ValidationNodeStatus.UNKNOWN)
+        self.assertIsNone(fourth_item["updated_by"])
+        self.assertEqual(fourth_item["type"], "TIMELINE")
+        self.assertEqual(fourth_item["order"], 1)
+        self.assertTrue(fourth_item["user_can_do_actions"])
 
         second_submission = res_data["submissions"][1]
 


### PR DESCRIPTION
## What problem is this PR solving?

In the validation workflow timeline:
* bypass validation nodes were displayed even though the user can't take any action. 
* User , for a pending submission, wanted to still see all the steps. 

### Related JIRA tickets

IA-5112

## Changes

Adapted front end and backend to change display of validation timeline: 

* If the submission is APPROVED or REJECTED: just display the history 
* If the submission is pending : 
  * We display all the steps 
  * Bypass steps where user cannot take any action or steps without any pending action are displayed greyed out without any text beside the title
  * Bypass step where user can take action and/or next pending action are displayed in orange with two buttons "approve" and "reject"

## How to test

Create a validation workflow with some bypass nodes and required roles
Trigger that workflow for an instance

User with the roles should see the bypass nodes 
User without the roles should not see them

## Notes

Will write fe tests once orval is implemented, will be easier with msw