### PR TITLE
[IA-4741] remove current user from user management list

### DIFF
--- a/iaso/api/profiles/policies.py
+++ b/iaso/api/profiles/policies.py
@@ -126,7 +126,7 @@ class ManagedUsersPolicy:
     @staticmethod
     def authorize_list(requester, queryset):
         if requester.has_perm(CORE_USERS_ADMIN_PERMISSION.full_name()):
-            return queryset
+            return queryset.exclude(user=requester)
 
         if requester.has_perm(CORE_USERS_MANAGED_PERMISSION.full_name()):
             managed_org_units = (

--- a/iaso/tests/api/profiles/test_views/test_list.py
+++ b/iaso/tests/api/profiles/test_views/test_list.py
@@ -66,14 +66,16 @@ class ProfileListAPITestCase(BaseProfileAPITestCase):
         self.client.force_authenticate(self.john)
         response = self.client.get(reverse("profiles-list"), {"managedUsersOnly": True})
         response_data = self.assertJSONResponse(response, 200)
-        self.assertValidProfileListData(response_data, 7)
+        self.assertValidProfileListData(response_data, 6)
+        self.assertNotIn(self.john.iaso_profile.id, [profile["id"] for profile in response_data["results"]])
 
     def test_profile_list_managed_user_only_user_admin(self):
-        """GET /profiles/ with auth (superuser)"""
-        self.client.force_authenticate(self.john)
+        """GET /profiles/ with auth (user has user admin permissions)"""
+        self.client.force_authenticate(self.jim)
         response = self.client.get(reverse("profiles-list"), {"managedUsersOnly": True})
         response_data = self.assertJSONResponse(response, 200)
-        self.assertValidProfileListData(response_data, 7)
+        self.assertValidProfileListData(response_data, 6)
+        self.assertNotIn(self.jim.iaso_profile.id, [profile["id"] for profile in response_data["results"]])
 
     def test_profile_list_managed_user_only_user_manager_no_org_unit(self):
         """GET /profiles/ with auth (superuser)"""


### PR DESCRIPTION
## What problem is this PR solving?

Remove the current user from the user management list when listing manageable users.

### Related JIRA tickets

IA-4741

## Changes

Updated the managed users listing policy so users with admin permissions no longer see their own profile in `GET /api/profiles/?managedUsersOnly=true`.

Added backend tests for both superuser and user admin cases to ensure the current user is excluded while the rest of the manageable profiles are still returned.

## How to test

1. Log in with a user admin account.
2. Open the Users / User management page.
3. Confirm the logged-in user does not appear in the table.
4. Confirm other users from the account are still listed.

Run the tests : 
```bash
iaso.tests.api.profiles.test_views.test_list.ProfileListAPITestCase
```
## Print screen / video

<img width="1788" height="1057" alt="image" src="https://github.com/user-attachments/assets/09e48350-7dcc-49d6-81c8-d8606e64a346" />
