### PR TITLE
SLEEP-1234: adding the new field in the initialValues

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/users/components/useInitialUser.ts
+++ b/hat/assets/js/apps/Iaso/domains/users/components/useInitialUser.ts
@@ -129,6 +129,10 @@ export const useInitialUser = (
                 value: get(initialData, 'coordination', null),
                 errors: [],
             },
+            institution: {
+                value: get(initialData, 'institution', null),
+                errors: [],
+            },
         };
     }, [initialData]);
     const [user, setUser] = useState<UserDialogData>(initialUser);

--- a/iaso/migrations/0371_merge_20260331_1612.py
+++ b/iaso/migrations/0371_merge_20260331_1612.py
@@ -4,11 +4,9 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
-        ('iaso', '0349_merge_20251014_1328'),
-        ('iaso', '0370_planning_target_org_unit_types_m2m'),
+        ("iaso", "0349_merge_20251014_1328"),
+        ("iaso", "0370_planning_target_org_unit_types_m2m"),
     ]
 
-    operations = [
-    ]
+    operations = []


### PR DESCRIPTION
## What problem is this PR solving?

This PR is about adding a new field on the User Creation

### Related JIRA tickets

[SLEEP-1234](https://bluesquare.atlassian.net/browse/SLEEP-1234)

## Changes

Added a new field in the initial values in `iaso-trypelim/iaso/hat/assets/js/apps/Iaso/domains/users/components/useInitialUser.ts`

## How to test

Linked to this PR: https://github.com/BLSQ/trypelim/pull/267

## Print screen / video

Upload here print screens or videos showing the changes.

## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).


[SLEEP-1234]: https://bluesquare.atlassian.net/browse/SLEEP-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ