### PR TITLE
[POLIO-2145] fixing the crash on the go back button

### DIFF
--- a/plugins/polio/js/src/domains/Campaigns/hooks/useCampaignTabs.tsx
+++ b/plugins/polio/js/src/domains/Campaigns/hooks/useCampaignTabs.tsx
@@ -5,7 +5,8 @@ export const useCampaignTabs = ({ formik, selectedCampaign }) => {
     const tabs = usePolioDialogTabs(formik, selectedCampaign);
     const [selectedTab, setSelectedTab] = useState<number>(0);
 
-    const ActiveForm = tabs[selectedTab].form;
+    const safeSelectedTab = selectedTab < tabs.length ? selectedTab : 0;
+    const ActiveForm = tabs[safeSelectedTab].form;
     const handleChangeTab = useCallback(
         (_event, newValue) => {
             setSelectedTab(newValue);
@@ -18,7 +19,7 @@ export const useCampaignTabs = ({ formik, selectedCampaign }) => {
             tabs,
             ActiveForm,
             handleChangeTab,
-            selectedTab,
+            selectedTab: safeSelectedTab,
         };
-    }, [tabs, ActiveForm, handleChangeTab, selectedTab]);
+    }, [tabs, ActiveForm, handleChangeTab, safeSelectedTab]);
 };


### PR DESCRIPTION
## What problem is this PR solving?

This PR is about fixing a crash happening while clicking the go back button on campaigns creation

### Related JIRA tickets

[POLIO-2145](https://bluesquare.atlassian.net/browse/POLIO-2145)

## Changes

Added a safe check to prevent tabs[selectedTab].form to be undefined. It now falls to index 0 thus preventing the crash

## How to test

> Create a new polio campaign
> When the Risk Assessment, Evaluation and Preparedness tabs show up, click on one of them
> Click on the go back button
> It should safely return to the campaign list

## Print screen / video


https://github.com/user-attachments/assets/47fbb607-e789-4047-90e0-19dcd246bffd



## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).


[POLIO-2145]: https://bluesquare.atlassian.net/browse/POLIO-2145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ