### PR TITLE
[IA-4909] Modifying the message on bulk update

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -1106,7 +1106,7 @@
     "iaso.orgUnits.fitToOutBounds": "Fit map to children bounds",
     "iaso.orgUnits.forms.noData": "No form",
     "iaso.orgUnits.formsHelperText": "Form submissions",
-    "iaso.orgUnits.GPSWarning": "GPS coordinates will NOT be updated for org units that already have coordinates or a shape",
+    "iaso.orgUnits.GPSWarning": "In case of multiple submissions for the same org unit, the average will be taken into account",
     "iaso.orgUnits.id": "ID",
     "iaso.orgUnits.infos": "Infos",
     "iaso.orgUnits.instances_count": "Number of submissions",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -1107,7 +1107,7 @@
     "iaso.orgUnits.fitToOutBounds": "Ajuster la carte aux enfants",
     "iaso.orgUnits.forms.noData": "Aucun formulaire",
     "iaso.orgUnits.formsHelperText": "Soumissions du formulaire",
-    "iaso.orgUnits.GPSWarning": "Les coordonnées GPS ne seront PAS mises à jour pour les unités d'org qui ont déjà des données géographiques",
+    "iaso.orgUnits.GPSWarning": "En cas de soumissions multiples pour une même unité organisationnelle, c'est la moyenne qui sera prise en compte",
     "iaso.orgUnits.infos": "Infos",
     "iaso.orgUnits.instances_count": "Nombre de soumissions",
     "iaso.orgUnits.missingGeolocation": "Aucune unité d'organisation trouvée avec une localisation",

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/messages.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/messages.ts
@@ -565,7 +565,7 @@ const MESSAGES = defineMessages({
     GPSWarning: {
         id: 'iaso.orgUnits.GPSWarning',
         defaultMessage:
-            'GPS coordinates will NOT be updated for org units that already have coordinates or a shape',
+            'In case of multiple submissions for the same org unit, the average will be taken into account',
     },
     multiReferenceInstancesLabel: {
         id: 'iaso.orgUnits.MultiReferenceInstancesLabel',


### PR DESCRIPTION
## What problem is this PR solving?

This PR is about changing the message on org units bulk update modal

### Related JIRA tickets

[IA-4909](https://bluesquare.atlassian.net/browse/IA-4909)

## Changes

-Changed the messages.ts and the generated text by scripts/update_trads.py

## How to test

> Go to org units list
> Try updating org units
> Hover on the information icon
> The new message should display

## Print screen / video
<img width="1136" height="875" alt="image" src="https://github.com/user-attachments/assets/5a6476b3-b3d2-462b-9983-41da226718a7" />
<img width="1136" height="875" alt="image" src="https://github.com/user-attachments/assets/28bd831a-bf29-4edb-b5b1-8950847e7216" />


## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).


[IA-4909]: https://bluesquare.atlassian.net/browse/IA-4909?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ