### PR TITLE
POLIO-2146 : generate and show on hold rounds in chronograms

### DIFF
--- a/plugins/polio/api/chronogram/filters.py
+++ b/plugins/polio/api/chronogram/filters.py
@@ -1,7 +1,7 @@
 import django_filters
 
 from dateutil.relativedelta import relativedelta
-from django.db.models import QuerySet
+from django.db.models import Q, QuerySet
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
@@ -51,6 +51,7 @@ class ChronogramFilter(django_filters.rest_framework.FilterSet):
         field_name="round__campaign__country", queryset=countries, label=_("Country")
     )
     on_time = django_filters.BooleanFilter(field_name="annotated_is_on_time", label=_("On time"))
+    on_hold = django_filters.BooleanFilter(method="get_is_on_hold", label=_("On hold"))
     search = django_filters.CharFilter(
         field_name="round__campaign__obr_name", lookup_expr="icontains", label=_("Search")
     )
@@ -67,6 +68,11 @@ class ChronogramFilter(django_filters.rest_framework.FilterSet):
         if value and value.lower() in ["1", "true"]:
             return filter_for_power_bi(queryset)
         return queryset
+
+    def get_is_on_hold(self, queryset, _, value):
+        if value == False:
+            return queryset.filter(Q(round__campaign__on_hold=False) & Q(round__on_hold=False))
+        return queryset.filter(Q(round__campaign__on_hold=True) | Q(round__on_hold=True))
 
 
 class ChronogramTaskFilter(django_filters.rest_framework.FilterSet):

--- a/plugins/polio/api/chronogram/serializers.py
+++ b/plugins/polio/api/chronogram/serializers.py
@@ -95,6 +95,10 @@ class ChronogramSerializer(DynamicFieldsModelSerializerBackwardCompatibleMixin, 
     tasks = ChronogramTaskSerializer(many=True, read_only=True)
     created_by = UserNestedSerializer(read_only=True)
     updated_by = UserNestedSerializer(read_only=True)
+    is_on_hold = serializers.SerializerMethodField(read_only=True)
+
+    def get_is_on_hold(self, chronogram):
+        return chronogram.round.campaign.on_hold or chronogram.round.on_hold
 
     class Meta:
         model = Chronogram
@@ -111,6 +115,7 @@ class ChronogramSerializer(DynamicFieldsModelSerializerBackwardCompatibleMixin, 
             "created_by",
             "updated_at",
             "updated_by",
+            "is_on_hold",
         ]
         default_fields = [
             "id",
@@ -120,6 +125,7 @@ class ChronogramSerializer(DynamicFieldsModelSerializerBackwardCompatibleMixin, 
             "is_on_time",
             "num_task_delayed",
             "percentage_of_completion",
+            "is_on_hold",
         ]
         extra_kwargs = {
             "created_at": {"read_only": True},

--- a/plugins/polio/api/chronogram/views.py
+++ b/plugins/polio/api/chronogram/views.py
@@ -62,7 +62,7 @@ class ChronogramViewSet(viewsets.ModelViewSet):
         rounds_ids = Campaign.polio_objects.filter_for_user(user).values_list("rounds", flat=True)
         return (
             Chronogram.objects.valid()
-            .filter(round_id__in=rounds_ids, round__on_hold=False)
+            .filter(round_id__in=rounds_ids)
             .select_related("round__campaign", "created_by", "updated_by")
             .prefetch_related(Prefetch("tasks", queryset=ChronogramTask.objects.valid()))
             .prefetch_related("tasks__created_by", "tasks__updated_by")
@@ -113,7 +113,8 @@ class ChronogramViewSet(viewsets.ModelViewSet):
         Returns all available rounds that can be used to create a new `Chronogram`.
         """
         user_campaigns = Campaign.polio_objects.filter_for_user(self.request.user).filter(
-            country__isnull=False, is_test=False, on_hold=False
+            country__isnull=False,
+            is_test=False,
         )
         already_linked_rounds = (
             Chronogram.objects.valid().filter(round__campaign__in=user_campaigns).values_list("round_id", flat=True)
@@ -141,7 +142,7 @@ class ChronogramTaskViewSet(viewsets.ModelViewSet):
     filter_backends = [filters.OrderingFilter, django_filters.rest_framework.DjangoFilterBackend]
     filterset_class = ChronogramTaskFilter
     pagination_class = ChronogramPagination
-    permission_classes = [HasChronogramPermission | HasChronogramRestrictedWritePermission]
+    permission_classes = [HasChronogramPermission | HasChronogramRestrictedWritePermission]  # pyright: ignore[reportGeneralTypeIssues]
     serializer_class = ChronogramTaskSerializer
 
     @property

--- a/plugins/polio/js/src/constants/translations/en.json
+++ b/plugins/polio/js/src/constants/translations/en.json
@@ -109,6 +109,7 @@
     "iaso.polio.chronogram.details.title": "Chronogram for {campaignName} Round {round_number} - Start: {round_start_date}",
     "iaso.polio.chronogram.filter.label.campaign": "Campaign",
     "iaso.polio.chronogram.filter.label.country": "Country",
+    "iaso.polio.chronogram.filter.label.on_hold": "On hold",
     "iaso.polio.chronogram.filter.label.on_time": "On time",
     "iaso.polio.chronogram.filter.label.search": "Search",
     "iaso.polio.chronogram.label.campaign": "Campaign",

--- a/plugins/polio/js/src/constants/translations/fr.json
+++ b/plugins/polio/js/src/constants/translations/fr.json
@@ -108,6 +108,7 @@
     "iaso.polio.chronogram.details.title": "Chronogramme pour {campaignName} Round {round_number} - Début : {round_start_date}",
     "iaso.polio.chronogram.filter.label.campaign": "Campagne",
     "iaso.polio.chronogram.filter.label.country": "Pays",
+    "iaso.polio.chronogram.filter.label.on_hold": "En pause",
     "iaso.polio.chronogram.filter.label.on_time": "Dans les délais",
     "iaso.polio.chronogram.filter.label.search": "Rechercher",
     "iaso.polio.chronogram.label.campaign": "Campagne",

--- a/plugins/polio/js/src/constants/urls.ts
+++ b/plugins/polio/js/src/constants/urls.ts
@@ -379,6 +379,7 @@ export const polioRouteConfigs: Record<string, RouteConfig> = {
             'campaign',
             'country',
             'on_time',
+            'on_hold',
         ],
     },
     chronogramTemplateTask: {

--- a/plugins/polio/js/src/domains/Chronogram/Chronogram/Filters/ChronogramFilters.test.tsx
+++ b/plugins/polio/js/src/domains/Chronogram/Chronogram/Filters/ChronogramFilters.test.tsx
@@ -1,0 +1,197 @@
+import React from 'react';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { renderWithThemeAndIntlProvider } from '../../../../../../../../hat/assets/js/tests/helpers';
+
+import { baseUrls } from '../../../../constants/urls';
+import { useGetCountries } from '../../../../hooks/useGetCountries';
+import { useOptionChronogram } from '../../api/useOptionChronogram';
+import MESSAGES from '../messages';
+import { ChronogramFilters } from './ChronogramFilters';
+
+const mockHandleChange = vi.fn();
+const mockHandleSearch = vi.fn();
+
+const mockUseFilterState = vi.fn();
+
+vi.mock(
+    '../../../../../../../../hat/assets/js/apps/Iaso/hooks/useFilterState',
+    () => ({
+        useFilterState: (...args: unknown[]) => mockUseFilterState(...args),
+    }),
+);
+
+vi.mock('../../api/useOptionChronogram', () => ({
+    useOptionChronogram: vi.fn(),
+}));
+
+vi.mock('../../../../hooks/useGetCountries', () => ({
+    useGetCountries: vi.fn(),
+}));
+
+vi.mock(
+    '../../../../../../../../hat/assets/js/apps/Iaso/components/DisplayIfUserHasPerm',
+    () => ({
+        DisplayIfUserHasPerm: ({ children }: { children: React.ReactNode }) => (
+            <>{children}</>
+        ),
+    }),
+);
+
+vi.mock('../Modals/CreateChronogramModal', () => ({
+    CreateChronogramModal: () => (
+        <button type="button" data-testid="create-chronogram-modal">
+            Create chronogram
+        </button>
+    ),
+}));
+
+const mockUseOptionChronogram = vi.mocked(useOptionChronogram);
+const mockUseGetCountries = vi.mocked(useGetCountries);
+
+const defaultFilters = {
+    search: '',
+    country: '',
+    campaign: '',
+    on_time: '',
+    on_hold: '',
+};
+
+const renderFilters = (params = {}) =>
+    renderWithThemeAndIntlProvider(
+        <MemoryRouter>
+            <ChronogramFilters params={params} />
+        </MemoryRouter>,
+    );
+
+describe('ChronogramFilters', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockUseFilterState.mockReturnValue({
+            filters: defaultFilters,
+            handleSearch: mockHandleSearch,
+            handleChange: mockHandleChange,
+            filtersUpdated: false,
+            changeAndSearch: vi.fn(),
+            setFiltersUpdated: vi.fn(),
+            setFilters: vi.fn(),
+        });
+        mockUseOptionChronogram.mockReturnValue({
+            data: {
+                campaigns: [{ label: 'Campaign A', value: 'camp-a' }],
+            },
+            isFetching: false,
+        } as ReturnType<typeof useOptionChronogram>);
+        mockUseGetCountries.mockReturnValue({
+            data: {
+                orgUnits: [
+                    { id: 1, name: 'Country One' },
+                    { id: 2, name: 'Country Two' },
+                ],
+            },
+            isFetching: false,
+        } as ReturnType<typeof useGetCountries>);
+    });
+
+    it('renders all filter fields', async () => {
+        renderFilters();
+
+        await waitFor(() => {
+            expect(screen.getByLabelText('search')).toBeInTheDocument();
+            expect(
+                screen.getByRole('combobox', {
+                    name: MESSAGES.filterLabelCountry.defaultMessage,
+                }),
+            ).toBeInTheDocument();
+            expect(
+                screen.getByRole('combobox', {
+                    name: MESSAGES.filterLabelCampaign.defaultMessage,
+                }),
+            ).toBeInTheDocument();
+            expect(
+                screen.getByRole('combobox', {
+                    name: MESSAGES.filterLabelOnTime.defaultMessage,
+                }),
+            ).toBeInTheDocument();
+            expect(
+                screen.getByRole('combobox', {
+                    name: MESSAGES.labelIsOnHold.defaultMessage,
+                }),
+            ).toBeInTheDocument();
+        });
+    });
+
+    it('initializes filter state from route params', () => {
+        renderFilters({ search: 'round 1', country: '1,2' });
+
+        expect(mockUseFilterState).toHaveBeenCalledWith(
+            expect.objectContaining({
+                params: { search: 'round 1', country: '1,2' },
+            }),
+        );
+    });
+
+    it('disables the search button when filters are unchanged', () => {
+        renderFilters();
+
+        expect(screen.getByTestId('search-button')).toBeDisabled();
+    });
+
+    it('enables the search button and triggers search when filters changed', async () => {
+        const user = userEvent.setup();
+        mockUseFilterState.mockReturnValue({
+            filters: { ...defaultFilters, search: 'delayed' },
+            handleSearch: mockHandleSearch,
+            handleChange: mockHandleChange,
+            filtersUpdated: true,
+            changeAndSearch: vi.fn(),
+            setFiltersUpdated: vi.fn(),
+            setFilters: vi.fn(),
+        });
+
+        renderFilters();
+
+        const searchButton = screen.getByTestId('search-button');
+        expect(searchButton).not.toBeDisabled();
+
+        await user.click(searchButton);
+
+        expect(mockHandleSearch).toHaveBeenCalledOnce();
+    });
+
+    it('calls handleChange when typing in the search field', async () => {
+        const user = userEvent.setup();
+        renderFilters();
+
+        const searchInput = screen.getByLabelText('search');
+
+        await user.type(searchInput, 'abc');
+
+        expect(mockHandleChange).toHaveBeenCalled();
+        expect(mockHandleChange).toHaveBeenCalledWith(
+            'search',
+            expect.any(String),
+        );
+    });
+
+    it('renders chronogram admin actions', async () => {
+        renderFilters();
+
+        await waitFor(() => {
+            expect(
+                screen.getByRole('link', {
+                    name: MESSAGES.linkToChronogramTemplateTask.defaultMessage,
+                }),
+            ).toHaveAttribute(
+                'href',
+                `/dashboard/${baseUrls.chronogramTemplateTask}`,
+            );
+            expect(
+                screen.getByTestId('create-chronogram-modal'),
+            ).toBeInTheDocument();
+        });
+    });
+});

--- a/plugins/polio/js/src/domains/Chronogram/Chronogram/Filters/ChronogramFilters.tsx
+++ b/plugins/polio/js/src/domains/Chronogram/Chronogram/Filters/ChronogramFilters.tsx
@@ -87,6 +87,8 @@ export const ChronogramFilters: FunctionComponent<Props> = ({ params }) => {
                         label={MESSAGES.filterLabelCampaign}
                     />
                 </Grid>
+            </Grid>
+            <Grid container spacing={2}>
                 <Grid item xs={12} md={3} lg={3}>
                     <InputComponent
                         type="select"
@@ -98,14 +100,32 @@ export const ChronogramFilters: FunctionComponent<Props> = ({ params }) => {
                         label={MESSAGES.filterLabelOnTime}
                     />
                 </Grid>
-            </Grid>
-            <Grid container item justifyContent="flex-end">
-                <Box mt={2}>
-                    <SearchButton
-                        disabled={!filtersUpdated}
-                        onSearch={handleSearch}
+                <Grid item xs={12} md={3} lg={3}>
+                    <InputComponent
+                        type="select"
+                        clearable
+                        keyValue="on_hold"
+                        value={filters.on_hold}
+                        onChange={handleChange}
+                        options={onTimeOptions}
+                        label={MESSAGES.labelIsOnHold}
                     />
-                </Box>
+                </Grid>
+                <Grid item xs={12} md={6} lg={6}>
+                    <Box
+                        display="flex"
+                        justifyContent="flex-end"
+                        mt={2}
+                        alignItems="center"
+                        alignContent="center"
+                        textAlign="center"
+                    >
+                        <SearchButton
+                            disabled={!filtersUpdated}
+                            onSearch={handleSearch}
+                        />
+                    </Box>
+                </Grid>
             </Grid>
             <DisplayIfUserHasPerm permissions={[Permission.POLIO_CHRONOGRAM]}>
                 <Grid container item justifyContent="flex-end" mt={4}>

--- a/plugins/polio/js/src/domains/Chronogram/Chronogram/Table/useChronogramTableColumns.tsx
+++ b/plugins/polio/js/src/domains/Chronogram/Chronogram/Table/useChronogramTableColumns.tsx
@@ -6,11 +6,11 @@ import {
     DateTimeCellRfc,
 } from '../../../../../../../../hat/assets/js/apps/Iaso/components/Cells/DateTimeCell';
 import { DisplayIfUserHasPerm } from '../../../../../../../../hat/assets/js/apps/Iaso/components/DisplayIfUserHasPerm';
+import * as Permission from '../../../../../../../../hat/assets/js/apps/Iaso/utils/permissions';
 import { baseUrls } from '../../../../constants/urls';
 
 import MESSAGES from '../messages';
 import { DeleteChronogram } from '../Modals/DeleteChronogramModal';
-import * as Permission from '../../../../../../../../hat/assets/js/apps/Iaso/utils/permissions';
 
 export const useChronogramTableColumns = (): Column[] => {
     const { formatMessage } = useSafeIntl();
@@ -39,9 +39,18 @@ export const useChronogramTableColumns = (): Column[] => {
                 Cell: DateCell,
             },
             {
-                Header: formatMessage(MESSAGES.labelIsOnTime),
+                Header: formatMessage(MESSAGES.labelIsOnHold),
                 id: 'annotated_is_on_time',
                 accessor: 'is_on_time',
+                Cell: settings =>
+                    settings.row.original.is_on_hold
+                        ? formatMessage(MESSAGES.yes)
+                        : formatMessage(MESSAGES.no),
+            },
+            {
+                Header: formatMessage(MESSAGES.labelIsOnTime),
+                id: 'is_on_hold',
+                accessor: 'is_on_hold',
                 Cell: settings =>
                     settings.row.original.is_on_time
                         ? formatMessage(MESSAGES.yes)

--- a/plugins/polio/js/src/domains/Chronogram/Chronogram/messages.ts
+++ b/plugins/polio/js/src/domains/Chronogram/Chronogram/messages.ts
@@ -89,6 +89,10 @@ const MESSAGES = defineMessages({
         id: 'iaso.polio.chronogram.filter.label.on_time',
         defaultMessage: 'On time',
     },
+    labelIsOnHold: {
+        id: 'iaso.polio.chronogram.filter.label.on_hold',
+        defaultMessage: 'On hold',
+    },
     linkToChronogramTemplateTask: {
         id: 'iaso.polio.chronogram.link_to_chronogram_template_task',
         defaultMessage: 'Edit Default Tasks',

--- a/plugins/polio/tests/api/chronogram/test_chronogram_filters.py
+++ b/plugins/polio/tests/api/chronogram/test_chronogram_filters.py
@@ -48,9 +48,7 @@ class ChronogramFiltersTestCase(APITestCase):
         )
 
         # Campaign on hold.
-        cls.campaign_on_hold = Campaign.objects.create(
-            obr_name="On Hold Campaign", account=cls.account, on_hold=True
-        )
+        cls.campaign_on_hold = Campaign.objects.create(obr_name="On Hold Campaign", account=cls.account, on_hold=True)
         cls.campaign_on_hold.campaign_types.add(cls.polio_type)
         cls.round_on_hold_campaign = Round.objects.create(
             number=1, campaign=cls.campaign_on_hold, started_at=TODAY.date()
@@ -60,16 +58,12 @@ class ChronogramFiltersTestCase(APITestCase):
         )
 
         # Round on hold (campaign not on hold).
-        cls.campaign_round_on_hold = Campaign.objects.create(
-            obr_name="Round On Hold Campaign", account=cls.account
-        )
+        cls.campaign_round_on_hold = Campaign.objects.create(obr_name="Round On Hold Campaign", account=cls.account)
         cls.campaign_round_on_hold.campaign_types.add(cls.polio_type)
         cls.round_on_hold = Round.objects.create(
             number=1, campaign=cls.campaign_round_on_hold, started_at=TODAY.date(), on_hold=True
         )
-        cls.chronogram_round_on_hold = Chronogram.objects.create(
-            round=cls.round_on_hold, created_by=cls.user
-        )
+        cls.chronogram_round_on_hold = Chronogram.objects.create(round=cls.round_on_hold, created_by=cls.user)
 
     def test_filter_for_power_bi(self):
         queryset = filter_for_power_bi(Chronogram.objects.all())

--- a/plugins/polio/tests/api/chronogram/test_chronogram_filters.py
+++ b/plugins/polio/tests/api/chronogram/test_chronogram_filters.py
@@ -2,9 +2,12 @@ import datetime
 
 import time_machine
 
+from iaso import models as m
 from iaso.test import APITestCase
 from plugins.polio.api.chronogram.filters import filter_for_power_bi
-from plugins.polio.models import Chronogram
+from plugins.polio.models import Campaign, CampaignType, Chronogram, Round
+from plugins.polio.models.chronogram import ChronogramTask, Period
+from plugins.polio.permissions import POLIO_CHRONOGRAM_PERMISSION
 
 
 TODAY = datetime.datetime(2024, 8, 23, 16, 0, 0, 0, tzinfo=datetime.timezone.utc)
@@ -16,6 +19,58 @@ class ChronogramFiltersTestCase(APITestCase):
     Test Chronogram Filters.
     """
 
+    @classmethod
+    def setUpTestData(cls):
+        cls.data_source = m.DataSource.objects.create(name="Data Source")
+        cls.source_version = m.SourceVersion.objects.create(data_source=cls.data_source, number=1)
+        cls.account = m.Account.objects.create(name="Account", default_version=cls.source_version)
+        cls.user = cls.create_user_with_profile(
+            email="john@polio.org",
+            username="john",
+            first_name="John",
+            last_name="Doe",
+            account=cls.account,
+            permissions=[POLIO_CHRONOGRAM_PERMISSION],
+        )
+
+        # Campaign not on hold.
+        cls.campaign = Campaign.objects.create(obr_name="Regular Campaign", account=cls.account)
+        cls.polio_type = CampaignType.objects.get(name=CampaignType.POLIO)
+        cls.campaign.campaign_types.add(cls.polio_type)
+        cls.round = Round.objects.create(number=1, campaign=cls.campaign, started_at=TODAY.date())
+        cls.chronogram = Chronogram.objects.create(round=cls.round, created_by=cls.user)
+        ChronogramTask.objects.create(
+            period=Period.BEFORE,
+            chronogram=cls.chronogram,
+            description_en="Task",
+            description_fr="Tâche",
+            start_offset_in_days=0,
+        )
+
+        # Campaign on hold.
+        cls.campaign_on_hold = Campaign.objects.create(
+            obr_name="On Hold Campaign", account=cls.account, on_hold=True
+        )
+        cls.campaign_on_hold.campaign_types.add(cls.polio_type)
+        cls.round_on_hold_campaign = Round.objects.create(
+            number=1, campaign=cls.campaign_on_hold, started_at=TODAY.date()
+        )
+        cls.chronogram_campaign_on_hold = Chronogram.objects.create(
+            round=cls.round_on_hold_campaign, created_by=cls.user
+        )
+
+        # Round on hold (campaign not on hold).
+        cls.campaign_round_on_hold = Campaign.objects.create(
+            obr_name="Round On Hold Campaign", account=cls.account
+        )
+        cls.campaign_round_on_hold.campaign_types.add(cls.polio_type)
+        cls.round_on_hold = Round.objects.create(
+            number=1, campaign=cls.campaign_round_on_hold, started_at=TODAY.date(), on_hold=True
+        )
+        cls.chronogram_round_on_hold = Chronogram.objects.create(
+            round=cls.round_on_hold, created_by=cls.user
+        )
+
     def test_filter_for_power_bi(self):
         queryset = filter_for_power_bi(Chronogram.objects.all())
 
@@ -23,3 +78,30 @@ class ChronogramFiltersTestCase(APITestCase):
         sql_query = str(queryset.query)
 
         self.assertIn(f'"created_at" >= {three_months_ago}', sql_query)
+
+    def test_filter_on_hold_true_returns_on_hold_chronograms(self):
+        self.client.force_authenticate(self.user)
+        response = self.client.get("/api/polio/chronograms/?on_hold=true")
+        self.assertEqual(response.status_code, 200)
+        ids = [item["id"] for item in response.data["results"]]
+        self.assertIn(self.chronogram_campaign_on_hold.pk, ids)
+        self.assertIn(self.chronogram_round_on_hold.pk, ids)
+        self.assertNotIn(self.chronogram.pk, ids)
+
+    def test_filter_on_hold_false_excludes_on_hold_chronograms(self):
+        self.client.force_authenticate(self.user)
+        response = self.client.get("/api/polio/chronograms/?on_hold=false")
+        self.assertEqual(response.status_code, 200)
+        ids = [item["id"] for item in response.data["results"]]
+        self.assertIn(self.chronogram.pk, ids)
+        self.assertNotIn(self.chronogram_campaign_on_hold.pk, ids)
+        self.assertNotIn(self.chronogram_round_on_hold.pk, ids)
+
+    def test_no_on_hold_filter_returns_all(self):
+        self.client.force_authenticate(self.user)
+        response = self.client.get("/api/polio/chronograms/")
+        self.assertEqual(response.status_code, 200)
+        ids = [item["id"] for item in response.data["results"]]
+        self.assertIn(self.chronogram.pk, ids)
+        self.assertIn(self.chronogram_campaign_on_hold.pk, ids)
+        self.assertIn(self.chronogram_round_on_hold.pk, ids)

--- a/plugins/polio/tests/api/chronogram/test_chronogram_serializers.py
+++ b/plugins/polio/tests/api/chronogram/test_chronogram_serializers.py
@@ -9,6 +9,7 @@ from iaso import models as m
 from iaso.test import TestCase
 from plugins.polio.api.chronogram.serializers import (
     ChronogramCreateSerializer,
+    ChronogramSerializer,
     ChronogramTaskSerializer,
     ChronogramTemplateTaskSerializer,
 )
@@ -136,6 +137,186 @@ class ChronogramTaskSerializerTestCase(TestCase):
         self.assertEqual(chronogram_task.comment, "Comment")
         self.assertEqual(chronogram_task.created_by, self.user)
         self.assertEqual(chronogram_task.created_at, TODAY)
+
+
+@time_machine.travel(TODAY, tick=False)
+class ChronogramSerializerTestCase(TestCase):
+    """
+    Test ChronogramSerializer.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.data_source = m.DataSource.objects.create(name="Data Source")
+        cls.source_version = m.SourceVersion.objects.create(data_source=cls.data_source, number=1)
+        cls.account = m.Account.objects.create(name="Account", default_version=cls.source_version)
+        cls.user = cls.create_user_with_profile(
+            email="john@polio.org",
+            username="test",
+            first_name="John",
+            last_name="Doe",
+            account=cls.account,
+        )
+
+        cls.campaign = Campaign.objects.create(obr_name="Campaign OBR name", account=cls.account)
+        cls.polio_type = CampaignType.objects.get(name=CampaignType.POLIO)
+        cls.campaign.campaign_types.add(cls.polio_type)
+
+        cls.round = Round.objects.create(number=1, campaign=cls.campaign, started_at=TODAY.date())
+        cls.chronogram = Chronogram.objects.create(round=cls.round, created_by=cls.user)
+        cls.task_before = ChronogramTask.objects.create(
+            period=Period.BEFORE,
+            chronogram=cls.chronogram,
+            description_en="Task before",
+            description_fr="Tâche avant",
+            start_offset_in_days=-5,
+            user_in_charge="John Doe",
+            status=ChronogramTask.Status.DONE,
+        )
+        cls.task_during = ChronogramTask.objects.create(
+            period=Period.DURING,
+            chronogram=cls.chronogram,
+            description_en="Task during",
+            description_fr="Tâche pendant",
+            start_offset_in_days=0,
+            user_in_charge="John Doe",
+        )
+        cls.task_after = ChronogramTask.objects.create(
+            period=Period.AFTER,
+            chronogram=cls.chronogram,
+            description_en="Task after",
+            description_fr="Tâche après",
+            start_offset_in_days=5,
+            user_in_charge="John Doe",
+        )
+
+    def _get_chronogram(self):
+        return Chronogram.objects.select_related("round__campaign", "created_by", "updated_by").get(
+            pk=self.chronogram.pk
+        )
+
+    def test_serialize_default_fields(self):
+        chronogram = self._get_chronogram()
+        serializer = ChronogramSerializer(chronogram)
+        data = serializer.data
+        self.assertEqual(
+            set(data.keys()),
+            {
+                "id",
+                "campaign_obr_name",
+                "round_number",
+                "round_start_date",
+                "is_on_time",
+                "num_task_delayed",
+                "percentage_of_completion",
+                "is_on_hold",
+            },
+        )
+
+    def test_serialize_all_fields(self):
+        chronogram = self._get_chronogram()
+        serializer = ChronogramSerializer(chronogram, fields=":all")
+        data = serializer.data
+        self.assertEqual(
+            set(data.keys()),
+            {
+                "id",
+                "campaign_obr_name",
+                "round_number",
+                "round_start_date",
+                "is_on_time",
+                "num_task_delayed",
+                "percentage_of_completion",
+                "tasks",
+                "created_at",
+                "created_by",
+                "updated_at",
+                "updated_by",
+                "is_on_hold",
+            },
+        )
+
+    def test_serialize_campaign_and_round_fields(self):
+        chronogram = self._get_chronogram()
+        serializer = ChronogramSerializer(chronogram)
+        data = serializer.data
+        self.assertEqual(data["campaign_obr_name"], "Campaign OBR name")
+        self.assertEqual(data["round_number"], "1")
+        self.assertEqual(data["round_start_date"], str(TODAY.date()))
+
+    def test_serialize_is_on_time_true_when_no_delayed_tasks(self):
+        chronogram = self._get_chronogram()
+        serializer = ChronogramSerializer(chronogram)
+        self.assertTrue(serializer.data["is_on_time"])
+        self.assertEqual(serializer.data["num_task_delayed"], 0)
+
+    def test_serialize_percentage_of_completion(self):
+        chronogram = self._get_chronogram()
+        serializer = ChronogramSerializer(chronogram)
+        self.assertEqual(
+            serializer.data["percentage_of_completion"],
+            {"BEFORE": 100, "DURING": 0, "AFTER": 0},
+        )
+
+    def test_serialize_tasks_included_with_all_fields(self):
+        chronogram = self._get_chronogram()
+        serializer = ChronogramSerializer(chronogram, fields=":all")
+        self.assertEqual(len(serializer.data["tasks"]), 3)
+
+    def test_serialize_created_by(self):
+        chronogram = self._get_chronogram()
+        serializer = ChronogramSerializer(chronogram, fields=":all")
+        self.assertEqual(
+            serializer.data["created_by"],
+            {"id": self.user.pk, "username": "test", "full_name": "John Doe"},
+        )
+
+    def test_serialize_updated_by_none(self):
+        chronogram = self._get_chronogram()
+        serializer = ChronogramSerializer(chronogram, fields=":all")
+        self.assertIsNone(serializer.data["updated_by"])
+
+    def test_is_on_hold_false_when_neither_campaign_nor_round_on_hold(self):
+        chronogram = self._get_chronogram()
+        serializer = ChronogramSerializer(chronogram)
+        self.assertFalse(serializer.data["is_on_hold"])
+
+    def test_is_on_hold_true_when_campaign_on_hold(self):
+        self.campaign.on_hold = True
+        self.campaign.save()
+
+        chronogram = self._get_chronogram()
+        serializer = ChronogramSerializer(chronogram)
+        self.assertTrue(serializer.data["is_on_hold"])
+
+        self.campaign.on_hold = False
+        self.campaign.save()
+
+    def test_is_on_hold_true_when_round_on_hold(self):
+        self.round.on_hold = True
+        self.round.save()
+
+        chronogram = self._get_chronogram()
+        serializer = ChronogramSerializer(chronogram)
+        self.assertTrue(serializer.data["is_on_hold"])
+
+        self.round.on_hold = False
+        self.round.save()
+
+    def test_is_on_hold_true_when_both_on_hold(self):
+        self.campaign.on_hold = True
+        self.campaign.save()
+        self.round.on_hold = True
+        self.round.save()
+
+        chronogram = self._get_chronogram()
+        serializer = ChronogramSerializer(chronogram)
+        self.assertTrue(serializer.data["is_on_hold"])
+
+        self.campaign.on_hold = False
+        self.campaign.save()
+        self.round.on_hold = False
+        self.round.save()
 
 
 @time_machine.travel(TODAY, tick=False)

--- a/plugins/polio/tests/api/chronogram/test_chronogram_views.py
+++ b/plugins/polio/tests/api/chronogram/test_chronogram_views.py
@@ -389,6 +389,7 @@ class ChronogramViewSetTestCase(APITestCase):
                     "is_on_time": True,
                     "num_task_delayed": 0,
                     "percentage_of_completion": {"BEFORE": 0, "DURING": 0, "AFTER": 0},
+                    "is_on_hold": False,
                 },
             )
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -42,9 +42,15 @@ export default defineConfig({
                     name: 'unit',
                     include: [
                         'hat/assets/js/**/*.test.{ts,tsx}',
+                        'plugins/polio/js/**/*.test.{ts,tsx}',
                     ],
                     exclude: [
-                        ...configDefaults.exclude, '**/build/', '**/dist/', '**/*.min.js', '**/playwright/**', 'hat/assets/js/__tests__/**',
+                        ...configDefaults.exclude,
+                        '**/build/',
+                        '**/dist/',
+                        '**/*.min.js',
+                        '**/playwright/**',
+                        'hat/assets/js/__tests__/**',
                     ],
                 },
             },
@@ -56,7 +62,11 @@ export default defineConfig({
                         'hat/assets/js/__tests__/integration/*.test.{ts,tsx}',
                     ],
                     exclude: [
-                        ...configDefaults.exclude, '**/build/', '**/dist/', '**/*.min.js', '**/playwright/**',
+                        ...configDefaults.exclude,
+                        '**/build/',
+                        '**/dist/',
+                        '**/*.min.js',
+                        '**/playwright/**',
                     ],
                 },
             },
@@ -64,11 +74,13 @@ export default defineConfig({
                 extends: true,
                 test: {
                     name: 'api-e2e',
-                    include: [
-                        'hat/assets/js/__tests__/api/*.test.{ts,tsx}',
-                    ],
+                    include: ['hat/assets/js/__tests__/api/*.test.{ts,tsx}'],
                     exclude: [
-                        ...configDefaults.exclude, '**/build/', '**/dist/', '**/*.min.js', '**/playwright/**',
+                        ...configDefaults.exclude,
+                        '**/build/',
+                        '**/dist/',
+                        '**/*.min.js',
+                        '**/playwright/**',
                     ],
                 },
             },


### PR DESCRIPTION
## What problem is this PR solving?

rounds on hold or from a campaign on hold were excluded from chronogram auto-generration

### Related JIRA tickets

POLIO-2146

## Changes

Backend
- add field to serializer. No DB impact since all was already prefeteched
- add filter
Front-end
- Add column to table
- Add filter

## How to test

- Create a campaign with a round on hold and save it (start date in the future)
- Go to Vaccine Module> Chronogram
- Filter by country : you should see all rounds for your campaign

## Print screen / video

https://github.com/user-attachments/assets/476a4230-1970-4ed3-9c57-904d6a3038cc





