### PR TITLE
IA-5118: remove instances from deleted forms from list response

### DIFF
--- a/iaso/api/instances/views.py
+++ b/iaso/api/instances/views.py
@@ -125,7 +125,7 @@ class InstancesViewSet(viewsets.ViewSet):
                     )
                 ),
             )
-        return queryset
+        return queryset.filter(form__deleted_at__isnull=True)
 
     def _get_filtered_attachments_queryset(self, request):
         """Helper method to get filtered attachments queryset with common logic"""

--- a/iaso/tests/api/instances/test_instances.py
+++ b/iaso/tests/api/instances/test_instances.py
@@ -822,6 +822,26 @@ class InstancesAPITestCase(TaskAPITestCase):
         self.assertJSONResponse(response, 200)
         self.assertValidInstanceListData(response.json(), 3)
 
+    def test_instance_list_excludes_instances_of_soft_deleted_forms(self):
+        """GET /instances/ should not return instances whose form has been soft-deleted."""
+        self.client.force_authenticate(self.yoda)
+
+        response = self.client.get(f"/api/instances/?form_id={self.form_1.pk}")
+        self.assertJSONResponse(response, 200)
+        self.assertValidInstanceListData(response.json(), 4)
+
+        self.form_1.delete()
+
+        response = self.client.get(f"/api/instances/?form_id={self.form_1.pk}")
+        self.assertJSONResponse(response, 200)
+        self.assertValidInstanceListData(response.json(), 0)
+
+        self.form_1.restore()
+
+        response = self.client.get(f"/api/instances/?form_id={self.form_1.pk}")
+        self.assertJSONResponse(response, 200)
+        self.assertValidInstanceListData(response.json(), 4)
+
     def test_instance_details_retrieve(self):
         """
         GET /instances/{instanceid}/ shouldn't have N+1 queries with deep org unit hierarchy.


### PR DESCRIPTION
## What problem is this PR solving?

Showing instances from deleted forms didn't make sense and made for inconsistent UI

### Related JIRA tickets

IA-5118

## Changes

- Add filter on form deletion status in `InstancesViewSet`'s `get_queryset`

## How to test

- Go to forms, click see submissions for a form
- go back
- delete form
- go to submissions's page
- try to select form in dropdown: it's not visible
- Try to pass the form id manually in the url: you should get empty results

## Print screen / video



https://github.com/user-attachments/assets/2d0d08c4-6b34-4f5f-ac50-3c91492642c3



