### PR TITLE
IA-4548: fix duplicate ou count in datasource details view

### DIFF
--- a/iaso/api/data_sources.py
+++ b/iaso/api/data_sources.py
@@ -4,7 +4,8 @@ import logging
 import dhis2
 import requests
 
-from django.db.models import Count, Prefetch
+from django.db.models import Count, IntegerField, OuterRef, Prefetch, Subquery
+from django.db.models.functions import Coalesce
 from drf_spectacular.utils import extend_schema
 from rest_framework import permissions, serializers
 from rest_framework.decorators import action
@@ -290,23 +291,45 @@ class DataSourceViewSet(ModelViewSet):
         project_ids = self.request.GET.get("project_ids")
         name = self.request.GET.get("name", None)
 
+        version_org_units_subquery = (
+            OrgUnit.objects.filter(version=OuterRef("pk"))
+            .values("version")
+            .annotate(c=Count("id"))
+            .values("c")
+        )
+
         versions_prefetch = Prefetch(
             "versions",
-            queryset=SourceVersion.objects.filter(data_source__projects__account=profile.account).annotate(
-                annotated_org_units_count=Count("orgunit")
+            queryset=SourceVersion.objects.filter(data_source__projects__account=profile.account)
+            .distinct()
+            .annotate(
+                annotated_org_units_count=Coalesce(
+                    Subquery(version_org_units_subquery, output_field=IntegerField()), 0
+                )
             ),
+        )
+
+        default_version_org_units_subquery = (
+            OrgUnit.objects.filter(version=OuterRef("default_version"))
+            .values("version")
+            .annotate(c=Count("id"))
+            .values("c")
         )
 
         sources = (
             DataSource.objects.select_related("default_version", "credentials")
             .prefetch_related("projects", versions_prefetch)
             .filter(projects__account=profile.account)
-            .annotate(annotated_org_units_count=Count("default_version__orgunit"))
+            .annotate(
+                annotated_org_units_count=Coalesce(
+                    Subquery(default_version_org_units_subquery, output_field=IntegerField()), 0
+                )
+            )
             .distinct()
         )
 
         if filter_empty_versions:
-            sources = sources.annotate(version_count=Count("versions")).filter(version_count__gt=0)
+            sources = sources.annotate(version_count=Count("versions", distinct=True)).filter(version_count__gt=0)
         if name:
             sources = sources.filter(name__icontains=name)
         if project_ids:

--- a/iaso/api/data_sources.py
+++ b/iaso/api/data_sources.py
@@ -292,10 +292,7 @@ class DataSourceViewSet(ModelViewSet):
         name = self.request.GET.get("name", None)
 
         version_org_units_subquery = (
-            OrgUnit.objects.filter(version=OuterRef("pk"))
-            .values("version")
-            .annotate(c=Count("id"))
-            .values("c")
+            OrgUnit.objects.filter(version=OuterRef("pk")).values("version").annotate(c=Count("id")).values("c")
         )
 
         versions_prefetch = Prefetch(
@@ -303,9 +300,7 @@ class DataSourceViewSet(ModelViewSet):
             queryset=SourceVersion.objects.filter(data_source__projects__account=profile.account)
             .distinct()
             .annotate(
-                annotated_org_units_count=Coalesce(
-                    Subquery(version_org_units_subquery, output_field=IntegerField()), 0
-                )
+                annotated_org_units_count=Coalesce(Subquery(version_org_units_subquery, output_field=IntegerField()), 0)
             ),
         )
 

--- a/iaso/tests/api/test_data_sources.py
+++ b/iaso/tests/api/test_data_sources.py
@@ -60,6 +60,34 @@ class DataSourcesAPITestCase(APITestCase):
             response = self.client.get("/api/datasources/")
         self.assertJSONResponse(response, 200)
 
+    def test_datasource_list_no_duplicates_when_multiple_projects(self):
+        """A DataSource linked to multiple projects in the same account must not produce inflated org unit counts."""
+        self.data_source.default_version = self.source_version
+        self.data_source.save()
+
+        m.OrgUnit.objects.create(name="OU1", version=self.source_version)
+        m.OrgUnit.objects.create(name="OU2", version=self.source_version)
+        m.OrgUnit.objects.create(name="OU3", version=self.source_version)
+
+        extra_project = m.Project.objects.create(name="Extra project", app_id="extra.app", account=self.account)
+        self.data_source.projects.add(extra_project)
+
+        self.client.force_authenticate(self.jane)
+
+        with self.assertNumQueries(6):
+            response = self.client.get("/api/datasources/")
+
+        data = self.assertJSONResponse(response, 200)
+        source_ids = [s["id"] for s in data["sources"]]
+        self.assertEqual(len(source_ids), len(set(source_ids)), "Duplicate DataSource entries found in response")
+
+        ds_entry = next(s for s in data["sources"] if s["id"] == self.data_source.pk)
+        self.assertEqual(
+            ds_entry["default_version"]["org_units_count"],
+            3,
+            "Org unit count is inflated by multi-project JOIN",
+        )
+
     def test_datasource_post_with_all_params(self):
         """POST /datasource/ with all params should work OK"""
         self.client.force_authenticate(self.joe)


### PR DESCRIPTION
## What problem is this PR solving?

Org unit count in datasources details view was multiplied by the number pf projects linked to the datasource

### Related JIRA tickets

IA-4548

## Changes

- Add subquery to count OU per version more accurately

## How to test

Explain how to test your PR.
Go to orgunits: see count on table
Go to data sources: add project to active (default) data source. If data source has more than one project already, skip this step
Go to data source details view (the eye icon button): the count of org units should be the same as the org units table

## Print screen / video


https://github.com/user-attachments/assets/d04376f4-ef2c-40a8-8c2f-48442e947460



