### PR TITLE
IA-5129 improve xlsform validation message

### DIFF
--- a/iaso/api/form_versions/serializers.py
+++ b/iaso/api/form_versions/serializers.py
@@ -141,7 +141,7 @@ class FormVersionSerializer(DynamicFieldsModelSerializerBackwardCompatible):
                 previous_version=previous_form_version.version_id if previous_form_version is not None else None,
             )
         except parsing.ParsingError as e:
-            raise serializers.ValidationError({"xls_file": str(e)})
+            raise serializers.ValidationError({"xls_file": "Invalid XLS form content: " + str(e)})
 
         # validate that form_id stays constant across versions
         if form.form_id is not None and survey.form_id != form.form_id:
@@ -218,7 +218,7 @@ class FormVersionPreviewSerializer(serializers.Serializer):
             )
         except parsing.ParsingError as e:
             logger.warning("Failed to parse XLS form during preview validation: %s", e)
-            raise serializers.ValidationError({"xls_file": str(e)})
+            raise serializers.ValidationError({"xls_file": "Invalid XLS form content: " + str(e)})
 
         data["survey"] = survey
         data["previous_form_version"] = previous_form_version

--- a/iaso/api/form_versions/serializers.py
+++ b/iaso/api/form_versions/serializers.py
@@ -217,8 +217,8 @@ class FormVersionPreviewSerializer(serializers.Serializer):
                 previous_version=previous_form_version.version_id if previous_form_version is not None else None,
             )
         except parsing.ParsingError as e:
-            logger.exception("Failed to parse XLS form during preview validation")
-            raise serializers.ValidationError({"xls_file": "Invalid XLS form content."})
+            logger.warning("Failed to parse XLS form during preview validation: %s", e)
+            raise serializers.ValidationError({"xls_file": str(e)})
 
         data["survey"] = survey
         data["previous_form_version"] = previous_form_version

--- a/iaso/odk/validator.py
+++ b/iaso/odk/validator.py
@@ -34,6 +34,7 @@ def parse_sheet(excel_file, sheet_name):
     excel_data = excel_file.parse(sheet_name=sheet_name, keep_default_na=False)
     excel_data = excel_data.reset_index()
     excel_data.rename(columns={"index": "line_number"}, inplace=True)
+    excel_data.columns = excel_data.columns.str.strip()
 
     cleanable_columns = ["name", "list_name", "list name"]
     for column_name in cleanable_columns:
@@ -183,6 +184,21 @@ def validate_xls_form(xls_file):
                                 "severity": "error",
                             }
                         )
+
+    for q in question_rows:
+        raw_params = q.get("parameters", "")
+        if raw_params:
+            for token in str(raw_params).split():
+                if len(token.split("=")) != 2:
+                    validation_errors.append(
+                        {
+                            "message": f"invalid 'parameters' column value '{raw_params}' for '{q.get('name')}': expecting 'parameter=value' pairs",
+                            "question": q,
+                            "sheet": "survey",
+                            "severity": "error",
+                        }
+                    )
+                    break
 
     # TODO more advanced validations
     #    - choices

--- a/iaso/tests/api/form_versions/test_form_versions.py
+++ b/iaso/tests/api/form_versions/test_form_versions.py
@@ -412,7 +412,9 @@ class FormsVersionAPITestCase(APITestCase):
             )
         self.assertJSONResponse(response, 400)
         self.assertHasError(
-            response.json(), "xls_file", "Invalid XLS file: Parsed version should be greater than previous version."
+            response.json(),
+            "xls_file",
+            "Invalid XLS form content: Invalid XLS file: Parsed version should be greater than previous version.",
         )
 
     def test_form_versions_create_invalid_xls_file(self):
@@ -430,7 +432,7 @@ class FormsVersionAPITestCase(APITestCase):
         self.assertHasError(
             response.json(),
             "xls_file",
-            "Invalid XLS file: The survey sheet is either empty or missing important column headers.",
+            "Invalid XLS form content: Invalid XLS file: The survey sheet is either empty or missing important column headers.",
         )
 
     def test_form_versions_create_no_xls_file(self):

--- a/iaso/tests/api/form_versions/test_form_versions_preview.py
+++ b/iaso/tests/api/form_versions/test_form_versions_preview.py
@@ -21,13 +21,16 @@ Expected diff v1 → v2:
     modified: age (integer → text)
 """
 
+import io
 import tempfile
 
 from unittest import mock
 
+import openpyxl
+
 from django.core.files import File
 from django.core.files.storage import default_storage
-from django.core.files.uploadedfile import UploadedFile
+from django.core.files.uploadedfile import SimpleUploadedFile, UploadedFile
 from django.test import override_settings
 
 from iaso import models as m
@@ -171,6 +174,35 @@ class FormVersionPreviewAPITestCase(APITestCase):
         self.assertTrue(
             "xls_file_validation_errors" in data or "xls_file" in data,
             f"Expected an xls_file error key in response, got: {data}",
+        )
+
+    def test_preview_bad_parameters_column_returns_descriptive_error(self):
+        """XLS with a malformed 'parameters' column → 400 with a message that names the column."""
+        wb = openpyxl.Workbook()
+        ws = wb.active
+        ws.title = "survey"
+        ws.append(["type", "name ", "label", "parameters"])
+        ws.append(["range", "amount", "What is the age?", "nd_period"])
+        buf = io.BytesIO()
+        wb.save(buf)
+        xls_file = SimpleUploadedFile(
+            "form.xlsx",
+            buf.getvalue(),
+            content_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        )
+
+        self.client.force_authenticate(self.yoda)
+        response = self.client.post(
+            PREVIEW_URL,
+            data={"form_id": self.form_with_version.id, "xls_file": xls_file},
+            format="multipart",
+        )
+        data = self.assertJSONResponse(response, 400)
+        self.assertIn("xls_file_validation_errors", data)
+        error_messages = [e["message"] for e in data["xls_file_validation_errors"]]
+        self.assertTrue(
+            any("parameters" in msg and "nd_period" in msg for msg in error_messages),
+            f"Expected a 'parameters' column error in: {error_messages}",
         )
 
     # -------------------------------------------------------------------------

--- a/iaso/tests/odk/test_validator.py
+++ b/iaso/tests/odk/test_validator.py
@@ -1,8 +1,12 @@
+import io
 import json
+
+import openpyxl
+import pandas as pd
 
 from django.test import SimpleTestCase
 
-from iaso.odk.validator import get_list_name_from_select, validate_xls_form
+from iaso.odk.validator import get_list_name_from_select, parse_sheet, validate_xls_form
 
 
 class ValidatorTestCase(SimpleTestCase):
@@ -19,6 +23,95 @@ class ValidatorTestCase(SimpleTestCase):
             errors = validate_xls_form(xls_file)
             # print(json.dumps(errors, indent=4))
             self.assertEqual(errors, expected_errors)
+
+    def test_parse_sheet_strips_header_trailing_blanks(self):
+        wb = openpyxl.Workbook()
+        ws = wb.active
+        ws.title = "survey"
+        ws.append(["type", "name ", "label"])
+        ws.append(["text", "q1", "Question 1"])
+
+        buf = io.BytesIO()
+        wb.save(buf)
+        buf.seek(0)
+
+        excel_file = pd.ExcelFile(buf, engine="openpyxl")
+        rows = parse_sheet(excel_file, "survey")
+
+        self.assertGreater(len(rows), 0)
+        self.assertIn("name", rows[0])
+        self.assertNotIn("name ", rows[0])
+
+    def _make_xlsx_buf(self, survey_rows, choices_rows=None):
+        wb = openpyxl.Workbook()
+        ws = wb.active
+        ws.title = "survey"
+        for row in survey_rows:
+            ws.append(row)
+        if choices_rows:
+            wc = wb.create_sheet("choices")
+            for row in choices_rows:
+                wc.append(row)
+        buf = io.BytesIO()
+        wb.save(buf)
+        buf.seek(0)
+        buf.name = "form.xlsx"
+        return buf
+
+    def test_invalid_parameters_column(self):
+        buf = self._make_xlsx_buf(
+            [
+                ["type", "name", "label", "parameters"],
+                ["text", "q1", "Question 1", "nd_period"],
+            ]
+        )
+        errors = validate_xls_form(buf)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("nd_period", errors[0]["message"])
+        self.assertEqual(errors[0]["severity"], "error")
+        self.assertEqual(errors[0]["sheet"], "survey")
+
+    def test_valid_parameters_column(self):
+        buf = self._make_xlsx_buf(
+            [
+                ["type", "name", "label", "parameters"],
+                ["text", "q1", "Question 1", "randomize=true seed=42"],
+            ]
+        )
+        errors = validate_xls_form(buf)
+        self.assertEqual(errors, [])
+
+    def test_valid_parameters_column_range(self):
+        buf = self._make_xlsx_buf(
+            [
+                ["type", "name", "label", "parameters"],
+                ["range", "amount", "What is the age of the child?", "start=0 end=17 step=1"],
+            ]
+        )
+        errors = validate_xls_form(buf)
+        self.assertEqual(errors, [])
+
+    def test_invalid_parameters_column_multiple_equals(self):
+        buf = self._make_xlsx_buf(
+            [
+                ["type", "name", "label", "parameters"],
+                ["range", "amount", "Age", "start=0=extra end=17 step=1"],
+            ]
+        )
+        errors = validate_xls_form(buf)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("start=0=extra", errors[0]["message"])
+        self.assertEqual(errors[0]["severity"], "error")
+
+    def test_valid_parameters_column_multiline(self):
+        buf = self._make_xlsx_buf(
+            [
+                ["type", "name", "label", "parameters"],
+                ["range", "amount", "What is the age of the child?", "start=0\nend=17\nstep=1"],
+            ]
+        )
+        errors = validate_xls_form(buf)
+        self.assertEqual(errors, [])
 
     def test_get_list_name_from_select_options(self):
         self.assertEqual(get_list_name_from_select({"type": "select_one demo_choices or_other"}), "demo_choices")


### PR DESCRIPTION
## What problem is this PR solving?

make the validation more robust

### Related JIRA tickets

IA-5129

## Changes

make the validation more robust
- handle trailing spacing in headers
- add a validation in our validation for parameters column

## How to test

- reuse an existing account or seed a new one
- create a form
- create a form version see in jira for the xlsform


## Print screen / video

<img width="2554" height="1342" alt="image" src="https://github.com/user-attachments/assets/118079b7-8ebd-44df-a9b6-4f94b57ad7e3" />

## Notes

-

## Doc

-
