### PR TITLE
POLIO-2148: add stricter exclusion rule

### DIFF
--- a/plugins/polio/preparedness/parser.py
+++ b/plugins/polio/preparedness/parser.py
@@ -26,6 +26,7 @@ def is_worksheet_exluded(worksheet, exclusions_list):
         worksheet.is_hidden
         or worksheet.title.lower() in WORKSHEET_EXCLUSION_LIST
         or worksheet.title.lower().startswith("sheet")
+        or worksheet.title.lower().startswith("synt_")
         or (worksheet.title in exclusions)
     )
 

--- a/plugins/polio/preparedness/parser.py
+++ b/plugins/polio/preparedness/parser.py
@@ -25,7 +25,7 @@ def is_worksheet_exluded(worksheet, exclusions_list):
     return (
         worksheet.is_hidden
         or worksheet.title.lower() in WORKSHEET_EXCLUSION_LIST
-or worksheet.title.lower().startswith(("sheet", "synt_"))
+        or worksheet.title.lower().startswith(("sheet", "synt_"))
         or (worksheet.title in exclusions)
     )
 

--- a/plugins/polio/preparedness/parser.py
+++ b/plugins/polio/preparedness/parser.py
@@ -25,8 +25,7 @@ def is_worksheet_exluded(worksheet, exclusions_list):
     return (
         worksheet.is_hidden
         or worksheet.title.lower() in WORKSHEET_EXCLUSION_LIST
-        or worksheet.title.lower().startswith("sheet")
-        or worksheet.title.lower().startswith("synt_")
+or worksheet.title.lower().startswith(("sheet", "synt_"))
         or (worksheet.title in exclusions)
     )
 


### PR DESCRIPTION
## What problem is this PR solving?

Sheet names with whitespace cannot be excluded using json config

### Related JIRA tickets

POLIO-2148

## Changes

- Added additional hardcoded string to to exclusion list for preparedness worksheet names

## How to test

- reproduce campaign in ticket on polio DB
- start worker
- launch preparedness refresh--> no 500

## Print screen / video
N/A

