### PR TITLE
SLEEP-1795: Fix wrong values on the entity merging screen

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/entities/duplicates/details/hooks/useDuplicationDetailsColumns.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/duplicates/details/hooks/useDuplicationDetailsColumns.tsx
@@ -59,14 +59,15 @@ export const useDuplicationDetailsColumns = ({
                         updateCellState,
                     });
 
-                    const descr = findDescriptorInChildren(
-                        settings.row.original.entity1.value,
+                    const fieldDescriptor = findDescriptorInChildren(
+                        field.field,
                         descriptors.descriptor1,
                     );
+                    const descr = fieldDescriptor?.children?.find(
+                        child => child.name === entity1.value,
+                    );
                     const result = convertValueIfDate(
-                        descr
-                            ? formatLabel(descr)
-                            : settings.row.original.entity1.value,
+                        descr ? formatLabel(descr) : entity1.value,
                     );
 
                     return (
@@ -92,14 +93,15 @@ export const useDuplicationDetailsColumns = ({
                         state,
                         updateCellState,
                     });
-                    const descr = findDescriptorInChildren(
-                        settings.row.original.entity2.value,
+                    const fieldDescriptor = findDescriptorInChildren(
+                        field.field,
                         descriptors.descriptor2,
                     );
+                    const descr = fieldDescriptor?.children?.find(
+                        child => child.name === entity2.value,
+                    );
                     const result = convertValueIfDate(
-                        descr
-                            ? formatLabel(descr)
-                            : settings.row.original.entity2.value,
+                        descr ? formatLabel(descr) : entity2.value,
                     );
 
                     return (
@@ -118,10 +120,13 @@ export const useDuplicationDetailsColumns = ({
                 resizable: false,
                 sortable: false,
                 Cell: settings => {
-                    const { final } = settings.row.original;
-                    const descr = findDescriptorInChildren(
-                        final.value,
+                    const { field, final } = settings.row.original;
+                    const fieldDescriptor = findDescriptorInChildren(
+                        field.field,
                         descriptors.descriptor1,
+                    );
+                    const descr = fieldDescriptor?.children?.find(
+                        child => child.name === final.value,
                     );
                     const result = convertValueIfDate(
                         descr ? formatLabel(descr) : final.value,


### PR DESCRIPTION
## What problem is this PR solving?

Fix values from the xlsform definition showing up in the Entity duplicate comparison screen seemingly at random. 

(See ticket SLEEP-1406 and comments for more information).

### Related JIRA tickets

SLEEP-1795 SLEEP-1406

## Changes

The frontend would substitute values by any match in the "choices" tab of the form definition. This PR implements a fix that checks for matching choices only for the current field.

## How to test

Disable the `ENTITY_DUPLICATES_SOFT_DELETE` feature flag for your Account.

You will need Enketo and a form that reproduces the issue (you can find one in the ticket comments [here](https://bluesquare.atlassian.net/browse/SLEEP-1406?focusedCommentId=92921)).  

- Create a new Form with the provided xls.
- Create a new EntityType with this form as its Reference Form
- Using Enketo, create two submissions using that form. Use similar answers so that they'll be identified as duplicates for the next steps.
    - (optional) If using the provided XLS file, try inputting a value of "1" (without the quotes) for one of your answers. 
- Using the django admin, create two entities with each of these Instances as their attributes.
- Go to Duplicates and start an analysis for your EntityType (requires the worker to run). This will identify the 2 entities you created as a pair of duplicates (as a fallback you can create an EntityDuplicate in the admin manually).
- Finally, visit the duplicate comparison screen and make sure none of the values are substituted strangely.

## Print screen / video

Before:
<img width="1422" height="264" alt="Screenshot 2026-06-03 at 14 03 39" src="https://github.com/user-attachments/assets/ccee73dc-8a7c-42c9-9faf-2119f87ca344" />

After:
<img width="1422" height="260" alt="Screenshot 2026-06-03 at 14 03 04" src="https://github.com/user-attachments/assets/32d6e015-1d87-4918-85f2-5cf9fed47eb6" />

## Notes
/ 

## Doc
/