### PR TITLE
SLEEP-1795: Lost InstanceFiles when merging entities

### DIFF
--- a/iaso/api/deduplication/entity_duplicate.py
+++ b/iaso/api/deduplication/entity_duplicate.py
@@ -27,7 +27,7 @@ from hat.audit.models import ENTITY_DUPLICATE_MERGE, log_modification
 from iaso.api.common import HasPermission, ModelViewSet
 from iaso.api.deduplication.serializers import BulkIgnoreRequestSerializer
 from iaso.api.workflows.serializers import find_question_by_name
-from iaso.models import Entity, EntityDuplicate, EntityDuplicateAnalyzis, EntityType, Form, Instance
+from iaso.models import Entity, EntityDuplicate, EntityDuplicateAnalyzis, EntityType, Form, Instance, InstanceFile
 from iaso.models.deduplication import ValidationStatus  # type: ignore
 from iaso.permissions.core_permissions import (
     CORE_ENTITIES_DUPLICATES_READ_PERMISSION,
@@ -206,6 +206,10 @@ def merge_attributes(e1: Entity, e2: Entity, new_entity_uuid: UUID, merge_def: D
     new_attributes.file.save(new_file_name, new_xml_content, save=True)  # saves the model here
     new_attributes.get_and_save_json_of_xml()
 
+    files_to_copy = InstanceFile.objects.filter(instance__in=[att1, att2])
+    for file in files_to_copy:
+        InstanceFile.objects.create(instance=new_attributes, file=file.file, name=file.name)
+
     return new_attributes
 
 
@@ -236,6 +240,13 @@ def copy_instance(inst: Instance, new_entity: Entity):
     new_inst.file_name = f"{slugify(inst.form.name)}_{new_uuid}.xml"
     new_inst.file.save(new_inst.file_name, new_xml_content, save=True)
     new_inst.get_and_save_json_of_xml()
+
+    files_to_copy = InstanceFile.objects.filter(instance=inst)
+    for file in files_to_copy:
+        file.pk = None
+        file.instance = new_inst
+        file.save()
+
     return new_inst
 
 

--- a/iaso/tests/api/deduplication/test_entity_duplicates_merging.py
+++ b/iaso/tests/api/deduplication/test_entity_duplicates_merging.py
@@ -85,6 +85,8 @@ class EntityDuplicatesMergingAPITestCase(APITestCase):
                 },
                 file=ContentFile(xml_content.encode("utf-8"), name=f"test_{i}.xml"),
             )
+            m.InstanceFile.objects.create(instance=instance, file=f"test_file_{i}.jpg", name=f"test_file_{i}.jpg")
+
             entity = m.Entity.objects.create(
                 name=f"Entity {i}",
                 entity_type=cls.entity_type,
@@ -94,6 +96,18 @@ class EntityDuplicatesMergingAPITestCase(APITestCase):
             )
             instance.entity = entity
             instance.save()
+
+            extra_instance = m.Instance.objects.create(
+                form=cls.form,
+                form_version=cls.form_version,
+                project=cls.project,
+                entity=entity,
+                file=ContentFile(xml_content.encode("utf-8"), name=f"extra_test_{i}.xml"),
+            )
+            m.InstanceFile.objects.create(
+                instance=extra_instance, file=f"extra_test_file_{i}.jpg", name=f"extra_test_file_{i}.jpg"
+            )
+
             cls.entities.append(entity)
 
         # Create duplicate pairs: (0, 1) and (0, 2)
@@ -144,6 +158,16 @@ class EntityDuplicatesMergingAPITestCase(APITestCase):
         self.dup2.refresh_from_db()
         self.assertEqual(self.dup2.entity1.pk, new_entity_id)
         self.assertEqual(self.dup2.entity2.pk, self.entities[2].pk)
+
+        # Verify InstanceFiles are copied
+        new_entity = m.Entity.objects.get(pk=new_entity_id)
+        # files from merged attributes
+        self.assertEqual(new_entity.attributes.instancefile_set.count(), 2)
+
+        other_instances = new_entity.instances.exclude(id=new_entity.attributes_id)
+        self.assertEqual(other_instances.count(), 2)
+        for inst in other_instances:
+            self.assertEqual(inst.instancefile_set.count(), 1)
 
     def test_detail_view_with_merged_entities(self):
         self.client.force_authenticate(self.user)

--- a/iaso/tests/api/deduplication/test_entity_duplicates_merging.py
+++ b/iaso/tests/api/deduplication/test_entity_duplicates_merging.py
@@ -313,5 +313,5 @@ class EntityDuplicatesMergingAPITestCase(APITestCase):
         self.assertEqual(entity2.merged_to_id, response_data["new_entity_id"])
 
         merged = entity1.merged_to
-        self.assertEqual(merged.instances.count(), 2)  # reference form + emoji form
-        self.assertEqual(merged.instances.last().json["prevous_muac_color"], "🟡Yellow")
+        self.assertEqual(merged.instances.count(), 4)  # 1 attributes + 1 emoji + 2 extra instances from setup
+        self.assertTrue(merged.instances.filter(json__prevous_muac_color="🟡Yellow").exists())


### PR DESCRIPTION
## What problem is this PR solving?

When using the entity merging feature with `ENTITY_DUPLICATES_SOFT_DELETE` disabled, InstanceFiles were not properly copied over to the new Instances of the merged entity. 

### Related JIRA tickets

SLEEP-1795 SLEEP-1787

## Changes

Updated the code responsible for merging to create new InstanceFiles for the merged entity. There's slightly different logic for the attributes Instance and regular Instances.

## How to test

Make sure to disable the `ENTITY_DUPLICATES_SOFT_DELETE` feature flag for your account.

- Run the duplicate analysis if you have no duplicates listed.
- Pick an entity from a duplicate pair to add an InstanceFile to (if it doesn't have one)
    - Make sure you have an InstanceFile for both (you can add InstanceFiles through the Django admin):
       - the attributes/registration Instance 
       - any regular Instance
- Merge the entity with another.
- Check that the merged entity has retained the InstanceFiles.

## Print screen / video

https://github.com/user-attachments/assets/c434ed1a-511e-4865-be1a-526d7f63b11f

## Notes

The migration code to retrieve InstanceFiles for existing merges has not been included in this PR. 
