### PR TITLE
POLIO-1398: show test and on hold campaigns in dropdown

### DIFF
--- a/plugins/polio/js/src/domains/GroupedCampaigns/GroupedCampaignDialog.tsx
+++ b/plugins/polio/js/src/domains/GroupedCampaigns/GroupedCampaignDialog.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/require-default-props */
 import React, {
     FunctionComponent,
     ReactNode,
@@ -46,7 +45,7 @@ export const GroupedCampaignDialog: FunctionComponent<Props> = ({
     const [campaignsToLink, setCampaignsToLink] = useState<string[]>(campaigns);
     // TODO refactor this hook to make more flexible
     const { data: allCampaigns, isFetching: isFetchingCamaigns } =
-        useGetCampaigns({ show_test: false });
+        useGetCampaigns({ show_test: true, on_hold: true });
     const allCampaignsDropdown = useMemo(
         () => makeCampaignsDropDownWithUUID(allCampaigns),
         [allCampaigns],


### PR DESCRIPTION
## What problem is this PR solving?

Test and on hold campaigns were not shown in EPID group campaign dropdown

### Related JIRA tickets

POLIO-1398

## Changes

- Change options of campaigns API call so on hold and test campaigns are returned
- Planned campaigns could be added, but left out of scope since it would require significant API changes and probably YAGNI

## How to test

In a polio DB
Create an EPID group
Edit one of the campaigns to be `test` or `on_hold`
Try editing the group: the test/on hold campaign should still be visible

## Print screen / video


https://github.com/user-attachments/assets/dcc616af-051e-4eab-99c5-193f1aa55e11





