### PR TITLE
POLIO-2156: update scan command

### DIFF
--- a/iaso/tests/utils/test_clamav.py
+++ b/iaso/tests/utils/test_clamav.py
@@ -5,12 +5,19 @@ from unittest.mock import MagicMock, patch
 
 import time_machine
 
-from django.core.files.uploadedfile import InMemoryUploadedFile
+from django.core.files.uploadedfile import InMemoryUploadedFile, SimpleUploadedFile
 from django.test import override_settings
 
 from hat import settings
+from iaso import models as m
 from iaso.test import MockClamavScanResults, TestCase
-from iaso.utils.virus_scan.clamav import VirusScanStatus, scan_disk_file_for_virus, scan_uploaded_file_for_virus
+from iaso.utils.virus_scan.clamav import (
+    VirusScanStatus,
+    scan_disk_file_for_virus,
+    scan_stored_file_for_virus,
+    scan_uploaded_file_for_virus,
+)
+from plugins.polio.models import NotificationImport
 
 
 @override_settings(
@@ -75,6 +82,37 @@ class ClamAVTestCase(TestCase):
 
             self.assertEqual(result, VirusScanStatus.INFECTED)
             self.assertEqual(timestamp_scan, self.DT)
+
+    @time_machine.travel(DT, tick=False)
+    @patch("clamav_client.get_scanner")
+    def test_negative_stored_file(self, mock_get_scanner):
+        mock_scanner = MagicMock()
+        mock_scanner.scan.return_value = MockClamavScanResults(
+            state="OK",
+            details="",
+            passed=True,
+        )
+        mock_get_scanner.return_value = mock_scanner
+
+        account = m.Account.objects.create(name="clamav-test-account")
+        user = self.create_user_with_profile(username="clamav-test-user", account=account)
+
+        with open(self.SAFE_FILE_PATH, "rb") as file:
+            notification_import = NotificationImport.objects.create(
+                account=account,
+                created_by=user,
+                file=SimpleUploadedFile(
+                    "safe.jpg",
+                    file.read(),
+                    content_type="image/jpeg",
+                ),
+                errors=[],
+            )
+
+        result, timestamp_scan = scan_stored_file_for_virus(notification_import.file)
+
+        self.assertEqual(result, VirusScanStatus.CLEAN)
+        self.assertEqual(timestamp_scan, self.DT)
 
     @time_machine.travel(DT, tick=False)
     @patch("clamav_client.get_scanner")

--- a/iaso/utils/virus_scan/clamav.py
+++ b/iaso/utils/virus_scan/clamav.py
@@ -1,12 +1,15 @@
 import logging
 import os
 import tempfile
+from typing import Union
 
 import clamav_client
 
 from clamav_client.clamd import CommunicationError
 from django.conf import settings
+from django.core.files.base import File
 from django.core.files.uploadedfile import InMemoryUploadedFile
+from django.db.models.fields.files import FieldFile
 from django.utils import timezone
 
 from iaso.utils.virus_scan.model import VirusScanStatus
@@ -82,6 +85,32 @@ def scan_disk_file_for_virus(file_path: str):
     return _scan_with_clamav(file_path)
 
 
+def scan_stored_file_for_virus(stored_file: Union[FieldFile, File]):
+    """
+    Scan a file from Django storage (local disk, S3, Azure, etc.) using ClamAV.
+
+    The file is downloaded to a temporary file on disk because ClamAV requires a
+    local path. Use this for backfill jobs on models that already have a FileField.
+
+    Args:
+        stored_file: A Django FieldFile or other File opened via storage.
+
+    Returns:
+        tuple: A tuple containing (VirusScanStatus, datetime or None)
+    """
+    logger.info(f"Scanning stored file {stored_file.name} for virus")
+    try:
+        with tempfile.NamedTemporaryFile(mode="wb") as temp_file:
+            with stored_file.open("rb") as file_handle:
+                for chunk in file_handle.chunks():
+                    temp_file.write(chunk)
+            temp_file.flush()
+            return _scan_with_clamav(temp_file.name)
+    except Exception as e:
+        logger.error(f"Could not read stored file {stored_file.name} for scanning - {e}")
+        return VirusScanStatus.ERROR, None
+
+
 def _scan_with_clamav(file_path: str):
     """
     Internal function to perform virus scanning using ClamAV.
@@ -99,7 +128,7 @@ def _scan_with_clamav(file_path: str):
 
     Note:
         This function is internal and should not be called directly.
-        Use scan_uploaded_file_for_virus() or scan_disk_file_for_virus() instead.
+        Use scan_uploaded_file_for_virus(), scan_stored_file_for_virus(), or scan_disk_file_for_virus() instead.
     """
     is_clamav_active = settings.CLAMAV_ACTIVE
     if not is_clamav_active:

--- a/iaso/utils/virus_scan/clamav.py
+++ b/iaso/utils/virus_scan/clamav.py
@@ -86,7 +86,7 @@ def scan_disk_file_for_virus(file_path: str):
     return _scan_with_clamav(file_path)
 
 
-def scan_stored_file_for_virus(stored_file: Union[FieldFile, File]):
+def scan_stored_file_for_virus(stored_file: Union[FieldFile, File], raise_on_error=True):
     """
     Scan a file from Django storage (local disk, S3, Azure, etc.) using ClamAV.
 
@@ -108,7 +108,11 @@ def scan_stored_file_for_virus(stored_file: Union[FieldFile, File]):
             temp_file.flush()
             return _scan_with_clamav(temp_file.name)
     except Exception as e:
-        logger.error(f"Could not read stored file {stored_file.name} for scanning - {e}")
+        error_msg = f"Could not read stored file {stored_file.name} for scanning - {e}"
+        if raise_on_error:
+            logger.error(error_msg)
+        else:
+            logger.warning(error_msg)
         return VirusScanStatus.ERROR, None
 
 

--- a/iaso/utils/virus_scan/clamav.py
+++ b/iaso/utils/virus_scan/clamav.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import tempfile
+
 from typing import Union
 
 import clamav_client

--- a/plugins/polio/management/commands/scan_files_for_viruses.py
+++ b/plugins/polio/management/commands/scan_files_for_viruses.py
@@ -34,7 +34,7 @@ class Command(BaseCommand):
         self.stdout.write(f" - {name}: {queryset.count()}")
         clean, infected, errors = 0, 0, 0
         for model_with_file in queryset:
-            result, timestamp = scan_stored_file_for_virus(model_with_file.file)
+            result, timestamp = scan_stored_file_for_virus(stored_file=model_with_file.file, raise_on_error=False)
             model_with_file.file_last_scan = timestamp
             model_with_file.file_scan_status = result
             model_with_file.save()

--- a/plugins/polio/management/commands/scan_files_for_viruses.py
+++ b/plugins/polio/management/commands/scan_files_for_viruses.py
@@ -5,7 +5,7 @@ from typing import Optional, Tuple
 from django.core.management.base import BaseCommand
 from django.db.models import Q
 
-from iaso.utils.virus_scan.clamav import scan_disk_file_for_virus
+from iaso.utils.virus_scan.clamav import scan_stored_file_for_virus
 from iaso.utils.virus_scan.model import ModelWithFile, VirusScanStatus
 from plugins.polio.models import (
     DestructionReport,
@@ -30,11 +30,11 @@ class Command(BaseCommand):
         queryset = clazz.objects.filter(~Q(file_scan_status=VirusScanStatus.INFECTED))
         if not scan_all:
             queryset = queryset.filter(file_scan_status=VirusScanStatus.PENDING)
+        queryset = queryset.exclude(file="").exclude(file__isnull=True)
         self.stdout.write(f" - {name}: {queryset.count()}")
         clean, infected, errors = 0, 0, 0
-        for model_with_file in queryset.all():
-            # No need for try/except, `scan_disk_file_for_virus` is already wrapped.
-            result, timestamp = scan_disk_file_for_virus(model_with_file.file.path)
+        for model_with_file in queryset:
+            result, timestamp = scan_stored_file_for_virus(model_with_file.file)
             model_with_file.file_last_scan = timestamp
             model_with_file.file_scan_status = result
             model_with_file.save()


### PR DESCRIPTION
## What problem is this PR solving?

scan_files_for_viruses command worked locally but not on the actual infra

### Related JIRA tickets

POLIO-2156

## Release config
**Run the command on polio prod after release**

## Changes

- temporary download file on disk to enable clamAV to scan it
- update test

## How to test

Explain how to test your PR.

mac silicon users: change line 3 in `docker-compose-clamav.yml` with `image: clamav/clamav-debian:stable_base`

`docker compose -f docker-compose.yml -f docker/docker-compose-clamav.yml up`
`docker compose run iaso manage scan_files_for_viruses`

Existing files might error, because the paths from imported DBs will be wrong

## Print screen / video

N/A


