### PR TITLE
POLIO-1199 improve polio admin

### DIFF
--- a/iaso/locale/fr/LC_MESSAGES/django.po
+++ b/iaso/locale/fr/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-18 15:02+0000\n"
+"POT-Creation-Date: 2026-06-05 07:16+0000\n"
 "PO-Revision-Date: 2025-02-06 10:24+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -30,6 +30,10 @@ msgstr "Le modèle {value} n'existe pas."
 #: iaso/api/comment.py
 msgid "Invalid value."
 msgstr "Valeur invalide"
+
+#: iaso/api/common/permissions.py
+msgid "This feature is disabled for your account."
+msgstr "Cette fonctionnalité est désactivée pour votre compte."
 
 #: iaso/api/common/permissions.py
 msgid "The related module(s) are not activated for your account."
@@ -520,11 +524,11 @@ msgstr "Les mots de passe doivent correspondre."
 msgid "Set up a password for your new account on {domain}"
 msgstr "Configurer un mot de passe pour votre nouveau compte sur {domain}"
 
-#: iaso/api/setup_account.py
+#: iaso/api/setup_account/serializers.py
 msgid "Email is required when email_invitation is True"
 msgstr "L'email est requis lorsque l'invitation par email est activée"
 
-#: iaso/api/setup_account.py
+#: iaso/api/setup_account/serializers.py
 msgid "Password is required when email_invitation is False"
 msgstr ""
 "Le mot de passe est requis lorsque l'invitation par email est désactivée"
@@ -739,6 +743,10 @@ msgstr "Entités"
 #: iaso/models/feature_flags.py
 msgid "Planning"
 msgstr "Planification"
+
+#: iaso/models/feature_flags.py iaso/permissions/core_permissions.py
+msgid "Stock management"
+msgstr "Management de stock"
 
 #: iaso/models/feature_flags.py
 msgid "Specific options"
@@ -1107,10 +1115,6 @@ msgid "Can change the default version of a data source"
 msgstr "Peut modifier la version par défaut d'une source de données"
 
 #: iaso/permissions/core_permissions.py
-msgid "Stock management"
-msgstr "Management de stock"
-
-#: iaso/permissions/core_permissions.py
 msgid "Storages"
 msgstr "Stockages"
 
@@ -1297,9 +1301,6 @@ msgstr "Virus détecté"
 #: iaso/utils/virus_scan/model.py
 msgid "Error"
 msgstr "Erreur lors de l'analyse"
-
-#~ msgid "This feature is disabled for your account."
-#~ msgstr "Cette fonctionnalité est désactivée pour votre compte."
 
 #~ msgid "Planning id is required in the URL path."
 #~ msgstr "L'ID du planning est requis dans le chemin de l'URL."

--- a/plugins/polio/admin.py
+++ b/plugins/polio/admin.py
@@ -7,6 +7,7 @@ from django.db import models
 from django.http import HttpResponseRedirect
 from django.urls import reverse
 from django.utils.safestring import mark_safe
+from django.utils.translation import gettext_lazy as _
 from translated_fields import TranslatedFieldAdmin
 
 from iaso.admin import IasoJSONEditorWidget
@@ -15,6 +16,9 @@ from plugins.polio.models.base import VaccineStockHistory
 
 from .budget.models import BudgetProcess, BudgetStep, BudgetStepFile, BudgetStepLink, MailTemplate, WorkflowModel
 from .models import (
+    MISSING_CAMPAIGN_LABEL,
+    ROUND_DEPRECATED_VACCINE_MANAGEMENT_FIELD_NAMES,
+    ROUND_DEPRECATED_VACCINE_MANAGEMENT_HELP,
     Campaign,
     CampaignGroup,
     CampaignType,
@@ -41,6 +45,7 @@ from .models import (
     VaccineRequestForm,
     VaccineStock,
     create_polio_notifications_async,
+    format_round_campaign_obr_name,
 )
 from .models.performance_thresholds import PerformanceThresholds
 
@@ -266,12 +271,83 @@ class EarmarkedStockAdmin(admin.ModelAdmin):
     model = EarmarkedStock
 
 
+_ROUND_EVALUATION_FIELDS = (
+    "mop_up_started_at",
+    "mop_up_ended_at",
+    "im_started_at",
+    "im_ended_at",
+    "lqas_started_at",
+    "lqas_ended_at",
+    "im_percentage_children_missed_in_household",
+    "im_percentage_children_missed_out_household",
+    "im_percentage_children_missed_in_plus_out_household",
+    "awareness_of_campaign_planning",
+    "main_awareness_problem",
+    "lqas_district_passing",
+    "lqas_district_failing",
+)
+
+
 @admin.register(Round)
 class RoundAdmin(admin.ModelAdmin):
-    model = Round
-    raw_id_fields = ("campaign",)
-    list_display = ["campaign", "number"]
-    list_filter = ["campaign"]
+    list_display = ("id", "get_obr_name", "number", "started_at", "ended_at", "on_hold")
+    list_display_links = ("get_obr_name", "number")
+    list_filter = ("campaign", "on_hold")
+    search_fields = ("campaign__obr_name", "number")
+    ordering = ("campaign__obr_name", "number")
+    raw_id_fields = ("campaign", "budget_process")
+    readonly_fields = ("id",) + ROUND_DEPRECATED_VACCINE_MANAGEMENT_FIELD_NAMES
+    fieldsets = (
+        (
+            None,
+            {
+                "fields": (
+                    "campaign",
+                    "number",
+                    "started_at",
+                    "ended_at",
+                    "on_hold",
+                    "is_planned",
+                    "budget_process",
+                    "age_min",
+                    "age_max",
+                    "age_type",
+                    "target_population",
+                    "percentage_covered_target_population",
+                    "doses_requested",
+                    "cost",
+                ),
+            },
+        ),
+        (_("Evaluation (LQAS/IM)"), {"classes": ("collapse",), "fields": _ROUND_EVALUATION_FIELDS}),
+        (
+            _("Preparedness"),
+            {"classes": ("collapse",), "fields": ("preparedness_spreadsheet_url", "preparedness_sync_status")},
+        ),
+        (
+            _("Deprecated – round-level vaccine management"),
+            {
+                "classes": ("collapse",),
+                "description": ROUND_DEPRECATED_VACCINE_MANAGEMENT_HELP,
+                "fields": ROUND_DEPRECATED_VACCINE_MANAGEMENT_FIELD_NAMES,
+            },
+        ),
+    )
+
+    @admin.display(
+        description="Campaign (OBR)",
+        ordering="campaign__obr_name",
+        empty_value=MISSING_CAMPAIGN_LABEL,
+    )
+    def get_obr_name(self, obj):
+        return format_round_campaign_obr_name(obj)
+
+    def get_search_results(self, request, queryset, search_term):
+        queryset, use_distinct = super().get_search_results(request, queryset, search_term)
+        return queryset.select_related("campaign"), use_distinct
+
+    def get_queryset(self, request):
+        return super().get_queryset(request).select_related("campaign")
 
 
 @admin.register(ReasonForDelay)
@@ -330,14 +406,13 @@ class NotificationAdmin(admin.ModelAdmin):
 
 @admin.register(VaccineStockHistory)
 class VaccineStockHistoryAdmin(admin.ModelAdmin):
-    list_display = ("get_campaign_name", "get_round_number", "round", "get_vaccine_name", "get_country")
+    list_display = ("get_campaign_name", "get_round_number", "get_vaccine_name", "get_country")
+    autocomplete_fields = ("round",)
     # list_filter = ("get_country", "get_vaccine_name","get_campaign_name")
 
-    @admin.display(description="Campaign name")
+    @admin.display(description="Campaign name", empty_value=MISSING_CAMPAIGN_LABEL)
     def get_campaign_name(self, obj):
-        if obj.round:
-            return obj.round.campaign.obr_name
-        return None
+        return format_round_campaign_obr_name(obj.round)
 
     @admin.display(description="Round number")
     def get_round_number(self, obj):
@@ -358,7 +433,15 @@ class VaccineStockHistoryAdmin(admin.ModelAdmin):
         return None
 
     def get_queryset(self, request):
-        return super().get_queryset(request).select_related("round", "vaccine_stock", "vaccine_stock__country")
+        return (
+            super()
+            .get_queryset(request)
+            .select_related(
+                "round__campaign",
+                "vaccine_stock",
+                "vaccine_stock__country",
+            )
+        )
 
 
 class RoundAdminInline(admin.TabularInline):
@@ -366,8 +449,15 @@ class RoundAdminInline(admin.TabularInline):
     extra = 0
     show_change_link = True
     can_delete = False
-    fields = ("id", "started_at", "number", "campaign")
-    readonly_fields = ("id", "started_at", "number", "campaign")
+    fields = ("get_obr_name", "number", "started_at", "ended_at", "on_hold")
+    readonly_fields = fields
+
+    @admin.display(description="Campaign (OBR)", empty_value=MISSING_CAMPAIGN_LABEL)
+    def get_obr_name(self, obj):
+        return format_round_campaign_obr_name(obj)
+
+    def get_queryset(self, request):
+        return super().get_queryset(request).select_related("campaign")
 
 
 class BudgetStepAdminInline(admin.TabularInline):
@@ -397,12 +487,33 @@ class SubActivityScopeInline(admin.StackedInline):
 class SubActivityAdmin(admin.ModelAdmin):
     list_display = (
         "name",
+        "get_campaign_obr_name",
+        "get_round_number",
         "start_date",
         "end_date",
     )
+    list_display_links = ("name",)
+    search_fields = ("name", "round__campaign__obr_name", "round__number")
     fields = ("name", "start_date", "end_date", "round")
-    raw_id_fields = ("round",)
+    autocomplete_fields = ("round",)
     inlines = [SubActivityScopeInline]
+
+    @admin.display(
+        description="Campaign (OBR)",
+        ordering="round__campaign__obr_name",
+        empty_value=MISSING_CAMPAIGN_LABEL,
+    )
+    def get_campaign_obr_name(self, obj):
+        return format_round_campaign_obr_name(obj.round)
+
+    @admin.display(description="Round", ordering="round__number")
+    def get_round_number(self, obj):
+        if obj.round_id and obj.round.number is not None:
+            return obj.round.number
+        return MISSING_CAMPAIGN_LABEL
+
+    def get_queryset(self, request):
+        return super().get_queryset(request).select_related("round__campaign")
 
     def save_related(self, request, form, formsets, change):
         for formset in formsets:
@@ -440,7 +551,8 @@ class ChronogramAdmin(TranslatedFieldAdmin, admin.ModelAdmin):
     list_display = ("pk", "obr_name", "created_at")
     list_display_links = ("pk", "obr_name")
     inlines = [ChronogramTaskAdminInline]
-    raw_id_fields = ("round", "created_by", "updated_by")
+    autocomplete_fields = ("round",)
+    raw_id_fields = ("created_by", "updated_by")
     readonly_fields = (
         "created_at",
         "created_by",
@@ -450,9 +562,13 @@ class ChronogramAdmin(TranslatedFieldAdmin, admin.ModelAdmin):
     )
     search_fields = ("pk", "round__campaign__obr_name")
 
-    @admin.display(empty_value="")
+    @admin.display(
+        description="Campaign (OBR)",
+        ordering="round__campaign__obr_name",
+        empty_value=MISSING_CAMPAIGN_LABEL,
+    )
     def obr_name(self, obj):
-        return obj.round.campaign.obr_name
+        return format_round_campaign_obr_name(obj.round)
 
     def get_queryset(self, request):
         return super().get_queryset(request).valid().select_related("round__campaign", "created_by", "updated_by")

--- a/plugins/polio/admin.py
+++ b/plugins/polio/admin.py
@@ -864,11 +864,7 @@ class RoundDateHistoryEntryAdmin(RoundRelatedAdminDisplayMixin, admin.ModelAdmin
         return MISSING_CAMPAIGN_LABEL
 
     def get_queryset(self, request):
-        return (
-            super()
-            .get_queryset(request)
-            .select_related("reason_for_delay", "modified_by")
-        )
+        return super().get_queryset(request).select_related("reason_for_delay", "modified_by")
 
 
 admin.site.register(CountryUsersGroup)

--- a/plugins/polio/admin.py
+++ b/plugins/polio/admin.py
@@ -4,6 +4,7 @@ from django import forms
 from django.contrib import admin, messages
 from django.contrib.admin import widgets
 from django.db import models
+from django.db.models import Count
 from django.http import HttpResponseRedirect
 from django.urls import reverse
 from django.utils.safestring import mark_safe
@@ -45,9 +46,47 @@ from .models import (
     VaccineRequestForm,
     VaccineStock,
     create_polio_notifications_async,
+    format_campaign_country,
+    format_campaign_obr_name,
     format_round_campaign_obr_name,
+    format_vaccine_stock_country,
+    format_vaccine_stock_vaccine,
 )
 from .models.performance_thresholds import PerformanceThresholds
+
+
+class VaccineStockAdminDisplayMixin:
+    @admin.display(description="Country", ordering="vaccine_stock__country__name", empty_value=MISSING_CAMPAIGN_LABEL)
+    def get_country(self, obj):
+        return format_vaccine_stock_country(obj.vaccine_stock)
+
+    @admin.display(description="Vaccine", ordering="vaccine_stock__vaccine", empty_value=MISSING_CAMPAIGN_LABEL)
+    def get_vaccine(self, obj):
+        return format_vaccine_stock_vaccine(obj.vaccine_stock)
+
+    def get_queryset(self, request):
+        return super().get_queryset(request).select_related("vaccine_stock__country")
+
+
+class CampaignRoundVaccineStockAdminDisplayMixin(VaccineStockAdminDisplayMixin):
+    def _alternate_campaign_name(self, obj):
+        return ""
+
+    @admin.display(description="Campaign (OBR)", ordering="campaign__obr_name", empty_value=MISSING_CAMPAIGN_LABEL)
+    def get_campaign_obr_name(self, obj):
+        return format_campaign_obr_name(
+            obj.campaign if obj.campaign_id else None,
+            non_obr_name=self._alternate_campaign_name(obj),
+        )
+
+    @admin.display(description="Round", ordering="round__number", empty_value=MISSING_CAMPAIGN_LABEL)
+    def get_round_number(self, obj):
+        if obj.round_id and obj.round.number is not None:
+            return obj.round.number
+        return MISSING_CAMPAIGN_LABEL
+
+    def get_queryset(self, request):
+        return super().get_queryset(request).select_related("campaign", "round")
 
 
 class IntegratedCampaignsInline(admin.TabularInline):
@@ -234,7 +273,46 @@ class VaccineRequestFormAdmin(admin.ModelAdmin):
     form = VaccineRequestAdminForm
     inlines = [VaccinePreAlertAdminInline, VaccineArrivalReportAdminInline]
     readonly_fields = ["created_at", "updated_at"]
-    list_display = ["campaign", "get_country", "count_pre_alerts", "count_arrival_reports", "created_at"]
+    list_display = (
+        "get_campaign_obr_name",
+        "get_country",
+        "vaccine_type",
+        "vrf_type",
+        "get_pre_alert_count",
+        "get_arrival_report_count",
+        "created_at",
+    )
+    list_display_links = ("get_campaign_obr_name",)
+    search_fields = ("campaign__obr_name", "vaccine_type")
+    list_filter = ("vrf_type", "vaccine_type")
+    raw_id_fields = ("campaign",)
+
+    @admin.display(description="Campaign (OBR)", ordering="campaign__obr_name", empty_value=MISSING_CAMPAIGN_LABEL)
+    def get_campaign_obr_name(self, obj):
+        return format_campaign_obr_name(obj.campaign if obj.campaign_id else None)
+
+    @admin.display(description="Country", ordering="campaign__country__name", empty_value=MISSING_CAMPAIGN_LABEL)
+    def get_country(self, obj):
+        return format_campaign_country(obj.campaign if obj.campaign_id else None)
+
+    @admin.display(description="Pre-alerts")
+    def get_pre_alert_count(self, obj):
+        return getattr(obj, "_pre_alert_count", 0) or 0
+
+    @admin.display(description="Arrival reports")
+    def get_arrival_report_count(self, obj):
+        return getattr(obj, "_arrival_report_count", 0) or 0
+
+    def get_queryset(self, request):
+        return (
+            super()
+            .get_queryset(request)
+            .select_related("campaign", "campaign__country")
+            .annotate(
+                _pre_alert_count=Count("vaccineprealert", distinct=True),
+                _arrival_report_count=Count("vaccinearrivalreport", distinct=True),
+            )
+        )
 
     def save_related(self, request, form, formsets, change):
         for formset in formsets:
@@ -252,23 +330,100 @@ class VaccineStockAdmin(admin.ModelAdmin):
 
 
 @admin.register(OutgoingStockMovement)
-class OutgoingStockMovementAdmin(admin.ModelAdmin):
-    model = OutgoingStockMovement
+class OutgoingStockMovementAdmin(CampaignRoundVaccineStockAdminDisplayMixin, admin.ModelAdmin):
+    list_display = (
+        "id",
+        "get_campaign_obr_name",
+        "get_round_number",
+        "get_country",
+        "get_vaccine",
+        "status",
+        "report_date",
+        "created_at",
+    )
+    list_display_links = ("id", "get_campaign_obr_name")
+    search_fields = (
+        "campaign__obr_name",
+        "non_obr_name",
+        "round__number",
+        "vaccine_stock__country__name",
+        "vaccine_stock__vaccine",
+    )
+    list_filter = ("status",)
+    autocomplete_fields = ("round",)
+    raw_id_fields = ("campaign", "vaccine_stock")
+    readonly_fields = ("created_at", "updated_at")
+    date_hierarchy = "report_date"
+
+    def _alternate_campaign_name(self, obj):
+        return obj.non_obr_name
 
 
 @admin.register(DestructionReport)
-class DestructionReport(admin.ModelAdmin):
-    model = DestructionReport
+class DestructionReportAdmin(VaccineStockAdminDisplayMixin, admin.ModelAdmin):
+    list_display = (
+        "id",
+        "get_country",
+        "get_vaccine",
+        "destruction_report_date",
+        "unusable_vials_destroyed",
+        "rrt_destruction_report_reception_date",
+        "created_at",
+    )
+    list_display_links = ("id",)
+    search_fields = ("vaccine_stock__country__name", "vaccine_stock__vaccine", "action")
+    raw_id_fields = ("vaccine_stock",)
+    readonly_fields = ("created_at", "updated_at")
+    date_hierarchy = "destruction_report_date"
 
 
 @admin.register(IncidentReport)
-class IncidentReport(admin.ModelAdmin):
-    model = IncidentReport
+class IncidentReportAdmin(VaccineStockAdminDisplayMixin, admin.ModelAdmin):
+    list_display = (
+        "id",
+        "get_country",
+        "get_vaccine",
+        "stock_correction",
+        "title",
+        "date_of_incident_report",
+        "created_at",
+    )
+    list_display_links = ("id", "title")
+    search_fields = ("vaccine_stock__country__name", "vaccine_stock__vaccine", "title")
+    list_filter = ("stock_correction",)
+    raw_id_fields = ("vaccine_stock",)
+    readonly_fields = ("created_at", "updated_at")
+    date_hierarchy = "date_of_incident_report"
 
 
 @admin.register(EarmarkedStock)
-class EarmarkedStockAdmin(admin.ModelAdmin):
-    model = EarmarkedStock
+class EarmarkedStockAdmin(CampaignRoundVaccineStockAdminDisplayMixin, admin.ModelAdmin):
+    list_display = (
+        "id",
+        "get_campaign_obr_name",
+        "get_round_number",
+        "get_country",
+        "get_vaccine",
+        "earmarked_stock_type",
+        "vials_earmarked",
+        "created_at",
+    )
+    list_display_links = ("id", "get_campaign_obr_name")
+    search_fields = (
+        "campaign__obr_name",
+        "temporary_campaign_name",
+        "round__number",
+        "vaccine_stock__country__name",
+        "vaccine_stock__vaccine",
+    )
+    list_filter = ("earmarked_stock_type",)
+    autocomplete_fields = ("round",)
+    raw_id_fields = ("campaign", "vaccine_stock", "form_a")
+    readonly_fields = ("created_at", "updated_at")
+    date_hierarchy = "created_at"
+
+    def _alternate_campaign_name(self, obj):
+        return obj.temporary_campaign_name
 
 
 _ROUND_EVALUATION_FIELDS = (
@@ -414,23 +569,19 @@ class VaccineStockHistoryAdmin(admin.ModelAdmin):
     def get_campaign_name(self, obj):
         return format_round_campaign_obr_name(obj.round)
 
-    @admin.display(description="Round number")
+    @admin.display(description="Round number", ordering="round__number", empty_value=MISSING_CAMPAIGN_LABEL)
     def get_round_number(self, obj):
-        if obj.round:
+        if obj.round_id and obj.round.number is not None:
             return obj.round.number
-        return None
+        return MISSING_CAMPAIGN_LABEL
 
-    @admin.display(description="Vaccine")
+    @admin.display(description="Vaccine", ordering="vaccine_stock__vaccine", empty_value=MISSING_CAMPAIGN_LABEL)
     def get_vaccine_name(self, obj):
-        if obj.round:
-            return obj.vaccine_stock.vaccine
-        return None
+        return format_vaccine_stock_vaccine(obj.vaccine_stock)
 
-    @admin.display(description="Country")
+    @admin.display(description="Country", ordering="vaccine_stock__country__name", empty_value=MISSING_CAMPAIGN_LABEL)
     def get_country(self, obj):
-        if obj.round:
-            return obj.vaccine_stock.country.name
-        return None
+        return format_vaccine_stock_country(obj.vaccine_stock)
 
     def get_queryset(self, request):
         return (

--- a/plugins/polio/admin.py
+++ b/plugins/polio/admin.py
@@ -14,10 +14,17 @@ from translated_fields import TranslatedFieldAdmin
 from iaso.admin import IasoJSONEditorWidget
 from plugins.polio.api.vaccines.supply_chain import validate_rounds_and_campaign
 from plugins.polio.models.base import VaccineStockHistory
+from plugins.polio.preparedness.display_utils import (
+    MISSING_CAMPAIGN_LABEL,
+    format_campaign_country,
+    format_campaign_obr_name,
+    format_round_campaign_obr_name,
+    format_vaccine_stock_country,
+    format_vaccine_stock_vaccine,
+)
 
 from .budget.models import BudgetProcess, BudgetStep, BudgetStepFile, BudgetStepLink, MailTemplate, WorkflowModel
 from .models import (
-    MISSING_CAMPAIGN_LABEL,
     ROUND_DEPRECATED_VACCINE_MANAGEMENT_FIELD_NAMES,
     ROUND_DEPRECATED_VACCINE_MANAGEMENT_HELP,
     Campaign,
@@ -46,11 +53,6 @@ from .models import (
     VaccineRequestForm,
     VaccineStock,
     create_polio_notifications_async,
-    format_campaign_country,
-    format_campaign_obr_name,
-    format_round_campaign_obr_name,
-    format_vaccine_stock_country,
-    format_vaccine_stock_vaccine,
 )
 from .models.performance_thresholds import PerformanceThresholds
 
@@ -89,6 +91,27 @@ class CampaignRoundVaccineStockAdminDisplayMixin(VaccineStockAdminDisplayMixin):
         return super().get_queryset(request).select_related("campaign", "round")
 
 
+class RoundRelatedAdminDisplayMixin:
+    """Display helpers for models with a ``round`` FK (datelogs, sub-activities, etc.)."""
+
+    @admin.display(
+        description="Campaign (OBR)",
+        ordering="round__campaign__obr_name",
+        empty_value=MISSING_CAMPAIGN_LABEL,
+    )
+    def get_campaign_obr_name(self, obj):
+        return format_round_campaign_obr_name(obj.round)
+
+    @admin.display(description="Round", ordering="round__number", empty_value=MISSING_CAMPAIGN_LABEL)
+    def get_round_number(self, obj):
+        if obj.round_id and obj.round.number is not None:
+            return obj.round.number
+        return MISSING_CAMPAIGN_LABEL
+
+    def get_queryset(self, request):
+        return super().get_queryset(request).select_related("round__campaign")
+
+
 class IntegratedCampaignsInline(admin.TabularInline):
     """Inline to show/edit campaigns that integrate into this campaign"""
 
@@ -113,12 +136,41 @@ class IntegratedCampaignsInline(admin.TabularInline):
 
 @admin.register(Campaign)
 class CampaignAdmin(admin.ModelAdmin):
-    raw_id_fields = ("initial_org_unit",)
+    list_display = (
+        "obr_name",
+        "get_country",
+        "virus",
+        "detection_status",
+        "is_test",
+        "on_hold",
+        "is_planned",
+        "updated_at",
+    )
+    list_display_links = ("obr_name",)
+    search_fields = ("obr_name", "epid")
+    list_filter = (
+        "virus",
+        "detection_status",
+        "risk_assessment_status",
+        "budget_status",
+        "campaign_types",
+        "is_test",
+        "on_hold",
+    )
+    raw_id_fields = ("account", "country", "initial_org_unit", "integrated_to")
+    readonly_fields = ("id", "created_at", "updated_at", "geojson")
+    date_hierarchy = "updated_at"
     formfield_overrides = {
         models.ForeignKey: {"widget": widgets.AdminTextInputWidget},
     }
-    list_filter = ["virus", "detection_status", "risk_assessment_status", "budget_status", "campaign_types"]
     inlines = [IntegratedCampaignsInline]
+
+    @admin.display(description="Country", ordering="country__name", empty_value=MISSING_CAMPAIGN_LABEL)
+    def get_country(self, obj):
+        return format_campaign_country(obj)
+
+    def get_queryset(self, request):
+        return super().get_queryset(request).select_related("country")
 
     # Exclude old budget tool fields
     exclude = (
@@ -209,7 +261,18 @@ class SpreadSheetImportAdmin(admin.ModelAdmin):
 
 @admin.register(CampaignGroup)
 class CampaignGroupAdmin(admin.ModelAdmin):
-    pass
+    list_display = ("name", "get_campaign_count", "created_at", "updated_at")
+    list_display_links = ("name",)
+    search_fields = ("name", "campaigns__obr_name")
+    readonly_fields = ("created_at", "updated_at")
+    autocomplete_fields = ("campaigns",)
+
+    @admin.display(description="Campaigns", ordering="_campaign_count")
+    def get_campaign_count(self, obj):
+        return getattr(obj, "_campaign_count", 0) or 0
+
+    def get_queryset(self, request):
+        return super().get_queryset(request).annotate(_campaign_count=Count("campaigns", distinct=True))
 
 
 @admin.register(MailTemplate)
@@ -507,7 +570,10 @@ class RoundAdmin(admin.ModelAdmin):
 
 @admin.register(ReasonForDelay)
 class ReasonForDelayAdmin(admin.ModelAdmin):
-    model = ReasonForDelay
+    search_fields = ("name", "key_name")
+    list_display = ("name", "key_name", "account")
+    list_filter = ("account",)
+    raw_id_fields = ("account",)
 
 
 @admin.register(NotificationImport)
@@ -635,7 +701,7 @@ class SubActivityScopeInline(admin.StackedInline):
 
 
 @admin.register(SubActivity)
-class SubActivityAdmin(admin.ModelAdmin):
+class SubActivityAdmin(RoundRelatedAdminDisplayMixin, admin.ModelAdmin):
     list_display = (
         "name",
         "get_campaign_obr_name",
@@ -648,23 +714,6 @@ class SubActivityAdmin(admin.ModelAdmin):
     fields = ("name", "start_date", "end_date", "round")
     autocomplete_fields = ("round",)
     inlines = [SubActivityScopeInline]
-
-    @admin.display(
-        description="Campaign (OBR)",
-        ordering="round__campaign__obr_name",
-        empty_value=MISSING_CAMPAIGN_LABEL,
-    )
-    def get_campaign_obr_name(self, obj):
-        return format_round_campaign_obr_name(obj.round)
-
-    @admin.display(description="Round", ordering="round__number")
-    def get_round_number(self, obj):
-        if obj.round_id and obj.round.number is not None:
-            return obj.round.number
-        return MISSING_CAMPAIGN_LABEL
-
-    def get_queryset(self, request):
-        return super().get_queryset(request).select_related("round__campaign")
 
     def save_related(self, request, form, formsets, change):
         for formset in formsets:
@@ -774,7 +823,54 @@ class PerformanceThresholdsAdmin(admin.ModelAdmin):
         return PerformanceThresholds.objects_include_deleted.all()
 
 
-admin.site.register(RoundDateHistoryEntry)
+@admin.register(RoundDateHistoryEntry)
+class RoundDateHistoryEntryAdmin(RoundRelatedAdminDisplayMixin, admin.ModelAdmin):
+    list_display = (
+        "id",
+        "get_campaign_obr_name",
+        "get_round_number",
+        "started_at",
+        "ended_at",
+        "previous_started_at",
+        "previous_ended_at",
+        "get_reason_for_delay",
+        "created_at",
+        "get_modified_by",
+    )
+    list_display_links = ("id", "get_campaign_obr_name")
+    search_fields = ("round__campaign__obr_name", "round__number", "reason_for_delay__name")
+    list_filter = ("reason_for_delay__key_name",)
+    autocomplete_fields = ("round", "reason_for_delay")
+    raw_id_fields = ("modified_by",)
+    readonly_fields = (
+        "previous_started_at",
+        "previous_ended_at",
+        "created_at",
+    )
+    date_hierarchy = "created_at"
+
+    @admin.display(
+        description="Reason for delay", ordering="reason_for_delay__name", empty_value=MISSING_CAMPAIGN_LABEL
+    )
+    def get_reason_for_delay(self, obj):
+        if obj.reason_for_delay_id:
+            return obj.reason_for_delay.name
+        return MISSING_CAMPAIGN_LABEL
+
+    @admin.display(description="Modified by", ordering="modified_by__username", empty_value=MISSING_CAMPAIGN_LABEL)
+    def get_modified_by(self, obj):
+        if obj.modified_by_id:
+            return obj.modified_by.get_username()
+        return MISSING_CAMPAIGN_LABEL
+
+    def get_queryset(self, request):
+        return (
+            super()
+            .get_queryset(request)
+            .select_related("reason_for_delay", "modified_by")
+        )
+
+
 admin.site.register(CountryUsersGroup)
 admin.site.register(URLCache)
 admin.site.register(CampaignType)

--- a/plugins/polio/api/rounds/serializers.py
+++ b/plugins/polio/api/rounds/serializers.py
@@ -1,12 +1,26 @@
 from django.db.transaction import atomic
+from drf_spectacular.utils import extend_schema_serializer
 from rest_framework import serializers
 
 from plugins.polio.api.rounds.round_date_history.serializers import RoundDateHistoryEntryForRoundSerializer
 from plugins.polio.api.shared_serializers import (
     GroupSerializer,
 )
-from plugins.polio.models import ReasonForDelay, Round, RoundDateHistoryEntry, RoundScope
+from plugins.polio.models import (
+    ROUND_DEPRECATED_VACCINE_MANAGEMENT_FIELD_NAMES,
+    ROUND_DEPRECATED_VACCINE_MANAGEMENT_HELP,
+    ReasonForDelay,
+    Round,
+    RoundDateHistoryEntry,
+    RoundScope,
+)
 from plugins.polio.preparedness.summary import set_preparedness_cache_for_round
+
+
+_ROUND_OPENAPI_SCHEMA_OVERRIDES = {
+    "deprecate_fields": ROUND_DEPRECATED_VACCINE_MANAGEMENT_FIELD_NAMES,
+    "description": ROUND_DEPRECATED_VACCINE_MANAGEMENT_HELP,
+}
 
 
 class RoundScopeSerializer(serializers.ModelSerializer):
@@ -17,7 +31,14 @@ class RoundScopeSerializer(serializers.ModelSerializer):
     group = GroupSerializer()
 
 
+@extend_schema_serializer(**_ROUND_OPENAPI_SCHEMA_OVERRIDES)
 class RoundSerializer(serializers.ModelSerializer):
+    """Round API serializer.
+
+    Deprecated fields (still returned for backwards compatibility):
+    {deprecated_fields}
+    """.format(deprecated_fields=", ".join(ROUND_DEPRECATED_VACCINE_MANAGEMENT_FIELD_NAMES))
+
     class Meta:
         model = Round
         fields = "__all__"
@@ -142,6 +163,7 @@ class RoundSerializer(serializers.ModelSerializer):
 
 
 # Don't display the url for Anonymous users
+@extend_schema_serializer(**_ROUND_OPENAPI_SCHEMA_OVERRIDES)
 class RoundAnonymousSerializer(RoundSerializer):
     class Meta:
         model = Round

--- a/plugins/polio/js/src/constants/types.ts
+++ b/plugins/polio/js/src/constants/types.ts
@@ -180,16 +180,24 @@ export type Round = {
     campaign: Nullable<string>; // uuid
     cost: Nullable<string>;
     datelogs: RoundDateHistoryEntry[];
+    /** @deprecated Use vaccine supply chain (DestructionReport). */
     date_destruction: Nullable<string>;
+    /** @deprecated Use vaccine supply chain (VaccineRequestForm). */
     date_signed_vrf_received: Nullable<string>; // date
     destructions: Destruction[];
     doses_requested: Nullable<number>;
     ended_at: string; // date
+    /** @deprecated Use vaccine supply chain (OutgoingStockMovement / Form A). */
     forma_comment: Nullable<string>;
+    /** @deprecated Use vaccine supply chain (OutgoingStockMovement / Form A). */
     forma_date: Nullable<string>; // date
+    /** @deprecated Use vaccine supply chain (OutgoingStockMovement / Form A). */
     forma_missing_vials: Nullable<number>;
+    /** @deprecated Use vaccine supply chain (OutgoingStockMovement / Form A). */
     forma_reception: Nullable<string>; // date
+    /** @deprecated Use vaccine supply chain (OutgoingStockMovement / Form A). */
     forma_unusable_vials: Nullable<number>;
+    /** @deprecated Use vaccine supply chain (OutgoingStockMovement / Form A). */
     forma_usable_vials: Nullable<number>;
     id: number;
     im_ended_at: Nullable<string>; // date
@@ -210,8 +218,11 @@ export type Round = {
     percentage_covered_target_population: Nullable<number>;
     preparedness_spreadsheet_url: Nullable<string>;
     preparedness_sync_status: Nullable<PreparednessSyncStatus>;
+    /** @deprecated Round-level reporting delay summary; use vaccine supply chain module. */
     reporting_delays_district_to_region: Nullable<number>;
+    /** @deprecated Round-level reporting delay summary; use vaccine supply chain module. */
     reporting_delays_hc_to_district: Nullable<number>;
+    /** @deprecated Round-level reporting delay summary; use vaccine supply chain module. */
     reporting_delays_region_to_national: Nullable<number>;
     scopes: Scope[];
     started_at: string; // date
@@ -220,6 +231,7 @@ export type Round = {
     vaccine_names: string;
     vaccine_names_extended: string;
     vaccines: RoundVaccine[];
+    /** @deprecated Use vaccine supply chain (DestructionReport). */
     vials_destroyed: Nullable<number>;
 };
 

--- a/plugins/polio/js/src/domains/Campaigns/CampaignHistory/config.tsx
+++ b/plugins/polio/js/src/domains/Campaigns/CampaignHistory/config.tsx
@@ -520,6 +520,7 @@ export const useGetConfig = (): Record<string, any> => {
                         },
                     ],
                 },
+                // deprecated – round-level fields; use vaccine supply chain module
                 {
                     key: 'reporting_delays_hc_to_district',
                 },
@@ -568,6 +569,7 @@ export const useGetConfig = (): Record<string, any> => {
                         },
                     ],
                 },
+                // deprecated – round-level Form A summary; use OutgoingStockMovement
                 {
                     key: 'forma_reception',
                     getLogValue: log => convertDate(log.forma_reception),

--- a/plugins/polio/locale/fr/LC_MESSAGES/django.po
+++ b/plugins/polio/locale/fr/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-11 12:19+0000\n"
+"POT-Creation-Date: 2026-06-05 07:16+0000\n"
 "PO-Revision-Date: 2025-02-05 14:43+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,6 +17,18 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 3.5\n"
+
+#: plugins/polio/admin.py
+msgid "Evaluation (LQAS/IM)"
+msgstr "Évaluation (LQAS/IM)"
+
+#: plugins/polio/admin.py
+msgid "Preparedness"
+msgstr "Préparation de campagne"
+
+#: plugins/polio/admin.py
+msgid "Deprecated – round-level vaccine management"
+msgstr "Déprécié – gestion des vaccins au niveau du round"
 
 #: plugins/polio/api/calendar/serializers.py
 #: plugins/polio/api/campaigns/serializers/campaigns.py
@@ -67,6 +79,7 @@ msgid "Preventive"
 msgstr "Préventive"
 
 #: plugins/polio/api/campaigns/filters/campaign_dashboards_filters.py
+#: plugins/polio/api/chronogram/filters.py
 msgid "On hold"
 msgstr "En pause"
 
@@ -340,6 +353,15 @@ msgstr "mois"
 #: plugins/polio/models/base.py
 msgid "name"
 msgstr "nom"
+
+#: plugins/polio/models/base.py
+msgid ""
+"Deprecated. Use VaccineRequestForm, OutgoingStockMovement, or "
+"DestructionReport in the vaccine supply chain module instead."
+msgstr ""
+"Déprécié. Utilisez VaccineRequestForm, OutgoingStockMovement ou "
+"DestructionReport dans le module de chaîne d'approvisionnement en vaccins à "
+"la place."
 
 #: plugins/polio/models/base.py
 msgid "When the campaign starts"

--- a/plugins/polio/models/base.py
+++ b/plugins/polio/models/base.py
@@ -390,6 +390,39 @@ def format_round_campaign_obr_name(round_obj, *, empty=MISSING_CAMPAIGN_LABEL):
     return campaign.obr_name
 
 
+def format_campaign_obr_name(campaign=None, *, non_obr_name="", empty=MISSING_CAMPAIGN_LABEL):
+    """Campaign OBR or alternative name (Form A may use non_obr_name when campaign is unset)."""
+    if campaign is not None:
+        return campaign.obr_name
+    if non_obr_name:
+        return non_obr_name
+    return empty
+
+
+def format_campaign_country(campaign, *, empty=MISSING_CAMPAIGN_LABEL):
+    if campaign is None or not campaign.country_id:
+        return empty
+    country = campaign.country
+    if country is None:
+        return empty
+    return country.name
+
+
+def format_vaccine_stock_country(vaccine_stock, *, empty=MISSING_CAMPAIGN_LABEL):
+    if vaccine_stock is None or not vaccine_stock.country_id:
+        return empty
+    country = vaccine_stock.country
+    if country is None:
+        return empty
+    return country.name
+
+
+def format_vaccine_stock_vaccine(vaccine_stock, *, empty=MISSING_CAMPAIGN_LABEL):
+    if vaccine_stock is None:
+        return empty
+    return vaccine_stock.vaccine
+
+
 ROUND_DEPRECATED_VACCINE_MANAGEMENT_FIELD_NAMES = (
     "date_signed_vrf_received",
     "date_destruction",
@@ -1790,10 +1823,15 @@ class EarmarkedStock(models.Model):
         ]
 
     def __str__(self):
-        if self.campaign and self.round:
-            return f"Earmarked {self.vials_earmarked} vials for {self.campaign.obr_name} Round {self.round.number}"
-        if self.temporary_campaign_name:
-            return f"Earmarked {self.vials_earmarked} vials for ({self.temporary_campaign_name})"
+        campaign_label = format_campaign_obr_name(
+            self.campaign if self.campaign_id else None,
+            non_obr_name=self.temporary_campaign_name,
+            empty="",
+        )
+        if campaign_label and self.round_id and self.round.number is not None:
+            return f"Earmarked {self.vials_earmarked} vials for {campaign_label} Round {self.round.number}"
+        if campaign_label:
+            return f"Earmarked {self.vials_earmarked} vials for {campaign_label}"
         return f"Earmarked {self.vials_earmarked} vials"
 
     @classmethod

--- a/plugins/polio/models/base.py
+++ b/plugins/polio/models/base.py
@@ -44,6 +44,10 @@ from iaso.utils.models.soft_deletable import (
     SoftDeletableModel,
 )
 from iaso.utils.virus_scan.model import ModelWithFile
+from plugins.polio.preparedness.display_utils import (
+    format_campaign_obr_name,
+    format_round_campaign_obr_name,
+)
 from plugins.polio.preparedness.parser import open_sheet_by_url
 from plugins.polio.preparedness.spread_cache import CachedSpread
 
@@ -227,6 +231,13 @@ class RoundDateHistoryEntry(models.Model):
     modified_by = models.ForeignKey("auth.User", on_delete=models.PROTECT, null=True, blank=True)
     created_at = models.DateTimeField(auto_now_add=True)
 
+    def __str__(self):
+        if not self.round_id:
+            return f"Round date history {self.pk}"
+        round_label = format_round_campaign_obr_name(self.round, empty="?")
+        number = self.round.number if self.round.number is not None else "?"
+        return f"{round_label} – Round {number} ({self.created_at:%Y-%m-%d})"
+
 
 class ReasonForDelay(SoftDeletableModel):
     name = TranslatedField(models.CharField(_("name"), max_length=200), {"fr": {"blank": True}})
@@ -377,52 +388,6 @@ ROUND_DEPRECATED_VACCINE_MANAGEMENT_HELP = _(
 )
 
 # Round-level summary fields kept for backwards compatibility (campaign history, legacy API).
-MISSING_CAMPAIGN_LABEL = "—"
-
-
-def format_round_campaign_obr_name(round_obj, *, empty=MISSING_CAMPAIGN_LABEL):
-    """OBR name for labels; rounds may exist without a linked campaign (legacy data)."""
-    if round_obj is None or not round_obj.campaign_id:
-        return empty
-    campaign = round_obj.campaign
-    if campaign is None:
-        return empty
-    return campaign.obr_name
-
-
-def format_campaign_obr_name(campaign=None, *, non_obr_name="", empty=MISSING_CAMPAIGN_LABEL):
-    """Campaign OBR or alternative name (Form A may use non_obr_name when campaign is unset)."""
-    if campaign is not None:
-        return campaign.obr_name
-    if non_obr_name:
-        return non_obr_name
-    return empty
-
-
-def format_campaign_country(campaign, *, empty=MISSING_CAMPAIGN_LABEL):
-    if campaign is None or not campaign.country_id:
-        return empty
-    country = campaign.country
-    if country is None:
-        return empty
-    return country.name
-
-
-def format_vaccine_stock_country(vaccine_stock, *, empty=MISSING_CAMPAIGN_LABEL):
-    if vaccine_stock is None or not vaccine_stock.country_id:
-        return empty
-    country = vaccine_stock.country
-    if country is None:
-        return empty
-    return country.name
-
-
-def format_vaccine_stock_vaccine(vaccine_stock, *, empty=MISSING_CAMPAIGN_LABEL):
-    if vaccine_stock is None:
-        return empty
-    return vaccine_stock.vaccine
-
-
 ROUND_DEPRECATED_VACCINE_MANAGEMENT_FIELD_NAMES = (
     "date_signed_vrf_received",
     "date_destruction",
@@ -1341,7 +1306,7 @@ class SpreadSheetImport(models.Model):
 
 class CampaignGroup(SoftDeletableModel):
     def __str__(self):
-        return f"{self.name} {','.join(str(c) for c in self.campaigns.all())}"
+        return self.name
 
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)

--- a/plugins/polio/models/base.py
+++ b/plugins/polio/models/base.py
@@ -371,6 +371,41 @@ class SubActivity(models.Model):
         return ", ".join(self.single_vaccine_list)
 
 
+ROUND_DEPRECATED_VACCINE_MANAGEMENT_HELP = _(
+    "Deprecated. Use VaccineRequestForm, OutgoingStockMovement, or DestructionReport "
+    "in the vaccine supply chain module instead."
+)
+
+# Round-level summary fields kept for backwards compatibility (campaign history, legacy API).
+MISSING_CAMPAIGN_LABEL = "—"
+
+
+def format_round_campaign_obr_name(round_obj, *, empty=MISSING_CAMPAIGN_LABEL):
+    """OBR name for labels; rounds may exist without a linked campaign (legacy data)."""
+    if round_obj is None or not round_obj.campaign_id:
+        return empty
+    campaign = round_obj.campaign
+    if campaign is None:
+        return empty
+    return campaign.obr_name
+
+
+ROUND_DEPRECATED_VACCINE_MANAGEMENT_FIELD_NAMES = (
+    "date_signed_vrf_received",
+    "date_destruction",
+    "vials_destroyed",
+    "reporting_delays_hc_to_district",
+    "reporting_delays_district_to_region",
+    "reporting_delays_region_to_national",
+    "forma_reception",
+    "forma_missing_vials",
+    "forma_usable_vials",
+    "forma_unusable_vials",
+    "forma_date",
+    "forma_comment",
+)
+
+
 class Round(models.Model):
     class Meta:
         ordering = ["number", "started_at"]
@@ -435,7 +470,7 @@ class Round(models.Model):
     # Preparedness
     preparedness_spreadsheet_url = models.URLField(null=True, blank=True)
     preparedness_sync_status = models.CharField(max_length=10, default="FINISHED", choices=PREPAREDNESS_SYNC_STATUS)
-    # Vaccine management
+    # Deprecated: round-level vaccine management summary (see ROUND_DEPRECATED_VACCINE_MANAGEMENT_FIELD_NAMES).
     date_signed_vrf_received = models.DateField(null=True, blank=True)
     date_destruction = models.DateField(null=True, blank=True)
     vials_destroyed = models.IntegerField(null=True, blank=True)
@@ -449,9 +484,14 @@ class Round(models.Model):
     forma_date = models.DateField(null=True, blank=True)
     forma_comment = models.TextField(blank=True, null=True)
 
-    # End of vaccine management
-
     objects = models.Manager.from_queryset(RoundQuerySet)()
+
+    def __str__(self):
+        if self.number is not None:
+            obr_name = format_round_campaign_obr_name(self, empty=None)
+            if obr_name:
+                return f"{obr_name} – Round {self.number}"
+        return f"Round {self.pk}"
 
     def delete(self, *args, **kwargs):
         # Explicitly delete groups related to the round's scopes, because the cascade deletion won't work reliably

--- a/plugins/polio/models/chronogram.py
+++ b/plugins/polio/models/chronogram.py
@@ -78,7 +78,9 @@ class Chronogram(SoftDeletableModel):
         verbose_name = _("Chronogram")
 
     def __str__(self) -> str:
-        return f"{self.id} - {self.round.campaign.obr_name} - Round {self.round.number}"
+        if self.round_id and self.round.campaign_id and self.round.number is not None:
+            return f"{self.id} - {self.round.campaign.obr_name} - Round {self.round.number}"
+        return f"Chronogram {self.id}"
 
     @property
     def percentage_of_completion(self) -> dict:

--- a/plugins/polio/preparedness/display_utils.py
+++ b/plugins/polio/preparedness/display_utils.py
@@ -1,0 +1,46 @@
+"""Human-readable labels for polio admin and model ``__str__`` (legacy null FKs)."""
+
+MISSING_CAMPAIGN_LABEL = "—"
+
+
+def format_round_campaign_obr_name(round_obj, *, empty=MISSING_CAMPAIGN_LABEL):
+    """OBR name for labels; rounds may exist without a linked campaign (legacy data)."""
+    if round_obj is None or not round_obj.campaign_id:
+        return empty
+    campaign = round_obj.campaign
+    if campaign is None:
+        return empty
+    return campaign.obr_name
+
+
+def format_campaign_obr_name(campaign=None, *, non_obr_name="", empty=MISSING_CAMPAIGN_LABEL):
+    """Campaign OBR or alternative name (Form A may use non_obr_name when campaign is unset)."""
+    if campaign is not None:
+        return campaign.obr_name
+    if non_obr_name:
+        return non_obr_name
+    return empty
+
+
+def format_campaign_country(campaign, *, empty=MISSING_CAMPAIGN_LABEL):
+    if campaign is None or not campaign.country_id:
+        return empty
+    country = campaign.country
+    if country is None:
+        return empty
+    return country.name
+
+
+def format_vaccine_stock_country(vaccine_stock, *, empty=MISSING_CAMPAIGN_LABEL):
+    if vaccine_stock is None or not vaccine_stock.country_id:
+        return empty
+    country = vaccine_stock.country
+    if country is None:
+        return empty
+    return country.name
+
+
+def format_vaccine_stock_vaccine(vaccine_stock, *, empty=MISSING_CAMPAIGN_LABEL):
+    if vaccine_stock is None:
+        return empty
+    return vaccine_stock.vaccine

--- a/plugins/polio/tests/models/test_round_models.py
+++ b/plugins/polio/tests/models/test_round_models.py
@@ -140,3 +140,10 @@ class RoundModelTestCase(APITestCase, PolioTestCaseMixin):
         self.assertEqual(
             round_6.chronograms.valid().count(), 1, "A new chronogram should be created for a campaign on hold."
         )
+
+    def test_str_with_campaign_and_number(self):
+        self.assertEqual(str(self.rnd1), f"{self.obr_name} – Round {self.rnd1.number}")
+
+    def test_str_without_campaign(self):
+        round_without_campaign = pm.Round.objects.create(number=99)
+        self.assertEqual(str(round_without_campaign), f"Round {round_without_campaign.pk}")


### PR DESCRIPTION
## What problem is this PR solving?

Explain here in one sentence.

### Related JIRA tickets

POLIO-1199

## Changes

- Improved list layout for polio models in admin:
    - Campaign
    - CampaignGroup
    - Round
    - RoundDateHistoryEntry
    - Subactivity
    - VaccineRequestForm
    -  OutgoingStockMovement (form a)
    - IncidentReport
    - DestructionReport
    - EarmarkedStock
    - VaccineStcokHistory
    - Chronogram
- Added some utils and Mixins for the polio admin 
- Marked vaccine (stock) related fields on Round model as deprecated in both F-E and B-E
- 

## How to test

On a polio DB with plugin activated, go to the page of listed models





