### PR TITLE
[Sleep-1788] add team selection to iaso user profile

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/users/components/Filters.tsx
+++ b/hat/assets/js/apps/Iaso/domains/users/components/Filters.tsx
@@ -21,6 +21,7 @@ import { useGetOrgUnitTypesDropdownOptions } from '../../orgUnits/orgUnitTypes/h
 import { useGetProjectsDropdownOptions } from '../../projects/hooks/requests';
 import { useGetTeamsDropdown } from '../../teams/hooks/requests/useGetTeams';
 import { useGetUserRolesDropDown } from '../../userRoles/hooks/requests/useGetUserRoles';
+import { useFindCustomComponent } from '../../../plugins/hooks/customComponents';
 import { useGetPermissionsDropDown } from '../hooks/useGetPermissionsDropdown';
 import MESSAGES from '../messages';
 
@@ -70,7 +71,8 @@ const Filters: FunctionComponent<Props> = ({
     const { data: allProjects, isFetching: isFetchingProjects } =
         useGetProjectsDropdownOptions(true, canBypassProjectRestrictions);
     const { data: teamsDropdown, isFetching: isFetchingTeams } =
-        useGetTeamsDropdown();
+        useGetTeamsDropdown({});
+    const TeamsFilterOverride = useFindCustomComponent('user.teams_filter');
 
     const orgUnitTypeDropdown = useMemo(() => {
         if (!orgUnitTypes?.length) return orgUnitTypes;
@@ -195,18 +197,26 @@ const Filters: FunctionComponent<Props> = ({
                     onEnterPressed={handleSearchUserRoles}
                 />
 
-                <InputComponent
-                    keyValue="teamsIds"
-                    onChange={handleChange}
-                    value={filters.teamsIds}
-                    type="select"
-                    options={teamsDropdown}
-                    label={MESSAGES.teams}
-                    loading={isFetchingTeams}
-                    onEnterPressed={handleSearchPerms}
-                    clearable
-                    multi
-                />
+                {TeamsFilterOverride ? (
+                    <TeamsFilterOverride
+                        value={filters.teamsIds}
+                        onChange={handleChange}
+                        onEnterPressed={handleSearchPerms}
+                    />
+                ) : (
+                    <InputComponent
+                        keyValue="teamsIds"
+                        onChange={handleChange}
+                        value={filters.teamsIds}
+                        type="select"
+                        options={teamsDropdown}
+                        label={MESSAGES.teams}
+                        loading={isFetchingTeams}
+                        onEnterPressed={handleSearchPerms}
+                        clearable
+                        multi
+                    />
+                )}
             </Grid>
             <Grid item xs={12} md={3}>
                 <InputComponent

--- a/hat/assets/js/apps/Iaso/domains/users/components/useInitialUser.ts
+++ b/hat/assets/js/apps/Iaso/domains/users/components/useInitialUser.ts
@@ -133,6 +133,10 @@ export const useInitialUser = (
                 value: get(initialData, 'institution', null),
                 errors: [],
             },
+            team: {
+                value: get(initialData, 'team', null),
+                errors: [],
+            },
         };
     }, [initialData]);
     const [user, setUser] = useState<UserDialogData>(initialUser);


### PR DESCRIPTION
## What problem is this PR solving?

This PR is about adding the team selection on the User creation and filter profile


### Related JIRA tickets

[SLEEP-1788](https://bluesquare.atlassian.net/browse/SLEEP-1788)


## Changes

Trypelim PR: https://github.com/BLSQ/trypelim/pull/270


## Print screen / video

Upload here print screens or videos showing the changes.

## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).


[SLEEP-1234]: https://bluesquare.atlassian.net/browse/SLEEP-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[SLEEP-1788]: https://bluesquare.atlassian.net/browse/SLEEP-1788?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ