### PR TITLE
IA-5182 make ReportVersion admin change page more efficient with searchable user fields

### DIFF
--- a/iaso/admin/base.py
+++ b/iaso/admin/base.py
@@ -1330,6 +1330,14 @@ class DataSourceVersionsSynchronizationAdmin(admin.ModelAdmin):
         )
 
 
+@admin.register(ReportVersion)
+class ReportVersionAdmin(admin.ModelAdmin):
+    list_display = ("name", "status", "created_at", "updated_at")
+    list_filter = ("status",)
+    search_fields = ("name",)
+    autocomplete_fields = ("created_by", "updated_by")
+
+
 class TemporaryFormAdmin(admin.ModelAdmin):
     list_display = ("uuid", "user", "account", "created_at")
     list_filter = ("account",)
@@ -1347,4 +1355,3 @@ admin.site.register(ExternalCredentials)
 admin.site.register(DevicePosition)
 admin.site.register(BulkCreateUserFile)
 admin.site.register(Report)
-admin.site.register(ReportVersion)


### PR DESCRIPTION
## Jira

[IA-5182](https://bluesquare.atlassian.net/browse/IA-5182)

## Problem

The admin change page for `ReportVersion` (`/admin/iaso/reportversion/<id>/change/`) was slow to load: the model was registered with a plain `admin.site.register(ReportVersion)`, so the `created_by` and `updated_by` foreign keys to `User` rendered as plain select boxes loading every user in the database into the page.

## Solution

Register `ReportVersion` with a dedicated `ModelAdmin` using `autocomplete_fields = ("created_by", "updated_by")`, which replaces the select boxes with Select2 autocomplete widgets searching users via AJAX — the same pattern already used by `TaskAdmin` and others in `iaso/admin/base.py`. Also adds `list_display`, `list_filter` and `search_fields` for the changelist.

The custom `UserAdmin` extends Django's `AuthUserAdmin`, which defines `search_fields`, so the autocomplete endpoint works out of the box.

[IA-5182]: https://bluesquare.atlassian.net/browse/IA-5182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ