### PR TITLE
[IA-5170]: Only return permissions from active modules in profile retrieve

### DIFF
--- a/iaso/api/profiles/serializers/retrieve.py
+++ b/iaso/api/profiles/serializers/retrieve.py
@@ -324,7 +324,7 @@ class ProfileRetrieveSerializer(ModelSerializer):
         user_group_permissions = [
             permission.split(".")[1]
             for permission in obj.user.get_group_permissions()
-            if permission.split(".")[1].startswith("iaso_")
+            if permission.split(".")[1].startswith("iaso_") and permission in permissions_active_modules
         ]
         user_permissions = list(
             obj.user.user_permissions.filter(

--- a/iaso/api/profiles/serializers/retrieve.py
+++ b/iaso/api/profiles/serializers/retrieve.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.db.models import Q
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema_field
 from phonenumbers.phonenumberutil import region_code_for_number
@@ -318,13 +319,17 @@ class ProfileRetrieveSerializer(ModelSerializer):
 
     @extend_schema_field(serializers.ListField(child=serializers.CharField()))
     def get_permissions(self, obj):
+        permissions_active_modules = [p.codename for p in obj.account.permissions_from_active_modules]
+
         user_group_permissions = [
             permission.split(".")[1]
             for permission in obj.user.get_group_permissions()
             if permission.split(".")[1].startswith("iaso_")
         ]
         user_permissions = list(
-            obj.user.user_permissions.filter(codename__startswith="iaso_").values_list("codename", flat=True)
+            obj.user.user_permissions.filter(
+                Q(codename__startswith="iaso_") & Q(codename__in=permissions_active_modules)
+            ).values_list("codename", flat=True)
         )
         all_permissions = user_group_permissions + user_permissions
         permissions = list(set(all_permissions))
@@ -332,7 +337,12 @@ class ProfileRetrieveSerializer(ModelSerializer):
 
     @extend_schema_field(serializers.ListField(child=serializers.CharField()))
     def get_user_permissions(self, obj):
-        return list(obj.user.user_permissions.filter(codename__startswith="iaso_").values_list("codename", flat=True))
+        permissions_active_modules = [p.codename for p in obj.account.permissions_from_active_modules]
+        return list(
+            obj.user.user_permissions.filter(
+                Q(codename__startswith="iaso_") & Q(codename__in=permissions_active_modules)
+            ).values_list("codename", flat=True)
+        )
 
     @extend_schema_field({"type": "string", "nullable": True})
     def get_country_code(self, obj):

--- a/iaso/tests/api/profiles/test_views/common.py
+++ b/iaso/tests/api/profiles/test_views/common.py
@@ -16,7 +16,7 @@ from iaso.test import APITestCase, SwaggerTestCaseMixin
 
 class BaseProfileAPITestCase(SwaggerTestCaseMixin, APITestCase):
     def setUp(self):
-        super().setUpTestData()
+        super().setUp()
         self.MODULES = [module.codename for module in MODULES]
         self.account = m.Account.objects.create(
             name="Global Health Initiative", modules=self.MODULES, enforce_password_validation=False

--- a/iaso/tests/api/profiles/test_views/common.py
+++ b/iaso/tests/api/profiles/test_views/common.py
@@ -15,129 +15,130 @@ from iaso.test import APITestCase, SwaggerTestCaseMixin
 
 
 class BaseProfileAPITestCase(SwaggerTestCaseMixin, APITestCase):
-    def setUp(self):
-        super().setUp()
-        self.MODULES = [module.codename for module in MODULES]
-        self.account = m.Account.objects.create(
-            name="Global Health Initiative", modules=self.MODULES, enforce_password_validation=False
+    @classmethod
+    def setUpTestData(cls):
+        super(BaseProfileAPITestCase, cls).setUpTestData()
+        cls.MODULES = [module.codename for module in MODULES]
+        cls.account = m.Account.objects.create(
+            name="Global Health Initiative", modules=cls.MODULES, enforce_password_validation=False
         )
-        self.another_account = m.Account.objects.create(name="Another account", enforce_password_validation=False)
+        cls.another_account = m.Account.objects.create(name="Another account", enforce_password_validation=False)
 
         # TODO : make the org unit creations shorter and reusable
-        self.project = m.Project.objects.create(
+        cls.project = m.Project.objects.create(
             name="Hydroponic gardens",
             app_id="stars.empire.agriculture.hydroponics",
-            account=self.account,
+            account=cls.account,
         )
         datasource = m.DataSource.objects.create(name="Evil Empire")
-        datasource.projects.add(self.project)
-        self.datasource = datasource
-        self.sub_unit_type = m.OrgUnitType.objects.create(name="Jedi Squad", short_name="Jds")
-        self.parent_org_unit_type = m.OrgUnitType.objects.create(name="Jedi Council", short_name="Cnc")
-        self.parent_org_unit_type.sub_unit_types.add(self.sub_unit_type)
+        datasource.projects.add(cls.project)
+        cls.datasource = datasource
+        cls.sub_unit_type = m.OrgUnitType.objects.create(name="Jedi Squad", short_name="Jds")
+        cls.parent_org_unit_type = m.OrgUnitType.objects.create(name="Jedi Council", short_name="Cnc")
+        cls.parent_org_unit_type.sub_unit_types.add(cls.sub_unit_type)
 
-        self.mock_multipolygon = None
-        self.mock_point = None
+        cls.mock_multipolygon = None
+        cls.mock_point = None
 
-        self.org_unit_group = m.Group.objects.create(name="Elite councils")
-        self.datasource = datasource
+        cls.org_unit_group = m.Group.objects.create(name="Elite councils")
+        cls.datasource = datasource
         source_version_1 = m.SourceVersion.objects.create(data_source=datasource, number=1)
-        self.account.default_version = source_version_1
-        self.account.save()
-        self.org_unit_from_sub_type = m.OrgUnit.objects.create(
-            org_unit_type=self.sub_unit_type,
+        cls.account.default_version = source_version_1
+        cls.account.save()
+        cls.org_unit_from_sub_type = m.OrgUnit.objects.create(
+            org_unit_type=cls.sub_unit_type,
             version=source_version_1,
             name="Jedi Squad 1",
-            geom=self.mock_multipolygon,
-            simplified_geom=self.mock_multipolygon,
-            catchment=self.mock_multipolygon,
-            location=self.mock_point,
+            geom=cls.mock_multipolygon,
+            simplified_geom=cls.mock_multipolygon,
+            catchment=cls.mock_multipolygon,
+            location=cls.mock_point,
             validation_status=m.OrgUnit.VALIDATION_VALID,
             source_ref=None,
         )
-        self.org_unit_type = m.OrgUnitType.objects.create(name="Org unit type")
-        self.another_org_unit = m.OrgUnit.objects.create(
-            org_unit_type=self.org_unit_type,
+        cls.org_unit_type = m.OrgUnitType.objects.create(name="Org unit type")
+        cls.another_org_unit = m.OrgUnit.objects.create(
+            org_unit_type=cls.org_unit_type,
             name="Hôpital Général",
         )
-        self.org_unit_from_parent_type = m.OrgUnit.objects.create(
-            org_unit_type=self.parent_org_unit_type,
+        cls.org_unit_from_parent_type = m.OrgUnit.objects.create(
+            org_unit_type=cls.parent_org_unit_type,
             version=source_version_1,
             name="Corruscant Jedi Council",
-            geom=self.mock_multipolygon,
-            simplified_geom=self.mock_multipolygon,
-            catchment=self.mock_multipolygon,
-            location=self.mock_point,
+            geom=cls.mock_multipolygon,
+            simplified_geom=cls.mock_multipolygon,
+            catchment=cls.mock_multipolygon,
+            location=cls.mock_point,
             validation_status=m.OrgUnit.VALIDATION_VALID,
             source_ref="FooBarB4z00",
         )
-        self.org_unit_from_parent_type.groups.set([self.org_unit_group])
+        cls.org_unit_from_parent_type.groups.set([cls.org_unit_group])
 
-        self.child_org_unit = m.OrgUnit.objects.create(
-            org_unit_type=self.parent_org_unit_type,
+        cls.child_org_unit = m.OrgUnit.objects.create(
+            org_unit_type=cls.parent_org_unit_type,
             version=source_version_1,
             name="Corruscant Jedi Council",
-            geom=self.mock_multipolygon,
-            simplified_geom=self.mock_multipolygon,
-            catchment=self.mock_multipolygon,
-            location=self.mock_point,
+            geom=cls.mock_multipolygon,
+            simplified_geom=cls.mock_multipolygon,
+            catchment=cls.mock_multipolygon,
+            location=cls.mock_point,
             validation_status=m.OrgUnit.VALIDATION_VALID,
             source_ref="PvtAI4RUMkr",
-            parent=self.org_unit_from_parent_type,
+            parent=cls.org_unit_from_parent_type,
         )
 
-        self.permission = Permission.objects.create(
+        cls.permission = Permission.objects.create(
             name="iaso permission", content_type_id=1, codename="iaso_permission"
         )
-        self.group = Group.objects.create(name="user role")
-        self.group.permissions.add(self.permission)
-        self.user_role = m.UserRole.objects.create(group=self.group, account=self.account)
+        cls.group = Group.objects.create(name="user role")
+        cls.group.permissions.add(cls.permission)
+        cls.user_role = m.UserRole.objects.create(group=cls.group, account=cls.account)
 
-        self.group_another_account = Group.objects.create(name="user role with another account")
-        self.group_another_account.permissions.add(self.permission)
-        self.user_role_another_account = m.UserRole.objects.create(
-            group=self.group_another_account, account=self.another_account
+        cls.group_another_account = Group.objects.create(name="user role with another account")
+        cls.group_another_account.permissions.add(cls.permission)
+        cls.user_role_another_account = m.UserRole.objects.create(
+            group=cls.group_another_account, account=cls.another_account
         )
 
         # Users.
-        self.jane = self.create_user_with_profile(
+        cls.jane = cls.create_user_with_profile(
             first_name="Jane",
             last_name="Doe",
             username="janedoe",
-            account=self.account,
+            account=cls.account,
             permissions=[CORE_FORMS_PERMISSION],
         )
-        self.john = self.create_user_with_profile(username="johndoe", account=self.account, is_superuser=True)
-        self.jim = self.create_user_with_profile(
-            username="jim", account=self.account, permissions=[CORE_FORMS_PERMISSION, CORE_USERS_ADMIN_PERMISSION]
+        cls.john = cls.create_user_with_profile(username="johndoe", account=cls.account, is_superuser=True)
+        cls.jim = cls.create_user_with_profile(
+            username="jim", account=cls.account, permissions=[CORE_FORMS_PERMISSION, CORE_USERS_ADMIN_PERMISSION]
         )
-        self.jam = self.create_user_with_profile(
+        cls.jam = cls.create_user_with_profile(
             username="jam",
-            account=self.account,
+            account=cls.account,
             permissions=[CORE_USERS_MANAGED_PERMISSION],
             language="en",
         )
-        self.jom = self.create_user_with_profile(username="jom", account=self.account, permissions=[], language="fr")
-        self.jum = self.create_user_with_profile(
-            username="jum", account=self.account, permissions=[], projects=[self.project]
+        cls.jom = cls.create_user_with_profile(username="jom", account=cls.account, permissions=[], language="fr")
+        cls.jum = cls.create_user_with_profile(
+            username="jum", account=cls.account, permissions=[], projects=[cls.project]
         )
-        self.user_managed_geo_limit = self.create_user_with_profile(
+        cls.user_managed_geo_limit = cls.create_user_with_profile(
             username="managedGeoLimit",
-            account=self.account,
+            account=cls.account,
             permissions=[CORE_USERS_MANAGED_PERMISSION],
-            org_units=[self.org_unit_from_parent_type],
+            org_units=[cls.org_unit_from_parent_type],
         )
-        self.team1 = m.Team.objects.create(project=self.project, name="team1", manager=self.jane)
-        self.team1.users.add(self.jane)
-        self.team2 = m.Team.objects.create(project=self.project, name="team2", manager=self.jim)
-        self.team2.users.add(self.jim)
-        self.user_managed_geo_limit.iaso_profile.user_roles.set([self.user_role, self.user_role_another_account])
+        cls.team1 = m.Team.objects.create(project=cls.project, name="team1", manager=cls.jane)
+        cls.team1.users.add(cls.jane)
+        cls.team2 = m.Team.objects.create(project=cls.project, name="team2", manager=cls.jim)
+        cls.team2.users.add(cls.jim)
+        cls.user_managed_geo_limit.iaso_profile.user_roles.set([cls.user_role, cls.user_role_another_account])
 
-        self.user_role_name = self.user_role.group.name.removeprefix(
-            f"{self.user_managed_geo_limit.iaso_profile.account.pk}_"
+        cls.user_role_name = cls.user_role.group.name.removeprefix(
+            f"{cls.user_managed_geo_limit.iaso_profile.account.pk}_"
         )
-        self.user_role_another_account_name = self.user_role_another_account.group.name.removeprefix(
-            f"{self.user_managed_geo_limit.iaso_profile.account.pk}_"
+        cls.user_role_another_account_name = cls.user_role_another_account.group.name.removeprefix(
+            f"{cls.user_managed_geo_limit.iaso_profile.account.pk}_"
         )
 
     def assertValidProfileListData(self, list_data: typing.Mapping, expected_length: int, paginated: bool = False):

--- a/iaso/tests/api/profiles/test_views/common.py
+++ b/iaso/tests/api/profiles/test_views/common.py
@@ -15,130 +15,129 @@ from iaso.test import APITestCase, SwaggerTestCaseMixin
 
 
 class BaseProfileAPITestCase(SwaggerTestCaseMixin, APITestCase):
-    @classmethod
-    def setUpTestData(cls):
-        super(BaseProfileAPITestCase, cls).setUpTestData()
-        cls.MODULES = [module.codename for module in MODULES]
-        cls.account = m.Account.objects.create(
-            name="Global Health Initiative", modules=cls.MODULES, enforce_password_validation=False
+    def setUp(self):
+        super().setUpTestData()
+        self.MODULES = [module.codename for module in MODULES]
+        self.account = m.Account.objects.create(
+            name="Global Health Initiative", modules=self.MODULES, enforce_password_validation=False
         )
-        cls.another_account = m.Account.objects.create(name="Another account", enforce_password_validation=False)
+        self.another_account = m.Account.objects.create(name="Another account", enforce_password_validation=False)
 
         # TODO : make the org unit creations shorter and reusable
-        cls.project = m.Project.objects.create(
+        self.project = m.Project.objects.create(
             name="Hydroponic gardens",
             app_id="stars.empire.agriculture.hydroponics",
-            account=cls.account,
+            account=self.account,
         )
         datasource = m.DataSource.objects.create(name="Evil Empire")
-        datasource.projects.add(cls.project)
-        cls.datasource = datasource
-        cls.sub_unit_type = m.OrgUnitType.objects.create(name="Jedi Squad", short_name="Jds")
-        cls.parent_org_unit_type = m.OrgUnitType.objects.create(name="Jedi Council", short_name="Cnc")
-        cls.parent_org_unit_type.sub_unit_types.add(cls.sub_unit_type)
+        datasource.projects.add(self.project)
+        self.datasource = datasource
+        self.sub_unit_type = m.OrgUnitType.objects.create(name="Jedi Squad", short_name="Jds")
+        self.parent_org_unit_type = m.OrgUnitType.objects.create(name="Jedi Council", short_name="Cnc")
+        self.parent_org_unit_type.sub_unit_types.add(self.sub_unit_type)
 
-        cls.mock_multipolygon = None
-        cls.mock_point = None
+        self.mock_multipolygon = None
+        self.mock_point = None
 
-        cls.org_unit_group = m.Group.objects.create(name="Elite councils")
-        cls.datasource = datasource
+        self.org_unit_group = m.Group.objects.create(name="Elite councils")
+        self.datasource = datasource
         source_version_1 = m.SourceVersion.objects.create(data_source=datasource, number=1)
-        cls.account.default_version = source_version_1
-        cls.account.save()
-        cls.org_unit_from_sub_type = m.OrgUnit.objects.create(
-            org_unit_type=cls.sub_unit_type,
+        self.account.default_version = source_version_1
+        self.account.save()
+        self.org_unit_from_sub_type = m.OrgUnit.objects.create(
+            org_unit_type=self.sub_unit_type,
             version=source_version_1,
             name="Jedi Squad 1",
-            geom=cls.mock_multipolygon,
-            simplified_geom=cls.mock_multipolygon,
-            catchment=cls.mock_multipolygon,
-            location=cls.mock_point,
+            geom=self.mock_multipolygon,
+            simplified_geom=self.mock_multipolygon,
+            catchment=self.mock_multipolygon,
+            location=self.mock_point,
             validation_status=m.OrgUnit.VALIDATION_VALID,
             source_ref=None,
         )
-        cls.org_unit_type = m.OrgUnitType.objects.create(name="Org unit type")
-        cls.another_org_unit = m.OrgUnit.objects.create(
-            org_unit_type=cls.org_unit_type,
+        self.org_unit_type = m.OrgUnitType.objects.create(name="Org unit type")
+        self.another_org_unit = m.OrgUnit.objects.create(
+            org_unit_type=self.org_unit_type,
             name="Hôpital Général",
         )
-        cls.org_unit_from_parent_type = m.OrgUnit.objects.create(
-            org_unit_type=cls.parent_org_unit_type,
+        self.org_unit_from_parent_type = m.OrgUnit.objects.create(
+            org_unit_type=self.parent_org_unit_type,
             version=source_version_1,
             name="Corruscant Jedi Council",
-            geom=cls.mock_multipolygon,
-            simplified_geom=cls.mock_multipolygon,
-            catchment=cls.mock_multipolygon,
-            location=cls.mock_point,
+            geom=self.mock_multipolygon,
+            simplified_geom=self.mock_multipolygon,
+            catchment=self.mock_multipolygon,
+            location=self.mock_point,
             validation_status=m.OrgUnit.VALIDATION_VALID,
             source_ref="FooBarB4z00",
         )
-        cls.org_unit_from_parent_type.groups.set([cls.org_unit_group])
+        self.org_unit_from_parent_type.groups.set([self.org_unit_group])
 
-        cls.child_org_unit = m.OrgUnit.objects.create(
-            org_unit_type=cls.parent_org_unit_type,
+        self.child_org_unit = m.OrgUnit.objects.create(
+            org_unit_type=self.parent_org_unit_type,
             version=source_version_1,
             name="Corruscant Jedi Council",
-            geom=cls.mock_multipolygon,
-            simplified_geom=cls.mock_multipolygon,
-            catchment=cls.mock_multipolygon,
-            location=cls.mock_point,
+            geom=self.mock_multipolygon,
+            simplified_geom=self.mock_multipolygon,
+            catchment=self.mock_multipolygon,
+            location=self.mock_point,
             validation_status=m.OrgUnit.VALIDATION_VALID,
             source_ref="PvtAI4RUMkr",
-            parent=cls.org_unit_from_parent_type,
+            parent=self.org_unit_from_parent_type,
         )
 
-        cls.permission = Permission.objects.create(
+        self.permission = Permission.objects.create(
             name="iaso permission", content_type_id=1, codename="iaso_permission"
         )
-        cls.group = Group.objects.create(name="user role")
-        cls.group.permissions.add(cls.permission)
-        cls.user_role = m.UserRole.objects.create(group=cls.group, account=cls.account)
+        self.group = Group.objects.create(name="user role")
+        self.group.permissions.add(self.permission)
+        self.user_role = m.UserRole.objects.create(group=self.group, account=self.account)
 
-        cls.group_another_account = Group.objects.create(name="user role with another account")
-        cls.group_another_account.permissions.add(cls.permission)
-        cls.user_role_another_account = m.UserRole.objects.create(
-            group=cls.group_another_account, account=cls.another_account
+        self.group_another_account = Group.objects.create(name="user role with another account")
+        self.group_another_account.permissions.add(self.permission)
+        self.user_role_another_account = m.UserRole.objects.create(
+            group=self.group_another_account, account=self.another_account
         )
 
         # Users.
-        cls.jane = cls.create_user_with_profile(
+        self.jane = self.create_user_with_profile(
             first_name="Jane",
             last_name="Doe",
             username="janedoe",
-            account=cls.account,
+            account=self.account,
             permissions=[CORE_FORMS_PERMISSION],
         )
-        cls.john = cls.create_user_with_profile(username="johndoe", account=cls.account, is_superuser=True)
-        cls.jim = cls.create_user_with_profile(
-            username="jim", account=cls.account, permissions=[CORE_FORMS_PERMISSION, CORE_USERS_ADMIN_PERMISSION]
+        self.john = self.create_user_with_profile(username="johndoe", account=self.account, is_superuser=True)
+        self.jim = self.create_user_with_profile(
+            username="jim", account=self.account, permissions=[CORE_FORMS_PERMISSION, CORE_USERS_ADMIN_PERMISSION]
         )
-        cls.jam = cls.create_user_with_profile(
+        self.jam = self.create_user_with_profile(
             username="jam",
-            account=cls.account,
+            account=self.account,
             permissions=[CORE_USERS_MANAGED_PERMISSION],
             language="en",
         )
-        cls.jom = cls.create_user_with_profile(username="jom", account=cls.account, permissions=[], language="fr")
-        cls.jum = cls.create_user_with_profile(
-            username="jum", account=cls.account, permissions=[], projects=[cls.project]
+        self.jom = self.create_user_with_profile(username="jom", account=self.account, permissions=[], language="fr")
+        self.jum = self.create_user_with_profile(
+            username="jum", account=self.account, permissions=[], projects=[self.project]
         )
-        cls.user_managed_geo_limit = cls.create_user_with_profile(
+        self.user_managed_geo_limit = self.create_user_with_profile(
             username="managedGeoLimit",
-            account=cls.account,
+            account=self.account,
             permissions=[CORE_USERS_MANAGED_PERMISSION],
-            org_units=[cls.org_unit_from_parent_type],
+            org_units=[self.org_unit_from_parent_type],
         )
-        cls.team1 = m.Team.objects.create(project=cls.project, name="team1", manager=cls.jane)
-        cls.team1.users.add(cls.jane)
-        cls.team2 = m.Team.objects.create(project=cls.project, name="team2", manager=cls.jim)
-        cls.team2.users.add(cls.jim)
-        cls.user_managed_geo_limit.iaso_profile.user_roles.set([cls.user_role, cls.user_role_another_account])
+        self.team1 = m.Team.objects.create(project=self.project, name="team1", manager=self.jane)
+        self.team1.users.add(self.jane)
+        self.team2 = m.Team.objects.create(project=self.project, name="team2", manager=self.jim)
+        self.team2.users.add(self.jim)
+        self.user_managed_geo_limit.iaso_profile.user_roles.set([self.user_role, self.user_role_another_account])
 
-        cls.user_role_name = cls.user_role.group.name.removeprefix(
-            f"{cls.user_managed_geo_limit.iaso_profile.account.pk}_"
+        self.user_role_name = self.user_role.group.name.removeprefix(
+            f"{self.user_managed_geo_limit.iaso_profile.account.pk}_"
         )
-        cls.user_role_another_account_name = cls.user_role_another_account.group.name.removeprefix(
-            f"{cls.user_managed_geo_limit.iaso_profile.account.pk}_"
+        self.user_role_another_account_name = self.user_role_another_account.group.name.removeprefix(
+            f"{self.user_managed_geo_limit.iaso_profile.account.pk}_"
         )
 
     def assertValidProfileListData(self, list_data: typing.Mapping, expected_length: int, paginated: bool = False):

--- a/iaso/tests/api/profiles/test_views/test_update.py
+++ b/iaso/tests/api/profiles/test_views/test_update.py
@@ -940,17 +940,14 @@ class ProfileUpdateAPITestCase(BaseProfileAPITestCase):
         - Edit from the UI : aka retrieve + just submits with initial data => should not crash
         """
 
-        self.client.force_authenticate(self.jom)
+        self.client.force_authenticate(self.jim)
+        self.account.modules = [MODULE_DEFAULT.codename, MODULE_VALIDATION_WORKFLOW.codename]
+        self.account.save()
+
         response = self.client.patch(
-            reverse("profiles-detail", kwargs={"pk": PK_ME}),
-            data={"modules": [MODULE_DEFAULT.codename, MODULE_VALIDATION_WORKFLOW.codename]},
-            format="json",
-        )
-        self.assertJSONResponse(response, status.HTTP_200_OK)
-        response = self.client.patch(
-            reverse("profiles-detail", kwargs={"pk": PK_ME}),
+            reverse("profiles-detail", kwargs={"pk": self.john.pk}),
             data={
-                "permissions": [
+                "user_permissions": [
                     CORE_VALIDATION_WORKFLOW_PERMISSION.codename,
                     CORE_USERS_MANAGED_PERMISSION.codename,
                     CORE_USERS_ADMIN_PERMISSION.codename,
@@ -961,23 +958,40 @@ class ProfileUpdateAPITestCase(BaseProfileAPITestCase):
 
         self.assertJSONResponse(response, status.HTTP_200_OK)
 
-        response = self.client.patch(
-            reverse("profiles-detail", kwargs={"pk": PK_ME}),
-            data={"modules": [MODULE_DEFAULT.codename]},
-            format="json",
+        response = self.client.get(
+            reverse("profiles-detail", kwargs={"pk": self.john.pk}),
         )
-        self.assertJSONResponse(response, status.HTTP_200_OK)
+
+        res_data = self.assertJSONResponse(response, status.HTTP_200_OK)
+        self.assertIn(CORE_VALIDATION_WORKFLOW_PERMISSION.codename, res_data["permissions"])
+        self.assertIn(CORE_VALIDATION_WORKFLOW_PERMISSION.codename, res_data["user_permissions"])
+
+        self.assertIn(CORE_USERS_MANAGED_PERMISSION.codename, res_data["permissions"])
+        self.assertIn(CORE_USERS_MANAGED_PERMISSION.codename, res_data["user_permissions"])
+
+        self.assertIn(CORE_USERS_ADMIN_PERMISSION.codename, res_data["permissions"])
+        self.assertIn(CORE_USERS_ADMIN_PERMISSION.codename, res_data["user_permissions"])
+
+        self.account.modules = [MODULE_DEFAULT.codename]
+        self.account.save()
 
         response = self.client.get(
-            reverse("profiles-detail", kwargs={"pk": PK_ME}),
+            reverse("profiles-detail", kwargs={"pk": self.john.pk}),
         )
 
         res_data = self.assertJSONResponse(response, status.HTTP_200_OK)
         self.assertNotIn(CORE_VALIDATION_WORKFLOW_PERMISSION.codename, res_data["permissions"])
+        self.assertNotIn(CORE_VALIDATION_WORKFLOW_PERMISSION.codename, res_data["user_permissions"])
+
+        self.assertIn(CORE_USERS_MANAGED_PERMISSION.codename, res_data["permissions"])
+        self.assertIn(CORE_USERS_MANAGED_PERMISSION.codename, res_data["user_permissions"])
+
+        self.assertIn(CORE_USERS_ADMIN_PERMISSION.codename, res_data["permissions"])
+        self.assertIn(CORE_USERS_ADMIN_PERMISSION.codename, res_data["user_permissions"])
 
         response = self.client.patch(
-            reverse("profiles-detail", kwargs={"pk": PK_ME}),
-            data=res_data,
+            reverse("profiles-detail", kwargs={"pk": self.john.pk}),
+            data={**res_data, "phone_number": ""},
             format="json",
         )
         self.assertJSONResponse(response, status.HTTP_200_OK)

--- a/iaso/tests/api/profiles/test_views/test_update.py
+++ b/iaso/tests/api/profiles/test_views/test_update.py
@@ -3,14 +3,17 @@ import jsonschema
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, Permission
 from django.urls import reverse
+from rest_framework import status
 
 from iaso.api.profiles.constants import PK_ME
 from iaso.models import Profile, Project, TenantUser, UserRole
+from iaso.modules import MODULE_DEFAULT, MODULE_VALIDATION_WORKFLOW
 from iaso.permissions.core_permissions import (
     CORE_FORMS_PERMISSION,
     CORE_ORG_UNITS_READ_PERMISSION,
     CORE_USERS_ADMIN_PERMISSION,
     CORE_USERS_MANAGED_PERMISSION,
+    CORE_VALIDATION_WORKFLOW_PERMISSION,
 )
 from iaso.tests.api.profiles.test_views.common import PROFILE_LOG_SCHEMA, BaseProfileAPITestCase
 
@@ -927,3 +930,54 @@ class ProfileUpdateAPITestCase(BaseProfileAPITestCase):
         self.jom.refresh_from_db()
         self.assertEqual(self.jom.first_name, "Jom")
         self.assertEqual(self.jom.user_permissions.count(), 0)
+
+    def test_update_permissions_after_related_module_has_been_deactivated(self):
+        """
+        This test mimick the flow of the UI
+        - Activate module
+        - Add related module's permissions to the user
+        - Deactivate module
+        - Edit from the UI : aka retrieve + just submits with initial data => should not crash
+        """
+
+        self.client.force_authenticate(self.jom)
+        response = self.client.patch(
+            reverse("profiles-detail", kwargs={"pk": PK_ME}),
+            data={"modules": [MODULE_DEFAULT.codename, MODULE_VALIDATION_WORKFLOW.codename]},
+            format="json",
+        )
+        self.assertJSONResponse(response, status.HTTP_200_OK)
+        response = self.client.patch(
+            reverse("profiles-detail", kwargs={"pk": PK_ME}),
+            data={
+                "permissions": [
+                    CORE_VALIDATION_WORKFLOW_PERMISSION.codename,
+                    CORE_USERS_MANAGED_PERMISSION.codename,
+                    CORE_USERS_ADMIN_PERMISSION.codename,
+                ]
+            },
+            format="json",
+        )
+
+        self.assertJSONResponse(response, status.HTTP_200_OK)
+
+        response = self.client.patch(
+            reverse("profiles-detail", kwargs={"pk": PK_ME}),
+            data={"modules": [MODULE_DEFAULT.codename]},
+            format="json",
+        )
+        self.assertJSONResponse(response, status.HTTP_200_OK)
+
+        response = self.client.get(
+            reverse("profiles-detail", kwargs={"pk": PK_ME}),
+        )
+
+        res_data = self.assertJSONResponse(response, status.HTTP_200_OK)
+        self.assertNotIn(CORE_VALIDATION_WORKFLOW_PERMISSION.codename, res_data["permissions"])
+
+        response = self.client.patch(
+            reverse("profiles-detail", kwargs={"pk": PK_ME}),
+            data=res_data,
+            format="json",
+        )
+        self.assertJSONResponse(response, status.HTTP_200_OK)

--- a/iaso/tests/api/profiles/test_views/test_update.py
+++ b/iaso/tests/api/profiles/test_views/test_update.py
@@ -942,10 +942,10 @@ class ProfileUpdateAPITestCase(BaseProfileAPITestCase):
 
         self.client.force_authenticate(self.jim)
         self.account.modules = [MODULE_DEFAULT.codename, MODULE_VALIDATION_WORKFLOW.codename]
-        self.account.save()
+        self.account.save(update_fields=["modules"])
 
         response = self.client.patch(
-            reverse("profiles-detail", kwargs={"pk": self.john.pk}),
+            reverse("profiles-detail", kwargs={"pk": self.john.iaso_profile.id}),
             data={
                 "user_permissions": [
                     CORE_VALIDATION_WORKFLOW_PERMISSION.codename,
@@ -959,7 +959,7 @@ class ProfileUpdateAPITestCase(BaseProfileAPITestCase):
         self.assertJSONResponse(response, status.HTTP_200_OK)
 
         response = self.client.get(
-            reverse("profiles-detail", kwargs={"pk": self.john.pk}),
+            reverse("profiles-detail", kwargs={"pk": self.john.iaso_profile.id}),
         )
 
         res_data = self.assertJSONResponse(response, status.HTTP_200_OK)
@@ -973,10 +973,10 @@ class ProfileUpdateAPITestCase(BaseProfileAPITestCase):
         self.assertIn(CORE_USERS_ADMIN_PERMISSION.codename, res_data["user_permissions"])
 
         self.account.modules = [MODULE_DEFAULT.codename]
-        self.account.save()
+        self.account.save(update_fields=["modules"])
 
         response = self.client.get(
-            reverse("profiles-detail", kwargs={"pk": self.john.pk}),
+            reverse("profiles-detail", kwargs={"pk": self.john.iaso_profile.id}),
         )
 
         res_data = self.assertJSONResponse(response, status.HTTP_200_OK)
@@ -990,7 +990,7 @@ class ProfileUpdateAPITestCase(BaseProfileAPITestCase):
         self.assertIn(CORE_USERS_ADMIN_PERMISSION.codename, res_data["user_permissions"])
 
         response = self.client.patch(
-            reverse("profiles-detail", kwargs={"pk": self.john.pk}),
+            reverse("profiles-detail", kwargs={"pk": self.john.iaso_profile.id}),
             data={**res_data, "phone_number": ""},
             format="json",
         )


### PR DESCRIPTION
## What problem is this PR solving?

Profile update would return a 400 when not modifying anything. It was caused by permission related to a module that was deactivated in the mean time. 

### Related JIRA tickets

IA-5170

## Changes

* In profile retrieve endpoint, filter out the permissions returned to only be related to active modules 
* Added test that mimick the UI workflow

## How to test

1. Activate a module for the user
2. Assign a permission related to the module to the user 
3. Deactivate the module
4. Edit the user and submits without changing anything
5. Should not crash