### PR TITLE
POLIO-2159: exclude copieds sheets from prep parser

### DIFF
--- a/plugins/polio/preparedness/parser.py
+++ b/plugins/polio/preparedness/parser.py
@@ -25,7 +25,7 @@ def is_worksheet_exluded(worksheet, exclusions_list):
     return (
         worksheet.is_hidden
         or worksheet.title.lower() in WORKSHEET_EXCLUSION_LIST
-        or worksheet.title.lower().startswith(("sheet", "synt_"))
+        or worksheet.title.lower().startswith(("sheet", "synt_", "copy"))
         or (worksheet.title in exclusions)
     )
 

--- a/plugins/polio/tests/fixtures/preparedness_expected_stats.json
+++ b/plugins/polio/tests/fixtures/preparedness_expected_stats.json
@@ -1974,7 +1974,6 @@
         "no districts info found in GULU",
         "no districts info found in MASAKA",
         "no districts info found in MBARARA",
-        "no districts info found in Copy of MBARARA",
         "no districts info found in ARUA"
     ]
 }

--- a/plugins/polio/tests/test_preparedness_parser.py
+++ b/plugins/polio/tests/test_preparedness_parser.py
@@ -2,8 +2,8 @@ import json
 
 from django.test import TestCase
 
-from plugins.polio.preparedness.parser import get_preparedness
-from plugins.polio.preparedness.spread_cache import CachedSpread
+from plugins.polio.preparedness.parser import get_preparedness, is_worksheet_exluded
+from plugins.polio.preparedness.spread_cache import CachedSheet, CachedSpread
 
 
 class PreparednessParserTests(TestCase):
@@ -19,6 +19,19 @@ class PreparednessParserTests(TestCase):
     def load_fixture(self, filename):
         with open(filename, "rb") as text:
             return json.load(text)
+
+    def make_worksheet(self, title, hidden=False):
+        return CachedSheet({"title": title, "values": [], "formulas": [], "properties": {"hidden": hidden}})
+
+    def test_excludes_worksheets_starting_with_copy(self):
+        for title in ["copy", "copy of national", "Copy", "Copy of National", "COPY"]:
+            with self.subTest(title=title):
+                self.assertTrue(is_worksheet_exluded(self.make_worksheet(title), None))
+
+    def test_does_not_exclude_regular_worksheets(self):
+        for title in ["National", "Region 1", "District data"]:
+            with self.subTest(title=title):
+                self.assertFalse(is_worksheet_exluded(self.make_worksheet(title), None))
 
     def test_reproduce_bad_district_naming(self):
         self.maxDiff = None


### PR DESCRIPTION
## What problem is this PR solving?

Another way clients add sheets that shouldn't be parsed needs exclusion

### Related JIRA tickets

POLIO-2159

## Changes

- Add `"copy"` to the list of prefixes to exclude

## How to test

reproduce campaign in ticket on polio DB
start worker
launch preparedness refresh--> no 500


## Note
to hotfix
