### PR TITLE
IA-5186 speed up backend unit tests (cache OpenAPI schema + run tests in parallel)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -153,7 +153,8 @@ jobs:
                   . ./venv/bin/activate &&  python manage.py createcachetable
                   # check we don't have missing migration
                   . ./venv/bin/activate &&  python manage.py makemigrations --check
-                  . ./venv/bin/activate &&  python -W "ignore" manage.py test
+                  # --parallel: run the suite across one process per CPU core (see IA-5186)
+                  . ./venv/bin/activate &&  python -W "ignore" manage.py test --parallel auto
               env:
                   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
                   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/hat/settings.py
+++ b/hat/settings.py
@@ -393,7 +393,7 @@ DATABASE_ROUTERS = [
 # This database settings which duplicate the main db settings, will be used by the background task worker so that they
 # can have a connexion outside of the transaction to report the progress on a Task. see Comments in services.py
 
-if "test" in sys.argv:
+if IN_TESTS:
     # `task_logs`, `worker` and `dashboard` are separate connection aliases that all use the same
     # physical database as `default`. By default the test runner builds (and, with `--parallel`,
     # clones per worker) one test database per alias, so it would create several test databases for

--- a/hat/settings.py
+++ b/hat/settings.py
@@ -394,14 +394,16 @@ DATABASE_ROUTERS = [
 # can have a connexion outside of the transaction to report the progress on a Task. see Comments in services.py
 
 if "test" in sys.argv:
-    # `task_logs`, `worker` and `dashboard` are extra aliases that all point to the same physical
-    # database as `default`. Without telling Django they are mirrors, the test runner tries to create
-    # a separate test database for each of them, which breaks `manage.py test --parallel`: it clones
-    # the same shared settings dict twice and the workers look for non-existent databases like
-    # `test_iaso_2_2`. We replace each of them with an independent dict that mirrors `default`, so
-    # every alias shares the single `default` test database (and its per-worker clones). See IA-5186.
+    # `task_logs`, `worker` and `dashboard` are separate connection aliases that all use the same
+    # physical database as `default`. By default the test runner builds (and, with `--parallel`,
+    # clones per worker) one test database per alias, so it would create several test databases for
+    # what is really a single one. Declaring these aliases as TEST mirrors of `default` tells Django
+    # they share `default`'s (cloned) test database instead of getting their own. This is required
+    # for `manage.py test --parallel` to work here. See IA-5186.
     for _mirror_alias in ("task_logs", "worker", "dashboard"):
         if _mirror_alias in DATABASES:
+            # Rebuild each as its own dict so setting TEST does not mutate `default` (in test mode
+            # `dashboard` is the very same dict object as `default`).
             DATABASES[_mirror_alias] = {**DATABASES["default"], "TEST": {"MIRROR": "default"}}
 
 # New django 3.2 settings to control which type of field is used by default for primary key

--- a/hat/settings.py
+++ b/hat/settings.py
@@ -393,6 +393,17 @@ DATABASE_ROUTERS = [
 # This database settings which duplicate the main db settings, will be used by the background task worker so that they
 # can have a connexion outside of the transaction to report the progress on a Task. see Comments in services.py
 
+if "test" in sys.argv:
+    # `task_logs`, `worker` and `dashboard` are extra aliases that all point to the same physical
+    # database as `default`. Without telling Django they are mirrors, the test runner tries to create
+    # a separate test database for each of them, which breaks `manage.py test --parallel`: it clones
+    # the same shared settings dict twice and the workers look for non-existent databases like
+    # `test_iaso_2_2`. We replace each of them with an independent dict that mirrors `default`, so
+    # every alias shares the single `default` test database (and its per-worker clones). See IA-5186.
+    for _mirror_alias in ("task_logs", "worker", "dashboard"):
+        if _mirror_alias in DATABASES:
+            DATABASES[_mirror_alias] = {**DATABASES["default"], "TEST": {"MIRROR": "default"}}
+
 # New django 3.2 settings to control which type of field is used by default for primary key
 # Added to remove unecessary warning
 # https://docs.djangoproject.com/en/4.0/releases/3.2/#customizing-type-of-auto-created-primary-keys

--- a/iaso/test.py
+++ b/iaso/test.py
@@ -1,3 +1,4 @@
+import copy
 import csv
 import importlib
 import io
@@ -175,10 +176,18 @@ class SwaggerTestCaseMixin(BaseAPITestCase):
     This mixin purpose is to be able to validate any response against the generated swagger schema
     """
 
+    # The OpenAPI schema is identical for the whole test run (it only depends on the URL conf and
+    # serializers, not on the request). Generating it via drf-spectacular is expensive (~1s for the
+    # whole API), so we cache it once for the whole process instead of regenerating it on every
+    # `validate_openapi_response` call. See IA-5186.
+    _openapi_schema_cache = None
+
     def get_openapi_schema(self):
-        res = self.client.get(reverse("swagger-schema"), data={"format": "json"})
-        self.assertEqual(res.status_code, 200)
-        return res.json()
+        if SwaggerTestCaseMixin._openapi_schema_cache is None:
+            res = self.client.get(reverse("swagger-schema"), data={"format": "json"})
+            self.assertEqual(res.status_code, 200)
+            SwaggerTestCaseMixin._openapi_schema_cache = res.json()
+        return SwaggerTestCaseMixin._openapi_schema_cache
 
     def resolve_refs(self, schema):
         return jsonref.replace_refs(schema)
@@ -219,7 +228,9 @@ class SwaggerTestCaseMixin(BaseAPITestCase):
         return openapi_schema["components"]["schemas"][name]
 
     def validate_openapi_response(self, data, schema_name: str, as_array: bool = False):
-        openapi = self.get_openapi_schema()
+        # Deep-copy the cached schema: `normalize_schema` mutates the schema in place, so we must not
+        # touch the shared cache (it is reused across every test of the run).
+        openapi = copy.deepcopy(self.get_openapi_schema())
 
         # resolve refs first
         resolved = self.resolve_refs(openapi)

--- a/plugins/polio/tests/test_vaccine_repository_reports.py
+++ b/plugins/polio/tests/test_vaccine_repository_reports.py
@@ -98,7 +98,11 @@ class VaccineRepositoryReportsAPITestCase(APITestCase, PolioTestCaseMixin):
     def test_reports_list_response_structure(self):
         """Test the structure of the reports list response"""
         self.client.force_authenticate(user=self.user)
-        response = self.client.get(REPORTS_URL)
+        # `limit` forces the paginated `{"results": [...]}` response. Without it the endpoint returns
+        # a bare list, and the test would only pass when another `Paginator`-based test has run first
+        # in the same process (it mutates the shared `Paginator.page_size`). That order dependency
+        # breaks under `manage.py test --parallel`. See IA-5186.
+        response = self.client.get(f"{REPORTS_URL}?limit=10")
         data = response.json()["results"]
 
         # Check result fields
@@ -114,24 +118,24 @@ class VaccineRepositoryReportsAPITestCase(APITestCase, PolioTestCaseMixin):
         self.client.force_authenticate(user=self.user)
 
         # Test filtering by country
-        response = self.client.get(f"{REPORTS_URL}?countries={self.testland.id}")
+        response = self.client.get(f"{REPORTS_URL}?countries={self.testland.id}&limit=10")
         data = response.json()["results"]
         self.assertEqual(len(data), 1)
         self.assertEqual(data[0]["country_name"], "Testland")
 
         # Test filtering by vaccine name
-        response = self.client.get(f"{REPORTS_URL}?vaccine_name={pm.VACCINES[0][0]}")
+        response = self.client.get(f"{REPORTS_URL}?vaccine_name={pm.VACCINES[0][0]}&limit=10")
         data = response.json()["results"]
         self.assertEqual(len(data), 1)
         self.assertEqual(data[0]["vaccine"], pm.VACCINES[0][0])
 
         # Test filtering by file type
-        response = self.client.get(f"{REPORTS_URL}?file_type=INCIDENT")
+        response = self.client.get(f"{REPORTS_URL}?file_type=INCIDENT&limit=10")
         data = response.json()["results"]
         self.assertEqual(len(data), 1)
         self.assertTrue(len(data[0]["incident_report_data"]) > 0)
 
-        response = self.client.get(f"{REPORTS_URL}?file_type=DESTRUCTION")
+        response = self.client.get(f"{REPORTS_URL}?file_type=DESTRUCTION&limit=10")
         data = response.json()["results"]
         self.assertEqual(len(data), 1)
         self.assertTrue(len(data[0]["destruction_report_data"]) > 0)
@@ -139,7 +143,7 @@ class VaccineRepositoryReportsAPITestCase(APITestCase, PolioTestCaseMixin):
         # Test filtering by country block
         country_group = self.testland.groups.first()
         if country_group:
-            response = self.client.get(f"{REPORTS_URL}?country_block={country_group.id}")
+            response = self.client.get(f"{REPORTS_URL}?country_block={country_group.id}&limit=10")
             data = response.json()["results"]
             self.assertEqual(len(data), 1)
             self.assertEqual(data[0]["country_name"], "Testland")
@@ -165,19 +169,19 @@ class VaccineRepositoryReportsAPITestCase(APITestCase, PolioTestCaseMixin):
         self.client.force_authenticate(user=self.user)
 
         # Test ordering by country name
-        response = self.client.get(f"{REPORTS_URL}?order=country__name")
+        response = self.client.get(f"{REPORTS_URL}?order=country__name&limit=10")
         data = response.json()["results"]
         self.assertEqual(data[0]["country_name"], "Testland")
         self.assertEqual(data[1]["country_name"], "Zambia")
 
         # Test reverse ordering by country name
-        response = self.client.get(f"{REPORTS_URL}?order=-country__name")
+        response = self.client.get(f"{REPORTS_URL}?order=-country__name&limit=10")
         data = response.json()["results"]
         self.assertEqual(data[0]["country_name"], "Zambia")
         self.assertEqual(data[1]["country_name"], "Testland")
 
         # Test ordering by vaccine
-        response = self.client.get(f"{REPORTS_URL}?order=vaccine")
+        response = self.client.get(f"{REPORTS_URL}?order=vaccine&limit=10")
         data = response.json()["results"]
         self.assertEqual(data[0]["vaccine"], pm.VACCINES[0][0])
         self.assertEqual(data[1]["vaccine"], pm.VACCINES[1][0])

--- a/requirements.txt
+++ b/requirements.txt
@@ -189,3 +189,4 @@ pydantic==2.11.3  # https://github.com/pydantic/pydantic/tags
 # Testing.
 # ------------------------------------------------------------------------------
 django-test-migrations==1.4.0 # https://github.com/wemake-services/django-test-migrations
+tblib==3.0.0  # https://github.com/ionelmc/python-tblib/tags - required by `manage.py test --parallel`


### PR DESCRIPTION
## What problem is this PR solving?

The backend unit test suite had become ~2× slower since April (the `test_python` CI job went from ~7 min to ~15.7 min); this PR brings it back down (~6m47s) by caching the generated OpenAPI schema in tests and running the suite in parallel in CI.

### Related JIRA tickets

IA-5186

## Changes

**1. Cache the OpenAPI schema in `SwaggerTestCaseMixin` (`iaso/test.py`)**

The slowdown was a *per-test* regression (test count only grew ~12%, but per-test time doubled). The single biggest new cost was the swagger-compliance assertions added in this period (`assertResponseCompliantToSwagger` / `validate_openapi_response`): 0 usages in April, ~29 now. Each call did `client.get(reverse("swagger-schema"))`, which **regenerates the entire drf-spectacular schema for the whole API (~0.5–1.4s) on every call**, uncached.

The schema only depends on the URL conf and serializers, not on the request, so it is now generated once per process and cached. `validate_openapi_response` deep-copies the cached schema before resolving refs / normalizing, because `normalize_schema` mutates the schema in place and must not corrupt the shared cache.

Measured on the 7 swagger-using test modules: **107s → 17s (~6.3×)**.

**2. Run the suite in parallel in CI (`hat/settings.py`, `requirements.txt`, `.github/workflows/main.yml`)**

- CI now runs `manage.py test --parallel auto` (one process per core).
- `task_logs`, `worker` and `dashboard` are separate connection aliases that all use the same physical database as `default`. By default the test runner builds (and clones per worker) one test database per alias; they are now declared as TEST mirrors of `default` so they share `default`'s test database instead. This is required for `--parallel` to work here. The block is guarded by `if "test" in sys.argv`, so normal runtime (where these are genuinely independent connections) is unaffected.
- Added `tblib`, required by Django's parallel test runner to pickle tracebacks across workers.

Measured on a 393-test, multi-package subset: test execution **28.0s → 11.6s (~2.4×)** with serial/parallel result parity.

**3. Make the vaccine repository reports tests order-independent (`plugins/polio/tests/test_vaccine_repository_reports.py`)**

Parallelization surfaced a pre-existing latent failure (it also fails on `develop` when the class is run in isolation). Three `VaccineRepositoryReportsAPITestCase` tests asserted a paginated `{"results": [...]}` response but did not pass a `limit`. `Paginator` (`iaso/api/common/pagination.py`) has no default page size, so the endpoint returns a bare list unless `limit` is given — *except* that `repository_forms` mutates the shared `Paginator.page_size` class attribute at request time, which made the reports endpoint paginate once a forms test had run earlier in the same process. The full serial suite happened to satisfy that ordering; splitting tests across parallel workers does not. The tests now pass `limit` explicitly so they paginate deterministically, regardless of order.

## Results

`test_python` CI job: **~15m42s (before) → ~6m47s (after)** — roughly back to the early-April level despite ~460 more tests since then. (Pure test execution dropped from ~14 min to ~3.7 min; the remainder of the job is env setup, `migrate`, `createcachetable`, `makemigrations --check` and per-worker DB cloning.)

## How to test

CI runs the full suite in parallel automatically. Locally:

```
# fast schema (any swagger test file)
docker compose run --rm iaso ./manage.py test iaso.tests.api.modules --keepdb

# parallel
docker compose run --rm iaso ./manage.py test --parallel auto iaso.tests.api.modules iaso.tests.api.validation_workflows
```

Everything should pass, and parallel should be noticeably faster on multi-core machines.

## Print screen / video

N/A (CI timing improvement).

## Notes

- The `Makefile` local test target (which uses `--keepdb --failfast`) is intentionally left unchanged: combining `--parallel` with `--keepdb` needs separate handling of the kept per-worker clones. Easy follow-up if we want local parallel too.
- **Follow-up worth a ticket:** `repository_forms` mutating the shared `Paginator.page_size` *class* attribute per request is the real latent hazard — any other `Paginator`-based test could carry the same hidden ordering dependency. Setting the page size per view/instance instead would remove that class of bug.
- The ticket also mentions auditing `setUp` vs `setUpTestData` across test classes — left as a separate, larger effort.

## Doc

No user-facing doc change. The rationale is documented in code comments (`iaso/test.py`, `hat/settings.py`) referencing IA-5186.
