### PR TITLE
IA-5203:  Remove .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-scripts-prepend-node-path=true


### PR DESCRIPTION
## What problem is this PR solving?

.npmrc is only used to override this scripts-prepend-node-path=true

But scripts-prepend-node-path is not used anymore on npm 11 (CI uses actions/setup-node@v4 with Node 22.18.0, so node is already on PATH for scripts) , we can safely remove it

### Related JIRA tickets

IA-5203

## Changes

deleted file

## How to test

nothing to test here