### PR TITLE
fix/IA-5205 dynamic fields validation error response)

### DIFF
--- a/dynamic_fields/filter_backends.py
+++ b/dynamic_fields/filter_backends.py
@@ -1,5 +1,6 @@
 from django.conf import settings
-from django.core.exceptions import ValidationError
+from django.utils.translation import gettext_lazy as _
+from rest_framework import serializers
 from rest_framework.filters import BaseFilterBackend
 
 from dynamic_fields.serializer import DynamicFieldsModelSerializerMixin
@@ -28,9 +29,11 @@ class DynamicFieldsFilterBackend(BaseFilterBackend):
             settings.DYNAMIC_FIELDS_ALL_FIELDS_PARAM_VALUE in values
             and settings.DYNAMIC_FIELDS_DEFAULT_FIELDS_PARAM_VALUE in values
         ):
-            raise ValidationError(
-                f"Dynamic fields cannot contain both {settings.DYNAMIC_FIELDS_ALL_FIELDS_PARAM_VALUE} and {settings.DYNAMIC_FIELDS_DEFAULT_FIELDS_PARAM_VALUE}"
+            message = _("Dynamic fields cannot contain both {all_fields} and {default_fields}").format(
+                all_fields=settings.DYNAMIC_FIELDS_ALL_FIELDS_PARAM_VALUE,
+                default_fields=settings.DYNAMIC_FIELDS_DEFAULT_FIELDS_PARAM_VALUE,
             )
+            raise serializers.ValidationError({settings.DYNAMIC_FIELDS_QUERY_PARAM_NAME: [message]})
 
         serializer_class = getattr(view, "dynamic_fields_serializer_class", None) or getattr(
             view, "serializer_class", None
@@ -40,7 +43,8 @@ class DynamicFieldsFilterBackend(BaseFilterBackend):
             valid = serializer_class.get_valid_options()
             invalid = set(values) - set(valid)
             if invalid:
-                raise ValidationError(f"Invalid dynamic fields: {invalid}")
+                message = _("Invalid dynamic fields: {fields}").format(fields=", ".join(invalid))
+                raise serializers.ValidationError({settings.DYNAMIC_FIELDS_QUERY_PARAM_NAME: [message]})
 
         return queryset
 

--- a/dynamic_fields/tests/test_filter_backends.py
+++ b/dynamic_fields/tests/test_filter_backends.py
@@ -1,5 +1,4 @@
 from django.contrib.auth import get_user_model
-from django.core.exceptions import ValidationError
 from django.test import TestCase, override_settings
 from rest_framework import serializers
 from rest_framework.request import Request
@@ -50,14 +49,24 @@ class DynamicFieldsFilterBackendTest(TestCase):
     def test_invalid_fields_raises(self):
         request = Request(self.factory.get("/?fields=invalid"))
 
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(serializers.ValidationError) as error:
             self.backend.filter_queryset(request, self.queryset, DummyView())
+
+        self.assertEqual(
+            str(error.exception.detail["fields"][0]),
+            "Invalid dynamic fields: invalid",
+        )
 
     def test_conflicting_params_raises(self):
         request = Request(self.factory.get("/?fields=:all&fields=:default"))
 
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(serializers.ValidationError) as error:
             self.backend.filter_queryset(request, self.queryset, DummyView())
+
+        self.assertEqual(
+            str(error.exception.detail["fields"][0]),
+            "Dynamic fields cannot contain both :all and :default",
+        )
 
     def test_get_schema_operation_parameters(self):
         class TestSerializer(DynamicFieldsModelSerializerMixin, serializers.Serializer):
@@ -125,14 +134,24 @@ class DynamicFieldsFilterBackendBackwardCompatibleTest(TestCase):
     def test_invalid_fields_raises(self):
         request = Request(self.factory.get("/?fields=invalid"))
 
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(serializers.ValidationError) as error:
             self.backend.filter_queryset(request, self.queryset, DummyView())
+
+        self.assertEqual(
+            str(error.exception.detail["fields"][0]),
+            "Invalid dynamic fields: invalid",
+        )
 
     def test_conflicting_params_raises(self):
         request = Request(self.factory.get("/?fields=:all,:default"))
 
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(serializers.ValidationError) as error:
             self.backend.filter_queryset(request, self.queryset, DummyView())
+
+        self.assertEqual(
+            str(error.exception.detail["fields"][0]),
+            "Dynamic fields cannot contain both :all and :default",
+        )
 
     def test_get_schema_operation_parameters(self):
         class TestSerializer(DynamicFieldsModelSerializerMixin, serializers.Serializer):

--- a/hat/locale/fr/LC_MESSAGES/django.po
+++ b/hat/locale/fr/LC_MESSAGES/django.po
@@ -232,6 +232,16 @@ msgstr "L'équipe %(site_name)s."
 msgid "Password reset on %(site_name)s"
 msgstr "Réinitialisation du mot de passe sur %(site_name)s"
 
+#: dynamic_fields/filter_backends.py
+msgid "Dynamic fields cannot contain both {all_fields} and {default_fields}"
+msgstr ""
+"Les champs dynamiques ne peuvent pas contenir à la fois {all_fields} et "
+"{default_fields}"
+
+#: dynamic_fields/filter_backends.py
+msgid "Invalid dynamic fields: {fields}"
+msgstr "Champs dynamiques invalides : {fields}"
+
 #~ msgid "User ID"
 #~ msgstr "ID utilisateur"
 


### PR DESCRIPTION
## What problem is this PR solving?

Invalid `fields` query parameters were returning a server error instead of a clear API validation error.

### Related JIRA tickets

IA-5205

## Changes

Updated the dynamic fields filter backend to raise a DRF `serializers.ValidationError` attached to the `fields` parameter.

The error response now returns `400 Bad Request` with a clear message, for example:

```json
{
  "fields": ["Invalid dynamic fields: fake"]
}
```

## How to test

Call an endpoint using dynamic fields with an invalid field:

```bash
curl -i "http://localhost:8081/api/forms/?fields=fake"
```

Expected result: 400 Bad Request with an error message under fields.

Also check that valid fields still work:

```bash
curl -i "http://localhost:8081/api/forms/?fields=id,name"
```

Expected result: 200 OK.

## Print screen / video

<img width="1224" height="582" alt="image" src="https://github.com/user-attachments/assets/cc738793-2a85-45c9-82de-6e52c6b7887c" />
<img width="2854" height="544" alt="image" src="https://github.com/user-attachments/assets/f54ef25c-713d-4912-98c2-2736ba0a89db" />

