### PR TITLE
hotfix: IA-5206:add perms to algorithm endpoints

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/algorithmRuns/Runs.tsx
+++ b/hat/assets/js/apps/Iaso/domains/algorithmRuns/Runs.tsx
@@ -40,7 +40,7 @@ export const Runs: FunctionComponent = () => {
         params,
         enabled: Boolean(params.searchActive),
     });
-    // declaring this here to ahev an easy access to isSaving
+    // declaring this here to have an easy access to isSaving
     const { mutateAsync: launchRun, isLoading: isSaving } =
         useLaunchAlgorithmRun();
 

--- a/iaso/api/algorithms.py
+++ b/iaso/api/algorithms.py
@@ -2,6 +2,7 @@ from django.db.models import Q
 from drf_spectacular.utils import extend_schema
 from rest_framework import permissions, serializers, viewsets
 
+from iaso.api.common import HasPermission
 from iaso.models import MatchingAlgorithm, Project
 from iaso.permissions.core_permissions import CORE_LINKS_PERMISSION
 
@@ -22,7 +23,7 @@ class AlgorithmsViewSet(viewsets.ModelViewSet):
     GET /api/algorithms/
     """
 
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [permissions.IsAuthenticated, HasPermission(CORE_LINKS_PERMISSION)]
 
     serializer_class = AlgorithmsSerializer
     http_method_names = ["get", "post", "put", "head", "options", "trace", "delete"]

--- a/iaso/api/algorithms_runs.py
+++ b/iaso/api/algorithms_runs.py
@@ -6,6 +6,7 @@ from drf_spectacular.utils import extend_schema
 from rest_framework import exceptions, permissions, viewsets
 from rest_framework.response import Response
 
+from iaso.api.common.permissions import HasPermission
 from iaso.models import AlgorithmRun, DataSource, MatchingAlgorithm, SourceVersion
 from iaso.permissions.core_permissions import CORE_LINKS_PERMISSION
 
@@ -22,7 +23,7 @@ class AlgorithmsRunsViewSet(viewsets.ViewSet):
     DELETE /api/algorithmsruns/<id>
     """
 
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [permissions.IsAuthenticated, HasPermission(CORE_LINKS_PERMISSION)]
 
     def list(self, request):
         limit = request.GET.get("limit", None)
@@ -67,14 +68,14 @@ class AlgorithmsRunsViewSet(viewsets.ViewSet):
                 page_offset = paginator.num_pages
             page = paginator.page(page_offset)
 
-            res["runs"] = map(lambda x: x.as_dict(), page.object_list)
+            res["runs"] = [x.as_dict() for x in page.object_list]
             res["has_next"] = page.has_next()
             res["has_previous"] = page.has_previous()
             res["page"] = page_offset
             res["pages"] = paginator.num_pages
             res["limit"] = limit
             return Response(res)
-        return Response(map(lambda x: x.as_list(), queryset))
+        return Response([x.as_list() for x in queryset])
 
     def create(self, request):
         algo_id = request.data.get("algo")
@@ -98,7 +99,7 @@ class AlgorithmsRunsViewSet(viewsets.ViewSet):
         run_item = get_object_or_404(AlgorithmRun, pk=pk)
         return Response(run_item.as_dict())
 
-    def delete(self, request, pk=None):
+    def destroy(self, request, pk=None):
         run_item = get_object_or_404(AlgorithmRun, pk=pk)
         run_item.delete()
         return Response(True)

--- a/iaso/tests/api/test_algorithms.py
+++ b/iaso/tests/api/test_algorithms.py
@@ -1,0 +1,197 @@
+from iaso import models as m
+from iaso.permissions.core_permissions import CORE_LINKS_PERMISSION
+from iaso.test import APITestCase
+
+
+class AlgorithmsAPITestCase(APITestCase):
+    BASE_URL = "/api/algorithms/"
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.data_source = m.DataSource.objects.create(name="Data source")
+        cls.version = m.SourceVersion.objects.create(number=1, data_source=cls.data_source)
+        cls.account = m.Account.objects.create(name="Account", default_version=cls.version)
+        cls.project = m.Project.objects.create(name="Project", account=cls.account, app_id="foo.bar.baz")
+        cls.data_source.projects.add(cls.project)
+
+        cls.algorithm = m.MatchingAlgorithm.objects.create(
+            name="iaso.matching.matching_on_external_id",
+            description="ID Matching",
+        )
+        cls.algorithm.projects.add(cls.project)
+
+        cls.global_algorithm = m.MatchingAlgorithm.objects.create(
+            name="iaso.matching.global",
+            description="Global algorithm",
+        )
+
+        cls.user = cls.create_user_with_profile(
+            username="user",
+            account=cls.account,
+            permissions=[CORE_LINKS_PERMISSION],
+        )
+        cls.user_no_perms = cls.create_user_with_profile(username="user_no_perms", account=cls.account)
+
+        cls.account_2, cls.data_source_2, cls.version_2, cls.project_2 = cls.create_account_datasource_version_project(
+            "Other source", "Other account", "Other project"
+        )
+        cls.user_other_account = cls.create_user_with_profile(
+            username="other_user",
+            account=cls.account_2,
+            permissions=[CORE_LINKS_PERMISSION],
+        )
+        cls.algorithm_other_account = m.MatchingAlgorithm.objects.create(
+            name="other.account.algo",
+            description="Other account algorithm",
+        )
+        cls.algorithm_other_account.projects.add(cls.project_2)
+
+    def test_list_unauthenticated(self):
+        response = self.client.get(self.BASE_URL)
+        self.assertJSONResponse(response, 401)
+
+    def test_list_without_permission(self):
+        self.client.force_authenticate(self.user_no_perms)
+        response = self.client.get(self.BASE_URL)
+        self.assertJSONResponse(response, 403)
+
+    def test_list(self):
+        self.client.force_authenticate(self.user)
+        response = self.client.get(self.BASE_URL)
+        data = self.assertJSONResponse(response, 200)
+
+        algorithm_ids = {algorithm["id"] for algorithm in data}
+        self.assertIn(self.algorithm.id, algorithm_ids)
+        self.assertIn(self.global_algorithm.id, algorithm_ids)
+        self.assertNotIn(self.algorithm_other_account.id, algorithm_ids)
+
+        algorithm = next(item for item in data if item["id"] == self.algorithm.id)
+        self.assertEqual(self.algorithm.name, algorithm["name"])
+        self.assertEqual(self.algorithm.description, algorithm["description"])
+        self.assertEqual([self.project.id], algorithm["projects"])
+
+    def test_retrieve_unauthenticated(self):
+        response = self.client.get(f"{self.BASE_URL}{self.algorithm.id}/")
+        self.assertJSONResponse(response, 401)
+
+    def test_retrieve_without_permission(self):
+        self.client.force_authenticate(self.user_no_perms)
+        response = self.client.get(f"{self.BASE_URL}{self.algorithm.id}/")
+        self.assertJSONResponse(response, 403)
+
+    def test_retrieve(self):
+        self.client.force_authenticate(self.user)
+        response = self.client.get(f"{self.BASE_URL}{self.algorithm.id}/")
+        data = self.assertJSONResponse(response, 200)
+
+        self.assertEqual(self.algorithm.id, data["id"])
+        self.assertEqual(self.algorithm.name, data["name"])
+        self.assertEqual(self.algorithm.description, data["description"])
+        self.assertEqual([self.project.id], data["projects"])
+
+    def test_retrieve_other_account_algorithm(self):
+        self.client.force_authenticate(self.user)
+        response = self.client.get(f"{self.BASE_URL}{self.algorithm_other_account.id}/")
+        self.assertJSONResponse(response, 404)
+
+    def test_create_unauthenticated(self):
+        response = self.client.post(
+            self.BASE_URL,
+            {
+                "name": "iaso.matching.new",
+                "description": "New algorithm",
+                "projects": [self.project.id],
+            },
+            format="json",
+        )
+        self.assertJSONResponse(response, 401)
+
+    def test_create_without_permission(self):
+        self.client.force_authenticate(self.user_no_perms)
+        response = self.client.post(
+            self.BASE_URL,
+            {
+                "name": "iaso.matching.new",
+                "description": "New algorithm",
+                "projects": [self.project.id],
+            },
+            format="json",
+        )
+        self.assertJSONResponse(response, 403)
+
+    def test_create(self):
+        self.client.force_authenticate(self.user)
+        response = self.client.post(
+            self.BASE_URL,
+            {
+                "name": "iaso.matching.new",
+                "description": "New algorithm",
+                "projects": [self.project.id],
+            },
+            format="json",
+        )
+        data = self.assertJSONResponse(response, 201)
+
+        self.assertEqual("iaso.matching.new", data["name"])
+        self.assertEqual("New algorithm", data["description"])
+        self.assertEqual([self.project.id], data["projects"])
+        self.assertTrue(m.MatchingAlgorithm.objects.filter(id=data["id"]).exists())
+
+    def test_update_unauthenticated(self):
+        response = self.client.put(
+            f"{self.BASE_URL}{self.algorithm.id}/",
+            {
+                "name": "iaso.matching.updated",
+                "description": "Updated algorithm",
+                "projects": [self.project.id],
+            },
+            format="json",
+        )
+        self.assertJSONResponse(response, 401)
+
+    def test_update_without_permission(self):
+        self.client.force_authenticate(self.user_no_perms)
+        response = self.client.put(
+            f"{self.BASE_URL}{self.algorithm.id}/",
+            {
+                "name": "iaso.matching.updated",
+                "description": "Updated algorithm",
+                "projects": [self.project.id],
+            },
+            format="json",
+        )
+        self.assertJSONResponse(response, 403)
+
+    def test_update(self):
+        self.client.force_authenticate(self.user)
+        response = self.client.put(
+            f"{self.BASE_URL}{self.algorithm.id}/",
+            {
+                "name": "iaso.matching.updated",
+                "description": "Updated algorithm",
+                "projects": [self.project.id],
+            },
+            format="json",
+        )
+        data = self.assertJSONResponse(response, 200)
+
+        self.assertEqual("iaso.matching.updated", data["name"])
+        self.assertEqual("Updated algorithm", data["description"])
+        self.algorithm.refresh_from_db()
+        self.assertEqual("iaso.matching.updated", self.algorithm.name)
+        self.assertEqual("Updated algorithm", self.algorithm.description)
+
+    def test_delete_unauthenticated(self):
+        response = self.client.delete(f"{self.BASE_URL}{self.algorithm.id}/")
+        self.assertJSONResponse(response, 401)
+
+    def test_delete_without_permission(self):
+        self.client.force_authenticate(self.user_no_perms)
+        response = self.client.delete(f"{self.BASE_URL}{self.algorithm.id}/")
+        self.assertJSONResponse(response, 403)
+
+    def test_delete(self):
+        self.client.force_authenticate(self.user)
+        response = self.client.delete(f"{self.BASE_URL}{self.algorithm.id}/")
+        self.assertJSONResponse(response, 204)
+        self.assertFalse(m.MatchingAlgorithm.objects.filter(id=self.algorithm.id).exists())

--- a/iaso/tests/api/test_algorithms_runs.py
+++ b/iaso/tests/api/test_algorithms_runs.py
@@ -1,0 +1,294 @@
+from iaso import models as m
+from iaso.permissions.core_permissions import CORE_LINKS_PERMISSION
+from iaso.test import APITestCase
+
+
+class AlgorithmsRunsAPITestCase(APITestCase):
+    BASE_URL = "/api/algorithmsruns/"
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.data_source_destination = m.DataSource.objects.create(name="Destination source")
+        cls.data_source_origin = m.DataSource.objects.create(name="Origin source")
+        cls.version_destination = m.SourceVersion.objects.create(number=1, data_source=cls.data_source_destination)
+        cls.version_origin = m.SourceVersion.objects.create(number=1, data_source=cls.data_source_origin)
+        cls.version_destination_2 = m.SourceVersion.objects.create(number=2, data_source=cls.data_source_destination)
+
+        cls.account = m.Account.objects.create(name="Account", default_version=cls.version_destination)
+        cls.project = m.Project.objects.create(name="Project", account=cls.account, app_id="foo.bar.baz")
+        cls.data_source_destination.projects.add(cls.project)
+        cls.data_source_origin.projects.add(cls.project)
+
+        cls.algorithm = m.MatchingAlgorithm.objects.create(
+            name="iaso.matching.matching_on_external_id",
+            description="ID Matching",
+        )
+        cls.algorithm.projects.add(cls.project)
+
+        cls.user = cls.create_user_with_profile(
+            username="user",
+            account=cls.account,
+            permissions=[CORE_LINKS_PERMISSION],
+        )
+        cls.user_no_perms = cls.create_user_with_profile(username="user_no_perms", account=cls.account)
+
+        cls.algorithm_run = m.AlgorithmRun.objects.create(
+            algorithm=cls.algorithm,
+            version_1=cls.version_destination,
+            version_2=cls.version_origin,
+            launcher=cls.user,
+        )
+
+        cls.account_2, cls.data_source_2, cls.version_2, cls.project_2 = cls.create_account_datasource_version_project(
+            "Other source", "Other account", "Other project"
+        )
+        cls.version_2_b = m.SourceVersion.objects.create(number=2, data_source=cls.data_source_2)
+        cls.user_other_account = cls.create_user_with_profile(
+            username="other_user",
+            account=cls.account_2,
+            permissions=[CORE_LINKS_PERMISSION],
+        )
+        cls.algorithm_other = m.MatchingAlgorithm.objects.create(name="other", description="other")
+        cls.run_other_account = m.AlgorithmRun.objects.create(
+            algorithm=cls.algorithm_other,
+            version_1=cls.version_2,
+            version_2=cls.version_2_b,
+            launcher=cls.user_other_account,
+        )
+
+        cls.org_unit_type = m.OrgUnitType.objects.create(name="District", category="district")
+        cls.org_unit_type.projects.add(cls.project)
+
+    def test_list_unauthenticated(self):
+        response = self.client.get(self.BASE_URL)
+        self.assertJSONResponse(response, 401)
+
+    def test_list_without_permission(self):
+        self.client.force_authenticate(self.user_no_perms)
+        response = self.client.get(self.BASE_URL)
+        self.assertJSONResponse(response, 403)
+
+    def test_list(self):
+        self.client.force_authenticate(self.user)
+        response = self.client.get(self.BASE_URL)
+        data = self.assertJSONResponse(response, 200)
+
+        self.assertEqual(1, len(data))
+        run = data[0]
+        self.assertEqual(self.algorithm_run.id, run["id"])
+        self.assertEqual(self.algorithm.id, run["algorithm_id"])
+        self.assertEqual(self.algorithm.name, run["algorithm_name"])
+        self.assertEqual(self.version_destination.id, run["destination"]["id"])
+        self.assertEqual(self.version_origin.id, run["source"]["id"])
+
+    def test_list_paginated(self):
+        self.client.force_authenticate(self.user)
+        response = self.client.get(self.BASE_URL, {"limit": 10, "page": 1, "order": "created_at"})
+        data = self.assertJSONResponse(response, 200)
+
+        self.assertEqual(1, data["count"])
+        self.assertEqual(1, data["page"])
+        self.assertEqual(1, data["pages"])
+        self.assertEqual(10, data["limit"])
+        self.assertFalse(data["has_next"])
+        self.assertFalse(data["has_previous"])
+        self.assertEqual(1, len(data["runs"]))
+        self.assertEqual(self.algorithm_run.id, data["runs"][0]["id"])
+
+    def test_list_filters(self):
+        self.client.force_authenticate(self.user)
+        other_run = m.AlgorithmRun.objects.create(
+            algorithm=self.algorithm,
+            version_1=self.version_destination_2,
+            version_2=self.version_origin,
+            launcher=self.user,
+        )
+
+        response = self.client.get(self.BASE_URL, {"algorithmId": self.algorithm.id})
+        data = self.assertJSONResponse(response, 200)
+        self.assertEqual({self.algorithm_run.id, other_run.id}, {run["id"] for run in data})
+
+        response = self.client.get(self.BASE_URL, {"origin": self.data_source_origin.id})
+        data = self.assertJSONResponse(response, 200)
+        self.assertEqual({self.algorithm_run.id, other_run.id}, {run["id"] for run in data})
+
+        response = self.client.get(self.BASE_URL, {"destination": self.data_source_destination.id})
+        data = self.assertJSONResponse(response, 200)
+        self.assertEqual({self.algorithm_run.id, other_run.id}, {run["id"] for run in data})
+
+        response = self.client.get(self.BASE_URL, {"originVersion": self.version_origin.number})
+        data = self.assertJSONResponse(response, 200)
+        self.assertEqual({self.algorithm_run.id, other_run.id}, {run["id"] for run in data})
+
+        response = self.client.get(self.BASE_URL, {"destinationVersion": self.version_destination_2.number})
+        data = self.assertJSONResponse(response, 200)
+        self.assertEqual([other_run.id], [run["id"] for run in data])
+
+        response = self.client.get(self.BASE_URL, {"launcher": self.user.id})
+        data = self.assertJSONResponse(response, 200)
+        self.assertEqual({self.algorithm_run.id, other_run.id}, {run["id"] for run in data})
+
+    def test_list_excludes_other_account_runs(self):
+        self.client.force_authenticate(self.user)
+        response = self.client.get(self.BASE_URL)
+        data = self.assertJSONResponse(response, 200)
+        run_ids = {run["id"] for run in data}
+        self.assertIn(self.algorithm_run.id, run_ids)
+        self.assertNotIn(self.run_other_account.id, run_ids)
+
+    def test_retrieve_unauthenticated(self):
+        response = self.client.get(f"{self.BASE_URL}{self.algorithm_run.id}/")
+        self.assertJSONResponse(response, 401)
+
+    def test_retrieve_without_permission(self):
+        self.client.force_authenticate(self.user_no_perms)
+        response = self.client.get(f"{self.BASE_URL}{self.algorithm_run.id}/")
+        self.assertJSONResponse(response, 403)
+
+    def test_retrieve(self):
+        self.client.force_authenticate(self.user)
+        response = self.client.get(f"{self.BASE_URL}{self.algorithm_run.id}/")
+        data = self.assertJSONResponse(response, 200)
+
+        self.assertEqual(self.algorithm_run.id, data["id"])
+        self.assertEqual(self.algorithm.id, data["algorithm"]["id"])
+        self.assertEqual(self.version_destination.id, data["destination"]["id"])
+        self.assertEqual(self.version_origin.id, data["source"]["id"])
+        self.assertEqual(self.user.id, data["launcher"]["user_id"])
+        self.assertEqual(0, data["links_count"])
+
+    def test_create_unauthenticated(self):
+        response = self.client.post(
+            self.BASE_URL,
+            {
+                "algo": self.algorithm.id,
+                "destination": self.version_destination.id,
+                "source": self.version_origin.id,
+            },
+            format="json",
+        )
+        self.assertJSONResponse(response, 401)
+
+    def test_create_without_permission(self):
+        self.client.force_authenticate(self.user_no_perms)
+        response = self.client.post(
+            self.BASE_URL,
+            {
+                "algo": self.algorithm.id,
+                "destination": self.version_destination.id,
+                "source": self.version_origin.id,
+            },
+            format="json",
+        )
+        self.assertJSONResponse(response, 403)
+
+    def test_create(self):
+        self.client.force_authenticate(self.user)
+        response = self.client.post(
+            self.BASE_URL,
+            {
+                "algo": self.algorithm.id,
+                "destination": self.version_destination.id,
+                "source": self.version_origin.id,
+            },
+            format="json",
+        )
+        data = self.assertJSONResponse(response, 200)
+
+        self.assertEqual(self.algorithm.id, data["algorithm"]["id"])
+        self.assertEqual(self.version_destination.id, data["destination"]["id"])
+        self.assertEqual(self.version_origin.id, data["source"]["id"])
+        self.assertEqual(self.user.id, data["launcher"]["user_id"])
+        self.assertTrue(m.AlgorithmRun.objects.filter(id=data["id"]).exists())
+
+    def test_create_permission_denied_for_other_account_versions(self):
+        self.client.force_authenticate(self.user)
+        response = self.client.post(
+            self.BASE_URL,
+            {
+                "algo": self.algorithm.id,
+                "destination": self.version_2.id,
+                "source": self.version_2_b.id,
+            },
+            format="json",
+        )
+        self.assertJSONResponse(response, 403)
+
+    def test_delete_unauthenticated(self):
+        response = self.client.delete(f"{self.BASE_URL}{self.algorithm_run.id}/")
+        self.assertJSONResponse(response, 401)
+
+    def test_delete_without_permission(self):
+        self.client.force_authenticate(self.user_no_perms)
+        response = self.client.delete(f"{self.BASE_URL}{self.algorithm_run.id}/")
+        self.assertJSONResponse(response, 403)
+
+    def test_delete(self):
+        self.client.force_authenticate(self.user)
+        response = self.client.delete(f"{self.BASE_URL}{self.algorithm_run.id}/")
+        data = self.assertJSONResponse(response, 200)
+        self.assertTrue(data)
+        self.assertFalse(m.AlgorithmRun.objects.filter(id=self.algorithm_run.id).exists())
+
+    def test_update_unauthenticated(self):
+        response = self.client.put(
+            f"{self.BASE_URL}0/",
+            {
+                "algoId": self.algorithm.id,
+                "sourceOriginId": self.data_source_origin.id,
+                "versionOrigin": self.version_origin.number,
+                "sourceDestinationId": self.data_source_destination.id,
+                "versionDestination": self.version_destination.number,
+            },
+            format="json",
+        )
+        self.assertJSONResponse(response, 401)
+
+    def test_update_without_permission(self):
+        self.client.force_authenticate(self.user_no_perms)
+        response = self.client.put(
+            f"{self.BASE_URL}0/",
+            {
+                "algoId": self.algorithm.id,
+                "sourceOriginId": self.data_source_origin.id,
+                "versionOrigin": self.version_origin.number,
+                "sourceDestinationId": self.data_source_destination.id,
+                "versionDestination": self.version_destination.number,
+            },
+            format="json",
+        )
+        self.assertJSONResponse(response, 403)
+
+    def test_update_launches_matching_algorithm(self):
+        m.OrgUnit.objects.create(
+            version=self.version_destination,
+            name="Unit destination",
+            org_unit_type=self.org_unit_type,
+            source_ref="shared-ref",
+        )
+        m.OrgUnit.objects.create(
+            version=self.version_origin,
+            name="Unit origin",
+            org_unit_type=self.org_unit_type,
+            source_ref="shared-ref",
+        )
+
+        self.client.force_authenticate(self.user)
+        response = self.client.put(
+            f"{self.BASE_URL}0/",
+            {
+                "algoId": self.algorithm.id,
+                "sourceOriginId": self.data_source_origin.id,
+                "versionOrigin": self.version_origin.number,
+                "sourceDestinationId": self.data_source_destination.id,
+                "versionDestination": self.version_destination.number,
+            },
+            format="json",
+        )
+        data = self.assertJSONResponse(response, 200)
+        self.assertTrue(data)
+
+        launched_run = m.AlgorithmRun.objects.latest("id")
+        self.assertTrue(launched_run.finished)
+        self.assertEqual(self.user, launched_run.launcher)
+        self.assertEqual(1, m.Link.objects.filter(algorithm_run=launched_run).count())


### PR DESCRIPTION
## What problem is this PR solving?

stricter permissions required on algorithm run endpoint
### Related JIRA tickets

IA-5206

## Changes

- match permission check with front-end
- fix delete operation

## How to test

- Try any action on `/api/algorithmruns/` without `CORE_LINKS_PERMISSION`, it should always fail
- same with `api/algorithms`

## Print screen / video

<img width="1447" height="793" alt="Screenshot 2026-06-11 at 12 01 18" src="https://github.com/user-attachments/assets/8943e62d-8f87-4ad5-87a5-99be0a002025" />

<img width="1447" height="793" alt="Screenshot 2026-06-11 at 12 01 31" src="https://github.com/user-attachments/assets/46abc056-a934-48ff-b31a-63fadf259bba" />


## Notes

Hotfix


