### PR TITLE
[IA-5216] change requests submenu lead to 404

### DIFF
--- a/hat/assets/js/apps/Iaso/constants/menu.tsx
+++ b/hat/assets/js/apps/Iaso/constants/menu.tsx
@@ -318,7 +318,7 @@ const menuItems = (
         {
             label: formatMessage(MESSAGES.changeRequests),
             icon: props => <RuleIcon {...props} />,
-            key: 'changeRequests',
+            key: 'validation',
             subMenu: [
                 {
                     label: formatMessage(MESSAGES.reviewChangeProposals),


### PR DESCRIPTION
## What problem is this PR solving?

The changes requests entries were showing a 404 page. This PR is about fixing it

### Related JIRA tickets

[IA-5126](https://bluesquare.atlassian.net/browse/IA-5216)

## Changes

Reverted to the previous key in the menu configuration

## How to test

> Go to the menu
> Access these pages under Change Requests: Review change requests, Change Request Configuration
> The 404 page shouldn't be displayed

## Print screen / video

[Screencast from 12-06-26 10:24:42.webm](https://github.com/user-attachments/assets/88b489f5-ec0e-4248-ac2e-43ccdc8bb9f6)


## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).


[IA-5126]: https://bluesquare.atlassian.net/browse/IA-5126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ