### PR TITLE
[IA-5210]: Validation workflows -> Submissions : change status badge display 

### DIFF
--- a/iaso/api/validation_workflow_instances/serializers/list.py
+++ b/iaso/api/validation_workflow_instances/serializers/list.py
@@ -28,6 +28,9 @@ class ValidationWorkflowInstanceListSerializer(ModelSerializer):
     requires_user_action = serializers.BooleanField(read_only=True, source="annotate_requires_user_action")
     last_updated = serializers.DateTimeField(read_only=True, source="annotate_last_updated")
     form = FormNestedSerializer(read_only=True)
+    general_validation_status = serializers.CharField(
+        read_only=True, allow_blank=True, source="get_general_validation_status_display"
+    )
 
     class Meta:
         model = Instance

--- a/iaso/tests/api/validation_workflow_instances/test_views/test_list.py
+++ b/iaso/tests/api/validation_workflow_instances/test_views/test_list.py
@@ -175,8 +175,12 @@ class ValidationWorkflowInstanceAPIListTestCase(SwaggerTestCaseMixin, APITestCas
                 self.assertEqual(first_result["id"], self.other_instance.id)
                 self.assertEqual(second_result["id"], self.instance.id)
 
-                self.assertEqual(first_result["general_validation_status"], ValidationWorkflowArtefactStatus.PENDING)
-                self.assertEqual(second_result["general_validation_status"], ValidationWorkflowArtefactStatus.PENDING)
+                self.assertEqual(
+                    first_result["general_validation_status"], ValidationWorkflowArtefactStatus.PENDING.label
+                )
+                self.assertEqual(
+                    second_result["general_validation_status"], ValidationWorkflowArtefactStatus.PENDING.label
+                )
 
                 self.assertFalse(first_result["user_has_been_involved"])
                 self.assertFalse(second_result["user_has_been_involved"])
@@ -208,8 +212,8 @@ class ValidationWorkflowInstanceAPIListTestCase(SwaggerTestCaseMixin, APITestCas
             self.assertEqual(first_result["id"], self.other_instance.id)
             self.assertEqual(second_result["id"], self.instance.id)
 
-            self.assertEqual(first_result["general_validation_status"], ValidationWorkflowArtefactStatus.PENDING)
-            self.assertEqual(second_result["general_validation_status"], ValidationWorkflowArtefactStatus.PENDING)
+            self.assertEqual(first_result["general_validation_status"], ValidationWorkflowArtefactStatus.PENDING.label)
+            self.assertEqual(second_result["general_validation_status"], ValidationWorkflowArtefactStatus.PENDING.label)
 
             self.assertFalse(first_result["user_has_been_involved"])
             self.assertFalse(second_result["user_has_been_involved"])
@@ -229,8 +233,8 @@ class ValidationWorkflowInstanceAPIListTestCase(SwaggerTestCaseMixin, APITestCas
             self.assertEqual(first_result["id"], self.other_instance.id)
             self.assertEqual(second_result["id"], self.instance.id)
 
-            self.assertEqual(first_result["general_validation_status"], ValidationWorkflowArtefactStatus.PENDING)
-            self.assertEqual(second_result["general_validation_status"], ValidationWorkflowArtefactStatus.PENDING)
+            self.assertEqual(first_result["general_validation_status"], ValidationWorkflowArtefactStatus.PENDING.label)
+            self.assertEqual(second_result["general_validation_status"], ValidationWorkflowArtefactStatus.PENDING.label)
 
             self.assertTrue(first_result["user_has_been_involved"])
             self.assertTrue(second_result["user_has_been_involved"])
@@ -251,7 +255,7 @@ class ValidationWorkflowInstanceAPIListTestCase(SwaggerTestCaseMixin, APITestCas
 
             self.assertEqual(first_result["id"], self.instance.id)
 
-            self.assertEqual(first_result["general_validation_status"], ValidationWorkflowArtefactStatus.PENDING)
+            self.assertEqual(first_result["general_validation_status"], ValidationWorkflowArtefactStatus.PENDING.label)
 
             self.assertFalse(first_result["user_has_been_involved"])
 
@@ -292,8 +296,8 @@ class ValidationWorkflowInstanceAPIListTestCase(SwaggerTestCaseMixin, APITestCas
             self.assertEqual(first_result["id"], self.other_instance.id)
             self.assertEqual(second_result["id"], self.instance.id)
 
-            self.assertEqual(first_result["general_validation_status"], ValidationWorkflowArtefactStatus.PENDING)
-            self.assertEqual(second_result["general_validation_status"], ValidationWorkflowArtefactStatus.PENDING)
+            self.assertEqual(first_result["general_validation_status"], ValidationWorkflowArtefactStatus.PENDING.label)
+            self.assertEqual(second_result["general_validation_status"], ValidationWorkflowArtefactStatus.PENDING.label)
 
             self.assertFalse(first_result["user_has_been_involved"])
             self.assertFalse(second_result["user_has_been_involved"])
@@ -313,8 +317,8 @@ class ValidationWorkflowInstanceAPIListTestCase(SwaggerTestCaseMixin, APITestCas
             self.assertEqual(first_result["id"], self.other_instance.id)
             self.assertEqual(second_result["id"], self.instance.id)
 
-            self.assertEqual(first_result["general_validation_status"], ValidationWorkflowArtefactStatus.PENDING)
-            self.assertEqual(second_result["general_validation_status"], ValidationWorkflowArtefactStatus.PENDING)
+            self.assertEqual(first_result["general_validation_status"], ValidationWorkflowArtefactStatus.PENDING.label)
+            self.assertEqual(second_result["general_validation_status"], ValidationWorkflowArtefactStatus.PENDING.label)
 
             self.assertTrue(first_result["user_has_been_involved"])
             self.assertTrue(second_result["user_has_been_involved"])
@@ -335,7 +339,7 @@ class ValidationWorkflowInstanceAPIListTestCase(SwaggerTestCaseMixin, APITestCas
 
             self.assertEqual(first_result["id"], self.instance.id)
 
-            self.assertEqual(first_result["general_validation_status"], ValidationWorkflowArtefactStatus.PENDING)
+            self.assertEqual(first_result["general_validation_status"], ValidationWorkflowArtefactStatus.PENDING.label)
 
             self.assertFalse(first_result["user_has_been_involved"])
 
@@ -381,8 +385,8 @@ class ValidationWorkflowInstanceAPIListTestCase(SwaggerTestCaseMixin, APITestCas
             self.assertEqual(first_result["id"], self.other_instance.id)
             self.assertEqual(second_result["id"], self.instance.id)
 
-            self.assertEqual(first_result["general_validation_status"], ValidationWorkflowArtefactStatus.PENDING)
-            self.assertEqual(second_result["general_validation_status"], ValidationWorkflowArtefactStatus.PENDING)
+            self.assertEqual(first_result["general_validation_status"], ValidationWorkflowArtefactStatus.PENDING.label)
+            self.assertEqual(second_result["general_validation_status"], ValidationWorkflowArtefactStatus.PENDING.label)
 
             self.assertFalse(first_result["user_has_been_involved"])
             self.assertFalse(second_result["user_has_been_involved"])
@@ -402,8 +406,8 @@ class ValidationWorkflowInstanceAPIListTestCase(SwaggerTestCaseMixin, APITestCas
             self.assertEqual(first_result["id"], self.other_instance.id)
             self.assertEqual(second_result["id"], self.instance.id)
 
-            self.assertEqual(first_result["general_validation_status"], ValidationWorkflowArtefactStatus.PENDING)
-            self.assertEqual(second_result["general_validation_status"], ValidationWorkflowArtefactStatus.PENDING)
+            self.assertEqual(first_result["general_validation_status"], ValidationWorkflowArtefactStatus.PENDING.label)
+            self.assertEqual(second_result["general_validation_status"], ValidationWorkflowArtefactStatus.PENDING.label)
 
             self.assertTrue(first_result["user_has_been_involved"])
             self.assertTrue(second_result["user_has_been_involved"])
@@ -424,7 +428,7 @@ class ValidationWorkflowInstanceAPIListTestCase(SwaggerTestCaseMixin, APITestCas
 
             self.assertEqual(first_result["id"], self.instance.id)
 
-            self.assertEqual(first_result["general_validation_status"], ValidationWorkflowArtefactStatus.PENDING)
+            self.assertEqual(first_result["general_validation_status"], ValidationWorkflowArtefactStatus.PENDING.label)
 
             self.assertFalse(first_result["user_has_been_involved"])
 
@@ -573,7 +577,7 @@ class ValidationWorkflowInstanceAPIListTestCase(SwaggerTestCaseMixin, APITestCas
             self.assertValidVFInstanceListData(res_data, 2)
             self.assertCountEqual(
                 [x["general_validation_status"] for x in res_data["results"]],
-                [ValidationWorkflowArtefactStatus.PENDING.value, ValidationWorkflowArtefactStatus.REJECTED.value],
+                [ValidationWorkflowArtefactStatus.PENDING.label, ValidationWorkflowArtefactStatus.REJECTED.label],
             )
 
             res = self.client.get(
@@ -584,7 +588,7 @@ class ValidationWorkflowInstanceAPIListTestCase(SwaggerTestCaseMixin, APITestCas
             self.assertValidVFInstanceListData(res_data, 1)
             self.assertCountEqual(
                 [x["general_validation_status"] for x in res_data["results"]],
-                [ValidationWorkflowArtefactStatus.PENDING.value],
+                [ValidationWorkflowArtefactStatus.PENDING.label],
             )
 
             res = self.client.get(
@@ -595,12 +599,12 @@ class ValidationWorkflowInstanceAPIListTestCase(SwaggerTestCaseMixin, APITestCas
             self.assertValidVFInstanceListData(res_data, 1)
             self.assertCountEqual(
                 [x["general_validation_status"] for x in res_data["results"]],
-                [ValidationWorkflowArtefactStatus.REJECTED.value],
+                [ValidationWorkflowArtefactStatus.REJECTED.label],
             )
 
             res = self.client.get(
                 reverse("validation_workflow_instances-list"),
-                data={"status": ValidationWorkflowArtefactStatus.APPROVED.value},
+                data={"status": ValidationWorkflowArtefactStatus.APPROVED.name},
             )
             res_data = self.assertJSONResponse(res, status.HTTP_200_OK)
             self.assertValidVFInstanceListData(res_data, 0)


### PR DESCRIPTION
## What problem is this PR solving?

In Validation workflows -> Submissions UI, the status badge was no translated (cfr ticket and screenshot)

### Related JIRA tickets

IA-5210

## Changes

Change the backend field to use display value

## How to test

Go to Validation workflows -> Submissions UI in french, the badge should be translated

## Print screen / video

<img width="1449" height="641" alt="image" src="https://github.com/user-attachments/assets/eabbcd74-0aa5-4469-9340-0c75a68e0d02" />
