### PR TITLE
[IA-5119]: Column selection: add offset to tooltip

### DIFF
--- a/hat/assets/js/apps/Iaso/components/tables/ColumnSelectDrawer/ColumnDrawerSwitch.tsx
+++ b/hat/assets/js/apps/Iaso/components/tables/ColumnSelectDrawer/ColumnDrawerSwitch.tsx
@@ -1,5 +1,11 @@
 import React, { ChangeEvent, FunctionComponent, ReactElement } from 'react';
-import { ListItemText, Switch, Tooltip } from '@mui/material';
+import {
+    ListItemText,
+    Switch,
+    Tooltip,
+    useMediaQuery,
+    useTheme,
+} from '@mui/material';
 import { truncateText } from 'bluesquare-components';
 
 type Props = {
@@ -23,6 +29,9 @@ export const ColumnDrawerSwitch: FunctionComponent<Props> = ({
     secondaryText,
     size = 'small',
 }) => {
+    const theme = useTheme();
+    const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+
     return (
         <>
             <Switch
@@ -38,7 +47,26 @@ export const ColumnDrawerSwitch: FunctionComponent<Props> = ({
                 }}
                 className={className}
             />
-            <Tooltip title={toolTipTitle} placement="left-start">
+            <Tooltip
+                title={toolTipTitle}
+                placement={isMobile ? 'bottom' : 'left-start'}
+                slotProps={
+                    isMobile
+                        ? {}
+                        : {
+                              popper: {
+                                  modifiers: [
+                                      {
+                                          name: 'offset',
+                                          options: {
+                                              offset: [0, 40],
+                                          },
+                                      },
+                                  ],
+                              },
+                          }
+                }
+            >
                 <ListItemText
                     style={{
                         cursor: 'default',


### PR DESCRIPTION
## What problem is this PR solving?

Submissions list: visible column toolitp should not be over the switch button

### Related JIRA tickets

IA-5119

## Changes

Added offset to ColumnDrawerSwitch so the tooltip does not go over the switch button. Made it go bottom on small screen.

## How to test

Submission list UI, click select visible columns; Place your mouse above any option, the tooltip should not go over the toggle button. 
On small screens, it should go under the label. 

