### PR TITLE
POLIO-2158: update scores endpoint to return more data

### DIFF
--- a/plugins/polio/api/dashboards/preparedness/filters.py
+++ b/plugins/polio/api/dashboards/preparedness/filters.py
@@ -18,7 +18,7 @@ class PreparednessScoreFilter(django_filters.rest_framework.FilterSet):
         That's because it's used to see the score of campaigns that missed the preparedness objectives on the reference date.
         If we pick a later date, we risk showing cache data that meets the objectives
         """
-        queryset = queryset.filter(created_at__lte=value)
+        queryset = queryset.filter(created_at__date__lte=value)
         return queryset.order_by("-created_at")[:1]
 
     class Meta:

--- a/plugins/polio/api/dashboards/preparedness/filters.py
+++ b/plugins/polio/api/dashboards/preparedness/filters.py
@@ -18,10 +18,9 @@ class PreparednessScoreFilter(django_filters.rest_framework.FilterSet):
         That's because it's used to see the score of campaigns that missed the preparedness objectives on the reference date.
         If we pick a later date, we risk showing cache data that meets the objectives
         """
-
         queryset = queryset.filter(created_at__lte=value)
         return queryset.order_by("-created_at")[:1]
 
     class Meta:
         model = SpreadSheetImport
-        fields = ["url"]
+        fields = ["spread_id"]

--- a/plugins/polio/api/dashboards/preparedness/serializers.py
+++ b/plugins/polio/api/dashboards/preparedness/serializers.py
@@ -8,6 +8,8 @@ from plugins.polio.preparedness.summary import preparedness_summary
 class PreparednessScoreSerializer(serializers.Serializer):
     campaign_details = serializers.SerializerMethodField()
     scores = serializers.SerializerMethodField()
+    created_at = serializers.DateTimeField()
+    id = serializers.IntegerField()
 
     def get_campaign_details(self, obj: SpreadSheetImport):
         if getattr(obj, "round_id", None) is None:

--- a/plugins/polio/api/dashboards/preparedness/serializers.py
+++ b/plugins/polio/api/dashboards/preparedness/serializers.py
@@ -19,9 +19,9 @@ class PreparednessScoreSerializer(serializers.Serializer):
         preparedness_data = get_preparedness(cached_spreadsheet)
         summary = preparedness_summary(preparedness_data)
         score = summary["overall_status_score"]
-        return {"score": score, **preparedness_data["totals"]}
+        return {"score": score, **preparedness_data}
 
 
 class ParamsSerializer(serializers.Serializer):
-    url = serializers.CharField(required=True)
+    spread_id = serializers.CharField(required=True)
     date = serializers.DateField(required=True)

--- a/plugins/polio/api/dashboards/preparedness/views.py
+++ b/plugins/polio/api/dashboards/preparedness/views.py
@@ -48,25 +48,26 @@ class PreparednessDashboardViewSet(viewsets.ViewSet):
     def score(self, request, **kwargs):
         params_serializer = ParamsSerializer(data=request.query_params)
         params_serializer.is_valid(raise_exception=True)
+        spread_id = params_serializer.data["spread_id"]
         queryset = self.get_queryset()
-        url_param = request.query_params.get("url")
-        filter = PreparednessScoreFilter(request.query_params, queryset=queryset)
+        filter = PreparednessScoreFilter(params_serializer.data, queryset=queryset)
         filtered_qs = filter.qs
         obj = filtered_qs.first()
+
+        if not obj:
+            return Response({})
+
         round_qs = (
-            Round.objects.filter(preparedness_spreadsheet_url=url_param)
+            Round.objects.filter(preparedness_spreadsheet_url=obj.url)
             .select_related("campaign")
             .only("id", "number", "campaign__obr_name")
         )
         if round_qs.count() > 1:
             rounds_list = list(round_qs.values_list("id", flat=True))
             return Response(
-                {"error": f"Found more than one round for url: {rounds_list}"},
+                {"error": f"Found more than one round for spreadsheet id {spread_id}: {rounds_list}"},
                 status=status.HTTP_409_CONFLICT,
             )
-
-        if not obj:
-            return Response({})
 
         round_obj = round_qs.first()
         obj.round_id = round_obj.id if round_obj else None

--- a/plugins/polio/preparedness/summary.py
+++ b/plugins/polio/preparedness/summary.py
@@ -14,6 +14,12 @@ from plugins.polio.preparedness.parser import get_preparedness, indicators
 logger = getLogger(__name__)
 
 
+def format_indicator(value, kind):
+    if kind == "percent":
+        return value / 10 if value else value
+    return value
+
+
 def get_summary(zones):
     r = {}
     for _, i, _, kind in indicators:
@@ -43,11 +49,6 @@ def preparedness_summary(prep_dict):
             indicators_per_zone["districts"]["status_score"],
         ]
     )
-
-    def format_indicator(value, kind):
-        if kind == "percent":
-            return value / 10 if value else value
-        return value
 
     # pivot
     r["indicators"] = {}

--- a/plugins/polio/tests/api/preparedness_dashboard/common_data.py
+++ b/plugins/polio/tests/api/preparedness_dashboard/common_data.py
@@ -6,6 +6,196 @@ from plugins.polio.permissions import POLIO_CONFIG_PERMISSION, POLIO_PERMISSION
 from plugins.polio.tests.api.test import PolioTestCaseMixin
 
 
+# The 10 preparedness indicators (everything in `parser.indicators` except `status_score`).
+INDICATOR_KEYS = [
+    "operational_fund",
+    "vaccine_and_droppers_received",
+    "vaccine_cold_chain_assessment",
+    "vaccine_monitors_training_and_deployment",
+    "penmarkers_supply",
+    "sia_training",
+    "sia_micro_planning",
+    "communication_sm_fund",
+    "communication_sm_activities",
+    "communication_c4d",
+]
+
+# Per-district section scores (computed from the score box, may be null).
+DISTRICT_SCORE_KEYS = [
+    "planning_score",
+    "training_score",
+    "monitoring_score",
+    "vaccine_score",
+    "advocacy_score",
+    "adverse_score",
+    "security_score",
+    "status_score",
+]
+
+# Indicator cells can hold a number, a leftover spreadsheet string ("3 semanas") or be empty/null.
+_INDICATOR_VALUE_SCHEMA = {"type": ["number", "string", "null"]}
+_SCORE_VALUE_SCHEMA = {"type": ["number", "null"]}
+
+_NATIONAL_SCHEMA = {
+    "type": "object",
+    "properties": {
+        **dict.fromkeys(INDICATOR_KEYS, _INDICATOR_VALUE_SCHEMA),
+        "status_score": _SCORE_VALUE_SCHEMA,
+        "round": {"type": "string"},
+    },
+    "required": INDICATOR_KEYS + ["status_score", "round"],
+}
+
+_REGION_SCHEMA = {
+    "type": "object",
+    "properties": {
+        **dict.fromkeys(INDICATOR_KEYS, _INDICATOR_VALUE_SCHEMA),
+        "status_score": _SCORE_VALUE_SCHEMA,
+    },
+    "required": INDICATOR_KEYS + ["status_score"],
+}
+
+# Districts always carry the section scores + a region, but indicators are optional
+# (broken "#REF!" rows only expose the score skeleton).
+_DISTRICT_SCHEMA = {
+    "type": "object",
+    "properties": {
+        **dict.fromkeys(DISTRICT_SCORE_KEYS, _SCORE_VALUE_SCHEMA),
+        "region": {"type": "string"},
+        **dict.fromkeys(INDICATOR_KEYS, _INDICATOR_VALUE_SCHEMA),
+    },
+    "required": DISTRICT_SCORE_KEYS + ["region"],
+}
+
+_TOTALS_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "national_score": {"type": "number"},
+        "regional_score": {"type": "number"},
+        "district_score": {"type": "number"},
+    },
+    "required": ["national_score", "regional_score", "district_score"],
+}
+
+SCORES_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "score": _SCORE_VALUE_SCHEMA,
+        "national": _NATIONAL_SCHEMA,
+        "regions": {"type": "object", "additionalProperties": _REGION_SCHEMA},
+        "districts": {"type": "object", "additionalProperties": _DISTRICT_SCHEMA},
+        "format": {"type": "string"},
+        "totals": _TOTALS_SCHEMA,
+    },
+    "required": ["score", "national", "regions", "districts", "format", "totals"],
+}
+
+SCORE_RESPONSE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "campaign_details": {
+            "type": "object",
+            "properties": {
+                "round_id": {"type": "integer"},
+                "round_number": {"type": "integer"},
+                "campaign": {"type": "string"},
+            },
+        },
+        "scores": SCORES_SCHEMA,
+    },
+    "required": ["campaign_details", "scores"],
+}
+
+# Realistic `get_preparedness()` payload (v2 / "v3.5" format) trimmed to a handful of
+# regions and districts while keeping every shape variation seen in production:
+#   - a non-numeric indicator value ("3 semanas")
+#   - a fully-null "#REF!" district with no indicator keys
+MOCK_PREPAREDNESS_DATA = {
+    "national": {
+        "operational_fund": 10,
+        "vaccine_and_droppers_received": 10,
+        "vaccine_cold_chain_assessment": 10,
+        "vaccine_monitors_training_and_deployment": 10,
+        "penmarkers_supply": 10,
+        "sia_training": 10,
+        "sia_micro_planning": 10,
+        "communication_sm_fund": 10,
+        "communication_sm_activities": 87.5,
+        "communication_c4d": 5,
+        "status_score": 97.5,
+        "round": "Round2",
+    },
+    "regions": {
+        "BIÉ": {
+            "operational_fund": 10,
+            "vaccine_and_droppers_received": 10,
+            "vaccine_cold_chain_assessment": 10,
+            "vaccine_monitors_training_and_deployment": 10,
+            "penmarkers_supply": 10,
+            "sia_training": 10,
+            "sia_micro_planning": 10,
+            "communication_sm_fund": 10,
+            "communication_sm_activities": 95.83333333333334,
+            "communication_c4d": 10,
+            "status_score": 99.16666666666669,
+        },
+        "LUNDA SUL": {
+            "operational_fund": "3 semanas",
+            "vaccine_and_droppers_received": 0,
+            "vaccine_cold_chain_assessment": 0,
+            "vaccine_monitors_training_and_deployment": 0,
+            "penmarkers_supply": 0,
+            "sia_training": 0,
+            "sia_micro_planning": 0,
+            "communication_sm_fund": 0,
+            "communication_sm_activities": 0,
+            "communication_c4d": 0,
+            "status_score": 0,
+        },
+    },
+    "districts": {
+        "Andulo": {
+            "planning_score": 100,
+            "training_score": 100,
+            "monitoring_score": 100,
+            "vaccine_score": 100,
+            "advocacy_score": 95.83333333333334,
+            "adverse_score": 99.16666666666669,
+            "security_score": None,
+            "status_score": 99.16666666666669,
+            "region": "BIÉ",
+            "operational_fund": 10,
+            "vaccine_and_droppers_received": 10,
+            "vaccine_cold_chain_assessment": 10,
+            "vaccine_monitors_training_and_deployment": 10,
+            "penmarkers_supply": 10,
+            "sia_training": 10,
+            "sia_micro_planning": 10,
+            "communication_sm_fund": 10,
+            "communication_sm_activities": 95.83333333333334,
+            "communication_c4d": 10,
+        },
+        "#REF! (Reference does not exist.)": {
+            "planning_score": None,
+            "training_score": None,
+            "monitoring_score": None,
+            "vaccine_score": None,
+            "advocacy_score": None,
+            "adverse_score": None,
+            "security_score": None,
+            "status_score": None,
+            "region": "BIÉ",
+        },
+    },
+    "format": "v3.5",
+    "totals": {
+        "national_score": 97.5,
+        "regional_score": 91.73,
+        "district_score": 90.33,
+    },
+}
+
+
 class PreparednessDashboardAPIBase(APITestCase, PolioTestCaseMixin):
     """
     Common setup for Preparedness Dashboard API tests.

--- a/plugins/polio/tests/api/preparedness_dashboard/test_filters.py
+++ b/plugins/polio/tests/api/preparedness_dashboard/test_filters.py
@@ -20,7 +20,7 @@ class PreparednessScoreFilterAPITestCase(PreparednessDashboardAPIBase):
         self.client.force_authenticate(self.user_polio)
 
     def test_filter_url_returns_empty_for_nonexistent(self):
-        response = self.client.get(self.SCORE_URL, {"url": 999999, "date": "2030-01-01"})
+        response = self.client.get(self.SCORE_URL, {"spread_id": 999999, "date": "2030-01-01"})
         data = self.assertJSONResponse(response, status.HTTP_200_OK)
         self.assertEqual(data, {})
 
@@ -48,12 +48,12 @@ class PreparednessScoreFilterAPITestCase(PreparednessDashboardAPIBase):
         SpreadSheetImport.objects.filter(pk=newer_ssi.pk).update(created_at=now - timedelta(days=1))
 
         date_str = (now - timedelta(days=1)).strftime("%Y-%m-%d")
-        response = self.client.get(self.SCORE_URL, {"url": older_ssi.url, "date": date_str})
+        response = self.client.get(self.SCORE_URL, {"spread_id": older_ssi.spread_id, "date": date_str})
         self.assertJSONResponse(response, status.HTTP_200_OK)
 
     def test_filter_date_returns_empty_when_no_entries_before_date(self):
         """When all SpreadSheetImport entries are after the given date, the filter returns empty."""
-        response = self.client.get(self.SCORE_URL, {"url": 1, "date": "2000-01-01"})
+        response = self.client.get(self.SCORE_URL, {"spread_id": self.ssi.spread_id, "date": "2000-01-01"})
         data = self.assertJSONResponse(response, status.HTTP_200_OK)
         self.assertEqual(data, {})
 
@@ -82,6 +82,6 @@ class PreparednessScoreFilterAPITestCase(PreparednessDashboardAPIBase):
         SpreadSheetImport.objects.filter(pk=ssi_recent.pk).update(created_at=base_date - timedelta(days=1))
 
         date_str = base_date.strftime("%Y-%m-%d")
-        response = self.client.get(self.SCORE_URL, {"url": ssi_old.url, "date": date_str})
+        response = self.client.get(self.SCORE_URL, {"spread_id": ssi_old.spread_id, "date": date_str})
         data = self.assertJSONResponse(response, status.HTTP_200_OK)
         self.assertIn("scores", data)

--- a/plugins/polio/tests/api/preparedness_dashboard/test_filters.py
+++ b/plugins/polio/tests/api/preparedness_dashboard/test_filters.py
@@ -47,9 +47,18 @@ class PreparednessScoreFilterAPITestCase(PreparednessDashboardAPIBase):
         )
         SpreadSheetImport.objects.filter(pk=newer_ssi.pk).update(created_at=now - timedelta(days=1))
 
-        date_str = (now - timedelta(days=1)).strftime("%Y-%m-%d")
-        response = self.client.get(self.SCORE_URL, {"spread_id": older_ssi.spread_id, "date": date_str})
-        self.assertJSONResponse(response, status.HTTP_200_OK)
+        exact_date_ssi = SpreadSheetImport.objects.create(
+            url="https://docs.google.com/spreadsheets/d/exact-date",
+            content={"title": "Exact Date Sheet", "sheets": []},
+            spread_id="exact-date",
+        )
+        query_date = now - timedelta(days=1)
+        SpreadSheetImport.objects.filter(pk=exact_date_ssi.pk).update(created_at=query_date)
+
+        date_str = query_date.strftime("%Y-%m-%d")
+        response = self.client.get(self.SCORE_URL, {"spread_id": exact_date_ssi.spread_id, "date": date_str})
+        data = self.assertJSONResponse(response, status.HTTP_200_OK)
+        self.assertIn("scores", data)
 
     def test_filter_date_returns_empty_when_no_entries_before_date(self):
         """When all SpreadSheetImport entries are after the given date, the filter returns empty."""

--- a/plugins/polio/tests/api/preparedness_dashboard/test_filters.py
+++ b/plugins/polio/tests/api/preparedness_dashboard/test_filters.py
@@ -1,4 +1,4 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 from unittest import mock
 
 from django.utils import timezone
@@ -52,13 +52,17 @@ class PreparednessScoreFilterAPITestCase(PreparednessDashboardAPIBase):
             content={"title": "Exact Date Sheet", "sheets": []},
             spread_id="exact-date",
         )
-        query_date = now - timedelta(days=1)
+        query_date = now
         SpreadSheetImport.objects.filter(pk=exact_date_ssi.pk).update(created_at=query_date)
 
         date_str = query_date.strftime("%Y-%m-%d")
         response = self.client.get(self.SCORE_URL, {"spread_id": exact_date_ssi.spread_id, "date": date_str})
         data = self.assertJSONResponse(response, status.HTTP_200_OK)
         self.assertIn("scores", data)
+        created_at = datetime.strptime(data["created_at"].split("T")[0], "%Y-%m-%d").date()
+        expected_created_at = query_date.date()
+        self.assertEqual(created_at, expected_created_at)
+        self.assertEqual(data["id"], exact_date_ssi.id)
 
     def test_filter_date_returns_empty_when_no_entries_before_date(self):
         """When all SpreadSheetImport entries are after the given date, the filter returns empty."""

--- a/plugins/polio/tests/api/preparedness_dashboard/test_serializers.py
+++ b/plugins/polio/tests/api/preparedness_dashboard/test_serializers.py
@@ -1,9 +1,13 @@
+import copy
+
 from unittest import mock
+
+import jsonschema
 
 from plugins.polio.api.dashboards.preparedness.serializers import PreparednessScoreSerializer
 from plugins.polio.models.base import SpreadSheetImport
 
-from .common_data import PreparednessDashboardAPIBase
+from .common_data import MOCK_PREPAREDNESS_DATA, SCORE_RESPONSE_SCHEMA, PreparednessDashboardAPIBase
 
 
 MOCK_PREPAREDNESS = "plugins.polio.api.dashboards.preparedness.serializers.get_preparedness"
@@ -18,7 +22,7 @@ class PreparednessScoreSerializerAPITestCase(PreparednessDashboardAPIBase):
     @mock.patch(MOCK_SUMMARY)
     @mock.patch(MOCK_PREPAREDNESS)
     def test_scores_field_returns_totals_and_score(self, mock_get_preparedness, mock_summary):
-        mock_get_preparedness.return_value = {"totals": {"national": 90, "regional": 75, "district": 60}}
+        mock_get_preparedness.return_value = MOCK_PREPAREDNESS_DATA
         mock_summary.return_value = {"overall_status_score": 75.0}
 
         self.ssi.round_id = self.round_with_ssi.id
@@ -27,10 +31,45 @@ class PreparednessScoreSerializerAPITestCase(PreparednessDashboardAPIBase):
         serializer = PreparednessScoreSerializer(instance=self.ssi)
         data = serializer.data
 
-        self.assertEqual(data["scores"]["score"], 75.0)
-        self.assertEqual(data["scores"]["national"], 90)
-        self.assertEqual(data["scores"]["regional"], 75)
-        self.assertEqual(data["scores"]["district"], 60)
+        try:
+            jsonschema.validate(instance=data, schema=SCORE_RESPONSE_SCHEMA)
+        except jsonschema.exceptions.ValidationError as ex:
+            self.fail(msg=str(ex))
+
+        scores = data["scores"]
+        # `score` is taken from preparedness_summary; everything else is the get_preparedness() payload.
+        self.assertEqual(scores["score"], 75.0)
+        self.assertEqual(scores["format"], "v3.5")
+        self.assertEqual(scores["totals"]["national_score"], 97.5)
+        self.assertEqual(scores["totals"]["regional_score"], 91.73)
+        self.assertEqual(scores["totals"]["district_score"], 90.33)
+        self.assertEqual(set(scores.keys()), {"score", "national", "regions", "districts", "format", "totals"})
+
+    @mock.patch(MOCK_SUMMARY)
+    @mock.patch(MOCK_PREPAREDNESS)
+    def test_scores_field_preserves_region_and_district_shape(self, mock_get_preparedness, mock_summary):
+        # Deep copy so per-test attribute access can't mutate the shared fixture.
+        mock_get_preparedness.return_value = copy.deepcopy(MOCK_PREPAREDNESS_DATA)
+        mock_summary.return_value = {"overall_status_score": 75.0}
+
+        self.ssi.round_id = self.round_with_ssi.id
+        self.ssi.round_number = self.round_with_ssi.number
+        self.ssi.campaign = self.campaign.obr_name
+        scores = PreparednessScoreSerializer(instance=self.ssi).data["scores"]
+
+        bie = scores["regions"]["BIÉ"]
+        self.assertEqual(bie["status_score"], 99.16666666666669)
+        self.assertEqual(bie["operational_fund"], 10)
+        # Non-numeric indicator cells are forwarded as-is.
+        self.assertEqual(scores["regions"]["LUNDA SUL"]["operational_fund"], "3 semanas")
+
+        andulo = scores["districts"]["Andulo"]
+        self.assertEqual(andulo["region"], "BIÉ")
+        self.assertIsNone(andulo["security_score"])
+        # Broken "#REF!" districts only expose the null score skeleton, no indicators.
+        broken = scores["districts"]["#REF! (Reference does not exist.)"]
+        self.assertIsNone(broken["status_score"])
+        self.assertNotIn("operational_fund", broken)
 
     @mock.patch(MOCK_SUMMARY)
     @mock.patch(MOCK_PREPAREDNESS)

--- a/plugins/polio/tests/api/preparedness_dashboard/test_views.py
+++ b/plugins/polio/tests/api/preparedness_dashboard/test_views.py
@@ -7,7 +7,7 @@ from rest_framework import status
 
 from plugins.polio.models.base import SpreadSheetImport
 
-from .common_data import PreparednessDashboardAPIBase
+from .common_data import MOCK_PREPAREDNESS_DATA, SCORE_RESPONSE_SCHEMA, PreparednessDashboardAPIBase
 
 
 INDICATOR_SCHEMA = {
@@ -208,7 +208,7 @@ class PreparednessDashboardScoreAPITestCase(PreparednessDashboardAPIBase):
     def setUp(self):
         super().setUp()
         self.client.force_authenticate(self.user_polio)
-        self.VALID_SCORE_PARAMS = {**self.VALID_SCORE_PARAMS, "url": self.spreadsheet_url}
+        self.VALID_SCORE_PARAMS = {**self.VALID_SCORE_PARAMS, "spread_id": self.ssi.spread_id}
 
     def test_score_requires_authentication(self):
         self.client.force_authenticate(self.anon)
@@ -224,27 +224,27 @@ class PreparednessDashboardScoreAPITestCase(PreparednessDashboardAPIBase):
         response = self.client.get(self.SCORE_URL)
         data = self.assertJSONResponse(response, status.HTTP_400_BAD_REQUEST)
 
-        self.assertIn("url", data)
+        self.assertIn("spread_id", data)
         self.assertIn("date", data)
 
     def test_score_raises_when_url_missing(self):
         response = self.client.get(self.SCORE_URL, {"date": "2030-01-01"})
         data = self.assertJSONResponse(response, status.HTTP_400_BAD_REQUEST)
 
-        self.assertIn("url", data)
+        self.assertIn("spread_id", data)
         self.assertNotIn("date", data)
 
     def test_score_raises_when_date_missing(self):
-        response = self.client.get(self.SCORE_URL, {"url": 1})
+        response = self.client.get(self.SCORE_URL, {"spread_id": 1})
         data = self.assertJSONResponse(response, status.HTTP_400_BAD_REQUEST)
 
         self.assertIn("date", data)
-        self.assertNotIn("url", data)
+        self.assertNotIn("spread_id", data)
 
     @mock.patch("plugins.polio.api.dashboards.preparedness.serializers.preparedness_summary")
     @mock.patch("plugins.polio.api.dashboards.preparedness.serializers.get_preparedness")
     def test_score_accessible_with_polio_permission(self, mock_get_preparedness, mock_summary):
-        mock_get_preparedness.return_value = {"totals": {"national": 80}}
+        mock_get_preparedness.return_value = MOCK_PREPAREDNESS_DATA
         mock_summary.return_value = {"overall_status_score": 80.0}
 
         response = self.client.get(self.SCORE_URL, self.VALID_SCORE_PARAMS)
@@ -253,7 +253,7 @@ class PreparednessDashboardScoreAPITestCase(PreparednessDashboardAPIBase):
     @mock.patch("plugins.polio.api.dashboards.preparedness.serializers.preparedness_summary")
     @mock.patch("plugins.polio.api.dashboards.preparedness.serializers.get_preparedness")
     def test_score_accessible_with_config_permission(self, mock_get_preparedness, mock_summary):
-        mock_get_preparedness.return_value = {"totals": {"national": 80}}
+        mock_get_preparedness.return_value = MOCK_PREPAREDNESS_DATA
         mock_summary.return_value = {"overall_status_score": 80.0}
 
         self.client.force_authenticate(self.user_config)
@@ -261,7 +261,7 @@ class PreparednessDashboardScoreAPITestCase(PreparednessDashboardAPIBase):
         self.assertJSONResponse(response, status.HTTP_200_OK)
 
     def test_score_returns_empty_when_no_match(self):
-        response = self.client.get(self.SCORE_URL, {"url": 999999, "date": "2030-01-01"})
+        response = self.client.get(self.SCORE_URL, {"spread_id": 999999, "date": "2030-01-01"})
         data = self.assertJSONResponse(response, status.HTTP_200_OK)
 
         self.assertEqual(data, {})
@@ -269,22 +269,45 @@ class PreparednessDashboardScoreAPITestCase(PreparednessDashboardAPIBase):
     @mock.patch("plugins.polio.api.dashboards.preparedness.serializers.preparedness_summary")
     @mock.patch("plugins.polio.api.dashboards.preparedness.serializers.get_preparedness")
     def test_score_returns_serialized_data(self, mock_get_preparedness, mock_summary):
-        mock_get_preparedness.return_value = {"totals": {"national": 80, "regional": 70, "district": 60}}
+        mock_get_preparedness.return_value = MOCK_PREPAREDNESS_DATA
         mock_summary.return_value = {"overall_status_score": 70.0}
 
         response = self.client.get(self.SCORE_URL, self.VALID_SCORE_PARAMS)
         data = self.assertJSONResponse(response, status.HTTP_200_OK)
-        print("DATA", data)
 
-        self.assertIn("scores", data)
-        self.assertEqual(data["scores"]["score"], 70.0)
-        self.assertEqual(data["scores"]["national"], 80)
-        self.assertIn("campaign_details", data)
+        try:
+            jsonschema.validate(instance=data, schema=SCORE_RESPONSE_SCHEMA)
+        except jsonschema.exceptions.ValidationError as ex:
+            self.fail(msg=str(ex))
+
+        # campaign_details mirrors the round attributes attached by the view.
+        self.assertEqual(
+            data["campaign_details"],
+            {
+                "round_id": self.round_with_ssi.id,
+                "round_number": 4,
+                "campaign": "test-campaign",
+            },
+        )
+
+        scores = data["scores"]
+        # `score` comes from preparedness_summary, the rest is the spread get_preparedness() payload.
+        self.assertEqual(scores["score"], 70.0)
+        self.assertEqual(scores["format"], "v3.5")
+        self.assertEqual(scores["totals"], {"national_score": 97.5, "regional_score": 91.73, "district_score": 90.33})
+        self.assertEqual(scores["national"]["status_score"], 97.5)
+        self.assertEqual(scores["national"]["round"], "Round2")
+        self.assertEqual(set(scores["regions"].keys()), {"BIÉ", "LUNDA SUL"})
+        # Non-numeric indicator cells are passed through untouched.
+        self.assertEqual(scores["regions"]["LUNDA SUL"]["operational_fund"], "3 semanas")
+        self.assertEqual(scores["districts"]["Andulo"]["region"], "BIÉ")
+        # Broken "#REF!" districts keep the null score skeleton.
+        self.assertIsNone(scores["districts"]["#REF! (Reference does not exist.)"]["status_score"])
 
     @mock.patch("plugins.polio.api.dashboards.preparedness.serializers.preparedness_summary")
     @mock.patch("plugins.polio.api.dashboards.preparedness.serializers.get_preparedness")
     def test_score_returns_campaign_details_with_linked_round(self, mock_get_preparedness, mock_summary):
-        mock_get_preparedness.return_value = {"totals": {"national": 80}}
+        mock_get_preparedness.return_value = MOCK_PREPAREDNESS_DATA
         mock_summary.return_value = {"overall_status_score": 80.0}
 
         response = self.client.get(self.SCORE_URL, self.VALID_SCORE_PARAMS)
@@ -300,14 +323,15 @@ class PreparednessDashboardScoreAPITestCase(PreparednessDashboardAPIBase):
         from plugins.polio.models.base import Round
 
         shared_url = "https://docs.google.com/spreadsheets/d/shared"
+        shared_spread_id = "shared"
         SpreadSheetImport.objects.create(
             url=shared_url,
             content={"title": "Shared", "sheets": []},
-            spread_id="shared",
+            spread_id=shared_spread_id,
         )
         Round.objects.create(campaign=self.campaign, number=10, preparedness_spreadsheet_url=shared_url)
         Round.objects.create(campaign=self.campaign, number=11, preparedness_spreadsheet_url=shared_url)
 
-        response = self.client.get(self.SCORE_URL, {"url": shared_url, "date": "2030-01-01"})
+        response = self.client.get(self.SCORE_URL, {"spread_id": shared_spread_id, "date": "2030-01-01"})
         data = self.assertJSONResponse(response, status.HTTP_409_CONFLICT)
-        self.assertIn("Found more than one round for url:", data["error"])
+        self.assertIn(f"Found more than one round for spreadsheet id {shared_spread_id}:", data["error"])


### PR DESCRIPTION

## What problem is this PR solving?

DS need more data to provide dashboard to client

### Related JIRA tickets
POLIO-2158

## Changes

- Pass spread_id i.o url to avoid parsing errors
- return full preparedness dict

## How to test

- On a polio DB
- go to `/api/polio/preparedness_dashboard/score/?date=<some date>&spread_id=<SpreadSheetImport.spread_id>`. Date should be greater than the SpreadSheetImport created_at. spread_id can be found in the django admin.
- Check that the payload contains the "critical activities" (See Jira ticket for details)


