### PR TITLE
fix: return role (group) permissions in profile retrieve (IA-5223)

### DIFF
--- a/iaso/api/profiles/serializers/retrieve.py
+++ b/iaso/api/profiles/serializers/retrieve.py
@@ -324,7 +324,7 @@ class ProfileRetrieveSerializer(ModelSerializer):
         user_group_permissions = [
             permission.split(".")[1]
             for permission in obj.user.get_group_permissions()
-            if permission.split(".")[1].startswith("iaso_") and permission in permissions_active_modules
+            if permission.split(".")[1].startswith("iaso_") and permission.split(".")[1] in permissions_active_modules
         ]
         user_permissions = list(
             obj.user.user_permissions.filter(

--- a/iaso/tests/api/profiles/test_views/test_update.py
+++ b/iaso/tests/api/profiles/test_views/test_update.py
@@ -995,3 +995,38 @@ class ProfileUpdateAPITestCase(BaseProfileAPITestCase):
             format="json",
         )
         self.assertJSONResponse(response, status.HTTP_200_OK)
+
+    def test_retrieve_returns_permissions_granted_through_a_role(self):
+        """
+        Regression test for IA-5223: permissions granted through a role (i.e. a Django group)
+        must be returned in `permissions`. They are delivered via `get_group_permissions()`
+        (fully-qualified `app_label.codename`) and were being wrongly filtered out against the
+        active-module codenames.
+        """
+        self.client.force_authenticate(self.jim)
+        self.account.modules = [MODULE_DEFAULT.codename, MODULE_VALIDATION_WORKFLOW.codename]
+        self.account.save(update_fields=["modules"])
+
+        role_group = Group.objects.create(name="role with validation workflow")
+        role_group.permissions.add(Permission.objects.get(codename=CORE_VALIDATION_WORKFLOW_PERMISSION.codename))
+        role = UserRole.objects.create(group=role_group, account=self.account)
+        self.jom.iaso_profile.user_roles.set([role])
+        # Assigning a role also adds the user to the underlying Django group (see ProfileViewSet),
+        # which is how role permissions are delivered through `get_group_permissions()`.
+        self.jom.groups.set([role_group])
+
+        response = self.client.get(reverse("profiles-detail", kwargs={"pk": self.jom.iaso_profile.id}))
+        res_data = self.assertJSONResponse(response, status.HTTP_200_OK)
+
+        # The role permission is granted through the group, so it appears in `permissions`
+        # but not in `user_permissions` (which only holds directly-assigned permissions).
+        self.assertIn(CORE_VALIDATION_WORKFLOW_PERMISSION.codename, res_data["permissions"])
+        self.assertNotIn(CORE_VALIDATION_WORKFLOW_PERMISSION.codename, res_data["user_permissions"])
+
+        # Role permissions are still gated by active modules: deactivating the module removes them.
+        self.account.modules = [MODULE_DEFAULT.codename]
+        self.account.save(update_fields=["modules"])
+
+        response = self.client.get(reverse("profiles-detail", kwargs={"pk": self.jom.iaso_profile.id}))
+        res_data = self.assertJSONResponse(response, status.HTTP_200_OK)
+        self.assertNotIn(CORE_VALIDATION_WORKFLOW_PERMISSION.codename, res_data["permissions"])


### PR DESCRIPTION
## What problem is this PR solving?

Assigning a role to a user (via the user management page) did not grant the user the role's accesses; role-based permissions were silently dropped from the profile API.

### Related JIRA tickets

IA-5223

## Changes

- `iaso/api/profiles/serializers/retrieve.py`: in `ProfileRetrieveSerializer.get_permissions`, the group-permission branch compared a fully-qualified permission string (`"iaso.iaso_forms"`, as returned by `User.get_group_permissions()`) against a list of bare codenames (`"iaso_forms"`, from `permissions_from_active_modules`). The check `permission in permissions_active_modules` therefore never matched and every permission coming from a group was filtered out. Since a `UserRole` is backed by a Django auth `Group`, all role permissions are delivered through `get_group_permissions()`, so role assignment granted no access. Fixed by comparing the split codename. The directly-assigned `user_permissions` branch was already correct.
- `iaso/tests/api/profiles/test_views/test_update.py`: added a regression test that assigns a role (group) to a user and asserts the role permission is returned in `permissions` (and still gated by active modules). This branch was previously untested, which is how the regression slipped through.

This is a regression introduced in #3088 (commit `8cfb8310b`, "fix: Only return permissions from active modules in profile retrieve", refs IA-5170), merged 2026-06-08.

## How to test

1. On an account, create a user role with some permissions (e.g. Validation workflows) for the corresponding active module.
2. Assign that role to a user that has no directly-assigned permissions.
3. Reload the user's profile — the role's permissions now appear in `permissions` and the user gets the corresponding accesses.

Automated: `manage.py test iaso.tests.api.profiles.test_views.test_update.ProfileUpdateAPITestCase.test_retrieve_returns_permissions_granted_through_a_role`. The test fails on the pre-fix code and passes with the fix.

## Print screen / video

N/A — backend serializer fix.

## Notes

- The fix keeps the active-modules gating intact: role permissions belonging to a deactivated module are still excluded (covered by the regression test).

## Doc

No doc changes needed.
