### PR TITLE
[Sleep-1794] add trypelim team to entity

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/entities/components/Filters.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/components/Filters.tsx
@@ -107,7 +107,9 @@ const Filters: FunctionComponent<Props> = ({
     const { data: types, isFetching: isFetchingTypes } =
         useGetEntityTypesDropdown();
     const { data: teamOptions } = useGetTeamsDropdown({});
-    const TeamsFilterOverride = useFindCustomComponent('entity.teams_filter');
+    const TeamsFilterOverride = useFindCustomComponent(
+        'iaso.entities.label.submitterTeam',
+    );
     const { data: selectedTeam } = useGetTeam(
         !TeamsFilterOverride && filters?.submitterTeamId
             ? parseInt(filters.submitterTeamId, 10)

--- a/hat/assets/js/apps/Iaso/domains/entities/components/Filters.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/components/Filters.tsx
@@ -30,6 +30,7 @@ import { LocationLimit } from 'Iaso/utils/map/LocationLimit';
 import { useCurrentUser } from 'Iaso/utils/usersUtils';
 import DownloadButtonsComponent from '../../../components/DownloadButtonsComponent';
 import InputComponent from '../../../components/forms/InputComponent';
+import { useFindCustomComponent } from '../../../plugins/hooks/customComponents';
 
 import { OrgUnitTreeviewModal } from '../../orgUnits/components/TreeView/OrgUnitTreeviewModal';
 import { useGetOrgUnit } from '../../orgUnits/components/TreeView/requests';
@@ -106,8 +107,11 @@ const Filters: FunctionComponent<Props> = ({
     const { data: types, isFetching: isFetchingTypes } =
         useGetEntityTypesDropdown();
     const { data: teamOptions } = useGetTeamsDropdown({});
+    const TeamsFilterOverride = useFindCustomComponent('entity.teams_filter');
     const { data: selectedTeam } = useGetTeam(
-        filters?.submitterTeamId ? parseInt(filters.submitterTeamId, 10) : 0,
+        !TeamsFilterOverride && filters?.submitterTeamId
+            ? parseInt(filters.submitterTeamId, 10)
+            : 0,
     );
     const { data: usersOptions } = useGetProfilesDropdown({
         team: selectedTeam,
@@ -148,30 +152,24 @@ const Filters: FunctionComponent<Props> = ({
         }
     }, [searchEnabled, getParams, params, filters, redirectTo]);
 
-    const handleChange = useCallback(
-        (key, value) => {
-            setFiltersUpdated(true);
-            if (key === 'location') {
-                setInitialOrgUnitId(value);
-            }
-            setFilters(prevFilters => ({
-                ...prevFilters,
-                [key]: value,
-            }));
-        },
-        [],
-    );
-    const handleTeamChange = useCallback(
-        (key, value) => {
-            setFiltersUpdated(true);
-            setFilters(prevFilters => ({
-                ...prevFilters,
-                [key]: value,
-                submitterId: undefined,
-            }));
-        },
-        [],
-    );
+    const handleChange = useCallback((key, value) => {
+        setFiltersUpdated(true);
+        if (key === 'location') {
+            setInitialOrgUnitId(value);
+        }
+        setFilters(prevFilters => ({
+            ...prevFilters,
+            [key]: value,
+        }));
+    }, []);
+    const handleTeamChange = useCallback((key, value) => {
+        setFiltersUpdated(true);
+        setFilters(prevFilters => ({
+            ...prevFilters,
+            [key]: value,
+            submitterId: undefined,
+        }));
+    }, []);
 
     const { url: apiUrl } = useGetEntitiesApiParams(params);
     return (
@@ -286,14 +284,21 @@ const Filters: FunctionComponent<Props> = ({
                     )}
                 </Grid>
                 <Grid item xs={12} sm={6} md={3}>
-                    <InputComponent
-                        keyValue="submitterTeamId"
-                        onChange={handleTeamChange}
-                        value={filters.submitterTeamId}
-                        type="select"
-                        label={MESSAGES.submitterTeam}
-                        options={teamOptions}
-                    />
+                    {TeamsFilterOverride ? (
+                        <TeamsFilterOverride
+                            value={filters.submitterTeamId}
+                            onChange={handleTeamChange}
+                        />
+                    ) : (
+                        <InputComponent
+                            keyValue="submitterTeamId"
+                            onChange={handleTeamChange}
+                            value={filters.submitterTeamId}
+                            type="select"
+                            label={MESSAGES.submitterTeam}
+                            options={teamOptions}
+                        />
+                    )}
                     <InputComponent
                         keyValue="submitterId"
                         onChange={handleChange}

--- a/iaso/api/entities/filters.py
+++ b/iaso/api/entities/filters.py
@@ -14,6 +14,7 @@ from rest_framework.exceptions import ValidationError
 
 from iaso.api.common import CharInFilter
 from iaso.models import Entity, Instance, OrgUnit
+from iaso.plugins import is_trypelim_plugin_active
 from iaso.utils.date_and_time import date_string_to_end_of_day, date_string_to_start_of_day
 from iaso.utils.jsonlogic import entities_jsonlogic_to_q
 
@@ -22,7 +23,13 @@ class EntityFilterSet(FilterSet):
     form_name = CharFilter(field_name="attributes__form__name", lookup_expr="icontains")
     by_uuid = UUIDFilter(field_name="uuid")
     created_by_id = CharFilter(field_name="attributes__created_by_id")
-    created_by_team_id = CharFilter(field_name="attributes__created_by__teams__id")
+    created_by_team_id = CharFilter(
+        field_name=(
+            "attributes__created_by__trypelim_profile__team_id"
+            if is_trypelim_plugin_active()
+            else "attributes__created_by__teams__id"
+        )
+    )
 
     entity_type_ids = CharInFilter(field_name="entity_type_id", lookup_expr="in")
     groups = CharInFilter(field_name="attributes__org_unit__groups", lookup_expr="in")


### PR DESCRIPTION
## What problem is this PR solving?

This PR is about impleting the team filter on the entity page

### Related JIRA tickets

[SLEEP-1794](https://bluesquare.atlassian.net/browse/SLEEP-1794)

## Changes

- Implemented a check on the backend to return the team related to trypelim when the plugin is active
- Overrided the frontend filter to do the same 

## How to test

> Go to entities list
> Use the team Dropdown, you should see trypelim related teams
> Filter by team

## Print screen / video

[Screencast from 15-06-26 10:31:53.webm](https://github.com/user-attachments/assets/44899c09-b2f7-457a-8590-d56c5b07cffa)


## Notes

This PR is linked to this trypelim PR: [SLEEP-1794](https://github.com/BLSQ/trypelim/pull/276)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).


[SLEEP-1794]: https://bluesquare.atlassian.net/browse/SLEEP-1794?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SLEEP-1794]: https://bluesquare.atlassian.net/browse/SLEEP-1794?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ