### PR TITLE
[IA-5168]: make orval custom query and mutation options TS compliants

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/accounts/components/modals/EditAIApiKeyModal.tsx
+++ b/hat/assets/js/apps/Iaso/domains/accounts/components/modals/EditAIApiKeyModal.tsx
@@ -31,7 +31,9 @@ const EditAIApiKeyModal: FunctionComponent<Props> = ({
     const { mutateAsync: saveAIApiKey } = useApiAccountsAiApiKeyUpdate({
         mutation: {
             onSuccess: () => closeDialog(),
-            ignoreErrorCodes: [400],
+            meta: {
+                ignoreErrorCodes: [400],
+            },
         },
     });
     const formik = useFormik({

--- a/hat/assets/js/apps/Iaso/domains/accounts/edit.tsx
+++ b/hat/assets/js/apps/Iaso/domains/accounts/edit.tsx
@@ -58,7 +58,9 @@ export const AccountsEdit: FunctionComponent = () => {
             onSuccess: () => {
                 redirectTo(redirectBackUrl);
             },
-            ignoreErrorCodes: [400],
+            meta: {
+                ignoreErrorCodes: [400],
+            },
         },
     });
 

--- a/hat/assets/js/apps/Iaso/domains/modules/components/ModulesDropdown.tsx
+++ b/hat/assets/js/apps/Iaso/domains/modules/components/ModulesDropdown.tsx
@@ -33,8 +33,10 @@ export const ModulesDropdown = ({
     // todo: queryKey def could maybe be more generic at orval config level?
     const { data, isLoading } = useApiModulesDropdownList(params, {
         query: {
+            meta: {
+                snackErrorMsg: MESSAGES.modulesDropDownError,
+            },
             enabled: hasPermissions,
-            snackErrorMsg: MESSAGES.modulesDropDownError,
             queryKey: [
                 ...getApiModulesDropdownListQueryKey(params),
                 moment().locale(),

--- a/hat/assets/js/orval/mutator/custom-mutation-options.ts
+++ b/hat/assets/js/orval/mutator/custom-mutation-options.ts
@@ -13,7 +13,7 @@ const isApiError = (error: unknown): error is ApiError => {
     return typeof error === 'object' && error !== null && 'status' in error;
 };
 
-type ExtraMutationOptions = {
+type MutationMeta = {
     snackSuccessMessage?: IntlMessage;
     snackErrorMsg?: IntlMessage;
     showSuccessSnackBar?: boolean;
@@ -29,40 +29,37 @@ type ExtraMutationOptions = {
     };
 };
 
-type UseMutationOptionsWithExtra<TData, TError, TVariables, TContext> =
-    UseMutationOptions<TData, TError, TVariables, TContext> &
-        ExtraMutationOptions;
-
 export const useCustomMutationOptions = <
-    TData = unknown, // All unknown because this is function is used across all mutations.
+    TData = unknown,
     TError = unknown,
     TVariables = void,
     TContext = unknown,
 >(
-    mutationOptions: UseMutationOptionsWithExtra<
-        TData,
-        TError,
-        TVariables,
-        TContext
-    >,
+    mutationOptions: UseMutationOptions<TData, TError, TVariables, TContext>,
 ): UseMutationOptions<TData, TError, TVariables, TContext> => {
     const { formatMessage } = useSafeIntl();
+
+    const meta = (mutationOptions.meta ?? {}) as MutationMeta;
+
     const {
         snackSuccessMessage = MESSAGES.defaultMutationApiSuccess,
         snackErrorMsg = MESSAGES.defaultMutationApiError,
         showSuccessSnackBar = true,
         ignoreErrorCodes = [],
         useApiErrorMessage = false,
+        successSnackBar = msg => succesfullSnackBar(undefined, msg),
+    } = meta;
+
+    const {
         onSuccess: optionsOnSuccess,
         onError: optionsOnError,
-        successSnackBar = msg => succesfullSnackBar(undefined, msg),
         ...newMutationOptions
     } = mutationOptions;
 
     return {
         onError: (error, variables, context) => {
             if (isApiError(error) && !ignoreErrorCodes.includes(error.status)) {
-                let errorMsg = snackErrorMsg;
+                let errorMsg = formatMessage(snackErrorMsg);
 
                 if (error.status === 403) {
                     if (error.details.detail) {
@@ -76,20 +73,18 @@ export const useCustomMutationOptions = <
 
                 openSnackBar(errorSnackBar(undefined, errorMsg, error));
             }
-            if (optionsOnError) {
-                return optionsOnError(error, variables, context);
-            }
-            return undefined;
+
+            return optionsOnError?.(error, variables, context);
         },
+
         onSuccess: (data, variables, context) => {
             if (snackSuccessMessage && showSuccessSnackBar) {
                 openSnackBar(successSnackBar(snackSuccessMessage));
             }
-            if (optionsOnSuccess) {
-                return optionsOnSuccess(data, variables, context);
-            }
-            return undefined;
+
+            return optionsOnSuccess?.(data, variables, context);
         },
+
         ...newMutationOptions,
     };
 };

--- a/hat/assets/js/orval/mutator/custom-query-options.ts
+++ b/hat/assets/js/orval/mutator/custom-query-options.ts
@@ -9,33 +9,31 @@ const isApiError = (error: unknown): error is ApiError => {
     return typeof error === 'object' && error !== null && 'status' in error;
 };
 
-type UseQueryOptions<TOptions, TError> = TOptions & {
+type QueryMeta = {
     dispatchOnError?: boolean;
     ignoreErrorCodes?: number[];
     snackErrorMsg?: IntlMessage;
-    onError?: (error: TError) => void;
 };
 
 export const getCustomQueryOptions = <TOptions, TError>(
-    options: UseQueryOptions<TOptions, TError>,
-): Omit<
-    UseQueryOptions<TOptions, TError>,
-    'dispatchOnError' | 'ignoreErrorCodes' | 'snackErrorMsg'
-> => {
+    options: TOptions,
+): TOptions => {
     // workaround for orval not injecting overrides when using a custom query
-    // see orval.config overrides commented out line
     const defaults =
         // @ts-ignore
         (OperationConfig?.operations?.[options?.queryKey?.[0]]?.query
-            ?.options as UseQueryOptions<TOptions, TError>) ?? {};
+            ?.options as TOptions) ?? {};
+
+    const meta = ((options as any)?.meta ?? {}) as QueryMeta;
 
     const {
         dispatchOnError = true,
         ignoreErrorCodes,
         snackErrorMsg = MESSAGES.defaultQueryApiSuccess,
-        onError: optionsOnError,
-        ...newOptions
-    } = options;
+    } = meta;
+
+    const optionsOnError = (options as any).onError;
+
     return {
         onError: (error: TError) => {
             if (
@@ -45,11 +43,10 @@ export const getCustomQueryOptions = <TOptions, TError>(
             ) {
                 openSnackBar(errorSnackBar(undefined, snackErrorMsg, error));
             }
-            if (optionsOnError) {
-                optionsOnError(error);
-            }
+
+            optionsOnError?.(error);
         },
         ...defaults,
-        ...(newOptions as TOptions),
-    } as const;
+        ...(options as object),
+    } as TOptions;
 };


### PR DESCRIPTION
## What problem is this PR solving?

orval custom query and mutation options were not TS compliants (see ticket example)

### Related JIRA tickets

IA-5168

## Changes

Moving the custom options to the meta field and adapting code. 

## How to test

Can't really, but this code doesn't throw a TS error anymore 
```typescript
const { mutateAsync: saveAIApiKey } = useApiAccountsAiApiKeyUpdate({
        mutation: {
            onSuccess: () => closeDialog(),
            meta: {
                ignoreErrorCodes: [400],
            },
        },
    });
```
