### PR TITLE
[IA-5229] [IA-5228]: Forbid node deletion and move action if running/past processes. Fix the impossibility to clear user roles when editing node

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/validationWorkflowsConfiguration/components/CreateEditNode/CreateEditNode.tsx
+++ b/hat/assets/js/apps/Iaso/domains/validationWorkflowsConfiguration/components/CreateEditNode/CreateEditNode.tsx
@@ -61,8 +61,7 @@ export const CreateEditNode: FunctionComponent<Props> = ({
     });
     const handleChangeUserRoles = useCallback(
         (_: string, newValue: string) => {
-            const value =
-                newValue && newValue.length > 0 ? newValue : undefined;
+            const value = newValue && newValue.length > 0 ? newValue : [];
             formik.setFieldTouched('roles_required', true);
             formik.setFieldValue('roles_required', value);
         },

--- a/hat/assets/js/apps/Iaso/domains/validationWorkflowsConfiguration/config.tsx
+++ b/hat/assets/js/apps/Iaso/domains/validationWorkflowsConfiguration/config.tsx
@@ -107,7 +107,10 @@ export const useWorkflowsTableColumns = (): Column[] => {
     }, [formatMessage, user, deleteWorkflow]);
 };
 
-export const useWorkflowNodesColumns = (workFlowSlug?: string) => {
+export const useWorkflowNodesColumns = (
+    workFlowSlug?: string,
+    hasProcesses?: boolean,
+) => {
     const { formatMessage } = useSafeIntl();
     const user = useCurrentUser();
     const { mutate: deleteNode } = useDeleteNode();
@@ -154,23 +157,25 @@ export const useWorkflowNodesColumns = (workFlowSlug?: string) => {
                                 nodeSlug={value}
                                 iconProps={{}}
                             />
-                            <DeleteModal
-                                key={`${workFlowSlug}${value}`}
-                                type="icon"
-                                titleMessage={MESSAGES.deleteNodeQuestion}
-                                onConfirm={() =>
-                                    deleteNode({
-                                        workflowSlug: workFlowSlug,
-                                        nodeSlug: value,
-                                    })
-                                }
-                                backdropClick
-                            />
+                            {!hasProcesses && (
+                                <DeleteModal
+                                    key={`${workFlowSlug}${value}`}
+                                    type="icon"
+                                    titleMessage={MESSAGES.deleteNodeQuestion}
+                                    onConfirm={() =>
+                                        deleteNode({
+                                            workflowSlug: workFlowSlug,
+                                            nodeSlug: value,
+                                        })
+                                    }
+                                    backdropClick
+                                />
+                            )}
                         </>
                     );
                 },
             });
         }
         return cols;
-    }, [deleteNode, formatMessage, user, workFlowSlug]);
+    }, [deleteNode, formatMessage, user, workFlowSlug, hasProcesses]);
 };

--- a/hat/assets/js/apps/Iaso/domains/validationWorkflowsConfiguration/details.tsx
+++ b/hat/assets/js/apps/Iaso/domains/validationWorkflowsConfiguration/details.tsx
@@ -72,7 +72,10 @@ export const ValidationWorkflowConfigurationDetail = () => {
         }));
         return saveOrder(itemsForApi).then(() => setIsOrderChanged(false));
     }, [items, saveOrder, setIsOrderChanged]);
-    const columns = useWorkflowNodesColumns(workflow?.slug);
+    const columns = useWorkflowNodesColumns(
+        workflow?.slug,
+        workflow?.has_processes,
+    );
     const title = workflow?.name
         ? `${formatMessage(MESSAGES.configureInstancesValidation)}: ${workflow.name}`
         : formatMessage(MESSAGES.addInstancesValidationWorkflow);
@@ -108,36 +111,42 @@ export const ValidationWorkflowConfigurationDetail = () => {
                         items={items}
                         onChange={handleSortChange}
                         columns={columns as ColumnWithAccessor[]}
+                        disabled={workflow?.has_processes}
                     />
-                    <Box m={2} textAlign="right">
-                        <Box display="inline-block" mr={2}>
-                            <Button
-                                color="primary"
-                                disabled={!isOrderChanged}
-                                data-test="reset-follow-up-order"
-                                onClick={handleResetOrder}
-                                variant="contained"
-                            >
-                                {formatMessage(MESSAGES.resetOrder)}
-                            </Button>
-                        </Box>
+                    {!workflow?.has_processes && (
+                        <Box m={2} textAlign="right">
+                            <Box display="inline-block" mr={2}>
+                                <Button
+                                    color="primary"
+                                    disabled={!isOrderChanged}
+                                    data-test="reset-follow-up-order"
+                                    onClick={handleResetOrder}
+                                    variant="contained"
+                                >
+                                    {formatMessage(MESSAGES.resetOrder)}
+                                </Button>
+                            </Box>
 
-                        <Box display="inline-block" mr={2}>
-                            <Button
-                                color="primary"
-                                disabled={!isOrderChanged}
-                                data-test="save-follow-up-order"
-                                onClick={saveItems}
-                                variant="contained"
-                            >
-                                {formatMessage(MESSAGES.saveOrder)}
-                            </Button>
+                            <Box display="inline-block" mr={2}>
+                                <Button
+                                    color="primary"
+                                    disabled={!isOrderChanged}
+                                    data-test="save-follow-up-order"
+                                    onClick={saveItems}
+                                    variant="contained"
+                                >
+                                    {formatMessage(MESSAGES.saveOrder)}
+                                </Button>
+                            </Box>
+
+                            <AddNode
+                                workflowSlug={workflow?.slug ?? ''}
+                                iconProps={{
+                                    disabled: !Boolean(workflow?.slug),
+                                }}
+                            />
                         </Box>
-                        <AddNode
-                            workflowSlug={workflow?.slug ?? ''}
-                            iconProps={{ disabled: !Boolean(workflow?.slug) }}
-                        />
-                    </Box>
+                    )}
                 </WidgetPaper>
             </Box>
         </>

--- a/hat/assets/js/apps/Iaso/domains/validationWorkflowsConfiguration/types/validationWorkflows.ts
+++ b/hat/assets/js/apps/Iaso/domains/validationWorkflowsConfiguration/types/validationWorkflows.ts
@@ -38,6 +38,7 @@ export type ValidationWorkflowRetrieveResponseItem = {
     created_at: string;
     updated_at: string;
     node_templates?: NestedNodeTemplate[];
+    has_processes: boolean;
 };
 
 export type ValidationWorkflowRetrieveResponseItemWithOrderedNodes = Omit<

--- a/iaso/api/validation_workflows/serializers/retrieve.py
+++ b/iaso/api/validation_workflows/serializers/retrieve.py
@@ -29,6 +29,9 @@ class ValidationWorkflowRetrieveSerializer(ModelSerializer):
 
     forms = NestedFormSerializer(many=True, read_only=True, source="form_set", allow_null=True)
     node_templates = serializers.SerializerMethodField(read_only=True, allow_null=True)
+    has_processes = serializers.BooleanField(
+        read_only=True, help_text="True if the workflow has past or ongoing validation processes"
+    )
 
     class Meta:
         model = ValidationWorkflow
@@ -42,6 +45,7 @@ class ValidationWorkflowRetrieveSerializer(ModelSerializer):
             "created_at",
             "updated_at",
             "node_templates",
+            "has_processes",
         ]
 
     @extend_schema_field(NestedValidationNodeTemplateSerializer(many=True, allow_null=True))

--- a/iaso/api/validation_workflows/views.py
+++ b/iaso/api/validation_workflows/views.py
@@ -1,4 +1,4 @@
-from django.db.models import Count, Q
+from django.db.models import Count, Exists, OuterRef, Prefetch, Q
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import extend_schema
 from rest_framework import permissions
@@ -17,7 +17,7 @@ from iaso.api.validation_workflows.serializers.dropdown import ValidationWorkflo
 from iaso.api.validation_workflows.serializers.list import ValidationWorkflowListSerializer
 from iaso.api.validation_workflows.serializers.retrieve import ValidationWorkflowRetrieveSerializer
 from iaso.api.validation_workflows.serializers.update import ValidationWorkflowUpdateSerializer
-from iaso.models import ValidationWorkflow
+from iaso.models import ValidationNode, ValidationNodeTemplate, ValidationWorkflow
 from iaso.modules import MODULE_VALIDATION_WORKFLOW
 
 
@@ -65,14 +65,23 @@ class ValidationWorkflowViewSet(ModelViewSet):
                 )
             )
         if self.action == "retrieve":
-            qs = qs.prefetch_related(
-                "node_templates",
-                "node_templates__next_node_templates",
-                "node_templates__previous_node_templates",
-                "form_set",
-                "node_templates__roles_required",
-                "node_templates__roles_required__group",
-            ).select_related("created_by", "updated_by")
+            qs = (
+                qs.prefetch_related(
+                    Prefetch(
+                        "node_templates",
+                        ValidationNodeTemplate.objects.prefetch_related(
+                            "next_node_templates", "previous_node_templates", "roles_required", "roles_required__group"
+                        ),
+                    ),
+                    "form_set",
+                )
+                .select_related("created_by", "updated_by")
+                .annotate(
+                    has_processes=Exists(
+                        ValidationNode.objects.filter(instance__form__validation_workflow=OuterRef("pk"))
+                    ),
+                )
+            )
         return qs
 
     @action(detail=False, methods=["get"])

--- a/iaso/tests/api/validation_workflows/test_views/test_retrieve.py
+++ b/iaso/tests/api/validation_workflows/test_views/test_retrieve.py
@@ -2,6 +2,7 @@ from django.contrib.auth.models import Group
 from django.urls import reverse
 from rest_framework import status
 
+from iaso.engine.validation_workflow import ValidationWorkflowEngine
 from iaso.models import Account, Form, Instance, Project, UserRole, ValidationNodeTemplate, ValidationWorkflow
 from iaso.tests.api.validation_workflows.test_views.common import BaseValidationWorkflowAPITestCase
 
@@ -20,8 +21,8 @@ class ValidationWorkflowAPIRetrieveTestCase(BaseValidationWorkflowAPITestCase):
         self.form.projects.add(self.project)
         self.form.save()
 
-        Instance.objects.create(name="instance", form=self.form)
-        Instance.objects.create(name="instance2", form=self.form)
+        self.instance = Instance.objects.create(name="instance", form=self.form)
+        self.instance_2 = Instance.objects.create(name="instance2", form=self.form)
 
         self.form_2 = Form.objects.create(name="form_2")
         self.form_2.projects.add(self.project)
@@ -109,6 +110,11 @@ class ValidationWorkflowAPIRetrieveTestCase(BaseValidationWorkflowAPITestCase):
         self.assertJSONResponse(res, status.HTTP_200_OK)
 
     def test_retrieve(self):
+        ValidationWorkflowEngine.start(self.validation_workflow, self.superuser, self.instance)
+        ValidationWorkflowEngine.complete_node(
+            self.instance.get_next_pending_nodes().first(), self.superuser, self.instance, True
+        )
+
         for user in [self.john_wick, self.superuser]:
             with self.subTest(f"with user {user}"):
                 self.client.force_authenticate(user)
@@ -129,6 +135,7 @@ class ValidationWorkflowAPIRetrieveTestCase(BaseValidationWorkflowAPITestCase):
                         "updated_by",
                         "updated_at",
                         "node_templates",
+                        "has_processes",
                     ]:
                         self.assertIn(k, res_data)
 
@@ -142,6 +149,7 @@ class ValidationWorkflowAPIRetrieveTestCase(BaseValidationWorkflowAPITestCase):
 
                     self.assertIsNotNone(res_data["forms"])
                     self.assertIsNotNone(res_data["node_templates"])
+                    self.assertTrue(res_data["has_processes"])
 
                 with self.subTest("checking forms"):
                     for form_value in res_data["forms"]:
@@ -181,6 +189,11 @@ class ValidationWorkflowAPIRetrieveTestCase(BaseValidationWorkflowAPITestCase):
                     )
 
     def test_num_queries(self):
+        ValidationWorkflowEngine.start(self.validation_workflow, self.superuser, self.instance)
+        ValidationWorkflowEngine.complete_node(
+            self.instance.get_next_pending_nodes(self.validation_workflow).first(), self.superuser, self.instance, True
+        )
+
         self.client.force_authenticate(self.john_wick)
         with self.assertNumQueries(10):
             res = self.client.get(


### PR DESCRIPTION
## What problem is this PR solving?

* Could not clear the user roles value when editing a validation node template
* Trying to delete a validation node with ongoing/past processes would raise a 500

### Related JIRA tickets

IA-5229 IA-5228

## Changes

* For user_roles: send an empty array instead of undefined value if null
* Added an has_processes field in retrieve api
  * The front end disables the add node, move and delete node actions if has_processes is True. It's a quick fix while awaiting for a proper way to handle this

