### PR TITLE
IA-5258: support SECRET_KEY rotation via SECRET_KEY_FALLBACKS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,9 @@
 # Minimum variables needed to run the application
 # ============================================================
 SECRET_KEY="secret"
+# Optional: old secret key(s) kept valid for signature verification while rotating
+# SECRET_KEY. Comma separated, e.g. SECRET_KEY_FALLBACKS="previous_secret"
+# SECRET_KEY_FALLBACKS=""
 
 ## DATABASE
 RDS_DB_NAME="iaso"

--- a/README.md
+++ b/README.md
@@ -816,6 +816,9 @@ DB_READONLY_USERNAME=
 # Used for encryption and authorisation
 ENCRYPTED_TEXT_FIELD_KEY=
 SECRET_KEY=
+# Old secret key(s) kept valid for signature verification while rotating SECRET_KEY
+# (comma separated). See "Rotating SECRET_KEY" below.
+SECRET_KEY_FALLBACKS=
 
 # To interact with Enketo/ODK
 ENKETO_API_TOKEN=
@@ -838,6 +841,21 @@ docker compose -f docker-compose.prod.yml up
 ```
 
 This will pull the necessary containers (iaso & nginx) and spin up the service at port 80.
+
+### Rotating SECRET_KEY
+
+`SECRET_KEY` signs sessions, password reset tokens and other signed data. Changing it
+naively logs every user out and invalidates outstanding tokens. To rotate it gracefully,
+use `SECRET_KEY_FALLBACKS`, which lists old keys Django still uses to *verify* (but not
+*sign*) signatures:
+
+1. Move the current `SECRET_KEY` value into `SECRET_KEY_FALLBACKS` (comma separated if
+   several old keys are kept).
+2. Set `SECRET_KEY` to the new value.
+3. Deploy. Existing sessions and tokens keep working because they are validated against
+   the fallback key, while new data is signed with the new key.
+4. Once the oldest signed data has expired (e.g. past `SESSION_COOKIE_AGE` /
+   `PASSWORD_RESET_TIMEOUT`), remove the old key from `SECRET_KEY_FALLBACKS`.
 
 
 ## System requirements

--- a/hat/settings.py
+++ b/hat/settings.py
@@ -73,6 +73,12 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = env.str("SECRET_KEY", default=None)
 
+# Old secret keys kept for signature verification only (not used to sign new values).
+# Set this to the previous SECRET_KEY(s) when rotating SECRET_KEY so that existing
+# sessions, password reset tokens and other signed data stay valid during the rollover.
+# Comma separated list of keys, e.g. SECRET_KEY_FALLBACKS=old_key_1,old_key_2
+SECRET_KEY_FALLBACKS = env.list("SECRET_KEY_FALLBACKS", default=[], delimiter=",")
+
 # SECURITY WARNING: keep the encryption key used in production secret!
 ENCRYPTED_TEXT_FIELD_KEY = env.str("ENCRYPTED_TEXT_FIELD_KEY", default=None)
 


### PR DESCRIPTION
## Jira
[IA-5258](https://bluesquare.atlassian.net/browse/IA-5258)

## What

Adds support for rotating IASO's Django `SECRET_KEY` without logging everyone out, by leveraging Django's built-in [`SECRET_KEY_FALLBACKS`](https://docs.djangoproject.com/en/stable/ref/settings/#std-setting-SECRET_KEY_FALLBACKS) setting.

- `hat/settings.py`: read a new `SECRET_KEY_FALLBACKS` env variable (comma-separated) into Django's `SECRET_KEY_FALLBACKS` setting. Defaults to an empty list — no behaviour change for existing deployments.
- `.env.example` and `README.md`: document the variable and the rotation procedure.

## Why

When `SECRET_KEY` changes, Django can no longer validate signatures produced with the old key, so all sessions, password-reset tokens and signed cookies become invalid. `SECRET_KEY_FALLBACKS` lists old keys Django still uses to *verify* (but not *sign*) signatures, enabling a graceful rollover.

## Rotation procedure

1. Move the current `SECRET_KEY` into `SECRET_KEY_FALLBACKS`.
2. Set `SECRET_KEY` to the new value.
3. Deploy — existing signed data stays valid, new data is signed with the new key.
4. Remove the old key from `SECRET_KEY_FALLBACKS` once outstanding signed data has expired.

## Tests

None — this is a thin wrapper that reads an env var into a built-in Django setting.

[IA-5258]: https://bluesquare.atlassian.net/browse/IA-5258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ