### PR TITLE
IA-5246 feat: add task monitoring

### DIFF
--- a/iaso/api/tasks/serializers.py
+++ b/iaso/api/tasks/serializers.py
@@ -66,11 +66,18 @@ class DeploymentStatusTaskSerializer(serializers.ModelSerializer):
         read_only_fields = fields
 
 
+class DeploymentStatusTaskGroupSerializer(serializers.Serializer):
+    name = serializers.CharField(read_only=True)
+    QUEUED = serializers.IntegerField(read_only=True)
+    RUNNING = serializers.IntegerField(read_only=True)
+    tasks = DeploymentStatusTaskSerializer(many=True, read_only=True)
+
+
 class DeploymentStatusSerializer(serializers.Serializer):
     can_deploy = serializers.BooleanField(read_only=True)
     blocking_tasks_count = serializers.IntegerField(read_only=True)
     statuses = serializers.DictField(child=serializers.IntegerField(), read_only=True)
-    blocking_tasks = DeploymentStatusTaskSerializer(many=True, read_only=True)
+    blocking_tasks = DeploymentStatusTaskGroupSerializer(many=True, read_only=True)
 
 
 class ExternalTaskSerializer(TaskSerializer):

--- a/iaso/api/tasks/serializers.py
+++ b/iaso/api/tasks/serializers.py
@@ -65,11 +65,13 @@ class DeploymentStatusTaskSerializer(serializers.ModelSerializer):
         fields = ["id", "name", "status", "created_at", "started_at", "launcher"]
         read_only_fields = fields
 
+
 class DeploymentStatusSerializer(serializers.Serializer):
     can_deploy = serializers.BooleanField(read_only=True)
     blocking_tasks_count = serializers.IntegerField(read_only=True)
     statuses = serializers.DictField(child=serializers.IntegerField(), read_only=True)
     blocking_tasks = DeploymentStatusTaskSerializer(many=True, read_only=True)
+
 
 class ExternalTaskSerializer(TaskSerializer):
     def update(self, task, validated_data):

--- a/iaso/api/tasks/serializers.py
+++ b/iaso/api/tasks/serializers.py
@@ -55,6 +55,22 @@ class TaskSerializer(serializers.ModelSerializer):
         return task
 
 
+class DeploymentStatusTaskSerializer(serializers.ModelSerializer):
+    launcher = serializers.CharField(source="launcher.username", allow_null=True)
+    created_at = TimestampField(read_only=True)
+    started_at = TimestampField(read_only=True)
+
+    class Meta:
+        model = Task
+        fields = ["id", "name", "status", "created_at", "started_at", "launcher"]
+        read_only_fields = fields
+
+class DeploymentStatusSerializer(serializers.Serializer):
+    can_deploy = serializers.BooleanField(read_only=True)
+    blocking_tasks_count = serializers.IntegerField(read_only=True)
+    statuses = serializers.DictField(child=serializers.IntegerField(), read_only=True)
+    blocking_tasks = DeploymentStatusTaskSerializer(many=True, read_only=True)
+
 class ExternalTaskSerializer(TaskSerializer):
     def update(self, task, validated_data):
         has_progress_message = validated_data.get("progress_message", None) is not None

--- a/iaso/api/tasks/views.py
+++ b/iaso/api/tasks/views.py
@@ -26,8 +26,14 @@ from iaso.permissions.core_permissions import CORE_DATA_TASKS_PERMISSION, CORE_P
 from iaso.utils.s3_client import generate_presigned_url_from_s3
 
 from ...models import TaskLog
-from .serializers import ExternalTaskPostSerializer, ExternalTaskSerializer, TaskLogSerializer, TaskSerializer, \
-    DeploymentStatusSerializer
+from .serializers import (
+    DeploymentStatusSerializer,
+    ExternalTaskPostSerializer,
+    ExternalTaskSerializer,
+    TaskLogSerializer,
+    TaskSerializer,
+)
+
 
 task_service = LazyService("BACKGROUND_TASK_SERVICE")
 logger = logging.getLogger(__name__)

--- a/iaso/api/tasks/views.py
+++ b/iaso/api/tasks/views.py
@@ -2,7 +2,6 @@ import logging
 
 import django_filters
 
-from django.db.models import Count
 from django.shortcuts import get_object_or_404
 from drf_spectacular.utils import extend_schema
 from gql import Client, gql
@@ -37,6 +36,7 @@ from .serializers import (
 
 task_service = LazyService("BACKGROUND_TASK_SERVICE")
 logger = logging.getLogger(__name__)
+DEPLOYMENT_BLOCKING_STATUSES = [QUEUED, RUNNING]
 
 
 @extend_schema(tags=["Tasks"])
@@ -80,7 +80,7 @@ class TaskSourceViewSet(ModelViewSet):
 
     def get_queryset(self):
         if self.action == "deployment_status":
-            return Task.objects.select_related("launcher").filter(status__in=[QUEUED, RUNNING])
+            return Task.objects.select_related("launcher").filter(status__in=DEPLOYMENT_BLOCKING_STATUSES)
         profile = self.request.user.iaso_profile
         return Task.objects.select_related("created_by", "launcher").filter(account=profile.account)
 
@@ -168,24 +168,35 @@ class TaskSourceViewSet(ModelViewSet):
         url_path="deployment-status",
     )
     def deployment_status(self, request):
-        if not request.user.is_superuser:
+        if not request.user.is_superuser or not request.user.is_staff:
             return Response(status=status.HTTP_403_FORBIDDEN)
 
-        blocking_statuses = [QUEUED, RUNNING]
         blocking_tasks = self.filter_queryset(self.get_queryset())
 
-        statuses = {status: 0 for status in blocking_statuses}
-        for status_count in blocking_tasks.values("status").annotate(count=Count("id")):
-            statuses[status_count["status"]] = status_count["count"]
+        statuses = dict.fromkeys(DEPLOYMENT_BLOCKING_STATUSES, 0)
 
-        blocking_tasks_count = blocking_tasks.count()
+        blocking_tasks_by_name = {}
+        for task in blocking_tasks:
+            statuses[task.status] += 1
+            if task.name not in blocking_tasks_by_name:
+                blocking_tasks_by_name[task.name] = {
+                    "name": task.name,
+                    QUEUED: 0,
+                    RUNNING: 0,
+                    "tasks": [],
+                }
+            group = blocking_tasks_by_name[task.name]
+            group[task.status] += 1
+            group["tasks"].append(task)
+
+        blocking_tasks_count = sum(statuses.values())
 
         serializer = DeploymentStatusSerializer(
             {
                 "can_deploy": blocking_tasks_count == 0,
                 "blocking_tasks_count": blocking_tasks_count,
                 "statuses": statuses,
-                "blocking_tasks": blocking_tasks,
+                "blocking_tasks": list(blocking_tasks_by_name.values()),
             }
         )
         return Response(serializer.data)

--- a/iaso/api/tasks/views.py
+++ b/iaso/api/tasks/views.py
@@ -2,6 +2,7 @@ import logging
 
 import django_filters
 
+from django.db.models import Count
 from django.shortcuts import get_object_or_404
 from drf_spectacular.utils import extend_schema
 from gql import Client, gql
@@ -25,8 +26,8 @@ from iaso.permissions.core_permissions import CORE_DATA_TASKS_PERMISSION, CORE_P
 from iaso.utils.s3_client import generate_presigned_url_from_s3
 
 from ...models import TaskLog
-from .serializers import ExternalTaskPostSerializer, ExternalTaskSerializer, TaskLogSerializer, TaskSerializer
-
+from .serializers import ExternalTaskPostSerializer, ExternalTaskSerializer, TaskLogSerializer, TaskSerializer, \
+    DeploymentStatusSerializer
 
 task_service = LazyService("BACKGROUND_TASK_SERVICE")
 logger = logging.getLogger(__name__)
@@ -151,6 +152,35 @@ class TaskSourceViewSet(ModelViewSet):
         available_types = Task.objects.order_by("name").values_list("name", flat=True).distinct("name")
 
         return Response(available_types)
+
+    @extend_schema(responses=DeploymentStatusSerializer)
+    @action(
+        detail=False,
+        methods=["get"],
+        url_path="deployment-status",
+    )
+    def deployment_status(self, request):
+        if not request.user.is_superuser:
+            return Response(status=status.HTTP_403_FORBIDDEN)
+
+        blocking_statuses = [QUEUED, RUNNING]
+        blocking_tasks = Task.objects.filter(status__in=blocking_statuses).select_related("launcher")
+
+        statuses = {status: 0 for status in blocking_statuses}
+        for status_count in blocking_tasks.values("status").annotate(count=Count("id")):
+            statuses[status_count["status"]] = status_count["count"]
+
+        blocking_tasks_count = blocking_tasks.count()
+
+        serializer = DeploymentStatusSerializer(
+            {
+                "can_deploy": blocking_tasks_count == 0,
+                "blocking_tasks_count": blocking_tasks_count,
+                "statuses": statuses,
+                "blocking_tasks": blocking_tasks,
+            }
+        )
+        return Response(serializer.data)
 
 
 class ExternalTaskModelViewSet(ModelViewSet):

--- a/iaso/api/tasks/views.py
+++ b/iaso/api/tasks/views.py
@@ -73,6 +73,8 @@ class TaskSourceViewSet(ModelViewSet):
     http_method_names = ["get", "patch", "head", "options", "trace"]
 
     def get_queryset(self):
+        if self.action == "deployment_status":
+            return Task.objects.select_related("launcher").filter(status__in=[QUEUED, RUNNING])
         profile = self.request.user.iaso_profile
         return Task.objects.select_related("created_by", "launcher").filter(account=profile.account)
 
@@ -164,7 +166,7 @@ class TaskSourceViewSet(ModelViewSet):
             return Response(status=status.HTTP_403_FORBIDDEN)
 
         blocking_statuses = [QUEUED, RUNNING]
-        blocking_tasks = Task.objects.filter(status__in=blocking_statuses).select_related("launcher")
+        blocking_tasks = self.filter_queryset(self.get_queryset())
 
         statuses = {status: 0 for status in blocking_statuses}
         for status_count in blocking_tasks.values("status").annotate(count=Count("id")):

--- a/iaso/tests/api/test_tasks.py
+++ b/iaso/tests/api/test_tasks.py
@@ -144,7 +144,20 @@ class IasoTasksTestCase(APITestCase):
             account=cls.account,
             permissions=[CORE_DATA_TASKS_PERMISSION],
             is_superuser=True,
+            is_staff=True,
         )
+
+    @staticmethod
+    def get_deployment_task_group(data, task_name):
+        return next(task_group for task_group in data["blocking_tasks"] if task_group["name"] == task_name)
+
+    @staticmethod
+    def get_deployment_task(data, task_id):
+        for task_group in data["blocking_tasks"]:
+            for task in task_group["tasks"]:
+                if task["id"] == task_id:
+                    return task
+        raise AssertionError(f"Task {task_id} not found in deployment status response")
 
     def test_tasks_user_without_permissions_access(self):
         self.client.force_authenticate(self.miguel)
@@ -406,24 +419,21 @@ class IasoTasksTestCase(APITestCase):
         self.assertEqual(data["can_deploy"], False)
         self.assertEqual(data["blocking_tasks_count"], 2)
         self.assertEqual(data["statuses"], {QUEUED: 1, RUNNING: 1})
-        self.assertNotIn("params", data)
 
-        blocking_tasks_by_id = {task["id"]: task for task in data["blocking_tasks"]}
-        self.assertEqual(set(blocking_tasks_by_id.keys()), {queued_task.id, running_task.id})
+        queued_task_group = self.get_deployment_task_group(data, "queued_task")
+        running_task_group = self.get_deployment_task_group(data, "running_task_from_another_account")
 
-        self.assertEqual(
-            set(blocking_tasks_by_id[queued_task.id].keys()),
-            {"id", "name", "status", "created_at", "started_at", "launcher"},
-        )
-        self.assertEqual(blocking_tasks_by_id[queued_task.id]["name"], "queued_task")
-        self.assertEqual(blocking_tasks_by_id[queued_task.id]["status"], QUEUED)
-        self.assertEqual(blocking_tasks_by_id[queued_task.id]["launcher"], "johnny")
-        self.assertIsNone(blocking_tasks_by_id[queued_task.id]["started_at"])
+        self.assertEqual(queued_task_group[QUEUED], 1)
+        self.assertEqual(running_task_group[RUNNING], 1)
 
-        self.assertEqual(blocking_tasks_by_id[running_task.id]["name"], "running_task_from_another_account")
-        self.assertEqual(blocking_tasks_by_id[running_task.id]["status"], RUNNING)
-        self.assertEqual(blocking_tasks_by_id[running_task.id]["launcher"], "daniel")
-        self.assertEqual(blocking_tasks_by_id[running_task.id]["started_at"], running_task.started_at.timestamp())
+        queued_task_data = self.get_deployment_task(data, queued_task.id)
+        running_task_data = self.get_deployment_task(data, running_task.id)
+
+        self.assertNotIn("params", queued_task_data)
+        self.assertNotIn("params", running_task_data)
+
+        self.assertEqual(queued_task_data["launcher"], "johnny")
+        self.assertEqual(running_task_data["launcher"], "daniel")
 
     def test_deployment_status_filters_blocking_tasks(self):
         self.client.force_authenticate(self.superuser)
@@ -471,7 +481,26 @@ class IasoTasksTestCase(APITestCase):
         self.assertEqual(data["can_deploy"], False)
         self.assertEqual(data["blocking_tasks_count"], 1)
         self.assertEqual(data["statuses"], {QUEUED: 0, RUNNING: 1})
-        self.assertEqual([task["id"] for task in data["blocking_tasks"]], [matching_task.id])
+        self.assertEqual(
+            data["blocking_tasks"],
+            [
+                {
+                    "name": "running_task",
+                    QUEUED: 0,
+                    RUNNING: 1,
+                    "tasks": [
+                        {
+                            "id": matching_task.id,
+                            "name": "running_task",
+                            "status": RUNNING,
+                            "created_at": matching_task.created_at.timestamp(),
+                            "started_at": matching_task.started_at.timestamp(),
+                            "launcher": "miguel",
+                        }
+                    ],
+                }
+            ],
+        )
 
     def test_deployment_status_requires_superuser(self):
         response = self.client.get("/api/tasks/deployment-status/")
@@ -488,6 +517,16 @@ class IasoTasksTestCase(APITestCase):
             is_staff=True,
         )
         self.client.force_authenticate(staff_user)
+        response = self.client.get("/api/tasks/deployment-status/")
+        self.assertEqual(response.status_code, 403)
+
+        superuser_without_staff = self.create_user_with_profile(
+            username="superuser_without_staff",
+            account=self.account,
+            permissions=[CORE_DATA_TASKS_PERMISSION],
+            is_superuser=True,
+        )
+        self.client.force_authenticate(superuser_without_staff)
         response = self.client.get("/api/tasks/deployment-status/")
         self.assertEqual(response.status_code, 403)
 

--- a/iaso/tests/api/test_tasks.py
+++ b/iaso/tests/api/test_tasks.py
@@ -139,6 +139,12 @@ class IasoTasksTestCase(APITestCase):
             username="johnny", account=cls.account, permissions=[CORE_DATA_TASKS_PERMISSION]
         )
         cls.miguel = cls.create_user_with_profile(username="miguel", account=cls.account, permissions=[])
+        cls.superuser = cls.create_user_with_profile(
+            username="superuser",
+            account=cls.account,
+            permissions=[CORE_DATA_TASKS_PERMISSION],
+            is_superuser=True,
+        )
 
     def test_tasks_user_without_permissions_access(self):
         self.client.force_authenticate(self.miguel)
@@ -334,6 +340,112 @@ class IasoTasksTestCase(APITestCase):
         )
         task_ids = [t["id"] for t in response.json()["tasks"]]
         self.assertEqual(task_ids, [task_5.id])
+
+    def test_deployment_status_without_blocking_tasks(self):
+        self.client.force_authenticate(self.superuser)
+
+        for task_status in [SUCCESS, ERRORED, EXPORTED]:
+            m.Task.objects.create(
+                account=self.account,
+                created_by=self.johnny,
+                launcher=self.johnny,
+                status=task_status,
+                name=f"task_{task_status.lower()}",
+                params={"password": "secret"},
+            )
+
+        response = self.client.get("/api/tasks/deployment-status/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            {
+                "can_deploy": True,
+                "blocking_tasks_count": 0,
+                "statuses": {QUEUED: 0, RUNNING: 0},
+                "blocking_tasks": [],
+            },
+        )
+
+    def test_deployment_status_with_blocking_tasks_is_global_and_hides_params(self):
+        self.client.force_authenticate(self.superuser)
+
+        other_account = m.Account.objects.create(name="Other account", default_version=self.new_version)
+        other_user = self.create_user_with_profile(username="daniel", account=other_account)
+
+        queued_task = m.Task.objects.create(
+            account=self.account,
+            created_by=self.johnny,
+            launcher=self.johnny,
+            status=QUEUED,
+            name="queued_task",
+            params={"password": "secret"},
+        )
+        running_task = m.Task.objects.create(
+            account=other_account,
+            created_by=other_user,
+            launcher=other_user,
+            status=RUNNING,
+            name="running_task_from_another_account",
+            started_at=datetime.datetime(2024, 1, 20, 15, 0, 0, 0, tzinfo=timezone.utc),
+            params={"password": "other-secret"},
+        )
+        m.Task.objects.create(
+            account=self.account,
+            created_by=self.johnny,
+            launcher=self.johnny,
+            status=SUCCESS,
+            name="non_blocking_task",
+            params={"password": "secret"},
+        )
+
+        response = self.client.get("/api/tasks/deployment-status/")
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["can_deploy"], False)
+        self.assertEqual(data["blocking_tasks_count"], 2)
+        self.assertEqual(data["statuses"], {QUEUED: 1, RUNNING: 1})
+        self.assertNotIn("params", data)
+
+        blocking_tasks_by_id = {task["id"]: task for task in data["blocking_tasks"]}
+        self.assertEqual(set(blocking_tasks_by_id.keys()), {queued_task.id, running_task.id})
+
+        self.assertEqual(
+            set(blocking_tasks_by_id[queued_task.id].keys()),
+            {"id", "name", "status", "created_at", "started_at", "launcher"},
+        )
+        self.assertEqual(blocking_tasks_by_id[queued_task.id]["name"], "queued_task")
+        self.assertEqual(blocking_tasks_by_id[queued_task.id]["status"], QUEUED)
+        self.assertEqual(blocking_tasks_by_id[queued_task.id]["launcher"], "johnny")
+        self.assertIsNone(blocking_tasks_by_id[queued_task.id]["started_at"])
+
+        self.assertEqual(blocking_tasks_by_id[running_task.id]["name"], "running_task_from_another_account")
+        self.assertEqual(blocking_tasks_by_id[running_task.id]["status"], RUNNING)
+        self.assertEqual(blocking_tasks_by_id[running_task.id]["launcher"], "daniel")
+        self.assertEqual(blocking_tasks_by_id[running_task.id]["started_at"], running_task.started_at.timestamp())
+
+    def test_deployment_status_requires_superuser(self):
+        response = self.client.get("/api/tasks/deployment-status/")
+        self.assertEqual(response.status_code, 401)
+
+        self.client.force_authenticate(self.johnny)
+        response = self.client.get("/api/tasks/deployment-status/")
+        self.assertEqual(response.status_code, 403)
+
+        staff_user = self.create_user_with_profile(
+            username="staff",
+            account=self.account,
+            permissions=[CORE_DATA_TASKS_PERMISSION],
+            is_staff=True,
+        )
+        self.client.force_authenticate(staff_user)
+        response = self.client.get("/api/tasks/deployment-status/")
+        self.assertEqual(response.status_code, 403)
+
+        self.client.force_authenticate(self.superuser)
+        response = self.client.get("/api/tasks/deployment-status/")
+        self.assertEqual(response.status_code, 200)
 
     def test_logs_not_found(self):
         self.client.force_authenticate(self.johnny)

--- a/iaso/tests/api/test_tasks.py
+++ b/iaso/tests/api/test_tasks.py
@@ -425,6 +425,54 @@ class IasoTasksTestCase(APITestCase):
         self.assertEqual(blocking_tasks_by_id[running_task.id]["launcher"], "daniel")
         self.assertEqual(blocking_tasks_by_id[running_task.id]["started_at"], running_task.started_at.timestamp())
 
+    def test_deployment_status_filters_blocking_tasks(self):
+        self.client.force_authenticate(self.superuser)
+
+        m.Task.objects.create(
+            account=self.account,
+            created_by=self.johnny,
+            launcher=self.johnny,
+            status=QUEUED,
+            name="queued_task",
+            started_at=datetime.datetime(2024, 1, 20, 15, 0, 0, 0, tzinfo=timezone.utc),
+        )
+        matching_task = m.Task.objects.create(
+            account=self.account,
+            created_by=self.miguel,
+            launcher=self.miguel,
+            status=RUNNING,
+            name="running_task",
+            started_at=datetime.datetime(2024, 1, 20, 15, 0, 0, 0, tzinfo=timezone.utc),
+        )
+        m.Task.objects.create(
+            account=self.account,
+            created_by=self.miguel,
+            launcher=self.miguel,
+            status=RUNNING,
+            name="other_running_task",
+            started_at=datetime.datetime(2024, 2, 20, 15, 0, 0, 0, tzinfo=timezone.utc),
+        )
+        m.Task.objects.create(
+            account=self.account,
+            created_by=self.miguel,
+            launcher=self.miguel,
+            status=SUCCESS,
+            name="running_task",
+            started_at=datetime.datetime(2024, 1, 20, 15, 0, 0, 0, tzinfo=timezone.utc),
+        )
+
+        response = self.client.get(
+            f"/api/tasks/deployment-status/?status=RUNNING&task_type=running_task&users={self.miguel.id}"
+            "&start_date=19-01-2024&end_date=21-01-2024"
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["can_deploy"], False)
+        self.assertEqual(data["blocking_tasks_count"], 1)
+        self.assertEqual(data["statuses"], {QUEUED: 0, RUNNING: 1})
+        self.assertEqual([task["id"] for task in data["blocking_tasks"]], [matching_task.id])
+
     def test_deployment_status_requires_superuser(self):
         response = self.client.get("/api/tasks/deployment-status/")
         self.assertEqual(response.status_code, 401)


### PR DESCRIPTION
## What problem is this PR solving?

Prevent deployments from interrupting queued or running background tasks.

### Related JIRA tickets

IA-5246

## Changes

Adds a `GET /api/tasks/deployment-status/` endpoint on the existing tasks API.

The endpoint returns whether deployment is currently safe based on global `QUEUED` and `RUNNING` tasks. It reuses the existing task filters where relevant and returns a compact response without sensitive task params.

Access is restricted to authenticated superusers for now.

## How to test

Run:

make test TARGET=iaso.tests.api.test_tasks.IasoTasksTestCase
```bash
docker compose exec iaso ./manage.py test iaso.tests.api.test_tasks.IasoTasksTestCase
```
Optional manual check:
```bash
GET /api/tasks/deployment-status/
```
You should have this result ⬇️ if there are not any task in RUNNING or QUEUED 
## Print screen / video

<img width="3840" height="2160" alt="Capture d’écran du 2026-06-22 11-48-51" src="https://github.com/user-attachments/assets/304f6d79-b34f-42b0-919a-ec3ca884562c" />

<img width="1425" height="1000" alt="Capture d’écran du 2026-06-22 14-25-11" src="https://github.com/user-attachments/assets/19127859-dc1b-453b-80c9-e85a678c437c" />

