### PR TITLE
POLIO-2154: fix on hold filter and styling

### DIFF
--- a/hat/assets/js/apps/Iaso/components/Buttons/XslxButton.tsx
+++ b/hat/assets/js/apps/Iaso/components/Buttons/XslxButton.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, ReactElement } from 'react';
+import React, { FunctionComponent, ReactNode } from 'react';
 import { Button } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import ExcellSvg from '../svg/ExcellSvgComponent';
@@ -6,7 +6,7 @@ import ExcellSvg from '../svg/ExcellSvgComponent';
 type Props = {
     xlsxUrl: string;
     variant?: 'contained' | 'outlined' | 'text';
-    children?: ReactElement;
+    children?: ReactNode;
     disabled?: boolean;
 };
 

--- a/plugins/polio/api/calendar/filter.py
+++ b/plugins/polio/api/calendar/filter.py
@@ -5,7 +5,7 @@ from logging import getLogger
 from django.db.models import Q
 from rest_framework import filters
 
-from plugins.polio.api.campaigns.filters.filters import CampaignFilterV2
+from plugins.polio.api.campaigns.filters.filters import CampaignFilter
 
 
 logger = getLogger(__name__)
@@ -58,7 +58,7 @@ class CalendarPeriodFilterBackend(filters.BaseFilterBackend):
         return queryset
 
 
-class CalendarFilter(CampaignFilterV2):
+class CalendarFilter(CampaignFilter):
     pass
 
 

--- a/plugins/polio/api/calendar/filter.py
+++ b/plugins/polio/api/calendar/filter.py
@@ -3,6 +3,7 @@ import datetime
 from logging import getLogger
 
 from django.db.models import Q
+from django.utils import timezone
 from rest_framework import filters
 
 from plugins.polio.api.campaigns.filters.filters import CampaignFilter
@@ -41,11 +42,11 @@ class CalendarPeriodFilterBackend(filters.BaseFilterBackend):
             reference_date = (
                 datetime.datetime.strptime(reference_date, "%Y-%m-%d").date()
                 if reference_date
-                else datetime.datetime.now().date()
+                else timezone.localdate()
             )
         except Exception:
             logger.warning("Error parsing reference date, defaulting to current date")
-            reference_date = datetime.datetime.now()
+            reference_date = timezone.localdate()
         if period_type not in [QUARTER, SEMESTER, YEAR]:
             logger.warning(f"Invalid period type: {period_type}, defaulting to {QUARTER}")
             period_type = QUARTER

--- a/plugins/polio/api/calendar/serializers.py
+++ b/plugins/polio/api/calendar/serializers.py
@@ -95,13 +95,13 @@ class CalendarCampaignSerializerV2(serializers.ModelSerializer):
         return SubactivitySerializer(sub_activities, many=True, context=self.context).data
 
     def get_general_status(self, campaign):
-        now_utc = timezone.now().date()
+        today = timezone.localdate()
         ordered_rounds = list(campaign.rounds.all())
         ordered_rounds.sort(key=lambda x: x.number, reverse=True)
         for round in ordered_rounds:
-            if round.ended_at and now_utc > round.ended_at:
+            if round.ended_at and today > round.ended_at:
                 return _("Round {} ended").format(round.number)
-            if round.started_at and now_utc >= round.started_at:
+            if round.started_at and today >= round.started_at:
                 return _("Round {} started").format(round.number)
         return _("Preparing")
 

--- a/plugins/polio/api/campaigns/filters/filters.py
+++ b/plugins/polio/api/campaigns/filters/filters.py
@@ -1,6 +1,9 @@
+from datetime import datetime
+
 import django_filters
 
-from django.db.models import Exists, OuterRef, Q, QuerySet
+from django.db.models import BooleanField, OuterRef, Q, QuerySet, Subquery, Value
+from django.db.models.functions import Coalesce
 from django.utils.translation import gettext_lazy as _
 
 from iaso.models import OrgUnit, OrgUnitType
@@ -25,7 +28,7 @@ def search_queryset(queryset, value):
     return queryset
 
 
-class CampaignFilterV2(django_filters.rest_framework.FilterSet):
+class CampaignFilter(django_filters.rest_framework.FilterSet):
     class Meta:
         model = Campaign
         fields = {
@@ -76,11 +79,19 @@ class CampaignFilterV2(django_filters.rest_framework.FilterSet):
 
         Individual filters for each boolean would make more sense, but that would require some UI design first
         """
-        rounds_on_hold = Round.objects.filter(
-            campaign_id=OuterRef("pk"),
-            on_hold=True,
+
+        next_active_round_on_hold = Subquery(
+            Round.objects.filter(
+                campaign_id=OuterRef("pk"),
+                ended_at__gt=datetime.now().date(),
+            )
+            .order_by("started_at")  # earliest not-yet-ended round; pick first
+            .values("on_hold")[:1]
         )
-        queryset = queryset.annotate(has_round_on_hold=Exists(rounds_on_hold))
+
+        queryset = queryset.annotate(
+            has_round_on_hold=Coalesce(next_active_round_on_hold, Value(False), output_field=BooleanField())
+        )
         if value == REGULAR:
             return (
                 queryset.filter(is_preventive=False)

--- a/plugins/polio/api/campaigns/filters/filters.py
+++ b/plugins/polio/api/campaigns/filters/filters.py
@@ -1,9 +1,8 @@
-from datetime import datetime
-
 import django_filters
 
-from django.db.models import BooleanField, OuterRef, Q, QuerySet, Subquery, Value
+from django.db.models import BooleanField, ExpressionWrapper, OuterRef, Q, QuerySet, Subquery, Value
 from django.db.models.functions import Coalesce
+from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
 from iaso.models import OrgUnit, OrgUnitType
@@ -72,7 +71,13 @@ class CampaignFilter(django_filters.rest_framework.FilterSet):
     def filter_campaign_category(self, queryset: QuerySet, _, value: str) -> QuerySet:
         """
         PLANNED and ON_HOLD are mutually exclusive on the business side (not on the model yet)
-        ON_HOLD returns campaigns on hold or with at least 1 round on hold
+        ON_HOLD returns a campaign when:
+          - it is on hold at campaign level, or
+          - it is not finished and its ongoing-or-next active round is on hold, or
+          - it is finished and its last round (highest `number`) was on hold.
+        An active round is one that has not ended yet (ended_at >= today); a campaign is finished
+        once its last round has ended (ended_at < today). A NULL ended_at means the campaign is
+        still unfinished, so it cannot match the "finished" branch.
         PREVENTIVE and REGULAR are "the same" except for the is_preventive field
         There is no fine-grained filtering for e.g preventive on hold campaigns at the moment as it would clutter the already
         charged UI
@@ -80,10 +85,14 @@ class CampaignFilter(django_filters.rest_framework.FilterSet):
         Individual filters for each boolean would make more sense, but that would require some UI design first
         """
 
+        today = timezone.localdate()
+
+        # ongoing-or-next active round on hold: earliest (by started_at) round not yet ended.
+        # With ended_at >= today, a round ending today still counts as active/ongoing.
         next_active_round_on_hold = Subquery(
             Round.objects.filter(
                 campaign_id=OuterRef("pk"),
-                ended_at__gt=datetime.now().date(),
+                ended_at__gte=today,
             )
             .order_by("started_at")  # earliest not-yet-ended round; pick first
             .values("on_hold")[:1]
@@ -105,7 +114,28 @@ class CampaignFilter(django_filters.rest_framework.FilterSet):
                 .filter(Q(on_hold=False) & Q(has_round_on_hold=False))
             )
         if value == ON_HOLD:
-            return queryset.filter(Q(on_hold=True) | Q(has_round_on_hold=True))
+            # finished campaign whose last round (highest `number`) was on hold.
+            # A single subquery returns the precomputed boolean to avoid a redundant scan;
+            # a NULL ended_at yields NULL here and is coalesced to False (unfinished -> excluded).
+            last_round_on_hold_finished = Subquery(
+                Round.objects.filter(campaign_id=OuterRef("pk"))
+                .order_by("-number")
+                .annotate(
+                    finished_on_hold=ExpressionWrapper(
+                        Q(on_hold=True) & Q(ended_at__lt=today),
+                        output_field=BooleanField(),
+                    )
+                )
+                .values("finished_on_hold")[:1]
+            )
+            queryset = queryset.annotate(
+                has_last_round_on_hold_finished=Coalesce(
+                    last_round_on_hold_finished, Value(False), output_field=BooleanField()
+                )
+            )
+            return queryset.filter(
+                Q(on_hold=True) | Q(has_round_on_hold=True) | Q(has_last_round_on_hold_finished=True)
+            )
         if value == PLANNED:
             return queryset.filter(is_planned=True)
         return queryset

--- a/plugins/polio/api/campaigns/serializers/campaigns.py
+++ b/plugins/polio/api/campaigns/serializers/campaigns.py
@@ -73,13 +73,13 @@ class CampaignSerializer(serializers.ModelSerializer):
         return obj.single_vaccines_extended
 
     def get_general_status(self, campaign):
-        now_utc = timezone.now().date()
+        today = timezone.localdate()
         ordered_rounds = list(campaign.rounds.all())
         ordered_rounds.sort(key=lambda x: x.number, reverse=True)
         for round in ordered_rounds:
-            if round.ended_at and now_utc > round.ended_at:
+            if round.ended_at and today > round.ended_at:
                 return _("Round {} ended").format(round.number)
-            if round.started_at and now_utc >= round.started_at:
+            if round.started_at and today >= round.started_at:
                 return _("Round {} started").format(round.number)
         return _("Preparing")
 

--- a/plugins/polio/api/campaigns/views/campaigns.py
+++ b/plugins/polio/api/campaigns/views/campaigns.py
@@ -5,7 +5,7 @@ from typing import Any, List, Union
 
 from django.conf import settings
 from django.core.mail import send_mail
-from django.db.models import Exists, Max, Min, OuterRef, Prefetch, Q
+from django.db.models import Max, Min, Prefetch, Q
 from django.db.models.query import QuerySet
 from django.http import HttpResponse, JsonResponse, StreamingHttpResponse
 from django.shortcuts import get_object_or_404
@@ -29,6 +29,7 @@ from plugins.polio.api.campaigns.campaigns_log import (
     log_campaign_modification,
     serialize_campaign,
 )
+from plugins.polio.api.campaigns.filters.filters import CampaignFilter
 from plugins.polio.api.campaigns.filters.search import SearchFilterBackend
 from plugins.polio.api.campaigns.serializers.anonymous import AnonymousCampaignSerializer
 from plugins.polio.api.campaigns.serializers.calendar import CalendarCampaignSerializer
@@ -71,6 +72,7 @@ class CampaignViewSet(ModelViewSet):
         SearchFilterBackend,
         DeletionFilterBackend,
     ]
+    filterset_class = CampaignFilter
 
     ordering_fields = [
         "obr_name",
@@ -111,61 +113,22 @@ class CampaignViewSet(ModelViewSet):
             return CampaignSerializer
         return AnonymousCampaignSerializer
 
-    def filter_queryset(self, queryset):
-        queryset = super().filter_queryset(queryset)
-        if self.action in ("update", "partial_update", "retrieve", "destroy", "preparedness"):
-            return queryset
-        campaign_category = self.request.query_params.get("campaign_category")
-        campaign_groups = self.request.query_params.get("campaign_groups")
-        show_test = self.request.query_params.get("show_test", "false")
-        # FIXME we exclude on hold by default but it means that selecting campaign_category=on_hold without passing on_hold=true will exclude campaigns on_hold
-        on_hold = self.request.query_params.get("on_hold", "false")
-        org_unit_groups = self.request.query_params.get("org_unit_groups")
-        campaign_types = self.request.query_params.get("campaign_types")
-        campaigns = queryset
-        rounds_on_hold = Round.objects.filter(
-            campaign_id=OuterRef("pk"),
-            on_hold=True,
-        )
-        campaigns = campaigns.annotate(has_round_on_hold=Exists(rounds_on_hold))
+    def get_queryset(self):
+        user = self.request.user
+        campaigns = Campaign.objects.all()
 
-        if show_test == "false":
-            campaigns = campaigns.filter(is_test=False)
+        # used for Ordering
+        campaigns = campaigns.annotate(last_round_started_at=Max("rounds__started_at"))
+        campaigns = campaigns.annotate(first_round_started_at=Min("rounds__started_at"))
 
-        if on_hold == "false":
-            campaigns = campaigns.filter(Q(on_hold=False) & Q(has_round_on_hold=False))
-
-        if campaign_category == "on_hold" and on_hold == "false":
-            campaigns = campaigns.none()
-        if campaign_category == "on_hold" and on_hold == "true":
-            campaigns = campaigns.filter(Q(on_hold=True) | Q(has_round_on_hold=True)).filter(is_planned=False)
-
-        if campaign_category == "is_planned":
-            campaigns = campaigns.filter(is_planned=True)
-
-        if campaign_category == "preventive":
-            campaigns = campaigns.filter(is_preventive=True).filter(is_planned=False)
-
-        if campaign_category == "regular" and on_hold == "true":
-            campaigns = campaigns.filter(is_preventive=False).filter(is_test=False).filter(is_planned=False)
-
-        if campaign_category == "regular" and on_hold == "false":
-            campaigns = (
-                campaigns.filter(is_preventive=False)
-                .filter(is_test=False)
-                .filter(is_planned=False)
-                .filter(Q(on_hold=False) & Q(has_round_on_hold=False))
-            )
-        if campaign_groups:
-            campaigns = campaigns.filter(grouped_campaigns__in=campaign_groups.split(","))
-        if org_unit_groups:
-            campaigns = campaigns.filter(country__groups__in=org_unit_groups.split(","))
-        if campaign_types:
-            campaign_types_list = campaign_types.split(",")
-            if all(item.isdigit() for item in campaign_types_list):
-                campaigns = campaigns.filter(campaign_types__id__in=campaign_types_list)
-            else:
-                campaigns = campaigns.filter(campaign_types__slug__in=campaign_types_list)
+        campaigns = campaigns.filter_for_user(user)
+        if not self.request.user.is_authenticated:
+            # For this endpoint since it's available anonymously we allow all user to list the campaigns
+            # and to additionally filter on the account_id
+            # In the future we may want to make the account_id parameter mandatory.
+            account_id = self.request.query_params.get("account_id", None)
+            if account_id is not None:
+                campaigns = campaigns.filter(account_id=account_id)
 
         org_units_id_only_qs = OrgUnit.objects.only("id", "name")
         country_prefetch = Prefetch("country", queryset=org_units_id_only_qs)
@@ -187,25 +150,6 @@ class CampaignViewSet(ModelViewSet):
             .prefetch_related(rounds_scopes_group_org_units_prefetch)
         )
         return campaigns.distinct()
-
-    def get_queryset(self):
-        user = self.request.user
-        campaigns = Campaign.objects.all()
-
-        # used for Ordering
-        campaigns = campaigns.annotate(last_round_started_at=Max("rounds__started_at"))
-        campaigns = campaigns.annotate(first_round_started_at=Min("rounds__started_at"))
-
-        campaigns = campaigns.filter_for_user(user)
-        if not self.request.user.is_authenticated:
-            # For this endpoint since it's available anonymously we allow all user to list the campaigns
-            # and to additionally filter on the account_id
-            # In the future we may want to make the account_id parameter mandatory.
-            account_id = self.request.query_params.get("account_id", None)
-            if account_id is not None:
-                campaigns = campaigns.filter(account_id=account_id)
-
-        return campaigns
 
     @action(detail=False, methods=["GET"], serializer_class=CampaignTypeSerializer)
     def available_campaign_types(self, request):

--- a/plugins/polio/js/src/constants/urls.ts
+++ b/plugins/polio/js/src/constants/urls.ts
@@ -63,7 +63,6 @@ export const campaignParams = [
     'campaignCategory',
     'campaignGroups',
     'show_test',
-    'on_hold',
     'filterLaunched',
 ];
 

--- a/plugins/polio/js/src/domains/Calendar/Calendar.tsx
+++ b/plugins/polio/js/src/domains/Calendar/Calendar.tsx
@@ -83,7 +83,7 @@ export const Calendar: FunctionComponent = () => {
         useGetFormattedCalendarData({
             params,
             isTypeSet,
-            order: params.order,
+            order: (params.order ?? '-obr_name') as CalendarOrdering,
             calendarData,
             isEmbedded,
             currentDate,

--- a/plugins/polio/js/src/domains/Calendar/campaignCalendar/CampaignsFilters.tsx
+++ b/plugins/polio/js/src/domains/Calendar/campaignCalendar/CampaignsFilters.tsx
@@ -116,10 +116,6 @@ export const CampaignsFilters: FunctionComponent<Props> = ({
                 page: undefined,
                 campaignType,
                 campaignCategory: campaignCategory ?? 'all',
-                on_hold:
-                    campaignCategory === 'all' || campaignCategory === 'on_hold'
-                        ? 'true'
-                        : 'false',
                 showOnlyDeleted: showOnlyDeleted ? 'true' : undefined,
                 show_test: hideTest ? 'false' : 'true',
                 campaignGroups,

--- a/plugins/polio/js/src/domains/Calendar/campaignCalendar/cells/RoundCell.tsx
+++ b/plugins/polio/js/src/domains/Calendar/campaignCalendar/cells/RoundCell.tsx
@@ -89,7 +89,10 @@ export const RoundCell: FunctionComponent<Props> = ({
             <Box
                 className={classes.coloredBox}
                 sx={{
-                    border: campaign.onHold ? '1px dashed red' : undefined,
+                    border:
+                        campaign.onHold || round.on_hold
+                            ? '1px dashed red'
+                            : undefined,
                 }}
             >
                 {vaccinesList.map((vaccine: string) => (

--- a/plugins/polio/js/src/domains/Calendar/campaignCalendar/types.ts
+++ b/plugins/polio/js/src/domains/Calendar/campaignCalendar/types.ts
@@ -37,7 +37,7 @@ export type CalendarRound = {
     hasSubActivities: boolean;
     subActivities: SubActivity[];
     is_planned: boolean;
-    on_holmd: boolean;
+    on_hold: boolean;
 };
 
 export type SubActivity = {

--- a/plugins/polio/js/src/domains/Calendar/campaignCalendar/types.ts
+++ b/plugins/polio/js/src/domains/Calendar/campaignCalendar/types.ts
@@ -37,6 +37,7 @@ export type CalendarRound = {
     hasSubActivities: boolean;
     subActivities: SubActivity[];
     is_planned: boolean;
+    on_holmd: boolean;
 };
 
 export type SubActivity = {

--- a/plugins/polio/js/src/domains/Calendar/campaignCalendar/utils/campaigns.ts
+++ b/plugins/polio/js/src/domains/Calendar/campaignCalendar/utils/campaigns.ts
@@ -245,7 +245,7 @@ export const mapCampaigns = (
             original: c,
             isPreventive: c.is_preventive,
             isTest: c.is_test,
-            onHold: c.on_hold || Boolean(rounds.find(rnd => rnd.on_hold)),
+            onHold: c.on_hold,
             isPlanned: c.is_planned,
             separateScopesPerRound: c.separate_scopes_per_round,
             scopes: c.scopes,

--- a/plugins/polio/js/src/domains/Calendar/hooks/useMergedCampaigns/useMergedCampaigns.tsx
+++ b/plugins/polio/js/src/domains/Calendar/hooks/useMergedCampaigns/useMergedCampaigns.tsx
@@ -52,7 +52,6 @@ export const useMergedCampaigns = ({
                 ? params.orgUnitGroups.split(',').map(Number)
                 : undefined,
             show_test: false,
-            on_hold: false,
             reference_date: currentDateString,
         };
 

--- a/plugins/polio/js/src/domains/Campaigns/CampaignsAsyncSelect/CampaignsAsyncSelect.tsx
+++ b/plugins/polio/js/src/domains/Campaigns/CampaignsAsyncSelect/CampaignsAsyncSelect.tsx
@@ -23,9 +23,7 @@ type Props = {
     keyValue?: string;
     clearable?: boolean;
     initialValue?: string; // obr name
-    onHold?: boolean;
     showTest?: boolean;
-    showPlanned?: boolean;
     campaignCategory?: CampaignCategory;
     campaignType?: 'polio' | 'non-polio' | string;
 };
@@ -45,8 +43,6 @@ export const CampaignAsyncSelect: FunctionComponent<Props> = ({
     clearable,
     initialValue,
     campaignCategory = 'regular' as CampaignCategory,
-    onHold = true,
-    showPlanned = true,
     showTest = false,
     campaignType = 'polio',
     label = MESSAGES.campaign,
@@ -61,11 +57,9 @@ export const CampaignAsyncSelect: FunctionComponent<Props> = ({
         return {
             fieldset: 'dropdown',
             campaignCategory,
-            on_hold: onHold,
-            is_planned: showPlanned,
             show_test: showTest,
         };
-    }, [campaignCategory, onHold, showPlanned, showTest]);
+    }, [campaignCategory, showTest]);
     const options: Options = useMemo(() => {
         return {
             enabled: isStateSet,

--- a/plugins/polio/js/src/domains/Campaigns/hooks/api/useGetCampaigns.ts
+++ b/plugins/polio/js/src/domains/Campaigns/hooks/api/useGetCampaigns.ts
@@ -10,7 +10,7 @@ const DEFAULT_PAGE = 1;
 const DEFAULT_ORDER = '-cvdpv2_notified_at';
 export const CAMPAIGNS_ENDPOINT = '/api/polio/campaigns/';
 
-export type CampaignCategory = 'all' | 'preventive' | 'on_hold' | 'regular';
+export type CampaignCategory = 'all' | 'is_preventive' | 'on_hold' | 'regular';
 
 export type Options = {
     pageSize?: number;

--- a/plugins/polio/js/src/domains/Campaigns/hooks/api/useGetCampaigns.ts
+++ b/plugins/polio/js/src/domains/Campaigns/hooks/api/useGetCampaigns.ts
@@ -26,7 +26,6 @@ export type Options = {
     campaignGroups?: number[];
     orgUnitGroups?: number[];
     show_test?: boolean;
-    on_hold?: boolean;
     is_planned?: boolean;
     is_embedded?: boolean;
     enabled?: boolean;
@@ -48,7 +47,6 @@ export type GetCampaignsParams = {
     campaign_groups?: number[];
     org_unit_groups?: number[];
     show_test?: boolean;
-    on_hold?: boolean;
     is_embedded?: boolean;
     // Ugly fix to prevent the full list of campaigns showing when waiting for the value of countries
     enabled?: boolean;
@@ -90,7 +88,6 @@ export const makeCampaignOptions = (options: Options, asCsv = false) => ({
     campaign_groups: options.campaignGroups,
     org_unit_groups: options.orgUnitGroups,
     show_test: options.show_test ?? false,
-    on_hold: options.on_hold ?? false,
     is_embedded: options.is_embedded ?? false,
     // Ugly fix to prevent the full list of campaigns showing when waiting for the value of countries
     enabled: options.enabled ?? true,
@@ -121,7 +118,6 @@ export const useGetCampaignsOptions = (
             options.show_test,
             options.enabled,
             options.fieldset,
-            options.on_hold,
             options.is_embedded,
         ],
     );
@@ -175,7 +171,6 @@ export const useCampaignsQueryKey = ({
         options.show_test,
         options.enabled,
         options.fieldset,
-        options.on_hold,
         options.is_embedded,
     ]);
 };
@@ -231,9 +226,6 @@ export const useCampaignParams = (params: Options): Options => {
             campaignCategory: params.campaignCategory,
             campaignGroups: params.campaignGroups,
             show_test: params.show_test ?? true,
-            on_hold:
-                params.campaignCategory === 'on_hold' ||
-                params.campaignCategory === 'all',
             fieldset: 'list',
             orgUnitGroups: params.orgUnitGroups,
         };

--- a/plugins/polio/js/src/domains/Campaigns/hooks/useCampaignCategoryOptions.ts
+++ b/plugins/polio/js/src/domains/Campaigns/hooks/useCampaignCategoryOptions.ts
@@ -10,7 +10,7 @@ export const useCampaignCategoryOptions = (): DropdownOptions<string>[] => {
             { label: formatMessage(MESSAGES.all), value: 'all' },
             {
                 label: formatMessage(MESSAGES.preventiveShort),
-                value: 'preventive',
+                value: 'is_preventive',
             },
             { label: formatMessage(MESSAGES.regular), value: 'regular' },
             { label: formatMessage(MESSAGES.campaignOnHold), value: 'on_hold' },

--- a/plugins/polio/js/src/domains/GroupedCampaigns/GroupedCampaignDialog.tsx
+++ b/plugins/polio/js/src/domains/GroupedCampaigns/GroupedCampaignDialog.tsx
@@ -45,7 +45,7 @@ export const GroupedCampaignDialog: FunctionComponent<Props> = ({
     const [campaignsToLink, setCampaignsToLink] = useState<string[]>(campaigns);
     // TODO refactor this hook to make more flexible
     const { data: allCampaigns, isFetching: isFetchingCamaigns } =
-        useGetCampaigns({ show_test: true, on_hold: true });
+        useGetCampaigns({ show_test: true });
     const allCampaignsDropdown = useMemo(
         () => makeCampaignsDropDownWithUUID(allCampaigns),
         [allCampaigns],

--- a/plugins/polio/js/src/domains/LQAS-IM/IM/index.tsx
+++ b/plugins/polio/js/src/domains/LQAS-IM/IM/index.tsx
@@ -40,7 +40,6 @@ export const ImStats: FunctionComponent = () => {
             countries: country,
             enabled: Boolean(country),
             show_test: false,
-            on_hold: true,
         }) as UseQueryResult<Campaign[], Error>;
 
     const {

--- a/plugins/polio/js/src/domains/LQAS-IM/LQAS/CountryOverview/Filters/LqasFilterByCountry.tsx
+++ b/plugins/polio/js/src/domains/LQAS-IM/LQAS/CountryOverview/Filters/LqasFilterByCountry.tsx
@@ -64,7 +64,6 @@ export const LqasFilterByCountry: FunctionComponent<Props> = ({
             countries: country,
             enabled: Boolean(country),
             show_test: false,
-            on_hold: true,
             is_embedded: isEmbedded,
         }) as UseQueryResult<Campaign[], Error>;
 
@@ -78,9 +77,9 @@ export const LqasFilterByCountry: FunctionComponent<Props> = ({
         return makeCampaignsDropDown(displayedCampaigns);
     }, [country, campaigns]);
 
-    //FIXME use new params
+    // FIXME: use new params
     const onChange = useCallback(
-        (key, value) => {
+        (key: string, value: string) => {
             const newFilters = {
                 ...filters,
                 leftRound: side === 'left' ? undefined : filters.leftRound,

--- a/plugins/polio/js/src/domains/VaccineModule/StockManagement/hooks/api.ts
+++ b/plugins/polio/js/src/domains/VaccineModule/StockManagement/hooks/api.ts
@@ -292,7 +292,7 @@ export const useCampaignOptions = (
     const { data, isFetching } = useGetCampaigns(
         // Show on hold and test campaigns to avoid missing forms
         // whose campaign has been changed after creation
-        { show_test: true, on_hold: true },
+        { show_test: true },
         CAMPAIGNS_ENDPOINT,
         undefined,
         queryOptions,

--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/hooks/api/vrf.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/hooks/api/vrf.tsx
@@ -153,7 +153,6 @@ export const useCampaignDropDowns = ({
         countries: Number.isSafeInteger(countryId) ? `${countryId}` : undefined,
         campaignCategory: 'regular' as CampaignCategory,
         campaignType: 'polio',
-        on_hold: true,
         show_test: false,
     };
 

--- a/plugins/polio/models/base.py
+++ b/plugins/polio/models/base.py
@@ -479,7 +479,7 @@ class Round(models.Model):
         if (
             self.started_at
             and isinstance(self.started_at, datetime.date)
-            and self.started_at >= timezone.now().date()
+            and self.started_at >= timezone.localdate()
             and self.campaign
             and self.campaign.has_polio_type
             and not self.campaign.is_test
@@ -494,7 +494,7 @@ class Round(models.Model):
     def is_round_over(round):
         if not round.ended_at:
             return False
-        return round.ended_at < date.today()
+        return round.ended_at < timezone.localdate()
 
     @property
     def actual_scopes(self):

--- a/plugins/polio/tests/api/campaigns/dashboards/test_campaign_dashboards_filters.py
+++ b/plugins/polio/tests/api/campaigns/dashboards/test_campaign_dashboards_filters.py
@@ -21,6 +21,7 @@ class CampaignDashboardsFiltersTestCase(CampaignFiltersTestBase):
             self.planned_campaign.obr_name,
             self.planned_preventive_campaign.obr_name,
             self.campaign_with_on_hold_round.obr_name,
+            self.finished_last_round_on_hold_campaign.obr_name,
             self.test_campaign.obr_name,
             self.on_hold_campaign.obr_name,
             self.planned_test_campaign.obr_name,

--- a/plugins/polio/tests/api/campaigns/list/test_campaign_filters.py
+++ b/plugins/polio/tests/api/campaigns/list/test_campaign_filters.py
@@ -15,12 +15,6 @@ URL = "/api/polio/campaigns/"
 
 class CampaignFiltersAPITestCase(CampaignFiltersTestBase):
     def test_no_filter_params(self):
-        """Campaign category can be one of 'preventive', 'on_hold', 'is_planned', or 'regular'.
-        There is also a category of test campaigns, which is handled via a separate query parameter `show_test`.
-        There is a separate `is_test` query param, to explicitly include/exclude test campaigns, it composes with campaign category.
-        If no option is selected, no filtering is performed. This is the option 'All' in the UI.
-
-        """
         expected_obr_names = list(Campaign.objects.all().values_list("obr_name", flat=True))
 
         self.client.force_authenticate(self.user)
@@ -29,6 +23,40 @@ class CampaignFiltersAPITestCase(CampaignFiltersTestBase):
         result = self.assertJSONResponse(response, HTTP_200_OK)
         obr_names = [cmp["obr_name"] for cmp in result]
         self.assertCountEqual(expected_obr_names, obr_names)
+
+    def test_show_test_default_behaviour(self):
+        """When `show_test` is omitted, no test filtering is applied: test campaigns are included,
+        identical to `show_test=true`. `show_test=false` is the only value that excludes them.
+        """
+        self.client.force_authenticate(self.user)
+
+        all_obr_names = list(Campaign.objects.values_list("obr_name", flat=True))
+        test_obr_names = list(Campaign.objects.filter(is_test=True).values_list("obr_name", flat=True))
+        non_test_obr_names = list(Campaign.objects.filter(is_test=False).values_list("obr_name", flat=True))
+
+        # the fixture must contain both test and non-test campaigns for this test to be meaningful
+        self.assertTrue(len(test_obr_names) > 0)
+        self.assertTrue(len(non_test_obr_names) > 0)
+
+        # param omitted: test campaigns are included
+        response = self.client.get(f"{URL}")
+        result = self.assertJSONResponse(response, HTTP_200_OK)
+        default_obr_names = [cmp["obr_name"] for cmp in result]
+        self.assertCountEqual(default_obr_names, all_obr_names)
+
+        # show_test=true behaves exactly like the omitted default
+        response = self.client.get(f"{URL}?show_test=true")
+        result = self.assertJSONResponse(response, HTTP_200_OK)
+        show_test_true_obr_names = [cmp["obr_name"] for cmp in result]
+        self.assertCountEqual(show_test_true_obr_names, default_obr_names)
+
+        # show_test=false is the only value that excludes test campaigns
+        response = self.client.get(f"{URL}?show_test=false")
+        result = self.assertJSONResponse(response, HTTP_200_OK)
+        show_test_false_obr_names = [cmp["obr_name"] for cmp in result]
+        self.assertCountEqual(show_test_false_obr_names, non_test_obr_names)
+        for name in test_obr_names:
+            self.assertNotIn(name, show_test_false_obr_names)
 
     def test_filter_by_campaign_types(self):
         self.client.force_authenticate(self.user)
@@ -91,12 +119,28 @@ class CampaignFiltersAPITestCase(CampaignFiltersTestBase):
         self.assertEqual(response.status_code, 200, response.content)
         self.assertEqual(len(response_data), 0)
 
+        # A test campaign sharing a type is included by default but excluded with show_test==false
+        test_campaign_typed = Campaign.objects.create(
+            obr_name="Test typed campaign", account=self.account, is_test=True
+        )
+        test_campaign_typed.campaign_types.add(campaign_type1)
+
+        response = self.client.get(f"{URL}?campaign_types={campaign_type1.id}", format="json")
+        response_data = self.assertJSONResponse(response, HTTP_200_OK)
+        campaign_ids = [c["id"] for c in response_data]
+        self.assertCountEqual(campaign_ids, [str(campaign1.id), str(test_campaign_typed.id)])
+
+        response = self.client.get(f"{URL}?campaign_types={campaign_type1.id}&show_test=false", format="json")
+        response_data = self.assertJSONResponse(response, HTTP_200_OK)
+        campaign_ids = [c["id"] for c in response_data]
+        self.assertEqual(campaign_ids, [str(campaign1.id)])
+
     def test_filter_test_campaigns(self):
         self.client.force_authenticate(self.user)
 
         initial_count = Campaign.objects.count()
-        # Count existing visible non-test campaigns from setUpTestData (default filters: show_test=false, on_hold=false)
 
+        # Count existing visible non-test campaigns from setUpTestData
         initial_visible_count = Campaign.objects.filter(is_test=False).count()
 
         payload1 = {
@@ -180,6 +224,16 @@ class CampaignFiltersAPITestCase(CampaignFiltersTestBase):
         self.assertCountEqual(
             obr_names,
             [self.regular_campaign.obr_name, self.test_campaign.obr_name],
+        )
+
+        # regular with show_test==false excludes the test campaign
+        response = self.client.get(f"{URL}?campaign_category=regular&show_test=false")
+        result = self.assertJSONResponse(response, HTTP_200_OK)
+        obr_names = [cmp["obr_name"] for cmp in result]
+        self.assertEqual(len(result), 1)
+        self.assertCountEqual(
+            obr_names,
+            [self.regular_campaign.obr_name],
         )
 
     def test_filter_category_preventive(self):
@@ -304,6 +358,19 @@ class CampaignFiltersAPITestCase(CampaignFiltersTestBase):
         result = self.assertJSONResponse(response, HTTP_200_OK)
         obr_names = [cmp["obr_name"] for cmp in result]
         self.assertCountEqual(expected_obr_names, obr_names)
+
+        # search combined with show_test==false excludes test campaigns from the results
+        response = self.client.get(f"{URL}?search=plann&show_test=false")
+        result = self.assertJSONResponse(response, HTTP_200_OK)
+        obr_names = [cmp["obr_name"] for cmp in result]
+        self.assertCountEqual(
+            obr_names,
+            [
+                self.planned_campaign.obr_name,
+                self.planned_preventive_campaign.obr_name,
+                campaign_with_epid.obr_name,
+            ],
+        )
 
         self.client.force_authenticate(geo_limited_user)
         # test search geo limited
@@ -433,3 +500,65 @@ class CampaignFiltersAPITestCase(CampaignFiltersTestBase):
         result = self.assertJSONResponse(response, HTTP_200_OK)
         obr_names = [cmp["obr_name"] for cmp in result]
         self.assertCountEqual(obr_names, [regular_campaign2.obr_name, regular_campaign3.obr_name])
+
+    def test_filter_composition_category_and_search(self):
+        """Filters compose (AND): campaign_category intersects with search, and show_test narrows further."""
+        self.client.force_authenticate(self.user)
+
+        # campaign_category=is_planned alone returns the 4 planned campaigns; intersecting with
+        # search=preventive keeps only the planned campaigns whose obr_name contains "preventive"
+        response = self.client.get(f"{URL}?campaign_category=is_planned&search=preventive")
+        result = self.assertJSONResponse(response, HTTP_200_OK)
+        obr_names = [cmp["obr_name"] for cmp in result]
+        self.assertCountEqual(
+            obr_names,
+            [
+                self.planned_preventive_campaign.obr_name,
+                self.planned_preventive_test_campaign.obr_name,
+            ],
+        )
+
+        # adding show_test=false drops the test campaign from the intersection
+        response = self.client.get(f"{URL}?campaign_category=is_planned&search=preventive&show_test=false")
+        result = self.assertJSONResponse(response, HTTP_200_OK)
+        obr_names = [cmp["obr_name"] for cmp in result]
+        self.assertCountEqual(obr_names, [self.planned_preventive_campaign.obr_name])
+
+    def test_filter_composition_category_and_deletion_status(self):
+        """campaign_category composes with the deletion status backend."""
+        self.client.force_authenticate(self.user)
+
+        on_hold_default = [
+            self.campaign_with_on_hold_round.obr_name,
+            self.test_on_hold_campaign.obr_name,
+            self.preventive_on_hold_campaign.obr_name,
+            self.preventive_test_on_hold_campaign.obr_name,
+            self.on_hold_campaign.obr_name,
+        ]
+
+        # soft-delete one of the on_hold campaigns
+        self.client.delete(f"{URL}{self.on_hold_campaign.id}/")
+
+        # default (active only) excludes the deleted campaign while keeping the category filter
+        response = self.client.get(f"{URL}?campaign_category=on_hold")
+        result = self.assertJSONResponse(response, HTTP_200_OK)
+        obr_names = [cmp["obr_name"] for cmp in result]
+        self.assertCountEqual(
+            obr_names,
+            [name for name in on_hold_default if name != self.on_hold_campaign.obr_name],
+        )
+
+        # deletion_status=deleted intersected with the category returns only the deleted on_hold campaign
+        response = self.client.get(f"{URL}?campaign_category=on_hold&deletion_status=deleted")
+        result = self.assertJSONResponse(response, HTTP_200_OK)
+        obr_names = [cmp["obr_name"] for cmp in result]
+        self.assertCountEqual(obr_names, [self.on_hold_campaign.obr_name])
+
+        # deletion_status=all brings the deleted campaign back into the category results
+        response = self.client.get(f"{URL}?campaign_category=on_hold&deletion_status=all")
+        result = self.assertJSONResponse(response, HTTP_200_OK)
+        obr_names = [cmp["obr_name"] for cmp in result]
+        self.assertCountEqual(obr_names, on_hold_default)
+
+        self.client.patch(f"{URL}restore_deleted_campaigns/", {"id": str(self.on_hold_campaign.id)})
+        self.assertJSONResponse(response, HTTP_200_OK)

--- a/plugins/polio/tests/api/campaigns/list/test_campaign_filters.py
+++ b/plugins/polio/tests/api/campaigns/list/test_campaign_filters.py
@@ -1,3 +1,7 @@
+from datetime import date, datetime, timedelta, timezone
+
+import time_machine
+
 from rest_framework.status import HTTP_200_OK
 
 from iaso.models.base import Group
@@ -11,6 +15,7 @@ from plugins.polio.tests.api.campaigns.setupData import CampaignFiltersTestBase
 
 
 URL = "/api/polio/campaigns/"
+FIXED_NOW = datetime(2026, 6, 22, 12, 0, 0, tzinfo=timezone.utc)
 
 
 class CampaignFiltersAPITestCase(CampaignFiltersTestBase):
@@ -215,25 +220,33 @@ class CampaignFiltersAPITestCase(CampaignFiltersTestBase):
         self.assertEqual(len(response.json()), remaining_visible)
 
     def test_filter_category_regular(self):
-        # regular category: excludes campaigns on hold and campaigns with current or next round on hold
+        # regular category: excludes campaigns on hold and campaigns with current or next round on hold.
+        # Finished campaigns whose last round was on hold are not excluded (known overlap with on_hold).
         response = self.client.get(f"{URL}?campaign_category=regular")
         result = self.assertJSONResponse(response, HTTP_200_OK)
-        self.assertEqual(len(result), 2)
+        self.assertEqual(len(result), 3)
 
         obr_names = [cmp["obr_name"] for cmp in result]
         self.assertCountEqual(
             obr_names,
-            [self.regular_campaign.obr_name, self.test_campaign.obr_name],
+            [
+                self.regular_campaign.obr_name,
+                self.test_campaign.obr_name,
+                self.finished_last_round_on_hold_campaign.obr_name,
+            ],
         )
 
         # regular with show_test==false excludes the test campaign
         response = self.client.get(f"{URL}?campaign_category=regular&show_test=false")
         result = self.assertJSONResponse(response, HTTP_200_OK)
         obr_names = [cmp["obr_name"] for cmp in result]
-        self.assertEqual(len(result), 1)
+        self.assertEqual(len(result), 2)
         self.assertCountEqual(
             obr_names,
-            [self.regular_campaign.obr_name],
+            [
+                self.regular_campaign.obr_name,
+                self.finished_last_round_on_hold_campaign.obr_name,
+            ],
         )
 
     def test_filter_category_preventive(self):
@@ -263,17 +276,18 @@ class CampaignFiltersAPITestCase(CampaignFiltersTestBase):
         )
 
     def test_filter_category_on_hold(self):
-        # on_hold category: returns campaigns on hold OR with active or next round on hold
+        # on_hold category: campaign on hold, active/next round on hold, or finished with last round on hold
 
         response = self.client.get(f"{URL}?campaign_category=on_hold")
         result = self.assertJSONResponse(response, HTTP_200_OK)
         obr_names = [cmp["obr_name"] for cmp in result]
-        self.assertEqual(len(result), 5)
+        self.assertEqual(len(result), 6)
         self.assertCountEqual(
             obr_names,
             [
                 self.on_hold_campaign.obr_name,
                 self.campaign_with_on_hold_round.obr_name,  # has round on hold
+                self.finished_last_round_on_hold_campaign.obr_name,  # finished, last round on hold
                 self.test_on_hold_campaign.obr_name,
                 self.preventive_on_hold_campaign.obr_name,
                 self.preventive_test_on_hold_campaign.obr_name,
@@ -284,12 +298,13 @@ class CampaignFiltersAPITestCase(CampaignFiltersTestBase):
         response = self.client.get(f"{URL}?campaign_category=on_hold&show_test=false")
         result = self.assertJSONResponse(response, HTTP_200_OK)
         obr_names = [cmp["obr_name"] for cmp in result]
-        self.assertEqual(len(result), 3)
+        self.assertEqual(len(result), 4)
         self.assertCountEqual(
             obr_names,
             [
                 self.on_hold_campaign.obr_name,
                 self.campaign_with_on_hold_round.obr_name,  # has round on hold
+                self.finished_last_round_on_hold_campaign.obr_name,
                 self.preventive_on_hold_campaign.obr_name,
             ],
         )
@@ -530,6 +545,7 @@ class CampaignFiltersAPITestCase(CampaignFiltersTestBase):
 
         on_hold_default = [
             self.campaign_with_on_hold_round.obr_name,
+            self.finished_last_round_on_hold_campaign.obr_name,
             self.test_on_hold_campaign.obr_name,
             self.preventive_on_hold_campaign.obr_name,
             self.preventive_test_on_hold_campaign.obr_name,
@@ -562,3 +578,117 @@ class CampaignFiltersAPITestCase(CampaignFiltersTestBase):
 
         self.client.patch(f"{URL}restore_deleted_campaigns/", {"id": str(self.on_hold_campaign.id)})
         self.assertJSONResponse(response, HTTP_200_OK)
+
+
+class CampaignOnHoldCategoryEdgeCasesTestCase(CampaignFiltersTestBase):
+    """Edge cases for on_hold category filtering rules 2 and 3."""
+
+    def setUp(self):
+        super().setUp()
+        self.client.force_authenticate(self.user)
+
+    def _on_hold_obr_names(self):
+        response = self.client.get(f"{URL}?campaign_category=on_hold")
+        result = self.assertJSONResponse(response, HTTP_200_OK)
+        return [campaign["obr_name"] for campaign in result]
+
+    def test_on_hold_excludes_finished_non_last_round_on_hold(self):
+        campaign, rnd1, _, _, _, _ = self.create_campaign(
+            obr_name="finished non-last round on hold",
+            account=self.account,
+            source_version=self.source_version_1,
+            country_ou_type=self.country_type,
+            district_ou_type=self.district_type,
+        )
+        rnd1.on_hold = True
+        rnd1.save()
+
+        self.assertNotIn(campaign.obr_name, self._on_hold_obr_names())
+
+    @time_machine.travel(FIXED_NOW, tick=False)
+    def test_on_hold_active_round_ending_today_is_included(self):
+        today = FIXED_NOW.date()
+        campaign, rnd1, rnd2, rnd3, _, _ = self.create_campaign(
+            obr_name="active round ending today on hold",
+            account=self.account,
+            source_version=self.source_version_1,
+            country_ou_type=self.country_type,
+            district_ou_type=self.district_type,
+        )
+        rnd1.started_at = today - timedelta(days=10)
+        rnd1.ended_at = today
+        rnd1.on_hold = True
+        rnd1.save()
+        rnd2.started_at = today + timedelta(days=30)
+        rnd2.ended_at = today + timedelta(days=40)
+        rnd2.on_hold = False
+        rnd2.save()
+        rnd3.started_at = today + timedelta(days=50)
+        rnd3.ended_at = today + timedelta(days=60)
+        rnd3.on_hold = False
+        rnd3.save()
+
+        self.assertIn(campaign.obr_name, self._on_hold_obr_names())
+
+    @time_machine.travel(FIXED_NOW, tick=False)
+    def test_on_hold_finished_last_round_ended_yesterday_is_included(self):
+        today = FIXED_NOW.date()
+        campaign, _, _, rnd3, _, _ = self.create_campaign(
+            obr_name="finished last round ended yesterday on hold",
+            account=self.account,
+            source_version=self.source_version_1,
+            country_ou_type=self.country_type,
+            district_ou_type=self.district_type,
+        )
+        rnd3.on_hold = True
+        rnd3.ended_at = today - timedelta(days=1)
+        rnd3.save()
+
+        self.assertIn(campaign.obr_name, self._on_hold_obr_names())
+
+    def test_on_hold_excludes_last_round_on_hold_with_null_ended_at(self):
+        campaign, _, _, rnd3, _, _ = self.create_campaign(
+            obr_name="last round on hold null ended_at",
+            account=self.account,
+            source_version=self.source_version_1,
+            country_ou_type=self.country_type,
+            district_ou_type=self.district_type,
+        )
+        rnd3.on_hold = True
+        rnd3.ended_at = None
+        rnd3.save()
+
+        self.assertNotIn(campaign.obr_name, self._on_hold_obr_names())
+
+    def test_on_hold_last_round_by_number_not_by_date(self):
+        campaign, _, rnd2, rnd3, _, _ = self.create_campaign(
+            obr_name="last round by number on hold",
+            account=self.account,
+            source_version=self.source_version_1,
+            country_ou_type=self.country_type,
+            district_ou_type=self.district_type,
+        )
+        rnd3.on_hold = True
+        rnd3.ended_at = date(2021, 3, 10)
+        rnd3.save()
+        rnd2.on_hold = False
+        rnd2.ended_at = date(2022, 6, 1)
+        rnd2.save()
+
+        self.assertIn(campaign.obr_name, self._on_hold_obr_names())
+
+        campaign2, _, rnd2b, rnd3b, _, _ = self.create_campaign(
+            obr_name="non-last round by number on hold only",
+            account=self.account,
+            source_version=self.source_version_1,
+            country_ou_type=self.country_type,
+            district_ou_type=self.district_type,
+        )
+        rnd2b.on_hold = True
+        rnd2b.ended_at = date(2022, 6, 1)
+        rnd2b.save()
+        rnd3b.on_hold = False
+        rnd3b.ended_at = date(2021, 3, 10)
+        rnd3b.save()
+
+        self.assertNotIn(campaign2.obr_name, self._on_hold_obr_names())

--- a/plugins/polio/tests/api/campaigns/list/test_campaign_filters.py
+++ b/plugins/polio/tests/api/campaigns/list/test_campaign_filters.py
@@ -1,4 +1,3 @@
-from django.db.models import Exists, OuterRef
 from rest_framework.status import HTTP_200_OK
 
 from iaso.models.base import Group
@@ -6,7 +5,7 @@ from iaso.permissions.core_permissions import CORE_FORMS_PERMISSION
 from plugins.polio.models import (
     Campaign,
 )
-from plugins.polio.models.base import CampaignGroup, CampaignType, Round
+from plugins.polio.models.base import CampaignGroup, CampaignType
 from plugins.polio.preparedness.spreadsheet_manager import *
 from plugins.polio.tests.api.campaigns.setupData import CampaignFiltersTestBase
 
@@ -17,22 +16,15 @@ URL = "/api/polio/campaigns/"
 class CampaignFiltersAPITestCase(CampaignFiltersTestBase):
     def test_no_filter_params(self):
         """Campaign category can be one of 'preventive', 'on_hold', 'is_planned', or 'regular'.
-        There is also an 'implicit' category of test campaigns. They will be excluded when selecting 'regular' but otherwise returned.
-        There is a separate `is_test` query param, to explicitly include/exclude test campaigns, but campaign_category takes precedence.
+        There is also a category of test campaigns, which is handled via a separate query parameter `show_test`.
+        There is a separate `is_test` query param, to explicitly include/exclude test campaigns, it composes with campaign category.
         If no option is selected, no filtering is performed. This is the option 'All' in the UI.
-        There is a separate 'on_hold' filter (query param: on_hold) which historically takes precedence, e.g on 'regular' filter
-        """
 
-        expected_obr_names = [
-            self.regular_campaign.obr_name,
-            self.preventive_campaign.obr_name,
-            self.planned_campaign.obr_name,
-            self.planned_preventive_campaign.obr_name,
-        ]  # using to obr_names to avoid having to cast UUID to string
+        """
+        expected_obr_names = list(Campaign.objects.all().values_list("obr_name", flat=True))
 
         self.client.force_authenticate(self.user)
 
-        # not passing the query params returns campaigns from all categories except test and on hold
         response = self.client.get(f"{URL}")
         result = self.assertJSONResponse(response, HTTP_200_OK)
         obr_names = [cmp["obr_name"] for cmp in result]
@@ -101,28 +93,11 @@ class CampaignFiltersAPITestCase(CampaignFiltersTestBase):
 
     def test_filter_test_campaigns(self):
         self.client.force_authenticate(self.user)
-        # Count existing campaigns from setUpTestData
-        # the show_test/is_test filter filters out test campaigns when false
-        # but returns ALL campaigns when true, i.E it doesn't exclude on test campaigns
-        # We filter out on hold in the test setup because these are excluded by default
-        rounds_on_hold = Round.objects.filter(
-            campaign_id=OuterRef("pk"),
-            on_hold=True,
-        )
-        initial_count = (
-            Campaign.objects.filter(on_hold=False)
-            .annotate(has_round_on_hold=Exists(rounds_on_hold))
-            .filter(has_round_on_hold=False)
-            .count()
-        )
+
+        initial_count = Campaign.objects.count()
         # Count existing visible non-test campaigns from setUpTestData (default filters: show_test=false, on_hold=false)
 
-        initial_visible_count = (
-            Campaign.objects.filter(is_test=False, on_hold=False)
-            .annotate(has_round_on_hold=Exists(rounds_on_hold))
-            .filter(has_round_on_hold=False)
-            .count()
-        )
+        initial_visible_count = Campaign.objects.filter(is_test=False).count()
 
         payload1 = {
             "account": self.account.pk,
@@ -148,15 +123,6 @@ class CampaignFiltersAPITestCase(CampaignFiltersTestBase):
         obr_names = [r["obr_name"] for r in result]
         self.assertIn(payload1["obr_name"], obr_names)
 
-        # return non test campaigns by default
-        response = self.client.get("/api/polio/campaigns/")
-        result = self.assertJSONResponse(response, HTTP_200_OK)
-
-        self.assertEqual(len(result), initial_visible_count + 1)
-        obr_names = [r["obr_name"] for r in result]
-        self.assertNotIn(payload1["obr_name"], obr_names)
-        self.assertFalse(result[0]["is_test"])
-
         # return non test campaigns  (explicit exclusion)
         response = self.client.get("/api/polio/campaigns/?show_test=false")
         result = self.assertJSONResponse(response, HTTP_200_OK)
@@ -167,17 +133,8 @@ class CampaignFiltersAPITestCase(CampaignFiltersTestBase):
 
     def test_filter_by_deletion_status(self):
         self.client.force_authenticate(self.user)
-        # Count existing campaigns from setUpTestData, excluding test and on_hold, to account for API default filtering
-        rounds_on_hold = Round.objects.filter(
-            campaign_id=OuterRef("pk"),
-            on_hold=True,
-        )
-        initial_total_count = (
-            Campaign.objects.filter(on_hold=False, is_test=False)
-            .annotate(has_round_on_hold=Exists(rounds_on_hold))
-            .filter(has_round_on_hold=False)
-            .count()
-        )
+
+        initial_total_count = Campaign.objects.count()
 
         new_ids = self._create_multiple_campaigns(10)
 
@@ -199,14 +156,8 @@ class CampaignFiltersAPITestCase(CampaignFiltersTestBase):
         result = self.assertJSONResponse(response, HTTP_200_OK)
         self.assertEqual(len(result), total_campaigns)
 
-        # per defaut it return undeleted, i.e "active" (with default filters: show_test=false, on_hold=false)
         # Calculate remaining visible campaigns after deletion
-        remaining_visible = (
-            Campaign.objects.filter(deleted_at__isnull=True, is_test=False, on_hold=False)
-            .annotate(has_round_on_hold=Exists(rounds_on_hold))
-            .filter(has_round_on_hold=False)
-            .count()
-        )
+        remaining_visible = Campaign.objects.filter(deleted_at__isnull=True).count()
 
         response = self.client.get(f"{URL}", format="json")
 
@@ -220,153 +171,47 @@ class CampaignFiltersAPITestCase(CampaignFiltersTestBase):
         self.assertEqual(len(response.json()), remaining_visible)
 
     def test_filter_category_regular(self):
-        # regular category: excludes campaigns on hold and campaigns with at least 1 round on hold
+        # regular category: excludes campaigns on hold and campaigns with current or next round on hold
         response = self.client.get(f"{URL}?campaign_category=regular")
         result = self.assertJSONResponse(response, HTTP_200_OK)
-        self.assertEqual(len(result), 1)
+        self.assertEqual(len(result), 2)
 
         obr_names = [cmp["obr_name"] for cmp in result]
         self.assertCountEqual(
             obr_names,
-            [self.regular_campaign.obr_name],
-        )
-
-        # regular campaign overrides is_test
-        response = self.client.get(f"{URL}?campaign_category=regular&show_test=true")
-        result = self.assertJSONResponse(response, HTTP_200_OK)
-        self.assertEqual(len(result), 1)
-        obr_names = [cmp["obr_name"] for cmp in result]
-        self.assertCountEqual(
-            obr_names,
-            [self.regular_campaign.obr_name],
-        )
-        # regular with show test explicitly false (for the sake of coverage)
-        response = self.client.get(f"{URL}?campaign_category=regular&show_test=false")
-        result = self.assertJSONResponse(response, HTTP_200_OK)
-        self.assertEqual(len(result), 1)
-        obr_names = [cmp["obr_name"] for cmp in result]
-        self.assertCountEqual(
-            obr_names,
-            [self.regular_campaign.obr_name],
-        )
-
-        # on_hold query param taken into account when selecting regular campaigns:
-        # regular campaign, with on_hold==True (includes on_hold campaigns and those with rounds on hold)
-        response = self.client.get(f"{URL}?campaign_category=regular&on_hold=true")
-        result = self.assertJSONResponse(response, HTTP_200_OK)
-        self.assertEqual(len(result), 3)
-        obr_names = [cmp["obr_name"] for cmp in result]
-        self.assertCountEqual(
-            obr_names,
-            [self.regular_campaign.obr_name, self.campaign_with_on_hold_round.obr_name, self.on_hold_campaign.obr_name],
-        )
-        # regular campaign, with on_hold==True (excludes on_hold campaigns and those with rounds on hold)
-        response = self.client.get(f"{URL}?campaign_category=regular&on_hold=false")
-        result = self.assertJSONResponse(response, HTTP_200_OK)
-        self.assertEqual(len(result), 1)
-        obr_names = [cmp["obr_name"] for cmp in result]
-        self.assertCountEqual(
-            obr_names,
-            [self.regular_campaign.obr_name],
+            [self.regular_campaign.obr_name, self.test_campaign.obr_name],
         )
 
     def test_filter_category_preventive(self):
-        # preventive category: excludes campaigns on hold and campaigns with at least 1 round on hold
-        response = self.client.get(f"{URL}?campaign_category=preventive")
+        # preventive campaigns cannot be on_hold
+        response = self.client.get(f"{URL}?campaign_category=is_preventive")
         result = self.assertJSONResponse(response, HTTP_200_OK)
-        self.assertEqual(len(result), 1)
         obr_names = [cmp["obr_name"] for cmp in result]
+        self.assertEqual(len(result), 2)
         self.assertCountEqual(
             obr_names,
             [
                 self.preventive_campaign.obr_name,  # planned campaigns are excluded
+                self.preventive_test_campaign.obr_name,
             ],
         )
 
-        # preventive with on_hold=true
-        response = self.client.get(f"{URL}?campaign_category=preventive&on_hold=true")
+        # preventive with show_test==false
+        response = self.client.get(f"{URL}?campaign_category=is_preventive&show_test=false")
         result = self.assertJSONResponse(response, HTTP_200_OK)
         obr_names = [cmp["obr_name"] for cmp in result]
-        self.assertCountEqual(
-            obr_names,
-            [
-                self.preventive_campaign.obr_name,  # planned campaigns are excluded
-                self.preventive_on_hold_campaign.obr_name,
-            ],
-        )
-        # preventive on hold == false (explicit)
-        response = self.client.get(f"{URL}?campaign_category=preventive&on_hold=false")
-        result = self.assertJSONResponse(response, HTTP_200_OK)
-        obr_names = [cmp["obr_name"] for cmp in result]
-        self.assertCountEqual(
-            obr_names,
-            [
-                self.preventive_campaign.obr_name,  # planned campaigns are excluded
-            ],
-        )
-        # preventive test
-        response = self.client.get(f"{URL}?campaign_category=preventive&show_test=true")
-        result = self.assertJSONResponse(response, HTTP_200_OK)
-        self.assertEqual(len(result), 2)
-        obr_names = [cmp["obr_name"] for cmp in result]
-        self.assertCountEqual(
-            obr_names,
-            [
-                self.preventive_campaign.obr_name,  # planned campaigns are excluded
-                self.preventive_test_campaign.obr_name,
-            ],
-        )
-        # preventive test==false (explicit)
-        response = self.client.get(f"{URL}?campaign_category=preventive&show_test=false")
-        result = self.assertJSONResponse(response, HTTP_200_OK)
         self.assertEqual(len(result), 1)
-        obr_names = [cmp["obr_name"] for cmp in result]
         self.assertCountEqual(
             obr_names,
             [
                 self.preventive_campaign.obr_name,  # planned campaigns are excluded
-            ],
-        )
-        # preventive test with on_hold=true
-        response = self.client.get(f"{URL}?campaign_category=preventive&show_test=true&on_hold=true")
-        result = self.assertJSONResponse(response, HTTP_200_OK)
-        obr_names = [cmp["obr_name"] for cmp in result]
-        self.assertCountEqual(
-            obr_names,
-            [
-                self.preventive_campaign.obr_name,  # planned campaigns are excluded
-                self.preventive_test_campaign.obr_name,
-                self.preventive_on_hold_campaign.obr_name,
-                self.preventive_test_on_hold_campaign.obr_name,
             ],
         )
 
     def test_filter_category_on_hold(self):
-        # on_hold category: returns campaigns on hold OR with at least 1 round on hold
+        # on_hold category: returns campaigns on hold OR with active or next round on hold
+
         response = self.client.get(f"{URL}?campaign_category=on_hold")
-        result = self.assertJSONResponse(response, HTTP_200_OK)
-        self.assertEqual(len(result), 0)  # on_hold query param takes precedence and defaults to false
-
-        # on_hold query param takes precedence
-        response = self.client.get(f"{URL}?campaign_category=on_hold&on_hold=false")
-        result = self.assertJSONResponse(response, HTTP_200_OK)
-        self.assertEqual(len(result), 0)
-
-        response = self.client.get(f"{URL}?campaign_category=on_hold&on_hold=true")
-        result = self.assertJSONResponse(response, HTTP_200_OK)
-        self.assertEqual(len(result), 3)
-        obr_names = [cmp["obr_name"] for cmp in result]
-        self.assertCountEqual(
-            obr_names,
-            [
-                self.on_hold_campaign.obr_name,
-                self.campaign_with_on_hold_round.obr_name,  # has round on hold
-                self.preventive_on_hold_campaign.obr_name,
-            ],
-        )
-
-        # on hold + show_test
-        response = self.client.get(f"{URL}?campaign_category=on_hold&on_hold=true&show_test=true")
         result = self.assertJSONResponse(response, HTTP_200_OK)
         obr_names = [cmp["obr_name"] for cmp in result]
         self.assertEqual(len(result), 5)
@@ -380,8 +225,9 @@ class CampaignFiltersAPITestCase(CampaignFiltersTestBase):
                 self.preventive_test_on_hold_campaign.obr_name,
             ],
         )
-        # on hold + show_test=false (explicit)
-        response = self.client.get(f"{URL}?campaign_category=on_hold&on_hold=true&show_test=false")
+
+        # on hold + show_test
+        response = self.client.get(f"{URL}?campaign_category=on_hold&show_test=false")
         result = self.assertJSONResponse(response, HTTP_200_OK)
         obr_names = [cmp["obr_name"] for cmp in result]
         self.assertEqual(len(result), 3)
@@ -398,27 +244,8 @@ class CampaignFiltersAPITestCase(CampaignFiltersTestBase):
         # planned
         response = self.client.get(f"{URL}?campaign_category=is_planned")
         result = self.assertJSONResponse(response, HTTP_200_OK)
-        self.assertEqual(len(result), 2)
         obr_names = [cmp["obr_name"] for cmp in result]
-        self.assertCountEqual(
-            obr_names,
-            [self.planned_campaign.obr_name, self.planned_preventive_campaign.obr_name],
-        )
-        # planned with show test explicitly false
-        response = self.client.get(f"{URL}?campaign_category=is_planned&show_test=false")
-        result = self.assertJSONResponse(response, HTTP_200_OK)
-        self.assertEqual(len(result), 2)
-        obr_names = [cmp["obr_name"] for cmp in result]
-        self.assertCountEqual(
-            obr_names,
-            [self.planned_campaign.obr_name, self.planned_preventive_campaign.obr_name],
-        )
-
-        # planned test
-        response = self.client.get(f"{URL}?campaign_category=is_planned&show_test=true")
-        result = self.assertJSONResponse(response, HTTP_200_OK)
         self.assertEqual(len(result), 4)
-        obr_names = [cmp["obr_name"] for cmp in result]
         self.assertCountEqual(
             obr_names,
             [
@@ -428,51 +255,14 @@ class CampaignFiltersAPITestCase(CampaignFiltersTestBase):
                 self.planned_preventive_test_campaign.obr_name,
             ],
         )
-
-    def test_filter_on_hold_campaigns(self):
-        # not passing the param is same as passing False
-        default_obr_names = [
-            self.regular_campaign.obr_name,
-            self.preventive_campaign.obr_name,
-            self.planned_campaign.obr_name,
-            self.planned_preventive_campaign.obr_name,
-        ]  # using to obr_names to avoid having to cast UUID to string
-
-        # explicitly pass false
-        response = self.client.get(f"{URL}?on_hold=false")
+        # planned with show test false
+        response = self.client.get(f"{URL}?campaign_category=is_planned&show_test=false")
         result = self.assertJSONResponse(response, HTTP_200_OK)
-        obr_names = [cmp["obr_name"] for cmp in result]
-        self.assertCountEqual(default_obr_names, obr_names)
-
-        # pass true
-        response = self.client.get(f"{URL}?on_hold=true")
-        result = self.assertJSONResponse(response, HTTP_200_OK)
-        obr_names = [cmp["obr_name"] for cmp in result]
-        expected_on_hold_obr_names = [
-            *default_obr_names,
-            self.preventive_on_hold_campaign.obr_name,
-            self.on_hold_campaign.obr_name,
-            self.campaign_with_on_hold_round.obr_name,
-        ]
-        self.assertCountEqual(expected_on_hold_obr_names, obr_names)
-
-        # test param precedence over campaign category
-        # This is a dupe of the same test in test_filter_category_on_hold, but I'd rather ensure we don't inadvertently remove coverage
-        response = self.client.get(f"{URL}?campaign_category=on_hold&on_hold=false")
-        result = self.assertJSONResponse(response, HTTP_200_OK)
-        self.assertEqual(len(result), 0)
-
-        response = self.client.get(f"{URL}?campaign_category=on_hold&on_hold=true")
-        result = self.assertJSONResponse(response, HTTP_200_OK)
-        self.assertEqual(len(result), 3)
+        self.assertEqual(len(result), 2)
         obr_names = [cmp["obr_name"] for cmp in result]
         self.assertCountEqual(
             obr_names,
-            [
-                self.on_hold_campaign.obr_name,
-                self.campaign_with_on_hold_round.obr_name,  # has round on hold
-                self.preventive_on_hold_campaign.obr_name,
-            ],
+            [self.planned_campaign.obr_name, self.planned_preventive_campaign.obr_name],
         )
 
     def test_search_filter(self):
@@ -498,6 +288,8 @@ class CampaignFiltersAPITestCase(CampaignFiltersTestBase):
             self.planned_campaign.obr_name,
             self.planned_preventive_campaign.obr_name,
             campaign_with_epid.obr_name,
+            self.planned_preventive_test_campaign.obr_name,
+            self.planned_test_campaign.obr_name,
         ]  # using to obr_names to avoid having to cast UUID to string
 
         self.client.force_authenticate(self.user)
@@ -512,11 +304,6 @@ class CampaignFiltersAPITestCase(CampaignFiltersTestBase):
         result = self.assertJSONResponse(response, HTTP_200_OK)
         obr_names = [cmp["obr_name"] for cmp in result]
         self.assertCountEqual(expected_obr_names, obr_names)
-
-        # default filters apply (on hold, test)
-        response = self.client.get(f"{URL}?search=test")
-        result = self.assertJSONResponse(response, HTTP_200_OK)
-        self.assertEqual(len(result), 0)
 
         self.client.force_authenticate(geo_limited_user)
         # test search geo limited

--- a/plugins/polio/tests/api/campaigns/list/test_campaign_status.py
+++ b/plugins/polio/tests/api/campaigns/list/test_campaign_status.py
@@ -3,6 +3,7 @@ import datetime
 from unittest.mock import patch
 
 from django.contrib.gis.geos import MultiPolygon, Point, Polygon
+from django.utils import timezone
 
 from iaso import models as m
 from iaso.permissions.core_permissions import CORE_ORG_UNITS_PERMISSION
@@ -134,15 +135,27 @@ class CampaignStatusPolioTestCase(APITestCase):
         c.rounds.create(number=2, started_at=datetime.date(2021, 3, 1), ended_at=datetime.date(2021, 3, 2))
         c.rounds.create(number=3, started_at=datetime.date(2021, 4, 1), ended_at=datetime.date(2021, 4, 20))
 
-        with patch("django.utils.timezone.now", lambda: datetime.datetime(2020, 2, 2, 2, 2, 2)):
+        with patch(
+            "django.utils.timezone.now",
+            lambda: timezone.make_aware(datetime.datetime(2020, 2, 2, 2, 2, 2)),
+        ):
             d = CampaignSerializer(instance=c).data
             self.assertEqual(d["general_status"], "Preparing")
-        with patch("django.utils.timezone.now", lambda: datetime.datetime(2021, 1, 1, 2, 2, 2)):
+        with patch(
+            "django.utils.timezone.now",
+            lambda: timezone.make_aware(datetime.datetime(2021, 1, 1, 2, 2, 2)),
+        ):
             d = CampaignSerializer(instance=c).data
             self.assertEqual(d["general_status"], "Round 1 started")
-        with patch("django.utils.timezone.now", lambda: datetime.datetime(2021, 1, 3, 10, 2, 2)):
+        with patch(
+            "django.utils.timezone.now",
+            lambda: timezone.make_aware(datetime.datetime(2021, 1, 3, 10, 2, 2)),
+        ):
             d = CampaignSerializer(instance=c).data
             self.assertEqual(d["general_status"], "Round 1 ended")
-        with patch("django.utils.timezone.now", lambda: datetime.datetime(2021, 4, 20, 10, 2, 2)):
+        with patch(
+            "django.utils.timezone.now",
+            lambda: timezone.make_aware(datetime.datetime(2021, 4, 20, 10, 2, 2)),
+        ):
             d = CampaignSerializer(instance=c).data
             self.assertEqual(d["general_status"], "Round 3 started")

--- a/plugins/polio/tests/api/campaigns/setupData.py
+++ b/plugins/polio/tests/api/campaigns/setupData.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 from django.utils import timezone
 from rest_framework.status import HTTP_201_CREATED
 from rest_framework.test import APIClient
@@ -100,6 +102,12 @@ class CampaignFiltersTestBase(APITestCase, IasoTestCaseMixin, PolioTestCaseMixin
             country_ou_type=cls.country_type,
             district_ou_type=cls.district_type,
         )
+        # The "has_round_on_hold" annotation is date-aware: it only flags a campaign whose
+        # *next active* round (earliest round with ended_at > today) is on hold.
+        # create_campaign() only produces past rounds (2021), so we push this campaign's
+        # on-hold round into the future to make it the next active round on hold.
+        cls.campaign_with_on_hold_rnd1.started_at = cls.now.date() + timedelta(days=5)
+        cls.campaign_with_on_hold_rnd1.ended_at = cls.now.date() + timedelta(days=15)
         cls.campaign_with_on_hold_rnd1.on_hold = True
         cls.campaign_with_on_hold_rnd1.save()
 

--- a/plugins/polio/tests/api/campaigns/setupData.py
+++ b/plugins/polio/tests/api/campaigns/setupData.py
@@ -103,13 +103,24 @@ class CampaignFiltersTestBase(APITestCase, IasoTestCaseMixin, PolioTestCaseMixin
             district_ou_type=cls.district_type,
         )
         # The "has_round_on_hold" annotation is date-aware: it only flags a campaign whose
-        # *next active* round (earliest round with ended_at > today) is on hold.
+        # *next active* round (earliest round with ended_at >= today) is on hold.
         # create_campaign() only produces past rounds (2021), so we push this campaign's
         # on-hold round into the future to make it the next active round on hold.
         cls.campaign_with_on_hold_rnd1.started_at = cls.now.date() + timedelta(days=5)
         cls.campaign_with_on_hold_rnd1.ended_at = cls.now.date() + timedelta(days=15)
         cls.campaign_with_on_hold_rnd1.on_hold = True
         cls.campaign_with_on_hold_rnd1.save()
+
+        # Rule 3: finished campaign whose last round (highest `number`) is on hold.
+        cls.finished_last_round_on_hold_campaign, _, _, cls.finished_last_round_on_hold_r3, _, _ = cls.create_campaign(
+            obr_name="finished last round on hold campaign",
+            account=cls.account,
+            source_version=cls.source_version_1,
+            country_ou_type=cls.country_type,
+            district_ou_type=cls.district_type,
+        )
+        cls.finished_last_round_on_hold_r3.on_hold = True
+        cls.finished_last_round_on_hold_r3.save()
 
         # planned preventive
         cls.planned_preventive_campaign, _, _, _, _, _ = cls.create_campaign(


### PR DESCRIPTION
## What problem is this PR solving?
The logic deciding whether to consider a campaign on hold based on its rounds status needed refinement, because the way it was displayed in the calendar was confusing

### Related JIRA tickets

POLIO-2154

## Changes

- BEFORE: if a campaign was on hold, or had at least 1 round on hold, it was considered on hold. This was creating confusion in the calendar, as all campaign rounds were marked on hold, even though only one round was.

- CHANGES:
**BACKEND**
- Remove legacy `filter_queryset`method from `campaigns` API and replace it with `CampaignFilters` that was already used by the calendar
- Remove overlapping parameter `on_hold`and keep only `campaign_category` to filter on that status
- Simplify filter logic: showing test campaigns is now entirely handled by passing the `show_test` query param. It defaults to `true` on the backend (previous behaviour) but the logic around test campaigns has been removed from campaign category filtering.
    - In effect, it means a small change in behaviour: the "All" filter will return all campaigns including tests. If that behaviour needs to be reverted, it should be changed front-end side by setting `show_test` to `false` by default and ticking the corresponding box in the UI.
- Refine logic for `on_hold` campaign category; returned campaigns are now:
    - on hold campaigns
    - campaigns that have the ongoing (if applicable) or next round on hold
    - past campaigns that have their last round on hold 
- Note that it means the 'on_hold`status takes precedence over e.g `preventive` status, i.e: a preventive campaign on hold will show in the `on_hold`category, but not the `preventive` category. This is consistent with existing behaviour. 
- Other category filters remain unchanged and mutually exclusive

**FRONT-END**
- Remove references to `on_hold` query param
- Fix some TS typing
- Use round status directly to set cell styling

## How to test
 On a polio DB, create:
 - a campaign with at least 1 future round. Put this round on hold
 - a campaign on hold
 - a finished campaign with it's last round on hold
 - a finished campaign with it penultimate round on hold
 
 Go to the calendar and tweak the campaign category filter:
 - All: should show all 4 campaigns
 - on hold: should show the first 3
     - check the display: campaign on hold should have all rounds styled as on hold, others should only have relevant rounds 
 - Combine with other filters and campaign categories (eg: preventive), see what breaks, hopefully nothing

## Print screen / video

<img width="2337" height="1359" alt="Screenshot 2026-06-23 at 10 57 43" src="https://github.com/user-attachments/assets/0d23afe0-c1f8-4887-907d-aef8402bf705" />


