### PR TITLE
[IA-5198]: Fix org unit types n+1 query

### DIFF
--- a/iaso/api/org_unit_types/viewsets.py
+++ b/iaso/api/org_unit_types/viewsets.py
@@ -12,7 +12,7 @@ from iaso.api.permission_checks import (
     IsAuthenticatedOrReadOnlyWhenNoAuthenticationRequired,
 )
 from iaso.api.query_params import APP_ID, ORDER, PROJECT, PROJECT_IDS, SEARCH
-from iaso.models import OrgUnitType, Project
+from iaso.models import Form, OrgUnitType, Project
 
 from ..common import ModelViewSet
 from .filters import OrgUnitTypeDropdownFilter
@@ -143,7 +143,14 @@ class OrgUnitTypeViewSetV2(ModelViewSet):
                     .all(),
                 ),
                 "allow_creating_sub_unit_types",
-                "reference_forms",
+                Prefetch(
+                    "reference_forms",
+                    queryset=Form.objects.prefetch_related(
+                        "projects",
+                        "projects__projectfeatureflags_set",
+                        "projects__projectfeatureflags_set__featureflag",
+                    ).all(),
+                ),
                 "sub_unit_types",
             )
 

--- a/iaso/api/org_unit_types/viewsets.py
+++ b/iaso/api/org_unit_types/viewsets.py
@@ -132,6 +132,21 @@ class OrgUnitTypeViewSetV2(ModelViewSet):
             self.request.user, self.request.query_params.get(APP_ID)
         )
 
+        if self.action in ["list", "retrieve"]:
+            # deleting previous prefetch_related from filter_for_user_and_app_id cause I don't want to break everything
+            # => more clean way would be to remove the prefetch_related from filter_for_user_and_app_id as it don't belong here
+            queryset = queryset.prefetch_related(None).prefetch_related(
+                Prefetch(
+                    "projects",
+                    queryset=Project.objects.select_related("account")
+                    .prefetch_related("projectfeatureflags_set", "projectfeatureflags_set__featureflag")
+                    .all(),
+                ),
+                "allow_creating_sub_unit_types",
+                "reference_forms",
+                "sub_unit_types",
+            )
+
         project = self.request.query_params.get(PROJECT, None)
         if project:
             queryset = queryset.filter(projects__id=project)

--- a/iaso/tests/api/test_org_unit_types_v2.py
+++ b/iaso/tests/api/test_org_unit_types_v2.py
@@ -7,6 +7,7 @@ from rest_framework.exceptions import ValidationError
 from iaso import models as m
 from iaso.api.org_unit_types.serializers import validate_reference_forms
 from iaso.api.query_params import PROJECT, SOURCE_VERSION_ID
+from iaso.models import FeatureFlag
 from iaso.permissions.core_permissions import CORE_FORMS_PERMISSION, CORE_ORG_UNITS_TYPES_PERMISSION
 from iaso.test import APITestCase
 
@@ -89,6 +90,13 @@ class OrgUnitTypesAPITestCase(APITestCase):
 
         wrong_project.forms.add(reference_form_wrong_project)
         wrong_project.save()
+
+        cls.feature_flag = FeatureFlag.objects.create(
+            code="send_location", name="Send GPS location", description="Send GPS location every time etc"
+        )
+        cls.feature_flag_2 = FeatureFlag.objects.create(code="first_test", name="first", order=1, category="DCO")
+
+        cls.ead.feature_flags.set([cls.feature_flag, cls.feature_flag_2])
 
     def test_org_unit_types_list_without_auth_or_app_id(self):
         """GET /orgunittypes/ without auth or app id should result in a 200 empty response"""
@@ -752,3 +760,19 @@ class OrgUnitTypesAPITestCase(APITestCase):
         child_data = response_data["sub_unit_types"][0]
         for field in expected_fields:
             self.assertIn(field, child_data)
+
+    def test_num_queries_list(self):
+        self.client.force_authenticate(self.jane)
+
+        with self.assertNumQueries(8):
+            response = self.client.get(f"{self.BASE_URL}")
+
+        self.assertJSONResponse(response, status.HTTP_200_OK)
+
+    def test_num_queries_retrieve(self):
+        self.client.force_authenticate(self.jane)
+
+        with self.assertNumQueries(13):
+            response = self.client.get(f"{self.BASE_URL}{self.org_unit_type_1.id}/")
+
+        self.assertJSONResponse(response, status.HTTP_200_OK)

--- a/iaso/tests/api/test_org_unit_types_v2.py
+++ b/iaso/tests/api/test_org_unit_types_v2.py
@@ -764,7 +764,7 @@ class OrgUnitTypesAPITestCase(APITestCase):
     def test_num_queries_list(self):
         self.client.force_authenticate(self.jane)
 
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(10):
             response = self.client.get(f"{self.BASE_URL}")
 
         self.assertJSONResponse(response, status.HTTP_200_OK)

--- a/iaso/tests/api/test_org_unit_types_v2.py
+++ b/iaso/tests/api/test_org_unit_types_v2.py
@@ -772,7 +772,7 @@ class OrgUnitTypesAPITestCase(APITestCase):
     def test_num_queries_retrieve(self):
         self.client.force_authenticate(self.jane)
 
-        with self.assertNumQueries(13):
+        with self.assertNumQueries(12):
             response = self.client.get(f"{self.BASE_URL}{self.org_unit_type_1.id}/")
 
         self.assertJSONResponse(response, status.HTTP_200_OK)


### PR DESCRIPTION
## What problem is this PR solving?

/api/v2/orgunittypes/ was causing a n+1 query.


### Related JIRA tickets

IA-5198

## Changes

Did the same fix as in IA-5189 + added some tests

## How to test

Make sure that the projects have some feature flags; call /api/v2/orgunittypes/ ; no n+1 should be triggered due to projects feature flags
 