### PR TITLE
POLIO-1816: deprecate vaccine authorisation

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/forms/components/FormFormComponent.tsx
+++ b/hat/assets/js/apps/Iaso/domains/forms/components/FormFormComponent.tsx
@@ -122,7 +122,7 @@ const FormForm: FunctionComponent<FormFormProps> = ({
         useGetGroupDropdown(
             { projectIds: currentForm.project_ids.value.join(',') },
             // we only want to fetch the groups if the project ids are set, project ids is a required field
-            Boolean(currentForm.project_ids?.value?.length)
+            Boolean(currentForm.project_ids?.value?.length),
         );
     useEffect(() => {
         if (
@@ -329,9 +329,7 @@ const FormForm: FunctionComponent<FormFormProps> = ({
                             options={allOrgUnitGroups || []}
                             label={MESSAGES.orgUnitsGroups}
                             loading={isOuGroupLoading}
-                            disabled={
-                                !currentForm.project_ids?.value?.length
-                            }
+                            disabled={!currentForm.project_ids?.value?.length}
                         />
                     </InputWithInfos>
                     <ValidationWorkflowDropdown

--- a/hat/assets/js/apps/Iaso/domains/users/utils.test.ts
+++ b/hat/assets/js/apps/Iaso/domains/users/utils.test.ts
@@ -31,9 +31,9 @@ const createUser = (overrides: Partial<User> = {}): User => ({
 
 describe('userHasPermission', () => {
     it('returns false when user is missing', () => {
-        expect(userHasPermission('iaso.users', undefined as unknown as User)).toBe(
-            false,
-        );
+        expect(
+            userHasPermission('iaso.users', undefined as unknown as User),
+        ).toBe(false);
     });
 
     it('returns false when user has no permissions array', () => {
@@ -66,7 +66,10 @@ describe('userHasPermission', () => {
 describe('userHasOneOfPermissions', () => {
     it('returns false when user is missing', () => {
         expect(
-            userHasOneOfPermissions(['iaso.users'], undefined as unknown as User),
+            userHasOneOfPermissions(
+                ['iaso.users'],
+                undefined as unknown as User,
+            ),
         ).toBe(false);
     });
 
@@ -111,23 +114,25 @@ describe('userHasAllPermissions', () => {
             permissions: ['iaso.users', 'iaso.forms'],
         });
 
-        expect(
-            userHasAllPermissions(['iaso.users', 'iaso.forms'], user),
-        ).toBe(true);
+        expect(userHasAllPermissions(['iaso.users', 'iaso.forms'], user)).toBe(
+            true,
+        );
     });
 
     it('returns false when user is missing one permission', () => {
         const user = createUser({ permissions: ['iaso.users'] });
 
-        expect(
-            userHasAllPermissions(['iaso.users', 'iaso.forms'], user),
-        ).toBe(false);
+        expect(userHasAllPermissions(['iaso.users', 'iaso.forms'], user)).toBe(
+            false,
+        );
     });
 });
 
 describe('listMenuPermission', () => {
     it('returns an empty array for a missing menu item', () => {
-        expect(listMenuPermission(undefined as unknown as MenuItem)).toEqual([]);
+        expect(listMenuPermission(undefined as unknown as MenuItem)).toEqual(
+            [],
+        );
     });
 
     it('collects permissions from a menu item', () => {
@@ -299,8 +304,11 @@ describe('getProfilesDropdownQueryKey', () => {
     });
 
     it('omits the empty-query flag when disabled', () => {
-        expect(
-            getProfilesDropdownQueryKey({ search: 'jane' }, false),
-        ).toEqual(['profiles', 'dropdown', 'search=jane', undefined]);
+        expect(getProfilesDropdownQueryKey({ search: 'jane' }, false)).toEqual([
+            'profiles',
+            'dropdown',
+            'search=jane',
+            undefined,
+        ]);
     });
 });

--- a/plugins/polio/api/vaccines/stock_management/incidents/views.py
+++ b/plugins/polio/api/vaccines/stock_management/incidents/views.py
@@ -11,7 +11,7 @@ from plugins.polio.permissions import (
 )
 
 
-@extend_schema(tags=["Polio - Inicdent reports"])
+@extend_schema(tags=["Polio - Incident reports"])
 class IncidentReportViewSet(VaccineStockSubitemBase):
     serializer_class = IncidentReportSerializer
     model_class = IncidentReport

--- a/plugins/polio/api/vaccines/vaccine_authorization.py
+++ b/plugins/polio/api/vaccines/vaccine_authorization.py
@@ -6,10 +6,11 @@ from typing import Any
 
 from django_filters.rest_framework import DjangoFilterBackend  # type: ignore
 from drf_spectacular.utils import extend_schema
-from rest_framework import filters, serializers
+from rest_framework import filters, serializers, status
 from rest_framework.decorators import action
 from rest_framework.request import Request
 from rest_framework.response import Response
+from typing_extensions import deprecated
 
 from iaso.api.common import (
     Custom403Exception,
@@ -118,12 +119,16 @@ class HasVaccineAuthorizationsPermissions(GenericReadWritePerm):
     write_perm = POLIO_VACCINE_AUTHORIZATIONS_ADMIN_PERMISSION
 
 
-@extend_schema(tags=["Polio - vaccine authorizations"])
+@deprecated("Deprecated at client's request. Could be reactivated at any moment, so the code hasn't been deleted")
+@extend_schema(exclude=True, tags=["Polio - vaccine authorizations"])
 class VaccineAuthorizationViewSet(ModelViewSet):
     """
-    Vaccine Authorizations API
-    list: /api/polio/vaccintauthorizations
-    action: /api/polio/get_most_recent_authorizations
+    Deprecated: Vaccine Authorizations API.
+
+    Deprecated at client's request. Could be reactivated at any moment, so the code hasn't been deleted
+
+    list: /api/polio/vaccineauthorizations
+    action: /api/polio/vaccineauthorizations/get_most_recent_authorizations
     """
 
     permission_classes = [HasVaccineAuthorizationsPermissions]
@@ -133,6 +138,18 @@ class VaccineAuthorizationViewSet(ModelViewSet):
     serializer_class = VaccineAuthorizationSerializer
     pagination_class = Paginator
     ordering_fields = ["status", "current_expiration_date", "next_expiration_date", "expiration_date", "quantity"]
+
+    def dispatch(self, request, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+        request = self.initialize_request(request, *args, **kwargs)
+        self.request = request
+        self.headers = self.default_response_headers
+        response = Response(
+            {"detail": "This endpoint is deprecated."},
+            status=status.HTTP_410_GONE,
+        )
+        return self.finalize_response(request, response, *args, **kwargs)
 
     def get_queryset(self):
         user = self.request.user

--- a/plugins/polio/js/src/constants/menu.tsx
+++ b/plugins/polio/js/src/constants/menu.tsx
@@ -14,7 +14,6 @@ import HomeWorkIcon from '@mui/icons-material/HomeWork';
 import InventoryIcon from '@mui/icons-material/Inventory';
 import DataSourceIcon from '@mui/icons-material/ListAltTwoTone';
 import LocalShippingIcon from '@mui/icons-material/LocalShipping';
-import MenuBookIcon from '@mui/icons-material/MenuBook';
 import NotificationsActiveIcon from '@mui/icons-material/NotificationsActive';
 import PendingActionsIcon from '@mui/icons-material/PendingActions';
 import PhotoSizeSelectActualIcon from '@mui/icons-material/PhotoSizeSelectActual';
@@ -37,7 +36,7 @@ import {
     imOhhPath,
     lqasAfroPath,
     lqasCountryPath,
-    nopvAuthPath,
+    // nopvAuthPath,
     notificationPath,
     reasonsForDelayConfigPath,
     stockManagementPath,
@@ -130,12 +129,12 @@ export const menu: MenuItem[] = [
                 key: 'vaccinemodule',
                 icon: props => <ExtensionIcon {...props} />,
                 subMenu: [
-                    {
-                        label: MESSAGES.nopv2Auth,
-                        key: 'nopv2authorisation',
-                        permissions: nopvAuthPath.permissions,
-                        icon: props => <MenuBookIcon {...props} />,
-                    },
+                    // {
+                    //     label: MESSAGES.nopv2Auth,
+                    //     key: 'nopv2authorisation',
+                    //     permissions: nopvAuthPath.permissions,
+                    //     icon: props => <MenuBookIcon {...props} />,
+                    // },
                     {
                         label: MESSAGES.vaccineSupplyChain,
                         key: 'supplychain',

--- a/plugins/polio/js/src/constants/routes.tsx
+++ b/plugins/polio/js/src/constants/routes.tsx
@@ -20,8 +20,6 @@ import { Lqas } from '../domains/LQAS-IM/LQAS';
 import { LqasAfroOverview } from '../domains/LQAS-IM/LQAS/LqasAfroOverview/LqasAfroOverview';
 import { Notifications } from '../domains/Notifications';
 import { NationalLogisticsPlan } from '../domains/VaccineModule/NationalLogisticsPlan/NationalLogisticsPlan';
-import { Nopv2AuthorisationsDetails } from '../domains/VaccineModule/Nopv2Authorisations/Details/Nopv2AuthorisationsDetails';
-import { Nopv2Authorisations } from '../domains/VaccineModule/Nopv2Authorisations/Nopv2Authorisations';
 import { PerformanceDashboard } from '../domains/VaccineModule/PerformanceDashboard/PerformanceDashboard';
 import { PerformanceThresholds } from '../domains/VaccineModule/PerformanceThresholds/PerformanceThresholds';
 import { VaccineRepository } from '../domains/VaccineModule/Repository/VaccineRepository';

--- a/plugins/polio/js/src/constants/routes.tsx
+++ b/plugins/polio/js/src/constants/routes.tsx
@@ -182,19 +182,21 @@ export const budgetDetailsPath: RoutePath = {
     permissions: [BUDGET, BUDGET_ADMIN],
 };
 
-export const nopvAuthPath: RoutePath = {
-    baseUrl: baseUrls.nopv2Auth,
-    routerUrl: `${baseUrls.nopv2Auth}/*`,
-    element: <Nopv2Authorisations />,
-    permissions: [POLIO, POLIO_ADMIN],
-};
+// feature deprecated at client's request, but kept "just in case" (at client's request also)
+// export const nopvAuthPath: RoutePath = {
+//     baseUrl: baseUrls.nopv2Auth,
+//     routerUrl: `${baseUrls.nopv2Auth}/*`,
+//     element: <Nopv2Authorisations />,
+//     permissions: [POLIO, POLIO_ADMIN],
+// };
 
-export const nopvAuthDetailsPath: RoutePath = {
-    baseUrl: baseUrls.nopv2AuthDetails,
-    routerUrl: `${baseUrls.nopv2AuthDetails}/*`,
-    element: <Nopv2AuthorisationsDetails />,
-    permissions: [POLIO, POLIO_ADMIN],
-};
+// feature deprecated at client's request, but kept "just in case" (at client's request also)
+// export const nopvAuthDetailsPath: RoutePath = {
+//     baseUrl: baseUrls.nopv2AuthDetails,
+//     routerUrl: `${baseUrls.nopv2AuthDetails}/*`,
+//     element: <Nopv2AuthorisationsDetails />,
+//     permissions: [POLIO, POLIO_ADMIN],
+// };
 
 export const supplychainPath: RoutePath = {
     baseUrl: baseUrls.vaccineSupplyChain,
@@ -330,8 +332,8 @@ export const routes: (RoutePath | AnonymousRoutePath)[] = [
     imOhhPath,
     budgetPath,
     budgetDetailsPath,
-    nopvAuthPath,
-    nopvAuthDetailsPath,
+    // nopvAuthPath,
+    // nopvAuthDetailsPath,
     supplychainPath,
     supplychainDetailsPath,
     stockManagementPath,

--- a/plugins/polio/js/src/domains/VaccineModule/Nopv2Authorisations/Details/Nopv2AuthorisationsDetails.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/Nopv2Authorisations/Details/Nopv2AuthorisationsDetails.tsx
@@ -21,6 +21,7 @@ type Params = {
     page?: string;
 };
 
+/** @deprecated at clients request. Code kept because the business need may arise again*/
 export const Nopv2AuthorisationsDetails: FunctionComponent = () => {
     const params = useParamsObject(baseUrls.nopv2AuthDetails) as Params;
     const { formatMessage } = useSafeIntl();

--- a/plugins/polio/js/src/domains/VaccineModule/Nopv2Authorisations/Filters/Nopv2AuthorisationsFilters.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/Nopv2Authorisations/Filters/Nopv2AuthorisationsFilters.tsx
@@ -17,7 +17,7 @@ import { VaccineAuthParams } from '../types';
 
 const baseUrl = baseUrls.nopv2Auth;
 type Props = { params: VaccineAuthParams };
-
+/** @deprecated at clients request. Code kept because the business need may arise again*/
 export const Nopv2AuthorisationsFilters: FunctionComponent<Props> = ({
     params,
 }) => {

--- a/plugins/polio/js/src/domains/VaccineModule/Nopv2Authorisations/Nopv2Authorisations.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/Nopv2Authorisations/Nopv2Authorisations.tsx
@@ -18,6 +18,7 @@ const defaultParams = {
 
 const baseUrl = baseUrls.nopv2Auth;
 
+/** @deprecated at clients request. Code kept because the business need may arise again*/
 export const Nopv2Authorisations: FunctionComponent = () => {
     const params = useParamsObject(baseUrl) as Partial<VaccineAuthParams>;
     const redirectToReplace = useRedirectToReplace();

--- a/plugins/polio/js/src/domains/VaccineModule/Nopv2Authorisations/Table/Nopv2AuthorisationsTable.tsx
+++ b/plugins/polio/js/src/domains/VaccineModule/Nopv2Authorisations/Table/Nopv2AuthorisationsTable.tsx
@@ -7,7 +7,7 @@ import { VaccineAuthParams } from '../types';
 import { useNopv2AuthTableColumns } from './useNopv2AuthTableColumns';
 
 type Props = { params: VaccineAuthParams & Partial<UrlParams> };
-
+/** @deprecated at clients request. Code kept because the business need may arise again*/
 export const Nopv2AuthorisationsTable: FunctionComponent<Props> = ({
     params,
 }) => {

--- a/plugins/polio/tests/test_vaccine_authorizations.py
+++ b/plugins/polio/tests/test_vaccine_authorizations.py
@@ -1,6 +1,7 @@
 import datetime
 
 from datetime import date
+from unittest import skip
 
 from django.contrib.auth.models import User
 from django.core import mail
@@ -31,6 +32,36 @@ from plugins.polio.tasks.vaccine_authorizations_mail_alerts import (
 )
 
 
+class VaccineAuthorizationDeprecatedAPITestCase(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.data_source = m.DataSource.objects.create(name="Default source")
+        cls.source_version_1 = m.SourceVersion.objects.create(data_source=cls.data_source, number=1)
+        cls.account = Account.objects.create(name="polio", default_version=cls.source_version_1)
+        cls.user = cls.create_user_with_profile(
+            username="vaccine_auth_user",
+            account=cls.account,
+            permissions=[
+                POLIO_VACCINE_AUTHORIZATIONS_ADMIN_PERMISSION,
+                POLIO_VACCINE_AUTHORIZATIONS_READ_ONLY_PERMISSION,
+            ],
+        )
+
+    def test_deprecated_endpoint_returns_410_gone(self):
+        self.client.force_authenticate(self.user)
+
+        for method, url, kwargs in [
+            ("get", "/api/polio/vaccineauthorizations/", {}),
+            ("post", "/api/polio/vaccineauthorizations/", {"data": {}, "format": "json"}),
+            ("get", "/api/polio/vaccineauthorizations/get_most_recent_authorizations/", {}),
+        ]:
+            with self.subTest(method=method, url=url):
+                response = getattr(self.client, method)(url, **kwargs)
+                self.assertJSONResponse(response, status.HTTP_410_GONE)
+                self.assertEqual(response.json(), {"detail": "This endpoint is deprecated."})
+
+
+@skip("deprecated vaccine authorization API")
 class VaccineAuthorizationAPITestCase(APITestCase):
     data_source: m.DataSource
     source_version_1: m.SourceVersion


### PR DESCRIPTION


## What problem is this PR solving?
Client doesn't need the feature but asked that we keep it under wraps just in case

### Related JIRA tickets

POLIO-1816
## Changes

- deprecate API: return 410 on all requests
- remove from front-end menu
- deprecate front-end components

## How to test

On a polio DB:
- Open menu > Vaccine module: NOPV authorizations should be gone
- go to swagger UI: same
- try reaching `/api/polio/vaccineauthorizations/`: you should get a 410

## Print screen / video
<img width="2335" height="1365" alt="Screenshot 2026-06-23 at 16 44 15" src="https://github.com/user-attachments/assets/6fae39cb-0f7d-4b1b-864e-4225f8be1550" />

<img width="2335" height="1365" alt="Screenshot 2026-06-23 at 16 41 28" src="https://github.com/user-attachments/assets/1c554164-e91f-4a79-8ba9-c8fe4836f7f0" />


