### PR TITLE
[IA-5252]: handle soft deleted validation workflows

### DIFF
--- a/hat/assets/js/apps/Iaso/constants/menu.tsx
+++ b/hat/assets/js/apps/Iaso/constants/menu.tsx
@@ -509,7 +509,8 @@ export const useMenuItems = (): MenuItems => {
                 {
                     label: formatMessage(MESSAGES.submissionsTitle),
                     key: 'submissions',
-                    permissions: paths.instancesPath.permissions,
+                    permissions:
+                        paths.validationWorkflowInstancesPath.permissions,
                     icon: props => <SearchIcon {...props} />,
                 },
             ],

--- a/hat/assets/js/apps/Iaso/domains/instances/components/ValidationWorkflow/useGetSubmissionValidationStatus.ts
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/ValidationWorkflow/useGetSubmissionValidationStatus.ts
@@ -31,6 +31,7 @@ export const useGetSubmissionValidationStatus = (id?: number) => {
     return useSnackQuery({
         queryKey: ['submission-validation-status', id],
         queryFn: () => getSubmissionValidationStatus(id!),
+        ignoreErrorCodes: [404],
         options: {
             staleTime: Infinity,
             cacheTime: Infinity,

--- a/iaso/api/instances/serializers/etl.py
+++ b/iaso/api/instances/serializers/etl.py
@@ -28,12 +28,14 @@ class ETLInstanceListSerializer(ModelSerializer):
     file_content = serializers.SerializerMethodField()
     file_url = serializers.SerializerMethodField()
     history = serializers.SerializerMethodField()
+    workflow_deprecated = serializers.BooleanField(read_only=True)
 
     class Meta:
         model = Instance
         fields = [
             "id",
             "general_validation_status",
+            "workflow_deprecated",
             "file_url",
             "file_content",
             "history",

--- a/iaso/api/instances/views_etl.py
+++ b/iaso/api/instances/views_etl.py
@@ -1,4 +1,4 @@
-from django.db.models import Prefetch
+from django.db.models import Prefetch, Q
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import extend_schema
 from rest_framework.filters import OrderingFilter
@@ -53,6 +53,7 @@ class ETLInstanceViewSet(CustomPaginationListModelMixin, GenericViewSet):
                     to_attr="prefeteched_validationnode_set",
                 )
             )
+            .annotate(workflow_deprecated=Q(form__validation_workflow__deleted_at__isnull=False))
             .only(
                 "id",
                 "json",

--- a/iaso/api/validation_workflow_instances/views.py
+++ b/iaso/api/validation_workflow_instances/views.py
@@ -65,7 +65,9 @@ class ValidationWorkflowInstanceViewSet(RetrieveModelMixin, CustomPaginationList
         return ValidationWorkflowInstanceRetrieveSerializer
 
     def get_queryset(self):
-        qs = Instance.objects.filter_for_user(user=self.request.user).filter(form__deleted_at__isnull=True)
+        qs = Instance.objects.filter_for_user(user=self.request.user).filter(
+            form__deleted_at__isnull=True, form__validation_workflow__deleted_at__isnull=True
+        )
 
         if self.action == "retrieve":
             return qs.select_related("form__validation_workflow").prefetch_related(

--- a/iaso/api/validation_workflows/views_mobile.py
+++ b/iaso/api/validation_workflows/views_mobile.py
@@ -27,6 +27,10 @@ class ValidationWorkflowMobileViewSet(CustomPaginationListModelMixin, GenericVie
         return (
             Instance.objects.filter_for_user(self.request.user)
             .select_related("form")
-            .filter(form__deleted_at__isnull=True, validationnode__isnull=False)
+            .filter(
+                form__deleted_at__isnull=True,
+                validationnode__isnull=False,
+                form__validation_workflow__deleted_at__isnull=True,
+            )
             .distinct("id")
         )

--- a/iaso/api/validation_workflows_node_templates/views.py
+++ b/iaso/api/validation_workflows_node_templates/views.py
@@ -69,7 +69,7 @@ class ValidationNodeTemplatesView(NestedViewSetMixin, ModelViewSet):
     def get_queryset(self):
         account = self.request.user.iaso_profile.account
         qs = super().get_queryset()
-        qs = qs.filter(workflow__account=account)
+        qs = qs.filter(workflow__account=account, workflow__deleted_at__isnull=True)
         if self.action in ["delete"]:
             return qs.prefetch_related("roles_required", "next_node_templates", "previous_node_templates")
         if self.action in ["retrieve", "list"]:

--- a/iaso/api/validation_workflows_nodes/views.py
+++ b/iaso/api/validation_workflows_nodes/views.py
@@ -32,7 +32,7 @@ class ValidationNodeViewSet(GenericViewSet):
             return (
                 Instance.objects.select_related("project__account", "form", "form__validation_workflow")
                 .filter_for_user(self.request.user)
-                .filter(form__deleted_at__isnull=True)
+                .filter(form__deleted_at__isnull=True, form__validation_workflow__deleted_at__isnull=True)
                 .annotate(
                     annotate_last_submission_created_at=Subquery(
                         ValidationNode.objects.filter(instance=OuterRef("pk"))
@@ -54,8 +54,9 @@ class ValidationNodeViewSet(GenericViewSet):
             .filter(
                 instance__in=Instance.objects.select_related("project__account", "form")
                 .filter_for_user(self.request.user)
-                .filter(form__deleted_at__isnull=True)
+                .filter(form__deleted_at__isnull=True, form__validation_workflow__deleted_at__isnull=True)
             )
+            .filter(node__workflow__deleted_at__isnull=True)
             .filter_for_user(self.request.user)
         )
 

--- a/iaso/models/validation_workflow/templates.py
+++ b/iaso/models/validation_workflow/templates.py
@@ -12,7 +12,11 @@ from django.db.models import Q
 from iaso.models import Instance
 from iaso.models.base import UserRole
 from iaso.models.common import BulkAutoSlugField, CreatedAndUpdatedModel
-from iaso.utils.models.soft_deletable import DefaultSoftDeletableManager, SoftDeletableModel
+from iaso.utils.models.soft_deletable import (
+    DefaultSoftDeletableManager,
+    OnlyDeletedSoftDeletableManager,
+    SoftDeletableModel,
+)
 
 
 class PositionChoices(models.TextChoices):
@@ -41,6 +45,7 @@ class ValidationWorkflow(CreatedAndUpdatedModel, SoftDeletableModel):
     )
 
     objects = DefaultSoftDeletableManager()
+    objects_only_deleted = OnlyDeletedSoftDeletableManager()
 
     def __str__(self):
         return self.name

--- a/iaso/tests/api/instances/test_views_etl.py
+++ b/iaso/tests/api/instances/test_views_etl.py
@@ -209,7 +209,8 @@ class ETLInstanceTestCase(SwaggerTestCaseMixin, APITestCase):
         res_data = self.assertJSONResponse(res, status.HTTP_200_OK)
         self.assertValidData(res_data, 2)
 
-        self.assertTrue(all(x["workflow_deprecated"] for x in res_data["results"]))
+        self.assertTrue(res_data["results"][0]["workflow_deprecated"])
+        self.assertFalse(res_data["results"][1]["workflow_deprecated"])
 
     def test_instance_without_file(self):
         self.client.force_authenticate(self.john_wick)

--- a/iaso/tests/api/instances/test_views_etl.py
+++ b/iaso/tests/api/instances/test_views_etl.py
@@ -149,6 +149,7 @@ class ETLInstanceTestCase(SwaggerTestCaseMixin, APITestCase):
         self.assertIsNotNone(first_instance["file_url"])
         self.assertIsNotNone(first_instance["file_content"])
         self.assertEqual(first_instance["form_id"], self.form_1.pk)
+        self.assertFalse(first_instance["workflow_deprecated"])
 
         history = first_instance["history"]
 
@@ -192,11 +193,23 @@ class ETLInstanceTestCase(SwaggerTestCaseMixin, APITestCase):
         self.assertIsNotNone(second_instance["file_url"])
         self.assertIsNotNone(second_instance["file_content"])
         self.assertEqual(second_instance["form_id"], self.form_2.pk)
+        self.assertFalse(second_instance["workflow_deprecated"])
 
         history = second_instance["history"]
 
         self.assertEqual(history, [])
         self.assertEqual(len(history), 0)
+
+        self.vf.delete()
+        self.vf.refresh_from_db()
+
+        self.assertIsNotNone(self.vf.deleted_at)
+
+        res = self.client.get(reverse("api-etl:instances-list"))
+        res_data = self.assertJSONResponse(res, status.HTTP_200_OK)
+        self.assertValidData(res_data, 2)
+
+        self.assertTrue(all(x["workflow_deprecated"] for x in res_data["results"]))
 
     def test_instance_without_file(self):
         self.client.force_authenticate(self.john_wick)

--- a/iaso/tests/api/validation_workflow_instances/test_views/test_list.py
+++ b/iaso/tests/api/validation_workflow_instances/test_views/test_list.py
@@ -664,3 +664,27 @@ class ValidationWorkflowInstanceAPIListTestCase(SwaggerTestCaseMixin, APITestCas
         with self.assertNumQueries(5):
             res = self.client.get(reverse("validation_workflow_instances-list"))
         self.assertJSONResponse(res, status.HTTP_200_OK)
+
+    def test_should_not_see_result_if_validation_workflow_is_soft_deleted(self):
+        ValidationWorkflowEngine.start(self.validation_workflow, self.john_doe, self.instance)
+
+        ValidationWorkflowEngine.start(self.other_validation_workflow, self.john_doe, self.other_instance)
+
+        ValidationWorkflowEngine.complete_node(
+            self.instance.get_next_pending_nodes().first(), self.john_wick, self.instance, True, "LGTM"
+        )
+        ValidationWorkflowEngine.complete_node(
+            self.other_instance.get_next_pending_nodes().first(), self.john_wick, self.other_instance, True, "LGTM"
+        )
+        self.client.force_authenticate(self.john_wick)
+        res = self.client.get(reverse("validation_workflow_instances-list"))
+        res_data = self.assertJSONResponse(res, status.HTTP_200_OK)
+        self.assertValidListData(list_data=res_data, results_key="results", expected_length=2, paginated=True)
+
+        self.validation_workflow.delete()
+        self.validation_workflow.refresh_from_db()
+        self.assertIsNotNone(self.validation_workflow.deleted_at)
+
+        res = self.client.get(reverse("validation_workflow_instances-list"))
+        res_data = self.assertJSONResponse(res, status.HTTP_200_OK)
+        self.assertValidListData(list_data=res_data, results_key="results", expected_length=1, paginated=True)

--- a/iaso/tests/api/validation_workflow_instances/test_views/test_retrieve.py
+++ b/iaso/tests/api/validation_workflow_instances/test_views/test_retrieve.py
@@ -724,3 +724,17 @@ class ValidationWorkflowInstanceAPIRetrieveTestCaseResubmissionWithNextByPass(Sw
         res = self.client.get(reverse("validation_workflow_instances-detail", kwargs={"pk": instance.pk}))
         res_data = self.assertJSONResponse(res, status.HTTP_200_OK)
         self.assertEqual(res_data, {"total_steps": 0, "validation_status": "", "submissions": []})
+
+    def test_should_not_see_result_if_validation_workflow_is_soft_deleted(self):
+        ValidationWorkflowEngine.start(self.validation_workflow, self.john_wick, self.instance)
+
+        self.client.force_authenticate(self.john_wick)
+        res = self.client.get(reverse("validation_workflow_instances-detail", kwargs={"pk": self.instance.pk}))
+        self.assertJSONResponse(res, status.HTTP_200_OK)
+
+        self.validation_workflow.delete()
+        self.validation_workflow.refresh_from_db()
+        self.assertIsNotNone(self.validation_workflow.deleted_at)
+
+        res = self.client.get(reverse("validation_workflow_instances-detail", kwargs={"pk": self.instance.pk}))
+        res_data = self.assertJSONResponse(res, status.HTTP_404_NOT_FOUND)

--- a/iaso/tests/api/validation_workflow_nodes/test_views/test_complete.py
+++ b/iaso/tests/api/validation_workflow_nodes/test_views/test_complete.py
@@ -241,3 +241,21 @@ class ValidationNodeAPICompleteTestCase(BaseAPITestCase):
         self.assertEqual(res.status_code, status.HTTP_404_NOT_FOUND)
 
         self.assertEqual(other_node.validationnode_set.count(), 2)
+
+    def test_exclude_if_validation_workflow_is_soft_deleted(self):
+        self.validation_workflow.delete()
+        self.validation_workflow.refresh_from_db()
+        self.assertIsNotNone(self.validation_workflow.deleted_at)
+
+        self.client.force_authenticate(self.john_wick)
+        res = self.client.post(
+            reverse(
+                "validation_workflow_nodes-complete",
+                kwargs={
+                    "instance_id": self.instance.id,
+                    "pk": self.instance.get_next_pending_nodes(self.validation_workflow).first().pk,
+                },
+            ),
+            data={"comment": "Nope"},
+        )
+        self.assertEqual(res.status_code, status.HTTP_404_NOT_FOUND)

--- a/iaso/tests/api/validation_workflow_nodes/test_views/test_complete_bypass.py
+++ b/iaso/tests/api/validation_workflow_nodes/test_views/test_complete_bypass.py
@@ -141,3 +141,15 @@ class ValidationNodeAPICompleteBypassTestCase(BaseAPITestCase):
         self.assertEqual(res.status_code, status.HTTP_404_NOT_FOUND)
 
         self.assertEqual(other_node.validationnode_set.count(), 2)
+
+    def test_exclude_if_validation_workflow_is_soft_deleted(self):
+        self.validation_workflow.delete()
+        self.validation_workflow.refresh_from_db()
+        self.assertIsNotNone(self.validation_workflow.deleted_at)
+
+        self.client.force_authenticate(self.john_wick)
+        res = self.client.post(
+            reverse("validation_workflow_nodes-complete-bypass", kwargs={"instance_id": self.instance.id}),
+            data={"node": "third-node", "approved": False, "comment": "Nope"},
+        )
+        self.assertEqual(res.status_code, status.HTTP_404_NOT_FOUND)

--- a/iaso/tests/api/validation_workflow_nodes/test_views/test_undo.py
+++ b/iaso/tests/api/validation_workflow_nodes/test_views/test_undo.py
@@ -126,3 +126,21 @@ class ValidationNodeAPIUndoTestCase(BaseAPITestCase):
         self.assertEqual(res.status_code, status.HTTP_404_NOT_FOUND)
 
         self.assertEqual(other_node.validationnode_set.count(), 2)
+
+    def test_exclude_if_validation_workflow_is_soft_deleted(self):
+        node = self.instance.get_next_pending_nodes().first()
+        node_pk = node.pk
+        # reject first node
+        ValidationWorkflowEngine.complete_node(
+            self.instance.get_next_pending_nodes().first(), self.john_wick, self.instance, approved=True, comment="LGTM"
+        )
+
+        self.validation_workflow.delete()
+        self.validation_workflow.refresh_from_db()
+        self.assertIsNotNone(self.validation_workflow.deleted_at)
+
+        self.client.force_authenticate(self.john_wick)
+        res = self.client.post(
+            reverse("validation_workflow_nodes-undo", kwargs={"instance_id": self.instance.id, "pk": node_pk})
+        )
+        self.assertEqual(res.status_code, status.HTTP_404_NOT_FOUND)

--- a/iaso/tests/api/validation_workflows/test_views_mobile.py
+++ b/iaso/tests/api/validation_workflows/test_views_mobile.py
@@ -596,3 +596,22 @@ class MobileValidationWorkflowAPITestCase(APITestCase):
             # 6-7: SERIALIZER
             res = self.client.get(reverse("mobile_validation_workflows-list"))
             self.assertJSONResponse(res, status.HTTP_200_OK)
+
+    def test_should_not_see_soft_deleted_workflows(self):
+        self.client.force_authenticate(self.john_wick)
+        self.setup_reject()
+
+        res = self.client.get(reverse("mobile_validation_workflows-list"))
+        res_data = self.assertJSONResponse(res, status.HTTP_200_OK)
+
+        self.assertValidListData(list_data=res_data, results_key="results", expected_length=1, paginated=True)
+
+        self.validation_workflow.delete()
+
+        self.validation_workflow.refresh_from_db()
+        self.assertIsNotNone(self.validation_workflow.deleted_at)
+
+        res = self.client.get(reverse("mobile_validation_workflows-list"))
+        res_data = self.assertJSONResponse(res, status.HTTP_200_OK)
+
+        self.assertValidListData(list_data=res_data, results_key="results", expected_length=0, paginated=True)

--- a/iaso/tests/api/validation_workflows_node_templates/test_views/test_bulk_create.py
+++ b/iaso/tests/api/validation_workflows_node_templates/test_views/test_bulk_create.py
@@ -290,3 +290,29 @@ class ValidationNodeTemplateAPIBulkCreateTestCase(BaseApiTestCase):
         self.assertHasError(
             res_data[0], api_settings.NON_FIELD_ERRORS_KEY, "The fields name, workflow must make a unique set."
         )
+
+    def test_forbidden_if_validation_workflow_is_soft_deleted(self):
+        self.validation_workflow.delete()
+        self.validation_workflow.refresh_from_db()
+        self.assertIsNotNone(self.validation_workflow.deleted_at)
+        self.client.force_authenticate(self.john_wick)
+        res = self.client.post(
+            reverse(
+                "validation_node_templates-bulk",
+                kwargs={"parent_lookup_workflow__slug": self.validation_workflow.slug},
+            ),
+            data=[
+                {
+                    "name": "First node",
+                    "description": "Here we should check something",
+                },
+                {"name": "Second node"},
+                {
+                    "name": "Last node",
+                    "can_skip_previous_nodes": True,
+                    "roles_required": [self.user_role.pk],
+                },
+            ],
+        )
+
+        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)

--- a/iaso/tests/api/validation_workflows_node_templates/test_views/test_bulk_update.py
+++ b/iaso/tests/api/validation_workflows_node_templates/test_views/test_bulk_update.py
@@ -401,3 +401,26 @@ class ValidationNodeTemplateAPIBulkUpdateTestCase(BaseApiTestCase):
         res_data = self.assertJSONResponse(res, status.HTTP_400_BAD_REQUEST)
 
         self.assertHasError(res_data, api_settings.NON_FIELD_ERRORS_KEY, "Names must be unique.")
+
+    def test_forbidden_if_validation_workflow_is_soft_deleted(self):
+        self.validation_workflow.delete()
+        self.validation_workflow.refresh_from_db()
+        self.assertIsNotNone(self.validation_workflow.deleted_at)
+        self.client.force_authenticate(self.john_wick)
+        res = self.client.put(
+            reverse(
+                "validation_node_templates-bulk",
+                kwargs={"parent_lookup_workflow__slug": self.validation_workflow.slug},
+            ),
+            data=[
+                {"slug": self.third_node.slug, "name": "new first node", "roles_required": [self.user_role.pk]},
+                {"slug": self.first_node.slug, "name": "new second node", "can_skip_previous_nodes": True},
+                {
+                    "slug": self.second_node.slug,
+                    "name": "new third node",
+                    "description": "some description",
+                },
+            ],
+        )
+
+        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)

--- a/iaso/tests/api/validation_workflows_node_templates/test_views/test_create.py
+++ b/iaso/tests/api/validation_workflows_node_templates/test_views/test_create.py
@@ -366,3 +366,24 @@ class ValidationNodeTemplateAPICreateTestCase(BaseApiTestCase):
         self.assertHasError(
             res_data, api_settings.NON_FIELD_ERRORS_KEY, "The fields name, workflow must make a unique set."
         )
+
+    def test_forbidden_if_validation_workflow_is_soft_deleted(self):
+        self.validation_workflow.delete()
+        self.validation_workflow.refresh_from_db()
+        self.assertIsNotNone(self.validation_workflow.deleted_at)
+        self.client.force_authenticate(self.john_wick)
+        res = self.client.post(
+            reverse(
+                "validation_node_templates-list",
+                kwargs={"parent_lookup_workflow__slug": self.validation_workflow.slug},
+            ),
+            data={
+                "name": "Random name 2",
+                "description": "Random description",
+                "roles_required": [self.user_role.pk],
+                "position": PositionChoices.first,
+                "can_skip_previous_nodes": True,
+            },
+        )
+
+        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)

--- a/iaso/tests/api/validation_workflows_node_templates/test_views/test_delete.py
+++ b/iaso/tests/api/validation_workflows_node_templates/test_views/test_delete.py
@@ -152,3 +152,17 @@ class ValidationNodeTemplateAPIDeleteTestCase(BaseApiTestCase):
         self.assertEqual(
             list(self.third_node.previous_node_templates.values_list("pk", flat=True)), [self.first_node.pk]
         )
+
+    def test_forbidden_if_validation_workflow_is_soft_deleted(self):
+        self.validation_workflow.delete()
+        self.validation_workflow.refresh_from_db()
+        self.assertIsNotNone(self.validation_workflow.deleted_at)
+        self.client.force_authenticate(self.john_wick)
+        res = self.client.delete(
+            reverse(
+                "validation_node_templates-detail",
+                kwargs={"parent_lookup_workflow__slug": self.validation_workflow.slug, "slug": self.second_node.slug},
+            )
+        )
+
+        self.assertEqual(res.status_code, status.HTTP_404_NOT_FOUND)

--- a/iaso/tests/api/validation_workflows_node_templates/test_views/test_list.py
+++ b/iaso/tests/api/validation_workflows_node_templates/test_views/test_list.py
@@ -164,3 +164,28 @@ class ValidationNodeTemplateAPIListTestCase(BaseApiTestCase):
         res_data = self.assertJSONResponse(res, status.HTTP_200_OK)
 
         self.assertValidListData(list_data=res_data, results_key="results", expected_length=1)
+
+    def test_exclude_if_validation_workflow_is_soft_deleted(self):
+        self.client.force_authenticate(self.john_wick)
+
+        res = self.client.get(
+            reverse(
+                "validation_node_templates-list", kwargs={"parent_lookup_workflow__slug": self.validation_workflow.slug}
+            )
+        )
+        res_data = self.assertJSONResponse(res, status.HTTP_200_OK)
+
+        self.assertValidListData(list_data=res_data, results_key="results", expected_length=3)
+
+        self.validation_workflow.delete()
+        self.validation_workflow.refresh_from_db()
+        self.assertIsNotNone(self.validation_workflow.deleted_at)
+        self.client.force_authenticate(self.john_wick)
+        res = self.client.get(
+            reverse(
+                "validation_node_templates-list", kwargs={"parent_lookup_workflow__slug": self.validation_workflow.slug}
+            )
+        )
+        res_data = self.assertJSONResponse(res, status.HTTP_200_OK)
+
+        self.assertValidListData(list_data=res_data, results_key="results", expected_length=0)

--- a/iaso/tests/api/validation_workflows_node_templates/test_views/test_move.py
+++ b/iaso/tests/api/validation_workflows_node_templates/test_views/test_move.py
@@ -199,3 +199,19 @@ class ValidationNodeTemplateAPIMoveTestCase(BaseApiTestCase):
                 data={"position": PositionChoices.child_of, "parent_node_templates": [self.first_node.slug]},
             )
             self.assertEqual(res.status_code, status.HTTP_204_NO_CONTENT)
+
+    def test_forbid_if_validation_workflow_is_soft_deleted(self):
+        self.client.force_authenticate(self.john_wick)
+
+        self.validation_workflow.delete()
+        self.validation_workflow.refresh_from_db()
+        self.assertIsNotNone(self.validation_workflow.deleted_at)
+
+        res = self.client.put(
+            reverse(
+                "validation_node_templates-move",
+                kwargs={"parent_lookup_workflow__slug": self.validation_workflow.slug, "slug": self.second_node.slug},
+            ),
+            data={"position": PositionChoices.first},
+        )
+        self.assertJSONResponse(res, status.HTTP_404_NOT_FOUND)

--- a/iaso/tests/api/validation_workflows_node_templates/test_views/test_partial_update.py
+++ b/iaso/tests/api/validation_workflows_node_templates/test_views/test_partial_update.py
@@ -246,3 +246,19 @@ class ValidationTemplateAPIPartialUpdateTestCase(BaseApiTestCase):
         )
 
         self.assertJSONResponse(res, status.HTTP_200_OK)
+
+    def test_forbid_if_validation_workflow_is_soft_deleted(self):
+        self.client.force_authenticate(self.john_wick)
+
+        self.validation_workflow.delete()
+        self.validation_workflow.refresh_from_db()
+        self.assertIsNotNone(self.validation_workflow.deleted_at)
+
+        res = self.client.patch(
+            reverse(
+                "validation_node_templates-detail",
+                kwargs={"parent_lookup_workflow__slug": self.validation_workflow.slug, "slug": self.node.slug},
+            ),
+            data={"name": "test", "roles_required": [self.user_role.pk]},
+        )
+        self.assertJSONResponse(res, status.HTTP_404_NOT_FOUND)

--- a/iaso/tests/api/validation_workflows_node_templates/test_views/test_retrieve.py
+++ b/iaso/tests/api/validation_workflows_node_templates/test_views/test_retrieve.py
@@ -154,3 +154,32 @@ class ValidationNodeTemplateAPIRetrieveTestCase(BaseApiTestCase):
                 self.assertEqual(res_data["description"], "some description")
                 self.assertEqual(res_data["roles_required"], [{"id": self.user_role.pk, "name": "Group"}])
                 self.assertTrue(res_data["can_skip_previous_nodes"])
+
+    def test_exclude_if_validation_workflow_is_soft_deleted(self):
+        self.client.force_authenticate(self.john_wick)
+
+        res = self.client.get(
+            reverse(
+                "validation_node_templates-detail",
+                kwargs={
+                    "parent_lookup_workflow__slug": self.validation_workflow.slug,
+                    "slug": self.second_node.slug,
+                },
+            )
+        )
+        self.assertJSONResponse(res, status.HTTP_200_OK)
+
+        self.validation_workflow.delete()
+        self.validation_workflow.refresh_from_db()
+        self.assertIsNotNone(self.validation_workflow.deleted_at)
+        self.client.force_authenticate(self.john_wick)
+        res = self.client.get(
+            reverse(
+                "validation_node_templates-detail",
+                kwargs={
+                    "parent_lookup_workflow__slug": self.validation_workflow.slug,
+                    "slug": self.second_node.slug,
+                },
+            )
+        )
+        self.assertJSONResponse(res, status.HTTP_404_NOT_FOUND)

--- a/iaso/tests/api/validation_workflows_node_templates/test_views/test_update.py
+++ b/iaso/tests/api/validation_workflows_node_templates/test_views/test_update.py
@@ -229,3 +229,19 @@ class ValidationNodeTemplateAPIUpdateTestCase(BaseApiTestCase):
         )
 
         self.assertJSONResponse(res, status.HTTP_200_OK)
+
+    def test_forbid_if_validation_workflow_is_soft_deleted(self):
+        self.client.force_authenticate(self.john_wick)
+
+        self.validation_workflow.delete()
+        self.validation_workflow.refresh_from_db()
+        self.assertIsNotNone(self.validation_workflow.deleted_at)
+
+        res = self.client.put(
+            reverse(
+                "validation_node_templates-detail",
+                kwargs={"parent_lookup_workflow__slug": self.validation_workflow.slug, "slug": self.node.slug},
+            ),
+            data={"name": "test", "roles_required": [self.user_role.pk]},
+        )
+        self.assertJSONResponse(res, status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
## What problem is this PR solving?

API was still returning some results related to soft deleted validation workflows

### Related JIRA tickets

IA-5252

## Changes

Checked all the endpoints and filter out soft deleted workflows
Adapted ETL endpoint by adding a new field : workflow_deprecated.

## How to test

Create a validation workflow, attach some form and start some process with instances. 
Delete the validation workflow
Everything should disappear from the UI


## Notes

Couldn't fix the form API

* Tried to implement a custom PK related field serializer that would filter out soft deleted models; but as the api code is not optimized, it would trigger n+1 queries on validation_workflow field for list endpoint. (solution would be to split serializer per operation)
* Cascading soft delete is not a good solution either because:
  * Form is attached to a validation workflow
  * Validation workflow is soft deleted, form FK is set to null
  * We decide to restore the validation workflow => form FK is still broken ? (even though if the user resaves the form from the UI , it'll be set to null)


