### PR TITLE
[SLEEP-1806] Refactor of the notification page

### DIFF
--- a/hat/webpack.dev.js
+++ b/hat/webpack.dev.js
@@ -130,7 +130,9 @@ module.exports = {
             __LOCALE: JSON.stringify(LOCALE),
         }),
         new webpack.DefinePlugin({
-           'process.env.ORVAL_API_BASE_URL': JSON.stringify(process.env?.ORVAL_API_BASE_URL ?? "")
+            'process.env.ORVAL_API_BASE_URL': JSON.stringify(
+                process.env?.ORVAL_API_BASE_URL ?? '',
+            ),
         }),
         // XLSX
         new webpack.IgnorePlugin({ resourceRegExp: /cptable/ }),
@@ -303,6 +305,10 @@ module.exports = {
             'bluesquare-components': path.resolve(
                 __dirname,
                 '../node_modules/bluesquare-components',
+            ),
+            'react-query': path.resolve(
+                __dirname,
+                '../node_modules/react-query',
             ),
             leaflet: path.resolve(__dirname, '../node_modules/leaflet'),
             'react-leaflet': path.resolve(

--- a/hat/webpack.prod.js
+++ b/hat/webpack.prod.js
@@ -65,7 +65,9 @@ module.exports = {
                 // need to do JSON stringify on all vars here to take effect,
                 // see https://github.com/eHealthAfrica/guinea-connect-universal-app/blob/development/webpack/prod.config.js
                 NODE_ENV: JSON.stringify('production'),
-                ORVAL_API_BASE_URL: JSON.stringify(process.env?.ORVAL_API_BASE_URL ?? "")
+                ORVAL_API_BASE_URL: JSON.stringify(
+                    process.env?.ORVAL_API_BASE_URL ?? '',
+                ),
             },
             __LOCALE: JSON.stringify(LOCALE),
         }),
@@ -107,6 +109,11 @@ module.exports = {
                     requiredVersion: false,
                 },
                 'bluesquare-components': {
+                    singleton: true,
+                    eager: true,
+                    requiredVersion: false,
+                },
+                'react-query': {
                     singleton: true,
                     eager: true,
                     requiredVersion: false,

--- a/orval.config.ts
+++ b/orval.config.ts
@@ -1,12 +1,23 @@
 import { mutationInvalidates as validationWorkflowsMutationInvalidates} from './hat/assets/js/orval/apiConfiguration/validationWorkflows/configuration';
 import { createSchemaTransformer, normalizeSchema } from './hat/assets/js/orval/transformer/fakerTransformer';
 
+const fs = require('fs');
+const path = require('path');
+const { getPluginFolders } = require('./hat/assets/js/apps/Iaso/bundle/plugins');
+
 require('dotenv').config();
 
 const ORVAL_TARGET = `${process.env.ORVAL_TARGET_URL_PROTOCOL || 'http'}://${process.env.ORVAL_TARGET_URL_DOMAIN || 'localhost:8000'}`;
 const ORVAL_TARGET_FILE = process.env?.ORVAL_TARGET_FILE
+const ORVAL_HELPERS_DIR = path.resolve(__dirname, 'hat/assets/js/orval/');
 
-const createConfig = (project: string, tags: string[] | RegExp[], mutationInvalidates?: any[], schemas?: string[] | RegExp[]) => {
+const createConfig = (
+    project: string,
+    tags: string[] | RegExp[],
+    mutationInvalidates?: any[],
+    schemas?: string[] | RegExp[],
+    workspace: string = `./hat/assets/js/apps/Iaso/api/${project}`,
+) => {
     return {
         input: {
             target: ORVAL_TARGET_FILE ? ORVAL_TARGET_FILE : new URL('/swagger/?format=json', ORVAL_TARGET).toString(),
@@ -38,7 +49,7 @@ const createConfig = (project: string, tags: string[] | RegExp[], mutationInvali
             baseUrl: {
                 runtime: 'process.env.ORVAL_API_BASE_URL'
             },
-            workspace: `./hat/assets/js/apps/Iaso/api/${project}`,
+            workspace,
             override: {
                 // operations: OperationConfig.operations,
                 requestOptions: {
@@ -53,17 +64,17 @@ const createConfig = (project: string, tags: string[] | RegExp[], mutationInvali
                     useInvalidate: true,
                     mutationInvalidates: mutationInvalidates ?? [],
                     queryOptions: {
-                        path: './hat/assets/js/orval/mutator/custom-query-options.ts',
+                        path: path.join(ORVAL_HELPERS_DIR, 'mutator/custom-query-options.ts'),
                         name: 'getCustomQueryOptions',
                     },
                     mutationOptions: {
-                        path: './hat/assets/js/orval/mutator/custom-mutation-options.ts',
+                        path: path.join(ORVAL_HELPERS_DIR, 'mutator/custom-mutation-options.ts'),
                         name: 'useCustomMutationOptions',
                         optionalQueryClient: true,
                     },
                 },
                 mutator: {
-                    path: '../../../../orval/client/custom-fetch.ts',
+                    path: path.join(ORVAL_HELPERS_DIR, 'client/custom-fetch.ts'),
                     name: 'customFetchInstance',
                     runtimeValidation: true
                 },
@@ -100,7 +111,31 @@ const createConfig = (project: string, tags: string[] | RegExp[], mutationInvali
     };
 };
 
+const loadPluginProjects = () => {
+    const projects = {};
+    // getPluginFolders expects the `hat` dir and resolves ../plugins from it.
+    getPluginFolders(path.resolve(__dirname, 'hat')).forEach((plugin: string) => {
+        const contribPath = path.resolve(
+            __dirname,
+            `plugins/${plugin}/js/orval.config.cjs`,
+        );
+        if (!fs.existsSync(contribPath)) return;
+        const descriptors = require(contribPath);
+        (Array.isArray(descriptors) ? descriptors : []).forEach((d: any) => {
+            projects[d.project] = createConfig(
+                d.project,
+                d.tags,
+                d.mutationInvalidates,
+                d.schemas,
+                d.workspace,
+            );
+        });
+    });
+    return projects;
+};
+
 module.exports = {
     // validationWorkflows: createConfig('validationWorkflows', ['Validation workflows'], validationWorkflowsMutationInvalidates),
     // profiles: createConfig('profiles', ['Profiles'])
+    ...loadPluginProjects(),
 };


### PR DESCRIPTION
## What problem is this PR solving?

Generating hooks and types with Orval in trypelim plugin causes a "no queryclient set" error because of the 2 different react context.
This PR is about fixing this issue by forcing the trypelim's react-query to resolve to IASO's copy

### Related JIRA tickets

[SLEEP-1806](https://bluesquare.atlassian.net/browse/SLEEP-1806)

## Changes

- in webpack.dev, I added react-query to the unconditional alias
- in webpack.prod, I added it to the module federation

## How to test

//

## Notes

Things that the reviewers should know:

Linked to this [PR](https://github.com/BLSQ/trypelim/pull/284)

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).


[SLEEP-1806]: https://bluesquare.atlassian.net/browse/SLEEP-1806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ