### PR TITLE
IA-5268 delete account command is no more working

### DIFF
--- a/iaso/management/commands/delete_accounts.py
+++ b/iaso/management/commands/delete_accounts.py
@@ -63,7 +63,7 @@ from django.contrib.sessions.models import Session
 from django.core.management.base import BaseCommand
 from django.db import connection
 from django.db.models import ForeignKey, ManyToManyRel, OneToOneField, Q, QuerySet, TextField
-from django.db.models.deletion import SET_NULL, Collector, ProtectedError
+from django.db.models.deletion import PROTECT, SET_NULL, Collector, ProtectedError
 from django.db.models.functions import Cast
 
 from hat.audit.models import Modification
@@ -465,6 +465,55 @@ class Command(BaseCommand):
 
         return total
 
+    def _delete_with_protect_retries(self, queryset, label):
+        """
+        Deletes `queryset`, auto-resolving ProtectedError by deleting the blocking rows
+        first — recursively, so a PROTECT chain deeper than one level (e.g. a multi-level
+        Team.parent hierarchy, where unblocking a parent uncovers a grandparent still
+        blocked by it) doesn't escape as an uncaught exception. Each level reuses this
+        same retry logic instead of a bare, non-retried delete.
+        """
+        deleted_count = 0
+        for attempt in range(_MAX_PROTECT_UNBLOCK_ATTEMPTS):
+            try:
+                deleted_count += self._delete_qs_in_chunks(queryset, label=label)
+                return deleted_count
+            except ProtectedError as exc:
+                blocking_pks_by_model = defaultdict(list)
+                for obj in exc.protected_objects:
+                    blocking_pks_by_model[type(obj)].append(obj.pk)
+                for blocker_model, pks in blocking_pks_by_model.items():
+                    self._log(f"  [auto-unblock] {blocker_model.__name__} ×{len(pks)} blocking {label}")
+                    self._delete_with_protect_retries(
+                        blocker_model.objects.filter(pk__in=pks),
+                        label=f"{blocker_model.__name__}[unblock]",
+                    )
+        raise RuntimeError(
+            f"Could not delete {label} after {_MAX_PROTECT_UNBLOCK_ATTEMPTS} attempts — PROTECT cycle not resolved"
+        )
+
+    def _null_self_referential_fks(self, model, qs, label):
+        """
+        Nulls any nullable, self-referential PROTECT FK on `qs` (e.g. Team.parent,
+        Entity.merged_to) before it gets deleted. Mirrors the OrgUnit.parent handling
+        above: on_delete=PROTECT raises as soon as ANY row references the one being
+        deleted, whether or not that row is also part of the same delete — so a tree
+        deleted in one batch always trips over itself unless the self-reference is
+        broken first.
+
+        Scoped to on_delete=PROTECT specifically (not e.g. CommentIaso's self-ref
+        CASCADE) — CASCADE already deletes the whole subtree without our help, so
+        nulling it first would just be unnecessary writes on rows about to disappear.
+        """
+        for field in model._meta.local_fields:
+            if (
+                isinstance(field, ForeignKey)
+                and field.related_model is model
+                and field.null
+                and field.remote_field.on_delete is PROTECT
+            ):
+                self._update_qs(qs, label=f"{label}.{field.name}=NULL[self-ref]", **{field.name: None})
+
     def _update_qs(self, queryset, label=None, **fields):
         """Dry-run-aware wrapper around queryset.update(**fields)."""
         label = label or queryset.model.__name__
@@ -512,7 +561,7 @@ class Command(BaseCommand):
                     blocking_pks_by_model[type(obj)].append(obj.pk)
                 for blocker_model, pks in blocking_pks_by_model.items():
                     self._log(f"  [auto-unblock] {blocker_model.__name__} ×{len(pks)} blocking {label} (collect phase)")
-                    self._delete_qs_in_chunks(
+                    self._delete_with_protect_retries(
                         blocker_model.objects.filter(pk__in=pks), label=f"{blocker_model.__name__}[unblock]"
                     )
         else:
@@ -1003,6 +1052,21 @@ class Command(BaseCommand):
             devices = Device.objects.filter(pk__in=device_ids)
             self._delete_qs(devices, label="Device")
 
+        # ---- Step 4g: Out-of-graph — Dashboard.owned_by (third-party, no FK to Account) ----
+        # django_sql_dashboard is only installed in some environments (see the _Dashboard
+        # import guard above) and isn't part of the auto-discovered graph (no FK to
+        # Account). Its FK to User must be cleared explicitly before Users are deleted
+        # below, or Postgres raises an IntegrityError — Django's on_delete is enforced by
+        # the ORM Collector, not a DB-level constraint, so a plain User.delete() only
+        # cascades relations the auto-discovery step actually walked.
+        if _Dashboard is not None:
+            with self._doing(f"account={account.id} Dashboard.owned_by=NULL"):
+                self._update_qs(
+                    _Dashboard.objects.filter(owned_by_id__in=user_ids),
+                    label="Dashboard.owned_by=NULL",
+                    owned_by=None,
+                )
+
         # ---- Step 5: Out-of-graph — User (upstream from Profile, not in reverse FK graph) ----
         # Profile was deleted in the auto step; use the user_ids collected at the top.
         with self._doing(f"account={account.id} User"):
@@ -1077,30 +1141,21 @@ class Command(BaseCommand):
             if info.is_partial_coverage:
                 label += " ⚠ partial"
 
+            # Self-referential PROTECT FKs (e.g. Team.parent, same idea as OrgUnit.parent
+            # above) always raise ProtectedError on delete, even when both ends of the
+            # reference are in the same batch — Collector's PROTECT check fires on any
+            # existing referencing row regardless of it also being staged for deletion.
+            # Null it upfront so the whole tree deletes in one shot, correct order.
+            self._null_self_referential_fks(model, qs, label)
+
             if self.dry_run:
                 self._log(f"  [DRY RUN] would delete {label}")
                 continue
 
-            deleted_count = 0
-            for attempt in range(_MAX_PROTECT_UNBLOCK_ATTEMPTS):
-                try:
-                    deleted_count += self._delete_qs_in_chunks(qs, label=label)
-                    break
-                except ProtectedError as exc:
-                    # Auto-clear blocking objects (e.g. nullable PROTECT FKs from partial-coverage models)
-                    blocking_pks_by_model = defaultdict(list)
-                    for obj in exc.protected_objects:
-                        blocking_pks_by_model[type(obj)].append(obj.pk)
-                    for blocker_model, pks in blocking_pks_by_model.items():
-                        self._log(f"  [auto-unblock] {blocker_model.__name__} ×{len(pks)} blocking {label}")
-                        self._delete_qs_in_chunks(
-                            blocker_model.objects.filter(pk__in=pks),
-                            label=f"{blocker_model.__name__}[unblock]",
-                        )
-            else:
-                raise RuntimeError(
-                    f"Could not delete {label} after {_MAX_PROTECT_UNBLOCK_ATTEMPTS} attempts — PROTECT cycle not resolved"
-                )
+            # Belt-and-braces: auto-clears any remaining blocking objects (e.g. nullable
+            # PROTECT FKs from partial-coverage models), recursively resolving PROTECT
+            # chains deeper than one level.
+            deleted_count = self._delete_with_protect_retries(qs, label=label)
 
             if deleted_count:
                 self._log(f"  {label}: {deleted_count:,} deleted")
@@ -1235,10 +1290,12 @@ class Command(BaseCommand):
         if mode == MODE_SHOW_GRAPH:
             return self._mode_show_graph(options, discovered_models, deletion_order)
         if mode == MODE_DELETE_ACCOUNTS:
-            return self._mode_delete_accounts(options, discovered_models, deletion_order)
-        if mode == MODE_KEEP_SINGLE_ACCOUNT:
-            return self._mode_keep_single_account(options, discovered_models, deletion_order)
+            result = self._mode_delete_accounts(options, discovered_models, deletion_order)
+        elif mode == MODE_KEEP_SINGLE_ACCOUNT:
+            result = self._mode_keep_single_account(options, discovered_models, deletion_order)
+        else:
+            raise ValueError(f"unknown mode, please fix parameters: {mode!r}")
 
         self._log("Done!")
         self._print_model_stats()
-        return 0
+        return result

--- a/iaso/management/commands/delete_accounts.py
+++ b/iaso/management/commands/delete_accounts.py
@@ -165,9 +165,21 @@ _OUT_OF_GRAPH_CLEANUP_NOTES = [
     ),
     OutOfGraphCleanupNote(label="iaso.Form", reason="linked via projects M2M"),
     OutOfGraphCleanupNote(label="iaso.OrgUnitType", reason="linked via projects M2M"),
+    OutOfGraphCleanupNote(label="iaso.MatchingAlgorithm", reason="linked via projects M2M"),
+    OutOfGraphCleanupNote(label="iaso.RecordType", reason="linked via projects M2M"),
+    OutOfGraphCleanupNote(label="iaso.Device", reason="linked via projects M2M"),
+    OutOfGraphCleanupNote(label="iaso.AccountFeatureFlag", reason="linked via Account.feature_flags M2M, not a FK"),
     OutOfGraphCleanupNote(
         label="iaso.CommentIaso",
         reason="GenericForeignKey (content_type + object_pk) to OrgUnit, not a real FK",
+    ),
+    OutOfGraphCleanupNote(
+        label="auth.User",
+        reason="upstream of Profile — Profile.user is a FK held BY the discovered model, pointing outward; BFS never follows that direction",
+    ),
+    OutOfGraphCleanupNote(
+        label="iaso.OpenHEXAInstance",
+        reason="upstream of OpenHEXAWorkspace, same shape as auth.User/Profile — OpenHEXAWorkspace.openhexa_instance points outward",
     ),
     OutOfGraphCleanupNote(
         label="iaso.ReportVersion",
@@ -180,6 +192,7 @@ _OUT_OF_GRAPH_CLEANUP_NOTES = [
     ),
     OutOfGraphCleanupNote(label="django_sql_dashboard.Dashboard", reason="no FK to Account"),
     OutOfGraphCleanupNote(label="django.contrib.sessions.Session", reason="no FK to Account"),
+    OutOfGraphCleanupNote(label="iaso.Config", reason="no relation to Account at all — only M2M to auth.User"),
     OutOfGraphCleanupNote(
         label="hat_api_import.APIImport [vector_control_apiimport]",
         reason="not a iaso/plugins app and no FK to Account",

--- a/iaso/management/commands/delete_accounts.py
+++ b/iaso/management/commands/delete_accounts.py
@@ -91,13 +91,6 @@ except (ImportError, RuntimeError):
 
 
 # ---------------------------------------------------------------------------
-# Logging
-# ---------------------------------------------------------------------------
-def _log(msg):
-    print(f"[{datetime.datetime.now().strftime('%H:%M:%S')}] {msg}")
-
-
-# ---------------------------------------------------------------------------
 # FK graph — discovery and topological sort
 # ---------------------------------------------------------------------------
 
@@ -254,7 +247,7 @@ def build_fk_graph(root_model):
     return discovered, graph_edges
 
 
-def topo_sort_deletion_order(discovered, graph_edges):
+def topo_sort_deletion_order(discovered, graph_edges, log):
     """
     Topological sort: model A before model B if A has a CASCADE or PROTECT FK to B
     (A must be deleted first to avoid blocking B's deletion).
@@ -279,22 +272,22 @@ def topo_sort_deletion_order(discovered, graph_edges):
     try:
         return list(ts.static_order())
     except Exception as exc:
-        _log(f"  [topo sort] cycle detected ({exc}), falling back to reverse-BFS order")
+        log(f"  [topo sort] cycle detected ({exc}), falling back to reverse-BFS order")
         return list(reversed(list(discovered.keys())))
 
 
 # ---------------------------------------------------------------------------
 # --show-graph mode
 # ---------------------------------------------------------------------------
-def show_graph(discovered, deletion_order, account=None):
+def show_graph(discovered, deletion_order, log, account=None):
     """
     Print what the FK graph discovered, flag partial-coverage paths,
     and optionally show which discovered models have data for the account.
     """
-    _log(f"=== FK Graph from Account — {len(discovered)} models discovered ===")
-    _log("")
-    _log(f"{'Model':55s} {'on_delete':12s} {'filter path'}")
-    _log("-" * 120)
+    log(f"=== FK Graph from Account — {len(discovered)} models discovered ===")
+    log("")
+    log(f"{'Model':55s} {'on_delete':12s} {'filter path'}")
+    log("-" * 120)
 
     for model in deletion_order:
         if model not in discovered:
@@ -309,17 +302,17 @@ def show_graph(discovered, deletion_order, account=None):
                 count_str = f"  [{count} rows]"
             except Exception:
                 count_str = "  [?]"
-        _log(f"  {flag} {model._meta.label:53s} {info.on_delete_value:12s}  {info.account_lookup}{count_str}")
+        log(f"  {flag} {model._meta.label:53s} {info.on_delete_value:12s}  {info.account_lookup}{count_str}")
 
-    _log("")
-    _log("⚠ = path contains a SET_NULL FK — rows where that FK is NULL are NOT found by this filter")
-    _log("    These models may need dedicated supplementary filters to fully cover SET_NULL rows.")
-    _log("")
+    log("")
+    log("⚠ = path contains a SET_NULL FK — rows where that FK is NULL are NOT found by this filter")
+    log("    These models may need dedicated supplementary filters to fully cover SET_NULL rows.")
+    log("")
 
-    _log("=== Out-of-graph models (dedicated handling required) ===")
+    log("=== Out-of-graph models (dedicated handling required) ===")
     for note in _OUT_OF_GRAPH_CLEANUP_NOTES:
-        _log(f"  - {note.label}")
-        _log(f"      reason: {note.reason}")
+        log(f"  - {note.label}")
+        log(f"      reason: {note.reason}")
 
 
 # ---------------------------------------------------------------------------
@@ -355,10 +348,14 @@ class Command(BaseCommand):
     # -----------------------------------------------------------------------
     # Helpers
     # -----------------------------------------------------------------------
+    def _log(self, message):
+        if self.verbosity > 0:
+            self.stdout.write(f"[{datetime.datetime.now().strftime('%H:%M:%S')}] {message}")
+
     def _delete_with_sql(self, sql, params=None, label="SQL"):
         """Deletes data by executing a SQL query - useful for deleting models where there's no clear FK path to the Account model (e.g. users_profile)."""
         if self.dry_run:
-            _log(f"  [DRY RUN] {label}: {sql[:100]}")
+            self._log(f"  [DRY RUN] {label}: {sql[:100]}")
             return 0
         if params:
             self.cursor.execute(sql, params)
@@ -366,7 +363,7 @@ class Command(BaseCommand):
             self.cursor.execute(sql)
         row_count = self.cursor.rowcount
         if row_count:
-            _log(f"  {label}: {row_count:,} deleted")
+            self._log(f"  {label}: {row_count:,} deleted")
         return row_count
 
     def _delete_qs(self, queryset, label=None):
@@ -374,14 +371,14 @@ class Command(BaseCommand):
         model = queryset.model
         label = label or model.__name__
         if self.dry_run:
-            _log(f"  [DRY RUN] {label}: ~{queryset.count()}")
+            self._log(f"  [DRY RUN] {label}: ~{queryset.count()}")
             return
         if model is not Modification:
             self._delete_modification_logs_for_pks(
                 ContentType.objects.get_for_model(model), list(queryset.values_list("pk", flat=True))
             )
         deleted_count, _ = queryset.delete()
-        _log(f"  {label}: {deleted_count} deleted")
+        self._log(f"  {label}: {deleted_count} deleted")
 
     def _delete_modification_logs_for_pks(self, content_type, pks):
         """
@@ -401,7 +398,7 @@ class Command(BaseCommand):
         model = queryset.model
         label = label or model.__name__
         if self.dry_run:
-            _log(f"  [DRY RUN] {label}: ~{queryset.count()}")
+            self._log(f"  [DRY RUN] {label}: ~{queryset.count()}")
             return 0
 
         content_type = ContentType.objects.get_for_model(model) if model is not Modification else None
@@ -417,13 +414,13 @@ class Command(BaseCommand):
             try:
                 deleted = chunk_qs._raw_delete(using=queryset.db)
             except Exception as exc:
-                _log(f"  {label}: _raw_delete failed ({exc!r}), falling back to .delete()")
+                self._log(f"  {label}: _raw_delete failed ({exc!r}), falling back to .delete()")
                 _, counts = chunk_qs.delete()
                 deleted = counts.get(model._meta.label, 0)
                 counts_str = ", ".join(
                     f"{model_label}: {count}" for model_label, count in sorted(counts.items()) if count
                 )
-                _log(f"  {label}: cascade counts: {counts_str}")
+                self._log(f"  {label}: cascade counts: {counts_str}")
             total += deleted
 
         return total
@@ -432,11 +429,11 @@ class Command(BaseCommand):
         """Dry-run-aware wrapper around queryset.update(**fields)."""
         label = label or queryset.model.__name__
         if self.dry_run:
-            _log(f"  [DRY RUN] {label}: would update ~{queryset.count()} rows to {fields}")
+            self._log(f"  [DRY RUN] {label}: would update ~{queryset.count()} rows to {fields}")
             return 0
         updated = queryset.update(**fields)
         if updated:
-            _log(f"  {label}: {updated} updated")
+            self._log(f"  {label}: {updated} updated")
         return updated
 
     @contextmanager
@@ -459,7 +456,9 @@ class Command(BaseCommand):
         fast_deletes — no instances are loaded into memory.
         """
         if self.dry_run:
-            _log(f"  [DRY RUN] {label}: would cascade-delete ~{queryset.count()} rows and everything referencing them")
+            self._log(
+                f"  [DRY RUN] {label}: would cascade-delete ~{queryset.count()} rows and everything referencing them"
+            )
             return
 
         for attempt in range(_MAX_PROTECT_UNBLOCK_ATTEMPTS):
@@ -472,7 +471,7 @@ class Command(BaseCommand):
                 for obj in exc.protected_objects:
                     blocking_pks_by_model[type(obj)].append(obj.pk)
                 for blocker_model, pks in blocking_pks_by_model.items():
-                    _log(f"  [auto-unblock] {blocker_model.__name__} ×{len(pks)} blocking {label} (collect phase)")
+                    self._log(f"  [auto-unblock] {blocker_model.__name__} ×{len(pks)} blocking {label} (collect phase)")
                     self._delete_qs_in_chunks(
                         blocker_model.objects.filter(pk__in=pks), label=f"{blocker_model.__name__}[unblock]"
                     )
@@ -545,34 +544,34 @@ class Command(BaseCommand):
         # Append cycle participants at the end in their original insertion order
         cycle_models = [m for m in plan_models if m not in set(ordered_models)]
         if cycle_models:
-            _log(f"  {label}: topo-sort cycle (ignored): {[m.__name__ for m in cycle_models]}")
+            self._log(f"  {label}: topo-sort cycle (ignored): {[m.__name__ for m in cycle_models]}")
         ordered_models.extend(cycle_models)
 
         model_to_item = {item.model: item for item in plan_items}
         skipped = [m for m in ordered_models if m not in model_to_item]
         if skipped:
-            _log(
+            self._log(
                 f"  [warn] {label}: {len(skipped)} model(s) in topo order but not in plan: {[m.__name__ for m in skipped]}"
             )
         ordered_items = [model_to_item[m] for m in ordered_models if m in model_to_item]
 
         if plan_items:
-            _log(f"  {label}: cascade plan — {', '.join(sorted(item.model._meta.label for item in plan_items))}")
+            self._log(f"  {label}: cascade plan — {', '.join(sorted(item.model._meta.label for item in plan_items))}")
 
         total_steps = len(ordered_items)
         for step, item in enumerate(ordered_items, 1):
             step_label = f"{label}→{item.model._meta.label}"
-            _log(f"  [{step}/{total_steps}] {step_label}…")
+            self._log(f"  [{step}/{total_steps}] {step_label}…")
             step_started_at = time.monotonic()
             item_qs = item.queryset if item.queryset is not None else item.model.objects.filter(pk__in=item.pks)
             deleted_count = self._delete_qs_in_chunks(item_qs, label=step_label)
             if deleted_count:
-                _log(f"  {step_label}: {deleted_count:,} deleted ({time.monotonic() - step_started_at:.1f}s)")
+                self._log(f"  {step_label}: {deleted_count:,} deleted ({time.monotonic() - step_started_at:.1f}s)")
 
     def _delete_datasource_tree(self, datasources, label_prefix=""):
         """Delete each DataSource fully before moving to the next."""
         ds_list = datasources if isinstance(datasources, list) else list(datasources)
-        _log(f"  Deleting {len(ds_list)} datasource(s)")
+        self._log(f"  Deleting {len(ds_list)} datasource(s)")
 
         for ds in ds_list:
             ds_label = f"{label_prefix}ds[{ds.id}]"
@@ -636,7 +635,7 @@ class Command(BaseCommand):
     # Pre/post-deletion cleanup
     # -----------------------------------------------------------------------
     def _pre_deletion_clean_up(self, accounts_to_delete):
-        _log("Pre-deletion cleanup: clearing users_profile, orphan Instance, InstanceFile, OrgUnit...")
+        self._log("Pre-deletion cleanup: clearing users_profile, orphan Instance, InstanceFile, OrgUnit...")
         try:
             self._delete_with_sql("DELETE FROM users_profile", label="users_profile")
         except django.db.utils.ProgrammingError:
@@ -667,7 +666,7 @@ class Command(BaseCommand):
             label="Task[queued→killed]",
             status=KILLED,
         )
-        _log("finished pre-deletion cleanup")
+        self._log("finished pre-deletion cleanup")
 
     def _post_deletion_clean_up(self, account_to_keep):
         """
@@ -678,18 +677,18 @@ class Command(BaseCommand):
         those are wiped in full rather than left as an unscoped leak. Accepted tradeoff, not
         a bug: only run --account-to-keep when losing that unscoped data is acceptable.
         """
-        _log(
+        self._log(
             "Post-deletion cleanup: clearing orphan DataSource, Forms, Instance, Project, InstanceFile, APIImport, Session, Device..."
         )
         # Orphan datasources — delete one by one, continue on error
         ds_ids_to_keep = DataSource.objects.filter(projects__account=account_to_keep).values_list("id", flat=True)
         orphan_ds = list(DataSource.objects.exclude(id__in=ds_ids_to_keep))
-        _log(f"Orphan datasources: {len(orphan_ds)}")
+        self._log(f"Orphan datasources: {len(orphan_ds)}")
         for ds in orphan_ds:
             try:
                 self._delete_datasource_tree([ds])
             except Exception as exc:
-                _log(f"  [error] orphan ds[{ds.id}] {ds.name!r}: {exc} — skipping")
+                self._log(f"  [error] orphan ds[{ds.id}] {ds.name!r}: {exc} — skipping")
 
         # Forms without projects
         forms_without_project = Form.objects_include_deleted.filter(projects=None)
@@ -720,7 +719,7 @@ class Command(BaseCommand):
             try:
                 self._delete_form_without_project(form_without_project)
             except Exception:
-                _log(traceback.format_exc())
+                self._log(traceback.format_exc())
 
         if _Dashboard is not None:
             self._delete_qs(_Dashboard.objects.all(), label="Dashboard")
@@ -730,23 +729,23 @@ class Command(BaseCommand):
         )
         self._cleanup_modification_logs()
         self._cleanup_export_logs()
-        _log("finished post-deletion cleanup")
+        self._log("finished post-deletion cleanup")
 
     def _delete_form_without_project(self, form):
         """Clear a project-less Form's M2M/version data and hard-delete it."""
         label = f"Form[no project][{form.id}]"
         if self.dry_run:
-            _log(f"  [DRY RUN] {label}: would clear org_unit_types, delete versions' instances/files, hard-delete")
+            self._log(f"  [DRY RUN] {label}: would clear org_unit_types, delete versions' instances/files, hard-delete")
             return
         OrgUnitType.reference_forms.through.objects.filter(form=form).delete()
         form.org_unit_types.clear()
         InstanceFile.objects.filter(instance__form_version__in=form.form_versions.all()).delete()
         Instance.objects.filter(form_version__in=form.form_versions.all()).delete()
         form.delete_hard()
-        _log(f"  {label}: done")
+        self._log(f"  {label}: done")
 
     def _cleanup_modification_logs(self):
-        _log("Cleaning modification logs...")
+        self._log("Cleaning modification logs...")
         if not self.dry_run:
             self.cursor.execute("SET work_mem = '1GB'")
 
@@ -803,13 +802,13 @@ class Command(BaseCommand):
             if deleted < self.chunk_size:
                 break
         if total:
-            _log(f"  ExportLog[orphan]: {total:,} total ({time.monotonic() - started_at:.1f}s)")
+            self._log(f"  ExportLog[orphan]: {total:,} total ({time.monotonic() - started_at:.1f}s)")
 
     # -----------------------------------------------------------------------
     # Main account deletion (graph-based)
     # -----------------------------------------------------------------------
     def _delete_account(self, account, discovered, deletion_order):
-        _log(f"Account {account.id}: {account.name!r}")
+        self._log(f"Account {account.id}: {account.name!r}")
 
         # ---- Null out self-referential FK cycles before any deletion ----
         # Account.default_version → SourceVersion and SourceVersion → DataSource → Account
@@ -877,7 +876,7 @@ class Command(BaseCommand):
 
         # ---- Step 3: Auto — topo-sorted FK-graph deletion ----
         with self._doing(f"account={account.id} FK-graph auto-deletion"):
-            _log(
+            self._log(
                 f"  Running FK-graph auto-deletion ({len(discovered)} models, "
                 f"skipping {len(out_of_graph_models)} out-of-graph)..."
             )
@@ -940,7 +939,7 @@ class Command(BaseCommand):
             try:
                 qs = manager.filter(**{info.account_lookup: account})
             except Exception as exc:
-                _log(f"  [skip] {model.__name__}: cannot build queryset ({exc})")
+                self._log(f"  [skip] {model.__name__}: cannot build queryset ({exc})")
                 continue
 
             models_processed += 1
@@ -949,7 +948,7 @@ class Command(BaseCommand):
                 label += " ⚠ partial"
 
             if self.dry_run:
-                _log(f"  [DRY RUN] would delete {label}")
+                self._log(f"  [DRY RUN] would delete {label}")
                 continue
 
             deleted_count = 0
@@ -963,7 +962,7 @@ class Command(BaseCommand):
                     for obj in exc.protected_objects:
                         blocking_pks_by_model[type(obj)].append(obj.pk)
                     for blocker_model, pks in blocking_pks_by_model.items():
-                        _log(f"  [auto-unblock] {blocker_model.__name__} ×{len(pks)} blocking {label}")
+                        self._log(f"  [auto-unblock] {blocker_model.__name__} ×{len(pks)} blocking {label}")
                         self._delete_qs_in_chunks(
                             blocker_model.objects.filter(pk__in=pks),
                             label=f"{blocker_model.__name__}[unblock]",
@@ -974,17 +973,17 @@ class Command(BaseCommand):
                 )
 
             if deleted_count:
-                _log(f"  {label}: {deleted_count:,} deleted")
+                self._log(f"  {label}: {deleted_count:,} deleted")
                 models_with_rows += 1
                 total_deleted += deleted_count
 
         if not self.dry_run:
-            _log(
+            self._log(
                 f"  topo step: {models_processed} models processed, {models_with_rows} non-empty, {total_deleted:,} rows deleted total"
             )
 
     def _print_model_stats(self):
-        _log("Row counts after deletion:")
+        self._log("Row counts after deletion:")
         all_models = sorted(django_apps.get_models(), key=lambda m: m._meta.label)
         for model in all_models:
             manager = getattr(model, "objects_include_deleted", model._default_manager)
@@ -992,15 +991,15 @@ class Command(BaseCommand):
                 row_count = manager.count()
             except Exception:
                 continue
-            _log(f"  {model._meta.label:<55s}: {row_count:>10,}")
+            self._log(f"  {model._meta.label:<55s}: {row_count:>10,}")
 
-        _log("Remaining accounts:")
+        self._log("Remaining accounts:")
         for account in Account.objects.order_by("id"):
-            _log(f"  {account.id:6d}  {account.name}")
+            self._log(f"  {account.id:6d}  {account.name}")
 
-        _log("Remaining credentials:")
+        self._log("Remaining credentials:")
         for cred in ExternalCredentials.objects.all():
-            _log(f"  credential: {cred.id} {cred.url} {cred.login} {cred.name}")
+            self._log(f"  credential: {cred.id} {cred.url} {cred.login} {cred.name}")
 
     def _determine_mode(self, options):
         if options.get("list_accounts"):
@@ -1014,17 +1013,17 @@ class Command(BaseCommand):
         raise ValueError("unknown mode, please fix parameters")
 
     def _mode_list_accounts(self):
-        _log("Available accounts:")
+        self._log("Available accounts:")
         for account in Account.objects.order_by("id"):
-            _log(f"  {account.id:6d}  {account.name}")
+            self._log(f"  {account.id:6d}  {account.name}")
         return 0
 
     def _build_model_graph(self):
         # Build FK graph once (same for all accounts)
-        _log("Building FK graph from Account...")
+        self._log("Building FK graph from Account...")
         discovered, graph_edges = build_fk_graph(Account)
-        deletion_order = topo_sort_deletion_order(discovered, graph_edges)
-        _log(f"  Discovered {len(discovered)} models, topo-sorted deletion order computed")
+        deletion_order = topo_sort_deletion_order(discovered, graph_edges, log=self._log)
+        self._log(f"  Discovered {len(discovered)} models, topo-sorted deletion order computed")
         return discovered, deletion_order
 
     def _mode_show_graph(self, options, discovered_models, deletion_order):
@@ -1032,12 +1031,12 @@ class Command(BaseCommand):
             account = Account.objects.get(pk=options["for_account"])
         else:
             raise ValueError("please provide the for_account parameter when running in show_graph mode")
-        show_graph(discovered_models, deletion_order, account=account)
+        show_graph(discovered_models, deletion_order, log=self._log, account=account)
         return 0
 
     def _mode_delete_accounts(self, options, discovered_models, deletion_order):
         if self.dry_run:
-            _log("*** DRY RUN — no data will be modified ***")
+            self._log("*** DRY RUN — no data will be modified ***")
         self._mode_list_accounts()
 
         ids = options["accounts_to_delete"]
@@ -1053,25 +1052,25 @@ class Command(BaseCommand):
 
     def _delete_accounts(self, accounts_to_delete, discovered_models, deletion_order):
         for account in accounts_to_delete:
-            _log(f"--- Deleting account={account.id} ({account.name!r}) ---")
+            self._log(f"--- Deleting account={account.id} ({account.name!r}) ---")
             try:
                 self._delete_account(account, discovered_models, deletion_order)
-                _log(f"--- OK account={account.id} ({account.name!r}) deleted ---")
+                self._log(f"--- OK account={account.id} ({account.name!r}) deleted ---")
             except Exception:
-                _log(
+                self._log(
                     f"ERROR account={account.id!r} ({account.name!r})"
                     f" at step [{self._current_step}]:\n{traceback.format_exc()}"
                 )
-                _log(f"--- FAILED account={account.id} ({account.name!r}) ---")
+                self._log(f"--- FAILED account={account.id} ({account.name!r}) ---")
 
     def _mode_keep_single_account(self, options, discovered_models, deletion_order):
         if self.dry_run:
-            _log("*** DRY RUN — no data will be modified ***")
+            self._log("*** DRY RUN — no data will be modified ***")
         self._mode_list_accounts()
 
         account_id_to_keep = options["account_to_keep"]
         account_to_keep = Account.objects.get(pk=account_id_to_keep)
-        _log(f"Keeping: {account_id_to_keep} — {account_to_keep.name!r}")
+        self._log(f"Keeping: {account_id_to_keep} — {account_to_keep.name!r}")
         accounts_to_delete = list(Account.objects.exclude(pk=account_id_to_keep).order_by("-id"))
         random.shuffle(accounts_to_delete)
 
@@ -1086,6 +1085,7 @@ class Command(BaseCommand):
     # -----------------------------------------------------------------------
 
     def handle(self, *args, **options):
+        self.verbosity = options.get("verbosity", 1)
         self.chunk_size = options["chunk_size"]
         self.dry_run = options.get("dry_run", False)
         self.cursor = connection.cursor()
@@ -1105,6 +1105,6 @@ class Command(BaseCommand):
         if mode == MODE_KEEP_SINGLE_ACCOUNT:
             return self._mode_keep_single_account(options, discovered_models, deletion_order)
 
-        _log("Done!")
+        self._log("Done!")
         self._print_model_stats()
         return 0

--- a/iaso/management/commands/delete_accounts.py
+++ b/iaso/management/commands/delete_accounts.py
@@ -403,7 +403,7 @@ class Command(BaseCommand):
         n, _ = queryset.delete()
         _log(f"  {label}: {n} deleted")
 
-    def _delete_chunked(self, queryset, label=None):
+    def _delete_streaming(self, queryset, label=None):
         """Dry-run-aware wrapper around the module-level _chunked_delete streaming delete."""
         label = label or queryset.model.__name__
         if self.dry_run:
@@ -483,21 +483,17 @@ class Command(BaseCommand):
             if pks:
                 plan_items.append(DeletionPlanItem(model=model, queryset=None, pks=pks))
 
-        # Topo sort via Kahn's algorithm: if model A has a FK to model B, delete A first.
-        # Use _meta.local_fields (forward FK/O2O only) — _meta.get_fields() also returns
-        # reverse relations which would flip the dependency direction and break the sort.
-        # Kahn's algorithm handles cycles gracefully: cycle participants are appended at the
-        # end in plan_items insertion order (fast_deletes before data, so SourceVersion before
-        # DataSource). DataSource.default_version is already nulled, so either order is safe.
+        # Discover forward-FK edges among plan_items' models: if model A has a FK to
+        # model B, A must be deleted first. Use _meta.local_fields (forward FK/O2O
+        # only) — _meta.get_fields() also returns reverse relations which would flip
+        # the dependency direction and break the sort.
         # plan_models as dict preserves insertion order for cycle-node fallback.
         plan_models = {}
         fk_targets_by_holder = {}
-        blocking_holder_count = {}
         for plan_item in plan_items:
             model = plan_item.model
             plan_models[model] = None
             fk_targets_by_holder[model] = set()
-            blocking_holder_count[model] = 0  # Kahn's algorithm: remaining FK holders blocking each model
 
         for model in plan_models:
             for field in model._meta.local_fields:
@@ -511,18 +507,29 @@ class Command(BaseCommand):
                     target = field.related_model
                     if target and target in plan_models and target is not model:
                         # model holds FK → delete model first → target depends on model
-                        if target not in fk_targets_by_holder[model]:  # deduplicate before incrementing
-                            fk_targets_by_holder[model].add(target)
-                            blocking_holder_count[target] += 1
-        ready_models = [m for m in plan_models if blocking_holder_count[m] == 0]
+                        fk_targets_by_holder[model].add(target)
+
+        # Topo sort via graphlib.TopologicalSorter (same tool topo_sort_deletion_order
+        # uses). Drained incrementally via get_ready()/done() rather than static_order()
+        # so a cycle doesn't abort the whole sort: whatever's left stuck when get_ready()
+        # comes back empty is appended at the end in plan_items insertion order instead
+        # (fast_deletes before data, so SourceVersion before DataSource). DataSource.
+        # default_version is already nulled, so either order is safe.
+        ts = TopologicalSorter()
+        for model in plan_models:
+            ts.add(model)
+        for holder, targets in fk_targets_by_holder.items():
+            for target in targets:
+                ts.add(target, holder)
+        ts.prepare()
         ordered_models = []
-        while ready_models:
-            model = ready_models.pop(0)
-            ordered_models.append(model)
-            for unblocked_model in fk_targets_by_holder[model]:
-                blocking_holder_count[unblocked_model] -= 1
-                if blocking_holder_count[unblocked_model] == 0:
-                    ready_models.append(unblocked_model)
+        while ts.is_active():
+            ready = ts.get_ready()
+            if not ready:
+                break
+            ordered_models.extend(ready)
+            ts.done(*ready)
+
         # Append cycle participants at the end in their original insertion order
         cycle_models = [m for m in plan_models if m not in set(ordered_models)]
         if cycle_models:
@@ -583,7 +590,7 @@ class Command(BaseCommand):
                 )
 
             with self._doing(f"Instance {ds_label}"):
-                self._delete_chunked(instances_in_ds, label=f"Instance[{ds_label}]")
+                self._delete_streaming(instances_in_ds, label=f"Instance[{ds_label}]")
 
             # Planning.org_unit = PROTECT blocks OrgUnit deletion (hence DataSource cascade).
             # Cycle: Planning.selected_sampling_result = PROTECT(PSR) ↔ PSR.planning = CASCADE(Planning)
@@ -595,11 +602,11 @@ class Command(BaseCommand):
                     label=f"Planning.selected_sampling_result=NULL[{ds_label}]",
                     selected_sampling_result=None,
                 )
-                self._delete_chunked(
+                self._delete_streaming(
                     PlanningSamplingResult.objects.filter(planning__in=planning_qs),
                     label=f"PlanningSamplingResult[{ds_label}]",
                 )
-                self._delete_chunked(planning_qs, label=f"Planning[{ds_label}]")
+                self._delete_streaming(planning_qs, label=f"Planning[{ds_label}]")
 
             with self._doing(f"DataSource cascade {ds_label}"):
                 # DataSource.default_version → SourceVersion cycle: null first.
@@ -902,7 +909,7 @@ class Command(BaseCommand):
         # Django's Collector raises PROTECT on PSR even when Planning is also being
         # collected — delete PSR first so Planning has no blocker.
         with self._doing(f"account={account.id} PlanningSamplingResult"):
-            self._delete_chunked(
+            self._delete_streaming(
                 PlanningSamplingResult.objects.filter(planning__project__account=account),
                 label="PlanningSamplingResult",
             )

--- a/iaso/management/commands/delete_accounts.py
+++ b/iaso/management/commands/delete_accounts.py
@@ -545,11 +545,7 @@ class Command(BaseCommand):
             step_label = f"{label}→{item.model._meta.label}"
             _log(f"  [{step}/{total_steps}] {step_label}…")
             step_started_at = time.monotonic()
-            item_qs = (
-                item.queryset
-                if item.queryset is not None
-                else item.model.objects.using(queryset.db).filter(pk__in=item.pks)
-            )
+            item_qs = item.queryset if item.queryset is not None else item.model.objects.filter(pk__in=item.pks)
             deleted_count = self._delete_qs_in_chunks(item_qs, label=step_label)
             if deleted_count:
                 _log(f"  {step_label}: {deleted_count:,} deleted ({time.monotonic() - step_started_at:.1f}s)")

--- a/iaso/management/commands/delete_accounts.py
+++ b/iaso/management/commands/delete_accounts.py
@@ -99,7 +99,7 @@ def _log(msg):
 # ---------------------------------------------------------------------------
 # Streaming chunked delete
 # ---------------------------------------------------------------------------
-def _chunked_delete(queryset, chunk_size=5000, label=None):
+def _chunked_raw_delete(queryset, chunk_size=5000, label=None):
     """Delete in streaming chunks — never loads more than chunk_size PKs at once."""
     model = queryset.model
     label = label or model.__name__
@@ -380,7 +380,8 @@ class Command(BaseCommand):
     # -----------------------------------------------------------------------
     # Helpers
     # -----------------------------------------------------------------------
-    def _sql(self, sql, params=None, label="SQL"):
+    def _delete_with_sql(self, sql, params=None, label="SQL"):
+        """Deletes data by executing a SQL query"""
         if self.dry_run:
             _log(f"  [DRY RUN] {label}: {sql[:100]}")
             return 0
@@ -394,6 +395,7 @@ class Command(BaseCommand):
         return row_count
 
     def _delete_qs(self, queryset, label=None):
+        """Deletes a whole queryset with a single queryset.delete()"""
         label = label or queryset.model.__name__
         if self.dry_run:
             _log(f"  [DRY RUN] {label}: ~{queryset.count()}")
@@ -401,13 +403,13 @@ class Command(BaseCommand):
         deleted_count, _ = queryset.delete()
         _log(f"  {label}: {deleted_count} deleted")
 
-    def _delete_streaming(self, queryset, label=None):
-        """Dry-run-aware wrapper around the module-level _chunked_delete streaming delete."""
+    def _delete_qs_in_chunks(self, queryset, label=None):
+        """Deletes a queryset by doing queryset.raw_delete in chunks"""
         label = label or queryset.model.__name__
         if self.dry_run:
             _log(f"  [DRY RUN] {label}: ~{queryset.count()}")
             return 0
-        return _chunked_delete(queryset, self.chunk_size, label=label)
+        return _chunked_raw_delete(queryset, self.chunk_size, label=label)
 
     def _update_qs(self, queryset, label=None, **fields):
         """Dry-run-aware wrapper around queryset.update(**fields)."""
@@ -459,7 +461,7 @@ class Command(BaseCommand):
                     blocking_pks_by_model[type(obj)].append(obj.pk)
                 for blocker_model, pks in blocking_pks_by_model.items():
                     _log(f"  [auto-unblock] {blocker_model.__name__} ×{len(pks)} blocking {label} (collect phase)")
-                    _chunked_delete(
+                    _chunked_raw_delete(
                         blocker_model.objects.filter(pk__in=pks), self.chunk_size, f"{blocker_model.__name__}[unblock]"
                     )
         else:
@@ -588,7 +590,7 @@ class Command(BaseCommand):
                 )
 
             with self._doing(f"Instance {ds_label}"):
-                self._delete_streaming(instances_in_ds, label=f"Instance[{ds_label}]")
+                self._delete_qs_in_chunks(instances_in_ds, label=f"Instance[{ds_label}]")
 
             # Planning.org_unit = PROTECT blocks OrgUnit deletion (hence DataSource cascade).
             # Cycle: Planning.selected_sampling_result = PROTECT(PSR) ↔ PSR.planning = CASCADE(Planning)
@@ -600,11 +602,11 @@ class Command(BaseCommand):
                     label=f"Planning.selected_sampling_result=NULL[{ds_label}]",
                     selected_sampling_result=None,
                 )
-                self._delete_streaming(
+                self._delete_qs_in_chunks(
                     PlanningSamplingResult.objects.filter(planning__in=planning_qs),
                     label=f"PlanningSamplingResult[{ds_label}]",
                 )
-                self._delete_streaming(planning_qs, label=f"Planning[{ds_label}]")
+                self._delete_qs_in_chunks(planning_qs, label=f"Planning[{ds_label}]")
 
             with self._doing(f"DataSource cascade {ds_label}"):
                 # DataSource.default_version → SourceVersion cycle: null first.
@@ -635,9 +637,9 @@ class Command(BaseCommand):
     # Pre/post-deletion cleanup
     # -----------------------------------------------------------------------
     def _pre_deletion_clean_up(self, accounts_to_delete):
-        _log("Pre-deletion cleanup: clearing users_profile, orphaned Instance, InstanceFile, OrgUnit...")
+        _log("Pre-deletion cleanup: clearing users_profile, orphan Instance, InstanceFile, OrgUnit...")
         try:
-            self._sql("DELETE FROM users_profile", label="users_profile")
+            self._delete_with_sql("DELETE FROM users_profile", label="users_profile")
         except django.db.utils.ProgrammingError:
             pass
 
@@ -700,7 +702,7 @@ class Command(BaseCommand):
         self._delete_qs(Instance.objects.filter(form__in=forms_no_form_id), label="Instance[form no form_id]")
         self._delete_qs(forms_no_form_id, label="Form[no form_id]")
         # Rows with no app_id can't be attributed to any account — delete them to avoid leaks.
-        self._sql(
+        self._delete_with_sql(
             "DELETE FROM vector_control_apiimport WHERE headers->>'QUERY_STRING' NOT LIKE '%app_id=%'",
             label="vector_control_apiimport[no app_id]",
         )
@@ -715,7 +717,7 @@ class Command(BaseCommand):
 
         if _Dashboard is not None:
             self._delete_qs(_Dashboard.objects.all(), label="Dashboard")
-        self._sql(
+        self._delete_with_sql(
             "DELETE FROM iaso_exportrequest WHERE id NOT IN (SELECT DISTINCT export_request_id FROM iaso_exportstatus)",
             label="iaso_exportrequest[orphan]",
         )
@@ -750,7 +752,7 @@ class Command(BaseCommand):
             ") DELETE FROM audit_modification WHERE id IN (SELECT id FROM cte)"
         )
         for i in range(2000):
-            deleted = self._sql(sql, label=f"Modification batch {i}")
+            deleted = self._delete_with_sql(sql, label=f"Modification batch {i}")
             if deleted == 0:
                 break
 
@@ -789,7 +791,7 @@ class Command(BaseCommand):
             ")"
         )
         while True:
-            deleted = self._sql(delete_sql, label="ExportLog[orphan] batch")
+            deleted = self._delete_with_sql(delete_sql, label="ExportLog[orphan] batch")
             total += deleted
             if deleted < self.chunk_size:
                 break
@@ -842,7 +844,7 @@ class Command(BaseCommand):
         # Django's Collector raises PROTECT on PSR even when Planning is also being
         # collected — delete PSR first so Planning has no blocker.
         with self._doing(f"account={account.id} PlanningSamplingResult"):
-            self._delete_streaming(
+            self._delete_qs_in_chunks(
                 PlanningSamplingResult.objects.filter(planning__project__account=account),
                 label="PlanningSamplingResult",
             )
@@ -879,7 +881,7 @@ class Command(BaseCommand):
         # Rows are filtered by app_id (from QUERY_STRING). Rows with no app_id cannot be
         # attributed to any account and are cleaned up in _post_flight (account-to-keep mode).
         for project in Project.objects.filter(account=account):
-            self._sql(
+            self._delete_with_sql(
                 "DELETE FROM vector_control_apiimport WHERE headers->>'QUERY_STRING' LIKE %s",
                 params=[f"%app_id={project.app_id}%"],
                 label=f"vector_control_apiimport[app_id={project.app_id}]",
@@ -923,7 +925,7 @@ class Command(BaseCommand):
             deleted_count = 0
             for attempt in range(_MAX_PROTECT_UNBLOCK_ATTEMPTS):
                 try:
-                    deleted_count += _chunked_delete(qs, self.chunk_size, label=label)
+                    deleted_count += _chunked_raw_delete(qs, self.chunk_size, label=label)
                     break
                 except ProtectedError as exc:
                     # Auto-clear blocking objects (e.g. nullable PROTECT FKs from partial-coverage models)
@@ -932,7 +934,7 @@ class Command(BaseCommand):
                         blocking_pks_by_model[type(obj)].append(obj.pk)
                     for blocker_model, pks in blocking_pks_by_model.items():
                         _log(f"  [auto-unblock] {blocker_model.__name__} ×{len(pks)} blocking {label}")
-                        _chunked_delete(
+                        _chunked_raw_delete(
                             blocker_model.objects.filter(pk__in=pks),
                             self.chunk_size,
                             f"{blocker_model.__name__}[unblock]",

--- a/iaso/management/commands/delete_accounts.py
+++ b/iaso/management/commands/delete_accounts.py
@@ -120,7 +120,7 @@ def _chunked_delete(queryset, chunk_size=5000, label=None):
             _log(f"  {label}: _raw_delete failed ({exc!r}), falling back to .delete()")
             _, counts = chunk_qs.delete()
             deleted = counts.get(model._meta.label, 0)
-            counts_str = ", ".join(f"{k}: {v}" for k, v in sorted(counts.items()) if v)
+            counts_str = ", ".join(f"{model_label}: {count}" for model_label, count in sorted(counts.items()) if count)
             _log(f"  {label}: cascade counts: {counts_str}")
         total += deleted
 
@@ -401,8 +401,8 @@ class Command(BaseCommand):
         if self.dry_run:
             _log(f"  [DRY RUN] {label}: ~{queryset.count()}")
             return
-        n, _ = queryset.delete()
-        _log(f"  {label}: {n} deleted")
+        deleted_count, _ = queryset.delete()
+        _log(f"  {label}: {deleted_count} deleted")
 
     def _delete_streaming(self, queryset, label=None):
         """Dry-run-aware wrapper around the module-level _chunked_delete streaming delete."""
@@ -770,7 +770,7 @@ class Command(BaseCommand):
         )
 
     def _cleanup_export_logs(self):
-        t0 = time.monotonic()
+        started_at = time.monotonic()
         total = 0
         # Single SQL per chunk — no Python-level ID transfer, no ORM LEFT JOIN.
         # NOT EXISTS with an indexed exportlog_id is efficient even on large tables.
@@ -790,7 +790,7 @@ class Command(BaseCommand):
             if deleted < self.chunk_size:
                 break
         if total:
-            _log(f"  ExportLog[orphan]: {total:,} total ({time.monotonic() - t0:.1f}s)")
+            _log(f"  ExportLog[orphan]: {total:,} total ({time.monotonic() - started_at:.1f}s)")
 
     # -----------------------------------------------------------------------
     # Main account deletion (graph-based)
@@ -996,8 +996,8 @@ class Command(BaseCommand):
             ids = options["accounts_to_delete"]
             accounts_to_delete = list(Account.objects.filter(pk__in=ids))
             if len(accounts_to_delete) != len(ids):
-                found = {a.id for a in accounts_to_delete}
-                raise SystemExit(f"Accounts not found: {[i for i in ids if i not in found]}")
+                found_ids = {a.id for a in accounts_to_delete}
+                raise SystemExit(f"Accounts not found: {[id for id in ids if id not in found_ids]}")
 
         self._pre_flight()
 
@@ -1023,14 +1023,14 @@ class Command(BaseCommand):
         for model in all_models:
             manager = getattr(model, "objects_include_deleted", model._default_manager)
             try:
-                n = manager.count()
+                row_count = manager.count()
             except Exception:
                 continue
-            _log(f"  {model._meta.label:<55s}: {n:>10,}")
+            _log(f"  {model._meta.label:<55s}: {row_count:>10,}")
 
         _log("Remaining accounts:")
-        for acct in Account.objects.order_by("id"):
-            _log(f"  {acct.id:6d}  {acct.name}")
+        for account in Account.objects.order_by("id"):
+            _log(f"  {account.id:6d}  {account.name}")
         _log("Remaining credentials:")
         for cred in ExternalCredentials.objects.all():
             _log(f"  credential: {cred.id} {cred.url} {cred.login} {cred.name}")

--- a/iaso/management/commands/delete_accounts.py
+++ b/iaso/management/commands/delete_accounts.py
@@ -806,6 +806,16 @@ class Command(BaseCommand):
         # deleted by the auto topo step.  Capture user_ids now before that happens.
         user_ids = list(Profile.objects.filter(account=account).values_list("user_id", flat=True))
 
+        # Project is also in the FK graph and will be deleted by the auto topo step —
+        # capture app_ids now, since step 5b needs them but can't look them up via
+        # Project.objects.filter(account=account) once Project rows are gone.
+        app_ids = list(
+            Project.objects.filter(account=account)
+            .exclude(app_id=None)
+            .exclude(app_id="")
+            .values_list("app_id", flat=True)
+        )
+
         # Models the manual sections own completely — exclude from the auto step so
         # the auto step doesn't redundantly re-attempt them (0-row no-ops are cheap
         # but the intent is clearer when responsibilities are explicit).
@@ -868,11 +878,12 @@ class Command(BaseCommand):
         # ---- Step 5b: vector_control_apiimport — delete rows for this account's projects ----
         # Rows are filtered by app_id (from QUERY_STRING). Rows with no app_id cannot be
         # attributed to any account and are cleaned up in _post_flight (account-to-keep mode).
-        for project in Project.objects.filter(account=account):
+        # Uses app_ids captured at the top — Project rows are already gone by now.
+        for app_id in app_ids:
             self._delete_with_sql(
                 "DELETE FROM vector_control_apiimport WHERE headers->>'QUERY_STRING' LIKE %s",
-                params=[f"%app_id={project.app_id}%"],
-                label=f"vector_control_apiimport[app_id={project.app_id}]",
+                params=[f"%app_id={app_id}%"],
+                label=f"vector_control_apiimport[app_id={app_id}]",
             )
 
         # ---- Step 6: Account itself ----

--- a/iaso/management/commands/delete_accounts.py
+++ b/iaso/management/commands/delete_accounts.py
@@ -195,6 +195,12 @@ _MANUAL_CLEANUP_NOTES = [
     ),
 ]
 
+# represents the different modes this command can be run in
+MODE_LIST_ACCOUNTS = "list_accounts"
+MODE_SHOW_GRAPH = "show_graph"
+MODE_DELETE_ACCOUNTS = "delete_accounts"
+MODE_KEEP_SINGLE_ACCOUNT = "keep_single_account"
+
 
 def _is_project_model(model):
     """True if this model belongs to iaso or a plugin (not a third-party or Django built-in app)."""
@@ -965,6 +971,85 @@ class Command(BaseCommand):
         for cred in ExternalCredentials.objects.all():
             _log(f"  credential: {cred.id} {cred.url} {cred.login} {cred.name}")
 
+    def _determine_mode(self, options):
+        if options.get("list_accounts"):
+            return MODE_LIST_ACCOUNTS
+        if options.get("show_graph"):
+            return MODE_SHOW_GRAPH
+        if options.get("account_to_keep") is not None:
+            return MODE_KEEP_SINGLE_ACCOUNT
+        if options.get("accounts_to_delete") is not None:
+            return MODE_DELETE_ACCOUNTS
+        raise ValueError("unknown mode, please fix parameters")
+
+    def _mode_list_accounts(self):
+        _log("Available accounts:")
+        for account in Account.objects.order_by("id"):
+            _log(f"  {account.id:6d}  {account.name}")
+        return 0
+
+    def _build_model_graph(self):
+        # Build FK graph once (same for all accounts)
+        _log("Building FK graph from Account...")
+        discovered, graph_edges = build_fk_graph(Account)
+        deletion_order = topo_sort_deletion_order(discovered, graph_edges)
+        _log(f"  Discovered {len(discovered)} models, topo-sorted deletion order computed")
+        return discovered, deletion_order
+
+    def _mode_show_graph(self, options, discovered_models, deletion_order):
+        if options.get("for_account"):
+            account = Account.objects.get(pk=options["for_account"])
+        else:
+            raise ValueError("please provide the for_account parameter when running in show_graph mode")
+        show_graph(discovered_models, deletion_order, account=account)
+        return 0
+
+    def _mode_delete_accounts(self, options, discovered_models, deletion_order):
+        if self.dry_run:
+            _log("*** DRY RUN — no data will be modified ***")
+        self._mode_list_accounts()
+
+        ids = options["accounts_to_delete"]
+        accounts_to_delete = list(Account.objects.filter(pk__in=ids))
+        if len(accounts_to_delete) != len(ids):
+            found_ids = {a.id for a in accounts_to_delete}
+            raise SystemExit(f"Accounts not found: {[id for id in ids if id not in found_ids]}")
+
+        self._pre_deletion_clean_up(accounts_to_delete)
+        self._delete_accounts(accounts_to_delete, discovered_models, deletion_order)
+
+        return 0
+
+    def _delete_accounts(self, accounts_to_delete, discovered_models, deletion_order):
+        for account in accounts_to_delete:
+            _log(f"--- Deleting account={account.id} ({account.name!r}) ---")
+            try:
+                self._delete_account(account, discovered_models, deletion_order)
+                _log(f"--- OK account={account.id} ({account.name!r}) deleted ---")
+            except Exception:
+                _log(
+                    f"ERROR account={account.id!r} ({account.name!r})"
+                    f" at step [{self._current_step}]:\n{traceback.format_exc()}"
+                )
+                _log(f"--- FAILED account={account.id} ({account.name!r}) ---")
+
+    def _mode_keep_single_account(self, options, discovered_models, deletion_order):
+        if self.dry_run:
+            _log("*** DRY RUN — no data will be modified ***")
+        self._mode_list_accounts()
+
+        account_id_to_keep = options["account_to_keep"]
+        account_to_keep = Account.objects.get(pk=account_id_to_keep)
+        _log(f"Keeping: {account_id_to_keep} — {account_to_keep.name!r}")
+        accounts_to_delete = list(Account.objects.exclude(pk=account_id_to_keep).order_by("-id"))
+        random.shuffle(accounts_to_delete)
+
+        self._pre_deletion_clean_up(accounts_to_delete)
+        self._delete_accounts(accounts_to_delete, discovered_models, deletion_order)
+        self._post_deletion_clean_up(account_to_keep)
+
+        return 0
+
     # -----------------------------------------------------------------------
     # Entry point
     # -----------------------------------------------------------------------
@@ -975,69 +1060,20 @@ class Command(BaseCommand):
         self.cursor = connection.cursor()
         self._current_step = ""
 
-        # Build FK graph once (same for all accounts)
-        _log("Building FK graph from Account...")
-        discovered, graph_edges = build_fk_graph(Account)
-        deletion_order = topo_sort_deletion_order(discovered, graph_edges)
-        _log(f"  Discovered {len(discovered)} models, topo-sorted deletion order computed")
+        mode = self._determine_mode(options)
 
-        # --list-accounts mode
-        if options.get("list_accounts"):
-            for account in Account.objects.order_by("id"):
-                _log(f"  {account.id:6d}  {account.name}")
-            return
+        if mode == MODE_LIST_ACCOUNTS:
+            return self._mode_list_accounts()
 
-        # --show-graph mode
-        if options.get("show_graph"):
-            account = None
-            if options.get("for_account"):
-                account = Account.objects.get(pk=options["for_account"])
-            show_graph(discovered, deletion_order, account=account)
-            return
+        discovered_models, deletion_order = self._build_model_graph()
 
-        if self.dry_run:
-            _log("*** DRY RUN — no data will be modified ***")
-
-        _log("Available accounts:")
-        for account in Account.objects.order_by("id"):
-            _log(f"  {account.id}: {account.name}")
-
-        account_to_keep = None
-        full_cleanup = False
-
-        # Checking whether we are in full cleanup mode (keep one account, delete all others) or in selective deletion mode (delete specific accounts)
-        if options.get("account_to_keep") is not None:
-            account_id_to_keep = options["account_to_keep"]
-            account_to_keep = Account.objects.get(pk=account_id_to_keep)
-            _log(f"Keeping: {account_id_to_keep} — {account_to_keep.name!r}")
-            accounts_to_delete = list(Account.objects.exclude(pk=account_id_to_keep).order_by("-id"))
-            random.shuffle(accounts_to_delete)
-            full_cleanup = True
-        else:
-            ids = options["accounts_to_delete"]
-            accounts_to_delete = list(Account.objects.filter(pk__in=ids))
-            if len(accounts_to_delete) != len(ids):
-                found_ids = {a.id for a in accounts_to_delete}
-                raise SystemExit(f"Accounts not found: {[id for id in ids if id not in found_ids]}")
-
-        # Starting some clean up before deleting selected accounts
-        self._pre_deletion_clean_up(accounts_to_delete)
-
-        for account in accounts_to_delete:
-            _log(f"--- Deleting account={account.id} ({account.name!r}) ---")
-            try:
-                self._delete_account(account, discovered, deletion_order)
-                _log(f"--- OK account={account.id} ({account.name!r}) deleted ---")
-            except Exception:
-                _log(
-                    f"ERROR account={account.id!r} ({account.name!r})"
-                    f" at step [{self._current_step}]:\n{traceback.format_exc()}"
-                )
-                _log(f"--- FAILED account={account.id} ({account.name!r}) ---")
-
-        # Finishing cleaning up - dangling/orphan data
-        if full_cleanup:
-            self._post_deletion_clean_up(account_to_keep)
+        if mode == MODE_SHOW_GRAPH:
+            return self._mode_show_graph(options, discovered_models, deletion_order)
+        if mode == MODE_DELETE_ACCOUNTS:
+            return self._mode_delete_accounts(options, discovered_models, deletion_order)
+        if mode == MODE_KEEP_SINGLE_ACCOUNT:
+            return self._mode_keep_single_account(options, discovered_models, deletion_order)
 
         _log("Done!")
         self._print_model_stats()
+        return 0

--- a/iaso/management/commands/delete_accounts.py
+++ b/iaso/management/commands/delete_accounts.py
@@ -49,16 +49,18 @@ import traceback
 
 from collections import defaultdict, deque
 from contextlib import contextmanager
+from dataclasses import dataclass
 from graphlib import TopologicalSorter
 
 import django
 
+from django.apps import apps as django_apps
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.sessions.models import Session
 from django.core.management.base import BaseCommand
 from django.db import connection
-from django.db.models import ForeignKey, ManyToManyRel, OneToOneField, TextField
+from django.db.models import ForeignKey, ManyToManyRel, OneToOneField, QuerySet, TextField
 from django.db.models.deletion import SET_NULL, Collector, ProtectedError
 from django.db.models.functions import Cast
 
@@ -131,30 +133,69 @@ def _chunked_delete(queryset, chunk_size=5000, label=None):
 # Only follow FK edges to models from these app module prefixes.
 # "iaso" covers the main app; "plugins" covers all plugin apps (polio, etc.).
 # Third-party app models (django_sql_dashboard, auth, etc.) are skipped — Django
-# CASCADE handles them automatically when their parent rows disappear.
+# CASCADE handles them automatically when the rows they target disappear.
 _PROJECT_APP_PREFIXES = ("iaso", "plugins")
-
-# Models discovered via a SET_NULL path — filter may miss rows where FK is NULL.
-# These are flagged as "partial coverage" in --show-graph.
-_PARTIAL_COVERAGE_NOTE = "⚠ partial: SET_NULL path, rows with NULL FK are missed"
 
 # Retry limit for auto-unblocking PROTECT errors: each attempt deletes the
 # blocking objects, so convergence depends on the depth of the PROTECT chain.
 _MAX_PROTECT_UNBLOCK_ATTEMPTS = 10
 
-# Models not reachable via reverse FK from Account — require manual handling.
-_MANUAL_MODELS_NOTE = [
-    (
-        "iaso.DataSource / SourceVersion / OrgUnit",
-        "linked via Project.data_sources M2M, BFS only finds those with credentials",
+
+@dataclass
+class DiscoveredModel:
+    """A model discovered via BFS from Account, and how to filter/delete it."""
+
+    account_lookup: str  # Django ORM lookup back to Account, e.g. 'project__account'
+    on_delete_value: str  # on_delete of the edge that discovered this model, e.g. 'CASCADE'
+    is_partial_coverage: bool  # True if any edge on the path is SET_NULL — filter may miss rows with a NULL FK
+
+
+@dataclass
+class FKEdge:
+    """A direct FK edge between two discovered models, used to order deletions."""
+
+    fk_holder: type  # model that declares the FK — must be deleted first
+    fk_target: type  # model the FK points to
+    on_delete_value: str
+
+
+@dataclass
+class ManualCleanupNote:
+    """A table that can't be reached by the FK-graph BFS and needs dedicated cleanup code."""
+
+    label: str  # e.g. "iaso.DataSource / SourceVersion / OrgUnit", or a bare table name
+    reason: str  # why this table needs manual/dedicated handling instead of the auto FK-graph
+
+
+@dataclass
+class DeletionPlanItem:
+    """One model's rows to delete in _cascade_chunked_delete's plan — from either
+    fast_deletes or data, never both."""
+
+    model: type
+    queryset: QuerySet  # set when this item came from collector.fast_deletes, else None
+    pks: list  # set when this item came from collector.data (no bulk queryset available), else None
+
+
+# Tables not reachable via reverse FK from Account — require manual handling.
+_MANUAL_CLEANUP_NOTES = [
+    ManualCleanupNote(
+        label="iaso.DataSource / SourceVersion / OrgUnit",
+        reason="linked via Project.data_sources M2M, BFS only finds those with credentials",
     ),
-    ("iaso.Form", "linked via projects M2M"),
-    ("audit.Modification", "content-type based, no FK to Account"),
-    ("iaso.ExportLog", "no FK to Account"),
-    ("django_sql_dashboard.Dashboard", "no FK to Account"),
-    ("django.contrib.sessions.Session", "no FK to Account"),
-    ("vector_control_apiimport", "raw SQL table, not a Django model"),
-    ("users_profile", "legacy raw SQL table"),
+    ManualCleanupNote(label="iaso.Form", reason="linked via projects M2M"),
+    ManualCleanupNote(label="audit.Modification", reason="content-type based, no FK to Account"),
+    ManualCleanupNote(label="iaso.ExportLog", reason="no FK to Account"),
+    ManualCleanupNote(label="django_sql_dashboard.Dashboard", reason="no FK to Account"),
+    ManualCleanupNote(label="django.contrib.sessions.Session", reason="no FK to Account"),
+    ManualCleanupNote(
+        label="hat_api_import.APIImport [vector_control_apiimport]",
+        reason="not a iaso/plugins app and no FK to Account",
+    ),
+    ManualCleanupNote(
+        label="users_profile",
+        reason="legacy table, no longer defined in the codebase — may still exist in older deployed databases",
+    ),
 ]
 
 
@@ -164,50 +205,57 @@ def _is_project_model(model):
     return app_module.startswith(_PROJECT_APP_PREFIXES)
 
 
+def _on_delete_name(on_delete):
+    """Human-readable name of a field's on_delete callable, e.g. 'CASCADE'."""
+    return getattr(on_delete, "__name__", str(on_delete))
+
+
 def build_fk_graph(root_model):
     """
     BFS from root_model through reverse FK relations.
 
     Returns:
-      discovered : {model: (filter_kwarg, on_delete_name, is_partial)}
-        filter_kwarg — Django ORM lookup, e.g. 'project__account'
-        on_delete_name — on_delete of the edge that discovered this model
-        is_partial — True if any edge on the path is SET_NULL (nullable FK)
-      graph_edges : list of (child_model, parent_model, on_delete_name)
-        Directed edges from FK holder → FK target (used for topo sort)
+      discovered : dict of {model: DiscoveredModel}
+      graph_edges : list of FKEdge — directed edges from FK holder → FK target (used for topo sort)
     """
-    discovered = {}  # model → (filter_kwarg, on_delete_name, is_partial)
+    discovered = {}  # model → DiscoveredModel
     graph_edges = []
 
-    visited = {root_model: (None, False)}  # model → (filter_kwarg, is_partial)
+    visited = {root_model}
     queue = deque([(root_model, None, False)])
 
     while queue:
-        current_model, current_filter, current_partial = queue.popleft()
+        current_model, current_lookup, current_partial = queue.popleft()
 
-        for rel in current_model._meta.related_objects:
-            if isinstance(rel, ManyToManyRel):
-                continue
-
-            child = rel.related_model
-            if child in visited:
-                continue
-            if getattr(child._meta, "abstract", False) or getattr(child._meta, "swapped", None):
-                continue
-            if getattr(child._meta, "proxy", False):
-                # Proxy models share the parent's DB table; deleting the parent rows covers them.
-                continue
-            if not _is_project_model(child):
+        for related_object in current_model._meta.related_objects:
+            if isinstance(related_object, ManyToManyRel):
                 continue
 
-            field_name = rel.field.name
-            new_filter = field_name if current_filter is None else f"{field_name}__{current_filter}"
-            on_delete_name = getattr(rel.on_delete, "__name__", str(rel.on_delete))
-            is_partial = current_partial or (rel.on_delete is SET_NULL)
+            # Despite the name, Django's `related_object.related_model` is the model that
+            # DEFINES the FK field (the holder) — current_model is the FK's target here.
+            fk_holder = related_object.related_model
+            if fk_holder in visited:
+                continue
+            if getattr(fk_holder._meta, "abstract", False) or getattr(fk_holder._meta, "swapped", None):
+                continue
+            if getattr(fk_holder._meta, "proxy", False):
+                # Proxy models share their base model's DB table; deleting the base model's rows covers them.
+                continue
+            if not _is_project_model(fk_holder):
+                continue
 
-            visited[child] = (new_filter, is_partial)
-            discovered[child] = (new_filter, on_delete_name, is_partial)
-            queue.append((child, new_filter, is_partial))
+            field_name = related_object.field.name
+
+            discovered_model = DiscoveredModel(
+                account_lookup=field_name if current_lookup is None else f"{field_name}__{current_lookup}",
+                on_delete_value=_on_delete_name(related_object.on_delete),
+                # if we got here through a nullable FK at some point, any model discovered downstream is marked too
+                is_partial_coverage=current_partial or (related_object.on_delete is SET_NULL),
+            )
+
+            discovered[fk_holder] = discovered_model
+            visited.add(fk_holder)
+            queue.append((fk_holder, discovered_model.account_lookup, discovered_model.is_partial_coverage))
 
     # Collect cross-edges between discovered models (for topo sort)
     for model in discovered:
@@ -217,8 +265,13 @@ def build_fk_graph(root_model):
             target = field.related_model
             if target not in discovered or target is model:
                 continue
-            on_delete_name = getattr(field.remote_field.on_delete, "__name__", "?")
-            graph_edges.append((model, target, on_delete_name))
+            graph_edges.append(
+                FKEdge(
+                    fk_holder=model,
+                    fk_target=target,
+                    on_delete_value=_on_delete_name(field.remote_field.on_delete),
+                )
+            )
 
     return discovered, graph_edges
 
@@ -239,11 +292,11 @@ def topo_sort_deletion_order(discovered, graph_edges):
     for model in discovered:
         ts.add(model)
 
-    for child, parent, on_delete_name in graph_edges:
-        if on_delete_name in ("CASCADE", "PROTECT"):
-            # child must be deleted BEFORE parent
+    for edge in graph_edges:
+        if edge.on_delete_value in ("CASCADE", "PROTECT"):
+            # fk_holder must be deleted BEFORE fk_target
             # ts.add(X, Y) means Y must come before X
-            ts.add(parent, child)
+            ts.add(edge.fk_target, edge.fk_holder)
 
     try:
         return list(ts.static_order())
@@ -253,75 +306,11 @@ def topo_sort_deletion_order(discovered, graph_edges):
 
 
 # ---------------------------------------------------------------------------
-# Graph-based deletion engine
-# ---------------------------------------------------------------------------
-
-
-def execute_graph_deletion(discovered, deletion_order, account, chunk_size, dry_run, skip_models=None):
-    """
-    Delete all discovered models in topological order.
-    Each model's rows are filtered using the auto-built filter_kwarg.
-    skip_models: set of model classes handled manually (excluded from this step).
-    """
-    skip_models = skip_models or set()
-    models_processed = 0
-    models_with_rows = 0
-    total_deleted = 0
-
-    for model in deletion_order:
-        if model not in discovered or model in skip_models:
-            continue
-        filter_kwarg, on_delete_name, is_partial = discovered[model]
-        manager = getattr(model, "objects_include_deleted", model._default_manager)
-
-        try:
-            qs = manager.filter(**{filter_kwarg: account})
-        except Exception as exc:
-            _log(f"  [skip] {model.__name__}: cannot build queryset ({exc})")
-            continue
-
-        models_processed += 1
-        label = f"{model.__name__}[{filter_kwarg}]"
-        if is_partial:
-            label += " ⚠ partial"
-
-        if dry_run:
-            _log(f"  [DRY RUN] would delete {label}")
-            continue
-
-        deleted_count = 0
-        for attempt in range(_MAX_PROTECT_UNBLOCK_ATTEMPTS):
-            try:
-                deleted_count += _chunked_delete(qs, chunk_size, label=label)
-                break
-            except ProtectedError as exc:
-                # Auto-clear blocking objects (e.g. nullable PROTECT FKs from partial-coverage models)
-                by_model = defaultdict(list)
-                for obj in exc.protected_objects:
-                    by_model[type(obj)].append(obj.pk)
-                for blocker_model, pks in by_model.items():
-                    _log(f"  [auto-unblock] {blocker_model.__name__} ×{len(pks)} blocking {label}")
-                    _chunked_delete(
-                        blocker_model.objects.filter(pk__in=pks), chunk_size, f"{blocker_model.__name__}[unblock]"
-                    )
-
-        if deleted_count:
-            _log(f"  {label}: {deleted_count:,} deleted")
-            models_with_rows += 1
-            total_deleted += deleted_count
-
-    if not dry_run:
-        _log(
-            f"  topo step: {models_processed} models processed, {models_with_rows} non-empty, {total_deleted:,} rows deleted total"
-        )
-
-
-# ---------------------------------------------------------------------------
 # --show-graph mode
 # ---------------------------------------------------------------------------
 
 
-def show_graph(discovered, graph_edges, deletion_order, account=None):
+def show_graph(discovered, deletion_order, account=None):
     """
     Print what the FK graph discovered, flag partial-coverage paths,
     and optionally show which discovered models have data for the account.
@@ -334,17 +323,17 @@ def show_graph(discovered, graph_edges, deletion_order, account=None):
     for model in deletion_order:
         if model not in discovered:
             continue
-        filter_kwarg, on_delete_name, is_partial = discovered[model]
-        flag = "⚠" if is_partial else " "
+        info = discovered[model]
+        flag = "⚠" if info.is_partial_coverage else " "
         count_str = ""
         if account is not None:
             try:
                 manager = getattr(model, "objects_include_deleted", model._default_manager)
-                count = manager.filter(**{filter_kwarg: account}).count()
+                count = manager.filter(**{info.account_lookup: account}).count()
                 count_str = f"  [{count} rows]"
             except Exception:
                 count_str = "  [?]"
-        _log(f"  {flag} {model._meta.label:53s} {on_delete_name:12s}  {filter_kwarg}{count_str}")
+        _log(f"  {flag} {model._meta.label:53s} {info.on_delete_value:12s}  {info.account_lookup}{count_str}")
 
     _log("")
     _log("⚠ = path contains a SET_NULL FK — rows where that FK is NULL are NOT found by this filter")
@@ -352,9 +341,9 @@ def show_graph(discovered, graph_edges, deletion_order, account=None):
     _log("")
 
     _log("=== Models NOT in FK graph (manual handling required) ===")
-    for label, reason in _MANUAL_MODELS_NOTE:
-        _log(f"  - {label}")
-        _log(f"      reason: {reason}")
+    for note in _MANUAL_CLEANUP_NOTES:
+        _log(f"  - {note.label}")
+        _log(f"      reason: {note.reason}")
 
 
 # ---------------------------------------------------------------------------
@@ -445,10 +434,10 @@ class Command(BaseCommand):
                 collector.collect(queryset)
                 break
             except ProtectedError as exc:
-                by_model = defaultdict(list)
+                blocking_pks_by_model = defaultdict(list)
                 for obj in exc.protected_objects:
-                    by_model[type(obj)].append(obj.pk)
-                for blocker_model, pks in by_model.items():
+                    blocking_pks_by_model[type(obj)].append(obj.pk)
+                for blocker_model, pks in blocking_pks_by_model.items():
                     _log(f"  [auto-unblock] {blocker_model.__name__} ×{len(pks)} blocking {label} (collect phase)")
                     _chunked_delete(
                         blocker_model.objects.filter(pk__in=pks), self.chunk_size, f"{blocker_model.__name__}[unblock]"
@@ -464,13 +453,13 @@ class Command(BaseCommand):
         # data (instance dicts). Topo-sort them together so FK holders are always
         # deleted before the models they reference, regardless of which list they
         # came from.
-        plan_items = []  # list of (model, queryset_or_None, pk_list_or_None)
+        plan_items = []
         for qs in collector.fast_deletes:
-            plan_items.append((qs.model, qs, None))
+            plan_items.append(DeletionPlanItem(model=qs.model, queryset=qs, pks=None))
         for model, instances in collector.data.items():
             pks = [obj.pk for obj in instances]
             if pks:
-                plan_items.append((model, None, pks))
+                plan_items.append(DeletionPlanItem(model=model, queryset=None, pks=pks))
 
         # Topo sort via Kahn's algorithm: if model A has a FK to model B, delete A first.
         # Use _meta.local_fields (forward FK/O2O only) — _meta.get_fields() also returns
@@ -479,14 +468,16 @@ class Command(BaseCommand):
         # end in plan_items insertion order (fast_deletes before data, so SourceVersion before
         # DataSource). DataSource.default_version is already nulled, so either order is safe.
         # plan_models as dict preserves insertion order for cycle-node fallback.
-        plan_models = dict.fromkeys(m for m, _, _ in plan_items)
-        successors = {m: set() for m in plan_models}
-        in_degree = {m: 0 for m in plan_models}  # Kahn's algorithm: number of incoming FK edges per model
+        plan_models = dict.fromkeys(item.model for item in plan_items)
+        fk_targets_by_holder = {m: set() for m in plan_models}
+        blocking_holder_count = {
+            m: 0 for m in plan_models
+        }  # Kahn's algorithm: remaining FK holders blocking each model
         for model in plan_models:
             for field in model._meta.local_fields:
                 if isinstance(field, (ForeignKey, OneToOneField)):
                     # Skip SET_NULL FKs: they don't create a hard ordering constraint
-                    # (the DB will null them on parent deletion, or we've already done so).
+                    # (the DB will null them on target deletion, or we've already done so).
                     # Including them creates false cycles (e.g. DataSource.default_version
                     # ↔ SourceVersion.data_source).
                     if field.remote_field.on_delete is SET_NULL:
@@ -494,49 +485,49 @@ class Command(BaseCommand):
                     target = field.related_model
                     if target and target in plan_models and target is not model:
                         # model holds FK → delete model first → target depends on model
-                        if target not in successors[model]:  # deduplicate before incrementing
-                            successors[model].add(target)
-                            in_degree[target] += 1
-        queue = [m for m in plan_models if in_degree[m] == 0]
+                        if target not in fk_targets_by_holder[model]:  # deduplicate before incrementing
+                            fk_targets_by_holder[model].add(target)
+                            blocking_holder_count[target] += 1
+        ready_models = [m for m in plan_models if blocking_holder_count[m] == 0]
         ordered_models = []
-        while queue:
-            m = queue.pop(0)
-            ordered_models.append(m)
-            for s in successors[m]:
-                in_degree[s] -= 1
-                if in_degree[s] == 0:
-                    queue.append(s)
+        while ready_models:
+            model = ready_models.pop(0)
+            ordered_models.append(model)
+            for unblocked_model in fk_targets_by_holder[model]:
+                blocking_holder_count[unblocked_model] -= 1
+                if blocking_holder_count[unblocked_model] == 0:
+                    ready_models.append(unblocked_model)
         # Append cycle participants at the end in their original insertion order
-        cycle_nodes = [m for m in plan_models if m not in set(ordered_models)]
-        if cycle_nodes:
-            _log(f"  {label}: topo-sort cycle (ignored): {[m.__name__ for m in cycle_nodes]}")
-        ordered_models.extend(cycle_nodes)
+        cycle_models = [m for m in plan_models if m not in set(ordered_models)]
+        if cycle_models:
+            _log(f"  {label}: topo-sort cycle (ignored): {[m.__name__ for m in cycle_models]}")
+        ordered_models.extend(cycle_models)
 
-        model_to_item = {m: (qs, pks) for m, qs, pks in plan_items}
+        model_to_item = {item.model: item for item in plan_items}
         skipped = [m for m in ordered_models if m not in model_to_item]
         if skipped:
             _log(
                 f"  [warn] {label}: {len(skipped)} model(s) in topo order but not in plan: {[m.__name__ for m in skipped]}"
             )
-        ordered_items = [(m, *model_to_item[m]) for m in ordered_models if m in model_to_item]
+        ordered_items = [model_to_item[m] for m in ordered_models if m in model_to_item]
 
         if plan_items:
-            _log(f"  {label}: cascade plan — {', '.join(sorted(m._meta.label for m, _, _ in plan_items))}")
+            _log(f"  {label}: cascade plan — {', '.join(sorted(item.model._meta.label for item in plan_items))}")
 
         total_steps = len(ordered_items)
-        for step, (model, qs, pks) in enumerate(ordered_items, 1):
-            step_label = f"{label}→{model._meta.label}"
+        for step, item in enumerate(ordered_items, 1):
+            step_label = f"{label}→{item.model._meta.label}"
             _log(f"  [{step}/{total_steps}] {step_label}…")
-            t0 = time.monotonic()
-            if qs is not None:
-                n = qs._raw_delete(using=qs.db)
+            step_started_at = time.monotonic()
+            if item.queryset is not None:
+                deleted_count = item.queryset._raw_delete(using=item.queryset.db)
             else:
-                n = 0
-                for i in range(0, len(pks), self.chunk_size):
-                    chunk = pks[i : i + self.chunk_size]
-                    n += model.objects.filter(pk__in=chunk)._raw_delete(using=queryset.db)
-            if n:
-                _log(f"  {step_label}: {n:,} deleted ({time.monotonic() - t0:.1f}s)")
+                deleted_count = 0
+                for offset in range(0, len(item.pks), self.chunk_size):
+                    chunk = item.pks[offset : offset + self.chunk_size]
+                    deleted_count += item.model.objects.filter(pk__in=chunk)._raw_delete(using=queryset.db)
+            if deleted_count:
+                _log(f"  {step_label}: {deleted_count:,} deleted ({time.monotonic() - step_started_at:.1f}s)")
 
     def _delete_datasource_tree(self, datasources, label_prefix=""):
         """Delete each DataSource fully before moving to the next."""
@@ -660,15 +651,15 @@ class Command(BaseCommand):
                 _log(f"  [error] orphan ds[{ds.id}] {ds.name!r}: {exc} — skipping")
 
         # Forms without projects
-        forms_no_project = Form.objects_include_deleted.filter(projects=None)
+        forms_without_project = Form.objects_include_deleted.filter(projects=None)
         self._delete_qs(
-            InstanceFile.objects.filter(instance__in=Instance.objects.filter(form__in=forms_no_project)),
+            InstanceFile.objects.filter(instance__in=Instance.objects.filter(form__in=forms_without_project)),
             label="InstanceFile[form no project]",
         )
-        self._delete_qs(Instance.objects.filter(form__in=forms_no_project), label="Instance[form no project]")
+        self._delete_qs(Instance.objects.filter(form__in=forms_without_project), label="Instance[form no project]")
 
         self._delete_qs(Project.objects.filter(account=None), label="Project[no account]")
-        # Forms with no form_id may still have instances (not covered by the forms_no_project cleanup above).
+        # Forms with no form_id may still have instances (not covered by the forms_without_project cleanup above).
         forms_no_form_id = Form.objects_include_deleted.filter(form_id=None)
         self._delete_qs(
             InstanceFile.objects.filter(instance__in=Instance.objects.filter(form__in=forms_no_form_id)),
@@ -684,14 +675,16 @@ class Command(BaseCommand):
         self._delete_qs(Session.objects.all(), label="Session")
         self._delete_qs(Device.objects.filter(projects=None), label="Device[orphan]")
 
-        for f in forms_no_project:
+        for form_without_project in forms_without_project:
             try:
                 if not self.dry_run:
-                    OrgUnitType.reference_forms.through.objects.filter(form=f).delete()
-                    f.org_unit_types.clear()
-                    InstanceFile.objects.filter(instance__form_version__in=f.form_versions.all()).delete()
-                    Instance.objects.filter(form_version__in=f.form_versions.all()).delete()
-                    f.delete_hard()
+                    OrgUnitType.reference_forms.through.objects.filter(form=form_without_project).delete()
+                    form_without_project.org_unit_types.clear()
+                    InstanceFile.objects.filter(
+                        instance__form_version__in=form_without_project.form_versions.all()
+                    ).delete()
+                    Instance.objects.filter(form_version__in=form_without_project.form_versions.all()).delete()
+                    form_without_project.delete_hard()
             except Exception:
                 _log(traceback.format_exc())
 
@@ -774,6 +767,66 @@ class Command(BaseCommand):
     # Main account deletion (graph-based)
     # -----------------------------------------------------------------------
 
+    def _execute_graph_deletion(self, discovered, deletion_order, account, skip_models=None):
+        """
+        Delete all discovered models in topological order.
+        Each model's rows are filtered using the auto-built account_lookup.
+        skip_models: set of model classes handled manually (excluded from this step).
+        """
+        skip_models = skip_models or set()
+        models_processed = 0
+        models_with_rows = 0
+        total_deleted = 0
+
+        for model in deletion_order:
+            if model not in discovered or model in skip_models:
+                continue
+            info = discovered[model]
+            manager = getattr(model, "objects_include_deleted", model._default_manager)
+
+            try:
+                qs = manager.filter(**{info.account_lookup: account})
+            except Exception as exc:
+                _log(f"  [skip] {model.__name__}: cannot build queryset ({exc})")
+                continue
+
+            models_processed += 1
+            label = f"{model.__name__}[{info.account_lookup}]"
+            if info.is_partial_coverage:
+                label += " ⚠ partial"
+
+            if self.dry_run:
+                _log(f"  [DRY RUN] would delete {label}")
+                continue
+
+            deleted_count = 0
+            for attempt in range(_MAX_PROTECT_UNBLOCK_ATTEMPTS):
+                try:
+                    deleted_count += _chunked_delete(qs, self.chunk_size, label=label)
+                    break
+                except ProtectedError as exc:
+                    # Auto-clear blocking objects (e.g. nullable PROTECT FKs from partial-coverage models)
+                    blocking_pks_by_model = defaultdict(list)
+                    for obj in exc.protected_objects:
+                        blocking_pks_by_model[type(obj)].append(obj.pk)
+                    for blocker_model, pks in blocking_pks_by_model.items():
+                        _log(f"  [auto-unblock] {blocker_model.__name__} ×{len(pks)} blocking {label}")
+                        _chunked_delete(
+                            blocker_model.objects.filter(pk__in=pks),
+                            self.chunk_size,
+                            f"{blocker_model.__name__}[unblock]",
+                        )
+
+            if deleted_count:
+                _log(f"  {label}: {deleted_count:,} deleted")
+                models_with_rows += 1
+                total_deleted += deleted_count
+
+        if not self.dry_run:
+            _log(
+                f"  topo step: {models_processed} models processed, {models_with_rows} non-empty, {total_deleted:,} rows deleted total"
+            )
+
     def _delete_account(self, account, discovered, deletion_order):
         _log(f"Account {account.id}: {account.name!r}")
 
@@ -835,12 +888,10 @@ class Command(BaseCommand):
             _log(
                 f"  Running FK-graph auto-deletion ({len(discovered)} models, skipping {len(manual_models)} manual)..."
             )
-            execute_graph_deletion(
+            self._execute_graph_deletion(
                 discovered,
                 deletion_order,
                 account,
-                self.chunk_size,
-                self.dry_run,
                 skip_models=manual_models,
             )
 
@@ -888,8 +939,8 @@ class Command(BaseCommand):
 
         # --list-accounts mode
         if options.get("list_accounts"):
-            for acct in Account.objects.order_by("id"):
-                _log(f"  {acct.id:6d}  {acct.name}")
+            for account in Account.objects.order_by("id"):
+                _log(f"  {account.id:6d}  {account.name}")
             return
 
         # --show-graph mode
@@ -897,15 +948,15 @@ class Command(BaseCommand):
             account = None
             if options.get("for_account"):
                 account = Account.objects.get(pk=options["for_account"])
-            show_graph(discovered, graph_edges, deletion_order, account=account)
+            show_graph(discovered, deletion_order, account=account)
             return
 
         if self.dry_run:
             _log("*** DRY RUN — no data will be modified ***")
 
         _log("Available accounts:")
-        for acct in Account.objects.order_by("id"):
-            _log(f"  {acct.id}: {acct.name}")
+        for account in Account.objects.order_by("id"):
+            _log(f"  {account.id}: {account.name}")
 
         account_to_keep = None
         full_cleanup = False
@@ -943,7 +994,6 @@ class Command(BaseCommand):
 
         _log("Done!")
         _log("Row counts after deletion:")
-        from django.apps import apps as django_apps
 
         all_models = sorted(django_apps.get_models(), key=lambda m: m._meta.label)
         for model in all_models:

--- a/iaso/management/commands/delete_accounts.py
+++ b/iaso/management/commands/delete_accounts.py
@@ -403,6 +403,25 @@ class Command(BaseCommand):
         n, _ = queryset.delete()
         _log(f"  {label}: {n} deleted")
 
+    def _delete_chunked(self, queryset, label=None):
+        """Dry-run-aware wrapper around the module-level _chunked_delete streaming delete."""
+        label = label or queryset.model.__name__
+        if self.dry_run:
+            _log(f"  [DRY RUN] {label}: ~{queryset.count()}")
+            return 0
+        return _chunked_delete(queryset, self.chunk_size, label=label)
+
+    def _update_qs(self, queryset, label=None, **fields):
+        """Dry-run-aware wrapper around queryset.update(**fields)."""
+        label = label or queryset.model.__name__
+        if self.dry_run:
+            _log(f"  [DRY RUN] {label}: would update ~{queryset.count()} rows to {fields}")
+            return 0
+        updated = queryset.update(**fields)
+        if updated:
+            _log(f"  {label}: {updated} updated")
+        return updated
+
     @contextmanager
     def _doing(self, step):
         """Context manager: logs current step; re-raises with context on error."""
@@ -427,6 +446,9 @@ class Command(BaseCommand):
         For models without signals (most iaso models), Collector stores querysets in
         fast_deletes — no instances are loaded into memory.
         """
+        if self.dry_run:
+            _log(f"  [DRY RUN] {label}: would cascade-delete ~{queryset.count()} rows and everything referencing them")
+            return
 
         for attempt in range(_MAX_PROTECT_UNBLOCK_ATTEMPTS):
             collector = Collector(using=queryset.db)
@@ -468,11 +490,15 @@ class Command(BaseCommand):
         # end in plan_items insertion order (fast_deletes before data, so SourceVersion before
         # DataSource). DataSource.default_version is already nulled, so either order is safe.
         # plan_models as dict preserves insertion order for cycle-node fallback.
-        plan_models = dict.fromkeys(item.model for item in plan_items)
-        fk_targets_by_holder = {m: set() for m in plan_models}
-        blocking_holder_count = {
-            m: 0 for m in plan_models
-        }  # Kahn's algorithm: remaining FK holders blocking each model
+        plan_models = {}
+        fk_targets_by_holder = {}
+        blocking_holder_count = {}
+        for plan_item in plan_items:
+            model = plan_item.model
+            plan_models[model] = None
+            fk_targets_by_holder[model] = set()
+            blocking_holder_count[model] = 0  # Kahn's algorithm: remaining FK holders blocking each model
+
         for model in plan_models:
             for field in model._meta.local_fields:
                 if isinstance(field, (ForeignKey, OneToOneField)):
@@ -543,8 +569,11 @@ class Command(BaseCommand):
             with self._doing(f"Entity {ds_label}"):
                 # Instance.entity is DO_NOTHING — PostgreSQL still enforces the FK.
                 # Null it out before deleting Entity to avoid IntegrityError.
-                if not self.dry_run:
-                    Instance.objects.filter(entity__in=entities_qs).update(entity=None)
+                self._update_qs(
+                    Instance.objects.filter(entity__in=entities_qs),
+                    label=f"Instance.entity=NULL[{ds_label}]",
+                    entity=None,
+                )
                 self._delete_qs(entities_qs, label=f"Entity[{ds_label}]")
 
             with self._doing(f"InstanceFile {ds_label}"):
@@ -554,34 +583,40 @@ class Command(BaseCommand):
                 )
 
             with self._doing(f"Instance {ds_label}"):
-                if not self.dry_run:
-                    _chunked_delete(instances_in_ds, self.chunk_size, f"Instance[{ds_label}]")
+                self._delete_chunked(instances_in_ds, label=f"Instance[{ds_label}]")
 
             # Planning.org_unit = PROTECT blocks OrgUnit deletion (hence DataSource cascade).
             # Cycle: Planning.selected_sampling_result = PROTECT(PSR) ↔ PSR.planning = CASCADE(Planning)
             # Break it: null Planning.selected_sampling_result → delete PSR → delete Planning.
             with self._doing(f"Planning/PSR cycle {ds_label}"):
-                if not self.dry_run:
-                    planning_qs = Planning.objects.filter(org_unit__version__in=versions_qs)
-                    planning_qs.update(selected_sampling_result=None)
-                    _chunked_delete(
-                        PlanningSamplingResult.objects.filter(planning__in=planning_qs),
-                        self.chunk_size,
-                        f"PlanningSamplingResult[{ds_label}]",
-                    )
-                    _chunked_delete(planning_qs, self.chunk_size, f"Planning[{ds_label}]")
+                planning_qs = Planning.objects.filter(org_unit__version__in=versions_qs)
+                self._update_qs(
+                    planning_qs,
+                    label=f"Planning.selected_sampling_result=NULL[{ds_label}]",
+                    selected_sampling_result=None,
+                )
+                self._delete_chunked(
+                    PlanningSamplingResult.objects.filter(planning__in=planning_qs),
+                    label=f"PlanningSamplingResult[{ds_label}]",
+                )
+                self._delete_chunked(planning_qs, label=f"Planning[{ds_label}]")
 
-            if not self.dry_run:
-                with self._doing(f"DataSource cascade {ds_label}"):
-                    # DataSource.default_version → SourceVersion cycle: null first.
-                    DataSource.objects.filter(pk=ds.pk).update(default_version=None)
-                    # OrgUnit.parent is a self-referential FK; batch _raw_delete fails if any
-                    # row's parent is another row in the same batch. Null all within this
-                    # datasource's versions before the cascade reaches OrgUnit.
-                    OrgUnit.objects.filter(version__in=versions_qs).update(parent=None)
-                    self._cascade_chunked_delete(DataSource.objects.filter(pk=ds.pk), ds_label)
-            else:
-                _log(f"  [DRY RUN] {ds_label}: would cascade-delete DataSource → SourceVersion → OrgUnit → …")
+            with self._doing(f"DataSource cascade {ds_label}"):
+                # DataSource.default_version → SourceVersion cycle: null first.
+                self._update_qs(
+                    DataSource.objects.filter(pk=ds.pk),
+                    label=f"DataSource.default_version=NULL[{ds_label}]",
+                    default_version=None,
+                )
+                # OrgUnit.parent is a self-referential FK; batch _raw_delete fails if any
+                # row's parent is another row in the same batch. Null all within this
+                # datasource's versions before the cascade reaches OrgUnit.
+                self._update_qs(
+                    OrgUnit.objects.filter(version__in=versions_qs),
+                    label=f"OrgUnit.parent=NULL[{ds_label}]",
+                    parent=None,
+                )
+                self._cascade_chunked_delete(DataSource.objects.filter(pk=ds.pk), ds_label)
 
     # -----------------------------------------------------------------------
     # Manual section: Form (M2M-linked)
@@ -622,8 +657,7 @@ class Command(BaseCommand):
         # OrgUnits with no version: null self-ref parent first, then delete instances/files
         # that reference them (DO_NOTHING FK — DB enforces NO ACTION so must be cleared first)
         no_version_ou = OrgUnit.objects.filter(version=None)
-        if not self.dry_run:
-            no_version_ou.update(parent=None)  # break self-ref tree
+        self._update_qs(no_version_ou, label="OrgUnit[no version].parent=NULL", parent=None)  # break self-ref tree
         no_version_instances = Instance.objects.filter(org_unit__in=no_version_ou)
         self._delete_qs(
             InstanceFile.objects.filter(instance__in=no_version_instances), label="InstanceFile[ou no version]"
@@ -635,9 +669,20 @@ class Command(BaseCommand):
         self._delete_qs(InstanceFile.objects.filter(instance__in=orphans), label="InstanceFile[orphan]")
         self._delete_qs(orphans, label="Instance[orphan]")
 
-        if not self.dry_run:
-            Task.objects.filter(status=QUEUED).update(status=KILLED)
-            _log("  Queued tasks killed")
+        self._update_qs(Task.objects.filter(status=QUEUED), label="Task[queued→killed]", status=KILLED)
+
+    def _delete_form_without_project(self, form):
+        """Clear a project-less Form's M2M/version data and hard-delete it."""
+        label = f"Form[no project][{form.id}]"
+        if self.dry_run:
+            _log(f"  [DRY RUN] {label}: would clear org_unit_types, delete versions' instances/files, hard-delete")
+            return
+        OrgUnitType.reference_forms.through.objects.filter(form=form).delete()
+        form.org_unit_types.clear()
+        InstanceFile.objects.filter(instance__form_version__in=form.form_versions.all()).delete()
+        Instance.objects.filter(form_version__in=form.form_versions.all()).delete()
+        form.delete_hard()
+        _log(f"  {label}: done")
 
     def _post_flight(self, account_to_keep):
         # Orphan datasources — delete one by one, continue on error
@@ -677,14 +722,7 @@ class Command(BaseCommand):
 
         for form_without_project in forms_without_project:
             try:
-                if not self.dry_run:
-                    OrgUnitType.reference_forms.through.objects.filter(form=form_without_project).delete()
-                    form_without_project.org_unit_types.clear()
-                    InstanceFile.objects.filter(
-                        instance__form_version__in=form_without_project.form_versions.all()
-                    ).delete()
-                    Instance.objects.filter(form_version__in=form_without_project.form_versions.all()).delete()
-                    form_without_project.delete_hard()
+                self._delete_form_without_project(form_without_project)
             except Exception:
                 _log(traceback.format_exc())
 
@@ -711,11 +749,8 @@ class Command(BaseCommand):
             ") DELETE FROM audit_modification WHERE id IN (SELECT id FROM cte)"
         )
         for i in range(2000):
-            if self.dry_run:
-                break
-            self.cursor.execute(sql)
-            _log(f"  Modification batch {i}: {self.cursor.rowcount} deleted")
-            if self.cursor.rowcount == 0:
+            deleted = self._sql(sql, label=f"Modification batch {i}")
+            if deleted == 0:
                 break
 
         for model_cls, app_label, model_name in [
@@ -738,27 +773,24 @@ class Command(BaseCommand):
         )
 
     def _cleanup_export_logs(self):
-        if self.dry_run:
-            return
         t0 = time.monotonic()
         total = 0
         # Single SQL per chunk — no Python-level ID transfer, no ORM LEFT JOIN.
         # NOT EXISTS with an indexed exportlog_id is efficient even on large tables.
+        delete_sql = (
+            "DELETE FROM iaso_exportlog"
+            " WHERE id IN ("
+            "   SELECT id FROM iaso_exportlog el"
+            "   WHERE NOT EXISTS ("
+            "     SELECT 1 FROM iaso_exportstatus_export_logs sel WHERE sel.exportlog_id = el.id"
+            "   )"
+            f"  LIMIT {self.chunk_size}"
+            ")"
+        )
         while True:
-            self.cursor.execute(
-                "DELETE FROM iaso_exportlog"
-                " WHERE id IN ("
-                "   SELECT id FROM iaso_exportlog el"
-                "   WHERE NOT EXISTS ("
-                "     SELECT 1 FROM iaso_exportstatus_export_logs sel WHERE sel.exportlog_id = el.id"
-                "   )"
-                f"  LIMIT {self.chunk_size}"
-                ")"
-            )
-            n = self.cursor.rowcount
-            total += n
-            _log(f"  ExportLog[orphan]: {total:,} deleted so far…")
-            if n < self.chunk_size:
+            deleted = self._sql(delete_sql, label="ExportLog[orphan] batch")
+            total += deleted
+            if deleted < self.chunk_size:
                 break
         if total:
             _log(f"  ExportLog[orphan]: {total:,} total ({time.monotonic() - t0:.1f}s)")
@@ -833,8 +865,11 @@ class Command(BaseCommand):
         # ---- Null out self-referential FK cycles before any deletion ----
         # Account.default_version → SourceVersion and SourceVersion → DataSource → Account
         # form a cycle that blocks cascade deletion of SourceVersion.
-        if not self.dry_run:
-            Account.objects.filter(pk=account.pk).update(default_version=None)
+        self._update_qs(
+            Account.objects.filter(pk=account.pk),
+            label=f"Account[{account.id}].default_version=NULL",
+            default_version=None,
+        )
 
         # ---- Collect data we'll need BEFORE any deletions start ----
         # Profile is in the FK graph (discovered via 'account' filter) and will be
@@ -867,21 +902,16 @@ class Command(BaseCommand):
         # Django's Collector raises PROTECT on PSR even when Planning is also being
         # collected — delete PSR first so Planning has no blocker.
         with self._doing(f"account={account.id} PlanningSamplingResult"):
-            if not self.dry_run:
-                _chunked_delete(
-                    PlanningSamplingResult.objects.filter(planning__project__account=account),
-                    self.chunk_size,
-                    "PlanningSamplingResult",
-                )
+            self._delete_chunked(
+                PlanningSamplingResult.objects.filter(planning__project__account=account),
+                label="PlanningSamplingResult",
+            )
 
         # Entity.attributes → Instance is PROTECT; Instance.entity → Entity is DO_NOTHING.
         with self._doing(f"account={account.id} Entity.attributes = NULL"):
-            if not self.dry_run:
-                Entity.objects_include_deleted.filter(account=account).update(attributes=None)
-            else:
-                _log(
-                    f"  [DRY RUN] Entity.attributes=NULL: ~{Entity.objects_include_deleted.filter(account=account).count()}"
-                )
+            self._update_qs(
+                Entity.objects_include_deleted.filter(account=account), label="Entity.attributes=NULL", attributes=None
+            )
 
         # ---- Step 3: Auto — topo-sorted FK-graph deletion ----
         with self._doing(f"account={account.id} FK-graph auto-deletion"):
@@ -916,10 +946,7 @@ class Command(BaseCommand):
             )
 
         # ---- Step 6: Account itself ----
-        if not self.dry_run:
-            account_id, account_name = account.id, account.name
-            account.delete()
-            _log(f"  Account {account_id} ({account_name!r}) deleted")
+        self._delete_qs(Account.objects.filter(pk=account.pk), label=f"Account[{account.id}] {account.name!r}")
 
     # -----------------------------------------------------------------------
     # Entry point

--- a/iaso/management/commands/delete_accounts.py
+++ b/iaso/management/commands/delete_accounts.py
@@ -255,7 +255,7 @@ def execute_graph_deletion(discovered, deletion_order, account, chunk_size, dry_
         models_processed += 1
         label = f"{model.__name__}[{filter_kwarg}]"
         if is_partial:
-            label += " ⚠partial"
+            label += " ⚠ partial"
 
         if dry_run:
             _log(f"  [DRY RUN] would delete {label}")

--- a/iaso/management/commands/delete_accounts.py
+++ b/iaso/management/commands/delete_accounts.py
@@ -640,7 +640,7 @@ class Command(BaseCommand):
     # Pre/post-flight cleanup
     # -----------------------------------------------------------------------
 
-    def _pre_flight(self):
+    def _pre_flight(self, accounts_to_delete):
         try:
             self._sql("DELETE FROM users_profile", label="users_profile")
         except django.db.utils.ProgrammingError:
@@ -666,7 +666,11 @@ class Command(BaseCommand):
         self._delete_qs(InstanceFile.objects.filter(instance__in=orphans), label="InstanceFile[orphan]")
         self._delete_qs(orphans, label="Instance[orphan]")
 
-        self._update_qs(Task.objects.filter(status=QUEUED), label="Task[queued→killed]", status=KILLED)
+        self._update_qs(
+            Task.objects.filter(status=QUEUED, account__in=accounts_to_delete),
+            label="Task[queued→killed]",
+            status=KILLED,
+        )
 
     def _delete_form_without_project(self, form):
         """Clear a project-less Form's M2M/version data and hard-delete it."""
@@ -1003,7 +1007,7 @@ class Command(BaseCommand):
                 found_ids = {a.id for a in accounts_to_delete}
                 raise SystemExit(f"Accounts not found: {[id for id in ids if id not in found_ids]}")
 
-        self._pre_flight()
+        self._pre_flight(accounts_to_delete)
 
         for account in accounts_to_delete:
             _log(f"--- Deleting account={account.id} ({account.name!r}) ---")

--- a/iaso/management/commands/delete_accounts.py
+++ b/iaso/management/commands/delete_accounts.py
@@ -1,9 +1,55 @@
+"""
+FK-graph-based account deletion.
+
+Core idea: instead of manually listing every model to delete, we traverse
+Django's FK metadata (Model._meta.related_objects) from Account via BFS to
+auto-discover related models and build their deletion filter path.  A
+topological sort then gives the correct deletion order.
+
+What is automatic:
+  - ~100 models discovered and deleted without any manual listing
+  - Plugin models (polio, wfp, …) included automatically
+  - New models added in future are picked up on next run
+  - Deletion order computed from FK constraints (no more ProtectedError
+    from cascade chains between discovered models)
+
+What still needs manual code (M2M gap):
+  - DataSource / SourceVersion / OrgUnit — linked to Account via
+    Project.data_sources M2M, not a direct FK; the BFS path via credentials
+    is SET_NULL and therefore partial
+  - Form — linked via projects M2M
+  - Orphan audit/export log cleanup (content-type based, not FK based)
+
+Usage:
+  docker compose run --rm iaso manage delete_accounts_v3 --account-to-keep 1
+  docker compose run --rm iaso manage delete_accounts_v3 --account-to-keep 1 --dry-run
+  docker compose run --rm iaso manage delete_accounts_v3 --show-graph
+
+
+how to test this crazyness
+
+launch the seed commands for different versions
+    docker compose run --rm iaso manage seed_test_data --mode=seed --dhis2version=2.40.10
+    docker compose run --rm iaso manage seed_test_data --mode=seed --dhis2version=2.42.3.1
+    docker compose run --rm iaso manage seed_test_data --mode=seed --dhis2version=2.42.3.1
+
+this clearly won't reproduce all potential issues in like in production (seed gives low volumes, good data quality)
+
+then launch the delete command with appropriate account to delete (or don't specify it a list will be displayed)
+
+    docker compose run --rm iaso manage delete_accounts --account-to-keep 1
+
+
+"""
+
 import datetime
 import random
 import time
 import traceback
 
-from collections import defaultdict
+from collections import defaultdict, deque
+from contextlib import contextmanager
+from graphlib import TopologicalSorter
 
 import django
 
@@ -12,575 +58,879 @@ from django.contrib.contenttypes.models import ContentType
 from django.contrib.sessions.models import Session
 from django.core.management.base import BaseCommand
 from django.db import connection
-from django.db.models import Count, Q, Subquery, TextField
+from django.db.models import ForeignKey, ManyToManyRel, OneToOneField, TextField
+from django.db.models.deletion import SET_NULL, Collector, ProtectedError
 from django.db.models.functions import Cast
-from django_sql_dashboard.models import Dashboard
 
 from hat.audit.models import Modification
 from iaso.models import (
     Account,
-    BulkCreateUserFile,
     CommentIaso,
-    ExportLog,
     Form,
     OrgUnitType,
-    StorageDevice,
-    StorageLogEntry,
-    StoragePassword,
     Task,
-    TenantUser,
 )
-from iaso.models.base import (
-    KILLED,
-    QUEUED,
-    DataSource,
-    ExternalCredentials,
-    Mapping,
-    Profile,
-)
+from iaso.models.base import KILLED, QUEUED, DataSource, ExternalCredentials, Profile
 from iaso.models.device import Device
-from iaso.models.entity import Entity, EntityType
-from iaso.models.instances import Instance, InstanceFile, InstanceLock
-from iaso.models.microplanning import Assignment, Planning
-from iaso.models.org_unit import OrgUnit, OrgUnitReferenceInstance
-from iaso.models.pages import Page
+from iaso.models.entity import Entity
+from iaso.models.instances import Instance, InstanceFile
+from iaso.models.microplanning import Planning, PlanningSamplingResult
+from iaso.models.org_unit import OrgUnit
 from iaso.models.project import Project
-from iaso.models.team import Team
 
 
-def flatten(l):
-    return [item for sublist in l for item in sublist]
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
 
 
-def fullname(m):
-    if m is None:
-        return ""
-    return m.__module__ + "." + m.__name__
+def _log(msg):
+    print(f"[{datetime.datetime.now().strftime('%H:%M:%S')}] {msg}")
 
 
-def chunked_delete_records(queryset, chunk_size=1000):
-    """
-    Efficiently deletes a large queryset in smaller chunks.
-    """
+# ---------------------------------------------------------------------------
+# Streaming chunked delete
+# ---------------------------------------------------------------------------
+
+
+def _chunked_delete(queryset, chunk_size=5000, label=None):
+    """Delete in streaming chunks — never loads more than chunk_size PKs at once."""
     model = queryset.model
+    label = label or model.__name__
+    total = 0
+    t0 = time.monotonic()
+
+    while True:
+        ids = list(queryset.order_by("pk").values_list("pk", flat=True)[:chunk_size])
+        if not ids:
+            break
+        chunk_qs = queryset.filter(pk__in=ids)
+        try:
+            deleted = chunk_qs._raw_delete(using=queryset.db)
+        except Exception as exc:
+            _log(f"  {label}: _raw_delete failed ({exc!r}), falling back to .delete()")
+            _, counts = chunk_qs.delete()
+            deleted = counts.get(model._meta.label, 0)
+            counts_str = ", ".join(f"{k}: {v}" for k, v in sorted(counts.items()) if v)
+            _log(f"  {label}: cascade counts: {counts_str}")
+        total += deleted
+
+    return total
+
+
+# ---------------------------------------------------------------------------
+# FK graph — discovery and topological sort
+# ---------------------------------------------------------------------------
+
+# Only follow FK edges to models from these app module prefixes.
+# "iaso" covers the main app; "plugins" covers all plugin apps (polio, etc.).
+# Third-party app models (django_sql_dashboard, auth, etc.) are skipped — Django
+# CASCADE handles them automatically when their parent rows disappear.
+_PROJECT_APP_PREFIXES = ("iaso", "plugins")
+
+# Models discovered via a SET_NULL path — filter may miss rows where FK is NULL.
+# These are flagged as "partial coverage" in --show-graph.
+_PARTIAL_COVERAGE_NOTE = "⚠ partial: SET_NULL path, rows with NULL FK are missed"
+
+
+def _is_project_model(model):
+    """True if this model belongs to iaso or a plugin (not a third-party or Django built-in app)."""
+    app_module = model._meta.app_config.__class__.__module__
+    return app_module.startswith(_PROJECT_APP_PREFIXES)
+
+
+def build_fk_graph(root_model):
+    """
+    BFS from root_model through reverse FK relations.
+
+    Returns:
+      discovered : {model: (filter_kwarg, on_delete_name, is_partial)}
+        filter_kwarg — Django ORM lookup, e.g. 'project__account'
+        on_delete_name — on_delete of the edge that discovered this model
+        is_partial — True if any edge on the path is SET_NULL (nullable FK)
+      graph_edges : list of (child_model, parent_model, on_delete_name)
+        Directed edges from FK holder → FK target (used for topo sort)
+    """
+    discovered = {}  # model → (filter_kwarg, on_delete_name, is_partial)
+    graph_edges = []
+
+    visited = {root_model: (None, False)}  # model → (filter_kwarg, is_partial)
+    queue = deque([(root_model, None, False)])
+
+    while queue:
+        current, current_filter, current_partial = queue.popleft()
+
+        for rel in current._meta.related_objects:
+            if isinstance(rel, ManyToManyRel):
+                continue
+
+            child = rel.related_model
+            if child in visited:
+                continue
+            if getattr(child._meta, "abstract", False) or getattr(child._meta, "swapped", None):
+                continue
+            if not _is_project_model(child):
+                continue
+
+            field_name = rel.field.name
+            new_filter = field_name if current_filter is None else f"{field_name}__{current_filter}"
+            od_name = getattr(rel.on_delete, "__name__", str(rel.on_delete))
+            is_partial = current_partial or (rel.on_delete is SET_NULL)
+
+            visited[child] = (new_filter, is_partial)
+            discovered[child] = (new_filter, od_name, is_partial)
+            queue.append((child, new_filter, is_partial))
+
+    # Collect cross-edges between discovered models (for topo sort)
+    for model in discovered:
+        for field in model._meta.get_fields():
+            if not isinstance(field, (ForeignKey, OneToOneField)):
+                continue
+            target = field.related_model
+            if target not in discovered or target is model:
+                continue
+            od_name = getattr(field.remote_field.on_delete, "__name__", "?")
+            graph_edges.append((model, target, od_name))
+
+    return discovered, graph_edges
+
+
+def topo_sort_deletion_order(discovered, graph_edges):
+    """
+    Topological sort: model A before model B if A has a CASCADE or PROTECT FK to B
+    (A must be deleted first to avoid blocking B's deletion).
+
+    SET_NULL and DO_NOTHING edges don't impose ordering (handled by breaking cycles
+    before deletion or nulling out before the batch delete runs).
+
+    Uses graphlib.TopologicalSorter (Python 3.9+).
+    Falls back gracefully if cycles remain after filtering.
+    """
+    ts = TopologicalSorter()
+
+    for model in discovered:
+        ts.add(model)
+
+    for child, parent, od_name in graph_edges:
+        if od_name in ("CASCADE", "PROTECT"):
+            # child must be deleted BEFORE parent
+            # ts.add(X, Y) means Y must come before X
+            ts.add(parent, child)
+
+    try:
+        return list(ts.static_order())
+    except Exception as exc:
+        _log(f"  [topo sort] cycle detected ({exc}), falling back to reverse-BFS order")
+        return list(reversed(list(discovered.keys())))
+
+
+# ---------------------------------------------------------------------------
+# Graph-based deletion engine
+# ---------------------------------------------------------------------------
+
+
+def execute_graph_deletion(discovered, deletion_order, account, chunk_size, dry_run, skip_models=None):
+    """
+    Delete all discovered models in topological order.
+    Each model's rows are filtered using the auto-built filter_kwarg.
+    skip_models: set of model classes handled manually (excluded from this step).
+    """
+    skip_models = skip_models or set()
+    models_processed = 0
+    models_with_rows = 0
     total_deleted = 0
-    start_time = time.time()
 
-    # Use .iterator() to avoid loading all 1.2M objects into memory
-    pk_list = list(queryset.values_list("pk", flat=True).iterator())
-    total_to_delete = len(pk_list)
-
-    print(f"Starting deletion of {total_to_delete} records...", model)
-
-    # Iterate over primary keys in chunks
-    for i in range(0, total_to_delete, chunk_size):
-        chunk_pks = pk_list[i : i + chunk_size]
+    for model in deletion_order:
+        if model not in discovered or model in skip_models:
+            continue
+        filter_kwarg, od_name, is_partial = discovered[model]
+        manager = getattr(model, "objects_include_deleted", model._default_manager)
 
         try:
-            # Use QuerySet._raw_delete() for efficiency within the database
-            # but fallback to .delete() in the except if there were other references to cascade
-            chunk_queryset = model.objects.filter(pk__in=chunk_pks)
-            deleted_count = chunk_queryset._raw_delete(using=queryset.db)
-            total_deleted += deleted_count
+            qs = manager.filter(**{filter_kwarg: account})
+        except Exception as exc:
+            _log(f"  [skip] {model.__name__}: cannot build queryset ({exc})")
+            continue
 
-            elapsed_time = time.time() - start_time
-            print(f"Deleted {total_deleted} / {total_to_delete} records so far in {elapsed_time:.2f}s...")
-        except Exception as err:
-            print("failed to _raw_delete, trying with delete", err, repr(err), err.args)
+        models_processed += 1
+        label = f"{model.__name__}[{filter_kwarg}]"
+        if is_partial:
+            label += " ⚠partial"
+
+        if dry_run:
+            _log(f"  [DRY RUN] would delete {label}")
+            continue
+
+        n = 0
+        for attempt in range(5):
             try:
-                chunk_queryset = model.objects.filter(pk__in=chunk_pks)
-                deleted_count = chunk_queryset.delete()
-                elapsed_time = time.time() - start_time
-                print(f"Deleted {total_deleted} / {total_to_delete} records so far in {elapsed_time:.2f}s...")
-            except Exception as err:
-                print(
-                    f"Failed to delete chunk :  {total_deleted} / {total_to_delete} | {elapsed_time:.2f}s...",
-                    err,
-                    repr(err),
-                )
+                n += _chunked_delete(qs, chunk_size, label=label)
+                break
+            except ProtectedError as exc:
+                # Auto-clear blocking objects (e.g. nullable PROTECT FKs from partial-coverage models)
+                by_model = defaultdict(list)
+                for obj in exc.protected_objects:
+                    by_model[type(obj)].append(obj.pk)
+                for blocker_model, pks in by_model.items():
+                    _log(f"  [auto-unblock] {blocker_model.__name__} ×{len(pks)} blocking {label}")
+                    _chunked_delete(
+                        blocker_model.objects.filter(pk__in=pks), chunk_size, f"{blocker_model.__name__}[unblock]"
+                    )
 
-    end_time = time.time()
-    print(f"Finished deleting all {total_deleted} records in total elapsed time: {end_time - start_time:.2f} seconds.")
+        if n:
+            _log(f"  {label}: {n:,} deleted")
+        if n:
+            models_with_rows += 1
+            total_deleted += n
 
-
-def dump_counts():
-    counts = defaultdict()
-    print("******************* COUNTS")
-    for ct in ContentType.objects.all():
-        m = None
-        if ct.model_class():
-            try:
-                m = ct.model_class()
-                count = m._default_manager.count()
-                # print(m.__module__, m.__name__, count)
-                counts[fullname(m)] = count
-            except:
-                # don't know why (abstract model ? missing migration) but I had to add this catch statement
-                # the error raised below :
-                # db_1       | 2022-10-19 08:30:32.838 UTC [153] ERROR:  relation "menupermissions_custompermissionsupport" does not exist at character 35
-                # db_1       | 2022-10-19 08:30:32.838 UTC [153] STATEMENT:  SELECT COUNT(*) AS "__count" FROM "menupermissions_custompermissionsupport"
-                print(fullname(m), "not available")
-
-    print("******************* ")
-
-    return counts
-
-
-def dump_diffs(counts_before, counts_after):
-    print("***** diff")
-    print("\t".join(["model", "before", "after", "deleted"]))
-    for model in counts_after.keys():
-        print(
-            "\t".join(
-                [
-                    model,
-                    str(counts_before.get(model, 0)),
-                    str(counts_after.get(model, 0)),
-                    str(counts_before.get(model, 0) - counts_after.get(model, 0)),
-                ]
-            )
+    if not dry_run:
+        _log(
+            f"  topo step: {models_processed} models processed, {models_with_rows} non-empty, {total_deleted:,} rows deleted total"
         )
 
 
-def dump_modification_stats():
-    for tuple in Modification.objects.values("content_type").annotate(content_type_count=Count("content_type")).all():
-        print(ContentType.objects.get(pk=tuple["content_type"]), tuple["content_type_count"])
+# ---------------------------------------------------------------------------
+# --show-graph mode
+# ---------------------------------------------------------------------------
 
 
-# how to test this crazyness
-#
-# launch the seed commands for different versions
-#    docker compose run --rm iaso manage seed_test_data --mode=seed --dhis2version=2.40.10
-#    docker compose run --rm iaso manage seed_test_data --mode=seed --dhis2version=2.42.3.1
-#    docker compose run --rm iaso manage seed_test_data --mode=seed --dhis2version=2.42.3.1
-#
-# this clearly won't reproduce all potential issues in like in production
-# (seed gives low volumes, good data quality)
-#
-# then launch the delete command with appropriate account to delete (or don't specify it a list will be displayed)
-#
-#    docker compose run --rm iaso manage delete_accounts --account-to-keep 1
+def show_graph(discovered, graph_edges, deletion_order, account=None):
+    """
+    Print what the FK graph discovered, flag partial-coverage paths,
+    and optionally show which discovered models have data for the account.
+    """
+    _log(f"=== FK Graph from Account — {len(discovered)} models discovered ===")
+    _log("")
+    _log(f"{'Model':55s} {'on_delete':12s} {'filter path'}")
+    _log("-" * 120)
+
+    for model in deletion_order:
+        if model not in discovered:
+            continue
+        filter_kwarg, od_name, is_partial = discovered[model]
+        flag = "⚠" if is_partial else " "
+        count_str = ""
+        if account is not None:
+            try:
+                manager = getattr(model, "objects_include_deleted", model._default_manager)
+                count = manager.filter(**{filter_kwarg: account}).count()
+                count_str = f"  [{count} rows]"
+            except Exception:
+                count_str = "  [?]"
+        _log(f"  {flag} {model._meta.label:53s} {od_name:12s}  {filter_kwarg}{count_str}")
+
+    _log("")
+    _log("⚠ = path contains a SET_NULL FK — rows where that FK is NULL are NOT found by this filter")
+    _log("    These models need manual handling or supplementary filters.")
+    _log("")
+
+    # Models NOT discovered (manual handling required)
+    manual = [
+        (
+            "iaso.DataSource / SourceVersion / OrgUnit",
+            "linked via Project.data_sources M2M, BFS only finds those with credentials",
+        ),
+        ("iaso.Form", "linked via projects M2M"),
+        ("audit.Modification", "content-type based, no FK to Account"),
+        ("iaso.ExportLog", "no FK to Account"),
+        ("django_sql_dashboard.Dashboard", "no FK to Account"),
+        ("django.contrib.sessions.Session", "no FK to Account"),
+        ("vector_control_apiimport", "raw SQL table, not a Django model"),
+        ("users_profile", "legacy raw SQL table"),
+    ]
+    _log("=== Models NOT in FK graph (manual handling required) ===")
+    for label, reason in manual:
+        _log(f"  - {label}")
+        _log(f"      reason: {reason}")
+
+
+# ---------------------------------------------------------------------------
+# Management command
+# ---------------------------------------------------------------------------
 
 
 class Command(BaseCommand):
-    help = "Local hosting delete all the data related to other accounts"
+    help = "FK-graph-based account deletion — auto-discovers related models"
 
     def add_arguments(self, parser):
-        parser.add_argument("--account-to-keep", type=int)
-
-    def delete_project(self, account, project):
-        Form.objects.raw(
-            f"delete vector_control_apiimport where headers->>'QUERY_STRING' like 'app_id={project.app_id}%'"
+        mode = parser.add_mutually_exclusive_group(required=True)
+        mode.add_argument("--account-to-keep", type=int, metavar="ID")
+        mode.add_argument(
+            "--account-to-delete",
+            type=int,
+            action="append",
+            dest="accounts_to_delete",
+            metavar="ID",
         )
-        forms = Form.objects_include_deleted.filter(projects__in=[project])
-
-        print(
-            "OrgUnitChangeRequestConfiguration delete",
-            project.orgunitchangerequestconfiguration_set.all().delete(),
+        mode.add_argument(
+            "--show-graph",
+            action="store_true",
+            help="Print the FK discovery graph and exit (use with --for-account to show row counts)",
         )
-
-        print(
-            "OrgUnit remove reference_instance",
-            OrgUnitReferenceInstance.objects.filter(instance__in=Instance.objects.filter(project=project)).delete(),
+        mode.add_argument(
+            "--list-accounts",
+            action="store_true",
+            help="List all accounts with their IDs and exit",
         )
-        print("Instance update", Instance.objects.filter(project=project).update(entity=None))
+        parser.add_argument("--for-account", type=int, metavar="ID", help="Account to count rows for with --show-graph")
+        parser.add_argument("--chunk-size", type=int, default=5000)
+        parser.add_argument("--dry-run", action="store_true")
 
-        for entity_type in EntityType.objects.filter(account=account):
-            if entity_type.reference_form:
-                chunked_delete_records(
-                    Entity.objects_include_deleted.filter(
-                        attributes__in=Subquery(entity_type.reference_form.instances.values("id"))
-                    )
-                )
-                print(
-                    "reference form: entities delete",
-                    Entity.objects_include_deleted.filter(attributes__in=entity_type.reference_form.instances.all())
-                    .all()
-                    .delete(),
-                )
+    # -----------------------------------------------------------------------
+    # Helpers
+    # -----------------------------------------------------------------------
 
-                print(
-                    "reference form : InstanceFile delete",
-                    InstanceFile.objects.filter(instance__in=entity_type.reference_form.instances.all()).delete(),
-                )
-                chunked_delete_records(entity_type.reference_form.instances.all())
-                print(
-                    "reference form : delete instances witht reference form",
-                    entity_type.reference_form.instances.all().delete(),
-                )
+    def _sql(self, sql, params=None, label="SQL"):
+        if self.dry_run:
+            _log(f"  [DRY RUN] {label}: {sql[:100]}")
+            return 0
+        if params:
+            self.cursor.execute(sql, params)
+        else:
+            self.cursor.execute(sql)
+        n = self.cursor.rowcount
+        if n:
+            _log(f"  {label}: {n:,} deleted")
+        return n
 
-        for entity in Entity.objects_include_deleted.filter(account=account):
-            if entity and entity.attributes:
-                print("Entity attributes", entity.attributes.delete())
+    def _delete_qs(self, queryset, label=None):
+        label = label or queryset.model.__name__
+        if self.dry_run:
+            _log(f"  [DRY RUN] {label}: ~{queryset.count()}")
+            return
+        n, _ = queryset.delete()
+        _log(f"  {label}: {n} deleted")
 
-        print("Entity", Entity.objects_include_deleted.filter(account=account).delete())
-
-        print("EntityType", EntityType.objects.filter(account=account).delete())
-        print(
-            "InstanceFile delete",
-            InstanceFile.objects.filter(instance__in=Instance.objects.filter(project=project)).delete(),
-        )
-
-        chunked_delete_records(Instance.objects.filter(project=project))
-
-        print("InstanceFile delete", InstanceFile.objects.filter(instance__form__in=forms).delete())
-        print("Instance delete", Instance.objects.filter(form__in=forms).delete())
-        print("Mapping", Mapping.objects.filter(form__in=forms).delete())
-        print("Forms", [f.name for f in forms])
-        for f in forms:
-            try:
-                print("Instance delete", Instance.objects.filter(form__in=forms).delete())
-                f.delete_hard()
-            except:
-                print("can't hard delete form ", f, "soft deleting")
-                f.delete()
-
-        print(
-            "Assignment",
-            Assignment.objects.filter(team__in=Team.objects.filter(project=project)).delete(),
-        )
-        print("Planning", Planning.objects.filter(project=project).delete())
-        print("Teams with parents")
-
-        teams = [t for t in Team.objects.order_by("path").all()]
-        teams.sort(key=lambda x: str(x.path).count("."), reverse=True)
-        # delete leafs before parents
-        for team in teams:
-            print("Hard delete team", team, team.path)
-            team.delete_hard()
-
-        datasources = project.data_sources.all()
-        for data_source in datasources:
-            print("missing related datasource", datasources)
-            print(
-                Entity.objects.filter(
-                    attributes__in=Instance.objects.filter(org_unit__version__in=data_source.versions.all()).all()
-                )
-                .all()
-                .delete()
-            )
-            print(InstanceFile.objects.filter(instance__org_unit__version__in=data_source.versions.all()).delete())
-            chunked_delete_records(Instance.objects.filter(org_unit__version__in=data_source.versions.all()))
-
-        print("deleting datasources might take awhile (all versions, orgunits, groups,...)")
-        print("datasources", datasources.delete())
-        print("StoragePassword", StoragePassword.objects.filter(project=project).delete())
-        print("project", project.delete())
-
-    def delete_account(self, account):
-        print("************ deleting data related to ", account.id, account.name)
-
-        forms = Form.objects_include_deleted.filter(projects__account=account)
-
-        for form in forms:
-            print(
-                "InstanceFile without project",
-                InstanceFile.objects.filter(instance__form=form, instance__project=None).delete(),
-            )
-
-            print("Instance without project", Instance.objects.filter(form=form, project=None).delete())
-
-        projects = Project.objects.filter(account=account)
-        for project in projects:
-            try:
-                self.delete_project(account, project)
-            except Exception as err:
-                # Sometimes the "delete by project" don't because there are multiple projects sharing a common pyramid
-                # the statements outside this will try to take care of it
-                # that's why I'm catching the error, and give a chance to the next project and the code below
-                # traceback.print_exception(type(err), err, err.__traceback__)
-                print("can't delete project", project, type(err), traceback.format_exc())  # , traceback.format_exc())
-
-        profiles = Profile.objects.filter(account=account)
-
-        print("Instance lock", InstanceLock.objects.filter(locked_by__in=[p.user for p in profiles.all()]).delete())
-
-        forms = Form.objects_include_deleted.filter(projects__account=account)
-
-        print(
-            "Entity through attributes",
-            Entity.objects_include_deleted.filter(
-                attributes__in=Instance.objects.filter(
-                    form__in=Form.objects_include_deleted.filter(projects__account=account)
-                )
-            )
-            .all()
-            .delete(),
-        )
-        print("Forms ", forms.all().delete())
-        print("Page", Page.objects.filter(account=account).delete())
-
-        print("User related resources (might take minutes due to modification log)")
-        print(
-            "Modification done account users ",
-            Modification.objects.filter(user__in=[p.user for p in profiles.all()]).delete(),
-        )
-
-        print(
-            "BulkCreateUserFile",
-            BulkCreateUserFile.objects.filter(created_by__in=[p.user for p in profiles.all()]).delete(),
-        )
-
-        print("users_profile (tripl old table)")
-        User.objects.raw("delete from users_profile")
-
-        print(
-            "Instance created_by",
-            Instance.objects.filter(created_by__in=User.objects.filter(iaso_profile__account=account)).delete(),
-        )
-        print(
-            "Instance last_modified_by",
-            Instance.objects.filter(last_modified_by__in=User.objects.filter(iaso_profile__account=account)).delete(),
-        )
-
-        print(
-            "StorageLogEntry",
-            StorageLogEntry.objects.filter(device__in=StorageDevice.objects.filter(account=account)).delete(),
-        )
-        print("StorageDevice", StorageDevice.objects.filter(account=account).delete())
-
-        user_ids = profiles.values_list("user_id")
-        print(
-            "TenantUser delete",
-            TenantUser.objects.filter(Q(main_user_id__in=user_ids) | Q(account_user_id__in=user_ids)).delete(),
-        )
-
-        print("Users", User.objects.filter(iaso_profile__account=account).delete())
-
-        print("Profiles", profiles.delete())
-
-        print("Accounts", account.delete())
-        print("Device", Device.objects.filter(projects=None).all().delete())
-
-        Instance.objects.raw("delete from vector_control_apiimport")
-
-    def delete_modification_logs_and_comments(self, cursor):
-        dump_modification_stats()
-        # this part is a bit brittle, may should become a loop on ContentType.objects.all() ?
-
-        # apparently this query does the same thing as the one below
-        # but in batches so we can delete as much as we can with this one
-        # and keep the last as "last measure" to be sure
-        instance_content_type = ContentType.objects.get_by_natural_key(app_label="iaso", model="instance")
-        pages = 2000
-        sql = "".join(
-            [
-                "WITH cte AS ( ",
-                'SELECT "id" FROM "audit_modification" WHERE "content_type_id" =' + str(instance_content_type.id) + "",
-                ' AND NOT ("object_id" IN (SELECT CAST(U0."id" AS text) AS "id_as_str" FROM "iaso_instance" U0)) ORDER BY "id" LIMIT 20000 ) ',
-                ' DELETE FROM "audit_modification" WHERE "id" IN (SELECT "id" FROM cte)',
-            ]
-        )
-        # speedup the delete by setting the work_mem to a much higher value
-        # the 20000 limit looks a good thread of between speed and seing progress
-        cursor.execute("SET work_mem = '1GB'")
-        for i in range(pages):
-            cursor.execute(sql)
-            print(i, cursor.rowcount, datetime.datetime.now())
-            if cursor.rowcount == 0:
-                break
-
-        print(
-            "instance related",
-            Modification.objects.filter(
-                content_type=ContentType.objects.get_by_natural_key(app_label="iaso", model="instance")
-            )
-            .exclude(
-                object_id__in=Instance.objects.all().annotate(id_as_str=Cast("id", TextField())).values("id_as_str")
-            )
-            .delete(),
-        )
-
-        print(
-            "form related",
-            Modification.objects.filter(
-                content_type=ContentType.objects.get_by_natural_key(app_label="iaso", model="form")
-            )
-            .exclude(object_id__in=Form.objects.all().annotate(id_as_str=Cast("id", TextField())).values("id_as_str"))
-            .delete(),
-        )
-
-        orgunit_content_type = ContentType.objects.get_by_natural_key(app_label="iaso", model="orgunit")
-
-        print(
-            "orgunit related",
-            Modification.objects.filter(content_type=orgunit_content_type)
-            .exclude(
-                object_id__in=OrgUnit.objects.all().annotate(id_as_str=Cast("id", TextField())).values("id_as_str")
-            )
-            .delete(),
-        )
-        print(
-            "Comments on orgunit to clean",
-            CommentIaso.objects.filter(content_type=orgunit_content_type)
-            .exclude(
-                object_pk__in=OrgUnit.objects.all().annotate(id_as_str=Cast("id", TextField())).values("id_as_str")
-            )
-            .delete(),
-        )
-
-        dump_modification_stats()
-
-    def handle(self, *args, **options):
-        account_id_to_keep = options.get("account_to_keep")
-        if account_id_to_keep is None:
-            for account in Account.objects.order_by("id").all():
-                print(account.id, account.name)
-            raise Exception("No account id provided via --account-to-keep")
-        for account in Account.objects.order_by("id").all():
-            print(account.id, account.name)
-        account_to_keep = Account.objects.get(pk=account_id_to_keep)
-        print("*****")
-        print("keeping", account_id_to_keep, account_to_keep)
-
-        print("****** counting")
-        print("   the first time is slow tons of audit_modification and apiimports")
-        counts_before = dump_counts()
-
-        print("keeping ", account_to_keep.name)
-        accounts = Account.objects.filter(~Q(id=account_id_to_keep)).order_by("-id")
-        print("all the others")
-
-        # sometime we are hitting always the same wall, so let's shuffle hoping another account will be processable
-        random.shuffle(accounts)
-
-        cursor = connection.cursor()
-
-        # OLD triplelym table, it's safe to delete and ignore if not there
+    @contextmanager
+    def _doing(self, step):
+        """Context manager: logs current step; re-raises with context on error."""
+        self._current_step = step
         try:
-            cursor.execute("delete from users_profile")
+            yield
+        except Exception as exc:
+            raise RuntimeError(f"[step: {step}] {exc}") from exc
+
+    # -----------------------------------------------------------------------
+    # Manual section: DataSource / SourceVersion / OrgUnit
+    # These are M2M-linked (Project.data_sources); the FK graph only finds
+    # DataSources that have credentials, so we handle the full set here.
+    # -----------------------------------------------------------------------
+
+    def _cascade_chunked_delete(self, queryset, label):
+        """
+        Drop-in replacement for queryset.delete() that:
+        - Uses Django's Collector to discover the full cascade (respects model evolution)
+        - Logs each model being deleted with its count
+        - Deletes in chunks instead of one giant transaction
+        For models without signals (most iaso models), Collector stores querysets in
+        fast_deletes — no instances are loaded into memory.
+        """
+
+        for attempt in range(10):
+            collector = Collector(using=queryset.db)
+            try:
+                collector.collect(queryset)
+                break
+            except ProtectedError as exc:
+                by_model = defaultdict(list)
+                for obj in exc.protected_objects:
+                    by_model[type(obj)].append(obj.pk)
+                for blocker_model, pks in by_model.items():
+                    _log(f"  [auto-unblock] {blocker_model.__name__} ×{len(pks)} blocking {label} (collect phase)")
+                    _chunked_delete(
+                        blocker_model.objects.filter(pk__in=pks), self.chunk_size, f"{blocker_model.__name__}[unblock]"
+                    )
+        else:
+            raise RuntimeError(f"Could not collect {label} after 10 attempts — PROTECT cycle not resolved")
+
+        collector.sort()
+
+        # Build a unified deletion plan from both fast_deletes (querysets) and
+        # data (instance dicts). Topo-sort them together so FK holders are always
+        # deleted before the models they reference, regardless of which list they
+        # came from.
+        plan_items = []  # list of (model, queryset_or_None, pk_list_or_None)
+        for qs in collector.fast_deletes:
+            plan_items.append((qs.model, qs, None))
+        for model, instances in collector.data.items():
+            pks = [obj.pk for obj in instances]
+            if pks:
+                plan_items.append((model, None, pks))
+
+        # Topo sort via Kahn's algorithm: if model A has a FK to model B, delete A first.
+        # Use _meta.local_fields (forward FK/O2O only) — _meta.get_fields() also returns
+        # reverse relations which would flip the dependency direction and break the sort.
+        # Kahn's algorithm handles cycles gracefully: cycle participants are appended at the
+        # end in plan_items insertion order (fast_deletes before data, so SourceVersion before
+        # DataSource). DataSource.default_version is already nulled, so either order is safe.
+        # plan_models as dict preserves insertion order for cycle-node fallback.
+        plan_models = dict.fromkeys(m for m, _, _ in plan_items)
+        successors = {m: set() for m in plan_models}
+        in_degree = {m: 0 for m in plan_models}
+        for model in plan_models:
+            for field in model._meta.local_fields:
+                if isinstance(field, (ForeignKey, OneToOneField)):
+                    # Skip SET_NULL FKs: they don't create a hard ordering constraint
+                    # (the DB will null them on parent deletion, or we've already done so).
+                    # Including them creates false cycles (e.g. DataSource.default_version
+                    # ↔ SourceVersion.data_source).
+                    if field.remote_field.on_delete is SET_NULL:
+                        continue
+                    target = field.related_model
+                    if target and target in plan_models and target is not model:
+                        # model holds FK → delete model first → target depends on model
+                        if target not in successors[model]:  # deduplicate before incrementing
+                            successors[model].add(target)
+                            in_degree[target] += 1
+        queue = [m for m in plan_models if in_degree[m] == 0]
+        ordered_models = []
+        while queue:
+            m = queue.pop(0)
+            ordered_models.append(m)
+            for s in successors[m]:
+                in_degree[s] -= 1
+                if in_degree[s] == 0:
+                    queue.append(s)
+        # Append cycle participants at the end in their original insertion order
+        cycle_nodes = [m for m in plan_models if m not in set(ordered_models)]
+        if cycle_nodes:
+            _log(f"  {label}: topo-sort cycle (ignored): {[m.__name__ for m in cycle_nodes]}")
+        ordered_models.extend(cycle_nodes)
+
+        model_to_item = {m: (qs, pks) for m, qs, pks in plan_items}
+        ordered_items = [(m, *model_to_item[m]) for m in ordered_models if m in model_to_item]
+
+        if plan_items:
+            _log(f"  {label}: cascade plan — {', '.join(sorted(m._meta.label for m, _, _ in plan_items))}")
+
+        total_steps = len(ordered_items)
+        for step, (model, qs, pks) in enumerate(ordered_items, 1):
+            lbl = f"{label}→{model._meta.label}"
+            _log(f"  [{step}/{total_steps}] {lbl}…")
+            t0 = time.monotonic()
+            if qs is not None:
+                n = qs._raw_delete(using=qs.db)
+            else:
+                n = 0
+                for i in range(0, len(pks), self.chunk_size):
+                    chunk = pks[i : i + self.chunk_size]
+                    n += model.objects.filter(pk__in=chunk)._raw_delete(using=queryset.db)
+            if n:
+                _log(f"  {lbl}: {n:,} deleted ({time.monotonic() - t0:.1f}s)")
+
+    def _delete_datasource_tree(self, datasources, label_prefix=""):
+        """Delete each DataSource fully before moving to the next."""
+        ds_list = datasources if isinstance(datasources, list) else list(datasources)
+        _log(f"  Deleting {len(ds_list)} datasource(s)")
+
+        for ds in ds_list:
+            lbl = f"{label_prefix}ds[{ds.id}]"
+            versions_qs = ds.versions.all()
+            instances_in_ds = Instance.objects.filter(org_unit__version__in=versions_qs)
+            entities_qs = Entity.objects_include_deleted.filter(attributes__in=instances_in_ds)
+
+            with self._doing(f"Entity {lbl}"):
+                # Instance.entity is DO_NOTHING — PostgreSQL still enforces the FK.
+                # Null it out before deleting Entity to avoid IntegrityError.
+                if not self.dry_run:
+                    Instance.objects.filter(entity__in=entities_qs).update(entity=None)
+                self._delete_qs(entities_qs, label=f"Entity[{lbl}]")
+
+            with self._doing(f"InstanceFile {lbl}"):
+                self._delete_qs(
+                    InstanceFile.objects.filter(instance__in=instances_in_ds),
+                    label=f"InstanceFile[{lbl}]",
+                )
+
+            with self._doing(f"Instance {lbl}"):
+                if not self.dry_run:
+                    _chunked_delete(instances_in_ds, self.chunk_size, f"Instance[{lbl}]")
+
+            # Planning.org_unit = PROTECT blocks OrgUnit deletion (hence DataSource cascade).
+            # Cycle: Planning.selected_sampling_result = PROTECT(PSR) ↔ PSR.planning = CASCADE(Planning)
+            # Break it: null Planning.selected_sampling_result → delete PSR → delete Planning.
+            with self._doing(f"Planning/PSR cycle {lbl}"):
+                if not self.dry_run:
+                    planning_qs = Planning.objects.filter(org_unit__version__in=versions_qs)
+                    planning_qs.update(selected_sampling_result=None)
+                    _chunked_delete(
+                        PlanningSamplingResult.objects.filter(planning__in=planning_qs),
+                        self.chunk_size,
+                        f"PlanningSamplingResult[{lbl}]",
+                    )
+                    _chunked_delete(planning_qs, self.chunk_size, f"Planning[{lbl}]")
+
+            if not self.dry_run:
+                with self._doing(f"DataSource cascade {lbl}"):
+                    # DataSource.default_version → SourceVersion cycle: null first.
+                    DataSource.objects.filter(pk=ds.pk).update(default_version=None)
+                    # OrgUnit.parent is a self-referential FK; batch _raw_delete fails if any
+                    # row's parent is another row in the same batch. Null all within this
+                    # datasource's versions before the cascade reaches OrgUnit.
+                    OrgUnit.objects.filter(version__in=versions_qs).update(parent=None)
+                    self._cascade_chunked_delete(DataSource.objects.filter(pk=ds.pk), lbl)
+            else:
+                _log(f"  [DRY RUN] {lbl}: would cascade-delete DataSource → SourceVersion → OrgUnit → …")
+
+    # -----------------------------------------------------------------------
+    # Manual section: Form (M2M-linked)
+    # -----------------------------------------------------------------------
+
+    def _delete_forms(self, account):
+        forms = Form.objects_include_deleted.filter(projects__account=account)
+        with self._doing(f"Form account={account.id}"):
+            self._delete_qs(forms, label="Form")
+
+    # -----------------------------------------------------------------------
+    # Manual section: User / Profile
+    # Profile.user is a forward FK (Profile → User); User is upstream so not
+    # in the BFS reverse graph.  We collect user_ids from profiles and delete.
+    # -----------------------------------------------------------------------
+
+    def _delete_users(self, account, profiles):
+        user_ids = list(profiles.values_list("user_id", flat=True))
+        users = User.objects.filter(pk__in=user_ids)
+        with self._doing(f"User account={account.id}"):
+            self._delete_qs(users, label="User")
+
+    # -----------------------------------------------------------------------
+    # Pre/post-flight cleanup
+    # -----------------------------------------------------------------------
+
+    def _pre_flight(self):
+        try:
+            self._sql("DELETE FROM users_profile", label="users_profile")
         except django.db.utils.ProgrammingError:
             pass
-        # audit log, hard to clean, so keeping them in the saas db but no in the tenant db
-        cursor.execute("delete from vector_control_apiimport")
+        self._sql("DELETE FROM vector_control_apiimport", label="vector_control_apiimport")
 
-        # See discussion, submission that were created but not assigned to a project/user
-        # iaso.models.project.Project.DoesNotExist: Could not find project for user AnonymousUser
-        # https://bluesquare.slack.com/archives/C032F8GFAUD/p1668423313730229?thread_ts=1668006249.898909&cid=C032F8GFAUD
+        # Instances with no form (PROTECT FK — must go before any Form cleanup)
+        no_form = Instance.objects.filter(form=None)
+        self._delete_qs(InstanceFile.objects.filter(instance__in=no_form), label="InstanceFile[no form]")
+        self._delete_qs(no_form, label="Instance[no form]")
 
-        print(
-            "Delete unrelated file instances",
-            InstanceFile.objects.filter(
-                instance__in=Instance.objects.filter(project=None, form=None, org_unit=None)
-            ).delete(),
+        # OrgUnits with no version: null self-ref parent first, then delete instances/files
+        # that reference them (DO_NOTHING FK — DB enforces NO ACTION so must be cleared first)
+        no_version_ou = OrgUnit.objects.filter(version=None)
+        if not self.dry_run:
+            no_version_ou.update(parent=None)  # break self-ref tree
+        no_version_instances = Instance.objects.filter(org_unit__in=no_version_ou)
+        self._delete_qs(
+            InstanceFile.objects.filter(instance__in=no_version_instances), label="InstanceFile[ou no version]"
         )
-        print("Delete unrelated instances", Instance.objects.filter(project=None, form=None, org_unit=None).delete())
+        self._delete_qs(no_version_instances, label="Instance[ou no version]")
+        self._delete_qs(no_version_ou, label="OrgUnit[no version]")
 
-        print(
-            "Avoid running queued tasks once restarting on new server : ",
-            Task.objects.filter(status=QUEUED).update(status=KILLED),
+        orphans = Instance.objects.filter(project=None, form=None, org_unit=None)
+        self._delete_qs(InstanceFile.objects.filter(instance__in=orphans), label="InstanceFile[orphan]")
+        self._delete_qs(orphans, label="Instance[orphan]")
+
+        if not self.dry_run:
+            Task.objects.filter(status=QUEUED).update(status=KILLED)
+            _log("  Queued tasks killed")
+
+    def _post_flight(self, account_to_keep):
+        # Orphan datasources — delete one by one, continue on error
+        ds_ids_to_keep = DataSource.objects.filter(projects__account=account_to_keep).values_list("id", flat=True)
+        orphan_ds = list(DataSource.objects.exclude(id__in=ds_ids_to_keep))
+        _log(f"Orphan datasources: {len(orphan_ds)}")
+        for ds in orphan_ds:
+            try:
+                self._delete_datasource_tree([ds])
+            except Exception as exc:
+                _log(f"  [error] orphan ds[{ds.id}] {ds.name!r}: {exc} — skipping")
+
+        # Forms without projects
+        forms_no_project = Form.objects_include_deleted.filter(projects=None)
+        self._delete_qs(
+            InstanceFile.objects.filter(instance__in=Instance.objects.filter(form__in=forms_no_project)),
+            label="InstanceFile[form no project]",
+        )
+        self._delete_qs(Instance.objects.filter(form__in=forms_no_project), label="Instance[form no project]")
+
+        self._delete_qs(Project.objects.filter(account=None), label="Project[no account]")
+        # Forms with no form_id may still have instances (not covered by the forms_no_project cleanup above).
+        forms_no_form_id = Form.objects_include_deleted.filter(form_id=None)
+        self._delete_qs(
+            InstanceFile.objects.filter(instance__in=Instance.objects.filter(form__in=forms_no_form_id)),
+            label="InstanceFile[form no form_id]",
+        )
+        self._delete_qs(Instance.objects.filter(form__in=forms_no_form_id), label="Instance[form no form_id]")
+        self._delete_qs(forms_no_form_id, label="Form[no form_id]")
+        self._delete_qs(Session.objects.all(), label="Session")
+        self._delete_qs(Device.objects.filter(projects=None), label="Device[orphan]")
+
+        for f in forms_no_project:
+            try:
+                if not self.dry_run:
+                    OrgUnitType.reference_forms.through.objects.filter(form=f).delete()
+                    f.org_unit_types.clear()
+                    InstanceFile.objects.filter(instance__form_version__in=f.form_versions.all()).delete()
+                    Instance.objects.filter(form_version__in=f.form_versions.all()).delete()
+                    f.delete_hard()
+            except Exception:
+                _log(traceback.format_exc())
+
+        try:
+            from django_sql_dashboard.models import Dashboard
+
+            self._delete_qs(Dashboard.objects.all(), label="Dashboard")
+        except (ImportError, RuntimeError):
+            # RuntimeError when django_sql_dashboard is installed but not in INSTALLED_APPS
+            pass
+        self._sql(
+            "DELETE FROM iaso_exportrequest WHERE id NOT IN (SELECT DISTINCT export_request_id FROM iaso_exportstatus)",
+            label="iaso_exportrequest[orphan]",
+        )
+        self._cleanup_modification_logs()
+        self._cleanup_export_logs()
+
+    def _cleanup_modification_logs(self):
+        _log("Cleaning modification logs...")
+        if not self.dry_run:
+            self.cursor.execute("SET work_mem = '1GB'")
+
+        instance_ct = ContentType.objects.get_by_natural_key(app_label="iaso", model="instance")
+        sql = (
+            "WITH cte AS ("
+            f" SELECT id FROM audit_modification WHERE content_type_id = {instance_ct.id}"
+            "  AND object_id NOT IN (SELECT CAST(id AS text) FROM iaso_instance)"
+            "  ORDER BY id LIMIT 20000"
+            ") DELETE FROM audit_modification WHERE id IN (SELECT id FROM cte)"
+        )
+        for i in range(2000):
+            if self.dry_run:
+                break
+            self.cursor.execute(sql)
+            _log(f"  Modification batch {i}: {self.cursor.rowcount} deleted")
+            if self.cursor.rowcount == 0:
+                break
+
+        for model_cls, app_label, model_name in [
+            (Instance, "iaso", "instance"),
+            (Form, "iaso", "form"),
+            (OrgUnit, "iaso", "orgunit"),
+        ]:
+            ct = ContentType.objects.get_by_natural_key(app_label=app_label, model=model_name)
+            surviving = model_cls.objects.annotate(id_as_str=Cast("id", TextField())).values("id_as_str")
+            self._delete_qs(
+                Modification.objects.filter(content_type=ct).exclude(object_id__in=surviving),
+                label=f"Modification[{model_name} orphan]",
+            )
+
+        orgunit_ct = ContentType.objects.get_by_natural_key(app_label="iaso", model="orgunit")
+        surviving_ids = OrgUnit.objects.annotate(id_as_str=Cast("id", TextField())).values("id_as_str")
+        self._delete_qs(
+            CommentIaso.objects.filter(content_type=orgunit_ct).exclude(object_pk__in=surviving_ids),
+            label="CommentIaso[orgunit orphan]",
         )
 
-        for account in accounts:
-            try:
-                # with transaction.atomic():
-                self.delete_account(account)
+    def _cleanup_export_logs(self):
+        if self.dry_run:
+            return
+        t0 = time.monotonic()
+        total = 0
+        # Single SQL per chunk — no Python-level ID transfer, no ORM LEFT JOIN.
+        # NOT EXISTS with an indexed exportlog_id is efficient even on large tables.
+        while True:
+            self.cursor.execute(
+                "DELETE FROM iaso_exportlog"
+                " WHERE id IN ("
+                "   SELECT id FROM iaso_exportlog el"
+                "   WHERE NOT EXISTS ("
+                "     SELECT 1 FROM iaso_exportstatus_export_logs sel WHERE sel.exportlog_id = el.id"
+                "   )"
+                f"  LIMIT {self.chunk_size}"
+                ")"
+            )
+            n = self.cursor.rowcount
+            total += n
+            _log(f"  ExportLog[orphan]: {total:,} deleted so far…")
+            if n < self.chunk_size:
+                break
+        if total:
+            _log(f"  ExportLog[orphan]: {total:,} total ({time.monotonic() - t0:.1f}s)")
 
-                # uncomment to dry run
-                # raise Exception("don't delete for now")
-            except Exception as err:
-                # traceback.print_exception(type(err), err, err.__traceback__)
-                print("can't delete account", type(err))  # account, err, traceback.format_exc())
+    # -----------------------------------------------------------------------
+    # Main account deletion (graph-based)
+    # -----------------------------------------------------------------------
 
-        # TODO delete remaining
-        # iaso.models.base.DataSource	27	27	0
-        # iaso.models.base.SourceVersion	38	38	0
+    def _delete_account(self, account, discovered, deletion_order):
+        _log(f"Account {account.id}: {account.name!r}")
 
-        projects = Project.objects.filter(account=account_to_keep)
-        datasources_to_keep = flatten([p.data_sources.all() for p in projects])
-        datasources_to_delete = DataSource.objects.filter(~Q(id__in=[ds.id for ds in datasources_to_keep]))
-        print("**** Delete orphan datasources unused by the account to keep")
-        for data_source in datasources_to_delete.all():
-            try:
-                print(data_source.id, data_source.name, data_source.description)
+        # ---- Null out self-referential FK cycles before any deletion ----
+        # Account.default_version → SourceVersion and SourceVersion → DataSource → Account
+        # form a cycle that blocks cascade deletion of SourceVersion.
+        if not self.dry_run:
+            Account.objects.filter(pk=account.pk).update(default_version=None)
 
-                print(
-                    Entity.objects_include_deleted.filter(
-                        attributes__in=Instance.objects.filter(org_unit__version__in=data_source.versions.all()).all()
-                    )
-                    .all()
-                    .delete()
+        # ---- Collect data we'll need BEFORE any deletions start ----
+        # Profile is in the FK graph (discovered via 'account' filter) and will be
+        # deleted by the auto topo step.  Capture user_ids now before that happens.
+        user_ids = list(Profile.objects.filter(account=account).values_list("user_id", flat=True))
+
+        # Models the manual sections own completely — exclude from the auto step so
+        # the auto step doesn't redundantly re-attempt them (0-row no-ops are cheap
+        # but the intent is clearer when responsibilities are explicit).
+        # Profile IS left in the auto step — it will be handled there in topo order.
+        manual_models = {
+            DataSource,  # M2M gap, handled via _delete_datasource_tree
+            Form,  # M2M gap, handled via _delete_forms
+        }
+
+        # ---- Step 1: Manual — DataSource tree (M2M gap) ----
+        # Must run BEFORE the auto step because Instance/OrgUnit deletions within it
+        # clear FK references that would otherwise block the topo-sorted deletions.
+        with self._doing(f"account={account.id} DataSource tree"):
+            for project in Project.objects.filter(account=account):
+                self._delete_datasource_tree(
+                    list(project.data_sources.all()),
+                    label_prefix=f"proj[{project.id}]/",
                 )
 
-                print(InstanceFile.objects.filter(instance__org_unit__version__in=data_source.versions.all()).delete())
-                print(Instance.objects.filter(org_unit__version__in=data_source.versions.all()).delete())
-            except Exception as err:
-                traceback.print_exception(type(err), err, err.__traceback__)
-                print("can't delete account", err, traceback.format_exc())
+        # ---- Step 2: Manual — break PROTECT cycles that topo sort can't handle ----
 
-        print(datasources_to_delete.delete())
-
-        forms_without_projects = [f for f in Form.objects_include_deleted.all() if len(f.projects.all()) == 0]
-
-        print(
-            "Delete unrelated file instances (forms without project)",
-            InstanceFile.objects.filter(instance__in=Instance.objects.filter(form__in=forms_without_projects)).delete(),
-        )
-
-        print(
-            "Delete unrelated instances (forms without project)",
-            Instance.objects.filter(form__in=forms_without_projects).delete(),
-        )
-
-        print("******* delete unrelated projects")
-
-        print(Project.objects.filter(account=None).delete())
-        print(Form.objects_include_deleted.filter(form_id=None).delete())
-        print("Session", Session.objects.all().delete())
-        print("deleteing devices might take sometime")
-        print(Device.objects.filter(projects=None).delete())
-
-        for f in forms_without_projects:
-            print("form_without_projects", f)
-            print("referenceforms", OrgUnitType.reference_forms.through.objects.filter(form=f).delete())
-            f.org_unit_types.clear()
-            print(
-                "instances files used one of the form_versions",
-                InstanceFile.objects.filter(instance__form_version__in=f.form_versions.all()).delete(),
-            )
-            print(
-                "instances used one of the form_versions",
-                Instance.objects.filter(form_version__in=f.form_versions.all()).delete(),
-            )
-            print("deleting hard", f.name)
-
-            f.delete_hard()
-
-        print("sql dashboard", Dashboard.objects.all().delete())
-
-        cursor.execute(
-            "delete from iaso_exportrequest where id not in ( select distinct export_request_id from iaso_exportstatus )"
-        )
-
-        print("******* Deleting Modification (might take a while too)")
-
-        self.delete_modification_logs_and_comments(cursor)
-
-        print("******* Starting delete of orphaned export log")
-
-        print("Delete orphaned export log", ExportLog.objects.filter(exportstatus=None).count())
-
-        # This table is so big and the content too, that django is fetching all the deleted models (not only the id)
-        # that I had to delete it with this strange construct deleting by x records and via sql instead of django queryset .delete()
-        has_more_export_logs = True
-        while has_more_export_logs:
-            export_logs_ids = ExportLog.objects.filter(exportstatus=None).values_list("id", flat=True)[0:500]
-            if len(export_logs_ids) > 0:
-                cursor.execute(
-                    "delete from iaso_exportlog where id in (" + ",".join([str(id) for id in export_logs_ids]) + " )"
+        # PlanningSamplingResult.planning = CASCADE(Planning) and
+        # Planning.selected_sampling_result = PROTECT(PSR) form a circular PROTECT.
+        # Django's Collector raises PROTECT on PSR even when Planning is also being
+        # collected — delete PSR first so Planning has no blocker.
+        with self._doing(f"account={account.id} PlanningSamplingResult"):
+            if not self.dry_run:
+                _chunked_delete(
+                    PlanningSamplingResult.objects.filter(planning__project__account=account),
+                    self.chunk_size,
+                    "PlanningSamplingResult",
                 )
-                print("deleted", export_logs_ids)
-            has_more_export_logs = len(export_logs_ids) > 0
 
-        # raise err
-        counts_after = dump_counts()
+        # Entity.attributes → Instance is PROTECT; Instance.entity → Entity is DO_NOTHING.
+        with self._doing(f"account={account.id} Entity.attributes = NULL"):
+            if not self.dry_run:
+                Entity.objects_include_deleted.filter(account=account).update(attributes=None)
+            else:
+                _log(
+                    f"  [DRY RUN] Entity.attributes=NULL: ~{Entity.objects_include_deleted.filter(account=account).count()}"
+                )
 
-        dump_diffs(counts_before, counts_after)
-        print("******* Review external credentials left")
-        for ext_cred in ExternalCredentials.objects.all():
-            print(ext_cred.id, ext_cred.url, ext_cred.login, ext_cred.name)
+        # ---- Step 3: Auto — topo-sorted FK-graph deletion ----
+        with self._doing(f"account={account.id} FK-graph auto-deletion"):
+            _log(
+                f"  Running FK-graph auto-deletion ({len(discovered)} models, skipping {len(manual_models)} manual)..."
+            )
+            execute_graph_deletion(
+                discovered,
+                deletion_order,
+                account,
+                self.chunk_size,
+                self.dry_run,
+                skip_models=manual_models,
+            )
 
-        print(
-            "\ncredential ids used in datasource\n", list(DataSource.objects.values_list("credentials_id", flat=True))
-        )
-        print("Done !")
+        # ---- Step 4: Manual — Form (M2M gap, after auto cleared FormVersion etc.) ----
+        with self._doing(f"account={account.id} Form"):
+            self._delete_forms(account)
+
+        # ---- Step 5: Manual — User (upstream from Profile, not in reverse FK graph) ----
+        # Profile was deleted in the auto step; use the user_ids collected at the top.
+        with self._doing(f"account={account.id} User"):
+            users = User.objects.filter(pk__in=user_ids)
+            self._delete_qs(users, label="User")
+
+        # ---- Step 6: Account itself ----
+        if not self.dry_run:
+            account_id, account_name = account.id, account.name
+            account.delete()
+            _log(f"  Account {account_id} ({account_name!r}) deleted")
+
+        self._delete_qs(Device.objects.filter(projects=None), label="Device[orphan]")
+        self._sql("DELETE FROM vector_control_apiimport", label="vector_control_apiimport")
+
+    # -----------------------------------------------------------------------
+    # Entry point
+    # -----------------------------------------------------------------------
+
+    def handle(self, *args, **options):
+        self.chunk_size = options["chunk_size"]
+        self.dry_run = options.get("dry_run", False)
+        self.cursor = connection.cursor()
+        self._current_step = ""
+
+        # Build FK graph once (same for all accounts)
+        _log("Building FK graph from Account...")
+        discovered, graph_edges = build_fk_graph(Account)
+        deletion_order = topo_sort_deletion_order(discovered, graph_edges)
+        _log(f"  Discovered {len(discovered)} models, topo-sorted deletion order computed")
+
+        # --list-accounts mode
+        if options.get("list_accounts"):
+            for acct in Account.objects.order_by("id"):
+                _log(f"  {acct.id:6d}  {acct.name}")
+            return
+
+        # --show-graph mode
+        if options.get("show_graph"):
+            account = None
+            if options.get("for_account"):
+                account = Account.objects.get(pk=options["for_account"])
+            show_graph(discovered, graph_edges, deletion_order, account=account)
+            return
+
+        if self.dry_run:
+            _log("*** DRY RUN — no data will be modified ***")
+
+        _log("Available accounts:")
+        for acct in Account.objects.order_by("id"):
+            _log(f"  {acct.id}: {acct.name}")
+
+        account_to_keep = None
+        full_cleanup = False
+
+        if options.get("account_to_keep") is not None:
+            account_id_to_keep = options["account_to_keep"]
+            account_to_keep = Account.objects.get(pk=account_id_to_keep)
+            _log(f"Keeping: {account_id_to_keep} — {account_to_keep.name!r}")
+            accounts_to_delete = list(Account.objects.exclude(pk=account_id_to_keep).order_by("-id"))
+            random.shuffle(accounts_to_delete)
+            full_cleanup = True
+        else:
+            ids = options["accounts_to_delete"]
+            accounts_to_delete = list(Account.objects.filter(pk__in=ids))
+            if len(accounts_to_delete) != len(ids):
+                found = {a.id for a in accounts_to_delete}
+                raise SystemExit(f"Accounts not found: {[i for i in ids if i not in found]}")
+
+        self._pre_flight()
+
+        for account in accounts_to_delete:
+            _log(f"--- Deleting account={account.id} ({account.name!r}) ---")
+            try:
+                self._delete_account(account, discovered, deletion_order)
+                _log(f"--- OK account={account.id} ({account.name!r}) deleted ---")
+            except Exception:
+                _log(
+                    f"ERROR account={account.id!r} ({account.name!r})"
+                    f" at step [{self._current_step}]:\n{traceback.format_exc()}"
+                )
+                _log(f"--- FAILED account={account.id} ({account.name!r}) ---")
+
+        if full_cleanup:
+            self._post_flight(account_to_keep)
+
+        _log("Done!")
+        _log("Row counts after deletion:")
+        from django.apps import apps as django_apps
+
+        all_models = sorted(django_apps.get_models(), key=lambda m: m._meta.label)
+        for model in all_models:
+            manager = getattr(model, "objects_include_deleted", model._default_manager)
+            try:
+                n = manager.count()
+            except Exception:
+                continue
+            _log(f"  {model._meta.label:<55s}: {n:>10,}")
+
+        _log("Remaining accounts:")
+        for acct in Account.objects.order_by("id"):
+            _log(f"  {acct.id:6d}  {acct.name}")
+        _log("Remaining credentials:")
+        for cred in ExternalCredentials.objects.all():
+            _log(f"  credential: {cred.id} {cred.url} {cred.login} {cred.name}")

--- a/iaso/management/commands/delete_accounts.py
+++ b/iaso/management/commands/delete_accounts.py
@@ -354,7 +354,7 @@ class Command(BaseCommand):
     # Helpers
     # -----------------------------------------------------------------------
     def _delete_with_sql(self, sql, params=None, label="SQL"):
-        """Deletes data by executing a SQL query"""
+        """Deletes data by executing a SQL query - useful for deleting models where there's no clear FK path to the Account model (e.g. users_profile)."""
         if self.dry_run:
             _log(f"  [DRY RUN] {label}: {sql[:100]}")
             return 0
@@ -368,7 +368,7 @@ class Command(BaseCommand):
         return row_count
 
     def _delete_qs(self, queryset, label=None):
-        """Deletes a whole queryset with a single queryset.delete()"""
+        """Deletes a whole queryset with a single queryset.delete() - useful for deleting small tables"""
         label = label or queryset.model.__name__
         if self.dry_run:
             _log(f"  [DRY RUN] {label}: ~{queryset.count()}")
@@ -377,7 +377,7 @@ class Command(BaseCommand):
         _log(f"  {label}: {deleted_count} deleted")
 
     def _delete_qs_in_chunks(self, queryset, label=None):
-        """Deletes a queryset in chunks with raw_delete() — never loads more than chunk_size PKs at once."""
+        """Deletes a queryset in chunks with raw_delete() — useful for deleting big tables that can't be loaded at once."""
         model = queryset.model
         label = label or model.__name__
         if self.dry_run:
@@ -545,13 +545,12 @@ class Command(BaseCommand):
             step_label = f"{label}→{item.model._meta.label}"
             _log(f"  [{step}/{total_steps}] {step_label}…")
             step_started_at = time.monotonic()
-            if item.queryset is not None:
-                deleted_count = item.queryset._raw_delete(using=item.queryset.db)
-            else:
-                deleted_count = 0
-                for offset in range(0, len(item.pks), self.chunk_size):
-                    chunk = item.pks[offset : offset + self.chunk_size]
-                    deleted_count += item.model.objects.filter(pk__in=chunk)._raw_delete(using=queryset.db)
+            item_qs = (
+                item.queryset
+                if item.queryset is not None
+                else item.model.objects.using(queryset.db).filter(pk__in=item.pks)
+            )
+            deleted_count = self._delete_qs_in_chunks(item_qs, label=step_label)
             if deleted_count:
                 _log(f"  {step_label}: {deleted_count:,} deleted ({time.monotonic() - step_started_at:.1f}s)")
 

--- a/iaso/management/commands/delete_accounts.py
+++ b/iaso/management/commands/delete_accounts.py
@@ -13,7 +13,7 @@ What is automatic:
   - Deletion order computed from FK constraints (no more ProtectedError
     from cascade chains between discovered models)
 
-What still needs manual code (M2M gap):
+What's out of graph (needs dedicated code):
   - DataSource / SourceVersion / OrgUnit — linked to Account via
     Project.data_sources M2M, not a direct FK; the BFS path via credentials
     is SET_NULL and therefore partial
@@ -141,30 +141,30 @@ class DeletionPlanItem:
 
 
 @dataclass
-class ManualCleanupNote:
+class OutOfGraphCleanupNote:
     """A table that can't be reached by the FK-graph BFS and needs dedicated cleanup code."""
 
     label: str  # e.g. "iaso.DataSource / SourceVersion / OrgUnit", or a bare table name
-    reason: str  # why this table needs manual/dedicated handling instead of the auto FK-graph
+    reason: str  # why this table is out of graph and needs dedicated handling instead of the auto FK-graph
 
 
-# Tables not reachable via reverse FK from Account — require manual handling.
-_MANUAL_CLEANUP_NOTES = [
-    ManualCleanupNote(
+# Tables not reachable via reverse FK from Account — out of graph, require dedicated handling.
+_OUT_OF_GRAPH_CLEANUP_NOTES = [
+    OutOfGraphCleanupNote(
         label="iaso.DataSource / SourceVersion / OrgUnit",
         reason="linked via Project.data_sources M2M, BFS only finds those with credentials",
     ),
-    ManualCleanupNote(label="iaso.Form", reason="linked via projects M2M"),
-    ManualCleanupNote(label="iaso.OrgUnitType", reason="linked via projects M2M"),
-    ManualCleanupNote(label="audit.Modification", reason="content-type based, no FK to Account"),
-    ManualCleanupNote(label="iaso.ExportLog", reason="no FK to Account"),
-    ManualCleanupNote(label="django_sql_dashboard.Dashboard", reason="no FK to Account"),
-    ManualCleanupNote(label="django.contrib.sessions.Session", reason="no FK to Account"),
-    ManualCleanupNote(
+    OutOfGraphCleanupNote(label="iaso.Form", reason="linked via projects M2M"),
+    OutOfGraphCleanupNote(label="iaso.OrgUnitType", reason="linked via projects M2M"),
+    OutOfGraphCleanupNote(label="audit.Modification", reason="content-type based, no FK to Account"),
+    OutOfGraphCleanupNote(label="iaso.ExportLog", reason="no FK to Account"),
+    OutOfGraphCleanupNote(label="django_sql_dashboard.Dashboard", reason="no FK to Account"),
+    OutOfGraphCleanupNote(label="django.contrib.sessions.Session", reason="no FK to Account"),
+    OutOfGraphCleanupNote(
         label="hat_api_import.APIImport [vector_control_apiimport]",
         reason="not a iaso/plugins app and no FK to Account",
     ),
-    ManualCleanupNote(
+    OutOfGraphCleanupNote(
         label="users_profile",
         reason="legacy table, no longer defined in the codebase — may still exist in older deployed databases",
     ),
@@ -313,11 +313,11 @@ def show_graph(discovered, deletion_order, account=None):
 
     _log("")
     _log("⚠ = path contains a SET_NULL FK — rows where that FK is NULL are NOT found by this filter")
-    _log("    These models need manual handling or supplementary filters.")
+    _log("    These models may need dedicated supplementary filters to fully cover SET_NULL rows.")
     _log("")
 
-    _log("=== Models NOT in FK graph (manual handling required) ===")
-    for note in _MANUAL_CLEANUP_NOTES:
+    _log("=== Out-of-graph models (dedicated handling required) ===")
+    for note in _OUT_OF_GRAPH_CLEANUP_NOTES:
         _log(f"  - {note.label}")
         _log(f"      reason: {note.reason}")
 
@@ -448,11 +448,6 @@ class Command(BaseCommand):
         except Exception as exc:
             raise RuntimeError(f"[step: {step}] {exc}") from exc
 
-    # -----------------------------------------------------------------------
-    # Manual section: DataSource / SourceVersion / OrgUnit
-    # These are M2M-linked (Project.data_sources); the FK graph only finds
-    # DataSources that have credentials, so we handle the full set here.
-    # -----------------------------------------------------------------------
     def _cascade_chunked_delete(self, queryset, label):
         """
         Drop-in replacement for queryset.delete() that:
@@ -842,17 +837,17 @@ class Command(BaseCommand):
             OrgUnitType.objects.filter(projects__account=account).values_list("pk", flat=True).distinct()
         )
 
-        # Models the manual sections own completely — exclude from the auto step so
+        # Models the out-of-graph sections own completely — exclude from the auto step so
         # the auto step doesn't redundantly re-attempt them (0-row no-ops are cheap
         # but the intent is clearer when responsibilities are explicit).
         # Profile IS left in the auto step — it will be handled there in topo order.
-        manual_models = {
+        out_of_graph_models = {
             DataSource,  # M2M gap, handled via _delete_datasource_tree
             Form,  # M2M gap
             OrgUnitType,  # M2M gap
         }
 
-        # ---- Step 1: Manual — DataSource tree (M2M gap) ----
+        # ---- Step 1: Out-of-graph — DataSource tree (M2M gap) ----
         # Must run BEFORE the auto step because Instance/OrgUnit deletions within it
         # clear FK references that would otherwise block the topo-sorted deletions.
         with self._doing(f"account={account.id} DataSource tree"):
@@ -862,7 +857,7 @@ class Command(BaseCommand):
                     label_prefix=f"proj[{project.id}]/",
                 )
 
-        # ---- Step 2: Manual — break PROTECT cycles that topo sort can't handle ----
+        # ---- Step 2: Break PROTECT cycles that topo sort can't handle ----
 
         # PlanningSamplingResult.planning = CASCADE(Planning) and
         # Planning.selected_sampling_result = PROTECT(PSR) form a circular PROTECT.
@@ -883,28 +878,29 @@ class Command(BaseCommand):
         # ---- Step 3: Auto — topo-sorted FK-graph deletion ----
         with self._doing(f"account={account.id} FK-graph auto-deletion"):
             _log(
-                f"  Running FK-graph auto-deletion ({len(discovered)} models, skipping {len(manual_models)} manual)..."
+                f"  Running FK-graph auto-deletion ({len(discovered)} models, "
+                f"skipping {len(out_of_graph_models)} out-of-graph)..."
             )
             self._execute_graph_deletion(
                 discovered,
                 deletion_order,
                 account,
-                skip_models=manual_models,
+                skip_models=out_of_graph_models,
             )
 
-        # ---- Step 4: Manual — Form (M2M gap, after auto cleared FormVersion etc.) ----
+        # ---- Step 4: Out-of-graph — Form (M2M gap, after auto cleared FormVersion etc.) ----
         # Uses form_ids captured at the top — Project rows are already gone by now.
         with self._doing(f"account={account.id} Form"):
             forms = Form.objects_include_deleted.filter(pk__in=form_ids)
             self._delete_qs(forms, label="Form")
 
-        # ---- Step 4b: Manual — OrgUnitType (M2M gap, same shape as Form) ----
+        # ---- Step 4b: Out-of-graph — OrgUnitType (M2M gap, same shape as Form) ----
         # Uses org_unit_type_ids captured at the top — Project rows are already gone by now.
         with self._doing(f"account={account.id} OrgUnitType"):
             org_unit_types = OrgUnitType.objects.filter(pk__in=org_unit_type_ids)
             self._delete_qs(org_unit_types, label="OrgUnitType")
 
-        # ---- Step 5: Manual — User (upstream from Profile, not in reverse FK graph) ----
+        # ---- Step 5: Out-of-graph — User (upstream from Profile, not in reverse FK graph) ----
         # Profile was deleted in the auto step; use the user_ids collected at the top.
         with self._doing(f"account={account.id} User"):
             users = User.objects.filter(pk__in=user_ids)
@@ -928,7 +924,7 @@ class Command(BaseCommand):
         """
         Delete all discovered models in topological order.
         Each model's rows are filtered using the auto-built account_lookup.
-        skip_models: set of model classes handled manually (excluded from this step).
+        skip_models: set of out-of-graph model classes (excluded from this step).
         """
         skip_models = skip_models or set()
         models_processed = 0

--- a/iaso/management/commands/delete_accounts.py
+++ b/iaso/management/commands/delete_accounts.py
@@ -79,6 +79,13 @@ from iaso.models.org_unit import OrgUnit
 from iaso.models.project import Project
 
 
+try:
+    from django_sql_dashboard.models import Dashboard as _Dashboard
+except (ImportError, RuntimeError):
+    # RuntimeError when django_sql_dashboard is installed but not in INSTALLED_APPS
+    _Dashboard = None
+
+
 # ---------------------------------------------------------------------------
 # Logging
 # ---------------------------------------------------------------------------
@@ -98,7 +105,6 @@ def _chunked_delete(queryset, chunk_size=5000, label=None):
     model = queryset.model
     label = label or model.__name__
     total = 0
-    t0 = time.monotonic()
 
     while True:
         ids = list(queryset.order_by("pk").values_list("pk", flat=True)[:chunk_size])
@@ -132,6 +138,25 @@ _PROJECT_APP_PREFIXES = ("iaso", "plugins")
 # These are flagged as "partial coverage" in --show-graph.
 _PARTIAL_COVERAGE_NOTE = "⚠ partial: SET_NULL path, rows with NULL FK are missed"
 
+# Retry limit for auto-unblocking PROTECT errors: each attempt deletes the
+# blocking objects, so convergence depends on the depth of the PROTECT chain.
+_MAX_PROTECT_UNBLOCK_ATTEMPTS = 10
+
+# Models not reachable via reverse FK from Account — require manual handling.
+_MANUAL_MODELS_NOTE = [
+    (
+        "iaso.DataSource / SourceVersion / OrgUnit",
+        "linked via Project.data_sources M2M, BFS only finds those with credentials",
+    ),
+    ("iaso.Form", "linked via projects M2M"),
+    ("audit.Modification", "content-type based, no FK to Account"),
+    ("iaso.ExportLog", "no FK to Account"),
+    ("django_sql_dashboard.Dashboard", "no FK to Account"),
+    ("django.contrib.sessions.Session", "no FK to Account"),
+    ("vector_control_apiimport", "raw SQL table, not a Django model"),
+    ("users_profile", "legacy raw SQL table"),
+]
+
 
 def _is_project_model(model):
     """True if this model belongs to iaso or a plugin (not a third-party or Django built-in app)."""
@@ -158,9 +183,9 @@ def build_fk_graph(root_model):
     queue = deque([(root_model, None, False)])
 
     while queue:
-        current, current_filter, current_partial = queue.popleft()
+        current_model, current_filter, current_partial = queue.popleft()
 
-        for rel in current._meta.related_objects:
+        for rel in current_model._meta.related_objects:
             if isinstance(rel, ManyToManyRel):
                 continue
 
@@ -169,16 +194,19 @@ def build_fk_graph(root_model):
                 continue
             if getattr(child._meta, "abstract", False) or getattr(child._meta, "swapped", None):
                 continue
+            if getattr(child._meta, "proxy", False):
+                # Proxy models share the parent's DB table; deleting the parent rows covers them.
+                continue
             if not _is_project_model(child):
                 continue
 
             field_name = rel.field.name
             new_filter = field_name if current_filter is None else f"{field_name}__{current_filter}"
-            od_name = getattr(rel.on_delete, "__name__", str(rel.on_delete))
+            on_delete_name = getattr(rel.on_delete, "__name__", str(rel.on_delete))
             is_partial = current_partial or (rel.on_delete is SET_NULL)
 
             visited[child] = (new_filter, is_partial)
-            discovered[child] = (new_filter, od_name, is_partial)
+            discovered[child] = (new_filter, on_delete_name, is_partial)
             queue.append((child, new_filter, is_partial))
 
     # Collect cross-edges between discovered models (for topo sort)
@@ -189,8 +217,8 @@ def build_fk_graph(root_model):
             target = field.related_model
             if target not in discovered or target is model:
                 continue
-            od_name = getattr(field.remote_field.on_delete, "__name__", "?")
-            graph_edges.append((model, target, od_name))
+            on_delete_name = getattr(field.remote_field.on_delete, "__name__", "?")
+            graph_edges.append((model, target, on_delete_name))
 
     return discovered, graph_edges
 
@@ -211,8 +239,8 @@ def topo_sort_deletion_order(discovered, graph_edges):
     for model in discovered:
         ts.add(model)
 
-    for child, parent, od_name in graph_edges:
-        if od_name in ("CASCADE", "PROTECT"):
+    for child, parent, on_delete_name in graph_edges:
+        if on_delete_name in ("CASCADE", "PROTECT"):
             # child must be deleted BEFORE parent
             # ts.add(X, Y) means Y must come before X
             ts.add(parent, child)
@@ -243,7 +271,7 @@ def execute_graph_deletion(discovered, deletion_order, account, chunk_size, dry_
     for model in deletion_order:
         if model not in discovered or model in skip_models:
             continue
-        filter_kwarg, od_name, is_partial = discovered[model]
+        filter_kwarg, on_delete_name, is_partial = discovered[model]
         manager = getattr(model, "objects_include_deleted", model._default_manager)
 
         try:
@@ -261,10 +289,10 @@ def execute_graph_deletion(discovered, deletion_order, account, chunk_size, dry_
             _log(f"  [DRY RUN] would delete {label}")
             continue
 
-        n = 0
-        for attempt in range(5):
+        deleted_count = 0
+        for attempt in range(_MAX_PROTECT_UNBLOCK_ATTEMPTS):
             try:
-                n += _chunked_delete(qs, chunk_size, label=label)
+                deleted_count += _chunked_delete(qs, chunk_size, label=label)
                 break
             except ProtectedError as exc:
                 # Auto-clear blocking objects (e.g. nullable PROTECT FKs from partial-coverage models)
@@ -277,11 +305,10 @@ def execute_graph_deletion(discovered, deletion_order, account, chunk_size, dry_
                         blocker_model.objects.filter(pk__in=pks), chunk_size, f"{blocker_model.__name__}[unblock]"
                     )
 
-        if n:
-            _log(f"  {label}: {n:,} deleted")
-        if n:
+        if deleted_count:
+            _log(f"  {label}: {deleted_count:,} deleted")
             models_with_rows += 1
-            total_deleted += n
+            total_deleted += deleted_count
 
     if not dry_run:
         _log(
@@ -307,7 +334,7 @@ def show_graph(discovered, graph_edges, deletion_order, account=None):
     for model in deletion_order:
         if model not in discovered:
             continue
-        filter_kwarg, od_name, is_partial = discovered[model]
+        filter_kwarg, on_delete_name, is_partial = discovered[model]
         flag = "⚠" if is_partial else " "
         count_str = ""
         if account is not None:
@@ -317,29 +344,15 @@ def show_graph(discovered, graph_edges, deletion_order, account=None):
                 count_str = f"  [{count} rows]"
             except Exception:
                 count_str = "  [?]"
-        _log(f"  {flag} {model._meta.label:53s} {od_name:12s}  {filter_kwarg}{count_str}")
+        _log(f"  {flag} {model._meta.label:53s} {on_delete_name:12s}  {filter_kwarg}{count_str}")
 
     _log("")
     _log("⚠ = path contains a SET_NULL FK — rows where that FK is NULL are NOT found by this filter")
     _log("    These models need manual handling or supplementary filters.")
     _log("")
 
-    # Models NOT discovered (manual handling required)
-    manual = [
-        (
-            "iaso.DataSource / SourceVersion / OrgUnit",
-            "linked via Project.data_sources M2M, BFS only finds those with credentials",
-        ),
-        ("iaso.Form", "linked via projects M2M"),
-        ("audit.Modification", "content-type based, no FK to Account"),
-        ("iaso.ExportLog", "no FK to Account"),
-        ("django_sql_dashboard.Dashboard", "no FK to Account"),
-        ("django.contrib.sessions.Session", "no FK to Account"),
-        ("vector_control_apiimport", "raw SQL table, not a Django model"),
-        ("users_profile", "legacy raw SQL table"),
-    ]
     _log("=== Models NOT in FK graph (manual handling required) ===")
-    for label, reason in manual:
+    for label, reason in _MANUAL_MODELS_NOTE:
         _log(f"  - {label}")
         _log(f"      reason: {reason}")
 
@@ -388,10 +401,10 @@ class Command(BaseCommand):
             self.cursor.execute(sql, params)
         else:
             self.cursor.execute(sql)
-        n = self.cursor.rowcount
-        if n:
-            _log(f"  {label}: {n:,} deleted")
-        return n
+        row_count = self.cursor.rowcount
+        if row_count:
+            _log(f"  {label}: {row_count:,} deleted")
+        return row_count
 
     def _delete_qs(self, queryset, label=None):
         label = label or queryset.model.__name__
@@ -426,7 +439,7 @@ class Command(BaseCommand):
         fast_deletes — no instances are loaded into memory.
         """
 
-        for attempt in range(10):
+        for attempt in range(_MAX_PROTECT_UNBLOCK_ATTEMPTS):
             collector = Collector(using=queryset.db)
             try:
                 collector.collect(queryset)
@@ -441,7 +454,9 @@ class Command(BaseCommand):
                         blocker_model.objects.filter(pk__in=pks), self.chunk_size, f"{blocker_model.__name__}[unblock]"
                     )
         else:
-            raise RuntimeError(f"Could not collect {label} after 10 attempts — PROTECT cycle not resolved")
+            raise RuntimeError(
+                f"Could not collect {label} after {_MAX_PROTECT_UNBLOCK_ATTEMPTS} attempts — PROTECT cycle not resolved"
+            )
 
         collector.sort()
 
@@ -466,7 +481,7 @@ class Command(BaseCommand):
         # plan_models as dict preserves insertion order for cycle-node fallback.
         plan_models = dict.fromkeys(m for m, _, _ in plan_items)
         successors = {m: set() for m in plan_models}
-        in_degree = {m: 0 for m in plan_models}
+        in_degree = {m: 0 for m in plan_models}  # Kahn's algorithm: number of incoming FK edges per model
         for model in plan_models:
             for field in model._meta.local_fields:
                 if isinstance(field, (ForeignKey, OneToOneField)):
@@ -498,6 +513,11 @@ class Command(BaseCommand):
         ordered_models.extend(cycle_nodes)
 
         model_to_item = {m: (qs, pks) for m, qs, pks in plan_items}
+        skipped = [m for m in ordered_models if m not in model_to_item]
+        if skipped:
+            _log(
+                f"  [warn] {label}: {len(skipped)} model(s) in topo order but not in plan: {[m.__name__ for m in skipped]}"
+            )
         ordered_items = [(m, *model_to_item[m]) for m in ordered_models if m in model_to_item]
 
         if plan_items:
@@ -505,8 +525,8 @@ class Command(BaseCommand):
 
         total_steps = len(ordered_items)
         for step, (model, qs, pks) in enumerate(ordered_items, 1):
-            lbl = f"{label}→{model._meta.label}"
-            _log(f"  [{step}/{total_steps}] {lbl}…")
+            step_label = f"{label}→{model._meta.label}"
+            _log(f"  [{step}/{total_steps}] {step_label}…")
             t0 = time.monotonic()
             if qs is not None:
                 n = qs._raw_delete(using=qs.db)
@@ -516,7 +536,7 @@ class Command(BaseCommand):
                     chunk = pks[i : i + self.chunk_size]
                     n += model.objects.filter(pk__in=chunk)._raw_delete(using=queryset.db)
             if n:
-                _log(f"  {lbl}: {n:,} deleted ({time.monotonic() - t0:.1f}s)")
+                _log(f"  {step_label}: {n:,} deleted ({time.monotonic() - t0:.1f}s)")
 
     def _delete_datasource_tree(self, datasources, label_prefix=""):
         """Delete each DataSource fully before moving to the next."""
@@ -524,53 +544,53 @@ class Command(BaseCommand):
         _log(f"  Deleting {len(ds_list)} datasource(s)")
 
         for ds in ds_list:
-            lbl = f"{label_prefix}ds[{ds.id}]"
+            ds_label = f"{label_prefix}ds[{ds.id}]"
             versions_qs = ds.versions.all()
             instances_in_ds = Instance.objects.filter(org_unit__version__in=versions_qs)
             entities_qs = Entity.objects_include_deleted.filter(attributes__in=instances_in_ds)
 
-            with self._doing(f"Entity {lbl}"):
+            with self._doing(f"Entity {ds_label}"):
                 # Instance.entity is DO_NOTHING — PostgreSQL still enforces the FK.
                 # Null it out before deleting Entity to avoid IntegrityError.
                 if not self.dry_run:
                     Instance.objects.filter(entity__in=entities_qs).update(entity=None)
-                self._delete_qs(entities_qs, label=f"Entity[{lbl}]")
+                self._delete_qs(entities_qs, label=f"Entity[{ds_label}]")
 
-            with self._doing(f"InstanceFile {lbl}"):
+            with self._doing(f"InstanceFile {ds_label}"):
                 self._delete_qs(
                     InstanceFile.objects.filter(instance__in=instances_in_ds),
-                    label=f"InstanceFile[{lbl}]",
+                    label=f"InstanceFile[{ds_label}]",
                 )
 
-            with self._doing(f"Instance {lbl}"):
+            with self._doing(f"Instance {ds_label}"):
                 if not self.dry_run:
-                    _chunked_delete(instances_in_ds, self.chunk_size, f"Instance[{lbl}]")
+                    _chunked_delete(instances_in_ds, self.chunk_size, f"Instance[{ds_label}]")
 
             # Planning.org_unit = PROTECT blocks OrgUnit deletion (hence DataSource cascade).
             # Cycle: Planning.selected_sampling_result = PROTECT(PSR) ↔ PSR.planning = CASCADE(Planning)
             # Break it: null Planning.selected_sampling_result → delete PSR → delete Planning.
-            with self._doing(f"Planning/PSR cycle {lbl}"):
+            with self._doing(f"Planning/PSR cycle {ds_label}"):
                 if not self.dry_run:
                     planning_qs = Planning.objects.filter(org_unit__version__in=versions_qs)
                     planning_qs.update(selected_sampling_result=None)
                     _chunked_delete(
                         PlanningSamplingResult.objects.filter(planning__in=planning_qs),
                         self.chunk_size,
-                        f"PlanningSamplingResult[{lbl}]",
+                        f"PlanningSamplingResult[{ds_label}]",
                     )
-                    _chunked_delete(planning_qs, self.chunk_size, f"Planning[{lbl}]")
+                    _chunked_delete(planning_qs, self.chunk_size, f"Planning[{ds_label}]")
 
             if not self.dry_run:
-                with self._doing(f"DataSource cascade {lbl}"):
+                with self._doing(f"DataSource cascade {ds_label}"):
                     # DataSource.default_version → SourceVersion cycle: null first.
                     DataSource.objects.filter(pk=ds.pk).update(default_version=None)
                     # OrgUnit.parent is a self-referential FK; batch _raw_delete fails if any
                     # row's parent is another row in the same batch. Null all within this
                     # datasource's versions before the cascade reaches OrgUnit.
                     OrgUnit.objects.filter(version__in=versions_qs).update(parent=None)
-                    self._cascade_chunked_delete(DataSource.objects.filter(pk=ds.pk), lbl)
+                    self._cascade_chunked_delete(DataSource.objects.filter(pk=ds.pk), ds_label)
             else:
-                _log(f"  [DRY RUN] {lbl}: would cascade-delete DataSource → SourceVersion → OrgUnit → …")
+                _log(f"  [DRY RUN] {ds_label}: would cascade-delete DataSource → SourceVersion → OrgUnit → …")
 
     # -----------------------------------------------------------------------
     # Manual section: Form (M2M-linked)
@@ -602,7 +622,6 @@ class Command(BaseCommand):
             self._sql("DELETE FROM users_profile", label="users_profile")
         except django.db.utils.ProgrammingError:
             pass
-        self._sql("DELETE FROM vector_control_apiimport", label="vector_control_apiimport")
 
         # Instances with no form (PROTECT FK — must go before any Form cleanup)
         no_form = Instance.objects.filter(form=None)
@@ -657,6 +676,11 @@ class Command(BaseCommand):
         )
         self._delete_qs(Instance.objects.filter(form__in=forms_no_form_id), label="Instance[form no form_id]")
         self._delete_qs(forms_no_form_id, label="Form[no form_id]")
+        # Rows with no app_id can't be attributed to any account — delete them to avoid leaks.
+        self._sql(
+            "DELETE FROM vector_control_apiimport WHERE headers->>'QUERY_STRING' NOT LIKE '%app_id=%'",
+            label="vector_control_apiimport[no app_id]",
+        )
         self._delete_qs(Session.objects.all(), label="Session")
         self._delete_qs(Device.objects.filter(projects=None), label="Device[orphan]")
 
@@ -671,13 +695,8 @@ class Command(BaseCommand):
             except Exception:
                 _log(traceback.format_exc())
 
-        try:
-            from django_sql_dashboard.models import Dashboard
-
-            self._delete_qs(Dashboard.objects.all(), label="Dashboard")
-        except (ImportError, RuntimeError):
-            # RuntimeError when django_sql_dashboard is installed but not in INSTALLED_APPS
-            pass
+        if _Dashboard is not None:
+            self._delete_qs(_Dashboard.objects.all(), label="Dashboard")
         self._sql(
             "DELETE FROM iaso_exportrequest WHERE id NOT IN (SELECT DISTINCT export_request_id FROM iaso_exportstatus)",
             label="iaso_exportrequest[orphan]",
@@ -835,14 +854,21 @@ class Command(BaseCommand):
             users = User.objects.filter(pk__in=user_ids)
             self._delete_qs(users, label="User")
 
+        # ---- Step 5b: vector_control_apiimport — delete rows for this account's projects ----
+        # Rows are filtered by app_id (from QUERY_STRING). Rows with no app_id cannot be
+        # attributed to any account and are cleaned up in _post_flight (account-to-keep mode).
+        for project in Project.objects.filter(account=account):
+            self._sql(
+                "DELETE FROM vector_control_apiimport WHERE headers->>'QUERY_STRING' LIKE %s",
+                params=[f"%app_id={project.app_id}%"],
+                label=f"vector_control_apiimport[app_id={project.app_id}]",
+            )
+
         # ---- Step 6: Account itself ----
         if not self.dry_run:
             account_id, account_name = account.id, account.name
             account.delete()
             _log(f"  Account {account_id} ({account_name!r}) deleted")
-
-        self._delete_qs(Device.objects.filter(projects=None), label="Device[orphan]")
-        self._sql("DELETE FROM vector_control_apiimport", label="vector_control_apiimport")
 
     # -----------------------------------------------------------------------
     # Entry point

--- a/iaso/management/commands/delete_accounts.py
+++ b/iaso/management/commands/delete_accounts.py
@@ -673,6 +673,14 @@ class Command(BaseCommand):
         _log("finished pre-deletion cleanup")
 
     def _post_deletion_clean_up(self, account_to_keep):
+        """
+        Sweeps data left over once only `account_to_keep` should remain.
+        Most cleanups here are scoped to actual orphans (no surviving FK/M2M link).
+        A few tables (e.g. Session, Dashboard) have no link to Account at all, not even
+        indirectly — there's no way to tell which rows belong to the deleted account(s), so
+        those are wiped in full rather than left as an unscoped leak. Accepted tradeoff, not
+        a bug: only run --account-to-keep when losing that unscoped data is acceptable.
+        """
         _log(
             "Post-deletion cleanup: clearing orphan DataSource, Forms, Instance, Project, InstanceFile, APIImport, Session, Device..."
         )

--- a/iaso/management/commands/delete_accounts.py
+++ b/iaso/management/commands/delete_accounts.py
@@ -1027,10 +1027,12 @@ class Command(BaseCommand):
         return discovered, deletion_order
 
     def _mode_show_graph(self, options, discovered_models, deletion_order):
-        if options.get("for_account"):
-            account = Account.objects.get(pk=options["for_account"])
-        else:
+        if not options.get("for_account"):
             raise ValueError("please provide the for_account parameter when running in show_graph mode")
+        for_account_id = options["for_account"]
+        account = Account.objects.filter(pk=for_account_id).first()
+        if account is None:
+            raise SystemExit(f"Account not found: {for_account_id}")
         show_graph(discovered_models, deletion_order, log=self._log, account=account)
         return 0
 
@@ -1069,7 +1071,9 @@ class Command(BaseCommand):
         self._mode_list_accounts()
 
         account_id_to_keep = options["account_to_keep"]
-        account_to_keep = Account.objects.get(pk=account_id_to_keep)
+        account_to_keep = Account.objects.filter(pk=account_id_to_keep).first()
+        if account_to_keep is None:
+            raise SystemExit(f"Account not found: {account_id_to_keep}")
         self._log(f"Keeping: {account_id_to_keep} — {account_to_keep.name!r}")
         accounts_to_delete = list(Account.objects.exclude(pk=account_id_to_keep).order_by("-id"))
         random.shuffle(accounts_to_delete)

--- a/iaso/management/commands/delete_accounts.py
+++ b/iaso/management/commands/delete_accounts.py
@@ -614,14 +614,6 @@ class Command(BaseCommand):
                 self._cascade_chunked_delete(DataSource.objects.filter(pk=ds.pk), ds_label)
 
     # -----------------------------------------------------------------------
-    # Manual section: Form (M2M-linked)
-    # -----------------------------------------------------------------------
-    def _delete_forms(self, account):
-        forms = Form.objects_include_deleted.filter(projects__account=account)
-        with self._doing(f"Form account={account.id}"):
-            self._delete_qs(forms, label="Form")
-
-    # -----------------------------------------------------------------------
     # Pre/post-deletion cleanup
     # -----------------------------------------------------------------------
     def _pre_deletion_clean_up(self, accounts_to_delete):
@@ -802,18 +794,17 @@ class Command(BaseCommand):
         )
 
         # ---- Collect data we'll need BEFORE any deletions start ----
-        # Profile is in the FK graph (discovered via 'account' filter) and will be
-        # deleted by the auto topo step.  Capture user_ids now before that happens.
+        # Profile and Project are in the FK graph (discovered via 'account' filter) and will be deleted by the auto topo step
+        # multiple data types depend on them so we need to save the required info
         user_ids = list(Profile.objects.filter(account=account).values_list("user_id", flat=True))
-
-        # Project is also in the FK graph and will be deleted by the auto topo step —
-        # capture app_ids now, since step 5b needs them but can't look them up via
-        # Project.objects.filter(account=account) once Project rows are gone.
         app_ids = list(
             Project.objects.filter(account=account)
             .exclude(app_id=None)
             .exclude(app_id="")
             .values_list("app_id", flat=True)
+        )
+        form_ids = list(
+            Form.objects_include_deleted.filter(projects__account=account).values_list("pk", flat=True).distinct()
         )
 
         # Models the manual sections own completely — exclude from the auto step so
@@ -822,7 +813,7 @@ class Command(BaseCommand):
         # Profile IS left in the auto step — it will be handled there in topo order.
         manual_models = {
             DataSource,  # M2M gap, handled via _delete_datasource_tree
-            Form,  # M2M gap, handled via _delete_forms
+            Form,  # M2M gap
         }
 
         # ---- Step 1: Manual — DataSource tree (M2M gap) ----
@@ -866,8 +857,10 @@ class Command(BaseCommand):
             )
 
         # ---- Step 4: Manual — Form (M2M gap, after auto cleared FormVersion etc.) ----
+        # Uses form_ids captured at the top — Project rows are already gone by now.
         with self._doing(f"account={account.id} Form"):
-            self._delete_forms(account)
+            forms = Form.objects_include_deleted.filter(pk__in=form_ids)
+            self._delete_qs(forms, label="Form")
 
         # ---- Step 5: Manual — User (upstream from Profile, not in reverse FK graph) ----
         # Profile was deleted in the auto step; use the user_ids collected at the top.

--- a/iaso/management/commands/delete_accounts.py
+++ b/iaso/management/commands/delete_accounts.py
@@ -845,6 +845,10 @@ class Command(BaseCommand):
                             self.chunk_size,
                             f"{blocker_model.__name__}[unblock]",
                         )
+            else:
+                raise RuntimeError(
+                    f"Could not delete {label} after {_MAX_PROTECT_UNBLOCK_ATTEMPTS} attempts — PROTECT cycle not resolved"
+                )
 
             if deleted_count:
                 _log(f"  {label}: {deleted_count:,} deleted")

--- a/iaso/management/commands/delete_accounts.py
+++ b/iaso/management/commands/delete_accounts.py
@@ -18,7 +18,8 @@ What still needs manual code (M2M gap):
     Project.data_sources M2M, not a direct FK; the BFS path via credentials
     is SET_NULL and therefore partial
   - Form — linked via projects M2M
-  - Orphan audit/export log cleanup (content-type based, not FK based)
+  - Orphan audit log cleanup (content-type based, not FK based)
+  - Orphan export log cleanup (no incoming M2M reference, not content-type or FK based)
 
 Usage:
   docker compose run --rm iaso manage delete_accounts --account-to-keep 1
@@ -440,6 +441,7 @@ class Command(BaseCommand):
     def _cascade_chunked_delete(self, queryset, label):
         """
         Drop-in replacement for queryset.delete() that:
+        - Is dry-run aware — logs an estimated row count and returns without touching the DB
         - Uses Django's Collector to discover the full cascade (respects model evolution)
         - Logs each model being deleted with its count
         - Deletes in chunks instead of one giant transaction
@@ -633,18 +635,6 @@ class Command(BaseCommand):
         forms = Form.objects_include_deleted.filter(projects__account=account)
         with self._doing(f"Form account={account.id}"):
             self._delete_qs(forms, label="Form")
-
-    # -----------------------------------------------------------------------
-    # Manual section: User / Profile
-    # Profile.user is a forward FK (Profile → User); User is upstream so not
-    # in the BFS reverse graph.  We collect user_ids from profiles and delete.
-    # -----------------------------------------------------------------------
-
-    def _delete_users(self, account, profiles):
-        user_ids = list(profiles.values_list("user_id", flat=True))
-        users = User.objects.filter(pk__in=user_ids)
-        with self._doing(f"User account={account.id}"):
-            self._delete_qs(users, label="User")
 
     # -----------------------------------------------------------------------
     # Pre/post-flight cleanup

--- a/iaso/management/commands/delete_accounts.py
+++ b/iaso/management/commands/delete_accounts.py
@@ -92,8 +92,6 @@ except (ImportError, RuntimeError):
 # ---------------------------------------------------------------------------
 # Logging
 # ---------------------------------------------------------------------------
-
-
 def _log(msg):
     print(f"[{datetime.datetime.now().strftime('%H:%M:%S')}] {msg}")
 
@@ -101,8 +99,6 @@ def _log(msg):
 # ---------------------------------------------------------------------------
 # Streaming chunked delete
 # ---------------------------------------------------------------------------
-
-
 def _chunked_delete(queryset, chunk_size=5000, label=None):
     """Delete in streaming chunks — never loads more than chunk_size PKs at once."""
     model = queryset.model
@@ -161,14 +157,6 @@ class FKEdge:
 
 
 @dataclass
-class ManualCleanupNote:
-    """A table that can't be reached by the FK-graph BFS and needs dedicated cleanup code."""
-
-    label: str  # e.g. "iaso.DataSource / SourceVersion / OrgUnit", or a bare table name
-    reason: str  # why this table needs manual/dedicated handling instead of the auto FK-graph
-
-
-@dataclass
 class DeletionPlanItem:
     """One model's rows to delete in _cascade_chunked_delete's plan — from either
     fast_deletes or data, never both."""
@@ -176,6 +164,14 @@ class DeletionPlanItem:
     model: type
     queryset: QuerySet  # set when this item came from collector.fast_deletes, else None
     pks: list  # set when this item came from collector.data (no bulk queryset available), else None
+
+
+@dataclass
+class ManualCleanupNote:
+    """A table that can't be reached by the FK-graph BFS and needs dedicated cleanup code."""
+
+    label: str  # e.g. "iaso.DataSource / SourceVersion / OrgUnit", or a bare table name
+    reason: str  # why this table needs manual/dedicated handling instead of the auto FK-graph
 
 
 # Tables not reachable via reverse FK from Account — require manual handling.
@@ -309,8 +305,6 @@ def topo_sort_deletion_order(discovered, graph_edges):
 # ---------------------------------------------------------------------------
 # --show-graph mode
 # ---------------------------------------------------------------------------
-
-
 def show_graph(discovered, deletion_order, account=None):
     """
     Print what the FK graph discovered, flag partial-coverage paths,
@@ -350,8 +344,6 @@ def show_graph(discovered, deletion_order, account=None):
 # ---------------------------------------------------------------------------
 # Management command
 # ---------------------------------------------------------------------------
-
-
 class Command(BaseCommand):
     help = "FK-graph-based account deletion — auto-discovers related models"
 
@@ -382,7 +374,6 @@ class Command(BaseCommand):
     # -----------------------------------------------------------------------
     # Helpers
     # -----------------------------------------------------------------------
-
     def _sql(self, sql, params=None, label="SQL"):
         if self.dry_run:
             _log(f"  [DRY RUN] {label}: {sql[:100]}")
@@ -437,7 +428,6 @@ class Command(BaseCommand):
     # These are M2M-linked (Project.data_sources); the FK graph only finds
     # DataSources that have credentials, so we handle the full set here.
     # -----------------------------------------------------------------------
-
     def _cascade_chunked_delete(self, queryset, label):
         """
         Drop-in replacement for queryset.delete() that:
@@ -630,16 +620,14 @@ class Command(BaseCommand):
     # -----------------------------------------------------------------------
     # Manual section: Form (M2M-linked)
     # -----------------------------------------------------------------------
-
     def _delete_forms(self, account):
         forms = Form.objects_include_deleted.filter(projects__account=account)
         with self._doing(f"Form account={account.id}"):
             self._delete_qs(forms, label="Form")
 
     # -----------------------------------------------------------------------
-    # Pre/post-flight cleanup
+    # Pre/post-deletion cleanup
     # -----------------------------------------------------------------------
-
     def _pre_deletion_clean_up(self, accounts_to_delete):
         _log("Pre-deletion cleanup: clearing users_profile, orphaned Instance, InstanceFile, OrgUnit...")
         try:
@@ -805,71 +793,6 @@ class Command(BaseCommand):
     # -----------------------------------------------------------------------
     # Main account deletion (graph-based)
     # -----------------------------------------------------------------------
-
-    def _execute_graph_deletion(self, discovered, deletion_order, account, skip_models=None):
-        """
-        Delete all discovered models in topological order.
-        Each model's rows are filtered using the auto-built account_lookup.
-        skip_models: set of model classes handled manually (excluded from this step).
-        """
-        skip_models = skip_models or set()
-        models_processed = 0
-        models_with_rows = 0
-        total_deleted = 0
-
-        for model in deletion_order:
-            if model not in discovered or model in skip_models:
-                continue
-            info = discovered[model]
-            manager = getattr(model, "objects_include_deleted", model._default_manager)
-
-            try:
-                qs = manager.filter(**{info.account_lookup: account})
-            except Exception as exc:
-                _log(f"  [skip] {model.__name__}: cannot build queryset ({exc})")
-                continue
-
-            models_processed += 1
-            label = f"{model.__name__}[{info.account_lookup}]"
-            if info.is_partial_coverage:
-                label += " ⚠ partial"
-
-            if self.dry_run:
-                _log(f"  [DRY RUN] would delete {label}")
-                continue
-
-            deleted_count = 0
-            for attempt in range(_MAX_PROTECT_UNBLOCK_ATTEMPTS):
-                try:
-                    deleted_count += _chunked_delete(qs, self.chunk_size, label=label)
-                    break
-                except ProtectedError as exc:
-                    # Auto-clear blocking objects (e.g. nullable PROTECT FKs from partial-coverage models)
-                    blocking_pks_by_model = defaultdict(list)
-                    for obj in exc.protected_objects:
-                        blocking_pks_by_model[type(obj)].append(obj.pk)
-                    for blocker_model, pks in blocking_pks_by_model.items():
-                        _log(f"  [auto-unblock] {blocker_model.__name__} ×{len(pks)} blocking {label}")
-                        _chunked_delete(
-                            blocker_model.objects.filter(pk__in=pks),
-                            self.chunk_size,
-                            f"{blocker_model.__name__}[unblock]",
-                        )
-            else:
-                raise RuntimeError(
-                    f"Could not delete {label} after {_MAX_PROTECT_UNBLOCK_ATTEMPTS} attempts — PROTECT cycle not resolved"
-                )
-
-            if deleted_count:
-                _log(f"  {label}: {deleted_count:,} deleted")
-                models_with_rows += 1
-                total_deleted += deleted_count
-
-        if not self.dry_run:
-            _log(
-                f"  topo step: {models_processed} models processed, {models_with_rows} non-empty, {total_deleted:,} rows deleted total"
-            )
-
     def _delete_account(self, account, discovered, deletion_order):
         _log(f"Account {account.id}: {account.name!r}")
 
@@ -959,6 +882,89 @@ class Command(BaseCommand):
         # ---- Step 6: Account itself ----
         self._delete_qs(Account.objects.filter(pk=account.pk), label=f"Account[{account.id}] {account.name!r}")
 
+    def _execute_graph_deletion(self, discovered, deletion_order, account, skip_models=None):
+        """
+        Delete all discovered models in topological order.
+        Each model's rows are filtered using the auto-built account_lookup.
+        skip_models: set of model classes handled manually (excluded from this step).
+        """
+        skip_models = skip_models or set()
+        models_processed = 0
+        models_with_rows = 0
+        total_deleted = 0
+
+        for model in deletion_order:
+            if model not in discovered or model in skip_models:
+                continue
+            info = discovered[model]
+            manager = getattr(model, "objects_include_deleted", model._default_manager)
+
+            try:
+                qs = manager.filter(**{info.account_lookup: account})
+            except Exception as exc:
+                _log(f"  [skip] {model.__name__}: cannot build queryset ({exc})")
+                continue
+
+            models_processed += 1
+            label = f"{model.__name__}[{info.account_lookup}]"
+            if info.is_partial_coverage:
+                label += " ⚠ partial"
+
+            if self.dry_run:
+                _log(f"  [DRY RUN] would delete {label}")
+                continue
+
+            deleted_count = 0
+            for attempt in range(_MAX_PROTECT_UNBLOCK_ATTEMPTS):
+                try:
+                    deleted_count += _chunked_delete(qs, self.chunk_size, label=label)
+                    break
+                except ProtectedError as exc:
+                    # Auto-clear blocking objects (e.g. nullable PROTECT FKs from partial-coverage models)
+                    blocking_pks_by_model = defaultdict(list)
+                    for obj in exc.protected_objects:
+                        blocking_pks_by_model[type(obj)].append(obj.pk)
+                    for blocker_model, pks in blocking_pks_by_model.items():
+                        _log(f"  [auto-unblock] {blocker_model.__name__} ×{len(pks)} blocking {label}")
+                        _chunked_delete(
+                            blocker_model.objects.filter(pk__in=pks),
+                            self.chunk_size,
+                            f"{blocker_model.__name__}[unblock]",
+                        )
+            else:
+                raise RuntimeError(
+                    f"Could not delete {label} after {_MAX_PROTECT_UNBLOCK_ATTEMPTS} attempts — PROTECT cycle not resolved"
+                )
+
+            if deleted_count:
+                _log(f"  {label}: {deleted_count:,} deleted")
+                models_with_rows += 1
+                total_deleted += deleted_count
+
+        if not self.dry_run:
+            _log(
+                f"  topo step: {models_processed} models processed, {models_with_rows} non-empty, {total_deleted:,} rows deleted total"
+            )
+
+    def _print_model_stats(self):
+        _log("Row counts after deletion:")
+        all_models = sorted(django_apps.get_models(), key=lambda m: m._meta.label)
+        for model in all_models:
+            manager = getattr(model, "objects_include_deleted", model._default_manager)
+            try:
+                row_count = manager.count()
+            except Exception:
+                continue
+            _log(f"  {model._meta.label:<55s}: {row_count:>10,}")
+
+        _log("Remaining accounts:")
+        for account in Account.objects.order_by("id"):
+            _log(f"  {account.id:6d}  {account.name}")
+
+        _log("Remaining credentials:")
+        for cred in ExternalCredentials.objects.all():
+            _log(f"  credential: {cred.id} {cred.url} {cred.login} {cred.name}")
+
     # -----------------------------------------------------------------------
     # Entry point
     # -----------------------------------------------------------------------
@@ -999,6 +1005,7 @@ class Command(BaseCommand):
         account_to_keep = None
         full_cleanup = False
 
+        # Checking whether we are in full cleanup mode (keep one account, delete all others) or in selective deletion mode (delete specific accounts)
         if options.get("account_to_keep") is not None:
             account_id_to_keep = options["account_to_keep"]
             account_to_keep = Account.objects.get(pk=account_id_to_keep)
@@ -1013,6 +1020,7 @@ class Command(BaseCommand):
                 found_ids = {a.id for a in accounts_to_delete}
                 raise SystemExit(f"Accounts not found: {[id for id in ids if id not in found_ids]}")
 
+        # Starting some clean up before deleting selected accounts
         self._pre_deletion_clean_up(accounts_to_delete)
 
         for account in accounts_to_delete:
@@ -1027,24 +1035,9 @@ class Command(BaseCommand):
                 )
                 _log(f"--- FAILED account={account.id} ({account.name!r}) ---")
 
+        # Finishing cleaning up - dangling/orphan data
         if full_cleanup:
             self._post_deletion_clean_up(account_to_keep)
 
         _log("Done!")
-        _log("Row counts after deletion:")
-
-        all_models = sorted(django_apps.get_models(), key=lambda m: m._meta.label)
-        for model in all_models:
-            manager = getattr(model, "objects_include_deleted", model._default_manager)
-            try:
-                row_count = manager.count()
-            except Exception:
-                continue
-            _log(f"  {model._meta.label:<55s}: {row_count:>10,}")
-
-        _log("Remaining accounts:")
-        for account in Account.objects.order_by("id"):
-            _log(f"  {account.id:6d}  {account.name}")
-        _log("Remaining credentials:")
-        for cred in ExternalCredentials.objects.all():
-            _log(f"  credential: {cred.id} {cred.url} {cred.login} {cred.name}")
+        self._print_model_stats()

--- a/iaso/management/commands/delete_accounts.py
+++ b/iaso/management/commands/delete_accounts.py
@@ -369,12 +369,30 @@ class Command(BaseCommand):
 
     def _delete_qs(self, queryset, label=None):
         """Deletes a whole queryset with a single queryset.delete() - useful for deleting small tables"""
-        label = label or queryset.model.__name__
+        model = queryset.model
+        label = label or model.__name__
         if self.dry_run:
             _log(f"  [DRY RUN] {label}: ~{queryset.count()}")
             return
+        if model is not Modification:
+            self._delete_modification_logs_for_pks(
+                ContentType.objects.get_for_model(model), list(queryset.values_list("pk", flat=True))
+            )
         deleted_count, _ = queryset.delete()
         _log(f"  {label}: {deleted_count} deleted")
+
+    def _delete_modification_logs_for_pks(self, content_type, pks):
+        """
+        Modification has no real DB-level FK to the model it logs (content_type + object_id,
+        GenericForeignKey-style) — rows referencing pks about to be deleted become invisible
+        orphans unless cleaned up right here, alongside the rows themselves.
+        """
+        if not pks:
+            return
+        self._delete_qs(
+            Modification.objects.filter(content_type=content_type, object_id__in=[str(pk) for pk in pks]),
+            label=f"Modification[{content_type.model}]",
+        )
 
     def _delete_qs_in_chunks(self, queryset, label=None):
         """Deletes a queryset in chunks with raw_delete() — useful for deleting big tables that can't be loaded at once."""
@@ -384,11 +402,15 @@ class Command(BaseCommand):
             _log(f"  [DRY RUN] {label}: ~{queryset.count()}")
             return 0
 
+        content_type = ContentType.objects.get_for_model(model) if model is not Modification else None
+
         total = 0
         while True:
             ids = list(queryset.order_by("pk").values_list("pk", flat=True)[: self.chunk_size])
             if not ids:
                 break
+            if content_type is not None:
+                self._delete_modification_logs_for_pks(content_type, ids)
             chunk_qs = queryset.filter(pk__in=ids)
             try:
                 deleted = chunk_qs._raw_delete(using=queryset.db)

--- a/iaso/management/commands/delete_accounts.py
+++ b/iaso/management/commands/delete_accounts.py
@@ -640,7 +640,8 @@ class Command(BaseCommand):
     # Pre/post-flight cleanup
     # -----------------------------------------------------------------------
 
-    def _pre_flight(self, accounts_to_delete):
+    def _pre_deletion_clean_up(self, accounts_to_delete):
+        _log("Pre-deletion cleanup: clearing users_profile, orphaned Instance, InstanceFile, OrgUnit...")
         try:
             self._sql("DELETE FROM users_profile", label="users_profile")
         except django.db.utils.ProgrammingError:
@@ -671,21 +672,12 @@ class Command(BaseCommand):
             label="Task[queued→killed]",
             status=KILLED,
         )
+        _log("finished pre-deletion cleanup")
 
-    def _delete_form_without_project(self, form):
-        """Clear a project-less Form's M2M/version data and hard-delete it."""
-        label = f"Form[no project][{form.id}]"
-        if self.dry_run:
-            _log(f"  [DRY RUN] {label}: would clear org_unit_types, delete versions' instances/files, hard-delete")
-            return
-        OrgUnitType.reference_forms.through.objects.filter(form=form).delete()
-        form.org_unit_types.clear()
-        InstanceFile.objects.filter(instance__form_version__in=form.form_versions.all()).delete()
-        Instance.objects.filter(form_version__in=form.form_versions.all()).delete()
-        form.delete_hard()
-        _log(f"  {label}: done")
-
-    def _post_flight(self, account_to_keep):
+    def _post_deletion_clean_up(self, account_to_keep):
+        _log(
+            "Post-deletion cleanup: clearing orphan DataSource, Forms, Instance, Project, InstanceFile, APIImport, Session, Device..."
+        )
         # Orphan datasources — delete one by one, continue on error
         ds_ids_to_keep = DataSource.objects.filter(projects__account=account_to_keep).values_list("id", flat=True)
         orphan_ds = list(DataSource.objects.exclude(id__in=ds_ids_to_keep))
@@ -735,6 +727,20 @@ class Command(BaseCommand):
         )
         self._cleanup_modification_logs()
         self._cleanup_export_logs()
+        _log("finished post-deletion cleanup")
+
+    def _delete_form_without_project(self, form):
+        """Clear a project-less Form's M2M/version data and hard-delete it."""
+        label = f"Form[no project][{form.id}]"
+        if self.dry_run:
+            _log(f"  [DRY RUN] {label}: would clear org_unit_types, delete versions' instances/files, hard-delete")
+            return
+        OrgUnitType.reference_forms.through.objects.filter(form=form).delete()
+        form.org_unit_types.clear()
+        InstanceFile.objects.filter(instance__form_version__in=form.form_versions.all()).delete()
+        Instance.objects.filter(form_version__in=form.form_versions.all()).delete()
+        form.delete_hard()
+        _log(f"  {label}: done")
 
     def _cleanup_modification_logs(self):
         _log("Cleaning modification logs...")
@@ -1007,7 +1013,7 @@ class Command(BaseCommand):
                 found_ids = {a.id for a in accounts_to_delete}
                 raise SystemExit(f"Accounts not found: {[id for id in ids if id not in found_ids]}")
 
-        self._pre_flight(accounts_to_delete)
+        self._pre_deletion_clean_up(accounts_to_delete)
 
         for account in accounts_to_delete:
             _log(f"--- Deleting account={account.id} ({account.name!r}) ---")
@@ -1022,7 +1028,7 @@ class Command(BaseCommand):
                 _log(f"--- FAILED account={account.id} ({account.name!r}) ---")
 
         if full_cleanup:
-            self._post_flight(account_to_keep)
+            self._post_deletion_clean_up(account_to_keep)
 
         _log("Done!")
         _log("Row counts after deletion:")

--- a/iaso/management/commands/delete_accounts.py
+++ b/iaso/management/commands/delete_accounts.py
@@ -21,9 +21,9 @@ What still needs manual code (M2M gap):
   - Orphan audit/export log cleanup (content-type based, not FK based)
 
 Usage:
-  docker compose run --rm iaso manage delete_accounts_v3 --account-to-keep 1
-  docker compose run --rm iaso manage delete_accounts_v3 --account-to-keep 1 --dry-run
-  docker compose run --rm iaso manage delete_accounts_v3 --show-graph
+  docker compose run --rm iaso manage delete_accounts --account-to-keep 1
+  docker compose run --rm iaso manage delete_accounts --account-to-keep 1 --dry-run
+  docker compose run --rm iaso manage delete_accounts --show-graph
 
 
 how to test this crazyness

--- a/iaso/management/commands/delete_accounts.py
+++ b/iaso/management/commands/delete_accounts.py
@@ -18,6 +18,7 @@ What still needs manual code (M2M gap):
     Project.data_sources M2M, not a direct FK; the BFS path via credentials
     is SET_NULL and therefore partial
   - Form — linked via projects M2M
+  - OrgUnitType — linked via projects M2M
   - Orphan audit log cleanup (content-type based, not FK based)
   - Orphan export log cleanup (no incoming M2M reference, not content-type or FK based)
 
@@ -154,6 +155,7 @@ _MANUAL_CLEANUP_NOTES = [
         reason="linked via Project.data_sources M2M, BFS only finds those with credentials",
     ),
     ManualCleanupNote(label="iaso.Form", reason="linked via projects M2M"),
+    ManualCleanupNote(label="iaso.OrgUnitType", reason="linked via projects M2M"),
     ManualCleanupNote(label="audit.Modification", reason="content-type based, no FK to Account"),
     ManualCleanupNote(label="iaso.ExportLog", reason="no FK to Account"),
     ManualCleanupNote(label="django_sql_dashboard.Dashboard", reason="no FK to Account"),
@@ -836,6 +838,9 @@ class Command(BaseCommand):
         form_ids = list(
             Form.objects_include_deleted.filter(projects__account=account).values_list("pk", flat=True).distinct()
         )
+        org_unit_type_ids = list(
+            OrgUnitType.objects.filter(projects__account=account).values_list("pk", flat=True).distinct()
+        )
 
         # Models the manual sections own completely — exclude from the auto step so
         # the auto step doesn't redundantly re-attempt them (0-row no-ops are cheap
@@ -844,6 +849,7 @@ class Command(BaseCommand):
         manual_models = {
             DataSource,  # M2M gap, handled via _delete_datasource_tree
             Form,  # M2M gap
+            OrgUnitType,  # M2M gap
         }
 
         # ---- Step 1: Manual — DataSource tree (M2M gap) ----
@@ -891,6 +897,12 @@ class Command(BaseCommand):
         with self._doing(f"account={account.id} Form"):
             forms = Form.objects_include_deleted.filter(pk__in=form_ids)
             self._delete_qs(forms, label="Form")
+
+        # ---- Step 4b: Manual — OrgUnitType (M2M gap, same shape as Form) ----
+        # Uses org_unit_type_ids captured at the top — Project rows are already gone by now.
+        with self._doing(f"account={account.id} OrgUnitType"):
+            org_unit_types = OrgUnitType.objects.filter(pk__in=org_unit_type_ids)
+            self._delete_qs(org_unit_types, label="OrgUnitType")
 
         # ---- Step 5: Manual — User (upstream from Profile, not in reverse FK graph) ----
         # Profile was deleted in the auto step; use the user_ids collected at the top.

--- a/iaso/management/commands/delete_accounts.py
+++ b/iaso/management/commands/delete_accounts.py
@@ -62,22 +62,38 @@ from django.contrib.contenttypes.models import ContentType
 from django.contrib.sessions.models import Session
 from django.core.management.base import BaseCommand
 from django.db import connection
-from django.db.models import ForeignKey, ManyToManyRel, OneToOneField, QuerySet, TextField
+from django.db.models import ForeignKey, ManyToManyRel, OneToOneField, Q, QuerySet, TextField
 from django.db.models.deletion import SET_NULL, Collector, ProtectedError
 from django.db.models.functions import Cast
 
 from hat.audit.models import Modification
 from iaso.models import (
     Account,
+    AccountFeatureFlag,
     CommentIaso,
     Form,
+    MatchingAlgorithm,
+    OpenHEXAInstance,
     OrgUnitType,
+    RecordType,
+    Report,
+    ReportVersion,
     Task,
 )
-from iaso.models.base import KILLED, QUEUED, DataSource, ExternalCredentials, Profile
+from iaso.models.base import (
+    KILLED,
+    QUEUED,
+    DataSource,
+    ExportLog,
+    ExportRequest,
+    ExportStatus,
+    ExternalCredentials,
+    Profile,
+)
 from iaso.models.device import Device
 from iaso.models.entity import Entity
 from iaso.models.instances import Instance, InstanceFile
+from iaso.models.json_config import Config
 from iaso.models.microplanning import Planning, PlanningSamplingResult
 from iaso.models.org_unit import OrgUnit
 from iaso.models.project import Project
@@ -149,8 +165,19 @@ _OUT_OF_GRAPH_CLEANUP_NOTES = [
     ),
     OutOfGraphCleanupNote(label="iaso.Form", reason="linked via projects M2M"),
     OutOfGraphCleanupNote(label="iaso.OrgUnitType", reason="linked via projects M2M"),
+    OutOfGraphCleanupNote(
+        label="iaso.CommentIaso",
+        reason="GenericForeignKey (content_type + object_pk) to OrgUnit, not a real FK",
+    ),
+    OutOfGraphCleanupNote(
+        label="iaso.ReportVersion",
+        reason="only Report points to it (PROTECT); no reverse-FK path back to Account for BFS to follow",
+    ),
     OutOfGraphCleanupNote(label="audit.Modification", reason="content-type based, no FK to Account"),
-    OutOfGraphCleanupNote(label="iaso.ExportLog", reason="no FK to Account"),
+    OutOfGraphCleanupNote(
+        label="iaso.ExportRequest / iaso.ExportLog",
+        reason="no FK to Account — only reachable via ExportStatus.instance",
+    ),
     OutOfGraphCleanupNote(label="django_sql_dashboard.Dashboard", reason="no FK to Account"),
     OutOfGraphCleanupNote(label="django.contrib.sessions.Session", reason="no FK to Account"),
     OutOfGraphCleanupNote(
@@ -672,7 +699,7 @@ class Command(BaseCommand):
         """
         Sweeps data left over once only `account_to_keep` should remain.
         Most cleanups here are scoped to actual orphans (no surviving FK/M2M link).
-        A few tables (e.g. Session, Dashboard) have no link to Account at all, not even
+        A few tables (e.g. Session, Dashboard, Config) have no link to Account at all, not even
         indirectly — there's no way to tell which rows belong to the deleted account(s), so
         those are wiped in full rather than left as an unscoped leak. Accepted tradeoff, not
         a bug: only run --account-to-keep when losing that unscoped data is acceptable.
@@ -712,7 +739,6 @@ class Command(BaseCommand):
             "DELETE FROM vector_control_apiimport WHERE headers->>'QUERY_STRING' NOT LIKE '%app_id=%'",
             label="vector_control_apiimport[no app_id]",
         )
-        self._delete_qs(Session.objects.all(), label="Session")
         self._delete_qs(Device.objects.filter(projects=None), label="Device[orphan]")
 
         for form_without_project in forms_without_project:
@@ -721,14 +747,22 @@ class Command(BaseCommand):
             except Exception:
                 self._log(traceback.format_exc())
 
-        if _Dashboard is not None:
-            self._delete_qs(_Dashboard.objects.all(), label="Dashboard")
         self._delete_with_sql(
             "DELETE FROM iaso_exportrequest WHERE id NOT IN (SELECT DISTINCT export_request_id FROM iaso_exportstatus)",
             label="iaso_exportrequest[orphan]",
         )
         self._cleanup_modification_logs()
         self._cleanup_export_logs()
+
+        # OpenHEXAWorkspace are deleted after Accounts are deleted (CASCADE), so any OHInstance without any workspace has to be deleted
+        self._delete_qs(OpenHEXAInstance.objects.filter(openhexa_workspaces__isnull=True), label="OpenHEXAInstance")
+
+        # the following models have no link at all with Account
+        if _Dashboard is not None:
+            self._delete_qs(_Dashboard.objects.all(), label="Dashboard")
+        self._delete_qs(Config.objects.all(), label="Config")
+        self._delete_qs(Session.objects.all(), label="Session")
+
         self._log("finished post-deletion cleanup")
 
     def _delete_form_without_project(self, form):
@@ -835,6 +869,30 @@ class Command(BaseCommand):
         org_unit_type_ids = list(
             OrgUnitType.objects.filter(projects__account=account).values_list("pk", flat=True).distinct()
         )
+        matching_algorithm_ids = list(
+            MatchingAlgorithm.objects.filter(projects__account=account).values_list("pk", flat=True)
+        )
+        org_unit_ids = list(
+            OrgUnit.objects.filter(version__data_source__projects__account=account)
+            .values_list("pk", flat=True)
+            .distinct()
+        )
+        record_type_ids = list(RecordType.objects.filter(projects__account=account).values_list("pk", flat=True))
+        report_version_ids = list(
+            Report.objects.filter(project__account=account).values_list("published_version_id", flat=True).distinct()
+        )
+        device_ids = list(Device.objects.filter(projects__account=account).values_list("pk", flat=True))
+        # ExportStatus has no FK to Account either — only reachable via its Instance, which
+        # can itself be tied to the account through any of 3 independent paths (project,
+        # org_unit's version/data_source, or form). Collect the ExportRequest/ExportLog ids
+        # it's about to orphan so Step 4g can clean them up once ExportStatus cascades away.
+        export_status_for_account = ExportStatus.objects.filter(
+            Q(instance__project__account=account)
+            | Q(instance__org_unit__version__data_source__projects__account=account)
+            | Q(instance__form__projects__account=account)
+        )
+        export_request_ids = list(export_status_for_account.values_list("export_request_id", flat=True).distinct())
+        export_log_ids = list(export_status_for_account.values_list("export_logs__id", flat=True).distinct())
 
         # Models the out-of-graph sections own completely — exclude from the auto step so
         # the auto step doesn't redundantly re-attempt them (0-row no-ops are cheap
@@ -855,6 +913,15 @@ class Command(BaseCommand):
                     list(project.data_sources.all()),
                     label_prefix=f"proj[{project.id}]/",
                 )
+
+        # ---- Step 1b: Out-of-graph — CommentIaso (GenericForeignKey to OrgUnit, no real FK) ----
+        # Uses org_unit_ids captured at the top — OrgUnit rows are already gone by now.
+        with self._doing(f"account={account.id} CommentIaso"):
+            orgunit_ct = ContentType.objects.get_for_model(OrgUnit)
+            self._delete_qs(
+                CommentIaso.objects.filter(content_type=orgunit_ct, object_pk__in=[str(pk) for pk in org_unit_ids]),
+                label="CommentIaso",
+            )
 
         # ---- Step 2: Break PROTECT cycles that topo sort can't handle ----
 
@@ -899,6 +966,30 @@ class Command(BaseCommand):
             org_unit_types = OrgUnitType.objects.filter(pk__in=org_unit_type_ids)
             self._delete_qs(org_unit_types, label="OrgUnitType")
 
+        # --- Step 4c: Out-of-graph - MatchingAlgorithm (M2M gap, linked to Projects) ----
+        # Uses matching_algorithm_ids captured at the top — Project rows are already gone by now.
+        with self._doing(f"account={account.id} MatchingAlgorithm"):
+            matching_algorithms = MatchingAlgorithm.objects.filter(pk__in=matching_algorithm_ids)
+            self._delete_qs(matching_algorithms, label="MatchingAlgorithm")
+
+        # --- Step 4d: Out-of-graph - RecordType (M2M gap, linked to Projects) ----
+        # Uses record_type_ids captured at the top — Project rows are already gone by now.
+        with self._doing(f"account={account.id} RecordType"):
+            record_types = RecordType.objects.filter(pk__in=record_type_ids)
+            self._delete_qs(record_types, label="RecordType")
+
+        # --- Step 4e: Out-of-graph - ReportVersion (Report.published_version = PROTECT, no reverse FK) ----
+        # Uses report_version_ids captured at the top — Report rows are already gone by now.
+        with self._doing(f"account={account.id} ReportVersion"):
+            report_versions = ReportVersion.objects.filter(pk__in=report_version_ids)
+            self._delete_qs(report_versions, label="ReportVersion")
+
+        # --- Step 4f: Out-of-graph - Device (M2M gap, linked to Projects) ----
+        # Uses device_ids captured at the top — Project rows are already gone by now.
+        with self._doing(f"account={account.id} Device"):
+            devices = Device.objects.filter(pk__in=device_ids)
+            self._delete_qs(devices, label="Device")
+
         # ---- Step 5: Out-of-graph — User (upstream from Profile, not in reverse FK graph) ----
         # Profile was deleted in the auto step; use the user_ids collected at the top.
         with self._doing(f"account={account.id} User"):
@@ -914,6 +1005,32 @@ class Command(BaseCommand):
                 "DELETE FROM vector_control_apiimport WHERE headers->>'QUERY_STRING' LIKE %s",
                 params=[f"%app_id={app_id}%"],
                 label=f"vector_control_apiimport[app_id={app_id}]",
+            )
+
+        # ---- Step 5c: Out-of-graph — AccountFeatureFlag (M2M with Account) ----
+        with self._doing(f"account={account.id} AccountFeatureFlag"):
+            self._delete_qs(AccountFeatureFlag.objects.filter(account=account), label="AccountFeatureFlag")
+
+        # ---- Step 5d: Out-of-graph — ExportRequest / ExportLog (no FK to Account at all; only
+        # reachable via ExportStatus.instance, which cascaded away with this account's Instances
+        # in Step 3). Scoped to export_request_ids/export_log_ids captured at the top — deletes
+        # them only if no other ExportStatus still references them.
+        with self._doing(f"account={account.id} ExportRequest/ExportLog"):
+            self._delete_qs(
+                ExportRequest.objects.filter(pk__in=export_request_ids).exclude(
+                    pk__in=ExportStatus.objects.filter(export_request_id__in=export_request_ids).values_list(
+                        "export_request_id", flat=True
+                    )
+                ),
+                label="ExportRequest[orphan]",
+            )
+            self._delete_qs(
+                ExportLog.objects.filter(pk__in=export_log_ids).exclude(
+                    pk__in=ExportStatus.objects.filter(export_logs__id__in=export_log_ids).values_list(
+                        "export_logs__id", flat=True
+                    )
+                ),
+                label="ExportLog[orphan]",
             )
 
         # ---- Step 6: Account itself ----

--- a/iaso/management/commands/delete_accounts.py
+++ b/iaso/management/commands/delete_accounts.py
@@ -97,33 +97,6 @@ def _log(msg):
 
 
 # ---------------------------------------------------------------------------
-# Streaming chunked delete
-# ---------------------------------------------------------------------------
-def _chunked_raw_delete(queryset, chunk_size=5000, label=None):
-    """Delete in streaming chunks — never loads more than chunk_size PKs at once."""
-    model = queryset.model
-    label = label or model.__name__
-    total = 0
-
-    while True:
-        ids = list(queryset.order_by("pk").values_list("pk", flat=True)[:chunk_size])
-        if not ids:
-            break
-        chunk_qs = queryset.filter(pk__in=ids)
-        try:
-            deleted = chunk_qs._raw_delete(using=queryset.db)
-        except Exception as exc:
-            _log(f"  {label}: _raw_delete failed ({exc!r}), falling back to .delete()")
-            _, counts = chunk_qs.delete()
-            deleted = counts.get(model._meta.label, 0)
-            counts_str = ", ".join(f"{model_label}: {count}" for model_label, count in sorted(counts.items()) if count)
-            _log(f"  {label}: cascade counts: {counts_str}")
-        total += deleted
-
-    return total
-
-
-# ---------------------------------------------------------------------------
 # FK graph — discovery and topological sort
 # ---------------------------------------------------------------------------
 
@@ -404,12 +377,32 @@ class Command(BaseCommand):
         _log(f"  {label}: {deleted_count} deleted")
 
     def _delete_qs_in_chunks(self, queryset, label=None):
-        """Deletes a queryset by doing queryset.raw_delete in chunks"""
-        label = label or queryset.model.__name__
+        """Deletes a queryset in chunks with raw_delete() — never loads more than chunk_size PKs at once."""
+        model = queryset.model
+        label = label or model.__name__
         if self.dry_run:
             _log(f"  [DRY RUN] {label}: ~{queryset.count()}")
             return 0
-        return _chunked_raw_delete(queryset, self.chunk_size, label=label)
+
+        total = 0
+        while True:
+            ids = list(queryset.order_by("pk").values_list("pk", flat=True)[: self.chunk_size])
+            if not ids:
+                break
+            chunk_qs = queryset.filter(pk__in=ids)
+            try:
+                deleted = chunk_qs._raw_delete(using=queryset.db)
+            except Exception as exc:
+                _log(f"  {label}: _raw_delete failed ({exc!r}), falling back to .delete()")
+                _, counts = chunk_qs.delete()
+                deleted = counts.get(model._meta.label, 0)
+                counts_str = ", ".join(
+                    f"{model_label}: {count}" for model_label, count in sorted(counts.items()) if count
+                )
+                _log(f"  {label}: cascade counts: {counts_str}")
+            total += deleted
+
+        return total
 
     def _update_qs(self, queryset, label=None, **fields):
         """Dry-run-aware wrapper around queryset.update(**fields)."""
@@ -461,8 +454,8 @@ class Command(BaseCommand):
                     blocking_pks_by_model[type(obj)].append(obj.pk)
                 for blocker_model, pks in blocking_pks_by_model.items():
                     _log(f"  [auto-unblock] {blocker_model.__name__} ×{len(pks)} blocking {label} (collect phase)")
-                    _chunked_raw_delete(
-                        blocker_model.objects.filter(pk__in=pks), self.chunk_size, f"{blocker_model.__name__}[unblock]"
+                    self._delete_qs_in_chunks(
+                        blocker_model.objects.filter(pk__in=pks), label=f"{blocker_model.__name__}[unblock]"
                     )
         else:
             raise RuntimeError(
@@ -925,7 +918,7 @@ class Command(BaseCommand):
             deleted_count = 0
             for attempt in range(_MAX_PROTECT_UNBLOCK_ATTEMPTS):
                 try:
-                    deleted_count += _chunked_raw_delete(qs, self.chunk_size, label=label)
+                    deleted_count += self._delete_qs_in_chunks(qs, label=label)
                     break
                 except ProtectedError as exc:
                     # Auto-clear blocking objects (e.g. nullable PROTECT FKs from partial-coverage models)
@@ -934,10 +927,9 @@ class Command(BaseCommand):
                         blocking_pks_by_model[type(obj)].append(obj.pk)
                     for blocker_model, pks in blocking_pks_by_model.items():
                         _log(f"  [auto-unblock] {blocker_model.__name__} ×{len(pks)} blocking {label}")
-                        _chunked_raw_delete(
+                        self._delete_qs_in_chunks(
                             blocker_model.objects.filter(pk__in=pks),
-                            self.chunk_size,
-                            f"{blocker_model.__name__}[unblock]",
+                            label=f"{blocker_model.__name__}[unblock]",
                         )
             else:
                 raise RuntimeError(

--- a/iaso/management/commands/pg_activity_watch.py
+++ b/iaso/management/commands/pg_activity_watch.py
@@ -1,0 +1,139 @@
+"""
+Poor man's `top` for Postgres.
+
+Repeatedly polls pg_stat_activity for the current database and renders a
+live-refreshing snapshot of what's actually running: which backends are
+active, how long they've been running, and what (if anything) is blocking
+them via pg_blocking_pids().
+
+Meant to be run in a second terminal while something long-running (a big
+migration, delete_accounts, a slow endpoint, ...) executes in the first —
+purely read-only, doesn't touch or need to know about whatever else is
+running.
+
+Usage:
+  docker compose exec iaso manage pg_activity_watch
+  docker compose exec iaso manage pg_activity_watch --all --min-duration 5
+  docker compose exec iaso manage pg_activity_watch --once
+
+Note: pg_stat_activity.query is only visible for other roles' backends if
+the connecting role is a superuser or has pg_monitor/pg_read_all_stats;
+otherwise Postgres reports "<insufficient privilege>" for those rows.
+
+Ctrl-C to stop.
+"""
+
+import datetime
+import shutil
+import time
+
+from django.core.management.base import BaseCommand
+from django.db import connection
+
+
+_CLEAR_SCREEN = "\033[2J\033[H"
+
+_QUERY_TEMPLATE = """
+SELECT * FROM (
+    SELECT
+        pid,
+        usename,
+        application_name,
+        state,
+        wait_event_type,
+        wait_event,
+        COALESCE(query_start, xact_start, backend_start) AS since,
+        EXTRACT(EPOCH FROM (clock_timestamp() - COALESCE(query_start, xact_start, backend_start)))::int AS seconds,
+        pg_blocking_pids(pid) AS blocked_by,
+        query
+    FROM pg_stat_activity
+    WHERE pid != pg_backend_pid()
+      AND datname = current_database()
+) activity
+WHERE seconds >= %(min_duration)s
+{state_filter}
+ORDER BY seconds DESC NULLS LAST
+LIMIT %(limit)s
+"""
+
+
+class Command(BaseCommand):
+    help = "Poor man's `top` for Postgres: repeatedly polls pg_stat_activity and shows what's actually running."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--interval", type=float, default=2.0, help="Refresh interval, in seconds.")
+        parser.add_argument(
+            "--all",
+            action="store_true",
+            help="Also show idle connections (default: active / idle-in-transaction only).",
+        )
+        parser.add_argument(
+            "--min-duration", type=float, default=0, help="Only show entries running at least this many seconds."
+        )
+        parser.add_argument("--limit", type=int, default=50, help="Max rows shown per refresh.")
+        parser.add_argument("--once", action="store_true", help="Print a single snapshot and exit instead of looping.")
+
+    def handle(self, *args, **options):
+        interval = options["interval"]
+        show_all = options["all"]
+        min_duration = options["min_duration"]
+        limit = options["limit"]
+        once = options["once"]
+
+        state_filter = "" if show_all else "AND state != 'idle'"
+        sql = _QUERY_TEMPLATE.format(state_filter=state_filter)
+
+        try:
+            while True:
+                rows = self._fetch(sql, min_duration, limit)
+                self._render(rows, show_all, min_duration)
+                if once:
+                    return
+                time.sleep(interval)
+        except KeyboardInterrupt:
+            return
+
+    def _fetch(self, sql, min_duration, limit):
+        with connection.cursor() as cursor:
+            cursor.execute(sql, {"min_duration": min_duration, "limit": limit})
+            columns = [col[0] for col in cursor.description]
+            return [dict(zip(columns, row)) for row in cursor.fetchall()]
+
+    def _render(self, rows, show_all, min_duration):
+        width = shutil.get_terminal_size((120, 40)).columns
+
+        if self._stdout_is_a_terminal():
+            self.stdout.write(_CLEAR_SCREEN)
+        header = f"pg_activity_watch — {len(rows)} row(s)" + ("  (active + idle)" if show_all else "  (active only)")
+        if min_duration:
+            header += f"  min_duration={min_duration:g}s"
+        self.stdout.write(header)
+        self.stdout.write("-" * width)
+        self.stdout.write(f"{'PID':>7}  {'STATE':16}  {'SINCE':17}  {'SECS':>6}  {'BLOCKED BY':12}  {'WAIT':16}  QUERY")
+        self.stdout.write("-" * width)
+
+        for row in rows:
+            blocked_by = row["blocked_by"] or []
+            blocked_str = ",".join(str(pid) for pid in blocked_by)
+            marker = "⛔" if blocked_str else ("▶" if row["state"] == "active" else " ")
+            query = (row["query"] or "").replace("\n", " ").strip()
+            self.stdout.write(
+                f"{row['pid']:>7}  {(row['state'] or ''):16}  {self._format_since(row['since']):17}  "
+                f"{row['seconds']:>6}  {blocked_str:12}  {(row['wait_event'] or ''):16}  {marker} {query}"
+            )
+        self.stdout.write("")
+
+    def _format_since(self, since):
+        """The wall-clock time the query/transaction/backend actually started —
+        full timestamp (with date) once it's no longer today."""
+        if since is None:
+            return ""
+        now = datetime.datetime.now(since.tzinfo) if since.tzinfo else datetime.datetime.now()
+        if since.date() == now.date():
+            return since.strftime("%H:%M:%S")
+        return since.strftime("%m-%d %H:%M:%S")
+
+    def _stdout_is_a_terminal(self):
+        # Clearing the screen only makes sense for an actual terminal — skip it when
+        # stdout is captured (tests, `--once` piped to a file, etc.) so output stays readable.
+        return getattr(self.stdout, "isatty", lambda: False)()

--- a/iaso/tests/commands/test_delete_accounts.py
+++ b/iaso/tests/commands/test_delete_accounts.py
@@ -1108,7 +1108,14 @@ class DeleteAccountsModelCoverageTestCase(TestCase):
         current_models = {
             model._meta.label
             for model in apps.get_models()
-            if model._meta.managed and _is_project_model(model) and model._meta.app_label == "iaso"
+            if model._meta.managed
+            and _is_project_model(model)
+            and model._meta.app_label == "iaso"
+            # Dummy models declared inline in test modules (e.g. to exercise a custom field or
+            # serializer) get registered under the "iaso" app label too, but they're test
+            # scaffolding only — never present outside of running that test, irrelevant to
+            # delete_accounts.py's scope. Exclude anything defined under iaso/tests/.
+            and not model.__module__.startswith("iaso.tests.")
         }
 
         new_models = current_models - self.KNOWN_IASO_MODELS

--- a/iaso/tests/commands/test_delete_accounts.py
+++ b/iaso/tests/commands/test_delete_accounts.py
@@ -1,4 +1,5 @@
 from decimal import Decimal
+from io import StringIO
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group as AuthGroup
@@ -7,8 +8,9 @@ from django.contrib.gis.geos import Point
 from django.contrib.sessions.models import Session
 from django.contrib.sites.models import Site
 from django.core import management
-from django.test import TransactionTestCase
+from django.test import TestCase, TransactionTestCase
 from django.utils import timezone
+from django_sql_dashboard.models import Dashboard as SqlDashboard
 
 from hat.api_import.models import APIImport
 from hat.audit.models import Modification
@@ -65,7 +67,19 @@ class DeleteAccountsCommandTestCase(TransactionTestCase, IasoTestCaseMixin):
         user = self.create_user_with_profile(username=f"user_{suffix}", account=account)
         profile = user.iaso_profile
 
-        team = m.Team.objects.create(project=project, name=f"team_{suffix}", manager=user)
+        # 3-level parent hierarchy (Team.parent is a self-referential PROTECT FK) with
+        # `users` M2M set on every level, so a batch delete of the whole team set both
+        # hits the raw_delete IntegrityError fallback (team_users join table) and a
+        # multi-level ProtectedError chain (IA-5268 regression: only 1 level was
+        # auto-unblocked, deeper hierarchies crashed the whole account deletion).
+        team_grandparent = m.Team.objects.create(project=project, name=f"team_grandparent_{suffix}", manager=user)
+        team_grandparent.users.set([user])
+        team_parent = m.Team.objects.create(
+            project=project, name=f"team_parent_{suffix}", manager=user, parent=team_grandparent
+        )
+        team_parent.users.set([user])
+        team = m.Team.objects.create(project=project, name=f"team_{suffix}", manager=user, parent=team_parent)
+        team.users.set([user])
         planning = m.Planning.objects.create(
             project=project, name=f"planning_{suffix}", team=team, org_unit=org_unit_parent
         )
@@ -96,6 +110,10 @@ class DeleteAccountsCommandTestCase(TransactionTestCase, IasoTestCaseMixin):
         feature_flag = m.FeatureFlag.objects.create(name=f"ff_{suffix}", code=f"ff_{suffix}")
         project_feature_flags = m.ProjectFeatureFlags.objects.create(featureflag=feature_flag, project=project)
         config = Config.objects.create(slug=f"config-{suffix}", content={})
+        # django_sql_dashboard is a third-party app with no FK to Account at all — its FK
+        # to User must still be cleared before that user is deleted (IA-5268 regression:
+        # Postgres raised an IntegrityError on commit because that FK wasn't nulled first).
+        sql_dashboard = SqlDashboard.objects.create(slug=f"dashboard-{suffix}", owned_by=user)
         openhexa_instance = m.OpenHEXAInstance.objects.create(
             name=f"openhexa_instance_{suffix}", url="https://openhexa.example.test", token="tok"
         )
@@ -273,6 +291,8 @@ class DeleteAccountsCommandTestCase(TransactionTestCase, IasoTestCaseMixin):
             "user": user,
             "profile": profile,
             "team": team,
+            "team_parent": team_parent,
+            "team_grandparent": team_grandparent,
             "planning": planning,
             "sampling_result": sampling_result,
             "assignment": assignment,
@@ -286,6 +306,7 @@ class DeleteAccountsCommandTestCase(TransactionTestCase, IasoTestCaseMixin):
             "config": config,
             "openhexa_instance": openhexa_instance,
             "openhexa_workspace": openhexa_workspace,
+            "sql_dashboard": sql_dashboard,
             "device": device,
             "device_ownership": device_ownership,
             "device_position": device_position,
@@ -494,7 +515,15 @@ class DeleteAccountsCommandTestCase(TransactionTestCase, IasoTestCaseMixin):
         self.assertFalse(m.StoragePassword.objects.filter(pk=other_models["storage_password"].pk).exists())
         self.assertFalse(m.Task.objects.filter(pk=other_models["task"].pk).exists())
         self.assertFalse(m.TaskLog.objects.filter(pk=other_models["task_log"].pk).exists())
-        self.assertFalse(m.Team.objects.filter(pk=other_models["team"].pk).exists())
+        self.assertFalse(
+            m.Team.objects.filter(
+                pk__in=[
+                    other_models["team"].pk,
+                    other_models["team_parent"].pk,
+                    other_models["team_grandparent"].pk,
+                ]
+            ).exists()
+        )
         self.assertFalse(m.TemporaryForm.objects.filter(pk=other_models["temporary_form"].pk).exists())
         self.assertFalse(m.TenantUser.objects.filter(pk=other_models["tenant_user"].pk).exists())
         self.assertFalse(m.User.objects.filter(pk=other_models["user"].pk).exists())
@@ -513,6 +542,13 @@ class DeleteAccountsCommandTestCase(TransactionTestCase, IasoTestCaseMixin):
         # exclusive to --account-to-keep mode.
         post_deletion_cleanup_ran = mode == MODE_KEEP_SINGLE_ACCOUNT
         assertion = self.assertFalse if post_deletion_cleanup_ran else self.assertTrue
+
+        if post_deletion_cleanup_ran:
+            # `_post_deletion_clean_up` wipes every Dashboard row (no FK to Account at all).
+            self.assertFalse(SqlDashboard.objects.filter(pk=other_models["sql_dashboard"].pk).exists())
+        else:
+            # Not wiped in this mode, but its FK to the now-deleted user must be null (IA-5268).
+            self.assertIsNone(SqlDashboard.objects.get(pk=other_models["sql_dashboard"].pk).owned_by_id)
 
         if pre_deletion_orphans is not None:
             self.assertFalse(m.Instance.objects.filter(pk=pre_deletion_orphans["instance_no_form"].pk).exists())
@@ -639,7 +675,16 @@ class DeleteAccountsCommandTestCase(TransactionTestCase, IasoTestCaseMixin):
         self.assertTrue(m.StoragePassword.objects.filter(pk=other_models["storage_password"].pk).exists())
         self.assertTrue(m.Task.objects.filter(pk=other_models["task"].pk).exists())
         self.assertTrue(m.TaskLog.objects.filter(pk=other_models["task_log"].pk).exists())
-        self.assertTrue(m.Team.objects.filter(pk=other_models["team"].pk).exists())
+        self.assertEqual(
+            m.Team.objects.filter(
+                pk__in=[
+                    other_models["team"].pk,
+                    other_models["team_parent"].pk,
+                    other_models["team_grandparent"].pk,
+                ]
+            ).count(),
+            3,
+        )
         self.assertTrue(m.TemporaryForm.objects.filter(pk=other_models["temporary_form"].pk).exists())
         self.assertTrue(m.TenantUser.objects.filter(pk=other_models["tenant_user"].pk).exists())
         self.assertTrue(m.User.objects.filter(pk=other_models["user"].pk).exists())
@@ -660,6 +705,13 @@ class DeleteAccountsCommandTestCase(TransactionTestCase, IasoTestCaseMixin):
         post_deletion_cleanup_ran = mode == MODE_KEEP_SINGLE_ACCOUNT
         assertion = self.assertFalse if post_deletion_cleanup_ran else self.assertTrue
         assertion(Config.objects.filter(pk=other_models["config"].pk).exists())
+
+        if post_deletion_cleanup_ran:
+            self.assertFalse(SqlDashboard.objects.filter(pk=other_models["sql_dashboard"].pk).exists())
+        else:
+            self.assertTrue(
+                SqlDashboard.objects.filter(pk=other_models["sql_dashboard"].pk, owned_by=other_models["user"]).exists()
+            )
 
         if pre_deletion_orphans is not None:
             self.assertTrue(m.Instance.objects.filter(pk=pre_deletion_orphans["instance_no_form"].pk).exists())
@@ -902,4 +954,176 @@ class DeleteAccountsCommandTestCase(TransactionTestCase, IasoTestCaseMixin):
             self.project_to_keep,
             extra_models_to_keep,
             mode=MODE_KEEP_SINGLE_ACCOUNT,
+        )
+
+    def test_keep_single_account_prints_stats_and_remaining_credentials(self):
+        """
+        `handle()` used to `return` straight out of each mode branch, making the trailing
+        `_log("Done!")` / `_print_model_stats()` unreachable dead code for every mode —
+        the "Row counts after deletion" / "Remaining accounts" / "Remaining credentials"
+        summary never actually printed. Verifies it's reachable again.
+        """
+        self._populate_account(self.account_to_keep, self.version_to_keep, self.project_to_keep, suffix="kept")
+        self._populate_account(self.account_to_delete, self.version_to_delete, self.project_to_delete, suffix="deleted")
+
+        out = StringIO()
+        management.call_command(
+            "delete_accounts",
+            account_to_keep=self.account_to_keep.pk,
+            verbosity=1,
+            stdout=out,
+        )
+        output = out.getvalue()
+
+        self.assertIn("Done!", output)
+        self.assertIn("Row counts after deletion:", output)
+        self.assertIn(f"{m.Team._meta.label:<55s}", output)  # a row-count line for a real model
+
+        # `account_to_delete`'s name legitimately appears earlier in the log (it's being
+        # deleted) — scope these checks to the final "Remaining ..." sections specifically.
+        self.assertIn("Remaining accounts:", output)
+        remaining_accounts_section = output.split("Remaining accounts:", 1)[1].split("Remaining credentials:", 1)[0]
+        self.assertIn(self.account_to_keep.name, remaining_accounts_section)
+        self.assertNotIn(self.account_to_delete.name, remaining_accounts_section)
+
+        self.assertIn("Remaining credentials:", output)
+        remaining_credentials_section = output.split("Remaining credentials:", 1)[1]
+        self.assertIn("cred_kept", remaining_credentials_section)  # kept account's credentials survive
+        self.assertNotIn("cred_deleted", remaining_credentials_section)  # deleted account's are gone
+
+
+class DeleteAccountsModelCoverageTestCase(TestCase):
+    """
+    Drift guard: fails as soon as a model is added to (or removed from) the `iaso` app,
+    so it can't silently go unhandled by delete_accounts.py / uncovered by
+    DeleteAccountsCommandTestCase above.
+
+    Uses the exact same "project model" filter (`_is_project_model`) the command itself
+    uses to decide which models the FK-graph BFS may auto-discover — see that function's
+    docstring in delete_accounts.py.
+
+    Limitation: plugin apps (polio, wfp, registry, wfp_auth) are NOT loaded in this test
+    environment ("Enabled plugins: []" — no `PLUGINS` env var set here), so
+    `apps.get_models()` never returns their models and this snapshot can't cover them.
+    Only `iaso` app models are checked.
+    """
+
+    # Snapshot of every managed `iaso`-app model as of the last time DeleteAccountsCommandTestCase's
+    # fixtures (_populate_account + both assertion helpers) were updated. When this test fails:
+    #   1. Read delete_accounts.py's module docstring ("What is automatic" / "What's out of graph")
+    #      to see whether the new model needs dedicated out-of-graph handling.
+    #   2. Add it to _populate_account and to both _assert_account_and_related_data_*  helpers.
+    #   3. Update KNOWN_IASO_MODELS below to match.
+    KNOWN_IASO_MODELS = frozenset(
+        {
+            "iaso.Account",
+            "iaso.AccountFeatureFlag",
+            "iaso.AlgorithmRun",
+            "iaso.Assignment",
+            "iaso.BulkCreateUserFile",
+            "iaso.CommentIaso",
+            "iaso.Config",
+            "iaso.DataSource",
+            "iaso.DataSourceVersionsSynchronization",
+            "iaso.Device",
+            "iaso.DeviceOwnership",
+            "iaso.DevicePosition",
+            "iaso.Entity",
+            "iaso.EntityDuplicate",
+            "iaso.EntityDuplicateAnalyzis",
+            "iaso.EntityType",
+            "iaso.ExportLog",
+            "iaso.ExportRequest",
+            "iaso.ExportStatus",
+            "iaso.ExternalCredentials",
+            "iaso.FeatureFlag",
+            "iaso.Form",
+            "iaso.FormAttachment",
+            "iaso.FormPredefinedFilter",
+            "iaso.FormVersion",
+            "iaso.Group",
+            "iaso.GroupSet",
+            "iaso.ImportGPKG",
+            "iaso.Instance",
+            "iaso.InstanceFile",
+            "iaso.InstanceLock",
+            "iaso.JsonDataStore",
+            "iaso.Link",
+            "iaso.Mapping",
+            "iaso.MappingVersion",
+            "iaso.MatchingAlgorithm",
+            "iaso.MetricType",
+            "iaso.MetricValue",
+            "iaso.OpenHEXAInstance",
+            "iaso.OpenHEXAWorkspace",
+            "iaso.OrgUnit",
+            "iaso.OrgUnitChangeRequest",
+            "iaso.OrgUnitChangeRequestConfiguration",
+            "iaso.OrgUnitReferenceInstance",
+            "iaso.OrgUnitType",
+            "iaso.Page",
+            "iaso.Payment",
+            "iaso.PaymentLot",
+            "iaso.Planning",
+            "iaso.PlanningSamplingResult",
+            "iaso.PotentialPayment",
+            "iaso.Profile",
+            "iaso.Project",
+            "iaso.ProjectFeatureFlags",
+            "iaso.Record",
+            "iaso.RecordType",
+            "iaso.Report",
+            "iaso.ReportVersion",
+            "iaso.SourceVersion",
+            "iaso.StockItem",
+            "iaso.StockItemRule",
+            "iaso.StockKeepingUnit",
+            "iaso.StockKeepingUnitChildren",
+            "iaso.StockLedgerItem",
+            "iaso.StockRulesVersion",
+            "iaso.StorageDevice",
+            "iaso.StorageLogEntry",
+            "iaso.StoragePassword",
+            "iaso.Task",
+            "iaso.TaskLog",
+            "iaso.Team",
+            "iaso.TemporaryForm",
+            "iaso.TenantUser",
+            "iaso.UserRole",
+            "iaso.ValidationNode",
+            "iaso.ValidationNodeTemplate",
+            "iaso.ValidationWorkflow",
+            "iaso.Workflow",
+            "iaso.WorkflowChange",
+            "iaso.WorkflowFollowup",
+            "iaso.WorkflowVersion",
+        }
+    )
+
+    def test_iaso_models_match_known_snapshot(self):
+        from django.apps import apps
+
+        from iaso.management.commands.delete_accounts import _is_project_model
+
+        current_models = {
+            model._meta.label
+            for model in apps.get_models()
+            if model._meta.managed and _is_project_model(model) and model._meta.app_label == "iaso"
+        }
+
+        new_models = current_models - self.KNOWN_IASO_MODELS
+        self.assertFalse(
+            new_models,
+            f"New iaso model(s) found: {sorted(new_models)}. Before adding to KNOWN_IASO_MODELS: "
+            "check whether delete_accounts.py needs dedicated out-of-graph handling for them "
+            "(see its module docstring), then add fixtures/assertions to "
+            "DeleteAccountsCommandTestCase covering them.",
+        )
+
+        removed_models = self.KNOWN_IASO_MODELS - current_models
+        self.assertFalse(
+            removed_models,
+            f"iaso model(s) removed since this snapshot was taken: {sorted(removed_models)}. "
+            "Remove them from KNOWN_IASO_MODELS here, and from DeleteAccountsCommandTestCase's "
+            "fixtures/assertions if still referenced there.",
         )

--- a/iaso/tests/commands/test_delete_accounts.py
+++ b/iaso/tests/commands/test_delete_accounts.py
@@ -144,11 +144,6 @@ class DeleteAccountsCommandTestCase(TransactionTestCase, IasoTestCaseMixin):
 
         return pre_deletion_orphans, post_deletion_only_orphans
 
-    def _assert_org_unit_type_survives(self, populated):
-        # OrgUnitType is linked to Project only through M2M and isn't even listed in
-        # _MANUAL_CLEANUP_NOTES — nothing in delete_accounts.py ever deletes it, in any mode.
-        self.assertTrue(m.OrgUnitType.objects.filter(pk=populated["org_unit_type"].pk).exists())
-
     def _assert_account_and_related_data_gone(
         self,
         account,
@@ -179,6 +174,7 @@ class DeleteAccountsCommandTestCase(TransactionTestCase, IasoTestCaseMixin):
         self.assertFalse(APIImport.objects.filter(pk=populated["api_import"].pk).exists())
         self.assertFalse(m.Form.objects_include_deleted.filter(pk=populated["form"].pk).exists())
         self.assertFalse(Modification.objects.filter(pk=populated["modification"].pk).exists())
+        self.assertFalse(m.OrgUnitType.objects.filter(pk=populated["org_unit_type"].pk).exists())
 
         # Everything below depends on whether `_post_deletion_clean_up` ran, which is
         # exclusive to --account-to-keep mode.
@@ -235,6 +231,7 @@ class DeleteAccountsCommandTestCase(TransactionTestCase, IasoTestCaseMixin):
         self.assertTrue(m.ExternalCredentials.objects.filter(pk=populated["credentials"].pk).exists())
         self.assertTrue(APIImport.objects.filter(pk=populated["api_import"].pk).exists())
         self.assertTrue(Modification.objects.filter(pk=populated["modification"].pk).exists())
+        self.assertTrue(m.OrgUnitType.objects.filter(pk=populated["org_unit_type"].pk).exists())
 
         if pre_deletion_orphans is not None:
             self.assertTrue(m.Instance.objects.filter(pk=pre_deletion_orphans["instance_no_form"].pk).exists())
@@ -309,7 +306,6 @@ class DeleteAccountsCommandTestCase(TransactionTestCase, IasoTestCaseMixin):
         self._assert_account_and_related_data_intact(
             self.account_to_keep, self.data_source_to_keep, self.version_to_keep, self.project_to_keep, self.kept
         )
-        self._assert_org_unit_type_survives(self.deleted)
 
     def test_delete_specific_account(self):
         pre_deletion_orphans, post_deletion_only_orphans = self._create_unscoped_data()
@@ -329,9 +325,6 @@ class DeleteAccountsCommandTestCase(TransactionTestCase, IasoTestCaseMixin):
         self._assert_account_and_related_data_intact(
             self.account_to_keep, self.data_source_to_keep, self.version_to_keep, self.project_to_keep, self.kept
         )
-        # M2M-only-reachable data (not in _MANUAL_CLEANUP_NOTES, no manual cleanup path
-        # anywhere) survives even though the rest of the account is gone.
-        self._assert_org_unit_type_survives(self.deleted)
 
     def test_keep_single_account(self):
         pre_deletion_orphans, post_deletion_only_orphans = self._create_unscoped_data()
@@ -351,4 +344,3 @@ class DeleteAccountsCommandTestCase(TransactionTestCase, IasoTestCaseMixin):
         self._assert_account_and_related_data_intact(
             self.account_to_keep, self.data_source_to_keep, self.version_to_keep, self.project_to_keep, self.kept
         )
-        self._assert_org_unit_type_survives(self.deleted)

--- a/iaso/tests/commands/test_delete_accounts.py
+++ b/iaso/tests/commands/test_delete_accounts.py
@@ -18,8 +18,8 @@ class DeleteAccountsCommandTestCase(TransactionTestCase, IasoTestCaseMixin):
     """
     Builds two fully-populated accounts (one to keep, one to delete) covering both the
     auto-discovered FK graph (Team, Planning, PlanningSamplingResult, Task, EntityType,
-    Entity, ExternalCredentials) and the manually-handled M2M gaps (DataSource/SourceVersion/
-    OrgUnit, Form) that delete_accounts.py owns.
+    Entity, ExternalCredentials) and the out-of-graph M2M gaps (DataSource/SourceVersion/
+    OrgUnit, Form, OrgUnitType) that delete_accounts.py owns.
     """
 
     def setUp(self):

--- a/iaso/tests/commands/test_delete_accounts.py
+++ b/iaso/tests/commands/test_delete_accounts.py
@@ -189,17 +189,12 @@ class DeleteAccountsCommandTestCase(TransactionTestCase, IasoTestCaseMixin):
         self.assertFalse(m.Task.objects.filter(pk=populated["task"].pk).exists())
         self.assertFalse(m.ExternalCredentials.objects.filter(pk=populated["credentials"].pk).exists())
         self.assertFalse(APIImport.objects.filter(pk=populated["api_import"].pk).exists())
+        self.assertFalse(m.Form.objects_include_deleted.filter(pk=populated["form"].pk).exists())
 
         # Everything below depends on whether `_post_deletion_clean_up` ran, which is
         # exclusive to --account-to-keep mode.
         post_deletion_cleanup_ran = mode == MODE_KEEP_SINGLE_ACCOUNT
         assertion = self.assertFalse if post_deletion_cleanup_ran else self.assertTrue
-
-        # `_delete_forms` (step 4) filters via the M2M `projects__account` lookup, but step 3
-        # already deleted the Project, cascading away that M2M link first — so this Form
-        # always survives step 4. It's only actually hard-deleted if `_post_deletion_clean_up`'s
-        # project-less-Form sweep runs afterward.
-        assertion(m.Form.objects_include_deleted.filter(pk=populated["form"].pk).exists())
 
         if pre_deletion_orphans is not None:
             self.assertFalse(m.Instance.objects.filter(pk=pre_deletion_orphans["instance_no_form"].pk).exists())

--- a/iaso/tests/commands/test_delete_accounts.py
+++ b/iaso/tests/commands/test_delete_accounts.py
@@ -1,5 +1,3 @@
-from io import StringIO
-
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.sessions.models import Session
 from django.core import management
@@ -260,20 +258,18 @@ class DeleteAccountsCommandTestCase(TransactionTestCase, IasoTestCaseMixin):
             )
 
     def test_list_accounts_mode(self):
-        management.call_command("delete_accounts", list_accounts=True, stdout=StringIO())
+        management.call_command("delete_accounts", list_accounts=True, verbosity=0)
 
         self.assertTrue(m.Account.objects.filter(pk=self.account_to_keep.pk).exists())
         self.assertTrue(m.Account.objects.filter(pk=self.account_to_delete.pk).exists())
 
     def test_show_graph_mode_without_for_account_raises(self):
         with self.assertRaises(ValueError):
-            management.call_command("delete_accounts", show_graph=True, stdout=StringIO())
+            management.call_command("delete_accounts", show_graph=True, verbosity=0)
 
     def test_show_graph_mode_with_for_account(self):
         # Should not raise and should not touch any data.
-        management.call_command(
-            "delete_accounts", show_graph=True, for_account=self.account_to_keep.pk, stdout=StringIO()
-        )
+        management.call_command("delete_accounts", show_graph=True, for_account=self.account_to_keep.pk, verbosity=0)
 
         self.assertTrue(m.Account.objects.filter(pk=self.account_to_keep.pk).exists())
         self.assertTrue(m.Account.objects.filter(pk=self.account_to_delete.pk).exists())
@@ -282,7 +278,7 @@ class DeleteAccountsCommandTestCase(TransactionTestCase, IasoTestCaseMixin):
         missing_id = m.Account.objects.order_by("-pk").first().pk + 1000
 
         with self.assertRaises(SystemExit):
-            management.call_command("delete_accounts", accounts_to_delete=[missing_id], stdout=StringIO())
+            management.call_command("delete_accounts", accounts_to_delete=[missing_id], verbosity=0)
 
     def test_dry_run_does_not_delete_anything(self):
         pre_deletion_orphans, post_deletion_only_orphans = self._create_unscoped_data()
@@ -291,7 +287,7 @@ class DeleteAccountsCommandTestCase(TransactionTestCase, IasoTestCaseMixin):
             "delete_accounts",
             accounts_to_delete=[self.account_to_delete.pk],
             dry_run=True,
-            stdout=StringIO(),
+            verbosity=0,
         )
 
         self._assert_account_and_related_data_intact(
@@ -310,7 +306,7 @@ class DeleteAccountsCommandTestCase(TransactionTestCase, IasoTestCaseMixin):
     def test_delete_specific_account(self):
         pre_deletion_orphans, post_deletion_only_orphans = self._create_unscoped_data()
 
-        management.call_command("delete_accounts", accounts_to_delete=[self.account_to_delete.pk], stdout=StringIO())
+        management.call_command("delete_accounts", accounts_to_delete=[self.account_to_delete.pk], verbosity=0)
 
         self._assert_account_and_related_data_gone(
             self.account_to_delete,
@@ -329,7 +325,7 @@ class DeleteAccountsCommandTestCase(TransactionTestCase, IasoTestCaseMixin):
     def test_keep_single_account(self):
         pre_deletion_orphans, post_deletion_only_orphans = self._create_unscoped_data()
 
-        management.call_command("delete_accounts", account_to_keep=self.account_to_keep.pk, stdout=StringIO())
+        management.call_command("delete_accounts", account_to_keep=self.account_to_keep.pk, verbosity=0)
 
         self._assert_account_and_related_data_gone(
             self.account_to_delete,

--- a/iaso/tests/commands/test_delete_accounts.py
+++ b/iaso/tests/commands/test_delete_accounts.py
@@ -407,6 +407,7 @@ class DeleteAccountsCommandTestCase(TransactionTestCase, IasoTestCaseMixin):
         self.assertFalse(m.Account.objects.filter(pk=account.pk).exists())
         self.assertFalse(m.AccountFeatureFlag.objects.filter(pk=other_models["account_feature_flag"].pk).exists())
         self.assertFalse(m.AlgorithmRun.objects.filter(pk=other_models["algorithm_run"].pk).exists())
+        self.assertFalse(APIImport.objects.filter(pk=other_models["api_import"].pk).exists())
         self.assertFalse(Assignment.objects.filter(pk=other_models["assignment"].pk).exists())
         self.assertFalse(m.BulkCreateUserFile.objects.filter(pk=other_models["bulk_create_user_file"].pk).exists())
         self.assertFalse(m.CommentIaso.objects.filter(pk=other_models["comment_iaso"].pk).exists())
@@ -450,7 +451,6 @@ class DeleteAccountsCommandTestCase(TransactionTestCase, IasoTestCaseMixin):
         self.assertFalse(m.MetricType.objects.filter(pk=other_models["metric_type"].pk).exists())
         self.assertFalse(m.MetricValue.objects.filter(pk=other_models["metric_value"].pk).exists())
         self.assertFalse(Modification.objects.filter(pk=other_models["modification"].pk).exists())
-        self.assertFalse(APIImport.objects.filter(pk=other_models["api_import"].pk).exists())
         self.assertFalse(m.OpenHEXAWorkspace.objects.filter(pk=other_models["openhexa_workspace"].pk).exists())
         self.assertFalse(
             m.OrgUnit.objects.filter(

--- a/iaso/tests/commands/test_delete_accounts.py
+++ b/iaso/tests/commands/test_delete_accounts.py
@@ -280,12 +280,47 @@ class DeleteAccountsCommandTestCase(TransactionTestCase, IasoTestCaseMixin):
         with self.assertRaises(SystemExit):
             management.call_command("delete_accounts", accounts_to_delete=[missing_id], verbosity=0)
 
-    def test_dry_run_does_not_delete_anything(self):
+    def test_keep_single_account_unknown_id_raises(self):
+        missing_id = m.Account.objects.order_by("-pk").first().pk + 1000
+
+        with self.assertRaises(SystemExit):
+            management.call_command("delete_accounts", account_to_keep=missing_id, verbosity=0)
+
+    def test_show_graph_mode_unknown_for_account_raises(self):
+        missing_id = m.Account.objects.order_by("-pk").first().pk + 1000
+
+        with self.assertRaises(SystemExit):
+            management.call_command("delete_accounts", show_graph=True, for_account=missing_id, verbosity=0)
+
+    def test_dry_run_delete_accounts_mode_does_not_delete_anything(self):
         pre_deletion_orphans, post_deletion_only_orphans = self._create_unscoped_data()
 
         management.call_command(
             "delete_accounts",
             accounts_to_delete=[self.account_to_delete.pk],
+            dry_run=True,
+            verbosity=0,
+        )
+
+        self._assert_account_and_related_data_intact(
+            self.account_to_delete,
+            self.data_source_to_delete,
+            self.version_to_delete,
+            self.project_to_delete,
+            self.deleted,
+            pre_deletion_orphans=pre_deletion_orphans,
+            post_deletion_only_orphans=post_deletion_only_orphans,
+        )
+        self._assert_account_and_related_data_intact(
+            self.account_to_keep, self.data_source_to_keep, self.version_to_keep, self.project_to_keep, self.kept
+        )
+
+    def test_dry_run_keep_single_account_mode_does_not_delete_anything(self):
+        pre_deletion_orphans, post_deletion_only_orphans = self._create_unscoped_data()
+
+        management.call_command(
+            "delete_accounts",
+            account_to_keep=self.account_to_keep.pk,
             dry_run=True,
             verbosity=0,
         )

--- a/iaso/tests/commands/test_delete_accounts.py
+++ b/iaso/tests/commands/test_delete_accounts.py
@@ -1,0 +1,191 @@
+from io import StringIO
+
+from django.core import management
+
+from iaso import models as m
+from iaso.models.microplanning import PlanningSamplingResult
+from iaso.test import TestCase
+
+
+class DeleteAccountsCommandTestCase(TestCase):
+    """
+    Builds two fully-populated accounts (one to keep, one to delete) covering both the
+    auto-discovered FK graph (Team, Planning, PlanningSamplingResult, Task, EntityType,
+    Entity, ExternalCredentials) and the manually-handled M2M gaps (DataSource/SourceVersion/
+    OrgUnit, Form) that delete_accounts.py owns.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.account_to_keep, cls.data_source_to_keep, cls.version_to_keep, cls.project_to_keep = (
+            cls.create_account_datasource_version_project("source kept", "account kept", "project kept")
+        )
+        cls.kept = cls._populate_account(cls.account_to_keep, cls.version_to_keep, cls.project_to_keep, suffix="kept")
+
+        cls.account_to_delete, cls.data_source_to_delete, cls.version_to_delete, cls.project_to_delete = (
+            cls.create_account_datasource_version_project("source deleted", "account deleted", "project deleted")
+        )
+        cls.deleted = cls._populate_account(
+            cls.account_to_delete, cls.version_to_delete, cls.project_to_delete, suffix="deleted"
+        )
+
+    @classmethod
+    def _populate_account(cls, account, source_version, project, suffix):
+        org_unit_type = cls.create_org_unit_type(f"type_{suffix}", [project])
+        org_unit_parent = cls.create_valid_org_unit(f"ou_parent_{suffix}", org_unit_type, source_version)
+        org_unit_child = m.OrgUnit.objects.create(
+            org_unit_type=org_unit_type,
+            version=source_version,
+            name=f"ou_child_{suffix}",
+            parent=org_unit_parent,
+        )
+
+        form = m.Form.objects.create(name=f"form_{suffix}")
+        project.forms.set([form])
+
+        instance = cls.create_form_instance(project=project, form=form, org_unit=org_unit_child)
+
+        entity_type = m.EntityType.objects.create(name=f"entity_type_{suffix}", account=account, reference_form=form)
+        entity = m.Entity.objects.create(entity_type=entity_type, account=account)
+        entity.attributes = instance
+        entity.save()
+
+        user = cls.create_user_with_profile(username=f"user_{suffix}", account=account)
+
+        team = m.Team.objects.create(project=project, name=f"team_{suffix}", manager=user)
+        planning = m.Planning.objects.create(
+            project=project, name=f"planning_{suffix}", team=team, org_unit=org_unit_parent
+        )
+        sampling_result = PlanningSamplingResult.objects.create(planning=planning, parameters={"k": "v"})
+        planning.selected_sampling_result = sampling_result
+        planning.save()
+
+        task = m.Task.objects.create(account=account, name=f"task_{suffix}", status=m.QUEUED)
+        credentials = m.ExternalCredentials.objects.create(
+            account=account, name=f"cred_{suffix}", login="login", password="pwd", url="http://example.com"
+        )
+
+        return {
+            "org_unit_type": org_unit_type,
+            "org_unit_parent": org_unit_parent,
+            "org_unit_child": org_unit_child,
+            "form": form,
+            "instance": instance,
+            "entity_type": entity_type,
+            "entity": entity,
+            "user": user,
+            "team": team,
+            "planning": planning,
+            "sampling_result": sampling_result,
+            "task": task,
+            "credentials": credentials,
+        }
+
+    def _assert_account_and_related_data_gone(self, account, data_source, source_version, project, populated):
+        self.assertFalse(m.Account.objects.filter(pk=account.pk).exists())
+        self.assertFalse(m.DataSource.objects.filter(pk=data_source.pk).exists())
+        self.assertFalse(m.SourceVersion.objects.filter(pk=source_version.pk).exists())
+        self.assertFalse(m.Project.objects.filter(pk=project.pk).exists())
+        self.assertFalse(
+            m.OrgUnit.objects.filter(pk__in=[populated["org_unit_parent"].pk, populated["org_unit_child"].pk]).exists()
+        )
+        self.assertFalse(m.Form.objects_include_deleted.filter(pk=populated["form"].pk).exists())
+        self.assertFalse(m.Instance.objects.filter(pk=populated["instance"].pk).exists())
+        self.assertFalse(m.EntityType.objects.filter(pk=populated["entity_type"].pk).exists())
+        self.assertFalse(m.Entity.objects_include_deleted.filter(pk=populated["entity"].pk).exists())
+        self.assertFalse(m.User.objects.filter(pk=populated["user"].pk).exists())
+        self.assertFalse(m.Team.objects.filter(pk=populated["team"].pk).exists())
+        self.assertFalse(m.Planning.objects.filter(pk=populated["planning"].pk).exists())
+        self.assertFalse(PlanningSamplingResult.objects.filter(pk=populated["sampling_result"].pk).exists())
+        self.assertFalse(m.Task.objects.filter(pk=populated["task"].pk).exists())
+        self.assertFalse(m.ExternalCredentials.objects.filter(pk=populated["credentials"].pk).exists())
+
+    def _assert_account_and_related_data_intact(self, account, data_source, source_version, project, populated):
+        self.assertTrue(m.Account.objects.filter(pk=account.pk).exists())
+        self.assertTrue(m.DataSource.objects.filter(pk=data_source.pk).exists())
+        self.assertTrue(m.SourceVersion.objects.filter(pk=source_version.pk).exists())
+        self.assertTrue(m.Project.objects.filter(pk=project.pk).exists())
+        self.assertTrue(m.OrgUnit.objects.filter(pk=populated["org_unit_parent"].pk).exists())
+        self.assertTrue(m.OrgUnit.objects.filter(pk=populated["org_unit_child"].pk).exists())
+        self.assertTrue(m.Form.objects_include_deleted.filter(pk=populated["form"].pk).exists())
+        self.assertTrue(m.Instance.objects.filter(pk=populated["instance"].pk).exists())
+        self.assertTrue(m.EntityType.objects.filter(pk=populated["entity_type"].pk).exists())
+        self.assertTrue(m.Entity.objects_include_deleted.filter(pk=populated["entity"].pk).exists())
+        self.assertTrue(m.User.objects.filter(pk=populated["user"].pk).exists())
+        self.assertTrue(m.Team.objects.filter(pk=populated["team"].pk).exists())
+        self.assertTrue(m.Planning.objects.filter(pk=populated["planning"].pk).exists())
+        self.assertTrue(PlanningSamplingResult.objects.filter(pk=populated["sampling_result"].pk).exists())
+        self.assertTrue(m.Task.objects.filter(pk=populated["task"].pk).exists())
+        self.assertTrue(m.ExternalCredentials.objects.filter(pk=populated["credentials"].pk).exists())
+
+    def test_list_accounts_mode(self):
+        management.call_command("delete_accounts", list_accounts=True, stdout=StringIO())
+
+        self.assertTrue(m.Account.objects.filter(pk=self.account_to_keep.pk).exists())
+        self.assertTrue(m.Account.objects.filter(pk=self.account_to_delete.pk).exists())
+
+    def test_show_graph_mode_without_for_account_raises(self):
+        with self.assertRaises(ValueError):
+            management.call_command("delete_accounts", show_graph=True, stdout=StringIO())
+
+    def test_show_graph_mode_with_for_account(self):
+        # Should not raise and should not touch any data.
+        management.call_command(
+            "delete_accounts", show_graph=True, for_account=self.account_to_keep.pk, stdout=StringIO()
+        )
+
+        self.assertTrue(m.Account.objects.filter(pk=self.account_to_keep.pk).exists())
+        self.assertTrue(m.Account.objects.filter(pk=self.account_to_delete.pk).exists())
+
+    def test_delete_accounts_unknown_id_raises(self):
+        missing_id = m.Account.objects.order_by("-pk").first().pk + 1000
+
+        with self.assertRaises(SystemExit):
+            management.call_command("delete_accounts", accounts_to_delete=[missing_id], stdout=StringIO())
+
+    def test_dry_run_does_not_delete_anything(self):
+        management.call_command(
+            "delete_accounts",
+            accounts_to_delete=[self.account_to_delete.pk],
+            dry_run=True,
+            stdout=StringIO(),
+        )
+
+        self._assert_account_and_related_data_intact(
+            self.account_to_delete,
+            self.data_source_to_delete,
+            self.version_to_delete,
+            self.project_to_delete,
+            self.deleted,
+        )
+        self._assert_account_and_related_data_intact(
+            self.account_to_keep, self.data_source_to_keep, self.version_to_keep, self.project_to_keep, self.kept
+        )
+
+    def test_delete_specific_account(self):
+        management.call_command("delete_accounts", accounts_to_delete=[self.account_to_delete.pk], stdout=StringIO())
+
+        self._assert_account_and_related_data_gone(
+            self.account_to_delete,
+            self.data_source_to_delete,
+            self.version_to_delete,
+            self.project_to_delete,
+            self.deleted,
+        )
+        self._assert_account_and_related_data_intact(
+            self.account_to_keep, self.data_source_to_keep, self.version_to_keep, self.project_to_keep, self.kept
+        )
+
+    def test_keep_single_account(self):
+        management.call_command("delete_accounts", account_to_keep=self.account_to_keep.pk, stdout=StringIO())
+
+        self._assert_account_and_related_data_gone(
+            self.account_to_delete,
+            self.data_source_to_delete,
+            self.version_to_delete,
+            self.project_to_delete,
+            self.deleted,
+        )
+        self._assert_account_and_related_data_intact(
+            self.account_to_keep, self.data_source_to_keep, self.version_to_keep, self.project_to_keep, self.kept
+        )

--- a/iaso/tests/commands/test_delete_accounts.py
+++ b/iaso/tests/commands/test_delete_accounts.py
@@ -1,13 +1,20 @@
 from io import StringIO
 
+from django.contrib.contenttypes.models import ContentType
+from django.contrib.sessions.models import Session
 from django.core import management
+from django.test import TransactionTestCase
+from django.utils import timezone
 
+from hat.api_import.models import APIImport
+from hat.audit.models import Modification
 from iaso import models as m
+from iaso.management.commands.delete_accounts import MODE_DELETE_ACCOUNTS, MODE_KEEP_SINGLE_ACCOUNT
 from iaso.models.microplanning import PlanningSamplingResult
-from iaso.test import TestCase
+from iaso.test import IasoTestCaseMixin
 
 
-class DeleteAccountsCommandTestCase(TestCase):
+class DeleteAccountsCommandTestCase(TransactionTestCase, IasoTestCaseMixin):
     """
     Builds two fully-populated accounts (one to keep, one to delete) covering both the
     auto-discovered FK graph (Team, Planning, PlanningSamplingResult, Task, EntityType,
@@ -15,24 +22,24 @@ class DeleteAccountsCommandTestCase(TestCase):
     OrgUnit, Form) that delete_accounts.py owns.
     """
 
-    @classmethod
-    def setUpTestData(cls):
-        cls.account_to_keep, cls.data_source_to_keep, cls.version_to_keep, cls.project_to_keep = (
-            cls.create_account_datasource_version_project("source kept", "account kept", "project kept")
+    def setUp(self):
+        self.account_to_keep, self.data_source_to_keep, self.version_to_keep, self.project_to_keep = (
+            self.create_account_datasource_version_project("source kept", "account kept", "project kept")
         )
-        cls.kept = cls._populate_account(cls.account_to_keep, cls.version_to_keep, cls.project_to_keep, suffix="kept")
-
-        cls.account_to_delete, cls.data_source_to_delete, cls.version_to_delete, cls.project_to_delete = (
-            cls.create_account_datasource_version_project("source deleted", "account deleted", "project deleted")
-        )
-        cls.deleted = cls._populate_account(
-            cls.account_to_delete, cls.version_to_delete, cls.project_to_delete, suffix="deleted"
+        self.kept = self._populate_account(
+            self.account_to_keep, self.version_to_keep, self.project_to_keep, suffix="kept"
         )
 
-    @classmethod
-    def _populate_account(cls, account, source_version, project, suffix):
-        org_unit_type = cls.create_org_unit_type(f"type_{suffix}", [project])
-        org_unit_parent = cls.create_valid_org_unit(f"ou_parent_{suffix}", org_unit_type, source_version)
+        self.account_to_delete, self.data_source_to_delete, self.version_to_delete, self.project_to_delete = (
+            self.create_account_datasource_version_project("source deleted", "account deleted", "project deleted")
+        )
+        self.deleted = self._populate_account(
+            self.account_to_delete, self.version_to_delete, self.project_to_delete, suffix="deleted"
+        )
+
+    def _populate_account(self, account, source_version, project, suffix):
+        org_unit_type = self.create_org_unit_type(suffix, [project])
+        org_unit_parent = self.create_valid_org_unit(f"ou_parent_{suffix}", org_unit_type, source_version)
         org_unit_child = m.OrgUnit.objects.create(
             org_unit_type=org_unit_type,
             version=source_version,
@@ -40,17 +47,17 @@ class DeleteAccountsCommandTestCase(TestCase):
             parent=org_unit_parent,
         )
 
-        form = m.Form.objects.create(name=f"form_{suffix}")
+        form = m.Form.objects.create(name=f"form_{suffix}", form_id=f"form_id_{suffix}")
         project.forms.set([form])
 
-        instance = cls.create_form_instance(project=project, form=form, org_unit=org_unit_child)
+        instance = self.create_form_instance(project=project, form=form, org_unit=org_unit_child)
 
         entity_type = m.EntityType.objects.create(name=f"entity_type_{suffix}", account=account, reference_form=form)
         entity = m.Entity.objects.create(entity_type=entity_type, account=account)
         entity.attributes = instance
         entity.save()
 
-        user = cls.create_user_with_profile(username=f"user_{suffix}", account=account)
+        user = self.create_user_with_profile(username=f"user_{suffix}", account=account)
 
         team = m.Team.objects.create(project=project, name=f"team_{suffix}", manager=user)
         planning = m.Planning.objects.create(
@@ -64,6 +71,7 @@ class DeleteAccountsCommandTestCase(TestCase):
         credentials = m.ExternalCredentials.objects.create(
             account=account, name=f"cred_{suffix}", login="login", password="pwd", url="http://example.com"
         )
+        api_import = APIImport.objects.create(json_body={}, headers={"QUERY_STRING": f"app_id={project.app_id}"})
 
         return {
             "org_unit_type": org_unit_type,
@@ -79,9 +87,91 @@ class DeleteAccountsCommandTestCase(TestCase):
             "sampling_result": sampling_result,
             "task": task,
             "credentials": credentials,
+            "api_import": api_import,
         }
 
-    def _assert_account_and_related_data_gone(self, account, data_source, source_version, project, populated):
+    def _create_unscoped_data(self):
+        """
+        Data with no usable link to any account, split by *when* the command cleans it up,
+        plus one dict of data that *does* belong to an account but through a link the
+        FK-graph BFS can't follow:
+        - "pre-deletion" orphans are swept by `_pre_deletion_clean_up`, which runs for both
+          --account-to-delete and --account-to-keep.
+        - "post-deletion" orphans are only swept by `_post_deletion_clean_up`, which runs
+          exclusively in --account-to-keep mode (it assumes a single surviving account).
+        - "deleted account gap" data belongs to `self.account_to_delete`'s own records
+          (see the inline comment below for why it's tracked separately from the orphans).
+        """
+        pre_deletion_orphans = {
+            "instance_no_form": m.Instance.objects.create(form=None),
+            "org_unit_no_version": m.OrgUnit.objects.create(name="orphan_ou_no_version"),
+        }
+
+        form_no_form_id = m.Form.objects.create(name="orphan_form_no_form_id", form_id=None)
+        form_no_form_id.projects.set([self.project_to_keep])
+
+        post_deletion_only_orphans = {
+            "form_no_project": m.Form.objects.create(
+                name="orphan_form_no_project", form_id="orphan_form_no_project_id"
+            ),
+            "form_no_form_id": form_no_form_id,
+            "device_no_project": m.Device.objects.create(imei="orphan-device"),
+            "session": Session.objects.create(
+                session_key="orphansessionkey", session_data="", expire_date=timezone.now()
+            ),
+            "data_source_no_project": m.DataSource.objects.create(name="orphan_data_source"),
+            "api_import_no_app_id": APIImport.objects.create(json_body={}, headers={"QUERY_STRING": "foo=bar"}),
+            "project_no_account": m.Project.objects.create(
+                name="orphan_project_no_account", app_id="orphan.project.no.account"
+            ),
+            "export_log_orphan": m.ExportLog.objects.create(),
+            "export_request_orphan": m.ExportRequest.objects.create(
+                instance_count=0, exported_count=0, errored_count=0, last_error_message=""
+            ),
+            "modification_orphan": Modification.objects.create(
+                content_type=ContentType.objects.get_for_model(m.Instance),
+                object_id="999999999999",
+                past_value={},
+                new_value={},
+                source="test",
+            ),
+        }
+        # Unlike the two dicts above, this data isn't unscoped — it belongs to
+        # `self.account_to_delete`'s own records, but only through a link the FK-graph
+        # BFS can't follow (M2M, or a GenericForeignKey with no DB-level FK at all — see
+        # `_MANUAL_CLEANUP_NOTES`), so it behaves differently across the three test modes.
+        deleted_account_gap_data = {
+            "api_import_for_deleted_account": APIImport.objects.create(
+                json_body={}, headers={"QUERY_STRING": f"app_id={self.project_to_delete.app_id}"}
+            ),
+            "modification_for_deleted_instance": Modification.objects.create(
+                content_type=ContentType.objects.get_for_model(m.Instance),
+                object_id=str(self.deleted["instance"].pk),
+                past_value={},
+                new_value={},
+                source="test",
+            ),
+        }
+
+        return pre_deletion_orphans, post_deletion_only_orphans, deleted_account_gap_data
+
+    def _assert_org_unit_type_survives(self, populated):
+        # OrgUnitType is linked to Project only through M2M and isn't even listed in
+        # _MANUAL_CLEANUP_NOTES — nothing in delete_accounts.py ever deletes it, in any mode.
+        self.assertTrue(m.OrgUnitType.objects.filter(pk=populated["org_unit_type"].pk).exists())
+
+    def _assert_account_and_related_data_gone(
+        self,
+        account,
+        data_source,
+        source_version,
+        project,
+        populated,
+        mode,
+        pre_deletion_orphans=None,
+        post_deletion_only_orphans=None,
+        gap_data=None,
+    ):
         self.assertFalse(m.Account.objects.filter(pk=account.pk).exists())
         self.assertFalse(m.DataSource.objects.filter(pk=data_source.pk).exists())
         self.assertFalse(m.SourceVersion.objects.filter(pk=source_version.pk).exists())
@@ -89,7 +179,6 @@ class DeleteAccountsCommandTestCase(TestCase):
         self.assertFalse(
             m.OrgUnit.objects.filter(pk__in=[populated["org_unit_parent"].pk, populated["org_unit_child"].pk]).exists()
         )
-        self.assertFalse(m.Form.objects_include_deleted.filter(pk=populated["form"].pk).exists())
         self.assertFalse(m.Instance.objects.filter(pk=populated["instance"].pk).exists())
         self.assertFalse(m.EntityType.objects.filter(pk=populated["entity_type"].pk).exists())
         self.assertFalse(m.Entity.objects_include_deleted.filter(pk=populated["entity"].pk).exists())
@@ -99,8 +188,58 @@ class DeleteAccountsCommandTestCase(TestCase):
         self.assertFalse(PlanningSamplingResult.objects.filter(pk=populated["sampling_result"].pk).exists())
         self.assertFalse(m.Task.objects.filter(pk=populated["task"].pk).exists())
         self.assertFalse(m.ExternalCredentials.objects.filter(pk=populated["credentials"].pk).exists())
+        self.assertFalse(APIImport.objects.filter(pk=populated["api_import"].pk).exists())
 
-    def _assert_account_and_related_data_intact(self, account, data_source, source_version, project, populated):
+        # Everything below depends on whether `_post_deletion_clean_up` ran, which is
+        # exclusive to --account-to-keep mode.
+        post_deletion_cleanup_ran = mode == MODE_KEEP_SINGLE_ACCOUNT
+        assertion = self.assertFalse if post_deletion_cleanup_ran else self.assertTrue
+
+        # `_delete_forms` (step 4) filters via the M2M `projects__account` lookup, but step 3
+        # already deleted the Project, cascading away that M2M link first — so this Form
+        # always survives step 4. It's only actually hard-deleted if `_post_deletion_clean_up`'s
+        # project-less-Form sweep runs afterward.
+        assertion(m.Form.objects_include_deleted.filter(pk=populated["form"].pk).exists())
+
+        if pre_deletion_orphans is not None:
+            self.assertFalse(m.Instance.objects.filter(pk=pre_deletion_orphans["instance_no_form"].pk).exists())
+            self.assertFalse(m.OrgUnit.objects.filter(pk=pre_deletion_orphans["org_unit_no_version"].pk).exists())
+
+        if post_deletion_only_orphans is not None:
+            assertion(
+                m.Form.objects_include_deleted.filter(pk=post_deletion_only_orphans["form_no_project"].pk).exists()
+            )
+            assertion(
+                m.Form.objects_include_deleted.filter(pk=post_deletion_only_orphans["form_no_form_id"].pk).exists()
+            )
+            assertion(m.Device.objects.filter(pk=post_deletion_only_orphans["device_no_project"].pk).exists())
+            assertion(Session.objects.filter(pk=post_deletion_only_orphans["session"].pk).exists())
+            assertion(m.DataSource.objects.filter(pk=post_deletion_only_orphans["data_source_no_project"].pk).exists())
+            assertion(APIImport.objects.filter(pk=post_deletion_only_orphans["api_import_no_app_id"].pk).exists())
+            assertion(m.Project.objects.filter(pk=post_deletion_only_orphans["project_no_account"].pk).exists())
+            assertion(m.ExportLog.objects.filter(pk=post_deletion_only_orphans["export_log_orphan"].pk).exists())
+            assertion(
+                m.ExportRequest.objects.filter(pk=post_deletion_only_orphans["export_request_orphan"].pk).exists()
+            )
+            assertion(Modification.objects.filter(pk=post_deletion_only_orphans["modification_orphan"].pk).exists())
+
+        if gap_data is not None:
+            self.assertFalse(APIImport.objects.filter(pk=gap_data["api_import_for_deleted_account"].pk).exists())
+            # The dangling Modification is only caught by `_cleanup_modification_logs`,
+            # part of `_post_deletion_clean_up`.
+            assertion(Modification.objects.filter(pk=gap_data["modification_for_deleted_instance"].pk).exists())
+
+    def _assert_account_and_related_data_intact(
+        self,
+        account,
+        data_source,
+        source_version,
+        project,
+        populated,
+        pre_deletion_orphans=None,
+        post_deletion_only_orphans=None,
+        gap_data=None,
+    ):
         self.assertTrue(m.Account.objects.filter(pk=account.pk).exists())
         self.assertTrue(m.DataSource.objects.filter(pk=data_source.pk).exists())
         self.assertTrue(m.SourceVersion.objects.filter(pk=source_version.pk).exists())
@@ -117,6 +256,43 @@ class DeleteAccountsCommandTestCase(TestCase):
         self.assertTrue(PlanningSamplingResult.objects.filter(pk=populated["sampling_result"].pk).exists())
         self.assertTrue(m.Task.objects.filter(pk=populated["task"].pk).exists())
         self.assertTrue(m.ExternalCredentials.objects.filter(pk=populated["credentials"].pk).exists())
+        self.assertTrue(APIImport.objects.filter(pk=populated["api_import"].pk).exists())
+
+        if pre_deletion_orphans is not None:
+            self.assertTrue(m.Instance.objects.filter(pk=pre_deletion_orphans["instance_no_form"].pk).exists())
+            self.assertTrue(m.OrgUnit.objects.filter(pk=pre_deletion_orphans["org_unit_no_version"].pk).exists())
+
+        if post_deletion_only_orphans is not None:
+            self.assertTrue(
+                m.Form.objects_include_deleted.filter(pk=post_deletion_only_orphans["form_no_project"].pk).exists()
+            )
+            self.assertTrue(
+                m.Form.objects_include_deleted.filter(pk=post_deletion_only_orphans["form_no_form_id"].pk).exists()
+            )
+            self.assertTrue(m.Device.objects.filter(pk=post_deletion_only_orphans["device_no_project"].pk).exists())
+            self.assertTrue(Session.objects.filter(pk=post_deletion_only_orphans["session"].pk).exists())
+            self.assertTrue(
+                m.DataSource.objects.filter(pk=post_deletion_only_orphans["data_source_no_project"].pk).exists()
+            )
+            self.assertTrue(APIImport.objects.filter(pk=post_deletion_only_orphans["api_import_no_app_id"].pk).exists())
+            self.assertTrue(m.Project.objects.filter(pk=post_deletion_only_orphans["project_no_account"].pk).exists())
+            self.assertTrue(m.ExportLog.objects.filter(pk=post_deletion_only_orphans["export_log_orphan"].pk).exists())
+            self.assertTrue(
+                m.ExportRequest.objects.filter(pk=post_deletion_only_orphans["export_request_orphan"].pk).exists()
+            )
+            self.assertTrue(
+                Modification.objects.filter(pk=post_deletion_only_orphans["modification_orphan"].pk).exists()
+            )
+
+        if gap_data is not None:
+            # Only pass the keys expected to be intact at this call site — the two pieces of
+            # gap_data don't necessarily share the same fate (see test bodies).
+            if "api_import_for_deleted_account" in gap_data:
+                self.assertTrue(APIImport.objects.filter(pk=gap_data["api_import_for_deleted_account"].pk).exists())
+            if "modification_for_deleted_instance" in gap_data:
+                self.assertTrue(
+                    Modification.objects.filter(pk=gap_data["modification_for_deleted_instance"].pk).exists()
+                )
 
     def test_list_accounts_mode(self):
         management.call_command("delete_accounts", list_accounts=True, stdout=StringIO())
@@ -144,6 +320,8 @@ class DeleteAccountsCommandTestCase(TestCase):
             management.call_command("delete_accounts", accounts_to_delete=[missing_id], stdout=StringIO())
 
     def test_dry_run_does_not_delete_anything(self):
+        pre_deletion_orphans, post_deletion_only_orphans, gap_data = self._create_unscoped_data()
+
         management.call_command(
             "delete_accounts",
             accounts_to_delete=[self.account_to_delete.pk],
@@ -157,12 +335,18 @@ class DeleteAccountsCommandTestCase(TestCase):
             self.version_to_delete,
             self.project_to_delete,
             self.deleted,
+            pre_deletion_orphans=pre_deletion_orphans,
+            post_deletion_only_orphans=post_deletion_only_orphans,
+            gap_data=gap_data,
         )
         self._assert_account_and_related_data_intact(
             self.account_to_keep, self.data_source_to_keep, self.version_to_keep, self.project_to_keep, self.kept
         )
+        self._assert_org_unit_type_survives(self.deleted)
 
     def test_delete_specific_account(self):
+        pre_deletion_orphans, post_deletion_only_orphans, gap_data = self._create_unscoped_data()
+
         management.call_command("delete_accounts", accounts_to_delete=[self.account_to_delete.pk], stdout=StringIO())
 
         self._assert_account_and_related_data_gone(
@@ -171,12 +355,21 @@ class DeleteAccountsCommandTestCase(TestCase):
             self.version_to_delete,
             self.project_to_delete,
             self.deleted,
+            mode=MODE_DELETE_ACCOUNTS,
+            pre_deletion_orphans=pre_deletion_orphans,
+            post_deletion_only_orphans=post_deletion_only_orphans,
+            gap_data=gap_data,
         )
         self._assert_account_and_related_data_intact(
             self.account_to_keep, self.data_source_to_keep, self.version_to_keep, self.project_to_keep, self.kept
         )
+        # M2M-only-reachable data (not in _MANUAL_CLEANUP_NOTES, no manual cleanup path
+        # anywhere) survives even though the rest of the account is gone.
+        self._assert_org_unit_type_survives(self.deleted)
 
     def test_keep_single_account(self):
+        pre_deletion_orphans, post_deletion_only_orphans, gap_data = self._create_unscoped_data()
+
         management.call_command("delete_accounts", account_to_keep=self.account_to_keep.pk, stdout=StringIO())
 
         self._assert_account_and_related_data_gone(
@@ -185,7 +378,12 @@ class DeleteAccountsCommandTestCase(TestCase):
             self.version_to_delete,
             self.project_to_delete,
             self.deleted,
+            mode=MODE_KEEP_SINGLE_ACCOUNT,
+            pre_deletion_orphans=pre_deletion_orphans,
+            post_deletion_only_orphans=post_deletion_only_orphans,
+            gap_data=gap_data,
         )
         self._assert_account_and_related_data_intact(
             self.account_to_keep, self.data_source_to_keep, self.version_to_keep, self.project_to_keep, self.kept
         )
+        self._assert_org_unit_type_survives(self.deleted)

--- a/iaso/tests/commands/test_delete_accounts.py
+++ b/iaso/tests/commands/test_delete_accounts.py
@@ -1,5 +1,11 @@
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group as AuthGroup
 from django.contrib.contenttypes.models import ContentType
+from django.contrib.gis.geos import Point
 from django.contrib.sessions.models import Session
+from django.contrib.sites.models import Site
 from django.core import management
 from django.test import TransactionTestCase
 from django.utils import timezone
@@ -8,34 +14,32 @@ from hat.api_import.models import APIImport
 from hat.audit.models import Modification
 from iaso import models as m
 from iaso.management.commands.delete_accounts import MODE_DELETE_ACCOUNTS, MODE_KEEP_SINGLE_ACCOUNT
-from iaso.models.microplanning import PlanningSamplingResult
+from iaso.models.data_store import JsonDataStore
+from iaso.models.json_config import Config
+from iaso.models.microplanning import Assignment, PlanningSamplingResult
 from iaso.test import IasoTestCaseMixin
 
 
 class DeleteAccountsCommandTestCase(TransactionTestCase, IasoTestCaseMixin):
     """
-    Builds two fully-populated accounts (one to keep, one to delete) covering both the
-    auto-discovered FK graph (Team, Planning, PlanningSamplingResult, Task, EntityType,
-    Entity, ExternalCredentials) and the out-of-graph M2M gaps (DataSource/SourceVersion/
-    OrgUnit, Form, OrgUnitType) that delete_accounts.py owns.
+    Builds two fully-populated accounts (one to keep, one to delete) covering the
+    auto-discovered FK graph, the out-of-graph M2M gaps (DataSource/SourceVersion/OrgUnit,
+    Form, OrgUnitType) that delete_accounts.py owns, and every other iaso model — so that
+    each one is exercised by these tests, whether it's expected to be deleted with the
+    account or to survive.
     """
 
     def setUp(self):
         self.account_to_keep, self.data_source_to_keep, self.version_to_keep, self.project_to_keep = (
             self.create_account_datasource_version_project("source kept", "account kept", "project kept")
         )
-        self.kept = self._populate_account(
-            self.account_to_keep, self.version_to_keep, self.project_to_keep, suffix="kept"
-        )
-
         self.account_to_delete, self.data_source_to_delete, self.version_to_delete, self.project_to_delete = (
             self.create_account_datasource_version_project("source deleted", "account deleted", "project deleted")
         )
-        self.deleted = self._populate_account(
-            self.account_to_delete, self.version_to_delete, self.project_to_delete, suffix="deleted"
-        )
 
     def _populate_account(self, account, source_version, project, suffix):
+        data_source = source_version.data_source
+
         org_unit_type = self.create_org_unit_type(suffix, [project])
         org_unit_parent = self.create_valid_org_unit(f"ou_parent_{suffix}", org_unit_type, source_version)
         org_unit_child = m.OrgUnit.objects.create(
@@ -48,14 +52,18 @@ class DeleteAccountsCommandTestCase(TransactionTestCase, IasoTestCaseMixin):
         form = m.Form.objects.create(name=f"form_{suffix}", form_id=f"form_id_{suffix}")
         project.forms.set([form])
 
-        instance = self.create_form_instance(project=project, form=form, org_unit=org_unit_child)
+        # 5 instances, so Instance deletion for this account has more than one row —
+        # exercises _delete_qs_in_chunks' chunking loop beyond a single iteration.
+        instances = [self.create_form_instance(project=project, form=form, org_unit=org_unit_child) for _ in range(5)]
 
         entity_type = m.EntityType.objects.create(name=f"entity_type_{suffix}", account=account, reference_form=form)
         entity = m.Entity.objects.create(entity_type=entity_type, account=account)
-        entity.attributes = instance
+        entity.attributes = instances[0]
         entity.save()
+        entity_2 = m.Entity.objects.create(entity_type=entity_type, account=account)
 
         user = self.create_user_with_profile(username=f"user_{suffix}", account=account)
+        profile = user.iaso_profile
 
         team = m.Team.objects.create(project=project, name=f"team_{suffix}", manager=user)
         planning = m.Planning.objects.create(
@@ -64,6 +72,7 @@ class DeleteAccountsCommandTestCase(TransactionTestCase, IasoTestCaseMixin):
         sampling_result = PlanningSamplingResult.objects.create(planning=planning, parameters={"k": "v"})
         planning.selected_sampling_result = sampling_result
         planning.save()
+        assignment = Assignment.objects.create(planning=planning, org_unit=org_unit_child, user=user, team=team)
 
         task = m.Task.objects.create(account=account, name=f"task_{suffix}", status=m.QUEUED)
         credentials = m.ExternalCredentials.objects.create(
@@ -73,28 +82,270 @@ class DeleteAccountsCommandTestCase(TransactionTestCase, IasoTestCaseMixin):
         api_import = APIImport.objects.create(json_body={}, headers={"QUERY_STRING": f"app_id={project.app_id}"})
         modification = Modification.objects.create(
             content_type=ContentType.objects.get_for_model(m.Instance),
-            object_id=str(instance.pk),
+            object_id=str(instances[0].pk),
             past_value={},
             new_value={},
             source="test",
         )
+
+        # Global catalog-style models: no real FK to account/project at all, only ever
+        # linked via M2M — the link disappears with the account, the catalog entry itself
+        # (shared across every account) survives.
+        account_feature_flag = m.AccountFeatureFlag.objects.create(name=f"aff_{suffix}", code=f"aff_{suffix}")
+        account.feature_flags.add(account_feature_flag)
+        feature_flag = m.FeatureFlag.objects.create(name=f"ff_{suffix}", code=f"ff_{suffix}")
+        project_feature_flags = m.ProjectFeatureFlags.objects.create(featureflag=feature_flag, project=project)
+        config = Config.objects.create(slug=f"config-{suffix}", content={})
+        openhexa_instance = m.OpenHEXAInstance.objects.create(
+            name=f"openhexa_instance_{suffix}", url="https://openhexa.example.test", token="tok"
+        )
+        openhexa_workspace = m.OpenHEXAWorkspace.objects.create(
+            openhexa_instance=openhexa_instance, account=account, slug=f"workspace-{suffix}"
+        )
+
+        device = m.Device.objects.create(imei=f"imei_{suffix}")
+        device.projects.set([project])
+        device_ownership = m.DeviceOwnership.objects.create(device=device, project=project, user=user)
+        device_position = m.DevicePosition.objects.create(
+            device=device,
+            location=Point(0, 0, 0, srid=4326),
+            transport=m.DevicePosition.CAR,
+            accuracy=Decimal("1.5"),
+            captured_at=timezone.now(),
+        )
+
+        matching_algorithm = m.MatchingAlgorithm.objects.create(name=f"algo_{suffix}", description="test")
+        matching_algorithm.projects.set([project])
+        record_type = m.RecordType.objects.create(name=f"record_type_{suffix}", description="test")
+        record_type.projects.set([project])
+        record = m.Record.objects.create(
+            value=Decimal("1"), version=source_version, org_unit=org_unit_child, record_type=record_type
+        )
+        algorithm_run = m.AlgorithmRun.objects.create(
+            algorithm=matching_algorithm, version_1=source_version, version_2=source_version
+        )
+        link = m.Link.objects.create(destination=org_unit_child, source=org_unit_parent, algorithm_run=algorithm_run)
+
+        group = m.Group.objects.create(name=f"group_{suffix}", source_version=source_version)
+        group.org_units.set([org_unit_child])
+        group_set = m.GroupSet.objects.create(name=f"group_set_{suffix}", source_version=source_version)
+        group_set.groups.set([group])
+
+        mapping = m.Mapping.objects.create(
+            name=f"mapping_{suffix}", data_source=data_source, form=form, mapping_type=m.AGGREGATE
+        )
+        form_version = m.FormVersion.objects.create(form=form, file="test.xml", version_id="v1", form_descriptor={})
+        mapping_version = m.MappingVersion.objects.create(
+            form_version=form_version, mapping=mapping, name=f"mv_{suffix}", json={}
+        )
+        form_predefined_filter = m.FormPredefinedFilter.objects.create(
+            form=form, name=f"filter_{suffix}", short_name=f"f_{suffix}", json_logic={}
+        )
+        form_attachment = m.FormAttachment.objects.create(form=form, name=f"attachment_{suffix}", file="test.txt")
+        temporary_form = m.TemporaryForm.objects.create(xls_file="form_ai/test.xlsx", user=user, account=account)
+        import_gpkg = m.ImportGPKG.objects.create(file="test.gpkg", data_source=data_source)
+
+        instance_file = m.InstanceFile.objects.create(instance=instances[0], name="file", file="test_file.jpg")
+        instance_lock = m.InstanceLock.objects.create(
+            instance=instances[0], locked_by=user, top_org_unit=org_unit_parent
+        )
+
+        json_data_store = JsonDataStore.objects.create(
+            slug=f"jds-{suffix}", content={}, account=account, org_unit=org_unit_child
+        )
+
+        metric_type = m.MetricType.objects.create(account=account, name=f"metric_{suffix}", code=f"metric_{suffix}")
+        metric_value = m.MetricValue.objects.create(
+            metric_type=metric_type, org_unit=org_unit_child, year=2024, value=1.0
+        )
+
+        org_unit_reference_instance = m.OrgUnitReferenceInstance.objects.create(
+            org_unit=org_unit_child, form=form, instance=instances[0]
+        )
+        org_unit_change_request = m.OrgUnitChangeRequest.objects.create(org_unit=org_unit_child)
+        org_unit_change_request_configuration = m.OrgUnitChangeRequestConfiguration.objects.create(
+            project=project, org_unit_type=org_unit_type, type="creation"
+        )
+
+        page = m.Page.objects.create(name=f"page_{suffix}", slug=f"page-{suffix}", account=account)
+
+        payment_lot = m.PaymentLot.objects.create(name=f"payment_lot_{suffix}", created_by=user, task=task)
+        payment = m.Payment.objects.create(user=user, payment_lot=payment_lot)
+        potential_payment = m.PotentialPayment.objects.create(user=user, payment_lot=payment_lot, task=task)
+
+        report_version = m.ReportVersion.objects.create(
+            file="report.pdf", name=f"report_version_{suffix}", created_by=user
+        )
+        report = m.Report.objects.create(name=f"report_{suffix}", published_version=report_version, project=project)
+
+        stock_keeping_unit = m.StockKeepingUnit.objects.create(
+            name=f"sku_{suffix}", short_name=f"sku_{suffix}", account=account
+        )
+        stock_keeping_unit.projects.set([project])
+        stock_keeping_unit_children = m.StockKeepingUnitChildren.objects.create(
+            parent=stock_keeping_unit, child=stock_keeping_unit, value=1
+        )
+        stock_item = m.StockItem.objects.create(org_unit=org_unit_child, sku=stock_keeping_unit)
+        stock_rules_version = m.StockRulesVersion.objects.create(account=account, name=f"stock_rules_{suffix}")
+        stock_item_rule = m.StockItemRule.objects.create(
+            sku=stock_keeping_unit, form=form, question="q1", version=stock_rules_version
+        )
+        stock_ledger_item = m.StockLedgerItem.objects.create(
+            sku=stock_keeping_unit,
+            org_unit=org_unit_child,
+            rule=stock_item_rule,
+            submission=instances[0],
+            value=1,
+            created_by=user,
+            created_at=timezone.now(),
+        )
+
+        storage_device = m.StorageDevice.objects.create(
+            customer_chosen_id=f"nfc_{suffix}", account=account, type=m.StorageDevice.NFC
+        )
+        storage_log_entry = m.StorageLogEntry.objects.create(
+            device=storage_device,
+            operation_type=m.StorageLogEntry.READ,
+            performed_at=timezone.now(),
+            performed_by=user,
+        )
+        storage_password = m.StoragePassword.objects.create(password="secret", project=project)
+
+        task_log = m.TaskLog.objects.create(task=task, message="log message")
+
+        user_model = get_user_model()
+        main_user = user_model.objects.create(username=f"main_user_{suffix}")
+        tenant_user = m.TenantUser.objects.create(main_user=main_user, account_user=user)
+
+        auth_group = AuthGroup.objects.create(name=f"auth_group_{suffix}")
+        user_role = m.UserRole.objects.create(account=account, group=auth_group)
+
+        workflow = m.Workflow.objects.create(entity_type=entity_type)
+        workflow_version = m.WorkflowVersion.objects.create(workflow=workflow, name=f"wfv_{suffix}")
+        workflow_followup = m.WorkflowFollowup.objects.create(workflow_version=workflow_version)
+        workflow_followup.forms.set([form])
+        workflow_change = m.WorkflowChange.objects.create(form=form, workflow_version=workflow_version)
+
+        validation_workflow = m.ValidationWorkflow.objects.create(account=account, name=f"validation_workflow_{suffix}")
+        validation_node_template = m.ValidationNodeTemplate.objects.create(
+            workflow=validation_workflow, name=f"validation_node_template_{suffix}"
+        )
+        validation_node = m.ValidationNode.objects.create(instance=instances[0], node=validation_node_template)
+
+        comment_iaso = m.CommentIaso.objects.create(
+            content_type=ContentType.objects.get_for_model(m.OrgUnit),
+            object_pk=str(org_unit_child.pk),
+            site=Site.objects.get_current(),
+            comment="test comment",
+            user=user,
+        )
+
+        entity_duplicate_analyzis = m.EntityDuplicateAnalyzis.objects.create(task=task)
+        entity_duplicate = m.EntityDuplicate.objects.create(entity1=entity, entity2=entity_2)
+
+        other_source_version = m.SourceVersion.objects.create(data_source=data_source, number=2)
+        data_source_versions_synchronization = m.DataSourceVersionsSynchronization.objects.create(
+            name=f"dsvs_{suffix}",
+            source_version_to_update=source_version,
+            source_version_to_compare_with=other_source_version,
+            account=account,
+        )
+        bulk_create_user_file = m.BulkCreateUserFile.objects.create(file="test.csv", created_by=user, account=account)
+
+        export_request = m.ExportRequest.objects.create(
+            instance_count=0, exported_count=0, errored_count=0, last_error_message=""
+        )
+        export_status = m.ExportStatus.objects.create(
+            export_request=export_request, instance=instances[0], mapping_version=mapping_version
+        )
+        export_log = m.ExportLog.objects.create()
+        export_status.export_logs.set([export_log])
 
         return {
             "org_unit_type": org_unit_type,
             "org_unit_parent": org_unit_parent,
             "org_unit_child": org_unit_child,
             "form": form,
-            "instance": instance,
+            "instances": instances,
             "entity_type": entity_type,
             "entity": entity,
+            "entity_2": entity_2,
             "user": user,
+            "profile": profile,
             "team": team,
             "planning": planning,
             "sampling_result": sampling_result,
+            "assignment": assignment,
             "task": task,
             "credentials": credentials,
             "api_import": api_import,
             "modification": modification,
+            "account_feature_flag": account_feature_flag,
+            "feature_flag": feature_flag,
+            "project_feature_flags": project_feature_flags,
+            "config": config,
+            "openhexa_instance": openhexa_instance,
+            "openhexa_workspace": openhexa_workspace,
+            "device": device,
+            "device_ownership": device_ownership,
+            "device_position": device_position,
+            "matching_algorithm": matching_algorithm,
+            "record_type": record_type,
+            "record": record,
+            "algorithm_run": algorithm_run,
+            "link": link,
+            "group": group,
+            "group_set": group_set,
+            "mapping": mapping,
+            "form_version": form_version,
+            "mapping_version": mapping_version,
+            "form_predefined_filter": form_predefined_filter,
+            "form_attachment": form_attachment,
+            "temporary_form": temporary_form,
+            "import_gpkg": import_gpkg,
+            "instance_file": instance_file,
+            "instance_lock": instance_lock,
+            "json_data_store": json_data_store,
+            "metric_type": metric_type,
+            "metric_value": metric_value,
+            "org_unit_reference_instance": org_unit_reference_instance,
+            "org_unit_change_request": org_unit_change_request,
+            "org_unit_change_request_configuration": org_unit_change_request_configuration,
+            "page": page,
+            "payment_lot": payment_lot,
+            "payment": payment,
+            "potential_payment": potential_payment,
+            "report_version": report_version,
+            "report": report,
+            "stock_keeping_unit": stock_keeping_unit,
+            "stock_keeping_unit_children": stock_keeping_unit_children,
+            "stock_item": stock_item,
+            "stock_rules_version": stock_rules_version,
+            "stock_item_rule": stock_item_rule,
+            "stock_ledger_item": stock_ledger_item,
+            "storage_device": storage_device,
+            "storage_log_entry": storage_log_entry,
+            "storage_password": storage_password,
+            "task_log": task_log,
+            "main_user": main_user,
+            "tenant_user": tenant_user,
+            "auth_group": auth_group,
+            "user_role": user_role,
+            "workflow": workflow,
+            "workflow_version": workflow_version,
+            "workflow_followup": workflow_followup,
+            "workflow_change": workflow_change,
+            "validation_workflow": validation_workflow,
+            "validation_node_template": validation_node_template,
+            "validation_node": validation_node,
+            "comment_iaso": comment_iaso,
+            "entity_duplicate_analyzis": entity_duplicate_analyzis,
+            "entity_duplicate": entity_duplicate,
+            "data_source_versions_synchronization": data_source_versions_synchronization,
+            "bulk_create_user_file": bulk_create_user_file,
+            "export_request": export_request,
+            "export_status": export_status,
+            "export_log": export_log,
         }
 
     def _create_unscoped_data(self):
@@ -148,31 +399,115 @@ class DeleteAccountsCommandTestCase(TransactionTestCase, IasoTestCaseMixin):
         data_source,
         source_version,
         project,
-        populated,
+        other_models,
         mode,
         pre_deletion_orphans=None,
         post_deletion_only_orphans=None,
     ):
         self.assertFalse(m.Account.objects.filter(pk=account.pk).exists())
+        self.assertFalse(m.AccountFeatureFlag.objects.filter(pk=other_models["account_feature_flag"].pk).exists())
+        self.assertFalse(m.AlgorithmRun.objects.filter(pk=other_models["algorithm_run"].pk).exists())
+        self.assertFalse(Assignment.objects.filter(pk=other_models["assignment"].pk).exists())
+        self.assertFalse(m.BulkCreateUserFile.objects.filter(pk=other_models["bulk_create_user_file"].pk).exists())
+        self.assertFalse(m.CommentIaso.objects.filter(pk=other_models["comment_iaso"].pk).exists())
         self.assertFalse(m.DataSource.objects.filter(pk=data_source.pk).exists())
-        self.assertFalse(m.SourceVersion.objects.filter(pk=source_version.pk).exists())
-        self.assertFalse(m.Project.objects.filter(pk=project.pk).exists())
         self.assertFalse(
-            m.OrgUnit.objects.filter(pk__in=[populated["org_unit_parent"].pk, populated["org_unit_child"].pk]).exists()
+            m.DataSourceVersionsSynchronization.objects.filter(
+                pk=other_models["data_source_versions_synchronization"].pk
+            ).exists()
         )
-        self.assertFalse(m.Instance.objects.filter(pk=populated["instance"].pk).exists())
-        self.assertFalse(m.EntityType.objects.filter(pk=populated["entity_type"].pk).exists())
-        self.assertFalse(m.Entity.objects_include_deleted.filter(pk=populated["entity"].pk).exists())
-        self.assertFalse(m.User.objects.filter(pk=populated["user"].pk).exists())
-        self.assertFalse(m.Team.objects.filter(pk=populated["team"].pk).exists())
-        self.assertFalse(m.Planning.objects.filter(pk=populated["planning"].pk).exists())
-        self.assertFalse(PlanningSamplingResult.objects.filter(pk=populated["sampling_result"].pk).exists())
-        self.assertFalse(m.Task.objects.filter(pk=populated["task"].pk).exists())
-        self.assertFalse(m.ExternalCredentials.objects.filter(pk=populated["credentials"].pk).exists())
-        self.assertFalse(APIImport.objects.filter(pk=populated["api_import"].pk).exists())
-        self.assertFalse(m.Form.objects_include_deleted.filter(pk=populated["form"].pk).exists())
-        self.assertFalse(Modification.objects.filter(pk=populated["modification"].pk).exists())
-        self.assertFalse(m.OrgUnitType.objects.filter(pk=populated["org_unit_type"].pk).exists())
+        self.assertFalse(m.Device.objects.filter(pk=other_models["device"].pk).exists())
+        self.assertFalse(m.DeviceOwnership.objects.filter(pk=other_models["device_ownership"].pk).exists())
+        self.assertFalse(m.DevicePosition.objects.filter(pk=other_models["device_position"].pk).exists())
+        self.assertFalse(m.Entity.objects_include_deleted.filter(pk=other_models["entity"].pk).exists())
+        self.assertFalse(m.Entity.objects_include_deleted.filter(pk=other_models["entity_2"].pk).exists())
+        self.assertFalse(m.EntityDuplicate.objects.filter(pk=other_models["entity_duplicate"].pk).exists())
+        self.assertFalse(
+            m.EntityDuplicateAnalyzis.objects.filter(pk=other_models["entity_duplicate_analyzis"].pk).exists()
+        )
+        self.assertFalse(m.EntityType.objects.filter(pk=other_models["entity_type"].pk).exists())
+        self.assertFalse(m.ExportLog.objects.filter(pk=other_models["export_log"].pk).exists())
+        self.assertFalse(m.ExportRequest.objects.filter(pk=other_models["export_request"].pk).exists())
+        self.assertFalse(m.ExportStatus.objects.filter(pk=other_models["export_status"].pk).exists())
+        self.assertFalse(m.ExternalCredentials.objects.filter(pk=other_models["credentials"].pk).exists())
+        # FeatureFlags are global and never deleted
+        self.assertTrue(m.FeatureFlag.objects.filter(pk=other_models["feature_flag"].pk).exists())
+        self.assertFalse(m.Form.objects_include_deleted.filter(pk=other_models["form"].pk).exists())
+        self.assertFalse(m.FormAttachment.objects.filter(pk=other_models["form_attachment"].pk).exists())
+        self.assertFalse(m.FormPredefinedFilter.objects.filter(pk=other_models["form_predefined_filter"].pk).exists())
+        self.assertFalse(m.FormVersion.objects.filter(pk=other_models["form_version"].pk).exists())
+        self.assertFalse(m.Group.objects.filter(pk=other_models["group"].pk).exists())
+        self.assertFalse(m.GroupSet.objects.filter(pk=other_models["group_set"].pk).exists())
+        self.assertFalse(m.ImportGPKG.objects.filter(pk=other_models["import_gpkg"].pk).exists())
+        self.assertFalse(m.Instance.objects.filter(pk__in=[i.pk for i in other_models["instances"]]).exists())
+        self.assertFalse(m.InstanceFile.objects.filter(pk=other_models["instance_file"].pk).exists())
+        self.assertFalse(m.InstanceLock.objects.filter(pk=other_models["instance_lock"].pk).exists())
+        self.assertFalse(JsonDataStore.objects.filter(pk=other_models["json_data_store"].pk).exists())
+        self.assertFalse(m.Link.objects.filter(pk=other_models["link"].pk).exists())
+        self.assertFalse(m.Mapping.objects.filter(pk=other_models["mapping"].pk).exists())
+        self.assertFalse(m.MappingVersion.objects.filter(pk=other_models["mapping_version"].pk).exists())
+        self.assertFalse(m.MatchingAlgorithm.objects.filter(pk=other_models["matching_algorithm"].pk).exists())
+        self.assertFalse(m.MetricType.objects.filter(pk=other_models["metric_type"].pk).exists())
+        self.assertFalse(m.MetricValue.objects.filter(pk=other_models["metric_value"].pk).exists())
+        self.assertFalse(Modification.objects.filter(pk=other_models["modification"].pk).exists())
+        self.assertFalse(APIImport.objects.filter(pk=other_models["api_import"].pk).exists())
+        self.assertFalse(m.OpenHEXAWorkspace.objects.filter(pk=other_models["openhexa_workspace"].pk).exists())
+        self.assertFalse(
+            m.OrgUnit.objects.filter(
+                pk__in=[other_models["org_unit_parent"].pk, other_models["org_unit_child"].pk]
+            ).exists()
+        )
+        self.assertFalse(m.OrgUnitChangeRequest.objects.filter(pk=other_models["org_unit_change_request"].pk).exists())
+        self.assertFalse(
+            m.OrgUnitChangeRequestConfiguration.objects.filter(
+                pk=other_models["org_unit_change_request_configuration"].pk
+            ).exists()
+        )
+        self.assertFalse(
+            m.OrgUnitReferenceInstance.objects.filter(pk=other_models["org_unit_reference_instance"].pk).exists()
+        )
+        self.assertFalse(m.OrgUnitType.objects.filter(pk=other_models["org_unit_type"].pk).exists())
+        self.assertFalse(m.Page.objects.filter(pk=other_models["page"].pk).exists())
+        self.assertFalse(m.Payment.objects.filter(pk=other_models["payment"].pk).exists())
+        self.assertFalse(m.PaymentLot.objects.filter(pk=other_models["payment_lot"].pk).exists())
+        self.assertFalse(m.Planning.objects.filter(pk=other_models["planning"].pk).exists())
+        self.assertFalse(PlanningSamplingResult.objects.filter(pk=other_models["sampling_result"].pk).exists())
+        self.assertFalse(m.PotentialPayment.objects.filter(pk=other_models["potential_payment"].pk).exists())
+        self.assertFalse(m.Profile.objects.filter(pk=other_models["profile"].pk).exists())
+        self.assertFalse(m.Project.objects.filter(pk=project.pk).exists())
+        self.assertFalse(m.ProjectFeatureFlags.objects.filter(pk=other_models["project_feature_flags"].pk).exists())
+        self.assertFalse(m.Record.objects.filter(pk=other_models["record"].pk).exists())
+        self.assertFalse(m.RecordType.objects.filter(pk=other_models["record_type"].pk).exists())
+        self.assertFalse(m.Report.objects.filter(pk=other_models["report"].pk).exists())
+        self.assertFalse(m.ReportVersion.objects.filter(pk=other_models["report_version"].pk).exists())
+        self.assertFalse(m.SourceVersion.objects.filter(pk=source_version.pk).exists())
+        self.assertFalse(m.StockItem.objects.filter(pk=other_models["stock_item"].pk).exists())
+        self.assertFalse(m.StockItemRule.objects.filter(pk=other_models["stock_item_rule"].pk).exists())
+        self.assertFalse(m.StockKeepingUnit.objects.filter(pk=other_models["stock_keeping_unit"].pk).exists())
+        self.assertFalse(
+            m.StockKeepingUnitChildren.objects.filter(pk=other_models["stock_keeping_unit_children"].pk).exists()
+        )
+        self.assertFalse(m.StockLedgerItem.objects.filter(pk=other_models["stock_ledger_item"].pk).exists())
+        self.assertFalse(m.StockRulesVersion.objects.filter(pk=other_models["stock_rules_version"].pk).exists())
+        self.assertFalse(m.StorageDevice.objects.filter(pk=other_models["storage_device"].pk).exists())
+        self.assertFalse(m.StorageLogEntry.objects.filter(pk=other_models["storage_log_entry"].pk).exists())
+        self.assertFalse(m.StoragePassword.objects.filter(pk=other_models["storage_password"].pk).exists())
+        self.assertFalse(m.Task.objects.filter(pk=other_models["task"].pk).exists())
+        self.assertFalse(m.TaskLog.objects.filter(pk=other_models["task_log"].pk).exists())
+        self.assertFalse(m.Team.objects.filter(pk=other_models["team"].pk).exists())
+        self.assertFalse(m.TemporaryForm.objects.filter(pk=other_models["temporary_form"].pk).exists())
+        self.assertFalse(m.TenantUser.objects.filter(pk=other_models["tenant_user"].pk).exists())
+        self.assertFalse(m.User.objects.filter(pk=other_models["user"].pk).exists())
+        self.assertFalse(m.UserRole.objects.filter(pk=other_models["user_role"].pk).exists())
+        self.assertFalse(m.ValidationNode.objects.filter(pk=other_models["validation_node"].pk).exists())
+        self.assertFalse(
+            m.ValidationNodeTemplate.objects.filter(pk=other_models["validation_node_template"].pk).exists()
+        )
+        self.assertFalse(m.ValidationWorkflow.objects.filter(pk=other_models["validation_workflow"].pk).exists())
+        self.assertFalse(m.Workflow.objects.filter(pk=other_models["workflow"].pk).exists())
+        self.assertFalse(m.WorkflowChange.objects.filter(pk=other_models["workflow_change"].pk).exists())
+        self.assertFalse(m.WorkflowFollowup.objects.filter(pk=other_models["workflow_followup"].pk).exists())
+        self.assertFalse(m.WorkflowVersion.objects.filter(pk=other_models["workflow_version"].pk).exists())
 
         # Everything below depends on whether `_post_deletion_clean_up` ran, which is
         # exclusive to --account-to-keep mode.
@@ -184,22 +519,24 @@ class DeleteAccountsCommandTestCase(TransactionTestCase, IasoTestCaseMixin):
             self.assertFalse(m.OrgUnit.objects.filter(pk=pre_deletion_orphans["org_unit_no_version"].pk).exists())
 
         if post_deletion_only_orphans is not None:
+            assertion(APIImport.objects.filter(pk=post_deletion_only_orphans["api_import_no_app_id"].pk).exists())
+            assertion(Config.objects.filter(pk=other_models["config"].pk).exists())
+            assertion(m.DataSource.objects.filter(pk=post_deletion_only_orphans["data_source_no_project"].pk).exists())
+            assertion(m.Device.objects.filter(pk=post_deletion_only_orphans["device_no_project"].pk).exists())
+            assertion(m.ExportLog.objects.filter(pk=post_deletion_only_orphans["export_log_orphan"].pk).exists())
+            assertion(
+                m.ExportRequest.objects.filter(pk=post_deletion_only_orphans["export_request_orphan"].pk).exists()
+            )
             assertion(
                 m.Form.objects_include_deleted.filter(pk=post_deletion_only_orphans["form_no_project"].pk).exists()
             )
             assertion(
                 m.Form.objects_include_deleted.filter(pk=post_deletion_only_orphans["form_no_form_id"].pk).exists()
             )
-            assertion(m.Device.objects.filter(pk=post_deletion_only_orphans["device_no_project"].pk).exists())
-            assertion(Session.objects.filter(pk=post_deletion_only_orphans["session"].pk).exists())
-            assertion(m.DataSource.objects.filter(pk=post_deletion_only_orphans["data_source_no_project"].pk).exists())
-            assertion(APIImport.objects.filter(pk=post_deletion_only_orphans["api_import_no_app_id"].pk).exists())
-            assertion(m.Project.objects.filter(pk=post_deletion_only_orphans["project_no_account"].pk).exists())
-            assertion(m.ExportLog.objects.filter(pk=post_deletion_only_orphans["export_log_orphan"].pk).exists())
-            assertion(
-                m.ExportRequest.objects.filter(pk=post_deletion_only_orphans["export_request_orphan"].pk).exists()
-            )
             assertion(Modification.objects.filter(pk=post_deletion_only_orphans["modification_orphan"].pk).exists())
+            assertion(m.OpenHEXAInstance.objects.filter(pk=other_models["openhexa_instance"].pk).exists())
+            assertion(m.Project.objects.filter(pk=post_deletion_only_orphans["project_no_account"].pk).exists())
+            assertion(Session.objects.filter(pk=post_deletion_only_orphans["session"].pk).exists())
 
     def _assert_account_and_related_data_intact(
         self,
@@ -207,29 +544,122 @@ class DeleteAccountsCommandTestCase(TransactionTestCase, IasoTestCaseMixin):
         data_source,
         source_version,
         project,
-        populated,
+        other_models,
+        mode=None,
         pre_deletion_orphans=None,
         post_deletion_only_orphans=None,
     ):
         self.assertTrue(m.Account.objects.filter(pk=account.pk).exists())
+        self.assertTrue(m.AccountFeatureFlag.objects.filter(pk=other_models["account_feature_flag"].pk).exists())
+        self.assertTrue(m.AlgorithmRun.objects.filter(pk=other_models["algorithm_run"].pk).exists())
+        self.assertTrue(APIImport.objects.filter(pk=other_models["api_import"].pk).exists())
+        self.assertTrue(Assignment.objects.filter(pk=other_models["assignment"].pk).exists())
+        self.assertTrue(m.BulkCreateUserFile.objects.filter(pk=other_models["bulk_create_user_file"].pk).exists())
+        self.assertTrue(m.CommentIaso.objects.filter(pk=other_models["comment_iaso"].pk).exists())
         self.assertTrue(m.DataSource.objects.filter(pk=data_source.pk).exists())
-        self.assertTrue(m.SourceVersion.objects.filter(pk=source_version.pk).exists())
+        self.assertTrue(
+            m.DataSourceVersionsSynchronization.objects.filter(
+                pk=other_models["data_source_versions_synchronization"].pk
+            ).exists()
+        )
+        self.assertTrue(m.Device.objects.filter(pk=other_models["device"].pk).exists())
+        self.assertTrue(m.DeviceOwnership.objects.filter(pk=other_models["device_ownership"].pk).exists())
+        self.assertTrue(m.DevicePosition.objects.filter(pk=other_models["device_position"].pk).exists())
+        self.assertTrue(m.Entity.objects_include_deleted.filter(pk=other_models["entity"].pk).exists())
+        self.assertTrue(m.Entity.objects_include_deleted.filter(pk=other_models["entity_2"].pk).exists())
+        self.assertTrue(m.EntityDuplicate.objects.filter(pk=other_models["entity_duplicate"].pk).exists())
+        self.assertTrue(
+            m.EntityDuplicateAnalyzis.objects.filter(pk=other_models["entity_duplicate_analyzis"].pk).exists()
+        )
+        self.assertTrue(m.EntityType.objects.filter(pk=other_models["entity_type"].pk).exists())
+        self.assertTrue(m.ExportLog.objects.filter(pk=other_models["export_log"].pk).exists())
+        self.assertTrue(m.ExportRequest.objects.filter(pk=other_models["export_request"].pk).exists())
+        self.assertTrue(m.ExportStatus.objects.filter(pk=other_models["export_status"].pk).exists())
+        self.assertTrue(m.ExternalCredentials.objects.filter(pk=other_models["credentials"].pk).exists())
+        self.assertTrue(m.FeatureFlag.objects.filter(pk=other_models["feature_flag"].pk).exists())
+        self.assertTrue(m.Form.objects_include_deleted.filter(pk=other_models["form"].pk).exists())
+        self.assertTrue(m.FormAttachment.objects.filter(pk=other_models["form_attachment"].pk).exists())
+        self.assertTrue(m.FormPredefinedFilter.objects.filter(pk=other_models["form_predefined_filter"].pk).exists())
+        self.assertTrue(m.FormVersion.objects.filter(pk=other_models["form_version"].pk).exists())
+        self.assertTrue(m.Group.objects.filter(pk=other_models["group"].pk).exists())
+        self.assertTrue(m.GroupSet.objects.filter(pk=other_models["group_set"].pk).exists())
+        self.assertTrue(m.ImportGPKG.objects.filter(pk=other_models["import_gpkg"].pk).exists())
+        self.assertEqual(
+            m.Instance.objects.filter(pk__in=[i.pk for i in other_models["instances"]]).count(),
+            len(other_models["instances"]),
+        )
+        self.assertTrue(m.InstanceFile.objects.filter(pk=other_models["instance_file"].pk).exists())
+        self.assertTrue(m.InstanceLock.objects.filter(pk=other_models["instance_lock"].pk).exists())
+        self.assertTrue(JsonDataStore.objects.filter(pk=other_models["json_data_store"].pk).exists())
+        self.assertTrue(m.Link.objects.filter(pk=other_models["link"].pk).exists())
+        self.assertTrue(m.Mapping.objects.filter(pk=other_models["mapping"].pk).exists())
+        self.assertTrue(m.MappingVersion.objects.filter(pk=other_models["mapping_version"].pk).exists())
+        self.assertTrue(m.MatchingAlgorithm.objects.filter(pk=other_models["matching_algorithm"].pk).exists())
+        self.assertTrue(m.MetricType.objects.filter(pk=other_models["metric_type"].pk).exists())
+        self.assertTrue(m.MetricValue.objects.filter(pk=other_models["metric_value"].pk).exists())
+        self.assertTrue(Modification.objects.filter(pk=other_models["modification"].pk).exists())
+        self.assertTrue(m.OpenHEXAInstance.objects.filter(pk=other_models["openhexa_instance"].pk).exists())
+        self.assertTrue(m.OpenHEXAWorkspace.objects.filter(pk=other_models["openhexa_workspace"].pk).exists())
+        self.assertTrue(m.OrgUnit.objects.filter(pk=other_models["org_unit_parent"].pk).exists())
+        self.assertTrue(m.OrgUnit.objects.filter(pk=other_models["org_unit_child"].pk).exists())
+        self.assertTrue(m.OrgUnitChangeRequest.objects.filter(pk=other_models["org_unit_change_request"].pk).exists())
+        self.assertTrue(
+            m.OrgUnitChangeRequestConfiguration.objects.filter(
+                pk=other_models["org_unit_change_request_configuration"].pk
+            ).exists()
+        )
+        self.assertTrue(
+            m.OrgUnitReferenceInstance.objects.filter(pk=other_models["org_unit_reference_instance"].pk).exists()
+        )
+        self.assertTrue(m.OrgUnitType.objects.filter(pk=other_models["org_unit_type"].pk).exists())
+        self.assertTrue(m.Page.objects.filter(pk=other_models["page"].pk).exists())
+        self.assertTrue(m.Payment.objects.filter(pk=other_models["payment"].pk).exists())
+        self.assertTrue(m.PaymentLot.objects.filter(pk=other_models["payment_lot"].pk).exists())
+        self.assertTrue(m.Planning.objects.filter(pk=other_models["planning"].pk).exists())
+        self.assertTrue(PlanningSamplingResult.objects.filter(pk=other_models["sampling_result"].pk).exists())
+        self.assertTrue(m.PotentialPayment.objects.filter(pk=other_models["potential_payment"].pk).exists())
+        self.assertTrue(m.Profile.objects.filter(pk=other_models["profile"].pk).exists())
         self.assertTrue(m.Project.objects.filter(pk=project.pk).exists())
-        self.assertTrue(m.OrgUnit.objects.filter(pk=populated["org_unit_parent"].pk).exists())
-        self.assertTrue(m.OrgUnit.objects.filter(pk=populated["org_unit_child"].pk).exists())
-        self.assertTrue(m.Form.objects_include_deleted.filter(pk=populated["form"].pk).exists())
-        self.assertTrue(m.Instance.objects.filter(pk=populated["instance"].pk).exists())
-        self.assertTrue(m.EntityType.objects.filter(pk=populated["entity_type"].pk).exists())
-        self.assertTrue(m.Entity.objects_include_deleted.filter(pk=populated["entity"].pk).exists())
-        self.assertTrue(m.User.objects.filter(pk=populated["user"].pk).exists())
-        self.assertTrue(m.Team.objects.filter(pk=populated["team"].pk).exists())
-        self.assertTrue(m.Planning.objects.filter(pk=populated["planning"].pk).exists())
-        self.assertTrue(PlanningSamplingResult.objects.filter(pk=populated["sampling_result"].pk).exists())
-        self.assertTrue(m.Task.objects.filter(pk=populated["task"].pk).exists())
-        self.assertTrue(m.ExternalCredentials.objects.filter(pk=populated["credentials"].pk).exists())
-        self.assertTrue(APIImport.objects.filter(pk=populated["api_import"].pk).exists())
-        self.assertTrue(Modification.objects.filter(pk=populated["modification"].pk).exists())
-        self.assertTrue(m.OrgUnitType.objects.filter(pk=populated["org_unit_type"].pk).exists())
+        self.assertTrue(m.ProjectFeatureFlags.objects.filter(pk=other_models["project_feature_flags"].pk).exists())
+        self.assertTrue(m.Record.objects.filter(pk=other_models["record"].pk).exists())
+        self.assertTrue(m.RecordType.objects.filter(pk=other_models["record_type"].pk).exists())
+        self.assertTrue(m.Report.objects.filter(pk=other_models["report"].pk).exists())
+        self.assertTrue(m.ReportVersion.objects.filter(pk=other_models["report_version"].pk).exists())
+        self.assertTrue(m.SourceVersion.objects.filter(pk=source_version.pk).exists())
+        self.assertTrue(m.StockItem.objects.filter(pk=other_models["stock_item"].pk).exists())
+        self.assertTrue(m.StockItemRule.objects.filter(pk=other_models["stock_item_rule"].pk).exists())
+        self.assertTrue(m.StockKeepingUnit.objects.filter(pk=other_models["stock_keeping_unit"].pk).exists())
+        self.assertTrue(
+            m.StockKeepingUnitChildren.objects.filter(pk=other_models["stock_keeping_unit_children"].pk).exists()
+        )
+        self.assertTrue(m.StockLedgerItem.objects.filter(pk=other_models["stock_ledger_item"].pk).exists())
+        self.assertTrue(m.StockRulesVersion.objects.filter(pk=other_models["stock_rules_version"].pk).exists())
+        self.assertTrue(m.StorageDevice.objects.filter(pk=other_models["storage_device"].pk).exists())
+        self.assertTrue(m.StorageLogEntry.objects.filter(pk=other_models["storage_log_entry"].pk).exists())
+        self.assertTrue(m.StoragePassword.objects.filter(pk=other_models["storage_password"].pk).exists())
+        self.assertTrue(m.Task.objects.filter(pk=other_models["task"].pk).exists())
+        self.assertTrue(m.TaskLog.objects.filter(pk=other_models["task_log"].pk).exists())
+        self.assertTrue(m.Team.objects.filter(pk=other_models["team"].pk).exists())
+        self.assertTrue(m.TemporaryForm.objects.filter(pk=other_models["temporary_form"].pk).exists())
+        self.assertTrue(m.TenantUser.objects.filter(pk=other_models["tenant_user"].pk).exists())
+        self.assertTrue(m.User.objects.filter(pk=other_models["user"].pk).exists())
+        self.assertTrue(m.UserRole.objects.filter(pk=other_models["user_role"].pk).exists())
+        self.assertTrue(m.ValidationNode.objects.filter(pk=other_models["validation_node"].pk).exists())
+        self.assertTrue(
+            m.ValidationNodeTemplate.objects.filter(pk=other_models["validation_node_template"].pk).exists()
+        )
+        self.assertTrue(m.ValidationWorkflow.objects.filter(pk=other_models["validation_workflow"].pk).exists())
+        self.assertTrue(m.Workflow.objects.filter(pk=other_models["workflow"].pk).exists())
+        self.assertTrue(m.WorkflowChange.objects.filter(pk=other_models["workflow_change"].pk).exists())
+        self.assertTrue(m.WorkflowFollowup.objects.filter(pk=other_models["workflow_followup"].pk).exists())
+        self.assertTrue(m.WorkflowVersion.objects.filter(pk=other_models["workflow_version"].pk).exists())
+
+        # some models have no FK to Account at all — `_post_deletion_clean_up`
+        # wipes them in full whenever it runs, regardless of which account "owns" them in this
+        # test's fixtures. It only runs for real (non-dry-run) --account-to-keep mode.
+        post_deletion_cleanup_ran = mode == MODE_KEEP_SINGLE_ACCOUNT
+        assertion = self.assertFalse if post_deletion_cleanup_ran else self.assertTrue
+        assertion(Config.objects.filter(pk=other_models["config"].pk).exists())
 
         if pre_deletion_orphans is not None:
             self.assertTrue(m.Instance.objects.filter(pk=pre_deletion_orphans["instance_no_form"].pk).exists())
@@ -294,6 +724,12 @@ class DeleteAccountsCommandTestCase(TransactionTestCase, IasoTestCaseMixin):
 
     def test_dry_run_delete_accounts_mode_does_not_delete_anything(self):
         pre_deletion_orphans, post_deletion_only_orphans = self._create_unscoped_data()
+        extra_models_to_keep = self._populate_account(
+            self.account_to_keep, self.version_to_keep, self.project_to_keep, suffix="kept"
+        )
+        extra_models_to_delete = self._populate_account(
+            self.account_to_delete, self.version_to_delete, self.project_to_delete, suffix="deleted"
+        )
 
         management.call_command(
             "delete_accounts",
@@ -307,16 +743,26 @@ class DeleteAccountsCommandTestCase(TransactionTestCase, IasoTestCaseMixin):
             self.data_source_to_delete,
             self.version_to_delete,
             self.project_to_delete,
-            self.deleted,
+            extra_models_to_delete,
             pre_deletion_orphans=pre_deletion_orphans,
             post_deletion_only_orphans=post_deletion_only_orphans,
         )
         self._assert_account_and_related_data_intact(
-            self.account_to_keep, self.data_source_to_keep, self.version_to_keep, self.project_to_keep, self.kept
+            self.account_to_keep,
+            self.data_source_to_keep,
+            self.version_to_keep,
+            self.project_to_keep,
+            extra_models_to_keep,
         )
 
     def test_dry_run_keep_single_account_mode_does_not_delete_anything(self):
         pre_deletion_orphans, post_deletion_only_orphans = self._create_unscoped_data()
+        extra_models_to_keep = self._populate_account(
+            self.account_to_keep, self.version_to_keep, self.project_to_keep, suffix="kept"
+        )
+        extra_models_to_delete = self._populate_account(
+            self.account_to_delete, self.version_to_delete, self.project_to_delete, suffix="deleted"
+        )
 
         management.call_command(
             "delete_accounts",
@@ -330,42 +776,66 @@ class DeleteAccountsCommandTestCase(TransactionTestCase, IasoTestCaseMixin):
             self.data_source_to_delete,
             self.version_to_delete,
             self.project_to_delete,
-            self.deleted,
+            extra_models_to_delete,
             pre_deletion_orphans=pre_deletion_orphans,
             post_deletion_only_orphans=post_deletion_only_orphans,
         )
         self._assert_account_and_related_data_intact(
-            self.account_to_keep, self.data_source_to_keep, self.version_to_keep, self.project_to_keep, self.kept
+            self.account_to_keep,
+            self.data_source_to_keep,
+            self.version_to_keep,
+            self.project_to_keep,
+            extra_models_to_keep,
         )
 
     def test_delete_specific_account(self):
         pre_deletion_orphans, post_deletion_only_orphans = self._create_unscoped_data()
+        extra_models_to_keep = self._populate_account(
+            self.account_to_keep, self.version_to_keep, self.project_to_keep, suffix="kept"
+        )
+        extra_models_to_delete = self._populate_account(
+            self.account_to_delete, self.version_to_delete, self.project_to_delete, suffix="deleted"
+        )
 
-        management.call_command("delete_accounts", accounts_to_delete=[self.account_to_delete.pk], verbosity=0)
+        # chunk_size=2 forces _delete_qs_in_chunks to loop across multiple chunks
+        # (5 Instance rows per account) instead of clearing everything in one pass.
+        management.call_command(
+            "delete_accounts", accounts_to_delete=[self.account_to_delete.pk], chunk_size=2, verbosity=0
+        )
 
         self._assert_account_and_related_data_gone(
             self.account_to_delete,
             self.data_source_to_delete,
             self.version_to_delete,
             self.project_to_delete,
-            self.deleted,
+            extra_models_to_delete,
             mode=MODE_DELETE_ACCOUNTS,
             pre_deletion_orphans=pre_deletion_orphans,
             post_deletion_only_orphans=post_deletion_only_orphans,
         )
         self._assert_account_and_related_data_intact(
-            self.account_to_keep, self.data_source_to_keep, self.version_to_keep, self.project_to_keep, self.kept
+            self.account_to_keep,
+            self.data_source_to_keep,
+            self.version_to_keep,
+            self.project_to_keep,
+            extra_models_to_keep,
         )
 
     def test_delete_multiple_specific_accounts(self):
+        pre_deletion_orphans, post_deletion_only_orphans = self._create_unscoped_data()
+        extra_models_to_keep = self._populate_account(
+            self.account_to_keep, self.version_to_keep, self.project_to_keep, suffix="kept"
+        )
+        extra_models_to_delete = self._populate_account(
+            self.account_to_delete, self.version_to_delete, self.project_to_delete, suffix="deleted"
+        )
+
         account_to_delete_2, data_source_to_delete_2, version_to_delete_2, project_to_delete_2 = (
             self.create_account_datasource_version_project("source deleted 2", "account deleted 2", "project deleted 2")
         )
-        deleted_2 = self._populate_account(
+        extra_models_to_delete_2 = self._populate_account(
             account_to_delete_2, version_to_delete_2, project_to_delete_2, suffix="deleted2"
         )
-
-        pre_deletion_orphans, post_deletion_only_orphans = self._create_unscoped_data()
 
         # call_command's list-kwarg support for action="append" only works for a single
         # value — passing multiple repeats the flag as separate argv-style args instead.
@@ -383,7 +853,7 @@ class DeleteAccountsCommandTestCase(TransactionTestCase, IasoTestCaseMixin):
             self.data_source_to_delete,
             self.version_to_delete,
             self.project_to_delete,
-            self.deleted,
+            extra_models_to_delete,
             mode=MODE_DELETE_ACCOUNTS,
             pre_deletion_orphans=pre_deletion_orphans,
             post_deletion_only_orphans=post_deletion_only_orphans,
@@ -393,15 +863,25 @@ class DeleteAccountsCommandTestCase(TransactionTestCase, IasoTestCaseMixin):
             data_source_to_delete_2,
             version_to_delete_2,
             project_to_delete_2,
-            deleted_2,
+            extra_models_to_delete_2,
             mode=MODE_DELETE_ACCOUNTS,
         )
         self._assert_account_and_related_data_intact(
-            self.account_to_keep, self.data_source_to_keep, self.version_to_keep, self.project_to_keep, self.kept
+            self.account_to_keep,
+            self.data_source_to_keep,
+            self.version_to_keep,
+            self.project_to_keep,
+            extra_models_to_keep,
         )
 
     def test_keep_single_account(self):
         pre_deletion_orphans, post_deletion_only_orphans = self._create_unscoped_data()
+        extra_models_to_keep = self._populate_account(
+            self.account_to_keep, self.version_to_keep, self.project_to_keep, suffix="kept"
+        )
+        extra_models_to_delete = self._populate_account(
+            self.account_to_delete, self.version_to_delete, self.project_to_delete, suffix="deleted"
+        )
 
         management.call_command("delete_accounts", account_to_keep=self.account_to_keep.pk, verbosity=0)
 
@@ -410,11 +890,16 @@ class DeleteAccountsCommandTestCase(TransactionTestCase, IasoTestCaseMixin):
             self.data_source_to_delete,
             self.version_to_delete,
             self.project_to_delete,
-            self.deleted,
+            extra_models_to_delete,
             mode=MODE_KEEP_SINGLE_ACCOUNT,
             pre_deletion_orphans=pre_deletion_orphans,
             post_deletion_only_orphans=post_deletion_only_orphans,
         )
         self._assert_account_and_related_data_intact(
-            self.account_to_keep, self.data_source_to_keep, self.version_to_keep, self.project_to_keep, self.kept
+            self.account_to_keep,
+            self.data_source_to_keep,
+            self.version_to_keep,
+            self.project_to_keep,
+            extra_models_to_keep,
+            mode=MODE_KEEP_SINGLE_ACCOUNT,
         )

--- a/iaso/tests/commands/test_delete_accounts.py
+++ b/iaso/tests/commands/test_delete_accounts.py
@@ -357,6 +357,49 @@ class DeleteAccountsCommandTestCase(TransactionTestCase, IasoTestCaseMixin):
             self.account_to_keep, self.data_source_to_keep, self.version_to_keep, self.project_to_keep, self.kept
         )
 
+    def test_delete_multiple_specific_accounts(self):
+        account_to_delete_2, data_source_to_delete_2, version_to_delete_2, project_to_delete_2 = (
+            self.create_account_datasource_version_project("source deleted 2", "account deleted 2", "project deleted 2")
+        )
+        deleted_2 = self._populate_account(
+            account_to_delete_2, version_to_delete_2, project_to_delete_2, suffix="deleted2"
+        )
+
+        pre_deletion_orphans, post_deletion_only_orphans = self._create_unscoped_data()
+
+        # call_command's list-kwarg support for action="append" only works for a single
+        # value — passing multiple repeats the flag as separate argv-style args instead.
+        management.call_command(
+            "delete_accounts",
+            "--account-to-delete",
+            str(self.account_to_delete.pk),
+            "--account-to-delete",
+            str(account_to_delete_2.pk),
+            verbosity=0,
+        )
+
+        self._assert_account_and_related_data_gone(
+            self.account_to_delete,
+            self.data_source_to_delete,
+            self.version_to_delete,
+            self.project_to_delete,
+            self.deleted,
+            mode=MODE_DELETE_ACCOUNTS,
+            pre_deletion_orphans=pre_deletion_orphans,
+            post_deletion_only_orphans=post_deletion_only_orphans,
+        )
+        self._assert_account_and_related_data_gone(
+            account_to_delete_2,
+            data_source_to_delete_2,
+            version_to_delete_2,
+            project_to_delete_2,
+            deleted_2,
+            mode=MODE_DELETE_ACCOUNTS,
+        )
+        self._assert_account_and_related_data_intact(
+            self.account_to_keep, self.data_source_to_keep, self.version_to_keep, self.project_to_keep, self.kept
+        )
+
     def test_keep_single_account(self):
         pre_deletion_orphans, post_deletion_only_orphans = self._create_unscoped_data()
 

--- a/iaso/tests/commands/test_delete_accounts.py
+++ b/iaso/tests/commands/test_delete_accounts.py
@@ -71,7 +71,15 @@ class DeleteAccountsCommandTestCase(TransactionTestCase, IasoTestCaseMixin):
         credentials = m.ExternalCredentials.objects.create(
             account=account, name=f"cred_{suffix}", login="login", password="pwd", url="http://example.com"
         )
+        # APIImport & Modification don't have any real FK to iaso models, but have some kind of FK
         api_import = APIImport.objects.create(json_body={}, headers={"QUERY_STRING": f"app_id={project.app_id}"})
+        modification = Modification.objects.create(
+            content_type=ContentType.objects.get_for_model(m.Instance),
+            object_id=str(instance.pk),
+            past_value={},
+            new_value={},
+            source="test",
+        )
 
         return {
             "org_unit_type": org_unit_type,
@@ -88,19 +96,16 @@ class DeleteAccountsCommandTestCase(TransactionTestCase, IasoTestCaseMixin):
             "task": task,
             "credentials": credentials,
             "api_import": api_import,
+            "modification": modification,
         }
 
     def _create_unscoped_data(self):
         """
-        Data with no usable link to any account, split by *when* the command cleans it up,
-        plus one dict of data that *does* belong to an account but through a link the
-        FK-graph BFS can't follow:
+        Data with no usable link to any account, split by *when* the command cleans it up:
         - "pre-deletion" orphans are swept by `_pre_deletion_clean_up`, which runs for both
           --account-to-delete and --account-to-keep.
         - "post-deletion" orphans are only swept by `_post_deletion_clean_up`, which runs
           exclusively in --account-to-keep mode (it assumes a single surviving account).
-        - "deleted account gap" data belongs to `self.account_to_delete`'s own records
-          (see the inline comment below for why it's tracked separately from the orphans).
         """
         pre_deletion_orphans = {
             "instance_no_form": m.Instance.objects.create(form=None),
@@ -136,24 +141,8 @@ class DeleteAccountsCommandTestCase(TransactionTestCase, IasoTestCaseMixin):
                 source="test",
             ),
         }
-        # Unlike the two dicts above, this data isn't unscoped — it belongs to
-        # `self.account_to_delete`'s own records, but only through a link the FK-graph
-        # BFS can't follow (M2M, or a GenericForeignKey with no DB-level FK at all — see
-        # `_MANUAL_CLEANUP_NOTES`), so it behaves differently across the three test modes.
-        deleted_account_gap_data = {
-            "api_import_for_deleted_account": APIImport.objects.create(
-                json_body={}, headers={"QUERY_STRING": f"app_id={self.project_to_delete.app_id}"}
-            ),
-            "modification_for_deleted_instance": Modification.objects.create(
-                content_type=ContentType.objects.get_for_model(m.Instance),
-                object_id=str(self.deleted["instance"].pk),
-                past_value={},
-                new_value={},
-                source="test",
-            ),
-        }
 
-        return pre_deletion_orphans, post_deletion_only_orphans, deleted_account_gap_data
+        return pre_deletion_orphans, post_deletion_only_orphans
 
     def _assert_org_unit_type_survives(self, populated):
         # OrgUnitType is linked to Project only through M2M and isn't even listed in
@@ -170,7 +159,6 @@ class DeleteAccountsCommandTestCase(TransactionTestCase, IasoTestCaseMixin):
         mode,
         pre_deletion_orphans=None,
         post_deletion_only_orphans=None,
-        gap_data=None,
     ):
         self.assertFalse(m.Account.objects.filter(pk=account.pk).exists())
         self.assertFalse(m.DataSource.objects.filter(pk=data_source.pk).exists())
@@ -190,6 +178,7 @@ class DeleteAccountsCommandTestCase(TransactionTestCase, IasoTestCaseMixin):
         self.assertFalse(m.ExternalCredentials.objects.filter(pk=populated["credentials"].pk).exists())
         self.assertFalse(APIImport.objects.filter(pk=populated["api_import"].pk).exists())
         self.assertFalse(m.Form.objects_include_deleted.filter(pk=populated["form"].pk).exists())
+        self.assertFalse(Modification.objects.filter(pk=populated["modification"].pk).exists())
 
         # Everything below depends on whether `_post_deletion_clean_up` ran, which is
         # exclusive to --account-to-keep mode.
@@ -218,12 +207,6 @@ class DeleteAccountsCommandTestCase(TransactionTestCase, IasoTestCaseMixin):
             )
             assertion(Modification.objects.filter(pk=post_deletion_only_orphans["modification_orphan"].pk).exists())
 
-        if gap_data is not None:
-            self.assertFalse(APIImport.objects.filter(pk=gap_data["api_import_for_deleted_account"].pk).exists())
-            # The dangling Modification is only caught by `_cleanup_modification_logs`,
-            # part of `_post_deletion_clean_up`.
-            assertion(Modification.objects.filter(pk=gap_data["modification_for_deleted_instance"].pk).exists())
-
     def _assert_account_and_related_data_intact(
         self,
         account,
@@ -233,7 +216,6 @@ class DeleteAccountsCommandTestCase(TransactionTestCase, IasoTestCaseMixin):
         populated,
         pre_deletion_orphans=None,
         post_deletion_only_orphans=None,
-        gap_data=None,
     ):
         self.assertTrue(m.Account.objects.filter(pk=account.pk).exists())
         self.assertTrue(m.DataSource.objects.filter(pk=data_source.pk).exists())
@@ -252,6 +234,7 @@ class DeleteAccountsCommandTestCase(TransactionTestCase, IasoTestCaseMixin):
         self.assertTrue(m.Task.objects.filter(pk=populated["task"].pk).exists())
         self.assertTrue(m.ExternalCredentials.objects.filter(pk=populated["credentials"].pk).exists())
         self.assertTrue(APIImport.objects.filter(pk=populated["api_import"].pk).exists())
+        self.assertTrue(Modification.objects.filter(pk=populated["modification"].pk).exists())
 
         if pre_deletion_orphans is not None:
             self.assertTrue(m.Instance.objects.filter(pk=pre_deletion_orphans["instance_no_form"].pk).exists())
@@ -279,16 +262,6 @@ class DeleteAccountsCommandTestCase(TransactionTestCase, IasoTestCaseMixin):
                 Modification.objects.filter(pk=post_deletion_only_orphans["modification_orphan"].pk).exists()
             )
 
-        if gap_data is not None:
-            # Only pass the keys expected to be intact at this call site — the two pieces of
-            # gap_data don't necessarily share the same fate (see test bodies).
-            if "api_import_for_deleted_account" in gap_data:
-                self.assertTrue(APIImport.objects.filter(pk=gap_data["api_import_for_deleted_account"].pk).exists())
-            if "modification_for_deleted_instance" in gap_data:
-                self.assertTrue(
-                    Modification.objects.filter(pk=gap_data["modification_for_deleted_instance"].pk).exists()
-                )
-
     def test_list_accounts_mode(self):
         management.call_command("delete_accounts", list_accounts=True, stdout=StringIO())
 
@@ -315,7 +288,7 @@ class DeleteAccountsCommandTestCase(TransactionTestCase, IasoTestCaseMixin):
             management.call_command("delete_accounts", accounts_to_delete=[missing_id], stdout=StringIO())
 
     def test_dry_run_does_not_delete_anything(self):
-        pre_deletion_orphans, post_deletion_only_orphans, gap_data = self._create_unscoped_data()
+        pre_deletion_orphans, post_deletion_only_orphans = self._create_unscoped_data()
 
         management.call_command(
             "delete_accounts",
@@ -332,7 +305,6 @@ class DeleteAccountsCommandTestCase(TransactionTestCase, IasoTestCaseMixin):
             self.deleted,
             pre_deletion_orphans=pre_deletion_orphans,
             post_deletion_only_orphans=post_deletion_only_orphans,
-            gap_data=gap_data,
         )
         self._assert_account_and_related_data_intact(
             self.account_to_keep, self.data_source_to_keep, self.version_to_keep, self.project_to_keep, self.kept
@@ -340,7 +312,7 @@ class DeleteAccountsCommandTestCase(TransactionTestCase, IasoTestCaseMixin):
         self._assert_org_unit_type_survives(self.deleted)
 
     def test_delete_specific_account(self):
-        pre_deletion_orphans, post_deletion_only_orphans, gap_data = self._create_unscoped_data()
+        pre_deletion_orphans, post_deletion_only_orphans = self._create_unscoped_data()
 
         management.call_command("delete_accounts", accounts_to_delete=[self.account_to_delete.pk], stdout=StringIO())
 
@@ -353,7 +325,6 @@ class DeleteAccountsCommandTestCase(TransactionTestCase, IasoTestCaseMixin):
             mode=MODE_DELETE_ACCOUNTS,
             pre_deletion_orphans=pre_deletion_orphans,
             post_deletion_only_orphans=post_deletion_only_orphans,
-            gap_data=gap_data,
         )
         self._assert_account_and_related_data_intact(
             self.account_to_keep, self.data_source_to_keep, self.version_to_keep, self.project_to_keep, self.kept
@@ -363,7 +334,7 @@ class DeleteAccountsCommandTestCase(TransactionTestCase, IasoTestCaseMixin):
         self._assert_org_unit_type_survives(self.deleted)
 
     def test_keep_single_account(self):
-        pre_deletion_orphans, post_deletion_only_orphans, gap_data = self._create_unscoped_data()
+        pre_deletion_orphans, post_deletion_only_orphans = self._create_unscoped_data()
 
         management.call_command("delete_accounts", account_to_keep=self.account_to_keep.pk, stdout=StringIO())
 
@@ -376,7 +347,6 @@ class DeleteAccountsCommandTestCase(TransactionTestCase, IasoTestCaseMixin):
             mode=MODE_KEEP_SINGLE_ACCOUNT,
             pre_deletion_orphans=pre_deletion_orphans,
             post_deletion_only_orphans=post_deletion_only_orphans,
-            gap_data=gap_data,
         )
         self._assert_account_and_related_data_intact(
             self.account_to_keep, self.data_source_to_keep, self.version_to_keep, self.project_to_keep, self.kept

--- a/iaso/tests/commands/test_pg_activity_watch.py
+++ b/iaso/tests/commands/test_pg_activity_watch.py
@@ -1,0 +1,28 @@
+from io import StringIO
+
+from django.core import management
+from django.test import TestCase
+
+
+class PgActivityWatchCommandTestCase(TestCase):
+    """pg_activity_watch is read-only (polls pg_stat_activity) — these just check it runs
+    and renders a snapshot without error, not any particular row content."""
+
+    def test_once_prints_a_snapshot_header(self):
+        out = StringIO()
+        management.call_command("pg_activity_watch", once=True, stdout=out)
+
+        self.assertIn("pg_activity_watch —", out.getvalue())
+        self.assertIn("PID", out.getvalue())
+
+    def test_all_and_min_duration_options_are_accepted(self):
+        out = StringIO()
+        management.call_command("pg_activity_watch", once=True, all=True, min_duration=0, stdout=out)
+
+        self.assertIn("(active + idle)", out.getvalue())
+
+    def test_limit_option_is_accepted(self):
+        out = StringIO()
+        management.call_command("pg_activity_watch", once=True, limit=1, stdout=out)
+
+        self.assertIn("pg_activity_watch —", out.getvalue())


### PR DESCRIPTION
## What problem is this PR solving?

new models are added, this is never re-tested, cycle between models make it sometimes hard to cleanup

### Related JIRA tickets

IA-5268

## Changes

tried to use to use dependencies between models to produce a delete order
some code comes from the previous command version, to handle these volumes

note that we have several cycle in our models that make toposort not working at his best
- Planning -> PlanningSamplingResult -> Planning.selected_sampling_result
- DataSource -> SourceVersion -> default_version
- OrgUnit -> OrgUnit
that's why if falls back on Bread First Search

## How to test

assuming you have a fresh db (adapt version against https://play.dhis2.org/)

```
docker compose run --rm iaso manage seed_test_data --mode=seed --dhis2version=2.40.12
docker compose run --rm iaso manage seed_test_data --mode=seed --dhis2version=2.41.8.2
docker compose run --rm iaso manage seed_test_data --mode=seed --dhis2version=2.42.5.1
docker compose run --rm iaso manage seed_test_data --mode=seed --dhis2version=2.43.0.1
```
add perhaps setuper created account

```
docker compose run --rm iaso manage delete_accounts --account-to-keep 1
```

the real test is to have a copy of the production db and test against it

## Print screen / video

## Notes

## Doc

https://github.com/BLSQ/ops-runbooks/blob/f14506f3cef2b40d4e983a64fae96912b7acdc06/local-hosting/iaso-produce-tenant-dump.md