### PR TITLE
IA-5273 export groups in pyramid parquet

### DIFF
--- a/iaso/api/org_units.py
+++ b/iaso/api/org_units.py
@@ -510,6 +510,9 @@ class OrgUnitViewSet(viewsets.ViewSet):
             "location_geojson",
             "simplified_geom_geojson",
             "biggest_polygon_geojson",
+            "groups_exploded",
+            "groups_exploded_code",
+            "groups_json",
             ":all",
         ]
 

--- a/iaso/exports/pyramid.py
+++ b/iaso/exports/pyramid.py
@@ -1,3 +1,6 @@
+import re
+import unicodedata
+
 from typing import Sequence
 
 from django.contrib.postgres.fields import JSONField
@@ -15,6 +18,8 @@ ALL_OPTIONAL_ORG_UNIT_FIELDS = [
     "location_geojson",
     "simplified_geom_geojson",
     "biggest_polygon_geojson",
+    "groups_exploded",
+    "groups_json",
 ]
 
 
@@ -24,11 +29,13 @@ def build_pyramid_queryset(qs: QuerySet[m.OrgUnit], extra_fields: Sequence[str])
     org_unit_annotations = build_org_unit_annotations(model_prefix)
     level_annotations = build_level_annotations(qs)
     geojson_annotations = build_geojson_annotations(model_prefix, extra_fields)
+    group_annotations = build_group_annotations(qs, extra_fields)
 
     all_keys = [
         *org_unit_annotations.keys(),
         *level_annotations.keys(),
         *geojson_annotations.keys(),
+        *group_annotations.keys(),
     ]
 
     return (
@@ -36,6 +43,7 @@ def build_pyramid_queryset(qs: QuerySet[m.OrgUnit], extra_fields: Sequence[str])
         .annotate(**org_unit_annotations)
         .annotate(**level_annotations)
         .annotate(**geojson_annotations)
+        .annotate(**group_annotations)
         .values(*all_keys)
     )
 
@@ -108,6 +116,66 @@ def build_level_annotations(qs: QuerySet[m.OrgUnit]):
             level_annotations[field_alias] = RawSQL(sql, [])
 
     return level_annotations
+
+
+def _strip_accents(name: str) -> str:
+    """
+    Convert name to ASCII:
+    - accented letters -> base letter (e.g. e-acute -> e, I-circumflex -> I)
+    - non-ASCII combining marks (diacritics left after NFD decomposition) -> dropped
+    - all other non-ASCII (dashes, smart quotes, symbols, NBSP, ellipsis...) -> "_"
+    """
+    return "".join(
+        c if ord(c) < 128 else ("" if unicodedata.category(c) == "Mn" else "_")
+        for c in unicodedata.normalize("NFD", name)
+    )
+
+
+def _safe_group_name(name: str) -> str:
+    """Accent-stripped, lowercase, non-alphanumeric replaced by underscores -- SQL-identifier-safe, no quoting needed."""
+    return re.sub(r"[^A-Za-z0-9]", "_", _strip_accents(name)).strip("_").lower()
+
+
+def _group_exists_sql(group_id: int):
+    return RawSQL(
+        """(SELECT CASE WHEN EXISTS (
+            SELECT 1 FROM iaso_group_org_units gou
+            WHERE gou.orgunit_id = iaso_orgunit.id AND gou.group_id = %s
+        ) THEN 1 ELSE 0 END)""",
+        [group_id],
+        output_field=IntegerField(),
+    )
+
+
+def build_group_annotations(qs: QuerySet[m.OrgUnit], extra_fields: Sequence[str]):
+    annotations = {}
+    include_all = ":all" in extra_fields
+
+    need_exploded = "groups_exploded" in extra_fields or include_all
+    need_exploded_code = "groups_exploded_code" in extra_fields
+
+    if need_exploded or need_exploded_code:
+        groups = m.Group.objects.filter(org_units__in=qs.all()).values("id", "name").order_by("id").distinct()
+        for group in groups:
+            if need_exploded:
+                annotations[f"group_{group['id']}_{_safe_group_name(group['name'])}"] = _group_exists_sql(group["id"])
+            if need_exploded_code:
+                annotations[f"group_{_safe_group_name(group['name'])}"] = _group_exists_sql(group["id"])
+
+    if "groups_json" in extra_fields or include_all:
+        annotations["org_unit_groups"] = RawSQL(
+            """(SELECT COALESCE(
+                json_agg(json_build_object('id', g.id, 'name', g.name) ORDER BY g.id),
+                '[]'::json
+            )
+            FROM iaso_group_org_units gou
+            JOIN iaso_group g ON g.id = gou.group_id
+            WHERE gou.orgunit_id = iaso_orgunit.id)""",
+            [],
+            output_field=JSONField(),
+        )
+
+    return annotations
 
 
 def build_geojson_annotations(model_prefix: str, extra_fields: Sequence[str]):

--- a/iaso/exports/pyramid.py
+++ b/iaso/exports/pyramid.py
@@ -3,10 +3,12 @@ import unicodedata
 
 from typing import Sequence
 
+from django.conf import settings
+from django.contrib.postgres.aggregates import JSONBAgg
 from django.contrib.postgres.fields import JSONField
-from django.db.models import F, FloatField, Func, IntegerField, Max, QuerySet
+from django.db.models import Exists, F, FloatField, Func, IntegerField, Max, OuterRef, QuerySet, Subquery, Value
 from django.db.models.expressions import RawSQL
-from django.db.models.functions import Cast
+from django.db.models.functions import Cast, Coalesce, JSONObject
 
 import iaso.models as m
 
@@ -137,25 +139,31 @@ def _safe_group_name(name: str) -> str:
 
 
 def _group_exists_sql(group_id: int):
-    return RawSQL(
-        """(SELECT CASE WHEN EXISTS (
-            SELECT 1 FROM iaso_group_org_units gou
-            WHERE gou.orgunit_id = iaso_orgunit.id AND gou.group_id = %s
-        ) THEN 1 ELSE 0 END)""",
-        [group_id],
+    return Cast(
+        Exists(m.Group.objects.filter(pk=group_id, org_units=OuterRef("pk"))),
         output_field=IntegerField(),
     )
 
 
 def build_group_annotations(qs: QuerySet[m.OrgUnit], extra_fields: Sequence[str]):
     annotations = {}
-    include_all = ":all" in extra_fields
+    include_all = settings.DYNAMIC_FIELDS_ALL_FIELDS_PARAM_VALUE in extra_fields
 
     need_exploded = "groups_exploded" in extra_fields or include_all
     need_exploded_code = "groups_exploded_code" in extra_fields
 
     if need_exploded or need_exploded_code:
         groups = m.Group.objects.filter(org_units__in=qs.all()).values("id", "name").order_by("id").distinct()
+        if need_exploded_code:
+            seen_safe_names: dict[str, int] = {}
+            for group in groups:
+                safe = _safe_group_name(group["name"])
+                if safe in seen_safe_names:
+                    raise ValueError(
+                        f"Group names '{group['name']}' and (id={seen_safe_names[safe]}) both normalize to '{safe}'. "
+                        "Use groups_exploded instead to avoid column collisions."
+                    )
+                seen_safe_names[safe] = group["id"]
         for group in groups:
             if need_exploded:
                 annotations[f"group_{group['id']}_{_safe_group_name(group['name'])}"] = _group_exists_sql(group["id"])
@@ -163,16 +171,15 @@ def build_group_annotations(qs: QuerySet[m.OrgUnit], extra_fields: Sequence[str]
                 annotations[f"group_{_safe_group_name(group['name'])}"] = _group_exists_sql(group["id"])
 
     if "groups_json" in extra_fields or include_all:
-        annotations["org_unit_groups"] = RawSQL(
-            """(SELECT COALESCE(
-                json_agg(json_build_object('id', g.id, 'name', g.name) ORDER BY g.id),
-                '[]'::json
-            )
-            FROM iaso_group_org_units gou
-            JOIN iaso_group g ON g.id = gou.group_id
-            WHERE gou.orgunit_id = iaso_orgunit.id)""",
-            [],
-            output_field=JSONField(),
+        annotations["org_unit_groups"] = Coalesce(
+            Subquery(
+                m.Group.objects.filter(org_units=OuterRef("pk"))
+                .values("org_units")
+                .annotate(j=JSONBAgg(JSONObject(id="id", name="name"), ordering="id"))
+                .values("j"),
+                output_field=JSONField(),
+            ),
+            Value([], output_field=JSONField()),
         )
 
     return annotations

--- a/iaso/tests/api/test_orgunits_parquet.py
+++ b/iaso/tests/api/test_orgunits_parquet.py
@@ -1,3 +1,4 @@
+import json
 import tempfile
 
 from django.contrib.gis.geos import GEOSGeometry, MultiPolygon, Point, Polygon
@@ -5,7 +6,12 @@ from django.db import connection
 
 from iaso import models as m
 from iaso.permissions.core_permissions import CORE_ORG_UNITS_PERMISSION, CORE_ORG_UNITS_READ_PERMISSION
-from iaso.tests.utils_parquet import BaseAPITransactionTestCase, compare_or_create_snapshot, write_response_to_file
+from iaso.tests.utils_parquet import (
+    BaseAPITransactionTestCase,
+    compare_or_create_snapshot,
+    read_parquet,
+    write_response_to_file,
+)
 
 
 # use BaseAPITransactionTestCase to make records are visible to duckdb (committed)
@@ -243,7 +249,7 @@ class OrgUnitAPITestCase(BaseAPITransactionTestCase):
 
         self.client.force_authenticate(self.yoda)
 
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(4):  # +1 for the groups_exploded pre-query included in :all
             response = self.client.get("/api/orgunits/?order=id&parquet=true&extra_fields=:all")
 
             self.assertEqual(response.status_code, 200)
@@ -284,13 +290,93 @@ class OrgUnitAPITestCase(BaseAPITransactionTestCase):
                     stable_columns,
                 )
 
+    def test_can_retrieve_org_units_with_groups_exploded(self):
+        """groups_exploded adds one binary column per group that has any org unit in the selection"""
+        self.client.force_authenticate(self.yoda)
+
+        response = self.client.get("/api/orgunits/?order=id&parquet=true&extra_fields=groups_exploded")
+
+        self.assertEqual(response.status_code, 200)
+        self.assert_parquet_content_type(response)
+
+        with tempfile.NamedTemporaryFile(suffix=".parquet") as f:
+            write_response_to_file(response, f)
+            rows = read_parquet(f)
+
+        # Only elite_group is linked to an org unit -- id + normalized name
+        expected_col = f"group_{self.elite_group.id}_elite_councils"
+        self.assertIn(expected_col, rows[0].keys())
+        # unofficial_group and another_group have no linked org units → no column
+        self.assertNotIn(f"group_{self.unofficial_group.id}_unofficial_jedi_councils", rows[0].keys())
+        self.assertNotIn(f"group_{self.another_group.id}_another_group", rows[0].keys())
+
+        corruscant_row = next(r for r in rows if r["org_unit_name"] == "Corruscant Jedi Council")
+        self.assertEqual(corruscant_row[expected_col], 1)
+
+        endor_row = next(r for r in rows if r["org_unit_name"] == "Endor Jedi Council")
+        self.assertEqual(endor_row[expected_col], 0)
+
+    def test_can_retrieve_org_units_with_groups_json(self):
+        """groups_json adds a single JSON column listing all groups per org unit"""
+        self.client.force_authenticate(self.yoda)
+
+        response = self.client.get("/api/orgunits/?order=id&parquet=true&extra_fields=groups_json")
+
+        self.assertEqual(response.status_code, 200)
+        self.assert_parquet_content_type(response)
+
+        with tempfile.NamedTemporaryFile(suffix=".parquet") as f:
+            write_response_to_file(response, f)
+            rows = read_parquet(f)
+
+        self.assertIn("org_unit_groups", rows[0].keys())
+
+        corruscant_row = next(r for r in rows if r["org_unit_name"] == "Corruscant Jedi Council")
+        groups = json.loads(corruscant_row["org_unit_groups"])
+        self.assertEqual(groups, [{"id": self.elite_group.id, "name": "Elite councils"}])
+
+        endor_row = next(r for r in rows if r["org_unit_name"] == "Endor Jedi Council")
+        self.assertEqual(json.loads(endor_row["org_unit_groups"]), [])
+
+    def test_can_retrieve_org_units_with_groups_exploded_code(self):
+        """groups_exploded_code uses accent-stripped normalized names — columns are safe SQL identifiers"""
+        self.client.force_authenticate(self.yoda)
+
+        # Create a group whose name has an accent and a hyphen to exercise normalization
+        accented_group = m.Group.objects.create(name="Île-de-France", source_version=self.sw_version_1)
+        accented_group.org_units.add(self.jedi_council_corruscant)
+
+        response = self.client.get("/api/orgunits/?order=id&parquet=true&extra_fields=groups_exploded_code")
+
+        self.assertEqual(response.status_code, 200)
+        self.assert_parquet_content_type(response)
+
+        with tempfile.NamedTemporaryFile(suffix=".parquet") as f:
+            write_response_to_file(response, f)
+            rows = read_parquet(f)
+
+        # groups_exploded_code: no id in column name, just normalized name
+        elite_col = "group_elite_councils"
+        accented_col = "group_ile_de_france"
+
+        self.assertIn(elite_col, rows[0].keys())
+        self.assertIn(accented_col, rows[0].keys())
+
+        corruscant_row = next(r for r in rows if r["org_unit_name"] == "Corruscant Jedi Council")
+        self.assertEqual(corruscant_row[elite_col], 1)
+        self.assertEqual(corruscant_row[accented_col], 1)
+
+        endor_row = next(r for r in rows if r["org_unit_name"] == "Endor Jedi Council")
+        self.assertEqual(endor_row[elite_col], 0)
+        self.assertEqual(endor_row[accented_col], 0)
+
     def test_bad_request_parquet_validates_unknown_extra_fields(self):
         response = self.client.get("/api/orgunits/?order=id&parquet=true&extra_fields=bad_param")
         self.assertEqual(response.status_code, 409)
         self.assertEqual(
             response.json(),
             {
-                "error": "Unknown extra_fields for parquet exports: bad_param, only supported geom_geojson, location_geojson, simplified_geom_geojson, biggest_polygon_geojson, :all."
+                "error": "Unknown extra_fields for parquet exports: bad_param, only supported geom_geojson, location_geojson, simplified_geom_geojson, biggest_polygon_geojson, groups_exploded, groups_exploded_code, groups_json, :all."
             },
         )
 

--- a/iaso/tests/exports/test_pyramid_export.py
+++ b/iaso/tests/exports/test_pyramid_export.py
@@ -1,10 +1,45 @@
 import tempfile
 
 from iaso.exports import parquet
+from iaso.exports.pyramid import _safe_group_name
 from iaso.models import OrgUnit
 from iaso.test import TestCase
 
 from .parquet_helper import get_columns_from_parquet
+
+
+class GroupNameNormalizationTest(TestCase):
+    def test_safe_group_name_accents(self):
+        self.assertEqual(_safe_group_name("Île-de-France"), "ile_de_france")
+        self.assertEqual(_safe_group_name("Santé"), "sante")
+
+    def test_safe_group_name_straight_quote(self):
+        self.assertEqual(_safe_group_name("groupe d'Afrique"), "groupe_d_afrique")
+
+    def test_safe_group_name_smart_single_quotes(self):
+        # Office/Word curly apostrophes
+        self.assertEqual(_safe_group_name("groupe d'Afrique"), "groupe_d_afrique")
+        self.assertEqual(_safe_group_name("groupe d'Afrique"), "groupe_d_afrique")
+
+    def test_safe_group_name_smart_double_quotes(self):
+        self.assertEqual(_safe_group_name("“Nord”"), "nord")
+
+    def test_safe_group_name_double_quote(self):
+        # space + opening quote both become "_", trailing quote is stripped
+        self.assertEqual(_safe_group_name('say "hello"'), "say__hello")
+
+    def test_safe_group_name_en_dash(self):
+        self.assertEqual(_safe_group_name("Nord–Sud"), "nord_sud")
+
+    def test_safe_group_name_non_breaking_space(self):
+        self.assertEqual(_safe_group_name("Nord Sud"), "nord_sud")
+
+    def test_safe_group_name_ellipsis(self):
+        self.assertEqual(_safe_group_name("etc…end"), "etc_end")
+
+    def test_safe_group_name_quotes_via_strip_accents(self):
+        # smart quote goes through _strip_accents -> becomes "_"
+        self.assertEqual(_safe_group_name("groupe d'Afrique"), "groupe_d_afrique")
 
 
 class PyramidExportTest(TestCase):
@@ -41,5 +76,6 @@ class PyramidExportTest(TestCase):
             ["org_unit_location_geojson", "VARCHAR"],
             ["org_unit_simplified_geom_geojson", "VARCHAR"],
             ["org_unit_biggest_polygon_geojson", "VARCHAR"],
+            ["org_unit_groups", "VARCHAR"],
         ]
         self.assertEqual(actual_columns, expected)

--- a/iaso/tests/exports/test_pyramid_export.py
+++ b/iaso/tests/exports/test_pyramid_export.py
@@ -1,8 +1,8 @@
 import tempfile
 
 from iaso.exports import parquet
-from iaso.exports.pyramid import _safe_group_name
-from iaso.models import OrgUnit
+from iaso.exports.pyramid import _safe_group_name, build_group_annotations
+from iaso.models import DataSource, Group, OrgUnit, SourceVersion
 from iaso.test import TestCase
 
 from .parquet_helper import get_columns_from_parquet
@@ -40,6 +40,61 @@ class GroupNameNormalizationTest(TestCase):
     def test_safe_group_name_quotes_via_strip_accents(self):
         # smart quote goes through _strip_accents -> becomes "_"
         self.assertEqual(_safe_group_name("groupe d'Afrique"), "groupe_d_afrique")
+
+
+class GroupsExplodedCollisionTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        source = DataSource.objects.create(name="Test source")
+        version = SourceVersion.objects.create(data_source=source, number=1)
+        cls.org_unit = OrgUnit.objects.create(name="Test OU", version=version)
+        cls.group_sante = Group.objects.create(name="Santé", source_version=version)
+        cls.group_sante_plain = Group.objects.create(name="Sante", source_version=version)
+        cls.org_unit.groups.add(cls.group_sante, cls.group_sante_plain)
+
+    def test_groups_exploded_code_raises_on_collision(self):
+        qs = OrgUnit.objects.filter(pk=self.org_unit.pk)
+        with self.assertRaises(ValueError) as ctx:
+            build_group_annotations(qs, ["groups_exploded_code"])
+        self.assertIn("sante", str(ctx.exception))
+
+    def test_groups_exploded_no_collision_because_of_id(self):
+        qs = OrgUnit.objects.filter(pk=self.org_unit.pk)
+        # Should not raise — column names include the group id
+        annotations = build_group_annotations(qs, ["groups_exploded"])
+        expected_keys = {
+            f"group_{self.group_sante.id}_sante",
+            f"group_{self.group_sante_plain.id}_sante",
+        }
+        self.assertEqual(set(annotations.keys()), expected_keys)
+
+
+class GroupsJsonTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        source = DataSource.objects.create(name="Test source")
+        version = SourceVersion.objects.create(data_source=source, number=1)
+        cls.ou_no_groups = OrgUnit.objects.create(name="No groups", version=version)
+        cls.ou_with_groups = OrgUnit.objects.create(name="With groups", version=version)
+        cls.group_a = Group.objects.create(name="Alpha", source_version=version)
+        cls.group_b = Group.objects.create(name="Beta", source_version=version)
+        cls.ou_with_groups.groups.add(cls.group_a, cls.group_b)
+
+    def _annotated(self, ou):
+        annotations = build_group_annotations(OrgUnit.objects.filter(pk=ou.pk), ["groups_json"])
+        return OrgUnit.objects.filter(pk=ou.pk).annotate(**annotations).get()
+
+    def test_no_groups_returns_empty_list(self):
+        ou = self._annotated(self.ou_no_groups)
+        self.assertEqual(ou.org_unit_groups, [])
+
+    def test_with_groups_returns_sorted_list(self):
+        ou = self._annotated(self.ou_with_groups)
+        expected = sorted(
+            [{"id": self.group_a.id, "name": "Alpha"}, {"id": self.group_b.id, "name": "Beta"}],
+            key=lambda g: g["id"],
+        )
+        self.assertEqual(ou.org_unit_groups, expected)
 
 
 class PyramidExportTest(TestCase):


### PR DESCRIPTION
## What problem is this PR solving?

optionally export groups either in raw json or 1 column per groups 

### Related JIRA tickets

IA-5273

## Changes

if you ask ?extra_fields=groups-exploded

## How to test

seed or setuper

then build an url to extract the orgunits
- http://localhost:8081/api/orgunits/?parquet=true&extra_fields=groups_exploded (`group_<group id>_<normalized name>` columns)
- http://localhost:8081/api/orgunits/?parquet=true&extra_fields=groups_exploded_code (`group_<normalized name>` columns
- http://localhost:8081/api/orgunits/?parquet=true&extra_fields=groups_json
(`org_unit_groups` column in json array of id/name objects)
<img width="2418" height="202" alt="image" src="https://github.com/user-attachments/assets/ca09b1e2-8140-4dbd-b25b-558f7b02fff4" />


<img width="2413" height="580" alt="image" src="https://github.com/user-attachments/assets/61767cb4-71ff-49ad-913d-793c8d54973a" />

## Print screen / video



## Notes

## Doc

