### PR TITLE
[IA-5275] Resolve n+1 query on the GET entity duplicates endpoint

### DIFF
--- a/iaso/api/deduplication/entity_duplicate.py
+++ b/iaso/api/deduplication/entity_duplicate.py
@@ -511,6 +511,12 @@ class EntityDuplicateViewSet(ModelViewSet):
         qs = qs.exclude(validation_status=ValidationStatus.PENDING, entity1__deleted_at__isnull=False).exclude(
             validation_status=ValidationStatus.PENDING, entity2__deleted_at__isnull=False
         )
+        qs = qs.select_related(
+            "analyze",
+            "entity1__entity_type__reference_form",
+            "entity1__attributes__org_unit",
+            "entity2__attributes__org_unit",
+        )
         return qs
 
     @extend_schema(parameters=[duplicate_detail_entities_param])


### PR DESCRIPTION
## What problem is this PR solving?

This PR is about resolving a n+1 query

### Related JIRA tickets

[IA-5275](https://bluesquare.atlassian.net/browse/IA-5275)

## Changes

Explain the changes that were made.

Added a select_related

## How to test

//

## Print screen / video

the queries went from this:
<img width="1192" height="200" alt="image" src="https://github.com/user-attachments/assets/7c003bfb-86cb-4a61-96b0-62efdd802300" />


To this:
<img width="1192" height="200" alt="image" src="https://github.com/user-attachments/assets/550920ca-b097-446f-95b6-99213f8dcc84" />


## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).


[IA-5275]: https://bluesquare.atlassian.net/browse/IA-5275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ