### PR TITLE
Enable `ROTATE_REFRESH_TOKENS` for mobile

### DIFF
--- a/hat/settings.py
+++ b/hat/settings.py
@@ -548,6 +548,7 @@ SIMPLE_JWT = {
     "ACCESS_TOKEN_LIFETIME": timedelta(days=3650),
     "REFRESH_TOKEN_LIFETIME": timedelta(days=3651),
     "TOKEN_OBTAIN_SERIALIZER": "iaso.serializers.CustomTokenObtainPairSerializer",
+    "ROTATE_REFRESH_TOKENS": True,
 }
 
 AWS_S3_REGION_NAME = env.str("AWS_S3_REGION_NAME", default="eu-central-1")


### PR DESCRIPTION
## What problem is this PR solving?

Change `ROTATE_REFRESH_TOKENS` to `True`. When this setting is off, calling `/api/token/refresh/` doesn't return a new `refresh` token.

[Django's documentation](https://django-rest-framework-simplejwt.readthedocs.io/en/latest/settings.html#rotate-refresh-tokens)

### Related JIRA tickets

IA-5258

## Changes

Change `ROTATE_REFRESH_TOKENS` to `True`.

## How to test

Call `/api/token/refresh/` with and without the setting to `True`.
