### PR TITLE
IA-5273 fix validation to return 409 and not 500 error

### DIFF
--- a/iaso/api/org_units.py
+++ b/iaso/api/org_units.py
@@ -526,7 +526,10 @@ class OrgUnitViewSet(viewsets.ViewSet):
                 status=status.HTTP_409_CONFLICT,
             )
 
-        export_queryset = parquet.build_pyramid_queryset(queryset, extra_fields)
+        try:
+            export_queryset = parquet.build_pyramid_queryset(queryset, extra_fields)
+        except ValueError as e:
+            return JsonResponse({"error": str(e)}, status=status.HTTP_409_CONFLICT)
 
         tmp = tempfile.NamedTemporaryFile(suffix=".parquet", delete=False)
 

--- a/iaso/tests/api/test_orgunits_parquet.py
+++ b/iaso/tests/api/test_orgunits_parquet.py
@@ -389,3 +389,17 @@ class OrgUnitAPITestCase(BaseAPITransactionTestCase):
                 "error": "Unsupported query parameters for parquet exports: unknown_unsupported_filter. Allowed parameters extra_fields, order, parquet, searches"
             },
         )
+
+    def test_groups_exploded_code_collision_returns_400(self):
+        """When two group names normalize to the same safe identifier, the API returns 400."""
+        self.client.force_authenticate(self.yoda)
+
+        collision_group = m.Group.objects.create(name="Élite councils", source_version=self.sw_version_1)
+        collision_group.org_units.add(self.jedi_council_corruscant)
+
+        response = self.client.get("/api/orgunits/?order=id&parquet=true&extra_fields=groups_exploded_code")
+        self.assertEqual(response.status_code, 409)
+        error = response.json()["error"]
+        self.assertIn("elite_councils", error)
+        self.assertIn("normalize to", error)
+        self.assertIn("Use groups_exploded instead to avoid column collisions", error)


### PR DESCRIPTION
## What problem is this PR solving?

catch ValueError to return 409 instead of 500

### Related JIRA tickets

IA-5273

## Changes

catch ValueError to return 409

## How to test

1. seed / setuper
2. play with group's name so they collide (ex accent)
3. export as parquet

## Print screen / video

Upload here print screens or videos showing the changes.

## Notes

## Doc

