### PR TITLE
IA-5291 entities sync slow : prevent extra query without filters

### DIFF
--- a/iaso/api/mobile/entity.py
+++ b/iaso/api/mobile/entity.py
@@ -13,7 +13,7 @@ from iaso.permissions.core_permissions import CORE_ENTITIES_PERMISSION
 
 
 def filter_for_mobile_entity(queryset, request):
-    if queryset:
+    if queryset is not None:
         try:
             queryset = queryset.filter_for_mobile_entity(
                 request.query_params.get("limit_date"), request.query_params.get("json_content")

--- a/iaso/api/mobile/entity_type.py
+++ b/iaso/api/mobile/entity_type.py
@@ -141,7 +141,7 @@ class MobileEntityTypesViewSet(ModelViewSet):
         else:
             queryset = filter_on_user_and_app_id(queryset, user, app_id)
 
-        if queryset:
+        if queryset is not None:
             queryset = queryset.filter(entity_type__pk=type_pk)
 
         queryset = filter_for_mobile_entity(queryset, self.request)

--- a/iaso/tests/api/entities/test_entities_mobile.py
+++ b/iaso/tests/api/entities/test_entities_mobile.py
@@ -1,5 +1,7 @@
 import uuid
 
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 from rest_framework import status
 
 from iaso import models as m
@@ -8,6 +10,18 @@ from iaso.tests.api.entities.common_base_with_setup import EntityAPITestCase
 
 class MobileEntityAPITestCase(EntityAPITestCase):
     BASE_URL = "/api/mobile/entities/"
+
+    def test_list_entities_empty_does_not_issue_extra_query_for_queryset_truthiness(self):
+        self.client.force_authenticate(self.yoda)
+
+        with CaptureQueriesContext(connection) as ctx:
+            response = self.client.get(self.BASE_URL, {"app_id": self.project.app_id})
+
+        response_json = self.assertJSONResponse(response, status.HTTP_200_OK)
+        self.assertEqual(response_json["count"], 0)
+        # `filter_for_mobile_entity` must not force early evaluation of an empty
+        # queryset (e.g. via `if queryset:`), which would add an extra query.
+        self.assertEqual(len(ctx.captured_queries), 7)
 
     def test_list_entities_with_filtered_out_entities_with_soft_deleted_instances(self):
         uuid_valid_instance = uuid.uuid4()

--- a/iaso/tests/api/entities/test_entity_types.py
+++ b/iaso/tests/api/entities/test_entity_types.py
@@ -4,6 +4,8 @@ import uuid
 from unittest import mock
 
 from django.core.files import File
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 from rest_framework import status
 
 from iaso import models as m
@@ -562,10 +564,17 @@ class EntityTypeAPITestCase(APITestCase):
         deleted_instance_2.save()
 
         self.client.force_authenticate(self.yoda)
-        response = self.client.get(f"/api/mobile/entitytypes/{entity_type.pk}/entities/?app_id={self.project.app_id}")
+
+        with CaptureQueriesContext(connection) as ctx:
+            response = self.client.get(
+                f"/api/mobile/entitytypes/{entity_type.pk}/entities/?app_id={self.project.app_id}"
+            )
         response_json = self.assertJSONResponse(response, status.HTTP_200_OK)
 
         self.assertEqual(response_json["count"], 0)  # all entities have their reference instance deleted
+        # `filter_for_mobile_entity` must not force early evaluation of an empty
+        # queryset (e.g. via `if queryset:`), which would add an extra query.
+        self.assertEqual(len(ctx.captured_queries), 4)
 
     def test_entity_types_are_account_restricted(self):
         self.client.force_authenticate(self.yoda)


### PR DESCRIPTION
## What problem is this PR solving?

The mobile sync is slow, we have recurring long running queries.
I found an `if queryset:` trigger the query (not just check if it's not None but `.__bool__()`)

### Related JIRA tickets

IA-5291

## Changes

without my modification the number of queries is bigger (see failing first commit)

```
FAIL: test_list_entities_empty_does_not_issue_extra_query_for_queryset_truthiness (iaso.tests.api.entities.test_entities_mobile.MobileEntityAPITestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/unittest/case.py", line 59, in testPartExecutor
    yield
  File "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/unittest/case.py", line 592, in run
    self._callTestMethod(testMethod)
  File "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/unittest/case.py", line 550, in _callTestMethod
    method()
  File "/home/runner/work/iaso/iaso/iaso/tests/api/entities/test_entities_mobile.py", line 24, in test_list_entities_empty_does_not_issue_extra_query_for_queryset_truthiness
    self.assertEqual(len(ctx.captured_queries), 7)
  File "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/unittest/case.py", line 837, in assertEqual
    assertion_func(first, second, msg=msg)
  File "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/unittest/case.py", line 830, in _baseAssertEqual
    raise self.failureException(msg)
AssertionError: 8 != 7



======================================================================
FAIL: test_get_entities_by_entity_type_empty_list_deleted_instances (iaso.tests.api.entities.test_entity_types.EntityTypeAPITestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/unittest/case.py", line 59, in testPartExecutor
    yield
  File "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/unittest/case.py", line 592, in run
    self._callTestMethod(testMethod)
  File "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/unittest/case.py", line 550, in _callTestMethod
    method()
  File "/home/runner/work/iaso/iaso/iaso/tests/api/entities/test_entity_types.py", line 577, in test_get_entities_by_entity_type_empty_list_deleted_instances
    self.assertEqual(len(ctx.captured_queries), 4)
  File "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/unittest/case.py", line 837, in assertEqual
    assertion_func(first, second, msg=msg)
  File "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/unittest/case.py", line 830, in _baseAssertEqual
    raise self.failureException(msg)
AssertionError: 6 != 4
```

## How to test

to test on copy of production like db size

```
docker compose exec iaso ./manage.py explain_request --url-path="/api/mobile/entities/?limit_date=2026-06-28&page=1&app_id=rci.pnlp.cps.denombrement.administration.2026&app_version=2820"  --username="OUATTARA_SA_VOL6" --threshold-duration=0 2>&1 > with-is-not-none.txt 2>&1
```

doing it with/without we can locate the query

https://gist.github.com/mestachs/55d8e1f5d38ab6388bed3b40cbd301b8#file-prod-txt-L13

```
SELECT "iaso_entity"."id", "iaso_entity"."deleted_at", "iaso_entity"."name", "iaso_entity"."uuid", "iaso_entity"."created_at", "iaso_entity"."updated_at", "iaso_entity"."entity_type_id", "iaso_entity"."attributes_id", "iaso_entity"."account_id", "iaso_entity"."merged_to_id" FROM "iaso_entity" INNER JOIN "iaso_entitytype" ON ("iaso_entity"."entity_type_id" = "iaso_entitytype"."id") INNER JOIN "iaso_form" ON ("iaso_entitytype"."reference_form_id" = "iaso_form"."id") INNER JOIN "iaso_project_forms" ON ("iaso_form"."id" = "iaso_project_forms"."form_id") INNER JOIN "iaso_project" ON ("iaso_project_forms"."project_id" = "iaso_project"."id") WHERE ("iaso_entity"."deleted_at" IS NULL AND "iaso_entity"."entity_type_id" IN (SELECT U0."id" FROM "iaso_entitytype" U0 INNER JOIN "iaso_form" U1 ON (U0."reference_form_id" = U1."id") INNER JOIN "iaso_project_forms" U2 ON (U1."id" = U2."form_id") WHERE U2."project_id" = 123) AND "iaso_entity"."account_id" = 37 AND "iaso_entity"."id" IN (SELECT DISTINCT W0."entity_id" FROM "iaso_instance" W0 WHERE W0."org_unit_id" IN (SELECT V0."id" FROM "iaso_orgunit" V0 WHERE V0."path" <@ (ARRAY(SELECT U0."path" FROM "iaso_orgunit" U0 INNER JOIN "iaso_profile_org_units" U1 ON (U0."id" = U1."orgunit_id") WHERE U1."profile_id" = 56655)))) AND "iaso_project"."app_id" = 'rci.pnlp.cps.denombrement.administration.2026'); args=(123, 37, 56655, 'rci.pnlp.cps.denombrement.administration.2026'); alias=default
```
that fetches everything and doesn't filter (yet) on date/pages

and point to the filter_for_mobile_entity
https://gist.github.com/mestachs/55d8e1f5d38ab6388bed3b40cbd301b8#file-prod-txt-L111


<img width="2394" height="828" alt="image" src="https://github.com/user-attachments/assets/a63390a9-3663-4dd5-b138-4b898c893d70" />

## Print screen / video



## Notes


## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).
