### PR TITLE
IA-5292 instance query optimize with_status

### DIFF
--- a/iaso/api/instances/views.py
+++ b/iaso/api/instances/views.py
@@ -66,6 +66,7 @@ from iaso.models import (
 )
 from iaso.models.common import ValidationWorkflowArtefactStatus
 from iaso.models.forms import CR_MODE_IF_REFERENCE_FORM
+from iaso.models.instances import resolve_status_form_ids
 from iaso.permissions.core_permissions import CORE_FORMS_PERMISSION, CORE_STORAGE_PERMISSION
 from iaso.utils.date_and_time import timestamp_to_datetime
 from iaso.utils.models.common import check_instance_bulk_gps_push, check_instance_reference_bulk_link, get_creator_name
@@ -614,6 +615,9 @@ class InstancesViewSet(viewsets.ViewSet):
         return Response({"res": "ok"})
 
     def retrieve(self, request, pk=None):
+        # Cheap lookup by pk to know which form the instance belongs to, so with_status() can skip the
+        # (expensive on large datasets) duplicates computation when that form isn't single_per_period.
+        form_id = Instance.objects.filter(pk=pk).values_list("form_id", flat=True).first()
         queryset = (
             self.get_queryset()
             .prefetch_related(
@@ -631,7 +635,7 @@ class InstancesViewSet(viewsets.ViewSet):
                 "org_unit__org_unit_type",
                 "org_unit__version__data_source__credentials",
             )
-            .with_status()
+            .with_status(form_ids=resolve_status_form_ids(form_id))
         )
         instance: Instance = get_object_or_404(queryset, pk=pk)
         self.check_object_permissions(request, instance)

--- a/iaso/api/instances/views.py
+++ b/iaso/api/instances/views.py
@@ -456,13 +456,24 @@ class InstancesViewSet(viewsets.ViewSet):
                 limit = int(limit)
                 page_offset = int(page_offset)
 
-                queryset = queryset.with_lock_info(user=request.user)
-
                 paginator = Paginator(queryset, limit)
                 res = {"count": paginator.count}
                 if page_offset > paginator.num_pages:
                     page_offset = paginator.num_pages
                 page = paginator.page(page_offset)
+
+                # with_lock_info has no filters related to it's just "enrichment" of the page, so it can be done after the pagination,
+                # and not on the whole queryset during the count.
+                # its JOIN/GROUP BY is cheap for a handful of rows, but
+                # forces PostgreSQL to evaluate (join, group, sort) the entire matching instance set
+                # before it can be truncated to a page when applied beforehand, which is extremely slow
+                # on large accounts (minutes, on an account with a few million instances).
+                # Fetched via values_list() (rather than iterating page.object_list) to avoid pulling in
+                # the queryset's select_related/prefetch_related for a result we only use for its ids.
+                #
+                #
+                page_ids = list(page.object_list.values_list("id", flat=True))
+                locked_page = queryset.filter(pk__in=page_ids).with_lock_info(user=request.user)
 
                 def as_dict_formatter(instance: Annotated[Instance, LockAnnotation]) -> Dict:
                     d = instance.as_dict_with_descriptor() if with_descriptor == "true" else instance.as_dict()
@@ -472,7 +483,7 @@ class InstancesViewSet(viewsets.ViewSet):
                     d["is_reference_instance"] = instance._is_reference_instance
                     return d
 
-                res["instances"] = map(as_dict_formatter, page.object_list)
+                res["instances"] = map(as_dict_formatter, locked_page)
                 res["has_next"] = page.has_next()
                 res["has_previous"] = page.has_previous()
                 res["page"] = page_offset

--- a/iaso/dhis2/export_request_builder.py
+++ b/iaso/dhis2/export_request_builder.py
@@ -2,6 +2,7 @@ from django.core.paginator import Paginator
 from django.db import transaction
 
 from iaso.models import ALIVE_STATUSES, DERIVED, ExportRequest, ExportStatus, Instance
+from iaso.models.instances import resolve_status_form_ids
 
 
 class NothingToExportError(Exception):
@@ -42,7 +43,9 @@ class ExportRequestBuilder:
         if launcher:
             instances = instances.filter(project__account=launcher.iaso_profile.account)
         # don't export duplicate instances
-        instances = instances.with_status().exclude(status=Instance.STATUS_DUPLICATED)
+        instances = instances.with_status(
+            form_ids=resolve_status_form_ids(filters.get("form_id"), filters.get("form_ids"))
+        ).exclude(status=Instance.STATUS_DUPLICATED)
         # don't export deleted instances
         instances = instances.filter(deleted=False)
         # don't export instances with json empty or test devices

--- a/iaso/models/instances.py
+++ b/iaso/models/instances.py
@@ -71,6 +71,19 @@ def instance_file_upload_to(instance_file: "InstanceFile", filename: str):
     )
 
 
+def resolve_status_form_ids(form_id=None, form_ids=None):
+    """
+    Combine the `form_id` / `form_ids` (comma-separated string) filter params into a single list of ids
+    suitable for `InstanceQuerySet.with_status(form_ids=...)`, or None if neither is set.
+    """
+    resolved = []
+    if form_id:
+        resolved.append(form_id)
+    if form_ids:
+        resolved.extend(form_ids.split(","))
+    return resolved or None
+
+
 class InstanceQuerySet(django_cte.CTEQuerySet):
     def with_lock_info(self, user):
         """
@@ -98,9 +111,36 @@ class InstanceQuerySet(django_cte.CTEQuerySet):
             .annotate(count_active_lock=Count("instancelock", Q(instancelock__unlocked_by__isnull=True)))
         )
 
-    def with_status(self):
+    def with_status(self, form_ids=None):
+        """
+        form_ids: ids of the forms already applied as a filter on this queryset, if any. When given, and
+        none of those forms are single_per_period (instances can only be STATUS_DUPLICATED for a
+        single_per_period form), skip the duplicates computation entirely: it costs one small query against
+        Form but avoids an expensive query/join against the (potentially huge) Instance queryset.
+        When form_ids is not given, we can't know in advance whether any form is single_per_period without
+        an extra query, so we keep computing duplicates unconditionally like before.
+        """
+        single_per_period_forms = Form.objects.filter(single_per_period=True)
+        if form_ids is not None:
+            single_per_period_forms = single_per_period_forms.filter(id__in=form_ids)
+            if not single_per_period_forms.exists():
+                return self.annotate(
+                    status=models.Case(
+                        models.When(
+                            last_export_success_at__isnull=False,
+                            then=models.Value(Instance.STATUS_EXPORTED),
+                        ),
+                        default=models.Value(Instance.STATUS_READY),
+                        output_field=models.CharField(),
+                    )
+                )
+
         duplicates_subquery = (
-            self.values("period", "form", "org_unit")
+            # A null/empty period can't be a "single per period" duplicate, and SQL groups NULLs together,
+            # so leaving them in would flag unrelated periodless instances as duplicates of each other.
+            self.exclude(period__isnull=True)
+            .exclude(period="")
+            .values("period", "form", "org_unit")
             .annotate(ids=ArrayAgg("id"))
             .annotate(
                 c=models.Func(
@@ -110,7 +150,7 @@ class InstanceQuerySet(django_cte.CTEQuerySet):
                     output_field=models.IntegerField(),
                 )
             )
-            .filter(form__in=Form.objects.filter(single_per_period=True))
+            .filter(form__in=single_per_period_forms)
             .filter(c__gt=1)
             .annotate(id=models.Func("ids", function="unnest"))
             .values("id")
@@ -323,7 +363,7 @@ class InstanceQuerySet(django_cte.CTEQuerySet):
                     Q(org_unit__name__icontains=search) | Q(org_unit__aliases__contains=[search])
                 )
         # add status annotation
-        queryset = queryset.with_status()
+        queryset = queryset.with_status(form_ids=resolve_status_form_ids(form_id, form_ids))
 
         if modification_from:
             queryset = queryset.filter(updated_at__gte=get_beginning_of_day(modification_from, "modification_from"))

--- a/iaso/tests/api/instances/test_instances.py
+++ b/iaso/tests/api/instances/test_instances.py
@@ -3226,7 +3226,11 @@ class InstancesAPITestCase(TaskAPITestCase):
         self.client.force_authenticate(self.yoda)
         self.yoda.iaso_profile.projects.add(self.project)
 
-        expected_queries = 14
+        # 15, not 14: with_lock_info() is now applied only to the page's ids (fetched via a separate,
+        # cheap id-only query) instead of to the whole queryset before pagination, to avoid forcing
+        # PostgreSQL to evaluate (join, group, sort) the entire matching instance set before truncating
+        # it to a page, which is extremely expensive on large accounts.
+        expected_queries = 15
 
         with self.assertNumQueries(expected_queries):
             response = self.client.get("/api/instances/?limit=3000")

--- a/iaso/tests/api/instances/test_instances.py
+++ b/iaso/tests/api/instances/test_instances.py
@@ -859,7 +859,10 @@ class InstancesAPITestCase(TaskAPITestCase):
 
         instance = self.create_form_instance(form=self.form_1, org_unit=parent, project=self.project)
 
-        with self.assertNumQueries(17):
+        # 19, not 17: retrieve() now spends one extra query fetching the instance's form_id upfront, and
+        # with_status() spends another checking whether that form is single_per_period, to be able to skip
+        # the (expensive on large datasets) duplicates computation otherwise.
+        with self.assertNumQueries(19):
             response = self.client.get(f"/api/instances/{instance.id}/")
         self.assertEqual(response.status_code, 200)
 
@@ -1338,7 +1341,9 @@ class InstancesAPITestCase(TaskAPITestCase):
             org_unit=self.jedi_council_corruscant, instance=self.instance_1, form=self.form_1
         )
 
-        with self.assertNumQueries(10):
+        # 11, not 10: with_status() now spends one extra query checking whether the filtered-in form(s) are
+        # single_per_period, to be able to skip the (expensive on large datasets) duplicates computation otherwise.
+        with self.assertNumQueries(11):
             response = self.client.get(
                 f"/api/instances/?form_ids={self.instance_1.form.id}&csv=true", headers={"Content-Type": "text/csv"}
             )

--- a/iaso/tests/api/instances/test_instances_parquet.py
+++ b/iaso/tests/api/instances/test_instances_parquet.py
@@ -267,7 +267,9 @@ class InstancesAPITestCase(BaseAPITransactionTestCase):
         )
         instances = [self.instance_1, self.instance_2, self.instance_3, self.instance_4]
 
-        with self.assertNumQueries(8):
+        # 9, not 8: with_status() now spends one extra query checking whether the filtered-in form(s) are
+        # single_per_period, to be able to skip the (expensive on large datasets) duplicates computation otherwise.
+        with self.assertNumQueries(9):
             response = self.client.get(
                 f"/api/instances/?form_ids={self.instance_1.form.id}&parquet=true&order=id",
                 headers={"Content-Type": "text/csv"},

--- a/iaso/tests/models/test_instance.py
+++ b/iaso/tests/models/test_instance.py
@@ -95,6 +95,29 @@ class InstanceModelTestCase(TestCase, InstanceBase):
         self.assertStatusIs(self.instance_5, m.Instance.STATUS_READY)
         self.assertStatusIs(self.instance_6, m.Instance.STATUS_READY)
 
+    def test_with_status_skips_duplicates_query_when_no_single_per_period_form(self):
+        """
+        with_status(form_ids=...) should drop the duplicates GROUP BY/HAVING computation from the
+        generated SQL when none of the given forms are single_per_period, since only single_per_period
+        forms can ever produce STATUS_DUPLICATED instances.
+        """
+        # form_2 alone: not single_per_period -> duplicates computation is skipped from the SQL entirely.
+        sql = str(m.Instance.objects.with_status(form_ids=[self.form_2.id]).query)
+        self.assertNotIn("GROUP BY", sql)
+
+        # form_1 alone: single_per_period -> duplicates computation is kept.
+        sql = str(m.Instance.objects.with_status(form_ids=[self.form_1.id]).query)
+        self.assertIn("GROUP BY", sql)
+
+        # form_1 and form_2: at least one single_per_period form -> duplicates computation is kept.
+        sql = str(m.Instance.objects.with_status(form_ids=[self.form_1.id, self.form_2.id]).query)
+        self.assertIn("GROUP BY", sql)
+
+        # No form_ids given: can't know in advance without an extra query, so duplicates computation is
+        # kept unconditionally, against every single_per_period form (previous behavior).
+        sql = str(m.Instance.objects.with_status().query)
+        self.assertIn("GROUP BY", sql)
+
     def test_instance_status_duplicated_over_exported(self):
         instance_1 = self.create_form_instance(
             form=self.form_1,


### PR DESCRIPTION
## What problem is this PR solving?

we suspect the performance of with_status() to be overkill on some projects.

### Related JIRA tickets

IA-5292

## Changes

try to bypass the duplicate check evaluated when not necessary (ex searching for submission for forms not tagged as single_per_period) and limit the scope if it has to be evaluated (if we have forms, check duplicate on that form, not all forms)

## How to test

Search in instances with/without forms, with forms "single per period"

## Print screen / video

Upload here print screens or videos showing the changes.

## Notes

check this PR before https://github.com/BLSQ/iaso/pull/3170

## Doc


