### PR TITLE
POLIO-2170: embedded calendar: show integrated campaigns

### DIFF
--- a/hat/assets/js/apps/Iaso/hooks/useBoundState.ts
+++ b/hat/assets/js/apps/Iaso/hooks/useBoundState.ts
@@ -12,6 +12,8 @@ export const useBoundState = <T>(
         if (!isEqual(value, boundValue)) {
             setValue(boundValue);
         }
-    }, [boundValue, value]);
+        // not including value is intentional, the hook would not have the required behaviour
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [boundValue]);
     return [value, setValue];
 };

--- a/plugins/polio/js/src/constants/urls.ts
+++ b/plugins/polio/js/src/constants/urls.ts
@@ -127,6 +127,7 @@ export const polioRouteConfigs: Record<string, RouteConfig> = {
             ...campaignParams,
             'orgUnitGroups',
             'periodType',
+            'showIntegrated',
         ],
     },
     embeddedVaccineRepository: {


### PR DESCRIPTION
## What problem is this PR solving?

Checking the box would not show the integrated campaigns (embedded calendar only)

### Related JIRA tickets

POLIO-2170

## Changes

- add missing query params in route config

## How to test

On a polio DB set up a campaign with one or more integrated campaigns (campaign page)


 go to `dashboard/polio/embeddedCalendar/currentDate/2026-05-18/order/first_round_started_at/campaignType/polio/campaignCategory/all/show_test/true/filterLaunched/true/showIntegrated/true`
 
 
 tick/untick 'integrated campaigns': it should toggle the display

## Print screen / video

https://github.com/user-attachments/assets/c4e99011-bcae-4e5e-a86d-54d980e531d1

## Notes 

integrates https://github.com/BLSQ/iaso/pull/3165
