### PR TITLE
IA-5300 instances optimize with_lock_info

### DIFF
--- a/iaso/api/instances/views.py
+++ b/iaso/api/instances/views.py
@@ -456,13 +456,24 @@ class InstancesViewSet(viewsets.ViewSet):
                 limit = int(limit)
                 page_offset = int(page_offset)
 
-                queryset = queryset.with_lock_info(user=request.user)
-
                 paginator = Paginator(queryset, limit)
                 res = {"count": paginator.count}
                 if page_offset > paginator.num_pages:
                     page_offset = paginator.num_pages
                 page = paginator.page(page_offset)
+
+                # with_lock_info has no filters related to it's just "enrichment" of the page, so it can be done after the pagination,
+                # and not on the whole queryset during the count.
+                # its JOIN/GROUP BY is cheap for a handful of rows, but
+                # forces PostgreSQL to evaluate (join, group, sort) the entire matching instance set
+                # before it can be truncated to a page when applied beforehand, which is extremely slow
+                # on large accounts (minutes, on an account with a few million instances).
+                # Fetched via values_list() (rather than iterating page.object_list) to avoid pulling in
+                # the queryset's select_related/prefetch_related for a result we only use for its ids.
+                #
+                #
+                page_ids = list(page.object_list.values_list("id", flat=True))
+                locked_page = queryset.filter(pk__in=page_ids).with_lock_info(user=request.user)
 
                 def as_dict_formatter(instance: Annotated[Instance, LockAnnotation]) -> Dict:
                     d = instance.as_dict_with_descriptor() if with_descriptor == "true" else instance.as_dict()
@@ -472,7 +483,7 @@ class InstancesViewSet(viewsets.ViewSet):
                     d["is_reference_instance"] = instance._is_reference_instance
                     return d
 
-                res["instances"] = map(as_dict_formatter, page.object_list)
+                res["instances"] = map(as_dict_formatter, locked_page)
                 res["has_next"] = page.has_next()
                 res["has_previous"] = page.has_previous()
                 res["page"] = page_offset

--- a/iaso/tests/api/instances/test_instances.py
+++ b/iaso/tests/api/instances/test_instances.py
@@ -3226,7 +3226,11 @@ class InstancesAPITestCase(TaskAPITestCase):
         self.client.force_authenticate(self.yoda)
         self.yoda.iaso_profile.projects.add(self.project)
 
-        expected_queries = 14
+        # 15, not 14: with_lock_info() is now applied only to the page's ids (fetched via a separate,
+        # cheap id-only query) instead of to the whole queryset before pagination, to avoid forcing
+        # PostgreSQL to evaluate (join, group, sort) the entire matching instance set before truncating
+        # it to a page, which is extremely expensive on large accounts.
+        expected_queries = 15
 
         with self.assertNumQueries(expected_queries):
             response = self.client.get("/api/instances/?limit=3000")


### PR DESCRIPTION
## What problem is this PR solving?

on TOP of IA-5292

### Related JIRA tickets

IA-5300

## Changes

with_lock_info is heavy but only used to return info not filtering moving it "outside" the main query (at least before counts) helps greatly

## How to test

a copy of the prod-like db and run filter on the big accounts
query were in 1-2 minutes, now 2-6 seconds
but it's a bit hard to ensure it's not a postgres cache kicking, but it really looks better.

## Print screen / video


## Notes


## Doc

