### PR TITLE
IA-5302 prefetch user when issuing a dropdown query

### DIFF
--- a/iaso/api/profiles/views.py
+++ b/iaso/api/profiles/views.py
@@ -124,7 +124,14 @@ class ProfilesViewSet(ModelViewSet):
 
     def get_queryset(self):
         account = self.request.user.iaso_profile.account
-        qs = Profile.objects.filter(account=account).with_editable_org_unit_types()
+        qs = Profile.objects.filter(account=account)
+
+        if self.action == "dropdown":
+            # ProfileDropdownSerializer only reads obj.user_id and obj.user.username/first_name/last_name,
+            # so skip the editable_org_unit_types annotation (extra joins + GROUP BY) it never uses.
+            return qs.select_related("user")
+
+        qs = qs.with_editable_org_unit_types()
 
         if self.action == "list":
             if self.request.query_params.get("managedUsersOnly", "").lower() in ["true", "1"]:

--- a/iaso/tests/api/profiles/test_views/test_dropdown.py
+++ b/iaso/tests/api/profiles/test_views/test_dropdown.py
@@ -1,3 +1,4 @@
+from django.contrib.auth.models import User
 from django.urls import reverse
 
 from iaso.tests.api.profiles.test_views.common import BaseProfileAPITestCase
@@ -38,3 +39,24 @@ class ProfileDropdownAPITestCase(BaseProfileAPITestCase):
             self.assertCountEqual(item.keys(), ["label", "value"])
             self.assertEqual(item["value"], self.jane.id)
             self.assertEqual(item["label"], f"{self.jane.username} ({self.jane.get_full_name()})")
+
+    def test_dropdown_endpoint_does_not_trigger_n_plus_1_queries(self):
+        # Re-fetch a fresh user instance before each measurement so Django's
+        # permission cache (populated by the first `has_perm` call) can't
+        # mask query growth on the second measurement.
+        self.client.force_authenticate(User.objects.get(pk=self.jane.pk))
+
+        with self.assertNumQueries(5):
+            response = self.client.get(reverse("profiles-dropdown"))
+            self.assertJSONResponse(response, 200)
+
+        for i in range(20):
+            self.create_user_with_profile(username=f"extra_user_{i}", account=self.account)
+
+        self.client.force_authenticate(User.objects.get(pk=self.jane.pk))
+
+        # The number of queries must stay constant no matter how many profiles are returned,
+        # otherwise the "user" relation is being fetched once per profile instead of via select_related.
+        with self.assertNumQueries(5):
+            response = self.client.get(reverse("profiles-dropdown"))
+            self.assertJSONResponse(response, 200)


### PR DESCRIPTION
## What problem is this PR solving?

When searching/pausing on a short non selective you have a lot of profiles and for each of them we do query to get the user.

### Related JIRA tickets

IA-5302

## Changes

select_related if dropdown call

## How to test

see the test
but you can create plenty of user (via ./manage.py shell or xlsx import)
and then use the entity screen (filter on submitter)

## Print screen / video


## Notes



## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).
