### PR TITLE
IA 5303 improve perf of entities xlsx/csv export

### DIFF
--- a/iaso/api/entities/views.py
+++ b/iaso/api/entities/views.py
@@ -1,6 +1,6 @@
 from logging import getLogger
 
-from django.db.models import Max, Prefetch
+from django.db.models import F, OuterRef, Prefetch, Subquery
 from django.db.models.functions import Coalesce
 from django.http import JsonResponse, StreamingHttpResponse
 from django.shortcuts import get_object_or_404
@@ -128,15 +128,46 @@ class EntityViewSet(ModelViewSet):
         queryset = Entity.objects.filter_for_user(self.request.user)
         if self.action == "count":
             return queryset
-        if self.action == "list" and "last_saved_instance" in self._requested_ordering_fields:
+
+        is_export = self.action == "list" and self.request.accepted_renderer.format in ("csv", "xlsx")
+
+        if self.action == "list":
+            # Compute last_saved_instance via a correlated subquery (one indexed lookup per
+            # entity, no GROUP BY) instead of a Max()+GROUP BY aggregate, which would join every
+            # submitted instance to its entity before collapsing the rows back down, or a Python
+            # max() over a full instances prefetch (see Entity.get_latest_instance_created_at).
+            last_saved_instance_subquery = (
+                Instance.objects.filter(entity=OuterRef("pk"))
+                .annotate(saved_at=Coalesce("source_created_at", "created_at"))
+                .order_by("-saved_at")
+                .values("saved_at")[:1]
+            )
             queryset = queryset.annotate(
-                last_saved_instance=Max(Coalesce("instances__source_created_at", "instances__created_at"))
+                last_saved_instance=Coalesce(Subquery(last_saved_instance_subquery), F("created_at"))
             )
 
         queryset = queryset.select_related(
             "attributes__org_unit",
-            "attributes__created_by",
             "entity_type",
+        )
+
+        if is_export:
+            # EntityExportSerializer doesn't use instances, duplicates, or the extra
+            # org_unit/attributes relations below, so skip them on the export path.
+            # It also only reads org_unit.name/id and entity_type.name, so restrict the
+            # select_related columns to avoid loading the org_unit's geometry fields
+            # (geom, simplified_geom, catchment, location), which can be large.
+            queryset = queryset.only(
+                "uuid",
+                "created_at",
+                "entity_type__name",
+                "attributes__json",
+                "attributes__org_unit__name",
+            )
+            return queryset
+
+        queryset = queryset.select_related(
+            "attributes__created_by",
         ).prefetch_related(
             "attributes__created_by__teams",
             "attributes__form",
@@ -144,10 +175,6 @@ class EntityViewSet(ModelViewSet):
             "attributes__org_unit__org_unit_type",
             "attributes__org_unit__parent",
             "attributes__org_unit__version__data_source",
-            Prefetch(
-                "instances",
-                queryset=Instance.objects.only("id", "entity_id", "source_created_at", "created_at"),
-            ),
             Prefetch(
                 "duplicates1",
                 queryset=EntityDuplicate.objects.filter(
@@ -163,6 +190,17 @@ class EntityViewSet(ModelViewSet):
                 to_attr="pending_duplicates2",
             ),
         )
+
+        if self.action != "list":
+            # EntitySerializer (used outside the "list" action) serializes the full `instances`
+            # field; EntityListSerializer only needs last_saved_instance, already annotated above.
+            queryset = queryset.prefetch_related(
+                Prefetch(
+                    "instances",
+                    queryset=Instance.objects.only("id", "entity_id", "source_created_at", "created_at"),
+                ),
+            )
+
         return queryset
 
     @cached_property

--- a/iaso/management/commands/explain_request.py
+++ b/iaso/management/commands/explain_request.py
@@ -97,30 +97,40 @@ def get_filename(response, default="download.bin"):
     return default
 
 
+def save_streaming_content_to_file(response, output_dir):
+    filename = get_filename(response)
+    fullpath_name = output_dir + "/" + filename
+    print(f"saving response in {fullpath_name}")
+    size_bytes = 0
+    with open(fullpath_name, "wb") as f:
+        for chunk in response.streaming_content:
+            if isinstance(chunk, str):
+                chunk = chunk.encode()
+            f.write(chunk)
+            size_bytes += len(chunk)
+    if fullpath_name.endswith(".parquet"):
+        print("to visualize the content :")
+        print(f"    duckdb -c 'select * from \"{fullpath_name}\"'")
+    return f"binary in {filename}", size_bytes / 1024 / 1024
+
+
 def consume_response(response, output_dir):
     content_type = response.get("Content-Type", "")
     is_textual = is_content_type_textual(content_type)
     size_mb = -1
     # ensure we use the response or stream all the response to get the correct sql, duration and content
     if isinstance(response, FileResponse):
-        filename = get_filename(response)
-        fullpath_name = output_dir + "/" + filename
-        print(f"saving response in {fullpath_name}")
-        with open(fullpath_name, "wb") as f:
-            for chunk in response.streaming_content:
-                f.write(chunk)
-            f.flush()
-            f.seek(0)
-            body = f"binary in {filename}"
-        if fullpath_name.endswith(".parquet"):
-            print("to visualize the content :")
-            print(f"    duckdb -c 'select * from \"{fullpath_name}\"'")
+        body, _ = save_streaming_content_to_file(response, output_dir)
         size_mb = float(response.get("Content-Length")) / 1024 / 1024
     elif isinstance(response, StreamingHttpResponse):
-        body = "".join(
-            chunk.decode() if isinstance(chunk, bytes) else str(chunk) for chunk in response.streaming_content
-        )
-        size_mb = len(body) / 1024 / 1024
+        if is_textual:
+            body = "".join(
+                chunk.decode() if isinstance(chunk, bytes) else str(chunk) for chunk in response.streaming_content
+            )
+            size_mb = len(body) / 1024 / 1024
+        else:
+            # e.g. xlsx exports: binary content, can't be decoded/joined as text.
+            body, size_mb = save_streaming_content_to_file(response, output_dir)
 
     else:
         size_mb = len(response.content) / 1024 / 1024

--- a/iaso/tests/api/entities/test_entities.py
+++ b/iaso/tests/api/entities/test_entities.py
@@ -342,7 +342,7 @@ class WebEntityAPITestCase(EntityAPITestCase):
         m.EntityDuplicate.objects.create(
             entity1=entities[0], entity2=entities[1], validation_status=ValidationStatus.PENDING
         )
-        with self.assertNumQueries(10):
+        with self.assertNumQueries(9):
             response = self.client.get("/api/entities/", format="json")
         self.assertEqual(response.status_code, 200)
         result = response.json()["result"]
@@ -351,9 +351,12 @@ class WebEntityAPITestCase(EntityAPITestCase):
         self.assertTrue(target_result["has_duplicates"])
 
     def test_list_entities_annotate_last_saved_at(self):
-        """Test `last_saved_instance` is annotated correctly without n+1 queries"""
+        """Test `last_saved_instance` is annotated via a cheap correlated subquery, without n+1 queries"""
 
-        expensive_annotation = """MAX(COALESCE("iaso_instance"."source_created_at", "iaso_instance"."created_at"))"""
+        subquery_annotation = (
+            """(SELECT COALESCE(U0."source_created_at", U0."created_at") AS "saved_at" """
+            """FROM "iaso_instance" U0 WHERE U0."entity_id" = ("iaso_entity"."id") ORDER BY 1 DESC LIMIT 1)"""
+        )
 
         self.client.force_authenticate(self.yoda)
         source_created_at = timezone.make_aware(datetime.datetime(2025, 2, 3))
@@ -366,6 +369,7 @@ class WebEntityAPITestCase(EntityAPITestCase):
                 source_created_at=source_created_at + timedelta(days=i),
             )
 
+        # The subquery annotation (no join fan-out, no GROUP BY) is used regardless of ordering.
         with CaptureQueriesContext(connection) as ctx:
             response = self.client.get("/api/entities/", data={"order": "id"}, format="json")
         data = self.assertJSONResponse(response, 200)
@@ -373,8 +377,8 @@ class WebEntityAPITestCase(EntityAPITestCase):
         self.assertEqual(len(result), 3)
         self.assertEqual(result[0]["last_saved_instance"], "2025-02-03T00:00:00Z")
 
-        self.assertEqual(len(ctx.captured_queries), 8)
-        self.assertNotIn(expensive_annotation, "".join(q["sql"] for q in ctx.captured_queries))
+        self.assertEqual(len(ctx.captured_queries), 7)
+        self.assertIn(subquery_annotation, "".join(q["sql"] for q in ctx.captured_queries))
 
         with CaptureQueriesContext(connection) as ctx:
             response = self.client.get("/api/entities/", data={"order": "-last_saved_instance"}, format="json")
@@ -383,8 +387,8 @@ class WebEntityAPITestCase(EntityAPITestCase):
         self.assertEqual(len(result), 3)
         self.assertEqual(result[0]["last_saved_instance"], "2025-02-05T00:00:00Z")
 
-        self.assertEqual(len(ctx.captured_queries), 6)
-        self.assertIn(expensive_annotation, "".join(q["sql"] for q in ctx.captured_queries))
+        self.assertEqual(len(ctx.captured_queries), 5)
+        self.assertIn(subquery_annotation, "".join(q["sql"] for q in ctx.captured_queries))
 
     @time_machine.travel(datetime.datetime(2021, 7, 18, 14, 57, 0, 1), tick=False)
     def test_list_entities_single_entity_type(self):


### PR DESCRIPTION
## What problem is this PR solving?

It's super slow, now it's a bit less slow.

### Related JIRA tickets

IA-5303

## Changes
in `iaso/api/entities/views.py — EntityViewSet.get_queryset()`

1. `last_saved_instance` computation: No more join fan-out, no GROUP BY.
2. Since this annotation is now cheap, it's applied to every list request (JSON and CSV/XLSX export alike) instead of only when explicitly sorting by that field.
3. Export path (csv/xlsx) skips `attributes__created_by`, duplicates, and the extra org_unit/attributes prefetches entirely (`geom, simplified_geom, catchment, location`)


## How to test
the export to csv
```
docker compose exec iaso ./manage.py explain_request      --url-path="/api/entities/?order_columns=-id&entity_type_ids=66&limit=20&page=1&tab=list&csv=true"      --username="smestachmiiciv" --threshold-duration=0 --explain=true 2>&1
```
 
before
```
Status: 200
Response size: (31.03 MB)
Total request time: 516.115s with 1225 queries
```

after
```
Headers: {'Content-Type': 'text/csv', 'Content-Disposition': 'attachment; filename="entities-2026-07-07-13-29.csv"', 'Vary': 'Accept', 'Allow': 'GET, POST, HEAD, OPTIONS'}
Status: 200
Response size: (31.03 MB)
Total request time: 160.717s with 5 queries
```

for xlsx : `&csv=true` to `&xlsx=true`

verify the performance in the entities list screen (json)

## Print screen / video

<img width="2551" height="474" alt="image" src="https://github.com/user-attachments/assets/25a9324f-b6b1-4c32-ab04-2fc0100d4dae" />


## Notes

Still slow but better

## Doc

