### PR TITLE
POLIO-2174: limit profiles api

### DIFF
--- a/iaso/api/profiles/permissions.py
+++ b/iaso/api/profiles/permissions.py
@@ -20,7 +20,7 @@ class HasProfilePermission(permissions.BasePermission):
         if request.user.has_perm(CORE_USERS_MANAGED_PERMISSION.full_name()):
             return self.has_permission_over_user(request, pk, view.action)
 
-        return view.action in ["retrieve", "list", "export_csv", "export_xlsx", "dropdown"]
+        return view.action == "dropdown"
 
     # We could `return False` instead of raising exceptions,
     # but it's better to be explicit about why the permission was denied.

--- a/iaso/api/profiles/views.py
+++ b/iaso/api/profiles/views.py
@@ -63,11 +63,9 @@ class ProfilesViewSet(ModelViewSet):
     f"""Profiles API
 
     This API is restricted to authenticated users having the "{CORE_USERS_ADMIN_PERMISSION}" or "{CORE_USERS_MANAGED_PERMISSION}"
-    permission for write core_permissions.
-    Read access is accessible to any authenticated users as it necessary to list profile or display a particular one in
-    the interface.
-
-    Any logged user can also edit his profile to set his language.
+    permission for write operations and for listing, retrieving, or exporting other users.
+    Users without those permissions can only read and update their own profile via `/me`, and use the dropdown endpoint
+    which returns limited information.
 
     GET /api/profiles/
     GET /api/profiles/me => current user

--- a/iaso/tests/api/profiles/test_views/test_list.py
+++ b/iaso/tests/api/profiles/test_views/test_list.py
@@ -14,25 +14,23 @@ class ProfileListAPITestCase(BaseProfileAPITestCase):
         self.assertJSONResponse(response, 401)
 
     def test_profile_list_number_queries_without_read_only_permissions(self):
-        """GET /profiles/ with auth (user has read only permissions)"""
+        """GET /profiles/ with auth (user without users admin/managed permissions)"""
         self.client.force_authenticate(self.jane)
-        with self.assertNumQueries(13):
-            response = self.client.get(reverse("profiles-list"), data={"fields": ":all"})
-        self.assertJSONResponse(response, 200)
+        response = self.client.get(reverse("profiles-list"), data={"fields": ":all"})
+        self.assertJSONResponse(response, 403)
 
-    def test_profile_list_ok(self):
-        """GET /profiles/ with auth"""
+    def test_profile_list_denied_without_users_permissions(self):
+        """GET /profiles/ with auth (user without users admin/managed permissions)"""
         self.client.force_authenticate(self.jane)
         response = self.client.get(reverse("profiles-list"))
-        response_data = self.assertJSONResponse(response, 200)
-        self.assertValidProfileListData(response_data, 7)
+        self.assertJSONResponse(response, 403)
 
     def test_profile_list_user_roles_do_not_include_account_prefix(self):
         group = Group.objects.create(name=f"{self.account.id}_Data manager")
         user_role = UserRole.objects.create(group=group, account=self.account)
         self.jane.iaso_profile.user_roles.set([user_role])
 
-        self.client.force_authenticate(self.jane)
+        self.client.force_authenticate(self.jim)
         response = self.client.get(reverse("profiles-list"), {"fields": ":all", "search": self.jane.username})
         response_data = self.assertJSONResponse(response, 200)
 
@@ -92,14 +90,13 @@ class ProfileListAPITestCase(BaseProfileAPITestCase):
         self.assertValidProfileListData(response_data, 2)
 
     def test_profile_list_managed_user_only_user_regular_user(self):
-        """GET /profiles/ with auth (superuser)"""
+        """GET /profiles/ with auth (user without users admin/managed permissions)"""
         self.client.force_authenticate(self.jane)
         response = self.client.get(reverse("profiles-list"), {"managedUsersOnly": True, "fields": ":all"})
-        response_data = self.assertJSONResponse(response, 200)
-        self.assertValidProfileListData(response_data, 0)
+        self.assertJSONResponse(response, 403)
 
     def test_search_user_by_has_email(self):
-        self.client.force_authenticate(self.jane)
+        self.client.force_authenticate(self.jim)
 
         response = self.client.get(reverse("profiles-list"), {"has_email": True, "fields": ":all"})
         response_data = self.assertJSONResponse(response, 200)
@@ -112,7 +109,7 @@ class ProfileListAPITestCase(BaseProfileAPITestCase):
         self.assertFalse(all(x["email"] for x in response_data["results"]))
 
     def test_search_user_by_permissions(self):
-        self.client.force_authenticate(self.jane)
+        self.client.force_authenticate(self.jim)
 
         response = self.client.get(reverse("profiles-list"), {"permissions": "iaso_users", "fields": ":all"})
         response_data = self.assertJSONResponse(response, 200)
@@ -120,7 +117,7 @@ class ProfileListAPITestCase(BaseProfileAPITestCase):
         self.assertEqual(response_data["results"][0]["user_name"], "jim")
 
     def test_search_user_by_org_units(self):
-        self.client.force_authenticate(self.jane)
+        self.client.force_authenticate(self.jim)
         self.jane.iaso_profile.org_units.set([self.org_unit_from_parent_type])
 
         response = self.client.get(
@@ -133,7 +130,7 @@ class ProfileListAPITestCase(BaseProfileAPITestCase):
         self.assertEqual(response_data["results"][0]["user_name"], "janedoe")
 
     def test_search_user_by_org_units_type(self):
-        self.client.force_authenticate(self.jane)
+        self.client.force_authenticate(self.jim)
         self.jane.iaso_profile.org_units.set([self.org_unit_from_parent_type])
 
         response = self.client.get(
@@ -146,7 +143,7 @@ class ProfileListAPITestCase(BaseProfileAPITestCase):
         self.assertEqual(response_data["results"][0]["user_name"], "janedoe")
 
     def test_search_user_by_children_ou(self):
-        self.client.force_authenticate(self.jane)
+        self.client.force_authenticate(self.jim)
         self.jane.iaso_profile.org_units.set([self.child_org_unit])
 
         response = self.client.get(
@@ -160,7 +157,7 @@ class ProfileListAPITestCase(BaseProfileAPITestCase):
         self.assertEqual(response_data["results"][0]["user_name"], "janedoe")
 
     def test_search_user_by_parent_ou(self):
-        self.client.force_authenticate(self.jane)
+        self.client.force_authenticate(self.jim)
         self.jane.iaso_profile.org_units.set([self.org_unit_from_parent_type])
 
         response = self.client.get(
@@ -172,7 +169,7 @@ class ProfileListAPITestCase(BaseProfileAPITestCase):
         self.assertEqual(response_data["results"][0]["user_name"], "janedoe")
 
     def test_list_by_ids(self):
-        self.client.force_authenticate(self.jane)
+        self.client.force_authenticate(self.jim)
         response = self.client.get(reverse("profiles-list"), {"ids": f"{self.jane.id},{self.jim.id}", "fields": ":all"})
         response_data = self.assertJSONResponse(response, 200)
         self.assertValidProfileListData(response_data, 2)
@@ -180,7 +177,7 @@ class ProfileListAPITestCase(BaseProfileAPITestCase):
         self.assertEqual(response_data["results"][1]["user_name"], "jim")
 
     def test_search_by_profile_ids(self):
-        self.client.force_authenticate(self.jane)
+        self.client.force_authenticate(self.jim)
         response = self.client.get(
             reverse("profiles-list"),
             {"search": f"ids:{self.jane.iaso_profile.id},{self.jim.iaso_profile.id}", "order": "id", "fields": ":all"},
@@ -191,7 +188,7 @@ class ProfileListAPITestCase(BaseProfileAPITestCase):
         self.assertEqual(response_data["results"][1]["user_name"], "jim")
 
     def test_search_by_dhis2_id(self):
-        self.client.force_authenticate(self.jane)
+        self.client.force_authenticate(self.jim)
         mydhis2_id = "mydhis2id"
 
         self.jim.iaso_profile.dhis2_id = mydhis2_id
@@ -203,7 +200,7 @@ class ProfileListAPITestCase(BaseProfileAPITestCase):
         self.assertEqual(response_data["results"][0]["user_name"], "jim")
 
     def test_search_by_teams(self):
-        self.client.force_authenticate(self.jane)
+        self.client.force_authenticate(self.jim)
         response = self.client.get(
             reverse("profiles-list"), {"teams": f"{self.team1.pk},{self.team2.pk}", "fields": ":all"}
         )
@@ -217,7 +214,7 @@ class ProfileListAPITestCase(BaseProfileAPITestCase):
         self.jane.iaso_profile.organization = "Some organization"
         self.jane.iaso_profile.save()
 
-        self.client.force_authenticate(self.jane)
+        self.client.force_authenticate(self.jim)
         response = self.client.get(reverse("profiles-list"), {"limit": 100, "fields": ":all"})
         response_data = self.assertJSONResponse(response, 200)
         self.assertValidProfileListData(response_data, 7)
@@ -233,7 +230,7 @@ class ProfileListAPITestCase(BaseProfileAPITestCase):
         self.assertValidProfileListData(response_data, 0)
 
     def test_search_parameters_default(self):
-        self.client.force_authenticate(self.jane)
+        self.client.force_authenticate(self.jim)
         self.jane.iaso_profile.org_units.set([self.org_unit_from_parent_type])
 
         response = self.client.get(reverse("profiles-list"), {"limit": 100, "fields": ":all"})
@@ -259,7 +256,7 @@ class ProfileListAPITestCase(BaseProfileAPITestCase):
         self.assertEqual(response_data["results"][0]["user_name"], "janedoe")
 
     def test_search_parameters(self):
-        self.client.force_authenticate(self.jane)
+        self.client.force_authenticate(self.jim)
         self.jane.iaso_profile.org_units.set([self.org_unit_from_parent_type])
 
         response = self.client.get(reverse("profiles-list"), {"limit": 100, "fields": ":all"})
@@ -435,7 +432,7 @@ class ProfileListAPITestCase(BaseProfileAPITestCase):
             ]
         )
 
-        self.client.force_authenticate(self.jane)
+        self.client.force_authenticate(self.jim)
         response = self.client.get(
             reverse("profiles-list"),
             {"location": self.org_unit_from_parent_type.pk, "ouChildren": True, "fields": ":all"},
@@ -467,7 +464,7 @@ class ProfileListAPITestCase(BaseProfileAPITestCase):
         self.jim.iaso_profile.org_units.set([self.org_unit_from_parent_type])  # Current
         self.jam.iaso_profile.org_units.set([self.child_org_unit])  # Child
 
-        self.client.force_authenticate(self.jane)
+        self.client.force_authenticate(self.jim)
         response = self.client.get(
             reverse("profiles-list"),
             {"location": self.org_unit_from_parent_type.pk, "ouParent": True, "ouChildren": True, "fields": ":all"},
@@ -510,7 +507,7 @@ class ProfileListAPITestCase(BaseProfileAPITestCase):
         self.jam.iaso_profile.org_units.set([child_of_child])  # Child of child
         self.jom.iaso_profile.org_units.set([grand_child])  # Grand child
 
-        self.client.force_authenticate(self.jane)
+        self.client.force_authenticate(self.jim)
         response = self.client.get(
             reverse("profiles-list"),
             {"location": self.org_unit_from_parent_type.pk, "ouChildren": True, "fields": ":all"},

--- a/iaso/tests/api/profiles/test_views/test_list_export.py
+++ b/iaso/tests/api/profiles/test_views/test_list_export.py
@@ -11,12 +11,20 @@ from iaso.tests.api.profiles.test_views.common import BaseProfileAPITestCase
 class ProfileListExportAPITestCase(BaseProfileAPITestCase):
     maxDiff = None
 
+    def test_profile_list_export_denied_without_users_permissions(self):
+        self.client.force_authenticate(self.jane)
+        response = self.client.get(reverse("profiles-export-csv"))
+        self.assertJSONResponse(response, 403)
+
+        response = self.client.get(reverse("profiles-export-xlsx"))
+        self.assertJSONResponse(response, 403)
+
     def test_profile_list_export_as_csv_multiple_teams(self):
         multi_user = self.create_user_with_profile(username="multiteam", account=self.account)
 
         multi_user.teams.set([self.team1, self.team2])
 
-        self.client.force_authenticate(self.jane)
+        self.client.force_authenticate(self.jim)
         response = self.client.get(reverse("profiles-export-csv"))
         self.assertEqual(response.status_code, 200)
 
@@ -38,7 +46,7 @@ class ProfileListExportAPITestCase(BaseProfileAPITestCase):
         self.john.iaso_profile.org_units.set([self.org_unit_from_sub_type, self.org_unit_from_parent_type])
         self.jum.iaso_profile.editable_org_unit_types.set([self.sub_unit_type])
 
-        self.client.force_authenticate(self.jane)
+        self.client.force_authenticate(self.jim)
         response = self.client.get(reverse("profiles-export-csv"))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response["Content-Type"], "text/csv")
@@ -82,7 +90,7 @@ class ProfileListExportAPITestCase(BaseProfileAPITestCase):
         self.john.iaso_profile.org_units.set([self.org_unit_from_sub_type, self.org_unit_from_parent_type])
         self.jum.iaso_profile.editable_org_unit_types.set([self.sub_unit_type])
 
-        self.client.force_authenticate(self.jane)
+        self.client.force_authenticate(self.jim)
         response = self.client.get(reverse("profiles-export-xlsx"))
         excel_columns, excel_data = self.assertXlsxFileResponse(response)
 

--- a/iaso/tests/api/profiles/test_views/test_retrieve.py
+++ b/iaso/tests/api/profiles/test_views/test_retrieve.py
@@ -64,13 +64,11 @@ class ProfileRetrieveAPITestCase(BaseProfileAPITestCase):
         self.assertEqual(response_data["account"]["feature_flags"], [])
 
     def test_profile_retrieve_read_only_permissions(self):
-        """GET /profiles/ with auth (user has read only permissions)"""
+        """GET /profiles/<id> without users admin/managed permissions is denied"""
 
         self.client.force_authenticate(self.jane)
         response = self.client.get(reverse("profiles-detail", kwargs={"pk": self.jane.iaso_profile.id}))
-        response_data = self.assertJSONResponse(response, 200)
-        self.assertValidProfileData(response_data)
-        self.assertEqual(response_data["user_name"], "janedoe")
+        self.assertJSONResponse(response, 403)
 
     def test_retrieve_profile_me_without_auth(self):
         """GET /profiles/me/ without auth should result in a 401"""


### PR DESCRIPTION
## What problem is this PR solving?
Vulnerability Description

It allows a low-privilege account to view sensitive user details that should only be accessible to administrators.
For example, the poliogo-test.afro.who.int/api/ or poliogo-test.afro.who.int/api/profile/[userID] endpoints are accessible to all user roles. Attackers can reach this endpoint just by fuzzing the path.


### Related JIRA tickets

POLIO-2174

## Changes

- limit  retrieve, list and export  profiles if not admin or having correct permission 
- let only pass /me and dropdown search

## How to test
Create a user without user permission, make sure profile dropdown are working and that you cannot acces profiles api

## Print screen / video


<img width="1659" height="863" alt="Screenshot 2026-07-07 at 17 08 26" src="https://github.com/user-attachments/assets/51269b5c-e1f4-4bcc-8074-7a98a6e1fe70" />
<img width="1708" height="823" alt="Screenshot 2026-07-07 at 17 06 00" src="https://github.com/user-attachments/assets/778fc957-3a82-4287-80bf-419270a4a5df" />
<img width="935" height="535" alt="Screenshot 2026-07-07 at 17 05 51" src="https://github.com/user-attachments/assets/6b548acc-1f89-4d5c-8abc-bdcb1164b382" />
<img width="1183" height="584" alt="Screenshot 2026-07-07 at 17 05 43" src="https://github.com/user-attachments/assets/98fa19bf-7838-472c-b17f-5962be19377a" />
