### PR TITLE
IA-5290: dhis2 menu entry bug

### DIFF
--- a/hat/assets/js/apps/Iaso/constants/menu.tsx
+++ b/hat/assets/js/apps/Iaso/constants/menu.tsx
@@ -540,7 +540,8 @@ export const useMenuItems = (): MenuItems => {
 
     if (
         hasFeatureFlag(currentUser, SHOW_DHIS2_LINK) &&
-        currentUser?.account?.default_version?.data_source.url
+        currentUser?.account?.default_version?.data_source.url &&
+        !basicItems.find(item => item.key === 'dhis2')
     ) {
         basicItems.push({
             label: formatMessage(MESSAGES.dhis2),


### PR DESCRIPTION

## What problem is this PR solving?

Explain here in one sentence.

### Related JIRA tickets

[IA-5290](https://bluesquare.atlassian.net/browse/IA-5290)

## Changes

Checking if the dhis2 menu key is existing in the list before add it

## How to test

From iaso, with user belongs to an account with `SHOW_DHIS2_LINK` feature flag and dhis2 module activated, try to click in the menu **Go to DHIS2** and look in the menu, you should see a single entry 


## Print screen / video

[DHis2 entry menu.webm](https://github.com/user-attachments/assets/0796877d-7393-463a-954e-2c95cb7eb2f7)


## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).


[IA-5290]: https://bluesquare.atlassian.net/browse/IA-5290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ