### PR TITLE
IA-5306: Form AI JSON not handled

### DIFF
--- a/iaso/api/form_ai/agent.py
+++ b/iaso/api/form_ai/agent.py
@@ -85,7 +85,7 @@ When the user asks you to create or modify a form, you MUST respond with valid J
 
 class SurveyRow(BaseModel, extra="allow"):
     type: str
-    name: str
+    name: str = ""
     label: str = ""
 
 
@@ -316,8 +316,15 @@ def generate_form(
             "conversation_history": new_history,
         }
 
-    except (json.JSONDecodeError, Exception) as e:
-        logger.info("Response was not a form (might be conversational): %s", e)
+    except json.JSONDecodeError as e:
+        logger.info("Response was not valid JSON (might be conversational): %s", e)
+        return {
+            "assistant_message": response_text,
+            "form": None,
+            "conversation_history": new_history,
+        }
+    except Exception as e:
+        logger.warning("Failed to parse AI form response: %s", e)
         return {
             "assistant_message": response_text,
             "form": None,

--- a/iaso/tests/api/test_form_ai.py
+++ b/iaso/tests/api/test_form_ai.py
@@ -54,6 +54,7 @@ class FormAIParseResponseTestCase(APITestCase):
         self.assertEqual(form.survey[4].type, "end_repeat")
         self.assertEqual(form.survey[4].name, "")
 
+
 @override_settings(MEDIA_ROOT=tempfile.mkdtemp())
 class FormAIChatTestCase(APITestCase):
     url = "/api/form_ai/"

--- a/iaso/tests/api/test_form_ai.py
+++ b/iaso/tests/api/test_form_ai.py
@@ -9,7 +9,7 @@ from django.core.files.uploadedfile import UploadedFile
 from django.test import override_settings
 
 from iaso import models as m
-from iaso.api.form_ai.agent import FormSettings, GeneratedForm, SurveyRow
+from iaso.api.form_ai.agent import FormSettings, GeneratedForm, SurveyRow, parse_form_response
 from iaso.models.form_ai import TemporaryForm
 from iaso.modules import MODULE_FORM_AI
 from iaso.permissions.core_permissions import CORE_FORMS_PERMISSION
@@ -30,6 +30,29 @@ def _make_generated_form() -> GeneratedForm:
         message="Here is your form.",
     )
 
+
+class FormAIParseResponseTestCase(APITestCase):
+    def test_parses_response_with_missing_names_on_structural_rows(self):
+        """end group/end repeat rows often omit name; parsing must still succeed."""
+        response_text = """{
+  "survey": [
+    {"type": "text", "name": "q1", "label": "Question 1"},
+    {"type": "begin group", "name": "grp", "label": "Group"},
+    {"type": "end group "},
+    {"type": "begin_repeat", "name": "rep", "label": "Repeat"},
+    {"type": "end_repeat"}
+  ],
+  "choices": [],
+  "settings": {"form_title": "Test", "form_id": "test", "version": "1"},
+  "message": "Added a question."
+}"""
+        form = parse_form_response(response_text)
+
+        self.assertEqual(form.message, "Added a question.")
+        self.assertEqual(form.survey[2].type, "end group ")
+        self.assertEqual(form.survey[2].name, "")
+        self.assertEqual(form.survey[4].type, "end_repeat")
+        self.assertEqual(form.survey[4].name, "")
 
 @override_settings(MEDIA_ROOT=tempfile.mkdtemp())
 class FormAIChatTestCase(APITestCase):


### PR DESCRIPTION
## What problem is this PR solving?
Sometimes, in the form AI, the answer from the model is not correctly interpreted and is directly output to the user. We need to investigate why and try to prevent that:
<img width="1440" height="822" alt="image" src="https://github.com/user-attachments/assets/32fda49d-5650-43af-b43a-47fc3b29e493" />


### Related JIRA tickets

IA-5306

## Changes

better error handling, init SurveyRow name to empty string + tests

## How to test

Tests should cover the case