### PR TITLE
[IA-5159] nginx and EBS configs

### DIFF
--- a/deployment/.ebextensions/cloudwatch_agent_metrics.config
+++ b/deployment/.ebextensions/cloudwatch_agent_metrics.config
@@ -1,0 +1,45 @@
+files:  
+  "/opt/aws/amazon-cloudwatch-agent/bin/config.json": 
+    mode: "000600"
+    owner: root
+    group: root
+    content: |
+      {
+        "agent": {
+          "metrics_collection_interval": 60,
+          "run_as_user": "root"
+        },
+        "metrics": {
+          "aggregation_dimensions": [
+            [
+                "InstanceId"
+            ]
+          ],        
+          "append_dimensions": {
+            "AutoScalingGroupName": "${aws:AutoScalingGroupName}",
+            "ImageId": "${aws:ImageId}",
+            "InstanceId": "${aws:InstanceId}",
+            "InstanceType": "${aws:InstanceType}"
+          },
+          "metrics_collected": {
+            "disk": {
+              "measurement": [
+                "used_percent"
+              ],
+              "metrics_collection_interval": 60,
+              "resources": [
+                "*"
+              ]
+            },
+            "mem": {
+              "measurement": [
+                "mem_used_percent"
+              ],
+              "metrics_collection_interval": 60
+            }
+          }
+        }
+      }  
+container_commands:
+  start_cloudwatch_agent: 
+    command: /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:/opt/aws/amazon-cloudwatch-agent/bin/config.json

--- a/deployment/.platform/hooks/postdeploy/03_migrate.sh
+++ b/deployment/.platform/hooks/postdeploy/03_migrate.sh
@@ -4,6 +4,9 @@ set -e
 echo "Compiling translations..."
 docker compose exec -T iaso python manage.py compilemessages
 
+echo "Compiling Django template SCSS to CSS..."
+docker compose exec -T iaso python manage.py compile_index_scss
+
 echo "Collecting static files..."
 docker compose exec -T iaso python manage.py collectstatic --noinput
 

--- a/deployment/.platform/nginx/nginx.conf
+++ b/deployment/.platform/nginx/nginx.conf
@@ -21,6 +21,9 @@ http {
         "" "http://localhost";
     }
 
+    # Disable server tokens to prevent revealing Nginx version
+    server_tokens off;
+
     server {
         listen 80;
         server_name _;


### PR DESCRIPTION
## What problem is this PR solving?

updates in nginx and EBS configs

### Related JIRA tickets

IA-5159

## Changes

- updated the docker nginx config 
- copied the EBS cloudwatch config that was missing in docker environment
- added missing command on deployment

## How to test

- impossible to test without deploying
- once it's deployed:
  - check cloudwatch for that server in AWS, you should see disk and memory metrics
  - check if response headers still include the nginx version (they should not)
<img width="371" height="318" alt="image" src="https://github.com/user-attachments/assets/af9e771e-5ff1-4f6d-9025-2db62696686e" />



## Print screen / video

result on a server where the fix is deployed:
<img width="356" height="327" alt="image" src="https://github.com/user-attachments/assets/62459472-5237-49e6-aecd-2a67bf07ca3c" />


## Notes

/

## Doc

/
