### PR TITLE
IA-5313 try to add some caching and remove a bit of db workload

### DIFF
--- a/iaso/api/instances/views.py
+++ b/iaso/api/instances/views.py
@@ -5,7 +5,7 @@ import tempfile
 
 from copy import copy
 from time import gmtime, strftime
-from typing import Any, Dict, Optional, Union
+from typing import Any, Callable, Dict, Optional, Union
 
 import pandas as pd
 
@@ -942,6 +942,15 @@ class InstancesViewSet(viewsets.ViewSet):
         return Response(log_dict)
 
 
+def cached(cache: dict, key: Any, fetch: Callable[[], Any]) -> Any:
+    """Return `cache[key]`, computing it via `fetch()` and storing it the first time it's missing."""
+    value = cache.get(key)
+    if value is None:
+        value = fetch()
+        cache[key] = value
+    return value
+
+
 def find_entity(account: Account, entity_uuid: str, entity_type_id: Optional[int] = None) -> Entity:
     # In case of duplicate UUIDs in the database, only allow 1 non-deleted one.
     # If a non-deleted entity was found, ignore potential duplicates.
@@ -987,6 +996,29 @@ def import_data(instances, user, app_id):
     project = Project.objects.get_for_user_and_app_id(user, app_id)
     rtn_instances = []
 
+    # A batch commonly has several instances (e.g. a registration + follow-up forms) pointing at
+    # the same org unit / form - bulk-prefetch those up front instead of hitting the DB once per
+    # instance. `cached()` still backs each lookup below as a safety net for any gap (e.g. an
+    # orgUnitId/formId that slipped through the prefetch for some reason).
+    org_unit_uuids = {
+        instance_data.get("orgUnitId")
+        for instance_data in instances
+        if not str(instance_data.get("orgUnitId")).isdigit()
+    }
+    org_unit_cache = {
+        org_unit.uuid: org_unit
+        for org_unit in OrgUnit.objects.filter(uuid__in=org_unit_uuids, version_id=project.account.default_version_id)
+    }
+
+    form_ids = {int(instance_data["formId"]) for instance_data in instances if instance_data.get("formId") is not None}
+    form_cache = {form.id: form for form in Form.objects.filter(id__in=form_ids)}
+
+    # Entities can't be bulk-prefetched the same way: resolving one may create it or pick the
+    # "best" one among duplicates (see `find_entity`), so each lookup still goes through `cached()`
+    # lazily, one query per distinct (uuid, entity_type_id) / entity_type_id encountered.
+    entity_cache = {}
+    entity_type_cache = {}
+
     for instance_data in instances:
         uuid = instance_data.get("id", None)
 
@@ -1021,17 +1053,30 @@ def import_data(instances, user, app_id):
         if str(tentative_org_unit_id).isdigit():
             instance.org_unit_id = tentative_org_unit_id
         else:
-            org_unit = OrgUnit.objects.get(uuid=tentative_org_unit_id, version_id=project.account.default_version_id)
-            instance.org_unit = org_unit
+            instance.org_unit = cached(
+                org_unit_cache,
+                tentative_org_unit_id,
+                lambda org_unit_uuid=tentative_org_unit_id: OrgUnit.objects.get(
+                    uuid=org_unit_uuid, version_id=project.account.default_version_id
+                ),
+            )
 
-        instance.form_id = instance_data.get("formId")
+        raw_form_id = instance_data.get("formId")
+        # Normalize to int: the mobile app sends this as a JSON string (e.g. "1"), and leaving it
+        # as-is would make later id comparisons (e.g. against `entity_type.reference_form_id`)
+        # silently fail ("1" != 1) and would fragment `form_cache` across differently-typed keys.
+        instance.form_id = int(raw_form_id) if raw_form_id is not None else None
 
         # TODO: check that planning_id is valid
         instance.planning_id = instance_data.get("planningId", None)
         entity_uuid = instance_data.get("entityUuid", None)
         entity_type_id = instance_data.get("entityTypeId", None)
         if entity_uuid and entity_type_id:
-            entity = find_entity(project.account, entity_uuid, entity_type_id)
+            entity = cached(
+                entity_cache,
+                (entity_uuid, entity_type_id),
+                lambda uuid=entity_uuid, type_id=entity_type_id: find_entity(project.account, uuid, type_id),
+            )
 
             if entity.deleted_at:
                 logger.info(
@@ -1056,8 +1101,10 @@ def import_data(instances, user, app_id):
 
             instance.entity = entity
 
+            entity_type = cached(entity_type_cache, entity.entity_type_id, lambda entity=entity: entity.entity_type)
+
             # If instance's form is the same as the type reference form, set the instance as reference_instance
-            if entity.entity_type.reference_form == instance.form:
+            if entity_type.reference_form_id == instance.form_id:
                 entity.attributes = instance
                 entity.save()
 
@@ -1076,8 +1123,13 @@ def import_data(instances, user, app_id):
             instance.location = Point(x=longitude, y=latitude, z=altitude, srid=4326)
         instance.save()
 
-        if instance.form.change_request_mode == CR_MODE_IF_REFERENCE_FORM:
-            if instance.form in instance.org_unit.org_unit_type.reference_forms.all():
+        form = cached(form_cache, instance.form_id, lambda instance=instance: instance.form)
+        # Also warm this instance's own FK cache (not just our local `form_cache`), since
+        # `instance.form` is accessed again later, in the loop over `rtn_instances` below.
+        instance.form = form
+
+        if form.change_request_mode == CR_MODE_IF_REFERENCE_FORM:
+            if form in instance.org_unit.org_unit_type.reference_forms.all():
                 oucr = OrgUnitChangeRequest()
                 oucr.org_unit = instance.org_unit
                 if user and not user.is_anonymous:

--- a/iaso/models/instances.py
+++ b/iaso/models/instances.py
@@ -17,7 +17,7 @@ from django.contrib.auth.models import User
 from django.contrib.gis.db.models.fields import PointField
 from django.contrib.gis.geos import Point
 from django.contrib.postgres.aggregates import ArrayAgg
-from django.core.exceptions import ObjectDoesNotExist, ValidationError
+from django.core.exceptions import ValidationError
 from django.core.paginator import Paginator
 from django.db import models
 from django.db.models import Count, Exists, F, FilteredRelation, Func, OuterRef, Q
@@ -896,13 +896,22 @@ class Instance(ValidationWorkflowArtefact):
     def has_org_unit(self):
         return self.org_unit if self.org_unit else None
 
+    # Cache of the `_version` string last resolved to `form_version_id` in `save()`, to avoid
+    # re-querying FormVersion on every save() call within one instance's lifetime (e.g. when
+    # convert_location_from_field/convert_device/convert_correlation each save() in turn).
+    _form_version_lookup_key = None
+
     def save(self, *args, **kwargs):
-        if self.json is not None and self.json.get("_version"):
-            try:
-                form_version = FormVersion.objects.get(version_id=self.json.get("_version"), form_id=self.form.id)
-                self.form_version = form_version
-            except ObjectDoesNotExist:
-                pass
+        version_id = self.json.get("_version") if self.json else None
+        if version_id and self._form_version_lookup_key != version_id:
+            form_version_id = (
+                FormVersion.objects.filter(version_id=version_id, form_id=self.form_id)
+                .values_list("id", flat=True)
+                .first()
+            )
+            if form_version_id is not None:
+                self.form_version_id = form_version_id
+            self._form_version_lookup_key = version_id
         return super(Instance, self).save(*args, **kwargs)
 
 

--- a/iaso/tasks/process_mobile_bulk_upload.py
+++ b/iaso/tasks/process_mobile_bulk_upload.py
@@ -85,11 +85,13 @@ def process_mobile_bulk_upload(api_import_id, project_id, task=None):
                     new_instance_files = []
                     dirs = get_directory_handlers(zip_ref)
 
-                    for instance_data in instances_data:
+                    total_instances = len(instances_data)
+                    for index, instance_data in enumerate(instances_data, start=1):
                         uuid = instance_data["id"]
                         instance = Instance.objects.get(uuid=uuid)
                         original = copy(instance)
-                        instance = process_instance_xml(instance, instance_data, zip_ref, user)
+                        prefix = f"({index}/{total_instances})"
+                        instance = process_instance_xml(instance, instance_data, zip_ref, user, prefix)
                         stats["new_instances"] += 1
                         new_instance_files += process_instance_attachments(dirs[uuid], instance)
                         log_modification(v1=original, v2=instance, source=BULK_UPLOAD, user=user)
@@ -163,10 +165,10 @@ def get_directory_handlers(zip_ref):
     return result
 
 
-def process_instance_xml(instance: Instance, instance_data, zip_ref, user):
+def process_instance_xml(instance: Instance, instance_data, zip_ref, user, prefix=""):
     uuid = instance.uuid
     filename = ntpath.basename(instance_data.get("file", None))
-    logger.info(f"Processing instance {instance.uuid}")
+    logger.info(f"{prefix} Processing instance {instance.uuid}")
     with zip_ref.open(os.path.join(uuid, filename), "r") as f:
         if not instance.file or not instance.json:  # new instance
             instance = process_instance_file(instance, File(f), user)

--- a/iaso/tests/api/test_forms_attachment.py
+++ b/iaso/tests/api/test_forms_attachment.py
@@ -28,6 +28,11 @@ BASE_URL = "/api/formattachments/"
 MANIFEST_MOBILE_URL = "/api/forms/{form_id}/manifest/"
 MANIFEST_ENKETO_URL = "/api/forms/{form_id}/manifest_enketo/"
 SAFE_FILE_PATH = "iaso/tests/fixtures/clamav/safe.jpg"
+
+# A pk that can't collide with any real row, regardless of how far the id sequence has advanced
+# elsewhere in the suite - unlike a small hardcoded id (e.g. 100), which a large enough test run
+# can legitimately reach.
+MISSING_FORM_PK = 999_999_999
 EICAR_FILE_PATH = "iaso/tests/fixtures/clamav/eicar.txt"
 
 
@@ -309,7 +314,7 @@ class FormAttachmentsAPITestCase(APITestCase):
     def test_manifest_form_not_found(self):
         f"""GET {MANIFEST_MOBILE_URL} with wrong id: 404"""
         self.client.force_authenticate(self.yoda)
-        response = self.client.get(MANIFEST_MOBILE_URL.format(form_id=100))
+        response = self.client.get(MANIFEST_MOBILE_URL.format(form_id=MISSING_FORM_PK))
         self.assertJSONResponse(response, 404)
 
     def test_manifest_form_found_but_empty_attachments(self):
@@ -496,7 +501,7 @@ class FormAttachmentsAPITestCase(APITestCase):
 
     def test_enketo_manifest_anonymous_with_signed_url_error_unknown_form(self):
         """Test that a signed anonymous URL generates an error when querying an unknown form"""
-        path = MANIFEST_ENKETO_URL.format(form_id=123456789)
+        path = MANIFEST_ENKETO_URL.format(form_id=MISSING_FORM_PK)
         signed_url = generate_signed_url(
             path, settings.ENKETO.get("ENKETO_SIGNING_SECRET"), extra_params={APP_ID: self.project_1.app_id}
         )

--- a/iaso/tests/api/test_sync_import_query_count.py
+++ b/iaso/tests/api/test_sync_import_query_count.py
@@ -1,0 +1,84 @@
+from iaso import models as m
+from iaso.test import APITestCase
+from iaso.tests.utils.query_profiler import QueryProfiler
+
+
+class SyncImportQueryCountTest(APITestCase):
+    """
+    Baseline for the one-by-one sync import path (POST /api/instances/ then
+    POST /sync/form_upload/), mirroring the bulk-upload baseline in
+    test_process_mobile_bulk_upload.py - see IA perf investigation notes.
+
+    Unlike the bulk zip fixture (4 instances, 2 shared (form, version) pairs), this is a
+    single instance - so the per-batch org_unit/entity caching added to import_data() has
+    nothing to cache across and shouldn't move the numbers here. The per-instance fixes
+    (Instance.save() FormVersion memoization, id-vs-object comparison in import_data())
+    should still show up, since they apply per instance regardless of batch size.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.account = m.Account.objects.create(name="Sync perf account")
+        cls.project = m.Project.objects.create(
+            name="Sync perf project", app_id="sync.perf.project", account=cls.account
+        )
+        cls.org_unit_type = m.OrgUnitType.objects.create(name="Health facility", short_name="HF")
+        cls.org_unit = m.OrgUnit.objects.create(name="Facility A", org_unit_type=cls.org_unit_type)
+        cls.form = m.Form.objects.create(name="Land Speeder", form_id="sample1")
+        # Matches the `version=` attribute in iaso/tests/fixtures/land_speeder.xml, so the
+        # FormVersion lookup path in Instance.save()/xml_file_to_json is actually exercised.
+        m.FormVersion.objects.create(form=cls.form, version_id="201911280919")
+
+    def test_one_by_one_sync_import_query_count(self):
+        uuid = "4b7c3954-f69a-4b99-83b1-db73957b32d2"
+        file_name = "land_speeder.xml"
+        instance_body = [
+            {
+                "id": uuid,
+                "latitude": 4.4,
+                "created_at": 1565258153704,
+                "updated_at": 1565258153704,
+                "orgUnitId": self.org_unit.id,
+                "formId": self.form.id,
+                "longitude": 4.4,
+                "accuracy": 10,
+                "altitude": 100,
+                "file": f"/storage/emulated/0/odk/instances/{file_name}",
+                "name": file_name,
+            }
+        ]
+
+        with QueryProfiler(
+            trace_tables=["iaso_formversion", "iaso_form", "iaso_orgunit", "iaso_entity", "iaso_entitytype"]
+        ) as profiler:
+            response = self.client.post(
+                f"/api/instances/?app_id={self.project.app_id}", data=instance_body, format="json"
+            )
+            self.assertEqual(response.status_code, 200)
+
+            with open(f"iaso/tests/fixtures/{file_name}") as fp:
+                self.client.post("/sync/form_upload/", {"xml_submission_file": fp}, format="multipart")
+
+        self.assertEqual(m.Instance.objects.count(), 1)
+        instance = m.Instance.objects.get(uuid=uuid)
+        self.assertIsNotNone(instance.form_version)
+        self.assertEqual(instance.form_version.version_id, "201911280919")
+
+        counts = profiler.table_counts()
+        # No entityUuid/entityTypeId in this payload, and orgUnitId is given as a numeric id
+        # (skipping the org_unit_cache lookup entirely) - so none of those tables are touched.
+        self.assertEqual(counts.get("iaso_orgunit", 0), 0)
+        self.assertEqual(counts.get("iaso_entity", 0), 0)
+        self.assertEqual(counts.get("iaso_entitytype", 0), 0)
+        # 1 form lookup from import_data()'s batch prefetch + 1 from xml_file_to_json while
+        # processing the attached XML file; same breakdown for iaso_formversion (the memoized
+        # Instance.save() lookup + xml_file_to_json's own lookup).
+        self.assertLessEqual(counts["iaso_form"], 2)
+        self.assertLessEqual(counts["iaso_formversion"], 2)
+        self.assertLessEqual(profiler.total_queries(), 30)
+
+        profiler.print_report()
+        path = profiler.write_markdown_report(
+            "sync_import_form_version.md", title="One-by-one sync import — FormVersion/Form query report"
+        )
+        print(f"Markdown report written to {path}")

--- a/iaso/tests/tasks/test_process_mobile_bulk_upload.py
+++ b/iaso/tests/tasks/test_process_mobile_bulk_upload.py
@@ -21,6 +21,7 @@ from iaso import models as m
 from iaso.api.deduplication.entity_duplicate import merge_entities
 from iaso.models.instances import instance_file_upload_to, instance_upload_to
 from iaso.tasks.process_mobile_bulk_upload import process_mobile_bulk_upload
+from iaso.tests.utils.query_profiler import QueryProfiler
 
 
 CATT_TABLET_DIR = "catt_one_test_with_image"
@@ -148,6 +149,95 @@ class ProcessMobileBulkUploadTest(TestCase):
             add_to_zip(zipf, zip_fixture_dir(CATT_TABLET_DIR), CORRECT_FILES_FOR_ZIP)
         save_file_to_api_import(self.api_import, zip_path)
 
+    def _create_zip_file_at_scale(self, num_patients=25):
+        """
+        `num_patients` distinct *new* patients, each with exactly one registration + one CATT
+        follow-up - the realistic shape of a large bulk sync from one facility: broad (many
+        distinct entities), not deep (a few entities repeated many times, which would be a
+        rarer "lots of follow-ups for the same patient" case). Same org unit and same 2 forms/
+        versions throughout, reusing the base fixture's registration/CATT xml content as
+        byte templates under fresh uuids.
+        """
+        base_dir = zip_fixture_dir(CATT_TABLET_DIR)
+        with open(
+            os.path.join(
+                base_dir,
+                DISASI_MAKULO_REGISTRATION,
+                "20_56_bd75c228-ee48-4df6-9226-d6360d0e6b6c_2024-04-05_16-08-56.xml",
+            ),
+            "rb",
+        ) as f:
+            registration_xml_bytes = f.read()
+        with open(
+            os.path.join(
+                base_dir, DISASI_MAKULO_CATT, "16_12_127775b2-06a2-4ae6-b2bd-cf64143a9dfe_2024-04-05_16-09-42.xml"
+            ),
+            "rb",
+        ) as f:
+            catt_xml_bytes = f.read()
+
+        with open(os.path.join(base_dir, "instances.json")) as f:
+            base_instances_data = json.load(f)
+        with open(os.path.join(base_dir, "orgUnits.json")) as f:
+            org_units_data = json.load(f)
+
+        org_unit_uuid = base_instances_data[0]["orgUnitId"]
+
+        zip_path = f"/tmp/{CATT_TABLET_DIR}_at_scale.zip"
+        with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zipf:
+            zipf.writestr("orgUnits.json", json.dumps(org_units_data))
+
+            new_instances = []
+            for _ in range(num_patients):
+                # Matches the base fixture's convention: entityUuid == the registration
+                # instance's own uuid.
+                registration_uuid = str(uuid.uuid4())
+                catt_uuid = str(uuid.uuid4())
+
+                reg_file_name = f"registration_{registration_uuid}.xml"
+                catt_file_name = f"followup_{catt_uuid}.xml"
+                zipf.writestr(f"{registration_uuid}/{reg_file_name}", registration_xml_bytes)
+                zipf.writestr(f"{catt_uuid}/{catt_file_name}", catt_xml_bytes)
+
+                new_instances.append(
+                    {
+                        "id": registration_uuid,
+                        "created_at": 1.712326150005e9,
+                        "updated_at": 1.712326150005e9,
+                        "file": f"/storage/emulated/0/Android/data/org.bluesquare/files/Documents/instances/{registration_uuid}/{reg_file_name}",
+                        "name": "Enregistrement",
+                        "formId": "1",
+                        "orgUnitId": org_unit_uuid,
+                        "entityUuid": registration_uuid,
+                        "entityTypeId": "1",
+                        "latitude": 50.6429429,
+                        "longitude": 4.6004524,
+                        "altitude": 128.3,
+                        "accuracy": 14.929,
+                    }
+                )
+                new_instances.append(
+                    {
+                        "id": catt_uuid,
+                        "created_at": 1.71232618245e9,
+                        "updated_at": 1.71232618245e9,
+                        "file": f"/storage/emulated/0/Android/data/org.bluesquare/files/Documents/instances/{catt_uuid}/{catt_file_name}",
+                        "name": "CATT",
+                        "formId": "2",
+                        "orgUnitId": org_unit_uuid,
+                        "entityUuid": registration_uuid,
+                        "entityTypeId": "1",
+                        "latitude": 50.6429501,
+                        "longitude": 4.6004282,
+                        "altitude": 128.3,
+                        "accuracy": 12.74,
+                    }
+                )
+
+            zipf.writestr("instances.json", json.dumps(new_instances))
+
+        save_file_to_api_import(self.api_import, zip_path)
+
     def test_success(self):
         self._create_zip_file()
 
@@ -187,6 +277,9 @@ class ProcessMobileBulkUploadTest(TestCase):
         reg_instance = m.Instance.objects.get(uuid=DISASI_MAKULO_REGISTRATION)
         self.assertEqual(reg_instance.json.get("_full_name"), "Disasi Makulo")
         self.assertEqual(reg_instance.entity, ent_disasi)
+        # The registration form is the entity type's reference form, so the entity's
+        # `attributes` should point back to this instance.
+        self.assertEqual(ent_disasi.attributes, reg_instance)
         self.assertEqual(reg_instance.instancefile_set.count(), 0)
 
         catt_instance = m.Instance.objects.get(uuid=DISASI_MAKULO_CATT)
@@ -211,6 +304,7 @@ class ProcessMobileBulkUploadTest(TestCase):
         reg_instance = m.Instance.objects.get(uuid=PATRICE_AKAMBU_REGISTRATION)
         self.assertEqual(reg_instance.json.get("_full_name"), "Patrice Akambu")
         self.assertEqual(reg_instance.entity, entity_patrice)
+        self.assertEqual(entity_patrice.attributes, reg_instance)
         self.assertEqual(reg_instance.instancefile_set.count(), 0)
 
         catt_instance = m.Instance.objects.get(uuid=PATRICE_AKAMBU_CATT)
@@ -220,6 +314,110 @@ class ProcessMobileBulkUploadTest(TestCase):
         # image from Disasi's CATT was duplicated to this test
         image = catt_instance.instancefile_set.first()
         self.assertEqual(image.name, "1712326156339.webp")
+
+    def test_form_version_query_count_baseline(self):
+        """
+        Baseline for the FormVersion/Form N+1 investigation (see IA perf investigation notes):
+        the zip contains 4 instances for 2 distinct entities, sharing only 2 distinct (form,
+        version) pairs and 1 org unit - a well-optimized import should hit `iaso_orgunit`/
+        `iaso_form`/`iaso_entitytype` O(distinct org units/forms/entity types) via import_data()'s
+        batch caching, not O(instances). `iaso_formversion`/`iaso_form` also get one query per
+        instance from `xml_file_to_json` while processing each instance's attached XML file -
+        that part is unrelated to import_data() and expected to scale with instance count.
+        """
+        m.FormVersion.objects.create(form=self.form_registration, version_id="2024032701")
+        m.FormVersion.objects.create(form=self.form_catt, version_id="2024031801")
+
+        self._create_zip_file()
+
+        with QueryProfiler(
+            trace_tables=["iaso_formversion", "iaso_form", "iaso_orgunit", "iaso_entity", "iaso_entitytype"]
+        ) as profiler:
+            process_mobile_bulk_upload(
+                api_import_id=self.api_import.id,
+                project_id=self.project.id,
+                task=self.task,
+                _immediate=True,
+            )
+
+        # Org unit was created (from the zip's orgUnits.json, not pre-existing - see orgunit.yaml
+        # fixture in setUp, which seeds unrelated org units under different UUIDs).
+        self.assertIsNotNone(m.OrgUnit.objects.get(name="New Org Unit"))
+        self.assertEqual(m.Instance.objects.count(), 4)
+        self.assertEqual(m.Entity.objects.count(), 2)
+        # Unlike test_success, this test creates matching FormVersion rows above, which changes
+        # xml_file_to_json's json-field filtering (it restricts to the form version's declared
+        # fields) and in turn whether the attachment-duplication path in duplicate_instance_files
+        # (keyed on a "serie_id" json field) fires - hence 1 here instead of test_success's 2.
+        self.assertEqual(m.InstanceFile.objects.count(), 1)
+
+        counts = profiler.table_counts()
+        # import_data()'s own org-unit/form/entity-type lookups are each a single batch query
+        # (1 org unit, 2 forms sharing 1 lookup, 1 entity type shared by both entities) - the
+        # small headroom below absorbs the org unit's own creation/path-calculation queries
+        # (unrelated to import_data's caching), while still catching a regression back to
+        # O(instances) (which would push these well past the bounds below at this batch size).
+        self.assertLessEqual(counts["iaso_orgunit"], 6)
+        self.assertLessEqual(counts["iaso_form"], 5)
+        self.assertEqual(counts["iaso_entitytype"], 1)
+        # 2 distinct entities -> O(2) via find_entity's exists-check + create, not O(4 instances).
+        self.assertLessEqual(counts["iaso_entity"], 6)
+        self.assertLessEqual(profiler.total_queries(), 130)
+
+        profiler.print_report()
+        path = profiler.write_markdown_report(
+            "mobile_bulk_upload_form_version.md", title="Mobile bulk upload — FormVersion/Form query report"
+        )
+        print(f"Markdown report written to {path}")
+
+    def test_form_version_query_count_at_scale(self):
+        """
+        Same investigation as test_form_version_query_count_baseline, but with 25 distinct new
+        patients, each with one registration + one CATT follow-up (50 instances total) - broad
+        (many entities), not deep (a few entities repeated many times), which is the more
+        realistic shape of a large bulk sync. Same org unit and 2 forms/versions throughout.
+        Exaggerates the O(instances) vs O(distinct) gap that the caching fixes in
+        Instance.save()/import_data() target.
+        """
+        m.FormVersion.objects.create(form=self.form_registration, version_id="2024032701")
+        m.FormVersion.objects.create(form=self.form_catt, version_id="2024031801")
+
+        self._create_zip_file_at_scale(num_patients=25)
+
+        with QueryProfiler(
+            trace_tables=["iaso_formversion", "iaso_form", "iaso_orgunit", "iaso_entity", "iaso_entitytype"]
+        ) as profiler:
+            process_mobile_bulk_upload(
+                api_import_id=self.api_import.id,
+                project_id=self.project.id,
+                task=self.task,
+                _immediate=True,
+            )
+
+        self.assertIsNotNone(m.OrgUnit.objects.get(name="New Org Unit"))
+        self.assertEqual(m.Instance.objects.count(), 50)
+        self.assertEqual(m.Entity.objects.count(), 25)
+
+        counts = profiler.table_counts()
+        # Same batch lookups as the baseline test, still O(1)/O(distinct) at 12.5x the instance
+        # count (50 vs 4) - proves import_data()'s caching doesn't regress to O(instances). A
+        # regression back to per-instance lookups would push iaso_orgunit/iaso_entitytype well
+        # past these bounds (e.g. ~50-55 instead of ~6/1), and iaso_form/iaso_entity roughly
+        # double (the "+1 form per instance" from xml_file_to_json is unrelated to import_data
+        # and already included in the bound below).
+        self.assertLessEqual(counts["iaso_orgunit"], 6)
+        self.assertLessEqual(counts["iaso_form"], 52)
+        self.assertEqual(counts["iaso_entitytype"], 1)
+        # 25 distinct entities -> O(25) via find_entity's exists-check + create + the reference-
+        # form save, not O(50 instances).
+        self.assertLessEqual(counts["iaso_entity"], 80)
+        self.assertLessEqual(profiler.total_queries(), 1000)
+
+        profiler.print_report()
+        path = profiler.write_markdown_report(
+            "mobile_bulk_upload_at_scale.md", title="Mobile bulk upload at scale — FormVersion/Form query report"
+        )
+        print(f"Markdown report written to {path}")
 
     def test_org_unit_already_exists(self):
         self._create_zip_file()

--- a/iaso/tests/utils/query_profiler.py
+++ b/iaso/tests/utils/query_profiler.py
@@ -1,0 +1,230 @@
+import os
+import re
+import traceback
+import typing
+
+from collections import Counter
+
+from django.conf import settings
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+
+
+class QueryProfiler:
+    """
+    Wraps `CaptureQueriesContext` to break down the queries executed in a block of code
+    by table, and (optionally) trace the call site (file:line) of every query hitting a
+    chosen set of tables. Useful to spot N+1s and duplicated queries when investigating
+    a performance issue.
+
+    Usage:
+        with QueryProfiler(trace_tables=["iaso_formversion", "iaso_form"]) as profiler:
+            do_something()
+        profiler.print_report()
+
+        # or drill into one table:
+        profiler.queries_for_table("iaso_formversion")
+        profiler.call_sites_for_table("iaso_formversion")
+
+    `to_markdown()` links each call site to GitHub (`github_repo`/`github_ref`) and includes a
+    collapsed code snippet read straight from the checked-out file - the container has no `.git`
+    mounted, so there's no way to auto-detect the repo/branch; override the defaults below if
+    reporting on a different repo or branch.
+    """
+
+    def __init__(
+        self,
+        trace_tables: typing.Sequence[str] = (),
+        github_repo: typing.Optional[str] = "BLSQ/iaso",
+        github_ref: str = "develop",
+        snippet_context: int = 4,
+    ):
+        self.trace_tables = trace_tables
+        self.github_repo = github_repo
+        self.github_ref = github_ref
+        self.snippet_context = snippet_context
+        self._stacks_by_table = {t: [] for t in trace_tables}
+        # Django's own connection.queries_log (what CaptureQueriesContext reads from) is a deque
+        # capped at connection.queries_limit (9000) - silently truncated past that, which makes
+        # `self.queries`/counts derived from it wrong for large batches (thousands of instances).
+        # Count total/per-table live in our own wrapper instead, which sees every query regardless.
+        self._total_queries = 0
+        self._table_counts: Counter = Counter()
+        self._capture = None
+        self._wrapper_ctx = None
+        self.queries: typing.Optional[list] = None
+
+    def _wrapper(self, execute, sql, params, many, context):
+        self._total_queries += 1
+        self._table_counts.update(re.findall(r'(?:FROM|UPDATE|INTO)\s+"?(\w+)"?', sql, re.IGNORECASE))
+        for table in self.trace_tables:
+            if f'"{table}"' in sql:
+                # Skip our own frames and test-code frames to land on the actual call site.
+                frames = [
+                    f for f in traceback.extract_stack()[:-1] if "/iaso/" in f.filename and "/tests/" not in f.filename
+                ]
+                self._stacks_by_table[table].append(frames[-1] if frames else None)
+        return execute(sql, params, many, context)
+
+    def __enter__(self):
+        self._capture = CaptureQueriesContext(connection)
+        self._capture.__enter__()
+        self._wrapper_ctx = connection.execute_wrapper(self._wrapper)
+        self._wrapper_ctx.__enter__()
+        return self
+
+    def __exit__(self, *exc_info):
+        self._wrapper_ctx.__exit__(*exc_info)
+        self._capture.__exit__(*exc_info)
+        self.queries = self._capture.captured_queries
+        return False
+
+    def total_queries(self) -> int:
+        return self._total_queries
+
+    def table_counts(self) -> Counter:
+        return self._table_counts
+
+    def queries_for_table(self, table: str) -> list:
+        """
+        Full captured-query dicts (SQL text + timing) for one table - sample data for the
+        markdown report's "show me example queries" section. Subject to Django's 9000-query
+        cap (see `__init__`), so on very large batches this may miss some occurrences; use
+        `table_counts()`/`call_sites_for_table()` for accurate counts regardless of scale.
+        """
+        return [q for q in self.queries if f'"{table}"' in q["sql"]]
+
+    def call_sites_for_table(self, table: str) -> Counter:
+        return Counter((f.filename, f.lineno, f.name) for f in self._stacks_by_table.get(table, []) if f)
+
+    def _relpath(self, filename: str) -> typing.Optional[str]:
+        relpath = os.path.relpath(filename, settings.BASE_DIR)
+        return None if relpath.startswith("..") else relpath
+
+    def _github_url(self, filename: str, lineno: int) -> typing.Optional[str]:
+        if not self.github_repo:
+            return None
+        relpath = self._relpath(filename)
+        if relpath is None:
+            return None
+        return f"https://github.com/{self.github_repo}/blob/{self.github_ref}/{relpath}#L{lineno}"
+
+    def _code_snippet(self, filename: str, lineno: int) -> typing.Optional[str]:
+        try:
+            with open(filename) as f:
+                all_lines = f.readlines()
+        except OSError:
+            return None
+        start = max(0, lineno - 1 - self.snippet_context)
+        end = min(len(all_lines), lineno + self.snippet_context)
+        width = len(str(end))
+        rendered = []
+        for i in range(start, end):
+            marker = ">" if (i + 1) == lineno else " "
+            rendered.append(f"{marker} {i + 1:>{width}} | {all_lines[i].rstrip()}")
+        return "\n".join(rendered)
+
+    _SQL_BREAK_KEYWORDS = ("FROM", "WHERE", "ORDER BY", "GROUP BY", "LIMIT", "AND", "OR")
+
+    def _format_sql(self, sql: str, line_width: int = 100) -> str:
+        """
+        Break a single-line SQL statement onto multiple lines - one per major clause, and the
+        column list wrapped once it gets long - so the code block doesn't need horizontal
+        scrolling to read. Not a real SQL parser: safe for the simple, literal-valued queries
+        Django's ORM generates here, not meant for arbitrary SQL.
+        """
+        formatted = sql
+        for keyword in self._SQL_BREAK_KEYWORDS:
+            formatted = re.sub(rf"\s+({keyword})\s+", r"\n\1 ", formatted)
+
+        wrapped_lines = []
+        for line in formatted.splitlines():
+            if len(line) <= line_width:
+                wrapped_lines.append(line)
+                continue
+            parts = line.split(", ")
+            current = ""
+            for part in parts:
+                candidate = f"{current}, {part}" if current else part
+                if len(candidate) > line_width and current:
+                    wrapped_lines.append(current + ",")
+                    current = part
+                else:
+                    current = candidate
+            if current:
+                wrapped_lines.append(current)
+        return "\n".join(wrapped_lines)
+
+    def print_report(self):
+        print(f"Total queries: {self.total_queries()}")
+        print("Queries per table:")
+        for table, count in self.table_counts().most_common():
+            print(f"  {table}: {count}")
+        for table in self.trace_tables:
+            sites = self.call_sites_for_table(table)
+            if sites:
+                print(f"Call sites for {table}:")
+                for (filename, lineno, name), count in sites.most_common():
+                    print(f"  {count}x {filename}:{lineno} in {name}")
+
+    def to_markdown(self, title: str = "Query report") -> str:
+        """
+        Render the same data as `print_report()` as markdown - table breakdown, call sites,
+        and deduplicated sample queries (identical SQL + params collapsed with an occurrence
+        count, which is exactly the duplicated-query signal this tool is looking for).
+        """
+        lines = [f"# {title}", "", f"**Total queries:** {self.total_queries()}", "", "## Queries per table", ""]
+        lines += ["| table | queries |", "|---|---|"]
+        for table, count in self.table_counts().most_common():
+            lines.append(f"| `{table}` | {count} |")
+
+        for table in self.trace_tables:
+            sites = self.call_sites_for_table(table)
+            table_queries = self.queries_for_table(table)
+            if not sites and not table_queries:
+                continue
+
+            lines += ["", f"## `{table}`", ""]
+
+            if sites:
+                lines += ["**Call sites:**", ""]
+                for (filename, lineno, name), count in sites.most_common():
+                    relpath = self._relpath(filename) or filename
+                    github_url = self._github_url(filename, lineno)
+                    location = f"[`{relpath}:{lineno}`]({github_url})" if github_url else f"`{relpath}:{lineno}`"
+                    lines.append(f"- **{count}×** {location} in `{name}`")
+
+                    snippet = self._code_snippet(filename, lineno)
+                    if snippet:
+                        lines += [
+                            "  <details><summary>show code</summary>",
+                            "",
+                            "  ```python",
+                            *(f"  {line}" for line in snippet.splitlines()),
+                            "  ```",
+                            "  </details>",
+                            "",
+                        ]
+                lines.append("")
+
+            if table_queries:
+                sql_counts = Counter(q["sql"] for q in table_queries)
+                lines += ["**Queries** (identical SQL collapsed, most frequent first):", ""]
+                for sql, count in sql_counts.most_common():
+                    lines.append(f"{count}×")
+                    lines += ["```sql", self._format_sql(sql), "```", ""]
+
+        return "\n".join(lines)
+
+    def write_markdown_report(self, filename: str, title: str = "Query report") -> str:
+        """
+        Write `to_markdown()` to `<MEDIA_ROOT>/query_reports/<filename>` - MEDIA_ROOT is bind-mounted
+        from the host (see docker-compose.yml), so the file is readable straight from the host
+        checkout (VSCode, etc.) without needing to exec into the container. Overwrites on every run.
+        """
+        report_dir = os.path.join(settings.MEDIA_ROOT, "query_reports")
+        os.makedirs(report_dir, exist_ok=True)
+        path = os.path.join(report_dir, filename)
+        with open(path, "w") as f:
+            f.write(self.to_markdown(title=title))
+        return path

--- a/iaso/tests/utils/test_query_profiler.py
+++ b/iaso/tests/utils/test_query_profiler.py
@@ -1,0 +1,357 @@
+import io
+import os
+import tempfile
+import traceback
+
+from collections import deque
+from contextlib import redirect_stdout
+from unittest import mock
+
+from django.conf import settings
+from django.db import connection
+from django.test import override_settings
+
+from iaso import models as m
+from iaso.test import TestCase
+from iaso.tests.utils.query_profiler import QueryProfiler
+
+
+# A pk that can't collide with any real row - lets tests run `.exists()`/`.get()` lookups that
+# always miss (and therefore always emit exactly the one query we want to count), regardless of
+# what fixtures/other tests have left in the DB.
+MISSING_PK = 999_999_999
+
+
+class QueryProfilerTest(TestCase):
+    def test_total_queries_counts_every_query_regardless_of_trace_tables(self):
+        with QueryProfiler() as profiler:
+            m.Account.objects.filter(pk=MISSING_PK).exists()
+            m.Project.objects.filter(pk=MISSING_PK).exists()
+            m.Account.objects.filter(pk=MISSING_PK - 1).exists()
+
+        self.assertEqual(profiler.total_queries(), 3)
+
+    def test_total_queries_is_zero_when_nothing_ran(self):
+        with QueryProfiler() as profiler:
+            pass
+
+        self.assertEqual(profiler.total_queries(), 0)
+        self.assertEqual(profiler.table_counts(), {})
+
+    def test_table_counts_attributes_select_queries_by_table(self):
+        with QueryProfiler() as profiler:
+            m.Account.objects.filter(pk=MISSING_PK).exists()
+            m.Account.objects.filter(pk=MISSING_PK - 1).exists()
+            m.Project.objects.filter(pk=MISSING_PK).exists()
+
+        counts = profiler.table_counts()
+        self.assertEqual(counts["iaso_account"], 2)
+        self.assertEqual(counts["iaso_project"], 1)
+
+    def test_table_counts_attributes_insert_and_update_queries(self):
+        with QueryProfiler() as profiler:
+            account = m.Account.objects.create(name="QueryProfiler test account")
+            m.Account.objects.filter(pk=account.pk).update(name="renamed")
+
+        # 1 INSERT INTO "iaso_account" + 1 UPDATE "iaso_account" - the regex matches both keywords.
+        self.assertEqual(profiler.table_counts()["iaso_account"], 2)
+
+    def test_queries_for_table_returns_only_matching_queries(self):
+        with QueryProfiler() as profiler:
+            m.Account.objects.filter(pk=MISSING_PK).exists()
+            m.Project.objects.filter(pk=MISSING_PK).exists()
+
+        account_queries = profiler.queries_for_table("iaso_account")
+        self.assertEqual(len(account_queries), 1)
+        self.assertIn("iaso_account", account_queries[0]["sql"])
+
+    def test_queries_for_table_returns_empty_list_for_untouched_table(self):
+        with QueryProfiler() as profiler:
+            m.Account.objects.filter(pk=MISSING_PK).exists()
+
+        self.assertEqual(profiler.queries_for_table("iaso_project"), [])
+
+    # -- call_sites_for_table --------------------------------------------------------------
+
+    def test_call_sites_for_table_groups_and_counts_by_file_line_and_function(self):
+        """Directly exercises the Counter-building logic in `call_sites_for_table`, independent
+        of how `_wrapper` decides which frame to record (see the tests below for that part)."""
+        profiler = QueryProfiler(trace_tables=["iaso_account"])
+        frame_a = traceback.FrameSummary("/opt/app/iaso/some_module.py", 42, "do_thing")
+        frame_b = traceback.FrameSummary("/opt/app/iaso/other_module.py", 7, "do_other_thing")
+        profiler._stacks_by_table["iaso_account"] = [frame_a, frame_a, frame_b, None]
+
+        sites = profiler.call_sites_for_table("iaso_account")
+
+        self.assertEqual(sites[("/opt/app/iaso/some_module.py", 42, "do_thing")], 2)
+        self.assertEqual(sites[("/opt/app/iaso/other_module.py", 7, "do_other_thing")], 1)
+        # The `None` entry (no attributable frame) is dropped, not counted as its own bucket.
+        self.assertEqual(sum(sites.values()), 3)
+
+    def test_call_sites_for_table_skips_test_frames_and_frames_outside_iaso(self):
+        """
+        `_wrapper` walks the stack looking for the closest frame that's genuine application code
+        under `/iaso/` and not itself test code under `/iaso/tests/` - otherwise every call site
+        traced from a test would just point back at the test, which isn't useful.
+        """
+        fake_stack = [
+            traceback.FrameSummary(f"{settings.BASE_DIR}/iaso/tests/utils/test_query_profiler.py", 200, "test_method"),
+            traceback.FrameSummary(f"{settings.BASE_DIR}/iaso/some_module.py", 55, "call_the_query"),
+            traceback.FrameSummary("/usr/local/lib/python3.9/site-packages/django/db/models/query.py", 100, "exists"),
+            traceback.FrameSummary("<wrapper's own frame, dropped by the [:-1] slice>", 1, "_wrapper"),
+        ]
+        with QueryProfiler(trace_tables=["iaso_account"]) as profiler:
+            with mock.patch("traceback.extract_stack", return_value=fake_stack):
+                m.Account.objects.filter(pk=MISSING_PK).exists()
+
+        sites = profiler.call_sites_for_table("iaso_account")
+        self.assertEqual(dict(sites), {(f"{settings.BASE_DIR}/iaso/some_module.py", 55, "call_the_query"): 1})
+
+    def test_call_sites_for_table_empty_when_no_attributable_frame(self):
+        """If every candidate frame is either test code or outside `/iaso/`, no call site can be
+        attributed - the query is still counted (see `total_queries`/`table_counts`), it's just
+        not attributed to any call site."""
+        fake_stack = [
+            traceback.FrameSummary(f"{settings.BASE_DIR}/iaso/tests/utils/test_query_profiler.py", 200, "test_method"),
+            traceback.FrameSummary("/usr/local/lib/python3.9/site-packages/django/db/models/query.py", 100, "exists"),
+            traceback.FrameSummary("<wrapper's own frame, dropped by the [:-1] slice>", 1, "_wrapper"),
+        ]
+        with QueryProfiler(trace_tables=["iaso_account"]) as profiler:
+            with mock.patch("traceback.extract_stack", return_value=fake_stack):
+                m.Account.objects.filter(pk=MISSING_PK).exists()
+
+        self.assertEqual(len(profiler.call_sites_for_table("iaso_account")), 0)
+        # The query still gets counted globally even though it can't be attributed to a call site.
+        self.assertEqual(profiler.total_queries(), 1)
+
+    def test_call_sites_for_table_returns_empty_counter_for_untraced_table(self):
+        profiler = QueryProfiler(trace_tables=["iaso_account"])
+        self.assertEqual(profiler.call_sites_for_table("iaso_project"), {})
+
+    # -- immunity to Django's queries_log truncation ---------------------------------------
+
+    def test_counts_are_not_truncated_by_djangos_queries_log_cap(self):
+        """
+        `connection.queries_log` (what `CaptureQueriesContext.captured_queries` reads from) is a
+        deque capped at `connection.queries_limit`. Our own wrapper counts every query as it
+        happens instead, so `total_queries()`/`table_counts()` stay accurate even once that cap
+        is exceeded - unlike `self.queries`/`queries_for_table()`, which mirror Django's own
+        (truncated) log.
+        """
+        original_log = connection.queries_log
+        connection.queries_log = deque(connection.queries_log, maxlen=3)
+        try:
+            with QueryProfiler() as profiler:
+                for _ in range(5):
+                    m.Account.objects.filter(pk=MISSING_PK).exists()
+        finally:
+            connection.queries_log = original_log
+
+        self.assertEqual(profiler.total_queries(), 5)
+        self.assertEqual(profiler.table_counts()["iaso_account"], 5)
+        # Django's own capture is truncated to the deque's maxlen.
+        self.assertLessEqual(len(profiler.queries), 3)
+
+    # -- _relpath / _github_url -------------------------------------------------------------
+
+    def test_relpath_returns_path_relative_to_base_dir(self):
+        profiler = QueryProfiler()
+        filename = os.path.join(settings.BASE_DIR, "iaso", "some_module.py")
+        self.assertEqual(profiler._relpath(filename), os.path.join("iaso", "some_module.py"))
+
+    def test_relpath_returns_none_outside_base_dir(self):
+        profiler = QueryProfiler()
+        self.assertIsNone(profiler._relpath("/usr/local/lib/python3.9/site-packages/django/db/models/query.py"))
+
+    def test_github_url_builds_expected_link(self):
+        profiler = QueryProfiler(github_repo="BLSQ/iaso", github_ref="develop")
+        filename = os.path.join(settings.BASE_DIR, "iaso", "some_module.py")
+
+        url = profiler._github_url(filename, 42)
+
+        self.assertEqual(url, "https://github.com/BLSQ/iaso/blob/develop/iaso/some_module.py#L42")
+
+    def test_github_url_returns_none_without_github_repo(self):
+        profiler = QueryProfiler(github_repo=None)
+        filename = os.path.join(settings.BASE_DIR, "iaso", "some_module.py")
+        self.assertIsNone(profiler._github_url(filename, 42))
+
+    def test_github_url_returns_none_outside_base_dir(self):
+        profiler = QueryProfiler(github_repo="BLSQ/iaso")
+        self.assertIsNone(profiler._github_url("/usr/local/lib/python3.9/site-packages/django/foo.py", 42))
+
+    # -- _code_snippet ------------------------------------------------------------------------
+
+    def test_code_snippet_returns_context_window_with_marker_on_target_line(self):
+        content_lines = [f"line {i}\n" for i in range(1, 21)]  # 20 lines
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
+            f.writelines(content_lines)
+            path = f.name
+
+        try:
+            profiler = QueryProfiler(snippet_context=4)
+            snippet = profiler._code_snippet(path, lineno=10)
+        finally:
+            os.remove(path)
+
+        self.assertIsNotNone(snippet)
+        rendered_lines = snippet.splitlines()
+        # Window: 0-indexed range(max(0, 10-1-4), min(20, 10+4)) = range(5, 14), i.e. 9 lines
+        # (1-indexed lines 6 through 14).
+        self.assertEqual(len(rendered_lines), 9)
+        # Exactly one line is marked as the target line, and it's line 10.
+        marked = [line for line in rendered_lines if line.startswith(">")]
+        self.assertEqual(len(marked), 1)
+        self.assertIn("line 10", marked[0])
+        # Every other line uses the blank marker.
+        unmarked = [line for line in rendered_lines if not line.startswith(">")]
+        self.assertTrue(all(line.startswith(" ") for line in unmarked))
+        self.assertEqual(len(unmarked), 8)
+
+    def test_code_snippet_clamps_window_to_file_bounds(self):
+        content_lines = [f"line {i}\n" for i in range(1, 4)]  # only 3 lines
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
+            f.writelines(content_lines)
+            path = f.name
+
+        try:
+            profiler = QueryProfiler(snippet_context=4)
+            snippet = profiler._code_snippet(path, lineno=1)
+        finally:
+            os.remove(path)
+
+        # Requesting 4 lines of context around line 1 in a 3-line file can't go past either edge.
+        self.assertEqual(len(snippet.splitlines()), 3)
+
+    def test_code_snippet_returns_none_for_missing_file(self):
+        profiler = QueryProfiler()
+        self.assertIsNone(profiler._code_snippet("/no/such/file.py", 1))
+
+    # -- _format_sql --------------------------------------------------------------------------
+
+    def test_format_sql_breaks_onto_separate_lines_per_keyword(self):
+        profiler = QueryProfiler()
+        sql = 'SELECT "iaso_form"."id" FROM "iaso_form" WHERE "iaso_form"."id" = 1 AND "iaso_form"."deleted_at" IS NULL ORDER BY "iaso_form"."id"'
+
+        formatted = profiler._format_sql(sql)
+
+        lines = formatted.splitlines()
+        self.assertTrue(any(line.startswith("FROM ") for line in lines))
+        self.assertTrue(any(line.startswith("WHERE ") for line in lines))
+        self.assertTrue(any(line.startswith("AND ") for line in lines))
+        self.assertTrue(any(line.startswith("ORDER BY ") for line in lines))
+
+    def test_format_sql_wraps_long_column_lists_without_exceeding_width(self):
+        profiler = QueryProfiler()
+        columns = ", ".join(f'"iaso_form"."column_{i}"' for i in range(20))
+        sql = f'SELECT {columns} FROM "iaso_form"'
+
+        formatted = profiler._format_sql(sql, line_width=60)
+
+        for line in formatted.splitlines():
+            # Wrapping only guarantees no *unforced* overflow: a single token longer than
+            # line_width on its own would still exceed it, but none of our columns do here.
+            self.assertLessEqual(len(line), 60 + 1)  # +1 for the trailing comma added when wrapping
+
+    def test_format_sql_leaves_short_statement_untouched_besides_keyword_breaks(self):
+        profiler = QueryProfiler()
+        sql = 'SELECT "id" FROM "iaso_form"'
+
+        formatted = profiler._format_sql(sql, line_width=100)
+
+        self.assertEqual(formatted, 'SELECT "id"\nFROM "iaso_form"')
+
+    # -- print_report -------------------------------------------------------------------------
+
+    def test_print_report_prints_totals_and_call_sites(self):
+        with QueryProfiler(trace_tables=["iaso_account"]) as profiler:
+            m.Account.objects.filter(pk=MISSING_PK).exists()
+
+        buffer = io.StringIO()
+        with redirect_stdout(buffer):
+            profiler.print_report()
+        output = buffer.getvalue()
+
+        self.assertIn("Total queries: 1", output)
+        self.assertIn("iaso_account: 1", output)
+
+    def test_print_report_omits_call_sites_section_for_table_with_no_hits(self):
+        with QueryProfiler(trace_tables=["iaso_account"]) as profiler:
+            pass  # no queries at all
+
+        buffer = io.StringIO()
+        with redirect_stdout(buffer):
+            profiler.print_report()
+
+        self.assertNotIn("Call sites for iaso_account", buffer.getvalue())
+
+    # -- to_markdown --------------------------------------------------------------------------
+
+    def test_to_markdown_includes_title_and_table_breakdown(self):
+        with QueryProfiler() as profiler:
+            m.Account.objects.filter(pk=MISSING_PK).exists()
+
+        markdown = profiler.to_markdown(title="My Report")
+
+        self.assertTrue(markdown.startswith("# My Report"))
+        self.assertIn("**Total queries:** 1", markdown)
+        self.assertIn("| `iaso_account` | 1 |", markdown)
+
+    def test_to_markdown_includes_call_sites_and_queries_sections_for_traced_table(self):
+        # A call site can only be attributed to non-test application code (see the
+        # call_sites_for_table tests above), so fake a stack with an /iaso/ app frame in it.
+        fake_stack = [
+            traceback.FrameSummary(f"{settings.BASE_DIR}/iaso/some_module.py", 55, "call_the_query"),
+            traceback.FrameSummary("<wrapper's own frame, dropped by the [:-1] slice>", 1, "_wrapper"),
+        ]
+        with QueryProfiler(trace_tables=["iaso_account"]) as profiler:
+            with mock.patch("traceback.extract_stack", return_value=fake_stack):
+                m.Account.objects.filter(pk=MISSING_PK).exists()
+
+        markdown = profiler.to_markdown()
+
+        self.assertIn("## `iaso_account`", markdown)
+        self.assertIn("**Call sites:**", markdown)
+        self.assertIn("**Queries** (identical SQL collapsed, most frequent first):", markdown)
+        self.assertIn("```sql", markdown)
+
+    def test_to_markdown_skips_traced_table_with_no_hits(self):
+        with QueryProfiler(trace_tables=["iaso_account", "iaso_project"]) as profiler:
+            m.Account.objects.filter(pk=MISSING_PK).exists()
+            # iaso_project is traced but never touched.
+
+        markdown = profiler.to_markdown()
+
+        self.assertIn("## `iaso_account`", markdown)
+        self.assertNotIn("## `iaso_project`", markdown)
+
+    # -- write_markdown_report ----------------------------------------------------------------
+
+    def test_write_markdown_report_writes_file_matching_to_markdown(self):
+        with tempfile.TemporaryDirectory() as tmp_media_root:
+            with override_settings(MEDIA_ROOT=tmp_media_root):
+                with QueryProfiler() as profiler:
+                    m.Account.objects.filter(pk=MISSING_PK).exists()
+
+                path = profiler.write_markdown_report("report.md", title="Written report")
+
+                self.assertEqual(path, os.path.join(tmp_media_root, "query_reports", "report.md"))
+                with open(path) as f:
+                    content = f.read()
+                self.assertEqual(content, profiler.to_markdown(title="Written report"))
+
+    def test_write_markdown_report_overwrites_existing_file(self):
+        with tempfile.TemporaryDirectory() as tmp_media_root:
+            with override_settings(MEDIA_ROOT=tmp_media_root):
+                report_dir = os.path.join(tmp_media_root, "query_reports")
+                os.makedirs(report_dir)
+                existing_path = os.path.join(report_dir, "report.md")
+                with open(existing_path, "w") as f:
+                    f.write("stale content")
+
+                with QueryProfiler() as profiler:
+                    pass
+                path = profiler.write_markdown_report("report.md", title="Fresh report")
+
+                with open(path) as f:
+                    self.assertEqual(f.read(), profiler.to_markdown(title="Fresh report"))


### PR DESCRIPTION

## What problem is this PR solving?

IA-5312 showed the the import is slow.

### Related JIRA tickets

IA-5313

## Changes

preventing recurring reload of data in a single zip
identified the problem/sources of problem with the new QueryProfiler that produced
a report like this : https://gist.github.com/mestachs/551ce42c49e99a8a086f5b90f6722be1#file-2000_before-md

you can the report after : 
https://gist.github.com/mestachs/551ce42c49e99a8a086f5b90f6722be1#file-2000_after-md

the next step is trying to fix the multiple save without impacting the other usecases (enketo, sync/upload, bulk, ...) but it will be in another PR.

## How to test

options
   - use the mobile (ideal)
      - adapt the project to use bulk or remove (test normal path is ok)
   - use IA-5312 (less-ideal)- 

## Print screen / video


## Notes



## Doc

