### PR TITLE
IA-5313 improve instance creation save optimisations

### DIFF
--- a/hat/sync/views.py
+++ b/hat/sync/views.py
@@ -32,9 +32,12 @@ def process_instance_file(instance, file, user):
     instance.file = file
     instance.created_by = user
     instance.last_modified_by = user
+    # This save must happen before get_and_save_json_of_xml(): on S3 storage, that method fetches
+    # the file back via its .url (urlopen) - it has to already be uploaded, which only happens
+    # here, in the FileField's own save.
     instance.save()
 
-    instance.get_and_save_json_of_xml()
+    instance.get_and_save_json_of_xml(save=False)
     try:
         instance.convert_location_from_field(save=False)
         instance.convert_device(save=False)
@@ -43,7 +46,8 @@ def process_instance_file(instance, file, user):
         logger.exception(error)
     finally:
         # Whatever succeeded before a conversion raised should still be persisted, exactly
-        # like when each convert_* method saved itself individually.
+        # like when each convert_* method saved itself individually. Also covers the json/
+        # form_version set by get_and_save_json_of_xml(save=False) above - one save for both.
         instance.save()
 
     return instance

--- a/hat/sync/views.py
+++ b/hat/sync/views.py
@@ -36,11 +36,15 @@ def process_instance_file(instance, file, user):
 
     instance.get_and_save_json_of_xml()
     try:
-        instance.convert_location_from_field()
-        instance.convert_device()
-        instance.convert_correlation()
+        instance.convert_location_from_field(save=False)
+        instance.convert_device(save=False)
+        instance.convert_correlation(save=False)
     except ValueError as error:
         logger.exception(error)
+    finally:
+        # Whatever succeeded before a conversion raised should still be persisted, exactly
+        # like when each convert_* method saved itself individually.
+        instance.save()
 
     return instance
 

--- a/iaso/api/enketo.py
+++ b/iaso/api/enketo.py
@@ -465,10 +465,14 @@ class EnketoSubmissionAPIView(APIView):
             try:
                 instance.get_and_save_json_of_xml()
                 try:
-                    instance.convert_location_from_field()
-                    instance.convert_device()
+                    instance.convert_location_from_field(save=False)
+                    instance.convert_device(save=False)
                 except ValueError as error:
                     print(error)
+                finally:
+                    # Whatever succeeded before a conversion raised should still be persisted,
+                    # exactly like when each convert_* method saved itself individually.
+                    instance.save()
             except:
                 pass
 

--- a/iaso/api/instances/views.py
+++ b/iaso/api/instances/views.py
@@ -1156,6 +1156,8 @@ def import_data(instances, user, app_id):
                 # so we avoid the whole instance creation crashing
                 logger.error(e)
 
+    return rtn_instances
+
 
 def _entity_correctness_score(entity):
     """

--- a/iaso/dhis2/derived_instance_generator.py
+++ b/iaso/dhis2/derived_instance_generator.py
@@ -193,6 +193,7 @@ def process_instance(record, project, cvs_stat_mapping_version, progress, aggreg
             charset="utf-8",
         )
         instance.file = file
+        instance.resolve_form_version()
         instance.save()
 
 

--- a/iaso/management/commands/clean_up_duplicate_submissions.py
+++ b/iaso/management/commands/clean_up_duplicate_submissions.py
@@ -104,6 +104,7 @@ class Command(BaseCommand):
                     first.device = file.device
                     if not first.correlation_id:
                         first.correlation_id = file.correlation_id
+                    first.resolve_form_version()
                     first.save()
                     self.stdout.write(self.style.WARNING(" - Deleting instances with file_name matching."))
                     file_name_qs.delete()

--- a/iaso/management/commands/csv_form_importer.py
+++ b/iaso/management/commands/csv_form_importer.py
@@ -195,6 +195,7 @@ class Command(BaseCommand):
                                 # print(f_name)
                                 instance.file = f_name
                                 instance.file_name = f_name
+                                instance.resolve_form_version()
                                 instance.save()
                                 # print(instance.id)
                             except:

--- a/iaso/management/commands/seed_test_data.py
+++ b/iaso/management/commands/seed_test_data.py
@@ -568,6 +568,7 @@ class Command(BaseCommand):
             if with_location:
                 instance.location = Point(-11.7868289 + (2 * random()), 8.4494988 + (2 * random()), 0)
             instance.entity = entity
+            instance.resolve_form_version()
             instance.save()
             entity.attributes = instance
             entity.name = " ".join([str(instance.json[k]) for k in form.label_keys])

--- a/iaso/models/instances.py
+++ b/iaso/models/instances.py
@@ -659,13 +659,16 @@ class Instance(ValidationWorkflowArtefact):
             return flat_parse_xml_soup(soup, [], None)["flat_json"]
         return flat_parse_xml_soup(soup, [], None)["flat_json"]
 
-    def get_and_save_json_of_xml(self, force=False, tries=3):
+    def get_and_save_json_of_xml(self, force=False, tries=3, save=True):
         """
         Convert the xml file to json and save it to the instance.
         If the instance already has a json, don't do anything unless `force=True`.
 
         When downloading from S3, attempt `tries` times (3 by default) with
         exponential backoff.
+
+        `save=False` skips the save, for callers that will save `self` themselves right after
+        (e.g. together with other in-memory changes, to avoid a separate round-trip).
 
         :return: in all cases, return the JSON representation of the instance
         """
@@ -689,7 +692,8 @@ class Instance(ValidationWorkflowArtefact):
                 file = self.file
 
             self.json = self.xml_file_to_json(file)
-            self.save()
+            if save:
+                self.save()
             return self.json
         # no file, no json, when/why does this happen?
         return {}

--- a/iaso/models/instances.py
+++ b/iaso/models/instances.py
@@ -639,6 +639,10 @@ class Instance(ValidationWorkflowArtefact):
             form_versions = self.form.form_versions.filter(version_id=form_version_id)  # type: ignore
             form_version = form_versions.first()
             if form_version:
+                # Same (version_id, form) pair `resolve_form_version()` would otherwise look up
+                # again right after this method returns (see `get_and_save_json_of_xml`) - set
+                # it here directly instead of re-querying FormVersion for the same instance.
+                self.form_version = form_version
                 questions_by_path = form_version.questions_by_path()
                 allowed_paths = set(questions_by_path.keys())
                 allowed_paths.update(self.ALWAYS_ALLOWED_PATHS_XML)
@@ -685,7 +689,6 @@ class Instance(ValidationWorkflowArtefact):
                 file = self.file
 
             self.json = self.xml_file_to_json(file)
-            self.resolve_form_version()
             self.save()
             return self.json
         # no file, no json, when/why does this happen?

--- a/iaso/models/instances.py
+++ b/iaso/models/instances.py
@@ -17,7 +17,7 @@ from django.contrib.auth.models import User
 from django.contrib.gis.db.models.fields import PointField
 from django.contrib.gis.geos import Point
 from django.contrib.postgres.aggregates import ArrayAgg
-from django.core.exceptions import ValidationError
+from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.core.paginator import Paginator
 from django.db import models
 from django.db.models import Count, Exists, F, FilteredRelation, Func, OuterRef, Q
@@ -587,7 +587,7 @@ class Instance(ValidationWorkflowArtefact):
     def get_absolute_url(self):
         return f"/dashboard/forms/submission/instanceId/{self.pk}"
 
-    def convert_location_from_field(self, field_name=None):
+    def convert_location_from_field(self, field_name=None, save=True):
         f = field_name
         if f is None:
             f = self.form.location_field
@@ -597,9 +597,10 @@ class Instance(ValidationWorkflowArtefact):
                 latitude, longitude, altitude = coords[:3]
                 self.location = Point(x=longitude, y=latitude, z=altitude, srid=4326)
                 self.accuracy = coords[3] if len(coords) > 3 else None
-                self.save()
+                if save:
+                    self.save()
 
-    def convert_device(self):
+    def convert_device(self, save=True):
         if self.json and not self.device:
             device_field = self.form.device_field
             if not device_field:
@@ -608,11 +609,12 @@ class Instance(ValidationWorkflowArtefact):
             if imei is not None:
                 device, created = Device.objects.get_or_create(imei=imei)
                 self.device = device
-                self.save()
+                if save:
+                    self.save()
                 if self.project:
                     self.device.projects.add(self.project)
 
-    def convert_correlation(self):
+    def convert_correlation(self, save=True):
         if not self.correlation_id:
             identifier = str(self.id)
             if self.form.correlation_field and self.json:
@@ -622,7 +624,8 @@ class Instance(ValidationWorkflowArtefact):
             value = int(identifier + random_number)
             suffix = f"{value % 97:02d}"
             self.correlation_id = identifier + random_number + suffix
-            self.save()
+            if save:
+                self.save()
 
     def xml_file_to_json(self, file: typing.IO) -> typing.Dict[str, typing.Any]:
         raw_content = file.read().decode("utf-8")
@@ -682,6 +685,7 @@ class Instance(ValidationWorkflowArtefact):
                 file = self.file
 
             self.json = self.xml_file_to_json(file)
+            self.resolve_form_version()
             self.save()
             return self.json
         # no file, no json, when/why does this happen?
@@ -896,23 +900,20 @@ class Instance(ValidationWorkflowArtefact):
     def has_org_unit(self):
         return self.org_unit if self.org_unit else None
 
-    # Cache of the `_version` string last resolved to `form_version_id` in `save()`, to avoid
-    # re-querying FormVersion on every save() call within one instance's lifetime (e.g. when
-    # convert_location_from_field/convert_device/convert_correlation each save() in turn).
-    _form_version_lookup_key = None
-
-    def save(self, *args, **kwargs):
-        version_id = self.json.get("_version") if self.json else None
-        if version_id and self._form_version_lookup_key != version_id:
-            form_version_id = (
-                FormVersion.objects.filter(version_id=version_id, form_id=self.form_id)
-                .values_list("id", flat=True)
-                .first()
-            )
-            if form_version_id is not None:
-                self.form_version_id = form_version_id
-            self._form_version_lookup_key = version_id
-        return super(Instance, self).save(*args, **kwargs)
+    def resolve_form_version(self):
+        """
+        Set `form_version` from `self.json["_version"]` + `form_id`, if a matching FormVersion
+        exists. Call this explicitly right after `self.json` is (re)computed from a submission's
+        XML/data -- it used to run on every single `save()` regardless of whether `json` had
+        changed, which meant a `FormVersion` lookup on every save in a save-heavy chain (location/
+        device/correlation conversions, etc.) even when nothing about the version could have
+        changed since the previous save.
+        """
+        if self.json is not None and self.json.get("_version"):
+            try:
+                self.form_version = FormVersion.objects.get(version_id=self.json.get("_version"), form_id=self.form.id)
+            except ObjectDoesNotExist:
+                pass
 
 
 class InstanceFileExtensionQuerySet(models.QuerySet):

--- a/iaso/tasks/process_mobile_bulk_upload.py
+++ b/iaso/tasks/process_mobile_bulk_upload.py
@@ -81,14 +81,20 @@ def process_mobile_bulk_upload(api_import_id, project_id, task=None):
                 if INSTANCES_JSON in zip_ref.namelist():
                     log_progress(the_task, 20, "Processing forms and files")
                     instances_data = read_json_file_from_zip(zip_ref, INSTANCES_JSON)
-                    import_instances(instances_data, user, project.app_id)
+                    imported_instances = import_instances(instances_data, user, project.app_id)
+                    # `import_instances` already built (and, for new instances, saved) each of these in
+                    # memory - reuse them instead of re-querying by uuid below. It can leave a uuid out
+                    # (an instance that already existed with a validation status outside
+                    # REJECTED/PENDING/empty gets skipped entirely, see `import_data`), hence the `.get()`
+                    # fallback to the original per-uuid query for that edge case.
+                    instances_by_uuid = {instance.uuid: instance for instance in imported_instances}
                     new_instance_files = []
                     dirs = get_directory_handlers(zip_ref)
 
                     total_instances = len(instances_data)
                     for index, instance_data in enumerate(instances_data, start=1):
                         uuid = instance_data["id"]
-                        instance = Instance.objects.get(uuid=uuid)
+                        instance = instances_by_uuid.get(uuid) or Instance.objects.get(uuid=uuid)
                         original = copy(instance)
                         prefix = f"({index}/{total_instances})"
                         instance = process_instance_xml(instance, instance_data, zip_ref, user, prefix)

--- a/iaso/tests/api/test_correlation.py
+++ b/iaso/tests/api/test_correlation.py
@@ -6,8 +6,9 @@ from django.contrib.auth.models import User
 from django.core.files.uploadedfile import UploadedFile
 from django.utils.timezone import now
 
+from hat.audit.models import Modification
 from iaso import models as m
-from iaso.models import FeatureFlag, Instance, Mapping, Profile
+from iaso.models import FeatureFlag, FormVersion, Instance, InstanceFile, Mapping, Profile
 from iaso.permissions.core_permissions import CORE_FORMS_PERMISSION
 from iaso.test import APITestCase
 
@@ -176,6 +177,174 @@ class CorrelationAPITestCase(APITestCase):
         self.assertEqual(response_form.status_code, 201)
         self.assertEqual(updated_instance.last_modified_by, user)
 
+    def _upload_land_speeder(self, form, uuid, file_name="land_speeder.xml"):
+        """POST the empty instance metadata then upload the XML file, returning the resulting Instance."""
+        instance_body = [
+            {
+                "id": uuid,
+                "latitude": 4.4,
+                "created_at": 1565258153704,
+                "updated_at": 1565258153704,
+                "orgUnitId": self.coruscant.id,
+                "formId": form.id,
+                "longitude": 4.4,
+                "accuracy": 10,
+                "altitude": 100,
+                "file": "\/storage\/emulated\/0\/odk\/instances\/%s" % file_name,
+                "name": file_name,
+            }
+        ]
+        response = self.client.post(
+            "/api/instances/?app_id=stars.empire.agriculture.hydroponics", data=instance_body, format="json"
+        )
+        self.assertEqual(response.status_code, 200)
+
+        with open("iaso/tests/fixtures/%s" % file_name) as fp:
+            self.client.post("/sync/form_upload/", {"xml_submission_file": fp}, format="multipart")
+
+        return m.Instance.objects.get(uuid=uuid)
+
+    def test_form_version_derived_on_sync_upload_when_version_matches(self):
+        """`Instance.save()` should auto-derive form_version from json['_version'] when a matching FormVersion exists."""
+        form_version = FormVersion.objects.create(
+            form=self.form_1,
+            version_id="201911280919",
+            file=UploadedFile(open("iaso/tests/fixtures/form_rapide_1666691000_with_injectables.xml")),
+        )
+        uuid = "4b7c3954-f69a-4b99-83b1-db73957b3401"
+
+        instance = self._upload_land_speeder(self.form_1, uuid)
+
+        self.assertEqual(instance.form_version, form_version)
+
+    def test_form_version_left_unset_on_sync_upload_when_version_does_not_match(self):
+        """No FormVersion with a matching version_id exists: `Instance.save()` silently skips derivation."""
+        uuid = "4b7c3954-f69a-4b99-83b1-db73957b3402"
+
+        instance = self._upload_land_speeder(self.form_1, uuid)
+
+        self.assertIsNone(instance.form_version)
+
+    def test_json_parsed_from_xml_on_sync_upload(self):
+        """`get_and_save_json_of_xml()` should parse the submitted XML fields into instance.json."""
+        uuid = "4b7c3954-f69a-4b99-83b1-db73957b3403"
+
+        instance = self._upload_land_speeder(self.form_2, uuid, file_name="land_speeder_with_service.xml")
+
+        self.assertEqual(instance.json["_version"], "201911280919")
+        self.assertEqual(instance.json["service"], "123")
+        self.assertEqual(instance.json["Ident_nom_responsable"], "Chggh")
+        self.assertEqual(instance.json["deviceid"], "358544083104930")
+
+    def test_location_and_accuracy_converted_on_sync_upload(self):
+        """`convert_location_from_field()` should set location/accuracy from the form's configured geo field."""
+        form = m.Form.objects.create(name="Land Speeder Geo", form_id="land_speeder_geo", location_field="gps")
+        uuid = "4b7c3954-f69a-4b99-83b1-db73957b3404"
+
+        instance = self._upload_land_speeder(form, uuid)
+
+        self.assertAlmostEqual(instance.location.y, 50.8367386)  # latitude
+        self.assertAlmostEqual(instance.location.x, 4.40093901)  # longitude
+        self.assertAlmostEqual(instance.location.z, 123.56201171875)  # altitude
+        self.assertAlmostEqual(float(instance.accuracy), 49.312, places=2)
+
+    def test_earlier_conversions_persist_when_a_later_one_raises_value_error_on_sync_upload(self):
+        """A ValueError in one convert_* step must not discard the ones that already succeeded.
+
+        `correlation_field` is pointed at "user_name" (a non-numeric field present in the fixture
+        XML), so `convert_correlation()` raises ValueError (`int("...Tttt...")`) after
+        `convert_location_from_field()` and `convert_device()` have already run. The location and
+        device conversions -- which run earlier in the chain -- must still be persisted even though
+        correlation fails; only `correlation_id` should be left unset.
+        """
+        form = m.Form.objects.create(
+            name="Land Speeder Geo Error",
+            form_id="land_speeder_geo_error",
+            location_field="gps",
+            correlation_field="user_name",
+        )
+        uuid = "4b7c3954-f69a-4b99-83b1-db73957b3408"
+
+        instance = self._upload_land_speeder(form, uuid)
+
+        self.assertAlmostEqual(instance.location.y, 50.8367386)  # latitude
+        self.assertAlmostEqual(instance.location.x, 4.40093901)  # longitude
+        self.assertAlmostEqual(float(instance.accuracy), 49.312, places=2)
+        self.assertIsNotNone(instance.device)
+        self.assertEqual(instance.device.imei, "358544083104930")
+        self.assertIsNone(instance.correlation_id)
+
+    def test_multiple_attachments_create_instance_files_on_sync_upload(self):
+        """Extra files posted alongside the xml_submission_file should become InstanceFile rows."""
+        uuid = "4b7c3954-f69a-4b99-83b1-db73957b3405"
+        file_name = "land_speeder.xml"
+        instance_body = [
+            {
+                "id": uuid,
+                "latitude": 4.4,
+                "created_at": 1565258153704,
+                "updated_at": 1565258153704,
+                "orgUnitId": self.coruscant.id,
+                "formId": self.form_1.id,
+                "longitude": 4.4,
+                "accuracy": 10,
+                "altitude": 100,
+                "file": "\/storage\/emulated\/0\/odk\/instances\/%s" % file_name,
+                "name": file_name,
+            }
+        ]
+        response = self.client.post(
+            "/api/instances/?app_id=stars.empire.agriculture.hydroponics", data=instance_body, format="json"
+        )
+        self.assertEqual(response.status_code, 200)
+
+        with (
+            open("iaso/tests/fixtures/%s" % file_name) as fp,
+            open("iaso/tests/fixtures/clamav/safe.jpg", "rb") as photo1,
+            open("iaso/tests/fixtures/clamav/safe.jpg", "rb") as photo2,
+        ):
+            self.client.post(
+                "/sync/form_upload/",
+                {"xml_submission_file": fp, "photo1.jpg": photo1, "photo2.jpg": photo2},
+                format="multipart",
+            )
+
+        instance = m.Instance.objects.get(uuid=uuid)
+        self.assertEqual(instance.instancefile_set.count(), 2)
+        self.assertEqual(
+            set(instance.instancefile_set.values_list("name", flat=True)),
+            {"photo1.jpg", "photo2.jpg"},
+        )
+        for instance_file in InstanceFile.objects.filter(instance=instance):
+            self.assertEqual(instance_file.instance_id, instance.id)
+
+    def test_audit_modification_created_on_sync_upload(self):
+        """A Modification audit record should be created with source='SYNC FORM UPLOAD'."""
+        uuid = "4b7c3954-f69a-4b99-83b1-db73957b3406"
+
+        instance = self._upload_land_speeder(self.form_1, uuid)
+
+        modification = Modification.objects.filter(object_id=instance.id).latest("created_at")
+        self.assertEqual(modification.source, "SYNC FORM UPLOAD")
+
+    def test_sync_upload_creates_new_instance_without_preexisting_skeleton(self):
+        """Calling /sync/form_upload/ with no prior POST /api/instances/ skeleton should still create an Instance.
+
+        Characterizes current behavior: such an instance has no `form` (nothing set it), so
+        `get_and_save_json_of_xml()` raises (`self.form` is None) and is silently swallowed by
+        `form_upload()`'s bare except -- the instance is created with its file, but `.json` stays unset.
+        """
+        self.assertEqual(Instance.objects.filter(file_name="land_speeder.xml").count(), 0)
+
+        with open("iaso/tests/fixtures/land_speeder.xml") as fp:
+            response = self.client.post("/sync/form_upload/", {"xml_submission_file": fp}, format="multipart")
+
+        self.assertEqual(response.status_code, 201)
+        instance = Instance.objects.get(file_name="land_speeder.xml")
+        self.assertIsNone(instance.form)
+        self.assertTrue(instance.file)
+        self.assertIsNone(instance.json)
+
     @responses.activate
     def test_creation_with_instant_export_feature_flag(self):
         """POST of a form with instant export feature is enabled"""
@@ -252,3 +421,41 @@ class CorrelationAPITestCase(APITestCase):
             self.client.post("/sync/form_upload/", {"xml_submission_file": fp}, format="multipart")
 
         instance = m.Instance.objects.get(uuid=uuid)
+        called_urls = [call.request.url for call in responses.calls]
+        self.assertIn("https://dhis2.com/api/dataValueSets", called_urls)
+        self.assertIn("https://dhis2.com/api/completeDataSetRegistrations", called_urls)
+
+    @responses.activate
+    def test_no_export_without_instant_export_feature_flag(self):
+        """Without the INSTANT_EXPORT feature flag, uploading should not trigger any DHIS2 export call."""
+        credentials, _ = m.ExternalCredentials.objects.get_or_create(
+            name="Test export api", url="https://dhis2.com", login="admin", password="whocares", account=self.star_wars
+        )
+        sw_source = m.DataSource.objects.create(name="Evil Empire", credentials=credentials)
+        sw_version = m.SourceVersion.objects.create(data_source=sw_source, number=1)
+        self.star_wars.default_version = sw_version
+        self.star_wars.save()
+
+        form_version_1 = m.FormVersion.objects.create(
+            form=self.form_2,
+            version_id="201911280919",
+            file=UploadedFile(open("iaso/tests/fixtures/form_rapide_1666691000_with_injectables.xml")),
+        )
+        mapping = Mapping(form=self.form_2, data_source=sw_source, mapping_type=m.AGGREGATE)
+        mapping.save()
+        m.MappingVersion(
+            name="aggregate", json=build_form_mapping(), form_version=form_version_1, mapping=mapping
+        ).save()
+
+        responses.add(
+            responses.POST,
+            "https://dhis2.com/api/dataValueSets",
+            json=load_dhis2_fixture("datavalues-ok.json"),
+            status=200,
+        )
+        responses.add(responses.POST, "https://dhis2.com/api/completeDataSetRegistrations", json={}, status=200)
+
+        uuid = "4b7c3954-f69a-4b99-83b1-db73957b3407"
+        self._upload_land_speeder(self.form_2, uuid, file_name="land_speeder_with_service.xml")
+
+        self.assertEqual(len(responses.calls), 0)

--- a/iaso/tests/api/test_enketo.py
+++ b/iaso/tests/api/test_enketo.py
@@ -5,12 +5,13 @@ from urllib.parse import parse_qs
 
 import responses
 
+from django.contrib.auth.models import User
 from django.core.files import File
 from django.core.files.uploadedfile import SimpleUploadedFile, UploadedFile
 from django.test import override_settings
 from django.utils import timezone
 
-from hat.audit.models import Modification
+from hat.audit.models import INSTANCE_API, Modification
 from iaso import models as m
 from iaso.enketo.enketo_xml import build_substitutions
 from iaso.models import Instance, InstanceFile
@@ -327,6 +328,45 @@ class EnketoAPITestCase(APITestCase):
 
         self.assertEqual(response.status_code, 403)
 
+    @override_settings(ENKETO=enketo_test_settings)
+    @responses.activate
+    def test_enketo_create_url_creates_instance_with_expected_fields(self):
+        """POST /api/enketo/create/ (dashboard-initiated instance creation)"""
+        self.client.force_authenticate(self.yoda)
+
+        def request_callback(request):
+            return (200, {}, json.dumps({"edit_url": "https://enketo_url.host.test/something"}))
+
+        responses.add_callback(
+            responses.POST,
+            "https://enketo_url.host.test/api_v2/instance",
+            callback=request_callback,
+            content_type="application/json",
+        )
+
+        old_count = Instance.objects.count()
+        response = self.client.post(
+            "/api/enketo/create/",
+            data={
+                "form_id": self.form_1.id,
+                "period": "202005",
+                "org_unit_id": self.jedi_council_corruscant.id,
+            },
+            format="json",
+        )
+        r = self.assertJSONResponse(response, 201)
+        self.assertEqual(r, {"edit_url": "https://enketo_url.host.test/something"})
+        self.assertEqual(Instance.objects.count(), old_count + 1)
+
+        instance = Instance.objects.latest("id")
+        self.assertEqual(instance.form_id, self.form_1.id)
+        self.assertEqual(instance.org_unit_id, self.jedi_council_corruscant.id)
+        self.assertEqual(instance.period, "202005")
+        self.assertEqual(instance.project_id, self.project.id)
+        self.assertEqual(instance.created_by, self.yoda)
+        self.assertEqual(instance.last_modified_by, self.yoda)
+        self.assertEqual(instance.name, self.form_1.name)
+
     def test_when_anonymous_head_submission_should_work(self):
         response = self.client.head("/api/enketo/submission")
 
@@ -386,6 +426,7 @@ class EnketoAPITestCase(APITestCase):
             self.assertEqual("1", modification.new_value[0]["fields"]["json"]["Ident_type_serv_medical"])
 
             self.assertEqual(instance, modification.content_object)
+            self.assertEqual(modification.source, INSTANCE_API)
 
     def assertXmlResponse(self, response, expected_status_code):
         self.assertEqual(expected_status_code, response.status_code, response)
@@ -410,6 +451,134 @@ class EnketoAPITestCase(APITestCase):
 
             self.assertEqual(response.status_code, 201)
             self.assertEqual(self.yoda, instance.last_modified_by)
+
+    def test_submission_sets_instance_fields(self):
+        """`EnketoSubmissionAPIView.post()` should set file/name/source_updated_at on the submitted instance."""
+        with open("iaso/tests/fixtures/hydroponics_test_upload_modified.xml") as modified_xml:
+            instance = self.form_1.instances.first()
+            source_updated_at_before = instance.source_updated_at
+            f = SimpleUploadedFile(
+                "file.txt",
+                modified_xml.read()
+                .replace("replaceInstanceId", str(instance.id))
+                .replace("REPLACEuserID", str(self.yoda.id))
+                .encode(),
+            )
+            response = self.client.post(
+                "/api/enketo/submission", {"name": "xml_submission_file", "xml_submission_file": f}, format="multipart"
+            )
+
+            self.assertEqual(response.status_code, 201)
+            instance.refresh_from_db()
+            self.assertTrue(instance.file)
+            self.assertEqual(instance.name, self.form_1.name)
+            self.assertNotEqual(instance.source_updated_at, source_updated_at_before)
+            self.assertEqual(instance.json.get("Ident_nom_responsable"), "Chggh")
+
+    def test_submission_derives_form_version(self):
+        """`Instance.save()` should auto-derive form_version from json['_version'] on submission."""
+        form_version = m.FormVersion.objects.create(
+            form=self.form_1,
+            version_id="201911280919",
+            file=UploadedFile(open("iaso/tests/fixtures/form_rapide_1666691000_with_injectables.xml")),
+        )
+        with open("iaso/tests/fixtures/hydroponics_test_upload_modified.xml") as modified_xml:
+            instance = self.form_1.instances.first()
+            f = SimpleUploadedFile(
+                "file.txt",
+                modified_xml.read()
+                .replace("replaceInstanceId", str(instance.id))
+                .replace("REPLACEuserID", str(self.yoda.id))
+                .encode(),
+            )
+            response = self.client.post(
+                "/api/enketo/submission", {"name": "xml_submission_file", "xml_submission_file": f}, format="multipart"
+            )
+
+            self.assertEqual(response.status_code, 201)
+            instance.refresh_from_db()
+            self.assertEqual(instance.form_version, form_version)
+
+    def test_submission_converts_location_and_device(self):
+        """`convert_location_from_field()`/`convert_device()` should run as part of the submission callback."""
+        self.form_1.location_field = "gps"
+        self.form_1.save()
+        with open("iaso/tests/fixtures/hydroponics_test_upload_modified.xml") as modified_xml:
+            instance = self.form_1.instances.first()
+            f = SimpleUploadedFile(
+                "file.txt",
+                modified_xml.read()
+                .replace("replaceInstanceId", str(instance.id))
+                .replace("REPLACEuserID", str(self.yoda.id))
+                .encode(),
+            )
+            response = self.client.post(
+                "/api/enketo/submission", {"name": "xml_submission_file", "xml_submission_file": f}, format="multipart"
+            )
+
+            self.assertEqual(response.status_code, 201)
+            instance.refresh_from_db()
+            self.assertAlmostEqual(instance.location.y, 50.8367386)  # latitude
+            self.assertAlmostEqual(instance.location.x, 4.40093901)  # longitude
+            self.assertAlmostEqual(instance.location.z, 123.56201171875)  # altitude
+            self.assertAlmostEqual(float(instance.accuracy), 49.312, places=2)
+            self.assertIsNotNone(instance.device)
+            self.assertEqual(instance.device.imei, "358544083104930")
+
+    def test_submission_creates_attachment_instance_files(self):
+        """Extra files posted alongside the xml_submission_file should become InstanceFile rows.
+
+        Characterizes a real quirk: `deprecated_files` is computed as a lazy queryset excluding
+        names referenced inside the XML body, but it's only evaluated (and saved with
+        `deleted=True`) *after* this request's own new InstanceFile rows are already created.
+        So an attachment whose name isn't referenced inside the submitted XML content -- like a
+        plain multipart field name that doesn't match any media reference in the form -- gets
+        marked `deleted=True` immediately, in the same request that created it.
+        """
+        with (
+            open("iaso/tests/fixtures/hydroponics_test_upload_modified.xml") as modified_xml,
+            open("iaso/tests/fixtures/clamav/safe.jpg", "rb") as photo,
+        ):
+            instance = self.form_1.instances.first()
+            f = SimpleUploadedFile(
+                "file.txt",
+                modified_xml.read()
+                .replace("replaceInstanceId", str(instance.id))
+                .replace("REPLACEuserID", str(self.yoda.id))
+                .encode(),
+            )
+            response = self.client.post(
+                "/api/enketo/submission",
+                {"name": "xml_submission_file", "xml_submission_file": f, "photo1.jpg": photo},
+                format="multipart",
+            )
+
+            self.assertEqual(response.status_code, 201)
+            instance.refresh_from_db()
+            attachment = instance.instancefile_set.get(name="photo1.jpg")
+            self.assertEqual(attachment.instance_id, instance.id)
+            self.assertTrue(attachment.deleted)
+
+    @responses.activate
+    def test_submission_export_not_triggered_when_to_export_false(self):
+        """Without to_export set, submitting should not call out to DHIS2 at all."""
+        with open("iaso/tests/fixtures/hydroponics_test_upload_modified.xml") as modified_xml:
+            instance = self.form_1.instances.first()
+            instance.to_export = False
+            instance.save()
+            f = SimpleUploadedFile(
+                "file.txt",
+                modified_xml.read()
+                .replace("replaceInstanceId", str(instance.id))
+                .replace("REPLACEuserID", str(self.yoda.id))
+                .encode(),
+            )
+            response = self.client.post(
+                "/api/enketo/submission", {"name": "xml_submission_file", "xml_submission_file": f}, format="multipart"
+            )
+
+            self.assertEqual(response.status_code, 201)
+            self.assertEqual(len(responses.calls), 0)
 
     @responses.activate
     def test_save_last_user_modified_submission_auto_export(self):
@@ -698,6 +867,7 @@ class EnketoAPITestCase(APITestCase):
             "form_id": form_id,
             "external_org_unit_id": self.jedi_council_corruscant.source_ref,
             "token": token,
+            "to_export": "true",
         }
 
         response = self.client.get("/api/enketo/public_create_url/", data=data)
@@ -706,6 +876,9 @@ class EnketoAPITestCase(APITestCase):
         self.assertEqual(len(responses.calls), 1)
         self.assertTrue(responses.assert_call_count("https://enketo_url.host.test/api_v2/instance", 1), responses.calls)
         self.assertEqual(old_count, Instance.objects.count())
+
+        instance.refresh_from_db()
+        self.assertTrue(instance.to_export)
 
     @override_settings(ENKETO=enketo_test_settings)
     @responses.activate
@@ -1002,6 +1175,37 @@ class EnketoAPITestCase(APITestCase):
         response = self.client.get(f"/api/fill/{form_with_injectables.uuid}/{self.jedi_council_corruscant.id}/202301")
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.url, "https://enketo_url.host.test/something")
+
+        instance = Instance.objects.filter(form=form_with_injectables).latest("id")
+        self.assertEqual(instance.org_unit_id, self.jedi_council_corruscant.id)
+        self.assertEqual(instance.period, "202301")
+        self.assertIsNone(instance.project)
+
+    @override_settings(ENKETO=enketo_test_settings)
+    @responses.activate
+    def test_public_create_url_creates_user_and_profile_for_external_user_id(self):
+        """`enketo_public_create_url` should auto-create a User+Profile for a never-seen external_user_id."""
+        self.setUpMockEnketo()
+        token = self.project.external_token
+        form_id = self.form_1.form_id
+        external_user_id = "ext-user-42"
+
+        self.assertFalse(User.objects.filter(username=f"external-{external_user_id}").exists())
+
+        data = {
+            "period": "202301",
+            "form_id": form_id,
+            "external_org_unit_id": self.jedi_council_corruscant.source_ref,
+            "token": token,
+            "external_user_id": external_user_id,
+        }
+        response = self.client.get("/api/enketo/public_create_url/", data=data)
+        self.assertJSONResponse(response, 201)
+
+        user = User.objects.get(username=f"external-{external_user_id}")
+        profile = m.Profile.objects.get(external_user_id=external_user_id)
+        self.assertEqual(profile.user, user)
+        self.assertEqual(profile.account, self.project.account)
 
     def test_enketo_instance_files(self):
         """GET /api/enketo/instance_files/<instance_file_id>/<file_name>"""

--- a/iaso/tests/api/test_sync_import_query_count.py
+++ b/iaso/tests/api/test_sync_import_query_count.py
@@ -64,18 +64,29 @@ class SyncImportQueryCountTest(APITestCase):
         self.assertIsNotNone(instance.form_version)
         self.assertEqual(instance.form_version.version_id, "201911280919")
 
-        counts = profiler.table_counts()
         # No entityUuid/entityTypeId in this payload, and orgUnitId is given as a numeric id
-        # (skipping the org_unit_cache lookup entirely) - so none of those tables are touched.
-        self.assertEqual(counts.get("iaso_orgunit", 0), 0)
-        self.assertEqual(counts.get("iaso_entity", 0), 0)
-        self.assertEqual(counts.get("iaso_entitytype", 0), 0)
-        # 1 form lookup from import_data()'s batch prefetch + 1 from xml_file_to_json while
-        # processing the attached XML file; same breakdown for iaso_formversion (the memoized
+        # (skipping the org_unit_cache lookup entirely) - so those tables get 0 hits. 1 form
+        # lookup from import_data()'s batch prefetch + 1 from xml_file_to_json while processing
+        # the attached XML file; same breakdown for iaso_formversion (the memoized
         # Instance.save() lookup + xml_file_to_json's own lookup).
-        self.assertLessEqual(counts["iaso_form"], 2)
-        self.assertLessEqual(counts["iaso_formversion"], 2)
-        self.assertLessEqual(profiler.total_queries(), 30)
+        profiler.assertLessEqualQueryCount(
+            {
+                "iaso_orgunit": 0,
+                "iaso_entity": 0,
+                "iaso_entitytype": 0,
+                "iaso_form": 2,
+                "iaso_formversion": 2,
+                "iaso_instance": 9,
+                "iaso_project": 2,
+                "vector_control_apiimport": 1,
+                "iaso_featureflag": 1,
+                "audit_modification": 1,
+            },
+            exclude=["django_content_type"],
+        )
+        # 22 observed as part of the full suite, 23 in isolation - `iaso_content_type`'s one-time
+        # cache warm depends on test run order; +1 of headroom for that only.
+        self.assertLessEqual(profiler.total_queries(), 23)
 
         profiler.print_report()
         path = profiler.write_markdown_report(

--- a/iaso/tests/api/test_sync_import_query_count.py
+++ b/iaso/tests/api/test_sync_import_query_count.py
@@ -12,8 +12,9 @@ class SyncImportQueryCountTest(APITestCase):
     Unlike the bulk zip fixture (4 instances, 2 shared (form, version) pairs), this is a
     single instance - so the per-batch org_unit/entity caching added to import_data() has
     nothing to cache across and shouldn't move the numbers here. The per-instance fixes
-    (Instance.save() FormVersion memoization, id-vs-object comparison in import_data())
-    should still show up, since they apply per instance regardless of batch size.
+    (xml_file_to_json setting form_version directly instead of a separate resolve_form_version()
+    lookup, id-vs-object comparison in import_data()) should still show up, since they apply per
+    instance regardless of batch size.
     """
 
     @classmethod
@@ -67,15 +68,16 @@ class SyncImportQueryCountTest(APITestCase):
         # No entityUuid/entityTypeId in this payload, and orgUnitId is given as a numeric id
         # (skipping the org_unit_cache lookup entirely) - so those tables get 0 hits. 1 form
         # lookup from import_data()'s batch prefetch + 1 from xml_file_to_json while processing
-        # the attached XML file; same breakdown for iaso_formversion (the memoized
-        # Instance.save() lookup + xml_file_to_json's own lookup).
+        # the attached XML file. `iaso_formversion` is a single lookup, also from
+        # xml_file_to_json - get_and_save_json_of_xml reuses the FormVersion it already found
+        # there instead of looking it up again separately.
         profiler.assertLessEqualQueryCount(
             {
                 "iaso_orgunit": 0,
                 "iaso_entity": 0,
                 "iaso_entitytype": 0,
                 "iaso_form": 2,
-                "iaso_formversion": 2,
+                "iaso_formversion": 1,
                 "iaso_instance": 9,
                 "iaso_project": 2,
                 "vector_control_apiimport": 1,
@@ -84,9 +86,9 @@ class SyncImportQueryCountTest(APITestCase):
             },
             exclude=["django_content_type"],
         )
-        # 22 observed as part of the full suite, 23 in isolation - `iaso_content_type`'s one-time
+        # 21 observed as part of the full suite, 22 in isolation - `iaso_content_type`'s one-time
         # cache warm depends on test run order; +1 of headroom for that only.
-        self.assertLessEqual(profiler.total_queries(), 23)
+        self.assertLessEqual(profiler.total_queries(), 22)
 
         profiler.print_report()
         path = profiler.write_markdown_report(

--- a/iaso/tests/api/test_sync_import_query_count.py
+++ b/iaso/tests/api/test_sync_import_query_count.py
@@ -68,9 +68,12 @@ class SyncImportQueryCountTest(APITestCase):
         # No entityUuid/entityTypeId in this payload, and orgUnitId is given as a numeric id
         # (skipping the org_unit_cache lookup entirely) - so those tables get 0 hits. 1 form
         # lookup from import_data()'s batch prefetch + 1 from xml_file_to_json while processing
-        # the attached XML file. `iaso_formversion` is a single lookup, also from
-        # xml_file_to_json - get_and_save_json_of_xml reuses the FormVersion it already found
-        # there instead of looking it up again separately.
+        # the attached XML file - unlike the bulk-upload path, this stays at 2: POST
+        # /api/instances/ and POST /sync/form_upload/ are two separate HTTP requests, so there's
+        # no in-memory Instance to reuse across them (the object-reuse fix that drops this to a
+        # single batch query in process_mobile_bulk_upload() doesn't apply here). `iaso_formversion`
+        # is a single lookup, also from xml_file_to_json - get_and_save_json_of_xml reuses the
+        # FormVersion it already found there instead of looking it up again separately.
         profiler.assertLessEqualQueryCount(
             {
                 "iaso_orgunit": 0,
@@ -78,7 +81,7 @@ class SyncImportQueryCountTest(APITestCase):
                 "iaso_entitytype": 0,
                 "iaso_form": 2,
                 "iaso_formversion": 1,
-                "iaso_instance": 9,
+                "iaso_instance": 8,
                 "iaso_project": 2,
                 "vector_control_apiimport": 1,
                 "iaso_featureflag": 1,
@@ -86,9 +89,9 @@ class SyncImportQueryCountTest(APITestCase):
             },
             exclude=["django_content_type"],
         )
-        # 21 observed as part of the full suite, 22 in isolation - `iaso_content_type`'s one-time
+        # 20 observed as part of the full suite, 21 in isolation - `iaso_content_type`'s one-time
         # cache warm depends on test run order; +1 of headroom for that only.
-        self.assertLessEqual(profiler.total_queries(), 22)
+        self.assertLessEqual(profiler.total_queries(), 21)
 
         profiler.print_report()
         path = profiler.write_markdown_report(

--- a/iaso/tests/tasks/test_process_mobile_bulk_upload.py
+++ b/iaso/tests/tasks/test_process_mobile_bulk_upload.py
@@ -19,6 +19,8 @@ from hat.api_import.models import APIImport
 from hat.audit.models import BULK_UPLOAD, Modification
 from iaso import models as m
 from iaso.api.deduplication.entity_duplicate import merge_entities
+from iaso.models.common import ValidationWorkflowArtefactStatus
+from iaso.models.forms import CR_MODE_IF_REFERENCE_FORM
 from iaso.models.instances import instance_file_upload_to, instance_upload_to
 from iaso.tasks.process_mobile_bulk_upload import process_mobile_bulk_upload
 from iaso.tests.utils.query_profiler import QueryProfiler
@@ -139,6 +141,16 @@ class ProcessMobileBulkUploadTest(TestCase):
 
         # Removing all InMemoryFileNodes inside the storage to avoid name conflicts - some can be kept by previous test classes
         default_storage._root._children.clear()  # see InMemoryFileStorage in django/core/files/storage/memory.py
+
+    def assertCorrelationIdFormat(self, instance):
+        """`convert_correlation()` always sets a correlation_id (str(id) + random digit + mod-97
+        checksum), regardless of whether the form configures a `correlation_field` -- assert on
+        the deterministic parts only, since one digit is random.
+        """
+        self.assertTrue(str(instance.correlation_id).startswith(str(instance.id)))
+        modulo = int(str(instance.correlation_id)[-2:])
+        base = int(str(instance.correlation_id)[0:-2])
+        self.assertEqual(base % 97, modulo)
 
     def _create_zip_file(self):
         # Create the zip file: we create it on the fly to be able to clearly
@@ -281,6 +293,18 @@ class ProcessMobileBulkUploadTest(TestCase):
         # `attributes` should point back to this instance.
         self.assertEqual(ent_disasi.attributes, reg_instance)
         self.assertEqual(reg_instance.instancefile_set.count(), 0)
+        # `location`/`accuracy` here come from the direct payload assignment in `import_data()`
+        # (latitude/longitude/altitude/accuracy in instances.json) -- form_registration has no
+        # `location_field` configured, so `convert_location_from_field()` is a no-op for it.
+        self.assertAlmostEqual(reg_instance.location.y, 50.6429429)  # latitude
+        self.assertAlmostEqual(reg_instance.location.x, 4.6004524)  # longitude
+        self.assertAlmostEqual(float(reg_instance.accuracy), 14.929, places=2)
+        # `convert_correlation()` (called via `process_instance_file()` for new instances) always
+        # assigns a correlation_id, even though neither form configures a `correlation_field`.
+        self.assertCorrelationIdFormat(reg_instance)
+        # No `deviceid`-like field in this fixture's XML, so `convert_device()` has nothing to
+        # convert and leaves this unset.
+        self.assertIsNone(reg_instance.device)
 
         catt_instance = m.Instance.objects.get(uuid=DISASI_MAKULO_CATT)
         self.assertEqual(catt_instance.json.get("result"), "positive")
@@ -288,6 +312,11 @@ class ProcessMobileBulkUploadTest(TestCase):
         self.assertEqual(catt_instance.instancefile_set.count(), 1)
         image = catt_instance.instancefile_set.first()
         self.assertEqual(image.name, "1712326156339.webp")
+        self.assertAlmostEqual(catt_instance.location.y, 50.6429501)  # latitude
+        self.assertAlmostEqual(catt_instance.location.x, 4.6004282)  # longitude
+        self.assertAlmostEqual(float(catt_instance.accuracy), 12.74, places=2)
+        self.assertCorrelationIdFormat(catt_instance)
+        self.assertIsNone(catt_instance.device)
 
         # Checking if files are uploaded to the correct location
         generated_file_name = instance_upload_to(catt_instance, DISASI_MAKULO_INSTANCE_FILE_NAME)
@@ -306,6 +335,11 @@ class ProcessMobileBulkUploadTest(TestCase):
         self.assertEqual(reg_instance.entity, entity_patrice)
         self.assertEqual(entity_patrice.attributes, reg_instance)
         self.assertEqual(reg_instance.instancefile_set.count(), 0)
+        self.assertAlmostEqual(reg_instance.location.y, 50.6429429)  # latitude
+        self.assertAlmostEqual(reg_instance.location.x, 4.6004524)  # longitude
+        self.assertAlmostEqual(float(reg_instance.accuracy), 14.929, places=2)
+        self.assertCorrelationIdFormat(reg_instance)
+        self.assertIsNone(reg_instance.device)
 
         catt_instance = m.Instance.objects.get(uuid=PATRICE_AKAMBU_CATT)
         self.assertEqual(catt_instance.json.get("result"), "positive")
@@ -314,6 +348,115 @@ class ProcessMobileBulkUploadTest(TestCase):
         # image from Disasi's CATT was duplicated to this test
         image = catt_instance.instancefile_set.first()
         self.assertEqual(image.name, "1712326156339.webp")
+        self.assertAlmostEqual(catt_instance.location.y, 50.6429501)  # latitude
+        self.assertAlmostEqual(catt_instance.location.x, 4.6004282)  # longitude
+        self.assertAlmostEqual(float(catt_instance.accuracy), 12.74, places=2)
+        self.assertCorrelationIdFormat(catt_instance)
+        self.assertIsNone(catt_instance.device)
+
+        # `duplicate_instance_files()`: both CATT instances share the same json["serie_id"]
+        # in their submitted XML, so the single uploaded attachment gets duplicated onto
+        # the other instance rather than each instance only keeping its own file (or none).
+        self.assertEqual(m.InstanceFile.objects.filter(name="1712326156339.webp").count(), 2)
+
+    def test_device_converted_from_configured_device_field_during_bulk_upload(self):
+        """`convert_device()` should actually assign a Device when the form's device_field
+        (or the default "deviceid") matches a field present in the submitted XML.
+
+        None of the CATT/registration fixture XMLs have a `deviceid` field, so `test_success`
+        only characterizes the no-op case. Point `form_catt.device_field` at `serie_id` (a field
+        both CATT instances' XML already carries, with the same shared value) to exercise the
+        actual assignment branch without needing a new fixture.
+        """
+        self.form_catt.device_field = "serie_id"
+        self.form_catt.save()
+
+        self._create_zip_file()
+        process_mobile_bulk_upload(
+            api_import_id=self.api_import.id,
+            project_id=self.project.id,
+            task=self.task,
+            _immediate=True,
+        )
+
+        self.task.refresh_from_db()
+        self.assertEqual(self.task.status, m.SUCCESS)
+
+        serie_id = "ad893d6d-355f-4ffe-a575-cea6bbe5914f"
+        self.assertEqual(m.Device.objects.count(), 1)
+        device = m.Device.objects.get(imei=serie_id)
+
+        for instance_uuid in (DISASI_MAKULO_CATT, PATRICE_AKAMBU_CATT):
+            catt_instance = m.Instance.objects.get(uuid=instance_uuid)
+            self.assertEqual(catt_instance.device, device)
+
+        # form_registration still has no device_field override: untouched.
+        for instance_uuid in (DISASI_MAKULO_REGISTRATION, PATRICE_AKAMBU_REGISTRATION):
+            reg_instance = m.Instance.objects.get(uuid=instance_uuid)
+            self.assertIsNone(reg_instance.device)
+
+    def test_change_request_created_via_bulk_upload(self):
+        """CR_MODE_IF_REFERENCE_FORM should create an OrgUnitChangeRequest per instance,
+        mirroring test_change_request_on_new_reference_form.py::test_instance_insertion
+        but driven through the mobile bulk-upload Celery task rather than POST /api/instances/.
+        """
+        self.form_registration.change_request_mode = CR_MODE_IF_REFERENCE_FORM
+        self.form_registration.save()
+        # The org unit created by the zip (org_unit_type_id=5) must recognize form_registration
+        # as one of its reference forms for the change-request branch to fire.
+        m.OrgUnitType.objects.filter(id=5).first().reference_forms.add(self.form_registration)
+
+        self._create_zip_file()
+
+        self.assertEqual(m.OrgUnitChangeRequest.objects.count(), 0)
+
+        process_mobile_bulk_upload(
+            api_import_id=self.api_import.id,
+            project_id=self.project.id,
+            task=self.task,
+            _immediate=True,
+        )
+
+        self.task.refresh_from_db()
+        self.assertEqual(self.task.status, m.SUCCESS)
+
+        # One change request per registration-form instance (Disasi Makulo + Patrice Akambu).
+        self.assertEqual(m.OrgUnitChangeRequest.objects.count(), 2)
+        reg_instance = m.Instance.objects.get(uuid=DISASI_MAKULO_REGISTRATION)
+        change_request = m.OrgUnitChangeRequest.objects.get(new_reference_instances=reg_instance)
+        self.assertEqual(change_request.org_unit, reg_instance.org_unit)
+        self.assertEqual(change_request.requested_fields, ["new_reference_instances"])
+        self.assertEqual(list(change_request.new_reference_instances.all()), [reg_instance])
+
+    def test_validation_workflow_triggered_via_bulk_upload(self):
+        """A form with a validation_workflow should trigger ValidationWorkflowEngine.start()
+        for instances created through the mobile bulk-upload Celery task, mirroring
+        test_validation_workflow.py::test_trigger_validation_workflow.
+        """
+        validation_workflow = m.ValidationWorkflow.objects.create(name="validation-workflow", account=self.account)
+        validation_workflow.form_set.add(self.form_registration)
+        m.ValidationNodeTemplate.objects.create(name="First node", workflow=validation_workflow)
+
+        self._create_zip_file()
+
+        process_mobile_bulk_upload(
+            api_import_id=self.api_import.id,
+            project_id=self.project.id,
+            task=self.task,
+            _immediate=True,
+        )
+
+        self.task.refresh_from_db()
+        self.assertEqual(self.task.status, m.SUCCESS)
+
+        for reg_uuid in (DISASI_MAKULO_REGISTRATION, PATRICE_AKAMBU_REGISTRATION):
+            reg_instance = m.Instance.objects.get(uuid=reg_uuid)
+            self.assertEqual(reg_instance.general_validation_status, ValidationWorkflowArtefactStatus.PENDING)
+
+        # The CATT form has no validation_workflow: its instances should be untouched.
+        for catt_uuid in (DISASI_MAKULO_CATT, PATRICE_AKAMBU_CATT):
+            catt_instance = m.Instance.objects.get(uuid=catt_uuid)
+            self.assertEqual(catt_instance.validationnode_set.count(), 0)
 
     def test_form_version_query_count_baseline(self):
         """
@@ -331,7 +474,15 @@ class ProcessMobileBulkUploadTest(TestCase):
         self._create_zip_file()
 
         with QueryProfiler(
-            trace_tables=["iaso_formversion", "iaso_form", "iaso_orgunit", "iaso_entity", "iaso_entitytype"]
+            trace_tables=[
+                "iaso_formversion",
+                "iaso_form",
+                "iaso_orgunit",
+                "iaso_entity",
+                "iaso_entitytype",
+                "iaso_instance",
+                "audit_modification",
+            ]
         ) as profiler:
             process_mobile_bulk_upload(
                 api_import_id=self.api_import.id,
@@ -351,18 +502,46 @@ class ProcessMobileBulkUploadTest(TestCase):
         # (keyed on a "serie_id" json field) fires - hence 1 here instead of test_success's 2.
         self.assertEqual(m.InstanceFile.objects.count(), 1)
 
-        counts = profiler.table_counts()
         # import_data()'s own org-unit/form/entity-type lookups are each a single batch query
         # (1 org unit, 2 forms sharing 1 lookup, 1 entity type shared by both entities) - the
-        # small headroom below absorbs the org unit's own creation/path-calculation queries
+        # small headroom on iaso_orgunit absorbs its own creation/path-calculation queries
         # (unrelated to import_data's caching), while still catching a regression back to
         # O(instances) (which would push these well past the bounds below at this batch size).
-        self.assertLessEqual(counts["iaso_orgunit"], 6)
-        self.assertLessEqual(counts["iaso_form"], 5)
-        self.assertEqual(counts["iaso_entitytype"], 1)
-        # 2 distinct entities -> O(2) via find_entity's exists-check + create, not O(4 instances).
-        self.assertLessEqual(counts["iaso_entity"], 6)
-        self.assertLessEqual(profiler.total_queries(), 130)
+        # `iaso_entity`: 2 distinct entities -> O(2) via find_entity's exists-check + create, not
+        # O(4 instances). `iaso_formversion`: 2 queries/instance (1 from `xml_file_to_json` + 1
+        # from `Instance.save()`, which currently re-derives `form_version` from `json["_version"]`
+        # on every save() call rather than caching it). `iaso_instance`/`audit_modification` scale
+        # 1:1 with the batch (8 and 1 per instance) - a regression would push these to a multiple
+        # of the bounds below, not a small overshoot. The rest (`iaso_task`/`iaso_tasklog`/
+        # `iaso_project`/`vector_control_apiimport`/`auth_user`/`iaso_profile`/`iaso_account`/
+        # `iaso_datasource`/`iaso_instancefile`) are fixed per-run bookkeeping overhead, unrelated
+        # to instance count - bounded at their exact observed value so a new query pattern on any
+        # of them still gets caught. `django_content_type` is excluded rather than bounded: it's a
+        # one-time framework cache warm that only fires the very first time `ContentType` is
+        # touched in the whole test process, so it's 0 here but can be 1 if this test runs in
+        # isolation instead of as part of the full suite.
+        profiler.assertLessEqualQueryCount(
+            {
+                "iaso_orgunit": 6,
+                "iaso_form": 5,
+                "iaso_entity": 6,
+                "iaso_formversion": 8,
+                "iaso_instance": 33,
+                "audit_modification": 4,
+                "iaso_entitytype": 1,
+                "iaso_task": 7,
+                "iaso_tasklog": 4,
+                "iaso_project": 3,
+                "vector_control_apiimport": 2,
+                "auth_user": 2,
+                "iaso_profile": 2,
+                "iaso_account": 2,
+                "iaso_datasource": 1,
+                "iaso_instancefile": 1,
+            },
+            exclude=["django_content_type"],
+        )
+        self.assertLessEqual(profiler.total_queries(), 112)
 
         profiler.print_report()
         path = profiler.write_markdown_report(
@@ -385,7 +564,15 @@ class ProcessMobileBulkUploadTest(TestCase):
         self._create_zip_file_at_scale(num_patients=25)
 
         with QueryProfiler(
-            trace_tables=["iaso_formversion", "iaso_form", "iaso_orgunit", "iaso_entity", "iaso_entitytype"]
+            trace_tables=[
+                "iaso_formversion",
+                "iaso_form",
+                "iaso_orgunit",
+                "iaso_entity",
+                "iaso_entitytype",
+                "iaso_instance",
+                "audit_modification",
+            ]
         ) as profiler:
             process_mobile_bulk_upload(
                 api_import_id=self.api_import.id,
@@ -398,20 +585,39 @@ class ProcessMobileBulkUploadTest(TestCase):
         self.assertEqual(m.Instance.objects.count(), 50)
         self.assertEqual(m.Entity.objects.count(), 25)
 
-        counts = profiler.table_counts()
         # Same batch lookups as the baseline test, still O(1)/O(distinct) at 12.5x the instance
         # count (50 vs 4) - proves import_data()'s caching doesn't regress to O(instances). A
-        # regression back to per-instance lookups would push iaso_orgunit/iaso_entitytype well
-        # past these bounds (e.g. ~50-55 instead of ~6/1), and iaso_form/iaso_entity roughly
-        # double (the "+1 form per instance" from xml_file_to_json is unrelated to import_data
-        # and already included in the bound below).
-        self.assertLessEqual(counts["iaso_orgunit"], 6)
-        self.assertLessEqual(counts["iaso_form"], 52)
-        self.assertEqual(counts["iaso_entitytype"], 1)
-        # 25 distinct entities -> O(25) via find_entity's exists-check + create + the reference-
-        # form save, not O(50 instances).
-        self.assertLessEqual(counts["iaso_entity"], 80)
-        self.assertLessEqual(profiler.total_queries(), 1000)
+        # regression back to per-instance lookups would push iaso_orgunit well past its bound
+        # (e.g. ~50-55 instead of ~6), and iaso_form/iaso_entity roughly double (the "+1 form per
+        # instance" from xml_file_to_json is unrelated to import_data and already included in the
+        # bound below). `iaso_entity`: 25 distinct entities -> O(25) via find_entity's exists-check
+        # + create + the reference-form save, not O(50 instances). `iaso_formversion`: same
+        # 2 queries/instance as the baseline test (see comment there), at scale: 100.
+        # `iaso_instance`/`audit_modification` scale 1:1 with the batch, at scale: 400 and 50. The
+        # rest is the same fixed per-run bookkeeping overhead as the baseline test (see comment
+        # there), still O(1) rather than scaling with the 12.5x larger batch - this zip has no
+        # attachments so `iaso_instancefile` never fires, unlike the baseline test.
+        profiler.assertLessEqualQueryCount(
+            {
+                "iaso_orgunit": 6,
+                "iaso_form": 52,
+                "iaso_entity": 80,
+                "iaso_formversion": 100,
+                "iaso_instance": 400,
+                "audit_modification": 50,
+                "iaso_entitytype": 1,
+                "iaso_task": 7,
+                "iaso_tasklog": 4,
+                "iaso_project": 3,
+                "vector_control_apiimport": 2,
+                "auth_user": 1,
+                "iaso_profile": 1,
+                "iaso_account": 1,
+                "iaso_datasource": 1,
+            },
+            exclude=["django_content_type"],
+        )
+        self.assertLessEqual(profiler.total_queries(), 820)
 
         profiler.print_report()
         path = profiler.write_markdown_report(

--- a/iaso/tests/tasks/test_process_mobile_bulk_upload.py
+++ b/iaso/tests/tasks/test_process_mobile_bulk_upload.py
@@ -508,24 +508,24 @@ class ProcessMobileBulkUploadTest(TestCase):
         # (unrelated to import_data's caching), while still catching a regression back to
         # O(instances) (which would push these well past the bounds below at this batch size).
         # `iaso_entity`: 2 distinct entities -> O(2) via find_entity's exists-check + create, not
-        # O(4 instances). `iaso_formversion`: 2 queries/instance (1 from `xml_file_to_json` + 1
-        # from `Instance.save()`, which currently re-derives `form_version` from `json["_version"]`
-        # on every save() call rather than caching it). `iaso_instance`/`audit_modification` scale
-        # 1:1 with the batch (8 and 1 per instance) - a regression would push these to a multiple
-        # of the bounds below, not a small overshoot. The rest (`iaso_task`/`iaso_tasklog`/
-        # `iaso_project`/`vector_control_apiimport`/`auth_user`/`iaso_profile`/`iaso_account`/
-        # `iaso_datasource`/`iaso_instancefile`) are fixed per-run bookkeeping overhead, unrelated
-        # to instance count - bounded at their exact observed value so a new query pattern on any
-        # of them still gets caught. `django_content_type` is excluded rather than bounded: it's a
-        # one-time framework cache warm that only fires the very first time `ContentType` is
-        # touched in the whole test process, so it's 0 here but can be 1 if this test runs in
-        # isolation instead of as part of the full suite.
+        # O(4 instances). `iaso_formversion`: 1 query/instance, from `xml_file_to_json` -
+        # `get_and_save_json_of_xml` reuses the FormVersion it already found there instead of
+        # looking it up again via `resolve_form_version()`. `iaso_instance`/`audit_modification`
+        # scale 1:1 with the batch (8 and 1 per instance) - a regression would push these to a
+        # multiple of the bounds below, not a small overshoot. The rest (`iaso_task`/
+        # `iaso_tasklog`/`iaso_project`/`vector_control_apiimport`/`auth_user`/`iaso_profile`/
+        # `iaso_account`/`iaso_datasource`/`iaso_instancefile`) are fixed per-run bookkeeping
+        # overhead, unrelated to instance count - bounded at their exact observed value so a new
+        # query pattern on any of them still gets caught. `django_content_type` is excluded
+        # rather than bounded: it's a one-time framework cache warm that only fires the very
+        # first time `ContentType` is touched in the whole test process, so it's 0 here but can
+        # be 1 if this test runs in isolation instead of as part of the full suite.
         profiler.assertLessEqualQueryCount(
             {
                 "iaso_orgunit": 6,
                 "iaso_form": 5,
                 "iaso_entity": 6,
-                "iaso_formversion": 8,
+                "iaso_formversion": 4,
                 "iaso_instance": 33,
                 "audit_modification": 4,
                 "iaso_entitytype": 1,
@@ -541,8 +541,8 @@ class ProcessMobileBulkUploadTest(TestCase):
             },
             exclude=["django_content_type"],
         )
-        # 108 observed, stable whether run alone or as part of the full suite.
-        self.assertLessEqual(profiler.total_queries(), 108)
+        # 104 observed, stable whether run alone or as part of the full suite.
+        self.assertLessEqual(profiler.total_queries(), 104)
 
         profiler.print_report()
         path = profiler.write_markdown_report(
@@ -593,7 +593,7 @@ class ProcessMobileBulkUploadTest(TestCase):
         # instance" from xml_file_to_json is unrelated to import_data and already included in the
         # bound below). `iaso_entity`: 25 distinct entities -> O(25) via find_entity's exists-check
         # + create + the reference-form save, not O(50 instances). `iaso_formversion`: same
-        # 2 queries/instance as the baseline test (see comment there), at scale: 100.
+        # 1 query/instance as the baseline test (see comment there), at scale: 50.
         # `iaso_instance`/`audit_modification` scale 1:1 with the batch, at scale: 400 and 50. The
         # rest is the same fixed per-run bookkeeping overhead as the baseline test (see comment
         # there), still O(1) rather than scaling with the 12.5x larger batch - this zip has no
@@ -603,7 +603,7 @@ class ProcessMobileBulkUploadTest(TestCase):
                 "iaso_orgunit": 6,
                 "iaso_form": 52,
                 "iaso_entity": 80,
-                "iaso_formversion": 100,
+                "iaso_formversion": 50,
                 "iaso_instance": 400,
                 "audit_modification": 50,
                 "iaso_entitytype": 1,
@@ -618,10 +618,10 @@ class ProcessMobileBulkUploadTest(TestCase):
             },
             exclude=["django_content_type"],
         )
-        # 815 observed as part of the full suite, 816 in isolation - `iaso_content_type`'s
+        # 765 observed as part of the full suite, 766 in isolation - `iaso_content_type`'s
         # one-time cache warm depends on test run order (see the `exclude` note above); +1 of
         # headroom for that only.
-        self.assertLessEqual(profiler.total_queries(), 816)
+        self.assertLessEqual(profiler.total_queries(), 766)
 
         profiler.print_report()
         path = profiler.write_markdown_report(

--- a/iaso/tests/tasks/test_process_mobile_bulk_upload.py
+++ b/iaso/tests/tasks/test_process_mobile_bulk_upload.py
@@ -510,23 +510,33 @@ class ProcessMobileBulkUploadTest(TestCase):
         # `iaso_entity`: 2 distinct entities -> O(2) via find_entity's exists-check + create, not
         # O(4 instances). `iaso_formversion`: 1 query/instance, from `xml_file_to_json` -
         # `get_and_save_json_of_xml` reuses the FormVersion it already found there instead of
-        # looking it up again via `resolve_form_version()`. `iaso_instance`/`audit_modification`
-        # scale 1:1 with the batch (8 and 1 per instance) - a regression would push these to a
-        # multiple of the bounds below, not a small overshoot. The rest (`iaso_task`/
-        # `iaso_tasklog`/`iaso_project`/`vector_control_apiimport`/`auth_user`/`iaso_profile`/
-        # `iaso_account`/`iaso_datasource`/`iaso_instancefile`) are fixed per-run bookkeeping
-        # overhead, unrelated to instance count - bounded at their exact observed value so a new
-        # query pattern on any of them still gets caught. `django_content_type` is excluded
-        # rather than bounded: it's a one-time framework cache warm that only fires the very
-        # first time `ContentType` is touched in the whole test process, so it's 0 here but can
-        # be 1 if this test runs in isolation instead of as part of the full suite.
+        # looking it up again via `resolve_form_version()`. `iaso_form`: down to the single batch
+        # prefetch - `process_mobile_bulk_upload()` now reuses the exact Instance objects
+        # `import_data()` already built (see `iaso_instance` below) instead of re-fetching each by
+        # uuid, which also means `xml_file_to_json`'s `self.form` access hits the FK cache
+        # `import_data()` already warmed instead of re-querying. `iaso_instance`: 6/instance -
+        # `import_data()`'s dedup filter (1) + get_or_create (2) + final save (1), then
+        # `process_instance_file()`'s file-persisting save (1, required before
+        # `get_and_save_json_of_xml()` can fetch the file back on S3 storage) + one merged save (1,
+        # covers json/form_version and the location/device/correlation conversions together) -
+        # down from 8/instance, since the previous separate uuid re-fetch and the previous 3rd
+        # save are both gone. `iaso_instance`/`audit_modification` scale 1:1 with the batch (6 and
+        # 1 per instance) - a regression would push these to a multiple of the bounds below, not a
+        # small overshoot. The rest (`iaso_task`/`iaso_tasklog`/`iaso_project`/
+        # `vector_control_apiimport`/`auth_user`/`iaso_profile`/`iaso_account`/`iaso_datasource`/
+        # `iaso_instancefile`) are fixed per-run bookkeeping overhead, unrelated to instance count -
+        # bounded at their exact observed value so a new query pattern on any of them still gets
+        # caught. `django_content_type` is excluded rather than bounded: it's a one-time framework
+        # cache warm that only fires the very first time `ContentType` is touched in the whole test
+        # process, so it's 0 here but can be 1 if this test runs in isolation instead of as part of
+        # the full suite.
         profiler.assertLessEqualQueryCount(
             {
                 "iaso_orgunit": 6,
-                "iaso_form": 5,
+                "iaso_form": 1,
                 "iaso_entity": 6,
                 "iaso_formversion": 4,
-                "iaso_instance": 33,
+                "iaso_instance": 25,
                 "audit_modification": 4,
                 "iaso_entitytype": 1,
                 "iaso_task": 7,
@@ -541,8 +551,8 @@ class ProcessMobileBulkUploadTest(TestCase):
             },
             exclude=["django_content_type"],
         )
-        # 104 observed, stable whether run alone or as part of the full suite.
-        self.assertLessEqual(profiler.total_queries(), 104)
+        # 92 observed, stable whether run alone or as part of the full suite.
+        self.assertLessEqual(profiler.total_queries(), 92)
 
         profiler.print_report()
         path = profiler.write_markdown_report(
@@ -589,22 +599,23 @@ class ProcessMobileBulkUploadTest(TestCase):
         # Same batch lookups as the baseline test, still O(1)/O(distinct) at 12.5x the instance
         # count (50 vs 4) - proves import_data()'s caching doesn't regress to O(instances). A
         # regression back to per-instance lookups would push iaso_orgunit well past its bound
-        # (e.g. ~50-55 instead of ~6), and iaso_form/iaso_entity roughly double (the "+1 form per
-        # instance" from xml_file_to_json is unrelated to import_data and already included in the
-        # bound below). `iaso_entity`: 25 distinct entities -> O(25) via find_entity's exists-check
-        # + create + the reference-form save, not O(50 instances). `iaso_formversion`: same
-        # 1 query/instance as the baseline test (see comment there), at scale: 50.
-        # `iaso_instance`/`audit_modification` scale 1:1 with the batch, at scale: 400 and 50. The
-        # rest is the same fixed per-run bookkeeping overhead as the baseline test (see comment
-        # there), still O(1) rather than scaling with the 12.5x larger batch - this zip has no
-        # attachments so `iaso_instancefile` never fires, unlike the baseline test.
+        # (e.g. ~50-55 instead of ~6). `iaso_form`: down to the single batch prefetch, same as the
+        # baseline test (see comment there) - `xml_file_to_json` hits `import_data()`'s already-
+        # warmed FK cache instead of re-querying. `iaso_entity`: 25 distinct entities -> O(25) via
+        # find_entity's exists-check + create + the reference-form save, not O(50 instances).
+        # `iaso_formversion`: same 1 query/instance as the baseline test, at scale: 50.
+        # `iaso_instance`: 6/instance as the baseline test (see comment there), at scale: 300.
+        # `audit_modification` scales 1:1 with the batch, at scale: 50. The rest is the same fixed
+        # per-run bookkeeping overhead as the baseline test (see comment there), still O(1) rather
+        # than scaling with the 12.5x larger batch - this zip has no attachments so
+        # `iaso_instancefile` never fires, unlike the baseline test.
         profiler.assertLessEqualQueryCount(
             {
                 "iaso_orgunit": 6,
-                "iaso_form": 52,
+                "iaso_form": 1,
                 "iaso_entity": 80,
                 "iaso_formversion": 50,
-                "iaso_instance": 400,
+                "iaso_instance": 300,
                 "audit_modification": 50,
                 "iaso_entitytype": 1,
                 "iaso_task": 7,
@@ -618,10 +629,10 @@ class ProcessMobileBulkUploadTest(TestCase):
             },
             exclude=["django_content_type"],
         )
-        # 765 observed as part of the full suite, 766 in isolation - `iaso_content_type`'s
+        # 615 observed as part of the full suite, 616 in isolation - `iaso_content_type`'s
         # one-time cache warm depends on test run order (see the `exclude` note above); +1 of
         # headroom for that only.
-        self.assertLessEqual(profiler.total_queries(), 766)
+        self.assertLessEqual(profiler.total_queries(), 616)
 
         profiler.print_report()
         path = profiler.write_markdown_report(

--- a/iaso/tests/tasks/test_process_mobile_bulk_upload.py
+++ b/iaso/tests/tasks/test_process_mobile_bulk_upload.py
@@ -541,7 +541,8 @@ class ProcessMobileBulkUploadTest(TestCase):
             },
             exclude=["django_content_type"],
         )
-        self.assertLessEqual(profiler.total_queries(), 112)
+        # 108 observed, stable whether run alone or as part of the full suite.
+        self.assertLessEqual(profiler.total_queries(), 108)
 
         profiler.print_report()
         path = profiler.write_markdown_report(
@@ -617,7 +618,10 @@ class ProcessMobileBulkUploadTest(TestCase):
             },
             exclude=["django_content_type"],
         )
-        self.assertLessEqual(profiler.total_queries(), 820)
+        # 815 observed as part of the full suite, 816 in isolation - `iaso_content_type`'s
+        # one-time cache warm depends on test run order (see the `exclude` note above); +1 of
+        # headroom for that only.
+        self.assertLessEqual(profiler.total_queries(), 816)
 
         profiler.print_report()
         path = profiler.write_markdown_report(

--- a/iaso/tests/utils/query_profiler.py
+++ b/iaso/tests/utils/query_profiler.py
@@ -97,6 +97,30 @@ class QueryProfiler:
     def call_sites_for_table(self, table: str) -> Counter:
         return Counter((f.filename, f.lineno, f.name) for f in self._stacks_by_table.get(table, []) if f)
 
+    def assertLessEqualQueryCount(self, expected: typing.Dict[str, int], exclude: typing.Sequence[str] = ()) -> None:
+        """
+        Assert that every table in `expected` was queried at most the given number of times, AND
+        that every *other* table hit (not listed in `expected`) is in `exclude`. The latter is
+        what catches a regression an allow-list alone would miss: a brand new query pattern
+        landing on a table nobody thought to bound. `exclude` is for tables whose query count is
+        real but not worth pinning down (e.g. framework/fixture overhead unrelated to what the
+        test investigates) - listing a table there means "I know about it, don't assert on it",
+        as opposed to just not showing up in `expected` by oversight.
+
+        Checks everything before failing, so the failure message lists every violation at once -
+        both bounds exceeded and unaccounted-for tables - rather than just the first hit.
+        """
+        counts = self.table_counts()
+        violations = [
+            f"{table}: expected <= {max_count}, got {counts[table]}"
+            for table, max_count in expected.items()
+            if counts[table] > max_count
+        ]
+        unaccounted = sorted(set(counts) - set(expected) - set(exclude))
+        violations += [f"{table}: not in `expected` or `exclude`, got {counts[table]}" for table in unaccounted]
+        if violations:
+            raise AssertionError("Query count(s) exceeded expected bound:\n" + "\n".join(violations))
+
     def _relpath(self, filename: str) -> typing.Optional[str]:
         relpath = os.path.relpath(filename, settings.BASE_DIR)
         return None if relpath.startswith("..") else relpath

--- a/iaso/tests/utils/test_query_profiler.py
+++ b/iaso/tests/utils/test_query_profiler.py
@@ -56,6 +56,54 @@ class QueryProfilerTest(TestCase):
         # 1 INSERT INTO "iaso_account" + 1 UPDATE "iaso_account" - the regex matches both keywords.
         self.assertEqual(profiler.table_counts()["iaso_account"], 2)
 
+    def test_assert_less_equal_query_count_passes_within_bounds(self):
+        with QueryProfiler() as profiler:
+            m.Account.objects.filter(pk=MISSING_PK).exists()
+            m.Account.objects.filter(pk=MISSING_PK - 1).exists()
+            m.Project.objects.filter(pk=MISSING_PK).exists()
+
+        profiler.assertLessEqualQueryCount({"iaso_account": 2, "iaso_project": 1})
+
+    def test_assert_less_equal_query_count_fails_on_unaccounted_table(self):
+        with QueryProfiler() as profiler:
+            m.Account.objects.filter(pk=MISSING_PK).exists()
+            m.Project.objects.filter(pk=MISSING_PK).exists()
+
+        # iaso_project was queried but isn't in `expected` or `exclude` - a bare allow-list check
+        # would silently miss this; catching it is the whole point of the accounting requirement.
+        with self.assertRaises(AssertionError) as cm:
+            profiler.assertLessEqualQueryCount({"iaso_account": 1})
+        self.assertIn("iaso_project: not in `expected` or `exclude`, got 1", str(cm.exception))
+
+    def test_assert_less_equal_query_count_exclude_skips_accounting(self):
+        with QueryProfiler() as profiler:
+            m.Account.objects.filter(pk=MISSING_PK).exists()
+            m.Project.objects.filter(pk=MISSING_PK).exists()
+
+        profiler.assertLessEqualQueryCount({"iaso_account": 1}, exclude=["iaso_project"])
+
+    def test_assert_less_equal_query_count_fails_when_bound_exceeded(self):
+        with QueryProfiler() as profiler:
+            m.Account.objects.filter(pk=MISSING_PK).exists()
+            m.Account.objects.filter(pk=MISSING_PK - 1).exists()
+
+        with self.assertRaises(AssertionError) as cm:
+            profiler.assertLessEqualQueryCount({"iaso_account": 1})
+        self.assertIn("iaso_account: expected <= 1, got 2", str(cm.exception))
+
+    def test_assert_less_equal_query_count_reports_every_violation_at_once(self):
+        with QueryProfiler() as profiler:
+            m.Account.objects.filter(pk=MISSING_PK).exists()
+            m.Account.objects.filter(pk=MISSING_PK - 1).exists()
+            m.Project.objects.filter(pk=MISSING_PK).exists()
+            m.Project.objects.filter(pk=MISSING_PK - 1).exists()
+
+        with self.assertRaises(AssertionError) as cm:
+            profiler.assertLessEqualQueryCount({"iaso_account": 1, "iaso_project": 1})
+        message = str(cm.exception)
+        self.assertIn("iaso_account: expected <= 1, got 2", message)
+        self.assertIn("iaso_project: expected <= 1, got 2", message)
+
     def test_queries_for_table_returns_only_matching_queries(self):
         with QueryProfiler() as profiler:
             m.Account.objects.filter(pk=MISSING_PK).exists()


### PR DESCRIPTION
## What problem is this PR solving?

Mobile bulk upload (zip sync) does far more DB work per submission than it needs to:

- Instance.save() was overridden and, on top of the row's own insert/update, triggered a cascade of extra saves whenever coordinates, device, correlation ID, etc. were set — so a single incoming instance did: get by uuid → 1 insert → 3-4 separate updates.
- The save override also caused iaso_formversion to be looked up more than once per instance: once while resolving the XML (xml_file_to_json), then again inside save(), even though the version had already been resolved.

At realistic batch sizes (thousands of submissions per sync) this turns into thousands of avoidable queries and materially slows down large bulk uploads.

### Related JIRA tickets

IA-5313

## Changes


The multiple save() called when processing coordinates/device/...

<img width="1191" height="862" alt="image" src="https://github.com/user-attachments/assets/20372b6d-af66-44a5-9735-2fa2d3454325" />

so it was 
1. get by uuid, 
2. one insert
3. 3-4 updates

now it's
1. get
2. one insert
3. one update

The override of "save()" triggers a lot of queries on iaso_formversion, now it's just a seperate function called in "save()" call site. and when called from with a fresh xml, the form_version query is done only once and the form_version is resolved.

- Stopped overriding Instance.save() for the coordinates/device/correlation-id handling; that logic is now a separate function called explicitly at the save call site instead of implicitly on every save().
- save() now reuses the FormVersion already resolved during XML processing instead of re-querying it.
- Net effect per instance: get → 1 insert → 1 update (was 3-4 updates), and iaso_formversion resolved once instead of repeatedly.

Measured with the QueryProfiler test harness at a 2000-submission bulk-upload scale:

| Table | Before this PR | After this PR |
|-------|----------------:|--------------:|
| `iaso_instance` | 16,000 | 12,000 |
| `iaso_formversion` | 6,000 (original) / 4,000 (previous PR) | 2,000 |

And before doing all that I've added test/assertions on the various creation/update path of instance

## How to test

see https://github.com/BLSQ/iaso/pull/3187

## Print screen / video


## Notes



## Doc


