### PR TITLE
[IA-5263] fix docker logs

### DIFF
--- a/docker/prod/docker-compose.prod.yml
+++ b/docker/prod/docker-compose.prod.yml
@@ -117,10 +117,6 @@ services:
         - WFP_AUTH_CLIENT_ID
         - WFP_EMAIL_RECIPIENTS_NEW_ACCOUNT
         - WORKER
-      logging: &iaso_logging
-        driver: json-file
-        options:
-          max-size: 5k
       stdin_open: true
       tty: true
     nginx:

--- a/iaso/tests/tasks/test_reference_instance_bulk_link.py
+++ b/iaso/tests/tasks/test_reference_instance_bulk_link.py
@@ -181,7 +181,7 @@ class ReferenceInstanceBulkLinkAPITestCase(TaskAPITestCase):
         self.assertEqual(
             self.not_linked_org_unit.reference_instances.filter(id=self.reference_instance_not_linked.id).count(), 0
         )
-        logs = m.TaskLog.objects.filter(task=task).all()
+        logs = m.TaskLog.objects.filter(task=task).order_by("created_at")
         self.assertEqual(len(logs), 2)
         self.assertEqual(logs[0].message, "Searching for Instances for link or unlink to/from Org unit")
         self.assertEqual(logs[1].message, "No matching instances found")


### PR DESCRIPTION
## What problem is this PR solving?

fix docker logs

### Related JIRA tickets

IA-5263

## Changes

- removed logging config in order to keep more logs and let EBS handle them
- added fix for flaky test

## How to test

flaky test: 
- I never managed to have it fail locally, but it did [on the CI](https://github.com/BLSQ/iaso/actions/runs/29238622917/job/86779092412) - run it enough times to check that it doesn't fail I guess

docker logging: 
- can't test it locally, it needs to be deployed

## Print screen / video
/

## Notes

/

## Doc

/
