### PR TITLE
WC2-943: Display Storage IDs as HEX

### DIFF
--- a/iaso/api/common/query.py
+++ b/iaso/api/common/query.py
@@ -1,0 +1,51 @@
+from django.db.models import Func, TextField
+
+
+class Decode(Func):
+    function = "DECODE"
+
+    def __init__(self, type: str, *expressions, **extra):
+        super().__init__(*expressions, **extra)
+        self.type = type
+
+    def as_sql(
+        self,
+        compiler,
+        connection,
+        function=...,
+        template=...,
+        arg_joiner=...,
+        **extra_context,
+    ):
+        return super().as_sql(
+            compiler,
+            connection,
+            function="DECODE",
+            template=f"%(function)s(%(expressions)s, '{self.type}')",
+            **extra_context,
+        )
+
+
+class Encode(Func):
+    function = "ENCODE"
+
+    def __init__(self, type: str, *expressions, **extra):
+        super().__init__(*expressions, output_field=TextField(), **extra)
+        self.type = type
+
+    def as_sql(
+        self,
+        compiler,
+        connection,
+        function=...,
+        template=...,
+        arg_joiner=...,
+        **extra_context,
+    ):
+        return super().as_sql(
+            compiler,
+            connection,
+            function="ENCODE",
+            template=f"%(function)s(%(expressions)s, '{self.type}')",
+            **extra_context,
+        )

--- a/iaso/api/storage.py
+++ b/iaso/api/storage.py
@@ -1,10 +1,12 @@
 # TODO: need better type annotations in this file
+import base64
+import binascii
 import datetime
 
 from typing import Any, List, Tuple, Union
 
 from django.core.paginator import Paginator
-from django.db.models import Q, QuerySet
+from django.db.models import Case, Q, QuerySet, When
 from django.http import HttpResponse, StreamingHttpResponse
 from drf_spectacular.utils import extend_schema
 from rest_framework import exceptions, permissions, serializers, status, viewsets
@@ -30,6 +32,7 @@ from .common import (
     UserSerializer,
     safe_api_import,
 )
+from .common.query import Decode, Encode
 from .instances.views import FileFormatEnum, find_entity
 
 
@@ -112,7 +115,7 @@ class StorageStatusSerializerForMobile(StorageStatusSerializer):
 
 
 class StorageSerializer(serializers.ModelSerializer):
-    storage_id = serializers.CharField(source="customer_chosen_id")
+    storage_id = serializers.SerializerMethodField(method_name="get_storage_id")
     storage_type = serializers.CharField(source="type")
     storage_status = StorageStatusSerializer(source="*")
     entity = EntityNestedSerializer(read_only=True)
@@ -132,6 +135,14 @@ class StorageSerializer(serializers.ModelSerializer):
             "org_unit",
             "entity",
         )
+
+    @staticmethod
+    def get_storage_id(obj: StorageDevice):
+        base64_id = obj.customer_chosen_id
+        try:
+            return f"{base64.b64decode(base64_id).hex(' ').upper()} ({base64_id})"
+        except (TypeError, binascii.Error):
+            return base64_id
 
 
 class StorageSerializerWithLogs(StorageSerializer):
@@ -247,8 +258,17 @@ class StorageViewSet(ListModelMixin, viewsets.GenericViewSet):
 
         # the search filter works on entity_id or storage (customer-chosen) id
         filter_search = self.request.query_params.get("search")
-        if filter_search is not None:
-            q = Q(customer_chosen_id__icontains=filter_search)
+        if filter_search is not None and len(filter_search) > 0:
+            qs = qs.annotate(
+                hex_id=Case(
+                    When(
+                        customer_chosen_id__regex="^[-A-Za-z0-9+/]*={0,3}$",
+                        then=Encode("hex", Decode("base64", "customer_chosen_id")),
+                    ),
+                    default=None,
+                )
+            )
+            q = Q(customer_chosen_id__icontains=filter_search) | Q(hex_id__icontains=filter_search.replace(" ", ""))
             try:
                 filter_search_int = int(filter_search)
                 q = q | Q(entity__id=filter_search_int)

--- a/iaso/tests/api/test_storage.py
+++ b/iaso/tests/api/test_storage.py
@@ -88,6 +88,14 @@ class StorageAPITestCase(APITestCase):
             entity=cls.entity,
         )
 
+        cls.existing_storage_device_4 = StorageDevice.objects.create(
+            customer_chosen_id="BFZ6yhYYkA==",
+            account=cls.star_wars,
+            type="NFC",
+            status="OK",
+            entity=cls.entity,
+        )
+
         # This one should be invisible to the "yoda" user
         cls.existing_storage_device_another_account = StorageDevice.objects.create(
             customer_chosen_id="EXISTING_STORAGE_ANOTHER_ACCOUNT",
@@ -583,6 +591,16 @@ class StorageAPITestCase(APITestCase):
                     "org_unit": None,
                     "entity": {"id": self.entity.id, "name": "New Client 3"},
                 },
+                {
+                    "updated_at": 1580608922.0,
+                    "created_at": 1580608922.0,
+                    "id": self.existing_storage_device_4.id,
+                    "storage_id": "04 56 7A CA 16 18 90 (BFZ6yhYYkA==)",
+                    "storage_type": "NFC",
+                    "storage_status": {"status": "OK", "updated_at": "2020-02-02T02:02:02Z"},
+                    "org_unit": None,
+                    "entity": {"id": mock.ANY, "name": "New Client 3"},
+                },
             ],
         )
 
@@ -688,6 +706,16 @@ class StorageAPITestCase(APITestCase):
                     "org_unit": None,
                     "entity": None,
                 },
+                {
+                    "updated_at": 1580608922.0,
+                    "created_at": 1580608922.0,
+                    "id": self.existing_storage_device_4.id,
+                    "storage_id": "04 56 7A CA 16 18 90 (BFZ6yhYYkA==)",
+                    "storage_type": "NFC",
+                    "storage_status": {"status": "OK", "updated_at": "2020-02-02T02:02:02Z"},
+                    "org_unit": None,
+                    "entity": {"id": mock.ANY, "name": "New Client 3"},
+                },
             ],
         )
 
@@ -703,6 +731,19 @@ class StorageAPITestCase(APITestCase):
         # We double-check that the results are the ones we expect
         for entry in received_json:
             self.assertIn("ANOTHER", entry["storage_id"])
+
+    def test_list_filter_by_storage_id_hex(self):
+        """The 'search' filter can be used to filter per (customer-chosen) storage ID"""
+        self.client.force_authenticate(self.yoda)
+        response = self.client.get("/api/storages/?search=56")
+        received_json = response.json()
+
+        # If the filter was not operational we would get 3 results.
+        # If the filter was not case-insensitive we would get 0 results.
+        self.assertEqual(len(received_json), 1)
+        # We double-check that the results are the ones we expect
+        for entry in received_json:
+            self.assertIn("04 56 7A CA 16 18 90", entry["storage_id"])
 
     def test_list_filter_by_entity_id(self):
         """The 'search' filter can be also be used to search per entity ID"""
@@ -739,6 +780,16 @@ class StorageAPITestCase(APITestCase):
                     "org_unit": None,
                     "entity": {"id": self.entity.id, "name": "New Client 3"},
                 },
+                {
+                    "updated_at": 1580608922.0,
+                    "created_at": 1580608922.0,
+                    "id": self.existing_storage_device_4.id,
+                    "storage_id": "04 56 7A CA 16 18 90 (BFZ6yhYYkA==)",
+                    "storage_type": "NFC",
+                    "storage_status": {"status": "OK", "updated_at": "2020-02-02T02:02:02Z"},
+                    "org_unit": None,
+                    "entity": {"id": mock.ANY, "name": "New Client 3"},
+                },
             ],
         )
 
@@ -756,9 +807,9 @@ class StorageAPITestCase(APITestCase):
         self.client.force_authenticate(self.yoda)
         response = self.client.get("/api/storages/?limit=1")
         received_json = response.json()
-        self.assertEqual(received_json["count"], 3)  # 3 devices in total
+        self.assertEqual(received_json["count"], 4)  # 3 devices in total
         self.assertEqual(len(received_json["results"]), 1)  # 1 result on this page
-        self.assertEqual(received_json["pages"], 3)  # 3 pages of results
+        self.assertEqual(received_json["pages"], 4)  # 3 pages of results
         self.assertTrue(received_json["has_next"])
         self.assertFalse(received_json["has_previous"])
         self.assertEqual(received_json["limit"], 1)
@@ -1573,7 +1624,7 @@ class StorageAPITestCase(APITestCase):
             ],
         )
 
-        self.assertEqual(len(data), 4)  # 3 rows + header
+        self.assertEqual(len(data), 5)  # 4 rows + header
         self.assertListEqual(
             data[1],
             [
@@ -1664,17 +1715,33 @@ class StorageAPITestCase(APITestCase):
                     0: "EXISTING_STORAGE",
                     1: "ANOTHER_EXISTING_STORAGE_BLACKLISTED_STOLEN",
                     2: "ANOTHER_EXISTING_STORAGE_BLACKLISTED_ABUSE",
+                    3: "BFZ6yhYYkA==",
                 },
-                "Storage Type": {0: "NFC", 1: "NFC", 2: "SD"},
-                "Created at": {0: "2020-02-02 02:02:02", 1: "2020-02-02 02:02:02", 2: "2020-02-02 02:02:02"},
-                "Updated at": {0: "2020-02-02 02:02:02", 1: "2020-02-02 02:02:02", 2: "2020-02-02 02:02:02"},
-                "Status": {0: "OK", 1: "BLACKLISTED", 2: "BLACKLISTED"},
-                "Status reason": {0: None, 1: "STOLEN", 2: "ABUSE"},
-                "Status comment": {0: None, 1: None, 2: None},
-                "Status updated at": {0: 43863.08474537037, 1: 43863.08474537037, 2: 43863.08474537037},
-                "Org unit id": {0: None, 1: None, 2: None},
+                "Storage Type": {0: "NFC", 1: "NFC", 2: "SD", 3: "NFC"},
+                "Created at": {
+                    0: "2020-02-02 02:02:02",
+                    1: "2020-02-02 02:02:02",
+                    2: "2020-02-02 02:02:02",
+                    3: "2020-02-02 02:02:02",
+                },
+                "Updated at": {
+                    0: "2020-02-02 02:02:02",
+                    1: "2020-02-02 02:02:02",
+                    2: "2020-02-02 02:02:02",
+                    3: "2020-02-02 02:02:02",
+                },
+                "Status": {0: "OK", 1: "BLACKLISTED", 2: "BLACKLISTED", 3: "OK"},
+                "Status reason": {0: None, 1: "STOLEN", 2: "ABUSE", 3: None},
+                "Status comment": {0: None, 1: None, 2: None, 3: None},
+                "Status updated at": {
+                    0: 43863.08474537037,
+                    1: 43863.08474537037,
+                    2: 43863.08474537037,
+                    3: 43863.08474537037,
+                },
+                "Org unit id": {0: None, 1: None, 2: None, 3: None},
                 # FIXME this is a float for a pk?
-                "Entity id": {0: self.entity.id * 1.0, 1: None, 2: self.entity.id * 1.0},
+                "Entity id": {0: self.entity.id * 1.0, 1: None, 2: self.entity.id * 1.0, 3: self.entity.id * 1.0},
             },
         )
 
@@ -1723,7 +1790,7 @@ class StorageAPITestCase(APITestCase):
         response = self.client.get("/api/storages/?csv=true&order=-type")
         data = self._csv_response_to_list(response)
         data_without_header = data[1:]
-        self.assertListEqual([e[1] for e in data_without_header], ["SD", "NFC", "NFC"])
+        self.assertListEqual([e[1] for e in data_without_header], ["SD", "NFC", "NFC", "NFC"])
 
     def test_export_logs_per_device_csv(self):
         """A CSV download with decent content is returned"""


### PR DESCRIPTION
## What problem is this PR solving?

Storage IDs are displayed as HEX on some cards; we should therefore be able to match what is displayed on the card.

### Related JIRA tickets

WC2-943

## Changes

Add the HEX value in front of the base64 value

## How to test

Have some Storage device with a BASE64 customer chosen ID and go in the External Storage screen.

Make sure to try to search for the HEX string as well.

## Print screen / video

<img width="2304" height="734" alt="image" src="https://github.com/user-attachments/assets/4dd6fd17-a8ed-468e-b016-6b6d823a9b22" />


## Notes

Example values are given in the ticket.
