### PR TITLE
docs: guides to read and modify the org units of a data source via the API

### DIFF
--- a/docs/pages/dev/how_to/modify_org_units_via_api/modify_org_units_via_api.en.md
+++ b/docs/pages/dev/how_to/modify_org_units_via_api/modify_org_units_via_api.en.md
@@ -1,0 +1,694 @@
+# Modify the org units of a data source via the API
+
+This guide is for an external organisation that needs to create and update org units in an IASO
+data source from its own systems, using Python. It covers the two write paths IASO offers —
+**direct modification** and **change requests** — how to choose between them, and the constraints
+and quirks you will run into.
+
+Everything below is plain JSON over HTTPS. The examples use
+[`requests`](https://requests.readthedocs.io/); nothing else is required.
+
+## The two write paths
+
+| | Direct modification | Change request |
+|---|---|---|
+| Endpoints | `POST /api/orgunits/create_org_unit/`, `PATCH /api/orgunits/<id>/` | `POST /api/orgunits/changes/` |
+| Effect | Applied immediately to the pyramid | Recorded as a proposal, applied only once a reviewer approves it |
+| Permission needed | `iaso_org_units` | None beyond being authenticated and able to see the org unit |
+| Reviewed by a human | No | Yes — by a user holding `iaso_org_unit_change_request_review` |
+| Audit trail | Modification log | Full before/after snapshot, per-field approval, rejection comment |
+| Can create an org unit | Yes | Not on its own — see below |
+| Bulk | Async bulk-update task available | None; one request per org unit |
+
+Use **change requests** when the IASO team wants to keep editorial control over the pyramid: your
+system proposes, they decide. Use **direct modification** when your organisation is the authority on
+this data and is trusted to write to it.
+
+!!! warning "A change request cannot create an org unit by itself"
+    Every change request points at an org unit that **already exists** — the `org_unit_id` field is
+    mandatory in practice. To get a change request of kind `org_unit_creation`, you first create the
+    org unit directly with `validation_status: "NEW"`, then submit a change request against it. IASO
+    detects that the target is still `NEW` and treats the request as a creation; approving it flips
+    the org unit to `VALID`, rejecting it flips it to `REJECTED`.
+
+    That first step is a direct write, so it needs the `iaso_org_units` permission. **A user with no
+    permission at all can only propose changes to existing org units, never add new ones.**
+
+## Prerequisites
+
+Ask the IASO administrator of the account for:
+
+- a dedicated **user account** (do not share a human's credentials — the audit trail records the author of every change);
+- the **permissions** matching the path you intend to use (see the table above);
+- the **id of the data source and of the source version** you are allowed to write into;
+- the **ids of the org unit types** and, if relevant, of the **groups** you will reference.
+
+Two constraints are enforced server-side and are worth knowing before you start:
+
+- The data source must not be flagged **read-only**. Every write to a read-only source is rejected.
+- A user profile can be restricted to certain **org unit types** (`editable_org_unit_types`) and to a
+  **branch of the hierarchy**. If yours is, you can only touch what falls inside those limits, and you
+  cannot create root org units.
+
+## Authentication
+
+IASO issues JSON Web Tokens. Post your credentials to `/api/token/`, then send the returned `access`
+token as a bearer token on every subsequent call.
+
+```python
+import requests
+
+SERVER = "https://iaso.example.org"
+
+r = requests.post(
+    f"{SERVER}/api/token/",
+    json={"username": "my-service-account", "password": "..."},
+    timeout=30,
+)
+r.raise_for_status()
+tokens = r.json()  # {"access": "...", "refresh": "..."}
+
+headers = {"Authorization": f"Bearer {tokens['access']}"}
+```
+
+Access tokens are long-lived on a default IASO deployment, but do not rely on that: handle a `401` by
+refreshing.
+
+```python
+r = requests.post(f"{SERVER}/api/token/refresh/", json={"refresh": tokens["refresh"]}, timeout=30)
+tokens = r.json()  # a fresh "access", and a rotated "refresh"
+```
+
+!!! note "Deployments behind single sign-on"
+    Some IASO instances disable password logins entirely, and on those `/api/token/` does not exist.
+    There, a user already authenticated in the browser can call `GET /api/apitoken/` to obtain a
+    token. It cannot be scripted from a username and a password — ask the administrator how machine
+    access is meant to work on your instance.
+
+### A small client to build on
+
+The rest of this guide uses this helper, which refreshes the token when it expires and raises a
+readable error when IASO rejects a payload.
+
+```python
+import requests
+
+
+class IasoError(Exception):
+    pass
+
+
+class IasoClient:
+    def __init__(self, server, username, password):
+        self.server = server.rstrip("/")
+        self.session = requests.Session()
+        self._username = username
+        self._password = password
+        self._login()
+
+    def _login(self):
+        r = self.session.post(
+            f"{self.server}/api/token/",
+            json={"username": self._username, "password": self._password},
+            timeout=30,
+        )
+        r.raise_for_status()
+        tokens = r.json()
+        self._refresh_token = tokens["refresh"]
+        self.session.headers["Authorization"] = f"Bearer {tokens['access']}"
+
+    def _refresh(self):
+        r = self.session.post(
+            f"{self.server}/api/token/refresh/",
+            json={"refresh": self._refresh_token},
+            timeout=30,
+        )
+        if r.status_code != 200:  # the refresh token itself has expired
+            self._login()
+            return
+        tokens = r.json()
+        self._refresh_token = tokens.get("refresh", self._refresh_token)
+        self.session.headers["Authorization"] = f"Bearer {tokens['access']}"
+
+    def request(self, method, path, **kwargs):
+        kwargs.setdefault("timeout", 60)
+        url = f"{self.server}{path}"
+        r = self.session.request(method, url, **kwargs)
+        if r.status_code == 401:
+            self._refresh()
+            r = self.session.request(method, url, **kwargs)
+        if r.status_code >= 400:
+            raise IasoError(f"{method} {path} -> {r.status_code}: {r.text}")
+        return r.json() if r.content else None
+
+    def get(self, path, **kw):
+        return self.request("GET", path, **kw)
+
+    def post(self, path, **kw):
+        return self.request("POST", path, **kw)
+
+    def patch(self, path, **kw):
+        return self.request("PATCH", path, **kw)
+```
+
+## Finding the ids you need
+
+Every write references a source version, an org unit type, and possibly groups and a parent — all by
+numeric id. Fetch them once at the start of your run.
+
+Note that each IASO endpoint wraps its results under its own key. They are not consistent, so read
+the examples carefully.
+
+```python
+iaso = IasoClient(SERVER, USERNAME, PASSWORD)
+
+# Data sources you can see, with their versions and their default version.
+sources = iaso.get("/api/datasources/")["sources"]
+for source in sources:
+    print(source["id"], source["name"], "read_only:", source["read_only"])
+    print("  default version:", source["default_version"])
+    print("  versions:", [(v["id"], v["number"]) for v in source["versions"]])
+
+# Org unit types, with the id you will pass as org_unit_type_id.
+types = iaso.get("/api/orgunittypes/")["orgUnitTypes"]
+type_by_name = {t["name"]: t["id"] for t in types}
+
+# Groups. A group belongs to one source version, and an org unit can only join
+# a group that lives in its own version.
+groups = iaso.get("/api/groups/")["groups"]
+```
+
+The **source version id** is the one that matters for writes, not the data source id. A data source
+is a container; a source version is a dated snapshot of the pyramid inside it, and an org unit
+belongs to exactly one version. If you omit `version_id` when creating, IASO uses the **default
+version of your account** — which is usually what you want when you write into the account's main
+pyramid, but be explicit if there is any doubt.
+
+## Reading org units
+
+```python
+# Search the default pyramid for a health facility by name.
+result = iaso.get("/api/orgunits/", params={
+    "version": 5,                 # source version id
+    "search": "Kalémie",
+    "validation_status": "all",
+    "limit": 50,
+    "page": 1,
+})
+```
+
+Three things trip people up here.
+
+**The list is filtered to `VALID` by default.** If you do not pass `validation_status`, org units
+that are still `NEW` or that were `REJECTED` are invisible — including the ones you just created.
+Pass `validation_status=all`, or an explicit comma-separated list such as `NEW,VALID`.
+
+**The response envelope changes depending on whether you paginate.** With a `limit`, you get
+`{"count": …, "orgunits": [...], "has_next": …, "page": …, "pages": …}` — note the lowercase
+`orgunits`. Without a `limit`, you get the whole result set under `{"orgUnits": [...]}` — camelCase.
+Always pass `limit` and paginate; it is both safer and cheaper.
+
+**`search` accepts prefixes for exact lookups**, which is how you resolve your own identifiers to
+IASO ids without fuzzy matching:
+
+- `search=ids:12,13,14` — by IASO id
+- `search=refs:ABC-001,ABC-002` — by `source_ref`, the external reference you control
+- `search=codes:XYZ` — by `code`
+
+Fetching a single org unit is `GET /api/orgunits/<id>/`.
+
+## Path A — modifying org units directly
+
+Requires the `iaso_org_units` permission.
+
+### Creating
+
+```python
+new_org_unit = iaso.post("/api/orgunits/create_org_unit/", json={
+    "name": "Centre de Santé de Kalémie",
+    "org_unit_type_id": type_by_name["Health facility"],
+    "parent_id": 4321,
+    "version_id": 5,                    # optional; defaults to the account's default version
+    "source_ref": "ABC-001",            # your own identifier — set it, you will need it later
+    "code": "CS-KAL-001",
+    "short_name": "CS Kalémie",
+    "aliases": ["Kalemie Health Centre"],
+    "validation_status": "VALID",       # defaults to "NEW" if omitted
+    "opening_date": "01-03-2019",       # dd-mm-yyyy — see the warning below
+    "latitude": -5.9236,
+    "longitude": 29.1947,
+    "altitude": 0,
+    "groups": [12, 15],
+})
+print(new_org_unit["id"])
+```
+
+Only `name` and `org_unit_type_id` are required. A few rules the server enforces:
+
+- `parent_id` must live in the **same source version** as the org unit being created.
+- Each group in `groups` must also live in that same source version.
+- `code` must be unique among valid org units of the version. A clash returns a `400` with
+  `errorKey: "code"`.
+- If your profile is restricted to a branch of the hierarchy, `parent_id` is mandatory — you cannot
+  create a root.
+
+For a polygon instead of a point, pass `geom` as a GeoJSON geometry object:
+
+```python
+"geom": {"type": "MultiPolygon", "coordinates": [[[[29.1, -5.9], [29.2, -5.9], [29.2, -6.0], [29.1, -5.9]]]]},
+```
+
+!!! warning "Dates on create are `dd-mm-yyyy`, and only that"
+    `POST /api/orgunits/create_org_unit/` parses `opening_date` and `closed_date` with the single
+    format `%d-%m-%Y`. An ISO date such as `2019-03-01` raises a server error, not a clean `400`.
+    Confusingly, `PATCH` is lenient and accepts `dd-mm-yyyy`, `dd/mm/yyyy`, `yyyy-mm-dd` and
+    `yyyy/mm/dd`, while change requests take **ISO `yyyy-mm-dd`**. Format the date for the endpoint
+    you are calling.
+
+    Also: if you send `closed_date` on create without an `opening_date`, the comparison between the
+    two fails server-side. Always send both, or neither.
+
+### Updating
+
+`PATCH /api/orgunits/<id>/` updates only the keys present in the body. Everything is optional.
+
+```python
+iaso.patch(f"/api/orgunits/{org_unit_id}/", json={
+    "name": "Centre de Santé de Kalémie Centre",
+    "parent_id": 4322,
+    "org_unit_type_id": type_by_name["Health facility"],
+    "groups": [12, 15],          # replaces the full list, it is not additive
+    "opening_date": "2019-03-01",  # PATCH accepts ISO too
+    "code": "CS-KAL-001",
+    "aliases": ["Kalemie Health Centre"],
+})
+```
+
+Points of note:
+
+- **`groups` replaces the whole list.** To add one group, read the current groups and send them all back.
+- **Coordinates travel as a trio.** To set a location, send `latitude`, `longitude` *and* `altitude`
+  together — the endpoint reads all three keys, and omitting `altitude` while sending the other two
+  causes a server error. Send `latitude: None, longitude: None, altitude: None` to clear the location.
+- **`version_id` cannot be patched.** An org unit cannot be moved between source versions through
+  this API.
+- An empty `name` is silently ignored rather than applied — you cannot blank out a name.
+
+### Changing the validation status
+
+```python
+iaso.patch(f"/api/orgunits/{org_unit_id}/", json={"validation_status": "VALID"})
+```
+
+Accepted values are `NEW`, `VALID` and `REJECTED`.
+
+### Bulk updates
+
+For a change that applies uniformly to many org units — the same type, the same groups, the same
+validation status — there is an asynchronous task rather than a loop of `PATCH` calls.
+
+```python
+task = iaso.post("/api/tasks/create/orgunitsbulkupdate/", json={
+    "selected_ids": [101, 102, 103],
+    "validation_status": "VALID",
+    "groups_added": [15],
+    "groups_removed": [12],
+})["task"]
+
+# Poll until it finishes.
+import time
+while True:
+    status = iaso.get(f"/api/tasks/{task['id']}/")
+    if status["status"] in ("SUCCESS", "ERRORED", "KILLED"):
+        print(status["status"], status.get("result"))
+        break
+    time.sleep(5)
+```
+
+You can target a search instead of an explicit list by passing `select_all: true` together with
+`searches` (the same filter objects the list endpoint accepts) and an optional `unselected_ids`.
+This task cannot rename org units or move them: it only sets type, groups and validation status.
+
+## Path B — submitting change requests
+
+Creating a change request requires no special permission — only that you are authenticated and that
+the target org unit is visible to you. What you submit is a *proposal*: it changes nothing until an
+IASO reviewer approves it.
+
+### Submitting
+
+```python
+import uuid
+
+change_request = iaso.post("/api/orgunits/changes/", json={
+    "uuid": str(uuid.uuid4()),        # optional but recommended, see below
+    "org_unit_id": 1234,              # the org unit you want changed — required
+    "new_name": "Centre de Santé de Kalémie Centre",
+    "new_org_unit_type_id": type_by_name["Health facility"],
+    "new_parent_id": 4322,
+    "new_groups": [12, 15],
+    "new_location": {"latitude": -5.9236, "longitude": 29.1947, "altitude": 0},
+    "new_opening_date": "2019-03-01",  # ISO here
+    "new_closed_date": "2030-12-31",
+})
+print(change_request["id"], change_request["status"])  # -> 42 new
+```
+
+The fields you may propose are exactly these:
+
+| Field | Shape |
+|---|---|
+| `new_name` | string |
+| `new_parent_id` | org unit id (or uuid), nullable |
+| `new_org_unit_type_id` | org unit type id |
+| `new_groups` | list of group ids — replaces the full list |
+| `new_location` | `{"latitude": …, "longitude": …, "altitude": …}`, nullable |
+| `new_location_accuracy` | decimal, in metres — metadata only, never applied to the org unit |
+| `new_opening_date` | ISO date `yyyy-mm-dd` |
+| `new_closed_date` | ISO date `yyyy-mm-dd` |
+| `new_reference_instances` | list of form submission ids (or uuids) |
+
+Rules the server enforces:
+
+- **At least one `new_*` field is required.** An otherwise empty request is a `400`.
+- Send only the fields you actually want changed. IASO derives the list of requested fields from the
+  keys present in your payload, and the reviewer approves them one by one. Do not send a full
+  snapshot of the org unit — every field you include becomes a change someone has to arbitrate.
+- Sending an explicit `null` means *erase this value*, which is different from omitting the key.
+- `new_parent_id` must be in the same source version as the org unit, and cannot be one of its own
+  descendants.
+- `new_closed_date` must be strictly later than `new_opening_date`.
+
+### Idempotency
+
+The `uuid` you supply is the deduplication key: posting a change request whose `uuid` already exists
+is a no-op that returns the existing one instead of creating a duplicate. Derive it deterministically
+from your own record — for instance `uuid.uuid5(NAMESPACE, f"{source_ref}:{content_hash}")` — and a
+re-run after a network failure becomes safe.
+
+### Proposing a new org unit
+
+As explained at the top, a change request cannot conjure an org unit. The two-step pattern is:
+
+```python
+# 1. Create it directly, unvalidated. Requires iaso_org_units.
+draft = iaso.post("/api/orgunits/create_org_unit/", json={
+    "name": "Nouveau Poste de Santé",
+    "org_unit_type_id": type_by_name["Health facility"],
+    "parent_id": 4321,
+    "source_ref": "ABC-042",
+    "validation_status": "NEW",     # <- keeps it out of the live pyramid
+})
+
+# 2. Submit the change request. IASO sees the org unit is still NEW and
+#    records the request with kind "org_unit_creation".
+iaso.post("/api/orgunits/changes/", json={
+    "org_unit_id": draft["id"],
+    "new_name": "Nouveau Poste de Santé",
+    "new_location": {"latitude": -5.93, "longitude": 29.20, "altitude": 0},
+})
+```
+
+Approval turns the org unit `VALID` and it enters the pyramid. Rejection turns it `REJECTED` and it
+stays out.
+
+### There is no bulk create
+
+`POST /api/orgunits/changes/` takes one change request at a time. For a hundred org units, make a
+hundred calls — sequentially, or with a small thread pool, but do not expect a batch endpoint. (Bulk
+*review* exists, but that is the reviewer's side, not yours.)
+
+### Tracking what happened to your requests
+
+```python
+page = 1
+while True:
+    resp = iaso.get("/api/orgunits/changes/", params={
+        "status": "new,approved,rejected",
+        "created_at_after": "2026-01-01",
+        "limit": 50,
+        "page": page,
+    })
+    for cr in resp["results"]:
+        print(cr["id"], cr["status"], cr["org_unit"]["name"], cr.get("rejection_comment"))
+    if not resp["has_next"]:
+        break
+    page += 1
+```
+
+The list endpoint paginates under `results`. A change request is `new` until someone reviews it, then
+`approved` or `rejected`; a rejection always carries a `rejection_comment` explaining why. Useful
+filters: `org_unit_id`, `source_version_id`, `status`, `created_at_after` / `created_at_before`,
+`kind`, `requested_fields`.
+
+A reviewer can approve some fields and reject others, so check `approved_fields` on an approved
+request rather than assuming everything you proposed was applied.
+
+## Errors
+
+The org unit endpoints do not return a DRF-style error object. On a `400` they return a **list**:
+
+```json
+[
+  {"errorKey": "code", "errorMessage": "Another valid OrgUnit already exists with the code 'CS-KAL-001' in this version"},
+  {"errorKey": "parent_id", "errorMessage": "Parent is not in the same version"}
+]
+```
+
+The change request endpoint, being a standard DRF serializer, returns the usual
+`{"field": ["message"]}` shape, sometimes with the message under `non_field_errors`. Handle both.
+
+```python
+def explain(err: IasoError) -> str:
+    import json
+    body = str(err).split(": ", 2)[-1]
+    try:
+        payload = json.loads(body)
+    except ValueError:
+        return body
+    if isinstance(payload, list):     # org unit endpoints
+        return "; ".join(f"{e['errorKey']}: {e['errorMessage']}" for e in payload)
+    return "; ".join(f"{k}: {v}" for k, v in payload.items())   # change requests
+```
+
+Do not blindly retry a `400` — it is a rejected payload, and it will be rejected again. Retry `502`,
+`503` and `504`, and make your writes idempotent (a stable `uuid` for change requests, a lookup on
+`source_ref` before creating) so that a retry after a timeout cannot double-write.
+
+## A complete example: syncing a CSV of facilities
+
+The script below reads a CSV exported from your own system, matches each row against IASO on
+`source_ref`, then creates what is missing and updates what has drifted. The same logic runs in
+either mode: `direct` writes straight to the pyramid, `change_request` proposes.
+
+```python
+"""Sync a CSV of health facilities into an IASO data source.
+
+Usage:
+    python sync_org_units.py facilities.csv direct
+    python sync_org_units.py facilities.csv change_request
+
+CSV columns: source_ref, name, parent_ref, type, latitude, longitude, opening_date (yyyy-mm-dd)
+"""
+
+import csv
+import sys
+import uuid
+
+# IasoClient and IasoError as defined earlier in this guide.
+from iaso_client import IasoClient, IasoError
+
+SERVER = "https://iaso.example.org"
+USERNAME = "my-service-account"
+PASSWORD = "..."
+VERSION_ID = 5          # the source version you write into
+NAMESPACE = uuid.UUID("6c1f0e6e-0f1a-4c6e-9f4a-2b7d0a1f0000")  # any fixed uuid of your own
+
+
+def load_existing(iaso, version_id):
+    """Every org unit of the version, indexed by source_ref."""
+    by_ref, page = {}, 1
+    while True:
+        resp = iaso.get("/api/orgunits/", params={
+            "version": version_id,
+            "validation_status": "all",   # otherwise NEW and REJECTED units are invisible
+            "limit": 500,
+            "page": page,
+        })
+        for org_unit in resp["orgunits"]:
+            if org_unit.get("source_ref"):
+                by_ref[org_unit["source_ref"]] = org_unit
+        if not resp["has_next"]:
+            return by_ref
+        page += 1
+
+
+def load_types(iaso):
+    return {t["name"]: t["id"] for t in iaso.get("/api/orgunittypes/")["orgUnitTypes"]}
+
+
+def has_drifted(row, existing, type_ids, parent_id):
+    """Fields where the CSV disagrees with IASO, in IASO's own vocabulary."""
+    changes = {}
+    if row["name"] != existing["name"]:
+        changes["name"] = row["name"]
+    if type_ids[row["type"]] != existing.get("org_unit_type_id"):
+        changes["org_unit_type_id"] = type_ids[row["type"]]
+    if parent_id != existing.get("parent_id"):
+        changes["parent_id"] = parent_id
+    if row.get("latitude") and row.get("longitude"):
+        lat, lon = float(row["latitude"]), float(row["longitude"])
+        if (existing.get("latitude"), existing.get("longitude")) != (lat, lon):
+            changes["latitude"], changes["longitude"] = lat, lon
+    return changes
+
+
+def to_iso(date_str):        # PATCH and change requests both accept ISO
+    return date_str or None
+
+
+def to_ddmmyyyy(date_str):   # create_org_unit accepts only dd-mm-yyyy
+    if not date_str:
+        return None
+    year, month, day = date_str.split("-")
+    return f"{day}-{month}-{year}"
+
+
+def create_direct(iaso, row, type_ids, parent_id):
+    return iaso.post("/api/orgunits/create_org_unit/", json={
+        "name": row["name"],
+        "org_unit_type_id": type_ids[row["type"]],
+        "parent_id": parent_id,
+        "version_id": VERSION_ID,
+        "source_ref": row["source_ref"],
+        "validation_status": "VALID",
+        "opening_date": to_ddmmyyyy(row.get("opening_date")),
+        "latitude": float(row["latitude"]) if row.get("latitude") else None,
+        "longitude": float(row["longitude"]) if row.get("longitude") else None,
+        "altitude": 0,
+    })
+
+
+def update_direct(iaso, org_unit, changes):
+    payload = dict(changes)
+    if "latitude" in payload:
+        payload["altitude"] = 0       # the endpoint reads all three keys together
+    return iaso.patch(f"/api/orgunits/{org_unit['id']}/", json=payload)
+
+
+def create_as_change_request(iaso, row, type_ids, parent_id):
+    """Create the org unit unvalidated, then propose it. Needs iaso_org_units."""
+    draft = iaso.post("/api/orgunits/create_org_unit/", json={
+        "name": row["name"],
+        "org_unit_type_id": type_ids[row["type"]],
+        "parent_id": parent_id,
+        "version_id": VERSION_ID,
+        "source_ref": row["source_ref"],
+        "validation_status": "NEW",
+        "opening_date": to_ddmmyyyy(row.get("opening_date")),
+    })
+    return submit_change_request(iaso, draft["id"], row, {
+        "name": row["name"],
+        "latitude": float(row["latitude"]) if row.get("latitude") else None,
+        "longitude": float(row["longitude"]) if row.get("longitude") else None,
+    })
+
+
+def submit_change_request(iaso, org_unit_id, row, changes):
+    """Translate the drifted fields into the change request vocabulary."""
+    payload = {
+        "uuid": str(uuid.uuid5(NAMESPACE, f"{row['source_ref']}:{sorted(changes.items())}")),
+        "org_unit_id": org_unit_id,
+    }
+    if "name" in changes:
+        payload["new_name"] = changes["name"]
+    if "org_unit_type_id" in changes:
+        payload["new_org_unit_type_id"] = changes["org_unit_type_id"]
+    if "parent_id" in changes:
+        payload["new_parent_id"] = changes["parent_id"]
+    if changes.get("latitude") is not None:
+        payload["new_location"] = {
+            "latitude": changes["latitude"],
+            "longitude": changes["longitude"],
+            "altitude": 0,
+        }
+    if row.get("opening_date"):
+        payload["new_opening_date"] = to_iso(row["opening_date"])
+    return iaso.post("/api/orgunits/changes/", json=payload)
+
+
+def main(csv_path, mode):
+    iaso = IasoClient(SERVER, USERNAME, PASSWORD)
+    type_ids = load_types(iaso)
+    existing = load_existing(iaso, VERSION_ID)
+
+    created = updated = unchanged = failed = 0
+
+    with open(csv_path, newline="", encoding="utf-8") as f:
+        for row in csv.DictReader(f):
+            parent = existing.get(row.get("parent_ref"))
+            parent_id = parent["id"] if parent else None
+            current = existing.get(row["source_ref"])
+
+            try:
+                if current is None:
+                    if mode == "direct":
+                        create_direct(iaso, row, type_ids, parent_id)
+                    else:
+                        create_as_change_request(iaso, row, type_ids, parent_id)
+                    created += 1
+                    continue
+
+                changes = has_drifted(row, current, type_ids, parent_id)
+                if not changes:
+                    unchanged += 1
+                    continue
+
+                if mode == "direct":
+                    update_direct(iaso, current, changes)
+                else:
+                    submit_change_request(iaso, current["id"], row, changes)
+                updated += 1
+
+            except IasoError as e:
+                failed += 1
+                print(f"FAILED {row['source_ref']}: {e}", file=sys.stderr)
+
+    verb = "created" if mode == "direct" else "proposed"
+    print(f"{verb}: {created}, updated: {updated}, unchanged: {unchanged}, failed: {failed}")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1], sys.argv[2])
+```
+
+Two habits this script illustrates and that are worth keeping:
+
+**Always carry your own identifier in `source_ref`.** It is the join key between your system and
+IASO, it survives renames, and it lets you re-run the sync without creating duplicates. IASO will
+happily create two org units with the same name.
+
+**Build parents before children.** The script above resolves a parent from the org units already in
+IASO, so a CSV must be sorted top-down — a facility whose district does not exist yet gets a `null`
+parent. If you are importing a whole hierarchy, process it level by level.
+
+## Other bulk paths
+
+If you are loading an entire pyramid rather than maintaining one, two heavier import routes exist and
+are usually a better fit. Both need the `iaso_sources` permission, both run as background tasks, and
+both are documented alongside the data source administration screens:
+
+- `POST /api/tasks/create/importgpkg/` — upload a GeoPackage into a data source and a version number.
+- `POST /api/dhis2ouimporter/` — import or refresh the pyramid straight from a DHIS2 instance.
+
+## Quick reference of the traps
+
+- The org unit list defaults to `validation_status=VALID`; pass `all` to see what you just created.
+- The list envelope is `orgunits` when paginated, `orgUnits` when not.
+- Dates: `dd-mm-yyyy` on create, anything reasonable on `PATCH`, ISO `yyyy-mm-dd` on change requests.
+- On create, never send `closed_date` without `opening_date`.
+- Latitude, longitude and altitude are read as a trio on both `PATCH` and `new_location`.
+- `groups` and `new_groups` replace the whole list; they do not append.
+- A parent and a group must belong to the same source version as the org unit.
+- `version_id` is set once, at creation, and can never be patched.
+- A change request always needs an existing `org_unit_id`, and there is no bulk-create for them.

--- a/docs/pages/dev/how_to/modify_org_units_via_api/modify_org_units_via_api.en.md
+++ b/docs/pages/dev/how_to/modify_org_units_via_api/modify_org_units_via_api.en.md
@@ -217,6 +217,12 @@ IASO ids without fuzzy matching:
 
 Fetching a single org unit is `GET /api/orgunits/<id>/`.
 
+!!! tip "If your system speaks FHIR"
+    IASO also exposes org units as read-only FHIR R4 `Location` resources. If you are integrating a
+    system that already consumes FHIR, see [reading org units through the FHIR
+    API](../read_org_units_via_fhir/read_org_units_via_fhir.md). It is a read path only — all writes
+    go through the endpoints described below.
+
 ## Path A — modifying org units directly
 
 Requires the `iaso_org_units` permission.

--- a/docs/pages/dev/how_to/modify_org_units_via_api/modify_org_units_via_api.fr.md
+++ b/docs/pages/dev/how_to/modify_org_units_via_api/modify_org_units_via_api.fr.md
@@ -224,6 +224,13 @@ propres identifiants en identifiants IASO sans correspondance approximative :
 
 Pour une seule unité d'organisation : `GET /api/orgunits/<id>/`.
 
+!!! tip "Si votre système parle FHIR"
+    IASO expose également les unités d'organisation sous forme de ressources FHIR R4 `Location`, en
+    lecture seule. Si vous intégrez un système qui consomme déjà du FHIR, voyez [lire les unités
+    d'organisation via l'API FHIR](../read_org_units_via_fhir/read_org_units_via_fhir.md). C'est une
+    voie de lecture uniquement — toutes les écritures passent par les points d'entrée décrits
+    ci-dessous.
+
 ## Voie A — modifier directement les unités d'organisation
 
 Exige la permission `iaso_org_units`.

--- a/docs/pages/dev/how_to/modify_org_units_via_api/modify_org_units_via_api.fr.md
+++ b/docs/pages/dev/how_to/modify_org_units_via_api/modify_org_units_via_api.fr.md
@@ -1,0 +1,715 @@
+# Modifier les unités d'organisation d'une source de données via l'API
+
+Ce guide s'adresse à une organisation externe qui doit créer et mettre à jour des unités
+d'organisation dans une source de données IASO depuis ses propres systèmes, en Python. Il couvre les
+deux voies d'écriture offertes par IASO — la **modification directe** et les **demandes de
+changement** — comment choisir entre les deux, ainsi que les contraintes et les pièges que vous
+rencontrerez.
+
+Tout ce qui suit est du JSON sur HTTPS. Les exemples utilisent
+[`requests`](https://requests.readthedocs.io/) ; rien d'autre n'est nécessaire.
+
+## Les deux voies d'écriture
+
+| | Modification directe | Demande de changement |
+|---|---|---|
+| Points d'entrée | `POST /api/orgunits/create_org_unit/`, `PATCH /api/orgunits/<id>/` | `POST /api/orgunits/changes/` |
+| Effet | Appliqué immédiatement à la pyramide | Enregistré comme proposition, appliqué seulement après approbation |
+| Permission requise | `iaso_org_units` | Aucune, au-delà d'être authentifié et de voir l'unité d'organisation |
+| Revue humaine | Non | Oui — par un utilisateur disposant de `iaso_org_unit_change_request_review` |
+| Traçabilité | Journal des modifications | Instantané avant/après complet, approbation champ par champ, commentaire de rejet |
+| Peut créer une unité d'organisation | Oui | Pas à elle seule — voir ci-dessous |
+| Traitement par lot | Tâche asynchrone de mise à jour groupée | Aucun ; une requête par unité d'organisation |
+
+Utilisez les **demandes de changement** lorsque l'équipe IASO souhaite garder le contrôle éditorial
+sur la pyramide : votre système propose, elle décide. Utilisez la **modification directe** lorsque
+votre organisation fait autorité sur ces données et qu'on lui fait confiance pour les écrire.
+
+!!! warning "Une demande de changement ne peut pas créer une unité d'organisation à elle seule"
+    Toute demande de changement porte sur une unité d'organisation qui **existe déjà** — le champ
+    `org_unit_id` est en pratique obligatoire. Pour obtenir une demande de changement de type
+    `org_unit_creation`, vous créez d'abord l'unité d'organisation directement avec
+    `validation_status: "NEW"`, puis vous soumettez une demande de changement à son sujet. IASO
+    détecte que la cible est encore `NEW` et traite la demande comme une création : l'approuver fait
+    passer l'unité d'organisation en `VALID`, la rejeter la fait passer en `REJECTED`.
+
+    Cette première étape est une écriture directe : elle exige donc la permission `iaso_org_units`.
+    **Un utilisateur sans aucune permission ne peut que proposer des changements sur des unités
+    d'organisation existantes, jamais en ajouter de nouvelles.**
+
+## Prérequis
+
+Demandez à l'administrateur IASO du compte :
+
+- un **compte utilisateur dédié** (ne partagez pas les identifiants d'une personne — la traçabilité enregistre l'auteur de chaque changement) ;
+- les **permissions** correspondant à la voie que vous comptez emprunter (voir le tableau ci-dessus) ;
+- l'**identifiant de la source de données et de la version de source** dans laquelle vous êtes autorisé à écrire ;
+- les **identifiants des types d'unité d'organisation** et, le cas échéant, des **groupes** que vous référencerez.
+
+Deux contraintes sont appliquées côté serveur et méritent d'être connues avant de commencer :
+
+- La source de données ne doit pas être marquée **en lecture seule**. Toute écriture dans une source en lecture seule est rejetée.
+- Un profil utilisateur peut être restreint à certains **types d'unité d'organisation**
+  (`editable_org_unit_types`) et à une **branche de la hiérarchie**. Si c'est votre cas, vous ne
+  pouvez toucher que ce qui entre dans ces limites, et vous ne pouvez pas créer d'unité racine.
+
+## Authentification
+
+IASO délivre des JSON Web Tokens. Envoyez vos identifiants à `/api/token/`, puis transmettez le token
+`access` reçu comme bearer token sur tous les appels suivants.
+
+```python
+import requests
+
+SERVER = "https://iaso.example.org"
+
+r = requests.post(
+    f"{SERVER}/api/token/",
+    json={"username": "mon-compte-de-service", "password": "..."},
+    timeout=30,
+)
+r.raise_for_status()
+tokens = r.json()  # {"access": "...", "refresh": "..."}
+
+headers = {"Authorization": f"Bearer {tokens['access']}"}
+```
+
+Les tokens d'accès ont une longue durée de vie sur un déploiement IASO par défaut, mais ne comptez
+pas dessus : traitez les `401` en rafraîchissant le token.
+
+```python
+r = requests.post(f"{SERVER}/api/token/refresh/", json={"refresh": tokens["refresh"]}, timeout=30)
+tokens = r.json()  # un nouveau "access", et un "refresh" pivoté
+```
+
+!!! note "Déploiements avec authentification unique (SSO)"
+    Certaines instances IASO désactivent complètement la connexion par mot de passe, et sur celles-ci
+    `/api/token/` n'existe pas. Un utilisateur déjà authentifié dans le navigateur peut alors appeler
+    `GET /api/apitoken/` pour obtenir un token. Cela ne peut pas être scripté à partir d'un nom
+    d'utilisateur et d'un mot de passe — demandez à l'administrateur comment l'accès machine est
+    prévu sur votre instance.
+
+### Un petit client comme socle
+
+La suite de ce guide s'appuie sur cet utilitaire, qui rafraîchit le token à son expiration et lève
+une erreur lisible quand IASO rejette une charge utile.
+
+```python
+import requests
+
+
+class IasoError(Exception):
+    pass
+
+
+class IasoClient:
+    def __init__(self, server, username, password):
+        self.server = server.rstrip("/")
+        self.session = requests.Session()
+        self._username = username
+        self._password = password
+        self._login()
+
+    def _login(self):
+        r = self.session.post(
+            f"{self.server}/api/token/",
+            json={"username": self._username, "password": self._password},
+            timeout=30,
+        )
+        r.raise_for_status()
+        tokens = r.json()
+        self._refresh_token = tokens["refresh"]
+        self.session.headers["Authorization"] = f"Bearer {tokens['access']}"
+
+    def _refresh(self):
+        r = self.session.post(
+            f"{self.server}/api/token/refresh/",
+            json={"refresh": self._refresh_token},
+            timeout=30,
+        )
+        if r.status_code != 200:  # le token de rafraîchissement a lui-même expiré
+            self._login()
+            return
+        tokens = r.json()
+        self._refresh_token = tokens.get("refresh", self._refresh_token)
+        self.session.headers["Authorization"] = f"Bearer {tokens['access']}"
+
+    def request(self, method, path, **kwargs):
+        kwargs.setdefault("timeout", 60)
+        url = f"{self.server}{path}"
+        r = self.session.request(method, url, **kwargs)
+        if r.status_code == 401:
+            self._refresh()
+            r = self.session.request(method, url, **kwargs)
+        if r.status_code >= 400:
+            raise IasoError(f"{method} {path} -> {r.status_code}: {r.text}")
+        return r.json() if r.content else None
+
+    def get(self, path, **kw):
+        return self.request("GET", path, **kw)
+
+    def post(self, path, **kw):
+        return self.request("POST", path, **kw)
+
+    def patch(self, path, **kw):
+        return self.request("PATCH", path, **kw)
+```
+
+## Trouver les identifiants nécessaires
+
+Toute écriture référence une version de source, un type d'unité d'organisation, et éventuellement des
+groupes et un parent — tous par identifiant numérique. Récupérez-les une fois au début de votre
+traitement.
+
+Notez que chaque point d'entrée IASO encapsule ses résultats sous sa propre clé. Elles ne sont pas
+homogènes : lisez les exemples attentivement.
+
+```python
+iaso = IasoClient(SERVER, USERNAME, PASSWORD)
+
+# Les sources de données visibles, avec leurs versions et leur version par défaut.
+sources = iaso.get("/api/datasources/")["sources"]
+for source in sources:
+    print(source["id"], source["name"], "lecture seule :", source["read_only"])
+    print("  version par défaut :", source["default_version"])
+    print("  versions :", [(v["id"], v["number"]) for v in source["versions"]])
+
+# Les types d'unité d'organisation, avec l'id à passer dans org_unit_type_id.
+types = iaso.get("/api/orgunittypes/")["orgUnitTypes"]
+type_by_name = {t["name"]: t["id"] for t in types}
+
+# Les groupes. Un groupe appartient à une version de source, et une unité d'organisation
+# ne peut rejoindre qu'un groupe qui vit dans sa propre version.
+groups = iaso.get("/api/groups/")["groups"]
+```
+
+C'est l'**identifiant de la version de source** qui compte pour les écritures, pas celui de la source
+de données. Une source de données est un conteneur ; une version de source est un instantané daté de
+la pyramide qu'elle contient, et une unité d'organisation appartient à exactement une version. Si
+vous omettez `version_id` à la création, IASO utilise la **version par défaut de votre compte** — ce
+qui est généralement le comportement voulu quand vous écrivez dans la pyramide principale du compte,
+mais soyez explicite au moindre doute.
+
+## Lire les unités d'organisation
+
+```python
+# Chercher un établissement de santé par son nom dans la pyramide par défaut.
+result = iaso.get("/api/orgunits/", params={
+    "version": 5,                 # identifiant de la version de source
+    "search": "Kalémie",
+    "validation_status": "all",
+    "limit": 50,
+    "page": 1,
+})
+```
+
+Trois choses font trébucher tout le monde ici.
+
+**La liste est filtrée sur `VALID` par défaut.** Si vous ne passez pas `validation_status`, les unités
+d'organisation encore en `NEW` ou passées en `REJECTED` sont invisibles — y compris celles que vous
+venez de créer. Passez `validation_status=all`, ou une liste explicite séparée par des virgules comme
+`NEW,VALID`.
+
+**L'enveloppe de la réponse change selon que vous paginez ou non.** Avec un `limit`, vous obtenez
+`{"count": …, "orgunits": [...], "has_next": …, "page": …, "pages": …}` — notez le `orgunits` en
+minuscules. Sans `limit`, vous obtenez l'ensemble des résultats sous `{"orgUnits": [...]}` — en
+camelCase. Passez toujours `limit` et paginez ; c'est à la fois plus sûr et moins coûteux.
+
+**`search` accepte des préfixes pour les recherches exactes**, ce qui vous permet de résoudre vos
+propres identifiants en identifiants IASO sans correspondance approximative :
+
+- `search=ids:12,13,14` — par identifiant IASO
+- `search=refs:ABC-001,ABC-002` — par `source_ref`, la référence externe que vous maîtrisez
+- `search=codes:XYZ` — par `code`
+
+Pour une seule unité d'organisation : `GET /api/orgunits/<id>/`.
+
+## Voie A — modifier directement les unités d'organisation
+
+Exige la permission `iaso_org_units`.
+
+### Créer
+
+```python
+new_org_unit = iaso.post("/api/orgunits/create_org_unit/", json={
+    "name": "Centre de Santé de Kalémie",
+    "org_unit_type_id": type_by_name["Health facility"],
+    "parent_id": 4321,
+    "version_id": 5,                    # optionnel ; par défaut, la version par défaut du compte
+    "source_ref": "ABC-001",            # votre propre identifiant — renseignez-le, il vous servira
+    "code": "CS-KAL-001",
+    "short_name": "CS Kalémie",
+    "aliases": ["Kalemie Health Centre"],
+    "validation_status": "VALID",       # vaut "NEW" si omis
+    "opening_date": "01-03-2019",       # jj-mm-aaaa — voir l'avertissement ci-dessous
+    "latitude": -5.9236,
+    "longitude": 29.1947,
+    "altitude": 0,
+    "groups": [12, 15],
+})
+print(new_org_unit["id"])
+```
+
+Seuls `name` et `org_unit_type_id` sont obligatoires. Quelques règles appliquées par le serveur :
+
+- `parent_id` doit vivre dans la **même version de source** que l'unité d'organisation créée.
+- Chaque groupe de `groups` doit également vivre dans cette même version de source.
+- `code` doit être unique parmi les unités d'organisation valides de la version. Un conflit renvoie un
+  `400` avec `errorKey: "code"`.
+- Si votre profil est restreint à une branche de la hiérarchie, `parent_id` est obligatoire — vous ne
+  pouvez pas créer de racine.
+
+Pour un polygone plutôt qu'un point, passez `geom` sous forme d'objet géométrie GeoJSON :
+
+```python
+"geom": {"type": "MultiPolygon", "coordinates": [[[[29.1, -5.9], [29.2, -5.9], [29.2, -6.0], [29.1, -5.9]]]]},
+```
+
+!!! warning "À la création, les dates sont en `jj-mm-aaaa`, et uniquement ainsi"
+    `POST /api/orgunits/create_org_unit/` analyse `opening_date` et `closed_date` avec le seul format
+    `%d-%m-%Y`. Une date ISO comme `2019-03-01` provoque une erreur serveur, et non un `400` propre.
+    De façon déroutante, `PATCH` est permissif et accepte `jj-mm-aaaa`, `jj/mm/aaaa`, `aaaa-mm-jj` et
+    `aaaa/mm/jj`, tandis que les demandes de changement attendent de l'**ISO `aaaa-mm-jj`**. Formatez
+    la date selon le point d'entrée que vous appelez.
+
+    Autre point : si vous envoyez `closed_date` à la création sans `opening_date`, la comparaison
+    entre les deux échoue côté serveur. Envoyez toujours les deux, ou aucun.
+
+### Mettre à jour
+
+`PATCH /api/orgunits/<id>/` ne met à jour que les clés présentes dans le corps de la requête. Tout est
+optionnel.
+
+```python
+iaso.patch(f"/api/orgunits/{org_unit_id}/", json={
+    "name": "Centre de Santé de Kalémie Centre",
+    "parent_id": 4322,
+    "org_unit_type_id": type_by_name["Health facility"],
+    "groups": [12, 15],            # remplace toute la liste, ce n'est pas un ajout
+    "opening_date": "2019-03-01",  # PATCH accepte aussi l'ISO
+    "code": "CS-KAL-001",
+    "aliases": ["Kalemie Health Centre"],
+})
+```
+
+À noter :
+
+- **`groups` remplace toute la liste.** Pour ajouter un seul groupe, relisez les groupes actuels et
+  renvoyez-les tous.
+- **Les coordonnées voyagent en trio.** Pour définir une position, envoyez `latitude`, `longitude`
+  *et* `altitude` ensemble — le point d'entrée lit les trois clés, et omettre `altitude` en envoyant
+  les deux autres provoque une erreur serveur. Envoyez `latitude: None, longitude: None,
+  altitude: None` pour effacer la position.
+- **`version_id` ne peut pas être modifié par `PATCH`.** Une unité d'organisation ne peut pas être
+  déplacée d'une version de source à une autre via cette API.
+- Un `name` vide est silencieusement ignoré plutôt qu'appliqué — vous ne pouvez pas effacer un nom.
+
+### Changer le statut de validation
+
+```python
+iaso.patch(f"/api/orgunits/{org_unit_id}/", json={"validation_status": "VALID"})
+```
+
+Les valeurs acceptées sont `NEW`, `VALID` et `REJECTED`.
+
+### Mises à jour groupées
+
+Pour un changement qui s'applique uniformément à de nombreuses unités d'organisation — même type,
+mêmes groupes, même statut de validation — il existe une tâche asynchrone, préférable à une boucle
+d'appels `PATCH`.
+
+```python
+task = iaso.post("/api/tasks/create/orgunitsbulkupdate/", json={
+    "selected_ids": [101, 102, 103],
+    "validation_status": "VALID",
+    "groups_added": [15],
+    "groups_removed": [12],
+})["task"]
+
+# Interroger jusqu'à la fin.
+import time
+while True:
+    status = iaso.get(f"/api/tasks/{task['id']}/")
+    if status["status"] in ("SUCCESS", "ERRORED", "KILLED"):
+        print(status["status"], status.get("result"))
+        break
+    time.sleep(5)
+```
+
+Vous pouvez cibler une recherche plutôt qu'une liste explicite en passant `select_all: true` avec
+`searches` (les mêmes objets de filtre que ceux acceptés par le point d'entrée de liste) et un
+`unselected_ids` optionnel. Cette tâche ne peut ni renommer ni déplacer les unités d'organisation :
+elle ne fait que définir le type, les groupes et le statut de validation.
+
+## Voie B — soumettre des demandes de changement
+
+Créer une demande de changement n'exige aucune permission particulière — seulement d'être authentifié
+et que l'unité d'organisation ciblée vous soit visible. Ce que vous soumettez est une *proposition* :
+elle ne change rien tant qu'un relecteur IASO ne l'a pas approuvée.
+
+### Soumettre
+
+```python
+import uuid
+
+change_request = iaso.post("/api/orgunits/changes/", json={
+    "uuid": str(uuid.uuid4()),        # optionnel mais recommandé, voir ci-dessous
+    "org_unit_id": 1234,              # l'unité d'organisation à modifier — obligatoire
+    "new_name": "Centre de Santé de Kalémie Centre",
+    "new_org_unit_type_id": type_by_name["Health facility"],
+    "new_parent_id": 4322,
+    "new_groups": [12, 15],
+    "new_location": {"latitude": -5.9236, "longitude": 29.1947, "altitude": 0},
+    "new_opening_date": "2019-03-01",  # ISO ici
+    "new_closed_date": "2030-12-31",
+})
+print(change_request["id"], change_request["status"])  # -> 42 new
+```
+
+Les champs que vous pouvez proposer sont exactement ceux-ci :
+
+| Champ | Forme |
+|---|---|
+| `new_name` | chaîne |
+| `new_parent_id` | id d'unité d'organisation (ou uuid), nullable |
+| `new_org_unit_type_id` | id de type d'unité d'organisation |
+| `new_groups` | liste d'ids de groupes — remplace toute la liste |
+| `new_location` | `{"latitude": …, "longitude": …, "altitude": …}`, nullable |
+| `new_location_accuracy` | décimal, en mètres — métadonnée seulement, jamais appliquée à l'unité d'organisation |
+| `new_opening_date` | date ISO `aaaa-mm-jj` |
+| `new_closed_date` | date ISO `aaaa-mm-jj` |
+| `new_reference_instances` | liste d'ids de soumissions de formulaire (ou uuids) |
+
+Les règles appliquées par le serveur :
+
+- **Au moins un champ `new_*` est requis.** Une demande autrement vide renvoie un `400`.
+- N'envoyez que les champs que vous voulez réellement changer. IASO déduit la liste des champs
+  demandés à partir des clés présentes dans votre charge utile, et le relecteur les approuve un à un.
+  N'envoyez pas un instantané complet de l'unité d'organisation — chaque champ inclus devient un
+  changement que quelqu'un devra arbitrer.
+- Envoyer explicitement `null` signifie *effacer cette valeur*, ce qui est différent d'omettre la clé.
+- `new_parent_id` doit être dans la même version de source que l'unité d'organisation, et ne peut pas
+  être l'un de ses propres descendants.
+- `new_closed_date` doit être strictement postérieure à `new_opening_date`.
+
+### Idempotence
+
+L'`uuid` que vous fournissez est la clé de déduplication : soumettre une demande de changement dont
+l'`uuid` existe déjà est sans effet et renvoie la demande existante plutôt que d'en créer un doublon.
+Dérivez-le de manière déterministe depuis votre propre enregistrement — par exemple
+`uuid.uuid5(NAMESPACE, f"{source_ref}:{content_hash}")` — et une reprise après une panne réseau
+devient sans risque.
+
+### Proposer une nouvelle unité d'organisation
+
+Comme expliqué en tête de guide, une demande de changement ne peut pas faire apparaître une unité
+d'organisation. Le schéma en deux temps est le suivant :
+
+```python
+# 1. La créer directement, non validée. Exige iaso_org_units.
+draft = iaso.post("/api/orgunits/create_org_unit/", json={
+    "name": "Nouveau Poste de Santé",
+    "org_unit_type_id": type_by_name["Health facility"],
+    "parent_id": 4321,
+    "source_ref": "ABC-042",
+    "validation_status": "NEW",     # <- la maintient hors de la pyramide active
+})
+
+# 2. Soumettre la demande de changement. IASO voit que l'unité est encore NEW
+#    et enregistre la demande avec le type "org_unit_creation".
+iaso.post("/api/orgunits/changes/", json={
+    "org_unit_id": draft["id"],
+    "new_name": "Nouveau Poste de Santé",
+    "new_location": {"latitude": -5.93, "longitude": 29.20, "altitude": 0},
+})
+```
+
+L'approbation fait passer l'unité d'organisation en `VALID` et elle entre dans la pyramide. Le rejet la
+fait passer en `REJECTED` et elle en reste exclue.
+
+### Il n'y a pas de création groupée
+
+`POST /api/orgunits/changes/` ne prend qu'une demande de changement à la fois. Pour cent unités
+d'organisation, faites cent appels — séquentiellement, ou avec un petit pool de threads, mais
+n'attendez pas de point d'entrée par lot. (La *revue* groupée existe, mais c'est le côté du relecteur,
+pas le vôtre.)
+
+### Suivre le sort de vos demandes
+
+```python
+page = 1
+while True:
+    resp = iaso.get("/api/orgunits/changes/", params={
+        "status": "new,approved,rejected",
+        "created_at_after": "2026-01-01",
+        "limit": 50,
+        "page": page,
+    })
+    for cr in resp["results"]:
+        print(cr["id"], cr["status"], cr["org_unit"]["name"], cr.get("rejection_comment"))
+    if not resp["has_next"]:
+        break
+    page += 1
+```
+
+Le point d'entrée de liste pagine sous `results`. Une demande de changement est `new` jusqu'à ce que
+quelqu'un la relise, puis `approved` ou `rejected` ; un rejet est toujours accompagné d'un
+`rejection_comment` qui en explique la raison. Filtres utiles : `org_unit_id`, `source_version_id`,
+`status`, `created_at_after` / `created_at_before`, `kind`, `requested_fields`.
+
+Un relecteur peut approuver certains champs et en rejeter d'autres : vérifiez donc `approved_fields`
+sur une demande approuvée plutôt que de supposer que tout ce que vous avez proposé a été appliqué.
+
+## Erreurs
+
+Les points d'entrée des unités d'organisation ne renvoient pas un objet d'erreur au format DRF. Sur un
+`400`, ils renvoient une **liste** :
+
+```json
+[
+  {"errorKey": "code", "errorMessage": "Another valid OrgUnit already exists with the code 'CS-KAL-001' in this version"},
+  {"errorKey": "parent_id", "errorMessage": "Parent is not in the same version"}
+]
+```
+
+Le point d'entrée des demandes de changement, qui repose sur un sérialiseur DRF standard, renvoie la
+forme habituelle `{"champ": ["message"]}`, parfois avec le message sous `non_field_errors`. Gérez les
+deux.
+
+```python
+def explain(err: IasoError) -> str:
+    import json
+    body = str(err).split(": ", 2)[-1]
+    try:
+        payload = json.loads(body)
+    except ValueError:
+        return body
+    if isinstance(payload, list):     # points d'entrée des unités d'organisation
+        return "; ".join(f"{e['errorKey']}: {e['errorMessage']}" for e in payload)
+    return "; ".join(f"{k}: {v}" for k, v in payload.items())   # demandes de changement
+```
+
+Ne réessayez pas aveuglément un `400` — c'est une charge utile rejetée, et elle le sera de nouveau.
+Réessayez les `502`, `503` et `504`, et rendez vos écritures idempotentes (un `uuid` stable pour les
+demandes de changement, une recherche sur `source_ref` avant de créer) afin qu'une reprise après un
+délai d'attente dépassé ne puisse pas écrire deux fois.
+
+## Un exemple complet : synchroniser un CSV d'établissements
+
+Le script ci-dessous lit un CSV exporté de votre propre système, rapproche chaque ligne d'IASO via le
+`source_ref`, puis crée ce qui manque et met à jour ce qui a divergé. La même logique fonctionne dans
+les deux modes : `direct` écrit directement dans la pyramide, `change_request` propose.
+
+```python
+"""Synchronise un CSV d'établissements de santé dans une source de données IASO.
+
+Utilisation :
+    python sync_org_units.py etablissements.csv direct
+    python sync_org_units.py etablissements.csv change_request
+
+Colonnes CSV : source_ref, name, parent_ref, type, latitude, longitude, opening_date (aaaa-mm-jj)
+"""
+
+import csv
+import sys
+import uuid
+
+# IasoClient et IasoError tels que définis plus haut dans ce guide.
+from iaso_client import IasoClient, IasoError
+
+SERVER = "https://iaso.example.org"
+USERNAME = "mon-compte-de-service"
+PASSWORD = "..."
+VERSION_ID = 5          # la version de source dans laquelle vous écrivez
+NAMESPACE = uuid.UUID("6c1f0e6e-0f1a-4c6e-9f4a-2b7d0a1f0000")  # un uuid fixe de votre choix
+
+
+def load_existing(iaso, version_id):
+    """Toutes les unités d'organisation de la version, indexées par source_ref."""
+    by_ref, page = {}, 1
+    while True:
+        resp = iaso.get("/api/orgunits/", params={
+            "version": version_id,
+            "validation_status": "all",   # sinon les unités NEW et REJECTED sont invisibles
+            "limit": 500,
+            "page": page,
+        })
+        for org_unit in resp["orgunits"]:
+            if org_unit.get("source_ref"):
+                by_ref[org_unit["source_ref"]] = org_unit
+        if not resp["has_next"]:
+            return by_ref
+        page += 1
+
+
+def load_types(iaso):
+    return {t["name"]: t["id"] for t in iaso.get("/api/orgunittypes/")["orgUnitTypes"]}
+
+
+def has_drifted(row, existing, type_ids, parent_id):
+    """Les champs où le CSV diverge d'IASO, exprimés dans le vocabulaire d'IASO."""
+    changes = {}
+    if row["name"] != existing["name"]:
+        changes["name"] = row["name"]
+    if type_ids[row["type"]] != existing.get("org_unit_type_id"):
+        changes["org_unit_type_id"] = type_ids[row["type"]]
+    if parent_id != existing.get("parent_id"):
+        changes["parent_id"] = parent_id
+    if row.get("latitude") and row.get("longitude"):
+        lat, lon = float(row["latitude"]), float(row["longitude"])
+        if (existing.get("latitude"), existing.get("longitude")) != (lat, lon):
+            changes["latitude"], changes["longitude"] = lat, lon
+    return changes
+
+
+def to_iso(date_str):        # PATCH et les demandes de changement acceptent tous deux l'ISO
+    return date_str or None
+
+
+def to_ddmmyyyy(date_str):   # create_org_unit n'accepte que jj-mm-aaaa
+    if not date_str:
+        return None
+    year, month, day = date_str.split("-")
+    return f"{day}-{month}-{year}"
+
+
+def create_direct(iaso, row, type_ids, parent_id):
+    return iaso.post("/api/orgunits/create_org_unit/", json={
+        "name": row["name"],
+        "org_unit_type_id": type_ids[row["type"]],
+        "parent_id": parent_id,
+        "version_id": VERSION_ID,
+        "source_ref": row["source_ref"],
+        "validation_status": "VALID",
+        "opening_date": to_ddmmyyyy(row.get("opening_date")),
+        "latitude": float(row["latitude"]) if row.get("latitude") else None,
+        "longitude": float(row["longitude"]) if row.get("longitude") else None,
+        "altitude": 0,
+    })
+
+
+def update_direct(iaso, org_unit, changes):
+    payload = dict(changes)
+    if "latitude" in payload:
+        payload["altitude"] = 0       # le point d'entrée lit les trois clés ensemble
+    return iaso.patch(f"/api/orgunits/{org_unit['id']}/", json=payload)
+
+
+def create_as_change_request(iaso, row, type_ids, parent_id):
+    """Créer l'unité d'organisation non validée, puis la proposer. Exige iaso_org_units."""
+    draft = iaso.post("/api/orgunits/create_org_unit/", json={
+        "name": row["name"],
+        "org_unit_type_id": type_ids[row["type"]],
+        "parent_id": parent_id,
+        "version_id": VERSION_ID,
+        "source_ref": row["source_ref"],
+        "validation_status": "NEW",
+        "opening_date": to_ddmmyyyy(row.get("opening_date")),
+    })
+    return submit_change_request(iaso, draft["id"], row, {
+        "name": row["name"],
+        "latitude": float(row["latitude"]) if row.get("latitude") else None,
+        "longitude": float(row["longitude"]) if row.get("longitude") else None,
+    })
+
+
+def submit_change_request(iaso, org_unit_id, row, changes):
+    """Traduire les champs divergents dans le vocabulaire des demandes de changement."""
+    payload = {
+        "uuid": str(uuid.uuid5(NAMESPACE, f"{row['source_ref']}:{sorted(changes.items())}")),
+        "org_unit_id": org_unit_id,
+    }
+    if "name" in changes:
+        payload["new_name"] = changes["name"]
+    if "org_unit_type_id" in changes:
+        payload["new_org_unit_type_id"] = changes["org_unit_type_id"]
+    if "parent_id" in changes:
+        payload["new_parent_id"] = changes["parent_id"]
+    if changes.get("latitude") is not None:
+        payload["new_location"] = {
+            "latitude": changes["latitude"],
+            "longitude": changes["longitude"],
+            "altitude": 0,
+        }
+    if row.get("opening_date"):
+        payload["new_opening_date"] = to_iso(row["opening_date"])
+    return iaso.post("/api/orgunits/changes/", json=payload)
+
+
+def main(csv_path, mode):
+    iaso = IasoClient(SERVER, USERNAME, PASSWORD)
+    type_ids = load_types(iaso)
+    existing = load_existing(iaso, VERSION_ID)
+
+    created = updated = unchanged = failed = 0
+
+    with open(csv_path, newline="", encoding="utf-8") as f:
+        for row in csv.DictReader(f):
+            parent = existing.get(row.get("parent_ref"))
+            parent_id = parent["id"] if parent else None
+            current = existing.get(row["source_ref"])
+
+            try:
+                if current is None:
+                    if mode == "direct":
+                        create_direct(iaso, row, type_ids, parent_id)
+                    else:
+                        create_as_change_request(iaso, row, type_ids, parent_id)
+                    created += 1
+                    continue
+
+                changes = has_drifted(row, current, type_ids, parent_id)
+                if not changes:
+                    unchanged += 1
+                    continue
+
+                if mode == "direct":
+                    update_direct(iaso, current, changes)
+                else:
+                    submit_change_request(iaso, current["id"], row, changes)
+                updated += 1
+
+            except IasoError as e:
+                failed += 1
+                print(f"ÉCHEC {row['source_ref']} : {e}", file=sys.stderr)
+
+    verbe = "créées" if mode == "direct" else "proposées"
+    print(f"{verbe} : {created}, mises à jour : {updated}, inchangées : {unchanged}, échecs : {failed}")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1], sys.argv[2])
+```
+
+Deux habitudes que ce script illustre et qu'il vaut la peine de conserver :
+
+**Portez toujours votre propre identifiant dans `source_ref`.** C'est la clé de jointure entre votre
+système et IASO, elle survit aux renommages, et elle vous permet de rejouer la synchronisation sans
+créer de doublons. IASO créera volontiers deux unités d'organisation portant le même nom.
+
+**Construisez les parents avant les enfants.** Le script ci-dessus résout un parent parmi les unités
+d'organisation déjà présentes dans IASO : un CSV doit donc être trié du haut vers le bas — un
+établissement dont le district n'existe pas encore se retrouve avec un parent `null`. Si vous importez
+une hiérarchie entière, traitez-la niveau par niveau.
+
+## Autres voies d'import en masse
+
+Si vous chargez une pyramide entière plutôt que d'en maintenir une, deux routes d'import plus lourdes
+existent et conviennent généralement mieux. Toutes deux exigent la permission `iaso_sources`, toutes
+deux s'exécutent en tâche de fond, et toutes deux sont documentées avec les écrans d'administration
+des sources de données :
+
+- `POST /api/tasks/create/importgpkg/` — téléverser un GeoPackage dans une source de données et un numéro de version.
+- `POST /api/dhis2ouimporter/` — importer ou rafraîchir la pyramide directement depuis une instance DHIS2.
+
+## Aide-mémoire des pièges
+
+- La liste des unités d'organisation filtre sur `validation_status=VALID` par défaut ; passez `all` pour voir ce que vous venez de créer.
+- L'enveloppe de la liste est `orgunits` avec pagination, `orgUnits` sans.
+- Dates : `jj-mm-aaaa` à la création, à peu près n'importe quoi de raisonnable en `PATCH`, ISO `aaaa-mm-jj` dans les demandes de changement.
+- À la création, n'envoyez jamais `closed_date` sans `opening_date`.
+- Latitude, longitude et altitude sont lues comme un trio, aussi bien en `PATCH` que dans `new_location`.
+- `groups` et `new_groups` remplacent toute la liste ; ils n'ajoutent pas.
+- Un parent et un groupe doivent appartenir à la même version de source que l'unité d'organisation.
+- `version_id` est fixé une fois, à la création, et ne peut jamais être modifié par `PATCH`.
+- Une demande de changement exige toujours un `org_unit_id` existant, et il n'existe pas de création groupée.

--- a/docs/pages/dev/how_to/read_org_units_via_fhir/read_org_units_via_fhir.en.md
+++ b/docs/pages/dev/how_to/read_org_units_via_fhir/read_org_units_via_fhir.en.md
@@ -1,0 +1,455 @@
+# Read org units through the FHIR API
+
+IASO exposes its org units as **FHIR R4 `Location` resources**, for external systems that already
+speak FHIR. This guide documents that API as it is actually implemented.
+
+It is a **read-only** API: it serves `GET` only, and there is no way to create or modify an org unit
+through it. To write, use the [guide to modifying org units via the
+API](../modify_org_units_via_api/modify_org_units_via_api.md).
+
+## What is and is not implemented
+
+Be clear-eyed about the scope before you plan an integration around it.
+
+**Implemented:** the `Location` resource (read and search), a `children` operation, a
+`CapabilityStatement`, `Bundle` responses of type `searchset`, and `OperationOutcome` on errors.
+
+**Not implemented:** any other FHIR resource — there is no `Organization`, `Patient`, `Encounter`,
+`Observation` or `QuestionnaireResponse` endpoint. No writes (`POST`/`PUT`/`PATCH`/`DELETE`). No
+`_include`, `_revinclude`, `_sort`, `_elements`, `_summary`, `_lastUpdated`, chained parameters, or
+modifiers such as `:exact` and `:contains`. No XML, and no `_format` parameter. No `$everything` or
+other FHIR operations beyond `children`.
+
+In practice this is a FHIR-shaped read view of the org unit pyramid, not a full FHIR server. If your
+client is a strict, general-purpose FHIR client, read the [conformance
+caveats](#conformance-caveats) at the bottom first — several responses will not validate cleanly.
+
+## Endpoints
+
+The FHIR routes live under IASO's `/api/` prefix, like every other IASO endpoint.
+
+| Method | Path | Returns |
+|---|---|---|
+| `GET` | `/api/fhir/Location/` | `Bundle` (`searchset`) of `Location` resources |
+| `GET` | `/api/fhir/Location/{id}/` | a single `Location` |
+| `GET` | `/api/fhir/Location/{id}/children/` | `Bundle` of the **direct** children of that location |
+| `GET` | `/api/fhir/Location/metadata/` | `CapabilityStatement` |
+
+!!! warning "The base path is `/api/fhir/`, not `/fhir/`"
+    The module's own `README.md` in `iaso/api/fhir/` documents the base URL as `/fhir/`. That is
+    wrong: the router is registered inside `iaso/urls.py`, which is mounted under `/api/`. Every path
+    is `/api/fhir/Location/…`. The same README also has the status mapping backwards and writes the
+    identifier systems with `http://` instead of `https://` — prefer this page over it.
+
+Note that `metadata` sits **under** `Location`, at `/api/fhir/Location/metadata/`. The FHIR
+specification puts the capability statement at the server root (`/metadata`); IASO does not. A
+generic FHIR client that auto-discovers conformance will not find it.
+
+## Authentication and permissions
+
+Authentication is IASO's standard JWT — the FHIR endpoints are not public and not separately
+credentialed.
+
+```python
+import requests
+
+SERVER = "https://iaso.example.org"
+
+r = requests.post(
+    f"{SERVER}/api/token/",
+    json={"username": "my-service-account", "password": "..."},
+    timeout=30,
+)
+r.raise_for_status()
+headers = {"Authorization": f"Bearer {r.json()['access']}"}
+```
+
+The caller needs **either `iaso_org_units` or `iaso_org_units_read`**. The read-only permission is
+enough, and it is the right one to ask for if you only consume this API. Superusers bypass the
+permission check.
+
+- Unauthenticated → `401`.
+- Authenticated but holding neither permission → `403`.
+
+### What you are allowed to see
+
+Results are scoped to the caller in two ways, and both are silent:
+
+- **Account isolation.** You only ever see org units belonging to your own account. This is not
+  bypassed by superuser status.
+- **Profile hierarchy restriction.** If the IASO administrator restricted your user profile to a
+  branch of the pyramid, you see that branch and its descendants, and nothing else — not the parent
+  above it, not sibling branches.
+
+Asking for an org unit outside your scope returns **`404` with an `OperationOutcome`, not `403`**.
+The API does not distinguish "does not exist" from "not yours", which is deliberate but means a `404`
+is not proof that an id is unused.
+
+## The Bundle
+
+The list and `children` endpoints both return a `searchset` Bundle.
+
+```json
+{
+  "resourceType": "Bundle",
+  "id": "search-results",
+  "meta": {"lastUpdated": "2026-07-14T10:30:00.123456+00:00"},
+  "type": "searchset",
+  "total": 150,
+  "link": [
+    {"relation": "self", "url": "https://iaso.example.org/api/fhir/Location/?_count=20"},
+    {"relation": "next", "url": "https://iaso.example.org/api/fhir/Location/?_count=20&_skip=20"}
+  ],
+  "entry": [
+    {
+      "resource": { "resourceType": "Location", "id": "123", "...": "..." },
+      "fullUrl": "https://iaso.example.org/api/fhir/Location//123"
+    }
+  ]
+}
+```
+
+`total` is the count of the **whole** result set, not of the current page. `link` carries `self`,
+plus `next` and `previous` when they exist — follow `next` rather than computing offsets yourself.
+Note the relation is spelled `previous`, not FHIR's `prev`. For the `children` endpoint the Bundle
+`id` is `children-{parent_id}` instead of `search-results`.
+
+The double slash in `fullUrl` is not a typo in this guide — the implementation joins a base URL that
+already ends in `/` with `/{id}`. Do not parse ids out of `fullUrl`; read `entry[].resource.id`.
+
+!!! danger "Paging is not stable — deduplicate by `id`"
+    The underlying query has **no ordering**: `OrgUnit` declares no default sort and the FHIR viewset
+    adds none, yet results are paged with a limit/offset scheme. PostgreSQL is free to return rows in
+    a different order on each query, so paging through a large result set **can show you the same org
+    unit twice and skip another entirely**. There is no `_sort` parameter to fix this.
+
+    Two practical mitigations, both used in the examples below: request the largest page you can
+    (`_count=100`) to minimise the number of round trips, and **deduplicate by `id`** as you go rather
+    than trusting that each page is disjoint. If you need a guaranteed-complete snapshot of a large
+    pyramid, `/api/orgunits/` is the safer read path.
+
+    Everything served in a single page (any result set of 100 or fewer, and most `children` calls) is
+    unaffected.
+
+## The Location resource
+
+A full example, for a health facility with a parent, coordinates and dates:
+
+```json
+{
+  "resourceType": "Location",
+  "id": "123",
+  "meta": {
+    "versionId": "1",
+    "profile": ["https://hl7.org/fhir/StructureDefinition/Location"],
+    "lastUpdated": "2026-07-14T10:30:00.123456+00:00"
+  },
+  "identifier": [
+    {"use": "official", "system": "https://openiaso.com/org-unit/National pyramid/source-ref", "value": "HF001"},
+    {"use": "secondary", "system": "https://openiaso.com/org-unit/uuid", "value": "country-uuid-123"},
+    {"use": "secondary", "system": "https://openiaso.com/org-unit/alias", "value": "TC"}
+  ],
+  "status": "active",
+  "name": "Test Health Facility",
+  "mode": "instance",
+  "type": [
+    {
+      "coding": [
+        {"system": "https://openiaso.com/org-unit-type", "code": "HF", "display": "Health Facility"}
+      ],
+      "text": "Health Facility"
+    }
+  ],
+  "physicalType": {
+    "coding": [{"system": "https://terminology.hl7.org/CodeSystem/location-physical-type", "code": "bu"}]
+  },
+  "position": {"longitude": 29.1947, "latitude": -5.9236, "altitude": 0.0},
+  "partOf": {"reference": "Location/122", "display": "Test District"},
+  "managingOrganization": {"display": "National pyramid"},
+  "operationalStatus": {
+    "coding": [{"system": "https://terminology.hl7.org/CodeSystem/v2-0116", "code": "O", "display": "Open"}]
+  },
+  "extension": [
+    {"url": "https://openiaso.com/fhir/StructureDefinition/org-unit-validation-status", "valueCode": "VALID"},
+    {"url": "https://openiaso.com/fhir/StructureDefinition/org-unit-type-depth", "valueInteger": 3},
+    {"url": "https://openiaso.com/fhir/StructureDefinition/source-version", "valueString": "1"},
+    {"url": "https://openiaso.com/fhir/StructureDefinition/opening-date", "valueDate": "2019-03-01"}
+  ]
+}
+```
+
+### Field by field
+
+| FHIR field | Comes from | Notes |
+|---|---|---|
+| `id` | `OrgUnit.id` | a string, not a number |
+| `meta.versionId` | — | hardcoded to `"1"`; it does not track revisions |
+| `meta.lastUpdated` | `updated_at` | ISO 8601 |
+| `identifier` | `source_ref`, `uuid`, `aliases` | see below |
+| `status` | `validation_status` | see the mapping below — **read it carefully** |
+| `name` | `name` | |
+| `mode` | — | always `"instance"` |
+| `type[].coding[].code` | `org_unit_type.short_name` | the **short name**, e.g. `HF` |
+| `type[].coding[].display`, `type[].text` | `org_unit_type.name` | e.g. `Health Facility` |
+| `physicalType` | `org_unit_type.category` | `COUNTRY`→`co`, `REGION`/`DISTRICT`→`area`, `HF`→`bu`, anything else→`si` |
+| `position` | `location` | `longitude`, `latitude`, and `altitude` when the point carries a Z |
+| `partOf` | `parent` | `{"reference": "Location/<id>", "display": "<parent name>"}` |
+| `managingOrganization.display` | `version.data_source.name` | a display string only — there is no `Organization` resource to reference |
+| `operationalStatus` | `closed_date` / `opening_date` | `C`/Closed if a closed date exists, else `O`/Open if an opening date exists, else absent |
+| `extension` | validation status, type depth, source version, opening and closed dates | see below |
+
+The `identifier` array holds up to three kinds of entry, and only those that are set:
+
+- the **source reference**, with `use: "official"` and a system that embeds the data source name:
+  `https://openiaso.com/org-unit/{data source name}/source-ref`. Because the name is interpolated
+  into the system URL, the system string differs per data source and may contain spaces.
+- the **IASO uuid**, with `use: "secondary"` and system `https://openiaso.com/org-unit/uuid`.
+- one entry **per alias**, with `use: "secondary"` and system `https://openiaso.com/org-unit/alias`.
+
+The `extension` array carries the IASO-specific data that has no FHIR home:
+
+| Extension URL (prefix `https://openiaso.com/fhir/StructureDefinition/`) | Value | Present when |
+|---|---|---|
+| `org-unit-validation-status` | `valueCode`: `NEW` \| `VALID` \| `REJECTED` | always |
+| `org-unit-type-depth` | `valueInteger` | the type has a depth |
+| `source-version` | `valueString` — the version **number**, not its id | the org unit has a version |
+| `opening-date` | `valueDate` | set |
+| `closed-date` | `valueDate` | set |
+
+If you care about the true IASO validation status, read the `org-unit-validation-status` extension
+rather than inferring it from `status` — it is the unmapped, unambiguous value.
+
+### The status mapping
+
+`Location.status` is a FHIR-constrained code, so IASO's three validation statuses are squeezed into
+it like this:
+
+| IASO `validation_status` | FHIR `Location.status` |
+|---|---|
+| `VALID` | `active` |
+| `NEW` | `inactive` |
+| `REJECTED` | `suspended` |
+
+!!! danger "This is counter-intuitive, and the module README states it backwards"
+    A **rejected** org unit surfaces as `suspended`, and a **new / not-yet-validated** one surfaces as
+    `inactive`. It is easy to assume the opposite. `iaso/api/fhir/README.md` documents exactly the
+    reverse mapping and is wrong; the code and its tests agree with the table above.
+
+    Filtering on `?status=active` is therefore the way to get only validated org units — which is
+    also what most integrations want.
+
+## Search parameters
+
+All parameters apply to `GET /api/fhir/Location/`.
+
+| Parameter | Type | Semantics |
+|---|---|---|
+| `name` | string | case-insensitive **substring** match on the org unit name |
+| `status` | token | `active` \| `inactive` \| `suspended`, mapped as above. An unknown value returns a plain `400`, not an `OperationOutcome` |
+| `identifier` | token | **exact** match against `source_ref`, or `uuid`, or any alias |
+| `type` | token | **exact** match on the org unit type's `short_name` (e.g. `HF`, not `Health Facility`), case-sensitive |
+| `search` | string | substring match on the name; a DRF convention, equivalent to `name` here |
+| `_count` | number | page size. Default **20**, maximum **100** — asking for more silently gives you 100 |
+| `_skip` | number | offset |
+
+Filters combine with AND.
+
+`identifier` is the parameter to use when resolving your own external references to IASO ids: it
+matches `source_ref` exactly, which is the field an IASO integration normally populates with the
+identifier from the source system. Pass the **bare value** — the FHIR `system|value` token syntax is
+not parsed, and a query like `?identifier=https://openiaso.com/org-unit/uuid|abc` simply matches
+nothing.
+
+There is no filter on parent, source version, date, or group, and no `_sort`, `_id`, `_lastUpdated`,
+`_include`, `_elements` or `_summary`. To walk the tree, use `children`.
+
+!!! warning "Results span every source version your account can see"
+    There is no way to restrict a FHIR search to one data source or source version. If your account
+    holds several pyramids, or several versions of the same one, they all appear in the same result
+    set — and the same real-world facility may legitimately appear more than once, as a distinct
+    `Location` per version. The `source-version` extension on each resource is the only way to tell
+    them apart. If this matters to you, filter client-side on that extension, or read the org units
+    through [`/api/orgunits/`](../modify_org_units_via_api/modify_org_units_via_api.md#reading-org-units)
+    instead, which does take a `version` parameter.
+
+## Walking the hierarchy
+
+```
+GET /api/fhir/Location/{id}/children/
+```
+
+Returns a Bundle of the **direct** children only — it is one level, not the whole subtree. To
+traverse a pyramid, recurse.
+
+## Python examples
+
+Using the same `IasoClient` as the [org unit write
+guide](../modify_org_units_via_api/modify_org_units_via_api.md#a-small-client-to-build-on):
+
+### Page through every Location
+
+Follow the `next` link rather than incrementing `_skip` yourself, and deduplicate as you go — paging
+is not stably ordered, so a resource can legitimately appear on two consecutive pages.
+
+```python
+def iter_locations(iaso, **params):
+    """Yield every Location resource exactly once, following the Bundle's next links."""
+    params.setdefault("_count", 100)          # 100 is the server-side maximum
+    bundle = iaso.get("/api/fhir/Location/", params=params)
+    seen = set()
+
+    while True:
+        for entry in bundle.get("entry", []):
+            location = entry["resource"]
+            if location["id"] in seen:        # paging is unordered; duplicates happen
+                continue
+            seen.add(location["id"])
+            yield location
+
+        next_link = next(
+            (l["url"] for l in bundle.get("link", []) if l["relation"] == "next"),
+            None,
+        )
+        if not next_link:
+            return
+        # next_link is an absolute URL; hand it back to the session as-is.
+        bundle = iaso.session.get(next_link, timeout=60).json()
+
+
+for location in iter_locations(iaso, status="active", type="HF"):
+    print(location["id"], location["name"])
+```
+
+Deduplicating protects you against seeing a resource twice, but nothing at the API level protects you
+against *missing* one. If completeness is critical, compare the number of unique ids you collected
+against the Bundle's `total`, and fall back to `/api/orgunits/` if they disagree.
+
+### Resolve one of your own references to an IASO id
+
+```python
+def find_by_source_ref(iaso, source_ref):
+    bundle = iaso.get("/api/fhir/Location/", params={"identifier": source_ref})
+    entries = bundle.get("entry", [])
+    if not entries:
+        return None
+    return entries[0]["resource"]
+
+location = find_by_source_ref(iaso, "HF001")
+if location:
+    print(location["id"], location["name"], location["status"])
+```
+
+### Walk the tree depth-first
+
+```python
+def walk(iaso, root_id, depth=0):
+    location = iaso.get(f"/api/fhir/Location/{root_id}/")
+    print("  " * depth + f"{location['name']} ({location['status']})")
+
+    bundle = iaso.get(f"/api/fhir/Location/{root_id}/children/", params={"_count": 100})
+    for entry in bundle.get("entry", []):
+        walk(iaso, entry["resource"]["id"], depth + 1)
+```
+
+Note this issues one request per node. For a whole pyramid, listing everything once with
+`iter_locations()` and rebuilding the tree in memory from `partOf` is far cheaper:
+
+```python
+def build_tree(iaso):
+    children_by_parent = {}
+    for location in iter_locations(iaso):
+        part_of = location.get("partOf") or {}
+        reference = part_of.get("reference")            # "Location/122" or absent for a root
+        parent_id = reference.split("/")[1] if reference else None
+        children_by_parent.setdefault(parent_id, []).append(location)
+    return children_by_parent                           # key None holds the roots
+```
+
+### Read the true IASO validation status
+
+```python
+VALIDATION_STATUS = "https://openiaso.com/fhir/StructureDefinition/org-unit-validation-status"
+
+def validation_status(location):
+    for ext in location.get("extension", []):
+        if ext["url"] == VALIDATION_STATUS:
+            return ext["valueCode"]      # "NEW" | "VALID" | "REJECTED"
+    return None
+```
+
+## Errors
+
+A missing — or out-of-scope — location returns `404` with a FHIR `OperationOutcome`:
+
+```json
+{
+  "resourceType": "OperationOutcome",
+  "issue": [
+    {
+      "severity": "error",
+      "code": "not-found",
+      "details": {"text": "Location with id '999' not found"}
+    }
+  ]
+}
+```
+
+`401` and `403` are plain DRF errors, **not** `OperationOutcome` resources, so do not assume every
+error body carries a `resourceType`.
+
+## Conformance caveats
+
+The API is FHIR R4-shaped and declares `fhirVersion: "4.0.1"` in its capability statement, but a
+strict FHIR client will notice the following. None of them are blockers if you are writing the client
+yourself; all of them matter if you are pointing an off-the-shelf FHIR tool at it.
+
+- **Empty elements are emitted as `{}` or `[]` rather than omitted.** An org unit with no
+  coordinates still returns `"position": {}`; one with no parent returns `"partOf": {}`; likewise
+  `physicalType`, `managingOrganization`, `operationalStatus` and `type`. FHIR expects absent
+  elements to be left out, and a validator will reject `"position": {}` because `longitude` and
+  `latitude` are required once `position` is present. **Test for truthiness, not for key presence.**
+- **Do not send `Accept: application/fhir+json` — you will get a `406`.** The endpoints are served by
+  the ordinary JSON renderer, which does not advertise the FHIR media type, so content negotiation
+  fails outright. Send `Accept: application/json` (or nothing at all). Responses come back as
+  `Content-Type: application/json`.
+- **The terminology systems are spelled `https://`**, e.g.
+  `https://terminology.hl7.org/CodeSystem/location-physical-type`. HL7's canonical system URIs use
+  `http://`, and a system URI is an opaque identifier rather than a URL to dereference — so these
+  codings will **not** match a standard terminology server or a validator expecting the canonical
+  form. The same applies to `meta.profile`, given as `https://hl7.org/fhir/StructureDefinition/Location`.
+- **The capability statement is at `/api/fhir/Location/metadata/`**, not at the server root
+  `/metadata`, and it **requires authentication** — both non-standard, so conformance auto-discovery
+  fails. It also omits R4-required elements (`url`, `version`, `name`), and the `OperationDefinition`
+  it references for `children` is not actually served anywhere.
+- **`meta.versionId` is always `"1"`** and there is no `_history`; the resource is not versioned. With
+  no `_lastUpdated` search parameter either, **there is no delta-sync story** — you re-read
+  everything, every time.
+- **The identifier `system` for a source reference embeds the data source name**, so it is not a
+  stable, opaque URI and may contain spaces. Match on `use == "official"` or on the value, never on
+  the system string.
+- **`managingOrganization` has a `display` but no `reference`**, because there is no `Organization`
+  endpoint to point at.
+- **`operationalStatus` is wrapped in `{"coding": [...]}`**, whereas FHIR types it as a bare `Coding`.
+  A closed date always wins over an opening date, even one set in the future.
+- **`fullUrl` contains a double slash** (`.../Location//123`).
+
+One operational note that is not a conformance issue: the service account you authenticate with must
+have an IASO profile attached. A user without one — which is possible for a bare superuser created
+outside the normal flow — causes a `500` rather than a clean error.
+
+## Quick reference of the traps
+
+- The base path is `/api/fhir/Location/`, **not** `/fhir/Location/` as the module README says.
+- `NEW` → `inactive` and `REJECTED` → `suspended`, not the reverse. The module README has these swapped.
+- Paging is **not stably ordered** — deduplicate by `id` and check your count against `total`.
+- `Accept: application/fhir+json` is rejected with a `406`. Ask for `application/json`.
+- Identifier and terminology systems use `https://`, not HL7's canonical `http://`.
+- Out-of-scope org units return `404`, not `403` — a `404` does not mean the id is free.
+- Results span every source version your account can see; there is no version filter.
+- `type` matches the org unit type's **short name**, not its display name.
+- `identifier` takes a bare value; the `system|value` token syntax matches nothing.
+- An invalid `status` returns a plain `400`, not an `OperationOutcome`.
+- `_count` caps at 100 and silently clamps; default page size is 20.
+- `children` returns direct children only, one level at a time.
+- Absent fields come back as `{}` / `[]`, not omitted — check truthiness.
+- Read `status` for the FHIR view, and the `org-unit-validation-status` extension for IASO's real one.

--- a/docs/pages/dev/how_to/read_org_units_via_fhir/read_org_units_via_fhir.fr.md
+++ b/docs/pages/dev/how_to/read_org_units_via_fhir/read_org_units_via_fhir.fr.md
@@ -1,0 +1,475 @@
+# Lire les unités d'organisation via l'API FHIR
+
+IASO expose ses unités d'organisation sous forme de ressources **FHIR R4 `Location`**, à destination
+des systèmes externes qui parlent déjà FHIR. Ce guide documente cette API telle qu'elle est réellement
+implémentée.
+
+C'est une API **en lecture seule** : elle ne sert que du `GET`, et il n'existe aucun moyen de créer ou
+de modifier une unité d'organisation par son intermédiaire. Pour écrire, voyez le [guide de
+modification des unités d'organisation via
+l'API](../modify_org_units_via_api/modify_org_units_via_api.md).
+
+## Ce qui est implémenté, et ce qui ne l'est pas
+
+Ayez une vision lucide du périmètre avant de bâtir une intégration dessus.
+
+**Implémenté :** la ressource `Location` (lecture et recherche), une opération `children`, un
+`CapabilityStatement`, des réponses `Bundle` de type `searchset`, et des `OperationOutcome` en cas
+d'erreur.
+
+**Non implémenté :** toute autre ressource FHIR — il n'y a pas de point d'entrée `Organization`,
+`Patient`, `Encounter`, `Observation` ni `QuestionnaireResponse`. Aucune écriture
+(`POST`/`PUT`/`PATCH`/`DELETE`). Pas de `_include`, `_revinclude`, `_sort`, `_elements`, `_summary`,
+`_lastUpdated`, ni de paramètres chaînés ou de modificateurs comme `:exact` et `:contains`. Pas de
+XML, ni de paramètre `_format`. Aucune opération FHIR au-delà de `children`.
+
+En pratique, il s'agit d'une vue en lecture de la pyramide des unités d'organisation, de forme FHIR,
+et non d'un serveur FHIR complet. Si votre client est un client FHIR générique et strict, lisez
+d'abord la section « Réserves de conformité » en fin de page : plusieurs réponses ne passeront pas la
+validation.
+
+## Points d'entrée
+
+Les routes FHIR vivent sous le préfixe `/api/` d'IASO, comme tous les autres points d'entrée.
+
+| Méthode | Chemin | Renvoie |
+|---|---|---|
+| `GET` | `/api/fhir/Location/` | un `Bundle` (`searchset`) de ressources `Location` |
+| `GET` | `/api/fhir/Location/{id}/` | une seule `Location` |
+| `GET` | `/api/fhir/Location/{id}/children/` | un `Bundle` des enfants **directs** de cette location |
+| `GET` | `/api/fhir/Location/metadata/` | un `CapabilityStatement` |
+
+!!! warning "Le chemin de base est `/api/fhir/`, et non `/fhir/`"
+    Le `README.md` du module, dans `iaso/api/fhir/`, documente l'URL de base comme `/fhir/`. C'est
+    faux : le routeur est enregistré dans `iaso/urls.py`, lui-même monté sous `/api/`. Tous les
+    chemins sont donc `/api/fhir/Location/…`. Ce même README indique aussi la correspondance des
+    statuts à l'envers et écrit les systèmes d'identifiants en `http://` au lieu de `https://` —
+    préférez cette page.
+
+Notez que `metadata` se trouve **sous** `Location`, à `/api/fhir/Location/metadata/`. La spécification
+FHIR place la déclaration de conformité à la racine du serveur (`/metadata`) ; ce n'est pas le cas
+d'IASO. Un client FHIR générique qui découvre la conformité automatiquement ne la trouvera pas.
+
+## Authentification et permissions
+
+L'authentification est le JWT standard d'IASO — les points d'entrée FHIR ne sont ni publics ni dotés
+d'identifiants distincts.
+
+```python
+import requests
+
+SERVER = "https://iaso.example.org"
+
+r = requests.post(
+    f"{SERVER}/api/token/",
+    json={"username": "mon-compte-de-service", "password": "..."},
+    timeout=30,
+)
+r.raise_for_status()
+headers = {"Authorization": f"Bearer {r.json()['access']}"}
+```
+
+L'appelant a besoin de **`iaso_org_units` ou de `iaso_org_units_read`**. La permission en lecture
+seule suffit, et c'est celle qu'il convient de demander si vous ne faites que consommer cette API. Les
+super-utilisateurs contournent la vérification de permission.
+
+- Non authentifié → `401`.
+- Authentifié mais ne détenant aucune des deux permissions → `403`.
+
+### Ce que vous avez le droit de voir
+
+Les résultats sont restreints à l'appelant de deux façons, toutes deux silencieuses :
+
+- **Isolation par compte.** Vous ne voyez jamais que les unités d'organisation de votre propre compte.
+  Le statut de super-utilisateur ne contourne pas cette règle.
+- **Restriction hiérarchique du profil.** Si l'administrateur IASO a restreint votre profil à une
+  branche de la pyramide, vous voyez cette branche et ses descendants, et rien d'autre — ni le parent
+  au-dessus, ni les branches sœurs.
+
+Demander une unité d'organisation hors de votre périmètre renvoie **un `404` avec un
+`OperationOutcome`, et non un `403`**. L'API ne distingue pas « n'existe pas » de « ne vous appartient
+pas », ce qui est délibéré, mais implique qu'un `404` ne prouve pas qu'un identifiant est libre.
+
+## Le Bundle
+
+Les points d'entrée de liste et `children` renvoient tous deux un Bundle `searchset`.
+
+```json
+{
+  "resourceType": "Bundle",
+  "id": "search-results",
+  "meta": {"lastUpdated": "2026-07-14T10:30:00.123456+00:00"},
+  "type": "searchset",
+  "total": 150,
+  "link": [
+    {"relation": "self", "url": "https://iaso.example.org/api/fhir/Location/?_count=20"},
+    {"relation": "next", "url": "https://iaso.example.org/api/fhir/Location/?_count=20&_skip=20"}
+  ],
+  "entry": [
+    {
+      "resource": { "resourceType": "Location", "id": "123", "...": "..." },
+      "fullUrl": "https://iaso.example.org/api/fhir/Location//123"
+    }
+  ]
+}
+```
+
+`total` est le décompte de **l'ensemble** des résultats, pas de la page courante. `link` porte `self`,
+plus `next` et `previous` lorsqu'ils existent — suivez `next` plutôt que de calculer les décalages
+vous-même. Notez que la relation s'écrit `previous`, et non `prev` comme en FHIR. Pour le point
+d'entrée `children`, l'`id` du Bundle vaut `children-{id_du_parent}` au lieu de `search-results`.
+
+Le double slash dans `fullUrl` n'est pas une coquille de ce guide : l'implémentation concatène une URL
+de base qui se termine déjà par `/` avec `/{id}`. N'extrayez pas les identifiants de `fullUrl` ; lisez
+`entry[].resource.id`.
+
+!!! danger "La pagination n'est pas stable — dédoublonnez par `id`"
+    La requête sous-jacente n'a **aucun tri** : `OrgUnit` ne déclare pas d'ordre par défaut et la vue
+    FHIR n'en ajoute aucun, alors même que les résultats sont paginés par limite et décalage.
+    PostgreSQL est libre de renvoyer les lignes dans un ordre différent à chaque requête : parcourir un
+    grand jeu de résultats **peut donc vous montrer deux fois la même unité d'organisation et en
+    omettre une autre**. Aucun paramètre `_sort` ne permet d'y remédier.
+
+    Deux parades concrètes, toutes deux employées dans les exemples ci-dessous : demandez la plus
+    grande page possible (`_count=100`) pour réduire le nombre d'allers-retours, et **dédoublonnez par
+    `id`** au fil de l'eau plutôt que de supposer les pages disjointes. S'il vous faut un instantané
+    garanti complet d'une grande pyramide, `/api/orgunits/` est la voie de lecture la plus sûre.
+
+    Tout ce qui tient en une seule page (tout jeu de 100 résultats ou moins, et la plupart des appels
+    à `children`) n'est pas concerné.
+
+## La ressource Location
+
+Un exemple complet, pour un établissement de santé doté d'un parent, de coordonnées et de dates :
+
+```json
+{
+  "resourceType": "Location",
+  "id": "123",
+  "meta": {
+    "versionId": "1",
+    "profile": ["https://hl7.org/fhir/StructureDefinition/Location"],
+    "lastUpdated": "2026-07-14T10:30:00.123456+00:00"
+  },
+  "identifier": [
+    {"use": "official", "system": "https://openiaso.com/org-unit/Pyramide nationale/source-ref", "value": "HF001"},
+    {"use": "secondary", "system": "https://openiaso.com/org-unit/uuid", "value": "country-uuid-123"},
+    {"use": "secondary", "system": "https://openiaso.com/org-unit/alias", "value": "TC"}
+  ],
+  "status": "active",
+  "name": "Test Health Facility",
+  "mode": "instance",
+  "type": [
+    {
+      "coding": [
+        {"system": "https://openiaso.com/org-unit-type", "code": "HF", "display": "Health Facility"}
+      ],
+      "text": "Health Facility"
+    }
+  ],
+  "physicalType": {
+    "coding": [{"system": "https://terminology.hl7.org/CodeSystem/location-physical-type", "code": "bu"}]
+  },
+  "position": {"longitude": 29.1947, "latitude": -5.9236, "altitude": 0.0},
+  "partOf": {"reference": "Location/122", "display": "Test District"},
+  "managingOrganization": {"display": "Pyramide nationale"},
+  "operationalStatus": {
+    "coding": [{"system": "https://terminology.hl7.org/CodeSystem/v2-0116", "code": "O", "display": "Open"}]
+  },
+  "extension": [
+    {"url": "https://openiaso.com/fhir/StructureDefinition/org-unit-validation-status", "valueCode": "VALID"},
+    {"url": "https://openiaso.com/fhir/StructureDefinition/org-unit-type-depth", "valueInteger": 3},
+    {"url": "https://openiaso.com/fhir/StructureDefinition/source-version", "valueString": "1"},
+    {"url": "https://openiaso.com/fhir/StructureDefinition/opening-date", "valueDate": "2019-03-01"}
+  ]
+}
+```
+
+### Champ par champ
+
+| Champ FHIR | Provient de | Notes |
+|---|---|---|
+| `id` | `OrgUnit.id` | une chaîne, pas un nombre |
+| `meta.versionId` | — | figé à `"1"` ; ne suit aucune révision |
+| `meta.lastUpdated` | `updated_at` | ISO 8601 |
+| `identifier` | `source_ref`, `uuid`, `aliases` | voir ci-dessous |
+| `status` | `validation_status` | voir la correspondance ci-dessous — **à lire attentivement** |
+| `name` | `name` | |
+| `mode` | — | toujours `"instance"` |
+| `type[].coding[].code` | `org_unit_type.short_name` | le **nom court**, p. ex. `HF` |
+| `type[].coding[].display`, `type[].text` | `org_unit_type.name` | p. ex. `Health Facility` |
+| `physicalType` | `org_unit_type.category` | `COUNTRY`→`co`, `REGION`/`DISTRICT`→`area`, `HF`→`bu`, tout le reste→`si` |
+| `position` | `location` | `longitude`, `latitude`, et `altitude` quand le point porte un Z |
+| `partOf` | `parent` | `{"reference": "Location/<id>", "display": "<nom du parent>"}` |
+| `managingOrganization.display` | `version.data_source.name` | une simple chaîne d'affichage — il n'existe aucune ressource `Organization` à référencer |
+| `operationalStatus` | `closed_date` / `opening_date` | `C`/Closed si une date de fermeture existe, sinon `O`/Open si une date d'ouverture existe, sinon absent |
+| `extension` | statut de validation, profondeur du type, version de source, dates d'ouverture et de fermeture | voir ci-dessous |
+
+Le tableau `identifier` contient jusqu'à trois types d'entrées, et seulement celles qui sont
+renseignées :
+
+- la **référence source**, avec `use: "official"` et un système qui incorpore le nom de la source de
+  données : `https://openiaso.com/org-unit/{nom de la source}/source-ref`. Le nom étant interpolé dans
+  l'URL du système, cette chaîne diffère d'une source à l'autre et peut contenir des espaces.
+- l'**uuid IASO**, avec `use: "secondary"` et le système `https://openiaso.com/org-unit/uuid`.
+- une entrée **par alias**, avec `use: "secondary"` et le système `https://openiaso.com/org-unit/alias`.
+
+Le tableau `extension` porte les données propres à IASO qui n'ont pas de place en FHIR :
+
+| URL d'extension (préfixe `https://openiaso.com/fhir/StructureDefinition/`) | Valeur | Présente quand |
+|---|---|---|
+| `org-unit-validation-status` | `valueCode` : `NEW` \| `VALID` \| `REJECTED` | toujours |
+| `org-unit-type-depth` | `valueInteger` | le type a une profondeur |
+| `source-version` | `valueString` — le **numéro** de version, pas son id | l'unité a une version |
+| `opening-date` | `valueDate` | renseignée |
+| `closed-date` | `valueDate` | renseignée |
+
+Si le véritable statut de validation IASO vous importe, lisez l'extension
+`org-unit-validation-status` plutôt que de le déduire de `status` : c'est la valeur non transformée et
+sans ambiguïté.
+
+### La correspondance des statuts
+
+`Location.status` est un code contraint par FHIR : les trois statuts de validation d'IASO y sont donc
+comprimés ainsi :
+
+| `validation_status` IASO | `Location.status` FHIR |
+|---|---|
+| `VALID` | `active` |
+| `NEW` | `inactive` |
+| `REJECTED` | `suspended` |
+
+!!! danger "C'est contre-intuitif, et le README du module l'indique à l'envers"
+    Une unité d'organisation **rejetée** apparaît comme `suspended`, et une unité **nouvelle / pas
+    encore validée** apparaît comme `inactive`. Il est facile de supposer l'inverse.
+    `iaso/api/fhir/README.md` documente exactement la correspondance inverse et se trompe ; le code et
+    ses tests s'accordent sur le tableau ci-dessus.
+
+    Filtrer sur `?status=active` est donc la bonne façon de n'obtenir que les unités validées — ce que
+    veut d'ailleurs la plupart des intégrations.
+
+## Paramètres de recherche
+
+Tous ces paramètres s'appliquent à `GET /api/fhir/Location/`.
+
+| Paramètre | Type | Sémantique |
+|---|---|---|
+| `name` | string | correspondance **partielle**, insensible à la casse, sur le nom |
+| `status` | token | `active` \| `inactive` \| `suspended`, selon la correspondance ci-dessus. Une valeur inconnue renvoie un `400` ordinaire, et non un `OperationOutcome` |
+| `identifier` | token | correspondance **exacte** sur `source_ref`, ou `uuid`, ou l'un des alias |
+| `type` | token | correspondance **exacte** et sensible à la casse sur le `short_name` du type d'unité (p. ex. `HF`, et non `Health Facility`) |
+| `search` | string | correspondance partielle sur le nom ; convention DRF, équivalente ici à `name` |
+| `_count` | number | taille de page. Défaut **20**, maximum **100** — au-delà, la valeur est silencieusement ramenée à 100 |
+| `_skip` | number | décalage |
+
+Les filtres se combinent en ET.
+
+`identifier` est le paramètre à utiliser pour résoudre vos propres références externes en identifiants
+IASO : il correspond exactement au `source_ref`, le champ qu'une intégration IASO renseigne
+habituellement avec l'identifiant du système source. Passez la **valeur nue** — la syntaxe de jeton
+FHIR `system|value` n'est pas analysée, et une requête comme
+`?identifier=https://openiaso.com/org-unit/uuid|abc` ne correspond tout simplement à rien.
+
+Il n'existe aucun filtre sur le parent, la version de source, la date ou le groupe, ni de `_sort`,
+`_id`, `_lastUpdated`, `_include`, `_elements` ou `_summary`. Pour parcourir l'arbre, utilisez
+`children`.
+
+!!! warning "Les résultats couvrent toutes les versions de source visibles par votre compte"
+    Il n'existe aucun moyen de restreindre une recherche FHIR à une source de données ou à une version
+    de source. Si votre compte détient plusieurs pyramides, ou plusieurs versions de la même, elles
+    apparaissent toutes dans le même jeu de résultats — et un même établissement réel peut légitimement
+    y figurer plusieurs fois, sous la forme d'une `Location` distincte par version. L'extension
+    `source-version` de chaque ressource est le seul moyen de les distinguer. Si cela vous importe,
+    filtrez côté client sur cette extension, ou lisez les unités d'organisation via
+    [`/api/orgunits/`](../modify_org_units_via_api/modify_org_units_via_api.md), qui accepte, lui, un
+    paramètre `version`.
+
+## Parcourir la hiérarchie
+
+```
+GET /api/fhir/Location/{id}/children/
+```
+
+Renvoie un Bundle des enfants **directs** uniquement — un seul niveau, pas tout le sous-arbre. Pour
+parcourir une pyramide, procédez par récursion.
+
+## Exemples en Python
+
+En réutilisant le même `IasoClient` que dans le [guide d'écriture des unités
+d'organisation](../modify_org_units_via_api/modify_org_units_via_api.md#un-petit-client-comme-socle) :
+
+### Parcourir toutes les Locations page par page
+
+Suivez le lien `next` plutôt que d'incrémenter `_skip` vous-même, et dédoublonnez au fil de l'eau : la
+pagination n'étant pas triée de façon stable, une ressource peut légitimement apparaître sur deux pages
+consécutives.
+
+```python
+def iter_locations(iaso, **params):
+    """Produit chaque ressource Location une seule fois, en suivant les liens next du Bundle."""
+    params.setdefault("_count", 100)          # 100 est le maximum côté serveur
+    bundle = iaso.get("/api/fhir/Location/", params=params)
+    seen = set()
+
+    while True:
+        for entry in bundle.get("entry", []):
+            location = entry["resource"]
+            if location["id"] in seen:        # pagination non triée : les doublons arrivent
+                continue
+            seen.add(location["id"])
+            yield location
+
+        next_link = next(
+            (l["url"] for l in bundle.get("link", []) if l["relation"] == "next"),
+            None,
+        )
+        if not next_link:
+            return
+        # next_link est une URL absolue ; on la redonne telle quelle à la session.
+        bundle = iaso.session.get(next_link, timeout=60).json()
+
+
+for location in iter_locations(iaso, status="active", type="HF"):
+    print(location["id"], location["name"])
+```
+
+Le dédoublonnage vous protège de voir deux fois la même ressource, mais rien, au niveau de l'API, ne
+vous protège d'en *manquer* une. Si l'exhaustivité est critique, comparez le nombre d'identifiants
+uniques collectés au `total` du Bundle, et repliez-vous sur `/api/orgunits/` en cas d'écart.
+
+### Résoudre une de vos références en identifiant IASO
+
+```python
+def find_by_source_ref(iaso, source_ref):
+    bundle = iaso.get("/api/fhir/Location/", params={"identifier": source_ref})
+    entries = bundle.get("entry", [])
+    if not entries:
+        return None
+    return entries[0]["resource"]
+
+location = find_by_source_ref(iaso, "HF001")
+if location:
+    print(location["id"], location["name"], location["status"])
+```
+
+### Parcourir l'arbre en profondeur
+
+```python
+def walk(iaso, root_id, depth=0):
+    location = iaso.get(f"/api/fhir/Location/{root_id}/")
+    print("  " * depth + f"{location['name']} ({location['status']})")
+
+    bundle = iaso.get(f"/api/fhir/Location/{root_id}/children/", params={"_count": 100})
+    for entry in bundle.get("entry", []):
+        walk(iaso, entry["resource"]["id"], depth + 1)
+```
+
+Notez que cela déclenche une requête par nœud. Pour une pyramide entière, tout lister une seule fois
+avec `iter_locations()` et reconstruire l'arbre en mémoire à partir de `partOf` revient bien moins
+cher :
+
+```python
+def build_tree(iaso):
+    children_by_parent = {}
+    for location in iter_locations(iaso):
+        part_of = location.get("partOf") or {}
+        reference = part_of.get("reference")            # "Location/122", ou absent pour une racine
+        parent_id = reference.split("/")[1] if reference else None
+        children_by_parent.setdefault(parent_id, []).append(location)
+    return children_by_parent                           # la clé None porte les racines
+```
+
+### Lire le véritable statut de validation IASO
+
+```python
+VALIDATION_STATUS = "https://openiaso.com/fhir/StructureDefinition/org-unit-validation-status"
+
+def validation_status(location):
+    for ext in location.get("extension", []):
+        if ext["url"] == VALIDATION_STATUS:
+            return ext["valueCode"]      # "NEW" | "VALID" | "REJECTED"
+    return None
+```
+
+## Erreurs
+
+Une location introuvable — ou hors périmètre — renvoie un `404` accompagné d'un `OperationOutcome`
+FHIR :
+
+```json
+{
+  "resourceType": "OperationOutcome",
+  "issue": [
+    {
+      "severity": "error",
+      "code": "not-found",
+      "details": {"text": "Location with id '999' not found"}
+    }
+  ]
+}
+```
+
+Les `401` et `403` sont des erreurs DRF classiques, et **non** des ressources `OperationOutcome` : ne
+supposez donc pas que tout corps d'erreur porte un `resourceType`.
+
+## Réserves de conformité
+
+L'API est de forme FHIR R4 et déclare `fhirVersion: "4.0.1"` dans sa déclaration de conformité, mais
+un client FHIR strict remarquera ce qui suit. Rien de bloquant si vous écrivez le client vous-même ;
+tout cela compte si vous branchez un outil FHIR du commerce dessus.
+
+- **Les éléments vides sont émis sous forme de `{}` ou `[]` plutôt qu'omis.** Une unité d'organisation
+  sans coordonnées renvoie tout de même `"position": {}` ; une unité sans parent renvoie
+  `"partOf": {}` ; de même pour `physicalType`, `managingOrganization`, `operationalStatus` et `type`.
+  FHIR attend que les éléments absents soient omis, et un validateur rejettera `"position": {}` car
+  `longitude` et `latitude` sont obligatoires dès lors que `position` est présent. **Testez la
+  véracité de la valeur, pas la présence de la clé.**
+- **N'envoyez pas `Accept: application/fhir+json` — vous obtiendrez un `406`.** Les points d'entrée
+  sont servis par le rendu JSON ordinaire, qui n'annonce pas le type de média FHIR : la négociation de
+  contenu échoue donc purement et simplement. Envoyez `Accept: application/json` (ou rien du tout).
+  Les réponses reviennent en `Content-Type: application/json`.
+- **Les systèmes de terminologie sont écrits en `https://`**, p. ex.
+  `https://terminology.hl7.org/CodeSystem/location-physical-type`. Les URI canoniques de HL7 utilisent
+  `http://`, et une URI de système est un identifiant opaque plutôt qu'une URL à déréférencer : ces
+  codages ne correspondront donc **pas** à un serveur de terminologie standard ni à un validateur
+  attendant la forme canonique. Il en va de même pour `meta.profile`, donné comme
+  `https://hl7.org/fhir/StructureDefinition/Location`.
+- **La déclaration de conformité est à `/api/fhir/Location/metadata/`**, et non à la racine du serveur
+  `/metadata`, et elle **exige une authentification** — deux écarts à la norme : la découverte
+  automatique de conformité échoue donc. Elle omet par ailleurs des éléments obligatoires en R4
+  (`url`, `version`, `name`), et l'`OperationDefinition` qu'elle référence pour `children` n'est servie
+  nulle part.
+- **`meta.versionId` vaut toujours `"1"`** et il n'existe pas d'`_history` ; la ressource n'est pas
+  versionnée. Faute de paramètre de recherche `_lastUpdated`, **il n'existe aucune synchronisation
+  incrémentale** : vous relisez tout, à chaque fois.
+- **Le `system` de l'identifiant de référence source incorpore le nom de la source de données** : ce
+  n'est donc pas une URI opaque et stable, et elle peut contenir des espaces. Appuyez-vous sur
+  `use == "official"` ou sur la valeur, jamais sur la chaîne du système.
+- **`managingOrganization` porte un `display` mais aucune `reference`**, faute de point d'entrée
+  `Organization` à référencer.
+- **`operationalStatus` est enveloppé dans `{"coding": [...]}`**, alors que FHIR le type comme un
+  simple `Coding`. Une date de fermeture l'emporte toujours sur une date d'ouverture, même si elle est
+  dans le futur.
+- **`fullUrl` contient un double slash** (`.../Location//123`).
+
+Une remarque d'exploitation, qui n'est pas un problème de conformité : le compte de service avec lequel
+vous vous authentifiez doit avoir un profil IASO rattaché. Un utilisateur qui n'en a pas — ce qui est
+possible pour un super-utilisateur créé hors du flux normal — provoque un `500` plutôt qu'une erreur
+propre.
+
+## Aide-mémoire des pièges
+
+- Le chemin de base est `/api/fhir/Location/`, et **non** `/fhir/Location/` comme l'affirme le README du module.
+- `NEW` → `inactive` et `REJECTED` → `suspended`, et non l'inverse. Le README du module les intervertit.
+- La pagination **n'est pas triée de façon stable** — dédoublonnez par `id` et comparez votre décompte au `total`.
+- `Accept: application/fhir+json` est rejeté par un `406`. Demandez `application/json`.
+- Les systèmes d'identifiants et de terminologie utilisent `https://`, et non le `http://` canonique de HL7.
+- Les unités hors périmètre renvoient un `404`, pas un `403` — un `404` ne signifie pas que l'identifiant est libre.
+- Les résultats couvrent toutes les versions de source visibles par votre compte ; aucun filtre de version n'existe.
+- `type` correspond au **nom court** du type d'unité, pas à son nom d'affichage.
+- `identifier` prend une valeur nue ; la syntaxe de jeton `system|value` ne correspond à rien.
+- Un `status` invalide renvoie un `400` ordinaire, et non un `OperationOutcome`.
+- `_count` plafonne à 100 et est silencieusement ramené ; la taille de page par défaut est 20.
+- `children` ne renvoie que les enfants directs, un niveau à la fois.
+- Les champs absents reviennent sous forme de `{}` / `[]`, et non omis — testez la véracité de la valeur.
+- Lisez `status` pour la vue FHIR, et l'extension `org-unit-validation-status` pour le vrai statut IASO.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,6 +62,8 @@ plugins:
                   - ./pages/dev/how_to/use_iaso_apis/use_iaso_apis.md
                   # - Modify org units via the API:
                   - ./pages/dev/how_to/modify_org_units_via_api/modify_org_units_via_api.md
+                  # - Read org units via the FHIR API:
+                  - ./pages/dev/how_to/read_org_units_via_fhir/read_org_units_via_fhir.md
                   # - Run docs locally:
                   #   - ./pages/dev/how_to/run_docs_locally/run_docs_locally.md
                   # - Write a visit on an NFC card:
@@ -117,6 +119,8 @@ plugins:
                   - ./pages/dev/how_to/use_iaso_apis/use_iaso_apis.md
                   # - Modify org units via the API:
                   - ./pages/dev/how_to/modify_org_units_via_api/modify_org_units_via_api.md
+                  # - Read org units via the FHIR API:
+                  - ./pages/dev/how_to/read_org_units_via_fhir/read_org_units_via_fhir.md
                   # - Run docs locally:
                   #   - ./pages/dev/how_to/run_docs_locally/run_docs_locally.md
                   # - Write a visit on an NFC card:
@@ -193,6 +197,8 @@ nav: # nav configures the side bar menu
       - ./pages/dev/how_to/use_iaso_apis/use_iaso_apis.md
       # - Modify org units via the API:
       - ./pages/dev/how_to/modify_org_units_via_api/modify_org_units_via_api.md
+      # - Read org units via the FHIR API:
+      - ./pages/dev/how_to/read_org_units_via_fhir/read_org_units_via_fhir.md
       # - Run docs locally:
       #   - ./pages/dev/how_to/run_docs_locally/run_docs_locally.md
       # - Write a visit on an NFC card:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,9 +60,11 @@ plugins:
                   #   - ./pages/dev/how_to/deploy/deploy.md
                   # - Use the APIs:
                   - ./pages/dev/how_to/use_iaso_apis/use_iaso_apis.md
+                  # - Modify org units via the API:
+                  - ./pages/dev/how_to/modify_org_units_via_api/modify_org_units_via_api.md
                   # - Run docs locally:
                   #   - ./pages/dev/how_to/run_docs_locally/run_docs_locally.md
-                  # - Write a visit on an NFC card: 
+                  # - Write a visit on an NFC card:
                   #   - ./pages/dev/how_to/write_visit_on_nfc/write_visit_on_nfc.md
 
               - En savoir plus sur IASO:
@@ -113,9 +115,11 @@ plugins:
                   #   - ./pages/dev/how_to/deploy/deploy.md
                   # - Use the APIs:
                   - ./pages/dev/how_to/use_iaso_apis/use_iaso_apis.md
+                  # - Modify org units via the API:
+                  - ./pages/dev/how_to/modify_org_units_via_api/modify_org_units_via_api.md
                   # - Run docs locally:
                   #   - ./pages/dev/how_to/run_docs_locally/run_docs_locally.md
-                  # - Write a visit on an NFC card: 
+                  # - Write a visit on an NFC card:
                   #   - ./pages/dev/how_to/write_visit_on_nfc/write_visit_on_nfc.md
 
               - Más sobre IASO:
@@ -187,6 +191,8 @@ nav: # nav configures the side bar menu
       #   - ./pages/dev/how_to/deploy/deploy.md
       # - Use the APIs:
       - ./pages/dev/how_to/use_iaso_apis/use_iaso_apis.md
+      # - Modify org units via the API:
+      - ./pages/dev/how_to/modify_org_units_via_api/modify_org_units_via_api.md
       # - Run docs locally:
       #   - ./pages/dev/how_to/run_docs_locally/run_docs_locally.md
       # - Write a visit on an NFC card:


### PR DESCRIPTION
## What problem is this PR solving?

External organisations that need to read and write the org units of an IASO data source from their own systems have no documentation to work from, and have to reverse-engineer the API.

### Related JIRA tickets

[CHAICMR-233](https://bluesquare.atlassian.net/browse/CHAICMR-233)

## Changes

Adds two developer how-tos, each in English and French, aimed at an external organisation integrating with IASO in Python. They cross-link: FHIR for reads, the org unit API for writes.

- `docs/pages/dev/how_to/modify_org_units_via_api/` — **writing** org units.
- `docs/pages/dev/how_to/read_org_units_via_fhir/` — **reading** them through the FHIR API.
- `mkdocs.yml` — one nav entry per page per language tree (en, fr, es), next to the existing "Use the APIs" guide. The es nav points at the same pages and falls back to English, which is what `use_iaso_apis` already does.

### Guide 1 — modifying org units

Organised around the two write paths and when to use each:

- **Direct modification** — `POST /api/orgunits/create_org_unit/` and `PATCH /api/orgunits/<id>/`, plus the async `orgunitsbulkupdate` task. Requires `iaso_org_units`.
- **Change requests** — `POST /api/orgunits/changes/`. Requires no permission beyond being authenticated and seeing the org unit; a reviewer holding `iaso_org_unit_change_request_review` decides.

It makes explicit something that is easy to get wrong: **a change request cannot create an org unit on its own.** `org_unit_id` is mandatory, so proposing a new org unit means first creating it directly with `validation_status: "NEW"` (which needs `iaso_org_units`) and then submitting a change request against it, which IASO records as kind `org_unit_creation`. A caller with no permissions at all can only propose changes to existing org units.

It also documents the sharp edges an integrator will otherwise hit at runtime: `create_org_unit` parses dates only as `%d-%m-%Y` (an ISO date gives a 500, not a clean 400) while `PATCH` accepts four formats and change requests want ISO; `GET /api/orgunits/` defaults to `validation_status=VALID`, so units you just created as `NEW` are invisible; the list envelope key flips between `orgunits` and `orgUnits` depending on whether you paginate; latitude/longitude/altitude are read as a trio; `groups` replaces rather than appends.

Closes with a complete, copy-pasteable CSV → IASO sync script that runs in either mode.

### Guide 2 — reading org units through FHIR

Documents the read-only FHIR R4 `Location` API: the OrgUnit → Location mapping field by field, the search parameters, `Bundle` pagination, the `children` operation, the `CapabilityStatement`, and `OperationOutcome` errors. States plainly what is *not* there — one resource type only, no writes, no `_include`/`_sort`/`_lastUpdated`, no delta sync.

Two findings worth a reviewer's attention:

- **`iaso/api/fhir/README.md` is wrong on three counts**, and the guide contradicts it deliberately. The base path is `/api/fhir/`, not `/fhir/` (the router is registered in `iaso/urls.py`, which `hat/urls.py:136` mounts under `/api/`). The identifier systems are emitted as `https://`, not `http://`. And the status mapping is `NEW → inactive`, `REJECTED → suspended` — the README states those two backwards, which would make an integrator misread every unvalidated org unit. `constants.py` and `test_validation_status_mapping` both agree with the guide.
- **List pagination is not stably ordered.** `OrgUnit` declares no default ordering and the FHIR viewset adds none, yet results are paged with limit/offset — so paging a large result set can repeat one org unit and skip another. There is no `_sort` to fix it. The guide documents this and the examples deduplicate by `id`.

Neither is fixed here; see Notes.

## How to test

No runtime code is touched — this is documentation only. To review the rendering:

```
mkdocs serve
```

then open *Developers → How to*, check both new pages, and confirm the language switcher shows the French versions.

Note that `docs/venv` in the repo is currently broken on Apple Silicon (its Python symlink points at `/usr/local/opt/python@3.13`, an Intel-homebrew path), so it needs a fresh env. I validated that `mkdocs.yml` parses, that all nav targets resolve to files on disk, and that the two guides' cross-links point at real pages — but I did not run a full `mkdocs build`.

The API behaviours documented here were each read off the current implementation (`iaso/api/org_units.py`, `iaso/api/org_unit_change_requests/`, `iaso/api/fhir/`) and its tests rather than assumed. Reviewers who know these endpoints well are the right people to sanity-check the quirks lists.

## Print screen / video

N/A — text documentation.

## Notes

- **The quirks are documented, not fixed.** Several look like genuine bugs worth their own tickets rather than warnings in prose: the `create_org_unit` 500 on an ISO date, the `orgunits`/`orgUnits` envelope switch, the unordered FHIR pagination, the `fullUrl` double slash (`.../Location//123`), and `Accept: application/fhir+json` being rejected with a 406 by a FHIR API. Happy to split these out if you agree they are real.
- **`iaso/api/fhir/README.md` is left untouched** even though this PR shows it to be wrong in three places. Correcting or deleting it felt out of scope for a docs PR, but it should not survive much longer in its current state — it actively misleads.
- The write guide deliberately stops at the submitter's side of change requests. The review API (`PATCH /api/orgunits/changes/<id>/`, `bulk_review`) is not documented, since an external organisation does not hold the review permission.
- No Spanish translations; the es nav entries fall back to English, consistent with the neighbouring guides.

## Doc

This PR *is* the doc: `docs/pages/dev/how_to/modify_org_units_via_api/` and `docs/pages/dev/how_to/read_org_units_via_fhir/`, published under Developers → How to.


[CHAICMR-233]: https://bluesquare.atlassian.net/browse/CHAICMR-233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ