### PR TITLE
SLEEP-1817: soft deleted instances in entity filters

### DIFF
--- a/iaso/api/entities/filters.py
+++ b/iaso/api/entities/filters.py
@@ -87,7 +87,7 @@ class EntityDateFilterBackend(filters.BaseFilterBackend):
             except ValueError:
                 end = timezone.make_aware(datetime.max, timezone.get_default_timezone())
 
-            instance_qs = Instance.objects.filter(entity=OuterRef("pk"))
+            instance_qs = Instance.objects.filter(entity=OuterRef("pk"), deleted=False)
             queryset = queryset.filter(
                 Exists(
                     instance_qs.filter(

--- a/iaso/api/entities/filters.py
+++ b/iaso/api/entities/filters.py
@@ -87,7 +87,7 @@ class EntityDateFilterBackend(filters.BaseFilterBackend):
             except ValueError:
                 end = timezone.make_aware(datetime.max, timezone.get_default_timezone())
 
-            instance_qs = Instance.objects.filter(entity=OuterRef("pk"), deleted=False)
+            instance_qs = Instance.non_deleted_objects.filter(entity=OuterRef("pk"))
             queryset = queryset.filter(
                 Exists(
                     instance_qs.filter(

--- a/iaso/api/entities/views.py
+++ b/iaso/api/entities/views.py
@@ -197,7 +197,9 @@ class EntityViewSet(ModelViewSet):
             queryset = queryset.prefetch_related(
                 Prefetch(
                     "instances",
-                    queryset=Instance.objects.only("id", "entity_id", "source_created_at", "created_at"),
+                    queryset=Instance.objects.filter(deleted=False).only(
+                        "id", "entity_id", "source_created_at", "created_at"
+                    ),
                 ),
             )
 
@@ -272,7 +274,7 @@ class EntityViewSet(ModelViewSet):
         return Response(serializer.data)
 
     def retrieve(self, request, pk=None):
-        queryset = Entity.objects.filter_for_user(self.request.user).distinct()
+        queryset = self.get_queryset().distinct()
         entity = get_object_or_404(queryset, pk=pk)
         serializer = self.get_serializer(entity, many=False)
         return Response(serializer.data)

--- a/iaso/api/entities/views.py
+++ b/iaso/api/entities/views.py
@@ -197,9 +197,7 @@ class EntityViewSet(ModelViewSet):
             queryset = queryset.prefetch_related(
                 Prefetch(
                     "instances",
-                    queryset=Instance.objects.filter(deleted=False).only(
-                        "id", "entity_id", "source_created_at", "created_at"
-                    ),
+                    queryset=Instance.non_deleted_objects.only("id", "entity_id", "source_created_at", "created_at"),
                 ),
             )
 

--- a/iaso/models/entity.py
+++ b/iaso/models/entity.py
@@ -137,7 +137,7 @@ class ProjectNotFoundError(ValidationError):
 
 class EntityQuerySet(models.QuerySet):
     def _filter_entities_with_instances(self, *, limit_date=None, org_units_qs=None):
-        instances = Instance.objects.all()
+        instances = Instance.non_deleted_objects.all()
 
         if org_units_qs is not None:
             instances = instances.filter(org_unit__in=org_units_qs)

--- a/iaso/tests/api/entities/test_entities.py
+++ b/iaso/tests/api/entities/test_entities.py
@@ -913,23 +913,43 @@ class WebEntityAPITestCase(EntityAPITestCase):
     def test_list_entities_filter_by_date_soft_deleted_instances(self):
         self.client.force_authenticate(self.yoda)
 
-        source_date = datetime.datetime(2024, 9, 12, 0, 0, 5, tzinfo=pytz.UTC)
+        source_date_attr = datetime.datetime(2024, 9, 12, 0, 0, 5, tzinfo=pytz.UTC)
+        source_date_attr_str = source_date_attr.strftime("%Y-%m-%d")
+
+        source_date = datetime.datetime(2024, 10, 15, 0, 0, 5, tzinfo=pytz.UTC)
         source_date_str = source_date.strftime("%Y-%m-%d")
 
         entity_type = EntityType.objects.create(name="ET", reference_form=self.form_1)
 
-        instance = Instance.objects.create(form=self.form_1, source_created_at=source_date)
-        instance.entity = Entity.objects.create(entity_type=entity_type, attributes=instance, account=self.account)
-        instance.save()
+        # initialize both an attribute and non-attribute Instance
+        inst_attr = Instance.objects.create(form=self.form_1, source_created_at=source_date_attr)
+        entity = Entity.objects.create(entity_type=entity_type, attributes=inst_attr, account=self.account)
+        inst_attr.entity = entity
+        inst_attr.save()
 
+        inst = Instance.objects.create(form=self.form_1, source_created_at=source_date, entity=entity)
+
+        # test regular instance
         response = self.client.get(f"/api/entities/?dateFrom={source_date_str}&dateTo={source_date_str}")
         resp = self.assertJSONResponse(response, status.HTTP_200_OK)
         self.assertEqual(len(resp["result"]), 1)
 
-        instance.deleted = True
-        instance.save()
+        inst.deleted = True
+        inst.save()
 
         response = self.client.get(f"/api/entities/?dateFrom={source_date_str}&dateTo={source_date_str}")
+        res = self.assertJSONResponse(response, status.HTTP_200_OK)
+        self.assertEqual(len(res["result"]), 0)
+
+        # test attribute instance
+        response = self.client.get(f"/api/entities/?dateFrom={source_date_attr_str}&dateTo={source_date_attr_str}")
+        resp = self.assertJSONResponse(response, status.HTTP_200_OK)
+        self.assertEqual(len(resp["result"]), 1)
+
+        inst_attr.deleted = True
+        inst_attr.save()
+
+        response = self.client.get(f"/api/entities/?dateFrom={source_date_attr_str}&dateTo={source_date_attr_str}")
         res = self.assertJSONResponse(response, status.HTTP_200_OK)
         self.assertEqual(len(res["result"]), 0)
 

--- a/iaso/tests/api/entities/test_entities.py
+++ b/iaso/tests/api/entities/test_entities.py
@@ -886,8 +886,22 @@ class WebEntityAPITestCase(EntityAPITestCase):
         res = self.assertJSONResponse(response, status.HTTP_200_OK)
         self.assertEqual(len(res["result"]), 1)
 
+        # Soft-delete non-attributes instance
         inst2.deleted = True
         inst2.save()
+
+        response = self.client.get(
+            "/api/entities/",
+            {"fields_search": self._generate_json_filter("and", "some", "F", "Bujumbura")},
+        )
+        res = self.assertJSONResponse(response, status.HTTP_200_OK)
+        self.assertEqual(len(res["result"]), 0)
+
+        # Restore non-attributes instance, and soft-delete attributes instance
+        inst2.deleted = False
+        inst2.save()
+        ent1_instance1.deleted = True
+        ent1_instance1.save()
 
         response = self.client.get(
             "/api/entities/",

--- a/iaso/tests/api/entities/test_entities.py
+++ b/iaso/tests/api/entities/test_entities.py
@@ -13,6 +13,7 @@ from django.core.files import File
 from django.db import connection
 from django.test.utils import CaptureQueriesContext
 from django.utils import timezone
+from rest_framework import status
 
 from iaso import models as m
 from iaso.api.common import EXPORTS_DATETIME_FORMAT
@@ -852,6 +853,90 @@ class WebEntityAPITestCase(EntityAPITestCase):
                 ]
             }
         )
+
+    def test_list_entities_fields_search_soft_deleted_instances(self):
+        self.client.force_authenticate(self.yoda)
+        self.form_2 = m.Form.objects.create(name="Form 2", form_id="form_2")
+
+        ent1_instance1 = Instance.objects.create(
+            org_unit=self.ou_country,
+            form=self.form_1,
+            json={"gender": "F"},
+        )
+        ent1 = Entity.objects.create(
+            name="Ent 1",
+            entity_type=self.entity_type,
+            attributes=ent1_instance1,
+            account=self.account,
+        )
+        ent1_instance1.entity = ent1
+        ent1_instance1.save()
+
+        inst2 = Instance.objects.create(
+            org_unit=self.ou_country,
+            form=self.form_2,
+            json={"residence": "Bujumbura"},
+            entity=ent1,
+        )
+
+        response = self.client.get(
+            "/api/entities/",
+            {"fields_search": self._generate_json_filter("and", "some", "F", "Bujumbura")},
+        )
+        res = self.assertJSONResponse(response, status.HTTP_200_OK)
+        self.assertEqual(len(res["result"]), 1)
+
+        inst2.deleted = True
+        inst2.save()
+
+        response = self.client.get(
+            "/api/entities/",
+            {"fields_search": self._generate_json_filter("and", "some", "F", "Bujumbura")},
+        )
+        res = self.assertJSONResponse(response, status.HTTP_200_OK)
+        self.assertEqual(len(res["result"]), 0)
+
+    def test_list_entities_filter_by_date_soft_deleted_instances(self):
+        self.client.force_authenticate(self.yoda)
+
+        source_date = datetime.datetime(2024, 9, 12, 0, 0, 5, tzinfo=pytz.UTC)
+        source_date_str = source_date.strftime("%Y-%m-%d")
+
+        entity_type = EntityType.objects.create(name="ET", reference_form=self.form_1)
+
+        instance = Instance.objects.create(form=self.form_1, source_created_at=source_date)
+        instance.entity = Entity.objects.create(entity_type=entity_type, attributes=instance, account=self.account)
+        instance.save()
+
+        response = self.client.get(f"/api/entities/?dateFrom={source_date_str}&dateTo={source_date_str}")
+        resp = self.assertJSONResponse(response, status.HTTP_200_OK)
+        self.assertEqual(len(resp["result"]), 1)
+
+        instance.deleted = True
+        instance.save()
+
+        response = self.client.get(f"/api/entities/?dateFrom={source_date_str}&dateTo={source_date_str}")
+        res = self.assertJSONResponse(response, status.HTTP_200_OK)
+        self.assertEqual(len(res["result"]), 0)
+
+    def test_list_entities_prefetch_soft_deleted_instances(self):
+        self.client.force_authenticate(self.yoda)
+
+        entity_type = EntityType.objects.create(name="ET2", reference_form=self.form_1)
+
+        # Entity with 1 active instance and 1 soft-deleted instance
+        instance_active = Instance.objects.create(form=self.form_1)
+        entity = Entity.objects.create(entity_type=entity_type, attributes=instance_active, account=self.account)
+        instance_active.entity = entity
+        instance_active.save()
+
+        Instance.objects.create(form=self.form_1, entity=entity, deleted=True)
+
+        response = self.client.get(f"/api/entities/{entity.id}/", format="json")
+        resp = self.assertJSONResponse(response, status.HTTP_200_OK)
+
+        self.assertEqual(len(resp["instances"]), 1)
+        self.assertEqual(resp["instances"][0], instance_active.id)
 
     def test_get_entity_by_id(self):
         self.client.force_authenticate(self.yoda)

--- a/iaso/tests/api/entities/test_entities_mobile.py
+++ b/iaso/tests/api/entities/test_entities_mobile.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 import uuid
 
 from django.db import connection
@@ -207,3 +208,64 @@ class MobileEntityAPITestCase(EntityAPITestCase):
         response = self.client.get(url, {"app_id": self.project.app_id, "limit_date": limit_date_str})
         response_json = self.assertJSONResponse(response, status.HTTP_200_OK)
         self.assertEqual(response_json["count"], 1)
+
+    def test_list_entities_filter_by_json_content(self):
+        self.client.force_authenticate(self.yoda)
+
+        # context for the serializer
+        m.FormVersion.objects.create(form=self.form_1, version_id="1")
+
+        inst_a = self.create_form_instance(
+            project=self.project,
+            org_unit=self.ou_country,
+            form=self.form_1,
+            json={"_version": "1", "name": "Robert", "age__int__": 25},
+        )
+        entity_a = m.Entity.objects.create(
+            name="entity_a",
+            entity_type=self.entity_type,
+            attributes=inst_a,
+            account=self.account,
+        )
+        inst_a.entity = entity_a
+        inst_a.save()
+
+        inst_b = self.create_form_instance(
+            project=self.project,
+            org_unit=self.ou_country,
+            form=self.form_1,
+            json={"_version": "1", "name": "Luke", "age__int__": 19},
+        )
+        entity_b = m.Entity.objects.create(
+            name="entity_b",
+            entity_type=self.entity_type,
+            attributes=inst_b,
+            account=self.account,
+        )
+        inst_b.entity = entity_b
+        inst_b.save()
+
+        json_content_filter_1 = json.dumps({"==": [{"var": "age__int__"}, 25]})
+        response = self.client.get(
+            self.BASE_URL, {"app_id": self.project.app_id, "json_content": json_content_filter_1}
+        )
+        response_json = self.assertJSONResponse(response, status.HTTP_200_OK)
+        self.assertEqual(response_json["count"], 1)
+        self.assertEqual(response_json["results"][0]["id"], str(entity_a.uuid))
+
+        json_content_filter_2 = json.dumps({"==": [{"var": "name"}, "Luke"]})
+        response = self.client.get(
+            self.BASE_URL, {"app_id": self.project.app_id, "json_content": json_content_filter_2}
+        )
+        response_json = self.assertJSONResponse(response, status.HTTP_200_OK)
+        self.assertEqual(response_json["count"], 1)
+        self.assertEqual(response_json["results"][0]["id"], str(entity_b.uuid))
+
+        inst_a.deleted = True
+        inst_a.save()
+
+        response = self.client.get(
+            self.BASE_URL, {"app_id": self.project.app_id, "json_content": json_content_filter_1}
+        )
+        response_json = self.assertJSONResponse(response, status.HTTP_200_OK)
+        self.assertEqual(response_json["count"], 0)

--- a/iaso/tests/api/entities/test_entities_mobile.py
+++ b/iaso/tests/api/entities/test_entities_mobile.py
@@ -209,7 +209,7 @@ class MobileEntityAPITestCase(EntityAPITestCase):
         response_json = self.assertJSONResponse(response, status.HTTP_200_OK)
         self.assertEqual(response_json["count"], 1)
 
-    def test_list_entities_filter_by_json_content(self):
+    def test_get_entities_by_type_filtered_by_json_content(self):
         self.client.force_authenticate(self.yoda)
 
         # context for the serializer
@@ -245,18 +245,16 @@ class MobileEntityAPITestCase(EntityAPITestCase):
         inst_b.entity = entity_b
         inst_b.save()
 
+        url = f"/api/mobile/entitytypes/{self.entity_type.pk}/entities/"
+
         json_content_filter_1 = json.dumps({"==": [{"var": "age__int__"}, 25]})
-        response = self.client.get(
-            self.BASE_URL, {"app_id": self.project.app_id, "json_content": json_content_filter_1}
-        )
+        response = self.client.get(url, {"app_id": self.project.app_id, "json_content": json_content_filter_1})
         response_json = self.assertJSONResponse(response, status.HTTP_200_OK)
         self.assertEqual(response_json["count"], 1)
         self.assertEqual(response_json["results"][0]["id"], str(entity_a.uuid))
 
         json_content_filter_2 = json.dumps({"==": [{"var": "name"}, "Luke"]})
-        response = self.client.get(
-            self.BASE_URL, {"app_id": self.project.app_id, "json_content": json_content_filter_2}
-        )
+        response = self.client.get(url, {"app_id": self.project.app_id, "json_content": json_content_filter_2})
         response_json = self.assertJSONResponse(response, status.HTTP_200_OK)
         self.assertEqual(response_json["count"], 1)
         self.assertEqual(response_json["results"][0]["id"], str(entity_b.uuid))
@@ -264,8 +262,6 @@ class MobileEntityAPITestCase(EntityAPITestCase):
         inst_a.deleted = True
         inst_a.save()
 
-        response = self.client.get(
-            self.BASE_URL, {"app_id": self.project.app_id, "json_content": json_content_filter_1}
-        )
+        response = self.client.get(url, {"app_id": self.project.app_id, "json_content": json_content_filter_1})
         response_json = self.assertJSONResponse(response, status.HTTP_200_OK)
         self.assertEqual(response_json["count"], 0)

--- a/iaso/tests/api/entities/test_entities_mobile.py
+++ b/iaso/tests/api/entities/test_entities_mobile.py
@@ -1,7 +1,9 @@
+import datetime
 import uuid
 
 from django.db import connection
 from django.test.utils import CaptureQueriesContext
+from django.utils import timezone
 from rest_framework import status
 
 from iaso import models as m
@@ -108,3 +110,100 @@ class MobileEntityAPITestCase(EntityAPITestCase):
 
         # Verify no duplicate entity IDs
         self.assertEqual(len(entity_ids), len(set(entity_ids)), "Found duplicate entities in response")
+
+    def test_list_entities_filter_by_limit_date_ignores_soft_deleted_instances(self):
+        self.client.force_authenticate(self.yoda)
+
+        # context for the serializer
+        m.FormVersion.objects.create(form=self.form_1, version_id="1")
+
+        now = timezone.now()
+        older_date = now - datetime.timedelta(days=10)
+        newer_date = now - datetime.timedelta(days=2)
+        limit_date_str = (now - datetime.timedelta(days=5)).strftime("%Y-%m-%d")
+
+        inst_older_1 = self.create_form_instance(
+            project=self.project,
+            org_unit=self.ou_country,
+            form=self.form_1,
+            json={"_version": "1"},
+        )
+        entity_1 = m.Entity.objects.create(
+            name="entity_1",
+            entity_type=self.entity_type,
+            attributes=inst_older_1,
+            account=self.account,
+        )
+        inst_older_1.entity = entity_1
+        inst_older_1.save()
+        m.Instance.objects.filter(pk=inst_older_1.pk).update(updated_at=older_date)
+
+        inst_newer_deleted = self.create_form_instance(
+            project=self.project,
+            org_unit=self.ou_country,
+            form=self.form_1,
+            json={"_version": "1"},
+            deleted=True,
+            entity=entity_1,
+        )
+        m.Instance.objects.filter(pk=inst_newer_deleted.pk).update(updated_at=newer_date)
+
+        response = self.client.get(self.BASE_URL, {"app_id": self.project.app_id, "limit_date": limit_date_str})
+        response_json = self.assertJSONResponse(response, status.HTTP_200_OK)
+        self.assertEqual(response_json["count"], 0)
+
+        inst_newer_deleted.deleted = False
+        inst_newer_deleted.save()
+
+        response = self.client.get(self.BASE_URL, {"app_id": self.project.app_id, "limit_date": limit_date_str})
+        response_json = self.assertJSONResponse(response, status.HTTP_200_OK)
+        self.assertEqual(response_json["count"], 1)
+
+    def test_get_entities_by_type_ignores_soft_deleted_instances(self):
+        self.client.force_authenticate(self.yoda)
+
+        # context for the serializer
+        m.FormVersion.objects.create(form=self.form_1, version_id="1")
+
+        now = timezone.now()
+        older_date = now - datetime.timedelta(days=10)
+        newer_date = now - datetime.timedelta(days=2)
+        limit_date_str = (now - datetime.timedelta(days=5)).strftime("%Y-%m-%d")
+
+        inst_older = self.create_form_instance(
+            project=self.project,
+            org_unit=self.ou_country,
+            form=self.form_1,
+            json={"_version": "1"},
+        )
+        entity = m.Entity.objects.create(
+            name="type_entity",
+            entity_type=self.entity_type,
+            attributes=inst_older,
+            account=self.account,
+        )
+        inst_older.entity = entity
+        inst_older.save()
+        m.Instance.objects.filter(pk=inst_older.pk).update(updated_at=older_date)
+
+        inst_newer_deleted = self.create_form_instance(
+            project=self.project,
+            org_unit=self.ou_country,
+            form=self.form_1,
+            json={"_version": "1"},
+            deleted=True,
+            entity=entity,
+        )
+        m.Instance.objects.filter(pk=inst_newer_deleted.pk).update(updated_at=newer_date)
+
+        url = f"/api/mobile/entitytypes/{self.entity_type.pk}/entities/"
+        response = self.client.get(url, {"app_id": self.project.app_id, "limit_date": limit_date_str})
+        response_json = self.assertJSONResponse(response, status.HTTP_200_OK)
+        self.assertEqual(response_json["count"], 0)
+
+        inst_newer_deleted.deleted = False
+        inst_newer_deleted.save()
+
+        response = self.client.get(url, {"app_id": self.project.app_id, "limit_date": limit_date_str})
+        response_json = self.assertJSONResponse(response, status.HTTP_200_OK)
+        self.assertEqual(response_json["count"], 1)

--- a/iaso/utils/jsonlogic.py
+++ b/iaso/utils/jsonlogic.py
@@ -590,7 +590,9 @@ def entities_jsonlogic_to_q(
         form_id_filter = Q(entity_id=OuterRef("id")) & Q(form__form_id=form_id)
 
         if operator == "some":
-            queryset, _ = annotate_suffixed_json_fields(Instance.objects, conditions, "json", index)
+            queryset, _ = annotate_suffixed_json_fields(
+                Instance.objects.filter(deleted=False), conditions, "json", index
+            )
             q, index = entities_jsonlogic_to_q(conditions, field_prefix, index)
             return Exists(queryset.filter(form_id_filter & q)), index
         if operator == "all":
@@ -598,11 +600,13 @@ def entities_jsonlogic_to_q(
             # - EXIST on the form without conditions to exclude entities that don't have the form
             # - NOT EXIST on the form with inverted conditions, so only get forms that only have
             #   the desired conditions
-            queryset, _ = annotate_suffixed_json_fields(Instance.objects, conditions, "json", index)
+            queryset, _ = annotate_suffixed_json_fields(
+                Instance.objects.filter(deleted=False), conditions, "json", index
+            )
             q, index = entities_jsonlogic_to_q(conditions, field_prefix, index)
             return Exists(queryset.filter(form_id_filter)) & ~Exists(queryset.filter(form_id_filter & ~q)), index
         # if operator == "none":
-        queryset, _ = annotate_suffixed_json_fields(Instance.objects, conditions, "json", index)
+        queryset, _ = annotate_suffixed_json_fields(Instance.objects.filter(deleted=False), conditions, "json", index)
         q, index = entities_jsonlogic_to_q(conditions, field_prefix, index)
         return ~Exists(queryset.filter(form_id_filter & q)), index
 

--- a/iaso/utils/jsonlogic.py
+++ b/iaso/utils/jsonlogic.py
@@ -590,9 +590,7 @@ def entities_jsonlogic_to_q(
         form_id_filter = Q(entity_id=OuterRef("id")) & Q(form__form_id=form_id)
 
         if operator == "some":
-            queryset, _ = annotate_suffixed_json_fields(
-                Instance.objects.filter(deleted=False), conditions, "json", index
-            )
+            queryset, _ = annotate_suffixed_json_fields(Instance.non_deleted_objects, conditions, "json", index)
             q, index = entities_jsonlogic_to_q(conditions, field_prefix, index)
             return Exists(queryset.filter(form_id_filter & q)), index
         if operator == "all":
@@ -600,13 +598,11 @@ def entities_jsonlogic_to_q(
             # - EXIST on the form without conditions to exclude entities that don't have the form
             # - NOT EXIST on the form with inverted conditions, so only get forms that only have
             #   the desired conditions
-            queryset, _ = annotate_suffixed_json_fields(
-                Instance.objects.filter(deleted=False), conditions, "json", index
-            )
+            queryset, _ = annotate_suffixed_json_fields(Instance.non_deleted_objects, conditions, "json", index)
             q, index = entities_jsonlogic_to_q(conditions, field_prefix, index)
             return Exists(queryset.filter(form_id_filter)) & ~Exists(queryset.filter(form_id_filter & ~q)), index
         # if operator == "none":
-        queryset, _ = annotate_suffixed_json_fields(Instance.objects.filter(deleted=False), conditions, "json", index)
+        queryset, _ = annotate_suffixed_json_fields(Instance.non_deleted_objects, conditions, "json", index)
         q, index = entities_jsonlogic_to_q(conditions, field_prefix, index)
         return ~Exists(queryset.filter(form_id_filter & q)), index
 


### PR DESCRIPTION
refs: SLEEP-1817

## What problem is this PR solving?

Soft-deleted Instances are taken into account when performing various searches on Entities (filter by date, jsonlogic filters, etc.)

### Related JIRA tickets

SLEEP-1817 SLEEP-1793

## Changes

Exclude soft-deleted Instances from Entity filters and jsonlogic filters.  

## How to test

Go to the entity list `/dashboard/entities/list/` and verify that the search and search in submitted fields behaves correctly and doesn't return results for soft-deleted instances.

## Notes

/ 