### PR TITLE
SLEEP-1819: Entity count ui glitches

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -1595,7 +1595,7 @@
     "iaso.snackBar.createExportRequestSuccess": "La demande d'export est bien créée et sera traitée en arrière plan",
     "iaso.snackBar.createFormError": "Une erreur est survenue en créant un formulaire",
     "iaso.snackBar.createFormVersionError": "Une erreur est survenue en créant une version de formulaire",
-    "iaso.snackBar.delete_successful": "Cette entrée à bien été effacée",
+    "iaso.snackBar.delete_successful": "Cette entrée a bien été effacée",
     "iaso.snackBar.deleteEntityError": "Une erreur est survenue en effaçant une entité",
     "iaso.snackBar.deleteEntityTypeError": "Une erreur est survenue en effaçant un type d'entité",
     "iaso.snackBar.deleteFormError": "Une erreur est survenue en effaçant un formulaire",

--- a/hat/assets/js/apps/Iaso/domains/entities/hooks/requests.ts
+++ b/hat/assets/js/apps/Iaso/domains/entities/hooks/requests.ts
@@ -141,7 +141,7 @@ export const useGetEntitiesLocations = (
 
 export const useGetEntitiesCount = (
     params: Params,
-    hasCursor: boolean,
+    enabled: boolean,
 ): UseQueryResult<{ count: number }, Error> => {
     // strip attributes that shouldn't affect the count cache or api
     const {
@@ -163,7 +163,7 @@ export const useGetEntitiesCount = (
         queryKey: ['entities-count', countParams],
         queryFn: () => getRequest(countUrl),
         options: {
-            enabled: hasCursor && apiParams.tab === 'list',
+            enabled: enabled && apiParams.tab === 'list',
             staleTime: 1000 * 60 * 5,
             cacheTime: 1000 * 60 * 10,
         },

--- a/hat/assets/js/apps/Iaso/domains/entities/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/index.tsx
@@ -86,11 +86,16 @@ export const Entities: FunctionComponent = () => {
     }, [data]);
 
     const hasCursor = !!(next || previous);
+
+    const requiresCount = !isFetching && hasCursor;
+
     const { data: countData, isFetching: isFetchingCount } =
-        useGetEntitiesCount(params, hasCursor);
+        useGetEntitiesCount(params, requiresCount);
 
     const lengthResults = data?.result?.length ?? 0;
-    const totalCount = countData?.count ?? lengthResults;
+    const totalCount = hasCursor
+        ? (countData?.count ?? lengthResults)
+        : lengthResults;
 
     const handleNextPage = () => {
         if (next) {


### PR DESCRIPTION
refs: SLEEP-1819

## What problem is this PR solving?

The result count in the entity list could be glitchy and not updated properly when the backend response is very fast or when there is less than a page of results. 

### Related JIRA tickets

SLEEP-1819

## Changes

Small tweaks to the frontend logic. 

## How to test

Go to the entities list page `/dashboard/entities/list/` and make sure the count behaves properly with less and more than one page of results. 

## Print screen / video

/
## Notes
/

## Doc

/