### PR TITLE
[IA-5256]: make date range component responsive

### DIFF
--- a/hat/assets/js/apps/Iaso/components/filters/DatesRange.test.tsx
+++ b/hat/assets/js/apps/Iaso/components/filters/DatesRange.test.tsx
@@ -19,8 +19,8 @@ vi.mock('../../utils/dates', () => ({
     getUrlParamDateObject: (value: string) => `parsed:${value}`,
 }));
 
-vi.mock('@mui/x-date-pickers/DesktopDatePicker', () => ({
-    DesktopDatePicker: (props: Record<string, any>) => {
+vi.mock('@mui/x-date-pickers/DatePicker', () => ({
+    DatePicker: (props: Record<string, any>) => {
         const testId =
             props?.slotProps?.textField?.InputProps?.['data-test'] ??
             'date-picker';

--- a/hat/assets/js/apps/Iaso/components/filters/DatesRange.tsx
+++ b/hat/assets/js/apps/Iaso/components/filters/DatesRange.tsx
@@ -2,7 +2,7 @@ import React, { useState, useCallback, FunctionComponent } from 'react';
 import EventIcon from '@mui/icons-material/Event';
 import { Grid, useTheme, useMediaQuery, Box } from '@mui/material';
 import { makeStyles } from '@mui/styles';
-import { DesktopDatePicker as DatePicker } from '@mui/x-date-pickers/DesktopDatePicker';
+import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 import {
     useSafeIntl,
     IconButton,
@@ -161,6 +161,9 @@ const DatesRange: FunctionComponent<Props> = ({
                                         // @ts-expect-error data-test for automated tests
                                         'data-test': 'start-date',
                                     },
+                                    InputLabelProps: {
+                                        shrink: true,
+                                    },
                                 },
                             }}
                         />
@@ -212,6 +215,9 @@ const DatesRange: FunctionComponent<Props> = ({
                                     InputProps: {
                                         // @ts-expect-error data-test for automated tests
                                         'data-test': 'end-date',
+                                    },
+                                    InputLabelProps: {
+                                        shrink: true,
                                     },
                                 },
                             }}


### PR DESCRIPTION
## What problem is this PR solving?

Label in daterange component was going over the open button in some cases 

### Related JIRA tickets

IA-5256

## Changes

Added shrink: true so the label is no more in the placeholder but above the input
Use DatePicker instead of DesktopDatePicker so it's responsive

## How to test

Go to any form and see related attachment , the daterange pickers labels should not display over the open button.
 
## Print screen / video

<img width="346" height="107" alt="image" src="https://github.com/user-attachments/assets/4e40355a-1742-4d2e-82d6-31d0164cac8b" />
