### PR TITLE
[IA-5327]: fix multiple bugs in mission edit/create

### DIFF
--- a/hat/assets/js/__tests__/integration/missions/MissionCreate.integration.test.tsx
+++ b/hat/assets/js/__tests__/integration/missions/MissionCreate.integration.test.tsx
@@ -600,6 +600,7 @@ describe('Mission create integration test', () => {
                                     'Invalid first min cardinality',
                             },
                             {
+                                form: 'Invalid second form',
                                 max_cardinality:
                                     'Invalid second max cardinality',
                             },
@@ -658,6 +659,7 @@ describe('Mission create integration test', () => {
         expect(screen.getByText('Invalid name')).toBeVisible();
         expect(screen.getByText('Invalid description')).toBeVisible();
         expect(screen.getByText('Invalid mission_type')).toBeVisible();
+        expect(screen.getByText('Invalid second form')).toBeVisible();
         expect(screen.getByText('Invalid first min cardinality')).toBeVisible();
         expect(
             screen.getByText('Invalid second max cardinality'),

--- a/hat/assets/js/__tests__/integration/missions/MissionEdit.integration.test.tsx
+++ b/hat/assets/js/__tests__/integration/missions/MissionEdit.integration.test.tsx
@@ -600,6 +600,7 @@ describe('Mission edit integration test', () => {
                         description: ['Invalid description'],
                         forms: [
                             {
+                                form: 'Invalid first form',
                                 min_cardinality:
                                     'Invalid first min cardinality',
                             },
@@ -659,6 +660,7 @@ describe('Mission edit integration test', () => {
 
         expect(screen.getByText('Invalid name')).toBeVisible();
         expect(screen.getByText('Invalid description')).toBeVisible();
+        expect(screen.getByText('Invalid first form')).toBeVisible();
         expect(screen.getByText('Invalid first min cardinality')).toBeVisible();
         expect(
             screen.getByText('Invalid second max cardinality'),

--- a/hat/assets/js/apps/Iaso/domains/missions/components/forms/MissionEntityTypeInput.test.tsx
+++ b/hat/assets/js/apps/Iaso/domains/missions/components/forms/MissionEntityTypeInput.test.tsx
@@ -121,9 +121,11 @@ describe('MissionEntityTypeInput', () => {
     });
 
     it('resets forms and updates params when entity type changes', async () => {
-        const formik = createFormik();
+        const formik = createFormik({
+            entity_type: undefined,
+        });
 
-        renderWithThemeAndIntlProvider(
+        const { rerender } = renderWithThemeAndIntlProvider(
             // @ts-ignore
             <MissionEntityTypeInput formik={formik} />,
         );
@@ -132,11 +134,19 @@ describe('MissionEntityTypeInput', () => {
             screen.getByTestId('select-input').click();
         });
 
+        expect(formik.setFieldValue).toHaveBeenCalledWith('forms', []);
+        expect(formik.setFieldTouched).toHaveBeenCalledWith('forms', false);
+
+        rerender(
+            <MissionEntityTypeInput
+                // @ts-ignore
+                formik={createFormik({
+                    entity_type: 12,
+                })}
+            />,
+        );
+
         await waitFor(() => {
-            expect(formik.setFieldValue).toHaveBeenCalledWith('forms', []);
-
-            expect(formik.setFieldTouched).toHaveBeenCalledWith('forms', false);
-
             expect(missionFormsBaseInputMock).toHaveBeenCalledWith(
                 expect.objectContaining({
                     params: {
@@ -144,6 +154,48 @@ describe('MissionEntityTypeInput', () => {
                             entity_type_ids: 12,
                         },
                     },
+                }),
+            );
+        });
+    });
+
+    it('passes params based on the selected entity type', async () => {
+        renderWithThemeAndIntlProvider(
+            <MissionEntityTypeInput
+                // @ts-ignore
+                formik={createFormik({
+                    entity_type: 12,
+                })}
+            />,
+        );
+
+        await waitFor(() => {
+            expect(missionFormsBaseInputMock).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    params: {
+                        params: {
+                            entity_type_ids: 12,
+                        },
+                    },
+                }),
+            );
+        });
+    });
+
+    it('passes empty params when no entity type is selected', async () => {
+        renderWithThemeAndIntlProvider(
+            <MissionEntityTypeInput
+                // @ts-ignore
+                formik={createFormik({
+                    entity_type: undefined,
+                })}
+            />,
+        );
+
+        await waitFor(() => {
+            expect(missionFormsBaseInputMock).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    params: {},
                 }),
             );
         });

--- a/hat/assets/js/apps/Iaso/domains/missions/components/forms/MissionEntityTypeInput.tsx
+++ b/hat/assets/js/apps/Iaso/domains/missions/components/forms/MissionEntityTypeInput.tsx
@@ -39,11 +39,15 @@ export const MissionEntityTypeInput = <
         setFormInputDisabled(!values?.entity_type);
     }, [values]);
 
-    const handleEntityTypeChange = (_keyValue: string, value: number) => {
-        if (value) {
-            setParams({ params: { entity_type_ids: value } });
+    React.useEffect(() => {
+        if (values?.entity_type) {
+            setParams({ params: { entity_type_ids: values?.entity_type } });
+        } else {
+            setParams({});
         }
+    }, [values?.entity_type]);
 
+    const handleEntityTypeChange = (_keyValue: string, _value: number) => {
         formik.setFieldValue('forms', []);
         formik.setFieldTouched('forms', false);
     };

--- a/hat/assets/js/apps/Iaso/domains/missions/components/forms/MissionFormsBaseInput.test.tsx
+++ b/hat/assets/js/apps/Iaso/domains/missions/components/forms/MissionFormsBaseInput.test.tsx
@@ -15,6 +15,7 @@ vi.mock('formik', async () => {
     return {
         ...actual,
         Field: () => <div data-testid="field" />,
+        ErrorMessage: () => null,
         FieldArray: ({ render }: any) =>
             render({
                 push,

--- a/hat/assets/js/apps/Iaso/domains/missions/components/forms/MissionFormsBaseInput.tsx
+++ b/hat/assets/js/apps/Iaso/domains/missions/components/forms/MissionFormsBaseInput.tsx
@@ -16,7 +16,7 @@ import {
 import { AlertProps } from '@mui/material/Alert/Alert';
 import Divider from '@mui/material/Divider';
 import { Select, useSafeIntl } from 'bluesquare-components';
-import { Field, FieldArray } from 'formik';
+import { ErrorMessage, Field, FieldArray } from 'formik';
 import { FormikContextType, FormikProps } from 'formik/dist/types';
 import { NumberInput } from 'Iaso/components/forms/NumberInput';
 import {
@@ -138,8 +138,32 @@ export const MissionFormsBaseInput = <TSchema extends BaseUpdateCreateRequest>({
                                 >
                                     <ListItemText
                                         primary={
-                                            findFormOptionFromValue(form.form)
-                                                ?.label
+                                            <Box
+                                                sx={{
+                                                    display: 'flex',
+                                                    flexDirection: 'column',
+                                                }}
+                                            >
+                                                <span>
+                                                    {
+                                                        findFormOptionFromValue(
+                                                            form.form,
+                                                        )?.label
+                                                    }
+                                                </span>
+                                                <ErrorMessage
+                                                    name={`forms.[${index}].form`}
+                                                >
+                                                    {msg => (
+                                                        <Alert
+                                                            severity={'error'}
+                                                            sx={{ mt: 1 }}
+                                                        >
+                                                            {msg}
+                                                        </Alert>
+                                                    )}
+                                                </ErrorMessage>
+                                            </Box>
                                         }
                                         secondary={
                                             <Box

--- a/hat/assets/js/apps/Iaso/domains/missions/components/forms/MissionOrgUnitTypeInput.test.tsx
+++ b/hat/assets/js/apps/Iaso/domains/missions/components/forms/MissionOrgUnitTypeInput.test.tsx
@@ -126,9 +126,11 @@ describe('MissionOrgUnitTypeInput', () => {
     });
 
     it('resets forms and updates params when org unit type changes', async () => {
-        const formik = createFormik();
+        const formik = createFormik({
+            org_unit_type: undefined,
+        });
 
-        renderWithThemeAndIntlProvider(
+        const { rerender } = renderWithThemeAndIntlProvider(
             // @ts-ignore
             <MissionOrgUnitTypeInput formik={formik} />,
         );
@@ -137,11 +139,19 @@ describe('MissionOrgUnitTypeInput', () => {
             screen.getByTestId('select-input').click();
         });
 
+        expect(formik.setFieldValue).toHaveBeenCalledWith('forms', []);
+        expect(formik.setFieldTouched).toHaveBeenCalledWith('forms', false);
+
+        rerender(
+            <MissionOrgUnitTypeInput
+                // @ts-ignore
+                formik={createFormik({
+                    org_unit_type: 12,
+                })}
+            />,
+        );
+
         await waitFor(() => {
-            expect(formik.setFieldValue).toHaveBeenCalledWith('forms', []);
-
-            expect(formik.setFieldTouched).toHaveBeenCalledWith('forms', false);
-
             expect(missionFormsBaseInputMock).toHaveBeenCalledWith(
                 expect.objectContaining({
                     params: {
@@ -149,6 +159,48 @@ describe('MissionOrgUnitTypeInput', () => {
                             orgUnitTypeIds: 12,
                         },
                     },
+                }),
+            );
+        });
+    });
+
+    it('passes params based on the selected org unit type', async () => {
+        renderWithThemeAndIntlProvider(
+            <MissionOrgUnitTypeInput
+                // @ts-ignore
+                formik={createFormik({
+                    org_unit_type: 12,
+                })}
+            />,
+        );
+
+        await waitFor(() => {
+            expect(missionFormsBaseInputMock).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    params: {
+                        params: {
+                            orgUnitTypeIds: 12,
+                        },
+                    },
+                }),
+            );
+        });
+    });
+
+    it('passes empty params when no org unit type is selected', async () => {
+        renderWithThemeAndIntlProvider(
+            <MissionOrgUnitTypeInput
+                // @ts-ignore
+                formik={createFormik({
+                    org_unit_type: undefined,
+                })}
+            />,
+        );
+
+        await waitFor(() => {
+            expect(missionFormsBaseInputMock).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    params: {},
                 }),
             );
         });

--- a/hat/assets/js/apps/Iaso/domains/missions/components/forms/MissionOrgUnitTypeInput.tsx
+++ b/hat/assets/js/apps/Iaso/domains/missions/components/forms/MissionOrgUnitTypeInput.tsx
@@ -42,13 +42,18 @@ export const MissionOrgUnitTypeInput = <
     const { values } = formik;
 
     React.useEffect(() => {
+        if (values?.org_unit_type) {
+            setParams({ params: { orgUnitTypeIds: values?.org_unit_type } });
+        } else {
+            setParams({});
+        }
+    }, [values?.org_unit_type]);
+
+    React.useEffect(() => {
         setFormInputDisabled(!values?.org_unit_type);
     }, [values]);
 
-    const handleOrgUnitTypeChange = (_keyValue: string, value: number) => {
-        if (value) {
-            setParams({ params: { orgUnitTypeIds: value } });
-        }
+    const handleOrgUnitTypeChange = (_keyValue: string, _value: number) => {
         formik.setFieldValue('forms', []);
         formik.setFieldTouched('forms', false);
     };

--- a/iaso/api/missions/serializers/update/mission_entity_type.py
+++ b/iaso/api/missions/serializers/update/mission_entity_type.py
@@ -120,7 +120,7 @@ class MissionEntityTypeUpdateSerializer(ModelSerializer):
             data = incoming[form_id]
 
             obj.min_cardinality = data["min_cardinality"]
-            obj.max_cardinality = data["max_cardinality"]
+            obj.max_cardinality = data.get("max_cardinality", None)
 
             bulk_updates.append(obj)
 

--- a/iaso/api/missions/serializers/update/mission_org_unit_type.py
+++ b/iaso/api/missions/serializers/update/mission_org_unit_type.py
@@ -121,7 +121,7 @@ class MissionOrgUnitTypeUpdateSerializer(ModelSerializer):
             data = incoming[form_id]
 
             obj.min_cardinality = data["min_cardinality"]
-            obj.max_cardinality = data["max_cardinality"]
+            obj.max_cardinality = data.get("max_cardinality", None)
 
             bulk_updates.append(obj)
 

--- a/iaso/tests/api/missions/test_views/test_update/test_mission_entity_type.py
+++ b/iaso/tests/api/missions/test_views/test_update/test_mission_entity_type.py
@@ -345,7 +345,7 @@ class MissionEntityTypeAPIUpdateTestCase(SwaggerTestCaseMixin, APITestCase):
             "max_cardinality": 2,
             "forms": [
                 {"form": self.form_1.pk, "min_cardinality": 9, "max_cardinality": 10},
-                {"form": self.form_4.pk, "min_cardinality": 10, "max_cardinality": 11},
+                {"form": self.form_4.pk, "min_cardinality": 10},
             ],
         }
         self.assertValidBodyData(body)
@@ -368,5 +368,5 @@ class MissionEntityTypeAPIUpdateTestCase(SwaggerTestCaseMixin, APITestCase):
                     "form_id", "min_cardinality", "max_cardinality"
                 )
             ),
-            [(self.form_1.pk, 9, 10), (self.form_4.pk, 10, 11)],
+            [(self.form_1.pk, 9, 10), (self.form_4.pk, 10, None)],
         )

--- a/iaso/tests/api/missions/test_views/test_update/test_mission_forms.py
+++ b/iaso/tests/api/missions/test_views/test_update/test_mission_forms.py
@@ -229,7 +229,7 @@ class MissionFormAPIUpdateTestCase(SwaggerTestCaseMixin, APITestCase):
             "description": "",
             "forms": [
                 {"form": self.form_1.pk, "min_cardinality": 12, "max_cardinality": 15},
-                {"form": self.form_4.pk, "min_cardinality": 1, "max_cardinality": 5},
+                {"form": self.form_4.pk, "min_cardinality": 1},
             ],
         }
         self.assertValidBodyData(body)
@@ -247,5 +247,5 @@ class MissionFormAPIUpdateTestCase(SwaggerTestCaseMixin, APITestCase):
                     "form_id", "min_cardinality", "max_cardinality"
                 )
             ),
-            [(self.form_1.pk, 12, 15), (self.form_4.pk, 1, 5)],
+            [(self.form_1.pk, 12, 15), (self.form_4.pk, 1, None)],
         )

--- a/iaso/tests/api/missions/test_views/test_update/test_mission_org_unit_type.py
+++ b/iaso/tests/api/missions/test_views/test_update/test_mission_org_unit_type.py
@@ -339,7 +339,7 @@ class MissionOrgUnitTypeAPIUpdateTestCase(SwaggerTestCaseMixin, APITestCase):
             "max_cardinality": 8,
             "forms": [
                 {"form": self.form_1.pk, "min_cardinality": 4, "max_cardinality": 9},
-                {"form": self.form_3.pk, "min_cardinality": 2, "max_cardinality": 4},
+                {"form": self.form_3.pk, "min_cardinality": 2},
             ],
         }
 
@@ -364,5 +364,5 @@ class MissionOrgUnitTypeAPIUpdateTestCase(SwaggerTestCaseMixin, APITestCase):
                     "form_id", "min_cardinality", "max_cardinality"
                 )
             ),
-            [(self.form_1.pk, 4, 9), (self.form_3.pk, 2, 4)],
+            [(self.form_1.pk, 4, 9), (self.form_3.pk, 2, None)],
         )


### PR DESCRIPTION
## What problem is this PR solving?

Multiple bugs in mission edit/create: 

* Providing a null max_cardinality in edit would make the backend raise a 500
* Editing an org unit / entity type mission form:
  * The initial org unit type/entity type param was not passed to the form combobox in initial rendering, causing invalid choices
  * Following this , the backend would raise a 400 that would not display on the front
  
### Related JIRA tickets

IA-5327

## Changes

* Fix backend to not crash when providing a null max_cardinality
* Fix initial rendering on the edit forms (front end)
* Display form errors on the forms
* Tests

## How to test

See summary above

## Notes

If needed, we can improve the form error message to be more user firendly (instead of Invalid , the form with pk x does not exist)
