### PR TITLE
POLIO-2178: No X-Frame-Options response header was set by the web application.

### DIFF
--- a/hat/dashboard/views.py
+++ b/hat/dashboard/views.py
@@ -4,6 +4,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.http import HttpResponse
 from django.http.request import HttpRequest
 from django.shortcuts import render
+from django.views.decorators.clickjacking import xframe_options_exempt
 from django.views.decorators.http import require_http_methods
 
 
@@ -61,9 +62,10 @@ def iaso(request: HttpRequest) -> HttpResponse:
     return _base_iaso(request, analytics_data=analytics_data)
 
 
+@xframe_options_exempt
 @require_http_methods(["GET"])
 def embeddable_iaso(request: HttpRequest) -> HttpResponse:
-    """Embeddable iaso page without login requirement and with correct header"""
+    """Embeddable iaso page without login requirement and without X-Frame-Options."""
     analytics_data = None
 
     if _should_enable_analytics(request):
@@ -72,9 +74,7 @@ def embeddable_iaso(request: HttpRequest) -> HttpResponse:
             "domain": domain,
         }
 
-    response = _base_iaso(request, analytics_data=analytics_data)
-    response["X-Frame-Options"] = "ALLOW"
-    return response
+    return _base_iaso(request, analytics_data=analytics_data)
 
 
 @require_http_methods(["GET"])

--- a/iaso/tests/test_xframe_options.py
+++ b/iaso/tests/test_xframe_options.py
@@ -1,0 +1,41 @@
+from iaso import models as m
+from iaso.models import Page
+from iaso.test import TestCase
+
+
+class XFrameOptionsTestCase(TestCase):
+    """Ensure only embeddable views are exempt from Django's X-Frame-Options: DENY."""
+
+    @classmethod
+    def setUpTestData(cls):
+        account = m.Account.objects.create(name="XFrame account")
+        cls.user = cls.create_user_with_profile(username="xframe_user", account=account)
+        cls.public_page = Page.objects.create(
+            type="RAW",
+            needs_authentication=False,
+            name="Public embed page",
+            slug="public-embed-page",
+            content="<html><body>ok</body></html>",
+            account=account,
+        )
+
+    def test_regular_dashboard_home_sets_deny(self):
+        response = self.client.get("/dashboard/home/")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get("X-Frame-Options"), "DENY")
+
+    def test_authenticated_dashboard_sets_deny(self):
+        self.client.force_login(self.user)
+        response = self.client.get("/dashboard/")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get("X-Frame-Options"), "DENY")
+
+    def test_embeddable_dashboard_is_exempt(self):
+        response = self.client.get("/dashboard/polio/embeddedCalendar/")
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(response.get("X-Frame-Options"))
+
+    def test_pages_view_is_exempt(self):
+        response = self.client.get(f"/pages/{self.public_page.slug}/")
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(response.get("X-Frame-Options"))

--- a/iaso/tests/test_xframe_options.py
+++ b/iaso/tests/test_xframe_options.py
@@ -1,3 +1,7 @@
+from unittest import mock
+
+from django.http import HttpResponse
+
 from iaso import models as m
 from iaso.models import Page
 from iaso.test import TestCase
@@ -20,18 +24,31 @@ class XFrameOptionsTestCase(TestCase):
         )
 
     def test_regular_dashboard_home_sets_deny(self):
-        response = self.client.get("/dashboard/home/")
+        # Avoid rendering iaso/index.html (needs webpack-stats.json in CI).
+        with mock.patch(
+            "hat.dashboard.views._base_iaso",
+            return_value=HttpResponse("ok"),
+        ):
+            response = self.client.get("/dashboard/home/")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.get("X-Frame-Options"), "DENY")
 
     def test_authenticated_dashboard_sets_deny(self):
         self.client.force_login(self.user)
-        response = self.client.get("/dashboard/")
+        with mock.patch(
+            "hat.dashboard.views._base_iaso",
+            return_value=HttpResponse("ok"),
+        ):
+            response = self.client.get("/dashboard/")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.get("X-Frame-Options"), "DENY")
 
     def test_embeddable_dashboard_is_exempt(self):
-        response = self.client.get("/dashboard/polio/embeddedCalendar/")
+        with mock.patch(
+            "hat.dashboard.views._base_iaso",
+            return_value=HttpResponse("ok"),
+        ):
+            response = self.client.get("/dashboard/polio/embeddedCalendar/")
         self.assertEqual(response.status_code, 200)
         self.assertIsNone(response.get("X-Frame-Options"))
 

--- a/iaso/views.py
+++ b/iaso/views.py
@@ -111,7 +111,6 @@ def page(request, page_slug):
     return response
 
 
-
 def user_can_access_page(user, page):
     """Check if user has access to view this page."""
 

--- a/iaso/views.py
+++ b/iaso/views.py
@@ -8,6 +8,7 @@ from django.contrib.auth.views import redirect_to_login
 from django.db import models
 from django.http import HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, render, resolve_url
+from django.views.decorators.clickjacking import xframe_options_exempt
 
 from iaso.models import IFRAME, POWERBI, SUPERSET, TEXT, Account, Page
 from iaso.permissions.core_permissions import CORE_PAGE_WRITE_PERMISSION
@@ -31,6 +32,7 @@ def load_powerbi_config_for_page(page: Page):
     return config
 
 
+@xframe_options_exempt
 def page(request, page_slug):
     content = {}
 
@@ -106,8 +108,8 @@ def page(request, page_slug):
         if analytics_script and raw_html is not None:
             raw_html = addTag(raw_html, analytics_script)
         response = HttpResponse(raw_html)
-    response["X-Frame-Options"] = "ALLOW"
     return response
+
 
 
 def user_can_access_page(user, page):


### PR DESCRIPTION
## What problem is this PR solving?

EMmbedding works today mostly by accident, not because ALLOW is a real directive.
What happens now:

Django’s `XFrameOptionsMiddleware` would normally sendX-Frame-Options: DENY (blocks iframes).

Browsers don’t recognize ALLOW, so they ignore the header → the ArcGIS Hub page can embed IASO.
So it “works” on [Vaccine Management](https://afro-rrt-who.hub.arcgis.com/pages/vaccine-management), but the value itself is invalid.


### Related JIRA tickets
POLIO-2178

## Changes

- use `xframe_options_exempt`
- wrote some tests

## How to test

### should show DENY
curl -sI http://localhost:8081/dashboard/home/ | grep -i x-frame

### should show nothing
curl -sI http://localhost:8081/dashboard/polio/embeddedCalendar/ | grep -i x-frame


## Print screens
<img width="850" height="184" alt="Screenshot 2026-07-17 at 14 29 59" src="https://github.com/user-attachments/assets/08aae679-2f2a-490f-8d39-5e296c446e94" />
<img width="864" height="214" alt="Screenshot 2026-07-17 at 14 29 37" src="https://github.com/user-attachments/assets/9a833e7d-90db-4d82-a876-23dd70cb5259" />

