### PR TITLE
[IA-5250] fix polio issues in docker

### DIFF
--- a/docker/prod/docker-compose.prod.yml
+++ b/docker/prod/docker-compose.prod.yml
@@ -46,6 +46,7 @@ services:
         - DB_READONLY_USERNAME
         - DEBUG
         - DEBUG_SQL
+        - DEFAULT_APP_ID
         - DEFAULT_FROM_EMAIL
         - DEPLOYED_BY
         - DEPLOYED_ON

--- a/plugins/polio/api/campaigns/views/campaigns.py
+++ b/plugins/polio/api/campaigns/views/campaigns.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from tempfile import NamedTemporaryFile
 from time import gmtime, strftime
 from typing import Any, List, Union
 
@@ -179,13 +178,9 @@ class CampaignViewSet(ModelViewSet):
         filename = xlsx_file_name("calendar", params)
         xlsx_file = generate_xlsx_campaigns_calendar(filename, calendar_data)
 
-        with NamedTemporaryFile() as tmp:
-            xlsx_file.save(tmp.name)
-            tmp.seek(0)
-            stream = tmp.read()
-
-        response = HttpResponse(stream, content_type=CONTENT_TYPE_XLSX)
+        response = HttpResponse(content_type=CONTENT_TYPE_XLSX)
         response["Content-Disposition"] = "attachment; filename=%s" % filename + ".xlsx"
+        xlsx_file.save(response)
         return response
 
     @action(methods=["GET"], detail=False, serializer_class=None)

--- a/plugins/polio/api/vaccines/export_utils.py
+++ b/plugins/polio/api/vaccines/export_utils.py
@@ -303,5 +303,4 @@ def download_xlsx_public_stock_variants(
             doses_out=doses_out,
         )
 
-    workbook.save(filename)
     return workbook

--- a/plugins/polio/api/vaccines/export_utils.py
+++ b/plugins/polio/api/vaccines/export_utils.py
@@ -134,7 +134,7 @@ def get_vaccine_country(vaccine_stock):
     return {"country": country, "vaccine": vaccine}
 
 
-def download_xlsx_stock_variants(request, filename, results, lambda_methods, vaccince_stock, tab):
+def download_xlsx_stock_variants(request, results, lambda_methods, vaccince_stock, tab):
     workbook = Workbook()
     sheet_configs = get_sheet_configs()
 

--- a/plugins/polio/api/vaccines/export_utils.py
+++ b/plugins/polio/api/vaccines/export_utils.py
@@ -251,7 +251,6 @@ def write_vials_doses_total(
 
 
 def download_xlsx_public_stock_variants(
-    filename,
     usable_results,
     unusable_results,
     usable_totals,

--- a/plugins/polio/api/vaccines/export_utils.py
+++ b/plugins/polio/api/vaccines/export_utils.py
@@ -169,7 +169,6 @@ def download_xlsx_stock_variants(request, filename, results, lambda_methods, vac
         write_vials_doses_stock_balance(sheet, config, sums, sum_columns_indices)
 
     workbook._sheets = [sheets[name] for name in sheets_order]
-    workbook.save(filename)
     return workbook
 
 

--- a/plugins/polio/api/vaccines/public_vaccine_stock.py
+++ b/plugins/polio/api/vaccines/public_vaccine_stock.py
@@ -218,7 +218,6 @@ class PublicVaccineStockViewset(ViewSet):
         filename = f"{filename_details}-stock-card-export"
 
         workbook = download_xlsx_public_stock_variants(
-            filename=filename,
             usable_results=sorted_usable,
             unusable_results=sorted_unusable,
             usable_totals=usable_totals,

--- a/plugins/polio/api/vaccines/public_vaccine_stock.py
+++ b/plugins/polio/api/vaccines/public_vaccine_stock.py
@@ -1,7 +1,6 @@
 import math
 
 from datetime import date
-from tempfile import NamedTemporaryFile
 
 from django.db.models import Model
 from django.http import HttpResponse
@@ -235,11 +234,7 @@ class PublicVaccineStockViewset(ViewSet):
             unusable_doses_out=unusable_doses_out,
         )
 
-        with NamedTemporaryFile() as tmp:
-            workbook.save(tmp.name)
-            tmp.seek(0)
-            stream = tmp.read()
-
-        response = HttpResponse(stream, content_type=CONTENT_TYPE_XLSX)
+        response = HttpResponse(content_type=CONTENT_TYPE_XLSX)
         response["Content-Disposition"] = "attachment; filename=%s" % filename + ".xlsx"
+        workbook.save(response)
         return response

--- a/plugins/polio/api/vaccines/stock_management/vaccine_stock/views.py
+++ b/plugins/polio/api/vaccines/stock_management/vaccine_stock/views.py
@@ -198,13 +198,10 @@ class VaccineStockManagementViewSet(ModelViewSet):
                 vaccine_stock,
                 "Usable",
             )
-            with NamedTemporaryFile() as tmp:
-                workbook.save(tmp.name)
-                tmp.seek(0)
-                stream = tmp.read()
 
-            response = HttpResponse(stream, content_type=CONTENT_TYPE_XLSX)
+            response = HttpResponse(content_type=CONTENT_TYPE_XLSX)
             response["Content-Disposition"] = "attachment; filename=%s" % filename + ".xlsx"
+            workbook.save(response)
             return response
 
         paginator = Paginator()

--- a/plugins/polio/api/vaccines/stock_management/vaccine_stock/views.py
+++ b/plugins/polio/api/vaccines/stock_management/vaccine_stock/views.py
@@ -1,5 +1,4 @@
 from datetime import date
-from tempfile import NamedTemporaryFile
 
 from django.http import HttpResponse
 from django.utils.dateparse import parse_date
@@ -189,7 +188,6 @@ class VaccineStockManagementViewSet(ModelViewSet):
             filename = f"{today}-{vaccine_stock.country.name}-{vaccine_stock.vaccine}-stock-card-export"
             workbook = download_xlsx_stock_variants(
                 request,
-                filename,
                 results,
                 {
                     "Unusable": lambda: calc.get_list_of_unusable_vials(end_date),
@@ -248,7 +246,6 @@ class VaccineStockManagementViewSet(ModelViewSet):
             filename = f"{today}-{vaccine_stock.country.name}-{vaccine_stock.vaccine}-stock-card-export"
             workbook = download_xlsx_stock_variants(
                 request,
-                filename,
                 results,
                 {
                     "Usable": lambda: calc.get_list_of_usable_vials(),
@@ -257,13 +254,10 @@ class VaccineStockManagementViewSet(ModelViewSet):
                 vaccine_stock,
                 "Unusable",
             )
-            with NamedTemporaryFile() as tmp:
-                workbook.save(tmp.name)
-                tmp.seek(0)
-                stream = tmp.read()
 
-            response = HttpResponse(stream, content_type=CONTENT_TYPE_XLSX)
+            response = HttpResponse(content_type=CONTENT_TYPE_XLSX)
             response["Content-Disposition"] = "attachment; filename=%s" % filename + ".xlsx"
+            workbook.save(response)
             return response
 
         paginator = Paginator()

--- a/plugins/polio/export_utils.py
+++ b/plugins/polio/export_utils.py
@@ -26,7 +26,7 @@ def generate_xlsx_campaigns_calendar(filename: str, datas: Any) -> Workbook:
                 datas (list[dict]): a list of data dictionaries
 
         returns:
-                file (openpyxl.workbook): Saved file openpyxl.workbook object
+                file (openpyxl.workbook): openpyxl.workbook object
     """
     file = Workbook()
     sheet = file.active
@@ -82,8 +82,6 @@ def generate_xlsx_campaigns_calendar(filename: str, datas: Any) -> Workbook:
                 cell_border(cell_format, False, True)
             else:
                 cell_border(cell_format, False, False)
-
-    file.save(filename)
 
     return file
 

--- a/plugins/polio/tests/api/calendar/xlsx_export/test_calendar_xlsx_export.py
+++ b/plugins/polio/tests/api/calendar/xlsx_export/test_calendar_xlsx_export.py
@@ -1,5 +1,4 @@
 import datetime
-import os
 
 from typing import List
 
@@ -148,8 +147,6 @@ class CalendarXLSXExportAPITestCase(APITestCase):
         self.assertEqual(data_dict["January"][1], self.format_date_to_test(c2, c2_round_1))
         self.assertEqual(data_dict["January"][2], self.format_date_to_test(c2, c2_round_2))
 
-        self._clean_up_tmp_file(file_name)
-
     def test_create_calendar_xlsx_sheet_campaign_without_country(self):
         """
         When a campaign was not linked to a country, export XLSX calendar triggered an error('NoneType' object has no attribute 'id'):
@@ -165,8 +162,6 @@ class CalendarXLSXExportAPITestCase(APITestCase):
 
         data_dict = excel_data.to_dict()
         self.assertEqual(len(data_dict["COUNTRY"]), 0)
-
-        self._clean_up_tmp_file(file_name)
 
     def test_create_calendar_xlsx_sheet_round_with_no_end_date(self):
         """
@@ -191,8 +186,6 @@ class CalendarXLSXExportAPITestCase(APITestCase):
         data_dict = excel_data.to_dict()
         self.assertEqual(data_dict["January"][0], self.format_date_to_test(c, round))
 
-        self._clean_up_tmp_file(file_name)
-
     def test_create_calendar_xlsx_sheet_without_test_campaigns(self):
         """
         Test campaigns appeared in the XLSX, but they should not
@@ -214,8 +207,6 @@ class CalendarXLSXExportAPITestCase(APITestCase):
 
         data_dict = excel_data.to_dict()
         self.assertEqual(len(data_dict["COUNTRY"]), 0)
-
-        self._clean_up_tmp_file(file_name)
 
     def test_create_calendar_xlsx_sheet_with_separate_scopes_per_round(self):
         """
@@ -282,7 +273,6 @@ class CalendarXLSXExportAPITestCase(APITestCase):
         self.assertEqual(data_dict["COUNTRY"][0], org_unit.name)
         self.assertEqual(data_dict["January"][0], self.format_date_to_test(c, c_round_1))
         self.assertEqual(data_dict["January"][1], self.format_date_to_test(c, c_round_2))
-        self._clean_up_tmp_file(file_name)
 
     @staticmethod
     def format_date_to_test(campaign, round):
@@ -300,8 +290,3 @@ class CalendarXLSXExportAPITestCase(APITestCase):
             + round.vaccine_names
             + "\n"
         )
-
-    def _clean_up_tmp_file(self, file_name):
-        # Some tests here create a tmp file through /api/polio/campaigns/create_calendar_xlsx_sheet/
-        if os.path.exists(file_name):
-            os.remove(file_name)


### PR DESCRIPTION
## What problem is this PR solving?

fix polio issues in docker

### Related JIRA tickets

IA-5250

## Changes

- updated various endpoints to not write xlsx files on disk before returning them
- added missing `DEFAULT_APP_ID` in prod docker compose file

## How to test

test the following endpoints locally and when deployed on a docker server - they should not crash (no `500` error) and you should be able to download an xlsx file:
- `api/polio/vaccine/vaccine_stock/1/usable_vials/?export_xlsx=true`
- `api/polio/vaccine/vaccine_stock/1/get_unusable_vials/?export_xlsx=true`
- `api/polio/campaigns/create_calendar_xlsx_sheet/`
- `api/polio/dashboards/public/vaccine_stock/export_xlsx/`


## Print screen / video

/

## Notes
/

## Doc

/
