### PR TITLE
IA-5328 remove load from postgres and put json parsing in duckdb instead (fast, vectorized)

### DIFF
--- a/iaso/api/instances/views.py
+++ b/iaso/api/instances/views.py
@@ -552,11 +552,13 @@ class InstancesViewSet(viewsets.ViewSet):
         # actually return parquet file
         form_ids = filters["form_ids"]
         form = Form.objects.get(pk=form_ids)
-        export_queryset, mapping = parquet.build_submissions_queryset(queryset, form.id)
+        export_queryset, mapping, json_fields, json_column = parquet.build_submissions_queryset(queryset, form.id)
 
         tmp = tempfile.NamedTemporaryFile(suffix=".parquet", delete=False)
 
-        parquet.export_django_query_to_parquet_via_duckdb(export_queryset, tmp.name, mapping)
+        parquet.export_django_query_to_parquet_via_duckdb(
+            export_queryset, tmp.name, mapping, json_fields=json_fields, json_column=json_column
+        )
 
         response = CleaningFileResponse(tmp.name, as_attachment=True, filename="submissions.parquet")
 

--- a/iaso/exports/duckdb_util.py
+++ b/iaso/exports/duckdb_util.py
@@ -12,7 +12,10 @@ from django.db.models import QuerySet
 logger = getLogger(__name__)
 
 
-def export_django_query_to_parquet_via_duckdb(qs: QuerySet, output_file_path: str, mapping=None):
+def export_django_query_to_parquet_via_duckdb(
+    qs: QuerySet, output_file_path: str, mapping=None, json_fields=None, json_column=None
+):
+    # json_fields/json_column: mapping entries whose value actually lives inside a single raw json column, extracted via DuckDB instead of being a plain rename.
     start = time.perf_counter()
 
     sql, params = qs.query.sql_with_params()
@@ -40,17 +43,35 @@ def export_django_query_to_parquet_via_duckdb(qs: QuerySet, output_file_path: st
 
         logger.info(f"exporting parquet : {output_file_path} \n\n {full_sql}")
         # had to specify ROW_GROUP_SIZE when exporting large rows like several geojson on the same row
+        source_sql = f"postgres_query('pg', $$ {full_sql} $$)"
         alias_stmt = " * "
+        query_params = []
         if mapping:
-            alias_stmt = dict_to_projection(mapping)
+            plain_cols, json_cols, json_pointers = build_projection_parts(mapping, json_fields, json_column)
+            if json_pointers:
+                # Extract every question in one shot per row (single JSON parse via a bound array
+                # of paths, materialized once through the CTE) instead of one json_extract_string()
+                # call per question -- calling it once per question would re-parse the same JSON
+                # text for every single question, which is slower *and* far more memory-hungry.
+                select_parts = plain_cols + [
+                    f'__json_extracted[{i + 1}] as "{orig}"' for i, orig in enumerate(json_cols)
+                ]
+                alias_stmt = ",\n    ".join(select_parts)
+                source_sql = f"""(
+                    SELECT *, json_extract_string("{json_column}", ?) AS __json_extracted
+                    FROM {source_sql}
+                ) AS src_with_json"""
+                query_params = [json_pointers]
+            else:
+                alias_stmt = ",\n    ".join(plain_cols)
 
         parquet_export_sql = f"""
             COPY (
-                SELECT {alias_stmt} FROM postgres_query('pg', $$ {full_sql} $$)
+                SELECT {alias_stmt} FROM {source_sql}
             ) TO '{output_file_path}' (FORMAT PARQUET, COMPRESSION 'ZSTD', ROW_GROUP_SIZE 10000)
         """
 
-        duckdb_connection.execute(parquet_export_sql)
+        duckdb_connection.execute(parquet_export_sql, query_params)
 
         row_count = duckdb_connection.execute(f"SELECT COUNT(*) FROM '{output_file_path}'").fetchone()[0]
         col_count = len(duckdb_connection.execute(f"DESCRIBE SELECT * FROM '{output_file_path}'").fetchall())
@@ -62,5 +83,17 @@ def export_django_query_to_parquet_via_duckdb(qs: QuerySet, output_file_path: st
     )
 
 
-def dict_to_projection(mapping):
-    return ",\n    ".join(f'"{safe}" as "{orig}"' for orig, safe in mapping.items())
+def build_projection_parts(mapping, json_fields=None, json_column=None):
+    json_fields = json_fields or set()
+    plain_cols = []
+    json_cols = []
+    json_pointers = []
+    for orig, safe in mapping.items():
+        escaped_orig = orig.replace('"', '""')
+        if orig in json_fields:
+            json_cols.append(escaped_orig)
+            # JSON Pointer (RFC 6901) syntax: only "~" and "/" need escaping, unlike JSONPath's quoting rules.
+            json_pointers.append("/" + orig.replace("~", "~0").replace("/", "~1"))
+        else:
+            plain_cols.append(f'"{safe}" as "{escaped_orig}"')
+    return plain_cols, json_cols, json_pointers

--- a/iaso/exports/duckdb_util.py
+++ b/iaso/exports/duckdb_util.py
@@ -54,7 +54,7 @@ def export_django_query_to_parquet_via_duckdb(
                 # call per question -- calling it once per question would re-parse the same JSON
                 # text for every single question, which is slower *and* far more memory-hungry.
                 select_parts = plain_cols + [
-                    f'__json_extracted[{i + 1}] as "{orig}"' for i, orig in enumerate(json_cols)
+                    f'__json_extracted[{i + 1}] as "{escaped_name}"' for i, escaped_name in enumerate(json_cols)
                 ]
                 alias_stmt = ",\n    ".join(select_parts)
                 source_sql = f"""(

--- a/iaso/exports/submissions.py
+++ b/iaso/exports/submissions.py
@@ -1,4 +1,5 @@
 from logging import getLogger
+from typing import Dict, Set, Tuple
 
 from django.db import models
 from django.db.models import Exists, F, Func, OuterRef, QuerySet
@@ -19,7 +20,9 @@ logger = getLogger(__name__)
 RAW_ANSWERS_JSON_COLUMN = "iaso_subm_raw_answers_json"
 
 
-def build_submissions_queryset(qs: QuerySet[m.Instance], form_id: str) -> QuerySet[m.Instance]:
+def build_submissions_queryset(
+    qs: QuerySet[m.Instance], form_id: str
+) -> Tuple[QuerySet, Dict[str, str], Set[str], str]:
     form = m.Form.objects.get(pk=form_id)
     if form.possible_fields == None or len(form.possible_fields) == 0:
         form.update_possible_fields()

--- a/iaso/exports/submissions.py
+++ b/iaso/exports/submissions.py
@@ -3,6 +3,7 @@ from logging import getLogger
 from django.db import models
 from django.db.models import Exists, F, Func, OuterRef, QuerySet
 from django.db.models.fields.json import KeyTextTransform
+from django.db.models.functions import Cast
 
 import iaso.models as m
 
@@ -11,6 +12,11 @@ from .utils import normalize_field_name
 
 
 logger = getLogger(__name__)
+
+# Holds the submission's raw json answers, passed through as a single column so DuckDB can
+# splat it into per-question columns instead of Postgres doing one "json ->> 'field'" per
+# question (that scales badly with the number of questions in the form).
+RAW_ANSWERS_JSON_COLUMN = "iaso_subm_raw_answers_json"
 
 
 def build_submissions_queryset(qs: QuerySet[m.Instance], form_id: str) -> QuerySet[m.Instance]:
@@ -23,22 +29,18 @@ def build_submissions_queryset(qs: QuerySet[m.Instance], form_id: str) -> QueryS
     prefixed_fields = build_submission_annotations()
 
     possible_fields = form.possible_fields
+    answer_field_names = [f["name"] for f in possible_fields]
 
-    answer_mappings = generate_safe_mapping(list(prefixed_fields.keys()) + [f["name"] for f in possible_fields])
-
-    json_annotations = {}
-    for field in possible_fields:
-        field_name = field["name"]
-        json_annotations[answer_mappings[field_name]] = KeyTextTransform(field_name, "json")
+    answer_mappings = generate_safe_mapping(list(prefixed_fields.keys()) + answer_field_names)
 
     qs = (
         qs.values("id")
         .annotate(**prefixed_fields)
-        .annotate(**json_annotations)
-        .values(*prefixed_fields.keys(), *json_annotations.keys())
+        .annotate(**{RAW_ANSWERS_JSON_COLUMN: Cast(F("json"), output_field=models.TextField())})
+        .values(*prefixed_fields.keys(), RAW_ANSWERS_JSON_COLUMN)
     )
 
-    return qs, answer_mappings
+    return qs, answer_mappings, set(answer_field_names), RAW_ANSWERS_JSON_COLUMN
 
 
 class ST_X(Func):

--- a/iaso/tests/exports/test_submissions_export.py
+++ b/iaso/tests/exports/test_submissions_export.py
@@ -48,10 +48,14 @@ class SubmissionsExportTest(TestCase):
         cls.maxDiff = None
 
     def test_expected_columns_all_fields_even_if_no_records(self):
-        qs, mapping = parquet.build_submissions_queryset(Instance.objects, self.form_to_export.id)
+        qs, mapping, json_fields, json_column = parquet.build_submissions_queryset(
+            Instance.objects, self.form_to_export.id
+        )
 
         with tempfile.NamedTemporaryFile(suffix=".parquet") as tmpfile:
-            parquet.export_django_query_to_parquet_via_duckdb(qs, tmpfile.name, mapping)
+            parquet.export_django_query_to_parquet_via_duckdb(
+                qs, tmpfile.name, mapping, json_fields=json_fields, json_column=json_column
+            )
             actual_columns = get_columns_from_parquet(tmpfile)
 
         expected = [
@@ -67,10 +71,14 @@ class SubmissionsExportTest(TestCase):
         ]
         self.form_to_export.save()
 
-        qs, mapping = parquet.build_submissions_queryset(Instance.objects, self.form_to_export.id)
+        qs, mapping, json_fields, json_column = parquet.build_submissions_queryset(
+            Instance.objects, self.form_to_export.id
+        )
 
         with tempfile.NamedTemporaryFile(suffix=".parquet") as tmpfile:
-            parquet.export_django_query_to_parquet_via_duckdb(qs, tmpfile.name, mapping)
+            parquet.export_django_query_to_parquet_via_duckdb(
+                qs, tmpfile.name, mapping, json_fields=json_fields, json_column=json_column
+            )
             actual_columns = get_columns_from_parquet(tmpfile)
 
         expected = [
@@ -89,10 +97,14 @@ class SubmissionsExportTest(TestCase):
         ]
         self.form_to_export.save()
 
-        qs, mapping = parquet.build_submissions_queryset(Instance.objects, self.form_to_export.id)
+        qs, mapping, json_fields, json_column = parquet.build_submissions_queryset(
+            Instance.objects, self.form_to_export.id
+        )
 
         with tempfile.NamedTemporaryFile(suffix=".parquet") as tmpfile:
-            parquet.export_django_query_to_parquet_via_duckdb(qs, tmpfile.name, mapping)
+            parquet.export_django_query_to_parquet_via_duckdb(
+                qs, tmpfile.name, mapping, json_fields=json_fields, json_column=json_column
+            )
             actual_columns = get_columns_from_parquet(tmpfile)
 
         expected = [
@@ -121,10 +133,14 @@ class SubmissionsExportTest(TestCase):
 
         self.form_to_export.save()
 
-        qs, mapping = parquet.build_submissions_queryset(Instance.objects, self.form_to_export.id)
+        qs, mapping, json_fields, json_column = parquet.build_submissions_queryset(
+            Instance.objects, self.form_to_export.id
+        )
 
         with tempfile.NamedTemporaryFile(suffix=".parquet") as tmpfile:
-            parquet.export_django_query_to_parquet_via_duckdb(qs, tmpfile.name, mapping)
+            parquet.export_django_query_to_parquet_via_duckdb(
+                qs, tmpfile.name, mapping, json_fields=json_fields, json_column=json_column
+            )
             actual_columns = get_columns_from_parquet(tmpfile)
 
         expected = [


### PR DESCRIPTION


## What problem is this PR solving?

the more question has a form... the slower parquet export gets

### Related JIRA tickets

IA-5328

## Changes

What changed:
- iaso/exports/submissions.py: instead of generating one KeyTextTransform (json ->> 'field') annotation per form question, it now casts the whole json column to text once (RAW_ANSWERS_JSON_COLUMN) and returns which field names live inside it.
- iaso/exports/duckdb_util.py: export_django_query_to_parquet_via_duckdb gained optional json_fields/json_column params. When set, it wraps the Postgres source in a CTE that calls json_extract_string(raw_json, [array of pointers]) once per row (parsing the JSON a single time) and then indexes into that list per output column — rather than calling json_extract_string once per field, which would re-parse the same JSON text N times.


Benchmark (form with many questions, thousands of submissions, real DB via docker): my first pass showed a misleadingly huge speedup (up to 100x) — turned out to be an artifact of DuckDB's postgres extension paying a one-time ~4.8s load cost that happened to land on whichever export ran first. After warming that up before timing both sides, the real numbers are:

```
┌───────────┬────────┬───────┬───────┬─────────┐
│ questions │  rows  │  old  │  new  │ speedup │
├───────────┼────────┼───────┼───────┼─────────┤
│ 200       │ 3,000  │ 0.86s │ 0.22s │ 3.9x    │
├───────────┼────────┼───────┼───────┼─────────┤
│ 500       │ 3,000  │ 5.8s  │ 0.83s │ 7.1x    │
├───────────┼────────┼───────┼───────┼─────────┤
│ 500       │ 10,000 │ 19.6s │ 2.5s  │ 7.8x    │
└───────────┴────────┴───────┴───────┴─────────┘
```

TODO
  - [x] test on copy of production

technically it's not 100% representative (since my laptop is on poor internet connection compared to ec2 close to rds in prod)

```
Canevas like form 

http://localhost:8081/api/instances/?orgUnitParentId=2324664&showDeleted=false&form_ids=908&parquet=true

with my changes 
  - WARNING  2026-07-19 10:02:10,484 iaso.exports.duckdb_util -- dumped to /tmp/tmpbmbxrqwu.parquet took 109.226 seconds for 20421 records and 523 columns, final file size 6.30 Mb
  - WARNING  2026-07-19 10:07:21,033 iaso.exports.duckdb_util -- dumped to /tmp/tmprkme7534.parquet took 121.552 seconds for 20421 records and 523 columns, final file size 6.30 Mb
  
without
  - WARNING  2026-07-19 10:13:09,335 iaso.exports.duckdb_util -- dumped to /tmp/tmpd4ukafp6.parquet took 150.204 seconds for 20421 records and 523 columns, final file size 6.30 Mb
  - WARNING  2026-07-19 10:17:12,119 iaso.exports.duckdb_util -- dumped to /tmp/tmp6zwex8q1.parquet took 158.010 seconds for 20421 records and 523 columns, final file size 6.30 Mb
```  

so it seem to improve by 30 seconds, let's say 20-25% better.

on campaign like form
```
http://localhost:8081/api/instances/?orgUnitParentId=2062839&showDeleted=false&form_ids=1379&parquet=true

with
  - 2026-07-19 10:33:38,093 iaso.exports.duckdb_util -- dumped to /tmp/tmpzuzu4r8x.parquet took 132.541 seconds for 314929 records and 52 columns, final file size 38.57 Mb
  - 2026-07-19 10:36:30,357 iaso.exports.duckdb_util -- dumped to /tmp/tmpar18q54r.parquet took 114.984 seconds for 314929 records and 52 columns, final file size 38.57 Mb

without
  - 2026-07-19 10:27:26,200 iaso.exports.duckdb_util -- dumped to /tmp/tmp63xl7opr.parquet took 72.163 seconds for 314929 records and 52 columns, final file size 38.57 Mb
  - 2026-07-19 10:29:11,067 iaso.exports.duckdb_util -- dumped to /tmp/tmp1nf3tggt.parquet took 71.859 seconds for 314929 records and 52 columns, final file size 38.57 Mb

```  

hmm that's annoying... clearly unsure if it should be merged in the end.

## How to test



## Print screen / video


## Notes



## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).
