### PR TITLE
POLIO-1959: use md5 for polio files

### DIFF
--- a/docs/pages/dev/reference/clamav/clamav.en.md
+++ b/docs/pages/dev/reference/clamav/clamav.en.md
@@ -1,20 +1,29 @@
 # ClamAV
 
 ## Description
+
 [ClamAV](https://docs.clamav.net/) is an open-source antivirus that can be used by Iaso to scan files that are uploaded by users.
 
 It uses a local Unix socket or a TCP socket. Be careful about how the Iaso-ClamAV connection is configured, there are security risks.
 
-
 ## Local ClamAV server
+
 This feature is experimental. For development, if you need a local ClamAV server, you can start one up in your docker compose by using the `docker/docker-compose-clamav.yml ` configuration file.
 
 Replace your invocations of `docker compose` by `docker compose -f docker-compose.yml -f docker/docker-compose-clamav.yml`. You need to specify both config files. e.g. to launch the cluster:
-``` bash
+
+```bash
 docker compose -f docker-compose.yml -f docker/docker-compose-clamav.yml up
 ```
 
+For Mac Silicon users:
+
+```bash
+DOCKER_DEFAULT_PLATFORM=linux/amd64 docker compose -f docker-compose.yml -f docker/docker-compose-clamav.yml up
+```
+
 To start scanning files, you'll need to set two environment variables in Iaso:
+
 - `CLAMAV_ACTIVE` set to `True`, in order to tell the backend that file uploads must be scanned (default = `False`)
 - `CLAMAV_FQDN` set to the address that Iaso can use to reach your ClamAV instance (`localhost` in a local IASO installation without Docker, `clamav` in a IASO installation with Docker)
 

--- a/iaso/tests/utils/test_encryption.py
+++ b/iaso/tests/utils/test_encryption.py
@@ -1,7 +1,7 @@
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import SimpleTestCase
 
-from iaso.utils.encryption import calculate_md5
+from iaso.utils.encryption import calculate_md5, file_content_changed
 
 
 class EncryptionTestCase(SimpleTestCase):
@@ -11,3 +11,19 @@ class EncryptionTestCase(SimpleTestCase):
         expected_md5 = "92bbcf620ceb5f5bf38f08e9a1f31e7b"
         md5 = calculate_md5(zip_file)
         self.assertEqual(md5, expected_md5)
+
+    def test_file_content_changed_empty_md5(self):
+        new_file = SimpleUploadedFile("file.zip", b"Some file content")
+        self.assertTrue(file_content_changed("", new_file))
+        self.assertTrue(file_content_changed(None, new_file))
+
+    def test_file_content_changed_same_content(self):
+        content = b"Some file content"
+        md5 = calculate_md5(SimpleUploadedFile("file.zip", content))
+        new_file = SimpleUploadedFile("renamed.zip", content)
+        self.assertFalse(file_content_changed(md5, new_file))
+
+    def test_file_content_changed_different_content(self):
+        old_md5 = calculate_md5(SimpleUploadedFile("file.zip", b"Some file content"))
+        new_file = SimpleUploadedFile("file.zip", b"Different content!!")
+        self.assertTrue(file_content_changed(old_md5, new_file))

--- a/iaso/tests/utils/test_virus_scan_serializers.py
+++ b/iaso/tests/utils/test_virus_scan_serializers.py
@@ -25,36 +25,42 @@ class ModelWithFileSerializerScanTestCase(TestCase):
 
     def test_create_always_needs_scanning(self):
         file = SimpleUploadedFile("doc.pdf", b"content")
-        self.assertTrue(self.serializer._check_if_file_exists_and_needs_scanning({"file": file}, obj=None))
+        new_md5 = calculate_md5(file)
+        self.assertTrue(self.serializer._check_if_file_exists_and_needs_scanning({"file": file}, None, new_md5))
 
     def test_update_needs_scanning_when_md5_empty(self):
         file = SimpleUploadedFile("doc.pdf", b"content")
+        new_md5 = calculate_md5(file)
         obj = MagicMock(spec=DummyModel)
         obj.file = SimpleUploadedFile("doc.pdf", b"content")
         obj.md5 = ""
-        self.assertTrue(self.serializer._check_if_file_exists_and_needs_scanning({"file": file}, obj=obj))
+        self.assertTrue(self.serializer._check_if_file_exists_and_needs_scanning({"file": file}, obj, new_md5))
 
     def test_update_skips_scanning_when_md5_matches(self):
         content = b"same content"
         file = SimpleUploadedFile("doc.pdf", content)
+        new_md5 = calculate_md5(file)
         obj = MagicMock(spec=DummyModel)
         obj.file = SimpleUploadedFile("old.pdf", content)
-        obj.md5 = calculate_md5(SimpleUploadedFile("x.pdf", content))
-        self.assertFalse(self.serializer._check_if_file_exists_and_needs_scanning({"file": file}, obj=obj))
+        obj.md5 = new_md5
+        self.assertFalse(self.serializer._check_if_file_exists_and_needs_scanning({"file": file}, obj, new_md5))
 
     def test_update_needs_scanning_when_md5_differs(self):
-        file = SimpleUploadedFile("doc.pdf", b"new content")
+        new_file = SimpleUploadedFile("doc.pdf", b"new content")
+        new_md5 = calculate_md5(new_file)
         obj = MagicMock(spec=DummyModel)
-        obj.file = SimpleUploadedFile("doc.pdf", b"old content")
-        obj.md5 = calculate_md5(SimpleUploadedFile("x.pdf", b"old content"))
-        self.assertTrue(self.serializer._check_if_file_exists_and_needs_scanning({"file": file}, obj=obj))
+        old_file = SimpleUploadedFile("x.pdf", b"old content")
+        obj.file = old_file
+        obj.md5 = calculate_md5(old_file)
+        self.assertTrue(self.serializer._check_if_file_exists_and_needs_scanning({"file": new_file}, obj, new_md5))
 
     def test_update_needs_scanning_when_no_previous_file(self):
         file = SimpleUploadedFile("doc.pdf", b"content")
+        new_md5 = calculate_md5(file)
         obj = MagicMock(spec=DummyModel)
         obj.file = None
         obj.md5 = ""
-        self.assertTrue(self.serializer._check_if_file_exists_and_needs_scanning({"file": file}, obj=obj))
+        self.assertTrue(self.serializer._check_if_file_exists_and_needs_scanning({"file": file}, obj, new_md5))
 
     @patch("iaso.utils.virus_scan.serializers.scan_uploaded_file_for_virus")
     def test_scan_file_if_exists_sets_md5(self, mock_scan):

--- a/iaso/tests/utils/test_virus_scan_serializers.py
+++ b/iaso/tests/utils/test_virus_scan_serializers.py
@@ -1,0 +1,51 @@
+from unittest.mock import MagicMock, patch
+
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import SimpleTestCase
+
+from iaso.utils.encryption import calculate_md5
+from iaso.utils.virus_scan.model import ModelWithFile, VirusScanStatus
+from plugins.polio.api.vaccines.stock_management.destructions.serializers import DestructionReportSerializer
+
+
+class ModelWithFileSerializerScanTestCase(SimpleTestCase):
+    def setUp(self):
+        self.serializer = DestructionReportSerializer()
+
+    def test_create_always_needs_scanning(self):
+        file = SimpleUploadedFile("doc.pdf", b"content")
+        self.assertTrue(self.serializer._check_if_file_exists_and_needs_scanning({"file": file}, obj=None))
+
+    def test_update_needs_scanning_when_md5_empty(self):
+        file = SimpleUploadedFile("doc.pdf", b"content")
+        obj = MagicMock(spec=ModelWithFile)
+        obj.file = SimpleUploadedFile("doc.pdf", b"content")
+        obj.md5 = ""
+        self.assertTrue(self.serializer._check_if_file_exists_and_needs_scanning({"file": file}, obj=obj))
+
+    def test_update_skips_scanning_when_md5_matches(self):
+        content = b"same content"
+        file = SimpleUploadedFile("doc.pdf", content)
+        obj = MagicMock(spec=ModelWithFile)
+        obj.file = SimpleUploadedFile("old.pdf", content)
+        obj.md5 = calculate_md5(SimpleUploadedFile("x.pdf", content))
+        self.assertFalse(self.serializer._check_if_file_exists_and_needs_scanning({"file": file}, obj=obj))
+
+    def test_update_needs_scanning_when_md5_differs(self):
+        file = SimpleUploadedFile("doc.pdf", b"new content")
+        obj = MagicMock(spec=ModelWithFile)
+        obj.file = SimpleUploadedFile("doc.pdf", b"old content")
+        obj.md5 = calculate_md5(SimpleUploadedFile("x.pdf", b"old content"))
+        self.assertTrue(self.serializer._check_if_file_exists_and_needs_scanning({"file": file}, obj=obj))
+
+    @patch("iaso.utils.virus_scan.serializers.scan_uploaded_file_for_virus")
+    def test_scan_file_if_exists_sets_md5(self, mock_scan):
+        mock_scan.return_value = (VirusScanStatus.CLEAN, None)
+        file = SimpleUploadedFile("doc.pdf", b"content")
+        validated_data = {"file": file}
+
+        scanned = self.serializer.scan_file_if_exists(validated_data)
+
+        self.assertTrue(scanned)
+        self.assertEqual(validated_data["md5"], calculate_md5(SimpleUploadedFile("doc.pdf", b"content")))
+        self.assertEqual(validated_data["file_scan_status"], VirusScanStatus.CLEAN)

--- a/iaso/tests/utils/test_virus_scan_serializers.py
+++ b/iaso/tests/utils/test_virus_scan_serializers.py
@@ -1,16 +1,27 @@
 from unittest.mock import MagicMock, patch
 
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.test import SimpleTestCase
+from django.db import models
 
+from iaso.test import TestCase
 from iaso.utils.encryption import calculate_md5
 from iaso.utils.virus_scan.model import ModelWithFile, VirusScanStatus
-from plugins.polio.api.vaccines.stock_management.destructions.serializers import DestructionReportSerializer
+from iaso.utils.virus_scan.serializers import ModelWithFileSerializer
 
 
-class ModelWithFileSerializerScanTestCase(SimpleTestCase):
+class DummyModel(ModelWithFile):
+    int_value = models.IntegerField(blank=True, null=True)
+
+
+class DummyModelSerializer(ModelWithFileSerializer):
+    class Meta:
+        model = DummyModel
+        fields = ["file", "int_value"]
+
+
+class ModelWithFileSerializerScanTestCase(TestCase):
     def setUp(self):
-        self.serializer = DestructionReportSerializer()
+        self.serializer = DummyModelSerializer()
 
     def test_create_always_needs_scanning(self):
         file = SimpleUploadedFile("doc.pdf", b"content")
@@ -18,7 +29,7 @@ class ModelWithFileSerializerScanTestCase(SimpleTestCase):
 
     def test_update_needs_scanning_when_md5_empty(self):
         file = SimpleUploadedFile("doc.pdf", b"content")
-        obj = MagicMock(spec=ModelWithFile)
+        obj = MagicMock(spec=DummyModel)
         obj.file = SimpleUploadedFile("doc.pdf", b"content")
         obj.md5 = ""
         self.assertTrue(self.serializer._check_if_file_exists_and_needs_scanning({"file": file}, obj=obj))
@@ -26,16 +37,23 @@ class ModelWithFileSerializerScanTestCase(SimpleTestCase):
     def test_update_skips_scanning_when_md5_matches(self):
         content = b"same content"
         file = SimpleUploadedFile("doc.pdf", content)
-        obj = MagicMock(spec=ModelWithFile)
+        obj = MagicMock(spec=DummyModel)
         obj.file = SimpleUploadedFile("old.pdf", content)
         obj.md5 = calculate_md5(SimpleUploadedFile("x.pdf", content))
         self.assertFalse(self.serializer._check_if_file_exists_and_needs_scanning({"file": file}, obj=obj))
 
     def test_update_needs_scanning_when_md5_differs(self):
         file = SimpleUploadedFile("doc.pdf", b"new content")
-        obj = MagicMock(spec=ModelWithFile)
+        obj = MagicMock(spec=DummyModel)
         obj.file = SimpleUploadedFile("doc.pdf", b"old content")
         obj.md5 = calculate_md5(SimpleUploadedFile("x.pdf", b"old content"))
+        self.assertTrue(self.serializer._check_if_file_exists_and_needs_scanning({"file": file}, obj=obj))
+
+    def test_update_needs_scanning_when_no_previous_file(self):
+        file = SimpleUploadedFile("doc.pdf", b"content")
+        obj = MagicMock(spec=DummyModel)
+        obj.file = None
+        obj.md5 = ""
         self.assertTrue(self.serializer._check_if_file_exists_and_needs_scanning({"file": file}, obj=obj))
 
     @patch("iaso.utils.virus_scan.serializers.scan_uploaded_file_for_virus")
@@ -49,3 +67,44 @@ class ModelWithFileSerializerScanTestCase(SimpleTestCase):
         self.assertTrue(scanned)
         self.assertEqual(validated_data["md5"], calculate_md5(SimpleUploadedFile("doc.pdf", b"content")))
         self.assertEqual(validated_data["file_scan_status"], VirusScanStatus.CLEAN)
+
+    @patch("iaso.utils.virus_scan.serializers.scan_uploaded_file_for_virus")
+    def test_scan_file_if_exists_sets_md5_on_update(self, mock_scan):
+        mock_scan.return_value = (VirusScanStatus.CLEAN, None)
+        file = SimpleUploadedFile("doc.pdf", b"new content")
+        obj = MagicMock(spec=DummyModel)
+        obj.file = SimpleUploadedFile("doc.pdf", b"old content")
+        obj.md5 = calculate_md5(SimpleUploadedFile("x.pdf", b"old content"))
+        validated_data = {"file": file}
+
+        scanned = self.serializer.scan_file_if_exists(validated_data, obj=obj)
+
+        self.assertTrue(scanned)
+        self.assertEqual(validated_data["md5"], calculate_md5(SimpleUploadedFile("doc.pdf", b"new content")))
+        self.assertEqual(validated_data["file_scan_status"], VirusScanStatus.CLEAN)
+
+    def test_scan_file_if_exists_removing_file_resets_scan_fields(self):
+        obj = MagicMock(spec=DummyModel)
+        obj.file = SimpleUploadedFile("doc.pdf", b"content")
+        obj.md5 = calculate_md5(SimpleUploadedFile("x.pdf", b"content"))
+        validated_data = {"file": None}
+
+        scanned = self.serializer.scan_file_if_exists(validated_data, obj=obj)
+
+        self.assertFalse(scanned)
+        self.assertEqual(validated_data["md5"], "")
+        self.assertEqual(validated_data["file_scan_status"], VirusScanStatus.PENDING)
+        self.assertIsNone(validated_data["file_last_scan"])
+
+    def test_scan_file_if_exists_removing_file_with_no_previous_file_does_not_touch_scan_fields(self):
+        obj = MagicMock(spec=DummyModel)
+        obj.file = None
+        obj.md5 = ""
+        validated_data = {"file": None}
+
+        scanned = self.serializer.scan_file_if_exists(validated_data, obj=obj)
+
+        self.assertFalse(scanned)
+        self.assertNotIn("md5", validated_data)
+        self.assertNotIn("file_scan_status", validated_data)
+        self.assertNotIn("file_last_scan", validated_data)

--- a/iaso/tests/utils/test_virus_scan_serializers.py
+++ b/iaso/tests/utils/test_virus_scan_serializers.py
@@ -9,13 +9,13 @@ from iaso.utils.virus_scan.model import ModelWithFile, VirusScanStatus
 from iaso.utils.virus_scan.serializers import ModelWithFileSerializer
 
 
-class DummyModel(ModelWithFile):
+class DummyFileModel(ModelWithFile):
     int_value = models.IntegerField(blank=True, null=True)
 
 
 class DummyModelSerializer(ModelWithFileSerializer):
     class Meta:
-        model = DummyModel
+        model = DummyFileModel
         fields = ["file", "int_value"]
 
 
@@ -31,7 +31,7 @@ class ModelWithFileSerializerScanTestCase(TestCase):
     def test_update_needs_scanning_when_md5_empty(self):
         file = SimpleUploadedFile("doc.pdf", b"content")
         new_md5 = calculate_md5(file)
-        obj = MagicMock(spec=DummyModel)
+        obj = MagicMock(spec=DummyFileModel)
         obj.file = SimpleUploadedFile("doc.pdf", b"content")
         obj.md5 = ""
         self.assertTrue(self.serializer._check_if_file_exists_and_needs_scanning({"file": file}, obj, new_md5))
@@ -40,7 +40,7 @@ class ModelWithFileSerializerScanTestCase(TestCase):
         content = b"same content"
         file = SimpleUploadedFile("doc.pdf", content)
         new_md5 = calculate_md5(file)
-        obj = MagicMock(spec=DummyModel)
+        obj = MagicMock(spec=DummyFileModel)
         obj.file = SimpleUploadedFile("old.pdf", content)
         obj.md5 = new_md5
         self.assertFalse(self.serializer._check_if_file_exists_and_needs_scanning({"file": file}, obj, new_md5))
@@ -48,7 +48,7 @@ class ModelWithFileSerializerScanTestCase(TestCase):
     def test_update_needs_scanning_when_md5_differs(self):
         new_file = SimpleUploadedFile("doc.pdf", b"new content")
         new_md5 = calculate_md5(new_file)
-        obj = MagicMock(spec=DummyModel)
+        obj = MagicMock(spec=DummyFileModel)
         old_file = SimpleUploadedFile("x.pdf", b"old content")
         obj.file = old_file
         obj.md5 = calculate_md5(old_file)
@@ -57,7 +57,7 @@ class ModelWithFileSerializerScanTestCase(TestCase):
     def test_update_needs_scanning_when_no_previous_file(self):
         file = SimpleUploadedFile("doc.pdf", b"content")
         new_md5 = calculate_md5(file)
-        obj = MagicMock(spec=DummyModel)
+        obj = MagicMock(spec=DummyFileModel)
         obj.file = None
         obj.md5 = ""
         self.assertTrue(self.serializer._check_if_file_exists_and_needs_scanning({"file": file}, obj, new_md5))
@@ -78,7 +78,7 @@ class ModelWithFileSerializerScanTestCase(TestCase):
     def test_scan_file_if_exists_sets_md5_on_update(self, mock_scan):
         mock_scan.return_value = (VirusScanStatus.CLEAN, None)
         file = SimpleUploadedFile("doc.pdf", b"new content")
-        obj = MagicMock(spec=DummyModel)
+        obj = MagicMock(spec=DummyFileModel)
         obj.file = SimpleUploadedFile("doc.pdf", b"old content")
         obj.md5 = calculate_md5(SimpleUploadedFile("x.pdf", b"old content"))
         validated_data = {"file": file}
@@ -90,7 +90,7 @@ class ModelWithFileSerializerScanTestCase(TestCase):
         self.assertEqual(validated_data["file_scan_status"], VirusScanStatus.CLEAN)
 
     def test_scan_file_if_exists_removing_file_resets_scan_fields(self):
-        obj = MagicMock(spec=DummyModel)
+        obj = MagicMock(spec=DummyFileModel)
         obj.file = SimpleUploadedFile("doc.pdf", b"content")
         obj.md5 = calculate_md5(SimpleUploadedFile("x.pdf", b"content"))
         validated_data = {"file": None}
@@ -103,7 +103,7 @@ class ModelWithFileSerializerScanTestCase(TestCase):
         self.assertIsNone(validated_data["file_last_scan"])
 
     def test_scan_file_if_exists_removing_file_with_no_previous_file_does_not_touch_scan_fields(self):
-        obj = MagicMock(spec=DummyModel)
+        obj = MagicMock(spec=DummyFileModel)
         obj.file = None
         obj.md5 = ""
         validated_data = {"file": None}

--- a/iaso/utils/encryption.py
+++ b/iaso/utils/encryption.py
@@ -1,6 +1,8 @@
 import hashlib
 import os
 
+from typing import Optional
+
 from Crypto.Cipher import AES
 from Crypto.Hash import SHA1
 from Crypto.Protocol.KDF import PBKDF2
@@ -24,6 +26,13 @@ def calculate_md5(file_obj: File, chunk_size: int = 8192) -> str:
     file_obj.seek(file_original_position)  # Restore original position
 
     return hasher.hexdigest()
+
+
+def file_content_changed(old_md5: Optional[str], new_file: File) -> bool:
+    """Return True if new_file content differs from the previously stored md5."""
+    if not old_md5:
+        return True
+    return old_md5 != calculate_md5(new_file)
 
 
 def encrypt_file(file_path, file_name_in, file_name_out, password):

--- a/iaso/utils/virus_scan/model.py
+++ b/iaso/utils/virus_scan/model.py
@@ -27,6 +27,7 @@ class ModelWithFile(models.Model):
 
     This model provides the basic fields needed for virus scanning functionality:
     - file: The uploaded file
+    - md5: MD5 checksum of the file content (used for change detection)
     - file_scan_status: The result of the virus scan
     - file_last_scan: When the file was last scanned
 
@@ -35,6 +36,7 @@ class ModelWithFile(models.Model):
 
     Attributes:
         file (FileField): The uploaded file, can be null/blank
+        md5 (CharField): MD5 checksum of the file content
         file_last_scan (DateTimeField): When the file was last scanned
         file_scan_status (CharField): The result of the virus scan (CLEAN, INFECTED, etc.)
 
@@ -43,7 +45,7 @@ class ModelWithFile(models.Model):
             title = models.CharField(max_length=200)
             content = models.TextField()
 
-        # Now Document has file, file_scan_status, and file_last_scan fields
+        # Now Document has file, md5, file_scan_status, and file_last_scan fields
         doc = Document.objects.create(title="Test Doc")
         # doc.file_scan_status defaults to PENDING
     """
@@ -52,6 +54,7 @@ class ModelWithFile(models.Model):
         null=True,
         blank=True,
     )
+    md5 = models.CharField(blank=True, max_length=32)
     file_last_scan = models.DateTimeField(blank=True, null=True)
     file_scan_status = models.CharField(max_length=10, choices=VirusScanStatus.choices, default=VirusScanStatus.PENDING)
 

--- a/iaso/utils/virus_scan/serializers.py
+++ b/iaso/utils/virus_scan/serializers.py
@@ -2,7 +2,7 @@ from rest_framework import serializers
 
 from iaso.utils.encryption import calculate_md5, file_content_changed
 from iaso.utils.virus_scan.clamav import scan_uploaded_file_for_virus
-from iaso.utils.virus_scan.model import ModelWithFile
+from iaso.utils.virus_scan.model import ModelWithFile, VirusScanStatus
 
 
 class ModelWithFileSerializer(serializers.ModelSerializer):
@@ -70,6 +70,10 @@ class ModelWithFileSerializer(serializers.ModelSerializer):
         during the creation of objects that inherit from ModelWithFile. It scans
         a potential file in validated_data and adds the scan results as additional fields.
 
+        If an update clears a previously set file (validated_data['file'] is falsy while
+        obj already has a file), the scan metadata (md5, file_scan_status, file_last_scan)
+        is reset to its defaults.
+
         Args:
             validated_data (dict): The validated data from a DRF serializer,
                 which may contain a 'file' key with an uploaded file.
@@ -98,7 +102,17 @@ class ModelWithFileSerializer(serializers.ModelSerializer):
             validated_data["file_scan_status"] = result
             validated_data["file_last_scan"] = timestamp
             validated_data["md5"] = new_md5
+        elif self._file_removed(validated_data, obj):
+            # The file is being cleared on an update: the scan metadata describes a file
+            # that no longer exists, so it must be reset to its defaults, not left stale.
+            validated_data["file_scan_status"] = VirusScanStatus.PENDING
+            validated_data["file_last_scan"] = None
+            validated_data["md5"] = ""
         return needs_scanning
+
+    def _file_removed(self, validated_data, obj) -> bool:
+        """Whether this update clears a file that was previously set on ``obj``."""
+        return bool(obj) and "file" in validated_data and not validated_data["file"] and bool(obj.file)
 
     def _check_if_file_exists_and_needs_scanning(self, validated_data, obj, new_md5=None):
         """

--- a/iaso/utils/virus_scan/serializers.py
+++ b/iaso/utils/virus_scan/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 
-from iaso.utils.encryption import calculate_md5, file_content_changed
+from iaso.utils.encryption import calculate_md5
 from iaso.utils.virus_scan.clamav import scan_uploaded_file_for_virus
 from iaso.utils.virus_scan.model import ModelWithFile, VirusScanStatus
 
@@ -114,12 +114,12 @@ class ModelWithFileSerializer(serializers.ModelSerializer):
         """Whether this update clears a file that was previously set on ``obj``."""
         return bool(obj) and "file" in validated_data and not validated_data["file"] and bool(obj.file)
 
-    def _check_if_file_exists_and_needs_scanning(self, validated_data, obj, new_md5=None):
+    def _check_if_file_exists_and_needs_scanning(self, validated_data, obj, new_md5):
         """
         Determines if a file exists in validated_data and if it needs scanning.
         Files are always scanned during creation. Files are scanned during update only if they have changed.
 
-        ``new_md5`` is the pre-computed md5 of the new file; when omitted it is computed on demand.
+        ``new_md5`` is the pre-computed md5 of the new file.
         """
         if "file" not in validated_data:
             return False
@@ -136,7 +136,5 @@ class ModelWithFileSerializer(serializers.ModelSerializer):
         if not old_file:
             return True  # no previous file, so we need to scan the new one
 
-        if new_md5 is None:
-            return file_content_changed(obj.md5, file)
         # Empty stored md5 means the previous content is unknown, so treat it as changed.
         return not obj.md5 or obj.md5 != new_md5

--- a/iaso/utils/virus_scan/serializers.py
+++ b/iaso/utils/virus_scan/serializers.py
@@ -1,7 +1,6 @@
-import os
-
 from rest_framework import serializers
 
+from iaso.utils.encryption import calculate_md5, file_content_changed
 from iaso.utils.virus_scan.clamav import scan_uploaded_file_for_virus
 from iaso.utils.virus_scan.model import ModelWithFile
 
@@ -83,24 +82,30 @@ class ModelWithFileSerializer(serializers.ModelSerializer):
         Example:
             # In a DRF serializer's create method:
             def create(self, validated_data):
-                self.scan_file_if_exists(validated_data)  # Adds file_scan_status and file_last_scan
+                self.scan_file_if_exists(validated_data)  # Adds file_scan_status, file_last_scan, md5
                 return super().create(**validated_data)
 
             validated_data before: {'file': <UploadedFile>, 'name': 'test'}
             validated_data after: {'file': <UploadedFile>, 'name': 'test',
-                                   'file_scan_status': 'CLEAN', 'file_last_scan': datetime}
+                                   'file_scan_status': 'CLEAN', 'file_last_scan': datetime, 'md5': '...'}
         """
-        needs_scanning = self._check_if_file_exists_and_needs_scanning(validated_data, obj)
+        # Compute the new file's md5 once and reuse it for both the change check and
+        # persistence, so the file is not hashed twice on a single upload.
+        new_md5 = calculate_md5(validated_data["file"]) if validated_data.get("file") else ""
+        needs_scanning = self._check_if_file_exists_and_needs_scanning(validated_data, obj, new_md5)
         if needs_scanning:
             result, timestamp = scan_uploaded_file_for_virus(validated_data["file"])
             validated_data["file_scan_status"] = result
             validated_data["file_last_scan"] = timestamp
+            validated_data["md5"] = new_md5
         return needs_scanning
 
-    def _check_if_file_exists_and_needs_scanning(self, validated_data, obj):
+    def _check_if_file_exists_and_needs_scanning(self, validated_data, obj, new_md5=None):
         """
         Determines if a file exists in validated_data and if it needs scanning.
         Files are always scanned during creation. Files are scanned during update only if they have changed.
+
+        ``new_md5`` is the pre-computed md5 of the new file; when omitted it is computed on demand.
         """
         if "file" not in validated_data:
             return False
@@ -117,7 +122,7 @@ class ModelWithFileSerializer(serializers.ModelSerializer):
         if not old_file:
             return True  # no previous file, so we need to scan the new one
 
-        # Compare the new file with the existing one
-        needs_scanning = os.path.basename(old_file.name) != os.path.basename(file.name) or old_file.size != file.size
-        # we should compare file hashes instead - see POLIO-1959
-        return needs_scanning
+        if new_md5 is None:
+            return file_content_changed(obj.md5, file)
+        # Empty stored md5 means the previous content is unknown, so treat it as changed.
+        return not obj.md5 or obj.md5 != new_md5

--- a/plugins/polio/api/notifications/views.py
+++ b/plugins/polio/api/notifications/views.py
@@ -91,7 +91,7 @@ class NotificationViewSet(viewsets.ModelViewSet):
             md5=calculate_md5(uploaded_file),
         )
         # TODO: don't do the async if the file is positive?
-        create_polio_notifications_async(pk=notification_import.pk)
+        create_polio_notifications_async(pk=notification_import.pk, user=user)
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
     @action(detail=True, methods=["get"])

--- a/plugins/polio/api/notifications/views.py
+++ b/plugins/polio/api/notifications/views.py
@@ -11,6 +11,7 @@ from rest_framework.response import Response
 
 from iaso.api.common import Paginator
 from iaso.models import OrgUnitType
+from iaso.utils.encryption import calculate_md5
 from iaso.utils.virus_scan.clamav import scan_uploaded_file_for_virus
 from plugins.polio.api.notifications.filters import NotificationFilter
 from plugins.polio.api.notifications.permissions import HasNotificationPermission
@@ -80,12 +81,17 @@ class NotificationViewSet(viewsets.ModelViewSet):
         account = user.iaso_profile.account
         serializer = NotificationImportSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
-        result, timestamp = scan_uploaded_file_for_virus(serializer.validated_data["file"])
+        uploaded_file = serializer.validated_data["file"]
+        result, timestamp = scan_uploaded_file_for_virus(uploaded_file)
         notification_import = serializer.save(
-            account=account, created_by=user, file_last_scan=timestamp, file_scan_status=result
+            account=account,
+            created_by=user,
+            file_last_scan=timestamp,
+            file_scan_status=result,
+            md5=calculate_md5(uploaded_file),
         )
         # TODO: don't do the async if the file is positive?
-        create_polio_notifications_async(pk=notification_import.pk, user=user)
+        create_polio_notifications_async(pk=notification_import.pk)
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
     @action(detail=True, methods=["get"])

--- a/plugins/polio/api/vaccines/stock_management/destructions/serializers.py
+++ b/plugins/polio/api/vaccines/stock_management/destructions/serializers.py
@@ -18,7 +18,7 @@ class DestructionReportSerializer(ModelWithFileSerializer):
 
     class Meta:
         model = DestructionReport
-        exclude = ["file_last_scan", "file_scan_status"]
+        exclude = ["file_last_scan", "file_scan_status", "md5"]
 
     def get_can_edit(self, obj):
         return has_vaccine_stock_edit_access(
@@ -34,7 +34,7 @@ class DestructionReportSerializer(ModelWithFileSerializer):
         return super().create(validated_data)
 
     def update(self, instance, validated_data):
-        self.scan_file_if_exists(validated_data)
+        self.scan_file_if_exists(validated_data, instance)
         return super().update(instance, validated_data)
 
     def to_representation(self, instance):

--- a/plugins/polio/api/vaccines/stock_management/incidents/serializers.py
+++ b/plugins/polio/api/vaccines/stock_management/incidents/serializers.py
@@ -18,7 +18,7 @@ class IncidentReportSerializer(ModelWithFileSerializer):
 
     class Meta:
         model = IncidentReport
-        exclude = ["file_last_scan", "file_scan_status"]
+        exclude = ["file_last_scan", "file_scan_status", "md5"]
 
     def get_can_edit(self, obj):
         return has_vaccine_stock_edit_access(
@@ -34,7 +34,7 @@ class IncidentReportSerializer(ModelWithFileSerializer):
         return super().create(validated_data)
 
     def update(self, instance, validated_data):
-        self.scan_file_if_exists(validated_data)
+        self.scan_file_if_exists(validated_data, instance)
         return super().update(instance, validated_data)
 
     def to_representation(self, instance):

--- a/plugins/polio/api/vaccines/supply_chain.py
+++ b/plugins/polio/api/vaccines/supply_chain.py
@@ -22,6 +22,7 @@ from rest_framework.response import Response
 
 from iaso.api.common import ModelViewSet, parse_comma_separated_numeric_values
 from iaso.models import OrgUnit
+from iaso.utils.encryption import calculate_md5, file_content_changed
 from iaso.utils.virus_scan.clamav import scan_uploaded_file_for_virus
 from iaso.utils.virus_scan.serializers import ModelWithFileSerializer
 from plugins.polio.api.vaccines.permissions import VaccineStockPermission, has_vaccine_stock_edit_access
@@ -141,7 +142,7 @@ class NestedVaccinePreAlertSerializerForPost(ModelWithFileSerializer):
 
     def update(self, instance, validated_data):
         validated_data["request_form"] = self.context["vaccine_request_form"]
-        self.scan_file_if_exists(validated_data)
+        self.scan_file_if_exists(validated_data, instance)
         return super().update(instance, validated_data)
 
 
@@ -192,8 +193,7 @@ class NestedVaccinePreAlertSerializerForPatch(NestedVaccinePreAlertSerializerFor
                     current_obj.file = new_file
                     continue
 
-                # Compare file names and sizes
-                if os.path.basename(old_file.name) != os.path.basename(new_file.name) or old_file.size != new_file.size:
+                if file_content_changed(current_obj.md5, new_file):
                     is_different = True
                     current_obj.file = new_file
             elif hasattr(current_obj, key) and getattr(current_obj, key) != attrs[key]:
@@ -290,24 +290,7 @@ class NestedVaccineArrivalReportSerializerForPatch(NestedVaccineArrivalReportSer
         # Check if any values are actually different
         is_different = False
         for key in attrs.keys():
-            if key == "file":
-                # Skip if no new document is being uploaded
-                if not attrs[key]:
-                    continue
-
-                new_file = attrs[key]
-                old_file = current_obj.file
-
-                # If there's no existing document but we're uploading one
-                if not old_file:
-                    is_different = True
-                    current_obj.file = new_file
-                    continue
-
-                if os.path.basename(old_file.name) != os.path.basename(new_file.name) or old_file.size != new_file.size:
-                    is_different = True
-                    current_obj.file = new_file
-            elif hasattr(current_obj, key) and getattr(current_obj, key) != attrs[key]:
+            if hasattr(current_obj, key) and getattr(current_obj, key) != attrs[key]:
                 is_different = True
                 break
 
@@ -369,15 +352,15 @@ class PatchPreAlertSerializer(serializers.Serializer):
                         new_file = item[key]
                         old_file = pa.file
 
-                        if not old_file or (
-                            os.path.basename(old_file.name) != os.path.basename(new_file.name)
-                            or old_file.size != new_file.size
-                        ):
+                        # Hash once and reuse for both the change check and persistence.
+                        new_md5 = calculate_md5(new_file)
+                        if not old_file or not pa.md5 or pa.md5 != new_md5:
                             is_different = True
                             result, timestamp = scan_uploaded_file_for_virus(new_file)
                             pa.file = new_file
                             pa.file_scan_status = result
                             pa.file_last_scan = timestamp
+                            pa.md5 = new_md5
                     elif hasattr(pa, key) and getattr(pa, key) != item[key]:
                         is_different = True
                         setattr(pa, key, item[key])
@@ -526,6 +509,7 @@ class VaccineRequestFormPostSerializer(ModelWithFileSerializer):
         if self.scan_file_if_exists(validated_data):
             request_form.file_last_scan = validated_data["file_last_scan"]
             request_form.file_scan_status = validated_data["file_scan_status"]
+            request_form.md5 = validated_data["md5"]
             request_form.save()
         return request_form
 
@@ -609,7 +593,7 @@ class VaccineRequestFormDetailSerializer(ModelWithFileSerializer):
         return super().create(validated_data)
 
     def update(self, instance, validated_data):
-        self.scan_file_if_exists(validated_data)
+        self.scan_file_if_exists(validated_data, instance)
         return super().update(instance, validated_data)
 
 

--- a/plugins/polio/migrations/0255_modelwithfile_md5.py
+++ b/plugins/polio/migrations/0255_modelwithfile_md5.py
@@ -1,0 +1,45 @@
+# Generated manually for ModelWithFile.md5
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    # Schema-only migration: runs in a transaction (default). The md5 backfill is
+    # done in a separate, non-atomic data migration so a failure here rolls back cleanly.
+
+    dependencies = [
+        ("polio", "0254_remove_round_date_destruction_and_more"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="destructionreport",
+            name="md5",
+            field=models.CharField(blank=True, max_length=32),
+        ),
+        migrations.AddField(
+            model_name="incidentreport",
+            name="md5",
+            field=models.CharField(blank=True, max_length=32),
+        ),
+        migrations.AddField(
+            model_name="notificationimport",
+            name="md5",
+            field=models.CharField(blank=True, max_length=32),
+        ),
+        migrations.AddField(
+            model_name="outgoingstockmovement",
+            name="md5",
+            field=models.CharField(blank=True, max_length=32),
+        ),
+        migrations.AddField(
+            model_name="vaccineprealert",
+            name="md5",
+            field=models.CharField(blank=True, max_length=32),
+        ),
+        migrations.AddField(
+            model_name="vaccinerequestform",
+            name="md5",
+            field=models.CharField(blank=True, max_length=32),
+        ),
+    ]

--- a/plugins/polio/migrations/0256_backfill_modelwithfile_md5.py
+++ b/plugins/polio/migrations/0256_backfill_modelwithfile_md5.py
@@ -24,8 +24,6 @@ def _backfill_model(Model, model_name):
     can safely be re-run (e.g. after a partial failure) without recomputing
     hashes that were already stored.
     """
-    print("-" * 80)
-    print(f"Start populating `{model_name}.md5`…")
 
     to_update = []
     # `only` keeps the SELECT narrow so we don't pull unused columns on large tables.
@@ -56,8 +54,6 @@ def _backfill_model(Model, model_name):
     if to_update:
         print(f"Updating {len(to_update)} {model_name}…")
         Model.objects.bulk_update(to_update, ["md5"])
-
-    print(f"Done with {model_name}.")
 
 
 def migrate_data_forward(apps, schema_editor):

--- a/plugins/polio/migrations/0256_backfill_modelwithfile_md5.py
+++ b/plugins/polio/migrations/0256_backfill_modelwithfile_md5.py
@@ -40,8 +40,8 @@ def _backfill_model(Model, model_name):
     for instance in queryset:
         try:
             md5 = calculate_md5(instance.file)
-        except (FileNotFoundError, OSError):
-            # Missing/unreadable file: skip this row, don't abort the whole run.
+        except (FileNotFoundError, OSError) as e:
+            print(f"there was an error while calculating file md5 - {str(e)}")
             continue
 
         if md5:

--- a/plugins/polio/migrations/0256_backfill_modelwithfile_md5.py
+++ b/plugins/polio/migrations/0256_backfill_modelwithfile_md5.py
@@ -1,0 +1,82 @@
+# Generated manually to backfill ModelWithFile.md5
+
+from django.db import migrations
+
+from iaso.utils.encryption import calculate_md5
+
+
+MODEL_NAMES = [
+    "VaccineRequestForm",
+    "VaccinePreAlert",
+    "OutgoingStockMovement",
+    "DestructionReport",
+    "IncidentReport",
+    "NotificationImport",
+]
+
+CHUNK_SIZE = 100
+
+
+def _backfill_model(Model, model_name):
+    """Idempotent, chunked backfill of md5 for rows that don't have one yet.
+
+    Only rows with a file and an empty md5 are considered, so the migration
+    can safely be re-run (e.g. after a partial failure) without recomputing
+    hashes that were already stored.
+    """
+    print("-" * 80)
+    print(f"Start populating `{model_name}.md5`…")
+
+    to_update = []
+    # `only` keeps the SELECT narrow so we don't pull unused columns on large tables.
+    queryset = (
+        Model.objects.filter(md5="")
+        .exclude(file="")
+        .exclude(file__isnull=True)
+        .only("pk", "file", "md5")
+        .iterator(chunk_size=CHUNK_SIZE)
+    )
+
+    for instance in queryset:
+        try:
+            md5 = calculate_md5(instance.file)
+        except (FileNotFoundError, OSError):
+            # Missing/unreadable file: skip this row, don't abort the whole run.
+            continue
+
+        if md5:
+            instance.md5 = md5
+            to_update.append(instance)
+
+            if len(to_update) >= CHUNK_SIZE:
+                print(f"Updating {len(to_update)} {model_name}…")
+                Model.objects.bulk_update(to_update, ["md5"])
+                to_update = []
+
+    if to_update:
+        print(f"Updating {len(to_update)} {model_name}…")
+        Model.objects.bulk_update(to_update, ["md5"])
+
+    print(f"Done with {model_name}.")
+
+
+def migrate_data_forward(apps, schema_editor):
+    for model_name in MODEL_NAMES:
+        Model = apps.get_model("polio", model_name)
+        _backfill_model(Model, model_name)
+
+
+class Migration(migrations.Migration):
+    # Non-atomic on purpose: the backfill commits per chunk so we don't hold a
+    # single long transaction/lock on large tables, and progress survives a late
+    # failure. It contains no schema (DDL) changes, so a mid-run failure leaves
+    # only already-committed md5 values, and re-running resumes where it stopped.
+    atomic = False
+
+    dependencies = [
+        ("polio", "0255_modelwithfile_md5"),
+    ]
+
+    operations = [
+        migrations.RunPython(migrate_data_forward, migrations.RunPython.noop, elidable=True),
+    ]

--- a/plugins/polio/models/base.py
+++ b/plugins/polio/models/base.py
@@ -2035,9 +2035,9 @@ class NotificationImport(ModelWithFile):
 @task_decorator(task_name="create_polio_notifications_async")
 def create_polio_notifications_async(pk: int, user: User = None, task: Task = None) -> None:
     task.report_progress_and_stop_if_killed(progress_message="Importing polio notifications…")
-    user = task.launcher
+    importer = user or task.launcher
     notification_import = NotificationImport.objects.get(pk=pk)
-    notification_import.create_notifications(created_by=user)
+    notification_import.create_notifications(created_by=importer)
     num_created = Notification.objects.filter(import_source=notification_import).count()
     task.report_success(message=f"{num_created} polio notifications created.")
 

--- a/plugins/polio/models/base.py
+++ b/plugins/polio/models/base.py
@@ -2033,7 +2033,7 @@ class NotificationImport(ModelWithFile):
 
 
 @task_decorator(task_name="create_polio_notifications_async")
-def create_polio_notifications_async(pk: int, task: Task = None) -> None:
+def create_polio_notifications_async(pk: int, user: User = None, task: Task = None) -> None:
     task.report_progress_and_stop_if_killed(progress_message="Importing polio notifications…")
     user = task.launcher
     notification_import = NotificationImport.objects.get(pk=pk)

--- a/plugins/polio/tests/api/test_notifications.py
+++ b/plugins/polio/tests/api/test_notifications.py
@@ -371,6 +371,7 @@ class NotificationViewSetTestCase(APITestCase):
         self.assertEqual(notification_import.created_by, self.user)
         self.assertEqual(notification_import.file_scan_status, VirusScanStatus.PENDING)  # Scanning not enabled
         self.assertEqual(notification_import.file_last_scan, None)
+        self.assertEqual(len(notification_import.md5), 32)
 
     @time_machine.travel(DT, tick=False)
     @override_settings(CLAMAV_ACTIVE=True)

--- a/plugins/polio/tests/api/vaccine_supply_chain/test_vaccine_request_form_virus_scan.py
+++ b/plugins/polio/tests/api/vaccine_supply_chain/test_vaccine_request_form_virus_scan.py
@@ -10,6 +10,7 @@ from rest_framework import status
 
 from hat import settings
 from iaso.test import MockClamavScanResults
+from iaso.utils.encryption import calculate_md5
 from iaso.utils.virus_scan.model import VirusScanStatus
 from plugins.polio import models as pm
 from plugins.polio.tests.api.vaccine_supply_chain.base import BaseVaccineSupplyChainAPITestCase
@@ -68,6 +69,7 @@ class VaccineRequestFormVirusScanAPITestCase(BaseVaccineSupplyChainAPITestCase):
         self.assertEqual(vaccine_request_form.file_scan_status, VirusScanStatus.CLEAN)
         self.assertEqual(vaccine_request_form.file_last_scan, self.DT)
         self.assertEqual(vaccine_request_form.quantities_ordered_in_doses, 500)
+        self.assertEqual(len(vaccine_request_form.md5), 32)
 
     @time_machine.travel(DT, tick=False)
     @override_settings(CLAMAV_ACTIVE=True)
@@ -418,3 +420,63 @@ class VaccineRequestFormVirusScanAPITestCase(BaseVaccineSupplyChainAPITestCase):
         self.assertEqual(vaccine_request_form_clean.file_scan_status, VirusScanStatus.ERROR)
         self.assertIsNone(vaccine_request_form_clean.file_last_scan)
         self.assertEqual(vaccine_request_form_clean.quantities_ordered_in_doses, 600)
+
+    @time_machine.travel(DT, tick=False)
+    @override_settings(CLAMAV_ACTIVE=True)
+    @patch("clamav_client.get_scanner")
+    def test_update_vaccine_request_form_skips_rescan_when_md5_unchanged(self, mock_get_scanner):
+        mock_scanner = MagicMock()
+        mock_scanner.scan.return_value = MockClamavScanResults(
+            state="FOUND",
+            details="Virus found :(",
+            passed=False,
+        )
+        mock_get_scanner.return_value = mock_scanner
+
+        previous_scan = datetime.datetime(2021, 10, 9, 16, 45, 27, tzinfo=datetime.timezone.utc)
+        with open(self.SAFE_FILE_PATH, "rb") as safe_file:
+            safe_file_content = safe_file.read()
+
+        md5 = calculate_md5(SimpleUploadedFile("safe_file.pdf", safe_file_content))
+        vaccine_request_form = pm.VaccineRequestForm.objects.create(
+            campaign=self.campaign_rdc_1,
+            vaccine_type=pm.VACCINES[0][0],
+            date_vrf_signature="2024-01-01",
+            date_vrf_reception="2024-01-02",
+            date_dg_approval="2024-01-03",
+            quantities_ordered_in_doses=500,
+            file_scan_status=VirusScanStatus.CLEAN,
+            file_last_scan=previous_scan,
+            md5=md5,
+            file=SimpleUploadedFile(
+                name="safe_file.pdf",
+                content=safe_file_content,
+                content_type="application/pdf",
+            ),
+        )
+        vaccine_request_form.rounds.set([self.campaign_rdc_1_round_1])
+
+        data = {
+            "quantities_ordered_in_doses": 600,
+            "file": SimpleUploadedFile(
+                name="safe_file_renamed.pdf",
+                content=safe_file_content,
+                content_type="application/pdf",
+            ),
+        }
+
+        self.client.force_authenticate(self.user_rw_perm)
+        response = self.client.patch(
+            f"{self.BASE_URL}{vaccine_request_form.id}/",
+            data=data,
+            format="multipart",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        vaccine_request_form.refresh_from_db()
+        # Same content → no re-scan even if filename changed
+        self.assertEqual(vaccine_request_form.file_scan_status, VirusScanStatus.CLEAN)
+        self.assertEqual(vaccine_request_form.file_last_scan, previous_scan)
+        self.assertEqual(vaccine_request_form.md5, md5)
+        self.assertEqual(vaccine_request_form.quantities_ordered_in_doses, 600)
+        mock_scanner.scan.assert_not_called()


### PR DESCRIPTION
## What problem is this PR solving?

Vaccine stock file upload was using a not so reliable method to check that an uploaded file had been modified

### Related JIRA tickets

POLIO-1959

## Changes

- use md5 hash to compare files for changes:
    - Update `ModelWithFile` abstract class to add `md5` field (cf existing pattern in `FormVersion`etc)
    - Update serializers
    - Add 2 step migration:
        - first add field
        - then populate md5 field with non atomic transaction
- Remove some dead code
- Update local clamav doc with command for mac silicon

## How to test

On a polio DB, with clamav active (see modified md file for procedure)

- Go to polio> notifications:
    - click submit and use template to submit a file: check terminal output for file scan
- Go to polio > Vaccine module:
   - Upload/update file for supply chain: VRF, Pre-Alert
   - Upload/update file for stock management: FormA, Incident Report, Destruction report
   All uploaded files should appeared as scanned

## Print screen / video
N/A no feature change

