### PR TITLE
SNT-549 Properly determine CSV delimiter when importing

### DIFF
--- a/iaso/api/metrics/serializers.py
+++ b/iaso/api/metrics/serializers.py
@@ -144,8 +144,12 @@ class ImportMetricValuesSerializer(serializers.Serializer):
         if not value.name.endswith(".csv"):
             raise serializers.ValidationError(_("The file must be a CSV."))
 
-        dialect = csv.Sniffer().sniff(value.read(1024).decode("utf-8", errors="ignore"))
-        value.seek(0)  # Reset file pointer after reading for dialect inference
+        try:
+            header_line = value.readline().decode("utf-8", errors="ignore")
+            value.seek(0)  # Reset file pointer after reading for dialect inference
+            dialect = csv.Sniffer().sniff(header_line, delimiters=";,|\t")
+        except csv.Error:
+            raise serializers.ValidationError(_("Unable to determine the CSV delimiter."))
         df = pd.read_csv(value, sep=dialect.delimiter)
         self.context["metric_values_df"] = df  # Store the DataFrame for use in the save method
         header_errors = get_missing_headers(df, REQUIRED_METRIC_VALUES_HEADERS)

--- a/iaso/locale/fr/LC_MESSAGES/django.po
+++ b/iaso/locale/fr/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-24 13:01+0000\n"
+"POT-Creation-Date: 2026-07-27 11:25+0000\n"
 "PO-Revision-Date: 2025-02-06 10:24+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,6 +17,18 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 3.5\n"
+
+#: dynamic_fields/filter_backends.py
+#, python-brace-format
+msgid "Dynamic fields cannot contain both {all_fields} and {default_fields}"
+msgstr ""
+"Les champs dynamiques ne peuvent pas contenir à la fois {all_fields} et "
+"{default_fields}"
+
+#: dynamic_fields/filter_backends.py
+#, python-brace-format
+msgid "Invalid dynamic fields: {fields}"
+msgstr "Champs dynamiques invalides : {fields}"
 
 #: iaso/api/api_import/filters.py iaso/api/pages.py iaso/api/payments/views.py
 msgid "User ID"
@@ -162,6 +174,10 @@ msgstr ""
 #: iaso/api/metrics/serializers.py
 msgid "The file must be a CSV."
 msgstr "Le fichier doit être un CSV"
+
+#: iaso/api/metrics/serializers.py
+msgid "Unable to determine the CSV delimiter."
+msgstr "Impossible de déterminer le délimiteur du CSV"
 
 #: iaso/api/metrics/serializers.py
 #, python-brace-format

--- a/iaso/tests/api/metrics/test_serializers.py
+++ b/iaso/tests/api/metrics/test_serializers.py
@@ -559,7 +559,7 @@ class ImportMetricValuesSerializerTestCase(TestCase):
         self.assertIn("The CSV must contain at least one metric type column.", serializer.errors["file"][0])
 
     def test_validate_missing_required_headers(self):
-        csv_content = "MT1\nCOMOE,738,1"
+        csv_content = "MT1,SMTH\nCOMOE,738,1"
         invalid_file = SimpleUploadedFile("test.csv", csv_content.encode(), content_type="text/csv")
         serializer = ImportMetricValuesSerializer(
             data={"file": invalid_file, "year": 2024}, context={"request": self.request}

--- a/plugins/polio/locale/fr/LC_MESSAGES/django.po
+++ b/plugins/polio/locale/fr/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-09 21:04+0000\n"
+"POT-Creation-Date: 2026-07-27 11:25+0000\n"
 "PO-Revision-Date: 2025-02-05 14:43+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -25,10 +25,6 @@ msgstr "Évaluation (LQAS/IM)"
 #: plugins/polio/admin.py
 msgid "Preparedness"
 msgstr "Préparation de campagne"
-
-#: plugins/polio/admin.py
-msgid "Deprecated – round-level vaccine management"
-msgstr "Déprécié – gestion des vaccins au niveau du round"
 
 #: plugins/polio/api/calendar/serializers.py
 #: plugins/polio/api/campaigns/serializers/campaigns.py
@@ -353,15 +349,6 @@ msgstr "mois"
 #: plugins/polio/models/base.py
 msgid "name"
 msgstr "nom"
-
-#: plugins/polio/models/base.py
-msgid ""
-"Deprecated. Use VaccineRequestForm, OutgoingStockMovement, or "
-"DestructionReport in the vaccine supply chain module instead."
-msgstr ""
-"Déprécié. Utilisez VaccineRequestForm, OutgoingStockMovement ou "
-"DestructionReport dans le module de chaîne d'approvisionnement en vaccins à "
-"la place."
 
 #: plugins/polio/models/base.py
 msgid "When the campaign starts"
@@ -794,3 +781,14 @@ msgstr "Polio - Seuils de performance (écriture)"
 #: plugins/polio/preparedness/spreadsheet_manager.py
 msgid "No country found for campaign"
 msgstr "Aucun pays trouvé pour la campagne"
+
+#~ msgid "Deprecated – round-level vaccine management"
+#~ msgstr "Déprécié – gestion des vaccins au niveau du round"
+
+#~ msgid ""
+#~ "Deprecated. Use VaccineRequestForm, OutgoingStockMovement, or "
+#~ "DestructionReport in the vaccine supply chain module instead."
+#~ msgstr ""
+#~ "Déprécié. Utilisez VaccineRequestForm, OutgoingStockMovement ou "
+#~ "DestructionReport dans le module de chaîne d'approvisionnement en vaccins "
+#~ "à la place."


### PR DESCRIPTION
## What problem is this PR solving?

Read the full header line when determining the CSV delimiter.

### Related JIRA tickets

SNT-549

## Changes

Read entire header line instead of first 1024bytes, which would break the sniffer for long files

## How to test

Go to SNT, Data layers.
Try to import the CSV in the Jira bug, it should fail without the fix.
It will fail with it but because org units doesn't match, which is fine.

## Print screen / video

N/A

## Notes

N/A

## Doc

N/A
