### PR TITLE
IA-5339: make the MappingVersion admin interface load fast

### DIFF
--- a/iaso/admin/base.py
+++ b/iaso/admin/base.py
@@ -475,14 +475,21 @@ class LinkAdmin(admin.GeoModelAdmin):
 @admin.register(Mapping)
 @admin_attr_decorator
 class MappingAdmin(admin.GeoModelAdmin):
-    list_filter = ("form_id",)
-    autocomplete_fields = ["data_source"]
+    list_filter = ("mapping_type",)
+    search_fields = ("name", "form__name", "form__form_id")
+    list_display = ("name", "form", "mapping_type", "data_source", "created_at")
+    list_select_related = ("form", "data_source")
+    autocomplete_fields = ["data_source", "form"]
 
 
 @admin.register(MappingVersion)
 @admin_attr_decorator
 class MappingVersionAdmin(admin.GeoModelAdmin):
-    list_filter = ("form_version_id",)
+    search_fields = ("name", "form_version__form__name", "form_version__form__form_id", "form_version__version_id")
+    list_display = ("name", "form_version", "mapping", "created_at", "updated_at")
+    list_select_related = ("form_version__form", "mapping__form")
+    autocomplete_fields = ["form_version", "mapping"]
+    ordering = ("-id",)
     formfield_overrides = {models.JSONField: {"widget": IasoJSONEditorWidget}}
 
 

--- a/iaso/admin/base.py
+++ b/iaso/admin/base.py
@@ -477,7 +477,8 @@ class LinkAdmin(admin.GeoModelAdmin):
 class MappingAdmin(admin.GeoModelAdmin):
     list_filter = ("mapping_type",)
     search_fields = ("name", "form__name", "form__form_id")
-    list_display = ("name", "form", "mapping_type", "data_source", "created_at")
+    list_display = ("id", "name", "form", "mapping_type", "data_source", "created_at")
+    list_display_links = ("id", "name")
     list_select_related = ("form", "data_source")
     autocomplete_fields = ["data_source", "form"]
 
@@ -486,7 +487,9 @@ class MappingAdmin(admin.GeoModelAdmin):
 @admin_attr_decorator
 class MappingVersionAdmin(admin.GeoModelAdmin):
     search_fields = ("name", "form_version__form__name", "form_version__form__form_id", "form_version__version_id")
-    list_display = ("name", "form_version", "mapping", "created_at", "updated_at")
+    # `name` is very often empty, so it can't be the only clickable column.
+    list_display = ("id", "name", "form_version", "mapping", "created_at", "updated_at")
+    list_display_links = ("id", "name")
     list_select_related = ("form_version__form", "mapping__form")
     autocomplete_fields = ["form_version", "mapping"]
     ordering = ("-id",)


### PR DESCRIPTION
## Problem

The `MappingVersion` admin is unusable in prod:

- **Detail / add page**: `form_version` (and `mapping`) are rendered as plain `<select>` widgets, so *every* `FormVersion` row is fetched and rendered as an `<option>`.
- **Changelist**: `list_filter = ("form_version_id",)` builds one filter entry per `FormVersion`, and rendering each entry's label (`FormVersion.__str__`) hits `form.name`, causing a query per form version.

## Fix

Replace the exhaustive dropdown/filter with autocomplete widgets + a text search, and `select_related` the FKs displayed in the list.

- `autocomplete_fields = ["form_version", "mapping"]`
- `search_fields` on form name / form_id / version_id, so you can still narrow down by form version
- `list_display` + `list_select_related` to avoid the N+1 when rendering rows
- `ordering = ("-id",)` for stable pagination

`MappingAdmin` had exactly the same pathology on `list_filter = ("form_id",)`, and needed `search_fields` anyway for the `mapping` autocomplete above, so it gets the same treatment.

## Measurements

Rendered through the Django test client on a local DB holding ~1180 form versions:

| page | before | after |
|---|---|---|
| `/admin/iaso/mappingversion/` | 1187 queries | **6 queries** |
| `/admin/iaso/mappingversion/add/` | 1185 queries, 1180 `<option>` | **5 queries, 0 `<option>`** |
| `/admin/iaso/mapping/` | 8 queries | **5 queries** |

Prod holds far more form versions than this local DB, so the real gain is bigger.

## Note for reviewers

The `form version` **filter** on the changelist is gone (it is the thing that was slow). Searching by form name / form id / version id replaces it.

<img width="3024" height="1098" alt="CleanShot 2026-07-27 at 17 52 07@2x" src="https://github.com/user-attachments/assets/6163722e-4e10-4016-8a6a-47fb4ffbe46b" />
<img width="3024" height="1736" alt="CleanShot 2026-07-27 at 17 52 34@2x" src="https://github.com/user-attachments/assets/ff36fc8e-d984-400a-a08e-b05da2f0cd45" />
