### PR TITLE
IA-5158 Add py-spy with ptrace capability in docker-compose

### DIFF
--- a/docker/prod/docker-compose.prod.yml
+++ b/docker/prod/docker-compose.prod.yml
@@ -122,6 +122,8 @@ services:
         - WORKER
       stdin_open: true
       tty: true
+      cap_add:
+        - SYS_PTRACE
     nginx:
       image: nginx:stable-alpine
       ports:


### PR DESCRIPTION
## What problem is this PR solving?

No py-spy in Docker based deployments

### Related JIRA tickets

IA-5158

## Changes

Just added a new pinned dependency for https://github.com/benfred/py-spy and added the `SYS_PTRACE` capability in the docker compose spec https://docs.docker.com/reference/compose-file/services/#cap_add

## How to test

Deploy and run py-spy https://github.com/benfred/py-spy#usage

## Print screen / video

-

## Notes

Work in progress, still testing.