### PR TITLE
[IA-5342] Fix "Cannot resolve keyword 'uuid' into field" in OUCRC.

### DIFF
--- a/iaso/api/org_unit_change_request_configurations/serializers.py
+++ b/iaso/api/org_unit_change_request_configurations/serializers.py
@@ -15,7 +15,6 @@ from iaso.api.org_unit_change_request_configurations.validation import (
 )
 from iaso.api.query_params import INCLUDE_CREATION, PROJECT_ID, TYPE
 from iaso.models import Form, Group, GroupSet, OrgUnitChangeRequestConfiguration, OrgUnitType, Project
-from iaso.utils.serializer.id_or_uuid_field import IdOrUuidRelatedField
 
 
 class UserNestedSerializer(serializers.ModelSerializer):
@@ -240,7 +239,7 @@ class OrgUnitChangeRequestConfigurationWriteSerializer(BaseOrgUnitChangeRequestC
     """
 
     id = serializers.IntegerField(read_only=True)
-    project_id = IdOrUuidRelatedField(source="project", queryset=Project.objects.all())
+    project_id = serializers.PrimaryKeyRelatedField(source="project", queryset=Project.objects.all())
     org_unit_type_id = serializers.PrimaryKeyRelatedField(source="org_unit_type", queryset=OrgUnitType.objects.all())
 
     class Meta(BaseOrgUnitChangeRequestConfigurationWriteUpdateSerializer.Meta):

--- a/iaso/tests/api/org_unit_change_request_configurations/test_org_unit_change_request_configs.py
+++ b/iaso/tests/api/org_unit_change_request_configurations/test_org_unit_change_request_configs.py
@@ -228,6 +228,42 @@ class OrgUnitChangeRequestConfigurationAPITestCase(OUCRCAPIBase):
         self.assertIn("project_id", result)
         self.assertIn("required", result["project_id"][0])
 
+    def test_create_wrong_project_pk(self):
+        # an OUCRC already exists with this combination of OUType & Project
+        self.client.force_authenticate(self.user_ash_ketchum)
+        data = {
+            "project_id": "test",
+            "type": m.OrgUnitChangeRequestConfiguration.Type.EDITION,
+            "org_unit_type_id": self.ou_type_water_pokemons.id,
+            "org_units_editable": False,
+            "editable_fields": m.OrgUnitChangeRequestConfiguration.LIST_OF_POSSIBLE_EDITABLE_FIELDS,
+            "possible_type_ids": [self.ou_type_rock_pokemons.id, self.ou_type_fire_pokemons.id],
+            "possible_parent_type_ids": [self.ou_type_rock_pokemons.id, self.ou_type_water_pokemons.id],
+            "group_set_ids": [self.group_set_brock_pokemons.id],
+            "editable_reference_form_ids": [self.form_rock_throw.id],
+            "other_group_ids": [self.other_group_film_1.id],
+        }
+        response = self.client.post(self.OUCRC_API_URL, data=data, format="json")
+        self.assertContains(response, "Expected pk value, received str.", status_code=status.HTTP_400_BAD_REQUEST)
+
+    def test_create_unknown_project(self):
+        # an OUCRC already exists with this combination of OUType & Project
+        self.client.force_authenticate(self.user_ash_ketchum)
+        data = {
+            "project_id": "-1",
+            "type": m.OrgUnitChangeRequestConfiguration.Type.EDITION,
+            "org_unit_type_id": self.ou_type_water_pokemons.id,
+            "org_units_editable": False,
+            "editable_fields": m.OrgUnitChangeRequestConfiguration.LIST_OF_POSSIBLE_EDITABLE_FIELDS,
+            "possible_type_ids": [self.ou_type_rock_pokemons.id, self.ou_type_fire_pokemons.id],
+            "possible_parent_type_ids": [self.ou_type_rock_pokemons.id, self.ou_type_water_pokemons.id],
+            "group_set_ids": [self.group_set_brock_pokemons.id],
+            "editable_reference_form_ids": [self.form_rock_throw.id],
+            "other_group_ids": [self.other_group_film_1.id],
+        }
+        response = self.client.post(self.OUCRC_API_URL, data=data, format="json")
+        self.assertContains(response, "Invalid pk", status_code=status.HTTP_400_BAD_REQUEST)
+
     def test_create_missing_org_unit_type_id(self):
         self.client.force_authenticate(self.user_brock)
         data = {


### PR DESCRIPTION
## What problem is this PR solving?

When passing a string value in `project_id`, the server would return a 500 instead of a 400.

### Related JIRA tickets

IA-5342

## Changes

Changed `IdOrUuidRelatedField` into `serializers.PrimaryKeyRelatedField` since there are no `uuid` on `Project`

## How to test

Run tests or call the API yourself with invalid values.
