### PR TITLE
SNT-551 Exclude composite layer when getting csv template

### DIFF
--- a/iaso/api/metrics/views.py
+++ b/iaso/api/metrics/views.py
@@ -12,6 +12,7 @@ from iaso.api.common import CONTENT_TYPE_CSV, DropdownOptionsWithRepresentationS
 from iaso.api.metrics.filters import ValueAndTypeFilterBackend, ValueFilterBackend
 from iaso.api.metrics.utils import REQUIRED_METRIC_VALUES_HEADERS
 from iaso.models import MetricType, MetricValue
+from iaso.plugins import is_snt_malaria_plugin_active
 from iaso.utils.org_units import get_valid_org_units_with_geography
 
 from .permissions import MetricsPermissions
@@ -107,6 +108,9 @@ class MetricValueViewSet(viewsets.ModelViewSet):
         account = request.user.iaso_profile.account
         # Get all custom metric types for the user's account
         metric_types = MetricType.objects.filter(account=account, origin=MetricType.MetricTypeOrigin.CUSTOM)
+        if is_snt_malaria_plugin_active():
+            # Composite metric types are computed from a graph, not meant to be filled in manually.
+            metric_types = metric_types.filter(composite_layer__isnull=True)
         # Get All org units for the user's account
         org_units = get_valid_org_units_with_geography(account).order_by("name")
 

--- a/iaso/tests/api/metrics/test_views.py
+++ b/iaso/tests/api/metrics/test_views.py
@@ -1,3 +1,5 @@
+from unittest import skipUnless
+
 from django.contrib.gis.geos import MultiPolygon, Point, Polygon
 from rest_framework import status
 
@@ -7,6 +9,7 @@ from iaso.models.metric import MetricType, MetricValue
 from iaso.models.org_unit import OrgUnit, OrgUnitType
 from iaso.models.project import Project
 from iaso.permissions.core_permissions import CORE_METRIC_TYPES_PERMISSION, CORE_ORG_UNITS_PERMISSION
+from iaso.plugins import is_snt_malaria_plugin_active
 from iaso.test import APITestCase
 
 
@@ -715,6 +718,32 @@ class MetricValueAPITestCase(APITestCase):
         self.assertEqual(csv[0], expected_header)
         expected_org_unit_values = ["", self.org_unit.name, str(self.org_unit.id)]
         self.assertEqual(csv[1], expected_org_unit_values)
+
+    @skipUnless(is_snt_malaria_plugin_active(), "requires the snt_malaria plugin")
+    def test_metric_value_csv_template_excludes_composite_metric_types(self):
+        from plugins.snt_malaria.models import CompositeLayer
+
+        custom_metric_type = MetricType.objects.create(
+            account=self.account,
+            code="MT_CUSTOM",
+            name="Custom Metric Type",
+            origin=MetricType.MetricTypeOrigin.CUSTOM,
+        )
+        composite_metric_type = MetricType.objects.create(
+            account=self.account,
+            code="MT_COMPOSITE",
+            name="Composite Metric Type",
+            category="Composite",
+            origin=MetricType.MetricTypeOrigin.CUSTOM,
+        )
+        CompositeLayer.objects.create(account=self.account, name="Composite Layer", metric_type=composite_metric_type)
+
+        self.client.force_authenticate(self.user)
+        response = self.client.get(f"{self.BASE_URL}csv_template/")
+        csv = self.assertCsvFileResponse(response, "metric_import_template.csv", return_as_lists=True)
+
+        expected_header = ["ADM1_NAME", "ADM2_NAME", "ADM2_ID", custom_metric_type.code]
+        self.assertEqual(csv[0], expected_header)
 
     def test_metric_value_csv_template_unauthenticated(self):
         response = self.client.get(f"{self.BASE_URL}csv_template/")


### PR DESCRIPTION
## What problem is this PR solving?

Exclude composite layer when getting csv template

### Related JIRA tickets

SNT-551

## Changes

If snt malaria plugin is activated, filter metric types to exclude composite layers hen getting CSV template

## How to test

Testable in SNT Malaria. In Data layer view, add some composite layers, verify their key.
Then export CSV template, it should not contains composite layers.

## Print screen / video

N/A

## Notes

N/A

## Doc

N/A
