### PR TITLE
IA-5348: npm 11.19 and min release age

### DIFF
--- a/.github/workflows/smoke_tests.yml
+++ b/.github/workflows/smoke_tests.yml
@@ -47,7 +47,7 @@ jobs:
       # https://github.com/npm/cli/issues/9151
       - name: upgrade npm
         run: |
-          npm install -g npm@11.13.0
+          npm install -g npm@11.19.0
 
       - name: install dependencies
         run: npm ci

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,5 @@
 # Fail npm ci/install when Node/npm do not match package.json "engines"
-# (aligned with Docker: node:22.18.0 + npm@11.13.0)
+# (aligned with Docker: node:22.18.0 + npm@11.19.0)
 engine-strict=true
+# Only install package versions _older_ than 7 days to mitigate supply chain attacks
+min-release-age=7

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ uv run ./manage.py runserver
 
 ### Node.js and npm (native frontend)
 
-Frontend tooling is pinned to the same versions as Docker/CI (`node:22.18.0`, `npm@11.13.0`) via `package.json` (`engines` + `packageManager`), `.nvmrc`, and `.npmrc` (`engine-strict=true`). Wrong versions will fail `npm ci` / `npm install`.
+Frontend tooling is pinned to the same versions as Docker/CI (`node:22.18.0`, `npm@11.19.0`) via `package.json` (`engines` + `packageManager`), `.nvmrc`, and `.npmrc` (`engine-strict=true`). Wrong versions will fail `npm ci` / `npm install`.
 
 ```bash
 # Node (nvm, fnm, or asdf all read .nvmrc)
@@ -161,10 +161,10 @@ nvm use
 
 # npm via Corepack (ships with Node 22) — do not add npm as a dependency
 corepack enable
-corepack prepare npm@11.13.0 --activate
+corepack prepare npm@11.19.0 --activate
 
 node -v   # v22.18.0
-npm -v    # 11.13.0
+npm -v    # 11.19.0
 npm ci
 ```
 
@@ -972,7 +972,7 @@ External service dependencies:
 
 Currently supported version of Python is 3.9.
 
-Frontend: Node.js **22.18.0** and npm **11.13.0** (see `.nvmrc` / `package.json` `engines`; required for `npm ci` with the versioned lockfile).
+Frontend: Node.js **22.18.0** and npm **11.19.0** (see `.nvmrc` / `package.json` `engines`; required for `npm ci` with the versioned lockfile).
 
 The PostgreSQL database server and Enketo server can both be deployed in Docker on the same physical machine, it is advised to double the recommended values in that case.
 

--- a/azure-pipelines-prod.yml
+++ b/azure-pipelines-prod.yml
@@ -31,7 +31,7 @@ steps:
   displayName: 'Install Node.js'
 
 - script: |
-    npm install -g npm@11.13.0
+    npm install -g npm@11.19.0
     node -v
     npm -v
     npm ci

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,7 +31,7 @@ steps:
   displayName: 'Install Node.js'
 
 - script: |
-    npm install -g npm@11.13.0
+    npm install -g npm@11.19.0
     node -v
     npm -v
     npm ci

--- a/docker/bundle/Dockerfile
+++ b/docker/bundle/Dockerfile
@@ -25,7 +25,7 @@ COPY package.json .
 COPY package-lock.json .
 
 
-RUN npm install -g npm@11.13.0
+RUN npm install -g npm@11.19.0
 
 RUN rm -rf node_modules
 RUN npm cache clean --force

--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /opt/app
 
 # Copy package files
 COPY ../../package.json package-lock.json ./
-RUN npm install -g npm@11.13.0 && \
+RUN npm install -g npm@11.19.0 && \
     rm -rf node_modules && \
     npm cache clean --force && \
     npm ci

--- a/docker/webpack/Dockerfile
+++ b/docker/webpack/Dockerfile
@@ -22,7 +22,7 @@ COPY package.json .
 COPY package-lock.json .
 
 # Upgrade npm to the latest version compatible with Node.js 22.18.0
-RUN npm install -g npm@11.13.0
+RUN npm install -g npm@11.19.0
 
 # Install project dependencies
 RUN npm ci

--- a/hat/assets/js/apps/Iaso/domains/pages/components/Rte.tsx
+++ b/hat/assets/js/apps/Iaso/domains/pages/components/Rte.tsx
@@ -3,7 +3,6 @@ import { FormControl, FormLabel } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import isEqual from 'lodash/isEqual';
 import { useQuill } from 'react-quilljs';
-import 'quill/dist/quill.snow.css';
 
 const useStyles = makeStyles(theme => ({
     formControl: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,6 @@
                 "moment": "^2.29.4",
                 "notistack": "^3.0.1",
                 "polyfill-object.fromentries": "^1.0.1",
-                "quill": "^2.0.2",
                 "react": "^18.2.0",
                 "react-color": "^2.17.3",
                 "react-dom": "^18.2.0",
@@ -98,8 +97,6 @@
                 "@vitest/coverage-v8": "^4.0.18",
                 "@vitest/eslint-plugin": "^1.6.7",
                 "babel-loader": "^9.1.3",
-                "babel-plugin-require-context-hook": "^1.0.0",
-                "babel-polyfill": "^6.26.0",
                 "canvas": "^3.1.2",
                 "clean-webpack-plugin": "^4.0.0",
                 "css-loader": "^7.1.2",
@@ -113,7 +110,6 @@
                 "eslint-plugin-prettier": "^5.4.0",
                 "eslint-plugin-react": "^7.37.5",
                 "eslint-plugin-react-hooks": "^5.2.0",
-                "eslint-webpack-plugin": "^5.0.1",
                 "fishery": "^2.4.0",
                 "jest-axe": "^10.0.0",
                 "jsdom": "^26.1.0",
@@ -8849,35 +8845,6 @@
                 "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
             }
         },
-        "node_modules/babel-plugin-require-context-hook": {
-            "version": "1.0.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/babel-polyfill": {
-            "version": "6.26.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "babel-runtime": "^6.26.0",
-                "core-js": "^2.5.0",
-                "regenerator-runtime": "^0.10.5"
-            }
-        },
-        "node_modules/babel-runtime": {
-            "version": "6.26.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "core-js": "^2.4.0",
-                "regenerator-runtime": "^0.11.0"
-            }
-        },
-        "node_modules/babel-runtime/node_modules/regenerator-runtime": {
-            "version": "0.11.1",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/bail": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
@@ -9683,12 +9650,6 @@
         "node_modules/cookie-signature": {
             "version": "1.0.7",
             "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/core-js": {
-            "version": "2.6.12",
-            "dev": true,
-            "hasInstallScript": true,
             "license": "MIT"
         },
         "node_modules/core-js-compat": {
@@ -11193,30 +11154,6 @@
                 "url": "https://opencollective.com/eslint"
             }
         },
-        "node_modules/eslint-webpack-plugin": {
-            "version": "5.0.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/eslint": "^9.6.1",
-                "flatted": "^3.3.3",
-                "jest-worker": "^29.7.0",
-                "micromatch": "^4.0.8",
-                "normalize-path": "^3.0.0",
-                "schema-utils": "^4.3.0"
-            },
-            "engines": {
-                "node": ">= 18.12.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/webpack"
-            },
-            "peerDependencies": {
-                "eslint": "^8.0.0 || ^9.0.0",
-                "webpack": "^5.0.0"
-            }
-        },
         "node_modules/eslint/node_modules/@types/estree": {
             "version": "1.0.8",
             "dev": true,
@@ -11374,7 +11311,8 @@
         },
         "node_modules/eventemitter3": {
             "version": "5.0.4",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/events": {
             "version": "3.3.0",
@@ -13796,109 +13734,6 @@
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
         },
-        "node_modules/jest-worker": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*",
-                "jest-util": "^29.7.0",
-                "merge-stream": "^2.0.0",
-                "supports-color": "^8.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-worker/node_modules/@jest/schemas": {
-            "version": "29.6.3",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@sinclair/typebox": "^0.27.8"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-worker/node_modules/@jest/types": {
-            "version": "29.6.3",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/schemas": "^29.6.3",
-                "@types/istanbul-lib-coverage": "^2.0.0",
-                "@types/istanbul-reports": "^3.0.0",
-                "@types/node": "*",
-                "@types/yargs": "^17.0.8",
-                "chalk": "^4.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-worker/node_modules/@sinclair/typebox": {
-            "version": "0.27.8",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/jest-worker/node_modules/ci-info": {
-            "version": "3.9.0",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/sibiraj-s"
-                }
-            ],
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/jest-worker/node_modules/jest-util": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/types": "^29.6.3",
-                "@types/node": "*",
-                "chalk": "^4.0.0",
-                "ci-info": "^3.2.0",
-                "graceful-fs": "^4.2.9",
-                "picomatch": "^2.2.3"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-worker/node_modules/picomatch": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8.6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/jonschlinkert"
-            }
-        },
-        "node_modules/jest-worker/node_modules/supports-color": {
-            "version": "8.1.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/supports-color?sponsor=1"
-            }
-        },
         "node_modules/jiti": {
             "version": "2.6.1",
             "dev": true,
@@ -14357,7 +14192,8 @@
         },
         "node_modules/lodash.clonedeep": {
             "version": "4.5.0",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/lodash.debounce": {
             "version": "4.0.8",
@@ -14385,7 +14221,8 @@
         },
         "node_modules/lodash.isequal": {
             "version": "4.5.0",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/lodash.memoize": {
             "version": "4.1.2",
@@ -16314,7 +16151,8 @@
         },
         "node_modules/parchment": {
             "version": "3.0.0",
-            "license": "BSD-3-Clause"
+            "license": "BSD-3-Clause",
+            "peer": true
         },
         "node_modules/parent-module": {
             "version": "1.0.1",
@@ -17080,6 +16918,7 @@
         "node_modules/quill": {
             "version": "2.0.3",
             "license": "BSD-3-Clause",
+            "peer": true,
             "dependencies": {
                 "eventemitter3": "^5.0.1",
                 "lodash-es": "^4.17.21",
@@ -17093,6 +16932,7 @@
         "node_modules/quill-delta": {
             "version": "5.1.0",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-diff": "^1.3.0",
                 "lodash.clonedeep": "^4.5.0",
@@ -17713,11 +17553,6 @@
             "engines": {
                 "node": ">=4"
             }
-        },
-        "node_modules/regenerator-runtime": {
-            "version": "0.10.5",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/regexp.prototype.flags": {
             "version": "1.5.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -132,7 +132,7 @@
             },
             "engines": {
                 "node": "22.18.0",
-                "npm": "11.13.0"
+                "npm": "11.19.0"
             }
         },
         "node_modules/@adobe/css-tools": {
@@ -8974,7 +8974,7 @@
         },
         "node_modules/bluesquare-components": {
             "version": "2.0.0",
-            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#b1832dd7dc57cb7ffd8a1c279eaed162581b963d",
+            "resolved": "git+ssh://git@github.com/BLSQ/bluesquare-components.git#4413156eecbf7308ae724d1cae5490b36af3249f",
             "license": "Apache-2.0",
             "dependencies": {
                 "@babel/plugin-transform-class-properties": "^7.24.6",
@@ -9000,7 +9000,7 @@
             },
             "engines": {
                 "node": "22.18.0",
-                "npm": "11.13.0"
+                "npm": "11.19.0"
             },
             "peerDependencies": {
                 "@mui/icons-material": "^5.15.7",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
         "moment": "^2.29.4",
         "notistack": "^3.0.1",
         "polyfill-object.fromentries": "^1.0.1",
-        "quill": "^2.0.2",
         "react": "^18.2.0",
         "react-color": "^2.17.3",
         "react-dom": "^18.2.0",
@@ -148,8 +147,6 @@
         "@vitest/coverage-v8": "^4.0.18",
         "@vitest/eslint-plugin": "^1.6.7",
         "babel-loader": "^9.1.3",
-        "babel-plugin-require-context-hook": "^1.0.0",
-        "babel-polyfill": "^6.26.0",
         "canvas": "^3.1.2",
         "clean-webpack-plugin": "^4.0.0",
         "css-loader": "^7.1.2",
@@ -163,7 +160,6 @@
         "eslint-plugin-prettier": "^5.4.0",
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^5.2.0",
-        "eslint-webpack-plugin": "^5.0.1",
         "fishery": "^2.4.0",
         "jest-axe": "^10.0.0",
         "jsdom": "^26.1.0",
@@ -183,5 +179,14 @@
     "overrides": {
         "canvg": "4.0.3",
         "jspdf": "4.2.1"
+    },
+    "allowScripts": {
+        "esbuild": true,
+        "unrs-resolver": true,
+        "fsevents@2.3.2": true,
+        "fsevents@2.3.3": true,
+        "canvas": true,
+        "msw": true,
+        "core-js": true
     }
 }

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
     "license": "Apache-2.0",
     "engines": {
         "node": "22.18.0",
-        "npm": "11.13.0"
+        "npm": "11.19.0"
     },
-    "packageManager": "npm@11.13.0",
+    "packageManager": "npm@11.19.0",
     "scripts": {
         "show-lint-problems": "eslint \"./hat/assets/js/**/*.{js,jsx,ts,tsx}\" \"./plugins/polio/js/**/*.{js,jsx,ts,tsx}\"",
         "fix-lint": "eslint \"./hat/assets/js/**/*.{js,jsx,ts,tsx}\" \"./plugins/polio/js/**/*.{js,jsx,ts,tsx}\" --cache --fix",

--- a/plugins/template/.github/workflows/ci.yml
+++ b/plugins/template/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
                   cache: npm
             - name: upgrade npm
               run: |
-                  npm install --global npm@11.13.0
+                  npm install --global npm@11.19.0
             - name: Environment info
               run: |
                   node --version

--- a/plugins/template/.github/workflows/deploy.yml
+++ b/plugins/template/.github/workflows/deploy.yml
@@ -85,7 +85,7 @@ jobs:
                   node-version: '20.13.1'
             - name: upgrade npm
               run: |
-                  npm install --global npm@11.13.0
+                  npm install --global npm@11.19.0
             - name: Set up Python 3.9
               uses: actions/setup-python@v1
               with:


### PR DESCRIPTION
## What problem is this PR solving?

⚠️ to make the CI working properly we need to merge this [pr](https://github.com/BLSQ/iaso-ci/pull/4) first

Only install package versions _older_ than 7 days to mitigate supply chain attacks

**npm 11.19**: min-release-age converts to an internal --before date. 
On npm 11.13, preparing a github: dependency (bluesquare-components) spawned a child install that still saw min-release-age in .npmrc, so npm crashed with “--min-release-age cannot be provided when using --before”. That conflict was fixed in npm 11.15+; we pin 11.19 so cooldown and git installs of BSC can coexist.

### Related JIRA tickets

IA-5348

## Changes

- bump to npm 11.19 everywhere
- add `min-release-age` to `.npmrc`

## How to test

- run `npm ci`
- run `npm run dev`

OR

 - run `docker-compose build webpack`
 -  un `docker-compose up webpack`

Make sure dashboard is loading

