### PR TITLE
IA-5349: Support more types on entity type dialog

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/entities/components/EntityBaseInfoContents.a11y.test.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/components/EntityBaseInfoContents.a11y.test.tsx
@@ -3,15 +3,20 @@ import { axe } from 'jest-axe';
 import { describe, expect, it } from 'vitest';
 
 import { renderWithThemeAndIntlProvider } from '../../../../../tests/helpers';
-import { Field } from '../types/fields';
 import { EntityBaseInfoContents } from '../components/EntityBaseInfoContents';
+import { Field } from '../types/fields';
 
 describe('EntityBaseInfoContents accessibility', () => {
     it('has no accessibility violations for common entity field types', async () => {
         const fields: Field[] = [
             { key: 'name', label: 'Name', type: 'text', value: 'Ada Lovelace' },
             { key: 'age', label: 'Age', type: 'integer', value: 36 },
-            { key: 'dob', label: 'Date of birth', type: 'date', value: '01/15/2020' },
+            {
+                key: 'dob',
+                label: 'Date of birth',
+                type: 'date',
+                value: '01/15/2020',
+            },
             {
                 key: 'appointment',
                 label: 'Appointment time',

--- a/hat/assets/js/apps/Iaso/domains/entities/components/EntityBaseInfoContents.a11y.test.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/components/EntityBaseInfoContents.a11y.test.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { axe } from 'jest-axe';
+import { describe, expect, it } from 'vitest';
+
+import { renderWithThemeAndIntlProvider } from '../../../../../tests/helpers';
+import { Field } from '../types/fields';
+import { EntityBaseInfoContents } from '../components/EntityBaseInfoContents';
+
+describe('EntityBaseInfoContents accessibility', () => {
+    it('has no accessibility violations for common entity field types', async () => {
+        const fields: Field[] = [
+            { key: 'name', label: 'Name', type: 'text', value: 'Ada Lovelace' },
+            { key: 'age', label: 'Age', type: 'integer', value: 36 },
+            { key: 'dob', label: 'Date of birth', type: 'date', value: '01/15/2020' },
+            {
+                key: 'appointment',
+                label: 'Appointment time',
+                type: 'time',
+                value: '10:30 AM',
+            },
+            {
+                key: 'gender',
+                label: 'Gender',
+                type: 'select_one',
+                value: 'Female',
+            },
+            {
+                key: 'symptoms',
+                label: 'Symptoms',
+                type: 'select_multiple',
+                value: 'Fever - Cough',
+            },
+            {
+                key: 'beneficiary_id',
+                label: 'Barcode',
+                type: 'barcode',
+                value: 'ABC-123',
+            },
+        ];
+
+        const { container } = renderWithThemeAndIntlProvider(
+            <EntityBaseInfoContents fields={fields} />,
+        );
+        const results = await axe(container);
+        expect(results).toHaveNoViolations();
+    });
+
+    it('has no accessibility violations with empty / placeholder values', async () => {
+        const fields: Field[] = [
+            { key: 'name', label: 'Name', type: 'text', value: '--' },
+            { key: 'time', label: 'Time', type: 'time', value: '--' },
+        ];
+
+        const { container } = renderWithThemeAndIntlProvider(
+            <EntityBaseInfoContents fields={fields} />,
+        );
+        const results = await axe(container);
+        expect(results).toHaveNoViolations();
+    });
+});

--- a/hat/assets/js/apps/Iaso/domains/entities/config.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/config.tsx
@@ -21,10 +21,12 @@ import {
 import { baseUrls } from '../../constants/urls';
 
 import getDisplayName from '../../utils/usersUtils';
+import { useGetFormDescriptor } from '../forms/fields/hooks/useGetFormDescriptor';
 import { LinkToInstance } from '../instances/components/LinkToInstance';
 import { formatLabel } from '../instances/utils';
 import { LinkToOrgUnit } from '../orgUnits/components/LinkToOrgUnit';
 import { useFilterOrgUnitsByGroupUrl } from '../orgUnits/utils';
+import { useGetType } from './entityTypes/hooks/requests/entitiyTypes';
 import { useGetFieldValue } from './hooks/useGetFieldValue';
 import MESSAGES from './messages';
 import { ExtraColumn } from './types/fields';
@@ -38,84 +40,103 @@ export const useStaticColumns = (): Array<Column> => {
     const { formatMessage }: { formatMessage: IntlFormatMessage } =
         useSafeIntl();
     const filterOrgUnitsByGroupUrl = useFilterOrgUnitsByGroupUrl();
-    return [
-        {
-            Header: formatMessage(MESSAGES.id),
-            id: 'uuid',
-            accessor: 'uuid',
-        },
-        {
-            Header: formatMessage(MESSAGES.lastVisit),
-            id: 'last_saved_instance',
-            accessor: 'last_saved_instance',
-            Cell: settings => {
-                return (
-                    <>
-                        {getValue(
-                            'last_saved_instance',
-                            settings.row.original,
-                            'date',
-                        )}
-                    </>
-                );
+    return useMemo(
+        () => [
+            {
+                Header: formatMessage(MESSAGES.id),
+                id: 'uuid',
+                accessor: 'uuid',
             },
-        },
-        {
-            Header: 'Groups',
-            id: 'attributes__org_unit__groups',
-            sortable: false,
-            Cell: settings => {
-                const groups = settings.row.original?.org_unit?.groups;
-                if (!groups || groups.length === 0) {
-                    return <span>{textPlaceholder}</span>;
-                }
+            {
+                Header: formatMessage(MESSAGES.lastVisit),
+                id: 'last_saved_instance',
+                accessor: 'last_saved_instance',
+                Cell: settings => {
+                    return (
+                        <>
+                            {getValue(
+                                'last_saved_instance',
+                                settings.row.original,
+                                'date',
+                            )}
+                        </>
+                    );
+                },
+            },
+            {
+                Header: 'Groups',
+                id: 'attributes__org_unit__groups',
+                sortable: false,
+                Cell: settings => {
+                    const groups = settings.row.original?.org_unit?.groups;
+                    if (!groups || groups.length === 0) {
+                        return <span>{textPlaceholder}</span>;
+                    }
 
-                return groups.map((group, index) => (
-                    <span key={group.id}>
-                        <LinkWithLocation
-                            to={filterOrgUnitsByGroupUrl(group.id)}
-                        >
-                            {group.name}
-                        </LinkWithLocation>
-                        {index !== groups.length - 1 && ', '}
-                    </span>
-                ));
+                    return groups.map((group, index) => (
+                        <span key={group.id}>
+                            <LinkWithLocation
+                                to={filterOrgUnitsByGroupUrl(group.id)}
+                            >
+                                {group.name}
+                            </LinkWithLocation>
+                            {index !== groups.length - 1 && ', '}
+                        </span>
+                    ));
+                },
             },
-        },
-        {
-            Header: 'HC',
-            id: 'attributes__org_unit__name',
-            accessor: 'attributes__org_unit__name',
-            Cell: settings => {
-                return settings.row.original?.org_unit ? (
-                    <LinkToOrgUnit orgUnit={settings.row.original?.org_unit} />
-                ) : (
-                    <span>{textPlaceholder}</span>
-                );
+            {
+                Header: 'HC',
+                id: 'attributes__org_unit__name',
+                accessor: 'attributes__org_unit__name',
+                Cell: settings => {
+                    return settings.row.original?.org_unit ? (
+                        <LinkToOrgUnit
+                            orgUnit={settings.row.original?.org_unit}
+                        />
+                    ) : (
+                        <span>{textPlaceholder}</span>
+                    );
+                },
             },
-        },
-    ];
+        ],
+        [formatMessage, getValue, filterOrgUnitsByGroupUrl],
+    );
+};
+
+type UseColumnsResult = {
+    columns: Array<Column>;
+    // Used to bust Table memo when async formDescriptors arrive (Cell closures
+    // are ignored by getSimplifiedColumns, which only compares accessors).
+    formDescriptorsReady: boolean;
 };
 
 export const useColumns = (
     entityTypeIds: string[],
     extraColumns: Array<ExtraColumn>,
-): Array<Column> => {
+): UseColumnsResult => {
     const { formatMessage }: { formatMessage: IntlFormatMessage } =
         useSafeIntl();
     const staticColumns = useStaticColumns();
-    const getValue = useGetFieldValue();
-    return useMemo(() => {
-        const columns: Array<Column> = staticColumns;
+    const { data: entityType } = useGetType(
+        entityTypeIds[0],
+        entityTypeIds.length === 1,
+    );
+    const { data: formDescriptors } = useGetFormDescriptor(
+        entityType?.reference_form,
+    );
+    const getValue = useGetFieldValue(formDescriptors);
+    const columns = useMemo(() => {
+        const cols: Array<Column> = [...staticColumns];
         if (entityTypeIds.length !== 1) {
-            columns.unshift({
+            cols.unshift({
                 Header: formatMessage(MESSAGES.type),
                 id: 'entity_type__name',
                 accessor: 'entity_type',
             });
         }
         extraColumns.forEach(extraColumn => {
-            columns.push({
+            cols.push({
                 Header: formatLabel(extraColumn),
                 id: extraColumn.name,
                 accessor: extraColumn.name,
@@ -132,7 +153,7 @@ export const useColumns = (
                 },
             });
         });
-        columns.push({
+        cols.push({
             Header: formatMessage(MESSAGES.actions),
             accessor: 'actions',
             resizable: false,
@@ -157,7 +178,7 @@ export const useColumns = (
                 );
             },
         });
-        return columns;
+        return cols;
     }, [
         staticColumns,
         entityTypeIds.length,
@@ -165,6 +186,11 @@ export const useColumns = (
         formatMessage,
         getValue,
     ]);
+
+    return {
+        columns,
+        formDescriptorsReady: Boolean(formDescriptors),
+    };
 };
 
 const generateColumnsFromFieldsList = (

--- a/hat/assets/js/apps/Iaso/domains/entities/duplicates/list/AnalysisModal.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/duplicates/list/AnalysisModal.tsx
@@ -102,6 +102,7 @@ const AnalysisModal: FunctionComponent<Props> = ({
     const { possibleFields, isFetchingForm } = useGetFormForEntityType({
         formId: referenceForm,
         enabled: isOpen,
+        possibleFieldsUsage: 'deduplication',
     });
 
     const isConfirm = algorithm && entityType && entityTypeFields.length > 0;

--- a/hat/assets/js/apps/Iaso/domains/entities/entityTypes/components/EntityTypesDialog.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/entityTypes/components/EntityTypesDialog.tsx
@@ -153,6 +153,7 @@ const EntityTypesDialog: FunctionComponent<Props> = ({
     } = useGetFormForEntityType({
         formId: values?.reference_form,
         enabled: isOpen,
+        possibleFieldsUsage: 'entity_type_config',
     });
 
     const possibleFieldsOptions = useMemo(

--- a/hat/assets/js/apps/Iaso/domains/entities/entityTypes/hooks/requests/entitiyTypes.ts
+++ b/hat/assets/js/apps/Iaso/domains/entities/entityTypes/hooks/requests/entitiyTypes.ts
@@ -86,10 +86,14 @@ export const useGetTypes = (): UseQueryResult<Array<EntityType>, Error> => {
 
 export const useGetType = (
     typeId: string,
+    enabled = true,
 ): UseQueryResult<EntityType, Error> => {
     return useSnackQuery({
         queryKey: ['entitytype', typeId],
-        queryFn: () => getRequest(`/api/entitytypes/${typeId}`),
+        queryFn: () => getRequest(`/api/entitytypes/${typeId}/`),
+        options: {
+            enabled,
+        },
     });
 };
 

--- a/hat/assets/js/apps/Iaso/domains/entities/entityTypes/hooks/requests/forms.ts
+++ b/hat/assets/js/apps/Iaso/domains/entities/entityTypes/hooks/requests/forms.ts
@@ -38,12 +38,17 @@ type Result = {
     isFetchingForm: boolean;
     name?: string;
 };
+
+export type PossibleFieldsUsage = 'deduplication' | 'entity_type_config';
+
 export const useGetFormForEntityType = ({
     formId,
     enabled = true,
+    possibleFieldsUsage = 'deduplication',
 }: {
     formId?: number;
     enabled?: boolean;
+    possibleFieldsUsage?: PossibleFieldsUsage;
 }): Result => {
     const { data: currentForm, isFetching: isFetchingForm } = useGetForm(
         formId,
@@ -53,6 +58,8 @@ export const useGetFormForEntityType = ({
             'name',
             'latest_form_version',
         ].join(','),
+        undefined,
+        { possible_fields_usage: possibleFieldsUsage },
     );
     return {
         ...usePossibleFields(

--- a/hat/assets/js/apps/Iaso/domains/entities/hooks/useGetFieldValue.test.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/hooks/useGetFieldValue.test.tsx
@@ -1,0 +1,254 @@
+import React from 'react';
+import { render, renderHook } from '@testing-library/react';
+import { textPlaceholder } from 'bluesquare-components';
+import moment from 'moment';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { FormDescriptor } from '../../forms/types/forms';
+import { useGetFieldValue } from './useGetFieldValue';
+
+const {
+    mockFormatMessage,
+    mockGetDescriptorValue,
+    mockFindDescriptorInChildren,
+    mockFormatLabel,
+} = vi.hoisted(() => ({
+    mockFormatMessage: vi.fn(
+        (msg, values) => `${msg.id || msg}:${values?.type ?? ''}`,
+    ),
+    mockGetDescriptorValue: vi.fn(),
+    mockFindDescriptorInChildren: vi.fn(),
+    mockFormatLabel: vi.fn(child => child.label || child.name),
+}));
+
+vi.mock('bluesquare-components', async importOriginal => {
+    const actual = await importOriginal<typeof import('bluesquare-components')>();
+    return {
+        ...actual,
+        useSafeIntl: () => ({
+            formatMessage: mockFormatMessage,
+        }),
+    };
+});
+
+vi.mock('Iaso/utils', () => ({
+    findDescriptorInChildren: mockFindDescriptorInChildren,
+    getDescriptorValue: mockGetDescriptorValue,
+}));
+
+vi.mock('../../instances/utils', () => ({
+    formatLabel: mockFormatLabel,
+}));
+
+vi.mock('../../../components/maps/MarkerMapComponent', () => ({
+    MarkerMap: ({ latitude, longitude }: { latitude?: number; longitude?: number }) => (
+        <div
+            data-testid="marker-map"
+            data-latitude={latitude}
+            data-longitude={longitude}
+        />
+    ),
+}));
+
+describe('useGetFieldValue', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        moment.locale('en');
+        mockGetDescriptorValue.mockReturnValue('Male');
+    });
+
+    const getValue = (formDescriptors?: FormDescriptor[]) => {
+        const { result } = renderHook(() => useGetFieldValue(formDescriptors));
+        return result.current;
+    };
+
+    describe('scalar text-like types', () => {
+        it.each([
+            ['text', 'hello'],
+            ['calculate', '42'],
+            ['integer', 7],
+            ['decimal', 3.14],
+            ['barcode', 'ABC-123'],
+            ['note', 'a note'],
+        ] as const)('returns raw value for %s', (type, value) => {
+            const getFieldValue = getValue();
+            expect(
+                getFieldValue('field', { field: value } as any, type),
+            ).toBe(value);
+        });
+
+        it('returns placeholder when value is missing', () => {
+            const getFieldValue = getValue();
+            expect(getFieldValue('field', {} as any, 'text')).toBe(
+                textPlaceholder,
+            );
+        });
+    });
+
+    describe('date / datetime', () => {
+        it('formats date with locale L', () => {
+            const getFieldValue = getValue();
+            expect(
+                getFieldValue('dob', { dob: '2020-01-15' } as any, 'date'),
+            ).toBe(moment('2020-01-15').format('L'));
+        });
+
+        it.each(['start', 'end', 'dateTime'] as const)(
+            'formats %s with locale LTS',
+            type => {
+                const getFieldValue = getValue();
+                const raw = '2020-01-15T10:30:00';
+                expect(
+                    getFieldValue('ts', { ts: raw } as any, type),
+                ).toBe(moment(raw).format('LTS'));
+            },
+        );
+
+        it('returns placeholder for empty date', () => {
+            const getFieldValue = getValue();
+            expect(getFieldValue('dob', {} as any, 'date')).toBe(
+                textPlaceholder,
+            );
+        });
+    });
+
+    describe('time', () => {
+        it('formats ODK time with offset using LT', () => {
+            const getFieldValue = getValue();
+            const raw = '10:30:00.000+02:00';
+            expect(
+                getFieldValue('appointment', { appointment: raw } as any, 'time'),
+            ).toBe(moment.parseZone(raw, ['HH:mm:ss.SSSZ']).format('LT'));
+        });
+
+        it('formats plain HH:mm:ss time', () => {
+            const getFieldValue = getValue();
+            const raw = '14:05:00';
+            expect(
+                getFieldValue('appointment', { appointment: raw } as any, 'time'),
+            ).toBe(moment.parseZone(raw, ['HH:mm:ss']).format('LT'));
+        });
+
+        it('formats HH:mm time', () => {
+            const getFieldValue = getValue();
+            const raw = '09:15';
+            expect(
+                getFieldValue('appointment', { appointment: raw } as any, 'time'),
+            ).toBe(moment.parseZone(raw, ['HH:mm']).format('LT'));
+        });
+
+        it('returns placeholder for empty time', () => {
+            const getFieldValue = getValue();
+            expect(
+                getFieldValue('appointment', {} as any, 'time'),
+            ).toBe(textPlaceholder);
+        });
+
+        it('returns placeholder for invalid time', () => {
+            const getFieldValue = getValue();
+            expect(
+                getFieldValue(
+                    'appointment',
+                    { appointment: 'not-a-time' } as any,
+                    'time',
+                ),
+            ).toBe(textPlaceholder);
+        });
+    });
+
+    describe('select one', () => {
+        it.each(['select one', 'select_one'] as const)(
+            'delegates to getDescriptorValue for %s',
+            type => {
+                const descriptors = [{ children: [] }] as unknown as FormDescriptor[];
+                const getFieldValue = getValue(descriptors);
+                const fileContent = { gender: 'M' } as any;
+
+                expect(getFieldValue('gender', fileContent, type)).toBe('Male');
+                expect(mockGetDescriptorValue).toHaveBeenCalledWith(
+                    'gender',
+                    fileContent,
+                    descriptors,
+                );
+            },
+        );
+    });
+
+    describe('select multiple', () => {
+        const formDescriptors = [
+            { children: [] },
+        ] as unknown as FormDescriptor[];
+
+        beforeEach(() => {
+            mockFindDescriptorInChildren.mockReturnValue({
+                children: [
+                    { name: 'fever', label: 'Fever' },
+                    { name: 'cough', label: 'Cough' },
+                    { name: 'rash', label: 'Rash' },
+                ],
+            });
+        });
+
+        it.each([
+            'select_multiple',
+            'select multiple',
+            'select_all_that_apply',
+            'select all that apply',
+        ] as const)('joins matching labels for %s', type => {
+            const getFieldValue = getValue(formDescriptors);
+            expect(
+                getFieldValue(
+                    'symptoms',
+                    { symptoms: 'fever cough' } as any,
+                    type,
+                ),
+            ).toBe('Fever - Cough');
+        });
+
+        it('returns placeholder when no matching choices', () => {
+            mockFindDescriptorInChildren.mockReturnValue({
+                children: [{ name: 'fever', label: 'Fever' }],
+            });
+            const getFieldValue = getValue(formDescriptors);
+            expect(
+                getFieldValue(
+                    'symptoms',
+                    { symptoms: 'unknown' } as any,
+                    'select_multiple',
+                ),
+            ).toBe(textPlaceholder);
+        });
+    });
+
+    describe('geopoint', () => {
+        it('renders MarkerMap with parsed coordinates', () => {
+            const getFieldValue = getValue();
+            const node = getFieldValue(
+                'location',
+                { location: '1.23 4.56 0 0' } as any,
+                'geopoint',
+            );
+            const { getByTestId } = render(<>{node}</>);
+            const map = getByTestId('marker-map');
+            expect(map).toHaveAttribute('data-latitude', '1.23');
+            expect(map).toHaveAttribute('data-longitude', '4.56');
+        });
+
+        it('returns placeholder when geopoint is empty', () => {
+            const getFieldValue = getValue();
+            expect(getFieldValue('location', {} as any, 'geopoint')).toBe(
+                textPlaceholder,
+            );
+        });
+    });
+
+    describe('unsupported type', () => {
+        it('returns translated unsupported message', () => {
+            const getFieldValue = getValue();
+            expect(
+                getFieldValue('secret', { secret: 'x' } as any, 'hidden'),
+            ).toBe('iaso.entities.typeNotSupported:hidden');
+            expect(mockFormatMessage).toHaveBeenCalled();
+        });
+    });
+});

--- a/hat/assets/js/apps/Iaso/domains/entities/hooks/useGetFieldValue.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/hooks/useGetFieldValue.tsx
@@ -4,28 +4,53 @@ import { Box } from '@mui/material';
 import { textPlaceholder, useSafeIntl } from 'bluesquare-components';
 import moment from 'moment';
 
-import { MarkerMap } from '../../../components/maps/MarkerMapComponent';
-import { findDescriptorInChildren, getDescriptorValue } from '../../../utils';
+import { findDescriptorInChildren, getDescriptorValue } from 'Iaso/utils';
 
-import { FieldType, FormDescriptor } from '../../forms/types/forms';
+import { MarkerMap } from '../../../components/maps/MarkerMapComponent';
+import {
+    ChildrenDescriptor,
+    FieldType,
+    FormDescriptor,
+} from '../../forms/types/forms';
 import { formatLabel } from '../../instances/utils';
 import MESSAGES from '../messages';
 import { Entity, FileContent } from '../types/entity';
 
+type FieldSource = FileContent | Entity;
+
+// Form answers and list-row extras are dynamic keys on FileContent / Entity.
+const getRawFieldValue = (
+    fileContent: FieldSource,
+    fieldKey: string,
+): unknown => (fileContent as Record<string, unknown>)[fieldKey];
+
+const getRawFieldString = (
+    fileContent: FieldSource,
+    fieldKey: string,
+): string | undefined => {
+    const value = getRawFieldValue(fileContent, fieldKey);
+    if (value == null || value === '') return undefined;
+    return typeof value === 'string' ? value : String(value);
+};
+
 const getDescriptorListValues = (
     fieldKey: string,
-    fileContent: FileContent | Entity,
+    fileContent: FieldSource,
     formDescriptors?: FormDescriptor[],
 ): string[] => {
-    const fieldsKeys = fileContent[fieldKey]?.split(' ') || [];
+    const fieldsKeys =
+        getRawFieldString(fileContent, fieldKey)?.split(' ') || [];
     let listValues: string[] = [];
     formDescriptors?.forEach(formDescriptor => {
         const descriptor = findDescriptorInChildren(fieldKey, formDescriptor);
         if (descriptor?.children) {
             listValues =
                 descriptor.children
-                    .filter(child => fieldsKeys.includes(child.name))
-                    .map(child => formatLabel(child)) || [];
+                    .filter((child: ChildrenDescriptor) =>
+                        fieldsKeys.includes(child.name),
+                    )
+                    .map((child: ChildrenDescriptor) => formatLabel(child)) ||
+                [];
         }
     });
     return listValues;
@@ -35,11 +60,15 @@ export const useGetFieldValue = (
     formDescriptors?: FormDescriptor[],
 ): ((
     fieldKey: string,
-    fileContent: FileContent | Entity,
+    fileContent: FieldSource,
     type: FieldType,
 ) => string | number | React.ReactNode) => {
     const { formatMessage } = useSafeIntl();
-    const getValue = (fieldKey, fileContent, type) => {
+    const getValue = (
+        fieldKey: string,
+        fileContent: FieldSource,
+        type: FieldType,
+    ): string | number | React.ReactNode => {
         switch (type) {
             case 'text':
             case 'calculate':
@@ -47,18 +76,21 @@ export const useGetFieldValue = (
             case 'decimal':
             case 'barcode':
             case 'note': {
-                return fileContent[fieldKey] || textPlaceholder;
+                const value = getRawFieldValue(fileContent, fieldKey);
+                return (
+                    (value as string | number | undefined) || textPlaceholder
+                );
             }
             case 'date': {
-                return fileContent[fieldKey]
-                    ? moment(fileContent[fieldKey]).format('L')
-                    : textPlaceholder;
+                const rawDate = getRawFieldString(fileContent, fieldKey);
+                return rawDate ? moment(rawDate).format('L') : textPlaceholder;
             }
             case 'start':
             case 'end':
             case 'dateTime': {
-                return fileContent[fieldKey]
-                    ? moment(fileContent[fieldKey]).format('LTS')
+                const rawDateTime = getRawFieldString(fileContent, fieldKey);
+                return rawDateTime
+                    ? moment(rawDateTime).format('LTS')
                     : textPlaceholder;
             }
             case 'select one':
@@ -84,14 +116,21 @@ export const useGetFieldValue = (
             }
 
             case 'geopoint': {
-                if (!fileContent[fieldKey]) return textPlaceholder;
-                const latitude = fileContent[fieldKey]?.split(' ')[0];
-                const longitude = fileContent[fieldKey]?.split(' ')[1];
+                const rawGeo = getRawFieldString(fileContent, fieldKey);
+                if (!rawGeo) return textPlaceholder;
+                const latitude = Number(rawGeo.split(' ')[0]);
+                const longitude = Number(rawGeo.split(' ')[1]);
                 return (
                     <Box width="100%" height="100%">
                         <MarkerMap
-                            longitude={longitude}
-                            latitude={latitude}
+                            longitude={
+                                Number.isFinite(longitude)
+                                    ? longitude
+                                    : undefined
+                            }
+                            latitude={
+                                Number.isFinite(latitude) ? latitude : undefined
+                            }
                             maxZoom={8}
                             mapHeight={200}
                         />
@@ -99,8 +138,19 @@ export const useGetFieldValue = (
                 );
             }
             case 'time': {
-                return fileContent[fieldKey]
-                    ? moment(fileContent[fieldKey]).format('T')
+                // ODK/XLSForm times look like "10:30:00.000+02:00" (time + offset, no date).
+                const rawTime = getRawFieldString(fileContent, fieldKey);
+                if (!rawTime) return textPlaceholder;
+                const parsedTime = moment.parseZone(rawTime, [
+                    'HH:mm:ss.SSSZ',
+                    'HH:mm:ss.SSSZZ',
+                    'HH:mm:ssZ',
+                    'HH:mm:ss.SSS',
+                    'HH:mm:ss',
+                    'HH:mm',
+                ]);
+                return parsedTime.isValid()
+                    ? parsedTime.format('LT')
                     : textPlaceholder;
             }
             default:

--- a/hat/assets/js/apps/Iaso/domains/entities/hooks/useGetFieldValue.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/hooks/useGetFieldValue.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 
 import { Box } from '@mui/material';
 import { textPlaceholder, useSafeIntl } from 'bluesquare-components';
@@ -64,98 +64,108 @@ export const useGetFieldValue = (
     type: FieldType,
 ) => string | number | React.ReactNode) => {
     const { formatMessage } = useSafeIntl();
-    const getValue = (
-        fieldKey: string,
-        fileContent: FieldSource,
-        type: FieldType,
-    ): string | number | React.ReactNode => {
-        switch (type) {
-            case 'text':
-            case 'calculate':
-            case 'integer':
-            case 'decimal':
-            case 'barcode':
-            case 'note': {
-                const value = getRawFieldValue(fileContent, fieldKey);
-                return (
-                    (value as string | number | undefined) || textPlaceholder
-                );
-            }
-            case 'date': {
-                const rawDate = getRawFieldString(fileContent, fieldKey);
-                return rawDate ? moment(rawDate).format('L') : textPlaceholder;
-            }
-            case 'start':
-            case 'end':
-            case 'dateTime': {
-                const rawDateTime = getRawFieldString(fileContent, fieldKey);
-                return rawDateTime
-                    ? moment(rawDateTime).format('LTS')
-                    : textPlaceholder;
-            }
-            case 'select one':
-            case 'select_one': {
-                return getDescriptorValue(
-                    fieldKey,
-                    fileContent,
-                    formDescriptors,
-                );
-            }
-            case 'select_all_that_apply':
-            case 'select all that apply':
-            case 'select_multiple':
-            case 'select multiple': {
-                const listValues = getDescriptorListValues(
-                    fieldKey,
-                    fileContent,
-                    formDescriptors,
-                );
-                return listValues.length > 0
-                    ? listValues.join(' - ')
-                    : textPlaceholder;
-            }
+    return useCallback(
+        (
+            fieldKey: string,
+            fileContent: FieldSource,
+            type: FieldType,
+        ): string | number | React.ReactNode => {
+            switch (type) {
+                case 'text':
+                case 'calculate':
+                case 'integer':
+                case 'decimal':
+                case 'barcode':
+                case 'note': {
+                    const value = getRawFieldValue(fileContent, fieldKey);
+                    return (
+                        (value as string | number | undefined) ||
+                        textPlaceholder
+                    );
+                }
+                case 'date': {
+                    const rawDate = getRawFieldString(fileContent, fieldKey);
+                    return rawDate
+                        ? moment(rawDate).format('L')
+                        : textPlaceholder;
+                }
+                case 'start':
+                case 'end':
+                case 'dateTime': {
+                    const rawDateTime = getRawFieldString(
+                        fileContent,
+                        fieldKey,
+                    );
+                    return rawDateTime
+                        ? moment(rawDateTime).format('LTS')
+                        : textPlaceholder;
+                }
+                case 'select one':
+                case 'select_one': {
+                    return getDescriptorValue(
+                        fieldKey,
+                        fileContent,
+                        formDescriptors,
+                    );
+                }
+                case 'select_all_that_apply':
+                case 'select all that apply':
+                case 'select_multiple':
+                case 'select multiple': {
+                    const listValues = getDescriptorListValues(
+                        fieldKey,
+                        fileContent,
+                        formDescriptors,
+                    );
+                    return listValues.length > 0
+                        ? listValues.join(' - ')
+                        : textPlaceholder;
+                }
 
-            case 'geopoint': {
-                const rawGeo = getRawFieldString(fileContent, fieldKey);
-                if (!rawGeo) return textPlaceholder;
-                const latitude = Number(rawGeo.split(' ')[0]);
-                const longitude = Number(rawGeo.split(' ')[1]);
-                return (
-                    <Box width="100%" height="100%">
-                        <MarkerMap
-                            longitude={
-                                Number.isFinite(longitude)
-                                    ? longitude
-                                    : undefined
-                            }
-                            latitude={
-                                Number.isFinite(latitude) ? latitude : undefined
-                            }
-                            maxZoom={8}
-                            mapHeight={200}
-                        />
-                    </Box>
-                );
+                case 'geopoint': {
+                    const rawGeo = getRawFieldString(fileContent, fieldKey);
+                    if (!rawGeo) return textPlaceholder;
+                    const latitude = Number(rawGeo.split(' ')[0]);
+                    const longitude = Number(rawGeo.split(' ')[1]);
+                    return (
+                        <Box width="100%" height="100%">
+                            <MarkerMap
+                                longitude={
+                                    Number.isFinite(longitude)
+                                        ? longitude
+                                        : undefined
+                                }
+                                latitude={
+                                    Number.isFinite(latitude)
+                                        ? latitude
+                                        : undefined
+                                }
+                                maxZoom={8}
+                                mapHeight={200}
+                            />
+                        </Box>
+                    );
+                }
+                case 'time': {
+                    // ODK/XLSForm times look like "10:30:00.000+02:00" (time + offset, no date).
+                    const rawTime = getRawFieldString(fileContent, fieldKey);
+                    if (!rawTime) return textPlaceholder;
+                    const parsedTime = moment.parseZone(rawTime, [
+                        'HH:mm:ss.SSSZ',
+                        'HH:mm:ss.SSSZZ',
+                        'HH:mm:ssZ',
+                        'HH:mm:ss.SSS',
+                        'HH:mm:ss',
+                        'HH:mm',
+                    ]);
+                    return parsedTime.isValid()
+                        ? parsedTime.format('LT')
+                        : textPlaceholder;
+                }
+                default:
+                    return formatMessage(MESSAGES.typeNotSupported, { type });
             }
-            case 'time': {
-                // ODK/XLSForm times look like "10:30:00.000+02:00" (time + offset, no date).
-                const rawTime = getRawFieldString(fileContent, fieldKey);
-                if (!rawTime) return textPlaceholder;
-                const parsedTime = moment.parseZone(rawTime, [
-                    'HH:mm:ss.SSSZ',
-                    'HH:mm:ss.SSSZZ',
-                    'HH:mm:ssZ',
-                    'HH:mm:ss.SSS',
-                    'HH:mm:ss',
-                    'HH:mm',
-                ]);
-                return parsedTime.isValid()
-                    ? parsedTime.format('LT')
-                    : textPlaceholder;
-            }
-            default:
-                return formatMessage(MESSAGES.typeNotSupported, { type });
-        }
-    };
-    return getValue;
+        },
+        [formDescriptors, formatMessage],
+    );
 };

--- a/hat/assets/js/apps/Iaso/domains/entities/hooks/useGetFields.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/hooks/useGetFields.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+
 import { FormDescriptor, PossibleField } from '../../forms/types/forms';
 
 import { formatLabel } from '../../instances/utils';
@@ -11,28 +13,30 @@ export const useGetFields = (
     possibleFields?: PossibleField[],
     formDescriptors?: FormDescriptor[],
 ): Field[] => {
-    const fields: Field[] = [];
     const getValue = useGetFieldValue(formDescriptors);
-    if (possibleFields && entity?.attributes?.file_content) {
-        const fileContent = entity.attributes.file_content;
-        fieldsKeys.forEach(fieldKey => {
-            const possibleField = possibleFields.find(
-                pf => pf.name === fieldKey,
-            );
-            if (possibleField) {
-                const value = getValue(
-                    fieldKey,
-                    fileContent,
-                    possibleField.type,
+    return useMemo(() => {
+        const fields: Field[] = [];
+        if (possibleFields && entity?.attributes?.file_content) {
+            const fileContent = entity.attributes.file_content;
+            fieldsKeys.forEach(fieldKey => {
+                const possibleField = possibleFields.find(
+                    pf => pf.name === fieldKey,
                 );
-                fields.push({
-                    value,
-                    label: formatLabel(possibleField),
-                    type: possibleField.type,
-                    key: fieldKey,
-                });
-            }
-        });
-    }
-    return fields;
+                if (possibleField) {
+                    const value = getValue(
+                        fieldKey,
+                        fileContent,
+                        possibleField.type,
+                    );
+                    fields.push({
+                        value,
+                        label: formatLabel(possibleField),
+                        type: possibleField.type,
+                        key: fieldKey,
+                    });
+                }
+            });
+        }
+        return fields;
+    }, [fieldsKeys, entity, possibleFields, getValue]);
 };

--- a/hat/assets/js/apps/Iaso/domains/entities/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/entities/index.tsx
@@ -118,7 +118,10 @@ export const Entities: FunctionComponent = () => {
 
     const { cursor: _cursor, ...tableParams } = params;
 
-    const columns = useColumns(entityTypeIds, extraColumns || []);
+    const { columns, formDescriptorsReady } = useColumns(
+        entityTypeIds,
+        extraColumns || [],
+    );
 
     const { data: types } = useGetEntityTypesDropdown();
 
@@ -195,7 +198,12 @@ export const Entities: FunctionComponent = () => {
                                 baseUrl={baseUrl}
                                 params={tableParams}
                                 showPagination={false}
-                                extraProps={{ loading: isFetching }}
+                                extraProps={{
+                                    loading: isFetching,
+                                    // Bust Table React.memo when select labels
+                                    // become available (Cell fn changes are ignored).
+                                    formDescriptorsReady,
+                                }}
                                 noDataMessage={
                                     !isSearchActive
                                         ? MESSAGES.searchToSeeEntities

--- a/hat/assets/js/apps/Iaso/domains/forms/requests.ts
+++ b/hat/assets/js/apps/Iaso/domains/forms/requests.ts
@@ -16,15 +16,20 @@ export const useGetForm = (
     enabled = Boolean(formId) && formId !== '0',
     fields?: string,
     appId?: string,
+    extraQueryParams?: Record<string, string>,
 ): UseQueryResult<Form, Error> => {
     const queryKey: any[] = ['forms', formId];
     if (fields) {
         queryKey.push(fields);
     }
+    if (extraQueryParams) {
+        queryKey.push(extraQueryParams);
+    }
 
     const params = {
         ...(appId ? { app_id: appId } : {}),
         ...(fields ? { fields: fields } : {}),
+        ...extraQueryParams,
     };
     const url = `/api/forms/${formId}/?${createSearchParamsWithArray(params).toString()}`;
     return useSnackQuery({

--- a/iaso/api/entities/serializers.py
+++ b/iaso/api/entities/serializers.py
@@ -9,8 +9,9 @@ class EntityTypeColumnSerializer(serializers.Serializer):
     """Serialize EntityType columns."""
 
     name = serializers.CharField()
-    type = serializers.CharField()
-    label = serializers.CharField()
+    type = serializers.CharField(allow_null=True)
+    # ODK meta fields (start/end) and some calculate questions often have no label.
+    label = serializers.CharField(allow_blank=True, required=False, default="")
 
 
 class EntityExportSerializer(serializers.ModelSerializer):

--- a/iaso/api/entities/views.py
+++ b/iaso/api/entities/views.py
@@ -223,8 +223,23 @@ class EntityViewSet(ModelViewSet):
         if serializer.is_valid():
             return serializer.validated_data
 
-        logger.warning(f"Invalid possible_fields in reference_form for EntityType {entity_type_id}")
-        return []
+        # Keep valid columns instead of dropping the whole list when one field
+        # has an unexpected shape (e.g. blank/missing label on start/end/calculate).
+        valid_columns = []
+        for field in fields:
+            field_serializer = EntityTypeColumnSerializer(data=field)
+            if field_serializer.is_valid():
+                valid_columns.append(field_serializer.validated_data)
+            else:
+                logger.warning(
+                    "Invalid possible_field for EntityType %s: %s errors=%s",
+                    entity_type_id,
+                    field,
+                    field_serializer.errors,
+                )
+        if not valid_columns:
+            logger.warning(f"Invalid possible_fields in reference_form for EntityType {entity_type_id}")
+        return valid_columns
 
     def create(self, request, *args, **kwargs):
         data = request.data

--- a/iaso/api/forms/possible_fields.py
+++ b/iaso/api/forms/possible_fields.py
@@ -1,0 +1,91 @@
+from typing import Any, Iterable, List, Optional, Sequence
+
+from iaso.models import EntityDuplicateAnalyzis
+
+
+# Named presets for filtering `possible_fields_with_latest_version`.
+# Keep `deduplication` aligned with EntityDuplicateAnalyzis.SUPPORTED_FIELD_TYPES.
+POSSIBLE_FIELDS_USAGE_DEDUPLICATION = "deduplication"
+POSSIBLE_FIELDS_USAGE_ENTITY_TYPE_CONFIG = "entity_type_config"
+
+# Displayable XLSForm question types for entity type list/detail/search config.
+# Based on https://xlsform.org/en/#question-types and types rendered by useGetFieldValue.
+# Excludes media (image/audio/video/file), complex geo (geotrace/geoshape), and structural types.
+ENTITY_TYPE_CONFIG_FIELD_TYPES = [
+    # text / numeric
+    "text",
+    "integer",
+    "decimal",
+    "number",
+    "range",
+    "barcode",
+    "calculate",
+    "note",
+    # temporal
+    "date",
+    "time",
+    "dateTime",
+    "datetime",
+    "start",
+    "end",
+    "today",
+    # choice (exact + with choice-list suffix via prefix match)
+    "select one",
+    "select_one",
+    "select multiple",
+    "select_multiple",
+    "select all that apply",
+    "select_all_that_apply",
+    # geo (single point is displayable as a map)
+    "geopoint",
+    # other scalar-ish XLSForm / ODK types
+    "acknowledge",
+    "phonenumber",
+    "username",
+    "email",
+    "deviceid",
+    None,
+]
+
+# Prefixes for select_* types that include a choice list name, e.g. "select_one gender".
+_SELECT_TYPE_PREFIXES = (
+    "select_one ",
+    "select one ",
+    "select_multiple ",
+    "select multiple ",
+    "select_all_that_apply ",
+    "select all that apply ",
+)
+
+POSSIBLE_FIELDS_USAGE_PRESETS = {
+    POSSIBLE_FIELDS_USAGE_DEDUPLICATION: EntityDuplicateAnalyzis.SUPPORTED_FIELD_TYPES,
+    POSSIBLE_FIELDS_USAGE_ENTITY_TYPE_CONFIG: ENTITY_TYPE_CONFIG_FIELD_TYPES,
+}
+
+
+def field_type_allowed(field_type: Any, allowed_types: Sequence[Any]) -> bool:
+    if field_type in allowed_types:
+        return True
+    if not isinstance(field_type, str):
+        return False
+    for prefix in _SELECT_TYPE_PREFIXES:
+        if field_type.startswith(prefix) and prefix.rstrip() in allowed_types:
+            return True
+    return False
+
+
+def filter_possible_fields_by_usage(
+    possible_fields: Optional[Iterable[dict]],
+    usage: Optional[str] = None,
+) -> List[dict]:
+    """
+    Filter form possible_fields for a given usage preset.
+
+    Unknown / missing usage falls back to deduplication.
+    """
+    resolved_usage = usage or POSSIBLE_FIELDS_USAGE_DEDUPLICATION
+    allowed_types = POSSIBLE_FIELDS_USAGE_PRESETS.get(
+        resolved_usage,
+        POSSIBLE_FIELDS_USAGE_PRESETS[POSSIBLE_FIELDS_USAGE_DEDUPLICATION],
+    )
+    return [field for field in (possible_fields or []) if field_type_allowed(field.get("type"), allowed_types)]

--- a/iaso/api/forms/possible_fields.py
+++ b/iaso/api/forms/possible_fields.py
@@ -11,24 +11,26 @@ POSSIBLE_FIELDS_USAGE_ENTITY_TYPE_CONFIG = "entity_type_config"
 # Displayable XLSForm question types for entity type list/detail/search config.
 # Based on https://xlsform.org/en/#question-types and types rendered by useGetFieldValue.
 # Excludes media (image/audio/video/file), complex geo (geotrace/geoshape), and structural types.
+# Frontend doesn't support all types yet, so we need to exclude them from the entity type config.
+# You can adapt frontend support by updating the useGetFieldValue function in the hooks/useGetFieldValue.tsx file.
 ENTITY_TYPE_CONFIG_FIELD_TYPES = [
     # text / numeric
     "text",
     "integer",
     "decimal",
     "number",
-    "range",
+    # "range", Type not supported yet
     "barcode",
     "calculate",
     "note",
-    # temporal
+    # temporal Type not supported yet
     "date",
     "time",
     "dateTime",
     "datetime",
     "start",
     "end",
-    "today",
+    # "today", Type not supported yet
     # choice (exact + with choice-list suffix via prefix match)
     "select one",
     "select_one",
@@ -39,11 +41,11 @@ ENTITY_TYPE_CONFIG_FIELD_TYPES = [
     # geo (single point is displayable as a map)
     "geopoint",
     # other scalar-ish XLSForm / ODK types
-    "acknowledge",
-    "phonenumber",
-    "username",
-    "email",
-    "deviceid",
+    # "acknowledge",
+    # "phonenumber", Type not supported yet
+    # "username", Type not supported yet
+    # "email", Type not supported yet
+    # "deviceid", Type not supported yet
     None,
 ]
 

--- a/iaso/api/forms/possible_fields.py
+++ b/iaso/api/forms/possible_fields.py
@@ -39,7 +39,7 @@ ENTITY_TYPE_CONFIG_FIELD_TYPES = [
     "select all that apply",
     "select_all_that_apply",
     # geo (single point is displayable as a map)
-    "geopoint",
+    # "geopoint", Type not supported yet
     # other scalar-ish XLSForm / ODK types
     # "acknowledge",
     # "phonenumber", Type not supported yet

--- a/iaso/api/forms/serializers.py
+++ b/iaso/api/forms/serializers.py
@@ -8,8 +8,12 @@ from dynamic_fields.serializer import DynamicFieldsModelSerializerBackwardCompat
 from hat.audit.models import FORM_API, log_modification
 from iaso.api.common import ModelSerializer, TimestampField
 from iaso.api.form_predefined_filters.serializers import FormPredefinedFilterSerializer
+from iaso.api.forms.possible_fields import (
+    POSSIBLE_FIELDS_USAGE_DEDUPLICATION,
+    filter_possible_fields_by_usage,
+)
 from iaso.api.projects import ProjectSerializer
-from iaso.models import EntityDuplicateAnalyzis, Form, FormVersion, Group, OrgUnitType, Project
+from iaso.models import Form, FormVersion, Group, OrgUnitType, Project
 
 
 class FormVersionNestedSerializer(ModelSerializer):
@@ -162,11 +166,13 @@ class FormSerializer(DynamicFieldsModelSerializerBackwardCompatible):
             return obj.has_attachments
         return obj.attachments.exists()
 
-    @staticmethod
-    def get_possible_fields_with_latest_version(obj: Form):
-        possible_fields = [
-            field for field in obj.possible_fields if field["type"] in EntityDuplicateAnalyzis.SUPPORTED_FIELD_TYPES
-        ]
+    def get_possible_fields_with_latest_version(self, obj: Form):
+        request = self.context.get("request")
+        usage = POSSIBLE_FIELDS_USAGE_DEDUPLICATION
+        if request is not None:
+            usage = request.query_params.get("possible_fields_usage", POSSIBLE_FIELDS_USAGE_DEDUPLICATION)
+
+        possible_fields = filter_possible_fields_by_usage(obj.possible_fields, usage)
 
         latest_version = obj.latest_version
         if not latest_version:

--- a/iaso/models/entity.py
+++ b/iaso/models/entity.py
@@ -114,7 +114,10 @@ class EntityType(models.Model):
         for field_data in self.reference_form.possible_fields:
             name = field_data.get("name")
             if name in selected_fields:
-                fields[name] = field_data
+                # ODK start/end/calculate often have an empty label; fall back to name
+                # so list/export columns remain displayable and serializer-valid.
+                label = field_data.get("label") or name
+                fields[name] = {**field_data, "label": label}
 
         return list(fields.values())
 

--- a/iaso/tests/api/entities/test_entities.py
+++ b/iaso/tests/api/entities/test_entities.py
@@ -490,6 +490,58 @@ class WebEntityAPITestCase(EntityAPITestCase):
         ]
         self.assertEqual(row_to_test, expected_row)
 
+    def test_list_entities_columns_with_blank_label_fields(self):
+        """start/end/calculate often have blank labels; columns must still be returned."""
+        self.client.force_authenticate(self.yoda)
+
+        possible_fields = [
+            {"name": "first_name", "type": "text", "label": "First Name"},
+            {"name": "start", "type": "start", "label": ""},
+            {"name": "end", "type": "end", "label": ""},
+            {"name": "score", "type": "calculate", "label": ""},
+        ]
+        form = m.Form.objects.create(
+            name="Meta fields form",
+            form_id="meta_fields_form",
+            possible_fields=possible_fields,
+        )
+        form.projects.add(self.project)
+        entity_type = m.EntityType.objects.create(
+            name="Type with meta fields",
+            reference_form=form,
+            account=self.account,
+            fields_list_view=["first_name", "start", "end", "score"],
+        )
+        instance = Instance.objects.create(
+            org_unit=self.ou_country,
+            form=form,
+            json={
+                "first_name": "Ada",
+                "start": "2026-08-07T10:00:00.000+02:00",
+                "end": "2026-08-07T10:05:00.000+02:00",
+                "score": "42",
+            },
+        )
+        entity = Entity.objects.create(
+            entity_type=entity_type,
+            attributes=instance,
+            account=self.yoda.iaso_profile.account,
+        )
+
+        response = self.client.get(f"/api/entities/?entity_type_ids={entity_type.pk}", format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        payload = response.json()
+        self.assertEqual(len(payload["result"]), 1)
+        self.assertEqual(payload["result"][0]["id"], entity.id)
+        self.assertEqual(payload["result"][0]["start"], "2026-08-07T10:00:00.000+02:00")
+        self.assertEqual(payload["result"][0]["score"], "42")
+
+        columns_by_name = {column["name"]: column for column in payload["columns"]}
+        self.assertEqual(set(columns_by_name), {"first_name", "start", "end", "score"})
+        self.assertEqual(columns_by_name["start"]["label"], "start")
+        self.assertEqual(columns_by_name["end"]["label"], "end")
+        self.assertEqual(columns_by_name["score"]["label"], "score")
+
     def test_list_entities_search_uuid_filter(self):
         """
         Test the 'uuids:' search filter of /api/entities with comma-separated UUIDs

--- a/iaso/tests/api/test_forms_possible_fields.py
+++ b/iaso/tests/api/test_forms_possible_fields.py
@@ -61,6 +61,7 @@ class PossibleFieldsFilterTestCase(SimpleTestCase):
             {"name": "trace", "type": "geotrace"},
             {"name": "secret", "type": "hidden"},
             # XLSForm types not supported yet by useGetFieldValue
+            {"name": "location", "type": "geopoint"},
             {"name": "score", "type": "range"},
             {"name": "today_field", "type": "today"},
             {"name": "consent", "type": "acknowledge"},
@@ -74,7 +75,7 @@ class PossibleFieldsFilterTestCase(SimpleTestCase):
 
         self.assertEqual(
             [field["name"] for field in result],
-            ["name", "age", "dob", "gender", "gender_with_list", "symptoms", "beneficiary_id", "location"],
+            ["name", "age", "dob", "gender", "gender_with_list", "symptoms", "beneficiary_id"],
         )
 
     def test_unknown_or_missing_usage_falls_back_to_deduplication(self):

--- a/iaso/tests/api/test_forms_possible_fields.py
+++ b/iaso/tests/api/test_forms_possible_fields.py
@@ -55,10 +55,19 @@ class PossibleFieldsFilterTestCase(SimpleTestCase):
             {"name": "symptoms", "type": "select_multiple"},
             {"name": "beneficiary_id", "type": "barcode"},
             {"name": "location", "type": "geopoint"},
+            # media / complex geo / structural — not displayable in entity type config
             {"name": "photo", "type": "image"},
             {"name": "audio_note", "type": "audio"},
             {"name": "trace", "type": "geotrace"},
             {"name": "secret", "type": "hidden"},
+            # XLSForm types not supported yet by useGetFieldValue
+            {"name": "score", "type": "range"},
+            {"name": "today_field", "type": "today"},
+            {"name": "consent", "type": "acknowledge"},
+            {"name": "phone", "type": "phonenumber"},
+            {"name": "collector", "type": "username"},
+            {"name": "contact_email", "type": "email"},
+            {"name": "device", "type": "deviceid"},
         ]
 
         result = filter_possible_fields_by_usage(fields, POSSIBLE_FIELDS_USAGE_ENTITY_TYPE_CONFIG)

--- a/iaso/tests/api/test_forms_possible_fields.py
+++ b/iaso/tests/api/test_forms_possible_fields.py
@@ -1,0 +1,89 @@
+from django.test import SimpleTestCase
+
+from iaso.api.forms.possible_fields import (
+    POSSIBLE_FIELDS_USAGE_DEDUPLICATION,
+    POSSIBLE_FIELDS_USAGE_ENTITY_TYPE_CONFIG,
+    field_type_allowed,
+    filter_possible_fields_by_usage,
+)
+from iaso.models.deduplication import EntityDuplicateAnalyzis
+
+
+class PossibleFieldsFilterTestCase(SimpleTestCase):
+    def test_field_type_allowed_exact_match(self):
+        self.assertTrue(field_type_allowed("text", ["text", "integer"]))
+        self.assertFalse(field_type_allowed("barcode", ["text", "integer"]))
+
+    def test_field_type_allowed_select_with_choice_list_suffix(self):
+        allowed = ["select_one", "select one", "text"]
+        self.assertTrue(field_type_allowed("select_one gender", allowed))
+        self.assertTrue(field_type_allowed("select one gender", allowed))
+        self.assertFalse(field_type_allowed("select_multiple symptoms", allowed))
+
+    def test_deduplication_usage_keeps_supported_types_only(self):
+        fields = [
+            {"name": "field1", "type": "text"},
+            {"name": "field2", "type": "number"},
+            {"name": "field3", "type": "photo"},
+            {"name": "field4", "type": "select"},
+            {"name": "field5", "type": "integer"},
+            {"name": "field6", "type": None},
+            {"name": "field7", "type": "barcode"},
+            {"name": "gender", "type": "select one"},
+        ]
+
+        result = filter_possible_fields_by_usage(fields, POSSIBLE_FIELDS_USAGE_DEDUPLICATION)
+
+        self.assertEqual(
+            result,
+            [
+                {"name": "field1", "type": "text"},
+                {"name": "field2", "type": "number"},
+                {"name": "field5", "type": "integer"},
+                {"name": "field6", "type": None},
+            ],
+        )
+        self.assertNotIn("barcode", EntityDuplicateAnalyzis.SUPPORTED_FIELD_TYPES)
+
+    def test_entity_type_config_includes_displayable_xlsform_types(self):
+        fields = [
+            {"name": "name", "type": "text"},
+            {"name": "age", "type": "integer"},
+            {"name": "dob", "type": "date"},
+            {"name": "gender", "type": "select one"},
+            {"name": "gender_with_list", "type": "select_one gender"},
+            {"name": "symptoms", "type": "select_multiple"},
+            {"name": "beneficiary_id", "type": "barcode"},
+            {"name": "location", "type": "geopoint"},
+            {"name": "photo", "type": "image"},
+            {"name": "audio_note", "type": "audio"},
+            {"name": "trace", "type": "geotrace"},
+            {"name": "secret", "type": "hidden"},
+        ]
+
+        result = filter_possible_fields_by_usage(fields, POSSIBLE_FIELDS_USAGE_ENTITY_TYPE_CONFIG)
+
+        self.assertEqual(
+            [field["name"] for field in result],
+            ["name", "age", "dob", "gender", "gender_with_list", "symptoms", "beneficiary_id", "location"],
+        )
+
+    def test_unknown_or_missing_usage_falls_back_to_deduplication(self):
+        fields = [
+            {"name": "field1", "type": "text"},
+            {"name": "field7", "type": "barcode"},
+            {"name": "gender", "type": "select one"},
+        ]
+
+        self.assertEqual(
+            filter_possible_fields_by_usage(fields, "not_a_real_preset"),
+            [{"name": "field1", "type": "text"}],
+        )
+        self.assertEqual(
+            filter_possible_fields_by_usage(fields, None),
+            [{"name": "field1", "type": "text"}],
+        )
+
+    def test_empty_possible_fields(self):
+        self.assertEqual(filter_possible_fields_by_usage(None), [])
+        self.assertEqual(filter_possible_fields_by_usage([]), [])

--- a/iaso/tests/api/test_forms_serializers.py
+++ b/iaso/tests/api/test_forms_serializers.py
@@ -5,6 +5,7 @@ from django.test import TestCase
 from rest_framework.test import APIRequestFactory
 
 from iaso import models as m
+from iaso.api.forms.possible_fields import POSSIBLE_FIELDS_USAGE_ENTITY_TYPE_CONFIG
 from iaso.api.forms.serializers import FormSerializer
 
 
@@ -79,27 +80,24 @@ class FormsSerializerTestCase(TestCase):
         with self.assertNumQueries(10):
             self.assertEqual(serializer.data, expected_data)
 
-    def test_get_possible_fields_with_latest_version_filters_by_supported_types(self):
-        """
-        Test that `get_possible_fields_with_latest_version()` only returns fields with supported types.
-        """
+    def test_possible_fields_with_latest_version_uses_query_param_usage(self):
         mock_form = Mock()
         mock_form.possible_fields = [
-            {"name": "field1", "type": "text"},  # supported
-            {"name": "field2", "type": "number"},  # supported
-            {"name": "field3", "type": "photo"},  # not supported
-            {"name": "field4", "type": "select"},  # not supported
-            {"name": "field5", "type": "integer"},  # supported
-            {"name": "field6", "type": None},  # supported
+            {"name": "name", "type": "text"},
+            {"name": "beneficiary_id", "type": "barcode"},
+            {"name": "photo", "type": "image"},
         ]
-        mock_form.latest_version = None  # No latest version to keep the test simple.
+        mock_form.latest_version = None
 
-        result = FormSerializer.get_possible_fields_with_latest_version(mock_form)
+        request = APIRequestFactory().get(f"/?possible_fields_usage={POSSIBLE_FIELDS_USAGE_ENTITY_TYPE_CONFIG}")
+        request.query_params = QueryDict(
+            f"possible_fields_usage={POSSIBLE_FIELDS_USAGE_ENTITY_TYPE_CONFIG}", mutable=True
+        )
+        serializer = FormSerializer(context={"request": request})
 
-        expected_fields = [
-            {"name": "field1", "type": "text"},
-            {"name": "field2", "type": "number"},
-            {"name": "field5", "type": "integer"},
-            {"name": "field6", "type": None},
-        ]
-        self.assertEqual(result, expected_fields)
+        result = serializer.get_possible_fields_with_latest_version(mock_form)
+
+        self.assertEqual(
+            [field["name"] for field in result],
+            ["name", "beneficiary_id"],
+        )

--- a/iaso/tests/models/test_entity_type.py
+++ b/iaso/tests/models/test_entity_type.py
@@ -58,3 +58,23 @@ class EntityTypeListFieldsTest(TestCase):
 
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0]["name"], "first_name")
+
+    def test_falls_back_to_name_when_label_blank(self):
+        self.form.possible_fields = [
+            {"name": "start", "type": "start", "label": ""},
+            {"name": "end", "type": "end", "label": ""},
+            {"name": "calc", "type": "calculate", "label": ""},
+            {"name": "first_name", "type": "text", "label": "Prénom"},
+        ]
+        self.form.save()
+        self.entity_type.fields_list_view = ["start", "end", "calc", "first_name"]
+        self.entity_type.save()
+
+        result = self.entity_type.get_list_view_fields()
+        by_name = {field["name"]: field for field in result}
+
+        self.assertEqual(len(result), 4)
+        self.assertEqual(by_name["start"]["label"], "start")
+        self.assertEqual(by_name["end"]["label"], "end")
+        self.assertEqual(by_name["calc"]["label"], "calc")
+        self.assertEqual(by_name["first_name"]["label"], "Prénom")


### PR DESCRIPTION
## What problem is this PR solving?

Form possible field is using entities duplicate field types, we should keep it while launching an entity duplicate analysis but we should be able to select other field types while editing a entity type
We should probably use more field types here https://xlsform.org/en/#question-types
Maybe also see what is really supported on mobile and on mobile when rendering those fields


### Related JIRA tickets

IA-5349

## Changes

- split types per usage, deduplication or entity type conifg
- adapt frontend to use correct usage
- backend test

## How to test

Use this form

[dev_test_form_all_field_types_2026080701.xlsx](https://github.com/user-attachments/files/30826662/dev_test_form_all_field_types_2026080701.xlsx)

Create a entity type, make sure you can select barcode field
try to launch a entity duplicate analysis, you should not be able to select barcode, time, date, select types

## Print screen / video

<img width="1011" height="986" alt="Screenshot 2026-08-07 at 12 51 51" src="https://github.com/user-attachments/assets/acc021cf-b7e8-4165-b0d1-2f3e7ded6954" />
<img width="3413" height="1015" alt="Screenshot 2026-08-07 at 12 46 08" src="https://github.com/user-attachments/assets/d76c597f-b24a-418e-bbad-81c9d86e7bec" />

<img width="642" height="929" alt="Screenshot 2026-08-07 at 12 07 50" src="https://github.com/user-attachments/assets/10306a8e-0fae-4fbb-a5ee-de562db59098" />
