### PR TITLE
SNT-560: Accept None year when importing CSV

### DIFF
--- a/iaso/api/metrics/serializers.py
+++ b/iaso/api/metrics/serializers.py
@@ -138,7 +138,7 @@ class MetricValueSerializer(serializers.ModelSerializer):
 
 class ImportMetricValuesSerializer(serializers.Serializer):
     file = serializers.FileField(required=True)
-    year = serializers.IntegerField(required=True, allow_null=False)
+    year = serializers.IntegerField(required=False, allow_null=True)
 
     def validate_file(self, value):
         if not value.name.endswith(".csv"):
@@ -194,6 +194,9 @@ class ImportMetricValuesSerializer(serializers.Serializer):
         return value
 
     def validate_year(self, value):
+        if value is None:
+            return value
+
         if value < 1900 or value > 2100:
             raise serializers.ValidationError(_("Year must be between 1900 and 2100."))
         return value
@@ -201,7 +204,7 @@ class ImportMetricValuesSerializer(serializers.Serializer):
     def save(self, **kwargs):
         df = self.context["metric_values_df"]
         existing_metric_types_map = self.context["existing_metric_types_map"]
-        year = self.validated_data["year"]
+        year = self.validated_data.get("year", None)
         metric_values = []
         for index, row in df.iterrows():
             org_unit_id = row["ADM2_ID"]

--- a/iaso/tests/api/metrics/test_serializers.py
+++ b/iaso/tests/api/metrics/test_serializers.py
@@ -604,8 +604,17 @@ class ImportMetricValuesSerializerTestCase(TestCase):
         csv_content = f"ADM1_NAME,ADM2_NAME,ADM2_ID,MT1\nDISTRICT,District 1,{self.district1.id},1"
         valid_file = SimpleUploadedFile("test.csv", csv_content.encode(), content_type="text/csv")
         serializer = ImportMetricValuesSerializer(data={"file": valid_file}, context={"request": self.request})
-        self.assertFalse(serializer.is_valid())
-        self.assertIn("This field is required.", serializer.errors["year"][0])
+        self.assertTrue(serializer.is_valid())
+
+    def test_save_without_year_creates_metric_value_with_year_none(self):
+        """Importing a CSV without a year should create MetricValues with year=None."""
+        csv_content = f"ADM1_NAME,ADM2_NAME,ADM2_ID,MT1\nDISTRICT,District 1,{self.district1.id},1"
+        valid_file = SimpleUploadedFile("test.csv", csv_content.encode(), content_type="text/csv")
+        serializer = ImportMetricValuesSerializer(data={"file": valid_file}, context={"request": self.request})
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        metric_values = serializer.save()
+        self.assertEqual(len(metric_values), 1)
+        self.assertIsNone(metric_values[0].year)
 
     def test_validate_year_not_integer(self):
         csv_content = f"ADM1_NAME,ADM2_NAME,ADM2_ID,MT1\nDISTRICT,District 1,{self.district1.id},1"


### PR DESCRIPTION
## What problem is this PR solving?

Data layer can be created without a year.

### Related JIRA tickets

SNT-560

## Changes

Accept empty year when importing metric CSV
Set year to None when year is not provided

## How to test

Nothing on IASO, should be tested on SNT.
Go to Data layer, create a custom layer, export the template CSV and fill some values.
Import the CSV and clear the year input.
It should work and import data layer with year set to None

## Print screen / video

N/A

## Notes

N/A

## Doc

N/A
