### PR TITLE
IA-5346: Fix datasource version comparison parameters

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/dataSources/hooks/useCreateJsonDiffAsync.ts
+++ b/hat/assets/js/apps/Iaso/domains/dataSources/hooks/useCreateJsonDiffAsync.ts
@@ -71,9 +71,7 @@ const createJsonDiffAsync = async ({
     }
 
     // Options
-    const nonEmptyFields = fieldsToExport.filter(
-        field => field !== 'geometry' && field !== 'groups' && field !== 'code',
-    );
+    const nonEmptyFields = fieldsToExport.filter(field => field !== 'groups');
     if (nonEmptyFields.length > 0) {
         params.field_names = nonEmptyFields;
     }

--- a/iaso/diffing/differ.py
+++ b/iaso/diffing/differ.py
@@ -82,6 +82,10 @@ class Differ:
         elif not isinstance(field_names, list):
             field_names = list(field_names)
 
+        # Filter out groups
+        # groups are synchronizable, but are handled via the `ignore_groups` param.
+        field_names = [f for f in field_names if f != "groups"]
+
         orgunits_dhis2 = self.load_pyramid(
             version,
             validation_status=validation_status,

--- a/iaso/models/data_source.py
+++ b/iaso/models/data_source.py
@@ -299,6 +299,9 @@ class DataSourceVersionsSynchronization(models.Model):
         if self.change_requests.exists():
             raise ValidationError("Change requests have already been created.")
 
+        if field_names is not None:
+            field_names = sorted(f for f in field_names if f != "groups")
+
         differ_params = {
             # Version to update.
             "version": self.source_version_to_update,

--- a/iaso/tests/api/data_source_versions_synchronization/test_views.py
+++ b/iaso/tests/api/data_source_versions_synchronization/test_views.py
@@ -186,7 +186,7 @@ class DataSourceVersionsSynchronizationViewSetTestCase(TaskAPITestCase):
             f"'org_unit_group_ref': {self.group_2.pk}, "
             "'ignore_groups': True, "
             "'show_deleted_org_units': False, "
-            "'field_names': {'name'}"
+            "'field_names': ['name']"
             "}"
         )
         self.assertEqual(self.data_source_sync_1.diff_config, expected_diff_config_str)
@@ -213,6 +213,29 @@ class DataSourceVersionsSynchronizationViewSetTestCase(TaskAPITestCase):
 
         self.data_source_sync_1.refresh_from_db()
         self.assertIsNone(self.data_source_sync_1.json_diff)
+
+    def test_create_json_diff_with_groups_and_code_and_geometry_in_field_names(self):
+        self.client.force_authenticate(self.user)
+
+        self.assertIsNone(self.data_source_sync_1.json_diff)
+
+        json_diff_params = {
+            "source_version_to_update_validation_status": m.OrgUnit.VALIDATION_NEW,
+            "source_version_to_compare_with_validation_status": m.OrgUnit.VALIDATION_NEW,
+            "source_version_to_update_org_unit_group": self.group_1.id,
+            "source_version_to_compare_with_org_unit_group": self.group_2.id,
+            "ignore_groups": True,
+            "show_deleted_org_units": False,
+            "field_names": ["name", "code", "geometry", "groups"],
+        }
+        response = self.client.patch(
+            f"/api/datasources/sync/{self.data_source_sync_1.id}/create_json_diff/", data=json_diff_params
+        )
+        self.assertJSONResponse(response, status.HTTP_200_OK)
+
+        self.data_source_sync_1.refresh_from_db()
+        self.assertIsNotNone(self.data_source_sync_1.json_diff)
+        self.assertIn("'field_names': ['code', 'geometry', 'name']", self.data_source_sync_1.diff_config)
 
     def test_synchronize_source_versions_async_without_perms(self):
         self.client.force_authenticate(self.user)


### PR DESCRIPTION
## What problem is this PR solving?

When syncing datasources, the `code` and `geometry`  fields were filtered out by the frontend, resulting in those fields being either ignored or the backend falling back to a default selection.

### Related JIRA tickets

IA-5346

## Changes

Removed the frontend logic that filtered out `code` and `geometry` (support for those fields was added in #3138).
Added some backend validation for the `groups` field.

## How to test

- Set up two versions of a Data Source:
  - Go to Admin > Data Sources > Data Sources list
  - Click on the "versions" button for one of the data sources.
  - Create a new version: download the geopackage for the existing version and reimport it using the "New version from a geopackage" button. Check the "Switch org units status to Valid" box. You need a running worker. 
- Modify the `code` attribute of an Org Unit in one of the versions:
  - Go to the Org units list, and pick a random org unit 
    - (make sure the org unit is part of your initial Data Source version, there is a filter under "show advanced settings" of the org units list).
  - Change the Org Unit `code` field and save.
- Test the Data Source synchronization:
  - Go to Admin > Data Sources > Data Sources list
  - Click the "Compare/Synchronize data sources" button for your Data Source.
  - Make sure `Code` is part of the list of "Fields to Export". 
  - In the bottom part, pick your second version. 
  - Click synchronize. Pick a name, click the "preview change request(s)".
  - You should see 1 "Org unit(s) to update". 

## Print screen / video

https://github.com/user-attachments/assets/ae90ed63-9cb5-4534-8f78-8050eeb293c6

https://github.com/user-attachments/assets/8bb4e45f-dc8b-41a0-b8be-a4eac75407b4

## Notes

Things that the reviewers should know:

/

## Doc

/