### PR TITLE
SLEEP-1803: Optimize mobile org unit api performance

### DIFF
--- a/iaso/api/mobile/org_units.py
+++ b/iaso/api/mobile/org_units.py
@@ -164,13 +164,7 @@ class MobileOrgUnitSerializer(serializers.ModelSerializer):
                 if parent_org_unit_type_id not in self.valid_org_unit_type_ids:
                     return None
             else:
-                # Fallback logic if the serializer is used in isolation (e.g. tests)
-                parent = org_unit.parent
-                parent_org_unit_type = parent.org_unit_type if parent is not None else None
-                if parent_org_unit_type is None or not any(
-                    p.app_id == self.app_id for p in parent_org_unit_type.projects.all()
-                ):
-                    return None
+                raise NotImplementedError("The serializer requires a valid project in its context.")
 
         return parent_id
 

--- a/iaso/api/mobile/org_units.py
+++ b/iaso/api/mobile/org_units.py
@@ -6,10 +6,12 @@ from django.contrib.gis.db.models import GeometryField
 from django.contrib.gis.db.models.aggregates import Extent
 from django.contrib.gis.db.models.functions import GeomOutputGeoFunc
 from django.core.cache import cache
+from django.db.models import F
 from django.db.models.expressions import RawSQL
 from django.db.models.functions import Cast
 from django.http import Http404, HttpResponseNotFound
 from django.shortcuts import get_object_or_404
+from django.utils.functional import cached_property
 from drf_spectacular.utils import extend_schema
 from rest_framework import serializers
 from rest_framework.decorators import action
@@ -124,17 +126,53 @@ class MobileOrgUnitSerializer(serializers.ModelSerializer):
 
     @staticmethod
     def get_org_unit_type_name(org_unit: OrgUnit):
+        name_annotated = getattr(org_unit, "org_unit_type_name_annotated", None)
+        if name_annotated is not None:
+            return name_annotated
         return org_unit.org_unit_type.name if org_unit.org_unit_type else None
 
+    @cached_property
+    def valid_org_unit_type_ids(self):
+        valid_ids = set()
+        project = self.context.get("project")
+        if project is not None:
+            valid_ids = set(project.unit_types.values_list("id", flat=True))
+        return valid_ids
+
     def get_parent_id(self, org_unit: OrgUnit):
-        parent = org_unit.parent
-        return (
-            org_unit.parent_id
-            if parent is None
-            or parent.validation_status == OrgUnit.VALIDATION_VALID
-            and (self.app_id is None or any(p.app_id == self.app_id for p in parent.org_unit_type.projects.all()))
-            else None
-        )
+        parent_id = org_unit.parent_id
+        if parent_id is None:
+            return None
+
+        # Retrieve annotated values if present
+        parent_validation_status = getattr(org_unit, "parent_validation_status", None)
+        parent_org_unit_type_id = getattr(org_unit, "parent_org_unit_type_id", None)
+
+        if parent_validation_status is None or parent_org_unit_type_id is None:
+            parent = org_unit.parent
+            if parent is None:
+                return None
+            parent_validation_status = parent.validation_status
+            parent_org_unit_type_id = parent.org_unit_type_id
+
+        if parent_validation_status != OrgUnit.VALIDATION_VALID:
+            return None
+
+        if self.app_id is not None:
+            project = self.context.get("project")
+            if project is not None:
+                if parent_org_unit_type_id not in self.valid_org_unit_type_ids:
+                    return None
+            else:
+                # Fallback logic if the serializer is used in isolation (e.g. tests)
+                parent = org_unit.parent
+                parent_org_unit_type = parent.org_unit_type if parent is not None else None
+                if parent_org_unit_type is None or not any(
+                    p.app_id == self.app_id for p in parent_org_unit_type.projects.all()
+                ):
+                    return None
+
+        return parent_id
 
     @staticmethod
     def get_latitude(org_unit: OrgUnit):
@@ -225,16 +263,24 @@ class MobileOrgUnitViewSet(ModelViewSet):
             return "instances"
         return "orgUnits"
 
-    def get_queryset(self):
+    @cached_property
+    def project(self):
+        if not hasattr(self, "request") or self.request is None:
+            return None
         user = self.request.user
         app_id = self.get_app_id()
+        try:
+            return Project.objects.get_for_user_and_app_id(user, app_id)
+        except Project.DoesNotExist:
+            return None
+
+    def get_queryset(self):
+        user = self.request.user
+        project = self.project
+        if project is None:
+            return OrgUnit.objects.none()
 
         limit_download_to_roots = False
-
-        try:
-            project = Project.objects.get_for_user_and_app_id(user, app_id)
-        except Project.DoesNotExist:
-            return OrgUnit.objects.none()
 
         if user and not user.is_anonymous:
             limit_download_to_roots = project.has_feature(FeatureFlag.LIMIT_OU_DOWNLOAD_TO_ROOTS)
@@ -246,8 +292,12 @@ class MobileOrgUnitViewSet(ModelViewSet):
         queryset = (
             org_units.filter(validation_status=OrgUnit.VALIDATION_VALID)
             .order_by("path")
-            .prefetch_related("parent__org_unit_type__projects", "groups")
-            .select_related("org_unit_type", "parent", "parent__org_unit_type")
+            .annotate(
+                parent_validation_status=F("parent__validation_status"),
+                parent_org_unit_type_id=F("parent__org_unit_type_id"),
+                org_unit_type_name_annotated=F("org_unit_type__name"),
+            )
+            .prefetch_related("groups")
         )
         include_geo_json = self.check_include_geo_json()
         if include_geo_json:
@@ -261,6 +311,7 @@ class MobileOrgUnitViewSet(ModelViewSet):
         context = super().get_serializer_context()
         context["include_geo_json"] = self.check_include_geo_json()
         context["app_id"] = self.get_app_id()
+        context["project"] = self.project
         return context
 
     def check_include_geo_json(self):
@@ -280,8 +331,12 @@ class MobileOrgUnitViewSet(ModelViewSet):
             queryset = (
                 OrgUnit.objects.filter_for_user_and_app_id(None, app_id)
                 .order_by("path")
-                .prefetch_related("parent__org_unit_type__projects", "groups")
-                .select_related("org_unit_type", "parent", "parent__org_unit_type")
+                .annotate(
+                    parent_validation_status=F("parent__validation_status"),
+                    parent_org_unit_type_id=F("parent__org_unit_type_id"),
+                    org_unit_type_name_annotated=F("org_unit_type__name"),
+                )
+                .prefetch_related("groups")
                 .filter(id__in=ids)
             )
             if len(queryset) != len(ids):

--- a/iaso/tests/api/test_mobile_orgunits.py
+++ b/iaso/tests/api/test_mobile_orgunits.py
@@ -173,9 +173,9 @@ class MobileOrgUnitAPITestCase(APITestCase):
             # 5. SELECT "iaso_project" LEFT JOIN "iaso_account" + "iaso_sourceversion"
             #    (Project.get_for_user_and_app_id — select_related avoids extra account/version queries)
             # 6. SELECT EXISTS "iaso_featureflag" (LIMIT_OU_DOWNLOAD_TO_ROOTS)
-            # 7. SELECT "iaso_orgunit" … (main list + parent + org unit type)
-            # 8. Prefetch org unit types → projects (M2M)
-            # 9. Prefetch org units → groups
+            # 7. SELECT "iaso_orgunit" … (main list + parent/org_unit_type joins for annotations)
+            # 8. Prefetch org units → groups (M2M)
+            # 9. Retrieve valid project unit type IDs (M2M via valid_org_unit_type_ids cached_property)
             # 10. SELECT COUNT(*) FROM "django_cache_table"
             # 11. SAVEPOINT (atomic cache write)
             # 12. SELECT "django_cache_table" (cache key)


### PR DESCRIPTION
## What problem is this PR solving?

The org unit mobile api can consume large amounts of memory and CPU time (~480MB / 26 seconds per API call for 25k org units) when syncing a large health pyramid. This PR attempts to alleviate the issue by reducing the amount of processing done in the view (reduced by about 50% to ~200MB / 13.5s per 25k).

### Related JIRA tickets

refs: SLEEP-1803

## Changes

Modified the mobile org unit API to load and initialize fewer related objects per org unit by relying on annotations instead. Specifically, a number of prefetches and selected related objects used to determine a valid parent_id for the org unit were replaced.

## How to test

There are no changes to the API so this is mostly about checking nothing was accidentally broken. 

- Ideally, test the api with the mobile app (sync health pyramid) to make sure the api works properly.
- You can also query the API directly:
`/api/mobile/orgunits/?limit=25000&page=1&shapes=false&app_id=your_project_app_id`

## Print screen / video
/

## Notes

The reviewer should be aware that the view has a custom cache mechanism (not related to this PR). When testing before/after the changes it might be necessary to clear the cache between calls to the api:
```
from django.core.cache import cache
cache.clear()
```

## Doc

/