### PR TITLE
POLIO-2188: Frontend error when visiting Vaccine supply chain details

### DIFF
--- a/plugins/polio/js/src/domains/VaccineModule/SupplyChain/hooks/utils.ts
+++ b/plugins/polio/js/src/domains/VaccineModule/SupplyChain/hooks/utils.ts
@@ -52,7 +52,7 @@ const canSaveArrayTab = (
     }
     const newElements = values[tab]
         ? // @ts-ignore we check that values[tab] is not undefined, so the ts error is wrong
-          values[tab].slice(initialValues[tab].length - 1)
+          values[tab].slice((initialValues[tab]?.length ?? 0) - 1)
         : [];
     // If an element has been added, we check that it's not empty
     return areArrayElementsChanged(newElements);


### PR DESCRIPTION
## What problem is this PR solving?

On the vaccine supply chain page, when visiting the same details page for a same entry twice in a row, the frontend errors out and the page goes blank (

### Related JIRA tickets

POLIO-2188

## Changes

=> simple fix on newElements computation

## How to test

Visit same detail page on supply chain
