### PR TITLE
Docs: top-level nav tabs, left-side page drilldown, light/dark theme

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,6 +1,6 @@
 :root {
     --md-primary-fg-color: #192041;
-    --md-accent-fg-color: #ffc200;
+    --md-accent-fg-color: #fcb900;
 }
 
 .md-footer {
@@ -14,7 +14,7 @@
     align-items: center;
 }
 #pdf-download {
-    background-color: #ffc200;
+    background-color: #fcb900;
     color: #192041;
     border-radius: 4px;
     vertical-align: middle;

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,11 +5,30 @@ theme:
   logo: ./assets/iaso.png
   favicon: ./assets/iaso-favicon.png
   custom_dir: ./docs/overrides # here we need to specify /docs in the path. That's just how it is
+  font:
+    text: Inter
+    code: JetBrains Mono
   palette:
-    primary: 'custom'
-    secondary: 'custom'
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: custom
+      accent: custom
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: custom
+      accent: custom
+      toggle:
+        icon: material/weather-night
+        name: Switch to light mode
   features:
     - content.action.edit
+    - navigation.tabs # top-level nav (Home/Users/Developers/More about IASO) as tabs instead of one long sidebar
+    - navigation.tabs.sticky # tabs stay visible while scrolling
+    - navigation.top # "back to top" button
+    - toc.integrate # page headings nest under the active page in the LEFT sidebar, no separate right-hand rail
 hooks:
   - docs_redirect_hook.py # writes redirects for pages moved by the 2026 pages/ flatten
 plugins:


### PR DESCRIPTION
## Summary

Follow-up to #3216 (the pages/ folder flatten). This is a config-only styling change — no content moved, no files renamed.

- **Top-level nav as tabs.** `navigation.tabs` turns Home / Users / Developers / More about IASO into a tab bar across the header instead of one long sidebar list. The existing `nav:` tree already has exactly this 4-section shape, so this is purely a theme feature flip — no nav restructuring needed.
- **Page headings move to the left sidebar.** `toc.integrate` nests a page's headings directly under its link in the sidebar, instead of a separate right-hand "on this page" column. One nav area instead of two.
- **Light/dark mode.** Added Material's `default` (light) + `slate` (dark) palette with a toggle. Both use Bluesquare's navy/yellow as primary/accent - the yellow hex needed correcting from `#ffc200` to the official brand code `#fcb900` (from the Bluesquare color sheet) while I was in there.
- **Typography.** Switched to Inter (text) and JetBrains Mono (code), matching OpenHEXA's docs so the two products read as siblings.

All four are built-in Material for MkDocs features/config - no new dependencies, no custom CSS beyond correcting the two existing yellow hex values in `extra.css`.

A mockup of this was reviewed before implementing: [screenshot/description available on request].

## Test plan

- [x] Local build: top-level tabs render with the correct 4 sections and labels
- [x] Local build: page headings (e.g. Environment variables) nest under the active sidebar link, no right-hand rail
- [x] Palette toggle switches `default` ↔ `slate`, accent color (`#fcb900`) unchanged in both
- [x] `Inter` resolves as the body font (confirmed via computed styles, not just config)
- [x] Existing features unaffected: glightbox zoom, mermaid diagrams, PDF download button, the old-URL redirect hook (60 redirects still generate correctly)
- [x] FR/ES builds still translate nav titles correctly (`nav_translations` unaffected by tabs/toc.integrate)
- [ ] Reviewer: click through a built preview if available, particularly the palette toggle and a page with several headings
