### PR TITLE
Docs: fix "More about IASO" tab, open external links in a new tab

### DIFF
--- a/docs/extrajs/external_links.js
+++ b/docs/extrajs/external_links.js
@@ -1,0 +1,11 @@
+// Open every external link (anywhere on the page - content, nav, header) in a
+// new tab, instead of navigating away from the docs. Internal links (relative
+// paths, or absolute links to this same host) are left alone.
+document.addEventListener("DOMContentLoaded", function () {
+    document.querySelectorAll('a[href^="http://"], a[href^="https://"]').forEach(function (link) {
+        if (link.hostname && link.hostname !== window.location.hostname) {
+            link.setAttribute("target", "_blank");
+            link.setAttribute("rel", "noopener noreferrer");
+        }
+    });
+});

--- a/docs/pages/more_about_iaso.en.md
+++ b/docs/pages/more_about_iaso.en.md
@@ -1,0 +1,6 @@
+# More about IASO
+
+- [IASO website](https://www.openiaso.com/)
+- [Digital Public Goods Registry](https://www.digitalpublicgoods.net/r/iaso)
+- [Release notes](https://github.com/BLSQ/iaso/releases)
+- [Bluesquare website](https://www.bluesquarehub.com/)

--- a/docs/pages/more_about_iaso.es.md
+++ b/docs/pages/more_about_iaso.es.md
@@ -1,0 +1,6 @@
+# Más sobre IASO
+
+- [Sitio web de IASO](https://www.openiaso.com/)
+- [Digital Public Goods Registry](https://www.digitalpublicgoods.net/r/iaso)
+- [Notas de versión](https://github.com/BLSQ/iaso/releases)
+- [Sitio web de Bluesquare](https://www.bluesquarehub.com/)

--- a/docs/pages/more_about_iaso.fr.md
+++ b/docs/pages/more_about_iaso.fr.md
@@ -1,0 +1,6 @@
+# En savoir plus sur IASO
+
+- [Demander une démo](https://www.openiaso.com/)
+- [Digital Public Goods Registry](https://www.digitalpublicgoods.net/r/iaso)
+- [Release notes](https://github.com/BLSQ/iaso/releases)
+- [Bluesquare](https://www.bluesquarehub.com/)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -97,6 +97,7 @@ extra_css:
 extra_javascript:
   - ./extrajs/html2pdf.bundle.min.js
   - ./extrajs/pdfDownload.js
+  - ./extrajs/external_links.js
   - https://plausible.io/js/script.js
 use_directory_urls: false # IMPORTANT: without this the paths to pictures will break on build
 nav: # nav configures the side bar menu - this is the ONLY place the nav tree is defined.
@@ -148,6 +149,7 @@ nav: # nav configures the side bar menu - this is the ONLY place the nav tree is
       - ./pages/dev/how_to/build_odk_preview.md
 
   - More about IASO:
+    - ./pages/more_about_iaso.md
     - IASO website: https://www.openiaso.com/
     - Digital Public Goods Registry: https://www.digitalpublicgoods.net/r/iaso
     - Release notes: https://github.com/BLSQ/iaso/releases


### PR DESCRIPTION
## Summary

Two fixes to the live site, both reported after #3249 shipped.

**1. "More about IASO" tab was leaving the site instead of showing its links**

With `navigation.tabs`, a top-level section with no page of its own gets its tab linked directly to its first child instead of behaving as a section. Every child of "More about IASO" was a plain external URL, so its tab went straight to openiaso.com - the other 3 links (Digital Public Goods Registry, Release notes, Bluesquare website) became unreachable from the top nav (they were still technically present, just buried inside a sidebar toggle nobody would think to open after being redirected off-site).

Fix: give the section a real internal landing page (`pages/more_about_iaso.md`, in all 3 languages) listing the same 4 links as normal hyperlinks. The tab now stays on-site and all 4 links are always visible in one place.

**2. External links now open in a new tab**

Added `docs/extrajs/external_links.js`: on load, any link anywhere on the page (content, sidebar, header - e.g. the GitHub source link, the "edit this page" button) whose hostname differs from the site's own gets `target="_blank" rel="noopener noreferrer"`. Internal/relative links are untouched.

## Test plan

- [x] Local build: "More about IASO" tab links to the new internal page, not openiaso.com
- [x] New page renders correctly in EN/FR/ES with all 4 links
- [x] Confirmed via live DOM (not just source) that external links get `target="_blank"` - checked a content link, the GitHub source link, and the edit-page link
- [x] Confirmed internal links (e.g. the Home tab) and same-page anchors are untouched
- [ ] Reviewer: click through the live preview if available