### PR TITLE
Docs: remove project-account line from Get started guide, add FR/ES translations

### DIFF
--- a/docs/pages/users/how_to/get_started_with_iaso.en.md
+++ b/docs/pages/users/how_to/get_started_with_iaso.en.md
@@ -18,10 +18,7 @@ You'll then receive an email with instructions to create your account.
 
 ## 2. Connect to your account
 
-Go to your server URL:
-
-- [app.openiaso.com](https://app.openiaso.com/) — if you have a SaaS account
-- [iaso.bluesquare.org](https://iaso.bluesquare.org/) — if you have a project account
+Go to [app.openiaso.com](https://app.openiaso.com/).
 
 Enter your credentials and click "Login".
 


### PR DESCRIPTION
## Summary

**1. Removes the "iaso.bluesquare.org — if you have a project account" line** from the "Connect to your account" step. The guide is aimed at people who just subscribed to a SaaS plan, so only the SaaS login (app.openiaso.com) applies here. Reworded the intro line into a single sentence since it no longer introduces a 2-item list.

**2. Adds French and Spanish translations** for the "Get started with IASO" guide and the homepage "New to IASO?" callout - both were English-only, which was an oversight (called out after #3250 shipped). Translations match existing site terminology (unités d'organisation / Unidades Organizacionales, formulaire/formulario de collecte/recolección de données, indicateur/indicador de fonctionnalité, etc.) rather than introducing new phrasing.

## Test plan

- [x] Local build: EN page renders with the single sentence, link intact, no new warnings
- [x] Local build: FR/ES pages render, screenshots resolve correctly (shared attachments folder, relative paths adjusted for the /fr//es/ prefix depth)
- [x] Internal anchor link to the org-unit-types section resolves correctly in all 3 languages (the FR/ES anchors needed correcting - mkdocs' slugifier strips accents, e.g. "unités" → "unites" in the anchor, "Gestión" → "gestion")
- [x] FR/ES homepage callouts render with working links