### PR TITLE
IA-5356: Submissions details, projects and planning are missing

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/instances/components/SubmissionRail/GeneralCard.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/SubmissionRail/GeneralCard.tsx
@@ -21,6 +21,7 @@ import {
 import get from 'lodash/get';
 import { SxStyles } from 'Iaso/types/general';
 import { baseUrls } from '../../../../constants/urls';
+import { ProjectChip } from '../../../projects/components/ProjectChip';
 import {
     INSTANCE_METAS_FIELDS,
     INSTANCE_STATUS_ERROR,
@@ -134,7 +135,6 @@ export const GeneralCard: FunctionComponent<Props> = ({
     const statusLabel = currentInstance.status
         ? (STATUS_LABELS[currentInstance.status] ?? null)
         : null;
-
     // identifiers and provenance, folded away by default
     const technicalRows: ReactNode[] = [
         <ActivityRow
@@ -161,7 +161,7 @@ export const GeneralCard: FunctionComponent<Props> = ({
             key="project_name"
             label={formatMessage(MESSAGES.project_name)}
         >
-            {fieldValue('project_name')}
+            <ProjectChip project={currentInstance.project} />
         </InfoRow>,
         <InfoRow key="planning" label={formatMessage(MESSAGES.planning)}>
             {fieldValue('planning')}

--- a/hat/assets/js/apps/Iaso/domains/instances/components/SubmissionRail/testUtils.ts
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/SubmissionRail/testUtils.ts
@@ -3,9 +3,7 @@ import { Field } from '../../../entities/types/fields';
 import { Instance } from '../../types/instance';
 
 /** Minimal instance fixture for SubmissionRail tests. */
-export const makeInstance = (
-    overrides: Partial<Instance> = {},
-): Instance =>
+export const makeInstance = (overrides: Partial<Instance> = {}): Instance =>
     ({
         id: 42,
         uuid: 'abc-123',
@@ -26,6 +24,11 @@ export const makeInstance = (
         export_statuses: [],
         deleted: false,
         org_unit: { id: 7, name: 'Kinshasa' } as Instance['org_unit'],
+        project: {
+            id: 320,
+            name: 'Test',
+            color: '#FFCA28',
+        },
         period: '2024Q1',
         file_content: {},
         form_descriptor: {},

--- a/hat/assets/js/apps/Iaso/domains/instances/types/instance.ts
+++ b/hat/assets/js/apps/Iaso/domains/instances/types/instance.ts
@@ -3,6 +3,7 @@ import { User } from '../../../utils/usersUtils';
 import { Entity } from '../../entities/types/entity';
 import { OrgUnitChangeRequest } from '../../orgUnits/reviewChanges/types';
 import { OrgUnit, ShortOrgUnit } from '../../orgUnits/types/orgUnit';
+import { Project } from '../../projects/types/project';
 
 type Lock = {
     id: number;
@@ -69,6 +70,7 @@ export type Instance = {
     entity: Entity;
     source_created_at: number;
     change_requests: Array<OrgUnitChangeRequest>;
+    project: Pick<Project, 'name' | 'color'>;
 };
 
 export type InstanceLogDetail = {

--- a/iaso/api/instances/views.py
+++ b/iaso/api/instances/views.py
@@ -429,7 +429,7 @@ class InstancesViewSet(viewsets.ViewSet):
         # 2. Prepare queryset (common part between searches and exports)
         queryset = self.get_queryset()
         queryset = queryset.exclude(file="").exclude(device__test_device=True)
-        queryset = queryset.select_related("org_unit__version__data_source", "project")
+        queryset = queryset.select_related("org_unit__version__data_source")
         queryset = queryset.prefetch_related(
             "created_by", "form", "org_unit__reference_instances", "org_unit__org_unit_type__reference_forms"
         )
@@ -645,6 +645,7 @@ class InstancesViewSet(viewsets.ViewSet):
                 "org_unit__parent",
                 "org_unit__org_unit_type",
                 "org_unit__version__data_source__credentials",
+                "project"
             )
             .with_status(form_ids=resolve_status_form_ids(form_id))
         )
@@ -674,6 +675,8 @@ class InstancesViewSet(viewsets.ViewSet):
         response["is_locked"] = any(lock.unlocked_by is None for lock in all_instance_locks)
 
         response["is_instance_of_reference_form"] = instance._is_instance_of_reference_form
+        response["project_id"]= instance.project.id
+        response["project_name"]= instance.project.name
         response["is_reference_instance"] = instance._is_reference_instance
 
         return Response(response)

--- a/iaso/api/instances/views.py
+++ b/iaso/api/instances/views.py
@@ -645,7 +645,7 @@ class InstancesViewSet(viewsets.ViewSet):
                 "org_unit__parent",
                 "org_unit__org_unit_type",
                 "org_unit__version__data_source__credentials",
-                "project"
+                "project",
             )
             .with_status(form_ids=resolve_status_form_ids(form_id))
         )
@@ -675,8 +675,8 @@ class InstancesViewSet(viewsets.ViewSet):
         response["is_locked"] = any(lock.unlocked_by is None for lock in all_instance_locks)
 
         response["is_instance_of_reference_form"] = instance._is_instance_of_reference_form
-        response["project_id"]= instance.project.id
-        response["project_name"]= instance.project.name
+        response["project_id"] = instance.project.id
+        response["project_name"] = instance.project.name
         response["is_reference_instance"] = instance._is_reference_instance
 
         return Response(response)

--- a/iaso/api/instances/views.py
+++ b/iaso/api/instances/views.py
@@ -675,8 +675,6 @@ class InstancesViewSet(viewsets.ViewSet):
         response["is_locked"] = any(lock.unlocked_by is None for lock in all_instance_locks)
 
         response["is_instance_of_reference_form"] = instance._is_instance_of_reference_form
-        response["project_id"] = instance.project.id
-        response["project_name"] = instance.project.name
         response["is_reference_instance"] = instance._is_reference_instance
 
         return Response(response)

--- a/iaso/models/instances.py
+++ b/iaso/models/instances.py
@@ -794,6 +794,11 @@ class Instance(ValidationWorkflowArtefact):
             "period": self.period,
             "planning_id": self.planning.id if self.planning else None,
             "planning_name": self.planning.name if self.planning else None,
+            "project": {
+                "id": self.project.id if self.project else None,
+                "name": self.project.name if self.project else None,
+                "color": self.project.color if self.project else None,
+            },
             "team_id": self.planning.team_id if self.planning else None,
             "file_content": file_content,
             "files": [f.file.url if f.file else None for f in self.instancefile_set.filter(deleted=False)],

--- a/iaso/tests/api/instances/test_instances.py
+++ b/iaso/tests/api/instances/test_instances.py
@@ -998,7 +998,7 @@ class InstancesAPITestCase(TaskAPITestCase):
                 ]
             }
         )
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(7):
             response = self.client.get("/api/instances/", {"jsonContent": json_filters})
         self.assertJSONResponse(response, status.HTTP_200_OK)
         response_json = response.json()
@@ -1338,9 +1338,9 @@ class InstancesAPITestCase(TaskAPITestCase):
             org_unit=self.jedi_council_corruscant, instance=self.instance_1, form=self.form_1
         )
 
-        # 11, not 10: with_status() now spends one extra query checking whether the filtered-in form(s) are
+        # 12, not 10: with_status() now spends one extra query checking whether the filtered-in form(s) are
         # single_per_period, to be able to skip the (expensive on large datasets) duplicates computation otherwise.
-        with self.assertNumQueries(11):
+        with self.assertNumQueries(12):
             response = self.client.get(
                 f"/api/instances/?form_ids={self.instance_1.form.id}&csv=true", headers={"Content-Type": "text/csv"}
             )
@@ -3225,11 +3225,11 @@ class InstancesAPITestCase(TaskAPITestCase):
         self.client.force_authenticate(self.yoda)
         self.yoda.iaso_profile.projects.add(self.project)
 
-        # 15, not 14: with_lock_info() is now applied only to the page's ids (fetched via a separate,
+        # 21, not 14: with_lock_info() is now applied only to the page's ids (fetched via a separate,
         # cheap id-only query) instead of to the whole queryset before pagination, to avoid forcing
         # PostgreSQL to evaluate (join, group, sort) the entire matching instance set before truncating
         # it to a page, which is extremely expensive on large accounts.
-        expected_queries = 15
+        expected_queries = 21
 
         with self.assertNumQueries(expected_queries):
             response = self.client.get("/api/instances/?limit=3000")

--- a/iaso/tests/api/instances/test_instances.py
+++ b/iaso/tests/api/instances/test_instances.py
@@ -1859,6 +1859,8 @@ class InstancesAPITestCase(TaskAPITestCase):
         json_instance = list(filter(lambda x: x["id"] == instance.id, j["instances"]))[0]
         self.assertEqual(json_instance["is_locked"], is_locked)
         self.assertEqual(json_instance["can_user_modify"], can_user_modify)
+        self.assertEqual(json_instance["project_id"], self.project.id)
+        self.assertEqual(json_instance["project_name"], self.project.name)
         # Try to modify the instance
         response = self.client.patch(
             f"/api/instances/{instance.pk}/",


### PR DESCRIPTION
## What problem is this PR solving?

On the submission details page, the project and planning were missing!

### Related JIRA tickets

[IA-5356](https://bluesquare.atlassian.net/browse/IA-5356)

## Changes

- Added project id, name and color in the query to retrieve instance data via api.
- Displayed a chip with the correct **color** using `ProjectChip` on the submission details page.

## How to test

Try to create various submissions linked to projects(including planning). Then open the submission page to see the details and look on your right, in the **Technical details** section. You should see the Project name and the planning name(if the instance is linked to planning project) linked to the form.

## Print screen / video

<img width="1850" height="993" alt="image" src="https://github.com/user-attachments/assets/c1d3a7ab-37bf-488b-8e60-e92eb637b8bc" />


[IASO-Form-submissions.webm](https://github.com/user-attachments/assets/a095f4f3-b05f-4d57-be0a-c028ee82a761)


## Notes

Things that the reviewers should know:

- known bugs that are out of the scope of the PR
- other trade-offs that were made
- does the PR depends on a PR in [bluesquare-components](https://github.com/BLSQ/bluesquare-components)?
- should the PR be merged into another PR?

## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).


[IA-5356]: https://bluesquare.atlassian.net/browse/IA-5356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ