### PR TITLE
Docs: add FR/ES translations for the Get started guide

### DIFF
--- a/docs/index.es.md
+++ b/docs/index.es.md
@@ -3,6 +3,9 @@
 # Introducción a IASO
 IASO es una plataforma innovadora, de código abierto, trilingüe (EN/FR/ES) de **recolección de datos con funcionalidades geoespaciales avanzadas** para planificar, monitorear y evaluar programas de salud, ambientales o sociales en países de ingresos bajos y medios (PIBM). IASO es reconocido como un **Bien Público Digital** por la Alianza de Bienes Públicos Digitales y figura entre los software **Global Goods** de Digital Square, testimoniando su utilidad pública.
 
+!!! tip "¿Nuevo en IASO?"
+    Siga la guía **[Primeros pasos con IASO](./pages/users/how_to/get_started_with_iaso.md)** para suscribirse a un plan, iniciar sesión y crear su primer formulario de recolección de datos.
+
 IASO incluye:
 
 - un **tablero web** - destinado a supervisores para organizar la recolección de datos y la gestión de datos geográficos

--- a/docs/index.fr.md
+++ b/docs/index.fr.md
@@ -3,6 +3,9 @@
 # Introduction à IASO
 IASO est une plateforme innovante, open-source, trilingue (EN/FR/ES) de **collecte de données à fonctionnalités géospatiales avancées** pour planifier, surveiller et évaluer les programmes de santé, environnementaux ou sociaux dans les pays à revenu faible et intermédiaire (PRFI). IASO est reconnu comme un **Bien Public Numérique** par l'Alliance des Biens Publics Numériques et figure parmi les logiciels **Global Goods** de Digital Square, témoignant de son utilité publique.
 
+!!! tip "Nouveau sur IASO ?"
+    Suivez le guide **[Bien démarrer avec IASO](./pages/users/how_to/get_started_with_iaso.md)** pour vous abonner à une offre, vous connecter et créer votre premier formulaire de collecte de données.
+
 IASO comprend :
 
 - un **tableau de bord web** - destiné aux superviseurs pour organiser la collecte de données et la gestion des données géographiques

--- a/docs/pages/users/how_to/get_started_with_iaso.es.md
+++ b/docs/pages/users/how_to/get_started_with_iaso.es.md
@@ -1,0 +1,86 @@
+# Primeros pasos con IASO
+
+*Una guía para la primera configuración básica.*
+
+Esta guía está dirigida a los administradores de cuenta que configuran una nueva cuenta SaaS
+de IASO por primera vez. Cubre la suscripción a un plan, el inicio de sesión, la configuración
+de sus datos geográficos, la creación de su primer formulario de recolección de datos y la
+conexión de la aplicación móvil.
+
+## 1. Suscribirse a un plan SaaS
+
+IASO ya está disponible como producto SaaS.
+
+Si aún no se ha suscrito, vaya a [openiaso.com/pricing](https://www.openiaso.com/pricing/) y
+elija un plan. Si todavía no está seguro, puede comenzar con una prueba gratuita para probar
+el producto.
+
+Luego recibirá un correo electrónico con las instrucciones para crear su cuenta.
+
+## 2. Conectarse a su cuenta
+
+Vaya a [app.openiaso.com](https://app.openiaso.com/).
+
+Introduzca sus credenciales y haga clic en "Login".
+
+## 3. Configurar sus datos geográficos
+
+Sus datos geográficos aparecen en el menú "Org Units" (Unidades Organizacionales). Está vacío
+por defecto en una cuenta nueva. Puede configurarlo manualmente, o importando un archivo
+geopackage (un formato de archivo estándar para datos de límites geográficos).
+
+**Configuración manual**
+
+- Vaya a "Org Units" > "Configuration" > "Organisation unit type" (Tipo de Unidad
+  Organizacional)
+- Cree los tipos de Unidad Organizacional que correspondan a los niveles geográficos de sus
+  datos (por ejemplo, país, región, distrito, centro de salud)
+- Consulte la [guía de tipos de Unidad Organizacional](../reference/user_guide.md#gestion-de-tipos-de-unidades-organizacionales)
+  para más detalles
+
+**Importar un geopackage**
+
+- Vaya a "Admin" > "Data sources list" (Lista de fuentes de datos) > "Create"
+- Nombre su fuente de datos y asígnela a uno o varios proyectos
+- Su archivo geopackage debe seguir este formato: [github.com/BLSQ/iaso](https://github.com/BLSQ/iaso/tree/main/iaso/gpkg)
+
+## 4. Crear sus formularios de recolección de datos
+
+Vaya al menú "Forms" (Formularios). Puede crear un formulario de dos maneras:
+
+**Opción A — Generar un formulario con Form AI**
+
+- Vaya a "Forms" > "Form AI"
+- Describa el formulario que desea en una instrucción: enumere las preguntas que necesita,
+  especifique si cada una debe ser una pregunta abierta o cerrada con opciones predefinidas, y
+  mencione cualquier lógica de salto.
+- IASO genera un formulario que puede previsualizar y ajustar en el panel derecho. Guárdelo
+  una vez que esté satisfecho con el resultado.
+
+**Opción B — Importar un formulario XLS existente**
+
+- Vaya a "Forms" > "Form list" > "Add form"
+
+![Lista de formularios, con el botón Add form](./get_started_with_iaso_attachments/add_form_button.png){ .doc-shot }
+
+Luego complete los campos:
+
+- Nombre del formulario (obligatorio)
+- Proyecto (obligatorio)
+- Tipo de Unidad Organizacional (recomendado)
+- Grupo de Unidad Organizacional (solo si es relevante, de lo contrario déjelo en blanco)
+- Período (solo si es relevante, de lo contrario déjelo en blanco)
+
+![Campos del formulario Add form](./get_started_with_iaso_attachments/add_form_fields.png){ .doc-shot }
+
+## 5. Descargar la aplicación móvil de IASO
+
+Obtenga la aplicación móvil de IASO en Google Play Store: [play.google.com](https://play.google.com/store/apps/details?id=com.bluesquarehub.iaso&hl=es)
+
+## 6. Escanear el código QR y comenzar
+
+Antes de escanear, asegúrese de que los indicadores de funcionalidad necesarios estén
+activados para su proyecto.
+
+Luego, en la aplicación web de IASO, vaya a "Projects" (Proyectos) y haga clic en el código QR
+de su proyecto. Escanéelo desde la aplicación móvil para finalizar la configuración.

--- a/docs/pages/users/how_to/get_started_with_iaso.fr.md
+++ b/docs/pages/users/how_to/get_started_with_iaso.fr.md
@@ -1,0 +1,87 @@
+# Bien démarrer avec IASO
+
+*Un guide pour une première configuration de base.*
+
+Ce guide s'adresse aux administrateurs de compte qui configurent un nouveau compte IASO SaaS
+pour la première fois. Il couvre l'abonnement à une offre, la connexion, la configuration de
+vos données géographiques, la création de votre premier formulaire de collecte de données, et
+la connexion de l'application mobile.
+
+## 1. S'abonner à une offre SaaS
+
+IASO est désormais disponible en tant que produit SaaS.
+
+Si vous n'êtes pas encore abonné, rendez-vous sur [openiaso.com/pricing](https://www.openiaso.com/pricing/)
+et choisissez une offre. Si vous n'êtes pas encore sûr, vous pouvez commencer par un essai
+gratuit pour découvrir le produit.
+
+Vous recevrez ensuite un email avec les instructions pour créer votre compte.
+
+## 2. Se connecter à votre compte
+
+Rendez-vous sur [app.openiaso.com](https://app.openiaso.com/).
+
+Saisissez vos identifiants et cliquez sur "Login".
+
+## 3. Configurer vos données géographiques
+
+Vos données géographiques apparaissent dans le menu "Org Units" (Unités d'organisation).
+Il est vide par défaut sur un nouveau compte. Vous pouvez le configurer manuellement, ou en
+important un fichier geopackage (un format de fichier standard pour les données de limites
+géographiques).
+
+**Configuration manuelle**
+
+- Allez dans "Org Units" > "Configuration" > "Organisation unit type" (Type d'unité
+  d'organisation)
+- Créez les types d'unité d'organisation correspondant aux niveaux géographiques de vos
+  données (par exemple pays, région, district, structure sanitaire)
+- Consultez le [guide des types d'unité d'organisation](../reference/user_guide.md#gestion-des-types-dunites-dorganisation)
+  pour plus de détails
+
+**Importer un geopackage**
+
+- Allez dans "Admin" > "Data sources list" (Liste des sources de données) > "Create"
+- Nommez votre source de données et associez-la à un ou plusieurs projets
+- Votre fichier geopackage doit respecter ce format : [github.com/BLSQ/iaso](https://github.com/BLSQ/iaso/tree/main/iaso/gpkg)
+
+## 4. Créer vos formulaires de collecte de données
+
+Allez dans le menu "Forms" (Formulaires). Vous pouvez créer un formulaire de deux façons :
+
+**Option A — Générer un formulaire avec Form AI**
+
+- Allez dans "Forms" > "Form AI"
+- Décrivez le formulaire souhaité dans une requête : listez les questions dont vous avez
+  besoin, précisez si chacune doit être une question ouverte ou fermée avec des choix
+  prédéfinis, et mentionnez toute logique de saut.
+- IASO génère un formulaire que vous pouvez prévisualiser et ajuster sur la partie droite.
+  Enregistrez-le une fois satisfait.
+
+**Option B — Importer un formulaire XLS existant**
+
+- Allez dans "Forms" > "Form list" > "Add form"
+
+![Liste des formulaires, avec le bouton Add form](./get_started_with_iaso_attachments/add_form_button.png){ .doc-shot }
+
+Renseignez ensuite les champs :
+
+- Nom du formulaire (obligatoire)
+- Projet (obligatoire)
+- Type d'unité d'organisation (recommandé)
+- Groupe d'unité d'organisation (uniquement si pertinent, sinon laissez vide)
+- Période (uniquement si pertinent, sinon laissez vide)
+
+![Champs du formulaire Add form](./get_started_with_iaso_attachments/add_form_fields.png){ .doc-shot }
+
+## 5. Télécharger l'application mobile IASO
+
+Téléchargez l'application mobile IASO sur le Google Play Store : [play.google.com](https://play.google.com/store/apps/details?id=com.bluesquarehub.iaso&hl=fr)
+
+## 6. Scanner le code QR et démarrer
+
+Avant de scanner, assurez-vous que les indicateurs de fonctionnalité requis sont activés pour
+votre projet.
+
+Ensuite, sur l'application web IASO, allez dans "Projects" (Projets) et cliquez sur le code QR
+de votre projet. Scannez-le depuis l'application mobile pour terminer la configuration.


### PR DESCRIPTION
## Summary

Follow-up to #3252, which merged before this commit was pushed to that branch - opening it separately so it actually lands.

Adds French and Spanish translations for the "Get started with IASO" guide and the homepage "New to IASO?" callout - both were English-only, which was an oversight. Translations match existing site terminology (unités d'organisation / Unidades Organizacionales, formulaire/formulario de collecte/recolección de données, indicateur/indicador de fonctionnalité, etc.) rather than introducing new phrasing.

## Test plan

- [x] Local build: FR/ES pages render, screenshots resolve correctly (shared attachments folder, relative paths adjusted for the /fr//es/ prefix depth)
- [x] Internal anchor link to the org-unit-types section resolves correctly in all 3 languages (the FR/ES anchors needed correcting - mkdocs' slugifier strips accents, e.g. "unités" → "unites" in the anchor, "Gestión" → "gestion")
- [x] FR/ES homepage callouts render with working links