### PR TITLE
Docs: make the language switcher visible

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -3,6 +3,29 @@
     --md-accent-fg-color: #fcb900;
 }
 
+/* Language switcher: by default this is a bare globe icon with no visible
+   label, easy to miss in the header. Show the current language as text
+   next to the icon - html[lang] is set correctly per built locale. */
+.md-header .md-select > .md-header__button.md-icon {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    width: auto;
+    padding-inline-end: 0.2rem;
+}
+.md-header .md-select > .md-header__button.md-icon::after {
+    content: "EN";
+    font-size: 0.68rem;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+}
+html[lang="fr"] .md-header .md-select > .md-header__button.md-icon::after {
+    content: "FR";
+}
+html[lang="es"] .md-header .md-select > .md-header__button.md-icon::after {
+    content: "ES";
+}
+
 .md-footer {
     display: none !important;
 }


### PR DESCRIPTION
## Summary

The language switcher was a bare globe icon in the header with no visible label - easy to miss, and it doesn't tell you what language you're currently on. This was flagged as a gap between the original nav-redesign mockup (which showed a visible "EN" label) and what actually shipped in #3249.

CSS-only fix, no JS: `html[lang]` is already set correctly per built locale (`en`/`fr`/`es`), so an attribute selector shows the current language as text next to the icon.

## Test plan

- [x] Verified in the live DOM (not just source) on all 3 built locales: EN page shows "EN", `/fr/` shows "FR", `/es/` shows "ES"
- [x] Confirmed it holds up in dark mode (inherits the header's text color correctly, no override needed)
- [x] No new build warnings