### PR TITLE
Docs: add subheadings for the 4 components + deployment note on homepage

### DIFF
--- a/docs/index.en.md
+++ b/docs/index.en.md
@@ -18,32 +18,40 @@ IASO comprises:
 
 In terms of features, IASO can be summarized around **four main components** which are interconnected and expand the powers of one another:
 
--  **Geospatial data management (Georegistry)**
-    -  Manage multiple master lists of organizational units (e.g. health areas, districts, facilities, or schools) including their GPS coordinates and boundaries
-    -  Keep track of changes made to the organization units
-    -   Map multiple geographic data sources
-    -   Propose changes to org units from IASO mobile application and validate them on the web
+### Geospatial data management (Georegistry)
 
-- **Geo-structured data collection**
-    -   Create data collection forms using the widely known XLS form format and upload them to IASO
-    -   Link your form to one or several organization unit type (e.g. National/Regional/District/Health facility) to geo-structure your data collection
-    -   Keep track of changes with versioning of your data collection forms
-    -   Validate from the web all data collection form submissions sent from IASO mobile application
-    -   Monitor data collection completeness per organization unit level and drill-down to identify where issues happen
+-  Manage multiple master lists of organizational units (e.g. health areas, districts, facilities, or schools) including their GPS coordinates and boundaries
+-  Keep track of changes made to the organization units
+-   Map multiple geographic data sources
+-   Propose changes to org units from IASO mobile application and validate them on the web
 
--   **Geo-enabled Microplanning**
-    - Manage teams of users and teams of teams
-    - Assign data collection duties to teams and users using a map interface
-    - Create plannings with a scope, a time span, and one or several data collection form(s)
- 
--   **Entities** - these can be individuals (e.g. health programme beneficiaries) or physical objects (e.g. vaccines parcel, mosquito net, etc.). Workflows allows the tracking of entities by opening specific forms according to previous answers given to previous forms.
-    - Create entity types (beneficiaries, stocks, or other)
-    - Assign workflows to entity types
-    - Register entities via mobile app (offline)
-    - Synchronize mobile and web applications
-    - Compare and merge entities as needed
-    - Record entity data in an NFC card
-  
+### Geo-structured data collection
+
+-   Create data collection forms using the widely known XLS form format and upload them to IASO
+-   Link your form to one or several organization unit type (e.g. National/Regional/District/Health facility) to geo-structure your data collection
+-   Keep track of changes with versioning of your data collection forms
+-   Validate from the web all data collection form submissions sent from IASO mobile application
+-   Monitor data collection completeness per organization unit level and drill-down to identify where issues happen
+
+### Geo-enabled Microplanning
+
+- Manage teams of users and teams of teams
+- Assign data collection duties to teams and users using a map interface
+- Create plannings with a scope, a time span, and one or several data collection form(s)
+
+### Entities
+
+These can be individuals (e.g. health programme beneficiaries) or physical objects (e.g. vaccines parcel, mosquito net, etc.). Workflows allows the tracking of entities by opening specific forms according to previous answers given to previous forms.
+
+- Create entity types (beneficiaries, stocks, or other)
+- Assign workflows to entity types
+- Register entities via mobile app (offline)
+- Synchronize mobile and web applications
+- Compare and merge entities as needed
+- Record entity data in an NFC card
+
+### Widely deployed
+
 The platform has been implemented in Benin, Burkina Faso, Burundi, Cameroon, Central African Republic, the Democratic Republic of Congo, Haiti, Ivory Coast, Mali, Niger, Nigeria and Uganda. It is the official georegistry in Burkina Faso since 2023. IASO has also been implemented at regional level (AFRO region) in support to the Global Polio Eradication Initiative for its geospatial and health facility registries capabilities.
 
 

--- a/docs/index.es.md
+++ b/docs/index.es.md
@@ -1,6 +1,6 @@
 # Bienvenido a la documentación de IASO
 
-# Introducción a IASO
+## Introducción a IASO
 IASO es una plataforma innovadora, de código abierto, trilingüe (EN/FR/ES) de **recolección de datos con funcionalidades geoespaciales avanzadas** para planificar, monitorear y evaluar programas de salud, ambientales o sociales en países de ingresos bajos y medios (PIBM). IASO es reconocido como un **Bien Público Digital** por la Alianza de Bienes Públicos Digitales y figura entre los software **Global Goods** de Digital Square, testimoniando su utilidad pública.
 
 !!! tip "¿Nuevo en IASO?"
@@ -15,35 +15,43 @@ IASO incluye:
   
 En términos de funcionalidades, IASO puede resumirse en torno a **cuatro componentes principales** que están interconectados y refuerzan sus capacidades mutuas:
 
-- **Gestión de datos geoespaciales (Georegister)**
-    - Gestionar múltiples listas de unidades organizacionales (por ejemplo, zonas de salud, distritos, establecimientos de salud o escuelas) incluyendo sus coordenadas GPS y fronteras
-    - Rastrear las modificaciones realizadas a las unidades organizacionales
-    - Comparar múltiples fuentes de datos geográficos
-    - Proponer modificaciones a las unidades organizacionales desde la aplicación móvil IASO y validarlas en la web
-   
-- **Recolección de datos geo-estructurados**
-    - Crear formularios de recolección de datos utilizando el popular formato XLS e importarlos en IASO
-    - Vincular sus formularios a uno o varios tipos de unidades organizacionales (por ejemplo, Nacional/Regional/Distrito/Establecimiento de salud) para estructurar geográficamente su recolección de datos
-    - Rastrear los cambios con la gestión de versiones de sus formularios
-    - Validar desde la web todas las presentaciones de formularios enviadas por la aplicación móvil IASO
-    - Rastrear la completitud de la recolección de datos por nivel de unidades organizacionales e identificar dónde se encuentran los problemas
- 
-- **Microplanificación**
-    - Gestionar equipos de usuarios y equipos de equipos
-    - Asignar tareas de recolección de datos a equipos y usuarios utilizando un mapa interactivo
-    - Crear calendarios con un perímetro, duración y uno o más formularios de recolección de datos
- 
-- **Entidades** - estas pueden consistir en individuos (por ejemplo, beneficiarios de programas de salud) u objetos físicos (por ejemplo, lotes de vacunas, mosquiteros, etc.). Los flujos de trabajo permiten rastrear las entidades abriendo formularios específicos en función de las respuestas dadas a formularios anteriores.
-    - Crear tipos de entidades (beneficiarios, stocks u otros)
-    - Asignar flujos de trabajo a tipos de entidades
-    - Registrar entidades a través de la aplicación móvil (sin conexión)
-    - Sincronizar las aplicaciones móvil y web
-    - Comparar y fusionar entidades si es necesario
-    - Registrar los datos de las entidades en una tarjeta NFC
- 
+### Gestión de datos geoespaciales (Georegister)
+
+- Gestionar múltiples listas de unidades organizacionales (por ejemplo, zonas de salud, distritos, establecimientos de salud o escuelas) incluyendo sus coordenadas GPS y fronteras
+- Rastrear las modificaciones realizadas a las unidades organizacionales
+- Comparar múltiples fuentes de datos geográficos
+- Proponer modificaciones a las unidades organizacionales desde la aplicación móvil IASO y validarlas en la web
+
+### Recolección de datos geo-estructurados
+
+- Crear formularios de recolección de datos utilizando el popular formato XLS e importarlos en IASO
+- Vincular sus formularios a uno o varios tipos de unidades organizacionales (por ejemplo, Nacional/Regional/Distrito/Establecimiento de salud) para estructurar geográficamente su recolección de datos
+- Rastrear los cambios con la gestión de versiones de sus formularios
+- Validar desde la web todas las presentaciones de formularios enviadas por la aplicación móvil IASO
+- Rastrear la completitud de la recolección de datos por nivel de unidades organizacionales e identificar dónde se encuentran los problemas
+
+### Microplanificación
+
+- Gestionar equipos de usuarios y equipos de equipos
+- Asignar tareas de recolección de datos a equipos y usuarios utilizando un mapa interactivo
+- Crear calendarios con un perímetro, duración y uno o más formularios de recolección de datos
+
+### Entidades
+
+Estas pueden consistir en individuos (por ejemplo, beneficiarios de programas de salud) u objetos físicos (por ejemplo, lotes de vacunas, mosquiteros, etc.). Los flujos de trabajo permiten rastrear las entidades abriendo formularios específicos en función de las respuestas dadas a formularios anteriores.
+
+- Crear tipos de entidades (beneficiarios, stocks u otros)
+- Asignar flujos de trabajo a tipos de entidades
+- Registrar entidades a través de la aplicación móvil (sin conexión)
+- Sincronizar las aplicaciones móvil y web
+- Comparar y fusionar entidades si es necesario
+- Registrar los datos de las entidades en una tarjeta NFC
+
+### Ampliamente implementado
+
 La plataforma ha sido implementada en Benín, Burkina Faso, Burundi, Camerún, República Centroafricana, República Democrática del Congo, Haití, Costa de Marfil, Mali, Níger, Nigeria y Uganda. Es el registro geográfico oficial en Burkina Faso desde 2023. IASO también ha sido implementado a nivel regional (región AFRO) para apoyar la Iniciativa Global para la Erradicación de la Polio gracias a sus capacidades de registros geoespaciales y de establecimientos de salud.
 
-# Tecnologías utilizadas
+### Tecnologías utilizadas
 IASO está compuesto por una aplicación Android white labeled utilizando Java/Kotlin, reutilizando una gran parte de los proyectos ODK, y una plataforma web programada en Python/GeoDjango sobre PostGIS. El frontend es principalmente en React/Leaflet. La API está implementada a través de Django Rest Framework, y todos los datos se almacenan en PostgreSQL o el directorio media/. Uno de los objetivos es la facilidad de integración con otras plataformas. Ya tenemos importaciones y exportaciones en formatos CSV y GeoPackage, y apuntamos a una fácil integración con OSM.
 
 La aplicación móvil para Android permite la presentación de formularios y la creación de unidades organizacionales. Los formularios también pueden completarse en una interfaz web a través del servicio complementario Enketo.

--- a/docs/index.fr.md
+++ b/docs/index.fr.md
@@ -1,6 +1,6 @@
 # Bienvenue dans la documentation d'IASO
 
-# Introduction à IASO
+## Introduction à IASO
 IASO est une plateforme innovante, open-source, trilingue (EN/FR/ES) de **collecte de données à fonctionnalités géospatiales avancées** pour planifier, surveiller et évaluer les programmes de santé, environnementaux ou sociaux dans les pays à revenu faible et intermédiaire (PRFI). IASO est reconnu comme un **Bien Public Numérique** par l'Alliance des Biens Publics Numériques et figure parmi les logiciels **Global Goods** de Digital Square, témoignant de son utilité publique.
 
 !!! tip "Nouveau sur IASO ?"
@@ -15,35 +15,43 @@ IASO comprend :
   
 En termes de fonctionnalités, IASO peut être résumé autour de **quatre composantes principales** qui sont interconnectées et renforcent leurs capacités mutuelles :
 
-- **Gestion des données géospatiales (Géoregistre)**
-    - Gérer plusieurs listes d'unités d'organisation (par exemple, zones de santé, districts, établissements de santé ou écoles) y compris leurs coordonnées GPS et frontières
-    - Suivre les modifications apportées aux unités d'organisation
-    - Comparer plusieurs sources de données géographiques
-    - Proposer des modifications aux unités d'organisation depuis l'application mobile IASO et les valider sur le web
-   
-- **Collecte de données géo-structurées**
-    - Créer des formulaires de collecte de données en utilisant le populaire format XLS et les importer dans IASO
-    - Lier vos formulaires à un ou plusieurs types d'unités organisationnelles (par exemple, National/Régional/District/Établissement de santé) pour structurer géographiquement votre collecte de données
-    - Suivre les changements avec la gestion des versions de vos formulaires
-    - Valider depuis le web toutes les soumissions de formulaires envoyées par l'application mobile IASO
-    - Suivre l'exhaustivité de la collecte de données par niveau d'unités d'organisation et identifier où se trouvent les problèmes
- 
-- **Microplanification**
-    - Gérer des équipes d'utilisateurs et des équipes d'équipes
-    - Attribuer des tâches de collecte de données aux équipes et aux utilisateurs en utilisant une carte interactive
-    - Créer des plannings avec un périmètre, une durée et un ou plusieurs formulaires de collecte de données
- 
-- **Entités** - celles-ci peut consister en des individus (par exemple, les bénéficiaires de programmes de santé) ou des objets physiques (par exemple, des lots de vaccins, des moustiquaires, etc.). Les workflows permettent de suivre les entités en ouvrant des formulaires spécifiques en fonction des réponses données à des formulaires précédents.
-    - Créer des types d'entités (bénéficiaires, stocks ou autres)
-    - Attribuer des workflows à des types d'entités
-    - Enregistrer des entités via l'application mobile (hors ligne)
-    - Synchroniser les applications mobile et web
-    - Comparer et fusionner des entités si nécessaire
-    - Enregistrer les données des entités sur une carte NFC
- 
+### Gestion des données géospatiales (Géoregistre)
+
+- Gérer plusieurs listes d'unités d'organisation (par exemple, zones de santé, districts, établissements de santé ou écoles) y compris leurs coordonnées GPS et frontières
+- Suivre les modifications apportées aux unités d'organisation
+- Comparer plusieurs sources de données géographiques
+- Proposer des modifications aux unités d'organisation depuis l'application mobile IASO et les valider sur le web
+
+### Collecte de données géo-structurées
+
+- Créer des formulaires de collecte de données en utilisant le populaire format XLS et les importer dans IASO
+- Lier vos formulaires à un ou plusieurs types d'unités organisationnelles (par exemple, National/Régional/District/Établissement de santé) pour structurer géographiquement votre collecte de données
+- Suivre les changements avec la gestion des versions de vos formulaires
+- Valider depuis le web toutes les soumissions de formulaires envoyées par l'application mobile IASO
+- Suivre l'exhaustivité de la collecte de données par niveau d'unités d'organisation et identifier où se trouvent les problèmes
+
+### Microplanification
+
+- Gérer des équipes d'utilisateurs et des équipes d'équipes
+- Attribuer des tâches de collecte de données aux équipes et aux utilisateurs en utilisant une carte interactive
+- Créer des plannings avec un périmètre, une durée et un ou plusieurs formulaires de collecte de données
+
+### Entités
+
+Celles-ci peuvent consister en des individus (par exemple, les bénéficiaires de programmes de santé) ou des objets physiques (par exemple, des lots de vaccins, des moustiquaires, etc.). Les workflows permettent de suivre les entités en ouvrant des formulaires spécifiques en fonction des réponses données à des formulaires précédents.
+
+- Créer des types d'entités (bénéficiaires, stocks ou autres)
+- Attribuer des workflows à des types d'entités
+- Enregistrer des entités via l'application mobile (hors ligne)
+- Synchroniser les applications mobile et web
+- Comparer et fusionner des entités si nécessaire
+- Enregistrer les données des entités sur une carte NFC
+
+### Largement déployé
+
 La plateforme a été mise en œuvre au Bénin, au Burkina Faso, au Burundi, au Cameroun, en République Centrafricaine, en République Démocratique du Congo, en Haïti, en Côte d'Ivoire, au Mali, au Niger, au Nigéria et en Ouganda. Elle est le registre géographique officiel au Burkina Faso depuis 2023. IASO a également été mise en œuvre au niveau régional (région AFRO) pour soutenir l'Initiative Mondiale pour l'Eradication de la Polio grâce à ses capacités de registres géospatiaux et d'établissements de santé.
 
-# Technologies utilisées
+### Technologies utilisées
 IASO est composée d'une application Android white labeled utilisant Java/Kotlin, réutilisant une grande partie des projets ODK, et d'une plateforme web programmée en Python/GeoDjango sur PostGIS. Le frontend est principalement en React/Leaflet. L'API est implémentée via Django Rest Framework, et toutes les données sont stockées dans PostgreSQL ou le répertoire media/. L'un des objectifs est la facilité d'intégration avec d'autres plateformes. Nous avons déjà des imports et exports en formats CSV et GeoPackage, et nous visons une intégration facile avec OSM.
 
 L'application mobile pour Android permet la soumission de formulaires et la création d'unités d'organisation. Les formulaires peuvent également être remplis dans une interface web via le service compagnon Enketo.


### PR DESCRIPTION
## Summary

Turns the four bold list-item labels under "Introduction to IASO" (Geospatial data management, Geo-structured data collection, Geo-enabled Microplanning, Entities) into real subheadings with their own anchors, and adds a "Widely deployed" heading before the country-deployment paragraph that previously had no heading at all. Applied to EN/FR/ES.

**Bonus fix:** doing this surfaced a pre-existing bug in the FR/ES homepages. "Introduction à IASO" / "Technologies utilisées" (and the ES equivalents) were H1 - the same level as the page's own title - instead of H2/H3 like the English version. This silently broke `toc.integrate`'s sidebar drilldown for that page: it showed *nothing* nested under "Accueil"/"Inicio", not just missing my new headings. Fixed the levels to mirror English's structure so the drilldown actually populates in all 3 languages.

## Test plan

- [x] Local build: all 4 new headings + "Widely deployed" get anchors in EN/FR/ES
- [x] Verified via live DOM (not just source) that the sidebar drilldown now lists all headings correctly in all 3 languages - before the heading-level fix, FR/ES showed an empty drilldown
- [x] No new build warnings