### PR TITLE
Docs: add a whole-user-guide PDF download button

### DIFF
--- a/docs/extrajs/pdfDownload.js
+++ b/docs/extrajs/pdfDownload.js
@@ -1,29 +1,107 @@
 const translations = {
-en:"Download current page",
-fr: "Télécharger la page"
+  en: { currentPage: "Download current page", userGuide: "Download user guide", generating: "Generating…" },
+  fr: { currentPage: "Télécharger la page", userGuide: "Télécharger le guide utilisateur", generating: "Génération…" },
+  es: { currentPage: "Descargar la página actual", userGuide: "Descargar la guía de usuario", generating: "Generando…" },
 }
 
-document$.subscribe( function () {
+// Every page under the Users tab (Home > Users in mkdocs.yml), in nav order.
+// Fetched and combined client-side into a single PDF by the "Download user
+// guide" button - update this list whenever a page is added to/removed from
+// that nav section.
+const USER_GUIDE_PAGES = [
+  "pages/users/how_to/get_started_with_iaso.html",
+  "pages/users/reference/iaso_concepts.html",
+  "pages/users/reference/iaso_modules.html",
+  "pages/users/reference/user_guide.html",
+  "pages/users/reference/iaso_mobile.html",
+  "pages/users/how_to/setup_dhis2_login_in_iaso.html",
+  "pages/users/FAQ/faq.html",
+]
 
-    const downloadButton = document.getElementById("pdf-download");
-    const buttonText = document.getElementById("button-text")
-    const currentLanguage = document.documentElement.lang || "en"
-  
-    downloadButton.addEventListener("click", function () {
-        const element = document.querySelector('.md-content');
-        const options = {
-        margin:       1,
-        filename:     'openiaso.pdf',
-        image:        { type: 'jpeg', quality: 0.98 },
-        html2canvas:  { scale: 2 },
-        jsPDF:        { unit: 'in', format: 'letter', orientation: 'portrait' }
-      };
-      html2pdf().from(element).set(options).save();
-    });
+document$.subscribe(function () {
+  const currentLanguage = document.documentElement.lang || "en"
+  const t = translations[currentLanguage] || translations.en
 
-    if (translations[currentLanguage]) {
-        buttonText.textContent = translations[currentLanguage];
-      } else {
-        buttonText.textContent = translations["en"];  // Default to English if the language is not available
-      }
+  const downloadButton = document.getElementById("pdf-download")
+  const buttonText = document.getElementById("button-text")
+  buttonText.textContent = t.currentPage
+
+  downloadButton.addEventListener("click", function () {
+    const element = document.querySelector('.md-content');
+    const options = {
+      margin:       1,
+      filename:     'openiaso.pdf',
+      image:        { type: 'jpeg', quality: 0.98 },
+      html2canvas:  { scale: 2 },
+      jsPDF:        { unit: 'in', format: 'letter', orientation: 'portrait' }
+    };
+    html2pdf().from(element).set(options).save();
   });
+
+  const userGuideButton = document.getElementById("pdf-download-user-guide")
+  const userGuideButtonText = document.getElementById("user-guide-button-text")
+  userGuideButtonText.textContent = t.userGuide
+
+  userGuideButton.addEventListener("click", function () {
+    downloadUserGuide(currentLanguage, userGuideButton, userGuideButtonText, t)
+  })
+});
+
+async function downloadUserGuide(lang, button, buttonText, t) {
+  const originalText = buttonText.textContent
+  const localePrefix = lang === "en" ? "" : lang + "/"
+  const origin = window.location.origin
+
+  button.disabled = true
+  buttonText.textContent = t.generating
+
+  const container = document.createElement("div")
+  container.style.position = "absolute"
+  container.style.left = "-99999px"
+  container.style.top = "0"
+  container.style.width = "800px"
+  document.body.appendChild(container)
+
+  try {
+    for (const path of USER_GUIDE_PAGES) {
+      const pageUrl = origin + "/" + localePrefix + path
+      const response = await fetch(pageUrl)
+      if (!response.ok) continue
+
+      const html = await response.text()
+      const parsedPage = new DOMParser().parseFromString(html, "text/html")
+      const content = parsedPage.querySelector(".md-content__inner")
+      if (!content) continue
+
+      // relative image/link paths are only valid on the page they came from -
+      // resolve them against that page's URL before moving the content over
+      content.querySelectorAll("img[src], a[href]").forEach(function (el) {
+        const attr = el.tagName === "IMG" ? "src" : "href"
+        const value = el.getAttribute(attr)
+        if (value && !/^([a-z]+:)?\/\//i.test(value) && !value.startsWith("#")) {
+          el.setAttribute(attr, new URL(value, pageUrl).href)
+        }
+      })
+
+      content.querySelectorAll(".md-content__button, .md-icon").forEach((el) => el.remove())
+
+      const section = document.createElement("div")
+      section.className = "pdf-user-guide-section"
+      section.appendChild(content)
+      container.appendChild(section)
+    }
+
+    await html2pdf().from(container).set({
+      margin: 0.5,
+      filename: "iaso-user-guide.pdf",
+      image: { type: "jpeg", quality: 0.98 },
+      html2canvas: { scale: 2, useCORS: true },
+      jsPDF: { unit: "in", format: "letter", orientation: "portrait" },
+      pagebreak: { mode: ["css"], before: ".pdf-user-guide-section:not(:first-child)" },
+    }).save()
+  } finally {
+    container.remove()
+    button.disabled = false
+    buttonText.textContent = originalText
+  }
+}

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -21,6 +21,17 @@
                     </svg>
                 </button>
             </div>
+            <!-- pdf download - whole user guide (all pages under the Users tab, combined) -->
+            <div id="pdf-download-user-guide-container">
+                <button id="pdf-download-user-guide" type="button">
+                    <span id="user-guide-button-text">Download user guide</span>
+                    <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px"
+                        fill="#192041">
+                        <path
+                            d="M360-460h40v-80h40q17 0 28.5-11.5T480-580v-40q0-17-11.5-28.5T440-660h-80v200Zm40-120v-40h40v40h-40Zm120 120h80q17 0 28.5-11.5T640-500v-120q0-17-11.5-28.5T600-660h-80v200Zm40-40v-120h40v120h-40Zm120 40h40v-80h40v-40h-40v-40h40v-40h-80v200ZM320-240q-33 0-56.5-23.5T240-320v-480q0-33 23.5-56.5T320-880h480q33 0 56.5 23.5T880-800v480q0 33-23.5 56.5T800-240H320Zm0-80h480v-480H320v480ZM160-80q-33 0-56.5-23.5T80-160v-560h80v560h560v80H160Zm160-720v480-480Z" />
+                    </svg>
+                </button>
+            </div>
         </div>
     </div>
 </div>

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -60,6 +60,45 @@ html[lang="es"] .md-header .md-select > .md-header__button.md-icon::after {
     display: inline-block;
 }
 
+#pdf-download-user-guide-container {
+    padding-top: 8px;
+    padding-bottom: 8px;
+    text-align: left;
+    padding-left: 12px;
+    display: flex;
+    align-items: center;
+}
+
+#pdf-download-user-guide {
+    background-color: #fcb900;
+    color: #192041;
+    border-radius: 4px;
+    vertical-align: middle;
+    padding-left: 8px;
+    padding-right: 8px;
+    padding-top: 8px;
+    padding-bottom: 8px;
+    font-size: 0.7rem;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+#pdf-download-user-guide[disabled] {
+    opacity: 0.6;
+    cursor: default;
+}
+
+#pdf-download-user-guide svg {
+    vertical-align: middle;
+}
+
+#user-guide-button-text {
+    margin-right: 8px;
+    display: inline-block;
+}
+
 /* Doc screenshot helpers — use with attr_list, e.g. ![](shot.png){ .doc-shot }
    mkdocs-glightbox wraps images in <a class="glightbox"> (inline by default),
    so size/layout must target that wrapper too. */


### PR DESCRIPTION
## Summary
- The existing "Download current page" button only ever exported the page you're on.
- Added a second sidebar button, **Download user guide**, that fetches every page under the Users tab (Get started, Concepts, Modules, User guide, Mobile, Advanced configuration > IASO and DHIS2 / FAQ) and combines them client-side into one PDF via html2pdf.js.
- Each page's relative image/link paths are resolved against that page's own URL before merging its content in, since they move into a different page's DOM.
- Works in all 3 languages (fetches the locale-prefixed URLs matching whatever language you're currently viewing).

## Known limitation (pre-existing, shared with the single-page button)
Images hosted externally on GitHub's user-content CDN (`user-images.githubusercontent.com`, `github.com/user-attachments/...`) can't be captured by html2canvas due to CORS — they render blank in the PDF. Locally-hosted screenshots are unaffected. Not something this PR introduces; the single-page download has the same gap for any page using an external image.

## Test plan
- [x] Verified locally: all 7 Users-tab pages fetch with 200s and combine into one PDF, in both EN and FR (checked via console + network logs)
- [ ] Click "Download user guide" on the live site and confirm the PDF opens with all sections in order