### PR TITLE
Docs: fix two broken images on the French user guide

### DIFF
--- a/docs/pages/users/reference/user_guide.fr.md
+++ b/docs/pages/users/reference/user_guide.fr.md
@@ -126,7 +126,7 @@ Si aucun formulaire n'est encore chargé :
 
 Depuis la liste des formulaires, vous pouvez rechercher parmi les formulaires disponibles du compte IASO auquel vous êtes connecté en utilisant les filtres suivants :
 
-![alt text](./user_guide_attachments/formsmanagement2fr.png)
+![alt text](./user_guide_attachments/formsmanagement2fr.jpg)
 
 Les boutons ci-dessous vous permettent de gérer les formulaires de collecte de données :
 
@@ -179,7 +179,7 @@ Vous pouvez également vérifier les soumissions dans la vue cartographique. Les
 
 L'onglet "Fichier" vous permet de visualiser les fichiers soumis avec les formulaires, tels que des photos. En cliquant sur un fichier donné, vous serez redirigé vers la soumission de formulaire correspondante. 
 
-![alt text](./user_guide_attachments/formsubmissionsfilesfr.png)
+![alt text](./user_guide_attachments/formsubmissionsfiles.png)
 
 ### Gérer les soumissions de formulaires
 


### PR DESCRIPTION
## Summary
Found while testing #3261 (whole-user-guide PDF download): two images on the French user guide page were broken.

- `formsmanagement2fr.png` never existed - the actual file on disk is `formsmanagement2fr.jpg`. Fixed the extension.
- `formsubmissionsfilesfr.png` never existed at all (no French screenshot was ever captured for that section). Now falls back to the English screenshot used in the same spot on the EN page, instead of a dead link.

## Test plan
- [x] Verified locally: both images now resolve to real files in the built site
- [ ] Spot-check the French user guide page renders both images correctly on the live site