### PR TITLE
Docs: restructure homepage into Introduction / Features / Technical stack

### DIFF
--- a/docs/index.en.md
+++ b/docs/index.en.md
@@ -15,6 +15,9 @@ IASO comprises:
 - a **matching and scripting interface** to analyze, compare and merge several geographic data sources
 - a bi-directional **integration with DHIS2**, the widely used Health Management Information System in Low- and middle-income countries
 
+The platform has been implemented in Benin, Burkina Faso, Burundi, Cameroon, Central African Republic, the Democratic Republic of Congo, Haiti, Ivory Coast, Mali, Niger, Nigeria and Uganda. It is the official georegistry in Burkina Faso since 2023. IASO has also been implemented at regional level (AFRO region) in support to the Global Polio Eradication Initiative for its geospatial and health facility registries capabilities.
+
+## Features
 
 In terms of features, IASO can be summarized around **four main components** which are interconnected and expand the powers of one another:
 
@@ -33,13 +36,13 @@ In terms of features, IASO can be summarized around **four main components** whi
 -   Validate from the web all data collection form submissions sent from IASO mobile application
 -   Monitor data collection completeness per organization unit level and drill-down to identify where issues happen
 
-### Geo-enabled Microplanning
+### Microplanning
 
 - Manage teams of users and teams of teams
 - Assign data collection duties to teams and users using a map interface
 - Create plannings with a scope, a time span, and one or several data collection form(s)
 
-### Entities
+### Entities (longitudinal tracking)
 
 These can be individuals (e.g. health programme beneficiaries) or physical objects (e.g. vaccines parcel, mosquito net, etc.). Workflows allows the tracking of entities by opening specific forms according to previous answers given to previous forms.
 
@@ -50,12 +53,7 @@ These can be individuals (e.g. health programme beneficiaries) or physical objec
 - Compare and merge entities as needed
 - Record entity data in an NFC card
 
-### Widely deployed
-
-The platform has been implemented in Benin, Burkina Faso, Burundi, Cameroon, Central African Republic, the Democratic Republic of Congo, Haiti, Ivory Coast, Mali, Niger, Nigeria and Uganda. It is the official georegistry in Burkina Faso since 2023. IASO has also been implemented at regional level (AFRO region) in support to the Global Polio Eradication Initiative for its geospatial and health facility registries capabilities.
-
-
-### Technical stack
+## Technical stack
 
 IASO is made of a white labeled Android application using Java/Kotlin, reusing large parts of the ODK projects, and a web platform programmed using Python/GeoDjango on top of PostGIS. 
 Frontend is mainly React/Leaflet. 

--- a/docs/index.es.md
+++ b/docs/index.es.md
@@ -12,7 +12,11 @@ IASO incluye:
 - una **aplicación móvil** que también funciona **sin conexión** - destinada a usuarios de campo para completar formularios y enviar datos cuando la red esté disponible
 - una **interfaz de correspondencia y script** para analizar, comparar y fusionar múltiples fuentes de datos geográficos
 - una **integración bidireccional con DHIS2**, el sistema de información de gestión de salud ampliamente utilizado en los PIBM
-  
+
+La plataforma ha sido implementada en Benín, Burkina Faso, Burundi, Camerún, República Centroafricana, República Democrática del Congo, Haití, Costa de Marfil, Mali, Níger, Nigeria y Uganda. Es el registro geográfico oficial en Burkina Faso desde 2023. IASO también ha sido implementado a nivel regional (región AFRO) para apoyar la Iniciativa Global para la Erradicación de la Polio gracias a sus capacidades de registros geoespaciales y de establecimientos de salud.
+
+## Funcionalidades
+
 En términos de funcionalidades, IASO puede resumirse en torno a **cuatro componentes principales** que están interconectados y refuerzan sus capacidades mutuas:
 
 ### Gestión de datos geoespaciales (Georegister)
@@ -36,7 +40,7 @@ En términos de funcionalidades, IASO puede resumirse en torno a **cuatro compon
 - Asignar tareas de recolección de datos a equipos y usuarios utilizando un mapa interactivo
 - Crear calendarios con un perímetro, duración y uno o más formularios de recolección de datos
 
-### Entidades
+### Entidades (seguimiento longitudinal)
 
 Estas pueden consistir en individuos (por ejemplo, beneficiarios de programas de salud) u objetos físicos (por ejemplo, lotes de vacunas, mosquiteros, etc.). Los flujos de trabajo permiten rastrear las entidades abriendo formularios específicos en función de las respuestas dadas a formularios anteriores.
 
@@ -47,11 +51,7 @@ Estas pueden consistir en individuos (por ejemplo, beneficiarios de programas de
 - Comparar y fusionar entidades si es necesario
 - Registrar los datos de las entidades en una tarjeta NFC
 
-### Ampliamente implementado
-
-La plataforma ha sido implementada en Benín, Burkina Faso, Burundi, Camerún, República Centroafricana, República Democrática del Congo, Haití, Costa de Marfil, Mali, Níger, Nigeria y Uganda. Es el registro geográfico oficial en Burkina Faso desde 2023. IASO también ha sido implementado a nivel regional (región AFRO) para apoyar la Iniciativa Global para la Erradicación de la Polio gracias a sus capacidades de registros geoespaciales y de establecimientos de salud.
-
-### Tecnologías utilizadas
+## Tecnologías utilizadas
 IASO está compuesto por una aplicación Android white labeled utilizando Java/Kotlin, reutilizando una gran parte de los proyectos ODK, y una plataforma web programada en Python/GeoDjango sobre PostGIS. El frontend es principalmente en React/Leaflet. La API está implementada a través de Django Rest Framework, y todos los datos se almacenan en PostgreSQL o el directorio media/. Uno de los objetivos es la facilidad de integración con otras plataformas. Ya tenemos importaciones y exportaciones en formatos CSV y GeoPackage, y apuntamos a una fácil integración con OSM.
 
 La aplicación móvil para Android permite la presentación de formularios y la creación de unidades organizacionales. Los formularios también pueden completarse en una interfaz web a través del servicio complementario Enketo.

--- a/docs/index.fr.md
+++ b/docs/index.fr.md
@@ -12,7 +12,11 @@ IASO comprend :
 - une **application mobile** qui fonctionne également **hors ligne** - destinée aux utilisateurs sur le terrain pour remplir des formulaires et envoyer des données lorsque le réseau est disponible
 - une **interface de correspondance et de script** pour analyser, comparer et fusionner plusieurs sources de données géographiques
 - une **intégration bidirectionnelle avec DHIS2**, le système d'information de gestion de la santé largement utilisé dans les PRFI
-  
+
+La plateforme a été mise en œuvre au Bénin, au Burkina Faso, au Burundi, au Cameroun, en République Centrafricaine, en République Démocratique du Congo, en Haïti, en Côte d'Ivoire, au Mali, au Niger, au Nigéria et en Ouganda. Elle est le registre géographique officiel au Burkina Faso depuis 2023. IASO a également été mise en œuvre au niveau régional (région AFRO) pour soutenir l'Initiative Mondiale pour l'Eradication de la Polio grâce à ses capacités de registres géospatiaux et d'établissements de santé.
+
+## Fonctionnalités
+
 En termes de fonctionnalités, IASO peut être résumé autour de **quatre composantes principales** qui sont interconnectées et renforcent leurs capacités mutuelles :
 
 ### Gestion des données géospatiales (Géoregistre)
@@ -36,7 +40,7 @@ En termes de fonctionnalités, IASO peut être résumé autour de **quatre compo
 - Attribuer des tâches de collecte de données aux équipes et aux utilisateurs en utilisant une carte interactive
 - Créer des plannings avec un périmètre, une durée et un ou plusieurs formulaires de collecte de données
 
-### Entités
+### Entités (suivi longitudinal)
 
 Celles-ci peuvent consister en des individus (par exemple, les bénéficiaires de programmes de santé) ou des objets physiques (par exemple, des lots de vaccins, des moustiquaires, etc.). Les workflows permettent de suivre les entités en ouvrant des formulaires spécifiques en fonction des réponses données à des formulaires précédents.
 
@@ -47,12 +51,7 @@ Celles-ci peuvent consister en des individus (par exemple, les bénéficiaires d
 - Comparer et fusionner des entités si nécessaire
 - Enregistrer les données des entités sur une carte NFC
 
-### Largement déployé
-
-La plateforme a été mise en œuvre au Bénin, au Burkina Faso, au Burundi, au Cameroun, en République Centrafricaine, en République Démocratique du Congo, en Haïti, en Côte d'Ivoire, au Mali, au Niger, au Nigéria et en Ouganda. Elle est le registre géographique officiel au Burkina Faso depuis 2023. IASO a également été mise en œuvre au niveau régional (région AFRO) pour soutenir l'Initiative Mondiale pour l'Eradication de la Polio grâce à ses capacités de registres géospatiaux et d'établissements de santé.
-
-### Technologies utilisées
+## Technologies utilisées
 IASO est composée d'une application Android white labeled utilisant Java/Kotlin, réutilisant une grande partie des projets ODK, et d'une plateforme web programmée en Python/GeoDjango sur PostGIS. Le frontend est principalement en React/Leaflet. L'API est implémentée via Django Rest Framework, et toutes les données sont stockées dans PostgreSQL ou le répertoire media/. L'un des objectifs est la facilité d'intégration avec d'autres plateformes. Nous avons déjà des imports et exports en formats CSV et GeoPackage, et nous visons une intégration facile avec OSM.
 
 L'application mobile pour Android permet la soumission de formulaires et la création d'unités d'organisation. Les formulaires peuvent également être remplis dans une interface web via le service compagnon Enketo.
-


### PR DESCRIPTION
## Summary
- **Introduction to IASO**, **Features**, and **Technical stack** are now sibling top-level sections (H2), instead of Features' 4 components and Technical stack all being nested under Introduction as H3s.
- The 4 components (Geospatial data management, Geo-structured data collection, Microplanning, Entities) moved under the new **Features** heading.
- Renamed two of them for clarity: "Geo-enabled Microplanning" → **Microplanning**, "Entities" → **Entities (longitudinal tracking)**. Kept "Geospatial data management (Georegistry)" as-is since it wasn't explicitly called out for a rename - let me know if you'd rather drop the "(Georegistry)" suffix too.
- "Widely deployed" is no longer its own heading. Its paragraph (country list, Burkina Faso georegistry status, AFRO/Polio work) now sits directly inside **Introduction to IASO**, right after the DHIS2 integration bullet, as a supporting fact rather than a fifth "feature".
- Applied consistently across EN, FR, and ES.

## Test plan
- [x] Verified locally: sidebar TOC now shows Introduction / Features (with 4 sub-items) / Technical stack as 3 top-level entries, in all 3 languages
- [x] Confirmed the deployment paragraph renders in Introduction with no anchor/heading
- [ ] Spot-check the live homepage in FR and ES after deploy