### PR TITLE
Docs: collapse page headings by default in left nav, fix duplicate "More about IASO"

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -29,6 +29,20 @@ html[lang="es"] .md-header .md-select > .md-header__button.md-icon::after {
 .md-footer {
     display: none !important;
 }
+
+/* toc.integrate merges each page's own headings into its left-sidebar nav
+   entry, but shows them unconditionally (Material's own CSS: plain
+   `.md-nav--secondary{display:block}`, no gating on the #__toc checkbox).
+   That makes every page look "pre-expanded" the moment you land on it.
+   Piggyback on the checkbox/label Material already renders for this
+   element (originally meant for the mobile drawer) so it behaves like
+   every other collapsible section: closed until clicked. */
+.md-nav__item--active > .md-nav--secondary {
+    display: none !important;
+}
+.md-nav__item--active > .md-nav__toggle:checked ~ .md-nav--secondary {
+    display: block !important;
+}
 #pdf-download-container {
     padding-top: 20px;
     text-align: left;

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,7 @@ plugins:
             Advanced configuration: Configuration avancée
             IASO and DHIS2: IASO et DHIS2
             More about IASO: En savoir plus sur IASO
+            Overview: Aperçu
             IASO website: Demander une démo
             Bluesquare website: Bluesquare
 
@@ -72,6 +73,7 @@ plugins:
             Advanced configuration: Configuración avanzada
             IASO and DHIS2: IASO y DHIS2
             More about IASO: Más sobre IASO
+            Overview: Resumen
             IASO website: Sitio web de IASO
             Release notes: Notas de versión
             Bluesquare website: Sitio web de Bluesquare
@@ -156,7 +158,7 @@ nav: # nav configures the side bar menu - this is the ONLY place the nav tree is
       - ./pages/dev/how_to/build_odk_preview.md
 
   - More about IASO:
-    - ./pages/more_about_iaso.md
+    - Overview: ./pages/more_about_iaso.md
     - IASO website: https://www.openiaso.com/
     - Digital Public Goods Registry: https://www.digitalpublicgoods.net/r/iaso
     - Release notes: https://github.com/BLSQ/iaso/releases


### PR DESCRIPTION
## Summary
- `toc.integrate` merges each page's own headings into its sidebar entry, but Material shows them unconditionally - every page looked "pre-expanded" the moment you opened it (e.g. "Get started with IASO"'s 6 steps, "Web Platform"'s "Create your form with AI" section and others). Added a scoped CSS override that gates this on the checkbox/label Material already renders for it, so it now behaves like every other collapsible section: closed until clicked.
- Gave the first page under "More about IASO" its own nav label (**Overview**) instead of inheriting its own page title "More about IASO" - it was rendering identically to, and directly under, the section header it belongs to. Added FR/ES translations for the new label.

Note: this was meant to be its own PR from the start, but the commit initially landed on the branch for #3263 after that PR had already been merged - re-opened here from a fresh branch off current `develop` so it doesn't get lost.

## Test plan
- [x] Verified locally: "Get started with IASO", "Web Platform" (and every other page) now show collapsed by default, with a click revealing the in-page headings
- [x] Verified locally: sidebar under "More about IASO" now shows "Overview" instead of a duplicate "More about IASO"
- [ ] Spot-check on the live site after deploy, in all 3 languages