### PR TITLE
Docs: rewrite the Modules page as one section per actual module

### DIFF
--- a/docs/pages/users/reference/iaso_modules.en.md
+++ b/docs/pages/users/reference/iaso_modules.en.md
@@ -1,34 +1,58 @@
 # Modules
 
-IASO is organized according to Modules, which are groups of functionalities which can be added up depending on the use case to cover. Here are the Modules available in IASO:
+IASO is organized according to Modules, which are groups of functionalities that can be activated depending on the use case to cover. Here are the Modules available in IASO:
 
-## Data collection functionalities
-- Manage data collection forms (XLS forms) and their related data submissions
-- Manage geographic data (import/export of geo data from Excel, DHIS2 or Geopackages, manage the Organizations Units and their hierarchy)
-- Monitor the data collection process with the completeness statistics table and map
-- Manage users and their permissions and geographies, user roles and teams
-- Create mobile application(s) IDs and manage related features options
+## Data collection - Forms
 
-## Georegistry 
-- Import several data sources from Excel, DHIS2 or Geopackages, compare and merge them as needed
-- Visualize on a dynamic map data collected at the different levels of the hierarchy (e.g. Country, Region, District, facility)
-- Validate changes on Organization Units (Name, Type, GPS coordinates, opening/closing dates) submitted from the field via the mobile application
-- Validate data submitted via data collection forms that are linked to specific Organization Units types, called "Reference forms"
+Create and upload data collection forms using the widely known XLS form format. Forms are versioned, so every time a new version is created, the previous one stays available in the system. Submissions sent from the mobile application can be validated from the web, and data collection completeness can be monitored per organization unit, with drill-down to identify where issues happen.
 
-##Payments
-- Based on the validated proposed changes per user, generate payment lots to send to Mobile Money provider
-- Indicate the status of the payments lots (pending, sent to Mobile Money provider, etc.)
+## Change requests
 
-## DHIS2 bi-directional integration 
-- Manage the mappings with DHIS2 data elements for import/export of data
+A core Georegistry feature that keeps geographic data up to date. From the mobile application, users can submit change requests to an organization unit - including the creation of a brand-new one. Once submitted, the request appears on the web for a manager to review, shown side by side with the previous version so what changed is easy to spot.
 
-## Planning
--  Plan ahead your data collection activities by creating a planning with a set timeframe, geography, data collection forms and teams
-- Assign data collection tasks to teams and users from the map-based interface available on the web
-- Once tasks have been assigned, the mobile application users on the field will only see the forms that have been assigned to them
+Which organization unit fields are open to change requests (Name, Organization unit type, Parent, Group, GPS coordinates, opening and closing date, or whether users can create new organization units at all) is configurable ahead of data collection from the IASO web platform.
+
+Change requests also support **reference forms**: a specific XLS form can be flagged as the reference form for an organization unit type, letting you attach fully custom "data attributes" to organization units - typically used for things like population figures or equipment inventories.
+
+## Completeness per Period
+
+Used for Performance-Based Financing (PBF) schemes, which IASO also supports as a data collection tool.
+
+## Validation workflow
+
+Enables "cascade validation" of submitted forms. Data managers define which user roles are responsible for approving data at each level of the hierarchy - for example, a "district manager" role approves first, then "region manager", then "country manager". The number of levels and who approves at each one is entirely configurable to match the hierarchy needed.
 
 ## Entities
-- Entities are items that can move from a geography to another, for instance a person, a pallet of goods, or other
-- Entities can be created from the mobile application and then managed from the web application
-- Find the entities duplicates by using the web application interface and make the decision to merge two similar entities or not
-- Assign workflows to entity types, enabling specific data collection forms to open according to previously given answers
+
+Entities are items that can move from one geography to another - a person, a pallet of goods, or anything else worth tracking over time. They can be created from the mobile application and then managed from the web.
+
+- Find likely duplicate entities from the web interface and decide whether to merge them
+- Assign **workflows** to entity types, so that specific data collection forms open automatically depending on answers already given
+
+## External storage
+
+Lets IASO work with NFC cards as a storage medium, enabling entity data to be read from and written to a physical card in the field.
+
+## Planning
+
+Using a dynamic, map-based interface, data managers assign specific places to specific users, with a defined timeframe and one or more data collection forms. Field users then see their assigned "missions" on the mobile application and can navigate directly to the points where they need to collect data.
+
+## Stock management
+
+Tracks quantities of items available at organization unit level, based on stock-related questions built into data collection forms. Every "plus" or "minus" movement of an item at an organization unit is recorded, and the mobile application shows a real-time view of how many items remain at a given location.
+
+## Payments
+
+Linked to change requests. Based on the change requests a manager has approved, users can generate payment lots and download an Excel file summarizing, per user, how many approved change requests they're owed payment for.
+
+## Form AI
+
+Lets users create or edit data collection forms with AI as an assistant, rather than building the XLS form by hand.
+
+## DHIS2 mapping
+
+Activated when IASO is used alongside DHIS2, the most widely used open-source Health Management Information System. IASO's integration with DHIS2 is bi-directional: geographic data can be imported from DHIS2, then IASO's advanced geospatial tools take over for field data collection, and the updated data is sent back to DHIS2.
+
+## Embedded links
+
+Lets users embed external links - such as dashboards - directly into their IASO account, each with its own dedicated, personalized URL slug. IASO's user management (per user or via user roles) controls access to these embedded links, which support raw HTML, plain text, iframes, and Superset dashboards.

--- a/docs/pages/users/reference/iaso_modules.es.md
+++ b/docs/pages/users/reference/iaso_modules.es.md
@@ -1,34 +1,58 @@
 # Módulos
 
-IASO está organizado según Módulos, que son grupos de funcionalidades que pueden agregarse dependiendo del caso de uso a cubrir. Aquí están los Módulos disponibles en IASO:
+IASO está organizado según Módulos, que son grupos de funcionalidades que pueden activarse dependiendo del caso de uso a cubrir. Aquí están los Módulos disponibles en IASO:
 
-## Funcionalidades de recolección de datos
-- Gestionar formularios de recolección de datos (formularios XLS) y sus envíos de datos relacionados
-- Gestionar datos geográficos (importar/exportar datos geo desde Excel, DHIS2 o Geopackages, gestionar las Unidades Organizacionales y su jerarquía)
-- Monitorear el proceso de recolección de datos con la tabla de estadísticas de completitud y el mapa
-- Gestionar usuarios y sus permisos y geografías, roles de usuario y equipos
-- Crear ID(s) de aplicación(es) móvil(es) y gestionar opciones de características relacionadas
+## Recolección de datos - Formularios
 
-## Georegistry 
-- Importar varias fuentes de datos desde Excel, DHIS2 o Geopackages, compararlas y fusionarlas según sea necesario
-- Visualizar en un mapa dinámico los datos recolectados en los diferentes niveles de la jerarquía (por ejemplo, País, Región, Distrito, establecimiento)
-- Validar cambios en Unidades Organizacionales (Nombre, Tipo, coordenadas GPS, fechas de apertura/cierre) enviados desde el campo a través de la aplicación móvil
-- Validar datos enviados a través de formularios de recolección de datos que están vinculados a tipos específicos de Unidades Organizacionales, llamados "Formularios de referencia"
+Cree y cargue formularios de recolección de datos utilizando el formato XLS form ampliamente conocido. Los formularios están versionados, así que cada vez que se crea una nueva versión, la anterior permanece disponible en el sistema. Las presentaciones enviadas desde la aplicación móvil pueden validarse desde el web, y la completitud de la recolección de datos puede monitorearse por unidad organizacional, con la posibilidad de explorar los datos para identificar dónde se encuentran los problemas.
 
-## Pagos
-- Basado en los cambios propuestos validados por usuario, generar lotes de pago para enviar al proveedor de Mobile Money
-- Indicar el estado de los lotes de pagos (pendiente, enviado al proveedor de Mobile Money, etc.)
+## Solicitudes de modificación
 
-## Integración bidireccional DHIS2 
-- Gestionar los mapeos con elementos de datos de DHIS2 para importación/exportación de datos
+Una funcionalidad central del Georegistry que permite mantener actualizados los datos geográficos. Desde la aplicación móvil, los usuarios pueden enviar solicitudes de modificación para una unidad organizacional - incluyendo la creación de una unidad completamente nueva. Una vez enviada, la solicitud aparece en el web para que un responsable la revise, mostrada junto a la versión anterior para poder identificar fácilmente qué ha cambiado.
 
-## Planificación
-- Planificar por adelantado sus actividades de recolección de datos creando una planificación con un marco temporal establecido, geografía, formularios de recolección de datos y equipos
-- Asignar tareas de recolección de datos a equipos y usuarios desde la interfaz basada en mapa disponible en la web
-- Una vez que las tareas han sido asignadas, los usuarios de aplicación móvil en el campo solo verán los formularios que les han sido asignados
+Qué campos de la unidad organizacional están abiertos a solicitudes de modificación (Nombre, Tipo de unidad organizacional, Padre, Grupo, coordenadas GPS, fechas de apertura y cierre, o si los usuarios pueden crear nuevas unidades organizacionales) es configurable de antemano desde la plataforma web de IASO.
+
+Las solicitudes de modificación también admiten **formularios de referencia**: un formulario XLS específico puede marcarse como formulario de referencia para un tipo de unidad organizacional, permitiendo adjuntar "atributos de datos" totalmente personalizados a las unidades organizacionales - utilizados típicamente para datos como cifras de población o inventario de equipos.
+
+## Completitud por período
+
+Utilizado para esquemas de Financiamiento Basado en el Desempeño (FBD), que IASO también admite como herramienta de recolección de datos.
+
+## Flujo de validación
+
+Habilita la "validación en cascada" de los formularios enviados. Los gestores de datos definen qué roles de usuario son responsables de aprobar los datos en cada nivel de la jerarquía - por ejemplo, el rol "gestor de distrito" aprueba primero, luego "gestor de región", y después "gestor de país". El número de niveles y quién aprueba en cada uno es totalmente configurable para adaptarse a la jerarquía necesaria.
 
 ## Entidades
-- Las entidades son elementos que pueden moverse de una geografía a otra, por ejemplo una persona, una paleta de bienes, u otros
-- Las entidades pueden ser creadas desde la aplicación móvil y luego gestionadas desde la aplicación web
-- Encontrar duplicados de entidades usando la interfaz de aplicación web y tomar la decisión de fusionar dos entidades similares o no
-- Asignar flujos de trabajo a tipos de entidades, habilitando que formularios específicos de recolección de datos se abran según respuestas previamente dadas
+
+Las entidades son elementos que pueden moverse de una geografía a otra - una persona, una paleta de bienes, o cualquier otro elemento que valga la pena rastrear a lo largo del tiempo. Pueden crearse desde la aplicación móvil y luego gestionarse desde el web.
+
+- Encontrar posibles entidades duplicadas desde la interfaz web y decidir si fusionarlas o no
+- Asignar **flujos de trabajo** a tipos de entidades, para que formularios específicos de recolección de datos se abran automáticamente según las respuestas ya dadas
+
+## Almacenamiento externo
+
+Permite que IASO funcione con tarjetas NFC como medio de almacenamiento, permitiendo leer y escribir datos de una entidad en una tarjeta física en el campo.
+
+## Planificación
+
+Mediante una interfaz dinámica basada en mapas, los gestores de datos asignan lugares específicos a usuarios específicos, con un marco temporal definido y uno o más formularios de recolección de datos. Los usuarios de campo ven entonces sus "misiones" asignadas en la aplicación móvil y pueden dirigirse directamente a los puntos donde deben recolectar datos.
+
+## Gestión de inventario
+
+Rastrea las cantidades de artículos disponibles a nivel de unidad organizacional, basándose en preguntas relacionadas con inventario integradas en los formularios de recolección de datos. Cada movimiento "más" o "menos" de un artículo en una unidad organizacional queda registrado, y la aplicación móvil muestra una vista en tiempo real de cuántos artículos quedan en un lugar determinado.
+
+## Pagos
+
+Vinculado a las solicitudes de modificación. Con base en las solicitudes de modificación aprobadas por un responsable, los usuarios pueden generar lotes de pago y descargar un archivo Excel que resume, por usuario, cuántas solicitudes de modificación aprobadas se le deben pagar.
+
+## Form AI
+
+Permite a los usuarios crear o editar formularios de recolección de datos con la IA como asistente, en lugar de construir el formulario XLS manualmente.
+
+## Mapeo con DHIS2
+
+Se activa cuando IASO se utiliza junto con DHIS2, el Sistema de Información de Gestión de Salud de código abierto más utilizado en el mundo. La integración de IASO con DHIS2 es bidireccional: los datos geográficos pueden importarse desde DHIS2, luego las herramientas geoespaciales avanzadas de IASO se encargan de la recolección de datos en el campo, y los datos actualizados se envían de vuelta a DHIS2.
+
+## Enlaces incrustados
+
+Permite a los usuarios incrustar enlaces externos - como paneles de control - directamente en su cuenta de IASO, cada uno con su propia URL personalizada y dedicada. La gestión de usuarios de IASO (por usuario o mediante roles de usuario) controla el acceso a estos enlaces incrustados, que admiten HTML sin procesar, texto simple, iframes y paneles de Superset.

--- a/docs/pages/users/reference/iaso_modules.fr.md
+++ b/docs/pages/users/reference/iaso_modules.fr.md
@@ -1,36 +1,58 @@
 # Modules
 
-IASO est organisé en Modules, qui sont des groupes de fonctionnalités pouvant être ajoutés en fonction des cas d'usage à couvrir. Voici les Modules disponibles dans IASO :
+IASO est organisé en Modules, qui sont des groupes de fonctionnalités pouvant être activés en fonction du cas d'usage à couvrir. Voici les Modules disponibles dans IASO :
 
-## Fonctionnalités de collecte de données
+## Collecte de données - Formulaires
 
--   Gérer les formulaires de collecte de données (formulaires XLS) et leurs soumissions de données associées
--   Gérer les données géographiques (import/export de données géographiques depuis Excel, DHIS2 ou Geopackages, gérer les unités d'organisation et leur hiérarchie)
--   Suivre le processus de collecte de données avec le tableau et la carte des statistiques de complétude
--   Gérer les utilisateurs, leurs permissions et leurs géographies, ainsi que les rôles et équipes des utilisateurs
--   Créer des ID d'application mobile et gérer les options de fonctionnalités associées
+Créez et téléversez des formulaires de collecte de données en utilisant le format XLS form largement répandu. Les formulaires sont versionnés : chaque nouvelle version créée conserve la précédente, disponible dans le système. Les soumissions envoyées depuis l'application mobile peuvent être validées depuis le web, et la complétude de la collecte de données peut être suivie par unité d'organisation, avec la possibilité d'explorer les données pour identifier où se situent les problèmes.
 
-## Géoregistre
+## Demandes de modification
 
--   Importer plusieurs sources de données depuis Excel, DHIS2 ou Geopackages, les comparer et les fusionner si nécessaire
--   Visualiser sur une carte dynamique les données collectées à différents niveaux de la hiérarchie (par exemple, Pays, Région, District, Infrastructure)
--   Valider les modifications des unités d'organisation (Nom, Type, coordonnées GPS, dates d'ouverture/fermeture) soumises depuis le terrain via l'application mobile
--   Valider les données soumises via des formulaires de collecte de données liés à des types spécifiques d'unités d'organisation, appelés "formulaires de référence"
--   Sur la base des modifications validées proposées par utilisateur, générer des lots de paiement à envoyer à un fournisseur de Mobile Money
+Une fonctionnalité centrale du Géoregistre qui permet de maintenir les données géographiques à jour. Depuis l'application mobile, les utilisateurs peuvent soumettre des demandes de modification pour une unité d'organisation - y compris la création d'une toute nouvelle unité. Une fois soumise, la demande apparaît sur le web pour être examinée par un responsable, affichée côte à côte avec la version précédente afin de repérer facilement ce qui a changé.
 
-## Intégration bidirectionnelle avec DHIS2
+Les champs d'unité d'organisation ouverts aux demandes de modification (Nom, Type d'unité d'organisation, Parent, Groupe, coordonnées GPS, dates d'ouverture et de fermeture, ou la possibilité pour les utilisateurs de créer de nouvelles unités d'organisation) sont configurables au préalable depuis la plateforme web IASO.
 
--   Gérer les correspondances avec les éléments de données de DHIS2 pour l'import/export de données
+Les demandes de modification prennent également en charge les **formulaires de référence** : un formulaire XLS spécifique peut être désigné comme formulaire de référence pour un type d'unité d'organisation, permettant d'y attacher des "attributs de données" entièrement personnalisés - typiquement utilisés pour des données comme la population ou l'inventaire d'équipements.
 
-## Planification
+## Complétude par période
 
--   Planifier à l'avance vos activités de collecte de données en créant un planning avec un cadre temporel, une géographie, des formulaires de collecte de données et des équipes
--   Attribuer des tâches de collecte de données à des équipes et des utilisateurs via l'interface basée sur une carte disponible sur le web
--   Une fois les tâches attribuées, les utilisateurs de l'application mobile sur le terrain ne verront que les formulaires qui leur ont été assignés
+Utilisé pour les dispositifs de Financement Basé sur la Performance (FBP), qu'IASO prend également en charge comme outil de collecte de données.
+
+## Workflow de validation
+
+Permet la "validation en cascade" des formulaires soumis. Les gestionnaires de données définissent quels rôles utilisateur sont responsables de l'approbation des données à chaque niveau de la hiérarchie - par exemple, le rôle "gestionnaire de district" approuve en premier, puis "gestionnaire de région", puis "gestionnaire de pays". Le nombre de niveaux et qui approuve à chaque niveau sont entièrement configurables pour s'adapter à la hiérarchie nécessaire.
 
 ## Entités
 
--   Les entités sont des éléments pouvant se déplacer d'une géographie à une autre, par exemple une personne, une palette de marchandises ou autre
--   Les entités peuvent être créées depuis l'application mobile, puis gérées depuis l'application web
--   Trouver les doublons d'entités à l'aide de l'interface de l'application web et décider de fusionner ou non deux entités similaires
--   Attribuer des workflows à des types d'entités, permettant d'ouvrir des formulaires de collecte de données spécifiques en fonction des réponses précédemment données
+Les entités sont des éléments pouvant se déplacer d'une géographie à une autre - une personne, une palette de marchandises, ou tout autre élément qu'il est utile de suivre dans le temps. Elles peuvent être créées depuis l'application mobile, puis gérées depuis le web.
+
+- Trouver les doublons d'entités probables depuis l'interface web et décider de les fusionner ou non
+- Attribuer des **workflows** à des types d'entités, afin que des formulaires de collecte de données spécifiques s'ouvrent automatiquement en fonction des réponses déjà données
+
+## Stockage externe
+
+Permet à IASO de fonctionner avec des cartes NFC comme support de stockage, permettant de lire et d'écrire les données d'une entité sur une carte physique sur le terrain.
+
+## Planification
+
+Grâce à une interface dynamique basée sur une carte, les gestionnaires de données assignent des lieux spécifiques à des utilisateurs spécifiques, avec un calendrier défini et un ou plusieurs formulaires de collecte de données. Les utilisateurs sur le terrain voient alors leurs "missions" assignées sur l'application mobile et peuvent se rendre directement aux points où ils doivent collecter des données.
+
+## Gestion des stocks
+
+Suit les quantités d'articles disponibles au niveau de l'unité d'organisation, sur la base de questions liées aux stocks intégrées dans les formulaires de collecte de données. Chaque mouvement "plus" ou "moins" d'un article à une unité d'organisation est enregistré, et l'application mobile affiche en temps réel le nombre d'articles restants à un lieu donné.
+
+## Paiements
+
+Lié aux demandes de modification. Sur la base des demandes de modification approuvées par un responsable, les utilisateurs peuvent générer des lots de paiement et télécharger un fichier Excel résumant, par utilisateur, le nombre de demandes de modification approuvées qui leur sont dues en paiement.
+
+## Form AI
+
+Permet aux utilisateurs de créer ou modifier des formulaires de collecte de données avec l'IA comme assistant, plutôt que de construire le formulaire XLS manuellement.
+
+## Correspondances DHIS2
+
+Activé lorsque IASO est utilisé conjointement avec DHIS2, le système d'information de gestion de la santé open source le plus utilisé au monde. L'intégration d'IASO avec DHIS2 est bidirectionnelle : les données géographiques peuvent être importées depuis DHIS2, puis les outils géospatiaux avancés d'IASO prennent le relais pour la collecte de données sur le terrain, et les données mises à jour sont renvoyées vers DHIS2.
+
+## Liens intégrés
+
+Permet aux utilisateurs d'intégrer des liens externes - comme des tableaux de bord - directement dans leur compte IASO, chacun avec sa propre URL personnalisée et dédiée. La gestion des utilisateurs d'IASO (par utilisateur ou par rôle utilisateur) contrôle l'accès à ces liens intégrés, qui prennent en charge le HTML brut, le texte simple, les iframes et les tableaux de bord Superset.


### PR DESCRIPTION
## Summary
The Modules page previously grouped a handful of features under loose thematic headings (Data collection functionalities, Georegistry, Payments, DHIS2 bi-directional integration, Planning, Entities) that didn't line up with the 12 modules IASO actually exposes.

Rewritten with one section per module, elaborated with what each one actually does, in an order that builds from core data collection through data-quality/workflow features, entities, field operations, and integrations:

Data collection - Forms, Change requests, Completeness per Period, Validation workflow, Entities, External storage, Planning, Stock management, Payments, Form AI, DHIS2 mapping, Embedded links.

Applied to EN, FR, and ES.

## Test plan
- [x] Verified locally: all 12 sections render correctly with the right heading order in all 3 languages
- [x] Checked for internal links pointing at old anchors on this page - none found
- [ ] Spot-check the live page in FR and ES after deploy