### PR TITLE
Feature SNT-562: Support for document upload in AI chat panel

### DIFF
--- a/hat/assets/js/apps/Iaso/components/ChatPanel/ChatPanel.tsx
+++ b/hat/assets/js/apps/Iaso/components/ChatPanel/ChatPanel.tsx
@@ -1,6 +1,7 @@
 import React, {
     ChangeEvent,
     FC,
+    ReactElement,
     ReactNode,
     useCallback,
     useEffect,
@@ -30,50 +31,17 @@ import ReactMarkdown from 'react-markdown';
 import { SxStyles } from 'Iaso/types/general';
 import { MessageQuickReplies } from './MessageQuickReplies';
 import MESSAGES from './messages';
+import {
+    ChatMessage,
+    ChatMessageRole,
+    ChatQuickReplyQuestion,
+    PendingAttachment,
+    PendingAttachmentStatus,
+    QuickReplyAnswer,
+    SendMessageOptions,
+} from './types';
 
-export type ChatMessageRole = 'user' | 'assistant';
-
-export type ChatQuickReplyQuestion = {
-    question: string;
-    options: string[];
-    selectedOptionIndex?: number;
-};
-
-export type ChatMessageAttachment = {
-    id: string;
-    filename: string;
-};
-
-export type ChatMessage = {
-    role: ChatMessageRole;
-    content: string;
-    id: string;
-    quickReplies?: ChatQuickReplyQuestion[];
-    attachments?: ChatMessageAttachment[];
-};
-
-export type QuickReplyAnswer = {
-    messageId: string;
-    // Group index -> selected option index.
-    selections: Record<number, number>;
-};
-
-export type PendingAttachmentStatus = 'uploading' | 'ready' | 'error';
-
-export type PendingAttachment = ChatMessageAttachment & {
-    status: PendingAttachmentStatus;
-};
-
-export type SendMessageOptions = {
-    // `message` is always what's sent to the conversation; `displayContent` overrides what's
-    // shown in the resulting user bubble (used for a quick-reply confirmation, whose picked
-    // answers are already visible in the question's own bubble).
-    displayContent?: string;
-    // Present when this send confirms a quick-reply form - pass to `applyQuickReplyAnswer` to
-    // record it on the originating message.
-    quickReplyAnswer?: QuickReplyAnswer;
-    attachments?: ChatMessageAttachment[];
-};
+export * from './types';
 
 // Applies a confirmed quick-reply answer onto the message it belongs to, setting each question's
 // `selectedOptionIndex`. Exported so every `ChatPanel` consumer applies answers the same way,
@@ -120,6 +88,22 @@ const bubble = (role: ChatMessageRole): SxProps<Theme> => ({
     color: role === 'user' ? 'primary.contrastText' : 'text.primary',
     borderRadius: 2,
 });
+
+const attachmentStatusIcon = (
+    status: PendingAttachmentStatus,
+): ReactElement => {
+    if (status === 'uploading') {
+        return (
+            <Box>
+                <CircularProgress size={16} sx={{ color: 'common.white' }} />
+            </Box>
+        );
+    }
+    if (status === 'error') {
+        return <ReportIcon fontSize="small" />;
+    }
+    return <InsertDriveFileIcon fontSize="small" />;
+};
 
 type Props = {
     messages: ChatMessage[];
@@ -276,11 +260,11 @@ const defaultStyles: SxStyles = {
     },
     attachmentChip: {
         border: 'none',
-        height: 32,
+        height: theme => theme.spacing(4),
         '& .MuiChip-icon': {
             color: 'common.white',
             margin: 0,
-            width: 32,
+            width: theme => theme.spacing(4),
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',
@@ -570,20 +554,7 @@ export const ChatPanel: FC<Props> = ({
                         {pendingAttachments.map(attachment => (
                             <Chip
                                 key={attachment.id}
-                                icon={
-                                    attachment.status === 'uploading' ? (
-                                        <Box>
-                                            <CircularProgress
-                                                size={16}
-                                                sx={{ color: 'common.white' }}
-                                            />
-                                        </Box>
-                                    ) : attachment.status === 'error' ? (
-                                        <ReportIcon fontSize="small" />
-                                    ) : (
-                                        <InsertDriveFileIcon fontSize="small" />
-                                    )
-                                }
+                                icon={attachmentStatusIcon(attachment.status)}
                                 label={attachment.filename}
                                 onDelete={
                                     onRemoveAttachment

--- a/hat/assets/js/apps/Iaso/components/ChatPanel/ChatPanel.tsx
+++ b/hat/assets/js/apps/Iaso/components/ChatPanel/ChatPanel.tsx
@@ -34,7 +34,6 @@ import MESSAGES from './messages';
 import {
     ChatMessage,
     ChatMessageRole,
-    ChatQuickReplyQuestion,
     PendingAttachment,
     PendingAttachmentStatus,
     QuickReplyAnswer,

--- a/hat/assets/js/apps/Iaso/components/ChatPanel/ChatPanel.tsx
+++ b/hat/assets/js/apps/Iaso/components/ChatPanel/ChatPanel.tsx
@@ -1,4 +1,5 @@
 import React, {
+    ChangeEvent,
     FC,
     ReactNode,
     useCallback,
@@ -6,13 +7,18 @@ import React, {
     useRef,
     useState,
 } from 'react';
+import AddIcon from '@mui/icons-material/Add';
+import InsertDriveFileIcon from '@mui/icons-material/InsertDriveFile';
 import PersonIcon from '@mui/icons-material/Person';
+import ReportIcon from '@mui/icons-material/Report';
 import SendIcon from '@mui/icons-material/Send';
 import SmartToyIcon from '@mui/icons-material/SmartToy';
 import {
     Box,
     Button,
+    Chip,
     CircularProgress,
+    IconButton,
     Paper,
     SxProps,
     TextField,
@@ -33,17 +39,29 @@ export type ChatQuickReplyQuestion = {
     selectedOptionIndex?: number;
 };
 
+export type ChatMessageAttachment = {
+    id: string;
+    filename: string;
+};
+
 export type ChatMessage = {
     role: ChatMessageRole;
     content: string;
     id: string;
     quickReplies?: ChatQuickReplyQuestion[];
+    attachments?: ChatMessageAttachment[];
 };
 
 export type QuickReplyAnswer = {
     messageId: string;
     // Group index -> selected option index.
     selections: Record<number, number>;
+};
+
+export type PendingAttachmentStatus = 'uploading' | 'ready' | 'error';
+
+export type PendingAttachment = ChatMessageAttachment & {
+    status: PendingAttachmentStatus;
 };
 
 export type SendMessageOptions = {
@@ -54,6 +72,7 @@ export type SendMessageOptions = {
     // Present when this send confirms a quick-reply form - pass to `applyQuickReplyAnswer` to
     // record it on the originating message.
     quickReplyAnswer?: QuickReplyAnswer;
+    attachments?: ChatMessageAttachment[];
 };
 
 // Applies a confirmed quick-reply answer onto the message it belongs to, setting each question's
@@ -116,6 +135,9 @@ type Props = {
     placeholder?: string;
     // When true, message content is rendered as markdown instead of plain text.
     interpretMarkdown?: boolean;
+    pendingAttachments?: PendingAttachment[];
+    onAttachFiles?: (files: File[]) => void;
+    onRemoveAttachment?: (id: string) => void;
     sx?: SxStyles;
 };
 
@@ -238,6 +260,44 @@ const defaultStyles: SxStyles = {
         flexShrink: 0,
         boxShadow: '0 2px 6px rgba(0, 0, 0, 0.12)',
     },
+    attachButton: {
+        width: 40,
+        height: 40,
+        flexShrink: 0,
+    },
+    attachmentsRow: {
+        display: 'flex',
+        flexWrap: 'wrap',
+        gap: 0.75,
+    },
+    pendingAttachmentsRow: {
+        mb: 1,
+        px: 0.5,
+    },
+    attachmentChip: {
+        border: 'none',
+        height: 32,
+        '& .MuiChip-icon': {
+            color: 'common.white',
+            margin: 0,
+            width: 32,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+        },
+        '& .MuiChip-label': {
+            pl: 0,
+            ml: -0.25,
+            fontWeight: 500,
+        },
+    },
+    pendingAttachmentChipError: {
+        bgcolor: 'error.light',
+        color: 'error.contrastText',
+    },
+    messageAttachmentsRow: {
+        mt: 1,
+    },
     markdownContent: {
         typography: 'body2',
         '& > :first-of-type': { mt: 0 },
@@ -271,23 +331,53 @@ export const ChatPanel: FC<Props> = ({
     titleIcon,
     placeholder,
     interpretMarkdown = false,
+    pendingAttachments = [],
+    onAttachFiles,
+    onRemoveAttachment,
     sx = {},
 }) => {
     const { formatMessage } = useSafeIntl();
     const [inputValue, setInputValue] = useState('');
     const messagesEndRef = useRef<HTMLDivElement>(null);
+    const fileInputRef = useRef<HTMLInputElement>(null);
 
     useEffect(() => {
         messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
     }, [messages]);
 
+    const hasUploadingAttachment = pendingAttachments.some(
+        attachment => attachment.status === 'uploading',
+    );
+    const hasReadyAttachment = pendingAttachments.some(
+        attachment => attachment.status === 'ready',
+    );
+
     const handleSend = useCallback(() => {
         const trimmed = inputValue.trim();
-        if (trimmed && !isLoading) {
-            onSendMessage(trimmed);
+        const readyAttachments = pendingAttachments
+            .filter(attachment => attachment.status === 'ready')
+            .map(({ id, filename }) => ({ id, filename }));
+        if (
+            (trimmed || readyAttachments.length > 0) &&
+            !isLoading &&
+            !hasUploadingAttachment
+        ) {
+            onSendMessage(
+                trimmed || formatMessage(MESSAGES.defaultAttachmentMessage),
+                readyAttachments.length
+                    ? { attachments: readyAttachments }
+                    : undefined,
+            );
             setInputValue('');
         }
-    }, [inputValue, isLoading, onSendMessage]);
+    }, [
+        inputValue,
+        isLoading,
+        hasUploadingAttachment,
+        pendingAttachments,
+        onSendMessage,
+        formatMessage,
+    ]);
 
     const handleKeyDown = useCallback(
         (e: React.KeyboardEvent) => {
@@ -297,6 +387,18 @@ export const ChatPanel: FC<Props> = ({
             }
         },
         [handleSend],
+    );
+
+    const handleFileInputChange = useCallback(
+        (e: ChangeEvent<HTMLInputElement>) => {
+            const files = e.target.files ? Array.from(e.target.files) : [];
+            // Reset so picking the exact same file again still fires a change event.
+            e.target.value = '';
+            if (files.length > 0) {
+                onAttachFiles?.(files);
+            }
+        },
+        [onAttachFiles],
     );
 
     const showEmptyState = messages.length === 0;
@@ -397,6 +499,30 @@ export const ChatPanel: FC<Props> = ({
                                     {msg.content}
                                 </Typography>
                             )}
+                            {msg.attachments && msg.attachments.length > 0 && (
+                                <Box
+                                    sx={
+                                        [
+                                            defaultStyles.attachmentsRow,
+                                            defaultStyles.messageAttachmentsRow,
+                                        ] as SxProps<Theme>
+                                    }
+                                >
+                                    {msg.attachments.map(attachment => (
+                                        <Chip
+                                            key={attachment.id}
+                                            variant="outlined"
+                                            icon={
+                                                <InsertDriveFileIcon fontSize="small" />
+                                            }
+                                            label={attachment.filename}
+                                            sx={
+                                                defaultStyles.attachmentChip as SxProps<Theme>
+                                            }
+                                        />
+                                    ))}
+                                </Box>
+                            )}
                             <MessageQuickReplies
                                 message={msg}
                                 isLast={messageIndex === messages.length - 1}
@@ -432,6 +558,50 @@ export const ChatPanel: FC<Props> = ({
             </Box>
 
             <Box sx={[defaultStyles.inputArea, sx.inputArea] as SxProps<Theme>}>
+                {onAttachFiles && pendingAttachments.length > 0 && (
+                    <Box
+                        sx={
+                            [
+                                defaultStyles.attachmentsRow,
+                                defaultStyles.pendingAttachmentsRow,
+                            ] as SxProps<Theme>
+                        }
+                    >
+                        {pendingAttachments.map(attachment => (
+                            <Chip
+                                key={attachment.id}
+                                icon={
+                                    attachment.status === 'uploading' ? (
+                                        <Box>
+                                            <CircularProgress
+                                                size={16}
+                                                sx={{ color: 'common.white' }}
+                                            />
+                                        </Box>
+                                    ) : attachment.status === 'error' ? (
+                                        <ReportIcon fontSize="small" />
+                                    ) : (
+                                        <InsertDriveFileIcon fontSize="small" />
+                                    )
+                                }
+                                label={attachment.filename}
+                                onDelete={
+                                    onRemoveAttachment
+                                        ? () =>
+                                              onRemoveAttachment(attachment.id)
+                                        : undefined
+                                }
+                                sx={
+                                    [
+                                        defaultStyles.attachmentChip,
+                                        attachment.status === 'error' &&
+                                            defaultStyles.pendingAttachmentChipError,
+                                    ] as SxProps<Theme>
+                                }
+                            />
+                        ))}
+                    </Box>
+                )}
                 <Box
                     sx={
                         [
@@ -440,6 +610,28 @@ export const ChatPanel: FC<Props> = ({
                         ] as SxProps<Theme>
                     }
                 >
+                    {onAttachFiles && (
+                        <>
+                            <input
+                                ref={fileInputRef}
+                                type="file"
+                                accept="application/pdf"
+                                multiple
+                                hidden
+                                onChange={handleFileInputChange}
+                            />
+                            <IconButton
+                                aria-label={formatMessage(MESSAGES.attachFile)}
+                                onClick={() => fileInputRef.current?.click()}
+                                disabled={isLoading}
+                                sx={
+                                    defaultStyles.attachButton as SxProps<Theme>
+                                }
+                            >
+                                <AddIcon />
+                            </IconButton>
+                        </>
+                    )}
                     <TextField
                         fullWidth
                         multiline
@@ -463,7 +655,11 @@ export const ChatPanel: FC<Props> = ({
                         variant="contained"
                         color="primary"
                         onClick={handleSend}
-                        disabled={isLoading || !inputValue.trim()}
+                        disabled={
+                            isLoading ||
+                            hasUploadingAttachment ||
+                            (!inputValue.trim() && !hasReadyAttachment)
+                        }
                         sx={
                             [
                                 defaultStyles.sendButton,

--- a/hat/assets/js/apps/Iaso/components/ChatPanel/messages.ts
+++ b/hat/assets/js/apps/Iaso/components/ChatPanel/messages.ts
@@ -5,6 +5,14 @@ const MESSAGES = defineMessages({
         defaultMessage: 'Sent selected answers',
         id: 'iaso.chatPanel.answeredQuestions',
     },
+    attachFile: {
+        defaultMessage: 'Attach a file',
+        id: 'iaso.chatPanel.attachFile',
+    },
+    defaultAttachmentMessage: {
+        defaultMessage: 'Please review the attached file(s).',
+        id: 'iaso.chatPanel.defaultAttachmentMessage',
+    },
     placeholder: {
         defaultMessage: 'Type a message...',
         id: 'iaso.chatPanel.placeholder',

--- a/hat/assets/js/apps/Iaso/components/ChatPanel/types.ts
+++ b/hat/assets/js/apps/Iaso/components/ChatPanel/types.ts
@@ -1,0 +1,43 @@
+export type ChatMessageRole = 'user' | 'assistant';
+
+export type ChatQuickReplyQuestion = {
+    question: string;
+    options: string[];
+    selectedOptionIndex?: number;
+};
+
+export type ChatMessageAttachment = {
+    id: string;
+    filename: string;
+};
+
+export type ChatMessage = {
+    role: ChatMessageRole;
+    content: string;
+    id: string;
+    quickReplies?: ChatQuickReplyQuestion[];
+    attachments?: ChatMessageAttachment[];
+};
+
+export type QuickReplyAnswer = {
+    messageId: string;
+    // Group index -> selected option index.
+    selections: Record<number, number>;
+};
+
+export type PendingAttachmentStatus = 'uploading' | 'ready' | 'error';
+
+export type PendingAttachment = ChatMessageAttachment & {
+    status: PendingAttachmentStatus;
+};
+
+export type SendMessageOptions = {
+    // `message` is always what's sent to the conversation; `displayContent` overrides what's
+    // shown in the resulting user bubble (used for a quick-reply confirmation, whose picked
+    // answers are already visible in the question's own bubble).
+    displayContent?: string;
+    // Present when this send confirms a quick-reply form - pass to `applyQuickReplyAnswer` to
+    // record it on the originating message.
+    quickReplyAnswer?: QuickReplyAnswer;
+    attachments?: ChatMessageAttachment[];
+};

--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -118,6 +118,8 @@
     "iaso.changeRequest.seeRejectedChanges": "See rejected change(s)",
     "iaso.changeRequest.showValuesAtCreation": "Show values at creation",
     "iaso.chatPanel.answeredQuestions": "Sent selected answers",
+    "iaso.chatPanel.attachFile": "Attach a file",
+    "iaso.chatPanel.defaultAttachmentMessage": "Please review the attached file(s).",
     "iaso.chatPanel.placeholder": "Type a message...",
     "iaso.chatPanel.sendAnswers": "Send answers",
     "iaso.completeness.chooseParent": "Select a form or a parent org unit to enable",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/es.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/es.json
@@ -66,6 +66,8 @@
     "iaso.changeRequest.seeRejectedChanges": "Ver cambio(s) rechazado(s)",
     "iaso.changeRequest.showValuesAtCreation": "Mostrar valores al crear",
     "iaso.chatPanel.answeredQuestions": "Respuestas seleccionadas enviadas",
+    "iaso.chatPanel.attachFile": "Adjuntar un archivo",
+    "iaso.chatPanel.defaultAttachmentMessage": "Por favor revise el/los archivo(s) adjunto(s).",
     "iaso.chatPanel.placeholder": "Escriba un mensaje...",
     "iaso.chatPanel.sendAnswers": "Enviar respuestas",
     "iaso.completeness.chooseParent": "Seleccione un formulario o una unidad organizativa padre para habilitar",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -119,6 +119,8 @@
     "iaso.changeRequest.seeRejectedChanges": "Voir le(s) changement(s) rejeté(s)",
     "iaso.changeRequest.showValuesAtCreation": "Montrer les valeurs à la création",
     "iaso.chatPanel.answeredQuestions": "Réponses sélectionnées envoyées",
+    "iaso.chatPanel.attachFile": "Joindre un fichier",
+    "iaso.chatPanel.defaultAttachmentMessage": "Merci de consulter le(s) fichier(s) joint(s).",
     "iaso.chatPanel.placeholder": "Écrivez un message...",
     "iaso.chatPanel.sendAnswers": "Envoyer les réponses",
     "iaso.completeness.chooseParent": "Selectionnez un formulaire ou une unité d'org parente pour activer",


### PR DESCRIPTION
## What problem is this PR solving?

Support for document upload in AI chat panel

### Related JIRA tickets

SNT-562

## Changes

Adds support for attaching documents to chat messages in a backwards-compatible way.
* Renders new upload button in the input field if consumer implements `onAttachFiles` callback
* Renders pending and uploaded files as chips above the message input prior sending the message
* Renders files that are attached to a message as the same chips inside the user's chat bubble
* Additional error-state file chips for failed uploads

## Print screen / video
Example of document upload in the SNT composite editor
* Single document attachment with message
* Multiple file attachment with broken file
* Single file attached to empty message


https://github.com/user-attachments/assets/d212a260-b07a-46b3-98c5-edb097fcff8c


