### PR TITLE
Docs: add a Developers reference page for the FHIR Organization Units API

### DIFF
--- a/docs/pages/dev/reference/fhir_api.en.md
+++ b/docs/pages/dev/reference/fhir_api.en.md
@@ -1,0 +1,57 @@
+# FHIR API - Organization Units
+
+IASO exposes Organization Units through a [FHIR R4](https://build.fhir.org/location.html)-compliant API, mapping them to the standard FHIR `Location` resource. This lets external systems that support FHIR - health information exchanges, national facility registries, EHRs - read IASO's organizational structure without a custom integration.
+
+This API is **read-only**.
+
+## Authentication
+
+All endpoints require authentication and the `iaso_org_units` permission.
+
+## Endpoints
+
+| Method | Endpoint | Description |
+|---|---|---|
+| GET | `/fhir/Location/` | List locations (returns a FHIR `Bundle`) |
+| GET | `/fhir/Location/{id}/` | Get a specific location |
+| GET | `/fhir/Location/{id}/children/` | Get the children of a location |
+| GET | `/fhir/Location/metadata/` | FHIR `CapabilityStatement` describing this API |
+
+## Field mapping
+
+| IASO Organization Unit | FHIR Location field |
+|---|---|
+| `id` | `id` |
+| `name` | `name` |
+| `validation_status` (NEW / VALID / REJECTED) | `status` (suspended / active / inactive) |
+| `source_ref`, `uuid`, `aliases` | `identifier` |
+| `org_unit_type` | `type` |
+| `org_unit_type.category` | `physicalType` |
+| `location` (GPS) | `position` |
+| `parent` | `partOf` |
+| `version.data_source` | `managingOrganization` |
+
+IASO-specific data without a native FHIR field - validation status, org unit type depth, source version, opening/closing dates - is carried as custom extensions under the `http://openiaso.com/fhir/StructureDefinition/...` namespace.
+
+## Searching
+
+| Parameter | Description | Example |
+|---|---|---|
+| `name` | Case-insensitive name search | `?name=hospital` |
+| `status` | `active`, `suspended`, or `inactive` | `?status=active` |
+| `identifier` | Matches source_ref, uuid, or alias | `?identifier=HF001` |
+| `type` | Organization unit type | `?type=HF` |
+| `_count` | Page size (max 100) | `?_count=50` |
+| `_skip` | Pagination offset | `?_skip=20` |
+
+## Example
+
+```http
+GET /fhir/Location/?name=hospital&status=active&_count=25
+```
+
+Returns a FHIR `Bundle` of matching `Location` resources - see the [FHIR Location](https://build.fhir.org/location.html) and [FHIR Search](https://build.fhir.org/search.html) specs for the full resource and query shape.
+
+## Errors
+
+Errors follow the FHIR `OperationOutcome` format rather than IASO's usual API error shape.

--- a/docs/pages/dev/reference/fhir_api.fr.md
+++ b/docs/pages/dev/reference/fhir_api.fr.md
@@ -1,0 +1,57 @@
+# API FHIR - Unités d'organisation
+
+IASO expose les unités d'organisation via une API conforme à [FHIR R4](https://build.fhir.org/location.html), en les associant à la ressource standard FHIR `Location`. Cela permet aux systèmes externes compatibles FHIR - plateformes d'échange d'information de santé, registres nationaux d'établissements, dossiers médicaux électroniques - de lire la structure organisationnelle d'IASO sans intégration sur mesure.
+
+Cette API est **en lecture seule**.
+
+## Authentification
+
+Tous les endpoints nécessitent une authentification et la permission `iaso_org_units`.
+
+## Endpoints
+
+| Méthode | Endpoint | Description |
+|---|---|---|
+| GET | `/fhir/Location/` | Liste des localisations (renvoie un `Bundle` FHIR) |
+| GET | `/fhir/Location/{id}/` | Récupère une localisation spécifique |
+| GET | `/fhir/Location/{id}/children/` | Récupère les localisations enfants d'une localisation |
+| GET | `/fhir/Location/metadata/` | `CapabilityStatement` FHIR décrivant cette API |
+
+## Correspondance des champs
+
+| Unité d'organisation IASO | Champ FHIR Location |
+|---|---|
+| `id` | `id` |
+| `name` | `name` |
+| `validation_status` (NEW / VALID / REJECTED) | `status` (suspended / active / inactive) |
+| `source_ref`, `uuid`, `aliases` | `identifier` |
+| `org_unit_type` | `type` |
+| `org_unit_type.category` | `physicalType` |
+| `location` (GPS) | `position` |
+| `parent` | `partOf` |
+| `version.data_source` | `managingOrganization` |
+
+Les données propres à IASO qui n'ont pas de champ FHIR natif - statut de validation, profondeur du type d'unité d'organisation, version de la source, dates d'ouverture/fermeture - sont transportées sous forme d'extensions personnalisées, dans l'espace de noms `http://openiaso.com/fhir/StructureDefinition/...`.
+
+## Recherche
+
+| Paramètre | Description | Exemple |
+|---|---|---|
+| `name` | Recherche par nom, insensible à la casse | `?name=hospital` |
+| `status` | `active`, `suspended`, ou `inactive` | `?status=active` |
+| `identifier` | Correspond à source_ref, uuid, ou alias | `?identifier=HF001` |
+| `type` | Type d'unité d'organisation | `?type=HF` |
+| `_count` | Taille de page (maximum 100) | `?_count=50` |
+| `_skip` | Décalage pour la pagination | `?_skip=20` |
+
+## Exemple
+
+```http
+GET /fhir/Location/?name=hospital&status=active&_count=25
+```
+
+Renvoie un `Bundle` FHIR contenant les ressources `Location` correspondantes - voir les spécifications [FHIR Location](https://build.fhir.org/location.html) et [FHIR Search](https://build.fhir.org/search.html) pour le détail complet du format des ressources et des requêtes.
+
+## Erreurs
+
+Les erreurs suivent le format `OperationOutcome` de FHIR plutôt que le format d'erreur habituel de l'API IASO.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -129,6 +129,7 @@ nav: # nav configures the side bar menu - this is the ONLY place the nav tree is
       - ./pages/dev/reference/docker.md
       - ./pages/dev/reference/background_tasks.md
       - ./pages/dev/reference/env_variables.md
+      - ./pages/dev/reference/fhir_api.md
       # - Entities:
       #   - ./pages/dev/reference/entities_in_iaso/entities_in_iaso.md
       # - Front-end:


### PR DESCRIPTION
## Summary
Adds a new page under **Developers > References** documenting the read-only FHIR R4 API added in #2220, which exposes IASO Organization Units as FHIR `Location` resources for external systems (HIEs, national facility registries, EHRs) to consume without a custom integration.

Covers:
- Endpoints (list, get by ID, children, `/metadata/` CapabilityStatement)
- Authentication (`iaso_org_units` permission)
- OrgUnit -> FHIR Location field mapping, including the custom extensions used for IASO-specific fields (validation status, org unit type depth, source version, opening/closing dates)
- Search parameters and pagination
- An example request
- The `OperationOutcome` error format

EN + FR, matching the existing convention for other Developers > References pages (none of them have ES).

## Test plan
- [x] Verified locally: page renders under Developers > References in EN and FR with correct heading structure
- [ ] Spot-check the live page after deploy