### PR TITLE
Fix error when creating missions in multi-project environments

### DIFF
--- a/iaso/api/missions/serializers/create/mission_entity_type.py
+++ b/iaso/api/missions/serializers/create/mission_entity_type.py
@@ -18,8 +18,10 @@ class EntityTypeScopedFormField(serializers.PrimaryKeyRelatedField):
         if not entity_type_pk:
             return Form.objects.none()
 
-        return Form.objects.filter_for_user_and_app_id(self.context["request"].user).filter_on_entity_type(
-            entity_type_pk
+        return (
+            Form.objects.filter_for_user_and_app_id(self.context["request"].user)
+            .filter_on_entity_type(entity_type_pk)
+            .distinct()
         )
 
 

--- a/iaso/api/missions/serializers/create/mission_org_unit_type.py
+++ b/iaso/api/missions/serializers/create/mission_org_unit_type.py
@@ -18,8 +18,10 @@ class OrgUnitTypeScopedFormField(serializers.PrimaryKeyRelatedField):
         if not org_unit_type_pk:
             return Form.objects.none()
 
-        return Form.objects.filter_for_user_and_app_id(self.context["request"].user).filter(
-            org_unit_types__id=org_unit_type_pk
+        return (
+            Form.objects.filter_for_user_and_app_id(self.context["request"].user)
+            .filter(org_unit_types__id=org_unit_type_pk)
+            .distinct()
         )
 
 
@@ -84,7 +86,7 @@ class MissionOrgUnitTypeCreateSerializer(ModelSerializer):
         account = getattr(iaso_profile, "account", None)
 
         if account:
-            self.fields["org_unit_type"].queryset = OrgUnitType.objects.filter(projects__account=account)
+            self.fields["org_unit_type"].queryset = OrgUnitType.objects.filter(projects__account=account).distinct()
 
     def validate(self, attrs):
         min_val = attrs.get("min_cardinality")

--- a/iaso/api/missions/serializers/update/mission_entity_type.py
+++ b/iaso/api/missions/serializers/update/mission_entity_type.py
@@ -18,8 +18,10 @@ class EntityTypeScopedFormField(serializers.PrimaryKeyRelatedField):
         if not entity_type_pk:
             return Form.objects.none()
 
-        return Form.objects.filter_for_user_and_app_id(self.context["request"].user).filter_on_entity_type(
-            entity_type_pk
+        return (
+            Form.objects.filter_for_user_and_app_id(self.context["request"].user)
+            .filter_on_entity_type(entity_type_pk)
+            .distinct()
         )
 
 

--- a/iaso/api/missions/serializers/update/mission_org_unit_type.py
+++ b/iaso/api/missions/serializers/update/mission_org_unit_type.py
@@ -18,8 +18,10 @@ class OrgUnitTypeScopedFormField(serializers.PrimaryKeyRelatedField):
         if not org_unit_type_pk:
             return Form.objects.none()
 
-        return Form.objects.filter_for_user_and_app_id(self.context["request"].user).filter(
-            org_unit_types__id=org_unit_type_pk
+        return (
+            Form.objects.filter_for_user_and_app_id(self.context["request"].user)
+            .filter(org_unit_types__id=org_unit_type_pk)
+            .distinct()
         )
 
 
@@ -77,7 +79,7 @@ class MissionOrgUnitTypeUpdateSerializer(ModelSerializer):
         account = getattr(iaso_profile, "account", None)
 
         if account:
-            self.fields["org_unit_type"].queryset = OrgUnitType.objects.filter(projects__account=account)
+            self.fields["org_unit_type"].queryset = OrgUnitType.objects.filter(projects__account=account).distinct()
 
     def validate(self, attrs):
         min_val = attrs.get("min_cardinality")

--- a/iaso/tests/api/missions/test_views/test_create/test_mission_entity_type.py
+++ b/iaso/tests/api/missions/test_views/test_create/test_mission_entity_type.py
@@ -88,6 +88,13 @@ class MissionEntityTypeAPICreateTestCase(SwaggerTestCaseMixin, APITestCase):
         )
         followup.forms.set(forms)
 
+        followup_2 = WorkflowFollowup.objects.create(
+            order=2,
+            condition={"==": [2, 2]},
+            workflow_version=workflow_et_version,
+        )
+        followup_2.forms.set(forms)
+
     def assertValidBodyData(self, data):
         self.assertResponseCompliantToSwagger(data, "MissionPolymorphicCreateRequest")
 

--- a/iaso/tests/api/missions/test_views/test_create/test_mission_org_unit_type.py
+++ b/iaso/tests/api/missions/test_views/test_create/test_mission_org_unit_type.py
@@ -45,13 +45,14 @@ class MissionOrgUnitTypeAPICreateTestCase(SwaggerTestCaseMixin, APITestCase):
         )
 
         cls.project = Project.objects.create(name="project", account=cls.account)
+        cls.project_2 = Project.objects.create(name="project_2", account=cls.account)
         cls.project_other_account = Project.objects.create(name="project", account=cls.other_account)
 
         cls.out = OrgUnitType.objects.create(name="out")
         cls.out_2 = OrgUnitType.objects.create(name="out2")
         cls.out_other_account = OrgUnitType.objects.create(name="out_other_account")
 
-        cls.out.projects.add(cls.project)
+        cls.out.projects.add(cls.project, cls.project_2)
         cls.out_2.projects.add(cls.project)
         cls.out_other_account.projects.add(cls.project_other_account)
 

--- a/iaso/tests/api/missions/test_views/test_update/test_mission_entity_type.py
+++ b/iaso/tests/api/missions/test_views/test_update/test_mission_entity_type.py
@@ -103,6 +103,13 @@ class MissionEntityTypeAPIUpdateTestCase(SwaggerTestCaseMixin, APITestCase):
         )
         followup.forms.set(forms)
 
+        followup_2 = WorkflowFollowup.objects.create(
+            order=2,
+            condition={"==": [2, 2]},
+            workflow_version=workflow_et_version,
+        )
+        followup_2.forms.set(forms)
+
     def setUp(self):
         super().setUp()
         self.mission_et_1 = MissionEntityType.objects.create(

--- a/iaso/tests/api/missions/test_views/test_update/test_mission_org_unit_type.py
+++ b/iaso/tests/api/missions/test_views/test_update/test_mission_org_unit_type.py
@@ -47,6 +47,7 @@ class MissionOrgUnitTypeAPIUpdateTestCase(SwaggerTestCaseMixin, APITestCase):
         # create some data
 
         cls.project = Project.objects.create(name="project", account=cls.account)
+        cls.project_2 = Project.objects.create(name="project_2", account=cls.account)
         cls.project_other_account = Project.objects.create(name="project", account=cls.other_account)
 
         # out
@@ -56,7 +57,7 @@ class MissionOrgUnitTypeAPIUpdateTestCase(SwaggerTestCaseMixin, APITestCase):
         cls.out_3 = OrgUnitType.objects.create(name="out2")
         cls.out_other_account = OrgUnitType.objects.create(name="out_other_account")
 
-        cls.out.projects.add(cls.project)
+        cls.out.projects.add(cls.project, cls.project_2)
         cls.out_2.projects.add(cls.project)
         cls.out_other_account.projects.add(cls.project_other_account)
 


### PR DESCRIPTION
## What problem is this PR solving?

Mission creation fails with a MultipleObjectsReturnedError if OrgUnitTypes or EntityTypes are shared across Projects.

### Related JIRA tickets

refs: IA-4872

## Changes

- Added distinct() calls to make sure the missions api accounts for the M2M relationship between EntityTypes/OrgUnitTypes and Projects.
- Updated test case setup to have multiple projects.

## How to test

- Make sure you have OrgUnitTypes/EntityTypes shared across multiple Projects (setuper should take care of that).
- Under /dashboard/planning/missions/, click Create
- Create a "Org Unit + Form" mission
- Create a "Entity + Form" mission.
- It should succeed without error.

## Print screen / video

/ 
## Notes

/ 
## Doc

/ 