### PR TITLE
IA-5368: Put the tick box "deduced from another form" in the DHIS2 module

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/forms/components/FormFormComponent.test.tsx
+++ b/hat/assets/js/apps/Iaso/domains/forms/components/FormFormComponent.test.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { fireEvent, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderWithThemeAndIntlProvider } from '../../../../../tests/helpers';
 import * as useGetGroupsModule from '../../orgUnits/hooks/requests/useGetGroups';
+import { userHasAccessToModule } from '../../users/utils';
 import FormForm from './FormFormComponent';
 
 vi.mock('../../projects/hooks/requests', () => ({
@@ -11,7 +13,6 @@ vi.mock('../../projects/hooks/requests', () => ({
         isFetching: false,
     })),
 }));
-
 vi.mock(
     '../../orgUnits/orgUnitTypes/hooks/useGetOrgUnitTypesDropdownOptions',
     () => ({
@@ -68,6 +69,15 @@ vi.mock('../../../components/forms/InputComponent', () => ({
         </div>
     ),
 }));
+
+vi.mock('../../users/utils', async () => {
+    const actual = await vi.importActual('../../users/utils');
+
+    return {
+        ...actual,
+        userHasAccessToModule: vi.fn(),
+    };
+});
 
 const mockUseGetGroupDropdown = vi.mocked(
     useGetGroupsModule.useGetGroupDropdown,
@@ -186,5 +196,30 @@ describe('FormFormComponent - org unit groups', () => {
             'org_unit_group_ids',
             [1, 2],
         );
+    });
+});
+
+describe('FormFormComponent - show advanced settings', () => {
+    it('shows the advanced settings and the tick box "deduced from another form" when user belongs to an account without Dhis2 module', async () => {
+        const user = userEvent.setup();
+        vi.mocked(userHasAccessToModule).mockReturnValue(true);
+        renderWithThemeAndIntlProvider(
+            <FormForm currentForm={makeForm()} setFieldValue={vi.fn()} />,
+        );
+        await user.click(screen.getByText('Show advanced settings'));
+        expect(screen.getByText('Hide advanced settings')).toBeInTheDocument();
+        expect(screen.getByTestId('input-field-derived')).toHaveValue('false');
+    });
+
+    it('hides the checkbox when user belongs to an account without Dhis2 module', async () => {
+        const user = userEvent.setup();
+        vi.mocked(userHasAccessToModule).mockReturnValue(false);
+        renderWithThemeAndIntlProvider(
+            <FormForm currentForm={makeForm()} setFieldValue={vi.fn()} />,
+        );
+        await user.click(screen.getByText('Show advanced settings'));
+        expect(
+            screen.queryByTestId('input-field-derived'),
+        ).not.toBeInTheDocument();
     });
 });

--- a/hat/assets/js/apps/Iaso/domains/forms/components/FormFormComponent.tsx
+++ b/hat/assets/js/apps/Iaso/domains/forms/components/FormFormComponent.tsx
@@ -17,6 +17,7 @@ import {
     commaSeparatedIdsToStringArray,
 } from '../../../utils/forms';
 import { SUBMISSIONS, SUBMISSIONS_UPDATE } from '../../../utils/permissions';
+import { useCurrentUser } from '../../../utils/usersUtils';
 import { formatLabel } from '../../instances/utils';
 import { useGetGroupDropdown } from '../../orgUnits/hooks/requests/useGetGroups';
 import { useGetOrgUnitTypesDropdownOptions } from '../../orgUnits/orgUnitTypes/hooks/useGetOrgUnitTypesDropdownOptions';
@@ -25,6 +26,7 @@ import {
     periodTypeOptionsWithNoPeriod,
 } from '../../periods/constants';
 import { useGetProjectsDropdownOptions } from '../../projects/hooks/requests';
+import { userHasAccessToModule } from '../../users/utils';
 import { CR_MODE_NONE, changeRequestModeOptions } from '../constants';
 import MESSAGES from '../messages';
 import { FormDataType } from '../types/forms';
@@ -67,6 +69,10 @@ const FormForm: FunctionComponent<FormFormProps> = ({
     const [showAdvancedSettings, setshowAdvancedSettings] = useState(false);
     const { data: allProjects, isFetching: isFetchingProjects } =
         useGetProjectsDropdownOptions();
+    const hasDhis2Module = userHasAccessToModule(
+        'DHIS2_MAPPING',
+        useCurrentUser(),
+    );
 
     const setPeriodType = (value: string | null) => {
         let periodTypeValue = value;
@@ -105,6 +111,7 @@ const FormForm: FunctionComponent<FormFormProps> = ({
     if (currentForm.project_ids.value.length > 0) {
         projects = currentForm.project_ids.value;
     }
+
     const { validation_workflow } = currentForm;
     const { data: allOrgUnitTypes, isFetching: isOuTypeLoading } =
         useGetOrgUnitTypesDropdownOptions({
@@ -392,23 +399,26 @@ const FormForm: FunctionComponent<FormFormProps> = ({
                                 options={changeRequestModeOptions}
                                 label={MESSAGES.changeRequestMode}
                             />
+
                             <Box
                                 style={{
                                     display: 'inline-flex',
                                     width: '100%',
                                 }}
                             >
-                                <InputComponent
-                                    keyValue="derived"
-                                    onChange={(key, value) =>
-                                        setFieldValue(key, value)
-                                    }
-                                    value={currentForm.derived.value}
-                                    errors={currentForm.derived.errors}
-                                    type="checkbox"
-                                    required
-                                    label={MESSAGES.derived}
-                                />
+                                {hasDhis2Module && (
+                                    <InputComponent
+                                        keyValue="derived"
+                                        onChange={(key, value) =>
+                                            setFieldValue(key, value)
+                                        }
+                                        value={currentForm.derived.value}
+                                        errors={currentForm.derived.errors}
+                                        type="checkbox"
+                                        required
+                                        label={MESSAGES.derived}
+                                    />
+                                )}
                                 {/* Splitting the Typography to be able to align it with the checkbox */}
                                 <Typography
                                     className={classes.advancedSettings}

--- a/iaso/management/commands/seed_test_data.py
+++ b/iaso/management/commands/seed_test_data.py
@@ -52,6 +52,7 @@ from iaso.models.entity import Entity, EntityType
 from iaso.models.microplanning import Planning
 from iaso.models.pages import Page
 from iaso.models.team import Team
+from iaso.modules import MODULES
 
 
 """
@@ -86,6 +87,9 @@ class Command(BaseCommand):
 
         for feat in AccountFeatureFlag.objects.all():
             account.feature_flags.add(feat)
+
+        account.modules = [module.codename for module in MODULES]
+        account.save()
 
         user, user_created = User.objects.get_or_create(
             username="testemail" + dhis2_version, email="testemail" + dhis2_version + "@bluesquarehub.com"


### PR DESCRIPTION
## What problem is this PR solving?

The tick box "Deduced from another form"  has been introduced in the form Form to allow a form derived from another that can be used for calculation and then map it to dhis2. So the checkbox should appear only when DHIS2 module is activated!

### Related JIRA tickets

[IA-5368](https://bluesquare.atlassian.net/browse/IA-5368)

## Changes

Show or hide the tick box "Deduced from another form" when user has access to Dhis2 module or not

## How to test

Try to access to form page with 2 account:  1 with Dhis2 module activated and another with the module deactivated. You should see the tick box "Deduced from another form" only for the user with Dhis2 module activated.

## Print screen / video

[Coda-2.webm](https://github.com/user-attachments/assets/56f291bf-22fb-4891-ad54-9ef72132c520)

[Iaso1.webm](https://github.com/user-attachments/assets/4ade6fc4-3f45-4e60-8ee8-911005209b99)


[IA-5368]: https://bluesquare.atlassian.net/browse/IA-5368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ