### PR TITLE
IA-5366: Task dialog overflow issue

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/tasks/components/TaskBaseInfo.tsx
+++ b/hat/assets/js/apps/Iaso/domains/tasks/components/TaskBaseInfo.tsx
@@ -1,5 +1,12 @@
 import React, { FunctionComponent, ReactNode } from 'react';
-import { Table, TableBody, TableRow, TableCell, Button } from '@mui/material';
+import {
+    Table,
+    TableBody,
+    TableRow,
+    TableCell,
+    Button,
+    Box,
+} from '@mui/material';
 import { TablePropsSizeOverrides } from '@mui/material/Table/Table';
 import { makeStyles } from '@mui/styles';
 import { OverridableStringUnion } from '@mui/types/esm';
@@ -24,14 +31,28 @@ const useStyles = makeStyles(theme => ({
 type RowProps = {
     label: string;
     value?: string | ReactNode;
+    isPreformatted?: boolean;
 };
 
-const Row: FunctionComponent<RowProps> = ({ label, value }) => {
+const Row: FunctionComponent<RowProps> = ({ label, value, isPreformatted }) => {
     const classes = useStyles();
     return (
         <TableRow>
             <TableCell className={classes.leftCell}>{label}</TableCell>
-            <TableCell>{value}</TableCell>
+            <TableCell>
+                {(isPreformatted && (
+                    <Box
+                        component="pre"
+                        sx={{
+                            whiteSpace: 'pre-wrap',
+                            wordBreak: 'break-all',
+                        }}
+                    >
+                        {value}
+                    </Box>
+                )) ||
+                    value}
+            </TableCell>
         </TableRow>
     );
 };
@@ -53,6 +74,8 @@ export const TaskBaseInfo: FunctionComponent<Props> = ({ task, size }) => {
         () => getRequest(`/api/tasks/${task.id}/presigned-url/`),
         { enabled: Boolean(taskHasDownloadableFile) },
     );
+    const hasUrlInProgressMessage = task.progress_message?.includes('url');
+
     return (
         <>
             <Table size={size} data-test="task-base-info">
@@ -87,6 +110,7 @@ export const TaskBaseInfo: FunctionComponent<Props> = ({ task, size }) => {
                         <Row
                             label={formatMessage(MESSAGES.result_message)}
                             value={task.progress_message}
+                            isPreformatted={hasUrlInProgressMessage}
                         />
                     )}
                 </TableBody>

--- a/iaso/models/task.py
+++ b/iaso/models/task.py
@@ -1,7 +1,9 @@
+import re
 import traceback
 
 from logging import getLogger
 from typing import Optional
+from urllib.parse import unquote
 
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -17,8 +19,7 @@ from iaso.models import (
     Account,
     KilledException,
 )
-import re
-from urllib.parse import unquote
+
 
 logger = getLogger(__name__)
 

--- a/iaso/models/task.py
+++ b/iaso/models/task.py
@@ -17,7 +17,8 @@ from iaso.models import (
     Account,
     KilledException,
 )
-
+import re
+from urllib.parse import unquote
 
 logger = getLogger(__name__)
 
@@ -140,6 +141,9 @@ class Task(models.Model):
         self.create_log_entry_if_needed(message)
         self.save()
 
+    def decode_dhis2_url(self, message: str) -> str:
+        return re.sub(r"https?://[^\s,]+", lambda match: unquote(match.group(0)), message)
+
     def report_failure(self, e: Exception):
         self.status = ERRORED
         self.ended_at = timezone.now()
@@ -150,6 +154,9 @@ class Task(models.Model):
             "last_progress_message": self.progress_message,
         }
         self.progress_message = e.message if hasattr(e, "message") else str(e)
+        if self.name == "dhis2_ou_importer":
+            self.progress_message = self.decode_dhis2_url(self.result.get("message", ""))
+
         # Extra debug info
         if hasattr(e, "extra"):
             self.result["extra"] = e.extra


### PR DESCRIPTION

## What problem is this PR solving?

Handle non breakable string Dhis2 URL in the UI.

### Related JIRA tickets

[IA-5366](https://bluesquare.atlassian.net/browse/IA-5368)

## Changes

Decoded dhis2 URL when import task fail in order to show better formatted URL in the UI.

## How to test

1. Try to run a background worker  `uv run ./manage.py tasks_worker` or  `docker compose run iaso manage tasks_worker`

2. Create a DHIS2 data source with correct user name and password, then create a new version from dhis2 and launch a dhis2 org unit import task.

3. Change the username and/or password for the DHIS2 data source in order to trigger an error then relaunch dhis2 ou import. From [the tasks list page](http://localhost:8081/dashboard/settings/tasks/), try to visualize the task information. You should see a better formatted **dhis2 url**  in **Result Message** on the Task section for the failed task.

<img width="1850" height="1324" alt="Tasks-Action" src="https://github.com/user-attachments/assets/6918ae9f-be02-4f66-84fb-170adb80b138" />



For the dhis2 you can use the [Demo instance](https://play.im.dhis2.org/stable-2-40-12/) : 

- URL: https://play.im.dhis2.org/stable-2-40-12
- Username: admin
- Password: district

**More details on how to test in the below video.**

## Print screen / video


[AwesomeScreenshot-21_08_202610_15_09.webm](https://github.com/user-attachments/assets/0d24ba85-a1b3-4472-8e73-96b0a0167eba)

[IA-5366]: https://bluesquare.atlassian.net/browse/IA-5366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ