### PR TITLE
POLIO-2190: gzip-compress static assets and set cache headers on Azure

### DIFF
--- a/iaso/storage.py
+++ b/iaso/storage.py
@@ -29,8 +29,13 @@ class AzureStaticStorage(AzureStorage):
     expiration_secs = None
     default_acl = "public-read"
 
+    def _is_compressible(self, name):
+        return name.lower().endswith(COMPRESSIBLE_EXTENSIONS)
+
     def _save(self, name, content):
-        if name.lower().endswith(COMPRESSIBLE_EXTENSIONS):
+        # get_object_parameters() below sets Content-Encoding: gzip based on the same
+        # check, so the two can never disagree about whether `content` was compressed.
+        if self._is_compressible(name):
             content.seek(0)
             buffer = BytesIO()
             with gzip.GzipFile(filename="", mode="wb", fileobj=buffer, mtime=0) as gzip_file:
@@ -40,7 +45,7 @@ class AzureStaticStorage(AzureStorage):
 
     def get_object_parameters(self, name):
         params = super().get_object_parameters(name).copy()
-        if name.lower().endswith(COMPRESSIBLE_EXTENSIONS):
+        if self._is_compressible(name):
             params["content_encoding"] = "gzip"
         if _HASHED_ASSET_RE.search(name):
             params["cache_control"] = "public, max-age=31536000, immutable"

--- a/iaso/storage.py
+++ b/iaso/storage.py
@@ -1,3 +1,9 @@
+import gzip
+import re
+
+from io import BytesIO
+
+from django.core.files.base import ContentFile
 from storages.backends.azure_storage import AzureStorage  # type: ignore
 from storages.backends.s3boto3 import S3Boto3Storage  # type: ignore
 
@@ -7,11 +13,40 @@ class StaticStorage(S3Boto3Storage):
     default_acl = "public-read"
 
 
+# Azure Blob Storage never compresses responses on the fly (unlike S3 behind CloudFront),
+# so without this static assets are served uncompressed and webpack bundles can be several MB.
+COMPRESSIBLE_EXTENSIONS = (".js", ".css", ".svg", ".json", ".txt", ".xml", ".map")
+
+# webpack.prod.js names bundles/fonts/videos with a contenthash (e.g. "common-0a9eef66a245a98d5295.js"),
+# so those filenames change whenever the content does and can be cached forever. Anything else
+# (e.g. Django admin's static files) keeps a fixed name across deploys and can't be cached that long.
+_HASHED_ASSET_RE = re.compile(r"[.-][0-9a-f]{8,}\.[^./]+$")
+
+
 class AzureStaticStorage(AzureStorage):
     azure_container = "iaso"
     location = "static"
     expiration_secs = None
     default_acl = "public-read"
+
+    def _save(self, name, content):
+        if name.lower().endswith(COMPRESSIBLE_EXTENSIONS):
+            content.seek(0)
+            buffer = BytesIO()
+            with gzip.GzipFile(filename="", mode="wb", fileobj=buffer, mtime=0) as gzip_file:
+                gzip_file.write(content.read())
+            content = ContentFile(buffer.getvalue())
+        return super()._save(name, content)
+
+    def get_object_parameters(self, name):
+        params = super().get_object_parameters(name).copy()
+        if name.lower().endswith(COMPRESSIBLE_EXTENSIONS):
+            params["content_encoding"] = "gzip"
+        if _HASHED_ASSET_RE.search(name):
+            params["cache_control"] = "public, max-age=31536000, immutable"
+        else:
+            params["cache_control"] = "public, max-age=3600"
+        return params
 
 
 class AzureMediaStorage(AzureStorage):


### PR DESCRIPTION
## Summary
- Azure Blob Storage doesn't compress responses on the fly (unlike S3 behind CloudFront), so JS/CSS bundles were served uncompressed — e.g. `common-<hash>.js` was ~6.3MB with no `Content-Encoding`.
- There was also no `Cache-Control` header at all, so unchanged assets get re-fetched on every page load.
- `AzureStaticStorage` now gzips compressible file types (`.js`, `.css`, `.svg`, `.json`, `.txt`, `.xml`, `.map`) before upload and sets `Content-Encoding: gzip`.
- Also sets `Cache-Control`: `public, max-age=31536000, immutable` for content-hashed webpack assets (bundles, fonts, videos — filename changes when content does), and a conservative `public, max-age=3600` for everything else (e.g. Django admin's static files, which keep fixed names across deploys).
- Only affects newly uploaded files, so it takes effect on the next `collectstatic`/deploy.

Jira: https://bluesquare.atlassian.net/browse/POLIO-2190

## Test plan
- [ ] Deploy and confirm via `curl -I` that a static asset response includes `Content-Encoding: gzip` and the expected `Cache-Control`
- [ ] Confirm the JS bundle still loads/executes correctly in the browser (gzip decoding works)
- [ ] Confirm Django admin static assets still load correctly