### PR TITLE
POLIO-2191: fix md5 backfill migration crashing on Azure blob storage

### DIFF
--- a/plugins/polio/migrations/0256_backfill_modelwithfile_md5.py
+++ b/plugins/polio/migrations/0256_backfill_modelwithfile_md5.py
@@ -36,6 +36,14 @@ def _backfill_model(Model, model_name):
     )
 
     for instance in queryset:
+        # Storage.exists() is implemented consistently across backends (local filesystem,
+        # S3, Azure), unlike the exception a missing file raises on read: Azure's blob
+        # download raises azure.core.exceptions.ResourceNotFoundError, which isn't an
+        # OSError, so it wasn't caught below and crashed the whole migration.
+        if not instance.file.storage.exists(instance.file.name):
+            print(f"skipping {model_name} pk={instance.pk}: file {instance.file.name!r} not found in storage")
+            continue
+
         try:
             md5 = calculate_md5(instance.file)
         except (FileNotFoundError, OSError) as e:


### PR DESCRIPTION
## What problem is this PR solving?

The `0256_backfill_modelwithfile_md5` migration crash-loops on production (`iaso-polio-prod`) because it doesn't handle a missing file on Azure blob storage.

### Related JIRA tickets

POLIO-2191

## Changes

- In `plugins/polio/migrations/0256_backfill_modelwithfile_md5.py`, before computing the md5, `_backfill_model` now checks `instance.file.storage.exists(instance.file.name)` and skips the row (with a log line) if the underlying file is missing.
- Root cause: the migration only caught `(FileNotFoundError, OSError)` around `calculate_md5()`. On local/S3 a missing file surfaces that way, but Azure's blob download raises `azure.core.exceptions.ResourceNotFoundError`, which isn't a subclass of `OSError`, so it wasn't caught and the whole migration (and the pod running it) crashed.
- `Storage.exists()` is implemented consistently across backends (local filesystem, S3, Azure), so this check avoids depending on any storage-specific exception type.

## How to test

- Migration is idempotent (`filter(md5="")`) and non-atomic per the existing code comment, so it can just be re-run on an environment with an orphaned file reference (a `VaccineRequestForm`/`VaccinePreAlert`/etc. row whose `file` points to a blob that no longer exists) — it should now log a "skipping ... not found in storage" line and continue instead of crashing.
- `docker-compose run iaso manage migrate polio 0256` (or the equivalent for the affected environment) after seeding/finding a row with a dangling file reference.

## Print screen / video

N/A — backend data migration fix, no UI change.

## Notes

- This does not repair the underlying orphaned file references (DB rows pointing to blobs that no longer exist in storage) — it only lets the migration complete instead of crashing. Worth a follow-up if those rows should be cleaned up or re-uploaded.
- Unblocks the currently crash-looping pod in `iaso-polio-prod`.

## Doc

N/A