### PR TITLE
IA-5380 improve entity sync to read less

### DIFF
--- a/iaso/management/commands/explain_request.py
+++ b/iaso/management/commands/explain_request.py
@@ -49,6 +49,12 @@ def enable_capture_queries(executed_queries=[]):
 
 
 def dump_executed_queries(executed_queries, threshold_duration=0.4, auto_explain=False, full_stack=False):
+    explained_count = 0
+    total_hit_blocks = 0
+    total_read_blocks = 0
+    total_io_read_ms = 0.0
+    total_execution_ms = 0.0
+
     for i, q in enumerate(executed_queries):
         if q["duration"] > threshold_duration:
             print(f"\n--- SQL #{i + 1} ---")
@@ -70,11 +76,45 @@ def dump_executed_queries(executed_queries, threshold_duration=0.4, auto_explain
                         cursor.execute("EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) " + q["sql"])
                         result = cursor.fetchone()[0]
                         parsed = json.loads(result) if isinstance(result, str) else result
+                        # The root plan node's Buffers/I-O stats are already cumulative totals for the
+                        # whole query (Postgres rolls child-node usage up into the parent), so this is
+                        # the actual per-execution disk footprint -- print it up front since it's easy to
+                        # miss inside the raw JSON below, and it's the number that matters when many
+                        # copies of a query run concurrently (buffer cache/I-O contention), not just wall time.
+                        plan = parsed[0]["Plan"]
+                        hit_blocks = plan.get("Shared Hit Blocks", 0)
+                        read_blocks = plan.get("Shared Read Blocks", 0)
+                        io_read_ms = plan.get("I/O Read Time", 0.0)
+                        execution_ms = parsed[0].get("Execution Time", 0.0)
+                        print(
+                            f"Explain summary: shared_hit={hit_blocks:,} blocks (~{hit_blocks * 8 / 1024:.1f} MB), "
+                            f"shared_read={read_blocks:,} blocks (~{read_blocks * 8 / 1024:.1f} MB), "
+                            f"io_read_time={io_read_ms:.1f}ms, "
+                            f"execution_time={execution_ms:.1f}ms"
+                        )
                         print("Explain plan: (drop it in https://tatiyants.com/pev/)")
                         # don't pretty print so it's easier to paste in the explain plan app
                         print(json.dumps(parsed))
+
+                        explained_count += 1
+                        total_hit_blocks += hit_blocks
+                        total_read_blocks += read_blocks
+                        total_io_read_ms += io_read_ms
+                        total_execution_ms += execution_ms
                 except Exception as e:
                     print(f"EXPLAIN failed: {e}")
+
+    if auto_explain and explained_count:
+        # Per-query numbers hide what actually saturates the DB under concurrent load: many small
+        # queries each reading a handful of cached blocks look harmless individually, but the sum
+        # across a whole request is the real buffer-cache/I-O pressure it puts on Postgres.
+        print(
+            f"\nExplain totals across {explained_count} explained queries: "
+            f"shared_hit={total_hit_blocks:,} blocks (~{total_hit_blocks * 8 / 1024:.1f} MB), "
+            f"shared_read={total_read_blocks:,} blocks (~{total_read_blocks * 8 / 1024:.1f} MB), "
+            f"io_read_time={total_io_read_ms:.1f}ms, "
+            f"execution_time={total_execution_ms:.1f}ms"
+        )
 
 
 def is_content_type_textual(content_type: str) -> bool:

--- a/iaso/models/entity.py
+++ b/iaso/models/entity.py
@@ -23,7 +23,7 @@ from django.contrib.auth.models import AnonymousUser, User
 from django.contrib.postgres.fields import ArrayField
 from django.core.exceptions import ValidationError
 from django.db import models
-from django.db.models import Prefetch, Subquery
+from django.db.models import Exists, OuterRef, Prefetch
 
 from iaso.models import Account, Instance, OrgUnit, Project
 from iaso.models.deduplication import ValidationStatus
@@ -151,7 +151,11 @@ class EntityQuerySet(models.QuerySet):
             except ValidationError:
                 raise InvalidLimitDateError(f"Invalid limit date {limit_date}")
 
-        return self.filter(id__in=Subquery(instances.values("entity_id").distinct()))
+        # Exists(...) with a correlated OuterRef lets Postgres push the entity_id correlation down
+        # (nested loop keyed on the entity's own instances) instead of the id__in=Subquery(...distinct())
+        # shape, which forced Postgres to materialize/sort/dedupe every matching instance row across the
+        # whole table before it could probe entities against it -- the dominant cost of this query in prod.
+        return self.filter(Exists(instances.filter(entity_id=OuterRef("pk"))))
 
     def filter_for_mobile_entity(self, limit_date=None, json_content=None):
         queryset = self


### PR DESCRIPTION
## What problem is this PR solving?

The query could be improved so postgres don't do a Seq Scan of most entities.

### Related JIRA tickets

IA-5380

## Changes

1. iaso/models/entity.py — the actual fix (commit 078254b)

Why: `_filter_entities_with_instances()` (used by every mobile entity sync request) filtered entities via `id__in=Subquery(instances.values("entity_id").distinct())`. The DISTINCT inside that subquery blocked Postgres from planning it as a cheap semi-join, forcing it instead to Parallel Seq Scan the entire iaso_instance table and run a per-row org-unit path check (8.5M loop iterations in the prod EXPLAIN) before it could even start matching entities. 

Fix: swapped it for a correlated `Exists(instances.filter(entity_id=OuterRef("pk")))`, which lets Postgres use the indexed iaso_instance.entity_id column to do a per-entity point lookup instead of scanning/sorting/deduping the whole table.

What it helped for (measured against a real prod-data copy, same account/profile/app_id as the incident):

```
┌────────────────────┬────────────────┬─────────────────────┐
│                    │ Execution time │ Disk blocks touched │
├────────────────────┼────────────────┼─────────────────────┤
│ Old (warm-storage) │ 4.94s          │ 727,014 (~5.5GB)    │
├────────────────────┼────────────────┼─────────────────────┤
│ New                │ 3.52s          │ 169 (~1.3MB)        │
└────────────────────┴────────────────┴─────────────────────┘
```

Identical result set (951 rows) both ways — no behavior change, 124 existing entity tests still pass. Wall time improved modestly (~1.4x), but the number that actually matters for the incident is the ~4,300x drop in disk blocks touched per execution — the old query dragged ~5.5GB through shared buffers on every single call, which is what turns "one device syncing" into "the DB falls over" once hundreds of devices do it at once.

Since the query get executed nearly twice (once as count(*) and once to get the actual page), the benefits are nearly doubled.

2. iaso/management/commands/explain_request.py — diagnostic tooling (commit 7daf74a)

Why: this is the command that produced the original slow-query trace pasted at the start of this session (EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)). The buffer/I-O data was already being captured but only existed buried inside a single-line JSON blob meant for pasting into pev — nobody scanning logs would spot "745,341 blocks read" by eye.

What it helped for: added a human-readable Explain summary: line per query (shared_hit/shared_read blocks in MB, I/O read time, execution time), plus an Explain totals across N explained queries: line at the end summing all of them. Makes this exact kind of investigation — "how much disk did this request actually touch" — visible directly in the command output next time, instead of requiring the manual EXPLAIN reconstruction I did in this session.


## How to test

if you really want, setup a copy of the database

Launch the command against it 
```
docker compose exec -e DEBUG=true -e DEBUG_SQL=true iaso python manage.py explain_request     --url-path="/api/mobile/entities/?limit_date=2026-08-24&app_id=rci.pnlp.cps.denombrement.administration.2026&limit=344&page=1"     --username="CSU_FOUMBOLO_VOL_07"     --threshold-duration=0 --explain=true
```

before the change to entity query
```
Explain totals across 12 explained queries: shared_hit=10,716,799 blocks (~83725.0 MB), shared_read=1,450,456 blocks (~11331.7 MB), io_read_time=3727.6ms, execution_time=11877.5ms
Headers: {'Content-Type': 'application/json', 'Vary': 'Accept', 'Allow': 'GET, POST, HEAD, OPTIONS'}
Status: 200
Response size: (0.96 MB)
Total request time: 11.574s with 12 queries
```
After
```
Explain totals across 12 explained queries: shared_hit=16,039,733 blocks (~125310.4 MB), shared_read=0 blocks (~0.0 MB), io_read_time=0.0ms, execution_time=5998.6ms
Headers: {'Content-Type': 'application/json', 'Vary': 'Accept', 'Allow': 'GET, POST, HEAD, OPTIONS'}
Status: 200
Response size: (0.96 MB)
Total request time: 6.148s with 12 queries
```
## Print screen / video



## Notes

## Doc


