### PR TITLE
POLIO-2195: SSO error pages crash with 500 instead of rendering

### DIFF
--- a/hat/locale/fr/LC_MESSAGES/django.po
+++ b/hat/locale/fr/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-10 19:43+0000\n"
+"POT-Creation-Date: 2026-08-27 20:22+0000\n"
 "PO-Revision-Date: 2025-02-05 14:41+0100\n"
 "Last-Translator: Olivier Le Thanh Duong <olivier@lethanh.be>\n"
 "Language-Team: \n"
@@ -69,6 +69,10 @@ msgstr "Erreur de connexion au compte"
 #: hat/sso_views.py
 msgid "Internal server error"
 msgstr "Erreur interne du serveur"
+
+#: hat/templates/account/base.html
+msgid "Messages:"
+msgstr "Messages :"
 
 #: hat/templates/iaso/forgot_password.html
 msgid "Forgot password?"

--- a/hat/templates/account/base.html
+++ b/hat/templates/account/base.html
@@ -1,0 +1,31 @@
+{% load i18n %}
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block head_title %}{% endblock %}</title>
+    {% block extra_head %}
+    {% endblock %}
+  </head>
+  <body>
+    {% block body %}
+
+    {% if messages %}
+    <div>
+      <strong>{% trans "Messages:" %}</strong>
+      <ul>
+        {% for message in messages %}
+        <li>{{ message }}</li>
+        {% endfor %}
+      </ul>
+    </div>
+    {% endif %}
+
+    {% block content %}
+    {% endblock %}
+    {% endblock %}
+    {% block extra_body %}
+    {% endblock %}
+  </body>
+</html>

--- a/hat/tests/test_sso_auth.py
+++ b/hat/tests/test_sso_auth.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 from allauth.socialaccount.models import SocialAccount
 from django.test import override_settings
+from django.urls import reverse
 
 from hat.sso_views import ExtraData
 from iaso import models as m
@@ -361,3 +362,33 @@ class SSOAuthTestCase(APITestCase):
         # The social account links to the tenant main_user, not one of the account users.
         social_account = SocialAccount.objects.get(uid="abc-123-def")
         self.assertEqual(social_account.user, main_user)
+
+    def test_web_callback_cancelled_login_does_not_crash(self):
+        """The provider's own 'user cancelled' error (?error=access_denied) must redirect
+        cleanly, not 500.
+
+        Regression test: allauth's render_authentication_error() reverses the URL name
+        'socialaccount_login_cancelled' for this case, which this project never registered
+        (it has its own login system, not allauth's account/socialaccount urls), causing a
+        NoReverseMatch crash instead of a redirect.
+        """
+        # hat.tests.urls (see its docstring) only registers the SSO provider urls, not
+        # the full app (e.g. no /login), so we only assert on the first redirect hop
+        # here rather than following the chain all the way to the login page.
+        response = self.client.get("/polio/login/callback/?error=access_denied")
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, reverse("socialaccount_login_cancelled"))
+
+    def test_web_callback_error_page_renders_without_crashing(self):
+        """Any other SSO error on the web (browser) callback must render a page, not 500.
+
+        Regression test for a NoReverseMatch crash: allauth's default error page
+        template chain references 'account_login'/'account_signup' etc., which this
+        project never registers (it has its own login system, not allauth's). This
+        made every SSO error page crash instead of showing a message. Using an error
+        code other than the provider's cancelled-login one (?error=server_error)
+        reaches the template-rendering branch without needing to mock the OAuth2
+        token exchange.
+        """
+        response = self.client.get("/polio/login/callback/?error=server_error")
+        self.assertEqual(response.status_code, 200)

--- a/hat/tests/test_sso_auth.py
+++ b/hat/tests/test_sso_auth.py
@@ -392,3 +392,18 @@ class SSOAuthTestCase(APITestCase):
         """
         response = self.client.get("/polio/login/callback/?error=server_error")
         self.assertEqual(response.status_code, 200)
+
+
+@override_settings(SSO_PROVIDERS={})
+class SocialAccountCancelledUrlTestCase(APITestCase):
+    def test_cancelled_url_registered_when_sso_providers_empty(self):
+        """WFP is configured via WFP_AUTH_CLIENT_ID, not SSO_PROVIDERS.
+
+        Cancelling a WFP login still goes through allauth's render_authentication_error(),
+        which reverses socialaccount_login_cancelled. That name must exist even when
+        SSO_PROVIDERS is empty (WFP-only deployments).
+        """
+        from hat.urls import get_sso_urlpatterns
+
+        names = [getattr(pattern, "name", None) for pattern in get_sso_urlpatterns()]
+        self.assertIn("socialaccount_login_cancelled", names)

--- a/hat/urls.py
+++ b/hat/urls.py
@@ -34,20 +34,21 @@ def _sso_providers():
 def get_sso_urlpatterns():
     """Generate URL patterns for all configured SSO providers."""
     patterns = []
-    sso_providers = getattr(settings, "SSO_PROVIDERS", {})
-    if sso_providers:
-        # allauth's own error-handling code (render_authentication_error) reverses this
-        # URL name when the user cancels the login on the provider's side. This project
-        # doesn't include allauth's own account/socialaccount urls (it has its own login
-        # system), so without this the cancelled-login case crashes with NoReverseMatch.
-        patterns.append(
-            path(
-                "accounts/login/cancelled/",
-                RedirectView.as_view(url=settings.LOGIN_URL),
-                name="socialaccount_login_cancelled",
-            )
+    # Always register this name: allauth's render_authentication_error() reverses it
+    # when the user cancels login on the provider's side. This project doesn't include
+    # allauth's own account/socialaccount urls (it has its own login system), so without
+    # this the cancelled-login case crashes with NoReverseMatch.
+    #
+    # Must not be gated on SSO_PROVIDERS: WFP is configured via WFP_AUTH_CLIENT_ID and
+    # is never added to SSO_PROVIDERS, but its callback uses the same allauth helper.
+    patterns.append(
+        path(
+            "accounts/login/cancelled/",
+            RedirectView.as_view(url=settings.LOGIN_URL),
+            name="socialaccount_login_cancelled",
         )
-    for provider_id, config in sso_providers.items():
+    )
+    for provider_id, config in getattr(settings, "SSO_PROVIDERS", {}).items():
         adapter_cls = get_adapter_class(provider_id)
 
         login_path = config.get("login_path", f"{provider_id}/login/")

--- a/hat/urls.py
+++ b/hat/urls.py
@@ -34,7 +34,20 @@ def _sso_providers():
 def get_sso_urlpatterns():
     """Generate URL patterns for all configured SSO providers."""
     patterns = []
-    for provider_id, config in getattr(settings, "SSO_PROVIDERS", {}).items():
+    sso_providers = getattr(settings, "SSO_PROVIDERS", {})
+    if sso_providers:
+        # allauth's own error-handling code (render_authentication_error) reverses this
+        # URL name when the user cancels the login on the provider's side. This project
+        # doesn't include allauth's own account/socialaccount urls (it has its own login
+        # system), so without this the cancelled-login case crashes with NoReverseMatch.
+        patterns.append(
+            path(
+                "accounts/login/cancelled/",
+                RedirectView.as_view(url=settings.LOGIN_URL),
+                name="socialaccount_login_cancelled",
+            )
+        )
+    for provider_id, config in sso_providers.items():
         adapter_cls = get_adapter_class(provider_id)
 
         login_path = config.get("login_path", f"{provider_id}/login/")

--- a/plugins/wfp_auth/tests/test_auth.py
+++ b/plugins/wfp_auth/tests/test_auth.py
@@ -4,6 +4,7 @@ import jwt
 
 from allauth.socialaccount.models import SocialAccount
 from django.conf import settings
+from django.urls import reverse
 
 from iaso import models as m
 from iaso.test import APITestCase
@@ -179,3 +180,17 @@ class WFPAuthTestCase(APITestCase):
         payload = jwt.decode(access_token, settings.SECRET_KEY, algorithms=["HS256"])
         token_user_id = payload["user_id"]
         self.assertEqual(token_user_id, tenant_user.id)  # It should be the tenant user.
+
+    def test_web_callback_cancelled_login_does_not_crash(self):
+        """Cancelling WFP login must redirect, not 500, even when SSO_PROVIDERS is empty.
+
+        WFP is not in SSO_PROVIDERS; allauth still reverses socialaccount_login_cancelled.
+        """
+        response = self.client.get("/wfp_auth/wfp/login/callback/?error=access_denied")
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, reverse("socialaccount_login_cancelled"))
+
+    def test_web_callback_error_page_renders_without_crashing(self):
+        """A generic WFP SSO error on the web callback must render a page, not 500."""
+        response = self.client.get("/wfp_auth/wfp/login/callback/?error=server_error")
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
## What problem is this PR solving?

Any SSO login error (invalid token, cancelled login, multiple accounts sharing an email, etc.) crashed with a raw 500 error instead of showing a friendly message.

### Related JIRA tickets

POLIO-2195

## Changes

- `hat/templates/account/base.html` (new): a project-owned override of allauth's default `account/base.html`. The stock allauth template's nav menu references URL names (`account_login`, `account_signup`, `account_email`, `account_logout`) that only exist if `allauth.account.urls` is registered — this project never registers them, since it has its own separate login system. Every SSO error page extends this template (via `socialaccount/base.html`), so rendering *any* SSO error crashed with `NoReverseMatch`. The override drops that menu block entirely (nothing in this project needs it).
- `hat/urls.py`: registers the missing `socialaccount_login_cancelled` URL name (redirecting to `settings.LOGIN_URL`). allauth's `render_authentication_error()` reverses this name specifically for the "user cancelled the login on the provider's side" case (`?error=access_denied`), which is a separate crash from the template one above — same root cause (unregistered allauth URLs), different code path.
- `hat/tests/test_sso_auth.py`: two new regression tests hitting the web (browser) callback directly — previously only the mobile/JSON token endpoint had test coverage, so this whole code path was untested. One test covers the cancelled-login redirect, the other covers the generic error-page render.

## How to test

- Automated: `./manage.py test hat.tests.test_sso_auth` (13 tests, all pass).
- Manual: with `SSO_WHO_*` configured, trigger any SSO error on the web login flow (e.g. click "Cancel" on the Microsoft login screen, or use an account that maps to more than one IASO user) — should land on a clean redirect/error page instead of a 500.

## Print screen / video

N/A — backend error-handling fix, no significant visual to capture.

## Notes

- Found while investigating a real production 500 for a WHO user who has two separate IASO accounts sharing the same email. SSO correctly detected the ambiguity and refused to guess which account to log into — but rendering that refusal as a page is what crashed. This PR fixes the crash; the underlying duplicate-account issue for that specific user is a separate, non-blocking data cleanup (tracked in POLIO-2195's description) that needs an admin decision on which account is canonical.
- Independent of (and does not depend on) the still-open POLIO-2192 PR (#3283, "SSO should not auto-provision unknown users") — that PR also touches this file but for a different reason (removing auto-account-creation). No functional overlap; only proximity in the same file.

## Doc

None.
