### PR TITLE
IA-5158-py-spy-replacement-via-signal-handler

### DIFF
--- a/iaso/apps.py
+++ b/iaso/apps.py
@@ -6,3 +6,6 @@ class IasoConfig(AppConfig):
 
     def ready(self):
         from .auth import signals  # noqa: F401
+        from .stack_dump import register_stack_dump_signal
+
+        register_stack_dump_signal()

--- a/iaso/stack_dump.py
+++ b/iaso/stack_dump.py
@@ -1,0 +1,28 @@
+import faulthandler
+import signal
+import sys
+
+
+def register_stack_dump_signal(file=None):
+    """Dump every thread's stack to stderr (-> container logs) on SIGUSR2.
+
+    Our production images run as a non-root user, and Elastic Beanstalk gives
+    us no way to grant the container SYS_PTRACE, so tools like py-spy can't
+    attach from inside the container. This gives us an equivalent, in-process
+    way to inspect a stuck process:
+
+        kill -USR2 <pid>
+
+    SIGUSR1 is intentionally left alone: gunicorn's master already uses it to
+    reopen log files.
+
+    chain=False (the default) is required here: SIGUSR2's default
+    disposition is to terminate the process, so chaining to it would kill
+    the process right after dumping its stack instead of just logging it.
+
+    `file` defaults to stderr; tests can pass a real file to inspect the dump.
+    """
+    if not hasattr(signal, "SIGUSR2"):
+        return  # no SIGUSR2 on Windows (local dev only)
+
+    faulthandler.register(signal.SIGUSR2, file=file or sys.stderr, all_threads=True, chain=False)

--- a/iaso/tests/test_stack_dump.py
+++ b/iaso/tests/test_stack_dump.py
@@ -1,0 +1,32 @@
+import os
+import signal
+import tempfile
+
+from django.test import SimpleTestCase
+
+from iaso.stack_dump import register_stack_dump_signal
+
+
+class StackDumpSignalTestCase(SimpleTestCase):
+    def tearDown(self):
+        # Don't leak our handler into other tests / the process.
+        if hasattr(signal, "SIGUSR2"):
+            signal.signal(signal.SIGUSR2, signal.SIG_DFL)
+
+    def test_sigusr2_dumps_stack_and_process_survives(self):
+        if not hasattr(signal, "SIGUSR2"):
+            self.skipTest("SIGUSR2 is not available on this platform")
+
+        with tempfile.NamedTemporaryFile() as tmp:
+            register_stack_dump_signal(file=tmp)
+
+            # If this regresses to chain=True, SIGUSR2's default disposition
+            # (terminate the process) fires right after the dump, and the
+            # test process is killed here instead of reaching the assertions.
+            os.kill(os.getpid(), signal.SIGUSR2)
+
+            tmp.seek(0)
+            dump = tmp.read().decode()
+
+        self.assertIn("Current thread", dump)
+        self.assertIn("test_sigusr2_dumps_stack_and_process_survives", dump)


### PR DESCRIPTION
## What problem is this PR solving?

py-spy is no more working since we are in root less container and ptrace is not working in these conditions (os limiting strace, no capabilities given to the container,...).
during an incident it adds a nice value to have such threaddump (see which portion of the code is running/looping/waiting/...)

### Related JIRA tickets

IA-5158

## Changes

it's a technique used in other languages (ruby, java) to issue signal and hope a thread can still dump the threadstack.

## How to test

if locally via docker, find your server (note it works with managed commands or workers)

```
ps ax | grep manage
 119640 pts/0    R+     0:01 python ./manage.py runserver 0.0.0.0:8081
 119715 pts/7    S+     0:00 grep --color=auto manage

```

then issue a USR2 signal

```
sudo kill -USR2 119640 

```
the stderr of the container will dump the running threads
```
iaso-1     | Thread 0x00007cd7227e96c0 (most recent call first):
iaso-1     |   File "/usr/local/lib/python3.9/selectors.py", line 416 in select
iaso-1     |   File "/usr/local/lib/python3.9/socketserver.py", line 232 in serve_forever
iaso-1     |   File "/usr/local/lib/python3.9/site-packages/django/core/servers/basehttp.py", line 281 in run
iaso-1     |   File "/usr/local/lib/python3.9/site-packages/django/core/management/commands/runserver.py", line 140 in inner_run
iaso-1     |   File "/usr/local/lib/python3.9/site-packages/django/utils/autoreload.py", line 64 in wrapper
iaso-1     |   File "/usr/local/lib/python3.9/threading.py", line 917 in run
iaso-1     |   File "/usr/local/lib/python3.9/threading.py", line 980 in _bootstrap_inner
iaso-1     |   File "/usr/local/lib/python3.9/threading.py", line 937 in _bootstrap
iaso-1     |
iaso-1     | Current thread 0x00007cd7573b9b80 (most recent call first):
iaso-1     |   File "/usr/local/lib/python3.9/site-packages/django/utils/autoreload.py", line 404 in tick
iaso-1     |   File "/usr/local/lib/python3.9/site-packages/django/utils/autoreload.py", line 349 in run_loop
iaso-1     |   File "/usr/local/lib/python3.9/site-packages/django/utils/autoreload.py", line 343 in run
iaso-1     |   File "/usr/local/lib/python3.9/site-packages/django/utils/autoreload.py", line 659 in start_django
iaso-1     |   File "/usr/local/lib/python3.9/site-packages/django/utils/autoreload.py", line 670 in run_with_reloader
iaso-1     |   File "/usr/local/lib/python3.9/site-packages/django/core/management/commands/runserver.py", line 118 in run
iaso-1     |   File "/usr/local/lib/python3.9/site-packages/django/core/management/commands/runserver.py", line 111 in handle
iaso-1     |   File "/usr/local/lib/python3.9/site-packages/django/core/management/base.py", line 458 in execute
iaso-1     |   File "/usr/local/lib/python3.9/site-packages/django/core/management/commands/runserver.py", line 74 in execute
iaso-1     |   File "/usr/local/lib/python3.9/site-packages/django/core/management/base.py", line 412 in run_from_argv
iaso-1     |   File "/usr/local/lib/python3.9/site-packages/django/core/management/__init__.py", line 436 in execute
iaso-1     |   File "/usr/local/lib/python3.9/site-packages/django/core/management/__init__.py", line 442 in execute_from_command_line
iaso-1     |   File "/opt/app/./manage.py", line 11 in <module>
```

the next step will be to adapt diagnose command of our devops toolbox

## Print screen / video

Upload here print screens or videos showing the changes.

## Notes

why usr2 ? other signals are already taken by gunicorn so it's the safest

## Doc

