### PR TITLE
IA-5377: Add follow task option to org unit bulk edit dialog

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -1190,6 +1190,8 @@
     "iaso.orgUnits.addSource": "Add source",
     "iaso.orgUnits.addToGroups": "Add to group(s)",
     "iaso.orgUnits.bulkChangeCount": "You are about to change {count} Org units",
+    "iaso.orgUnits.bulkChangeTaskHelp": "The modification runs in the background and can take a few minutes.",
+    "iaso.orgUnits.modifyAndFollow": "Modify and follow",
     "iaso.orgUnits.closingDate": "Closing date",
     "iaso.orgUnits.code": "Code",
     "iaso.orgUnits.confirmMultiChange": "Confirm bulk changes ?",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/es.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/es.json
@@ -972,6 +972,8 @@
     "iaso.orgUnits.addSource": "Agregar fuente",
     "iaso.orgUnits.addToGroups": "Agregar a grupo(s)",
     "iaso.orgUnits.bulkChangeCount": "Está a punto de cambiar {count} unidades organizativas",
+    "iaso.orgUnits.bulkChangeTaskHelp": "La modificación se ejecuta en segundo plano y puede tardar unos minutos.",
+    "iaso.orgUnits.modifyAndFollow": "Modificar y seguir",
     "iaso.orgUnits.closingDate": "Fecha de cierre",
     "iaso.orgUnits.confirmMultiChange": "¿Confirmar cambios masivos?",
     "iaso.orgUnits.createdBy": "Creado por",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -1191,6 +1191,8 @@
     "iaso.orgUnits.addSource": "Ajouter une source",
     "iaso.orgUnits.addToGroups": "Ajouter au(x) groupe(s)",
     "iaso.orgUnits.bulkChangeCount": "Vous allez modifier {count} unités d'org.",
+    "iaso.orgUnits.bulkChangeTaskHelp": "La modification s'exécute en arrière-plan et peut prendre quelques minutes.",
+    "iaso.orgUnits.modifyAndFollow": "Modifier et suivre",
     "iaso.orgUnits.closingDate": "Date de fermeture",
     "iaso.orgUnits.code": "Code",
     "iaso.orgUnits.confirmMultiChange": "Confirmer les modifications multiples ?",

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitsMultiActionsDialog.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitsMultiActionsDialog.tsx
@@ -68,16 +68,6 @@ const useStyles = makeStyles(theme => ({
         display: 'flex',
         alignItems: 'center',
     },
-    warningIcon: {
-        display: 'inline-block',
-        marginLeft: theme.spacing(1),
-        marginRight: theme.spacing(1),
-    },
-    warningMessage: {
-        display: 'flex',
-        justifyContent: 'center',
-        alignItems: 'center',
-    },
 }));
 
 const stringOfIdsToArrayofIds = stringValue =>

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitsMultiActionsDialog.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitsMultiActionsDialog.tsx
@@ -3,6 +3,7 @@ import React, { FunctionComponent, useMemo, useState } from 'react';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import ReportIcon from '@mui/icons-material/Report';
 import {
+    Alert,
     Box,
     Button,
     Dialog,
@@ -17,13 +18,16 @@ import { makeStyles } from '@mui/styles';
 import {
     commonStyles,
     formatThousand,
+    useRedirectTo,
     useSafeIntl,
 } from 'bluesquare-components';
 // @ts-ignore
 import { UseMutateAsyncFunction } from 'react-query';
-import ConfirmDialog from '../../../components/dialogs/ConfirmDialogComponent';
 import InputComponent from '../../../components/forms/InputComponent';
+import { baseUrls } from '../../../constants/urls';
+import * as Permission from '../../../utils/permissions';
 import { useCurrentUser } from '../../../utils/usersUtils';
+import { userHasPermission } from '../../users/utils';
 
 import { useGetGroupDropdown } from '../hooks/requests/useGetGroups';
 import { useGetOrgUnitValidationStatus } from '../hooks/utils/useGetOrgUnitValidationStatus';
@@ -72,6 +76,7 @@ const useStyles = makeStyles(theme => ({
     warningMessage: {
         display: 'flex',
         justifyContent: 'center',
+        alignItems: 'center',
     },
 }));
 
@@ -90,6 +95,7 @@ export const OrgUnitsMultiActionsDialog: FunctionComponent<Props> = ({
     const { formatMessage } = useSafeIntl();
     const classes: Record<string, string> = useStyles();
     const theme = useTheme();
+    const redirectTo = useRedirectTo();
     const { data: orgUnitTypes } = useGetOrgUnitTypesDropdownOptions({
         onlyWriteAccess: true,
     });
@@ -105,8 +111,13 @@ export const OrgUnitsMultiActionsDialog: FunctionComponent<Props> = ({
     const [validationStatus, setValidationStatus] = useState<
         string | undefined
     >(undefined);
+    const [openConfirmDialog, setOpenConfirmDialog] = useState<boolean>(false);
 
     const currentUser = useCurrentUser();
+    const hasTaskPermission = userHasPermission(
+        Permission.DATA_TASKS,
+        currentUser,
+    );
     const searches = useMemo(
         () => decodeSearch(decodeURI(params.searches)),
         [params.searches],
@@ -173,9 +184,10 @@ export const OrgUnitsMultiActionsDialog: FunctionComponent<Props> = ({
         setEditValidation(false);
         setUpdateGPS(false);
         setValidationStatus(undefined);
+        setOpenConfirmDialog(false);
         closeDialog();
     };
-    const saveAndReset = () => {
+    const saveAndReset = (redirect = false) => {
         const data: SaveData = {};
         if (editGroups) {
             if (groupsAdded.length > 0) {
@@ -209,7 +221,14 @@ export const OrgUnitsMultiActionsDialog: FunctionComponent<Props> = ({
             ...data,
             saveGPS: updateGPS,
             saveOtherField: editValidation || editOrgUnitType || editGroups,
-        }).then(() => closeAndReset());
+        }).then(() => {
+            closeAndReset();
+            if (redirect) {
+                redirectTo(baseUrls.tasks, {
+                    order: '-created_at',
+                });
+            }
+        });
     };
     return (
         <Dialog
@@ -363,41 +382,73 @@ export const OrgUnitsMultiActionsDialog: FunctionComponent<Props> = ({
                     {formatMessage(MESSAGES.cancel)}
                 </Button>
 
-                <ConfirmDialog
-                    withDivider
-                    btnMessage={formatMessage(MESSAGES.validate)}
-                    question={
-                        <Box className={classes.warningTitle}>
-                            <ReportIcon
-                                className={classes.warningIcon}
-                                color="error"
-                                fontSize="large"
-                            />
-                            {formatMessage(MESSAGES.confirmMultiChange)}
-                            <ReportIcon
-                                className={classes.warningIcon}
-                                color="error"
-                                fontSize="large"
-                            />
-                        </Box>
-                    }
-                    message={
-                        <Typography
-                            variant="body2"
-                            color="error"
-                            component="span"
-                            className={classes.warningMessage}
-                        >
-                            {formatMessage(MESSAGES.bulkChangeCount, {
-                                count: `${formatThousand(selectCount)}`,
-                            })}
-                        </Typography>
-                    }
-                    confirm={() => saveAndReset()}
-                    btnDisabled={isSaveDisabled()}
-                    btnVariant="text"
-                />
+                <Button
+                    onClick={() => setOpenConfirmDialog(true)}
+                    disabled={isSaveDisabled()}
+                    color="primary"
+                >
+                    {formatMessage(MESSAGES.validate)}
+                </Button>
             </DialogActions>
+            <Dialog
+                open={openConfirmDialog}
+                onClose={(event, reason) => {
+                    if (reason === 'backdropClick') {
+                        setOpenConfirmDialog(false);
+                    }
+                }}
+            >
+                <DialogTitle>
+                    <Box className={classes.warningTitle}>
+                        {formatMessage(MESSAGES.confirmMultiChange)}
+                    </Box>
+                </DialogTitle>
+                <DialogContent>
+                    <Box display="flex" flexDirection="column" gap={2} pt={1}>
+                        <Alert
+                            severity="error"
+                            icon={<ReportIcon />}
+                            sx={{
+                                alignItems: 'center',
+                            }}
+                        >
+                            <Typography variant="body2" fontWeight="bold">
+                                {formatMessage(MESSAGES.bulkChangeCount, {
+                                    count: `${formatThousand(selectCount)}`,
+                                })}
+                            </Typography>
+                        </Alert>
+                        <Typography variant="body2" color="text.secondary">
+                            {formatMessage(MESSAGES.bulkChangeTaskHelp)}
+                        </Typography>
+                    </Box>
+                </DialogContent>
+                <DialogActions className={classes.action}>
+                    <Button
+                        onClick={() => setOpenConfirmDialog(false)}
+                        color="primary"
+                    >
+                        {formatMessage(MESSAGES.no)}
+                    </Button>
+                    <Button
+                        onClick={() => saveAndReset()}
+                        color="primary"
+                        autoFocus={!hasTaskPermission}
+                    >
+                        {formatMessage(MESSAGES.yes)}
+                    </Button>
+                    {hasTaskPermission && (
+                        <Button
+                            onClick={() => saveAndReset(true)}
+                            color="primary"
+                            variant="contained"
+                            autoFocus
+                        >
+                            {formatMessage(MESSAGES.modifyAndFollow)}
+                        </Button>
+                    )}
+                </DialogActions>
+            </Dialog>
         </Dialog>
     );
 };

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/messages.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/messages.ts
@@ -390,6 +390,15 @@ const MESSAGES = defineMessages({
         id: 'iaso.orgUnits.bulkChangeCount',
         defaultMessage: 'You are about to change {count} Org units',
     },
+    bulkChangeTaskHelp: {
+        id: 'iaso.orgUnits.bulkChangeTaskHelp',
+        defaultMessage:
+            'The modification runs in the background and can take a few minutes.',
+    },
+    modifyAndFollow: {
+        id: 'iaso.orgUnits.modifyAndFollow',
+        defaultMessage: 'Modify and follow',
+    },
     fetchAlgorithmsError: {
         id: 'iaso.snackBar.fetchAlgorithmsError',
         defaultMessage: 'An error occurred while fetching algorithms list',
@@ -632,6 +641,18 @@ const MESSAGES = defineMessages({
     orgUnitRejected: {
         id: 'iaso.orgUnits.orgUnitRejected',
         defaultMessage: 'Org Unit rejected successfully',
+    },
+    goToCurrentTask: {
+        id: 'iaso.label.goToCurrentTask',
+        defaultMessage: 'Launch and show task',
+    },
+    yes: {
+        id: 'iaso.label.yes',
+        defaultMessage: 'Yes',
+    },
+    no: {
+        id: 'iaso.label.no',
+        defaultMessage: 'No',
     },
 });
 

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/messages.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/messages.ts
@@ -642,10 +642,6 @@ const MESSAGES = defineMessages({
         id: 'iaso.orgUnits.orgUnitRejected',
         defaultMessage: 'Org Unit rejected successfully',
     },
-    goToCurrentTask: {
-        id: 'iaso.label.goToCurrentTask',
-        defaultMessage: 'Launch and show task',
-    },
     yes: {
         id: 'iaso.label.yes',
         defaultMessage: 'Yes',


### PR DESCRIPTION
## What problem is this PR solving?

Add a button to confirm and follow the task when editing org units in bulk. 

### Related JIRA tickets

refs: IA-5377

## Changes

Similar to what we already have for the data sources dialog, add a confirm & follow task button. 

## How to test

- Test the bulk edit confirmation dialog:
  - Go the Org Unit list page
  - select multiple org units
  - use the speed dial actions to edit the org units
  - pick a random attribute to modify and click "validate"
- To be extra thorough, check that the dialog works properly when the user doesn't have the tasks permissions ("Batch monitoring" under user permissions), in which case the follow button should not appear. 

## Print screen / video

<img width="628" height="564" alt="Screenshot 2026-08-31 at 11 25 47" src="https://github.com/user-attachments/assets/4f92bd58-5a96-4ebd-bae6-af462742477a" />

## Notes

/ 

## Doc

/