### PR TITLE
[IA-5393] Fix Mobile Validation Workflow returns all instances

### DIFF
--- a/iaso/api/validation_workflows/serializers/mobile.py
+++ b/iaso/api/validation_workflows/serializers/mobile.py
@@ -7,8 +7,6 @@ from iaso.api.common import ModelSerializer, TimestampField
 from iaso.api.validation_workflows.constants import DEFAULT_COLOR, MOBILE_STATUS_TO_COLOR
 from iaso.api.validation_workflows.serializers.common import UserDisplayNameField
 from iaso.models import Instance, ValidationNode
-from iaso.models.common import ValidationWorkflowArtefactStatus
-from iaso.models.validation_workflow.validation_node import ValidationNodeStatus
 
 
 class NestedHistorySerializer(ModelSerializer):
@@ -40,9 +38,9 @@ class NestedHistorySerializer(ModelSerializer):
 class MobileValidationWorkflowListSerializer(ModelSerializer):
     instance_id = serializers.CharField(read_only=True, source="uuid")
     created_at = TimestampField(read_only=True)
-    history = serializers.SerializerMethodField(read_only=True)
+    history = NestedHistorySerializer(source="all_validation_nodes", many=True)
     validation_status = serializers.CharField(read_only=True, source="general_validation_status")
-    rejection_comment = serializers.SerializerMethodField(read_only=True)
+    rejection_comment = serializers.CharField(read_only=True)
     updated_at = serializers.SerializerMethodField(label="Timestamp of the last update (history)", read_only=True)
     name = serializers.CharField(read_only=True, source="form.name")
     display_name = serializers.SerializerMethodField(read_only=True)
@@ -60,26 +58,9 @@ class MobileValidationWorkflowListSerializer(ModelSerializer):
             "history",
         ]
 
-    @extend_schema_field({"type": "string", "nullable": True})
-    def get_rejection_comment(self, obj):
-        if obj.general_validation_status == ValidationWorkflowArtefactStatus.REJECTED:
-            return (
-                obj.validationnode_set.filter(status=ValidationNodeStatus.REJECTED)
-                .only("status", "comment")
-                .first()
-                .comment
-            )
-        return None
-
-    @extend_schema_field(NestedHistorySerializer(many=True))
-    def get_history(self, obj):
-        return NestedHistorySerializer(
-            obj.get_all_validation_nodes().select_related("created_by", "updated_by", "node"), many=True
-        ).data
-
     @extend_schema_field({"type": "integer", "format": "int64", "nullable": True})
     def get_updated_at(self, obj):
-        updated_at = getattr(obj.validationnode_set.all().order_by("-updated_at").first(), "updated_at", None)
+        updated_at = obj.last_updated_at
         return updated_at.timestamp() if updated_at else None
 
     @extend_schema_field({"type": "string", "nullable": True})

--- a/iaso/api/validation_workflows/views_mobile.py
+++ b/iaso/api/validation_workflows/views_mobile.py
@@ -25,12 +25,16 @@ class ValidationWorkflowMobileViewSet(CustomPaginationListModelMixin, GenericVie
 
     def get_queryset(self):
         return (
-            Instance.objects.filter_for_user(self.request.user)
+            Instance.objects.with_all_validation_nodes()
+            .with_rejection_comment()
+            .with_last_updated_at()
+            .filter_for_user(self.request.user)
             .select_related("form")
             .filter(
                 form__deleted_at__isnull=True,
                 validationnode__isnull=False,
                 form__validation_workflow__deleted_at__isnull=True,
             )
+            .filter(created_by=self.request.user)
             .distinct("id")
         )

--- a/iaso/api/validation_workflows_nodes/serializers/retrieve.py
+++ b/iaso/api/validation_workflows_nodes/serializers/retrieve.py
@@ -30,7 +30,7 @@ class NestedHistorySerializer(ModelSerializer):
 class MobileValidationWorkflowListSerializer(ModelSerializer):
     instance_id = serializers.CharField(read_only=True, source="uuid")
     created_at = TimestampField(read_only=True)
-    history = NestedHistorySerializer(read_only=True, source="get_all_validation_nodes", many=True)
+    history = NestedHistorySerializer(read_only=True, source="all_validation_nodes", many=True)
     validation_status = serializers.CharField(read_only=True, source="general_validation_status")
     rejection_comment = serializers.SerializerMethodField(read_only=True)
     updated_at = serializers.SerializerMethodField(label="Timestamp of the last update (history)", read_only=True)

--- a/iaso/models/common.py
+++ b/iaso/models/common.py
@@ -1,6 +1,8 @@
 from autoslug import AutoSlugField
 from autoslug.utils import crop_slug, get_prepopulated_value
 from django.db import models
+from django.db.models import Prefetch
+from django.db.models.expressions import Case, OuterRef, Subquery, When
 from django.utils.translation import gettext_lazy as _
 
 
@@ -16,6 +18,48 @@ class ValidationWorkflowArtefactStatus(models.TextChoices):
     APPROVED = "APPROVED", _("Approved")
     REJECTED = "REJECTED", _("Rejected")
     PENDING = "PENDING", _("Pending")
+
+
+class ValidationWorkflowArtefactQuerySet(models.QuerySet):
+    def with_rejection_comment(self):
+        from iaso.models import ValidationNode
+        from iaso.models.validation_workflow.validation_node import ValidationNodeStatus
+
+        return self.annotate(
+            rejection_comment=Case(
+                When(
+                    general_validation_status=ValidationWorkflowArtefactStatus.REJECTED,
+                    then=Subquery(
+                        ValidationNode.objects.filter(instance=OuterRef("pk"), status=ValidationNodeStatus.REJECTED)
+                        .order_by("-updated_at")
+                        .values("comment")[:1]
+                    ),
+                ),
+                default=None,
+            ),
+        )
+
+    def with_last_updated_at(self):
+        from iaso.models import ValidationNode
+
+        return self.annotate(
+            last_updated_at=Subquery(
+                ValidationNode.objects.filter(instance=OuterRef("pk")).order_by("-updated_at").values("updated_at")[:1]
+            )
+        )
+
+    def with_all_validation_nodes(self, workflow=None):
+        from iaso.models import ValidationNode
+
+        return self.prefetch_related(
+            Prefetch(
+                "validationnode_set",
+                queryset=ValidationNode.objects.filter(**{"node__workflow": workflow} if workflow else {})
+                .order_by("-created_at")
+                .select_related("created_by", "updated_by", "node"),
+                to_attr="all_validation_nodes",
+            )
+        )
 
 
 class ValidationWorkflowArtefact(models.Model):
@@ -35,16 +79,6 @@ class ValidationWorkflowArtefact(models.Model):
         return self.validationnode_set.filter(
             status=ValidationNodeStatus.UNKNOWN, **{"node__workflow": workflow} if workflow else {}
         )
-
-    def get_all_validation_nodes(self, workflow=None):
-        """
-        Function to recursively get all validation nodes and order them
-        """
-        from iaso.models import ValidationNode
-
-        return ValidationNode.objects.filter(
-            instance_id=self.pk, **{"node__workflow": workflow} if workflow else {}
-        ).order_by("-created_at")
 
 
 class BulkAutoSlugField(AutoSlugField):

--- a/iaso/models/instances.py
+++ b/iaso/models/instances.py
@@ -34,7 +34,7 @@ from iaso.utils.models.sized_file_field import SizedFileField
 from iaso.utils.models.upload_to import get_account_name_based_on_user
 
 from ..utils.dhis2 import generate_id_for_dhis_2
-from .common import ValidationWorkflowArtefact
+from .common import ValidationWorkflowArtefact, ValidationWorkflowArtefactQuerySet
 from .device import Device, DeviceOwnership
 from .forms import Form, FormVersion
 from .org_unit import OrgUnit, OrgUnitReferenceInstance
@@ -85,7 +85,7 @@ def resolve_status_form_ids(form_id=None, form_ids=None):
     return resolved or None
 
 
-class InstanceQuerySet(django_cte.CTEQuerySet):
+class InstanceQuerySet(django_cte.CTEQuerySet, ValidationWorkflowArtefactQuerySet):
     def with_lock_info(self, user):
         """
         Annotate the QuerySet with the lock info for the given user.

--- a/iaso/tests/api/validation_workflow_instances/test_views/test_retrieve.py
+++ b/iaso/tests/api/validation_workflow_instances/test_views/test_retrieve.py
@@ -5,7 +5,7 @@ from django.urls import reverse
 from rest_framework import status
 
 from iaso.engine.validation_workflow import ValidationWorkflowEngine
-from iaso.models import Account, Form, Project, UserRole, ValidationNodeTemplate, ValidationWorkflow
+from iaso.models import Account, Form, Instance, Project, UserRole, ValidationNodeTemplate, ValidationWorkflow
 from iaso.models.common import ValidationWorkflowArtefactStatus
 from iaso.models.validation_workflow.validation_node import ValidationNodeStatus
 from iaso.modules import MODULE_VALIDATION_WORKFLOW
@@ -247,7 +247,7 @@ class ValidationWorkflowInstanceAPIRetrieveTestCase(SwaggerTestCaseMixin, APITes
 
     def test_node_in_wrong_workflow(self):
         self.setup_approve()
-        nodes = self.instance.get_all_validation_nodes()
+        nodes = Instance.objects.filter(pk=self.instance.pk).with_all_validation_nodes().first().all_validation_nodes
         node = nodes[1]
         node.node = self.wrong_node
         node.save()

--- a/iaso/tests/api/validation_workflows/test_views_mobile.py
+++ b/iaso/tests/api/validation_workflows/test_views_mobile.py
@@ -68,12 +68,46 @@ class MobileValidationWorkflowAPITestCase(APITestCase):
                 "C": "Item C",
                 "D": "Item D",
             },
+            created_by=self.john_wick,
+        )
+        self.instance2 = self.create_form_instance(
+            form=self.form,
+            project=self.project,
+            uuid=str(uuid.uuid4()),
+            json={
+                "A": "Item A",
+                "B": "Item B",
+                "C": "Item C",
+            },
+            created_by=self.john_wick,
+        )
+        self.instance3 = self.create_form_instance(
+            form=self.form,
+            project=self.project,
+            uuid=str(uuid.uuid4()),
+            json={
+                "A": "Item A",
+                "C": "Item C",
+            },
+            created_by=self.john_wick,
+        )
+
+        self.john_doe_instance = self.create_form_instance(
+            form=self.form,
+            project=self.project,
+            uuid=str(uuid.uuid4()),
+            json={
+                "A": "Item A",
+                "B": "Item B",
+            },
+            created_by=self.john_doe,
         )
 
         self.other_instance = self.create_form_instance(
             form=self.other_form,
             project=self.other_project,
             uuid=str(uuid.uuid4()),
+            created_by=self.jane_doe,
         )
 
     @staticmethod
@@ -87,9 +121,17 @@ class MobileValidationWorkflowAPITestCase(APITestCase):
 
     def setup_start(self):
         ValidationWorkflowEngine.start(self.validation_workflow, self.john_wick, self.instance)
+        ValidationWorkflowEngine.start(self.validation_workflow, self.john_wick, self.instance2)
+        ValidationWorkflowEngine.start(self.validation_workflow, self.john_wick, self.instance3)
+        ValidationWorkflowEngine.start(self.validation_workflow, self.jane_doe, self.other_instance)
+        ValidationWorkflowEngine.start(self.validation_workflow, self.john_doe, self.john_doe_instance)
 
     def setup_approve(self):
         ValidationWorkflowEngine.start(self.validation_workflow, self.john_wick, self.instance)
+        ValidationWorkflowEngine.start(self.validation_workflow, self.john_wick, self.instance2)
+        ValidationWorkflowEngine.start(self.validation_workflow, self.john_wick, self.instance3)
+        ValidationWorkflowEngine.start(self.validation_workflow, self.jane_doe, self.other_instance)
+        ValidationWorkflowEngine.start(self.validation_workflow, self.john_doe, self.john_doe_instance)
 
         i = 0
         while self.instance.get_next_pending_nodes(self.validation_workflow).count():
@@ -104,6 +146,10 @@ class MobileValidationWorkflowAPITestCase(APITestCase):
 
     def setup_reject(self):
         ValidationWorkflowEngine.start(self.validation_workflow, self.john_wick, self.instance)
+        ValidationWorkflowEngine.start(self.validation_workflow, self.john_wick, self.instance2)
+        ValidationWorkflowEngine.start(self.validation_workflow, self.john_wick, self.instance3)
+        ValidationWorkflowEngine.start(self.validation_workflow, self.jane_doe, self.other_instance)
+        ValidationWorkflowEngine.start(self.validation_workflow, self.john_doe, self.john_doe_instance)
 
         i = 0
         while self.instance.get_next_pending_nodes(self.validation_workflow).count():
@@ -139,6 +185,7 @@ class MobileValidationWorkflowAPITestCase(APITestCase):
             form=self.form,
             project=self.project,
             uuid=str(uuid.uuid4()),
+            created_by=self.john_wick,
         )
 
         self.client.force_authenticate(self.john_wick)
@@ -149,7 +196,7 @@ class MobileValidationWorkflowAPITestCase(APITestCase):
         res = self.client.get(reverse("mobile_validation_workflows-list"))
 
         res_data = self.assertJSONResponse(res, status.HTTP_200_OK)
-        self.assertValidListData(list_data=res_data, results_key="results", expected_length=2, paginated=True)
+        self.assertValidListData(list_data=res_data, results_key="results", expected_length=4, paginated=True)
 
         res = self.client.get(reverse("mobile_validation_workflows-list"), data={"limit": 1})
 
@@ -170,10 +217,14 @@ class MobileValidationWorkflowAPITestCase(APITestCase):
 
         res_data = self.assertJSONResponse(res, status.HTTP_200_OK)
 
-        self.assertValidListData(list_data=res_data, results_key="results", expected_length=1, paginated=True)
+        self.assertValidListData(list_data=res_data, results_key="results", expected_length=3, paginated=True)
 
         self.instance.form = None
         self.instance.save()
+        self.instance2.form = None
+        self.instance2.save()
+        self.instance3.form = None
+        self.instance3.save()
 
         res = self.client.get(reverse("mobile_validation_workflows-list"), data={"app_id": "1.1"})
 
@@ -183,8 +234,13 @@ class MobileValidationWorkflowAPITestCase(APITestCase):
 
         self.instance.project = None
         self.instance.form = self.form
-
         self.instance.save()
+        self.instance2.project = None
+        self.instance2.form = self.form
+        self.instance2.save()
+        self.instance3.project = None
+        self.instance3.form = self.form
+        self.instance3.save()
 
         res = self.client.get(reverse("mobile_validation_workflows-list"), data={"app_id": "1.1"})
 
@@ -214,7 +270,7 @@ class MobileValidationWorkflowAPITestCase(APITestCase):
 
         res_data = self.assertJSONResponse(res, status.HTTP_200_OK)
 
-        self.assertValidListData(list_data=res_data, results_key="results", expected_length=1, paginated=True)
+        self.assertValidListData(list_data=res_data, results_key="results", expected_length=3, paginated=True)
 
         res = self.client.get(
             reverse("mobile_validation_workflows-list"),
@@ -227,7 +283,7 @@ class MobileValidationWorkflowAPITestCase(APITestCase):
 
         res_data = self.assertJSONResponse(res, status.HTTP_200_OK)
 
-        self.assertValidListData(list_data=res_data, results_key="results", expected_length=1, paginated=True)
+        self.assertValidListData(list_data=res_data, results_key="results", expected_length=3, paginated=True)
 
     def test_should_not_contain_instances_where_form_are_soft_deleted(self):
         self.client.force_authenticate(self.john_wick)
@@ -237,7 +293,7 @@ class MobileValidationWorkflowAPITestCase(APITestCase):
         res = self.client.get(reverse("mobile_validation_workflows-list"))
 
         res_data = self.assertJSONResponse(res, status.HTTP_200_OK)
-        self.assertValidListData(list_data=res_data, results_key="results", expected_length=1, paginated=True)
+        self.assertValidListData(list_data=res_data, results_key="results", expected_length=3, paginated=True)
 
         self.form.delete()
 
@@ -258,7 +314,7 @@ class MobileValidationWorkflowAPITestCase(APITestCase):
         res = self.client.get(reverse("mobile_validation_workflows-list"))
 
         res_data = self.assertJSONResponse(res, status.HTTP_200_OK)
-        self.assertValidListData(list_data=res_data, results_key="results", expected_length=1, paginated=True)
+        self.assertValidListData(list_data=res_data, results_key="results", expected_length=3, paginated=True)
 
         self.assertEqual(res_data["results"][0]["instance_id"], self.instance.uuid)
 
@@ -291,7 +347,7 @@ class MobileValidationWorkflowAPITestCase(APITestCase):
         res = self.client.get(reverse("mobile_validation_workflows-list"))
 
         res_data = self.assertJSONResponse(res, status.HTTP_200_OK)
-        self.assertValidListData(list_data=res_data, results_key="results", expected_length=1, paginated=True)
+        self.assertValidListData(list_data=res_data, results_key="results", expected_length=3, paginated=True)
 
         instance_data = res_data["results"][0]
 
@@ -337,7 +393,7 @@ class MobileValidationWorkflowAPITestCase(APITestCase):
         res = self.client.get(reverse("mobile_validation_workflows-list"))
 
         res_data = self.assertJSONResponse(res, status.HTTP_200_OK)
-        self.assertValidListData(list_data=res_data, results_key="results", expected_length=1, paginated=True)
+        self.assertValidListData(list_data=res_data, results_key="results", expected_length=3, paginated=True)
 
         instance_data = res_data["results"][0]
 
@@ -399,7 +455,7 @@ class MobileValidationWorkflowAPITestCase(APITestCase):
         res = self.client.get(reverse("mobile_validation_workflows-list"))
 
         res_data = self.assertJSONResponse(res, status.HTTP_200_OK)
-        self.assertValidListData(list_data=res_data, results_key="results", expected_length=1, paginated=True)
+        self.assertValidListData(list_data=res_data, results_key="results", expected_length=3, paginated=True)
 
         instance_data = res_data["results"][0]
 
@@ -463,7 +519,7 @@ class MobileValidationWorkflowAPITestCase(APITestCase):
 
         res_data = self.assertJSONResponse(res, status.HTTP_200_OK)
 
-        self.assertValidListData(list_data=res_data, results_key="results", expected_length=1, paginated=True)
+        self.assertValidListData(list_data=res_data, results_key="results", expected_length=3, paginated=True)
 
         instance_data = res_data["results"][0]
 
@@ -521,7 +577,7 @@ class MobileValidationWorkflowAPITestCase(APITestCase):
 
         res_data = self.assertJSONResponse(res, status.HTTP_200_OK)
 
-        self.assertValidListData(list_data=res_data, results_key="results", expected_length=1, paginated=True)
+        self.assertValidListData(list_data=res_data, results_key="results", expected_length=3, paginated=True)
 
         instance_data = res_data["results"][0]
 
@@ -589,11 +645,11 @@ class MobileValidationWorkflowAPITestCase(APITestCase):
     def test_num_queries(self):
         self.client.force_authenticate(self.john_wick)
         self.setup_approve()
-        with self.assertNumQueries(5):
-            # 1: PERM
-            # 3 ORGUNIT
-            # 4-5: QUERYSET + FILTER
-            # 6-7: SERIALIZER
+        with self.assertNumQueries(4):
+            # 1: profile_org_units
+            # 2: COUNT instance
+            # 3: instance
+            # 4: validationnode
             res = self.client.get(reverse("mobile_validation_workflows-list"))
             self.assertJSONResponse(res, status.HTTP_200_OK)
 
@@ -604,7 +660,7 @@ class MobileValidationWorkflowAPITestCase(APITestCase):
         res = self.client.get(reverse("mobile_validation_workflows-list"))
         res_data = self.assertJSONResponse(res, status.HTTP_200_OK)
 
-        self.assertValidListData(list_data=res_data, results_key="results", expected_length=1, paginated=True)
+        self.assertValidListData(list_data=res_data, results_key="results", expected_length=3, paginated=True)
 
         self.validation_workflow.delete()
 

--- a/iaso/tests/test_engine/test_validation_workflow.py
+++ b/iaso/tests/test_engine/test_validation_workflow.py
@@ -862,12 +862,17 @@ class TestResubmitFeature(TestCase):
             artifact=self.instance,
         )
 
-        validations = self.instance.get_all_validation_nodes(self.workflow)
-        self.assertEqual(validations.count(), 4)
-        first_validation = validations.first()
+        validations = (
+            Instance.objects.filter(pk=self.instance.pk)
+            .with_all_validation_nodes(self.workflow)
+            .first()
+            .all_validation_nodes
+        )
+        self.assertEqual(len(validations), 4)
+        first_validation = validations[0]
         second_validation = validations[1]
         third_validation = validations[2]
-        last_validation = validations.last()
+        last_validation = validations[3]
 
         self.assertEqual(first_validation.comment, "Nope for the second time")
         self.assertEqual(first_validation.instance, self.instance)
@@ -902,8 +907,13 @@ class TestResubmitFeature(TestCase):
         self.instance.refresh_from_db()
 
         self.assertEqual(self.instance.general_validation_status, ValidationWorkflowArtefactStatus.PENDING)
-        validations = self.instance.get_all_validation_nodes(self.workflow)
-        self.assertEqual(validations.count(), 3)
+        validations = (
+            Instance.objects.filter(pk=self.instance.pk)
+            .with_all_validation_nodes(self.workflow)
+            .first()
+            .all_validation_nodes
+        )
+        self.assertEqual(len(validations), 3)
 
         first_validation_node = validations[0]
         second_validation_node = validations[1]
@@ -926,8 +936,13 @@ class TestResubmitFeature(TestCase):
         self.instance.refresh_from_db()
 
         self.assertEqual(self.instance.general_validation_status, ValidationWorkflowArtefactStatus.PENDING)
-        validations = self.instance.get_all_validation_nodes(self.workflow)
-        self.assertEqual(validations.count(), 4)
+        validations = (
+            Instance.objects.filter(pk=self.instance.pk)
+            .with_all_validation_nodes(self.workflow)
+            .first()
+            .all_validation_nodes
+        )
+        self.assertEqual(len(validations), 4)
 
         first_validation_node = validations[0]
         second_validation_node = validations[1]
@@ -972,8 +987,13 @@ class TestResubmitFeature(TestCase):
         self.instance.refresh_from_db()
 
         self.assertEqual(self.instance.general_validation_status, ValidationWorkflowArtefactStatus.APPROVED)
-        validations = self.instance.get_all_validation_nodes(self.workflow)
-        self.assertEqual(validations.count(), 3)
+        validations = (
+            Instance.objects.filter(pk=self.instance.pk)
+            .with_all_validation_nodes(self.workflow)
+            .first()
+            .all_validation_nodes
+        )
+        self.assertEqual(len(validations), 3)
 
         with self.assertRaisesMessage(
             ValidationWorkflowEngineException, "Artifact is already attached to a related workflow"
@@ -982,8 +1002,13 @@ class TestResubmitFeature(TestCase):
 
         self.instance.refresh_from_db()
 
-        validations = self.instance.get_all_validation_nodes(self.workflow)
-        self.assertEqual(validations.count(), 3)
+        validations = (
+            Instance.objects.filter(pk=self.instance.pk)
+            .with_all_validation_nodes(self.workflow)
+            .first()
+            .all_validation_nodes
+        )
+        self.assertEqual(len(validations), 3)
 
         self.assertEqual(self.instance.general_validation_status, ValidationWorkflowArtefactStatus.APPROVED)
 


### PR DESCRIPTION
## What problem is this PR solving?

The endpoint should return only instances created by the user. 
This PR also fixes a couple of N+1 issues.

### Related JIRA tickets

IA-5393

## Changes

The query for mobile was missing a filter on the `created_by`.

I also moved queries that were made directly inside the `Serializer` into a `QuerySet` object that can be inherited.

## How to test

1. Have validation workflow configured
2. Create new instances with different users
3. Call the mobile endpoint and check that only your own instances are returned.
