### PR TITLE
WC2-949: failing tests in Azure pipelines

### DIFF
--- a/azure-pipelines-prod.yml
+++ b/azure-pipelines-prod.yml
@@ -55,8 +55,8 @@ steps:
   displayName: 'apt update'
 
 - script: |
-    sudo apt install gdal-bin
-  displayName: 'install gdal'
+    sudo apt install gdal-bin gettext
+  displayName: 'install gdal and gettext'
 
 - script: |
     python --version
@@ -78,10 +78,12 @@ steps:
 # The secret key is done with an export because Azure pipelines will
 # remove all env variables that start with SECRET_
 - script: |
+    set -euo pipefail
     export SECRET_KEY=${SECRETKEY}
     export DJANGO_SUPERUSER_PASSWORD=${DJANGO_SUPERUSER_PASSWORD}
     export DJANGO_SUPERUSER_USERNAME=${DJANGO_SUPERUSER_USERNAME}
     export DJANGO_SUPERUSER_EMAIL=${DJANGO_SUPERUSER_EMAIL}
+    uv run python manage.py compile_translations
     uv run python manage.py migrate
     uv run python manage.py createcachetable
     uv run python manage.py createsuperuser --noinput

--- a/azure-pipelines-prod.yml
+++ b/azure-pipelines-prod.yml
@@ -134,7 +134,12 @@ steps:
     echo "Disk space after Docker cleanup:" && df -h
   displayName: 'Clean up Docker system'
 
-- script: docker build -t prod-coda2 --target prod -f $(Build.SourcesDirectory)/docker/prod/Dockerfile .
+- script: |
+    docker build -t prod-coda2 --target prod \
+      --build-arg DEPLOYED_ON="$(date --rfc-3339=seconds)" \
+      --build-arg DEPLOYED_BY="$(Build.RequestedFor)" \
+      --build-arg IASO_VERSION="$(Build.SourceBranchName)-$(git rev-parse --short HEAD)" \
+      -f $(Build.SourcesDirectory)/docker/prod/Dockerfile .
   displayName: 'Build docker image'
 
 # Save the Docker image compressed, in a dedicated folder for the artifact

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,8 +52,8 @@ steps:
 
 - script: |
     sudo apt-get update
-    sudo apt --fix-missing install gdal-bin
-  displayName: 'install gdal'
+    sudo apt --fix-missing install gdal-bin gettext
+  displayName: 'install gdal and gettext'
 
 - script: |
     python --version
@@ -76,10 +76,12 @@ steps:
 # The secret key is done with an export because Azure pipelines will
 # remove all env variables that start with SECRET_
 - script: |
+    set -euo pipefail
     export SECRET_KEY=${SECRETKEY}
     export DJANGO_SUPERUSER_PASSWORD=${DJANGO_SUPERUSER_PASSWORD}
     export DJANGO_SUPERUSER_USERNAME=${DJANGO_SUPERUSER_USERNAME}
     export DJANGO_SUPERUSER_EMAIL=${DJANGO_SUPERUSER_EMAIL}
+    uv run python manage.py compile_translations
     uv run python manage.py migrate
     uv run python manage.py createcachetable
     uv run python manage.py createsuperuser --noinput

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -137,7 +137,11 @@ steps:
   displayName: 'Clean up Docker system'
 
 - script: |
-    docker build -t dev-coda2 --target prod -f $(Build.SourcesDirectory)/docker/prod/Dockerfile .
+    docker build -t dev-coda2 --target prod \
+      --build-arg DEPLOYED_ON="$(date --rfc-3339=seconds)" \
+      --build-arg DEPLOYED_BY="$(Build.RequestedFor)" \
+      --build-arg IASO_VERSION="$(Build.SourceBranchName)-$(git rev-parse --short HEAD)" \
+      -f $(Build.SourcesDirectory)/docker/prod/Dockerfile .
   displayName: 'Build docker image'
 
 # Save the Docker image compressed to reduce disk usage

--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -60,6 +60,13 @@ RUN find ./.venv -type d -name "__pycache__" -exec rm -rf {} + && \
 # Slim image with runtime-only libraries.
 FROM python:3.9-slim-bullseye AS prod
 
+ARG DEPLOYED_ON=unknown
+ARG DEPLOYED_BY=unknown
+ARG IASO_VERSION=
+ENV DEPLOYED_ON=$DEPLOYED_ON \
+    DEPLOYED_BY=$DEPLOYED_BY \
+    IASO_VERSION=$IASO_VERSION
+
 # Create non-root user early so COPY --chown can use it (avoids chown layer duplication)
 RUN groupadd --gid 1001 appuser && \
     useradd --uid 1001 --gid appuser --shell /bin/bash --create-home appuser

--- a/hat/settings.py
+++ b/hat/settings.py
@@ -117,7 +117,7 @@ try:
     version = pyproject_toml["project"]["version"]
 except Exception as e:
     version = "error - unknown version"
-IASO_VERSION = version
+IASO_VERSION = env.str("IASO_VERSION", default=version)
 
 DEV_SERVER = env.bool("DEV_SERVER", default=False)
 ENVIRONMENT = env.str("SENTRY_ENVIRONMENT", default="development").lower()

--- a/hat/settings.py
+++ b/hat/settings.py
@@ -139,6 +139,10 @@ USE_CELERY = env.bool("USE_CELERY", default=False)
 
 # It is possible to deactivate password login for the API, the website and the admin using this environment variable
 DISABLE_PASSWORD_LOGINS = env.bool("DISABLE_PASSWORD_LOGINS", default=False)
+# Token/login tests need /api/token/ registered. Dedicated tests still cover the
+# disabled path via override_settings + URL reload.
+if IN_TESTS:
+    DISABLE_PASSWORD_LOGINS = False
 
 # env variables allowing to configure the cache used by Iaso. By default, it's using a table in Postgres
 # to setup Redis, use django_redis.cache.RedisCache as CACHE_BACKEND and something like "redis://127.0.0.1:6379" as CACHE_LOCATION

--- a/iaso/auth/backends.py
+++ b/iaso/auth/backends.py
@@ -1,9 +1,22 @@
 from django.contrib.auth import get_user_model
 from django.contrib.auth.backends import ModelBackend
-from django.urls import reverse
+from django.urls import NoReverseMatch, reverse
 
 
 UserModel = get_user_model()
+
+
+def _is_token_obtain_request(request) -> bool:
+    """True when this authenticate() call is for JWT token issuance.
+
+    `token_obtain_pair` is not registered when DISABLE_PASSWORD_LOGINS is on.
+    """
+    if not request or not hasattr(request, "path"):
+        return False
+    try:
+        return request.path == reverse("token_obtain_pair")
+    except NoReverseMatch:
+        return False
 
 
 class MultiTenantAuthBackend(ModelBackend):
@@ -16,7 +29,7 @@ class MultiTenantAuthBackend(ModelBackend):
 
         if user:
             # Skip tenant switching for token generation requests.
-            if request and hasattr(request, "path") and request.path == reverse("token_obtain_pair"):
+            if _is_token_obtain_request(request):
                 return user
 
             # When users switch accounts, `login()` is called and automatically updates `last_login`.

--- a/iaso/tests/auth/test_backends.py
+++ b/iaso/tests/auth/test_backends.py
@@ -1,5 +1,8 @@
+from unittest.mock import patch
+
 from django.contrib.auth import get_user_model
 from django.test import RequestFactory
+from django.urls import NoReverseMatch
 
 from iaso.auth.backends import MultiTenantAuthBackend
 from iaso.models import Account, TenantUser
@@ -58,3 +61,13 @@ class MultiTenantAuthBackendTestCase(TestCase):
 
         result = self.backend.authenticate(self.request, username="main_user", password="wrong_password")
         self.assertIsNone(result)
+
+    @patch("iaso.auth.backends.reverse", side_effect=NoReverseMatch("token_obtain_pair"))
+    def test_authenticate_when_token_url_is_not_registered(self, _mock_reverse):
+        """DISABLE_PASSWORD_LOGINS unregisters token_obtain_pair; authenticate must still succeed."""
+        user = self.create_user_with_profile(username="single_user", account=self.account1)
+        user.set_password("password")
+        user.save()
+
+        result = self.backend.authenticate(self.request, username="single_user", password="password")
+        self.assertEqual(result, user)

--- a/iaso/tests/gpkg/test_import.py
+++ b/iaso/tests/gpkg/test_import.py
@@ -426,7 +426,7 @@ class GPKGImport(TestCase):
                 # Ensure the DataSource is created with the project
                 source = DataSource.objects.create(name=f"test_column_validation_{i}")
                 source.projects.add(self.project)
-                with self.assertRaisesMessage(ValueError, f"Missing required column: {column}"):
+                with self.assertRaisesMessage(ValueError, f"Column '{column}' is required but missing from GPKG"):
                     import_gpkg_file(
                         f"./iaso/tests/fixtures/gpkg/missing_column_{column}.gpkg",
                         source_name=f"test_column_validation_{i}",


### PR DESCRIPTION
## What problem is this PR solving?
Due to latest change  in azure config, now we can see that python tests are failing since a while, but it wasn’t stopping the pipeline (due to order of commands in yaml config).

Those tests should pass in azure pipeline, we should not ignore them.
### Related JIRA tickets

WC2-949

## Changes

Azure was failing tests that are green on GitHub because the two CIs don’t share the same env: Azure sets DISABLE_PASSWORD_LOGINS, doesn’t compile .mo files, and (after #3233) actually fails the job when manage.py test is last.

Compile translations in Azure (same as GitHub)
Keep password logins off in YAML; force them on only during manage.py test
Don’t crash auth when token_obtain_pair is missing
Align the GPKG missing-column assertion with the current error message

Also fixed /health endpoint returning empty values on Azure

## How to test

- this should run on azure pipeline
<img width="731" height="634" alt="Screenshot 2026-09-02 at 13 16 35" src="https://github.com/user-attachments/assets/50045ca7-c430-42ba-b730-50f54cc55dd0" />
