### PR TITLE
[IA-5391] Add "OU Code" and "OU Status" in the submission export

### DIFF
--- a/hat/assets/js/apps/Iaso/constants/urls.ts
+++ b/hat/assets/js/apps/Iaso/constants/urls.ts
@@ -127,6 +127,7 @@ export const baseRouteConfigs: Record<string, RouteConfig> = {
             'projectIds',
             'isSearchActive',
             'referenceInstances',
+            'org_unit_status',
         ],
     },
     instanceDetail: {

--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -591,6 +591,7 @@
     "iaso.instance.notReferenceSubmission": "Not a reference",
     "iaso.instance.oneColumn": "One column",
     "iaso.instance.org_unit": "Org unit",
+    "iaso.instance.org_unit_status": "Org unit status",
     "iaso.instance.org_unit_type_name": "Org unit type",
     "iaso.instance.patchInstanceError": "An error occurred while saving submission",
     "iaso.instance.patchInstanceSuccesfull": "Submission saved successfully",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/es.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/es.json
@@ -451,6 +451,7 @@
     "iaso.instance.noGpsForSomeInstaces": "Algunas instancias no tienen ubicaciones. No se aplicará nada para esas unidades organizativas.",
     "iaso.instance.NoLocksHistory": "No hay historial",
     "iaso.instance.org_unit": "Unidad organizativa",
+    "iaso.instance.org_unit_status": "Estado de unidad organizativa",
     "iaso.instance.org_unit_type_name": "Tipo de unidad organizativa",
     "iaso.instance.patchInstanceError": "Ocurrió un error al guardar el envío",
     "iaso.instance.patchInstanceSuccesfull": "Envío guardado exitosamente",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -592,6 +592,7 @@
     "iaso.instance.notReferenceSubmission": "Pas une référence",
     "iaso.instance.oneColumn": "Une colonne",
     "iaso.instance.org_unit": "Unités d'organisation",
+    "iaso.instance.org_unit_status": "Status d'unités d'org.",
     "iaso.instance.org_unit_type_name": "Type d'unité d'org.",
     "iaso.instance.patchInstanceError": "Une erreur est survenue lors de la sauvegarde de la soumission",
     "iaso.instance.patchInstanceSuccesfull": "Soumission sauvée avec succès",

--- a/hat/assets/js/apps/Iaso/domains/instances/components/InstancesFiltersComponent.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/components/InstancesFiltersComponent.tsx
@@ -14,6 +14,7 @@ import {
 import { UserAsyncSelect } from 'Iaso/components/filters/UserAsyncSelect';
 import { UserOrgUnitRestriction } from 'Iaso/components/UserOrgUnitRestriction';
 import { useGetFormsDropdownOptions } from 'Iaso/domains/forms/hooks/useGetFormsDropdownOptions';
+import { useGetOrgUnitValidationStatus } from 'Iaso/domains/orgUnits/hooks/utils/useGetOrgUnitValidationStatus';
 import { PlanningsDropdown } from 'Iaso/domains/plannings/components/PlanningsDropdown';
 import { getInstancesFilterValues, useFormState } from 'Iaso/hooks/form';
 import { LocationLimit } from 'Iaso/utils/map/LocationLimit';
@@ -137,6 +138,10 @@ const InstancesFiltersComponent = ({
         formState.formIds.value?.split(',').length === 1
             ? formState.formIds.value.split(',')[0]
             : undefined;
+    const {
+        data: validationStatusOptions,
+        isLoading: isLoadingValidationStatusOptions,
+    } = useGetOrgUnitValidationStatus();
 
     const { data: formDescriptor } = useGetFormDescriptor(formId);
     const fields = useGetQueryBuildersFields(formDescriptor, possibleFields);
@@ -412,6 +417,16 @@ const InstancesFiltersComponent = ({
                         options={orgUnitTypes || []}
                         label={MESSAGES.org_unit_type_id}
                         loading={isFetchingOuTypes}
+                    />
+                    <InputComponent
+                        keyValue="org_unit_status"
+                        clearable
+                        onChange={handleFormChange}
+                        value={formState.org_unit_status.value || null}
+                        type="select"
+                        loading={isLoadingValidationStatusOptions}
+                        options={validationStatusOptions}
+                        label={MESSAGES.org_unit_status}
                     />
                     <Box mt={2}>
                         <UserAsyncSelect

--- a/hat/assets/js/apps/Iaso/domains/instances/constants.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/constants.tsx
@@ -221,6 +221,17 @@ export const INSTANCE_METAS_FIELDS = [
         type: 'location',
     },
     {
+        key: 'org_unit_status',
+        Cell: settings => {
+            const data = settings.row.original;
+            return data.org_unit.validation_status;
+        },
+        sortable: false,
+        active: false,
+        type: 'info',
+        tableOrder: 7,
+    },
+    {
         key: 'period',
         render: value => <PrettyPeriod value={value} />,
         tableOrder: 8,

--- a/hat/assets/js/apps/Iaso/domains/instances/messages.ts
+++ b/hat/assets/js/apps/Iaso/domains/instances/messages.ts
@@ -998,6 +998,10 @@ const MESSAGES = defineMessages({
         defaultMessage: 'Not a reference',
         id: 'iaso.instance.notReferenceSubmission',
     },
+    org_unit_status: {
+        id: 'iaso.instance.org_unit_status',
+        defaultMessage: 'Org Unit Status',
+    },
 });
 
 export default MESSAGES;

--- a/hat/assets/js/apps/Iaso/domains/instances/utils/index.tsx
+++ b/hat/assets/js/apps/Iaso/domains/instances/utils/index.tsx
@@ -656,6 +656,7 @@ export const getFilters = (
             params.referenceInstances && params.referenceInstances !== 'all'
                 ? params.referenceInstances
                 : undefined,
+        org_unit_status: params.org_unit_status,
     };
     const filters = {};
     Object.keys(allFilters).forEach(k => {

--- a/iaso/api/instances/views.py
+++ b/iaso/api/instances/views.py
@@ -268,6 +268,8 @@ class InstancesViewSet(viewsets.ViewSet):
             {"title": "Org unit", "width": 20},
             {"title": "Org unit id", "width": 20},
             {"title": "Référence externe", "width": 20},
+            {"title": "OU Code", "width": 20},
+            {"title": "OU Status", "width": 20},
             {"title": "parent1", "width": 20},
             {"title": "parent2", "width": 20},
             {"title": "parent3", "width": 20},
@@ -334,6 +336,8 @@ class InstancesViewSet(viewsets.ViewSet):
                 instance.org_unit.name,
                 instance.org_unit.id,
                 instance.org_unit.source_ref,
+                instance.org_unit.code,
+                instance.org_unit.validation_status,
             ]
 
             parent = org_unit.parent

--- a/iaso/tests/api/instances/test_instances.py
+++ b/iaso/tests/api/instances/test_instances.py
@@ -73,34 +73,40 @@ class InstancesAPITestCase(TaskAPITestCase):
             version=sw_version,
             validation_status="VALID",
             uuid=cls.jedi_council_corruscant_uuid,
+            code="coruscant_code",
         )
         cls.ou_top_1 = m.OrgUnit.objects.create(
             name="ou_top_1",
             source_ref="jedi_council_corruscant_ref",
             version=sw_version,
+            code="top1_code",
         )
         cls.ou_top_2 = m.OrgUnit.objects.create(
             name="ou_top_2",
             source_ref="jedi_council_corruscant_ref",
             parent=cls.ou_top_1,
             version=sw_version,
+            code="top2_code",
         )
         cls.ou_top_3 = m.OrgUnit.objects.create(
             name="ou_top_3",
             source_ref="jedi_council_corruscant_ref",
             parent=cls.ou_top_2,
             version=sw_version,
+            code="top3_code",
         )
         cls.jedi_council_endor = m.OrgUnit.objects.create(
             name="Endor Jedi Council",
             source_ref="jedi_council_endor_ref",
             version=sw_version,
+            code="endor_code",
         )
         cls.jedi_council_endor_region = m.OrgUnit.objects.create(
             name="Endor Region Jedi Council",
             parent=cls.jedi_council_endor,
             source_ref="jedi_council_endor_region_ref",
             version=sw_version,
+            code="endor_region_code",
         )
 
         cls.project = m.Project.objects.create(
@@ -1470,6 +1476,8 @@ class InstancesAPITestCase(TaskAPITestCase):
             "Coruscant Jedi Council,"
             f"{self.jedi_council_corruscant.id},"
             "jedi_council_corruscant_ref,"
+            "coruscant_code,"
+            "VALID,"
             ","
             ","
             ","
@@ -1531,6 +1539,8 @@ class InstancesAPITestCase(TaskAPITestCase):
             "Coruscant Jedi Council,"
             f"{self.jedi_council_corruscant.id},"
             "jedi_council_corruscant_ref,"
+            "coruscant_code,"
+            "VALID,"
             ","
             ","
             ","


### PR DESCRIPTION
## What problem is this PR solving?

Add "OU Code" and "OU Status" to the Submissions export.
And allow to filter on OU Status, in the Submissions list.

### Related JIRA tickets

IA-5391

## Changes

1. Add 2 columns to the CSV and XLS Submissions export.
1. Add a new filter to the Submissions list. 
1. Display the OU status in the list.

## How to test

1. Go to the Submissions list page.
1. Click on the XLS/CSV buttons to see if the OU code and status have been correctly added. 
1. Filter on the OU status and see if it works.

## Print screen / video

<img width="4011" height="1987" alt="image" src="https://github.com/user-attachments/assets/97aa60a4-202d-45e7-b59e-6b916daf9b1d" />
<img width="4011" height="1987" alt="image" src="https://github.com/user-attachments/assets/5678470f-297e-4c8c-bf83-dcfbb1de73fe" />

