### PR TITLE
POLIO-2198: Cancel Campaign edition is emptying the form

### DIFF
--- a/plugins/polio/js/src/domains/Campaigns/CampaignDetails.tsx
+++ b/plugins/polio/js/src/domains/Campaigns/CampaignDetails.tsx
@@ -65,6 +65,7 @@ export const CampaignDetails: FunctionComponent = () => {
         isFetching,
         saveDisabled,
         showObrInTitle,
+        isFormChanged,
     } = useCampaignFormState({
         campaignId,
     });
@@ -124,7 +125,7 @@ export const CampaignDetails: FunctionComponent = () => {
                         <Button
                             onClick={handleCancel}
                             color="primary"
-                            disabled={isSaving}
+                            disabled={isSaving || !isFormChanged}
                         >
                             {formatMessage(MESSAGES.cancel)}
                         </Button>

--- a/plugins/polio/js/src/domains/Campaigns/hooks/useCampaignFormState.tsx
+++ b/plugins/polio/js/src/domains/Campaigns/hooks/useCampaignFormState.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useRedirectToReplace } from 'bluesquare-components';
-import { useFormik } from 'formik';
+import { FormikHelpers, useFormik } from 'formik';
 import { isEqual, merge } from 'lodash';
+import { cloneDeep } from 'lodash';
 import { useQueryClient } from 'react-query';
 import { useParamsObject } from 'Iaso/routing/hooks/useParamsObject';
 import { UuidAsString } from 'Iaso/types/general';
@@ -101,7 +102,10 @@ export const useCampaignFormState = ({
     } = formik;
 
     const handleSubmit = useCallback(
-        (values, helpers) => {
+        (
+            values: CampaignFormValues,
+            helpers: FormikHelpers<CampaignFormValues>,
+        ) => {
             saveCampaign(convertEmptyStringToNull(values), {
                 onSuccess: (result: Campaign) => {
                     setIsUpdated(true);
@@ -133,13 +137,12 @@ export const useCampaignFormState = ({
     );
 
     const handleClose = useCallback(() => {
-        formik.setValues(baseValues);
-        setSelectedCampaignId(undefined);
+        formik.setValues(cloneDeep(formikInitialValues));
         if (isUpdated) {
             queryClient.invalidateQueries('campaigns');
             queryClient.invalidateQueries('subActivities');
         }
-    }, [isUpdated, formik, queryClient]);
+    }, [formik, formikInitialValues, isUpdated, queryClient]);
     const isFormChanged = !isEqual(values, formikInitialValues);
 
     const handleConfirm = useCallback(() => {


### PR DESCRIPTION
## What problem is this PR solving?

When editing a campaign, pressing on cancel is removing values in all the fields.

It should reset the form to the original state.

Cancel button should not be enabled if not having changes.

### Related JIRA tickets

POLIO-2198

## Changes

Changes made on this PR are fixing initial issue but creating this one, since the campaign edition and creation in on a dedicated page, `setSelectedCampaignId` is not used here anymore.

## How to test

Edit a campaign.
Cancel should be disable.
Change something.
Press on Cancel, your changes should be removed.
change something and save

## Print screen / video



https://github.com/user-attachments/assets/24ec7708-fef8-41be-bb86-4bd18b7e4634

