### PR TITLE
IA-5389: fix org unit list reject button

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/app/translations/en.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/en.json
@@ -1231,6 +1231,7 @@
     "iaso.orgUnits.referenceForm": "Reference form",
     "iaso.orgUnits.referenceForms": "Reference forms",
     "iaso.orgUnits.rejectOrgUnit": "Reject Org Unit",
+    "iaso.orgUnits.rejectOrgUnitQuestion": "Are you sure you want to reject this org unit: {name}?",
     "iaso.orgUnits.removeAsDefaultImage": "Remove as default image",
     "iaso.orgUnits.removeFromGroups": "Remove from group(s)",
     "iaso.orgUnits.search": "Search org unit",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/es.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/es.json
@@ -1007,6 +1007,8 @@
     "iaso.orgUnits.project": "Proyecto",
     "iaso.orgUnits.referenceForm": "Formulario de referencia",
     "iaso.orgUnits.referenceForms": "Formularios de referencia",
+    "iaso.orgUnits.rejectOrgUnit": "Rechazar unidad organizativa",
+    "iaso.orgUnits.rejectOrgUnitQuestion": "¿Está seguro de que desea rechazar esta unidad organizativa: {name}?",
     "iaso.orgUnits.removeAsDefaultImage": "Quitar como imagen predeterminada",
     "iaso.orgUnits.removeFromGroups": "Quitar de grupo(s)",
     "iaso.orgUnits.search": "Buscar unidad organizativa",

--- a/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
+++ b/hat/assets/js/apps/Iaso/domains/app/translations/fr.json
@@ -1231,6 +1231,7 @@
     "iaso.orgUnits.referenceForm": "Formulaire de référence",
     "iaso.orgUnits.referenceForms": "Formulaires de référence",
     "iaso.orgUnits.rejectOrgUnit": "Rejeter l'unité d'organisation",
+    "iaso.orgUnits.rejectOrgUnitQuestion": "Êtes-vous sûr de vouloir rejeter cette unité d'organisation : {name} ?",
     "iaso.orgUnits.removeAsDefaultImage": "Retirer l'image par défaut",
     "iaso.orgUnits.removeFromGroups": "Retirer du(des) groupe(s)",
     "iaso.orgUnits.search": "Rechercher une unité d'org.",

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/ActionCell.test.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/ActionCell.test.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { userHasPermission } from 'Iaso/domains/users/utils';
+import { useCurrentUser } from 'Iaso/utils/usersUtils';
+import { renderWithThemeAndIntlProvider } from '../../../../../tests/helpers';
+import { ActionCell } from './ActionCell';
+
+const mockMutateAsync = vi.fn();
+
+vi.mock('Iaso/domains/orgUnits/hooks', () => ({
+    useSaveOrgUnit: () => ({
+        mutateAsync: mockMutateAsync,
+        isLoading: false,
+    }),
+}));
+
+vi.mock('Iaso/utils/usersUtils', () => ({
+    useCurrentUser: vi.fn(),
+}));
+
+vi.mock('Iaso/domains/users/utils', () => ({
+    userHasPermission: vi.fn(),
+}));
+
+const renderActionCell = (ui: React.ReactElement) => {
+    return renderWithThemeAndIntlProvider(<MemoryRouter>{ui}</MemoryRouter>);
+};
+
+const defaultOrgUnit = {
+    id: 1,
+    name: 'Test Org Unit',
+    validation_status: 'NEW',
+    has_geo_json: true,
+    latitude: 1.23,
+    longitude: 4.56,
+} as any;
+
+describe('ActionCell', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(useCurrentUser).mockReturnValue({} as any);
+        vi.mocked(userHasPermission).mockReturnValue(true);
+    });
+
+    it('renders reject button when user has permission and orgUnit validation_status is not REJECTED', () => {
+        vi.mocked(userHasPermission).mockReturnValue(true);
+        renderActionCell(<ActionCell orgUnit={defaultOrgUnit} />);
+
+        expect(screen.getByTestId('DeleteIcon')).toBeInTheDocument();
+    });
+
+    it('does not render reject button when user does not have permission', () => {
+        vi.mocked(userHasPermission).mockReturnValue(false);
+        renderActionCell(<ActionCell orgUnit={defaultOrgUnit} />);
+
+        expect(screen.queryByTestId('DeleteIcon')).not.toBeInTheDocument();
+    });
+
+    it('does not render reject button when validation_status is REJECTED', () => {
+        vi.mocked(userHasPermission).mockReturnValue(true);
+        const rejectedOrgUnit = {
+            ...defaultOrgUnit,
+            validation_status: 'REJECTED',
+        };
+        renderActionCell(<ActionCell orgUnit={rejectedOrgUnit} />);
+
+        expect(screen.queryByTestId('DeleteIcon')).not.toBeInTheDocument();
+    });
+
+    it('opens confirm modal and calls saveOu on confirm', async () => {
+        const user = userEvent.setup();
+        renderActionCell(<ActionCell orgUnit={defaultOrgUnit} />);
+
+        // Modal should *not* be in document initially
+        expect(screen.queryByText('Reject Org Unit')).not.toBeInTheDocument();
+
+        const rejectButton = screen
+            .getByTestId('DeleteIcon')
+            .closest('button')!;
+        await user.click(rejectButton);
+
+        expect(screen.getByText('Reject Org Unit')).toBeInTheDocument();
+        expect(
+            screen.getByText(/are you sure you want to reject this org unit/i),
+        ).toBeInTheDocument();
+
+        const confirmButton = screen.getByRole('button', { name: /yes/i });
+        await user.click(confirmButton);
+
+        expect(mockMutateAsync).toHaveBeenCalledWith({
+            id: defaultOrgUnit.id,
+            validation_status: 'REJECTED',
+        });
+    });
+});

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/ActionCell.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/ActionCell.tsx
@@ -9,6 +9,9 @@ import { IconButton, ConfirmCancelModal } from 'bluesquare-components';
 import { FormattedMessage } from 'react-intl';
 import { baseUrls } from '../../../constants/urls';
 import { isValidCoordinate } from '../../../utils/map/mapUtils';
+import { ORG_UNITS } from '../../../utils/permissions';
+import { useCurrentUser } from '../../../utils/usersUtils';
+import { userHasPermission } from '../../users/utils';
 import { useSaveOrgUnit } from '../hooks';
 import MESSAGES from '../messages';
 import { OrgUnit } from '../types/orgUnit';
@@ -18,11 +21,14 @@ type Props = {
 
 export const ActionCell: FunctionComponent<Props> = ({ orgUnit }) => {
     const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false);
+    const currentUser = useCurrentUser();
     const { mutateAsync: saveOu, isLoading: isSaving } = useSaveOrgUnit(
         undefined,
         ['orgunits'],
         MESSAGES.orgUnitRejected,
     );
+
+    const hasOrgUnitsPermission = userHasPermission(ORG_UNITS, currentUser);
 
     const handleRejectOrgUnit = useCallback(() => {
         saveOu({
@@ -53,37 +59,38 @@ export const ActionCell: FunctionComponent<Props> = ({ orgUnit }) => {
                     icon="history"
                     tooltipMessage={MESSAGES.history}
                 />
-                {orgUnit.validation_status !== 'REJECTED' && (
-                    <>
-                        <IconButton
-                            onClick={() => setIsConfirmModalOpen(true)}
-                            icon="delete"
-                            tooltipMessage={MESSAGES.rejectOrgUnit}
-                            disabled={isSaving}
-                        />
-                        <ConfirmCancelModal
-                            open={isConfirmModalOpen}
-                            closeDialog={() => setIsConfirmModalOpen(false)}
-                            onClose={() => null}
-                            id={`reject-orgunit-${orgUnit.id}`}
-                            dataTestId={`reject-orgunit-modal-${orgUnit.id}`}
-                            titleMessage={MESSAGES.rejectOrgUnit}
-                            onConfirm={handleRejectOrgUnit}
-                            onCancel={() => setIsConfirmModalOpen(false)}
-                            confirmMessage={MESSAGES.yes}
-                            cancelMessage={MESSAGES.no}
-                        >
-                            <DialogContentText id="alert-dialog-description">
-                                <FormattedMessage
-                                    {...MESSAGES.rejectOrgUnitQuestion}
-                                    values={{
-                                        name: orgUnit.name,
-                                    }}
-                                />
-                            </DialogContentText>
-                        </ConfirmCancelModal>
-                    </>
-                )}
+                {orgUnit.validation_status !== 'REJECTED' &&
+                    hasOrgUnitsPermission && (
+                        <>
+                            <IconButton
+                                onClick={() => setIsConfirmModalOpen(true)}
+                                icon="delete"
+                                tooltipMessage={MESSAGES.rejectOrgUnit}
+                                disabled={isSaving}
+                            />
+                            <ConfirmCancelModal
+                                open={isConfirmModalOpen}
+                                closeDialog={() => setIsConfirmModalOpen(false)}
+                                onClose={() => null}
+                                id={`reject-orgunit-${orgUnit.id}`}
+                                dataTestId={`reject-orgunit-modal-${orgUnit.id}`}
+                                titleMessage={MESSAGES.rejectOrgUnit}
+                                onConfirm={handleRejectOrgUnit}
+                                onCancel={() => setIsConfirmModalOpen(false)}
+                                confirmMessage={MESSAGES.yes}
+                                cancelMessage={MESSAGES.no}
+                            >
+                                <DialogContentText id="alert-dialog-description">
+                                    <FormattedMessage
+                                        {...MESSAGES.rejectOrgUnitQuestion}
+                                        values={{
+                                            name: orgUnit.name,
+                                        }}
+                                    />
+                                </DialogContentText>
+                            </ConfirmCancelModal>
+                        </>
+                    )}
             </section>
         );
     }, [
@@ -96,6 +103,7 @@ export const ActionCell: FunctionComponent<Props> = ({ orgUnit }) => {
         handleRejectOrgUnit,
         isConfirmModalOpen,
         isSaving,
+        hasOrgUnitsPermission,
     ]);
     return cell;
 };

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/ActionCell.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/ActionCell.tsx
@@ -1,16 +1,23 @@
-import React, { FunctionComponent, useMemo, useCallback } from 'react';
-import { IconButton } from 'bluesquare-components';
+import React, {
+    FunctionComponent,
+    useMemo,
+    useCallback,
+    useState,
+} from 'react';
+import { DialogContentText } from '@mui/material';
+import { IconButton, ConfirmCancelModal } from 'bluesquare-components';
+import { FormattedMessage } from 'react-intl';
 import { baseUrls } from '../../../constants/urls';
 import { isValidCoordinate } from '../../../utils/map/mapUtils';
 import { useSaveOrgUnit, SaveOrgUnitPayload } from '../hooks';
 import MESSAGES from '../messages';
 import { OrgUnit } from '../types/orgUnit';
-
 type Props = {
     orgUnit: OrgUnit;
 };
 
 export const ActionCell: FunctionComponent<Props> = ({ orgUnit }) => {
+    const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false);
     const { mutateAsync: saveOu, isLoading: isSaving } = useSaveOrgUnit(
         undefined,
         ['orgunits'],
@@ -50,12 +57,37 @@ export const ActionCell: FunctionComponent<Props> = ({ orgUnit }) => {
                     icon="history"
                     tooltipMessage={MESSAGES.history}
                 />
-                <IconButton
-                    onClick={handleRejectOrgUnit}
-                    icon="delete"
-                    tooltipMessage={MESSAGES.rejectOrgUnit}
-                    disabled={isSaving}
-                />
+                {orgUnit.validation_status !== 'REJECTED' && (
+                    <>
+                        <IconButton
+                            onClick={() => setIsConfirmModalOpen(true)}
+                            icon="delete"
+                            tooltipMessage={MESSAGES.rejectOrgUnit}
+                            disabled={isSaving}
+                        />
+                        <ConfirmCancelModal
+                            open={isConfirmModalOpen}
+                            closeDialog={() => setIsConfirmModalOpen(false)}
+                            onClose={() => null}
+                            id={`reject-orgunit-${orgUnit.id}`}
+                            dataTestId={`reject-orgunit-modal-${orgUnit.id}`}
+                            titleMessage={MESSAGES.rejectOrgUnit}
+                            onConfirm={handleRejectOrgUnit}
+                            onCancel={() => setIsConfirmModalOpen(false)}
+                            confirmMessage={MESSAGES.yes}
+                            cancelMessage={MESSAGES.no}
+                        >
+                            <DialogContentText id="alert-dialog-description">
+                                <FormattedMessage
+                                    {...MESSAGES.rejectOrgUnitQuestion}
+                                    values={{
+                                        name: orgUnit.name,
+                                    }}
+                                />
+                            </DialogContentText>
+                        </ConfirmCancelModal>
+                    </>
+                )}
             </section>
         );
     }, [
@@ -63,7 +95,10 @@ export const ActionCell: FunctionComponent<Props> = ({ orgUnit }) => {
         orgUnit.has_geo_json,
         orgUnit.latitude,
         orgUnit.longitude,
+        orgUnit.name,
+        orgUnit.validation_status,
         handleRejectOrgUnit,
+        isConfirmModalOpen,
         isSaving,
     ]);
     return cell;

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/ActionCell.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/ActionCell.tsx
@@ -2,7 +2,7 @@ import React, { FunctionComponent, useMemo, useCallback } from 'react';
 import { IconButton } from 'bluesquare-components';
 import { baseUrls } from '../../../constants/urls';
 import { isValidCoordinate } from '../../../utils/map/mapUtils';
-import { useSaveOrgUnit } from '../hooks';
+import { useSaveOrgUnit, SaveOrgUnitPayload } from '../hooks';
 import MESSAGES from '../messages';
 import { OrgUnit } from '../types/orgUnit';
 
@@ -18,11 +18,14 @@ export const ActionCell: FunctionComponent<Props> = ({ orgUnit }) => {
     );
 
     const handleRejectOrgUnit = useCallback(() => {
-        saveOu({
+        const payload: SaveOrgUnitPayload = {
             id: orgUnit.id,
             validation_status: 'REJECTED',
-            groups: orgUnit.groups.map(g => g.id),
-        });
+        };
+        if (orgUnit.groups) {
+            payload.groups = orgUnit.groups.map(g => g.id);
+        }
+        saveOu(payload);
     }, [saveOu, orgUnit.id, orgUnit.groups]);
 
     const cell = useMemo(() => {

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/ActionCell.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/ActionCell.tsx
@@ -9,7 +9,7 @@ import { IconButton, ConfirmCancelModal } from 'bluesquare-components';
 import { FormattedMessage } from 'react-intl';
 import { baseUrls } from '../../../constants/urls';
 import { isValidCoordinate } from '../../../utils/map/mapUtils';
-import { useSaveOrgUnit, SaveOrgUnitPayload } from '../hooks';
+import { useSaveOrgUnit } from '../hooks';
 import MESSAGES from '../messages';
 import { OrgUnit } from '../types/orgUnit';
 type Props = {
@@ -25,15 +25,11 @@ export const ActionCell: FunctionComponent<Props> = ({ orgUnit }) => {
     );
 
     const handleRejectOrgUnit = useCallback(() => {
-        const payload: SaveOrgUnitPayload = {
+        saveOu({
             id: orgUnit.id,
             validation_status: 'REJECTED',
-        };
-        if (orgUnit.groups) {
-            payload.groups = orgUnit.groups.map(g => g.id);
-        }
-        saveOu(payload);
-    }, [saveOu, orgUnit.id, orgUnit.groups]);
+        });
+    }, [saveOu, orgUnit.id]);
 
     const cell = useMemo(() => {
         return (

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/messages.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/messages.ts
@@ -629,6 +629,19 @@ const MESSAGES = defineMessages({
         id: 'iaso.orgUnits.rejectOrgUnit',
         defaultMessage: 'Reject Org Unit',
     },
+    rejectOrgUnitQuestion: {
+        id: 'iaso.orgUnits.rejectOrgUnitQuestion',
+        defaultMessage:
+            'Are you sure you want to reject this org unit: {name}?',
+    },
+    yes: {
+        id: 'iaso.label.yes',
+        defaultMessage: 'Yes',
+    },
+    no: {
+        id: 'iaso.label.no',
+        defaultMessage: 'No',
+    },
     orgUnitRejected: {
         id: 'iaso.orgUnits.orgUnitRejected',
         defaultMessage: 'Org Unit rejected successfully',


### PR DESCRIPTION
## What problem is this PR solving?

Fix the quick reject button on the org unit list. It wasn't responding when clicked.

### Related JIRA tickets

IA-5389

## Changes

- Fixed the error related to org unit groups (removed the logic as it was unnecessary).
- added a confirmation modal to the button.
- hide the button when the org unit is already rejected
- hide the button for users without the permission

## How to test

Go to the org unit list and click the reject button (trash icon) for an org unit. It should work without errors.

The button should be hidden for users without the org unit write permission, and also when the org unit is also rejected.

## Print screen / video

## Notes

## Doc

