### PR TITLE
SNT-590 Allow OH DataLayer deletion

### DIFF
--- a/iaso/api/metrics/views.py
+++ b/iaso/api/metrics/views.py
@@ -6,7 +6,7 @@ from django.db.models import Q
 from django.http import HttpResponse
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import extend_schema
-from rest_framework import serializers, status, viewsets
+from rest_framework import status, viewsets
 from rest_framework.decorators import action
 from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
@@ -56,11 +56,6 @@ class MetricTypeViewSet(viewsets.ModelViewSet):
             if self.action in ["update", "partial_update"]
             else MetricTypeSerializer
         )
-
-    def perform_destroy(self, instance):
-        if instance.origin == MetricType.MetricTypeOrigin.OPENHEXA.value:
-            raise serializers.ValidationError("Cannot delete OpenHexa metric types")
-        return super().perform_destroy(instance)
 
     @action(detail=False, methods=["get"])
     def grouped_per_category(self, request):

--- a/iaso/tests/api/metrics/test_views.py
+++ b/iaso/tests/api/metrics/test_views.py
@@ -236,15 +236,13 @@ class MetricTypeAPITestCase(APITestCase):
         response = self.client.delete(f"{self.BASE_URL}{self.metric_type_1.id}/")
         self.assertJSONResponse(response, status.HTTP_403_FORBIDDEN)
 
-    def test_delete_openhexa_metric_type_forbidden(self):
+    def test_delete_openhexa_metric_type(self):
+        """OpenHexa data layers can be removed like any other layer (re-importable afterwards)."""
         self.client.force_authenticate(self.user)
         response = self.client.delete(f"{self.BASE_URL}{self.metric_type_2.id}/")
-        data = self.assertJSONResponse(response, status.HTTP_400_BAD_REQUEST)
-        # Verify data contains error message
-        self.assertIn("Cannot delete OpenHexa metric types", data)
-        # Verify that the MetricType still exists
-        metric_type = MetricType.objects.get(id=self.metric_type_2.id)
-        self.assertIsNotNone(metric_type)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        with self.assertRaises(MetricType.DoesNotExist):
+            MetricType.objects.get(id=self.metric_type_2.id)
 
     def test_metric_type_grouped_per_category(self):
         self.client.force_authenticate(self.user)


### PR DESCRIPTION
## What problem is this PR solving?

Authorize deletion of OH Data layers

### Related JIRA tickets

SNT-590

## Changes

Don't block OH data layer deletions as it is now managed differently.

## How to test

You'll need an SNT config to test this. 
You can go through the readme here: https://github.com/BLSQ/snt-malaria

Once done, go to DataLayers and try to remove one of the DataLayers, it should work.

## Print screen / video

N/A

## Notes

N/A

## Doc

N/A
