### PR TITLE
IA-5387: remove unnecessary prefetch for instance forms in entity mobile api

### DIFF
--- a/iaso/api/mobile/entity.py
+++ b/iaso/api/mobile/entity.py
@@ -103,7 +103,7 @@ class MobileEntityAttributesSerializer(serializers.ModelSerializer):
         if obj.json is None:
             return None
         possible_form_versions = self.context.get("possible_form_versions")
-        key = "%s|%s" % (obj.json.get("_version"), str(obj.form.id))
+        key = "%s|%s" % (obj.json.get("_version"), str(obj.form_id))
         return possible_form_versions.get(key)
 
 

--- a/iaso/api/mobile/entity_type.py
+++ b/iaso/api/mobile/entity_type.py
@@ -144,12 +144,7 @@ class MobileEntityTypesViewSet(ModelViewSet):
         else:
             queryset = filter_for_mobile_entity(queryset, user, self.request)
 
-        queryset = queryset.select_related("entity_type").prefetch_related(
-            "instances__org_unit",
-            "attributes__org_unit",
-            "instances__form__form_versions",
-            "attributes__form__form_versions",
-        )
+        queryset = queryset.select_related("entity_type", "attributes")
 
         page = self.paginate_queryset(queryset)
         serializer = MobileEntitySerializer(

--- a/iaso/models/entity.py
+++ b/iaso/models/entity.py
@@ -268,7 +268,7 @@ class EntityQuerySet(models.QuerySet):
 
         queryset = queryset.filter(attributes_id__isnull=False, attributes__deleted=False)
 
-        queryset = queryset.prefetch_related(p).prefetch_related("instances__form")
+        queryset = queryset.prefetch_related(p)
 
         return queryset
 

--- a/iaso/tests/api/entities/test_entities_mobile.py
+++ b/iaso/tests/api/entities/test_entities_mobile.py
@@ -89,6 +89,19 @@ class MobileEntityAPITestCase(EntityAPITestCase):
             f"expected a single count+data entity query, got {len(entity_queries)}: {entity_queries}",
         )
         self.assertIn("OVER (", entity_queries[0])
+
+        # No query should touch "iaso_form": get_form_version_id and get_possible_form_versions_dict
+        # both read the FK column (obj.form_id / version.form_id) instead of the related Form object,
+        # so the `instances__form` prefetch that used to pull it in was removed as dead weight. If this
+        # ever comes back, either a Form-object access crept back in, or the prefetch was re-added
+        # needlessly -- in both cases that's the regression this assertion exists to catch.
+        form_queries = [q["sql"] for q in ctx.captured_queries if 'FROM "iaso_form"' in q["sql"]]
+        self.assertEqual(form_queries, [])
+
+        # The remaining 8 queries, in order: 2 permission checks (user + group permissions), 2 Project
+        # lookups (filter_on_app_id, then filter_for_mobile_entity), 1 org-unit-restriction EXISTS check,
+        # 1 merged entity count+data query (asserted above), 1 instances prefetch, and 1 FormVersion
+        # lookup for get_serializer_context's possible_form_versions dict.
         self.assertEqual(len(ctx.captured_queries), 8)
 
     def test_list_entities_with_filtered_out_entities_with_soft_deleted_instances(self):

--- a/iaso/tests/api/entities/test_entities_mobile.py
+++ b/iaso/tests/api/entities/test_entities_mobile.py
@@ -89,6 +89,7 @@ class MobileEntityAPITestCase(EntityAPITestCase):
             f"expected a single count+data entity query, got {len(entity_queries)}: {entity_queries}",
         )
         self.assertIn("OVER (", entity_queries[0])
+        self.assertEqual(len(ctx.captured_queries), 8)
 
     def test_list_entities_with_filtered_out_entities_with_soft_deleted_instances(self):
         uuid_valid_instance = uuid.uuid4()

--- a/iaso/tests/api/entities/test_entity_types.py
+++ b/iaso/tests/api/entities/test_entity_types.py
@@ -565,14 +565,36 @@ class EntityTypeAPITestCase(APITestCase):
         make_entity("out_of_scope_old", ou_other, old_date)
 
         self.client.force_authenticate(self.chewie)
-        response = self.client.get(
-            f"/api/mobile/entitytypes/{entity_type.pk}/entities/",
-            {"app_id": self.project.app_id, "limit_date": limit_date_str},
-        )
+        with CaptureQueriesContext(connection) as ctx:
+            response = self.client.get(
+                f"/api/mobile/entitytypes/{entity_type.pk}/entities/",
+                {"app_id": self.project.app_id, "limit_date": limit_date_str},
+            )
         response_json = response.json()
 
         self.assertEqual(response_json["count"], 1)
         self.assertEqual(response_json["results"][0]["id"], str(entity_in_scope_recent.uuid))
+
+        # No query should touch "iaso_form": get_form_version_id and get_possible_form_versions_dict
+        # both read the FK column (obj.form_id / version.form_id) instead of the related Form object,
+        # so `instances__form__form_versions` / `attributes__form__form_versions` in get_entities_by_types's
+        # prefetch are dead weight -- mirrors MobileEntityAPITestCase's equivalent assertion for
+        # /api/mobile/entities/. If this ever comes back, either a Form-object access crept back in, or
+        # the prefetch was re-added needlessly -- in both cases that's the regression this catches.
+        form_queries = [q["sql"] for q in ctx.captured_queries if 'FROM "iaso_form"' in q["sql"]]
+        self.assertEqual(form_queries, [])
+
+        # The remaining 8 queries: 1 Project lookup (filter_on_app_id), 3 org-unit-scope queries
+        # (restriction EXISTS check, profile org units, descendants path), 2 merged entity count+data
+        # queries -- select_related("attributes") folds the entity's attribute instance into these two
+        # via JOIN instead of a separate prefetch round trip -- 1 instances prefetch, and 1 FormVersion
+        # lookup for get_serializer_context's possible_form_versions dict. No dedicated org_unit prefetch
+        # query either: MobileEntityAttributesSerializer.org_unit_id reads the FK column directly, so
+        # `instances__org_unit` / `attributes__org_unit` were dead weight, same as the form ones above --
+        # if select_related("attributes") ever gets dropped without a replacement, entity.attributes
+        # falls back to one query per entity (a real N+1, not just a harmless extra prefetch), which this
+        # exact-count assertion also catches (4 entities created above -> +4 queries).
+        self.assertEqual(len(ctx.captured_queries), 8)
 
     def test_get_entities_by_entity_type_empty_list_deleted_instances(self):
         entity_type = EntityType.objects.create(


### PR DESCRIPTION
## What problem is this PR solving?

There was an unnecessary prefetch on the Forms when prefetching an entity's instances.

### Related JIRA tickets

IA-5387 (stumbled upon this while reviewing the PR on mobile sync performance #3294)

## Changes

Removed the prefetch and added assertion about the number of queries to tests.

## How to test

Test that the mobile entity api and mobile sync are not broken. 

