### PR TITLE
IA-5416 allow opt-out of instance count via ?fields=...

### DIFF
--- a/docs/pages/dev/how_to/setuper.en.md
+++ b/docs/pages/dev/how_to/setuper.en.md
@@ -21,6 +21,22 @@ Once the script has run, you can log in to your server using the account name as
 
 ## How To Use
 
+### Quick start (local)
+
+If you're running the stack locally via `docker compose` and just want a fresh
+account without going through the manual `createsuperuser` step below, use the
+`--local` flag. It creates a Django admin directly in the `iaso` container
+(via `docker compose exec ... manage.py createsuperuser --noinput`) and uses
+those credentials right away to set up the account:
+
+    cd setuper
+    python3 setuper.py --local
+
+This can be combined with the other flags (`-n`, `-a`, `--create_main_org_unit`, `--create_demo_form`, ...).
+The steps below and `credentials.py` are not needed in this mode.
+
+### Manual setup
+
 1. Backup your DB
 
         docker compose exec db pg_dump -U postgres iaso  -Fc > ~/Desktop/iaso.dump

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/hooks.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/hooks.ts
@@ -20,6 +20,46 @@ import { PaginatedDataSources } from './types/dataSources';
 import { OrgUnit } from './types/orgUnit';
 import { PaginatedOrgUnitTypes } from './types/orgunitTypes';
 
+// Every key OrgUnitViewSet.retrieve() returns by default, EXCEPT `instances_count` and
+// `catchment` (both expensive to compute -- see the comment on the `fields=` fetch below). Keep in
+// sync with `OrgUnit.as_dict_with_parents()` (iaso/models/org_unit.py) and the extra keys
+// `retrieve()` itself adds (iaso/api/org_units.py).
+const ORG_UNIT_DETAIL_FIELDS = [
+    'id',
+    'name',
+    'short_name',
+    'code',
+    'sub_source',
+    'sub_source_id',
+    'source_ref',
+    'source_url',
+    'parent_id',
+    'validation_status',
+    'parent_name',
+    'parent',
+    'org_unit_type_id',
+    'created_at',
+    'updated_at',
+    'aliases',
+    'latitude',
+    'longitude',
+    'altitude',
+    'has_geo_json',
+    'creator',
+    'opening_date',
+    'closed_date',
+    'default_image_id',
+    'groups',
+    'org_unit_type_name',
+    'org_unit_type',
+    'source',
+    'source_id',
+    'version',
+    'version_id',
+    'geo_json',
+    'reference_instances',
+].join(',');
+
 type UseOrgUnitDetailDataReturn = {
     groups: GroupDropdownOption[];
     orgUnitTypes: OrgUnitTypeDropdownOption[];
@@ -42,10 +82,22 @@ export const useOrgUnitDetailData = (
     tab: string,
 ): UseOrgUnitDetailDataReturn => {
     const { data: colors } = useGetColors(true);
+    // `/api/orgunits/{id}/?fields=` both narrows the response to exactly these keys AND skips
+    // computing whichever of `instances_count`/`catchment` isn't listed (both expensive: the
+    // former walks the whole descendant subtree, the latter serializes a geometry). Every other
+    // key here is cheap and mirrors what OrgUnitViewSet.retrieve() returns by default (see
+    // `OrgUnit.as_dict_with_parents()` + the extra keys `retrieve()` itself adds), minus
+    // `instances_count` and `catchment` -- neither is read from this query's result anywhere on the
+    // org unit detail page: map marker popups fetch their own org unit data independently (see
+    // OrgUnitPopupComponent / useGetOrgUnitDetail), which still requests the full default response.
+    // If the backend response shape changes, this list needs updating to match.
     const { data: originalOrgUnit, isFetching: isFetchingDetail } =
         useSnackQuery(
             ['currentOrgUnit', orgUnitId],
-            () => getRequest(`/api/orgunits/${orgUnitId}/`),
+            () =>
+                getRequest(
+                    `/api/orgunits/${orgUnitId}/?fields=${ORG_UNIT_DETAIL_FIELDS}`,
+                ),
             MESSAGES.fetchOrgUnitError,
             {
                 enabled: !isNewOrgunit,

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/hooks.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/hooks.ts
@@ -20,10 +20,12 @@ import { PaginatedDataSources } from './types/dataSources';
 import { OrgUnit } from './types/orgUnit';
 import { PaginatedOrgUnitTypes } from './types/orgunitTypes';
 
-// Every key OrgUnitViewSet.retrieve() returns by default, EXCEPT `instances_count` and
-// `catchment` (both expensive to compute -- see the comment on the `fields=` fetch below). Keep in
-// sync with `OrgUnit.as_dict_with_parents()` (iaso/models/org_unit.py) and the extra keys
-// `retrieve()` itself adds (iaso/api/org_units.py).
+// Every key OrgUnitViewSet.retrieve() returns by default, EXCEPT `instances_count` (expensive to
+// compute -- see the comment on the `fields=` fetch below). `catchment` IS included: the Map tab
+// (OrgUnitMap / EditOrgUnitOptionComponent / getBounds) reads `currentOrgUnit.catchment` directly
+// to render/edit the existing shape, so it can't be dropped here. Keep in sync with
+// `OrgUnit.as_dict_with_parents()` (iaso/models/org_unit.py) and the extra keys `retrieve()` itself
+// adds (iaso/api/org_units.py).
 const ORG_UNIT_DETAIL_FIELDS = [
     'id',
     'name',
@@ -58,6 +60,7 @@ const ORG_UNIT_DETAIL_FIELDS = [
     'version_id',
     'geo_json',
     'reference_instances',
+    'catchment',
 ].join(',');
 
 type UseOrgUnitDetailDataReturn = {
@@ -83,13 +86,13 @@ export const useOrgUnitDetailData = (
 ): UseOrgUnitDetailDataReturn => {
     const { data: colors } = useGetColors(true);
     // `/api/orgunits/{id}/?fields=` both narrows the response to exactly these keys AND skips
-    // computing whichever of `instances_count`/`catchment` isn't listed (both expensive: the
-    // former walks the whole descendant subtree, the latter serializes a geometry). Every other
-    // key here is cheap and mirrors what OrgUnitViewSet.retrieve() returns by default (see
-    // `OrgUnit.as_dict_with_parents()` + the extra keys `retrieve()` itself adds), minus
-    // `instances_count` and `catchment` -- neither is read from this query's result anywhere on the
-    // org unit detail page: map marker popups fetch their own org unit data independently (see
-    // OrgUnitPopupComponent / useGetOrgUnitDetail), which still requests the full default response.
+    // computing `instances_count` since it isn't listed (expensive: walks the whole descendant
+    // subtree, and isn't read from this query's result anywhere on the org unit detail page -- map
+    // marker popups fetch their own org unit data independently, see OrgUnitPopupComponent /
+    // useGetOrgUnitDetail, which still requests the full default response). `catchment` IS listed
+    // (see the comment on ORG_UNIT_DETAIL_FIELDS above) so its geometry serialization still runs on
+    // this fetch. Every other key here is cheap and mirrors what OrgUnitViewSet.retrieve() returns
+    // by default (see `OrgUnit.as_dict_with_parents()` + the extra keys `retrieve()` itself adds).
     // If the backend response shape changes, this list needs updating to match.
     const { data: originalOrgUnit, isFetching: isFetchingDetail } =
         useSnackQuery(

--- a/iaso/api/org_units.py
+++ b/iaso/api/org_units.py
@@ -1006,8 +1006,14 @@ class OrgUnitViewSet(viewsets.ViewSet):
             self.get_queryset().select_related(*related_args).prefetch_related(*prefetch_args),
             pk=pk,
         )
-        # Count instances for the Org unit and its descendants.
-        org_unit.instances_count = org_unit.descendants().aggregate(Count("instance"))["instance__count"]
+        # Count instances for the Org unit and its descendants. For a high-level org unit (e.g. a
+        # country) this walks essentially the whole account's org unit tree and can take seconds, so
+        # mirror the `fields=` opt-in already used by list(): only compute it when explicitly asked
+        # for. `fields` absent keeps the historical (expensive) default, for callers that don't send
+        # it (e.g. the mobile app).
+        requested_fields = request.query_params.get("fields")
+        if is_field_referenced("instances_count", requested_fields, []):
+            org_unit.instances_count = org_unit.descendants().aggregate(Count("instance"))["instance__count"]
 
         self.check_object_permissions(request, org_unit)
 
@@ -1046,10 +1052,25 @@ class OrgUnitViewSet(viewsets.ViewSet):
             elif org_unit.simplified_geom:
                 res["geo_json"] = geojson_queryset(geo_queryset, geometry_field="simplified_geom")
 
-            if org_unit.catchment:
+            # Catchment geometry serialization can be expensive (large polygon) and, like
+            # instances_count above, isn't always needed by the caller -- skip it unless asked for.
+            if org_unit.catchment and is_field_referenced("catchment", requested_fields, []):
                 res["catchment"] = geojson_queryset(geo_queryset, geometry_field="catchment")
 
         res["reference_instances"] = org_unit.get_reference_instances_details_for_api()
+
+        # `fields=` also trims the response to just the requested top-level keys (in addition to
+        # skipping the `instances_count`/`catchment` computations above when they're not among
+        # them). This is a response-shaping step only: every value above is still computed/fetched
+        # unconditionally (prefetch_related/select_related, ancestors, geo_json, reference_instances)
+        # regardless of `fields` -- only the two known-expensive computations are actually skipped,
+        # and only the returned dict is narrowed here. `:all` (same sentinel as elsewhere, e.g.
+        # /api/group_sets/) opts back into the full response.
+        if requested_fields:
+            wanted_fields = set(requested_fields.split(","))
+            if ":all" not in wanted_fields:
+                res = {key: value for key, value in res.items() if key in wanted_fields}
+
         return Response(res)
 
 

--- a/iaso/api/org_units.py
+++ b/iaso/api/org_units.py
@@ -1038,7 +1038,11 @@ class OrgUnitViewSet(viewsets.ViewSet):
         res["geo_json"] = None
         res["catchment"] = None
 
-        if org_unit.geom or org_unit.simplified_geom or org_unit.catchment:
+        # `or org_unit.catchment is not None` (rather than plain truthiness): `MultiPolygonField`
+        # values are `GeometryCollection`s, which define `__len__`, so a non-null but empty
+        # MultiPolygon is falsy -- using truthiness here would skip this whole block (and so skip
+        # serializing that empty catchment below) even when it's the only populated geometry field.
+        if org_unit.geom or org_unit.simplified_geom or org_unit.catchment is not None:
             can_edit_shape = False
             if request.user.is_authenticated:
                 can_edit_shape = request.user.iaso_profile.account.feature_flags.filter(
@@ -1054,7 +1058,9 @@ class OrgUnitViewSet(viewsets.ViewSet):
 
             # Catchment geometry serialization can be expensive (large polygon) and, like
             # instances_count above, isn't always needed by the caller -- skip it unless asked for.
-            if org_unit.catchment and is_field_referenced("catchment", requested_fields, []):
+            # `is not None` (not truthiness): an empty MultiPolygon is falsy but still a real,
+            # explicitly-requestable value -- see the comment above on the outer `if`.
+            if is_field_referenced("catchment", requested_fields, []) and org_unit.catchment is not None:
                 res["catchment"] = geojson_queryset(geo_queryset, geometry_field="catchment")
 
         res["reference_instances"] = org_unit.get_reference_instances_details_for_api()

--- a/iaso/tests/api/test_orgunits.py
+++ b/iaso/tests/api/test_orgunits.py
@@ -961,6 +961,20 @@ class OrgUnitAPITestCase(APITestCase):
         self.assertEqual(set(response.json().keys()), {"id", "name", "catchment"})
         self.assertIsNotNone(response.json()["catchment"])
 
+    def test_org_unit_retrieve_requested_catchment_empty_geometry(self):
+        """A non-null but empty MultiPolygon `catchment` (falsy in Python, since MultiPolygon is a
+        GeometryCollection and defines __len__) must still be serialized when explicitly requested
+        via 'fields' -- it shouldn't be treated the same as no catchment at all."""
+        self.client.force_authenticate(self.yoda)
+        org_unit = self.jedi_council_endor  # catchment is `MULTIPOLYGON EMPTY`, not null
+
+        response = self.client.get(f"/api/orgunits/{org_unit.id}/?fields=id,name,catchment")
+
+        self.assertJSONResponse(response, status.HTTP_200_OK)
+        self.assertEqual(set(response.json().keys()), {"id", "name", "catchment"})
+        self.assertIsNotNone(response.json()["catchment"])
+        self.assertEqual(response.json()["catchment"]["features"][0]["id"], org_unit.id)
+
     def test_org_unit_performance_optimization_no_instance_count(self):
         """Test if instances_count is NOT queried when not in 'fields'"""
         self.client.force_authenticate(self.yoda)

--- a/iaso/tests/api/test_orgunits.py
+++ b/iaso/tests/api/test_orgunits.py
@@ -975,6 +975,48 @@ class OrgUnitAPITestCase(APITestCase):
         self.assertIsNotNone(response.json()["catchment"])
         self.assertEqual(response.json()["catchment"]["features"][0]["id"], org_unit.id)
 
+    def test_org_unit_retrieve_reference_instances_shape(self):
+        """`fields=reference_instances` should return each reference instance's full shape, i.e. the
+        submission's answers (`file_content`) and its form's question definitions (`form_descriptor`,
+        resolved from the submission's `_version`) -- not just presence/count."""
+        self.client.force_authenticate(self.yoda)
+        org_unit = self.jedi_council_corruscant
+
+        version_id = "2022090601"
+        # Reused below for both setting up the FormVersion/Instance and asserting the response, so
+        # the test can't pass by accident with an assertion that has quietly drifted from the input.
+        form_descriptor = {"name": "data", "type": "survey", "children": [{"name": "age", "type": "integer"}]}
+        file_content = {"_version": version_id, "age": 42}
+
+        form_version = m.FormVersion.objects.create(
+            form=self.reference_form,
+            version_id=version_id,
+            form_descriptor=form_descriptor,
+        )
+        instance = self.create_form_instance(
+            form=self.reference_form,
+            period="202003",
+            org_unit=org_unit,
+            project=self.project,
+            json=file_content,
+        )
+        m.OrgUnitReferenceInstance.objects.create(org_unit=org_unit, instance=instance, form=self.reference_form)
+
+        with self.assertNumQueries(28):
+            response = self.client.get(f"/api/orgunits/{org_unit.id}/?fields=reference_instances")
+
+        self.assertJSONResponse(response, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(set(data.keys()), {"reference_instances"})
+        self.assertEqual(len(data["reference_instances"]), 1)
+
+        [reference_instance] = data["reference_instances"]
+        self.assertEqual(reference_instance["id"], instance.id)
+        self.assertEqual(reference_instance["form_id"], self.reference_form.id)
+        self.assertEqual(reference_instance["form_version_id"], form_version.id)
+        self.assertEqual(reference_instance["file_content"], file_content)
+        self.assertEqual(reference_instance["form_descriptor"], form_descriptor)
+
     def test_org_unit_performance_optimization_no_instance_count(self):
         """Test if instances_count is NOT queried when not in 'fields'"""
         self.client.force_authenticate(self.yoda)

--- a/iaso/tests/api/test_orgunits.py
+++ b/iaso/tests/api/test_orgunits.py
@@ -22,6 +22,10 @@ from iaso.utils.gis import simplify_geom
 
 
 COUNT_INSTANCES = 'COUNT(DISTINCT "iaso_instance"."id")'.lower()
+# retrieve()'s `instances_count` (org_unit.descendants().aggregate(Count("instance"))) uses a plain,
+# non-distinct COUNT and an ltree descendants filter, so it needs its own marker (COUNT_INSTANCES
+# above matches list()'s annotation, which is a different query).
+DESCENDANTS_COUNT_QUERY_MARKER = '"iaso_orgunit"."path" <@'.lower()
 
 
 class OrgUnitAPIUtilsTestCase(SimpleTestCase):
@@ -866,6 +870,96 @@ class OrgUnitAPITestCase(APITestCase):
         self.assertJSONResponse(response_parent, status.HTTP_200_OK)
         parent_instances_count = response_parent.json()["instances_count"]
         self.assertEqual(parent_instances_count, 2)
+
+    def test_org_unit_retrieve_performance_optimization_no_instance_count(self):
+        """Test that instances_count is NOT computed on retrieve() when 'fields' doesn't ask for it"""
+        self.client.force_authenticate(self.yoda)
+
+        org_unit = m.OrgUnit.objects.create(
+            org_unit_type=self.jedi_council,
+            version=self.sw_version_1,
+            name="Coruscant Jedi Temple",
+            validation_status=m.OrgUnit.VALIDATION_VALID,
+        )
+        self.create_form_instance(
+            form=self.form_1,
+            period="202001",
+            org_unit=org_unit,
+            project=self.project,
+            json={"name": "a", "age": 18, "gender": "M"},
+        )
+
+        with CaptureQueriesContext(connection) as ctx:
+            response = self.client.get(f"/api/orgunits/{org_unit.id}/?fields=id,name")
+
+        self.assertJSONResponse(response, status.HTTP_200_OK)
+        self.assertEqual(response.json(), {"id": org_unit.id, "name": org_unit.name})
+        self.assertNotIn("instances_count", response.json())
+
+        for q in ctx.captured_queries:
+            self.assertNotIn(DESCENDANTS_COUNT_QUERY_MARKER, q["sql"].lower(), f"Found unexpected query: {q['sql']}")
+
+    def test_org_unit_retrieve_requested_instances_count_success(self):
+        """Verify instances_count IS computed and returned on retrieve() when explicitly requested via 'fields'"""
+        self.client.force_authenticate(self.yoda)
+
+        org_unit = m.OrgUnit.objects.create(
+            org_unit_type=self.jedi_council,
+            version=self.sw_version_1,
+            name="Coruscant Jedi Temple",
+            validation_status=m.OrgUnit.VALIDATION_VALID,
+        )
+        self.create_form_instance(
+            form=self.form_1,
+            period="202001",
+            org_unit=org_unit,
+            project=self.project,
+            json={"name": "a", "age": 18, "gender": "M"},
+        )
+
+        with CaptureQueriesContext(connection) as ctx:
+            response = self.client.get(f"/api/orgunits/{org_unit.id}/?fields=id,name,instances_count")
+
+        self.assertJSONResponse(response, status.HTTP_200_OK)
+        self.assertEqual(response.json(), {"id": org_unit.id, "name": org_unit.name, "instances_count": 1})
+
+        self.assertTrue(
+            any(DESCENDANTS_COUNT_QUERY_MARKER in q["sql"].lower() for q in ctx.captured_queries),
+            "Expected a query computing instances_count",
+        )
+
+    def test_org_unit_retrieve_catchment_default(self):
+        """Default behavior (no 'fields') is unchanged: catchment is still serialized"""
+        self.client.force_authenticate(self.yoda)
+        org_unit = self.jedi_council_corruscant  # has a non-empty `catchment` geometry
+
+        response = self.client.get(f"/api/orgunits/{org_unit.id}/")
+
+        self.assertJSONResponse(response, status.HTTP_200_OK)
+        self.assertIsNotNone(response.json()["catchment"])
+
+    def test_org_unit_retrieve_performance_optimization_no_catchment(self):
+        """Test that catchment geometry is NOT serialized (nor even present) on retrieve() when
+        'fields' doesn't ask for it -- `fields=` also trims the response to just the requested keys."""
+        self.client.force_authenticate(self.yoda)
+        org_unit = self.jedi_council_corruscant  # has a non-empty `catchment` geometry
+
+        response = self.client.get(f"/api/orgunits/{org_unit.id}/?fields=id,name")
+
+        self.assertJSONResponse(response, status.HTTP_200_OK)
+        self.assertEqual(response.json(), {"id": org_unit.id, "name": org_unit.name})
+        self.assertNotIn("catchment", response.json())
+
+    def test_org_unit_retrieve_requested_catchment_success(self):
+        """Verify catchment geometry IS returned on retrieve() when explicitly requested via 'fields'"""
+        self.client.force_authenticate(self.yoda)
+        org_unit = self.jedi_council_corruscant  # has a non-empty `catchment` geometry
+
+        response = self.client.get(f"/api/orgunits/{org_unit.id}/?fields=id,name,catchment")
+
+        self.assertJSONResponse(response, status.HTTP_200_OK)
+        self.assertEqual(set(response.json().keys()), {"id", "name", "catchment"})
+        self.assertIsNotNone(response.json()["catchment"])
 
     def test_org_unit_performance_optimization_no_instance_count(self):
         """Test if instances_count is NOT queried when not in 'fields'"""

--- a/setuper/README.md
+++ b/setuper/README.md
@@ -21,6 +21,22 @@ Once the script has run, you can log in to your server using the account name as
 
 ## How To Use
 
+### Quick start (local)
+
+If you're running the stack locally via `docker compose` and just want a fresh
+account without going through the manual `createsuperuser` step below, use the
+`--local` flag. It creates a Django admin directly in the `iaso` container
+(via `docker compose exec ... manage.py createsuperuser --noinput`) and uses
+those credentials right away to set up the account:
+
+    cd setuper
+    python3 setuper.py --local
+
+This can be combined with the other flags (`-n`, `-a`, `--create_main_org_unit`, `--create_demo_form`, ...).
+Steps 1-6 below and `credentials.py` are not needed in this mode.
+
+### Manual setup
+
 1.  Backup your DB
 
         docker compose exec db pg_dump -U postgres iaso  -Fc > ~/Desktop/iaso.dump

--- a/setuper/setuper.py
+++ b/setuper/setuper.py
@@ -3,6 +3,8 @@ import os
 
 # Get the setuper directory path
 SETUPER_DIR = os.path.dirname(os.path.abspath(__file__))
+# The repo root is where docker-compose.yml lives, one level up from setuper/
+REPO_ROOT_DIR = os.path.dirname(SETUPER_DIR)
 # Change the working directory to the setuper directory
 os.chdir(SETUPER_DIR)
 
@@ -10,6 +12,7 @@ import argparse
 import random
 import re
 import string
+import subprocess
 import sys
 
 from additional_projects import create_projects, link_new_projects_to_main_data_source
@@ -38,6 +41,48 @@ seed_entities = True
 seed_registry = True
 
 seed_review_change_proposal = True
+
+
+def create_local_django_superuser(username, password, email=None):
+    """
+    Create a Django superuser directly inside the local `iaso` docker compose
+    service, via `manage.py createsuperuser --noinput`, so the setuper can run
+    end-to-end without the manual `docker compose exec iaso ./manage.py
+    createsuperuser` step.
+    """
+    email = email or f"{username}@example.com"
+    print(f"Creating local Django superuser '{username}' via docker compose...")
+    result = subprocess.run(
+        [
+            "docker",
+            "compose",
+            "exec",
+            "-T",
+            "-e",
+            f"DJANGO_SUPERUSER_USERNAME={username}",
+            "-e",
+            f"DJANGO_SUPERUSER_PASSWORD={password}",
+            "-e",
+            f"DJANGO_SUPERUSER_EMAIL={email}",
+            "iaso",
+            "./manage.py",
+            "createsuperuser",
+            "--noinput",
+        ],
+        cwd=REPO_ROOT_DIR,
+        capture_output=True,
+        text=True,
+    )
+
+    if result.returncode != 0:
+        if "already taken" in result.stderr:
+            print(f"Local Django superuser '{username}' already exists, reusing it.")
+        else:
+            print(result.stdout)
+            print(result.stderr)
+            sys.exit("ERROR: could not create the local Django superuser")
+    else:
+        print(f"Local Django superuser '{username}' created.")
 
 
 def admin_login(server_url, username, password):
@@ -167,6 +212,15 @@ if __name__ == "__main__":
         help="Flag to create the main organizational unit (default: False)",
     )
     parser.add_argument("--create_demo_form", action="store_true", help="Flag to create a demo form (default: False")
+    parser.add_argument(
+        "--local",
+        action="store_true",
+        help=(
+            "Create a fresh Django admin via `docker compose exec ... manage.py createsuperuser` "
+            "on the local stack, then use those credentials to set up the account "
+            "(no need to run createsuperuser manually or configure credentials.py)."
+        ),
+    )
 
     args = parser.parse_args()
     server_url = args.server_url
@@ -177,7 +231,12 @@ if __name__ == "__main__":
     create_main_org_unit = args.create_main_org_unit
     create_demo_form = args.create_demo_form
 
-    if server_url is None or username is None or password is None:
+    if args.local:
+        server_url = server_url or "http://localhost:8081"
+        username = username or "admin_" + "".join(random.choices(string.ascii_lowercase, k=7))
+        password = password or "".join(random.choices(string.ascii_letters + string.digits, k=16))
+        create_local_django_superuser(username, password)
+    elif server_url is None or username is None or password is None:
         from credentials import *
 
         try:


### PR DESCRIPTION
## What problem is this PR solving?

I notice /api/orgunits/<the_id> was slow due to instance_count

### Related JIRA tickets

IA-5416

## Changes

GET /api/orgunits/{id}/ (single org unit retrieve) now honors ?fields=... like the list endpoint already does:

- If instances_count isn't in the requested fields, skip the expensive descendants-count query

## How to test

 - seed command, setuper or other way
    - docker compose up
    - docker compose run iaso manage tasks_worker 
    - cd setuper
    - uv run setuper.py --local
 - search in orgunits
 - open details of the map
 - click on the shape the number of submission should still show up

<img width="2545" height="1021" alt="image" src="https://github.com/user-attachments/assets/8624f283-45c7-4a02-8319-66814f343235" />


## Print screen / video


## Notes



## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).
