### PR TITLE
[WC2-916] Fix `Project.DoesNotExist` in `WFP2Adapter`

### DIFF
--- a/plugins/wfp_auth/views.py
+++ b/plugins/wfp_auth/views.py
@@ -19,6 +19,7 @@ from django.contrib.sites.shortcuts import get_current_site
 from django.core.exceptions import PermissionDenied
 from django.core.mail import EmailMultiAlternatives
 from django.http import HttpRequest, JsonResponse
+from django.shortcuts import get_object_or_404
 from django.template import loader
 from django.views.decorators.csrf import csrf_exempt
 from oauthlib.oauth2 import OAuth2Error
@@ -131,9 +132,7 @@ class WFP2Adapter(Auth0OAuth2Adapter):
         app_id = request.GET.get(APP_ID, None)
 
         if app_id:
-            account = (
-                Project.objects.filter(account__name=self.settings["IASO_ACCOUNT_NAME"]).get(app_id=app_id).account
-            )
+            account = get_object_or_404(Project, app_id=app_id).account
             if app_id != self.settings["IASO_ACCOUNT_NAME"]:
                 uid = f"{app_id}_{uid}"
         else:


### PR DESCRIPTION
## What problem is this PR solving?

A bug was introduced when the `filter(account__name=self.settings["IASO_ACCOUNT_NAME"])` was added. 
The goal of this line is to find the account associated with the `app_id`. 
By filtering on the `Account` name, we make it work only on the `IASO_ACCOUNT_NAME`.

### Related JIRA tickets

WC2-916

## Changes

Revert breaking change

## How to test

Hard to test outside of WFP's environment.
