### PR TITLE
[IA-5414] Fix derived From's FormVersion should not be returned to mobile

### DIFF
--- a/iaso/api/form_versions/views.py
+++ b/iaso/api/form_versions/views.py
@@ -61,7 +61,8 @@ class FormVersionsViewSet(ModelViewSet):
                     raise exceptions.NotAuthenticated
                 raise exceptions.NotFound(f"Project not found for {app_id}")
             queryset = FormVersion.objects.filter(
-                Exists(Project.objects.filter(app_id=app_id, forms=OuterRef("form_id")))
+                Exists(Project.objects.filter(app_id=app_id, forms=OuterRef("form_id"))),
+                form__derived=False,
             )
         elif self.request.user.is_anonymous:
             raise exceptions.NotAuthenticated

--- a/iaso/tests/api/form_versions/test_form_versions.py
+++ b/iaso/tests/api/form_versions/test_form_versions.py
@@ -493,6 +493,35 @@ class FormsVersionAPITestCase(APITestCase):
         response = self.client.get("/api/formversions/", {APP_ID: self.project.app_id})
         self.assertJSONResponse(response, status.HTTP_200_OK)
 
+    def test_formversions_list_with_app_id_filters_out_version_of_derived_forms(self):
+        """GET /formversions/ with auth for project which requires it: 200"""
+
+        form_derived = m.Form.objects.create(
+            name="Derived",
+            form_id="sample2",
+            period_type="MONTH",
+            single_per_period=False,
+            derived=True,
+        )
+        self.project.forms.add(form_derived)
+        self.project.save()
+        form_derived.org_unit_types.set([self.sith_council])
+        form_derived_file_mock = mock.MagicMock(spec=File)
+        form_derived_file_mock.name = "test.xml"
+        with open("iaso/tests/fixtures/odk_form_valid_no_settings.xlsx", "rb") as xls_file:
+            form_derived.form_versions.create(
+                file=form_derived_file_mock, xls_file=UploadedFile(xls_file), version_id="2020022401"
+            )
+
+        self.client.force_authenticate(user=self.yoda)
+        response = self.client.get("/api/formversions/", {APP_ID: self.project.app_id})
+        self.assertJSONResponse(response, status.HTTP_200_OK)
+        response_data = response.json()
+        self.assertEqual(len(response_data["form_versions"]), 1)
+        # form_1 is not returned because it doesn't have a version
+        # form_derived is not returned because it is derived
+        self.assertEqual(response_data["form_versions"][0]["form_id"], self.form_2.pk)
+
     def assertValidFormVersionData(
         self, form_version_data: typing.Mapping, *, check_annotated_fields: bool = True
     ):  # TODO: check for other fields


### PR DESCRIPTION
## What problem is this PR solving?

When the mobile application retrieves the `FormVersion`s, some of them are pointing to `Form`s that are "derived" and not returned to the mobile. This results in a Foreign Key exception in the mobile app.

### Related JIRA tickets

IA-5414

## Changes

When an `app_id` is passed, filter out the `derived` `Form`s.

## How to test

1. Request the `FormVersion` using the API:  `/api/formversions/?app_id=...`
2. Mark a form as derived
3. Check that the versions of that form are not returned when calling the same endpoint.
