### PR TITLE
IA-5422 fix: mobile reports endpoint ignores app_id (develop backport)

### DIFF
--- a/iaso/api/mobile/reports.py
+++ b/iaso/api/mobile/reports.py
@@ -3,7 +3,8 @@ from drf_spectacular.utils import extend_schema
 from rest_framework import filters, permissions, serializers
 
 from iaso.api.common import ModelViewSet, TimestampField
-from iaso.models import Report
+from iaso.api.serializers import AppIdSerializer
+from iaso.models import Project, Report
 
 
 class MobileReportSerializer(serializers.ModelSerializer):
@@ -38,8 +39,13 @@ class MobileReportsViewSet(ModelViewSet):
         return MobileReportSerializer
 
     def get_queryset(self):
+        app_id = AppIdSerializer(data=self.request.query_params).get_app_id(raise_exception=False)
+        if app_id:
+            project = Project.objects.get_for_user_and_app_id(self.request.user, app_id)
+            queryset = Report.objects.filter(project=project)
+        else:
+            queryset = Report.objects.filter(project__account=self.request.user.iaso_profile.account)
         search = self.request.query_params.get("search", None)
-        queryset = Report.objects.filter(project__account=self.request.user.iaso_profile.account)
         if search:
             queryset = queryset.filter(name__icontains=search)
         return queryset

--- a/iaso/tests/api/test_reports.py
+++ b/iaso/tests/api/test_reports.py
@@ -12,7 +12,8 @@ class ReportsAPITestCase(APITestCase):
     def setUpTestData(cls):
         kame_house = m.Account.objects.create(name="Kame House")
         rr_army = m.Account.objects.create(name="Red Ribbon Army")
-        cls.sayanj = m.Project.objects.create(account=kame_house, name="sayanJ")
+        cls.sayanj = m.Project.objects.create(account=kame_house, name="sayanJ", app_id="sayanj.app")
+        cls.freeza_project = m.Project.objects.create(account=kame_house, name="Freeza Force", app_id="freeza.app")
         cls.kefla = cls.create_user_with_profile(
             username="Kefla", account=kame_house, permissions=[CORE_REPORTS_PERMISSION]
         )
@@ -101,7 +102,61 @@ class ReportsAPITestCase(APITestCase):
 
         Report.objects.create(name="TEST_REPORT_A", published_version=report_version, project=self.sayanj)
 
-        response = self.client.get("/api/mobile/reports/")
+        response = self.client.get(f"/api/mobile/reports/?app_id={self.sayanj.app_id}")
 
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         self.assertEqual(response.json()[0]["name"], "TEST_REPORT_A")
+
+    def test_get_reports_mobile_filters_by_project(self):
+        # IA-5422: /api/mobile/reports/ must only return the reports for the project
+        # matching `app_id`, not every report on the account.
+        self.client.force_authenticate(self.kefla)
+
+        file = File(open("iaso/tests/fixtures/bulk_create_users/test_user_bulk_create_valid.csv", "rb"))
+
+        sayanj_version = ReportVersion.objects.create(
+            file=file,
+            name="TEST_REPORT_VERSION_A",
+            status="published",
+        )
+        Report.objects.create(name="TEST_REPORT_A", published_version=sayanj_version, project=self.sayanj)
+
+        freeza_version = ReportVersion.objects.create(
+            file=file,
+            name="TEST_REPORT_VERSION_B",
+            status="published",
+        )
+        Report.objects.create(name="TEST_REPORT_B", published_version=freeza_version, project=self.freeza_project)
+
+        response = self.client.get(f"/api/mobile/reports/?app_id={self.sayanj.app_id}")
+
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        report_names = [report["name"] for report in response.json()]
+        self.assertEqual(report_names, ["TEST_REPORT_A"])
+
+    def test_get_reports_mobile_without_app_id_falls_back_to_account(self):
+        # Backward compatibility: a caller that doesn't pass `app_id` keeps the previous
+        # behaviour (every report on the account), instead of being rejected.
+        self.client.force_authenticate(self.kefla)
+
+        file = File(open("iaso/tests/fixtures/bulk_create_users/test_user_bulk_create_valid.csv", "rb"))
+
+        sayanj_version = ReportVersion.objects.create(
+            file=file,
+            name="TEST_REPORT_VERSION_A",
+            status="published",
+        )
+        Report.objects.create(name="TEST_REPORT_A", published_version=sayanj_version, project=self.sayanj)
+
+        freeza_version = ReportVersion.objects.create(
+            file=file,
+            name="TEST_REPORT_VERSION_B",
+            status="published",
+        )
+        Report.objects.create(name="TEST_REPORT_B", published_version=freeza_version, project=self.freeza_project)
+
+        response = self.client.get("/api/mobile/reports/")
+
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        report_names = {report["name"] for report in response.json()}
+        self.assertEqual(report_names, {"TEST_REPORT_A", "TEST_REPORT_B"})


### PR DESCRIPTION
## What problem is this PR solving?

Backport of the IA-5422 hotfix (#3321, merged to `main`) to `develop` — `GET /api/mobile/reports/` accepted an `app_id` parameter but never used it, returning every report on the account instead of only the ones for the requesting project.

### Related JIRA tickets

IA-5422

## Changes

Clean cherry-pick of the squash-merged hotfix commit from `main` (a1cc77bfe6), no changes needed.

- `MobileReportsViewSet.get_queryset()` resolves the project from `app_id` when present (`Project.objects.get_for_user_and_app_id`, same pattern as `StockKeepingUnitMobileViewSet`/`StockRulesVersionMobileViewSet`) and filters `Report` by that project. When `app_id` is absent, falls back to the previous account-wide behaviour instead of rejecting the request.

## How to test

Same as #3321 — see that PR.

## Notes

Without this backport, the fix would be reverted the next time `develop` merges into `main`.

## Doc

N/A