### PR TITLE
IA-5424 omit heavy instance_count for breadcrumb display

### DIFF
--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitInfos.test.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitInfos.test.tsx
@@ -1,0 +1,175 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderWithThemeAndIntlProvider } from '../../../../../tests/helpers';
+import { OrgUnitInfos, PARENT_BREADCRUMB_FIELDS } from './OrgUnitInfos';
+
+const {
+    mockUseGetOrgUnit,
+    mockUseGetOrgUnitValidationStatus,
+    mockUseCheckUserHasWritePermissionOnOrgunit,
+} = vi.hoisted(() => ({
+    mockUseGetOrgUnit: vi.fn(),
+    mockUseGetOrgUnitValidationStatus: vi.fn(),
+    mockUseCheckUserHasWritePermissionOnOrgunit: vi.fn(),
+}));
+
+vi.mock('./TreeView/requests', () => ({
+    useGetOrgUnit: mockUseGetOrgUnit,
+}));
+
+vi.mock('../hooks/utils/useGetOrgUnitValidationStatus', () => ({
+    useGetOrgUnitValidationStatus: mockUseGetOrgUnitValidationStatus,
+}));
+
+vi.mock('../../../utils/usersUtils', async importOriginal => {
+    const actual =
+        await importOriginal<typeof import('../../../utils/usersUtils')>();
+    return {
+        ...actual,
+        useCheckUserHasWritePermissionOnOrgunit:
+            mockUseCheckUserHasWritePermissionOnOrgunit,
+    };
+});
+
+vi.mock('./TreeView/OrgUnitTreeviewModal', () => ({
+    OrgUnitTreeviewModal: ({ initialSelection }: any) => (
+        <div data-testid="treeview-modal">
+            {initialSelection ? JSON.stringify(initialSelection) : 'none'}
+        </div>
+    ),
+}));
+
+vi.mock('./OrgUnitCreationDetails', () => ({
+    OrgUnitCreationDetails: () => <div data-testid="creation-details" />,
+}));
+
+vi.mock('./OrgUnitMultiReferenceInstances', () => ({
+    OrgUnitMultiReferenceInstances: () => (
+        <div data-testid="reference-instances" />
+    ),
+}));
+
+// DatesRange renders a real MUI DatePicker, which needs a LocalizationProvider
+// this test doesn't set up -- stub it out, it's unrelated to the fields=
+// behaviour under test here.
+vi.mock('../../../components/filters/DatesRange', () => ({
+    default: () => <div data-testid="dates-range" />,
+}));
+
+// InputComponent pulls in its own heavy dropdown/select machinery -- stub it
+// out too, for the same reason.
+vi.mock('../../../components/forms/InputComponent', () => ({
+    default: () => <div data-testid="input-component" />,
+}));
+
+const makeOrgUnitState = (parent?: { id: number }): any => ({
+    name: { value: 'Test OU', errors: [] },
+    org_unit_type_id: { value: 1, errors: [] },
+    groups: { value: [], errors: [] },
+    code: { value: '', errors: [] },
+    aliases: { value: [], errors: [] },
+    validation_status: { value: 'VALID', errors: [] },
+    source_ref: { value: '', errors: [] },
+    parent: { value: parent, errors: [] },
+    opening_date: { value: undefined, errors: [] },
+    closed_date: { value: undefined, errors: [] },
+});
+
+const defaultProps = {
+    onChangeInfo: vi.fn(),
+    orgUnitTypes: [],
+    groups: [],
+    resetTrigger: false,
+    handleSave: vi.fn(),
+    handleReset: vi.fn(),
+    orgUnitModified: false,
+    isFetchingOrgUnitTypes: false,
+    isFetchingGroups: false,
+    referenceInstances: [],
+    orgUnit: {},
+};
+
+describe('OrgUnitInfos', () => {
+    beforeEach(() => {
+        mockUseGetOrgUnit.mockReset();
+        mockUseGetOrgUnit.mockReturnValue({ data: undefined });
+        mockUseGetOrgUnitValidationStatus.mockReset();
+        mockUseGetOrgUnitValidationStatus.mockReturnValue({
+            data: [],
+            isLoading: false,
+        });
+        mockUseCheckUserHasWritePermissionOnOrgunit.mockReset();
+        mockUseCheckUserHasWritePermissionOnOrgunit.mockReturnValue(true);
+    });
+
+    it('requests the parent org unit with the breadcrumb-only fields allow-list, omitting instances_count', () => {
+        renderWithThemeAndIntlProvider(
+            <OrgUnitInfos
+                {...defaultProps}
+                orgUnitState={makeOrgUnitState({ id: 7 })}
+                params={{ orgUnitId: '42' }}
+            />,
+        );
+
+        expect(mockUseGetOrgUnit).toHaveBeenCalledWith(
+            '7',
+            PARENT_BREADCRUMB_FIELDS,
+        );
+        expect(PARENT_BREADCRUMB_FIELDS).not.toContain('instances_count');
+    });
+
+    it('uses parentOrgUnitId from params (not the org unit state) when creating a new org unit', () => {
+        renderWithThemeAndIntlProvider(
+            <OrgUnitInfos
+                {...defaultProps}
+                orgUnitState={makeOrgUnitState(undefined)}
+                params={{ orgUnitId: '0', parentOrgUnitId: '99' }}
+            />,
+        );
+
+        expect(mockUseGetOrgUnit).toHaveBeenCalledWith(
+            '99',
+            PARENT_BREADCRUMB_FIELDS,
+        );
+    });
+
+    it('does not fetch a parent when there is none, but still passes the fields allow-list', () => {
+        renderWithThemeAndIntlProvider(
+            <OrgUnitInfos
+                {...defaultProps}
+                orgUnitState={makeOrgUnitState(undefined)}
+                params={{ orgUnitId: '42' }}
+            />,
+        );
+
+        expect(mockUseGetOrgUnit).toHaveBeenCalledWith(
+            undefined,
+            PARENT_BREADCRUMB_FIELDS,
+        );
+    });
+
+    it('forwards the trimmed parent org unit (without instances_count) as the treeview initial selection', () => {
+        const trimmedParent = {
+            id: 7,
+            name: 'Parent OU',
+            org_unit_type: { sub_unit_types: [{ id: 3 }] },
+        };
+        mockUseGetOrgUnit.mockReturnValue({ data: trimmedParent });
+
+        renderWithThemeAndIntlProvider(
+            <OrgUnitInfos
+                {...defaultProps}
+                orgUnitState={makeOrgUnitState({ id: 7 })}
+                params={{ orgUnitId: '42' }}
+            />,
+        );
+
+        expect(screen.getByTestId('treeview-modal')).toHaveTextContent(
+            'Parent OU',
+        );
+        expect(screen.getByTestId('treeview-modal').textContent).not.toContain(
+            'instances_count',
+        );
+    });
+});

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitInfos.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/OrgUnitInfos.tsx
@@ -28,6 +28,10 @@ import { OrgUnitMultiReferenceInstances } from './OrgUnitMultiReferenceInstances
 import { OrgUnitTreeviewModal } from './TreeView/OrgUnitTreeviewModal';
 import { useGetOrgUnit } from './TreeView/requests';
 
+// Only the fields needed for the tree/breadcrumb, to skip the expensive instances_count.
+export const PARENT_BREADCRUMB_FIELDS =
+    'id,name,short_name,org_unit_type,org_unit_type_id,org_unit_type_name,validation_status,parent,parent_id,parent_name';
+
 const useStyles = makeStyles(theme => ({
     '@global': {
         body: {
@@ -104,8 +108,10 @@ export const OrgUnitInfos: FunctionComponent<Props> = ({
     const parentId = isNewOrgunit
         ? parentOrgUnitId
         : orgUnitState.parent.value?.id;
+    // Only need tree/breadcrumb fields here, skip the expensive instances_count.
     const { data: parentOrgunit } = useGetOrgUnit(
         parentId ? `${parentId}` : undefined,
+        PARENT_BREADCRUMB_FIELDS,
     );
 
     useEffect(() => {

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/TreeView/requests.test.tsx
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/TreeView/requests.test.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useGetOrgUnit } from './requests';
+
+const { mockGetRequest } = vi.hoisted(() => ({
+    mockGetRequest: vi.fn(),
+}));
+
+vi.mock('Iaso/libs/Api', () => ({
+    getRequest: (...args: unknown[]) => mockGetRequest(...args),
+}));
+
+const createWrapper = () => {
+    const queryClient = new QueryClient({
+        defaultOptions: {
+            queries: { retry: false },
+        },
+    });
+    const Wrapper = ({ children }: { children: React.ReactNode }) => (
+        <IntlProvider locale="en" messages={{}}>
+            <QueryClientProvider client={queryClient}>
+                {children}
+            </QueryClientProvider>
+        </IntlProvider>
+    );
+    Wrapper.displayName = 'TestQueryClientWrapper';
+    return Wrapper;
+};
+
+const orgUnitResponse = { id: 1, name: 'OU 1' };
+
+describe('useGetOrgUnit', () => {
+    beforeEach(() => {
+        mockGetRequest.mockReset();
+    });
+
+    it('fetches the full org unit when no fields are requested', async () => {
+        mockGetRequest.mockResolvedValue(orgUnitResponse);
+
+        const { result } = renderHook(() => useGetOrgUnit('1'), {
+            wrapper: createWrapper(),
+        });
+
+        await waitFor(() => {
+            expect(result.current.isSuccess).toBe(true);
+        });
+
+        expect(mockGetRequest).toHaveBeenCalledWith('/api/orgunits/1/');
+        expect(result.current.data).toEqual(orgUnitResponse);
+    });
+
+    it('appends a fields query param when fields are requested', async () => {
+        mockGetRequest.mockResolvedValue(orgUnitResponse);
+
+        const { result } = renderHook(
+            () => useGetOrgUnit('1', 'id,name,parent'),
+            { wrapper: createWrapper() },
+        );
+
+        await waitFor(() => {
+            expect(result.current.isSuccess).toBe(true);
+        });
+
+        expect(mockGetRequest).toHaveBeenCalledWith(
+            '/api/orgunits/1/?fields=id,name,parent',
+        );
+    });
+
+    it('does not fetch when orgUnitId is missing', async () => {
+        const { result } = renderHook(() => useGetOrgUnit(undefined), {
+            wrapper: createWrapper(),
+        });
+
+        await act(async () => {
+            await Promise.resolve();
+        });
+
+        expect(mockGetRequest).not.toHaveBeenCalled();
+        expect(result.current.isLoading).toBe(false);
+        expect(result.current.isFetching).toBe(false);
+    });
+
+    it('uses a distinct query cache entry per fields value', async () => {
+        mockGetRequest.mockResolvedValue(orgUnitResponse);
+        const wrapper = createWrapper();
+
+        const { result: withoutFields } = renderHook(() => useGetOrgUnit('1'), {
+            wrapper,
+        });
+        await waitFor(() => expect(withoutFields.current.isSuccess).toBe(true));
+
+        const { result: withFields } = renderHook(
+            () => useGetOrgUnit('1', 'id,name'),
+            { wrapper },
+        );
+        await waitFor(() => expect(withFields.current.isSuccess).toBe(true));
+
+        // Both a plain refetch and the `fields=`-scoped variant should have
+        // hit the API separately rather than sharing a cache entry keyed only
+        // on the org unit id.
+        expect(mockGetRequest).toHaveBeenCalledWith('/api/orgunits/1/');
+        expect(mockGetRequest).toHaveBeenCalledWith(
+            '/api/orgunits/1/?fields=id,name',
+        );
+        expect(mockGetRequest).toHaveBeenCalledTimes(2);
+    });
+});

--- a/hat/assets/js/apps/Iaso/domains/orgUnits/components/TreeView/requests.ts
+++ b/hat/assets/js/apps/Iaso/domains/orgUnits/components/TreeView/requests.ts
@@ -161,10 +161,15 @@ export const searchOrgUnits = async ({
 
 export const useGetOrgUnit = (
     orgUnitId?: string,
+    // Optional `fields=` allow-list to skip the expensive instances_count.
+    fields?: string,
 ): UseQueryResult<OrgUnit, Error> =>
     useSnackQuery(
-        ['orgunits', `${orgUnitId}`],
-        () => getRequest(`/api/orgunits/${orgUnitId}/`),
+        ['orgunits', `${orgUnitId}`, fields],
+        () =>
+            getRequest(
+                `/api/orgunits/${orgUnitId}/${fields ? `?fields=${fields}` : ''}`,
+            ),
         undefined,
         {
             enabled: Boolean(orgUnitId),


### PR DESCRIPTION
## What problem is this PR solving?

Getting the instance_count is heavy on orgunit, so let's skip it for the breadcrumb display.

### Related JIRA tickets

IA-5424

## Changes

Continuation of the work of https://github.com/BLSQ/iaso/pull/3315
The breadcrumb is still asking orgunit with instance_count
Specify the `fields` to have only the one used for that part of the widget.

## How to test



 - Launch seed management command or setuper
 - open network view
 - go the an orgunit detail page of the country, drill down to one of the children
 - do a page refresh and looks at the network calls no more /api/orgunits/<id> without `fields=...` param
 - verify everything still displays

## Print screen / video

<img width="1795" height="1042" alt="image" src="https://github.com/user-attachments/assets/f49197d1-923b-4163-b382-e07bac0256c0" />


## Notes



## Doc

Tell us where the doc can be found (docs folder, wiki, in the code...).
